### PR TITLE
Round time to nearest second in memory storage.

### DIFF
--- a/storage/metric/memory.go
+++ b/storage/metric/memory.go
@@ -55,7 +55,7 @@ func (s *stream) add(timestamp time.Time, value clientmodel.SampleValue) {
 	// BUG(all): https://github.com/prometheus/prometheus/pull/265/files#r4336435.
 
 	s.values = append(s.values, &SamplePair{
-		Timestamp: timestamp,
+		Timestamp: timestamp.Round(time.Second).UTC(),
 		Value:     value,
 	})
 }


### PR DESCRIPTION
When samples get flushed to disk, they lose sub-second precision anyways. By
already dropping sub-second precision, data fetched from memory vs. disk will
behave the same. Later, we should consider also storing a more compact
representation than time.Time in memory if we're not going to use its full
precision.

This is one of the possible solutions to https://github.com/prometheus/prometheus/issues/332, and the one I prefer for now.
