### PR TITLE
Add double-start protection.

### DIFF
--- a/storage/local/flock/flock.go
+++ b/storage/local/flock/flock.go
@@ -1,0 +1,37 @@
+// Package flock provides portable file locking. It is essentially ripped out
+// from the code of github.com/syndtr/goleveldb. Strange enough that the
+// standard library does not provide this functionality. Once this package has
+// proven to work as expected, we should probably turn it into a separate
+// general purpose package for humanity.
+package flock
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Releaser provides the Release method to release a file lock.
+type Releaser interface {
+	Release() error
+}
+
+// New locks the file with the provided name. If the file does not exist, it is
+// created. The returned Releaser is used to release the lock. The returned
+// boolean is true if the file to lock already existed. A non-nil error is
+// returned if the locking has failed. Neither this function nor the returned
+// Releaser is goroutine-safe.
+func New(fileName string) (Releaser, bool, error) {
+	if err := os.MkdirAll(filepath.Dir(fileName), 0755); err != nil {
+		return nil, false, err
+	}
+
+	_, err := os.Stat(fileName)
+	existed := err == nil
+
+	lock, err := newLock(fileName)
+	if err != nil {
+		return nil, existed, err
+	}
+
+	return lock, existed, nil
+}

--- a/storage/local/flock/flock.go
+++ b/storage/local/flock/flock.go
@@ -16,22 +16,18 @@ type Releaser interface {
 }
 
 // New locks the file with the provided name. If the file does not exist, it is
-// created. The returned Releaser is used to release the lock. The returned
-// boolean is true if the file to lock already existed. A non-nil error is
-// returned if the locking has failed. Neither this function nor the returned
-// Releaser is goroutine-safe.
-func New(fileName string) (Releaser, bool, error) {
-	if err := os.MkdirAll(filepath.Dir(fileName), 0755); err != nil {
-		return nil, false, err
+// created. The returned Releaser is used to release the lock. existed is true
+// if the file to lock already existed. A non-nil error is returned if the
+// locking has failed. Neither this function nor the returned Releaser is
+// goroutine-safe.
+func New(fileName string) (r Releaser, existed bool, err error) {
+	if err = os.MkdirAll(filepath.Dir(fileName), 0755); err != nil {
+		return
 	}
 
-	_, err := os.Stat(fileName)
-	existed := err == nil
+	_, err = os.Stat(fileName)
+	existed = err == nil
 
-	lock, err := newLock(fileName)
-	if err != nil {
-		return nil, existed, err
-	}
-
-	return lock, existed, nil
+	r, err = newLock(fileName)
+	return
 }

--- a/storage/local/flock/flock_plan9.go
+++ b/storage/local/flock/flock_plan9.go
@@ -1,0 +1,19 @@
+package flock
+
+import "os"
+
+type plan9Lock struct {
+	f *os.File
+}
+
+func (l *plan9Lock) Release() error {
+	return l.f.Close()
+}
+
+func newLock(fileName string) (Releaser, error) {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, os.ModeExclusive|0644)
+	if err != nil {
+		return nil, err
+	}
+	return &plan9Lock{f}, nil
+}

--- a/storage/local/flock/flock_solaris.go
+++ b/storage/local/flock/flock_solaris.go
@@ -1,0 +1,46 @@
+// +build solaris
+
+package flock
+
+import (
+	"os"
+	"syscall"
+)
+
+type unixLock struct {
+	f *os.File
+}
+
+func (l *unixLock) Release() error {
+	if err := l.set(false); err != nil {
+		return err
+	}
+	return l.f.Close()
+}
+
+func (l *unixLock) set(lock bool) error {
+	flock := syscall.Flock_t{
+		Type:   syscall.F_UNLCK,
+		Start:  0,
+		Len:    0,
+		Whence: 1,
+	}
+	if lock {
+		flock.Type = syscall.F_WRLCK
+	}
+	return syscall.FcntlFlock(l.f.Fd(), syscall.F_SETLK, &flock)
+}
+
+func newLock(fileName string) (Releaser, error) {
+	f, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, err
+	}
+	l := &unixLock{f}
+	err = l.set(true)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return l, nil
+}

