### PR TITLE
Adjust memory queue size after change to send arrays over channel.

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 	ruleResultsQueueCapacity     = flag.Int("ruleResultsQueueCapacity", 4096, "The size of the rule results queue.")
 	concurrentRetrievalAllowance = flag.Int("concurrentRetrievalAllowance", 15, "The number of concurrent metrics retrieval requests allowed.")
 	diskAppendQueueCapacity      = flag.Int("queue.diskAppendCapacity", 1000000, "The size of the queue for items that are pending writing to disk.")
-	memoryAppendQueueCapacity    = flag.Int("queue.memoryAppendCapacity", 1000000, "The size of the queue for items that are pending writing to memory.")
+	memoryAppendQueueCapacity    = flag.Int("queue.memoryAppendCapacity", 10000, "The size of the queue for items that are pending writing to memory.")
 )
 
 type prometheus struct {

--- a/storage/metric/test_helper.go
+++ b/storage/metric/test_helper.go
@@ -27,7 +27,7 @@ var (
 )
 
 const (
-	appendQueueSize = 1000
+	appendQueueSize = 100
 )
 
 func testAppendSample(p MetricPersistence, s model.Sample, t test.Tester) {


### PR DESCRIPTION
All samples from one scrape are now sent as a single array from the scrape to the memory storage. Given a conservative estimate of 100 metrics per target, I divide the channel to-memory-channel capacity by 100.
