### PR TITLE
Fix positional flags for ``cp`` on Darwin.

### DIFF
--- a/web/Makefile
+++ b/web/Makefile
@@ -23,6 +23,6 @@ static/generated:
 	mkdir -vp static/generated
 
 static/generated/protocol_buffer.descriptor: static/generated ../model/generated/descriptor.blob
-	cp ../model/generated/descriptor.blob -f $@
+	cp -f ../model/generated/descriptor.blob $@
 
 .PHONY: blob clean


### PR DESCRIPTION
Unfortunately `cp` on Darwin regards some flags as positional and
requires them to be in a specific place.  The new Protocol Buffer
descriptor bundling fails on Mac OS.
