### PR TITLE
Harden the tests against OOMs.

### DIFF
--- a/model/metric.go
+++ b/model/metric.go
@@ -49,7 +49,6 @@ func (l LabelSet) Merge(other LabelSet) LabelSet {
 	return result
 }
 
-
 func (l LabelSet) String() string {
 	var (
 		buffer     bytes.Buffer

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -86,7 +86,7 @@ func TestTargetScrapeTimeout(t *testing.T) {
 	}
 
 	// let the deadline lapse
-	time.Sleep(15*time.Millisecond)
+	time.Sleep(15 * time.Millisecond)
 
 	// now scrape again
 	signal <- true

--- a/storage/metric/test_helper.go
+++ b/storage/metric/test_helper.go
@@ -26,6 +26,10 @@ var (
 	testInstant  = time.Date(1972, 7, 18, 19, 5, 45, 0, usEastern).In(time.UTC)
 )
 
+const (
+	appendQueueSize = 1000
+)
+
 func testAppendSample(p MetricPersistence, s model.Sample, t test.Tester) {
 	err := p.AppendSample(s)
 	if err != nil {
@@ -86,7 +90,7 @@ func (t testTieredStorageCloser) Close() {
 func NewTestTieredStorage(t test.Tester) (storage Storage, closer test.Closer) {
 	var directory test.TemporaryDirectory
 	directory = test.NewTemporaryDirectory("test_tiered_storage", t)
-	storage, err := NewTieredStorage(5000000, 2500, 1000, 5*time.Second, 15*time.Second, 0*time.Second, directory.Path())
+	storage, err := NewTieredStorage(appendQueueSize, 2500, 1000, 5*time.Second, 15*time.Second, 0*time.Second, directory.Path())
 
 	if err != nil {
 		if storage != nil {


### PR DESCRIPTION
This commit employs explicit memory freeing for the in-memory storage
arenas.  Secondarily, we take advantage of smaller channel buffer sizes
in the test.
