### PR TITLE
Add global labels to all timeseries.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,10 +16,14 @@ package config
 import (
 	"code.google.com/p/goprotobuf/proto"
 	"fmt"
-	pb "github.com/prometheus/prometheus/config/generated"
-	"github.com/prometheus/prometheus/utility"
 	"regexp"
 	"time"
+
+	clientmodel "github.com/prometheus/client_golang/model"
+
+	pb "github.com/prometheus/prometheus/config/generated"
+
+	"github.com/prometheus/prometheus/utility"
 )
 
 var jobNameRE = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_-]*$")
@@ -96,6 +100,17 @@ func (c Config) GetJobByName(name string) *JobConfig {
 		}
 	}
 	return nil
+}
+
+// Return the global labels as a LabelSet.
+func (c Config) GlobalLabels() clientmodel.LabelSet {
+	labels := clientmodel.LabelSet{}
+	if c.Global.Labels != nil {
+		for _, label := range c.Global.Labels.Label {
+			labels[clientmodel.LabelName(label.GetName())] = clientmodel.LabelValue(label.GetValue())
+		}
+	}
+	return labels
 }
 
 // Jobs returns all the jobs in a Config object.

--- a/retrieval/helpers_test.go
+++ b/retrieval/helpers_test.go
@@ -15,6 +15,8 @@ package retrieval
 
 import (
 	"time"
+
+	"github.com/prometheus/client_golang/extraction"
 )
 
 type literalScheduler time.Time
@@ -24,4 +26,10 @@ func (s literalScheduler) ScheduledFor() time.Time {
 }
 
 func (s literalScheduler) Reschedule(earliest time.Time, future TargetState) {
+}
+
+type nopIngester struct{}
+
+func (i nopIngester) Ingest(*extraction.Result) error {
+	return nil
 }

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -37,13 +37,13 @@ type TargetManager interface {
 type targetManager struct {
 	requestAllowance chan bool
 	poolsByJob       map[string]*TargetPool
-	results          chan<- *extraction.Result
+	ingester         extraction.Ingester
 }
 
-func NewTargetManager(results chan<- *extraction.Result, requestAllowance int) TargetManager {
+func NewTargetManager(ingester extraction.Ingester, requestAllowance int) TargetManager {
 	return &targetManager{
 		requestAllowance: make(chan bool, requestAllowance),
-		results:          results,
+		ingester:         ingester,
 		poolsByJob:       make(map[string]*TargetPool),
 	}
 }
@@ -71,7 +71,7 @@ func (m *targetManager) TargetPoolForJob(job config.JobConfig) *TargetPool {
 		interval := job.ScrapeInterval()
 		m.poolsByJob[job.GetName()] = targetPool
 		// BUG(all): Investigate whether this auto-goroutine creation is desired.
-		go targetPool.Run(m.results, interval)
+		go targetPool.Run(m.ingester, interval)
 	}
 
 	return targetPool

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -56,7 +56,7 @@ func (t fakeTarget) Interval() time.Duration {
 	return t.interval
 }
 
-func (t *fakeTarget) Scrape(e time.Time, r chan<- *extraction.Result) error {
+func (t *fakeTarget) Scrape(e time.Time, i extraction.Ingester) error {
 	t.scrapeCount++
 
 	return nil
@@ -78,8 +78,7 @@ func (t *fakeTarget) Merge(newTarget Target) {}
 func (t *fakeTarget) EstimatedTimeToExecute() time.Duration { return 0 }
 
 func testTargetManager(t test.Tester) {
-	results := make(chan *extraction.Result, 5)
-	targetManager := NewTargetManager(results, 3)
+	targetManager := NewTargetManager(nopIngester{}, 3)
 	testJob1 := config.JobConfig{
 		JobConfig: pb.JobConfig{
 			Name:           proto.String("test_job1"),

--- a/retrieval/targetpool.go
+++ b/retrieval/targetpool.go
@@ -50,14 +50,14 @@ func NewTargetPool(m TargetManager, p TargetProvider) *TargetPool {
 	}
 }
 
-func (p *TargetPool) Run(results chan<- *extraction.Result, interval time.Duration) {
+func (p *TargetPool) Run(ingester extraction.Ingester, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			p.runIteration(results, interval)
+			p.runIteration(ingester, interval)
 		case newTarget := <-p.addTargetQueue:
 			p.addTarget(newTarget)
 		case newTargets := <-p.replaceTargetsQueue:
@@ -116,14 +116,14 @@ func (p *TargetPool) replaceTargets(newTargets []Target) {
 	p.targets = newTargets
 }
 
-func (p *TargetPool) runSingle(earliest time.Time, results chan<- *extraction.Result, t Target) {
+func (p *TargetPool) runSingle(earliest time.Time, ingester extraction.Ingester, t Target) {
 	p.manager.acquire()
 	defer p.manager.release()
 
-	t.Scrape(earliest, results)
+	t.Scrape(earliest, ingester)
 }
 
-func (p *TargetPool) runIteration(results chan<- *extraction.Result, interval time.Duration) {
+func (p *TargetPool) runIteration(ingester extraction.Ingester, interval time.Duration) {
 	if p.targetProvider != nil {
 		targets, err := p.targetProvider.Targets()
 		if err != nil {
@@ -155,7 +155,7 @@ func (p *TargetPool) runIteration(results chan<- *extraction.Result, interval ti
 		wait.Add(1)
 
 		go func(t Target) {
-			p.runSingle(now, results, t)
+			p.runSingle(now, ingester, t)
 			wait.Done()
 		}(target)
 	}

--- a/retrieval/targetpool_test.go
+++ b/retrieval/targetpool_test.go
@@ -18,8 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/extraction"
-
 	"github.com/prometheus/prometheus/utility/test"
 )
 
@@ -150,7 +148,7 @@ func TestTargetPoolIterationWithUnhealthyTargetsFinishes(t *testing.T) {
 
 	done := make(chan bool)
 	go func() {
-		pool.runIteration(make(chan *extraction.Result), time.Duration(0))
+		pool.runIteration(nopIngester{}, time.Duration(0))
 		done <- true
 	}()
 


### PR DESCRIPTION
Due to the structure of targetmanager/targetpool/target and who has visiblity
of which data, this is a bit ugly in places (like upon target add/replace,
getting each targets' existing labels, merging in the global ones, storing them
back).  But I doubt it can be done much nicer without completely refactoring
the retrieval code, which we should do at some point.

At least this approach is compatible with configuration reloading
(barring other things that need to be done for that).
