### PR TITLE
Add caching to static assets when served from blob handler.

### DIFF
--- a/web/blob/blob.go
+++ b/web/blob/blob.go
@@ -61,5 +61,6 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		contentType = mimeMap[parts[len(parts)-1]]
 	}
 	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Cache-Control", "public, max-age=259200")
 	w.Write(file)
 }


### PR DESCRIPTION
Add 72h caching for static assets.
