### PR TITLE
Fix handling of negative deltas for non-counter values.

### DIFF
--- a/rules/helpers_test.go
+++ b/rules/helpers_test.go
@@ -145,12 +145,19 @@ var testMatrix = ast.Matrix{
 		},
 		Values: getTestValueStream(0, 100, 10, testStartTime),
 	},
-	// Counter resets.
+	// Counter reset in the middle of range.
 	{
 		Metric: model.Metric{
-			model.MetricNameLabel: "testcounter",
+			model.MetricNameLabel: "testcounter_reset_middle",
 		},
 		Values: append(getTestValueStream(0, 40, 10, testStartTime), getTestValueStream(0, 50, 10, testStartTime.Add(testSampleInterval*5))...),
+	},
+	// Counter reset at the end of range.
+	{
+		Metric: model.Metric{
+			model.MetricNameLabel: "testcounter_reset_end",
+		},
+		Values: append(getTestValueStream(0, 90, 10, testStartTime), getTestValueStream(0, 0, 10, testStartTime.Add(testSampleInterval*10))...),
 	},
 }
 

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -319,15 +319,27 @@ func TestExpressions(t *testing.T) {
 			fullRanges:     1,
 			intervalRanges: 0,
 		}, {
-			// Counter resets are ignored by delta() if counter == 1.
-			expr:           "delta(testcounter[50m], 1)",
-			output:         []string{"testcounter{} => 90 @[%v]"},
+			// Counter resets in middle of range are ignored by delta() if counter == 1.
+			expr:           "delta(testcounter_reset_middle[50m], 1)",
+			output:         []string{"testcounter_reset_middle{} => 90 @[%v]"},
 			fullRanges:     1,
 			intervalRanges: 0,
 		}, {
-			// Counter resets are not ignored by delta() if counter == 0.
-			expr:           "delta(testcounter[50m], 0)",
-			output:         []string{"testcounter{} => 50 @[%v]"},
+			// Counter resets in middle of range are not ignored by delta() if counter == 0.
+			expr:           "delta(testcounter_reset_middle[50m], 0)",
+			output:         []string{"testcounter_reset_middle{} => 50 @[%v]"},
+			fullRanges:     1,
+			intervalRanges: 0,
+		}, {
+			// Counter resets at end of range are ignored by delta() if counter == 1.
+			expr:           "delta(testcounter_reset_end[5m], 1)",
+			output:         []string{"testcounter_reset_end{} => 0 @[%v]"},
+			fullRanges:     1,
+			intervalRanges: 0,
+		}, {
+			// Counter resets at end of range are not ignored by delta() if counter == 0.
+			expr:           "delta(testcounter_reset_end[5m], 0)",
+			output:         []string{"testcounter_reset_end{} => -90 @[%v]"},
 			fullRanges:     1,
 			intervalRanges: 0,
 		}, {


### PR DESCRIPTION
The delta() counter reset correction was always applied, even when the counter argument
was set to 0.
