### PR TITLE
Change JobConfig to ScrapeConfig.

### DIFF
--- a/Godeps/_workspace/src/github.com/prometheus/client_golang/model/labelname.go
+++ b/Godeps/_workspace/src/github.com/prometheus/client_golang/model/labelname.go
@@ -30,6 +30,10 @@ const (
 	// a scrape target.
 	AddressLabel LabelName = "__address__"
 
+	// MetricsPathLabel is the name of the label that holds the path on which to
+	// scrape a target.
+	MetricsPathLabel LabelName = "__metrics_path__"
+
 	// ReservedLabelPrefix is a prefix which is not legal in user-supplied
 	// label names.
 	ReservedLabelPrefix = "__"

--- a/config/config.proto
+++ b/config/config.proto
@@ -48,12 +48,22 @@ message TargetGroup {
 	optional LabelPairs labels = 2;
 }
 
+// The configuration for DNS based service discovery.
+message DNSConfig {
+	// The list of DNS-SD service names pointing to SRV records
+	// containing endpoint information.
+	repeated string name = 1;
+	// Discovery refresh period when using DNS-SD to discover targets. Must be a
+	// valid Prometheus duration string in the form "[0-9]+[smhdwy]".
+	optional string refresh_interval = 2 [default = "30s"];
+}
+
 // The configuration for a Prometheus job to scrape.
 //
-// The next field no. is 8.
-message JobConfig {
+// The next field no. is 10.
+message ScrapeConfig {
 	// The job name. Must adhere to the regex "[a-zA-Z_][a-zA-Z0-9_-]*".
-	required string name = 1;
+	required string job_name = 1;
 	// How frequently to scrape targets from this job. Overrides the global
 	// default. Must be a valid Prometheus duration string in the form
 	// "[0-9]+[smhdwy]".
@@ -61,15 +71,9 @@ message JobConfig {
 	// Per-target timeout when scraping this job. Must be a valid Prometheus
 	// duration string in the form "[0-9]+[smhdwy]".
 	optional string scrape_timeout = 7 [default = "10s"];
-	// The DNS-SD service name pointing to SRV records containing endpoint
-	// information for a job. When this field is provided, no target_group
-	// elements may be set.
-	optional string sd_name = 3;
-	// Discovery refresh period when using DNS-SD to discover targets. Must be a
-	// valid Prometheus duration string in the form "[0-9]+[smhdwy]".
-	optional string sd_refresh_interval = 4 [default = "30s"];
-	// List of labeled target groups for this job. Only legal when DNS-SD isn't
-	// used for a job.
+	// List of DNS service discovery configurations.
+	repeated DNSConfig dns_config = 9;
+	// List of labeled target groups for this job.
 	repeated TargetGroup target_group = 5;
 	// The HTTP resource path on which to fetch metrics from targets.
 	optional string metrics_path = 6 [default = "/metrics"];
@@ -83,6 +87,6 @@ message PrometheusConfig {
 	// configuration with default values (see GlobalConfig definition) will be
 	// created.
 	optional GlobalConfig global = 1;
-	// The list of jobs to scrape.
-	repeated JobConfig job = 2;
+	// The list of scrape configs.
+	repeated ScrapeConfig scrape_config = 3;
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,14 +56,9 @@ var configTests = []struct {
 		errContains: "invalid label name",
 	},
 	{
-		inputFile:   "mixing_sd_and_manual_targets.conf.input",
-		shouldFail:  true,
-		errContains: "specified both DNS-SD name and target group",
-	},
-	{
 		inputFile:   "repeated_job_name.conf.input",
 		shouldFail:  true,
-		errContains: "found multiple jobs configured with the same name: 'testjob1'",
+		errContains: "found multiple scrape configs configured with the same job name: \"testjob1\"",
 	},
 }
 

--- a/config/fixtures/invalid_job_name.conf.input
+++ b/config/fixtures/invalid_job_name.conf.input
@@ -1,3 +1,3 @@
-job: <
-  name: "1testjob"
+scrape_config: <
+  job_name: "1testjob"
 >

--- a/config/fixtures/minimal.conf.input
+++ b/config/fixtures/minimal.conf.input
@@ -10,8 +10,8 @@ global <
   rule_file: "prometheus.rules"
 >
 
-job: <
-  name: "prometheus"
+scrape_config: <
+  job_name: "prometheus"
   scrape_interval: "15s"
   metrics_path: "/metrics"
   scheme: "http"

--- a/config/fixtures/mixing_sd_and_manual_targets.conf.input
+++ b/config/fixtures/mixing_sd_and_manual_targets.conf.input
@@ -1,7 +1,0 @@
-job: <
-  name: "testjob"
-  sd_name: "sd_name"
-  target_group: <
-    target: "sampletarget:8080"
-  >
->

--- a/config/fixtures/repeated_job_name.conf.input
+++ b/config/fixtures/repeated_job_name.conf.input
@@ -1,11 +1,11 @@
-job: <
-  name: "testjob1"
+scrape_config: <
+  job_name: "testjob1"
 >
 
-job: <
-  name: "testjob2"
+scrape_config: <
+  job_name: "testjob2"
 >
 
-job: <
-  name: "testjob1"
+scrape_config: <
+  job_name: "testjob1"
 >

--- a/config/fixtures/sample.conf.input
+++ b/config/fixtures/sample.conf.input
@@ -10,8 +10,8 @@ global <
   rule_file: "prometheus.rules"
 >
 
-job: <
-  name: "prometheus"
+scrape_config: <
+  job_name: "prometheus"
   scrape_interval: "15s"
 
   target_group: <
@@ -25,8 +25,8 @@ job: <
   >
 >
 
-job: <
-  name: "random"
+scrape_config: <
+  job_name: "random"
   scrape_interval: "30s"
 
   target_group: <

--- a/config/fixtures/sd_targets.conf.input
+++ b/config/fixtures/sd_targets.conf.input
@@ -1,4 +1,6 @@
-job: <
-  name: "testjob"
-  sd_name: "sd_name"
+scrape_config: <
+  job_name: "testjob"
+  dns_config: <
+  	name: "sd_name"
+  >
 >

--- a/config/load.go
+++ b/config/load.go
@@ -30,9 +30,9 @@ func LoadFromString(configStr string) (Config, error) {
 	if configProto.Global == nil {
 		configProto.Global = &pb.GlobalConfig{}
 	}
-	for _, job := range configProto.Job {
-		if job.ScrapeInterval == nil {
-			job.ScrapeInterval = proto.String(configProto.Global.GetScrapeInterval())
+	for _, scfg := range configProto.GetScrapeConfig() {
+		if scfg.ScrapeInterval == nil {
+			scfg.ScrapeInterval = proto.String(configProto.Global.GetScrapeInterval())
 		}
 	}
 

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -91,8 +91,8 @@ func TestTargetScrapeWithFullChannel(t *testing.T) {
 }
 
 func TestTargetRecordScrapeHealth(t *testing.T) {
-	jcfg := config.JobConfig{}
-	proto.SetDefaults(&jcfg.JobConfig)
+	scfg := &config.ScrapeConfig{}
+	proto.SetDefaults(&scfg.ScrapeConfig)
 
 	testTarget := newTestTarget("example.url", 0, clientmodel.LabelSet{clientmodel.JobLabel: "testjob"})
 
@@ -150,8 +150,8 @@ func TestTargetScrapeTimeout(t *testing.T) {
 	)
 	defer server.Close()
 
-	jcfg := config.JobConfig{}
-	proto.SetDefaults(&jcfg.JobConfig)
+	scfg := &config.ScrapeConfig{}
+	proto.SetDefaults(&scfg.ScrapeConfig)
 
 	var testTarget Target = newTestTarget(server.URL, 10*time.Millisecond, clientmodel.LabelSet{})
 


### PR DESCRIPTION
This commit changes the configuration interface from job configs to scrape
configs. This includes allowing multiple ways of target definition at once
and moving DNS SD to its own config message. DNS SD can now contain multiple
DNS names per configured discovery.