### PR TITLE
Convert the TestInstant value into UTC.

### DIFF
--- a/storage/metric/test_helper.go
+++ b/storage/metric/test_helper.go
@@ -23,7 +23,7 @@ import (
 var (
 	// ``hg clone https://code.google.com/p/go ; cd go ; hg log | tail -n 20``
 	usEastern, _ = time.LoadLocation("US/Eastern")
-	testInstant  = time.Date(1972, 7, 18, 19, 5, 45, 0, usEastern)
+	testInstant  = time.Date(1972, 7, 18, 19, 5, 45, 0, usEastern).In(time.UTC)
 )
 
 func testAppendSample(p MetricPersistence, s model.Sample, t test.Tester) {


### PR DESCRIPTION
For the forthcoming Curator, we don't record timezone information in
the samples, nor do we in the curation remarks.  All times are
recorded UTC.  That said, for the test environment to better match
production, the special instant should be in UTC.
