### PR TITLE
Remove useless dependencies

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -19,16 +19,6 @@
 			"Rev": "b65f52f3f0dd1afa25cbbf63f8e7eb15fb5c0641"
 		},
 		{
-			"ImportPath": "github.com/prometheus/client_golang/_vendor/goautoneg",
-			"Comment": "0.2.0",
-			"Rev": "39e4bc83f974fb141a9e67c042b26322bacc917b"
-		},
-		{
-			"ImportPath": "github.com/prometheus/client_golang/_vendor/perks/quantile",
-			"Comment": "0.2.0",
-			"Rev": "39e4bc83f974fb141a9e67c042b26322bacc917b"
-		},
-		{
 			"ImportPath": "github.com/prometheus/client_golang/extraction",
 			"Comment": "0.2.0",
 			"Rev": "39e4bc83f974fb141a9e67c042b26322bacc917b"


### PR DESCRIPTION
goautoneg and perks/quantile are not needed anymore.
Without this patch, I get :
    src/prometheous $ docker build -t prometheus
    [...]
    Step 5 : RUN  godep restore && go get -d
     ---> Running in fdef00b2d873
    package github.com/prometheus/client_golang/_vendor/goautoneg
            imports github.com/prometheus/client_golang/_vendor/goautoneg
            imports github.com/prometheus/client_golang/_vendor/goautoneg: cannot find package
"github.com/prometheus/client_golang/_vendor/goautoneg" in any of:
            /usr/src/go/src/github.com/prometheus/client_golang/_vendor/goautoneg (from
$GOROOT)
            /go/src/github.com/prometheus/client_golang/_vendor/goautoneg (from $GOPATH)
    godep: restore: exit status 1
    package github.com/prometheus/client_golang/_vendor/perks/quantile
            imports github.com/prometheus/client_golang/_vendor/perks/quantile
            imports github.com/prometheus/client_golang/_vendor/perks/quantile: cannot find
package "github.com/prometheus/client_golang/_vendor/perks/quantile" in any of:
            /usr/src/go/src/github.com/prometheus/client_golang/_vendor/perks/quantile (from
$GOROOT)
            /go/src/github.com/prometheus/client_golang/_vendor/perks/quantile (from $GOPATH)
    godep: restore: exit status 1
    2015/02/26 15:45:28 The command [/bin/sh -c godep restore && go get -d] returned a non-zero
code: 1
