### PR TITLE
Cleanup and idiomaticize rule/expression dot graph output.

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -14,6 +14,7 @@
 package rules
 
 import (
+	"fmt"
 	"github.com/prometheus/prometheus/model"
 	"github.com/prometheus/prometheus/rules/ast"
 	"github.com/prometheus/prometheus/utility"
@@ -129,6 +130,15 @@ func (rule AlertingRule) Eval(timestamp time.Time) (vector ast.Vector, err error
 		vector = append(vector, activeAlert.sample(timestamp, 1))
 	}
 	return
+}
+
+func (rule AlertingRule) ToDotGraph() string {
+	graph := fmt.Sprintf(`digraph "Rules" {
+	  %#p[shape="box",label="ALERT %s IF FOR %s"];
+		%#p -> %#p;
+		%s
+	}`, &rule, rule.name, utility.DurationToString(rule.holdDuration), &rule, rule.vector, rule.vector.NodeTreeToDotGraph())
+	return graph
 }
 
 // Construct a new AlertingRule.

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -55,13 +55,12 @@ func (rule RecordingRule) Eval(timestamp time.Time) (vector ast.Vector, err erro
 	return
 }
 
-// RuleToDotGraph returns a Graphviz dot graph of the recording rule.
-func (rule RecordingRule) RuleToDotGraph() string {
-	graph := "digraph \"Rules\" {\n"
-	graph += fmt.Sprintf("%#p[shape=\"box\",label=\"%v = \"];\n", rule, rule.name)
-	graph += fmt.Sprintf("%#p -> %#p;\n", &rule, rule.vector)
-	graph += rule.vector.NodeTreeToDotGraph()
-	graph += "}\n"
+func (rule RecordingRule) ToDotGraph() string {
+	graph := fmt.Sprintf(`digraph "Rules" {
+	  %#p[shape="box",label="%s = "];
+		%#p -> %#p;
+		%s
+	}`, &rule, rule.name, &rule, rule.vector, rule.vector.NodeTreeToDotGraph())
 	return graph
 }
 

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -28,4 +28,6 @@ type Rule interface {
 	EvalRaw(timestamp time.Time) (vector ast.Vector, err error)
 	// Eval evaluates the rule, including any associated recording or alerting actions.
 	Eval(timestamp time.Time) (vector ast.Vector, err error)
+	// ToDotGraph returns a Graphviz dot graph of the rule.
+	ToDotGraph() string
 }


### PR DESCRIPTION
This idiomaticizes the rule printing code a bit. I didn't end up using templates for the multi-line Sprintfs() because I think it would have been uglier (having to define multiple one-use struct types just for the templates) than just using Sprintf().
