### PR TITLE
Hot Fix: Use extracted time.

### DIFF
--- a/storage/metric/tiered.go
+++ b/storage/metric/tiered.go
@@ -328,19 +328,15 @@ func (t *TieredStorage) seriesTooOld(f *clientmodel.Fingerprint, i time.Time) (b
 			}
 		}
 
-		value := &dto.MetricHighWatermark{}
-		k := &dto.Fingerprint{}
-		dumpFingerprint(k, f)
-		_, diskHit, err := t.DiskStorage.MetricHighWatermarks.Get(f)
+		highTime, diskHit, err := t.DiskStorage.MetricHighWatermarks.Get(f)
 		if err != nil {
 			return false, err
 		}
 
 		if diskHit {
-			wmTime := time.Unix(*value.Timestamp, 0).UTC()
-			t.wmCache.Set(f, &watermarks{High: wmTime})
+			t.wmCache.Set(f, &watermarks{High: highTime})
 
-			return wmTime.Before(i), nil
+			return highTime.Before(i), nil
 		}
 
 		t.wmCache.Set(f, &watermarks{})


### PR DESCRIPTION
This was overlooked in the bulk migration.
