### PR TITLE
Make all URLs absolute to support proxies

### DIFF
--- a/console_libraries/menu.lib
+++ b/console_libraries/menu.lib
@@ -12,12 +12,12 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="/">Prometheus</a>
+      <a class="navbar-brand" href="{{ pathPrefix }}">Prometheus</a>
     </div>
 
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">
-        <li><a href="/alerts">Alerts</a></li>
+        <li><a href="{{ pathPrefix }}alerts">Alerts</a></li>
         <li><a href="https://www.pagerduty.com/">PagerDuty</a></li>
       </div>
     </ul>

--- a/console_libraries/prom.lib
+++ b/console_libraries/prom.lib
@@ -1,15 +1,17 @@
 {{/* vim: set ft=html: */}}
 {{/* Load Prometheus console library JS/CSS. Should go in <head> */}}
 {{ define "prom_console_head" }}
-<link type="text/css" rel="stylesheet" href="/static/vendor/rickshaw/rickshaw.min.css">
-<link type="text/css" rel="stylesheet" href="/static/vendor/bootstrap-3.3.1/css/bootstrap.min.css">
-<link type="text/css" rel="stylesheet" href="/static/css/prom_console.css">
-<script src="/static/vendor/rickshaw/vendor/d3.v3.js"></script>
-<script src="/static/vendor/rickshaw/vendor/d3.layout.min.js"></script>
-<script src="/static/vendor/rickshaw/rickshaw.min.js"></script>
-<script src="/static/vendor/js/jquery.min.js"></script>
-<script src="/static/vendor/bootstrap-3.3.1/js/bootstrap.min.js"></script>
-<script src="/static/js/prom_console.js"></script>
+<link type="text/css" rel="stylesheet" href="{{ pathPrefix }}static/vendor/rickshaw/rickshaw.min.css">
+<link type="text/css" rel="stylesheet" href="{{ pathPrefix }}static/vendor/bootstrap-3.3.1/css/bootstrap.min.css">
+<link type="text/css" rel="stylesheet" href="{{ pathPrefix }}static/css/prom_console.css">
+<script src="{{ pathPrefix }}static/vendor/rickshaw/vendor/d3.v3.js"></script>
+<script src="{{ pathPrefix }}static/vendor/rickshaw/vendor/d3.layout.min.js"></script>
+<script src="{{ pathPrefix }}static/vendor/rickshaw/rickshaw.min.js"></script>
+<script src="{{ pathPrefix }}static/vendor/js/jquery.min.js"></script>
+<script src="{{ pathPrefix }}static/vendor/bootstrap-3.3.1/js/bootstrap.min.js"></script>
+
+<script>var PATH_PREFIX = "{{ pathPrefix }}";</script>
+<script src="{{ pathPrefix }}static/js/prom_console.js"></script>
 {{ end }}
 
 {{/* Top of all pages. */}}

--- a/rules/manager/manager.go
+++ b/rules/manager/manager.go
@@ -99,6 +99,7 @@ type ruleManager struct {
 	notificationHandler *notification.NotificationHandler
 
 	prometheusURL string
+	pathPrefix string
 }
 
 // RuleManagerOptions bundles options for the RuleManager.
@@ -110,6 +111,7 @@ type RuleManagerOptions struct {
 	SampleAppender      storage.SampleAppender
 
 	PrometheusURL string
+	PathPrefix string
 }
 
 // NewRuleManager returns an implementation of RuleManager, ready to be started
