### PR TITLE
Makefile: Calculate $(GOROOT), etc. relative to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ config:
 	$(MAKE) -C config
 
 $(SELFLINK): $(GOPATH)
-	ln -s $(CURDIR) $@
+	ln -s $(MAKEFILE_DIR) $@
 
 $(GOPATH):
-	cp -a $(CURDIR)/Godeps/_workspace $(GOPATH)
+	cp -a $(MAKEFILE_DIR)/Godeps/_workspace $(GOPATH)
 
 dependencies: $(GOCC) | $(SELFLINK)
 

--- a/Makefile.INCLUDE
+++ b/Makefile.INCLUDE
@@ -24,7 +24,9 @@ ARCH=$(shell uname -m)
 # Mac OS X release family.
 MAC_OS_X_VERSION ?= 10.8
 
-BUILD_PATH = $(PWD)/.build
+MAKEFILE_DIR ?= $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
+
+BUILD_PATH = $(MAKEFILE_DIR)/.build
 
 GO_VERSION := 1.4
 GOOS = $(subst Darwin,darwin,$(subst Linux,linux,$(subst FreeBSD,freebsd,$(OS))))


### PR DESCRIPTION
Same commit as [this one for alertmanager](https://github.com/prometheus/alertmanager/pull/36), also applies here.

When building a Debian package with `debuild`, which uses fakeroot, Make doesn't have `$(PWD)` for some reason. Apparently this is a shell-dependent thing. For that reason, the `touch` command gets the wrong path in `$@`:

```
curl -o .deps/go1.4.1.linux-amd64.tar.gz -L https://golang.org/dl/go1.4.1.linux-amd64.tar.gz
tar -C .deps -xzf .deps/go1.4.1.linux-amd64.tar.gz
touch /.deps/go/bin/go
touch: cannot touch ‘/.deps/go/bin/go’: No such file or directory
make[1]: *** [/.deps/go/bin/go] Error 1
```

This uses the initial location of the first makefile to calculate relative paths.
