### PR TITLE
Stochastic test support plural SampleValueSeries.

### DIFF
--- a/storage/metric/stochastic_test.go
+++ b/storage/metric/stochastic_test.go
@@ -233,10 +233,12 @@ func levelDBGetRangeValues(l *LevelDBMetricPersistence, fp model.Fingerprint, i 
 			return nil, err
 		}
 
-		samples = append(samples, model.SamplePair{
-			Value:     model.SampleValue(*retrievedValue.Value[0].Value),
-			Timestamp: indexable.DecodeTime(retrievedKey.Timestamp),
-		})
+		for _, value := range retrievedValue.Value {
+			samples = append(samples, model.SamplePair{
+				Value:     model.SampleValue(*value.Value),
+				Timestamp: time.Unix(*value.Timestamp, 0),
+			})
+		}
 	}
 
 	return


### PR DESCRIPTION
After SampleValue was refactored into SampleValueSeries, which
involves plural values under a common super key, the stochastic
test was never refreshed to reflect this reality.  We had other
tests that validated the functionality, but this one was
insufficently forward-ported.
