### PR TITLE
Allow selecting metric from Insert Metric

### DIFF
--- a/web/static/js/graph.js
+++ b/web/static/js/graph.js
@@ -132,7 +132,7 @@ Prometheus.Graph.prototype.initialize = function() {
 
   self.insertMetric.change(function() {
     self.expr.selection("replace", {text: self.insertMetric.val(), mode: "before"});
-    self.insertMetric.focus(); // refocusing
+    self.expr.focus(); // refocusing
   });
 
   self.expr.focus(); // TODO: move to external Graph method.


### PR DESCRIPTION
It's impossible to select a metric from the "Insert Metric at Cursor" drop-down because as soon as you click on it the focus shifts to something else. This fixes that.

![srnrq](https://cloud.githubusercontent.com/assets/830952/4290557/af21900a-3dbc-11e4-8b1f-509e17afd8db.png)
