### PR TITLE
Fix query error notification in tabular view.

### DIFF
--- a/web/static/js/graph.js
+++ b/web/static/js/graph.js
@@ -534,6 +534,9 @@ Prometheus.Graph.prototype.handleConsoleResponse = function(data, textStatus) {
   case "scalar":
     tBody.append("<tr><td>scalar</td><td>" + data.Value + "</td></tr>");
     break;
+  case "error":
+    alert(json.Value);
+    break;
   default:
     alert("Unsupported value type!");
     break;


### PR DESCRIPTION
Instead of "Unsupported value type" when type="error", the delivered
error message should be shown.
