### PR TITLE
Simplifications of GetFingerprintsForLabelSet.

### DIFF
--- a/rules/ast/persistence_adapter.go
+++ b/rules/ast/persistence_adapter.go
@@ -31,7 +31,7 @@ type PersistenceAdapter struct {
 var persistenceAdapter *PersistenceAdapter = nil
 
 func (p *PersistenceAdapter) getMetricsWithLabels(labels model.LabelSet) ([]*model.Metric, error) {
-	fingerprints, err := p.persistence.GetFingerprintsForLabelSet(&labels)
+	fingerprints, err := p.persistence.GetFingerprintsForLabelSet(labels)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/metric/interface.go
+++ b/storage/metric/interface.go
@@ -34,7 +34,7 @@ type MetricPersistence interface {
 
 	// Get all of the metric fingerprints that are associated with the provided
 	// label set.
-	GetFingerprintsForLabelSet(labelSet *model.LabelSet) ([]*model.Fingerprint, error)
+	GetFingerprintsForLabelSet(labelSet model.LabelSet) ([]*model.Fingerprint, error)
 
 	// Get all of the metric fingerprints that are associated for a given label
 	// name.

--- a/storage/metric/leveldb/leveldb_test.go
+++ b/storage/metric/leveldb/leveldb_test.go
@@ -710,9 +710,9 @@ func TestGetFingerprintsForLabelSet(t *testing.T) {
 		t.Error(appendErr)
 	}
 
-	result, getErr := persistence.GetFingerprintsForLabelSet(&(model.LabelSet{
+	result, getErr := persistence.GetFingerprintsForLabelSet(model.LabelSet{
 		model.LabelName("name"): model.LabelValue("my_metric"),
-	}))
+	})
 
 	if getErr != nil {
 		t.Error(getErr)
@@ -722,9 +722,9 @@ func TestGetFingerprintsForLabelSet(t *testing.T) {
 		t.Errorf("Expected two elements.")
 	}
 
-	result, getErr = persistence.GetFingerprintsForLabelSet(&(model.LabelSet{
+	result, getErr = persistence.GetFingerprintsForLabelSet(model.LabelSet{
 		model.LabelName("request_type"): model.LabelValue("your_mom"),
-	}))
+	})
 
 	if getErr != nil {
 		t.Error(getErr)
@@ -734,9 +734,9 @@ func TestGetFingerprintsForLabelSet(t *testing.T) {
 		t.Errorf("Expected one element.")
 	}
 
-	result, getErr = persistence.GetFingerprintsForLabelSet(&(model.LabelSet{
+	result, getErr = persistence.GetFingerprintsForLabelSet(model.LabelSet{
 		model.LabelName("request_type"): model.LabelValue("your_dad"),
-	}))
+	})
 
 	if getErr != nil {
 		t.Error(getErr)
@@ -875,9 +875,9 @@ func TestGetMetricForFingerprint(t *testing.T) {
 		t.Error(appendErr)
 	}
 
-	result, getErr := persistence.GetFingerprintsForLabelSet(&(model.LabelSet{
+	result, getErr := persistence.GetFingerprintsForLabelSet(model.LabelSet{
 		model.LabelName("request_type"): model.LabelValue("your_mom"),
-	}))
+	})
 
 	if getErr != nil {
 		t.Error(getErr)
@@ -900,9 +900,9 @@ func TestGetMetricForFingerprint(t *testing.T) {
 		t.Errorf("Expected metric to match.")
 	}
 
-	result, getErr = persistence.GetFingerprintsForLabelSet(&(model.LabelSet{
+	result, getErr = persistence.GetFingerprintsForLabelSet(model.LabelSet{
 		model.LabelName("request_type"): model.LabelValue("your_dad"),
-	}))
+	})
 
 	if getErr != nil {
 		t.Error(getErr)

--- a/storage/metric/leveldb/reading.go
+++ b/storage/metric/leveldb/reading.go
@@ -180,7 +180,7 @@ func (l *LevelDBMetricPersistence) GetLabelNameFingerprints(n *dto.LabelName) (c
 	return
 }
 
-func (l *LevelDBMetricPersistence) GetFingerprintsForLabelSet(labelSet *model.LabelSet) (fps []*model.Fingerprint, err error) {
+func (l *LevelDBMetricPersistence) GetFingerprintsForLabelSet(labelSet model.LabelSet) (fps []*model.Fingerprint, err error) {
 	begin := time.Now()
 
 	defer func() {
@@ -191,7 +191,7 @@ func (l *LevelDBMetricPersistence) GetFingerprintsForLabelSet(labelSet *model.La
 
 	sets := []utility.Set{}
 
-	for _, labelSetDTO := range model.LabelSetToDTOs(labelSet) {
+	for _, labelSetDTO := range model.LabelSetToDTOs(&labelSet) {
 		f, err := l.labelSetToFingerprints.Get(coding.NewProtocolBufferEncoder(labelSetDTO))
 		if err != nil {
 			return fps, err

--- a/storage/metric/leveldb/regressions_test.go
+++ b/storage/metric/leveldb/regressions_test.go
@@ -65,7 +65,7 @@ func TestGetFingerprintsForLabelSetUsesAnd(t *testing.T) {
 		"percentile": "0.010000",
 	}
 
-	fingerprints, err := persistence.GetFingerprintsForLabelSet(&labelSet)
+	fingerprints, err := persistence.GetFingerprintsForLabelSet(labelSet)
 	if err != nil {
 		t.Errorf("could not get labels: %s", err)
 	}


### PR DESCRIPTION
`MetricPersistence.GetFingerprintsForLabelSet(s *model.LabelSet)` ->
`MetricPersistence.GetFingerprintsForLabelSet(s model.LabelSet)`.
