### PR TITLE
Disable url.Encoding of srv metrics_path

### DIFF
--- a/retrieval/target_provider.go
+++ b/retrieval/target_provider.go
@@ -107,10 +107,7 @@ func (p *sdTargetProvider) Targets() ([]Target, error) {
 	}
 
 	targets := make([]Target, 0, len(response.Answer))
-	endpoint := &url.URL{
-		Scheme: "http",
-		Path:   p.job.GetMetricsPath(),
-	}
+	endpoint := &url.URL{Scheme: "http"}
 	for _, record := range response.Answer {
 		addr, ok := record.(*dns.SRV)
 		if !ok {
@@ -122,7 +119,7 @@ func (p *sdTargetProvider) Targets() ([]Target, error) {
 			addr.Target = addr.Target[:len(addr.Target)-1]
 		}
 		endpoint.Host = fmt.Sprintf("%s:%d", addr.Target, addr.Port)
-		t := NewTarget(endpoint.String(), p.job.ScrapeTimeout(), baseLabels)
+		t := NewTarget(endpoint.String() + p.job.GetMetricsPath(), p.job.ScrapeTimeout(), baseLabels)
 		targets = append(targets, t)
 	}
 


### PR DESCRIPTION
Prior to this commit metrics_path was being urlencoded which resulted
in "?" being encoded as "%3F" and thus using querystring args was not
possible. For metric endpoints whose behavior can be be influenced by
querystring variables this is very useful. Specifically this commit is
to enable complete usage of:

https://github.com/TheClimateCorporation/label_exporter#using-query-string-arguments

@beorn
@julius