### PR TITLE
Add debug timers to instant and range queries.

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"github.com/prometheus/prometheus/model"
 	"github.com/prometheus/prometheus/rules/ast"
+	"github.com/prometheus/prometheus/stats"
 	"github.com/prometheus/prometheus/storage/metric"
 	"github.com/prometheus/prometheus/utility"
 	"time"
@@ -90,7 +91,7 @@ type AlertingRule struct {
 func (rule AlertingRule) Name() string { return rule.name }
 
 func (rule AlertingRule) EvalRaw(timestamp time.Time, storage *metric.TieredStorage) (ast.Vector, error) {
-	return ast.EvalVectorInstant(rule.vector, timestamp, storage)
+	return ast.EvalVectorInstant(rule.vector, timestamp, storage, stats.NewTimerGroup())
 }
 
 func (rule AlertingRule) Eval(timestamp time.Time, storage *metric.TieredStorage) (ast.Vector, error) {

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"github.com/prometheus/prometheus/model"
 	"github.com/prometheus/prometheus/rules/ast"
+	"github.com/prometheus/prometheus/stats"
 	"github.com/prometheus/prometheus/storage/metric"
 	"time"
 )
@@ -32,7 +33,7 @@ type RecordingRule struct {
 func (rule RecordingRule) Name() string { return rule.name }
 
 func (rule RecordingRule) EvalRaw(timestamp time.Time, storage *metric.TieredStorage) (ast.Vector, error) {
-	return ast.EvalVectorInstant(rule.vector, timestamp, storage)
+	return ast.EvalVectorInstant(rule.vector, timestamp, storage, stats.NewTimerGroup())
 }
 
 func (rule RecordingRule) Eval(timestamp time.Time, storage *metric.TieredStorage) (ast.Vector, error) {

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"github.com/prometheus/prometheus/model"
 	"github.com/prometheus/prometheus/rules/ast"
+	"github.com/prometheus/prometheus/stats"
 	"github.com/prometheus/prometheus/storage/metric"
 	"github.com/prometheus/prometheus/utility/test"
 	"path"
@@ -377,7 +378,7 @@ func TestExpressions(t *testing.T) {
 				t.Errorf("%d. Test should fail, but didn't", i)
 			}
 			failed := false
-			resultStr := ast.EvalToString(testExpr, testEvalTime, ast.TEXT, tieredStorage)
+			resultStr := ast.EvalToString(testExpr, testEvalTime, ast.TEXT, tieredStorage, stats.NewTimerGroup())
 			resultLines := strings.Split(resultStr, "\n")
 
 			if len(exprTest.output) != len(resultLines) {

--- a/stats/query_stats.go
+++ b/stats/query_stats.go
@@ -1,0 +1,81 @@
+// Copyright 2013 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+// QueryTiming identifies the code area or functionality in which time is spent
+// during a query.
+type QueryTiming int
+
+// Query timings.
+const (
+	TotalEvalTime QueryTiming = iota
+	ResultSortTime
+	JsonEncodeTime
+	TotalViewBuildingTime
+	ViewRequestBuildTime
+	InnerViewBuildingTime
+	InnerEvalTime
+	ResultAppendTime
+	QueryAnalysisTime
+	GetValueAtTimeTime
+	GetBoundaryValuesTime
+	GetRangeValuesTime
+	ViewQueueTime
+	ViewDiskPreparationTime
+	ViewScanJobsTime
+	ViewDataExtractionTime
+	ViewDiskExtractionTime
+)
+
+// Return a string represenation of a QueryTiming identifier.
+func (s QueryTiming) String() string {
+	switch s {
+	case TotalEvalTime:
+		return "Total eval time"
+	case ResultSortTime:
+		return "Result sorting time"
+	case JsonEncodeTime:
+		return "JSON encoding time"
+	case TotalViewBuildingTime:
+		return "Total view building time"
+	case ViewRequestBuildTime:
+		return "View request building time"
+	case InnerViewBuildingTime:
+		return "Inner view building time"
+	case InnerEvalTime:
+		return "Inner eval time"
+	case ResultAppendTime:
+		return "Result append time"
+	case QueryAnalysisTime:
+		return "Query analysis time"
+	case GetValueAtTimeTime:
+		return "GetValueAtTime() time"
+	case GetBoundaryValuesTime:
+		return "GetBoundaryValues() time"
+	case GetRangeValuesTime:
+		return "GetRangeValues() time"
+	case ViewQueueTime:
+		return "View queue wait time"
+	case ViewScanJobsTime:
+		return "View building job scanning time"
+	case ViewDiskPreparationTime:
+		return "View building disk preparation time"
+	case ViewDataExtractionTime:
+		return "Total view data extraction time"
+	case ViewDiskExtractionTime:
+		return "View disk data extraction time"
+	default:
+		return "Unknown query timing"
+	}
+}

--- a/stats/timer.go
+++ b/stats/timer.go
@@ -1,0 +1,100 @@
+// Copyright 2013 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// A timer that can be started and stopped and accumulates the total time it
+// was running (the time between Start() and Stop()).
+type Timer struct {
+	name     fmt.Stringer
+	created  time.Time
+	start    time.Time
+	duration time.Duration
+}
+
+// Start the timer.
+func (t *Timer) Start() *Timer {
+	t.start = time.Now()
+	return t
+}
+
+// Stop the timer.
+func (t *Timer) Stop() {
+	t.duration += time.Since(t.start)
+}
+
+// Return a string representation of the Timer.
+func (t *Timer) String() string {
+	return fmt.Sprintf("%s: %s", t.name, t.duration)
+}
+
+// A TimerGroup represents a group of timers relevant to a single query.
+type TimerGroup struct {
+	timers map[fmt.Stringer]*Timer
+	child  *TimerGroup
+}
+
+// Construct a new TimerGroup.
+func NewTimerGroup() *TimerGroup {
+	return &TimerGroup{timers: map[fmt.Stringer]*Timer{}}
+}
+
+// Get (and create, if necessary) the Timer for a given code section.
+func (t *TimerGroup) GetTimer(name fmt.Stringer) *Timer {
+	if timer, exists := t.timers[name]; exists {
+		return timer
+	}
+	timer := &Timer{
+		name:    name,
+		created: time.Now(),
+	}
+	t.timers[name] = timer
+	return timer
+}
+
+type Timers []*Timer
+
+type byCreationTimeSorter struct{ Timers }
+
+func (t Timers) Len() int {
+	return len(t)
+}
+
+func (t Timers) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}
+
+func (s byCreationTimeSorter) Less(i, j int) bool {
+	return s.Timers[i].created.Before(s.Timers[j].created)
+}
+
+// Return a string representation of a TimerGroup.
+func (t *TimerGroup) String() string {
+	timers := byCreationTimeSorter{}
+	for _, timer := range t.timers {
+		timers.Timers = append(timers.Timers, timer)
+	}
+	sort.Sort(timers)
+	result := &bytes.Buffer{}
+	for _, timer := range timers.Timers {
+		fmt.Fprintf(result, "%s\n", timer)
+	}
+	return result.String()
+}

--- a/storage/metric/tiered_test.go
+++ b/storage/metric/tiered_test.go
@@ -15,6 +15,7 @@ package metric
 
 import (
 	"github.com/prometheus/prometheus/model"
+	"github.com/prometheus/prometheus/stats"
 	"github.com/prometheus/prometheus/utility/test"
 	"sort"
 	"testing"
@@ -363,7 +364,7 @@ func testMakeView(t test.Tester, flushToDisk bool) {
 			requestBuilder.GetMetricRange(fingerprint, alongRange.from, alongRange.through)
 		}
 
-		v, err := tiered.MakeView(requestBuilder, time.Second*5)
+		v, err := tiered.MakeView(requestBuilder, time.Second*5, stats.NewTimerGroup())
 
 		if err != nil {
 			t.Fatalf("%d. failed due to %s", i, err)


### PR DESCRIPTION
This adds timers around several query-relevant code blocks. For now, the
query timer stats are only logged for queries initiated through the UI.
In other cases (rule evaluations), the stats are simply thrown away.

My hope is that this helps us understand where queries spend time,
especially in cases where they sometimes hang for unusual amounts of
time.
