### PR TITLE
Implement config reloading on SIGHUP

### DIFF
--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -285,6 +285,7 @@ func (t *target) RunScraper(sampleAppender storage.SampleAppender) {
 				// On changed scrape interval the new interval becomes effective
 				// after the next scrape.
 				if lastScrapeInterval != t.scrapeInterval {
+					ticker.Stop()
 					ticker = time.NewTicker(t.scrapeInterval)
 					lastScrapeInterval = t.scrapeInterval
 				}

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -277,19 +277,15 @@ func TestTargetManagerConfigUpdate(t *testing.T) {
 	}
 	conf := &config.Config{DefaultedConfig: config.DefaultConfig}
 
-	targetManager, err := NewTargetManager(conf, nopAppender{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	targetManager := NewTargetManager(nopAppender{})
+	targetManager.ApplyConfig(conf)
+
 	targetManager.Run()
 	defer targetManager.Stop()
 
 	for i, step := range sequence {
 		conf.ScrapeConfigs = step.scrapeConfigs
-		err := targetManager.ApplyConfig(conf)
-		if err != nil {
-			t.Fatal(err)
-		}
+		targetManager.ApplyConfig(conf)
 
 		<-time.After(1 * time.Millisecond)
 

--- a/web/status.go
+++ b/web/status.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/retrieval"
 	"github.com/prometheus/prometheus/rules"
 )
@@ -47,5 +48,14 @@ func (h *PrometheusStatusHandler) TargetStateToClass() map[retrieval.TargetState
 }
 
 func (h *PrometheusStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mu.RLock()
 	executeTemplate(w, "status", h, h.PathPrefix)
+	h.mu.RUnlock()
+}
+
+// ApplyConfig updates the status handler's state as the new config requires.
+func (h *PrometheusStatusHandler) ApplyConfig(conf *config.Config) {
+	h.mu.Lock()
+	h.Config = conf.String()
+	h.mu.Unlock()
 }


### PR DESCRIPTION
`master` is already merged in `fabxc/servdisc`.

Prometheus now does start with a missing config file but logs errors. As an empty config file is valid, should we just allow starting with `-config.file=""` without any complaints? Would be convenient for testing.