### PR TITLE
Make LevelDB sample keys fixed-length to ensure correct sort-order.

### DIFF
--- a/model/data.proto
+++ b/model/data.proto
@@ -38,11 +38,14 @@ message LabelSet {
   repeated LabelPair member = 1;
 }
 
+// The default LevelDB comparator sorts not only lexicographically, but also by
+// key length (which takes precedence). Thus, no variable-length fields may be
+// introduced into the key definition below.
 message SampleKey {
   optional Fingerprint fingerprint    = 1;
   optional bytes       timestamp      = 2;
-  optional int64       last_timestamp = 3;
-  optional uint32      sample_count   = 4;
+  optional sfixed64    last_timestamp = 3;
+  optional fixed32     sample_count   = 4;
 }
 
 message SampleValueSeries {

--- a/model/fingerprinting.go
+++ b/model/fingerprinting.go
@@ -106,7 +106,7 @@ func NewFingerprintFromMetric(metric Metric) (f Fingerprint) {
 	return fingerprint{
 		firstCharacterOfFirstLabelName: firstCharacterOfFirstLabelName,
 		hash:                           binary.LittleEndian.Uint64(summer.Sum(nil)),
-		labelMatterLength:              uint(labelMatterLength),
+		labelMatterLength:              uint(labelMatterLength % 10),
 		lastCharacterOfLastLabelValue:  lastCharacterOfLastLabelValue,
 	}
 }

--- a/model/metric_test.go
+++ b/model/metric_test.go
@@ -35,7 +35,7 @@ func testMetric(t test.Tester) {
 				"occupation":   "robot",
 				"manufacturer": "westinghouse",
 			},
-			rowkey: "04776841610193542734-f-56-t",
+			rowkey: "04776841610193542734-f-6-t",
 			hash:   4776841610193542734,
 		},
 		{


### PR DESCRIPTION
The default LevelDB comparator sorts not only lexicographically, but also by 
key length (which takes precedence). Thus, all variable-length fields must be 
eliminated from the key to ensure the expected lexicographical key sorting.

Note from @matttproud: This reality was unexpected and was exercised in an
explicit test, but apparently the test was not sufficiently thorough.  It is
likely that the rowkey format will be re-evaluated again down the road due to
_not_ wanting to write a custom comparator and expand the requisite amount of C
_and_ C++-level bindings.
