### PR TITLE
Update forgotten exposition client links in Make.

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -90,7 +90,8 @@ gvm-stamp: bison-stamp cc-stamp mercurial-stamp
 	touch $@
 
 instrumentation-stamp: go-stamp
-	$(GO_GET) github.com/prometheus/client_golang $(THIRD_PARTY_BUILD_OUTPUT)
+	$(GO_GET) github.com/prometheus/client_golang/prometheus $(THIRD_PARTY_BUILD_OUTPUT)
+	$(GO_GET) github.com/prometheus/client_golang/prometheus/exp $(THIRD_PARTY_BUILD_OUTPUT)
 	touch $@
 
 leveldb-stamp: cache-stamp cache/leveldb-$(LEVELDB_VERSION).tar.gz cc-stamp rsync-stamp snappy-stamp


### PR DESCRIPTION
The links in the Makefile, which Travis uses, were out-of-date in
terms of fetching the Go client library.
