### PR TITLE
Fix Go download path for i686 architecture.

### DIFF
--- a/Makefile.INCLUDE
+++ b/Makefile.INCLUDE
@@ -27,7 +27,7 @@ MAC_OS_X_VERSION ?= 10.8
 BUILD_PATH = $(PWD)/.build
 
 GO_VERSION	 := 1.4
-GOOS		  = $(subst Darwin,darwin,$(subst Linux,linux,$(OS)))
+GOOS		  = $(subst Darwin,darwin,$(subst Linux,linux,$(subst FreeBSD,freebsd,$(OS))))
 
 ifeq ($(GOOS),darwin)
 RELEASE_SUFFIX ?= -osx$(MAC_OS_X_VERSION)

--- a/Makefile.INCLUDE
+++ b/Makefile.INCLUDE
@@ -38,7 +38,7 @@ endif
 # Never honor GOBIN, should it be set at all.
 unexport GOBIN
 
-GOARCH		  = $(subst x86_64,amd64,$(ARCH))
+GOARCH		  = $(subst x86_64,amd64,$(patsubst i%86,386,$(ARCH)))
 GOPKG		 ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
 GOURL		 ?= https://golang.org/dl
 GOROOT		  = $(BUILD_PATH)/root/go


### PR DESCRIPTION
At least this should fix builds for i686 - there might be others over time that we need substitutions for.

This fixes https://github.com/prometheus/prometheus/issues/503