### PR TITLE
Validate diskFrontier domain for series candidate.

### DIFF
--- a/storage/metric/interface.go
+++ b/storage/metric/interface.go
@@ -24,7 +24,7 @@ import (
 type MetricPersistence interface {
 	// A storage system may rely on external resources and thusly should be
 	// closed when finished.
-	Close() error
+	Close()
 
 	// Commit all pending operations, if any, since some of the storage components
 	// queue work on channels and operate on it in bulk.

--- a/storage/metric/memory.go
+++ b/storage/metric/memory.go
@@ -327,7 +327,7 @@ func (s memorySeriesStorage) GetRangeValues(fp model.Fingerprint, i model.Interv
 	return
 }
 
-func (s memorySeriesStorage) Close() (err error) {
+func (s memorySeriesStorage) Close() {
 	// This can probably be simplified:
 	//
 	// s.fingerPrintToSeries = map[model.Fingerprint]*stream{}
@@ -344,8 +344,6 @@ func (s memorySeriesStorage) Close() (err error) {
 	for labelName := range s.labelNameToFingerprints {
 		delete(s.labelNameToFingerprints, labelName)
 	}
-
-	return
 }
 
 func (s memorySeriesStorage) GetAllValuesForLabel(labelName model.LabelName) (values model.LabelValues, err error) {

--- a/storage/metric/rule_integration_test.go
+++ b/storage/metric/rule_integration_test.go
@@ -552,13 +552,8 @@ func GetValueAtTimeTests(persistenceMaker func() (MetricPersistence, test.Closer
 		func() {
 			p, closer := persistenceMaker()
 
-			defer func() {
-				defer closer.Close()
-				err := p.Close()
-				if err != nil {
-					t.Fatalf("Encountered anomaly closing persistence: %q\n", err)
-				}
-			}()
+			defer closer.Close()
+			defer p.Close()
 
 			m := model.Metric{
 				model.MetricNameLabel: "age_in_years",
@@ -994,13 +989,8 @@ func GetBoundaryValuesTests(persistenceMaker func() (MetricPersistence, test.Clo
 		func() {
 			p, closer := persistenceMaker()
 
-			defer func() {
-				defer closer.Close()
-				err := p.Close()
-				if err != nil {
-					t.Fatalf("Encountered anomaly closing persistence: %q\n", err)
-				}
-			}()
+			defer closer.Close()
+			defer p.Close()
 
 			m := model.Metric{
 				model.MetricNameLabel: "age_in_years",
@@ -1348,13 +1338,8 @@ func GetRangeValuesTests(persistenceMaker func() (MetricPersistence, test.Closer
 		func() {
 			p, closer := persistenceMaker()
 
-			defer func() {
-				defer closer.Close()
-				err := p.Close()
-				if err != nil {
-					t.Fatalf("Encountered anomaly closing persistence: %q\n", err)
-				}
-			}()
+			defer closer.Close()
+			defer p.Close()
 
 			m := model.Metric{
 				model.MetricNameLabel: "age_in_years",

--- a/storage/metric/stochastic_test.go
+++ b/storage/metric/stochastic_test.go
@@ -189,12 +189,7 @@ func StochasticTests(persistenceMaker func() (MetricPersistence, test.Closer), t
 	stochastic := func(x int) (success bool) {
 		p, closer := persistenceMaker()
 		defer closer.Close()
-		defer func() {
-			err := p.Close()
-			if err != nil {
-				t.Error(err)
-			}
-		}()
+		defer p.Close()
 
 		seed := rand.NewSource(int64(x))
 		random := rand.New(seed)

--- a/storage/metric/test_helper.go
+++ b/storage/metric/test_helper.go
@@ -56,12 +56,7 @@ func buildLevelDBTestPersistence(name string, f func(p MetricPersistence, t test
 			t.Errorf("Could not create LevelDB Metric Persistence: %q\n", err)
 		}
 
-		defer func() {
-			err := p.Close()
-			if err != nil {
-				t.Errorf("Anomaly while closing database: %q\n", err)
-			}
-		}()
+		defer p.Close()
 
 		f(p, t)
 	}
@@ -72,12 +67,7 @@ func buildMemoryTestPersistence(f func(p MetricPersistence, t test.Tester)) func
 
 		p := NewMemorySeriesStorage()
 
-		defer func() {
-			err := p.Close()
-			if err != nil {
-				t.Errorf("Anomaly while closing database: %q\n", err)
-			}
-		}()
+		defer p.Close()
 
 		f(p, t)
 	}

--- a/storage/raw/index/interface.go
+++ b/storage/raw/index/interface.go
@@ -21,5 +21,5 @@ type MembershipIndex interface {
 	Has(key coding.Encoder) (bool, error)
 	Put(key coding.Encoder) error
 	Drop(key coding.Encoder) error
-	Close() error
+	Close()
 }

--- a/storage/raw/index/leveldb/leveldb.go
+++ b/storage/raw/index/leveldb/leveldb.go
@@ -28,8 +28,8 @@ type LevelDBMembershipIndex struct {
 	persistence *leveldb.LevelDBPersistence
 }
 
-func (l *LevelDBMembershipIndex) Close() error {
-	return l.persistence.Close()
+func (l *LevelDBMembershipIndex) Close() {
+	l.persistence.Close()
 }
 
 func (l *LevelDBMembershipIndex) Has(key coding.Encoder) (bool, error) {

--- a/storage/raw/interface.go
+++ b/storage/raw/interface.go
@@ -16,14 +16,14 @@ package raw
 import (
 	"github.com/prometheus/prometheus/coding"
 	"github.com/prometheus/prometheus/storage"
-	"io"
 )
 
 // Persistence models a key-value store for bytes that supports various
 // additional operations.
 type Persistence interface {
-	io.Closer
-
+	// Close reaps all of the underlying system resources associated with this
+	// persistence.
+	Close()
 	// Has informs the user whether a given key exists in the database.
 	Has(key coding.Encoder) (bool, error)
 	// Get retrieves the key from the database if it exists or returns nil if
@@ -50,8 +50,9 @@ type Persistence interface {
 // en masse.  The interface implies no protocol around the atomicity of
 // effectuation.
 type Batch interface {
-	io.Closer
-
+	// Close reaps all of the underlying system resources associated with this
+	// batch mutation.
+	Close()
 	// Put follows the same protocol as Persistence.Put.
 	Put(key, value coding.Encoder)
 	// Drop follows the same protocol as Persistence.Drop.

--- a/storage/raw/leveldb/batch.go
+++ b/storage/raw/leveldb/batch.go
@@ -50,8 +50,6 @@ func (b batch) Put(key, value coding.Encoder) {
 	b.batch.Put(keyEncoded, valueEncoded)
 }
 
-func (b batch) Close() (err error) {
+func (b batch) Close() {
 	b.batch.Close()
-
-	return
 }

--- a/storage/raw/leveldb/iterator.go
+++ b/storage/raw/leveldb/iterator.go
@@ -38,4 +38,5 @@ type Iterator interface {
 	SeekToFirst() (ok bool)
 	SeekToLast() (ok bool)
 	Value() []byte
+	Close()
 }

--- a/storage/raw/leveldb/test/fixtures.go
+++ b/storage/raw/leveldb/test/fixtures.go
@@ -68,12 +68,8 @@ func (p preparer) Prepare(n string, f FixtureFactory) (t test.TemporaryDirectory
 		defer t.Close()
 		p.tester.Fatal(err)
 	}
-	defer func() {
-		err = persistence.Close()
-		if err != nil {
-			p.tester.Fatal(err)
-		}
-	}()
+
+	defer persistence.Close()
 
 	for f.HasNext() {
 		key, value := f.Next()


### PR DESCRIPTION
# Code Review

@juliusv please note that https://github.com/prometheus/prometheus/commit/b87766021e70#L0R98 causes ./rules/... tests to abort.  Could you please have a look at that?
# Change Description

It is the case with the benchmark tool that we thought that we
generated multiple series and saved them to the disk as such, when
in reality, we overwrote the fields of the outgoing metrics via
Go map reference behavior.  This was accidental.  In the course of
diagnosing this, a few errors were found:
1. `newSeriesFrontier` should check to see if the candidate fingerprint is within the given domain of the `diskFrontier`.  If not, as the contract in the docstring stipulates, a `nil` `seriesFrontier` should be emitted.
2. In the interests of aiding debugging, the raw LevelDB `levigoIterator` type now includes a helpful forensics `String()` method.

This work produced additional cleanups:
1. `Close() error` with the storage stack is technically incorrect, since nowhere in the bowels of it does an error actually occur.  The interface has been simplified to remove this for now.
