### PR TITLE
Update base packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM       golang:1.4
 MAINTAINER The Prometheus Authors <prometheus-developers@googlegroups.com>
-RUN        apt-get -qy update && apt-get -qy install vim-common gcc mercurial && apt-get clean && \
-           go get github.com/tools/godep
+RUN        apt-get -qy update && apt-get -qq upgrade && apt-get -qy install vim-common gcc mercurial \
+           && apt-get clean && go get github.com/tools/godep
 
 WORKDIR    /go/src/github.com/prometheus/prometheus
 ADD        . /go/src/github.com/prometheus/prometheus


### PR DESCRIPTION
I noticed when building this that it pulled in an insecure version of OpenSSL - It's important to make sure that such packages are kept up to date so adding an apt-get upgrade at the start of the dockerfile will prevent this.

Similar to https://github.com/prometheus/promdash/pull/331