### PR TITLE
Make Dockerfile build prometheus in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-# Cannot use busybox image since Prometheus depends on libc.
-FROM base
-
+FROM       ubuntu:13.10
 MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
-EXPOSE 9090
-ENTRYPOINT ["/opt/prometheus/run_prometheus.sh"]
-ADD .build/package/ /opt/prometheus
+EXPOSE     9090
+VOLUME     [ "/prometheus" ]
+WORKDIR    /prometheus
+
+ENTRYPOINT [ "/prometheus-src/.build/package/run_prometheus.sh" ]
+RUN        apt-get update && apt-get install -yq make git curl sudo mercurial
+ADD        . /prometheus-src
+RUN        cd /prometheus-src && make binary


### PR DESCRIPTION
Hey everyone,

I've got an PR for you :)

This makes the Dockerfile build prometheus in container. This way the binary will be built in a clear environment and prometheus can be added to the docker index.

(You could also get rid of all the Makefile complexity and move installing of dependencies into this Dockerfile and just run `docker build` in travis/jenkins.)
