### PR TITLE
pass a Vector to the query template

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.build/build/
+.build/cache/*.gz
+.build/cache/*.bz2
+.build/root/

--- a/consoles/node-cpu.html
+++ b/consoles/node-cpu.html
@@ -2,7 +2,7 @@
 
 {{ template "prom_right_table_head" }}
   <tr>
-    <th colspan="2">CPU(s): {{ template "prom_query_drilldown" (args (printf "scalar(count(count by (cpu)(node_cpu{job='node',instance='%s'})))" .Params.instance)) }}</th>
+    <th colspan="2">CPU(s): {{ template "prom_query_drilldown" (args (printf "count(count by (cpu)(node_cpu{job='node',instance='%s'}))" .Params.instance)) }}</th>
   </tr>
 {{ range printf "sum by (mode)(rate(node_cpu{job='node',instance='%s'}[5m])) * 100 / scalar(count(count by (cpu)(node_cpu{job='node',instance='%s'})))" .Params.instance .Params.instance | query | sortByLabel "mode" }}
   <tr>


### PR DESCRIPTION
The func `query` currently only allows Vector as result, but the `node-cpu.html` queries a scalar value and fails with the error:

```
error executing template __console_node-cpu.html: template: prom.lib:43:69: executing "prom_query_drilldown" at <query $expr>: error calling query: query result is not a vector
```

I'm not sure if the query func should also support other results beside Vector, but I prefer the current examples to work as expected :-)
