### PR TITLE
Fix goroutine leak in leveldb.AppendSamples

### DIFF
--- a/storage/metric/leveldb.go
+++ b/storage/metric/leveldb.go
@@ -538,8 +538,8 @@ func (l *LevelDBMetricPersistence) AppendSamples(samples model.Samples) (err err
 
 	var (
 		fingerprintToSamples = groupByFingerprint(samples)
-		indexErrChan         = make(chan error)
-		watermarkErrChan     = make(chan error)
+		indexErrChan         = make(chan error, 1)
+		watermarkErrChan     = make(chan error, 1)
 	)
 
 	go func(groups map[model.Fingerprint]model.Samples) {


### PR DESCRIPTION
The error channels in AppendSamples need to be buffered, since in the presence of errors their values may not be consumed.

This was surfaced while digging through a goroutine dump for an unrelated issue, when I discovered 400 goroutines blocked on sending to watermarkErrChan.
