### PR TITLE
Fix target health state update.

### DIFF
--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -129,6 +129,7 @@ func (t *target) Scrape(earliest time.Time, results chan format.Result) (err err
 		}
 
 		t.scheduler.Reschedule(earliest, futureState)
+		t.state = futureState
 	}()
 
 	done := make(chan bool)

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -1,0 +1,32 @@
+// Copyright 2013 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retrieval
+
+import (
+	"github.com/prometheus/prometheus/retrieval/format"
+	"testing"
+	"time"
+)
+
+func TestTargetScrapeUpdatesState(t *testing.T) {
+	testTarget := target{
+		scheduler: literalScheduler{},
+		state:     UNKNOWN,
+		address:   "bad schema",
+	}
+	testTarget.Scrape(time.Time{}, make(chan format.Result))
+	if testTarget.state != UNREACHABLE {
+		t.Errorf("Expected target state %v, actual: %v", UNREACHABLE, testTarget.state)
+	}
+}

--- a/retrieval/targetpool_test.go
+++ b/retrieval/targetpool_test.go
@@ -21,15 +21,6 @@ import (
 	"time"
 )
 
-type literalScheduler time.Time
-
-func (s literalScheduler) ScheduledFor() time.Time {
-	return time.Time(s)
-}
-
-func (s literalScheduler) Reschedule(earliest time.Time, future TargetState) {
-}
-
 func testTargetPool(t test.Tester) {
 	type expectation struct {
 		size int

--- a/retrieval/test_helper.go
+++ b/retrieval/test_helper.go
@@ -1,0 +1,27 @@
+// Copyright 2013 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retrieval
+
+import (
+	"time"
+)
+
+type literalScheduler time.Time
+
+func (s literalScheduler) ScheduledFor() time.Time {
+	return time.Time(s)
+}
+
+func (s literalScheduler) Reschedule(earliest time.Time, future TargetState) {
+}


### PR DESCRIPTION
Right now, futureState is only used to give hints to the health scheduler, but
nowhere is this future state persisted into the target's state field, so we
don't actually track a target's state over time.
