### PR TITLE
Add `sd_lookup_type` config option, to allow TCP or UDP

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ import (
 
 var jobNameRE = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_-]*$")
 var labelNameRE = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
+var sdLookupTypeRE = regexp.MustCompile("^(?:tcp|udp)$")
 
 // Config encapsulates the configuration of a Prometheus instance. It wraps the
 // raw configuration protocol buffer to be able to add custom methods to it.
@@ -96,6 +97,10 @@ func (c Config) Validate() error {
 		}
 		if job.SdName != nil && len(job.TargetGroup) > 0 {
 			return fmt.Errorf("specified both DNS-SD name and target group for job: %s", job.GetName())
+		}
+
+		if !sdLookupTypeRE.MatchString(job.GetSdLookupType()) {
+			return fmt.Errorf("invalid SD lookup type for job '%s': %s", job.GetName(), job.GetSdLookupType())
 		}
 	}
 

--- a/config/config.proto
+++ b/config/config.proto
@@ -73,6 +73,8 @@ message JobConfig {
 	repeated TargetGroup target_group = 5;
 	// The HTTP resource path to fetch metrics from on targets.
 	optional string metrics_path = 6 [default = "/metrics"];
+	// Should DNS lookups for SD use UDP (Default) or TCP?
+	optional string sd_lookup_type = 8 [default = "udp"];
 }
 
 // The top-level Prometheus configuration.

--- a/config/generated/config.pb.go
+++ b/config/generated/config.pb.go
@@ -170,7 +170,9 @@ type JobConfig struct {
 	// used for a job.
 	TargetGroup []*TargetGroup `protobuf:"bytes,5,rep,name=target_group" json:"target_group,omitempty"`
 	// The HTTP resource path to fetch metrics from on targets.
-	MetricsPath      *string `protobuf:"bytes,6,opt,name=metrics_path,def=/metrics" json:"metrics_path,omitempty"`
+	MetricsPath *string `protobuf:"bytes,6,opt,name=metrics_path,def=/metrics" json:"metrics_path,omitempty"`
+	// Should DNS lookups for SD use UDP (Default) or TCP?
+	SdLookupType     *string `protobuf:"bytes,8,opt,name=sd_lookup_type,def=udp" json:"sd_lookup_type,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -181,6 +183,7 @@ func (*JobConfig) ProtoMessage()    {}
 const Default_JobConfig_ScrapeTimeout string = "10s"
 const Default_JobConfig_SdRefreshInterval string = "30s"
 const Default_JobConfig_MetricsPath string = "/metrics"
+const Default_JobConfig_SdLookupType string = "udp"
 
 func (m *JobConfig) GetName() string {
 	if m != nil && m.Name != nil {
@@ -229,6 +232,13 @@ func (m *JobConfig) GetMetricsPath() string {
 		return *m.MetricsPath
 	}
 	return Default_JobConfig_MetricsPath
+}
+
+func (m *JobConfig) GetSdLookupType() string {
+	if m != nil && m.SdLookupType != nil {
+		return *m.SdLookupType
+	}
+	return Default_JobConfig_SdLookupType
 }
 
 // The top-level Prometheus configuration.

--- a/retrieval/target_provider.go
+++ b/retrieval/target_provider.go
@@ -93,7 +93,7 @@ func (p *sdTargetProvider) Targets() ([]Target, error) {
 		return p.targets, nil
 	}
 
-	response, err := lookupSRV(p.job.GetSdName())
+	response, err := lookupSRV(p.job.GetSdName(), p.job.GetSdLookupType())
 
 	if err != nil {
 		return nil, err
@@ -130,13 +130,15 @@ func (p *sdTargetProvider) Targets() ([]Target, error) {
 	return targets, nil
 }
 
-func lookupSRV(name string) (*dns.Msg, error) {
+func lookupSRV(name, lookup_type string) (*dns.Msg, error) {
 	conf, err := dns.ClientConfigFromFile(resolvConf)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't load resolv.conf: %s", err)
 	}
 
-	client := &dns.Client{}
+	client := &dns.Client{
+		Net: lookup_type,
+	}
 	response := &dns.Msg{}
 
 	for _, server := range conf.Servers {

--- a/retrieval/target_provider.go
+++ b/retrieval/target_provider.go
@@ -130,14 +130,14 @@ func (p *sdTargetProvider) Targets() ([]Target, error) {
 	return targets, nil
 }
 
-func lookupSRV(name, lookup_type string) (*dns.Msg, error) {
+func lookupSRV(name, lookupType string) (*dns.Msg, error) {
 	conf, err := dns.ClientConfigFromFile(resolvConf)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't load resolv.conf: %s", err)
 	}
 
 	client := &dns.Client{
-		Net: lookup_type,
+		Net: lookupType,
 	}
 	response := &dns.Msg{}
 


### PR DESCRIPTION
I'm using Consul's DNS for discovery SRV records. Yesterday while I was trying to figure out why my graphs had lots of gaps in them, I discovered that Consul only returns three records for a SRV request made over UDP, but will return all configured records for a request made over TCP. When I had more than three nodes registered for a service, the UDP query was getting a random three each time.

This change adds an optional `sd_lookup_type` to the job config, allowing you to specify "tcp" on a per-job basis (mainly because it was easier than figuring out how to pass a global config setting through).

Default is `udp`, which matches the existing default when we weren't providing a setting.

I'll probably just switch over to using something like consul-template to write a non-SD config for now, but this seemed like an easy and innocuous enough change that I thought I would propose it.