### PR TITLE
Implement getValueRangeAtIntervalOp for faster range queries.

### DIFF
--- a/rules/ast/query_analyzer.go
+++ b/rules/ast/query_analyzer.go
@@ -132,9 +132,10 @@ func viewAdapterForRangeQuery(node Node, start time.Time, end time.Time, interva
 	requestBuildTimer := queryStats.GetTimer(stats.ViewRequestBuildTime).Start()
 	viewBuilder := metric.NewViewRequestBuilder()
 	for fingerprint, rangeDuration := range analyzer.FullRanges {
-		// TODO: we should support GetMetricRangeAtInterval() or similar ops in the view builder.
-		for t := start; t.Before(end); t = t.Add(interval) {
-			viewBuilder.GetMetricRange(&fingerprint, t.Add(-rangeDuration), t)
+		if interval < rangeDuration {
+			viewBuilder.GetMetricRange(&fingerprint, start.Add(-rangeDuration), end)
+		} else {
+			viewBuilder.GetMetricRangeAtInterval(&fingerprint, start.Add(-rangeDuration), end, interval, rangeDuration)
 		}
 	}
 	for fingerprint := range analyzer.IntervalRanges {

--- a/storage/metric/tiered.go
+++ b/storage/metric/tiered.go
@@ -471,7 +471,7 @@ func (t *TieredStorage) renderView(viewJob viewJob) {
 
 				currentChunk = currentChunk.TruncateBefore(*(op.CurrentTime()))
 
-				for op.CurrentTime() != nil && !op.CurrentTime().After(targetTime) {
+				for !op.Consumed() && !op.CurrentTime().After(targetTime) {
 					out = op.ExtractSamples(Values(currentChunk))
 
 					// Append the extracted samples to the materialized view.
@@ -482,7 +482,7 @@ func (t *TieredStorage) renderView(viewJob viewJob) {
 			// Throw away standing ops which are finished.
 			filteredOps := ops{}
 			for _, op := range standingOps {
-				if op.CurrentTime() != nil {
+				if !op.Consumed() {
 					filteredOps = append(filteredOps, op)
 				}
 			}


### PR DESCRIPTION
This also short-circuits optimize() for now, since it is complex to implement
for the new operator, and ops generated by the query layer already fulfill the
needed invariants. We should still investigate later whether to completely
delete operator optimization code or extend it to support
getValueRangeAtIntervalOp operators.
