### PR TITLE
Fix graph JS glitches and simplify graphing code.

### DIFF
--- a/web/static/js/graph_template.handlebar
+++ b/web/static/js/graph_template.handlebar
@@ -109,10 +109,7 @@
                         </div>
                       </div>
 
-                      <div class="graph_area">
-                        <div class="y_axis"></div>
-                        <div class="graph"></div>
-                      </div>
+                      <div class="graph_area"></div>
                       <div class="legend"></div>
                     </div>
                     <div role="tabpanel" class="tab-pane active console reload" id="console{{id}}">


### PR DESCRIPTION
- original series data is saved so it can be re-transformed after
  Rickshaw's stacking modified the series data

- always reconstruct graphs from scratch instead of updating the
  settings of an existing one (simplification)

- always wipe and recreate all graph-related DOM elements completely so
  that no left-over event handlers cause background event handlers