### PR TITLE
Limit maximum number of concurrent queries.

### DIFF
--- a/stats/query_stats.go
+++ b/stats/query_stats.go
@@ -31,7 +31,7 @@ const (
 	GetValueAtTimeTime
 	GetBoundaryValuesTime
 	GetRangeValuesTime
-	ViewQueueTime
+	ExecQueueTime
 	ViewDiskPreparationTime
 	ViewDataExtractionTime
 	ViewDiskExtractionTime
@@ -64,8 +64,8 @@ func (s QueryTiming) String() string {
 		return "GetBoundaryValues() time"
 	case GetRangeValuesTime:
 		return "GetRangeValues() time"
-	case ViewQueueTime:
-		return "View queue wait time"
+	case ExecQueueTime:
+		return "Exec queue wait time"
 	case ViewDiskPreparationTime:
 		return "View building disk preparation time"
 	case ViewDataExtractionTime:


### PR DESCRIPTION
A high number of concurrent queries can slow each other down
so that none of them is reasonbly responsive. This commit limits
the number of queries being concurrently executed.

@beorn7 brought this issue up some time ago.
I think this simple approach will suffice until there are practical concerns
that would require more elaborate scheduling.

Suggestions for a better default value?