### PR TITLE
Fix rate() per-second adjustment.

### DIFF
--- a/rules/ast/functions.go
+++ b/rules/ast/functions.go
@@ -137,8 +137,8 @@ func rateImpl(timestamp time.Time, view *viewAdapter, args []Node) interface{} {
 	// MatrixLiteral exists). Find a better way of getting the duration of a
 	// matrix, such as looking at the samples themselves.
 	interval := args[0].(*MatrixLiteral).interval
-	for _, sample := range vector {
-		sample.Value /= model.SampleValue(interval / time.Second)
+	for i, _ := range vector {
+		vector[i].Value /= model.SampleValue(interval / time.Second)
 	}
 	return vector
 }

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -233,6 +233,12 @@ var expressionTests = []struct {
 		fullRanges:     1,
 		intervalRanges: 0,
 	}, {
+		// Rates should transform per-interval deltas to per-second rates.
+		expr:           "rate(http_requests{group='canary',instance='1',job='app-server'}[10m])",
+		output:         []string{"http_requests{group='canary',instance='1',job='app-server'} => 0.26666668 @[%v]"},
+		fullRanges:     1,
+		intervalRanges: 0,
+	}, {
 		// Empty expressions shouldn't parse.
 		expr:       "",
 		shouldFail: true,


### PR DESCRIPTION
This got broken during the depointerization of the Vector type.

Fixes https://github.com/prometheus/prometheus/issues/136
