### PR TITLE
Fix scrape timeout in config.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -163,5 +163,5 @@ func (c JobConfig) ScrapeInterval() time.Duration {
 
 // ScrapeTimeout gets the scrape timeout for a job.
 func (c JobConfig) ScrapeTimeout() time.Duration {
-	return stringToDuration(c.GetScrapeInterval())
+	return stringToDuration(c.GetScrapeTimeout())
 }


### PR DESCRIPTION
The scrape timeout helper was wrapping the scrape interval.