### PR TITLE
Make LevelDB operating modes invocation-time conf.

### DIFF
--- a/storage/raw/leveldb/leveldb.go
+++ b/storage/raw/leveldb/leveldb.go
@@ -14,10 +14,15 @@
 package leveldb
 
 import (
+	"flag"
 	"github.com/jmhodges/levigo"
 	"github.com/prometheus/prometheus/coding"
 	"github.com/prometheus/prometheus/storage/raw"
 	"io"
+)
+
+var (
+	leveldbFlushOnMutate = flag.Bool("leveldbFlushOnMutate", true, "Whether LevelDB should flush every operation to disk upon mutation before returning (bool).")
 )
 
 type LevelDBPersistence struct {
@@ -54,8 +59,7 @@ func NewLevelDBPersistence(storageRoot string, cacheCapacity, bitsPerBloomFilter
 
 	readOptions := levigo.NewReadOptions()
 	writeOptions := levigo.NewWriteOptions()
-	writeOptions.SetSync(true)
-
+	writeOptions.SetSync(*leveldbFlushOnMutate)
 	p = &LevelDBPersistence{
 		cache:        cache,
 		filterPolicy: filterPolicy,


### PR DESCRIPTION
Presently our use of LevelDB and its operating modes are hardcoded
into the storage stack.  This pull request decouples this and
re-exposes this through flags.  We can now perform benchmarking
and remedial tuning.

https://github.com/prometheus/prometheus/issues/47
