### PR TITLE
Add relabelling to target management.

### DIFF
--- a/config/config.proto
+++ b/config/config.proto
@@ -58,9 +58,32 @@ message DNSConfig {
 	optional string refresh_interval = 2 [default = "30s"];
 }
 
+// The configuration for relabeling of target label sets.
+message RelabelConfig {
+	// A list of labels from which values are taken and concatenated
+	// with the configured separator in order.
+	repeated string source_label = 1;
+	// Regex against which the concatenation is matched.
+	required string regex = 2;
+	// The label to which the resulting string is written in a replacement.
+	optional string target_label = 3;
+	// Replacement is the regex replacement pattern to be used.
+	optional string replacement = 4;
+	// Separator is the string between concatenated values from the source labels.
+	optional string separator = 5 [default = ";"];
+
+	// Action is the action to be performed for the relabeling.
+	enum Action {
+		REPLACE = 0; // Performs a regex replacement.
+		KEEP = 1;    // Drops targets for which the input does not match the regex.
+		DROP = 2;    // Drops targets for which the input does match the regex.
+	}
+	optional Action action = 6 [default = REPLACE];
+}
+
 // The configuration for a Prometheus job to scrape.
 //
-// The next field no. is 10.
+// The next field no. is 11.
 message ScrapeConfig {
 	// The job name. Must adhere to the regex "[a-zA-Z_][a-zA-Z0-9_-]*".
 	required string job_name = 1;
@@ -75,6 +98,8 @@ message ScrapeConfig {
 	repeated DNSConfig dns_config = 9;
 	// List of labeled target groups for this job.
 	repeated TargetGroup target_group = 5;
+	// List of relabel configurations.
+	repeated RelabelConfig relabel_config = 10;
 	// The HTTP resource path on which to fetch metrics from targets.
 	optional string metrics_path = 6 [default = "/metrics"];
 	// The URL scheme with which to fetch metrics from targets.

--- a/retrieval/discovery/dns.go
+++ b/retrieval/discovery/dns.go
@@ -32,6 +32,7 @@ const (
 	resolvConf = "/etc/resolv.conf"
 
 	dnsSourcePrefix = "dns"
+	DNSNameLabel    = clientmodel.MetaLabelPrefix + "dns_srv_name"
 
 	// Constants for instrumentation.
 	namespace = "prometheus"
@@ -148,6 +149,7 @@ func (dd *DNSDiscovery) refresh(name string, ch chan<- *config.TargetGroup) erro
 		target := clientmodel.LabelValue(fmt.Sprintf("%s:%d", addr.Target, addr.Port))
 		tg.Targets = append(tg.Targets, clientmodel.LabelSet{
 			clientmodel.AddressLabel: target,
+			DNSNameLabel:             clientmodel.LabelValue(name),
 		})
 	}
 

--- a/retrieval/relabel.go
+++ b/retrieval/relabel.go
@@ -1,0 +1,70 @@
+package retrieval
+
+import (
+	"regexp"
+	"strings"
+
+	clientmodel "github.com/prometheus/client_golang/model"
+
+	"github.com/prometheus/prometheus/config"
+	pb "github.com/prometheus/prometheus/config/generated"
+)
+
+// Relabel returns a relabeled copy of the given label set. The relabel configurations
+// are applied in order of input.
+// If a label set is dropped, nil is returned.
+func Relabel(labels clientmodel.LabelSet, cfgs ...*config.RelabelConfig) (clientmodel.LabelSet, error) {
+	out := clientmodel.LabelSet{}
+	for ln, lv := range labels {
+		out[ln] = lv
+	}
+	var err error
+	for _, cfg := range cfgs {
+		if out, err = relabel(out, cfg); err != nil {
+			return nil, err
+		}
+		if out == nil {
+			return nil, nil
+		}
+	}
+	return out, nil
+}
+
+func relabel(labels clientmodel.LabelSet, cfg *config.RelabelConfig) (clientmodel.LabelSet, error) {
+	pat, err := regexp.Compile(cfg.GetRegex())
+	if err != nil {
+		return nil, err
+	}
+
+	values := make([]string, 0, len(cfg.GetSourceLabel()))
+	for _, name := range cfg.GetSourceLabel() {
+		values = append(values, string(labels[clientmodel.LabelName(name)]))
+	}
+	val := strings.Join(values, cfg.GetSeparator())
+
+	switch cfg.GetAction() {
+	case pb.RelabelConfig_DROP:
+		if pat.MatchString(val) {
+			return nil, nil
+		}
+	case pb.RelabelConfig_KEEP:
+		if !pat.MatchString(val) {
+			return nil, nil
+		}
+	case pb.RelabelConfig_REPLACE:
+		// If there is no match no replacement must take place.
+		if !pat.MatchString(val) {
+			break
+		}
+		res := pat.ReplaceAllString(val, cfg.GetReplacement())
+		ln := clientmodel.LabelName(cfg.GetTargetLabel())
+		if res == "" {
+			delete(labels, ln)
+		} else {
+			labels[ln] = clientmodel.LabelValue(res)
+		}
+	default:
+		panic("retrieval.relabel: unknown relabel action type")
+	}
+	return labels, nil
+}

--- a/retrieval/relabel_test.go
+++ b/retrieval/relabel_test.go
@@ -1,0 +1,172 @@
+package retrieval
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+
+	clientmodel "github.com/prometheus/client_golang/model"
+
+	"github.com/prometheus/prometheus/config"
+	pb "github.com/prometheus/prometheus/config/generated"
+)
+
+func TestRelabel(t *testing.T) {
+	tests := []struct {
+		input   clientmodel.LabelSet
+		relabel []pb.RelabelConfig
+		output  clientmodel.LabelSet
+	}{
+		{
+			input: clientmodel.LabelSet{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+			},
+			relabel: []pb.RelabelConfig{
+				{
+					SourceLabel: []string{"a"},
+					Regex:       proto.String("f(.*)"),
+					TargetLabel: proto.String("d"),
+					Separator:   proto.String(";"),
+					Replacement: proto.String("ch${1}-ch${1}"),
+					Action:      pb.RelabelConfig_REPLACE.Enum(),
+				},
+			},
+			output: clientmodel.LabelSet{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+				"d": "choo-choo",
+			},
+		},
+		{
+			input: clientmodel.LabelSet{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+			},
+			relabel: []pb.RelabelConfig{
+				{
+					SourceLabel: []string{"a", "b"},
+					Regex:       proto.String("^f(.*);(.*)r$"),
+					TargetLabel: proto.String("a"),
+					Separator:   proto.String(";"),
+					Replacement: proto.String("b${1}${2}m"), // boobam
+				},
+				{
+					SourceLabel: []string{"c", "a"},
+					Regex:       proto.String("(b).*b(.*)ba(.*)"),
+					TargetLabel: proto.String("d"),
+					Separator:   proto.String(";"),
+					Replacement: proto.String("$1$2$2$3"),
+					Action:      pb.RelabelConfig_REPLACE.Enum(),
+				},
+			},
+			output: clientmodel.LabelSet{
+				"a": "boobam",
+				"b": "bar",
+				"c": "baz",
+				"d": "boooom",
+			},
+		},
+		{
+			input: clientmodel.LabelSet{
+				"a": "foo",
+			},
+			relabel: []pb.RelabelConfig{
+				{
+					SourceLabel: []string{"a"},
+					Regex:       proto.String("o$"),
+					Action:      pb.RelabelConfig_DROP.Enum(),
+				}, {
+					SourceLabel: []string{"a"},
+					Regex:       proto.String("f(.*)"),
+					TargetLabel: proto.String("d"),
+					Separator:   proto.String(";"),
+					Replacement: proto.String("ch$1-ch$1"),
+					Action:      pb.RelabelConfig_REPLACE.Enum(),
+				},
+			},
+			output: nil,
+		},
+		{
+			input: clientmodel.LabelSet{
+				"a": "foo",
+			},
+			relabel: []pb.RelabelConfig{
+				{
+					SourceLabel: []string{"a"},
+					Regex:       proto.String("no-match"),
+					Action:      pb.RelabelConfig_DROP.Enum(),
+				},
+			},
+			output: clientmodel.LabelSet{
+				"a": "foo",
+			},
+		},
+		{
+			input: clientmodel.LabelSet{
+				"a": "foo",
+			},
+			relabel: []pb.RelabelConfig{
+				{
+					SourceLabel: []string{"a"},
+					Regex:       proto.String("no-match"),
+					Action:      pb.RelabelConfig_KEEP.Enum(),
+				},
+			},
+			output: nil,
+		},
+		{
+			input: clientmodel.LabelSet{
+				"a": "foo",
+			},
+			relabel: []pb.RelabelConfig{
+				{
+					SourceLabel: []string{"a"},
+					Regex:       proto.String("^f"),
+					Action:      pb.RelabelConfig_KEEP.Enum(),
+				},
+			},
+			output: clientmodel.LabelSet{
+				"a": "foo",
+			},
+		},
+		{
+			// No replacement must be applied if there is no match.
+			input: clientmodel.LabelSet{
+				"a": "boo",
+			},
+			relabel: []pb.RelabelConfig{
+				{
+					SourceLabel: []string{"a"},
+					Regex:       proto.String("^f"),
+					Action:      pb.RelabelConfig_REPLACE.Enum(),
+					TargetLabel: proto.String("b"),
+					Replacement: proto.String("bar"),
+				},
+			},
+			output: clientmodel.LabelSet{
+				"a": "boo",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		var relabel []*config.RelabelConfig
+		for _, rl := range test.relabel {
+			proto.SetDefaults(&rl)
+			relabel = append(relabel, &config.RelabelConfig{rl})
+		}
+		res, err := Relabel(test.input, relabel...)
+		if err != nil {
+			t.Errorf("Test %d: error relabeling: %s", i+1, err)
+		}
+
+		if !reflect.DeepEqual(res, test.output) {
+			t.Errorf("Test %d: relabel output mismatch: expected %#v, got %#v", i+1, test.output, res)
+		}
+	}
+}

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -172,10 +172,10 @@ type target struct {
 }
 
 // NewTarget creates a reasonably configured target for querying.
-func NewTarget(address string, cfg *config.ScrapeConfig, baseLabels clientmodel.LabelSet) Target {
+func NewTarget(cfg *config.ScrapeConfig, baseLabels clientmodel.LabelSet) Target {
 	t := &target{
 		url: &url.URL{
-			Host: address,
+			Host: string(baseLabels[clientmodel.AddressLabel]),
 		},
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
@@ -197,15 +197,15 @@ func (t *target) Update(cfg *config.ScrapeConfig, baseLabels clientmodel.LabelSe
 	t.deadline = cfg.ScrapeTimeout()
 	t.httpClient = utility.NewDeadlineClient(cfg.ScrapeTimeout())
 
-	t.baseLabels = clientmodel.LabelSet{
-		clientmodel.InstanceLabel: clientmodel.LabelValue(t.InstanceIdentifier()),
-	}
-
+	t.baseLabels = clientmodel.LabelSet{}
 	// All remaining internal labels will not be part of the label set.
 	for name, val := range baseLabels {
 		if !strings.HasPrefix(string(name), clientmodel.ReservedLabelPrefix) {
 			t.baseLabels[name] = val
 		}
+	}
+	if _, ok := t.baseLabels[clientmodel.InstanceLabel]; !ok {
+		t.baseLabels[clientmodel.InstanceLabel] = clientmodel.LabelValue(t.InstanceIdentifier())
 	}
 }
 


### PR DESCRIPTION
This commit adds a relabelling stage on the set of base
labels from which a target is created. It allows to drop
targets and rewrite any regular or internal label.