### PR TITLE
Convert addresses pointing to localhost in status.

### DIFF
--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -33,6 +33,10 @@ func (t fakeTarget) Address() string {
 	return "fake"
 }
 
+func (t fakeTarget) GlobalAddress() string {
+	return t.Address()
+}
+
 func (t fakeTarget) BaseLabels() model.LabelSet {
 	return model.LabelSet{}
 }

--- a/web/templates/status.html
+++ b/web/templates/status.html
@@ -26,7 +26,7 @@
             <ul>
               {{range $pool.Targets}}
                 <li>
-                <a href="{{.Address}}">{{.Address}}</a> (State: {{.State}}, Base Labels: {{.BaseLabels}})
+                <a href="{{.GlobalAddress}}">{{.Address}}</a> (State: {{.State}}, Base Labels: {{.BaseLabels}})
                 </li>
               {{end}}
             </ul>


### PR DESCRIPTION
Until now, targets pointing to localhost in the status view are linked to localhost, so you can't follow those links by clicking on them.
This change converts the links to point to the hostname of the prometheus server.

Before:
<a href="http://localhost:9090/metrics.json">http://localhost:9090/metrics.json</a>

After:
<a href="http://hostname-of-prometheus-server:9090/metrics.json">http://localhost:9090/metrics.json</a>

Still not 100% sure we should do it like that, but it pretty straight forward. Another option would be to convert the address right before serving the view, either in the template (web/templates/status.html) or when rendering it (web/status.go).
Beside that, we might want that feature configurable - but I'm not sure about that.

So what do you think?
