### PR TITLE
Include uptime in the status console.

### DIFF
--- a/main.go
+++ b/main.go
@@ -224,6 +224,7 @@ func main() {
 			Config:      conf.String(),
 			TargetPools: targetManager.Pools(),
 			Flags:       flags,
+			Birth:       time.Now(),
 		},
 		CurationState: curationState,
 	}

--- a/web/status.go
+++ b/web/status.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/prometheus/storage/metric"
 	"net/http"
 	"sync"
+	"time"
 )
 
 type PrometheusStatus struct {
@@ -27,6 +28,8 @@ type PrometheusStatus struct {
 	Flags       map[string]string
 	Rules       string
 	TargetPools map[string]*retrieval.TargetPool
+
+	Birth time.Time
 }
 
 type StatusHandler struct {

--- a/web/templates/status.html
+++ b/web/templates/status.html
@@ -1,7 +1,18 @@
 {{define "head"}}<!-- nix -->{{end}}
 
 {{define "content"}}
-    <h2>Build Info</h2>
+    <h2>Runtime Information</h2>
+    <div class="grouping_box">
+      <table>
+        <tbody>
+          <tr>
+            <th>Uptime</th>
+            <td>{{.Birth}}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <h2>Build Information</h2>
     <div class="grouping_box">
       <table>
         <tbody>


### PR DESCRIPTION
In order to help corroborate whether a Prometheus instance has
flapped until meta-monitoring is in-place, we ought to provide the
instance's start time in the console to aid in diagnostics.
