### PR TITLE
Persist solely Protocol Buffers.

### DIFF
--- a/storage/metric/processor_test.go
+++ b/storage/metric/processor_test.go
@@ -14,15 +14,17 @@
 package metric
 
 import (
-	"code.google.com/p/goprotobuf/proto"
 	"fmt"
-	"github.com/prometheus/prometheus/coding"
-	"github.com/prometheus/prometheus/model"
-	dto "github.com/prometheus/prometheus/model/generated"
-	"github.com/prometheus/prometheus/storage/raw/leveldb"
-	fixture "github.com/prometheus/prometheus/storage/raw/leveldb/test"
 	"testing"
 	"time"
+
+	"code.google.com/p/goprotobuf/proto"
+
+	dto "github.com/prometheus/prometheus/model/generated"
+	fixture "github.com/prometheus/prometheus/storage/raw/leveldb/test"
+
+	"github.com/prometheus/prometheus/model"
+	"github.com/prometheus/prometheus/storage/raw/leveldb"
 )
 
 type curationState struct {
@@ -56,40 +58,40 @@ type out struct {
 	sampleGroups   []sampleGroup
 }
 
-func (c curationState) Get() (key, value coding.Encoder) {
+func (c curationState) Get() (key, value proto.Message) {
 	signature, err := c.processor.Signature()
 	if err != nil {
 		panic(err)
 	}
-	key = coding.NewPBEncoder(model.CurationKey{
+	key = model.CurationKey{
 		Fingerprint:              model.NewFingerprintFromRowKey(c.fingerprint),
 		ProcessorMessageRaw:      signature,
 		ProcessorMessageTypeName: c.processor.Name(),
 		IgnoreYoungerThan:        c.ignoreYoungerThan,
-	}.ToDTO())
+	}.ToDTO()
 
-	value = coding.NewPBEncoder(model.CurationRemark{
+	value = model.CurationRemark{
 		LastCompletionTimestamp: c.lastCurated,
-	}.ToDTO())
+	}.ToDTO()
 
 	return
 }
 
-func (w watermarkState) Get() (key, value coding.Encoder) {
-	key = coding.NewPBEncoder(model.NewFingerprintFromRowKey(w.fingerprint).ToDTO())
-	value = coding.NewPBEncoder(model.NewWatermarkFromTime(w.lastAppended).ToMetricHighWatermarkDTO())
+func (w watermarkState) Get() (key, value proto.Message) {
+	key = model.NewFingerprintFromRowKey(w.fingerprint).ToDTO()
+	value = model.NewWatermarkFromTime(w.lastAppended).ToMetricHighWatermarkDTO()
 	return
 }
 
-func (s sampleGroup) Get() (key, value coding.Encoder) {
-	key = coding.NewPBEncoder(model.SampleKey{
+func (s sampleGroup) Get() (key, value proto.Message) {
+	key = model.SampleKey{
 		Fingerprint:    model.NewFingerprintFromRowKey(s.fingerprint),
 		FirstTimestamp: s.values[0].Timestamp,
 		LastTimestamp:  s.values[len(s.values)-1].Timestamp,
 		SampleCount:    uint32(len(s.values)),
-	}.ToDTO())
+	}.ToDTO()
 
-	value = coding.NewPBEncoder(s.values.ToDTO())
+	value = s.values.ToDTO()
 
 	return
 }

--- a/storage/raw/index/interface.go
+++ b/storage/raw/index/interface.go
@@ -13,13 +13,11 @@
 
 package index
 
-import (
-	"github.com/prometheus/prometheus/coding"
-)
+import "code.google.com/p/goprotobuf/proto"
 
 type MembershipIndex interface {
-	Has(key coding.Encoder) (bool, error)
-	Put(key coding.Encoder) error
-	Drop(key coding.Encoder) error
+	Has(key proto.Message) (bool, error)
+	Put(key proto.Message) error
+	Drop(key proto.Message) error
 	Close()
 }

--- a/storage/raw/index/leveldb/leveldb.go
+++ b/storage/raw/index/leveldb/leveldb.go
@@ -14,20 +14,15 @@
 package leveldb
 
 import (
-	"github.com/prometheus/prometheus/coding"
+	"code.google.com/p/goprotobuf/proto"
+
+	dto "github.com/prometheus/prometheus/model/generated"
+
 	"github.com/prometheus/prometheus/storage/raw"
 	"github.com/prometheus/prometheus/storage/raw/leveldb"
 )
 
-type indexValue struct{}
-
-func (i *indexValue) MustEncode() []byte {
-	return []byte{}
-}
-
-var (
-	existenceValue = &indexValue{}
-)
+var existenceValue = &dto.MembershipIndexValue{}
 
 type LevelDBMembershipIndex struct {
 	persistence *leveldb.LevelDBPersistence
@@ -37,16 +32,16 @@ func (l *LevelDBMembershipIndex) Close() {
 	l.persistence.Close()
 }
 
-func (l *LevelDBMembershipIndex) Has(key coding.Encoder) (bool, error) {
-	return l.persistence.Has(key)
+func (l *LevelDBMembershipIndex) Has(k proto.Message) (bool, error) {
+	return l.persistence.Has(k)
 }
 
-func (l *LevelDBMembershipIndex) Drop(key coding.Encoder) error {
-	return l.persistence.Drop(key)
+func (l *LevelDBMembershipIndex) Drop(k proto.Message) error {
+	return l.persistence.Drop(k)
 }
 
-func (l *LevelDBMembershipIndex) Put(key coding.Encoder) error {
-	return l.persistence.Put(key, existenceValue)
+func (l *LevelDBMembershipIndex) Put(k proto.Message) error {
+	return l.persistence.Put(k, existenceValue)
 }
 
 func NewLevelDBMembershipIndex(storageRoot string, cacheCapacity, bitsPerBloomFilterEncoded int) (i *LevelDBMembershipIndex, err error) {

--- a/storage/raw/interface.go
+++ b/storage/raw/interface.go
@@ -14,7 +14,8 @@
 package raw
 
 import (
-	"github.com/prometheus/prometheus/coding"
+	"code.google.com/p/goprotobuf/proto"
+
 	"github.com/prometheus/prometheus/storage"
 )
 
@@ -25,14 +26,14 @@ type Persistence interface {
 	// persistence.
 	Close()
 	// Has informs the user whether a given key exists in the database.
-	Has(key coding.Encoder) (bool, error)
+	Has(key proto.Message) (bool, error)
 	// Get retrieves the key from the database if it exists or returns nil if
 	// it is absent.
-	Get(key coding.Encoder) ([]byte, error)
+	Get(key, value proto.Message) (present bool, err error)
 	// Drop removes the key from the database.
-	Drop(key coding.Encoder) error
+	Drop(key proto.Message) error
 	// Put sets the key to a given value.
-	Put(key, value coding.Encoder) error
+	Put(key, value proto.Message) error
 	// ForEach is responsible for iterating through all records in the database
 	// until one of the following conditions are met:
 	//
@@ -41,7 +42,7 @@ type Persistence interface {
 	// 3.) A FilterResult of STOP is emitted by the Filter.
 	//
 	// Decoding errors for an entity cause that entity to be skipped.
-	ForEach(decoder storage.RecordDecoder, filter storage.RecordFilter, operator storage.RecordOperator) (scannedEntireCorpus bool, err error)
+	ForEach(storage.RecordDecoder, storage.RecordFilter, storage.RecordOperator) (scannedEntireCorpus bool, err error)
 	// Commit applies the Batch operations to the database.
 	Commit(Batch) error
 }
@@ -54,7 +55,7 @@ type Batch interface {
 	// batch mutation.
 	Close()
 	// Put follows the same protocol as Persistence.Put.
-	Put(key, value coding.Encoder)
+	Put(key, value proto.Message)
 	// Drop follows the same protocol as Persistence.Drop.
-	Drop(key coding.Encoder)
+	Drop(key proto.Message)
 }

--- a/storage/raw/leveldb/batch.go
+++ b/storage/raw/leveldb/batch.go
@@ -15,7 +15,10 @@ package leveldb
 
 import (
 	"fmt"
+
+	"code.google.com/p/goprotobuf/proto"
 	"github.com/jmhodges/levigo"
+
 	"github.com/prometheus/prometheus/coding"
 )
 
@@ -31,25 +34,23 @@ func NewBatch() *batch {
 	}
 }
 
-func (b *batch) Drop(key coding.Encoder) {
-	keyEncoded := key.MustEncode()
-	b.drops++
+func (b *batch) Drop(key proto.Message) {
+	b.batch.Delete(coding.NewPBEncoder(key).MustEncode())
 
-	b.batch.Delete(keyEncoded)
+	b.drops++
 }
 
-func (b *batch) Put(key, value coding.Encoder) {
-	keyEncoded := key.MustEncode()
-	valueEncoded := value.MustEncode()
+func (b *batch) Put(key, value proto.Message) {
+	b.batch.Put(coding.NewPBEncoder(key).MustEncode(), coding.NewPBEncoder(value).MustEncode())
+
 	b.puts++
 
-	b.batch.Put(keyEncoded, valueEncoded)
 }
 
-func (b batch) Close() {
+func (b *batch) Close() {
 	b.batch.Close()
 }
 
-func (b batch) String() string {
+func (b *batch) String() string {
 	return fmt.Sprintf("LevelDB batch with %d puts and %d drops.", b.puts, b.drops)
 }

--- a/storage/raw/leveldb/test/fixtures.go
+++ b/storage/raw/leveldb/test/fixtures.go
@@ -14,7 +14,8 @@
 package test
 
 import (
-	"github.com/prometheus/prometheus/coding"
+	"code.google.com/p/goprotobuf/proto"
+
 	"github.com/prometheus/prometheus/storage/raw/leveldb"
 	"github.com/prometheus/prometheus/utility/test"
 )
@@ -28,7 +29,7 @@ type (
 	// Pair models a prospective (key, value) double that will be committed to
 	// a database.
 	Pair interface {
-		Get() (key, value coding.Encoder)
+		Get() (key, value proto.Message)
 	}
 
 	// Pairs models a list of Pair for disk committing.
@@ -47,7 +48,7 @@ type (
 		// data to build.
 		HasNext() (has bool)
 		// Next emits the next (key, value) double for storage.
-		Next() (key coding.Encoder, value coding.Encoder)
+		Next() (key, value proto.Message)
 	}
 
 	preparer struct {
@@ -88,7 +89,7 @@ func (f cassetteFactory) HasNext() bool {
 	return f.index < f.count
 }
 
-func (f *cassetteFactory) Next() (key, value coding.Encoder) {
+func (f *cassetteFactory) Next() (key, value proto.Message) {
 	key, value = f.pairs[f.index].Get()
 
 	f.index++

--- a/tools/dumper/main.go
+++ b/tools/dumper/main.go
@@ -19,17 +19,20 @@
 package main
 
 import (
-	"code.google.com/p/goprotobuf/proto"
 	"encoding/csv"
 	"flag"
 	"fmt"
-	"github.com/prometheus/prometheus/model"
-	dto "github.com/prometheus/prometheus/model/generated"
-	"github.com/prometheus/prometheus/storage"
-	"github.com/prometheus/prometheus/storage/metric"
 	"log"
 	"os"
 	"strconv"
+
+	"code.google.com/p/goprotobuf/proto"
+
+	dto "github.com/prometheus/prometheus/model/generated"
+
+	"github.com/prometheus/prometheus/model"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/metric"
 )
 
 var (

--- a/web/web.go
+++ b/web/web.go
@@ -102,7 +102,6 @@ func getEmbeddedTemplate(name string) (*template.Template, error) {
 	return t, nil
 }
 
-
 func getTemplate(name string) (t *template.Template, err error) {
 	if *useLocalAssets {
 		t, err = getLocalTemplate(name)


### PR DESCRIPTION
An design question was open for me in the beginning was whether to
serialize other types to disk, but Protocol Buffers quickly won out,
which allows us to drop support for other types.  This is a good
start to cleaning up a lot of cruft in the storage stack and
can let us eventually decouple the various moving parts into
separate subsystems for easier reasoning.

This commit is not strictly required, but it is a start to making
the rest a lot more enjoyable to interact with.
