### PR TITLE
Proof of concept for federation via console templates.

### DIFF
--- a/consoles/federation_template_example.txt
+++ b/consoles/federation_template_example.txt
@@ -1,0 +1,3 @@
+{{/* Adjust the query below to select the samples to expose. */}}
+{{ range query "{__name__=~'^job:.*'}" }}
+{{ .Labels.__name__ }}{{ "{" }}{{ range $k, $v := .Labels }}{{ if ne "__name__" $k }}{{ $k }}="{{ $v | reReplaceAll "([\\\\\"])" "\\$1" | reReplaceAll "\n" "\\n"| safeHtml }}",{{ end }}{{ end }}{{ "}" }} {{ print .Value | safeHtml }}{{ end }}


### PR DESCRIPTION
This exposes samples via the console templates in the
text exposition format, which the parser will fall back to.

This is not a proper federation solution, but should tide us
over for now. Extenions could include passing in a query or queries in
the url parameters.