### PR TITLE
Adjust to the new version of goleveldb.

### DIFF
--- a/storage/local/index/leveldb.go
+++ b/storage/local/index/leveldb.go
@@ -17,7 +17,6 @@ import (
 	"encoding"
 
 	"github.com/syndtr/goleveldb/leveldb"
-	leveldb_cache "github.com/syndtr/goleveldb/leveldb/cache"
 	leveldb_filter "github.com/syndtr/goleveldb/leveldb/filter"
 	leveldb_iterator "github.com/syndtr/goleveldb/leveldb/iterator"
 	leveldb_opt "github.com/syndtr/goleveldb/leveldb/opt"
@@ -52,9 +51,8 @@ type LevelDBOptions struct {
 // use.
 func NewLevelDB(o LevelDBOptions) (KeyValueStore, error) {
 	options := &leveldb_opt.Options{
-		Compression: leveldb_opt.SnappyCompression,
-		BlockCache:  leveldb_cache.NewLRUCache(o.CacheSizeBytes),
-		Filter:      leveldb_filter.NewBloomFilter(10),
+		BlockCacheCapacity: o.CacheSizeBytes,
+		Filter:             leveldb_filter.NewBloomFilter(10),
 	}
 
 	storage, err := leveldb.OpenFile(o.Path, options)


### PR DESCRIPTION
(And yes, we do want vendoring for that... This is just the quick fix.)

Snappy is actually the default compression. No need to mention it.

@juliusv 
