### PR TITLE
Simplify syncing target updates.

### DIFF
--- a/config/fixtures/invalid_label_name.conf.input
+++ b/config/fixtures/invalid_label_name.conf.input
@@ -1,10 +1,10 @@
 global <
-	scrape_interval: "30s"
-	evaluation_interval: "30s"
-	labels: <
+  scrape_interval: "30s"
+  evaluation_interval: "30s"
+  labels: <
     label: <
       name: "monitor-test"
       value: "test"
     >
-	>
+  >
 >

--- a/config/fixtures/invalid_proto_format.conf.input
+++ b/config/fixtures/invalid_proto_format.conf.input
@@ -1,11 +1,11 @@
 global <
-	scrape_interval: "30s"
-	evaluation_interval: "30s"
+  scrape_interval: "30s"
+  evaluation_interval: "30s"
   unknown_field: "foo"
-	labels: <
+  labels: <
     label: <
       name: "monitor"
       value: "test"
     >
-	>
+  >
 >

--- a/config/fixtures/invalid_scrape_interval.conf.input
+++ b/config/fixtures/invalid_scrape_interval.conf.input
@@ -1,10 +1,10 @@
 global <
-	scrape_interval: "30"
-	evaluation_interval: "30s"
-	labels: <
+  scrape_interval: "30"
+  evaluation_interval: "30s"
+  labels: <
     label: <
       name: "monitor"
       value: "test"
     >
-	>
+  >
 >

--- a/config/fixtures/minimal.conf.input
+++ b/config/fixtures/minimal.conf.input
@@ -1,20 +1,20 @@
 global <
-	scrape_interval: "30s"
-	evaluation_interval: "30s"
-	labels: <
+  scrape_interval: "30s"
+  evaluation_interval: "30s"
+  labels: <
     label: <
       name: "monitor"
       value: "test"
     >
-	>
-	rule_file: "prometheus.rules"
+  >
+  rule_file: "prometheus.rules"
 >
 
 job: <
-	name: "prometheus"
-	scrape_interval: "15s"
+  name: "prometheus"
+  scrape_interval: "15s"
 
-	target_group: <
-		target: "http://localhost:9090/metrics.json"
+  target_group: <
+    target: "http://localhost:9090/metrics.json"
   >
 >

--- a/config/fixtures/sample.conf.input
+++ b/config/fixtures/sample.conf.input
@@ -1,55 +1,55 @@
 global <
-	scrape_interval: "30s"
-	evaluation_interval: "30s"
-	labels: <
+  scrape_interval: "30s"
+  evaluation_interval: "30s"
+  labels: <
     label: <
       name: "monitor"
       value: "test"
     >
-	>
-	rule_file: "prometheus.rules"
+  >
+  rule_file: "prometheus.rules"
 >
 
 job: <
-	name: "prometheus"
-	scrape_interval: "15s"
+  name: "prometheus"
+  scrape_interval: "15s"
 
-	target_group: <
-		target: "http://localhost:9090/metrics.json"
-		labels: <
+  target_group: <
+    target: "http://localhost:9090/metrics.json"
+    labels: <
       label: <
         name: "group"
         value: "canary"
       >
-		>
-	>
+    >
+  >
 >
 
 job: <
-	name: "random"
-	scrape_interval: "30s"
+  name: "random"
+  scrape_interval: "30s"
 
-	target_group: <
-		target: "http://random.com:8080/metrics.json"
+  target_group: <
+    target: "http://random.com:8080/metrics.json"
     target: "http://random.com:8081/metrics.json"
-		target: "http://random.com:8082/metrics.json"
-		target: "http://random.com:8083/metrics.json"
-		target: "http://random.com:8084/metrics.json"
-		labels: <
+    target: "http://random.com:8082/metrics.json"
+    target: "http://random.com:8083/metrics.json"
+    target: "http://random.com:8084/metrics.json"
+    labels: <
       label: <
         name: "group"
         value: "production"
       >
-		>
-	>
-	target_group: <
-		target: "http://random.com:8085/metrics.json"
+    >
+  >
+  target_group: <
+    target: "http://random.com:8085/metrics.json"
     target: "http://random.com:8086/metrics.json"
-		labels: <
+    labels: <
       label: <
         name: "group"
         value: "canary"
       >
-		>
-	>
+    >
+  >
 >

--- a/retrieval/targetpool_test.go
+++ b/retrieval/targetpool_test.go
@@ -17,8 +17,6 @@ import (
 	"net/http"
 	"testing"
 	"time"
-
-	clientmodel "github.com/prometheus/client_golang/model"
 )
 
 func testTargetPool(t testing.TB) {
@@ -84,9 +82,8 @@ func testTargetPool(t testing.TB) {
 
 		for _, input := range scenario.inputs {
 			target := target{
-				url:           input.url,
-				newBaseLabels: make(chan clientmodel.LabelSet, 1),
-				httpClient:    &http.Client{},
+				url:        input.url,
+				httpClient: &http.Client{},
 			}
 			pool.addTarget(&target)
 		}
@@ -118,7 +115,6 @@ func TestTargetPoolReplaceTargets(t *testing.T) {
 		state:           Unhealthy,
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
-		newBaseLabels:   make(chan clientmodel.LabelSet, 1),
 		httpClient:      &http.Client{},
 	}
 	oldTarget2 := &target{
@@ -126,7 +122,6 @@ func TestTargetPoolReplaceTargets(t *testing.T) {
 		state:           Unhealthy,
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
-		newBaseLabels:   make(chan clientmodel.LabelSet, 1),
 		httpClient:      &http.Client{},
 	}
 	newTarget1 := &target{
@@ -134,7 +129,6 @@ func TestTargetPoolReplaceTargets(t *testing.T) {
 		state:           Healthy,
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
-		newBaseLabels:   make(chan clientmodel.LabelSet, 1),
 		httpClient:      &http.Client{},
 	}
 	newTarget2 := &target{
@@ -142,7 +136,6 @@ func TestTargetPoolReplaceTargets(t *testing.T) {
 		state:           Healthy,
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
-		newBaseLabels:   make(chan clientmodel.LabelSet, 1),
 		httpClient:      &http.Client{},
 	}
 


### PR DESCRIPTION
Using two distinct sync mechanisms in the updating process can be resolved using read locks.
This makes things easier in the future when more than base labels have to be updated.