### PR TITLE
Eliminate need to get fingerprints during query execution time.

### DIFF
--- a/rules/ast/ast.go
+++ b/rules/ast/ast.go
@@ -146,6 +146,8 @@ type (
 	// Vector literal, i.e. metric name plus labelset.
 	VectorLiteral struct {
 		labels model.LabelSet
+		// Fingerprints are populated from labels at query analysis time.
+		fingerprints model.Fingerprints
 	}
 
 	// A function of vector return type.
@@ -176,6 +178,8 @@ type (
 	// Matrix literal, i.e. metric name plus labelset and timerange.
 	MatrixLiteral struct {
 		labels   model.LabelSet
+		// Fingerprints are populated from labels at query analysis time.
+		fingerprints model.Fingerprints
 		interval time.Duration
 	}
 )
@@ -358,7 +362,7 @@ func (node *VectorAggregation) Eval(timestamp *time.Time, view *viewAdapter) Vec
 }
 
 func (node *VectorLiteral) Eval(timestamp *time.Time, view *viewAdapter) Vector {
-	values, err := view.GetValueAtTime(node.labels, timestamp)
+	values, err := view.GetValueAtTime(node.fingerprints, timestamp)
 	if err != nil {
 		log.Printf("Unable to get vector values")
 		return Vector{}
@@ -546,7 +550,7 @@ func (node *MatrixLiteral) Eval(timestamp *time.Time, view *viewAdapter) Matrix 
 		OldestInclusive: timestamp.Add(-node.interval),
 		NewestInclusive: *timestamp,
 	}
-	values, err := view.GetRangeValues(node.labels, interval)
+	values, err := view.GetRangeValues(node.fingerprints, interval)
 	if err != nil {
 		log.Printf("Unable to get values for vector interval")
 		return Matrix{}
@@ -559,7 +563,7 @@ func (node *MatrixLiteral) EvalBoundaries(timestamp *time.Time, view *viewAdapte
 		OldestInclusive: timestamp.Add(-node.interval),
 		NewestInclusive: *timestamp,
 	}
-	values, err := view.GetBoundaryValues(node.labels, interval)
+	values, err := view.GetBoundaryValues(node.fingerprints, interval)
 	if err != nil {
 		log.Printf("Unable to get boundary values for vector interval")
 		return Matrix{}

--- a/rules/ast/persistence_adapter.go
+++ b/rules/ast/persistence_adapter.go
@@ -57,12 +57,7 @@ func (v *viewAdapter) chooseClosestSample(samples []model.SamplePair, timestamp 
 	return
 }
 
-func (v *viewAdapter) GetValueAtTime(labels model.LabelSet, timestamp *time.Time) (samples []*model.Sample, err error) {
-	fingerprints, err := queryStorage.GetFingerprintsForLabelSet(labels)
-	if err != nil {
-		return
-	}
-
+func (v *viewAdapter) GetValueAtTime(fingerprints model.Fingerprints, timestamp *time.Time) (samples []*model.Sample, err error) {
 	for _, fingerprint := range fingerprints {
 		sampleCandidates := v.view.GetValueAtTime(fingerprint, *timestamp)
 		samplePair := v.chooseClosestSample(sampleCandidates, timestamp)
@@ -81,12 +76,7 @@ func (v *viewAdapter) GetValueAtTime(labels model.LabelSet, timestamp *time.Time
 	return
 }
 
-func (v *viewAdapter) GetBoundaryValues(labels model.LabelSet, interval *model.Interval) (sampleSets []*model.SampleSet, err error) {
-	fingerprints, err := queryStorage.GetFingerprintsForLabelSet(labels)
-	if err != nil {
-		return
-	}
-
+func (v *viewAdapter) GetBoundaryValues(fingerprints model.Fingerprints, interval *model.Interval) (sampleSets []*model.SampleSet, err error) {
 	for _, fingerprint := range fingerprints {
 		// TODO: change to GetBoundaryValues() once it has the right return type.
 		samplePairs := v.view.GetRangeValues(fingerprint, *interval)
@@ -109,12 +99,7 @@ func (v *viewAdapter) GetBoundaryValues(labels model.LabelSet, interval *model.I
 	return sampleSets, nil
 }
 
-func (v *viewAdapter) GetRangeValues(labels model.LabelSet, interval *model.Interval) (sampleSets []*model.SampleSet, err error) {
-	fingerprints, err := queryStorage.GetFingerprintsForLabelSet(labels)
-	if err != nil {
-		return
-	}
-
+func (v *viewAdapter) GetRangeValues(fingerprints model.Fingerprints, interval *model.Interval) (sampleSets []*model.SampleSet, err error) {
 	for _, fingerprint := range fingerprints {
 		samplePairs := v.view.GetRangeValues(fingerprint, *interval)
 		if samplePairs == nil {

--- a/rules/ast/query_analyzer.go
+++ b/rules/ast/query_analyzer.go
@@ -66,6 +66,7 @@ func (analyzer *QueryAnalyzer) Visit(node Node) {
 			log.Printf("Error getting fingerprints for labelset %v: %v", n.labels, err)
 			return
 		}
+		n.fingerprints = fingerprints
 		for _, fingerprint := range fingerprints {
 			if !analyzer.IntervalRanges[fingerprint] {
 				analyzer.IntervalRanges[fingerprint] = true
@@ -77,6 +78,7 @@ func (analyzer *QueryAnalyzer) Visit(node Node) {
 			log.Printf("Error getting fingerprints for labelset %v: %v", n.labels, err)
 			return
 		}
+		n.fingerprints = fingerprints
 		for _, fingerprint := range fingerprints {
 			interval := n.interval
 			// If an interval has already been recorded for this fingerprint, merge


### PR DESCRIPTION
Why do fingerprinting at all during query execution time? The query analyzer already needs to get all fingerprints in question upfront for each AST node, so we can save fingerprint information in the AST nodes and then not deal with labels at all later.

This speeds up a 1h query for a single timeseries from 1.5s to 50ms. Also, less code! :)
