### PR TITLE
Always treat series without watermarks as too old.

### DIFF
--- a/storage/metric/tiered.go
+++ b/storage/metric/tiered.go
@@ -343,7 +343,8 @@ func (t *TieredStorage) seriesTooOld(f *clientmodel.Fingerprint, i time.Time) (b
 			return wmTime.Before(i), nil
 		}
 
-		return false, nil
+		t.wmCache.Set(f, &watermarks{})
+		return true, nil
 	}
 
 	return wm.High.Before(i), nil


### PR DESCRIPTION
Current series always get watermarks written out upon append now. This
drops support for old series without any watermarks by always reporting
them as too old (stale) during queries.
