### PR TITLE
Wrap dto.SampleKey with business logic type.

### DIFF
--- a/model/samplekey.go
+++ b/model/samplekey.go
@@ -1,0 +1,79 @@
+// Copyright 2013 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"code.google.com/p/goprotobuf/proto"
+	"github.com/prometheus/prometheus/coding/indexable"
+	dto "github.com/prometheus/prometheus/model/generated"
+	"time"
+)
+
+// SampleKey models the business logic around the data-transfer object
+// SampleKey.
+type SampleKey struct {
+	Fingerprint    Fingerprint
+	FirstTimestamp time.Time
+	LastTimestamp  time.Time
+	SampleCount    uint32
+}
+
+// MayContain indicates whether the given SampleKey could potentially contain a
+// value at the provided time.  Even if true is emitted, that does not mean a
+// satisfactory value, in fact, exists.
+func (s SampleKey) MayContain(t time.Time) (could bool) {
+	switch {
+	case t.Before(s.FirstTimestamp):
+		return
+	case t.After(s.LastTimestamp):
+		return
+	}
+
+	return true
+}
+
+// ToDTO converts this SampleKey into a DTO for use in serialization purposes.
+func (s SampleKey) ToDTO() (out *dto.SampleKey) {
+	out = &dto.SampleKey{
+		Fingerprint:   s.Fingerprint.ToDTO(),
+		Timestamp:     indexable.EncodeTime(s.FirstTimestamp),
+		LastTimestamp: proto.Int64(s.LastTimestamp.Unix()),
+		SampleCount:   proto.Uint32(s.SampleCount),
+	}
+
+	return
+}
+
+// ToPartialDTO converts this SampleKey into a DTO that is only suitable for
+// database exploration purposes for a given (Fingerprint, First Sample Time)
+// tuple.
+func (s SampleKey) ToPartialDTO(out *dto.SampleKey) {
+	out = &dto.SampleKey{
+		Fingerprint: s.Fingerprint.ToDTO(),
+		Timestamp:   indexable.EncodeTime(s.FirstTimestamp),
+	}
+
+	return
+}
+
+// NewSampleKeyFromDTO builds a new SampleKey from a provided data-transfer
+// object.
+func NewSampleKeyFromDTO(dto *dto.SampleKey) SampleKey {
+	return SampleKey{
+		Fingerprint:    NewFingerprintFromDTO(dto.Fingerprint),
+		FirstTimestamp: indexable.DecodeTime(dto.Timestamp),
+		LastTimestamp:  time.Unix(*dto.LastTimestamp, 0),
+		SampleCount:    *dto.SampleCount,
+	}
+}

--- a/storage/metric/tiered.go
+++ b/storage/metric/tiered.go
@@ -472,7 +472,7 @@ func (t *tieredStorage) loadChunkAroundTime(iterator leveldb.Iterator, frontier 
 		targetKey = &dto.SampleKey{
 			Fingerprint: fingerprint.ToDTO(),
 		}
-		foundKey   = &dto.SampleKey{}
+		foundKey   model.SampleKey
 		foundValue *dto.SampleValueSeries
 	)
 
@@ -504,7 +504,7 @@ func (t *tieredStorage) loadChunkAroundTime(iterator leveldb.Iterator, frontier 
 	//
 	// Only do the rewind if there is another chunk before this one.
 	rewound := false
-	firstTime := indexable.DecodeTime(foundKey.Timestamp)
+	firstTime := foundKey.FirstTimestamp
 	if ts.Before(firstTime) && !frontier.firstSupertime.After(ts) {
 		iterator.Previous()
 		rewound = true
@@ -522,7 +522,7 @@ func (t *tieredStorage) loadChunkAroundTime(iterator leveldb.Iterator, frontier 
 		if err != nil {
 			panic(err)
 		}
-		currentChunkLastTime := time.Unix(*foundKey.LastTimestamp, 0)
+		currentChunkLastTime := foundKey.LastTimestamp
 
 		if ts.After(currentChunkLastTime) {
 			sampleCount := len(foundValue.Value)


### PR DESCRIPTION
The curator work can be done easier if dto.SampleKey is no longer
directly accessed but rather has a higher level type around it that
captures a certain modicum of business logic.  This doesn't look
terribly interesting today, but it will get more so.
