### PR TITLE
Slim down the files we embed into the binary.

### DIFF
--- a/console_libraries/prom.lib
+++ b/console_libraries/prom.lib
@@ -2,7 +2,7 @@
 {{/* Load Prometheus console library JS/CSS. Should go in <head> */}}
 {{ define "prom_console_head" }}
 <link type="text/css" rel="stylesheet" href="/static/vendor/rickshaw/rickshaw.min.css">
-<link type="text/css" rel="stylesheet" href="/static/vendor/bootstrap-3.3.1/css/bootstrap.css">
+<link type="text/css" rel="stylesheet" href="/static/vendor/bootstrap-3.3.1/css/bootstrap.min.css">
 <link type="text/css" rel="stylesheet" href="/static/css/prom_console.css">
 <script src="/static/vendor/rickshaw/vendor/d3.min.js"></script>
 <script src="/static/vendor/rickshaw/vendor/d3.layout.min.js"></script>

--- a/utility/embed-static.sh
+++ b/utility/embed-static.sh
@@ -14,7 +14,8 @@ do
   cd "${dir}"
   echo "\"$(basename ${dir})\": {"
 
-  find . -type f | while read file
+  # Do not embed map files and the non-minified bootstrap files.
+  find . -type f \! -name \*.map \! -name bootstrap.js \! -name bootstrap-theme.css \! -name bootstrap.css | while read file
   do
     name=$(echo "${file}"|sed 's|\.\/||')
     echo "\"$name\": {"

--- a/web/Makefile
+++ b/web/Makefile
@@ -11,14 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-all: blob-stamp
+all: blob
 
-blob-stamp: templates/*
+blob:
 	$(MAKE) -C blob
-	touch $@
 
 clean:
 	$(MAKE) -C blob clean
-	-rm -f *-stamp
 
-.PHONY: clean
+.PHONY: clean blob

--- a/web/blob/Makefile
+++ b/web/blob/Makefile
@@ -17,6 +17,7 @@ all: files.go
 
 SUFFIXES:
 
+# Do not embed map files and the non-minified bootstrap files.
 files.go: $(shell find ../templates/ ../static/ -type f)
 	../../utility/embed-static.sh ../static ../templates | $(GOFMT) > $@
 

--- a/web/templates/_base.html
+++ b/web/templates/_base.html
@@ -5,7 +5,7 @@
     <title>Prometheus Time Series Collection and Processing Server</title>
     <script src="/static/vendor/js/jquery.min.js"></script>
 
-    <link type="text/css" rel="stylesheet" href="/static/vendor/bootstrap-3.3.1/css/bootstrap.css">
+    <link type="text/css" rel="stylesheet" href="/static/vendor/bootstrap-3.3.1/css/bootstrap.min.css">
     <link type="text/css" rel="stylesheet" href="/static/css/prometheus.css">
 
     {{template "head" .}}


### PR DESCRIPTION
- Use only the minified versions of bootstrap.

- Do not embed non-minified bootstrap files and bootstrap map files.

- Simplify the 'blob-stamp' Makefile contraption.

@juliusv @stuartnelson3 