### PR TITLE
Several interface cleanups.

### DIFF
--- a/storage/metric/iterator.go
+++ b/storage/metric/iterator.go
@@ -20,7 +20,3 @@ type Iterator interface {
 	Key() interface{}
 	Value() interface{}
 }
-
-type IteratorManager interface {
-	Iterator() Iterator
-}

--- a/storage/raw/index/leveldb/leveldb.go
+++ b/storage/raw/index/leveldb/leveldb.go
@@ -16,6 +16,7 @@ package leveldb
 import (
 	"github.com/prometheus/prometheus/coding"
 	dto "github.com/prometheus/prometheus/model/generated"
+	"github.com/prometheus/prometheus/storage/raw"
 	"github.com/prometheus/prometheus/storage/raw/leveldb"
 )
 
@@ -57,6 +58,6 @@ func NewLevelDBMembershipIndex(storageRoot string, cacheCapacity, bitsPerBloomFi
 	return
 }
 
-func (l *LevelDBMembershipIndex) Commit(batch leveldb.Batch) error {
+func (l *LevelDBMembershipIndex) Commit(batch raw.Batch) error {
 	return l.persistence.Commit(batch)
 }

--- a/storage/raw/leveldb/batch.go
+++ b/storage/raw/leveldb/batch.go
@@ -1,0 +1,57 @@
+// Copyright 2013 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leveldb
+
+import (
+	"github.com/jmhodges/levigo"
+	"github.com/prometheus/prometheus/coding"
+)
+
+type batch struct {
+	batch *levigo.WriteBatch
+}
+
+func NewBatch() batch {
+	return batch{
+		batch: levigo.NewWriteBatch(),
+	}
+}
+
+func (b batch) Drop(key coding.Encoder) {
+	keyEncoded, err := key.Encode()
+	if err != nil {
+		panic(err)
+	}
+
+	b.batch.Delete(keyEncoded)
+}
+
+func (b batch) Put(key, value coding.Encoder) {
+	keyEncoded, err := key.Encode()
+	if err != nil {
+		panic(err)
+	}
+	valueEncoded, err := value.Encode()
+	if err != nil {
+		panic(err)
+	}
+
+	b.batch.Put(keyEncoded, valueEncoded)
+}
+
+func (b batch) Close() (err error) {
+	b.batch.Close()
+
+	return
+}


### PR DESCRIPTION
- Kill Close in Persistent and document interface.
  - Extract batching behavior into interface.
  - Kill IteratorManager, which was used for unknown reasons.
