### PR TITLE
Revert "Merge pull request #317 from prometheus/fix/miekg-dns-for-srv"

### DIFF
--- a/.build/Makefile
+++ b/.build/Makefile
@@ -45,7 +45,7 @@ cc-implementation-Linux-stamp:
 	[ -x "$$(which cc)" ] || $(APT_GET_INSTALL) build-essential
 	touch $@
 
-dependencies-stamp: cache-stamp cc-stamp leveldb-stamp snappy-stamp godns-stamp
+dependencies-stamp: cache-stamp cc-stamp leveldb-stamp snappy-stamp
 	touch $@
 
 goprotobuf-protoc-gen-go-stamp: protoc-stamp goprotobuf-stamp
@@ -54,10 +54,6 @@ goprotobuf-protoc-gen-go-stamp: protoc-stamp goprotobuf-stamp
 
 goprotobuf-stamp: protoc-stamp
 	$(GO_GET) code.google.com/p/goprotobuf/proto $(THIRD_PARTY_BUILD_OUTPUT)
-	touch $@
-
-godns-stamp:
-	$(GO_GET) github.com/miekg/dns $(THIRD_PARTY_BUILD_OUTPUT)
 	touch $@
 
 leveldb-stamp: cache-stamp cache/leveldb-$(LEVELDB_VERSION).tar.gz cc-stamp rsync-stamp snappy-stamp

--- a/retrieval/target_provider.go
+++ b/retrieval/target_provider.go
@@ -15,19 +15,17 @@ package retrieval
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/miekg/dns"
 
 	clientmodel "github.com/prometheus/client_golang/model"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/utility"
 )
-
-const resolvConf = "/etc/resolv.conf"
 
 // TargetProvider encapsulates retrieving all targets for a job.
 type TargetProvider interface {
@@ -61,7 +59,7 @@ func (p *sdTargetProvider) Targets() ([]Target, error) {
 		return p.targets, nil
 	}
 
-	response, err := lookupSRV(p.job.GetSdName())
+	_, addrs, err := net.LookupSRV("", "", p.job.GetSdName())
 	if err != nil {
 		return nil, err
 	}
@@ -70,17 +68,12 @@ func (p *sdTargetProvider) Targets() ([]Target, error) {
 		clientmodel.JobLabel: clientmodel.LabelValue(p.job.GetName()),
 	}
 
-	targets := make([]Target, 0, len(response.Answer))
+	targets := make([]Target, 0, len(addrs))
 	endpoint := &url.URL{
 		Scheme: "http",
 		Path:   p.job.GetMetricsPath(),
 	}
-	for _, record := range response.Answer {
-		addr, ok := record.(*dns.SRV)
-		if !ok {
-			glog.Warningf("%s is not a valid SRV record", addr)
-			continue
-		}
+	for _, addr := range addrs {
 		// Remove the final dot from rooted DNS names to make them look more usual.
 		if addr.Target[len(addr.Target)-1] == '.' {
 			addr.Target = addr.Target[:len(addr.Target)-1]
@@ -92,61 +85,4 @@ func (p *sdTargetProvider) Targets() ([]Target, error) {
 
 	p.targets = targets
 	return targets, nil
-}
-
-func lookupSRV(name string) (*dns.Msg, error) {
-	name = dns.Fqdn(name)
-	conf, err := dns.ClientConfigFromFile(resolvConf)
-	if err != nil {
-		return nil, fmt.Errorf("Couldn't load resolv.conf: %s", err)
-	}
-	client := &dns.Client{}
-	msg := &dns.Msg{}
-	msg.SetQuestion(name, dns.TypeSRV)
-
-	response := &dns.Msg{}
-	for _, server := range conf.Servers {
-		server := fmt.Sprintf("%s:%s", server, conf.Port)
-		response, err = lookup(msg, client, server, false)
-		if err == nil {
-			return response, nil
-		}
-	}
-	return response, fmt.Errorf("Couldn't resolve %s: No server responded", name)
-}
-
-func lookup(msg *dns.Msg, client *dns.Client, server string, edns bool) (*dns.Msg, error) {
-	if edns {
-		opt := &dns.OPT{
-			Hdr: dns.RR_Header{
-				Name:   ".",
-				Rrtype: dns.TypeOPT,
-			},
-		}
-		opt.SetUDPSize(dns.DefaultMsgSize)
-		msg.Extra = append(msg.Extra, opt)
-	}
-
-	response, _, err := client.Exchange(msg, server)
-	if err != nil {
-		return nil, err
-	}
-
-	if msg.Id != response.Id {
-		return nil, fmt.Errorf("DNS ID mismatch, request: %d, response: %d", msg.Id, response.Id)
-	}
-
-	if response.MsgHdr.Truncated {
-		if client.Net == "tcp" {
-			return nil, fmt.Errorf("Got truncated message on tcp")
-		}
-
-		if edns { // Truncated even though EDNS is used
-			client.Net = "tcp"
-		}
-
-		return lookup(msg, client, server, !edns)
-	}
-
-	return response, nil
 }


### PR DESCRIPTION
This reverts the introduction of our own miekg/dns based resolver.
Since the missing tcp retry on long responses is fixed (https://code.google.com/p/go/issues/detail?id=5686), we can drop this external dependency.
Beside that, LookupSRV respects the local domain search path which our resolver based on miekg/dns does not.
