### PR TITLE
Upgrade to Go 1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ core
 
 *-stamp
 prometheus
+benchmark.txt
 
 .#*
 command-line-arguments.test

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ tag:
 $(BUILD_PATH)/cache/$(GOPKG):
 	$(CURL) -o $@ -L $(GOURL)/$(GOPKG)
 
-benchmark: test
-	$(GO) test $(GO_TEST_FLAGS) -test.bench='Benchmark' ./...
+benchmark: config dependencies tools
+	$(GO) test $(GO_TEST_FLAGS) -test.run='NONE' -test.bench='.*' -test.benchmem ./... | tee benchmark.txt
 
 clean:
 	$(MAKE) -C $(BUILD_PATH) clean

--- a/Makefile.INCLUDE
+++ b/Makefile.INCLUDE
@@ -26,7 +26,7 @@ MAC_OS_X_VERSION ?= 10.8
 
 BUILD_PATH = $(PWD)/.build
 
-GO_VERSION	 := 1.3.3
+GO_VERSION	 := 1.4
 GOOS		  = $(subst Darwin,darwin,$(subst Linux,linux,$(OS)))
 
 ifeq ($(GOOS),darwin)


### PR DESCRIPTION
This change set upgrades Prometheus to use Go 1.4
The other modifications were intended to compare benchmarks between the
old and new versions using `golang.org/x/tools/cmd/benchcmp`
![screen shot 2014-12-15 at 13 55 55](https://cloud.githubusercontent.com/assets/67471/5436071/56f29dba-8462-11e4-9e06-6961bd358093.png)
