### PR TITLE
Allow replacing job targets via HTTP API.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,7 +58,7 @@ func (config *Config) AddJob(options map[string]string, targets []Targets) error
 	if len(targets) == 0 {
 		return fmt.Errorf("No targets configured for job '%v'", name)
 	}
-	job := &JobConfig{
+	job := JobConfig{
 		Targets: tmpJobTargets,
 	}
 	for option, value := range options {
@@ -66,8 +66,18 @@ func (config *Config) AddJob(options map[string]string, targets []Targets) error
 			return err
 		}
 	}
-	config.Jobs = append(config.Jobs, *job)
+	config.Jobs = append(config.Jobs, job)
 	return nil
+}
+
+func (config *Config) GetJobByName(name string) (jobConfig *JobConfig) {
+	for _, job := range config.Jobs {
+		if job.Name == name {
+			jobConfig = &job
+			break
+		}
+	}
+	return
 }
 
 func (config *GlobalConfig) SetOption(option string, value string) (err error) {

--- a/web/api/api.go
+++ b/web/api/api.go
@@ -1,8 +1,21 @@
+// Copyright 2013 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package api
 
 import (
 	"code.google.com/p/gorest"
-	"github.com/prometheus/prometheus/storage/metric"
+	"github.com/prometheus/prometheus/appstate"
 	"github.com/prometheus/prometheus/utility"
 )
 
@@ -13,12 +26,14 @@ type MetricsService struct {
 	queryRange gorest.EndPoint `method:"GET" path:"/query_range?{expr:string}&{end:int64}&{range:int64}&{step:int64}" output:"string"`
 	metrics    gorest.EndPoint `method:"GET" path:"/metrics" output:"string"`
 
-	persistence metric.MetricPersistence
-	time        utility.Time
+	setTargets gorest.EndPoint `method:"PUT" path:"/jobs/{jobName:string}/targets" postdata:"[]TargetGroup"`
+
+	appState *appstate.ApplicationState
+	time     utility.Time
 }
 
-func NewMetricsService(persistence metric.MetricPersistence) *MetricsService {
+func NewMetricsService(appState *appstate.ApplicationState) *MetricsService {
 	return &MetricsService{
-		persistence: persistence,
+		appState: appState,
 	}
 }

--- a/web/api/query.go
+++ b/web/api/query.go
@@ -1,3 +1,16 @@
+// Copyright 2013 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package api
 
 import (
@@ -70,7 +83,7 @@ func (serv MetricsService) QueryRange(Expr string, End int64, Range int64, Step 
 }
 
 func (serv MetricsService) Metrics() string {
-	metricNames, err := serv.persistence.GetAllMetricNames()
+	metricNames, err := serv.appState.Persistence.GetAllMetricNames()
 	rb := serv.ResponseBuilder()
 	rb.SetContentType(gorest.Application_Json)
 	if err != nil {

--- a/web/api/targets.go
+++ b/web/api/targets.go
@@ -1,0 +1,48 @@
+// Copyright 2013 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"github.com/prometheus/prometheus/model"
+	"github.com/prometheus/prometheus/retrieval"
+	"net/http"
+	"time"
+)
+
+type TargetGroup struct {
+	Endpoints  []string          `json:"endpoints"`
+	BaseLabels map[string]string `json:"baseLabels"`
+}
+
+func (serv MetricsService) SetTargets(targetGroups []TargetGroup, jobName string) {
+	if job := serv.appState.Config.GetJobByName(jobName); job == nil {
+		rb := serv.ResponseBuilder()
+		rb.SetResponseCode(http.StatusNotFound)
+	} else {
+		newTargets := []retrieval.Target{}
+		for _, targetGroup := range targetGroups {
+			// Do mandatory map type conversion due to Go shortcomings.
+			baseLabels := model.LabelSet{}
+			for label, value := range targetGroup.BaseLabels {
+				baseLabels[model.LabelName(label)] = model.LabelValue(value)
+			}
+
+			for _, endpoint := range targetGroup.Endpoints {
+				newTarget := retrieval.NewTarget(endpoint, time.Second*5, baseLabels)
+				newTargets = append(newTargets, newTarget)
+			}
+		}
+		serv.appState.TargetManager.ReplaceTargets(job, newTargets, serv.appState.Config.Global.ScrapeInterval)
+	}
+}

--- a/web/status.go
+++ b/web/status.go
@@ -15,15 +15,16 @@ package web
 
 import (
 	"github.com/prometheus/prometheus/appstate"
+	"github.com/prometheus/prometheus/retrieval"
 	"html/template"
 	"net/http"
 )
 
 type PrometheusStatus struct {
-	Config  string
-	Rules   string
-	Status  string
-	Targets string
+	Config      string
+	Rules       string
+	Status      string
+	TargetPools map[string]*retrieval.TargetPool
 }
 
 type StatusHandler struct {
@@ -32,10 +33,10 @@ type StatusHandler struct {
 
 func (h *StatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	status := &PrometheusStatus{
-		Config:  h.appState.Config.ToString(0),
-		Rules:   "TODO: list rules here",
-		Status:  "TODO: add status information here",
-		Targets: "TODO: list targets here",
+		Config:      h.appState.Config.ToString(0),
+		Rules:       "TODO: list rules here",
+		Status:      "TODO: add status information here",
+		TargetPools: h.appState.TargetManager.Pools(),
 	}
 	t, _ := template.ParseFiles("web/templates/status.html")
 	t.Execute(w, status)

--- a/web/templates/status.html
+++ b/web/templates/status.html
@@ -26,8 +26,20 @@
 		</div>
 
 		<h2>Targets</h2>
-		<div class="grouping_box">
-{{.Targets}}
+    <div class="grouping_box">
+      <ul>
+        {{range $job, $pool := .TargetPools}}
+          <li>{{$job}}
+            <ul>
+              {{range $pool.Targets}}
+                <li>
+                <a href="{{.Address}}">{{.Address}}</a> (State: {{.State}}, Base labels: {{.BaseLabels}})
+                </li>
+              {{end}}
+            </ul>
+          </li>
+        {{end}}
+      </ul>
 		</div>
   </body>
 </html>

--- a/web/web.go
+++ b/web/web.go
@@ -29,7 +29,7 @@ var (
 )
 
 func StartServing(appState *appstate.ApplicationState) {
-	gorest.RegisterService(api.NewMetricsService(appState.Persistence))
+	gorest.RegisterService(api.NewMetricsService(appState))
 	exporter := registry.DefaultRegistry.YieldExporter()
 
 	http.Handle("/status", &StatusHandler{appState: appState})


### PR DESCRIPTION
This ended up much uglier than I would like :( Part of the reason is that the existing retrieval structure doesn't lend itself very well to swapping out targets or getting information out for display (like heap elements being juggled around during scrape). Other ugly parts are how the config+job state needs to get passed around to populate targets and pools with the right parameters. Meh, but my brain stopped producing better results, so I hope this is ok for now. I think it would be a good idea to rewrite the retrieval layer from scratch sometime, with these pain points in mind. It could all be much more beautiful.

This roughly comprises the following changes:
- index target pools by job instead of scrape interval
- make targets within a pool exchangable while preserving existing
  health state for targets
- allow exchanging targets via HTTP API (PUT)
- show target lists in /status (experimental and broken!)
