### PR TITLE
initial service discovery extension

### DIFF
--- a/config/config.proto
+++ b/config/config.proto
@@ -48,9 +48,24 @@ message TargetGroup {
 	optional LabelPairs labels = 2;
 }
 
+// Information about the service discovery.
+message ServiceDiscovery {
+	// The name by which the service information can be found for
+	// the specified discovery service.
+	required string name = 1;
+	// The type of discovery to be used.
+	required string type = 2;
+	// Path to a configuration file that is used for setting up
+	// the discovery.
+	optional string config_file = 3;
+	// Discovery refresh period when using DNS-SD to discover targets. Must be a
+	// valid Prometheus duration string in the form "[0-9]+[smhdwy]".
+	optional string refresh_interval = 4 [default = "30s"];
+}
+
 // The configuration for a Prometheus job to scrape.
 //
-// The next field no. is 8.
+// The next field no. is 7.
 message JobConfig {
 	// The job name. Must adhere to the regex "[a-zA-Z_][a-zA-Z0-9_-]*".
 	required string name = 1;
@@ -60,14 +75,10 @@ message JobConfig {
 	optional string scrape_interval = 2;
 	// Per-target timeout when scraping this job. Must be a valid Prometheus
 	// duration string in the form "[0-9]+[smhdwy]".
-	optional string scrape_timeout = 7 [default = "10s"];
-	// The DNS-SD service name pointing to SRV records containing endpoint
-	// information for a job. When this field is provided, no target_group
-	// elements may be set.
-	optional string sd_name = 3;
-	// Discovery refresh period when using DNS-SD to discover targets. Must be a
-	// valid Prometheus duration string in the form "[0-9]+[smhdwy]".
-	optional string sd_refresh_interval = 4 [default = "30s"];
+	optional string scrape_timeout = 3 [default = "10s"];
+	// The service discovery information for a job.
+	// When this field is provided, no target_group elements may be set.
+	optional ServiceDiscovery service_discovery = 4;
 	// List of labeled target groups for this job. Only legal when DNS-SD isn't
 	// used for a job.
 	repeated TargetGroup target_group = 5;

--- a/config/generated/config.pb.go
+++ b/config/generated/config.pb.go
@@ -13,6 +13,7 @@ It has these top-level messages:
 	LabelPairs
 	GlobalConfig
 	TargetGroup
+	ServiceDiscovery
 	JobConfig
 	PrometheusConfig
 */
@@ -146,9 +147,59 @@ func (m *TargetGroup) GetLabels() *LabelPairs {
 	return nil
 }
 
+// Information about the service discovery.
+type ServiceDiscovery struct {
+	// The name by which the service information can be found for
+	// the specified discovery service.
+	Name *string `protobuf:"bytes,1,req,name=name" json:"name,omitempty"`
+	// The type of discovery to be used.
+	Type *string `protobuf:"bytes,2,req,name=type" json:"type,omitempty"`
+	// Path to a configuration file that is used for setting up
+	// the discovery.
+	ConfigFile *string `protobuf:"bytes,3,opt,name=config_file" json:"config_file,omitempty"`
+	// Discovery refresh period when using DNS-SD to discover targets. Must be a
+	// valid Prometheus duration string in the form "[0-9]+[smhdwy]".
+	RefreshInterval  *string `protobuf:"bytes,4,opt,name=refresh_interval,def=30s" json:"refresh_interval,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *ServiceDiscovery) Reset()         { *m = ServiceDiscovery{} }
+func (m *ServiceDiscovery) String() string { return proto.CompactTextString(m) }
+func (*ServiceDiscovery) ProtoMessage()    {}
+
+const Default_ServiceDiscovery_RefreshInterval string = "30s"
+
+func (m *ServiceDiscovery) GetName() string {
+	if m != nil && m.Name != nil {
+		return *m.Name
+	}
+	return ""
+}
+
+func (m *ServiceDiscovery) GetType() string {
+	if m != nil && m.Type != nil {
+		return *m.Type
+	}
+	return ""
+}
+
+func (m *ServiceDiscovery) GetConfigFile() string {
+	if m != nil && m.ConfigFile != nil {
+		return *m.ConfigFile
+	}
+	return ""
+}
+
+func (m *ServiceDiscovery) GetRefreshInterval() string {
+	if m != nil && m.RefreshInterval != nil {
+		return *m.RefreshInterval
+	}
+	return Default_ServiceDiscovery_RefreshInterval
+}
+
 // The configuration for a Prometheus job to scrape.
 //
-// The next field no. is 8.
+// The next field no. is 7.
 type JobConfig struct {
 	// The job name. Must adhere to the regex "[a-zA-Z_][a-zA-Z0-9_-]*".
 	Name *string `protobuf:"bytes,1,req,name=name" json:"name,omitempty"`
@@ -158,14 +209,10 @@ type JobConfig struct {
 	ScrapeInterval *string `protobuf:"bytes,2,opt,name=scrape_interval" json:"scrape_interval,omitempty"`
 	// Per-target timeout when scraping this job. Must be a valid Prometheus
 	// duration string in the form "[0-9]+[smhdwy]".
-	ScrapeTimeout *string `protobuf:"bytes,7,opt,name=scrape_timeout,def=10s" json:"scrape_timeout,omitempty"`
-	// The DNS-SD service name pointing to SRV records containing endpoint
-	// information for a job. When this field is provided, no target_group
-	// elements may be set.
-	SdName *string `protobuf:"bytes,3,opt,name=sd_name" json:"sd_name,omitempty"`
-	// Discovery refresh period when using DNS-SD to discover targets. Must be a
-	// valid Prometheus duration string in the form "[0-9]+[smhdwy]".
-	SdRefreshInterval *string `protobuf:"bytes,4,opt,name=sd_refresh_interval,def=30s" json:"sd_refresh_interval,omitempty"`
+	ScrapeTimeout *string `protobuf:"bytes,3,opt,name=scrape_timeout,def=10s" json:"scrape_timeout,omitempty"`
+	// The service discovery information for a job.
+	// When this field is provided, no target_group elements may be set.
+	ServiceDiscovery *ServiceDiscovery `protobuf:"bytes,4,opt,name=service_discovery" json:"service_discovery,omitempty"`
 	// List of labeled target groups for this job. Only legal when DNS-SD isn't
 	// used for a job.
 	TargetGroup []*TargetGroup `protobuf:"bytes,5,rep,name=target_group" json:"target_group,omitempty"`
@@ -179,7 +226,6 @@ func (m *JobConfig) String() string { return proto.CompactTextString(m) }
 func (*JobConfig) ProtoMessage()    {}
 
 const Default_JobConfig_ScrapeTimeout string = "10s"
-const Default_JobConfig_SdRefreshInterval string = "30s"
 const Default_JobConfig_MetricsPath string = "/metrics"
 
 func (m *JobConfig) GetName() string {
@@ -203,18 +249,11 @@ func (m *JobConfig) GetScrapeTimeout() string {
 	return Default_JobConfig_ScrapeTimeout
 }
 
-func (m *JobConfig) GetSdName() string {
-	if m != nil && m.SdName != nil {
-		return *m.SdName
+func (m *JobConfig) GetServiceDiscovery() *ServiceDiscovery {
+	if m != nil {
+		return m.ServiceDiscovery
 	}
-	return ""
-}
-
-func (m *JobConfig) GetSdRefreshInterval() string {
-	if m != nil && m.SdRefreshInterval != nil {
-		return *m.SdRefreshInterval
-	}
-	return Default_JobConfig_SdRefreshInterval
+	return nil
 }
 
 func (m *JobConfig) GetTargetGroup() []*TargetGroup {

--- a/retrieval/target_provider.go
+++ b/retrieval/target_provider.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-etcd/etcd"
 	"github.com/golang/glog"
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,29 +28,37 @@ import (
 	clientmodel "github.com/prometheus/client_golang/model"
 
 	"github.com/prometheus/prometheus/config"
-	"github.com/prometheus/prometheus/utility"
 )
 
-const resolvConf = "/etc/resolv.conf"
+const (
+	sdTypeDNS  = "dns"
+	sdTypeEtcd = "etcd"
+
+	defaultResolvConf = "/etcd/resolv.conf"
+)
 
 var (
-	dnsSDLookupsCount = prometheus.NewCounter(
+	sdLookupsCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,
-			Name:      "dns_sd_lookups_total",
-			Help:      "The number of DNS-SD lookups.",
-		})
-	dnsSDLookupFailuresCount = prometheus.NewCounter(
+			Name:      "sd_lookups_total",
+			Help:      "The number of SD lookups.",
+		},
+		[]string{"type"},
+	)
+	sdLookupFailuresCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,
-			Name:      "dns_sd_lookup_failures_total",
-			Help:      "The number of DNS-SD lookup failures.",
-		})
+			Name:      "sd_lookup_failures_total",
+			Help:      "The number of SD lookup failures.",
+		},
+		[]string{"type"},
+	)
 )
 
 func init() {
-	prometheus.MustRegister(dnsSDLookupFailuresCount)
-	prometheus.MustRegister(dnsSDLookupsCount)
+	prometheus.MustRegister(sdLookupFailuresCount)
+	prometheus.MustRegister(sdLookupsCount)
 }
 
 // TargetProvider encapsulates retrieving all targets for a job.
@@ -58,6 +67,8 @@ type TargetProvider interface {
 	Targets() ([]Target, error)
 }
 
+// sdTargetProvider provides target information based on and underlying
+// TargetDiscovery from which it fetches and caches the targets.
 type sdTargetProvider struct {
 	job config.JobConfig
 
@@ -67,46 +78,79 @@ type sdTargetProvider struct {
 	refreshInterval time.Duration
 }
 
-// NewSdTargetProvider constructs a new sdTargetProvider for a job.
-func NewSdTargetProvider(job config.JobConfig) *sdTargetProvider {
-	i, err := utility.StringToDuration(job.GetSdRefreshInterval())
-	if err != nil {
-		panic(fmt.Sprintf("illegal refresh duration string %s: %s", job.GetSdRefreshInterval(), err))
-	}
+// NewSDTargetProvider constructs a new sdTargetProvider for a job.
+func NewSDTargetProvider(job config.JobConfig) TargetProvider {
 	return &sdTargetProvider{
 		job:             job,
-		refreshInterval: i,
+		refreshInterval: job.ServiceDiscoveryConfig().RefreshInterval(),
 	}
 }
 
-func (p *sdTargetProvider) Targets() ([]Target, error) {
-	var err error
+// Targets implements TargetPrvovider.
+func (p *sdTargetProvider) Targets() (targets []Target, err error) {
+	sd := p.job.ServiceDiscoveryConfig()
+	discoveryType := sd.GetType()
+
 	defer func() {
-		dnsSDLookupsCount.Inc()
+		sdLookupsCount.WithLabelValues(discoveryType).Inc()
 		if err != nil {
-			dnsSDLookupFailuresCount.Inc()
+			sdLookupFailuresCount.WithLabelValues(discoveryType).Inc()
 		}
 	}()
 
 	if time.Since(p.lastRefresh) < p.refreshInterval {
 		return p.targets, nil
 	}
+	baseLabels := clientmodel.LabelSet{
+		clientmodel.JobLabel: clientmodel.LabelValue(p.job.GetName()),
+	}
+	endpoint := &url.URL{
+		Scheme: "http://",
+		Path:   p.job.GetMetricsPath(),
+	}
+	deadline := p.job.ScrapeTimeout()
 
-	response, err := lookupSRV(p.job.GetSdName())
+	var tp TargetProvider
 
+	switch discoveryType {
+	case sdTypeDNS:
+		tp = &dnsTargetProvider{sd, endpoint, baseLabels, deadline}
+
+	case sdTypeEtcd:
+		tp = &etcdTargetProvider{sd, endpoint, baseLabels, deadline}
+
+	default:
+		return nil, fmt.Errorf("unknown discovery type %s", discoveryType)
+	}
+	targets, err = tp.Targets()
+	if err != nil {
+		return nil, fmt.Errorf("SD provider: error retrieving targets via %s: %s", discoveryType, err)
+	}
+
+	p.targets = targets
+	return targets, nil
+}
+
+// dnsTargetProvider provides target information from DNS.
+type dnsTargetProvider struct {
+	srv        config.ServiceDiscoveryConfig
+	endpoint   *url.URL
+	baseLabels clientmodel.LabelSet
+	deadline   time.Duration
+}
+
+// Targets implements the TargetProvider interface.
+func (tp *dnsTargetProvider) Targets() ([]Target, error) {
+	cfgFile := tp.srv.GetConfigFile()
+	if cfgFile == "" {
+		cfgFile = defaultResolvConf
+	}
+	response, err := dnsLoopkupSRV(cfgFile, tp.srv.GetName())
 	if err != nil {
 		return nil, err
 	}
 
-	baseLabels := clientmodel.LabelSet{
-		clientmodel.JobLabel: clientmodel.LabelValue(p.job.GetName()),
-	}
-
 	targets := make([]Target, 0, len(response.Answer))
-	endpoint := &url.URL{
-		Scheme: "http",
-		Path:   p.job.GetMetricsPath(),
-	}
 	for _, record := range response.Answer {
 		addr, ok := record.(*dns.SRV)
 		if !ok {
@@ -117,19 +161,77 @@ func (p *sdTargetProvider) Targets() ([]Target, error) {
 		if addr.Target[len(addr.Target)-1] == '.' {
 			addr.Target = addr.Target[:len(addr.Target)-1]
 		}
-		endpoint.Host = fmt.Sprintf("%s:%d", addr.Target, addr.Port)
-		t := NewTarget(endpoint.String(), p.job.ScrapeTimeout(), baseLabels)
+		tp.endpoint.Host = fmt.Sprintf("%s:%d", addr.Target, addr.Port)
+		t := NewTarget(tp.endpoint.String(), tp.deadline, tp.baseLabels)
 		targets = append(targets, t)
 	}
+	return targets, err
+}
 
-	p.targets = targets
+// etcdTargetProvider provides target information from the etcd key-value store
+// based on a provided config file.
+type etcdTargetProvider struct {
+	srv        config.ServiceDiscoveryConfig
+	endpoint   *url.URL
+	baseLabels clientmodel.LabelSet
+	deadline   time.Duration
+}
+
+// Targets implements the TargetProvider interface.
+func (tp *etcdTargetProvider) Targets() ([]Target, error) {
+	cfgFile := tp.srv.GetConfigFile()
+	if cfgFile == "" {
+		return nil, fmt.Errorf("missing config file for etcd service discovery")
+	}
+	c, err := etcd.NewClientFromFile(cfgFile)
+	if err != nil {
+		return nil, fmt.Errorf("etcd discovery: error creating client: %s", err)
+	}
+	resp, err := c.Get(tp.srv.GetName(), true, true)
+	if err != nil {
+		return nil, fmt.Errorf("etcd discovery: error on get request: %s", err)
+	}
+	// we expect the service information to be located in the node itself
+	// or on the first level below.
+	urls := make([]string, 0)
+	if !resp.Node.Dir {
+		urls = append(urls, resp.Node.Value)
+	} else {
+		for _, node := range resp.Node.Nodes {
+			if node.Dir {
+				glog.Warningf("etcd discovery: node %s is a directory, should be service entry", node.Key)
+				continue
+			}
+			urls = append(urls, node.Value)
+		}
+	}
+
+	targets := make([]Target, 0, len(urls))
+	for _, u := range urls {
+		// use provided endpoint as a template to fill
+		// information not provided by the etcd entry.
+
+		// missing scheme causes different behaviour for IPs and hostnames, add here if missing
+		if strings.Index(u, "://") == -1 {
+			u = tp.endpoint.Scheme + u
+		}
+		pu, err := url.Parse(u)
+		if err != nil {
+			glog.Warningf("etcd discovery: %s is not a valid URL: %s", u, err)
+			continue
+		}
+		if pu.Path == "" {
+			pu.Path = tp.endpoint.Path
+		}
+		targets = append(targets, NewTarget(pu.String(), tp.deadline, tp.baseLabels))
+	}
 	return targets, nil
 }
 
-func lookupSRV(name string) (*dns.Msg, error) {
-	conf, err := dns.ClientConfigFromFile(resolvConf)
+func dnsLoopkupSRV(cfgFile, name string) (*dns.Msg, error) {
+	conf, err := dns.ClientConfigFromFile(cfgFile)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't load resolv.conf: %s", err)
+		return nil, fmt.Errorf("couldn't load %s: %s", cfgFile, err)
 	}
 
 	client := &dns.Client{}
@@ -138,7 +240,7 @@ func lookupSRV(name string) (*dns.Msg, error) {
 	for _, server := range conf.Servers {
 		servAddr := net.JoinHostPort(server, conf.Port)
 		for _, suffix := range conf.Search {
-			response, err = lookup(name, dns.TypeSRV, client, servAddr, suffix, false)
+			response, err = dnsLookup(name, dns.TypeSRV, client, servAddr, suffix, false)
 			if err == nil {
 				if len(response.Answer) > 0 {
 					return response, nil
@@ -147,15 +249,15 @@ func lookupSRV(name string) (*dns.Msg, error) {
 				glog.Warningf("resolving %s.%s failed: %s", name, suffix, err)
 			}
 		}
-		response, err = lookup(name, dns.TypeSRV, client, servAddr, "", false)
+		response, err = dnsLookup(name, dns.TypeSRV, client, servAddr, "", false)
 		if err == nil {
-			return response, nil
+			return response, err
 		}
 	}
-	return response, fmt.Errorf("couldn't resolve %s: No server responded", name)
+	return nil, fmt.Errorf("couldn't resolve %s: No server responded", name)
 }
 
-func lookup(name string, queryType uint16, client *dns.Client, servAddr string, suffix string, edns bool) (*dns.Msg, error) {
+func dnsLookup(name string, queryType uint16, client *dns.Client, servAddr string, suffix string, edns bool) (*dns.Msg, error) {
 	msg := &dns.Msg{}
 	lname := strings.Join([]string{name, suffix}, ".")
 	msg.SetQuestion(dns.Fqdn(lname), queryType)
@@ -179,17 +281,14 @@ func lookup(name string, queryType uint16, client *dns.Client, servAddr string, 
 	if msg.Id != response.Id {
 		return nil, fmt.Errorf("DNS ID mismatch, request: %d, response: %d", msg.Id, response.Id)
 	}
-
 	if response.MsgHdr.Truncated {
 		if client.Net == "tcp" {
 			return nil, fmt.Errorf("got truncated message on tcp")
 		}
-
 		if edns { // Truncated even though EDNS is used
 			client.Net = "tcp"
 		}
-
-		return lookup(name, queryType, client, servAddr, suffix, !edns)
+		return dnsLookup(name, queryType, client, servAddr, suffix, !edns)
 	}
 
 	return response, nil

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -53,8 +53,8 @@ func (m *targetManager) targetPoolForJob(job config.JobConfig) *TargetPool {
 
 	if !ok {
 		var provider TargetProvider
-		if job.SdName != nil {
-			provider = NewSdTargetProvider(job)
+		if job.ServiceDiscovery != nil {
+			provider = NewSDTargetProvider(job)
 		}
 
 		interval := job.ScrapeInterval()
@@ -91,7 +91,7 @@ func (m *targetManager) Remove(t Target) {
 
 func (m *targetManager) AddTargetsFromConfig(config config.Config) {
 	for _, job := range config.Jobs() {
-		if job.SdName != nil {
+		if job.ServiceDiscovery != nil {
 			m.Lock()
 			m.targetPoolForJob(job)
 			m.Unlock()


### PR DESCRIPTION
This is basically working (minus tests) but not meant to be a finished PR. Just a base for discussion.
Prometheus should be able to integrate with different discovery services, which requires some external changes.

- Counters: changing prometheus' internal counters should be straightforward
- Config: I think my general idea is easy to understand. Being able to provide a list of servers instead of a config filepath is probably more reasonable for ZK, consul and etcd, though.
Integrating consul and ZK as well should be straightforward.

The roadmap mentions a possible plugin system for discovery. Are there any existing ideas. Providing a generic target provider which queries a set of urls for lists of targets (in some predefined formats) would be straightforward.

Thoughts?