### PR TITLE
Quote schema in accept header

### DIFF
--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -227,7 +227,7 @@ func (t *target) StopScraper() {
 	t.stopScraper <- true
 }
 
-const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3,application/json;schema=prometheus/telemetry;version=0.0.2;q=0.2,*/*;q=0.1`
+const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3,application/json;schema="prometheus/telemetry";version=0.0.2;q=0.2,*/*;q=0.1`
 
 func (t *target) scrape(ingester extraction.Ingester) (err error) {
 	timestamp := clientmodel.Now()


### PR DESCRIPTION
HTTP 1.1 does not permit a slash inside an accept extension, unless it is inside a quoted string. The Accept header used by Prometheus is incorrect.

From [RFC 7230](http://tools.ietf.org/html/rfc7230):

```
     token          = 1*tchar

     tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
                    / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
                    / DIGIT / ALPHA
                    ; any VCHAR, except delimiters
```

From [RFC rfc7231](http://tools.ietf.org/html/rfc7231):

```
    accept-ext = OWS ";" OWS token [ "=" ( token / quoted-string ) ]
```
