### PR TITLE
Dramatically decrease resources for file embedding.

### DIFF
--- a/utility/embed-static.sh
+++ b/utility/embed-static.sh
@@ -21,9 +21,9 @@ do
   find . -type f \! -name \*.map \! -name bootstrap.js \! -name bootstrap-theme.css \! -name bootstrap.css | while read file
   do
     name=$(echo "${file}"|sed 's|\.\/||')
-    echo "\"$name\": {"
-    gzip -9 -c "${file}" | xxd -p |sed 's/\(..\)/0x\1, /g'
-    echo "},"
+    echo -n "\"$name\": []byte(\""
+    gzip -9 -c "${file}" | xxd -p | tr -d '\n' | sed 's/\(..\)/\\x\1/g'
+    echo "\"),"
     echo
   done
   echo "},"


### PR DESCRIPTION
This dramatically decreases the needed time and memory for building the
embedded blob files. The memory numbers are measured via the
memory.max_usage_in_bytes value from cgroups.

* generating files.go:
OLD: 466MB   19s
NEW:  80MB    1s

* building files.go:
OLD: 1210MB  2.25s
NEW:    7MB  0.05s