### PR TITLE
Move `-f` option to `cp` to command start

### DIFF
--- a/web/Makefile
+++ b/web/Makefile
@@ -23,6 +23,6 @@ static/generated:
 	mkdir -vp static/generated
 
 static/generated/protocol_buffer.descriptor: static/generated ../model/generated/descriptor.blob
-	cp ../model/generated/descriptor.blob -f $@
+	cp -f ../model/generated/descriptor.blob $@
 
 .PHONY: blob clean


### PR DESCRIPTION
`cp file -f file` fails on OS X.
