### PR TITLE
Improve readability of usage text

### DIFF
--- a/main.go
+++ b/main.go
@@ -317,15 +317,15 @@ func usage() {
 		}
 
 		for _, fl := range groups[groupName] {
-			format := "  -%s=%s: "
+			format := "  -%s=%s"
 			if strings.Contains(fl.DefValue, " ") || fl.DefValue == "" {
-				format = "  -%s=%q: "
+				format = "  -%s=%q"
 			}
-			flagUsage := fmt.Sprintf(format, fl.Name, fl.DefValue)
+			flagUsage := fmt.Sprintf(format+lineSep, fl.Name, fl.DefValue)
 
 			// Format the usage text to not exceed maxLineLength characters per line.
 			words := strings.SplitAfter(fl.Usage, " ")
-			lineLength := len(flagUsage)
+			lineLength := len(lineSep) - 1
 			for _, w := range words {
 				if lineLength+len(w) > maxLineLength {
 					flagUsage += lineSep

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ type prometheus struct {
 func NewPrometheus() *prometheus {
 	conf, err := config.LoadFromFile(*configFile)
 	if err != nil {
-		glog.Errorf("Error loading configuration from %s: %v\n", *configFile, err)
+		glog.Errorf("Couldn't load configuration (-config.file=%s): %v\n", *configFile, err)
 		os.Exit(2)
 	}
 
@@ -305,7 +305,7 @@ func usage() {
 	}
 	sort.Sort(groupsOrdered)
 
-	fmt.Fprintf(os.Stderr, "Usage: %s [options ...] -config.file=<config_file>:\n\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "Usage: %s [options ...]:\n\n", os.Args[0])
 
 	const (
 		maxLineLength = 80


### PR DESCRIPTION
Removes the special mention of -config.file, as it's not required if a
file with the default name "prometheus.conf" is available.

Separates flag and description by a newline to make it easier to read
the flags with long descriptions.

---

Before:

```
...

  -storage.local.dirty=false: If set, the local storage layer will perform 
      crash recovery even if the last shutdown appears to be clean.
  -storage.local.index-cache-size.fingerprint-to-metric=10485760: The size in 
      bytes for the fingerprint to metric index cache.
  -storage.local.index-cache-size.fingerprint-to-timerange=5242880: The size in 
      bytes for the metric time range index cache.
  -storage.local.index-cache-size.label-name-to-label-values=10485760: The size 
      in bytes for the label name to label values index cache.
  -storage.local.index-cache-size.label-pair-to-fingerprints=20971520: The size 
      in bytes for the label pair to fingerprints index cache.

...
```

After:

```
...

  -storage.local.dirty=false
      If set, the local storage layer will perform crash recovery even if the 
      last shutdown appears to be clean.
  -storage.local.index-cache-size.fingerprint-to-metric=10485760
      The size in bytes for the fingerprint to metric index cache.
  -storage.local.index-cache-size.fingerprint-to-timerange=5242880
      The size in bytes for the metric time range index cache.
  -storage.local.index-cache-size.label-name-to-label-values=10485760
      The size in bytes for the label name to label values index cache.
  -storage.local.index-cache-size.label-pair-to-fingerprints=20971520
      The size in bytes for the label pair to fingerprints index cache.

...
```