### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM       golang:1.4
 MAINTAINER The Prometheus Authors <prometheus-developers@googlegroups.com>
-RUN        apt-get -qy update && apt-get -qy install vim-common gcc mercurial && rm -rf /var/lib/apt/lists/* && \
+RUN        apt-get -qy update && apt-get -qy install vim-common && rm -rf /var/lib/apt/lists/* && \
            go get github.com/tools/godep
 
 WORKDIR    /go/src/github.com/prometheus/prometheus

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM       golang:1.4
 MAINTAINER The Prometheus Authors <prometheus-developers@googlegroups.com>
-RUN        apt-get -qy update && apt-get -qy install vim-common gcc mercurial && apt-get clean && \
+RUN        apt-get -qy update && apt-get -qy install vim-common gcc mercurial && rm -rf /var/lib/apt/lists/* && \
            go get github.com/tools/godep
 
 WORKDIR    /go/src/github.com/prometheus/prometheus


### PR DESCRIPTION
Hi,

Here are some improvements on weight and build's speed of the docker image.

`apt-get clean` is useless because debian base image is already configured to remove the package cache after each`apt-get install`. (`/etc/apt/apt.conf.d/docker-clean`).

However, image can be lightened with `rm -rf /var/lib/apt/lists/*`. Anyway, this change fixes the following error when extending prom/promtheus image :
```
W: Size of file /var/lib/apt/lists/http.debian.net_debian_dists_jessie_main_binary-amd64_Packages.gz is not what the server reported 9037866 9039181
```

Here a picture to illustrate this change :
![prometheus_dockerfile_improvement_1](https://cloud.githubusercontent.com/assets/1931038/7133566/e7f251e4-e294-11e4-9104-a26fb345d9f7.png)

Finally gcc and mercurial package are already installed by inherited images.

In my opinion, there are more ways to optimise this image. Presently it's pretty heavy. A lot of this heavyness is coming from the golang base image. Maybe can we find a way to build this from a base image like gliderlabs/alpine in the way others golang programs does like gliderlabs/registrator or gliderlabs/logspout.
Although maybe can we, in the first place, find a way to replace xxd usage in order to remove the vim-common package, adding 59MB to the image.

Hope this helps.

@beorn7 @juliusv @discordianfish 