### PR TITLE
Storage interface to TieredStorage.

### DIFF
--- a/appstate/appstate.go
+++ b/appstate/appstate.go
@@ -26,7 +26,7 @@ import (
 type ApplicationState struct {
 	Config        config.Config
 	RuleManager   rules.RuleManager
-	Storage       metric.Storage
+	Storage       metric.TieredStorage
 	TargetManager retrieval.TargetManager
 	BuildInfo     map[string]string
 	CurationState chan metric.CurationState

--- a/rules/ast/persistence_adapter.go
+++ b/rules/ast/persistence_adapter.go
@@ -24,7 +24,9 @@ var defaultStalenessDelta = flag.Int("defaultStalenessDelta", 300, "Default stal
 
 // AST-global storage to use for operations that are not supported by views
 // (i.e. metric->fingerprint lookups).
-var queryStorage metric.Storage = nil
+//
+// BUG(julius): Wrap this into non-global state.
+var queryStorage *metric.TieredStorage
 
 // Describes the lenience limits to apply to values from the materialized view.
 type StalenessPolicy struct {
@@ -167,8 +169,8 @@ func (v *viewAdapter) GetRangeValues(fingerprints model.Fingerprints, interval *
 	return sampleSets, nil
 }
 
-func SetStorage(storage metric.Storage) {
-	queryStorage = storage
+func SetStorage(storage metric.TieredStorage) {
+	queryStorage = &storage
 }
 
 func NewViewAdapter(view metric.View) *viewAdapter {

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -49,10 +49,13 @@ func vectorComparisonString(expected []string, actual []string) string {
 		separator)
 }
 
-func newTestStorage(t test.Tester) (storage metric.Storage, closer test.Closer) {
+func newTestStorage(t test.Tester) (storage *metric.TieredStorage, closer test.Closer) {
 	storage, closer = metric.NewTestTieredStorage(t)
-	ast.SetStorage(storage)
-	storeMatrix(storage, testMatrix)
+	if storage == nil {
+		t.Fatal("storage == nil")
+	}
+	ast.SetStorage(*storage)
+	storeMatrix(*storage, testMatrix)
 	return
 }
 

--- a/rules/testdata.go
+++ b/rules/testdata.go
@@ -51,7 +51,7 @@ func getTestVectorFromTestMatrix(matrix ast.Matrix) ast.Vector {
 	return vector
 }
 
-func storeMatrix(storage metric.Storage, matrix ast.Matrix) (err error) {
+func storeMatrix(storage metric.TieredStorage, matrix ast.Matrix) (err error) {
 	pendingSamples := model.Samples{}
 	for _, sampleSet := range matrix {
 		for _, sample := range sampleSet.Values {

--- a/storage/metric/test_helper.go
+++ b/storage/metric/test_helper.go
@@ -78,7 +78,7 @@ func buildMemoryTestPersistence(f func(p MetricPersistence, t test.Tester)) func
 }
 
 type testTieredStorageCloser struct {
-	storage   Storage
+	storage   *TieredStorage
 	directory test.Closer
 }
 
@@ -87,7 +87,7 @@ func (t testTieredStorageCloser) Close() {
 	t.directory.Close()
 }
 
-func NewTestTieredStorage(t test.Tester) (storage Storage, closer test.Closer) {
+func NewTestTieredStorage(t test.Tester) (storage *TieredStorage, closer test.Closer) {
 	var directory test.TemporaryDirectory
 	directory = test.NewTemporaryDirectory("test_tiered_storage", t)
 	storage, err := NewTieredStorage(appendQueueSize, 2500, 1000, 5*time.Second, 15*time.Second, 0*time.Second, directory.Path())

--- a/storage/metric/tiered_test.go
+++ b/storage/metric/tiered_test.go
@@ -348,7 +348,7 @@ func testMakeView(t test.Tester, flushToDisk bool) {
 		if flushToDisk {
 			tiered.Flush()
 		} else {
-			tiered.(*tieredStorage).writeMemory()
+			tiered.writeMemory()
 		}
 
 		requestBuilder := NewViewRequestBuilder()
@@ -480,12 +480,12 @@ func TestGetAllValuesForLabel(t *testing.T) {
 				Metric: model.Metric{model.MetricNameLabel: model.LabelValue(metric.metricName)},
 			}
 			if metric.appendToMemory {
-				if err := tiered.(*tieredStorage).memoryArena.AppendSample(sample); err != nil {
+				if err := tiered.memoryArena.AppendSample(sample); err != nil {
 					t.Fatalf("%d.%d. failed to add fixture data: %s", i, j, err)
 				}
 			}
 			if metric.appendToDisk {
-				if err := tiered.(*tieredStorage).diskStorage.AppendSample(sample); err != nil {
+				if err := tiered.diskStorage.AppendSample(sample); err != nil {
 					t.Fatalf("%d.%d. failed to add fixture data: %s", i, j, err)
 				}
 			}
@@ -517,10 +517,10 @@ func TestGetFingerprintsForLabelSet(t *testing.T) {
 	diskSample := model.Sample{
 		Metric: model.Metric{model.MetricNameLabel: "http_requests", "method": "/bar"},
 	}
-	if err := tiered.(*tieredStorage).memoryArena.AppendSample(memorySample); err != nil {
+	if err := tiered.memoryArena.AppendSample(memorySample); err != nil {
 		t.Fatalf("Failed to add fixture data: %s", err)
 	}
-	if err := tiered.(*tieredStorage).diskStorage.AppendSample(diskSample); err != nil {
+	if err := tiered.diskStorage.AppendSample(diskSample); err != nil {
 		t.Fatalf("Failed to add fixture data: %s", err)
 	}
 	tiered.Flush()


### PR DESCRIPTION
This commit drops the Storage interface and just replaces it with a
publicized TieredStorage type.  Storage had been anticipated to be
used as a wrapper for testability but just was not used due to
practicality.  Merely overengineered.  My bad.  Anyway, we will
eventually instantiate the TieredStorage dependencies in main.go and
pass them in for more intelligent lifecycle management.

These changes will pave the way for managing the curators without
Law of Demeter violations.
