### PR TITLE
Set job label for targets registered through the API

### DIFF
--- a/web/api/targets.go
+++ b/web/api/targets.go
@@ -33,7 +33,9 @@ func (serv MetricsService) SetTargets(targetGroups []TargetGroup, jobName string
 		newTargets := []retrieval.Target{}
 		for _, targetGroup := range targetGroups {
 			// Do mandatory map type conversion due to Go shortcomings.
-			baseLabels := model.LabelSet{}
+			baseLabels := model.LabelSet{
+				model.LabelName("job"): model.LabelValue(job.Name),
+			}
 			for label, value := range targetGroup.BaseLabels {
 				baseLabels[model.LabelName(label)] = model.LabelValue(value)
 			}


### PR DESCRIPTION
This is set when jobs are statically registered (see
[retrieval/targetmanager.go](https://github.com/prometheus/prometheus/blob/master/retrieval/targetmanager.go#L92)), and should be set here, too.
