### PR TITLE
Correct delta()/rate() intervals and temporal aliasing.

### DIFF
--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -224,6 +224,12 @@ var expressionTests = []struct {
 		fullRanges:     0,
 		intervalRanges: 8,
 	}, {
+		// Deltas should be adjusted for target interval vs. samples under target interval.
+		expr:           "delta(http_requests{group='canary',instance='1',job='app-server'}[18m], 1)",
+		output:         []string{"http_requests{group='canary',instance='1',job='app-server'} => 288 @[%v]"},
+		fullRanges:     1,
+		intervalRanges: 0,
+	}, {
 		// Empty expressions shouldn't parse.
 		expr:       "",
 		shouldFail: true,


### PR DESCRIPTION
This addresses https://github.com/prometheus/prometheus/issues/137.

Before:
![aliased_rate](https://f.cloud.github.com/assets/538008/375840/a8e342ee-a3d3-11e2-9951-d7f62c4f8a7f.png)

After:
![corrected_rate](https://f.cloud.github.com/assets/538008/375842/b25dd73a-a3d3-11e2-9cfb-04f817d0f478.png)
