### PR TITLE
Small size docker image refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,35 @@
-FROM       golang:1.4
+FROM alpine:edge
 MAINTAINER The Prometheus Authors <prometheus-developers@googlegroups.com>
-RUN        apt-get -qy update && apt-get -qy install vim-common && rm -rf /var/lib/apt/lists/* && \
-           go get github.com/tools/godep
 
-WORKDIR    /go/src/github.com/prometheus/prometheus
-ADD        . /go/src/github.com/prometheus/prometheus
+ENV GOPATH /go
+COPY . /go/src/github.com/prometheus/prometheus
 
-RUN  godep restore && go get -d
-RUN  ./utility/embed-static.sh web/static web/templates | gofmt > web/blob/files.go
-
-RUN  go build -ldflags " \
-       -X main.buildVersion  $(cat VERSION) \
-       -X main.buildRevision $(git rev-parse --short HEAD) \
-       -X main.buildBranch   $(git rev-parse --abbrev-ref HEAD) \
-       -X main.buildUser     root \
-       -X main.buildDate     $(date +%Y%m%d-%H:%M:%S) \
-       -X main.goVersion     $GOLANG_VERSION \
-     "
-RUN  cd tools/rule_checker && go build
-ADD  ./documentation/examples/prometheus.conf /prometheus.conf
+RUN apk add --update -t build-deps go git mercurial vim \
+    && apk add -u musl && rm -rf /var/cache/apk/* \
+    && go get github.com/tools/godep \
+    && cd /go/src/github.com/prometheus/prometheus \
+    && $GOPATH/bin/godep restore && go get -d \
+    && ./utility/embed-static.sh web/static web/templates | gofmt > web/blob/files.go \
+    && go build -ldflags " \
+            -X main.buildVersion  $(cat VERSION) \
+            -X main.buildRevision $(git rev-parse --short HEAD) \
+            -X main.buildBranch   $(git rev-parse --abbrev-ref HEAD) \
+            -X main.buildUser     root \
+            -X main.buildDate     $(date +%Y%m%d-%H:%M:%S) \
+            -X main.goVersion     $(go version | awk '{print substr($3,3)}') \
+        " -o /bin/prometheus \
+    && cd tools/rule_checker && go build && cd ../.. \
+    && mkdir -p /etc/prometheus \
+    && mv ./documentation/examples/prometheus.conf /etc/prometheus/prometheus.conf \
+    && mv ./console_libraries/ ./consoles/ /etc/prometheus/ \
+    && rm -rf /go \
+    && apk del --purge build-deps
 
 EXPOSE     9090
-VOLUME     [ "/prometheus" ]
+VOLUME     [ "/prometheus", "/etc/prometheus" ]
 WORKDIR    /prometheus
-ENTRYPOINT [ "/go/src/github.com/prometheus/prometheus/prometheus" ]
-CMD        [ "-logtostderr", "-config.file=/prometheus.conf", \
+ENTRYPOINT [ "/bin/prometheus" ]
+CMD        [ "-logtostderr", "-config.file=/etc/prometheus/prometheus.conf", \
              "-storage.local.path=/prometheus", \
-             "-web.console.libraries=/go/src/github.com/prometheus/prometheus/console_libraries", \
-             "-web.console.templates=/go/src/github.com/prometheus/prometheus/consoles" ]
+             "-web.console.libraries=/etc/prometheus/console_libraries", \
+             "-web.console.templates=/etc/prometheus/consoles" ]


### PR DESCRIPTION
Hi

As asked in #636, here the PR with my small size docker image refactoring.
![prometheus_small_size_docker_image](https://cloud.githubusercontent.com/assets/1931038/7305465/44e185f8-e9fe-11e4-8564-9c78ccdde09e.png)

This is a breaking change and will affect people having extended the `prom/prometheus` image for the following reasons :
* Switching from the way to heavy golang base image (`debian:jessie`) to `alpine:edge`.
I used the `edge` tag of alpine base image because of golang version. In `alpine:3.1`, golang version is `1.3.3`. In alpine:edge, it's `1.4.2`. Later on, we will be able to change to `alpine:3.2` when it released.
* `/go/src/github.com/prometheus/prometheus/console_libraries` and `/go/src/github.com/prometheus/prometheus/consoles` folders moved to /etc/prometheus
* `/prometheus.conf` file moved to `/etc/prometheus` too.

In this case, there is maybe some way of limiting the impact by pushing the current image as a new tag on docker hub. Therefore, people will be able to make the transition easily.

A PR will follow for the https://github.com/prometheus/docs repository.

Moreover, I will give a try on reducing docker image size of available exporters.

@discordianfish @juliusv 