### PR TITLE
Remove Cruft from Storage Interfaces

### DIFF
--- a/storage/raw/interface.go
+++ b/storage/raw/interface.go
@@ -19,13 +19,6 @@ import (
 	"io"
 )
 
-type Pair struct {
-	Left  []byte
-	Right []byte
-}
-
-type EachFunc func(pair *Pair)
-
 // Persistence models a key-value store for bytes that supports various
 // additional operations.
 type Persistence interface {
@@ -51,8 +44,6 @@ type Persistence interface {
 	ForEach(decoder storage.RecordDecoder, filter storage.RecordFilter, operator storage.RecordOperator) (scannedEntireCorpus bool, err error)
 	// Commit applies the Batch operations to the database.
 	Commit(Batch) error
-	// Pending removal.
-	GetAll() ([]Pair, error)
 }
 
 // Batch models a pool of mutations for the database that can be committed

--- a/storage/raw/leveldb/leveldb.go
+++ b/storage/raw/leveldb/leveldb.go
@@ -185,29 +185,6 @@ func (l *LevelDBPersistence) Commit(b raw.Batch) (err error) {
 	return l.storage.Write(l.writeOptions, batch.batch)
 }
 
-func (l *LevelDBPersistence) GetAll() (pairs []raw.Pair, err error) {
-	snapshot := l.storage.NewSnapshot()
-	defer l.storage.ReleaseSnapshot(snapshot)
-	readOptions := levigo.NewReadOptions()
-	defer readOptions.Close()
-
-	readOptions.SetSnapshot(snapshot)
-	iterator := l.storage.NewIterator(readOptions)
-	defer iterator.Close()
-	iterator.SeekToFirst()
-
-	for iterator := iterator; iterator.Valid(); iterator.Next() {
-		pairs = append(pairs, raw.Pair{Left: iterator.Key(), Right: iterator.Value()})
-
-		err = iterator.GetError()
-		if err != nil {
-			return
-		}
-	}
-
-	return
-}
-
 func (i *iteratorCloser) Close() (err error) {
 	defer func() {
 		if i.storage != nil {


### PR DESCRIPTION
As noted in the commit logs, none of this stuff is used anymore and nor will it be used again in the future.

/CC: @juliusv 
