### PR TITLE
Update embedding script to support BSD find.

### DIFF
--- a/utility/embed-static.sh
+++ b/utility/embed-static.sh
@@ -1,25 +1,28 @@
 #!/bin/sh
 
+set -e
+
 cat <<EOF
 package blob
 var files = map [string] map [string] []byte {
 EOF
 
-CDIR=`pwd`
+ORIGINAL_PWD=${PWD}
+
 for dir in $@
 do
-  cd "$dir"
-  echo "\"`basename $dir`\": {"
+  cd "${dir}"
+  echo "\"$(basename ${dir})\": {"
 
-  find -type f | while read file
+  find . -type f | while read file
   do
-    name=`echo "$file"|sed 's|\.\/||'`
+    name=$(echo "${file}"|sed 's|\.\/||')
     echo "\"$name\": {"
-    gzip -9 -c "$file" | xxd -p |sed 's/\(..\)/0x\1, /g'
+    gzip -9 -c "${file}" | xxd -p |sed 's/\(..\)/0x\1, /g'
     echo "},"
     echo
   done
   echo "},"
-  cd $CDIR
+  cd "${ORIGINAL_PWD}"
 done
 echo '}'


### PR DESCRIPTION
Mac OS X (shudder) needs to have a slightly modified find execution
pattern.
