### PR TITLE
Target uses HTTP transport with deadlines

### DIFF
--- a/retrieval/deadline_client.go
+++ b/retrieval/deadline_client.go
@@ -1,0 +1,30 @@
+package retrieval
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+// NewDeadlineClient returns a new http.Client which will time out long running
+// requests.
+func NewDeadlineClient(timeout time.Duration) http.Client {
+	return http.Client{
+		Transport: &http.Transport{
+			// We need to disable keepalive, becasue we set a deadline on the
+			// underlying connection.
+			DisableKeepAlives: true,
+			Dial: func(netw, addr string) (c net.Conn, err error) {
+				start := time.Now()
+
+				c, err = net.DialTimeout(netw, addr, timeout)
+
+				if err == nil {
+					c.SetDeadline(start.Add(timeout))
+				}
+
+				return
+			},
+		},
+	}
+}


### PR DESCRIPTION
Instead of externally handling timeouts when scraping a target, we set
timeouts on the HTTP connection. This ensures that we don't leak
goroutines on timeouts.

[fixes #181]
