### PR TITLE
Simplify Metric.Fingerprint.

### DIFF
--- a/model/metric.go
+++ b/model/metric.go
@@ -14,17 +14,16 @@
 package model
 
 import (
-	"bytes"
-	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 	"sort"
 	"time"
 )
 
 const (
 	// XXX: Re-evaluate down the road.
-	reservedDelimiter = '"'
+	reservedDelimiter = `"`
 )
 
 // A Fingerprint is a simplified representation of an entity---e.g., a hash of
@@ -60,15 +59,13 @@ func (m Metric) Fingerprint() Fingerprint {
 
 	sort.Strings(labelNames)
 
-	summer := md5.New()
+	summer := fnv.New64a()
 
-	buffer := bytes.Buffer{}
 	for _, labelName := range labelNames {
-		buffer.WriteString(labelName)
-		buffer.WriteRune(reservedDelimiter)
-		buffer.WriteString(string(m[LabelName(labelName)]))
+		summer.Write([]byte(labelName))
+		summer.Write([]byte(reservedDelimiter))
+		summer.Write([]byte(m[LabelName(labelName)]))
 	}
-	summer.Write(buffer.Bytes())
 
 	return Fingerprint(hex.EncodeToString(summer.Sum(nil)))
 }

--- a/model/metric_test.go
+++ b/model/metric_test.go
@@ -25,7 +25,7 @@ func testMetric(t test.Tester) {
 	}{
 		{
 			input:  map[string]string{},
-			output: "d41d8cd98f00b204e9800998ecf8427e",
+			output: "cbf29ce484222325",
 		},
 		{
 			input: map[string]string{
@@ -33,7 +33,7 @@ func testMetric(t test.Tester) {
 				"occupation":   "robot",
 				"manufacturer": "westinghouse",
 			},
-			output: "18596f03fce001153495d903b8b577c0",
+			output: "4e1ee4bb22c04a42",
 		},
 	}
 


### PR DESCRIPTION
Metric.Fingerprint is called in tight loops and should be thusly
performant, even if optimizations in the interactions around it
are to be improved, yielding even larger improvements themselves.

To this end, we do not need a cryptographic hash for our metrics;
rather, we can rely on a standard 64-bit Fowler–Noll–Vo (FNV-1a)
identity, which is both computationally less expensive but also
yields smaller fingerprints.

Interesting Read:
http://programmers.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed
