### PR TITLE
Reduce work level for stochastic tests.

### DIFF
--- a/storage/metric/leveldb/leveldb_test.go
+++ b/storage/metric/leveldb/leveldb_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	stochasticMaximumVariance = 64
+	stochasticMaximumVariance = 8
 )
 
 var testBasicLifecycle func(t test.Tester) = func(t test.Tester) {


### PR DESCRIPTION
The LevelDB stochastic tests could take a long time.

Original:

```
Matt:prometheus mtp$ make test
make -C model
protoc --go_out=generated/ data.proto
go build ./...
go test ./...
warning: building out-of-date packages:
    github.com/matttproud/golang_instrumentation/maths
    github.com/matttproud/golang_instrumentation/utility
    github.com/matttproud/golang_instrumentation/metrics
    github.com/matttproud/golang_instrumentation
installing these packages with 'go test -i ./...' will speed future tests.

?       github.com/matttproud/prometheus    [no test files]
?       github.com/matttproud/prometheus/coding [no test files]
ok      github.com/matttproud/prometheus/coding/indexable   0.012s
?       github.com/matttproud/prometheus/model  [no test files]
?       github.com/matttproud/prometheus/model/generated    [no test files]
?       github.com/matttproud/prometheus/retrieval  [no test files]
?       github.com/matttproud/prometheus/storage/metric [no test files]
ok      github.com/matttproud/prometheus/storage/metric/leveldb 70.800s
?       github.com/matttproud/prometheus/storage/raw    [no test files]
?       github.com/matttproud/prometheus/storage/raw/index  [no test files]
ok      github.com/matttproud/prometheus/storage/raw/index/leveldb  0.012s
ok      github.com/matttproud/prometheus/storage/raw/leveldb    0.016s
ok      github.com/matttproud/prometheus/utility    0.012s
?       github.com/matttproud/prometheus/utility/test   [no test files]
```

to

```
Matt:prometheus mtp$ make test
make -C model
protoc --go_out=generated/ data.proto
go build ./...
go test ./...
warning: building out-of-date packages:
    github.com/matttproud/golang_instrumentation/maths
    github.com/matttproud/golang_instrumentation/utility
    github.com/matttproud/golang_instrumentation/metrics
    github.com/matttproud/golang_instrumentation
installing these packages with 'go test -i ./...' will speed future tests.

?       github.com/matttproud/prometheus    [no test files]
?       github.com/matttproud/prometheus/coding [no test files]
ok      github.com/matttproud/prometheus/coding/indexable   0.011s
?       github.com/matttproud/prometheus/model  [no test files]
?       github.com/matttproud/prometheus/model/generated    [no test files]
?       github.com/matttproud/prometheus/retrieval  [no test files]
?       github.com/matttproud/prometheus/storage/metric [no test files]
ok      github.com/matttproud/prometheus/storage/metric/leveldb 2.158s
?       github.com/matttproud/prometheus/storage/raw    [no test files]
?       github.com/matttproud/prometheus/storage/raw/index  [no test files]
ok      github.com/matttproud/prometheus/storage/raw/index/leveldb  0.013s
ok      github.com/matttproud/prometheus/storage/raw/leveldb    0.013s
ok      github.com/matttproud/prometheus/utility    0.013s
?       github.com/matttproud/prometheus/utility/test   [no test files]
```
