### PR TITLE
Fix graph redraw upon stacked -> line switch.

### DIFF
--- a/web/static/js/graph.js
+++ b/web/static/js/graph.js
@@ -119,7 +119,7 @@ Prometheus.Graph.prototype.initialize = function() {
   self.stackedBtn.click(function() {
     self.stacked.val(self.isStacked() ? '0' : '1');
     styleStackBtn();
-    self.updateGraph();
+    self.updateGraph(true);
   });
 
   self.queryForm.submit(function() {


### PR DESCRIPTION
Currently the graph is not completely redrawn when switching from
stacked to line graph, resulting in the Y-axis being way too large for
the non-stacked data. This fixes that.