### PR TITLE
Rename UNREACHABLE to UNHEALTHY.

### DIFF
--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -72,26 +72,22 @@ func (t TargetState) String() string {
 	switch t {
 	case Unknown:
 		return "UNKNOWN"
-	case Alive:
-		return "ALIVE"
-	case Unreachable:
-		return "UNREACHABLE"
+	case Healthy:
+		return "HEALTHY"
+	case Unhealthy:
+		return "UNHEALTHY"
 	}
 
 	panic("unknown state")
 }
 
 const (
-	// Unknown is the state of a Target that has not been seen; we know
-	// nothing about it, except that it is on our docket for examination.
+	// Unknown is the state of a Target before it is first scraped.
 	Unknown TargetState = iota
-	// Alive is the state of a Target that has been found and successfully
-	// queried.
-	Alive
-	// Unreachable is the state of a Target that was either historically
-	// found or not found and then determined to be unhealthy by either not
-	// responding or disappearing.
-	Unreachable
+	// Healthy is the state of a Target that has been successfully scraped.
+	Healthy
+	// Unhealthy is the state of a Target that was scraped unsuccessfully.
+	Unhealthy
 )
 
 // A Target represents an endpoint that should be interrogated for metrics.
@@ -294,9 +290,9 @@ func (t *target) scrape(ingester extraction.Ingester) (err error) {
 	defer func(start time.Time) {
 		t.Lock() // Writing t.state and t.lastError requires the lock.
 		if err == nil {
-			t.state = Alive
+			t.state = Healthy
 		} else {
-			t.state = Unreachable
+			t.state = Unhealthy
 		}
 		t.lastError = err
 		t.Unlock()

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -61,8 +61,8 @@ func TestTargetScrapeUpdatesState(t *testing.T) {
 		httpClient: utility.NewDeadlineClient(0),
 	}
 	testTarget.scrape(nopIngester{})
-	if testTarget.state != Unreachable {
-		t.Errorf("Expected target state %v, actual: %v", Unreachable, testTarget.state)
+	if testTarget.state != Unhealthy {
+		t.Errorf("Expected target state %v, actual: %v", Unhealthy, testTarget.state)
 	}
 }
 
@@ -84,8 +84,8 @@ func TestTargetScrapeWithFullChannel(t *testing.T) {
 	).(*target)
 
 	testTarget.scrape(ChannelIngester(make(chan clientmodel.Samples))) // Capacity 0.
-	if testTarget.state != Unreachable {
-		t.Errorf("Expected target state %v, actual: %v", Unreachable, testTarget.state)
+	if testTarget.state != Unhealthy {
+		t.Errorf("Expected target state %v, actual: %v", Unhealthy, testTarget.state)
 	}
 	if testTarget.lastError != errIngestChannelFull {
 		t.Errorf("Expected target error %q, actual: %q", errIngestChannelFull, testTarget.lastError)

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -77,7 +77,7 @@ func (t fakeTarget) StopScraper() {
 }
 
 func (t fakeTarget) State() TargetState {
-	return Alive
+	return Healthy
 }
 
 func (t *fakeTarget) SetBaseLabelsFrom(newTarget Target) {}

--- a/retrieval/targetpool_test.go
+++ b/retrieval/targetpool_test.go
@@ -115,7 +115,7 @@ func TestTargetPoolReplaceTargets(t *testing.T) {
 	pool := NewTargetPool(nil, nil, nopIngester{}, time.Duration(1))
 	oldTarget1 := &target{
 		url:             "example1",
-		state:           Unreachable,
+		state:           Unhealthy,
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
 		newBaseLabels:   make(chan clientmodel.LabelSet, 1),
@@ -123,7 +123,7 @@ func TestTargetPoolReplaceTargets(t *testing.T) {
 	}
 	oldTarget2 := &target{
 		url:             "example2",
-		state:           Unreachable,
+		state:           Unhealthy,
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
 		newBaseLabels:   make(chan clientmodel.LabelSet, 1),
@@ -131,7 +131,7 @@ func TestTargetPoolReplaceTargets(t *testing.T) {
 	}
 	newTarget1 := &target{
 		url:             "example1",
-		state:           Alive,
+		state:           Healthy,
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
 		newBaseLabels:   make(chan clientmodel.LabelSet, 1),
@@ -139,7 +139,7 @@ func TestTargetPoolReplaceTargets(t *testing.T) {
 	}
 	newTarget2 := &target{
 		url:             "example3",
-		state:           Alive,
+		state:           Healthy,
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
 		newBaseLabels:   make(chan clientmodel.LabelSet, 1),


### PR DESCRIPTION
The current wording suggests that a target is not reachable at all,
although it might also get set when the target was reachable, but there
was some other error during the scrape (invalid headers or invalid
scrape content). UNHEALTHY is a more general wording that includes all
these cases.