### PR TITLE
Continue scraping old targets on SD fail.

### DIFF
--- a/retrieval/targetpool.go
+++ b/retrieval/targetpool.go
@@ -127,10 +127,10 @@ func (p *TargetPool) runIteration(results chan<- *extraction.Result, interval ti
 	if p.targetProvider != nil {
 		targets, err := p.targetProvider.Targets()
 		if err != nil {
-			log.Printf("Error looking up targets: %s", err)
-			return
+			log.Printf("Error looking up targets, keeping old list: %s", err)
+		} else {
+			p.ReplaceTargets(targets)
 		}
-		p.ReplaceTargets(targets)
 	}
 
 	p.RLock()


### PR DESCRIPTION
When we have trouble resolving the targets for a job via service
discovery, we shouldn't just stop scraping the targets we currently
have.
