### PR TITLE
Add floats to align inputs, and clear the float on the parent.

### DIFF
--- a/web/static/js/graph_template.handlebar
+++ b/web/static/js/graph_template.handlebar
@@ -36,10 +36,10 @@
                   </ul>
                   <div class="tab-content">
                     <div role="tabpanel" class="tab-pane graph_container reload" id="graph{{id}}">
-                      <div>
+                      <div class="clearfix">
                         <!-- Extracted to force grouped inputs. -->
                         <input type="hidden" name="range">
-                        <div class="prometheus_input_group range_input">
+                        <div class="prometheus_input_group range_input pull-left">
                           <button
                             class="btn btn-default pull-left"
                             type="button"
@@ -66,7 +66,7 @@
 
                         <!-- Extracted to force grouped inputs. -->
                         <input type="hidden" name="end">
-                        <div class="prometheus_input_group">
+                        <div class="prometheus_input_group pull-left">
 
                           <button
                               class="btn btn-default pull-left"
@@ -96,12 +96,12 @@
                           </button>
                         </div>
 
-                        <div class="prometheus_input_group">
+                        <div class="prometheus_input_group pull-left">
                           <input class="input" title="Resolution in seconds" placeholder="Res. (s)" type="text" name="step_input" id="step_input{{id}}" value="{{step_input}}" size="6">
                           <input type="hidden" name="step">
                         </div>
 
-                        <div class="prometheus_input_group">
+                        <div class="prometheus_input_group pull-left">
                           <button type="button" class="btn btn-default stacked_btn">
                             <i class="glyphicon"></i> stacked
                           </button>


### PR DESCRIPTION
@juliusv i can confirm that this works on my machine, but hop on someone else's max and double check. it works for me on safari, ff, and chrome. it would be good to check your ubuntu also :)

one issue i noticed, though: hovering over a time series in the right third of the graph space has this weird visual effect on the time series hover point.
![image](https://cloud.githubusercontent.com/assets/1398104/5855608/7998af12-a23a-11e4-91ef-4d2277b18f44.png)

i checked and it is present in master (before these changes)

do you see this?
