### PR TITLE
Synchronous memory appends and more fine-grained storage locks.

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func main() {
 		log.Fatalf("Error loading configuration from %s: %v", *configFile, err)
 	}
 
-	ts, err := metric.NewTieredStorage(uint(*memoryAppendQueueCapacity), uint(*diskAppendQueueCapacity), 100, time.Second*30, time.Second*1, time.Second*20, *metricsStoragePath)
+	ts, err := metric.NewTieredStorage(uint(*diskAppendQueueCapacity), 100, time.Second*30, time.Second*1, time.Second*20, *metricsStoragePath)
 	if err != nil {
 		log.Fatalf("Error opening storage: %s", err)
 	}

--- a/storage/metric/interface.go
+++ b/storage/metric/interface.go
@@ -33,7 +33,7 @@ type MetricPersistence interface {
 	// Record a new sample in the storage layer.
 	AppendSample(model.Sample) error
 
-	// Record a new sample in the storage layer.
+	// Record a group of new samples in the storage layer.
 	AppendSamples(model.Samples) error
 
 	// Get all of the metric fingerprints that are associated with the provided

--- a/storage/metric/test_helper.go
+++ b/storage/metric/test_helper.go
@@ -26,10 +26,6 @@ var (
 	testInstant  = time.Date(1972, 7, 18, 19, 5, 45, 0, usEastern).In(time.UTC)
 )
 
-const (
-	appendQueueSize = 100
-)
-
 func testAppendSample(p MetricPersistence, s model.Sample, t test.Tester) {
 	err := p.AppendSample(s)
 	if err != nil {
@@ -90,7 +86,7 @@ func (t testTieredStorageCloser) Close() {
 func NewTestTieredStorage(t test.Tester) (storage *TieredStorage, closer test.Closer) {
 	var directory test.TemporaryDirectory
 	directory = test.NewTemporaryDirectory("test_tiered_storage", t)
-	storage, err := NewTieredStorage(appendQueueSize, 2500, 1000, 5*time.Second, 15*time.Second, 0*time.Second, directory.Path())
+	storage, err := NewTieredStorage(2500, 1000, 5*time.Second, 15*time.Second, 0*time.Second, directory.Path())
 
 	if err != nil {
 		if storage != nil {

--- a/storage/metric/tiered_test.go
+++ b/storage/metric/tiered_test.go
@@ -347,8 +347,6 @@ func testMakeView(t test.Tester, flushToDisk bool) {
 
 		if flushToDisk {
 			tiered.Flush()
-		} else {
-			tiered.writeMemory()
 		}
 
 		requestBuilder := NewViewRequestBuilder()


### PR DESCRIPTION
This does two things:

1) Make TieredStorage.AppendSamples() write directly to memory instead of
   buffering to a channel first. This is needed in cases where a rule might
   immediately need the data generated by a previous rule.

2) Replace the single storage mutex by two new ones:
- memoryMutex - needs to be locked at any time that two concurrent
                 goroutines could be accessing the TieredStorage
                 memoryArena.
- memoryDeleteMutex - used to prevent any deletion of samples from
                       memoryArena as long as renderView is running and
                       assembling data from it.
  The LevelDB disk storage does not need to be protected by a mutex when
  rendering a view since renderView works off a LevelDB snapshot.

The rationale against adding memoryMutex directly to the memory storage: taking
a mutex does come with a small inherent time cost, and taking it is only
required in few places. In fact, no locking is required for the memory storage
instance which is part of a view (and not the TieredStorage).