--- a/storage/local/flock/flock_test.go
+++ b/storage/local/flock/flock_test.go
@@ -1,0 +1,67 @@
+package flock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/prometheus/utility/test"
+)
+
+func TestLocking(t *testing.T) {
+	dir := test.NewTemporaryDirectory("test_flock", t)
+	defer dir.Close()
+
+	fileName := filepath.Join(dir.Path(), "LOCK")
+
+	if _, err := os.Stat(fileName); err == nil {
+		t.Fatalf("File %q unexpectedly exists.", fileName)
+	}
+
+	lock, existed, err := New(fileName)
+	if err != nil {
+		t.Fatalf("Error locking file %q: %s", fileName, err)
+	}
+	if existed {
+		t.Errorf("File %q reported as existing during locking.", fileName)
+	}
+
+	// File must now exist.
+	if _, err := os.Stat(fileName); err != nil {
+		t.Errorf("Could not stat file %q expected to exist: %s", fileName, err)
+	}
+
+	// Try to lock again.
+	lockedAgain, existed, err := New(fileName)
+	if err == nil {
+		t.Fatalf("File %q locked twice.", fileName)
+	}
+	if lockedAgain != nil {
+		t.Error("Unsuccessful locking did not return nil.")
+	}
+	if !existed {
+		t.Errorf("Existing file %q not recognized.", fileName)
+	}
+
+	if err := lock.Release(); err != nil {
+		t.Errorf("Error releasing lock for file %q: %s", fileName, err)
+	}
+
+	// File must still exist.
+	if _, err := os.Stat(fileName); err != nil {
+		t.Errorf("Could not stat file %q expected to exist: %s", fileName, err)
+	}
+
+	// Lock existing file.
+	lock, existed, err = New(fileName)
+	if err != nil {
+		t.Fatalf("Error locking file %q: %s", fileName, err)
+	}
+	if !existed {
+		t.Errorf("Existing file %q not recognized.", fileName)
+	}
+
+	if err := lock.Release(); err != nil {
+		t.Errorf("Error releasing lock for file %q: %s", fileName, err)
+	}
+}

--- a/storage/local/flock/flock_unix.go
+++ b/storage/local/flock/flock_unix.go
@@ -1,0 +1,41 @@
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package flock
+
+import (
+	"os"
+	"syscall"
+)
+
+type unixLock struct {
+	f *os.File
+}
+
+func (l *unixLock) Release() error {
+	if err := l.set(false); err != nil {
+		return err
+	}
+	return l.f.Close()
+}
+
+func (l *unixLock) set(lock bool) error {
+	how := syscall.LOCK_UN
+	if lock {
+		how = syscall.LOCK_EX
+	}
+	return syscall.Flock(int(l.f.Fd()), how|syscall.LOCK_NB)
+}
+
+func newLock(fileName string) (Releaser, error) {
+	f, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, err
+	}
+	l := &unixLock{f}
+	err = l.set(true)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return l, nil
+}

--- a/storage/local/flock/flock_windows.go
+++ b/storage/local/flock/flock_windows.go
@@ -1,0 +1,23 @@
+package flock
+
+import "syscall"
+
+type windowsLock struct {
+	fd syscall.Handle
+}
+
+func (fl *windowsLock) Release() error {
+	return syscall.Close(fl.fd)
+}
+
+func newLock(fileName string) (Releaser, error) {
+	pathp, err := syscall.UTF16PtrFromString(fileName)
+	if err != nil {
+		return nil, err
+	}
+	fd, err := syscall.CreateFile(pathp, syscall.GENERIC_READ|syscall.GENERIC_WRITE, 0, nil, syscall.CREATE_ALWAYS, syscall.FILE_ATTRIBUTE_NORMAL, 0)
+	if err != nil {
+		return nil, err
+	}
+	return &windowsFileLock{fd}, nil
+}


### PR DESCRIPTION
    Add double-start protection.
    
    This mimics the locking leveldb is performing anyway. Advantages of
    doing it separately:
    
    - Should we ever replace the leveldb implementation by one without
      double-start protection, we are still good.
    
    - In contrast to leveldb, the new code creates a meaningful error
      message.

@juliusv 