### PR TITLE
Improve performance of ingestion.

### DIFF
--- a/main.go
+++ b/main.go
@@ -218,11 +218,9 @@ func (p *prometheus) Serve() {
 	}()
 
 	for samples := range p.unwrittenSamples {
-		if len(samples) > 0 {
-			p.storage.AppendSamples(samples)
-			if p.remoteTSDBQueue != nil {
-				p.remoteTSDBQueue.Queue(samples)
-			}
+		p.storage.AppendSamples(samples)
+		if p.remoteTSDBQueue != nil {
+			p.remoteTSDBQueue.Queue(samples)
 		}
 	}
 

--- a/storage/local/crashrecovery.go
+++ b/storage/local/crashrecovery.go
@@ -16,7 +16,6 @@ package local
 import (
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"path"
 	"strings"
@@ -342,7 +341,7 @@ func (p *persistence) cleanUpArchiveIndexes(
 		if err := kv.Value(&m); err != nil {
 			return err
 		}
-		series := newMemorySeries(clientmodel.Metric(m), false, math.MinInt64)
+		series := newMemorySeries(clientmodel.Metric(m), false, clientmodel.Earliest)
 		cds, err := p.loadChunkDescs(clientmodel.Fingerprint(fp), clientmodel.Now())
 		if err != nil {
 			return err

--- a/storage/local/interface.go
+++ b/storage/local/interface.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Storage ingests and manages samples, along with various indexes. All methods
-// are goroutine-safe.
+// except AppendSamples are goroutine-safe.
 type Storage interface {
 	prometheus.Collector
 	// AppendSamples stores a group of new samples. Multiple samples for the
@@ -32,7 +32,7 @@ type Storage interface {
 	// oldest to newest (both in the same call to AppendSamples and across
 	// multiple calls).  When AppendSamples has returned, the appended
 	// samples might not be queryable immediately. (Use WaitForIndexing to
-	// wait for complete processing.)
+	// wait for complete processing.) This method is not goroutine-safe.
 	AppendSamples(clientmodel.Samples)
 	// NewPreloader returns a new Preloader which allows preloading and pinning
 	// series data into memory for use within a query.

--- a/storage/local/interface.go
+++ b/storage/local/interface.go
@@ -27,9 +27,12 @@ import (
 // are goroutine-safe.
 type Storage interface {
 	prometheus.Collector
-	// AppendSamples stores a group of new samples. Multiple samples for the same
-	// fingerprint need to be submitted in chronological order, from oldest to
-	// newest (both in the same call to AppendSamples and across multiple calls).
+	// AppendSamples stores a group of new samples. Multiple samples for the
+	// same fingerprint need to be submitted in chronological order, from
+	// oldest to newest (both in the same call to AppendSamples and across
+	// multiple calls).  When AppendSamples has returned, the appended
+	// samples might not be queryable immediately. (Use WaitForIndexing to
+	// wait for complete processing.)
 	AppendSamples(clientmodel.Samples)
 	// NewPreloader returns a new Preloader which allows preloading and pinning
 	// series data into memory for use within a query.

--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -84,7 +84,7 @@ type indexingOp struct {
 
 // A Persistence is used by a Storage implementation to store samples
 // persistently across restarts. The methods are only goroutine-safe if
-// explicitly marked as such below. The chunk-related methods PersistChunk,
+// explicitly marked as such below. The chunk-related methods persistChunk,
 // dropChunks, loadChunks, and loadChunkDescs can be called concurrently with
 // each other if each call refers to a different fingerprint.
 type persistence struct {

--- a/storage/local/series.go
+++ b/storage/local/series.go
@@ -14,7 +14,6 @@
 package local
 
 import (
-	"math"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -169,7 +168,7 @@ type memorySeries struct {
 // will be set properly upon the first eviction of chunkDescs).
 func newMemorySeries(m clientmodel.Metric, reallyNew bool, firstTime clientmodel.Timestamp) *memorySeries {
 	if reallyNew {
-		firstTime = math.MinInt64
+		firstTime = clientmodel.Earliest
 	}
 	s := memorySeries{
 		metric:             m,
@@ -337,7 +336,7 @@ func (s *memorySeries) preloadChunksForRange(
 	from clientmodel.Timestamp, through clientmodel.Timestamp,
 	fp clientmodel.Fingerprint, mss *memorySeriesStorage,
 ) ([]*chunkDesc, error) {
-	firstChunkDescTime := clientmodel.Timestamp(math.MaxInt64)
+	firstChunkDescTime := clientmodel.Latest
 	if len(s.chunkDescs) > 0 {
 		firstChunkDescTime = s.chunkDescs[0].firstTime()
 	}

--- a/storage/local/storage_test.go
+++ b/storage/local/storage_test.go
@@ -70,6 +70,7 @@ func TestChunk(t *testing.T) {
 	defer closer.Close()
 
 	s.AppendSamples(samples)
+	s.WaitForIndexing()
 
 	for m := range s.(*memorySeriesStorage).fpToSeries.iter() {
 		s.(*memorySeriesStorage).fpLocker.Lock(m.fp)
@@ -109,6 +110,7 @@ func TestGetValueAtTime(t *testing.T) {
 	defer closer.Close()
 
 	s.AppendSamples(samples)
+	s.WaitForIndexing()
 
 	fp := clientmodel.Metric{}.Fingerprint()
 
@@ -191,6 +193,7 @@ func TestGetRangeValues(t *testing.T) {
 	defer closer.Close()
 
 	s.AppendSamples(samples)
+	s.WaitForIndexing()
 
 	fp := clientmodel.Metric{}.Fingerprint()
 
@@ -334,6 +337,7 @@ func TestEvictAndPurgeSeries(t *testing.T) {
 	ms := s.(*memorySeriesStorage) // Going to test the internal purgeSeries method.
 
 	s.AppendSamples(samples)
+	s.WaitForIndexing()
 
 	fp := clientmodel.Metric{}.Fingerprint()
 
@@ -368,6 +372,7 @@ func TestEvictAndPurgeSeries(t *testing.T) {
 
 	// Recreate series.
 	s.AppendSamples(samples)
+	s.WaitForIndexing()
 
 	series, ok := ms.fpToSeries.get(fp)
 	if !ok {
@@ -450,6 +455,7 @@ func TestFuzz(t *testing.T) {
 
 		samples := createRandomSamples()
 		s.AppendSamples(samples)
+		s.WaitForIndexing()
 
 		return verifyStorage(t, s, samples, 24*7*time.Hour)
 	}

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -115,6 +115,9 @@ func NewTSDBQueueManager(tsdb TSDBClient, queueCapacity int) *TSDBQueueManager {
 // Queue queues a sample batch to be sent to the TSDB. It drops the most
 // recently queued samples on the floor if the queue is full.
 func (t *TSDBQueueManager) Queue(s clientmodel.Samples) {
+	if len(s) == 0 {
+		return
+	}
 	select {
 	case t.queue <- s:
 	default:


### PR DESCRIPTION
@juliusv Last of my tweaks based on investigating my aging personal server.
With the changes below, it's now very easy to drive it to the disk limit. Sadly, it needs on average about 20ms per chunk write. With 8.9ms specified seek rate of my disks, I was hoping for a bit better. So the above 20k/sec is still the limit (with the artifical test targets).

- Parallelize AppendSamples as much as possible without breaking the
  contract about temporal order.

- Allocate more fingerprint locker slots.

- Do not run early checkpoints if we are behind on chunk persistence.

- Increase fpMinWaitDuration to give the disk more time for more
  important things.

Also, switch math.MaxInt64 and math.MinInt64 to the new constants.