@@ -190,7 +192,7 @@ func (m *ruleManager) queueAlertNotifications(rule *rules.AlertingRule, timestam
 		defs := "{{$labels := .Labels}}{{$value := .Value}}"
 
 		expand := func(text string) string {
-			template := templates.NewTemplateExpander(defs+text, "__alert_"+rule.Name(), tmplData, timestamp, m.storage)
+			template := templates.NewTemplateExpander(defs+text, "__alert_"+rule.Name(), tmplData, timestamp, m.storage, m.pathPrefix)
 			result, err := template.Expand()
 			if err != nil {
 				result = err.Error()

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -92,7 +92,7 @@ type templateExpander struct {
 }
 
 // NewTemplateExpander returns a template expander ready to use.
-func NewTemplateExpander(text string, name string, data interface{}, timestamp clientmodel.Timestamp, storage local.Storage) *templateExpander {
+func NewTemplateExpander(text string, name string, data interface{}, timestamp clientmodel.Timestamp, storage local.Storage, pathPrefix string) *templateExpander {
 	return &templateExpander{
 		text: text,
 		name: name,
@@ -217,6 +217,9 @@ func NewTemplateExpander(text string, name string, data interface{}, timestamp c
 					v *= 1000
 				}
 				return fmt.Sprintf("%.4g%ss", v, prefix)
+			},
+			"pathPrefix": func() string {
+				return pathPrefix;
 			},
 		},
 	}

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -178,7 +178,7 @@ func TestTemplateExpansion(t *testing.T) {
 	for i, s := range scenarios {
 		var result string
 		var err error
-		expander := NewTemplateExpander(s.text, "test", s.input, time, storage)
+		expander := NewTemplateExpander(s.text, "test", s.input, time, storage, "/")
 		if s.html {
 			result, err = expander.ExpandHTML(nil)
 		} else {

--- a/web/alerts.go
+++ b/web/alerts.go
@@ -47,9 +47,9 @@ func (s byAlertStateSorter) Swap(i, j int) {
 
 // AlertsHandler implements http.Handler.
 type AlertsHandler struct {
+	mutex       sync.Mutex
 	RuleManager manager.RuleManager
-
-	mutex sync.Mutex
+	PathPrefix  string
 }
 
 func (h *AlertsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -68,5 +68,5 @@ func (h *AlertsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			rules.Firing:   "danger",
 		},
 	}
-	executeTemplate(w, "alerts", alertStatus)
+	executeTemplate(w, "alerts", alertStatus, h.PathPrefix)
 }

--- a/web/api/api.go
+++ b/web/api/api.go
@@ -31,19 +31,19 @@ type MetricsService struct {
 }
 
 // RegisterHandler registers the handler for the various endpoints below /api.
-func (msrv *MetricsService) RegisterHandler() {
+func (msrv *MetricsService) RegisterHandler(pathPrefix string) {
 	handler := func(h func(http.ResponseWriter, *http.Request)) http.Handler {
 		return httputils.CompressionHandler{
 			Handler: http.HandlerFunc(h),
 		}
 	}
-	http.Handle("/api/query", prometheus.InstrumentHandler(
-		"/api/query", handler(msrv.Query),
+	http.Handle(pathPrefix + "api/query", prometheus.InstrumentHandler(
+		pathPrefix + "api/query", handler(msrv.Query),
 	))
-	http.Handle("/api/query_range", prometheus.InstrumentHandler(
-		"/api/query_range", handler(msrv.QueryRange),
+	http.Handle(pathPrefix + "api/query_range", prometheus.InstrumentHandler(
+		pathPrefix + "api/query_range", handler(msrv.QueryRange),
 	))
-	http.Handle("/api/metrics", prometheus.InstrumentHandler(
-		"/api/metrics", handler(msrv.Metrics),
+	http.Handle(pathPrefix + "api/metrics", prometheus.InstrumentHandler(
+		pathPrefix + "api/metrics", handler(msrv.Metrics),
 	))
 }

--- a/web/api/api_test.go
+++ b/web/api/api_test.go
@@ -95,7 +95,7 @@ func TestQuery(t *testing.T) {
 		Now:     testNow,
 		Storage: storage,
 	}
-	api.RegisterHandler()
+	api.RegisterHandler("/")
 
 	server := httptest.NewServer(http.DefaultServeMux)
 	defer server.Close()

--- a/web/consoles.go
+++ b/web/consoles.go
@@ -34,6 +34,7 @@ var (
 // ConsolesHandler implements http.Handler.
 type ConsolesHandler struct {
 	Storage local.Storage
+	PathPrefix string
 }
 
 func (h *ConsolesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -69,7 +70,7 @@ func (h *ConsolesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Path:      r.URL.Path,
 	}
 
-	template := templates.NewTemplateExpander(string(text), "__console_"+r.URL.Path, data, clientmodel.Now(), h.Storage)
+	template := templates.NewTemplateExpander(string(text), "__console_"+r.URL.Path, data, clientmodel.Now(), h.Storage, h.PathPrefix)
 	filenames, err := filepath.Glob(*consoleLibrariesPath + "/*.lib")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/web/handler.go
+++ b/web/handler.go
@@ -17,6 +17,11 @@ import (
 	"net/http"
 )
 
-func graphHandler(w http.ResponseWriter, r *http.Request) {
-	executeTemplate(w, "graph", nil)
+// GraphsHandler implements http.Handler.
+type GraphsHandler struct {
+	PathPrefix string
+}
+
+func (h *GraphsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	executeTemplate(w, "graph", nil, h.PathPrefix)
 }

--- a/web/static/js/graph.js
+++ b/web/static/js/graph.js
@@ -4,6 +4,8 @@ var graphTemplate;
 
 var SECOND = 1000;
 
+Handlebars.registerHelper('pathPrefix', function() { return PATH_PREFIX; });
+
 Prometheus.Graph = function(element, options) {
   this.el = element;
   this.options = options;
@@ -158,7 +160,7 @@ Prometheus.Graph.prototype.populateInsertableMetrics = function() {
   var self = this;
   $.ajax({
       method: "GET",
-      url: "/api/metrics",
+      url: PATH_PREFIX + "api/metrics",
       dataType: "json",
       success: function(json, textStatus) {
         var availableMetrics = [];
@@ -310,7 +312,7 @@ Prometheus.Graph.prototype.submitQuery = function() {
     url  = self.queryForm.attr("action");
     success = function(json, textStatus) { self.handleGraphResponse(json, textStatus); };
   } else {
-    url  = "/api/query";
+    url  = PATH_PREFIX + "api/query";
     success = function(text, textStatus) { self.handleConsoleResponse(text, textStatus); };
   }
 
@@ -609,7 +611,7 @@ function init() {
   });
 
   $.ajax({
-    url: "/static/js/graph_template.handlebar",
+    url: PATH_PREFIX + "static/js/graph_template.handlebar",
     success: function(data) {
       graphTemplate = Handlebars.compile(data);
       var options = parseGraphOptionsFromURL();

--- a/web/static/js/graph_template.handlebar
+++ b/web/static/js/graph_template.handlebar
@@ -1,5 +1,5 @@
         <div id="graph_wrapper{{id}}" class="graph_wrapper">
-          <form action="/api/query_range" method="GET" class="query_form form-inline">
+          <form action="{{ pathPrefix }}api/query_range" method="GET" class="query_form form-inline">
             <div class="row">
               <div class="col-lg-10">
                 <span class="input-group expression_input_group">
@@ -14,7 +14,7 @@
               </div>
               <div class="col-lg-2">
                 <div class="eval_stats pull-right"></div>
-                <img src="/static/img/ajax-loader.gif" class="spinner" alt="ajax_spinner">
+                <img src="{{ pathPrefix }}static/img/ajax-loader.gif" class="spinner" alt="ajax_spinner">
               </div>
             </div>
             <div class="row">

--- a/web/static/js/prom_console.js
+++ b/web/static/js/prom_console.js
@@ -502,7 +502,7 @@ PromConsole.Graph.prototype.dispatch = function() {
   var pending_requests = this.params.expr.length;
   for (var i = 0; i < this.params.expr.length; ++i) {
     var endTime = this.params.endTime;
-    var url = "/api/query_range?expr=" + encodeURIComponent(this.params.expr[i])
+    var url = PATH_PREFIX + "api/query_range?expr=" + encodeURIComponent(this.params.expr[i])
       + "&step=" + this.params.duration / this.graphTd.offsetWidth
       + "&range=" + this.params.duration + "&end=" + endTime;
     var xhr = new XMLHttpRequest();
@@ -539,7 +539,7 @@ PromConsole.Graph.prototype.dispatch = function() {
   }
 
   var loadingImg = document.createElement("img");
-  loadingImg.src = '/static/img/ajax-loader.gif';
+  loadingImg.src = PATH_PREFIX + 'static/img/ajax-loader.gif';
   loadingImg.alt = 'Loading...';
   loadingImg.className = 'prom_graph_loading';
   this.graphTd.appendChild(loadingImg);
@@ -605,6 +605,6 @@ PromConsole._graphsToSlashGraphURL = function(exprs) {
   for (var i = 0; i < exprs.length; ++i) {
     data.push({'expr': exprs[i], 'tab': 0});
   }
-  return '/graph#' + encodeURIComponent(JSON.stringify(data));
+  return PATH_PREFIX + 'graph#' + encodeURIComponent(JSON.stringify(data));
 
 };

--- a/web/status.go
+++ b/web/status.go
@@ -33,6 +33,7 @@ type PrometheusStatusHandler struct {
 	TargetPools map[string]*retrieval.TargetPool
 
 	Birth time.Time
+	PathPrefix string
 }
 
 // TargetStateToClass returns a map of TargetState to the name of a Bootstrap CSS class.
@@ -45,5 +46,5 @@ func (h *PrometheusStatusHandler) TargetStateToClass() map[retrieval.TargetState
 }
 
 func (h *PrometheusStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	executeTemplate(w, "status", h)
+	executeTemplate(w, "status", h, h.PathPrefix)
 }

--- a/web/templates/_base.html
+++ b/web/templates/_base.html
@@ -3,10 +3,12 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Prometheus Time Series Collection and Processing Server</title>
-    <script src="/static/vendor/js/jquery.min.js"></script>
+    <script src="{{ pathPrefix }}static/vendor/js/jquery.min.js"></script>
 
-    <link type="text/css" rel="stylesheet" href="/static/vendor/bootstrap-3.3.1/css/bootstrap.min.css">
-    <link type="text/css" rel="stylesheet" href="/static/css/prometheus.css">
+    <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}static/vendor/bootstrap-3.3.1/css/bootstrap.min.css">
+    <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}static/css/prometheus.css">
+
+    <script>var PATH_PREFIX = "{{ pathPrefix }}";</script>
 
     {{template "head" .}}
   </head>
@@ -21,17 +23,17 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="/">Prometheus</a>
+          <a class="navbar-brand" href="{{ pathPrefix }}">Prometheus</a>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
           <ul class="nav navbar-nav navbar-left">
             {{$consoles := getConsoles}}
             {{if $consoles}}
-            <li><a href="{{$consoles}}">Consoles</a></li>
+            <li><a href="{{ pathPrefix }}{{$consoles}}">Consoles</a></li>
             {{ end }}
-            <li><a href="/alerts">Alerts</a></li>
-            <li><a href="/graph">Graph</a></li>
-            <li><a href="/">Status</a></li>
+            <li><a href="{{ pathPrefix }}alerts">Alerts</a></li>
+            <li><a href="{{ pathPrefix }}graph">Graph</a></li>
+            <li><a href="{{ pathPrefix }}">Status</a></li>
             <li>
               <a href="http://prometheus.io" target="_blank">Help</a>
             </li>

--- a/web/templates/alerts.html
+++ b/web/templates/alerts.html
@@ -1,6 +1,6 @@
 {{define "head"}}
-    <link type="text/css" rel="stylesheet" href="/static/css/alerts.css">
-    <script src="/static/js/alerts.js"></script>
+    <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}static/css/alerts.css">
+    <script src="{{ pathPrefix }}static/js/alerts.js"></script>
 {{end}}
 
 {{define "content"}}

--- a/web/templates/graph.html
+++ b/web/templates/graph.html
@@ -1,22 +1,22 @@
 {{define "head"}}
-    <script src="/static/vendor/bootstrap-3.3.1/js/bootstrap.min.js"></script>
+    <script src="{{ pathPrefix }}static/vendor/bootstrap-3.3.1/js/bootstrap.min.js"></script>
 
-    <link type="text/css" rel="stylesheet" href="/static/css/graph.css">
+    <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}static/css/graph.css">
 
-    <link type="text/css" rel="stylesheet" href="/static/vendor/rickshaw/rickshaw.min.css">
-    <link type="text/css" rel="stylesheet" href="/static/vendor/bootstrap-datetimepicker/bootstrap-datetimepicker.min.css">
+    <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}static/vendor/rickshaw/rickshaw.min.css">
+    <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}static/vendor/bootstrap-datetimepicker/bootstrap-datetimepicker.min.css">
 
-    <script src="/static/vendor/rickshaw/vendor/d3.v3.js"></script>
-    <script src="/static/vendor/rickshaw/vendor/d3.layout.min.js"></script>
-    <script src="/static/vendor/rickshaw/rickshaw.min.js"></script>
-    <script src="/static/vendor/bootstrap-datetimepicker/bootstrap-datetimepicker.js"></script>
-    <script src="/static/vendor/bootstrap3-typeahead/bootstrap3-typeahead.min.js"></script>
+    <script src="{{ pathPrefix }}static/vendor/rickshaw/vendor/d3.v3.js"></script>
+    <script src="{{ pathPrefix }}static/vendor/rickshaw/vendor/d3.layout.min.js"></script>
+    <script src="{{ pathPrefix }}static/vendor/rickshaw/rickshaw.min.js"></script>
+    <script src="{{ pathPrefix }}static/vendor/bootstrap-datetimepicker/bootstrap-datetimepicker.js"></script>
+    <script src="{{ pathPrefix }}static/vendor/bootstrap3-typeahead/bootstrap3-typeahead.min.js"></script>
 
-    <script src="/static/vendor/js/handlebars.js"></script>
-    <script src="/static/vendor/js/jquery.selection.js"></script>
-    <script src="/static/vendor/js/jquery.hotkeys.js"></script>
+    <script src="{{ pathPrefix }}static/vendor/js/handlebars.js"></script>
+    <script src="{{ pathPrefix }}static/vendor/js/jquery.selection.js"></script>
+    <script src="{{ pathPrefix }}static/vendor/js/jquery.hotkeys.js"></script>
 
-    <script src="/static/js/graph.js"></script>
+    <script src="{{ pathPrefix }}static/js/graph.js"></script>
 
     <script id="graph_template" type="text/x-handlebars-template"></script>
 {{end}}


### PR DESCRIPTION
Related:  #528 and #519

**Feedback greatly appreciated**

This code implement a configuration option to set a global URL prefix, making all links start with the given prefix. The default prefix is `/` (so nothing changes). 

### Rationale ###

I would like to run Prometheus (and PromDash eventually) behind a proxy. This proxy does the user authentication, and once approved proxies requests for certain prefixes (`/graphite/`, `/jenkins/`, `/smokeping/` etc) to services on separate machines. When these services use the same prefix on their own (fe. `http://jenkins-vm/jenkins/`) you can pass responses from these services back to the user unaltered; otherwise you'd have to let the proxy rewrite links from a response (`<a href="/build/3/">`) to include the prefix (`<a href="/jenkins/build/3/">`) to make sure the user can click on things.

### Alternatives ###

Using a separate DNS entry (as suggested in #528) would not be nice because then users would have to re-enter their credentials when using Prometheus (twice if they also want to use PromDash). 

## ToDo ##

* Needs to be code reviewed, I've never worked with golang nor the Prometheus codebase before
* ~~Code under `notifications/` and `rules/` have to use the URL prefix as well somehow~~
* ~~Prometheus should do some sanity checking on the setting to make sure the user starts and ends the option with a slash~~
* ~~Prometheus should do some escaping on the setting, otherwise a prefix of `/foo">/` will break all templates~~
