### PR TITLE
Update vendored client_golang to 0.3.2.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -29,23 +29,23 @@
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/extraction",
-			"Comment": "0.3.1",
-			"Rev": "f688948916633c167d810a9548d4b775da43b0b0"
+			"Comment": "0.3.2",
+			"Rev": "1cf6d4b964951c63779ba7513c57fe389b609014"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/model",
-			"Comment": "0.3.1",
-			"Rev": "f688948916633c167d810a9548d4b775da43b0b0"
+			"Comment": "0.3.2",
+			"Rev": "1cf6d4b964951c63779ba7513c57fe389b609014"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/prometheus",
-			"Comment": "0.3.1",
-			"Rev": "f688948916633c167d810a9548d4b775da43b0b0"
+			"Comment": "0.3.2",
+			"Rev": "1cf6d4b964951c63779ba7513c57fe389b609014"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/text",
-			"Comment": "0.3.1",
-			"Rev": "f688948916633c167d810a9548d4b775da43b0b0"
+			"Comment": "0.3.2",
+			"Rev": "1cf6d4b964951c63779ba7513c57fe389b609014"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_model/go",

--- a/Godeps/_workspace/src/github.com/prometheus/client_golang/model/metric.go
+++ b/Godeps/_workspace/src/github.com/prometheus/client_golang/model/metric.go
@@ -101,7 +101,7 @@ type COWMetric struct {
 
 // Set sets a label name in the wrapped Metric to a given value and copies the
 // Metric initially, if it is not already a copy.
-func (m COWMetric) Set(ln LabelName, lv LabelValue) {
+func (m *COWMetric) Set(ln LabelName, lv LabelValue) {
 	m.doCOW()
 	m.Metric[ln] = lv
 }


### PR DESCRIPTION
For the Prometheus server, this fixes a bug where rules with a
right-hand-side that had a metric name would not correctly replace that
metric name with the left-hand side's rule name.