### PR TITLE
Fix the embarrassing bug introduced in commit 0851945.

### DIFF
--- a/storage/local/crashrecovery.go
+++ b/storage/local/crashrecovery.go
@@ -78,8 +78,8 @@ func (p *persistence) recoverFromCrash(fingerprintToSeries map[clientmodel.Finge
 				// Oops, head chunk was persisted, but nothing on disk.
 				// Thus, we lost that series completely. Clean up the remnants.
 				delete(fingerprintToSeries, fp)
-				if err := p.dropArchivedMetric(fp); err != nil {
-					// Dropping the archived metric didn't work, so try
+				if err := p.purgeArchivedMetric(fp); err != nil {
+					// Purging the archived metric didn't work, so try
 					// to unindex it, just in case it's in the indexes.
 					p.unindexMetric(fp, s.metric)
 				}

--- a/storage/local/instrumentation.go
+++ b/storage/local/instrumentation.go
@@ -67,7 +67,7 @@ const (
 	unpin           = "unpin" // Excluding the unpin on persisting.
 	clone           = "clone"
 	transcode       = "transcode"
-	purge           = "purge"
+	drop            = "drop"
 
 	// Op-types for chunkOps and chunkDescOps.
 	evict = "evict"

--- a/storage/local/persistence_test.go
+++ b/storage/local/persistence_test.go
@@ -349,11 +349,11 @@ func TestDropArchivedMetric(t *testing.T) {
 		t.Error("want FP 2 archived")
 	}
 
-	if err != p.dropArchivedMetric(1) {
+	if err != p.purgeArchivedMetric(1) {
 		t.Fatal(err)
 	}
-	if err != p.dropArchivedMetric(3) {
-		// Dropping something that has not beet archived is not an error.
+	if err != p.purgeArchivedMetric(3) {
+		// Purging something that has not beet archived is not an error.
 		t.Fatal(err)
 	}
 	p.waitForIndexing()

--- a/storage/local/series.go
+++ b/storage/local/series.go
@@ -242,11 +242,11 @@ func (s *memorySeries) evictChunkDescs(iOldestNotEvicted int) {
 	}
 }
 
-// purgeOlderThan removes chunkDescs older than t. It returns the number of
-// purged chunkDescs and true if all chunkDescs have been purged.
+// dropChunks removes chunkDescs older than t. It returns the number of dropped
+// chunkDescs and true if all chunkDescs have been dropped.
 //
 // The caller must have locked the fingerprint of the series.
-func (s *memorySeries) purgeOlderThan(t clientmodel.Timestamp) (int, bool) {
+func (s *memorySeries) dropChunks(t clientmodel.Timestamp) (int, bool) {
 	keepIdx := len(s.chunkDescs)
 	for i, cd := range s.chunkDescs {
 		if !cd.lastTime().Before(t) {


### PR DESCRIPTION
In that commit, the 'maintainSeries' call was accidentally removed.

This commit refactors things a bit so that there is now a clean
'maintainMemorySeries' and a 'maintainArchivedSeries' call.

Straighten the nomenclature a bit (consistently use 'drop' for
chunks and 'purge' for series/metrics).

Remove the annoying 'Completed maintenance sweep through archived
fingerprints' message if there were no archived fingerprints to do
maintenance on.

@juliusv 