### PR TITLE
Show correct error on wrong DNS response.

### DIFF
--- a/retrieval/target_provider.go
+++ b/retrieval/target_provider.go
@@ -114,7 +114,7 @@ func (p *sdTargetProvider) Targets() ([]Target, error) {
 	for _, record := range response.Answer {
 		addr, ok := record.(*dns.SRV)
 		if !ok {
-			glog.Warningf("%s is not a valid SRV record", addr)
+			glog.Warningf("%q is not a valid SRV record", record)
 			continue
 		}
 		// Remove the final dot from rooted DNS names to make them look more usual.


### PR DESCRIPTION
While #632 was not a direct problem with Prometheus, the wrong error logging was.