### PR TITLE
Have scrape time as a pseudovariable, not a prometheus variable.

### DIFF
--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -15,6 +15,7 @@ package retrieval
 
 import (
 	"sync"
+
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/extraction"
 

--- a/retrieval/targetpool_test.go
+++ b/retrieval/targetpool_test.go
@@ -27,7 +27,7 @@ func testTargetPool(t testing.TB) {
 	}
 
 	type input struct {
-		url      string
+		url          string
 		scheduledFor time.Time
 	}
 
@@ -84,7 +84,7 @@ func testTargetPool(t testing.TB) {
 
 		for _, input := range scenario.inputs {
 			target := target{
-				url:       input.url,
+				url:           input.url,
 				newBaseLabels: make(chan clientmodel.LabelSet, 1),
 				httpClient:    &http.Client{},
 			}
@@ -114,7 +114,7 @@ func TestTargetPool(t *testing.T) {
 func TestTargetPoolReplaceTargets(t *testing.T) {
 	pool := NewTargetPool(nil, nil, nopIngester{}, time.Duration(1))
 	oldTarget1 := &target{
-		url:         "example1",
+		url:             "example1",
 		state:           Unreachable,
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
@@ -122,7 +122,7 @@ func TestTargetPoolReplaceTargets(t *testing.T) {
 		httpClient:      &http.Client{},
 	}
 	oldTarget2 := &target{
-		url:         "example2",
+		url:             "example2",
 		state:           Unreachable,
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
@@ -130,7 +130,7 @@ func TestTargetPoolReplaceTargets(t *testing.T) {
 		httpClient:      &http.Client{},
 	}
 	newTarget1 := &target{
-		url:         "example1",
+		url:             "example1",
 		state:           Alive,
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
@@ -138,7 +138,7 @@ func TestTargetPoolReplaceTargets(t *testing.T) {
 		httpClient:      &http.Client{},
 	}
 	newTarget2 := &target{
-		url:         "example3",
+		url:             "example3",
 		state:           Alive,
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),

--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -869,7 +869,7 @@ func (p *persistence) checkpointSeriesMapAndHeads(fingerprintToSeries *seriesMap
 	iter := fingerprintToSeries.iter()
 	defer func() {
 		// Consume the iterator in any case to not leak goroutines.
-		for _ = range iter {
+		for range iter {
 		}
 	}()
 

--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -567,7 +567,7 @@ func (s *memorySeriesStorage) cycleThroughMemoryFingerprints() chan clientmodel.
 
 		defer func() {
 			if fpIter != nil {
-				for _ = range fpIter {
+				for range fpIter {
 					// Consume the iterator.
 				}
 			}
@@ -661,9 +661,9 @@ loop:
 		}
 	}
 	// Wait until both channels are closed.
-	for _ = range memoryFingerprints {
+	for range memoryFingerprints {
 	}
-	for _ = range archivedFingerprints {
+	for range archivedFingerprints {
 	}
 }
 


### PR DESCRIPTION
This ensures it has the right timestamp, and is easier to work with.

Switch sd variable away from 'outcome', using total/failed instead.