### PR TITLE
Sort timeseries on tabular view.

### DIFF
--- a/web/static/js/graph.js
+++ b/web/static/js/graph.js
@@ -527,6 +527,14 @@ Prometheus.Graph.prototype.handleConsoleResponse = function(data, textStatus) {
   var tBody = self.consoleTab.find(".console_table tbody");
   tBody.empty();
 
+  if (data.Type == "vector" || data.Type == "matrix") {
+    data.Value.sort(function (a, b) {
+      var aName = self.metricToTsName(a.Metric);
+      var bName = self.metricToTsName(b.Metric);
+      return aName.localeCompare(bName);
+    });
+  }
+
   switch(data.Type) {
   case "vector":
     for (var i = 0; i < data.Value.length; i++) {


### PR DESCRIPTION
Having timeseries jump around every time you hit Execute is annoying.
Some ordering is required, so sort the timeseries. localCompare is
browser-dependant, but that's sufficient for this use case.

More powerful sorting/grouping options would be nice, this should cover most
use cases as a sane ordering like this is sufficient for eyeballing data.