### PR TITLE
Ensure database access waits until it is started.

### DIFF
--- a/main.go
+++ b/main.go
@@ -266,7 +266,10 @@ func main() {
 	}
 	defer prometheus.close()
 
-	go ts.Serve()
+	storageStarted := make(chan bool)
+	go ts.Serve(storageStarted)
+	<-storageStarted
+
 	go prometheus.interruptHandler()
 	go prometheus.reportDatabaseState()
 

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -79,8 +79,9 @@ func NewTestTieredStorage(t test.Tester) (storage *metric.TieredStorage, closer 
 		directory.Close()
 		t.Fatalf("storage == nil")
 	}
-
-	go storage.Serve()
+	started := make(chan bool)
+	go storage.Serve(started)
+	<-started
 	closer = &testTieredStorageCloser{
 		storage:   storage,
 		directory: directory,

--- a/storage/metric/helpers_test.go
+++ b/storage/metric/helpers_test.go
@@ -101,7 +101,10 @@ func NewTestTieredStorage(t test.Tester) (storage *TieredStorage, closer test.Cl
 		t.Fatalf("storage == nil")
 	}
 
-	go storage.Serve()
+	started := make(chan bool)
+	go storage.Serve(started)
+	<-started
+
 	closer = &testTieredStorageCloser{
 		storage:   storage,
 		directory: directory,

--- a/storage/metric/tiered.go
+++ b/storage/metric/tiered.go
@@ -156,7 +156,7 @@ func (t *TieredStorage) MakeView(builder ViewRequestBuilder, deadline time.Durat
 }
 
 // Starts serving requests.
-func (t *TieredStorage) Serve() {
+func (t *TieredStorage) Serve(started chan<- bool) {
 	flushMemoryTicker := time.NewTicker(t.flushMemoryInterval)
 	defer flushMemoryTicker.Stop()
 	queueReportTicker := time.NewTicker(time.Second)
@@ -167,6 +167,8 @@ func (t *TieredStorage) Serve() {
 			t.reportQueues()
 		}
 	}()
+
+	started <- true
 
 	for {
 		select {


### PR DESCRIPTION
This commit introduces a channel message to ensure serving
state has been reached with the storage stack before anything attempts
to use it.
