### PR TITLE
Add initial file based service discovery.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -69,6 +69,10 @@
 			"Rev": "b6fdb7d8a4ccefede406f8fe0f017fb58265054c"
 		},
 		{
+			"ImportPath": "gopkg.in/fsnotify.v1",
+			"Rev": "96c060f6a6b7e0d6f75fddd10efeaca3e5d1bcb0",
+		},
+		{
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "49c95bdc21843256fb6c4e0d370a05f24a0bf213"
 		}

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/.gitignore
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/.gitignore
@@ -1,0 +1,6 @@
+# Setup a Global .gitignore for OS and editor generated files:
+# https://help.github.com/articles/ignoring-files
+# git config --global core.excludesfile ~/.gitignore_global
+
+.vagrant
+*.sublime-project

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/.travis.yml
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/.travis.yml
@@ -1,0 +1,15 @@
+sudo: false
+language: go
+
+go:
+  - 1.4.1
+
+before_script:
+  - FIXED=$(go fmt ./... | wc -l); if [ $FIXED -gt 0 ]; then echo "gofmt - $FIXED file(s) not formatted correctly, please run gofmt to fix this." && exit 1; fi
+
+os:
+  - linux
+  - osx
+
+notifications:
+  email: false

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/AUTHORS
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/AUTHORS
@@ -1,0 +1,34 @@
+# Names should be added to this file as
+#	Name or Organization <email address>
+# The email address is not required for organizations.
+
+# You can update this list using the following command:
+#
+#   $ git shortlog -se | awk '{print $2 " " $3 " " $4}'
+
+# Please keep the list sorted.
+
+Adrien Bustany <adrien@bustany.org>
+Caleb Spare <cespare@gmail.com>
+Case Nelson <case@teammating.com>
+Chris Howey <howeyc@gmail.com> <chris@howey.me>
+Christoffer Buchholz <christoffer.buchholz@gmail.com>
+Dave Cheney <dave@cheney.net>
+Francisco Souza <f@souza.cc>
+Hari haran <hariharan.uno@gmail.com>
+John C Barstow
+Kelvin Fo <vmirage@gmail.com>
+Matt Layher <mdlayher@gmail.com>
+Nathan Youngman <git@nathany.com>
+Paul Hammond <paul@paulhammond.org>
+Pieter Droogendijk <pieter@binky.org.uk>
+Pursuit92 <JoshChase@techpursuit.net>
+Rob Figueiredo <robfig@gmail.com>
+Soge Zhang <zhssoge@gmail.com>
+Tilak Sharma <tilaks@google.com>
+Travis Cline <travis.cline@gmail.com>
+Tudor Golubenco <tudor.g@gmail.com>
+Yukang <moorekang@gmail.com>
+bronze1man <bronze1man@gmail.com>
+debrando <denis.brandolini@gmail.com>
+henrikedwards <henrik.edwards@gmail.com>

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/CHANGELOG.md
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/CHANGELOG.md
@@ -1,0 +1,263 @@
+# Changelog
+
+## v1.2.0 / 2015-02-08
+
+* inotify: use epoll to wake up readEvents [#66](https://github.com/go-fsnotify/fsnotify/pull/66) (thanks @PieterD)
+* inotify: closing watcher should now always shut down goroutine [#63](https://github.com/go-fsnotify/fsnotify/pull/63) (thanks @PieterD)
+* kqueue: close kqueue after removing watches, fixes [#59](https://github.com/go-fsnotify/fsnotify/issues/59)
+
+## v1.1.1 / 2015-02-05
+
+* inotify: Retry read on EINTR [#61](https://github.com/go-fsnotify/fsnotify/issues/61) (thanks @PieterD)
+
+## v1.1.0 / 2014-12-12
+
+* kqueue: rework internals [#43](https://github.com/go-fsnotify/fsnotify/pull/43)
+    * add low-level functions
+    * only need to store flags on directories
+    * less mutexes [#13](https://github.com/go-fsnotify/fsnotify/issues/13)
+    * done can be an unbuffered channel
+    * remove calls to os.NewSyscallError
+* More efficient string concatenation for Event.String() [#52](https://github.com/go-fsnotify/fsnotify/pull/52) (thanks @mdlayher)
+* kqueue: fix regression in  rework causing subdirectories to be watched [#48](https://github.com/go-fsnotify/fsnotify/issues/48)
+* kqueue: cleanup internal watch before sending remove event [#51](https://github.com/go-fsnotify/fsnotify/issues/51)
+
+## v1.0.4 / 2014-09-07
+
+* kqueue: add dragonfly to the build tags.
+* Rename source code files, rearrange code so exported APIs are at the top.
+* Add done channel to example code. [#37](https://github.com/go-fsnotify/fsnotify/pull/37) (thanks @chenyukang)
+
+## v1.0.3 / 2014-08-19
+
+* [Fix] Windows MOVED_TO now translates to Create like on BSD and Linux. [#36](https://github.com/go-fsnotify/fsnotify/issues/36)
+
+## v1.0.2 / 2014-08-17
+
+* [Fix] Missing create events on OS X. [#14](https://github.com/go-fsnotify/fsnotify/issues/14) (thanks @zhsso)
+* [Fix] Make ./path and path equivalent. (thanks @zhsso)
+
+## v1.0.0 / 2014-08-15
+
+* [API] Remove AddWatch on Windows, use Add.
+* Improve documentation for exported identifiers. [#30](https://github.com/go-fsnotify/fsnotify/issues/30)
+* Minor updates based on feedback from golint.
+
+## dev / 2014-07-09
+
+* Moved to [github.com/go-fsnotify/fsnotify](https://github.com/go-fsnotify/fsnotify).
+* Use os.NewSyscallError instead of returning errno (thanks @hariharan-uno)
+ 
+## dev / 2014-07-04
+
+* kqueue: fix incorrect mutex used in Close()
+* Update example to demonstrate usage of Op.
+
+## dev / 2014-06-28
+
+* [API] Don't set the Write Op for attribute notifications [#4](https://github.com/go-fsnotify/fsnotify/issues/4)
+* Fix for String() method on Event (thanks Alex Brainman)
+* Don't build on Plan 9 or Solaris (thanks @4ad)
+
+## dev / 2014-06-21
+
+* Events channel of type Event rather than *Event.
+* [internal] use syscall constants directly for inotify and kqueue.
+* [internal] kqueue: rename events to kevents and fileEvent to event.
+
+## dev / 2014-06-19
+
+* Go 1.3+ required on Windows (uses syscall.ERROR_MORE_DATA internally).
+* [internal] remove cookie from Event struct (unused).
+* [internal] Event struct has the same definition across every OS.
+* [internal] remove internal watch and removeWatch methods.
+
+## dev / 2014-06-12
+
+* [API] Renamed Watch() to Add() and RemoveWatch() to Remove().
+* [API] Pluralized channel names: Events and Errors.
+* [API] Renamed FileEvent struct to Event.
+* [API] Op constants replace methods like IsCreate().
+
+## dev / 2014-06-12
+
+* Fix data race on kevent buffer (thanks @tilaks) [#98](https://github.com/howeyc/fsnotify/pull/98)
+
+## dev / 2014-05-23
+
+* [API] Remove current implementation of WatchFlags.
+    * current implementation doesn't take advantage of OS for efficiency
+    * provides little benefit over filtering events as they are received, but has  extra bookkeeping and mutexes
+    * no tests for the current implementation
+    * not fully implemented on Windows [#93](https://github.com/howeyc/fsnotify/issues/93#issuecomment-39285195)
+
+## v0.9.3 / 2014-12-31
+
+* kqueue: cleanup internal watch before sending remove event [#51](https://github.com/go-fsnotify/fsnotify/issues/51)
+
+## v0.9.2 / 2014-08-17
+
+* [Backport] Fix missing create events on OS X. [#14](https://github.com/go-fsnotify/fsnotify/issues/14) (thanks @zhsso)
+
+## v0.9.1 / 2014-06-12
+
+* Fix data race on kevent buffer (thanks @tilaks) [#98](https://github.com/howeyc/fsnotify/pull/98)
+
+## v0.9.0 / 2014-01-17
+
+* IsAttrib() for events that only concern a file's metadata [#79][] (thanks @abustany)
+* [Fix] kqueue: fix deadlock [#77][] (thanks @cespare)
+* [NOTICE] Development has moved to `code.google.com/p/go.exp/fsnotify` in preparation for inclusion in the Go standard library.
+
+## v0.8.12 / 2013-11-13
+
+* [API] Remove FD_SET and friends from Linux adapter
+
+## v0.8.11 / 2013-11-02
+
+* [Doc] Add Changelog [#72][] (thanks @nathany)
+* [Doc] Spotlight and double modify events on OS X [#62][] (reported by @paulhammond)
+
+## v0.8.10 / 2013-10-19
+
+* [Fix] kqueue: remove file watches when parent directory is removed [#71][] (reported by @mdwhatcott)
+* [Fix] kqueue: race between Close and readEvents [#70][] (reported by @bernerdschaefer)
+* [Doc] specify OS-specific limits in README (thanks @debrando)
+
+## v0.8.9 / 2013-09-08
+
+* [Doc] Contributing (thanks @nathany)
+* [Doc] update package path in example code [#63][] (thanks @paulhammond)
+* [Doc] GoCI badge in README (Linux only) [#60][]
+* [Doc] Cross-platform testing with Vagrant  [#59][] (thanks @nathany)
+
+## v0.8.8 / 2013-06-17
+
+* [Fix] Windows: handle `ERROR_MORE_DATA` on Windows [#49][] (thanks @jbowtie)
+
+## v0.8.7 / 2013-06-03
+
+* [API] Make syscall flags internal
+* [Fix] inotify: ignore event changes
+* [Fix] race in symlink test [#45][] (reported by @srid)
+* [Fix] tests on Windows
+* lower case error messages
+
+## v0.8.6 / 2013-05-23
+
+* kqueue: Use EVT_ONLY flag on Darwin
+* [Doc] Update README with full example
+
+## v0.8.5 / 2013-05-09
+
+* [Fix] inotify: allow monitoring of "broken" symlinks (thanks @tsg)
+
+## v0.8.4 / 2013-04-07
+
+* [Fix] kqueue: watch all file events [#40][] (thanks @ChrisBuchholz)
+
+## v0.8.3 / 2013-03-13
+
+* [Fix] inoitfy/kqueue memory leak [#36][] (reported by @nbkolchin)
+* [Fix] kqueue: use fsnFlags for watching a directory [#33][] (reported by @nbkolchin)
+
+## v0.8.2 / 2013-02-07
+
+* [Doc] add Authors
+* [Fix] fix data races for map access [#29][] (thanks @fsouza)
+
+## v0.8.1 / 2013-01-09
+
+* [Fix] Windows path separators
+* [Doc] BSD License
+
+## v0.8.0 / 2012-11-09
+
+* kqueue: directory watching improvements (thanks @vmirage)
+* inotify: add `IN_MOVED_TO` [#25][] (requested by @cpisto)
+* [Fix] kqueue: deleting watched directory [#24][] (reported by @jakerr)
+
+## v0.7.4 / 2012-10-09
+
+* [Fix] inotify: fixes from https://codereview.appspot.com/5418045/ (ugorji)
+* [Fix] kqueue: preserve watch flags when watching for delete [#21][] (reported by @robfig)
+* [Fix] kqueue: watch the directory even if it isn't a new watch (thanks @robfig)
+* [Fix] kqueue: modify after recreation of file
+
+## v0.7.3 / 2012-09-27
+
+* [Fix] kqueue: watch with an existing folder inside the watched folder (thanks @vmirage)
+* [Fix] kqueue: no longer get duplicate CREATE events
+
+## v0.7.2 / 2012-09-01
+
+* kqueue: events for created directories
+
+## v0.7.1 / 2012-07-14
+
+* [Fix] for renaming files
+
+## v0.7.0 / 2012-07-02
+
+* [Feature] FSNotify flags
+* [Fix] inotify: Added file name back to event path
+
+## v0.6.0 / 2012-06-06
+
+* kqueue: watch files after directory created (thanks @tmc)
+
+## v0.5.1 / 2012-05-22
+
+* [Fix] inotify: remove all watches before Close()
+
+## v0.5.0 / 2012-05-03
+
+* [API] kqueue: return errors during watch instead of sending over channel
+* kqueue: match symlink behavior on Linux
+* inotify: add `DELETE_SELF` (requested by @taralx)
+* [Fix] kqueue: handle EINTR (reported by @robfig)
+* [Doc] Godoc example [#1][] (thanks @davecheney)
+
+## v0.4.0 / 2012-03-30
+
+* Go 1 released: build with go tool
+* [Feature] Windows support using winfsnotify
+* Windows does not have attribute change notifications
+* Roll attribute notifications into IsModify
+
+## v0.3.0 / 2012-02-19
+
+* kqueue: add files when watch directory
+
+## v0.2.0 / 2011-12-30
+
+* update to latest Go weekly code
+
+## v0.1.0 / 2011-10-19
+
+* kqueue: add watch on file creation to match inotify
+* kqueue: create file event
+* inotify: ignore `IN_IGNORED` events
+* event String()
+* linux: common FileEvent functions
+* initial commit
+
+[#79]: https://github.com/howeyc/fsnotify/pull/79
+[#77]: https://github.com/howeyc/fsnotify/pull/77
+[#72]: https://github.com/howeyc/fsnotify/issues/72
+[#71]: https://github.com/howeyc/fsnotify/issues/71
+[#70]: https://github.com/howeyc/fsnotify/issues/70
+[#63]: https://github.com/howeyc/fsnotify/issues/63
+[#62]: https://github.com/howeyc/fsnotify/issues/62
+[#60]: https://github.com/howeyc/fsnotify/issues/60
+[#59]: https://github.com/howeyc/fsnotify/issues/59
+[#49]: https://github.com/howeyc/fsnotify/issues/49
+[#45]: https://github.com/howeyc/fsnotify/issues/45
+[#40]: https://github.com/howeyc/fsnotify/issues/40
+[#36]: https://github.com/howeyc/fsnotify/issues/36
+[#33]: https://github.com/howeyc/fsnotify/issues/33
+[#29]: https://github.com/howeyc/fsnotify/issues/29
+[#25]: https://github.com/howeyc/fsnotify/issues/25
+[#24]: https://github.com/howeyc/fsnotify/issues/24
+[#21]: https://github.com/howeyc/fsnotify/issues/21
+

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/CONTRIBUTING.md
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing
+
+## Issues
+
+* Request features and report bugs using the [GitHub Issue Tracker](https://github.com/go-fsnotify/fsnotify/issues).
+* Please indicate the platform you are using fsnotify on.
+* A code example to reproduce the problem is appreciated.
+
+## Pull Requests
+
+### Contributor License Agreement
+
+fsnotify is derived from code in the [golang.org/x/exp](https://godoc.org/golang.org/x/exp) package and it may be included [in the standard library](https://github.com/go-fsnotify/fsnotify/issues/1) in the future. Therefore fsnotify carries the same [LICENSE](https://github.com/go-fsnotify/fsnotify/blob/master/LICENSE) as Go. Contributors retain their copyright, so you need to fill out a short form before we can accept your contribution: [Google Individual Contributor License Agreement](https://developers.google.com/open-source/cla/individual).
+
+Please indicate that you have signed the CLA in your pull request.
+
+### How fsnotify is Developed
+
+* Development is done on feature branches.
+* Tests are run on BSD, Linux, OS X and Windows.
+* Pull requests are reviewed and [applied to master][am] using [hub][].
+  * Maintainers may modify or squash commits rather than asking contributors to.
+* To issue a new release, the maintainers will:
+  * Update the CHANGELOG
+  * Tag a version, which will become available through gopkg.in.
+ 
+### How to Fork
+
+For smooth sailing, always use the original import path. Installing with `go get` makes this easy. 
+
+1. Install from GitHub (`go get -u github.com/go-fsnotify/fsnotify`)
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Ensure everything works and the tests pass (see below)
+4. Commit your changes (`git commit -am 'Add some feature'`)
+
+Contribute upstream:
+
+1. Fork fsnotify on GitHub
+2. Add your remote (`git remote add fork git@github.com:mycompany/repo.git`)
+3. Push to the branch (`git push fork my-new-feature`)
+4. Create a new Pull Request on GitHub
+
+This workflow is [thoroughly explained by Katrina Owen](https://blog.splice.com/contributing-open-source-git-repositories-go/).
+
+### Testing
+
+fsnotify uses build tags to compile different code on Linux, BSD, OS X, and Windows.
+
+Before doing a pull request, please do your best to test your changes on multiple platforms, and list which platforms you were able/unable to test on.
+
+To aid in cross-platform testing there is a Vagrantfile for Linux and BSD.
+
+* Install [Vagrant](http://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/)
+* Setup [Vagrant Gopher](https://github.com/nathany/vagrant-gopher) in your `src` folder.
+* Run `vagrant up` from the project folder. You can also setup just one box with `vagrant up linux` or `vagrant up bsd` (note: the BSD box doesn't support Windows hosts at this time, and NFS may prompt for your host OS password)
+* Once setup, you can run the test suite on a given OS with a single command `vagrant ssh linux -c 'cd go-fsnotify/fsnotify; go test'`.
+* When you're done, you will want to halt or destroy the Vagrant boxes.
+
+Notice: fsnotify file system events won't trigger in shared folders. The tests get around this limitation by using the /tmp directory.
+
+Right now there is no equivalent solution for Windows and OS X, but there are Windows VMs [freely available from Microsoft](http://www.modern.ie/en-us/virtualization-tools#downloads).
+
+### Maintainers
+
+Help maintaining fsnotify is welcome. To be a maintainer:
+
+* Submit a pull request and sign the CLA as above.
+* You must be able to run the test suite on Mac, Windows, Linux and BSD.
+
+To keep master clean, the fsnotify project uses the "apply mail" workflow outlined in Nathaniel Talbott's post ["Merge pull request" Considered Harmful][am]. This requires installing [hub][].
+
+All code changes should be internal pull requests.
+
+Releases are tagged using [Semantic Versioning](http://semver.org/).
+
+[hub]: https://github.com/github/hub
+[am]: http://blog.spreedly.com/2014/06/24/merge-pull-request-considered-harmful/#.VGa5yZPF_Zs

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/LICENSE
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2012 fsnotify Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/README.md
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/README.md
@@ -1,0 +1,59 @@
+# File system notifications for Go
+
+[![Coverage](http://gocover.io/_badge/github.com/go-fsnotify/fsnotify)](http://gocover.io/github.com/go-fsnotify/fsnotify) [![GoDoc](https://godoc.org/gopkg.in/fsnotify.v1?status.svg)](https://godoc.org/gopkg.in/fsnotify.v1)
+
+Go 1.3+ required.
+
+Cross platform: Windows, Linux, BSD and OS X.
+
+|Adapter   |OS        |Status    |
+|----------|----------|----------|
+|inotify   |Linux, Android\*|Supported [![Build Status](https://travis-ci.org/go-fsnotify/fsnotify.svg?branch=master)](https://travis-ci.org/go-fsnotify/fsnotify)|
+|kqueue    |BSD, OS X, iOS\*|Supported [![Circle CI](https://circleci.com/gh/go-fsnotify/fsnotify.svg?style=svg)](https://circleci.com/gh/go-fsnotify/fsnotify)|
+|ReadDirectoryChangesW|Windows|Supported [![Build status](https://ci.appveyor.com/api/projects/status/ivwjubaih4r0udeh/branch/master?svg=true)](https://ci.appveyor.com/project/NathanYoungman/fsnotify/branch/master)|
+|FSEvents  |OS X          |[Planned](https://github.com/go-fsnotify/fsnotify/issues/11)|
+|FEN       |Solaris 11    |[Planned](https://github.com/go-fsnotify/fsnotify/issues/12)|
+|fanotify  |Linux 2.6.37+ | |
+|USN Journals |Windows    |[Maybe](https://github.com/go-fsnotify/fsnotify/issues/53)|
+|Polling   |*All*         |[Maybe](https://github.com/go-fsnotify/fsnotify/issues/9)|
+
+\* Android and iOS are untested.
+
+Please see [the documentation](https://godoc.org/gopkg.in/fsnotify.v1) for usage. Consult the [Wiki](https://github.com/go-fsnotify/fsnotify/wiki) for the FAQ and further information.
+
+## API stability
+
+Two major versions of fsnotify exist. 
+
+**[fsnotify.v0](https://gopkg.in/fsnotify.v0)** is API-compatible with [howeyc/fsnotify](https://godoc.org/github.com/howeyc/fsnotify). Bugfixes *may* be backported, but I recommend upgrading to v1.
+
+```go
+import "gopkg.in/fsnotify.v0"
+```
+
+\* Refer to the package as fsnotify (without the .v0 suffix).
+
+**[fsnotify.v1](https://gopkg.in/fsnotify.v1)** provides [a new API](https://godoc.org/gopkg.in/fsnotify.v1) based on [this design document](http://goo.gl/MrYxyA). You can import v1 with:
+
+```go
+import "gopkg.in/fsnotify.v1"
+```
+
+Further API changes are [planned](https://github.com/go-fsnotify/fsnotify/milestones), but a new major revision will be tagged, so you can depend on the v1 API.
+
+**Master** may have unreleased changes. Use it to test the very latest code or when [contributing][], but don't expect it to remain API-compatible:
+
+```go
+import "github.com/go-fsnotify/fsnotify"
+```
+
+## Contributing
+
+Please refer to [CONTRIBUTING][] before opening an issue or pull request.
+
+## Example
+
+See [example_test.go](https://github.com/go-fsnotify/fsnotify/blob/master/example_test.go).
+
+
+[contributing]: https://github.com/go-fsnotify/fsnotify/blob/master/CONTRIBUTING.md

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/circle.yml
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/circle.yml
@@ -1,0 +1,26 @@
+## OS X build (CircleCI iOS beta)
+
+# Pretend like it's an Xcode project, at least to get it running.
+machine:
+  environment:
+    XCODE_WORKSPACE: NotUsed.xcworkspace
+    XCODE_SCHEME: NotUsed
+    # This is where the go project is actually checked out to:
+    CIRCLE_BUILD_DIR: $HOME/.go_project/src/github.com/go-fsnotify/fsnotify
+
+dependencies:
+  pre:
+    - brew upgrade go
+
+test:
+  override:
+    - go test ./...
+
+# Idealized future config, eventually with cross-platform build matrix :-)
+
+# machine:
+#   go:
+#     version: 1.4
+#   os:
+#     - osx
+#     - linux

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/example_test.go
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/example_test.go
@@ -1,0 +1,42 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !plan9,!solaris
+
+package fsnotify_test
+
+import (
+	"log"
+
+	"github.com/go-fsnotify/fsnotify"
+)
+
+func ExampleNewWatcher() {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer watcher.Close()
+
+	done := make(chan bool)
+	go func() {
+		for {
+			select {
+			case event := <-watcher.Events:
+				log.Println("event:", event)
+				if event.Op&fsnotify.Write == fsnotify.Write {
+					log.Println("modified file:", event.Name)
+				}
+			case err := <-watcher.Errors:
+				log.Println("error:", err)
+			}
+		}
+	}()
+
+	err = watcher.Add("/tmp/foo")
+	if err != nil {
+		log.Fatal(err)
+	}
+	<-done
+}

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/fsnotify.go
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/fsnotify.go
@@ -1,0 +1,62 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !plan9,!solaris
+
+// Package fsnotify provides a platform-independent interface for file system notifications.
+package fsnotify
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Event represents a single file system notification.
+type Event struct {
+	Name string // Relative path to the file or directory.
+	Op   Op     // File operation that triggered the event.
+}
+
+// Op describes a set of file operations.
+type Op uint32
+
+// These are the generalized file operations that can trigger a notification.
+const (
+	Create Op = 1 << iota
+	Write
+	Remove
+	Rename
+	Chmod
+)
+
+// String returns a string representation of the event in the form
+// "file: REMOVE|WRITE|..."
+func (e Event) String() string {
+	// Use a buffer for efficient string concatenation
+	var buffer bytes.Buffer
+
+	if e.Op&Create == Create {
+		buffer.WriteString("|CREATE")
+	}
+	if e.Op&Remove == Remove {
+		buffer.WriteString("|REMOVE")
+	}
+	if e.Op&Write == Write {
+		buffer.WriteString("|WRITE")
+	}
+	if e.Op&Rename == Rename {
+		buffer.WriteString("|RENAME")
+	}
+	if e.Op&Chmod == Chmod {
+		buffer.WriteString("|CHMOD")
+	}
+
+	// If buffer remains empty, return no event names
+	if buffer.Len() == 0 {
+		return fmt.Sprintf("%q: ", e.Name)
+	}
+
+	// Return a list of event names, with leading pipe character stripped
+	return fmt.Sprintf("%q: %s", e.Name, buffer.String()[1:])
+}

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/inotify.go
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/inotify.go
@@ -1,0 +1,306 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package fsnotify
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+// Watcher watches a set of files, delivering events to a channel.
+type Watcher struct {
+	Events   chan Event
+	Errors   chan error
+	mu       sync.Mutex // Map access
+	fd       int
+	poller   *fdPoller
+	watches  map[string]*watch // Map of inotify watches (key: path)
+	paths    map[int]string    // Map of watched paths (key: watch descriptor)
+	done     chan struct{}     // Channel for sending a "quit message" to the reader goroutine
+	doneResp chan struct{}     // Channel to respond to Close
+}
+
+// NewWatcher establishes a new watcher with the underlying OS and begins waiting for events.
+func NewWatcher() (*Watcher, error) {
+	// Create inotify fd
+	fd, errno := syscall.InotifyInit()
+	if fd == -1 {
+		return nil, errno
+	}
+	// Create epoll
+	poller, err := newFdPoller(fd)
+	if err != nil {
+		syscall.Close(fd)
+		return nil, err
+	}
+	w := &Watcher{
+		fd:       fd,
+		poller:   poller,
+		watches:  make(map[string]*watch),
+		paths:    make(map[int]string),
+		Events:   make(chan Event),
+		Errors:   make(chan error),
+		done:     make(chan struct{}),
+		doneResp: make(chan struct{}),
+	}
+
+	go w.readEvents()
+	return w, nil
+}
+
+func (w *Watcher) isClosed() bool {
+	select {
+	case <-w.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// Close removes all watches and closes the events channel.
+func (w *Watcher) Close() error {
+	if w.isClosed() {
+		return nil
+	}
+
+	// Send 'close' signal to goroutine, and set the Watcher to closed.
+	close(w.done)
+
+	// Wake up goroutine
+	w.poller.wake()
+
+	// Wait for goroutine to close
+	<-w.doneResp
+
+	return nil
+}
+
+// Add starts watching the named file or directory (non-recursively).
+func (w *Watcher) Add(name string) error {
+	name = filepath.Clean(name)
+	if w.isClosed() {
+		return errors.New("inotify instance already closed")
+	}
+
+	const agnosticEvents = syscall.IN_MOVED_TO | syscall.IN_MOVED_FROM |
+		syscall.IN_CREATE | syscall.IN_ATTRIB | syscall.IN_MODIFY |
+		syscall.IN_MOVE_SELF | syscall.IN_DELETE | syscall.IN_DELETE_SELF
+
+	var flags uint32 = agnosticEvents
+
+	w.mu.Lock()
+	watchEntry, found := w.watches[name]
+	w.mu.Unlock()
+	if found {
+		watchEntry.flags |= flags
+		flags |= syscall.IN_MASK_ADD
+	}
+	wd, errno := syscall.InotifyAddWatch(w.fd, name, flags)
+	if wd == -1 {
+		return errno
+	}
+
+	w.mu.Lock()
+	w.watches[name] = &watch{wd: uint32(wd), flags: flags}
+	w.paths[wd] = name
+	w.mu.Unlock()
+
+	return nil
+}
+
+// Remove stops watching the named file or directory (non-recursively).
+func (w *Watcher) Remove(name string) error {
+	name = filepath.Clean(name)
+
+	// Fetch the watch.
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	watch, ok := w.watches[name]
+
+	// Remove it from inotify.
+	if !ok {
+		return fmt.Errorf("can't remove non-existent inotify watch for: %s", name)
+	}
+	// inotify_rm_watch will return EINVAL if the file has been deleted;
+	// the inotify will already have been removed.
+	// That means we can safely delete it from our watches, whatever inotify_rm_watch does.
+	delete(w.watches, name)
+	success, errno := syscall.InotifyRmWatch(w.fd, watch.wd)
+	if success == -1 {
+		// TODO: Perhaps it's not helpful to return an error here in every case.
+		// the only two possible errors are:
+		// EBADF, which happens when w.fd is not a valid file descriptor of any kind.
+		// EINVAL, which is when fd is not an inotify descriptor or wd is not a valid watch descriptor.
+		// Watch descriptors are invalidated when they are removed explicitly or implicitly;
+		// explicitly by inotify_rm_watch, implicitly when the file they are watching is deleted.
+		return errno
+	}
+	return nil
+}
+
+type watch struct {
+	wd    uint32 // Watch descriptor (as returned by the inotify_add_watch() syscall)
+	flags uint32 // inotify flags of this watch (see inotify(7) for the list of valid flags)
+}
+
+// readEvents reads from the inotify file descriptor, converts the
+// received events into Event objects and sends them via the Events channel
+func (w *Watcher) readEvents() {
+	var (
+		buf   [syscall.SizeofInotifyEvent * 4096]byte // Buffer for a maximum of 4096 raw events
+		n     int                                     // Number of bytes read with read()
+		errno error                                   // Syscall errno
+		ok    bool                                    // For poller.wait
+	)
+
+	defer close(w.doneResp)
+	defer close(w.Errors)
+	defer close(w.Events)
+	defer syscall.Close(w.fd)
+	defer w.poller.close()
+
+	for {
+		// See if we have been closed.
+		if w.isClosed() {
+			return
+		}
+
+		ok, errno = w.poller.wait()
+		if errno != nil {
+			select {
+			case w.Errors <- errno:
+			case <-w.done:
+				return
+			}
+			continue
+		}
+
+		if !ok {
+			continue
+		}
+
+		n, errno = syscall.Read(w.fd, buf[:])
+		// If a signal interrupted execution, see if we've been asked to close, and try again.
+		// http://man7.org/linux/man-pages/man7/signal.7.html :
+		// "Before Linux 3.8, reads from an inotify(7) file descriptor were not restartable"
+		if errno == syscall.EINTR {
+			continue
+		}
+
+		// syscall.Read might have been woken up by Close. If so, we're done.
+		if w.isClosed() {
+			return
+		}
+
+		if n < syscall.SizeofInotifyEvent {
+			var err error
+			if n == 0 {
+				// If EOF is received. This should really never happen.
+				err = io.EOF
+			} else if n < 0 {
+				// If an error occured while reading.
+				err = errno
+			} else {
+				// Read was too short.
+				err = errors.New("notify: short read in readEvents()")
+			}
+			select {
+			case w.Errors <- err:
+			case <-w.done:
+				return
+			}
+			continue
+		}
+
+		var offset uint32
+		// We don't know how many events we just read into the buffer
+		// While the offset points to at least one whole event...
+		for offset <= uint32(n-syscall.SizeofInotifyEvent) {
+			// Point "raw" to the event in the buffer
+			raw := (*syscall.InotifyEvent)(unsafe.Pointer(&buf[offset]))
+
+			mask := uint32(raw.Mask)
+			nameLen := uint32(raw.Len)
+			// If the event happened to the watched directory or the watched file, the kernel
+			// doesn't append the filename to the event, but we would like to always fill the
+			// the "Name" field with a valid filename. We retrieve the path of the watch from
+			// the "paths" map.
+			w.mu.Lock()
+			name := w.paths[int(raw.Wd)]
+			w.mu.Unlock()
+			if nameLen > 0 {
+				// Point "bytes" at the first byte of the filename
+				bytes := (*[syscall.PathMax]byte)(unsafe.Pointer(&buf[offset+syscall.SizeofInotifyEvent]))
+				// The filename is padded with NULL bytes. TrimRight() gets rid of those.
+				name += "/" + strings.TrimRight(string(bytes[0:nameLen]), "\000")
+			}
+
+			event := newEvent(name, mask)
+
+			// Send the events that are not ignored on the events channel
+			if !event.ignoreLinux(mask) {
+				select {
+				case w.Events <- event:
+				case <-w.done:
+					return
+				}
+			}
+
+			// Move to the next event in the buffer
+			offset += syscall.SizeofInotifyEvent + nameLen
+		}
+	}
+}
+
+// Certain types of events can be "ignored" and not sent over the Events
+// channel. Such as events marked ignore by the kernel, or MODIFY events
+// against files that do not exist.
+func (e *Event) ignoreLinux(mask uint32) bool {
+	// Ignore anything the inotify API says to ignore
+	if mask&syscall.IN_IGNORED == syscall.IN_IGNORED {
+		return true
+	}
+
+	// If the event is not a DELETE or RENAME, the file must exist.
+	// Otherwise the event is ignored.
+	// *Note*: this was put in place because it was seen that a MODIFY
+	// event was sent after the DELETE. This ignores that MODIFY and
+	// assumes a DELETE will come or has come if the file doesn't exist.
+	if !(e.Op&Remove == Remove || e.Op&Rename == Rename) {
+		_, statErr := os.Lstat(e.Name)
+		return os.IsNotExist(statErr)
+	}
+	return false
+}
+
+// newEvent returns an platform-independent Event based on an inotify mask.
+func newEvent(name string, mask uint32) Event {
+	e := Event{Name: name}
+	if mask&syscall.IN_CREATE == syscall.IN_CREATE || mask&syscall.IN_MOVED_TO == syscall.IN_MOVED_TO {
+		e.Op |= Create
+	}
+	if mask&syscall.IN_DELETE_SELF == syscall.IN_DELETE_SELF || mask&syscall.IN_DELETE == syscall.IN_DELETE {
+		e.Op |= Remove
+	}
+	if mask&syscall.IN_MODIFY == syscall.IN_MODIFY {
+		e.Op |= Write
+	}
+	if mask&syscall.IN_MOVE_SELF == syscall.IN_MOVE_SELF || mask&syscall.IN_MOVED_FROM == syscall.IN_MOVED_FROM {
+		e.Op |= Rename
+	}
+	if mask&syscall.IN_ATTRIB == syscall.IN_ATTRIB {
+		e.Op |= Chmod
+	}
+	return e
+}

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/inotify_poller.go
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/inotify_poller.go
@@ -1,0 +1,186 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package fsnotify
+
+import (
+	"errors"
+	"syscall"
+)
+
+type fdPoller struct {
+	fd   int    // File descriptor (as returned by the inotify_init() syscall)
+	epfd int    // Epoll file descriptor
+	pipe [2]int // Pipe for waking up
+}
+
+func emptyPoller(fd int) *fdPoller {
+	poller := new(fdPoller)
+	poller.fd = fd
+	poller.epfd = -1
+	poller.pipe[0] = -1
+	poller.pipe[1] = -1
+	return poller
+}
+
+// Create a new inotify poller.
+// This creates an inotify handler, and an epoll handler.
+func newFdPoller(fd int) (*fdPoller, error) {
+	var errno error
+	poller := emptyPoller(fd)
+	defer func() {
+		if errno != nil {
+			poller.close()
+		}
+	}()
+	poller.fd = fd
+
+	// Create epoll fd
+	poller.epfd, errno = syscall.EpollCreate(1)
+	if poller.epfd == -1 {
+		return nil, errno
+	}
+	// Create pipe; pipe[0] is the read end, pipe[1] the write end.
+	errno = syscall.Pipe2(poller.pipe[:], syscall.O_NONBLOCK)
+	if errno != nil {
+		return nil, errno
+	}
+
+	// Register inotify fd with epoll
+	event := syscall.EpollEvent{
+		Fd:     int32(poller.fd),
+		Events: syscall.EPOLLIN,
+	}
+	errno = syscall.EpollCtl(poller.epfd, syscall.EPOLL_CTL_ADD, poller.fd, &event)
+	if errno != nil {
+		return nil, errno
+	}
+
+	// Register pipe fd with epoll
+	event = syscall.EpollEvent{
+		Fd:     int32(poller.pipe[0]),
+		Events: syscall.EPOLLIN,
+	}
+	errno = syscall.EpollCtl(poller.epfd, syscall.EPOLL_CTL_ADD, poller.pipe[0], &event)
+	if errno != nil {
+		return nil, errno
+	}
+
+	return poller, nil
+}
+
+// Wait using epoll.
+// Returns true if something is ready to be read,
+// false if there is not.
+func (poller *fdPoller) wait() (bool, error) {
+	// 3 possible events per fd, and 2 fds, makes a maximum of 6 events.
+	// I don't know whether epoll_wait returns the number of events returned,
+	// or the total number of events ready.
+	// I decided to catch both by making the buffer one larger than the maximum.
+	events := make([]syscall.EpollEvent, 7)
+	for {
+		n, errno := syscall.EpollWait(poller.epfd, events, -1)
+		if n == -1 {
+			if errno == syscall.EINTR {
+				continue
+			}
+			return false, errno
+		}
+		if n == 0 {
+			// If there are no events, try again.
+			continue
+		}
+		if n > 6 {
+			// This should never happen. More events were returned than should be possible.
+			return false, errors.New("epoll_wait returned more events than I know what to do with")
+		}
+		ready := events[:n]
+		epollhup := false
+		epollerr := false
+		epollin := false
+		for _, event := range ready {
+			if event.Fd == int32(poller.fd) {
+				if event.Events&syscall.EPOLLHUP != 0 {
+					// This should not happen, but if it does, treat it as a wakeup.
+					epollhup = true
+				}
+				if event.Events&syscall.EPOLLERR != 0 {
+					// If an error is waiting on the file descriptor, we should pretend
+					// something is ready to read, and let syscall.Read pick up the error.
+					epollerr = true
+				}
+				if event.Events&syscall.EPOLLIN != 0 {
+					// There is data to read.
+					epollin = true
+				}
+			}
+			if event.Fd == int32(poller.pipe[0]) {
+				if event.Events&syscall.EPOLLHUP != 0 {
+					// Write pipe descriptor was closed, by us. This means we're closing down the
+					// watcher, and we should wake up.
+				}
+				if event.Events&syscall.EPOLLERR != 0 {
+					// If an error is waiting on the pipe file descriptor.
+					// This is an absolute mystery, and should never ever happen.
+					return false, errors.New("Error on the pipe descriptor.")
+				}
+				if event.Events&syscall.EPOLLIN != 0 {
+					// This is a regular wakeup, so we have to clear the buffer.
+					err := poller.clearWake()
+					if err != nil {
+						return false, err
+					}
+				}
+			}
+		}
+
+		if epollhup || epollerr || epollin {
+			return true, nil
+		}
+		return false, nil
+	}
+}
+
+// Close the write end of the poller.
+func (poller *fdPoller) wake() error {
+	buf := make([]byte, 1)
+	n, errno := syscall.Write(poller.pipe[1], buf)
+	if n == -1 {
+		if errno == syscall.EAGAIN {
+			// Buffer is full, poller will wake.
+			return nil
+		}
+		return errno
+	}
+	return nil
+}
+
+func (poller *fdPoller) clearWake() error {
+	// You have to be woken up a LOT in order to get to 100!
+	buf := make([]byte, 100)
+	n, errno := syscall.Read(poller.pipe[0], buf)
+	if n == -1 {
+		if errno == syscall.EAGAIN {
+			// Buffer is empty, someone else cleared our wake.
+			return nil
+		}
+		return errno
+	}
+	return nil
+}
+
+// Close all poller file descriptors, but not the one passed to it.
+func (poller *fdPoller) close() {
+	if poller.pipe[1] != -1 {
+		syscall.Close(poller.pipe[1])
+	}
+	if poller.pipe[0] != -1 {
+		syscall.Close(poller.pipe[0])
+	}
+	if poller.epfd != -1 {
+		syscall.Close(poller.epfd)
+	}
+}

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/inotify_poller_test.go
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/inotify_poller_test.go
@@ -1,0 +1,228 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package fsnotify
+
+import (
+	"syscall"
+	"testing"
+	"time"
+)
+
+type testFd [2]int
+
+func makeTestFd(t *testing.T) testFd {
+	var tfd testFd
+	errno := syscall.Pipe(tfd[:])
+	if errno != nil {
+		t.Fatalf("Failed to create pipe: %v", errno)
+	}
+	return tfd
+}
+
+func (tfd testFd) fd() int {
+	return tfd[0]
+}
+
+func (tfd testFd) closeWrite(t *testing.T) {
+	errno := syscall.Close(tfd[1])
+	if errno != nil {
+		t.Fatalf("Failed to close write end of pipe: %v", errno)
+	}
+}
+
+func (tfd testFd) put(t *testing.T) {
+	buf := make([]byte, 10)
+	_, errno := syscall.Write(tfd[1], buf)
+	if errno != nil {
+		t.Fatalf("Failed to write to pipe: %v", errno)
+	}
+}
+
+func (tfd testFd) get(t *testing.T) {
+	buf := make([]byte, 10)
+	_, errno := syscall.Read(tfd[0], buf)
+	if errno != nil {
+		t.Fatalf("Failed to read from pipe: %v", errno)
+	}
+}
+
+func (tfd testFd) close() {
+	syscall.Close(tfd[1])
+	syscall.Close(tfd[0])
+}
+
+func makePoller(t *testing.T) (testFd, *fdPoller) {
+	tfd := makeTestFd(t)
+	poller, err := newFdPoller(tfd.fd())
+	if err != nil {
+		t.Fatalf("Failed to create poller: %v", err)
+	}
+	return tfd, poller
+}
+
+func TestPollerWithBadFd(t *testing.T) {
+	_, err := newFdPoller(-1)
+	if err != syscall.EBADF {
+		t.Fatalf("Expected EBADF, got: %v", err)
+	}
+}
+
+func TestPollerWithData(t *testing.T) {
+	tfd, poller := makePoller(t)
+	defer tfd.close()
+	defer poller.close()
+
+	tfd.put(t)
+	ok, err := poller.wait()
+	if err != nil {
+		t.Fatalf("poller failed: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected poller to return true")
+	}
+	tfd.get(t)
+}
+
+func TestPollerWithWakeup(t *testing.T) {
+	tfd, poller := makePoller(t)
+	defer tfd.close()
+	defer poller.close()
+
+	err := poller.wake()
+	if err != nil {
+		t.Fatalf("wake failed: %v", err)
+	}
+	ok, err := poller.wait()
+	if err != nil {
+		t.Fatalf("poller failed: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected poller to return false")
+	}
+}
+
+func TestPollerWithClose(t *testing.T) {
+	tfd, poller := makePoller(t)
+	defer tfd.close()
+	defer poller.close()
+
+	tfd.closeWrite(t)
+	ok, err := poller.wait()
+	if err != nil {
+		t.Fatalf("poller failed: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected poller to return true")
+	}
+}
+
+func TestPollerWithWakeupAndData(t *testing.T) {
+	tfd, poller := makePoller(t)
+	defer tfd.close()
+	defer poller.close()
+
+	tfd.put(t)
+	err := poller.wake()
+	if err != nil {
+		t.Fatalf("wake failed: %v", err)
+	}
+
+	// both data and wakeup
+	ok, err := poller.wait()
+	if err != nil {
+		t.Fatalf("poller failed: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected poller to return true")
+	}
+
+	// data is still in the buffer, wakeup is cleared
+	ok, err = poller.wait()
+	if err != nil {
+		t.Fatalf("poller failed: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected poller to return true")
+	}
+
+	tfd.get(t)
+	// data is gone, only wakeup now
+	err = poller.wake()
+	if err != nil {
+		t.Fatalf("wake failed: %v", err)
+	}
+	ok, err = poller.wait()
+	if err != nil {
+		t.Fatalf("poller failed: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected poller to return false")
+	}
+}
+
+func TestPollerConcurrent(t *testing.T) {
+	tfd, poller := makePoller(t)
+	defer tfd.close()
+	defer poller.close()
+
+	oks := make(chan bool)
+	live := make(chan bool)
+	defer close(live)
+	go func() {
+		defer close(oks)
+		for {
+			ok, err := poller.wait()
+			if err != nil {
+				t.Fatalf("poller failed: %v", err)
+			}
+			oks <- ok
+			if !<-live {
+				return
+			}
+		}
+	}()
+
+	// Try a write
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-oks:
+		t.Fatalf("poller did not wait")
+	}
+	tfd.put(t)
+	if !<-oks {
+		t.Fatalf("expected true")
+	}
+	tfd.get(t)
+	live <- true
+
+	// Try a wakeup
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-oks:
+		t.Fatalf("poller did not wait")
+	}
+	err := poller.wake()
+	if err != nil {
+		t.Fatalf("wake failed: %v", err)
+	}
+	if <-oks {
+		t.Fatalf("expected false")
+	}
+	live <- true
+
+	// Try a close
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-oks:
+		t.Fatalf("poller did not wait")
+	}
+	tfd.closeWrite(t)
+	if !<-oks {
+		t.Fatalf("expected true")
+	}
+	tfd.get(t)
+}

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/inotify_test.go
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/inotify_test.go
@@ -1,0 +1,292 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package fsnotify
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestInotifyCloseRightAway(t *testing.T) {
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("Failed to create watcher")
+	}
+
+	// Close immediately; it won't even reach the first syscall.Read.
+	w.Close()
+
+	// Wait for the close to complete.
+	<-time.After(50 * time.Millisecond)
+	isWatcherReallyClosed(t, w)
+}
+
+func TestInotifyCloseSlightlyLater(t *testing.T) {
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("Failed to create watcher")
+	}
+
+	// Wait until readEvents has reached syscall.Read, and Close.
+	<-time.After(50 * time.Millisecond)
+	w.Close()
+
+	// Wait for the close to complete.
+	<-time.After(50 * time.Millisecond)
+	isWatcherReallyClosed(t, w)
+}
+
+func TestInotifyCloseSlightlyLaterWithWatch(t *testing.T) {
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("Failed to create watcher")
+	}
+	w.Add(testDir)
+
+	// Wait until readEvents has reached syscall.Read, and Close.
+	<-time.After(50 * time.Millisecond)
+	w.Close()
+
+	// Wait for the close to complete.
+	<-time.After(50 * time.Millisecond)
+	isWatcherReallyClosed(t, w)
+}
+
+func TestInotifyCloseAfterRead(t *testing.T) {
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("Failed to create watcher")
+	}
+
+	err = w.Add(testDir)
+	if err != nil {
+		t.Fatalf("Failed to add .")
+	}
+
+	// Generate an event.
+	os.Create(filepath.Join(testDir, "somethingSOMETHINGsomethingSOMETHING"))
+
+	// Wait for readEvents to read the event, then close the watcher.
+	<-time.After(50 * time.Millisecond)
+	w.Close()
+
+	// Wait for the close to complete.
+	<-time.After(50 * time.Millisecond)
+	isWatcherReallyClosed(t, w)
+}
+
+func isWatcherReallyClosed(t *testing.T, w *Watcher) {
+	select {
+	case err, ok := <-w.Errors:
+		if ok {
+			t.Fatalf("w.Errors is not closed; readEvents is still alive after closing (error: %v)", err)
+		}
+	default:
+		t.Fatalf("w.Errors would have blocked; readEvents is still alive!")
+	}
+
+	select {
+	case _, ok := <-w.Events:
+		if ok {
+			t.Fatalf("w.Events is not closed; readEvents is still alive after closing")
+		}
+	default:
+		t.Fatalf("w.Events would have blocked; readEvents is still alive!")
+	}
+}
+
+func TestInotifyCloseCreate(t *testing.T) {
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("Failed to create watcher: %v", err)
+	}
+	defer w.Close()
+
+	err = w.Add(testDir)
+	if err != nil {
+		t.Fatalf("Failed to add testDir: %v", err)
+	}
+	h, err := os.Create(filepath.Join(testDir, "testfile"))
+	if err != nil {
+		t.Fatalf("Failed to create file in testdir: %v", err)
+	}
+	h.Close()
+	select {
+	case _ = <-w.Events:
+	case err := <-w.Errors:
+		t.Fatalf("Error from watcher: %v", err)
+	case <-time.After(50 * time.Millisecond):
+		t.Fatalf("Took too long to wait for event")
+	}
+
+	// At this point, we've received one event, so the goroutine is ready.
+	// It's also blocking on syscall.Read.
+	// Now we try to swap the file descriptor under its nose.
+	w.Close()
+	w, err = NewWatcher()
+	defer w.Close()
+	if err != nil {
+		t.Fatalf("Failed to create second watcher: %v", err)
+	}
+
+	<-time.After(50 * time.Millisecond)
+	err = w.Add(testDir)
+	if err != nil {
+		t.Fatalf("Error adding testDir again: %v", err)
+	}
+}
+
+func TestInotifyStress(t *testing.T) {
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+	testFile := filepath.Join(testDir, "testfile")
+
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("Failed to create watcher: %v", err)
+	}
+	defer w.Close()
+
+	killchan := make(chan struct{})
+	defer close(killchan)
+
+	err = w.Add(testDir)
+	if err != nil {
+		t.Fatalf("Failed to add testDir: %v", err)
+	}
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("Error finding process: %v", err)
+	}
+
+	go func() {
+		for {
+			select {
+			case <-time.After(5 * time.Millisecond):
+				err := proc.Signal(syscall.SIGUSR1)
+				if err != nil {
+					t.Fatalf("Signal failed: %v", err)
+				}
+			case <-killchan:
+				return
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-time.After(11 * time.Millisecond):
+				err := w.poller.wake()
+				if err != nil {
+					t.Fatalf("Wake failed: %v", err)
+				}
+			case <-killchan:
+				return
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-killchan:
+				return
+			default:
+				handle, err := os.Create(testFile)
+				if err != nil {
+					t.Fatalf("Create failed: %v", err)
+				}
+				handle.Close()
+				time.Sleep(time.Millisecond)
+				err = os.Remove(testFile)
+				if err != nil {
+					t.Fatalf("Remove failed: %v", err)
+				}
+			}
+		}
+	}()
+
+	creates := 0
+	removes := 0
+	after := time.After(5 * time.Second)
+	for {
+		select {
+		case <-after:
+			if creates-removes > 1 || creates-removes < -1 {
+				t.Fatalf("Creates and removes should not be off by more than one: %d creates, %d removes", creates, removes)
+			}
+			if creates < 50 {
+				t.Fatalf("Expected at least 50 creates, got %d", creates)
+			}
+			return
+		case err := <-w.Errors:
+			t.Fatalf("Got an error from watcher: %v", err)
+		case evt := <-w.Events:
+			if evt.Name != testFile {
+				t.Fatalf("Got an event for an unknown file: %s", evt.Name)
+			}
+			if evt.Op == Create {
+				creates++
+			}
+			if evt.Op == Remove {
+				removes++
+			}
+		}
+	}
+}
+
+func TestInotifyRemoveTwice(t *testing.T) {
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+	testFile := filepath.Join(testDir, "testfile")
+
+	handle, err := os.Create(testFile)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	handle.Close()
+
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("Failed to create watcher: %v", err)
+	}
+	defer w.Close()
+
+	err = w.Add(testFile)
+	if err != nil {
+		t.Fatalf("Failed to add testFile: %v", err)
+	}
+
+	err = os.Remove(testFile)
+	if err != nil {
+		t.Fatalf("Failed to remove testFile: %v", err)
+	}
+
+	err = w.Remove(testFile)
+	if err != syscall.EINVAL {
+		t.Fatalf("Expected EINVAL from Remove, got: %v", err)
+	}
+
+	err = w.Remove(testFile)
+	if err == syscall.EINVAL {
+		t.Fatalf("Got EINVAL again, watch was not removed")
+	}
+}

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/integration_test.go
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/integration_test.go
@@ -1,0 +1,1135 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !plan9,!solaris
+
+package fsnotify
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// An atomic counter
+type counter struct {
+	val int32
+}
+
+func (c *counter) increment() {
+	atomic.AddInt32(&c.val, 1)
+}
+
+func (c *counter) value() int32 {
+	return atomic.LoadInt32(&c.val)
+}
+
+func (c *counter) reset() {
+	atomic.StoreInt32(&c.val, 0)
+}
+
+// tempMkdir makes a temporary directory
+func tempMkdir(t *testing.T) string {
+	dir, err := ioutil.TempDir("", "fsnotify")
+	if err != nil {
+		t.Fatalf("failed to create test directory: %s", err)
+	}
+	return dir
+}
+
+// newWatcher initializes an fsnotify Watcher instance.
+func newWatcher(t *testing.T) *Watcher {
+	watcher, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("NewWatcher() failed: %s", err)
+	}
+	return watcher
+}
+
+// addWatch adds a watch for a directory
+func addWatch(t *testing.T, watcher *Watcher, dir string) {
+	if err := watcher.Add(dir); err != nil {
+		t.Fatalf("watcher.Add(%q) failed: %s", dir, err)
+	}
+}
+
+func TestFsnotifyMultipleOperations(t *testing.T) {
+	watcher := newWatcher(t)
+
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for err := range watcher.Errors {
+			t.Fatalf("error received: %s", err)
+		}
+	}()
+
+	// Create directory to watch
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	// Create directory that's not watched
+	testDirToMoveFiles := tempMkdir(t)
+	defer os.RemoveAll(testDirToMoveFiles)
+
+	testFile := filepath.Join(testDir, "TestFsnotifySeq.testfile")
+	testFileRenamed := filepath.Join(testDirToMoveFiles, "TestFsnotifySeqRename.testfile")
+
+	addWatch(t, watcher, testDir)
+
+	// Receive events on the event channel on a separate goroutine
+	eventstream := watcher.Events
+	var createReceived, modifyReceived, deleteReceived, renameReceived counter
+	done := make(chan bool)
+	go func() {
+		for event := range eventstream {
+			// Only count relevant events
+			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFile) {
+				t.Logf("event received: %s", event)
+				if event.Op&Remove == Remove {
+					deleteReceived.increment()
+				}
+				if event.Op&Write == Write {
+					modifyReceived.increment()
+				}
+				if event.Op&Create == Create {
+					createReceived.increment()
+				}
+				if event.Op&Rename == Rename {
+					renameReceived.increment()
+				}
+			} else {
+				t.Logf("unexpected event received: %s", event)
+			}
+		}
+		done <- true
+	}()
+
+	// Create a file
+	// This should add at least one event to the fsnotify event queue
+	var f *os.File
+	f, err := os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	f.Sync()
+
+	time.Sleep(time.Millisecond)
+	f.WriteString("data")
+	f.Sync()
+	f.Close()
+
+	time.Sleep(50 * time.Millisecond) // give system time to sync write change before delete
+
+	if err := testRename(testFile, testFileRenamed); err != nil {
+		t.Fatalf("rename failed: %s", err)
+	}
+
+	// Modify the file outside of the watched dir
+	f, err = os.Open(testFileRenamed)
+	if err != nil {
+		t.Fatalf("open test renamed file failed: %s", err)
+	}
+	f.WriteString("data")
+	f.Sync()
+	f.Close()
+
+	time.Sleep(50 * time.Millisecond) // give system time to sync write change before delete
+
+	// Recreate the file that was moved
+	f, err = os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	f.Close()
+	time.Sleep(50 * time.Millisecond) // give system time to sync write change before delete
+
+	// We expect this event to be received almost immediately, but let's wait 500 ms to be sure
+	time.Sleep(500 * time.Millisecond)
+	cReceived := createReceived.value()
+	if cReceived != 2 {
+		t.Fatalf("incorrect number of create events received after 500 ms (%d vs %d)", cReceived, 2)
+	}
+	mReceived := modifyReceived.value()
+	if mReceived != 1 {
+		t.Fatalf("incorrect number of modify events received after 500 ms (%d vs %d)", mReceived, 1)
+	}
+	dReceived := deleteReceived.value()
+	rReceived := renameReceived.value()
+	if dReceived+rReceived != 1 {
+		t.Fatalf("incorrect number of rename+delete events received after 500 ms (%d vs %d)", rReceived+dReceived, 1)
+	}
+
+	// Try closing the fsnotify instance
+	t.Log("calling Close()")
+	watcher.Close()
+	t.Log("waiting for the event channel to become closed...")
+	select {
+	case <-done:
+		t.Log("event channel closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("event stream was not closed after 2 seconds")
+	}
+}
+
+func TestFsnotifyMultipleCreates(t *testing.T) {
+	watcher := newWatcher(t)
+
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for err := range watcher.Errors {
+			t.Fatalf("error received: %s", err)
+		}
+	}()
+
+	// Create directory to watch
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	testFile := filepath.Join(testDir, "TestFsnotifySeq.testfile")
+
+	addWatch(t, watcher, testDir)
+
+	// Receive events on the event channel on a separate goroutine
+	eventstream := watcher.Events
+	var createReceived, modifyReceived, deleteReceived counter
+	done := make(chan bool)
+	go func() {
+		for event := range eventstream {
+			// Only count relevant events
+			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFile) {
+				t.Logf("event received: %s", event)
+				if event.Op&Remove == Remove {
+					deleteReceived.increment()
+				}
+				if event.Op&Create == Create {
+					createReceived.increment()
+				}
+				if event.Op&Write == Write {
+					modifyReceived.increment()
+				}
+			} else {
+				t.Logf("unexpected event received: %s", event)
+			}
+		}
+		done <- true
+	}()
+
+	// Create a file
+	// This should add at least one event to the fsnotify event queue
+	var f *os.File
+	f, err := os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	f.Sync()
+
+	time.Sleep(time.Millisecond)
+	f.WriteString("data")
+	f.Sync()
+	f.Close()
+
+	time.Sleep(50 * time.Millisecond) // give system time to sync write change before delete
+
+	os.Remove(testFile)
+
+	time.Sleep(50 * time.Millisecond) // give system time to sync write change before delete
+
+	// Recreate the file
+	f, err = os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	f.Close()
+	time.Sleep(50 * time.Millisecond) // give system time to sync write change before delete
+
+	// Modify
+	f, err = os.OpenFile(testFile, os.O_WRONLY, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	f.Sync()
+
+	time.Sleep(time.Millisecond)
+	f.WriteString("data")
+	f.Sync()
+	f.Close()
+
+	time.Sleep(50 * time.Millisecond) // give system time to sync write change before delete
+
+	// Modify
+	f, err = os.OpenFile(testFile, os.O_WRONLY, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	f.Sync()
+
+	time.Sleep(time.Millisecond)
+	f.WriteString("data")
+	f.Sync()
+	f.Close()
+
+	time.Sleep(50 * time.Millisecond) // give system time to sync write change before delete
+
+	// We expect this event to be received almost immediately, but let's wait 500 ms to be sure
+	time.Sleep(500 * time.Millisecond)
+	cReceived := createReceived.value()
+	if cReceived != 2 {
+		t.Fatalf("incorrect number of create events received after 500 ms (%d vs %d)", cReceived, 2)
+	}
+	mReceived := modifyReceived.value()
+	if mReceived < 3 {
+		t.Fatalf("incorrect number of modify events received after 500 ms (%d vs atleast %d)", mReceived, 3)
+	}
+	dReceived := deleteReceived.value()
+	if dReceived != 1 {
+		t.Fatalf("incorrect number of rename+delete events received after 500 ms (%d vs %d)", dReceived, 1)
+	}
+
+	// Try closing the fsnotify instance
+	t.Log("calling Close()")
+	watcher.Close()
+	t.Log("waiting for the event channel to become closed...")
+	select {
+	case <-done:
+		t.Log("event channel closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("event stream was not closed after 2 seconds")
+	}
+}
+
+func TestFsnotifyDirOnly(t *testing.T) {
+	watcher := newWatcher(t)
+
+	// Create directory to watch
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	// Create a file before watching directory
+	// This should NOT add any events to the fsnotify event queue
+	testFileAlreadyExists := filepath.Join(testDir, "TestFsnotifyEventsExisting.testfile")
+	{
+		var f *os.File
+		f, err := os.OpenFile(testFileAlreadyExists, os.O_WRONLY|os.O_CREATE, 0666)
+		if err != nil {
+			t.Fatalf("creating test file failed: %s", err)
+		}
+		f.Sync()
+		f.Close()
+	}
+
+	addWatch(t, watcher, testDir)
+
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for err := range watcher.Errors {
+			t.Fatalf("error received: %s", err)
+		}
+	}()
+
+	testFile := filepath.Join(testDir, "TestFsnotifyDirOnly.testfile")
+
+	// Receive events on the event channel on a separate goroutine
+	eventstream := watcher.Events
+	var createReceived, modifyReceived, deleteReceived counter
+	done := make(chan bool)
+	go func() {
+		for event := range eventstream {
+			// Only count relevant events
+			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFile) || event.Name == filepath.Clean(testFileAlreadyExists) {
+				t.Logf("event received: %s", event)
+				if event.Op&Remove == Remove {
+					deleteReceived.increment()
+				}
+				if event.Op&Write == Write {
+					modifyReceived.increment()
+				}
+				if event.Op&Create == Create {
+					createReceived.increment()
+				}
+			} else {
+				t.Logf("unexpected event received: %s", event)
+			}
+		}
+		done <- true
+	}()
+
+	// Create a file
+	// This should add at least one event to the fsnotify event queue
+	var f *os.File
+	f, err := os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	f.Sync()
+
+	time.Sleep(time.Millisecond)
+	f.WriteString("data")
+	f.Sync()
+	f.Close()
+
+	time.Sleep(50 * time.Millisecond) // give system time to sync write change before delete
+
+	os.Remove(testFile)
+	os.Remove(testFileAlreadyExists)
+
+	// We expect this event to be received almost immediately, but let's wait 500 ms to be sure
+	time.Sleep(500 * time.Millisecond)
+	cReceived := createReceived.value()
+	if cReceived != 1 {
+		t.Fatalf("incorrect number of create events received after 500 ms (%d vs %d)", cReceived, 1)
+	}
+	mReceived := modifyReceived.value()
+	if mReceived != 1 {
+		t.Fatalf("incorrect number of modify events received after 500 ms (%d vs %d)", mReceived, 1)
+	}
+	dReceived := deleteReceived.value()
+	if dReceived != 2 {
+		t.Fatalf("incorrect number of delete events received after 500 ms (%d vs %d)", dReceived, 2)
+	}
+
+	// Try closing the fsnotify instance
+	t.Log("calling Close()")
+	watcher.Close()
+	t.Log("waiting for the event channel to become closed...")
+	select {
+	case <-done:
+		t.Log("event channel closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("event stream was not closed after 2 seconds")
+	}
+}
+
+func TestFsnotifyDeleteWatchedDir(t *testing.T) {
+	watcher := newWatcher(t)
+	defer watcher.Close()
+
+	// Create directory to watch
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	// Create a file before watching directory
+	testFileAlreadyExists := filepath.Join(testDir, "TestFsnotifyEventsExisting.testfile")
+	{
+		var f *os.File
+		f, err := os.OpenFile(testFileAlreadyExists, os.O_WRONLY|os.O_CREATE, 0666)
+		if err != nil {
+			t.Fatalf("creating test file failed: %s", err)
+		}
+		f.Sync()
+		f.Close()
+	}
+
+	addWatch(t, watcher, testDir)
+
+	// Add a watch for testFile
+	addWatch(t, watcher, testFileAlreadyExists)
+
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for err := range watcher.Errors {
+			t.Fatalf("error received: %s", err)
+		}
+	}()
+
+	// Receive events on the event channel on a separate goroutine
+	eventstream := watcher.Events
+	var deleteReceived counter
+	go func() {
+		for event := range eventstream {
+			// Only count relevant events
+			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFileAlreadyExists) {
+				t.Logf("event received: %s", event)
+				if event.Op&Remove == Remove {
+					deleteReceived.increment()
+				}
+			} else {
+				t.Logf("unexpected event received: %s", event)
+			}
+		}
+	}()
+
+	os.RemoveAll(testDir)
+
+	// We expect this event to be received almost immediately, but let's wait 500 ms to be sure
+	time.Sleep(500 * time.Millisecond)
+	dReceived := deleteReceived.value()
+	if dReceived < 2 {
+		t.Fatalf("did not receive at least %d delete events, received %d after 500 ms", 2, dReceived)
+	}
+}
+
+func TestFsnotifySubDir(t *testing.T) {
+	watcher := newWatcher(t)
+
+	// Create directory to watch
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	testFile1 := filepath.Join(testDir, "TestFsnotifyFile1.testfile")
+	testSubDir := filepath.Join(testDir, "sub")
+	testSubDirFile := filepath.Join(testDir, "sub/TestFsnotifyFile1.testfile")
+
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for err := range watcher.Errors {
+			t.Fatalf("error received: %s", err)
+		}
+	}()
+
+	// Receive events on the event channel on a separate goroutine
+	eventstream := watcher.Events
+	var createReceived, deleteReceived counter
+	done := make(chan bool)
+	go func() {
+		for event := range eventstream {
+			// Only count relevant events
+			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testSubDir) || event.Name == filepath.Clean(testFile1) {
+				t.Logf("event received: %s", event)
+				if event.Op&Create == Create {
+					createReceived.increment()
+				}
+				if event.Op&Remove == Remove {
+					deleteReceived.increment()
+				}
+			} else {
+				t.Logf("unexpected event received: %s", event)
+			}
+		}
+		done <- true
+	}()
+
+	addWatch(t, watcher, testDir)
+
+	// Create sub-directory
+	if err := os.Mkdir(testSubDir, 0777); err != nil {
+		t.Fatalf("failed to create test sub-directory: %s", err)
+	}
+
+	// Create a file
+	var f *os.File
+	f, err := os.OpenFile(testFile1, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	f.Sync()
+	f.Close()
+
+	// Create a file (Should not see this! we are not watching subdir)
+	var fs *os.File
+	fs, err = os.OpenFile(testSubDirFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	fs.Sync()
+	fs.Close()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Make sure receive deletes for both file and sub-directory
+	os.RemoveAll(testSubDir)
+	os.Remove(testFile1)
+
+	// We expect this event to be received almost immediately, but let's wait 500 ms to be sure
+	time.Sleep(500 * time.Millisecond)
+	cReceived := createReceived.value()
+	if cReceived != 2 {
+		t.Fatalf("incorrect number of create events received after 500 ms (%d vs %d)", cReceived, 2)
+	}
+	dReceived := deleteReceived.value()
+	if dReceived != 2 {
+		t.Fatalf("incorrect number of delete events received after 500 ms (%d vs %d)", dReceived, 2)
+	}
+
+	// Try closing the fsnotify instance
+	t.Log("calling Close()")
+	watcher.Close()
+	t.Log("waiting for the event channel to become closed...")
+	select {
+	case <-done:
+		t.Log("event channel closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("event stream was not closed after 2 seconds")
+	}
+}
+
+func TestFsnotifyRename(t *testing.T) {
+	watcher := newWatcher(t)
+
+	// Create directory to watch
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	addWatch(t, watcher, testDir)
+
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for err := range watcher.Errors {
+			t.Fatalf("error received: %s", err)
+		}
+	}()
+
+	testFile := filepath.Join(testDir, "TestFsnotifyEvents.testfile")
+	testFileRenamed := filepath.Join(testDir, "TestFsnotifyEvents.testfileRenamed")
+
+	// Receive events on the event channel on a separate goroutine
+	eventstream := watcher.Events
+	var renameReceived counter
+	done := make(chan bool)
+	go func() {
+		for event := range eventstream {
+			// Only count relevant events
+			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFile) || event.Name == filepath.Clean(testFileRenamed) {
+				if event.Op&Rename == Rename {
+					renameReceived.increment()
+				}
+				t.Logf("event received: %s", event)
+			} else {
+				t.Logf("unexpected event received: %s", event)
+			}
+		}
+		done <- true
+	}()
+
+	// Create a file
+	// This should add at least one event to the fsnotify event queue
+	var f *os.File
+	f, err := os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	f.Sync()
+
+	f.WriteString("data")
+	f.Sync()
+	f.Close()
+
+	// Add a watch for testFile
+	addWatch(t, watcher, testFile)
+
+	if err := testRename(testFile, testFileRenamed); err != nil {
+		t.Fatalf("rename failed: %s", err)
+	}
+
+	// We expect this event to be received almost immediately, but let's wait 500 ms to be sure
+	time.Sleep(500 * time.Millisecond)
+	if renameReceived.value() == 0 {
+		t.Fatal("fsnotify rename events have not been received after 500 ms")
+	}
+
+	// Try closing the fsnotify instance
+	t.Log("calling Close()")
+	watcher.Close()
+	t.Log("waiting for the event channel to become closed...")
+	select {
+	case <-done:
+		t.Log("event channel closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("event stream was not closed after 2 seconds")
+	}
+
+	os.Remove(testFileRenamed)
+}
+
+func TestFsnotifyRenameToCreate(t *testing.T) {
+	watcher := newWatcher(t)
+
+	// Create directory to watch
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	// Create directory to get file
+	testDirFrom := tempMkdir(t)
+	defer os.RemoveAll(testDirFrom)
+
+	addWatch(t, watcher, testDir)
+
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for err := range watcher.Errors {
+			t.Fatalf("error received: %s", err)
+		}
+	}()
+
+	testFile := filepath.Join(testDirFrom, "TestFsnotifyEvents.testfile")
+	testFileRenamed := filepath.Join(testDir, "TestFsnotifyEvents.testfileRenamed")
+
+	// Receive events on the event channel on a separate goroutine
+	eventstream := watcher.Events
+	var createReceived counter
+	done := make(chan bool)
+	go func() {
+		for event := range eventstream {
+			// Only count relevant events
+			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFile) || event.Name == filepath.Clean(testFileRenamed) {
+				if event.Op&Create == Create {
+					createReceived.increment()
+				}
+				t.Logf("event received: %s", event)
+			} else {
+				t.Logf("unexpected event received: %s", event)
+			}
+		}
+		done <- true
+	}()
+
+	// Create a file
+	// This should add at least one event to the fsnotify event queue
+	var f *os.File
+	f, err := os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	f.Sync()
+	f.Close()
+
+	if err := testRename(testFile, testFileRenamed); err != nil {
+		t.Fatalf("rename failed: %s", err)
+	}
+
+	// We expect this event to be received almost immediately, but let's wait 500 ms to be sure
+	time.Sleep(500 * time.Millisecond)
+	if createReceived.value() == 0 {
+		t.Fatal("fsnotify create events have not been received after 500 ms")
+	}
+
+	// Try closing the fsnotify instance
+	t.Log("calling Close()")
+	watcher.Close()
+	t.Log("waiting for the event channel to become closed...")
+	select {
+	case <-done:
+		t.Log("event channel closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("event stream was not closed after 2 seconds")
+	}
+
+	os.Remove(testFileRenamed)
+}
+
+func TestFsnotifyRenameToOverwrite(t *testing.T) {
+	switch runtime.GOOS {
+	case "plan9", "windows":
+		t.Skipf("skipping test on %q (os.Rename over existing file does not create event).", runtime.GOOS)
+	}
+
+	watcher := newWatcher(t)
+
+	// Create directory to watch
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	// Create directory to get file
+	testDirFrom := tempMkdir(t)
+	defer os.RemoveAll(testDirFrom)
+
+	testFile := filepath.Join(testDirFrom, "TestFsnotifyEvents.testfile")
+	testFileRenamed := filepath.Join(testDir, "TestFsnotifyEvents.testfileRenamed")
+
+	// Create a file
+	var fr *os.File
+	fr, err := os.OpenFile(testFileRenamed, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	fr.Sync()
+	fr.Close()
+
+	addWatch(t, watcher, testDir)
+
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for err := range watcher.Errors {
+			t.Fatalf("error received: %s", err)
+		}
+	}()
+
+	// Receive events on the event channel on a separate goroutine
+	eventstream := watcher.Events
+	var eventReceived counter
+	done := make(chan bool)
+	go func() {
+		for event := range eventstream {
+			// Only count relevant events
+			if event.Name == filepath.Clean(testFileRenamed) {
+				eventReceived.increment()
+				t.Logf("event received: %s", event)
+			} else {
+				t.Logf("unexpected event received: %s", event)
+			}
+		}
+		done <- true
+	}()
+
+	// Create a file
+	// This should add at least one event to the fsnotify event queue
+	var f *os.File
+	f, err = os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	f.Sync()
+	f.Close()
+
+	if err := testRename(testFile, testFileRenamed); err != nil {
+		t.Fatalf("rename failed: %s", err)
+	}
+
+	// We expect this event to be received almost immediately, but let's wait 500 ms to be sure
+	time.Sleep(500 * time.Millisecond)
+	if eventReceived.value() == 0 {
+		t.Fatal("fsnotify events have not been received after 500 ms")
+	}
+
+	// Try closing the fsnotify instance
+	t.Log("calling Close()")
+	watcher.Close()
+	t.Log("waiting for the event channel to become closed...")
+	select {
+	case <-done:
+		t.Log("event channel closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("event stream was not closed after 2 seconds")
+	}
+
+	os.Remove(testFileRenamed)
+}
+
+func TestRemovalOfWatch(t *testing.T) {
+	// Create directory to watch
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	// Create a file before watching directory
+	testFileAlreadyExists := filepath.Join(testDir, "TestFsnotifyEventsExisting.testfile")
+	{
+		var f *os.File
+		f, err := os.OpenFile(testFileAlreadyExists, os.O_WRONLY|os.O_CREATE, 0666)
+		if err != nil {
+			t.Fatalf("creating test file failed: %s", err)
+		}
+		f.Sync()
+		f.Close()
+	}
+
+	watcher := newWatcher(t)
+	defer watcher.Close()
+
+	addWatch(t, watcher, testDir)
+	if err := watcher.Remove(testDir); err != nil {
+		t.Fatalf("Could not remove the watch: %v\n", err)
+	}
+
+	go func() {
+		select {
+		case ev := <-watcher.Events:
+			t.Fatalf("We received event: %v\n", ev)
+		case <-time.After(500 * time.Millisecond):
+			t.Log("No event received, as expected.")
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	// Modify the file outside of the watched dir
+	f, err := os.Open(testFileAlreadyExists)
+	if err != nil {
+		t.Fatalf("Open test file failed: %s", err)
+	}
+	f.WriteString("data")
+	f.Sync()
+	f.Close()
+	if err := os.Chmod(testFileAlreadyExists, 0700); err != nil {
+		t.Fatalf("chmod failed: %s", err)
+	}
+	time.Sleep(400 * time.Millisecond)
+}
+
+func TestFsnotifyAttrib(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("attributes don't work on Windows.")
+	}
+
+	watcher := newWatcher(t)
+
+	// Create directory to watch
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for err := range watcher.Errors {
+			t.Fatalf("error received: %s", err)
+		}
+	}()
+
+	testFile := filepath.Join(testDir, "TestFsnotifyAttrib.testfile")
+
+	// Receive events on the event channel on a separate goroutine
+	eventstream := watcher.Events
+	// The modifyReceived counter counts IsModify events that are not IsAttrib,
+	// and the attribReceived counts IsAttrib events (which are also IsModify as
+	// a consequence).
+	var modifyReceived counter
+	var attribReceived counter
+	done := make(chan bool)
+	go func() {
+		for event := range eventstream {
+			// Only count relevant events
+			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFile) {
+				if event.Op&Write == Write {
+					modifyReceived.increment()
+				}
+				if event.Op&Chmod == Chmod {
+					attribReceived.increment()
+				}
+				t.Logf("event received: %s", event)
+			} else {
+				t.Logf("unexpected event received: %s", event)
+			}
+		}
+		done <- true
+	}()
+
+	// Create a file
+	// This should add at least one event to the fsnotify event queue
+	var f *os.File
+	f, err := os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file failed: %s", err)
+	}
+	f.Sync()
+
+	f.WriteString("data")
+	f.Sync()
+	f.Close()
+
+	// Add a watch for testFile
+	addWatch(t, watcher, testFile)
+
+	if err := os.Chmod(testFile, 0700); err != nil {
+		t.Fatalf("chmod failed: %s", err)
+	}
+
+	// We expect this event to be received almost immediately, but let's wait 500 ms to be sure
+	// Creating/writing a file changes also the mtime, so IsAttrib should be set to true here
+	time.Sleep(500 * time.Millisecond)
+	if modifyReceived.value() != 0 {
+		t.Fatal("received an unexpected modify event when creating a test file")
+	}
+	if attribReceived.value() == 0 {
+		t.Fatal("fsnotify attribute events have not received after 500 ms")
+	}
+
+	// Modifying the contents of the file does not set the attrib flag (although eg. the mtime
+	// might have been modified).
+	modifyReceived.reset()
+	attribReceived.reset()
+
+	f, err = os.OpenFile(testFile, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("reopening test file failed: %s", err)
+	}
+
+	f.WriteString("more data")
+	f.Sync()
+	f.Close()
+
+	time.Sleep(500 * time.Millisecond)
+
+	if modifyReceived.value() != 1 {
+		t.Fatal("didn't receive a modify event after changing test file contents")
+	}
+
+	if attribReceived.value() != 0 {
+		t.Fatal("did receive an unexpected attrib event after changing test file contents")
+	}
+
+	modifyReceived.reset()
+	attribReceived.reset()
+
+	// Doing a chmod on the file should trigger an event with the "attrib" flag set (the contents
+	// of the file are not changed though)
+	if err := os.Chmod(testFile, 0600); err != nil {
+		t.Fatalf("chmod failed: %s", err)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	if attribReceived.value() != 1 {
+		t.Fatal("didn't receive an attribute change after 500ms")
+	}
+
+	// Try closing the fsnotify instance
+	t.Log("calling Close()")
+	watcher.Close()
+	t.Log("waiting for the event channel to become closed...")
+	select {
+	case <-done:
+		t.Log("event channel closed")
+	case <-time.After(1e9):
+		t.Fatal("event stream was not closed after 1 second")
+	}
+
+	os.Remove(testFile)
+}
+
+func TestFsnotifyClose(t *testing.T) {
+	watcher := newWatcher(t)
+	watcher.Close()
+
+	var done int32
+	go func() {
+		watcher.Close()
+		atomic.StoreInt32(&done, 1)
+	}()
+
+	time.Sleep(50e6) // 50 ms
+	if atomic.LoadInt32(&done) == 0 {
+		t.Fatal("double Close() test failed: second Close() call didn't return")
+	}
+
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	if err := watcher.Add(testDir); err == nil {
+		t.Fatal("expected error on Watch() after Close(), got nil")
+	}
+}
+
+func TestFsnotifyFakeSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks don't work on Windows.")
+	}
+
+	watcher := newWatcher(t)
+
+	// Create directory to watch
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	var errorsReceived counter
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for errors := range watcher.Errors {
+			t.Logf("Received error: %s", errors)
+			errorsReceived.increment()
+		}
+	}()
+
+	// Count the CREATE events received
+	var createEventsReceived, otherEventsReceived counter
+	go func() {
+		for ev := range watcher.Events {
+			t.Logf("event received: %s", ev)
+			if ev.Op&Create == Create {
+				createEventsReceived.increment()
+			} else {
+				otherEventsReceived.increment()
+			}
+		}
+	}()
+
+	addWatch(t, watcher, testDir)
+
+	if err := os.Symlink(filepath.Join(testDir, "zzz"), filepath.Join(testDir, "zzznew")); err != nil {
+		t.Fatalf("Failed to create bogus symlink: %s", err)
+	}
+	t.Logf("Created bogus symlink")
+
+	// We expect this event to be received almost immediately, but let's wait 500 ms to be sure
+	time.Sleep(500 * time.Millisecond)
+
+	// Should not be error, just no events for broken links (watching nothing)
+	if errorsReceived.value() > 0 {
+		t.Fatal("fsnotify errors have been received.")
+	}
+	if otherEventsReceived.value() > 0 {
+		t.Fatal("fsnotify other events received on the broken link")
+	}
+
+	// Except for 1 create event (for the link itself)
+	if createEventsReceived.value() == 0 {
+		t.Fatal("fsnotify create events were not received after 500 ms")
+	}
+	if createEventsReceived.value() > 1 {
+		t.Fatal("fsnotify more create events received than expected")
+	}
+
+	// Try closing the fsnotify instance
+	t.Log("calling Close()")
+	watcher.Close()
+}
+
+// TestConcurrentRemovalOfWatch tests that concurrent calls to RemoveWatch do not race.
+// See https://codereview.appspot.com/103300045/
+// go test -test.run=TestConcurrentRemovalOfWatch -test.cpu=1,1,1,1,1 -race
+func TestConcurrentRemovalOfWatch(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("regression test for race only present on darwin")
+	}
+
+	// Create directory to watch
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	// Create a file before watching directory
+	testFileAlreadyExists := filepath.Join(testDir, "TestFsnotifyEventsExisting.testfile")
+	{
+		var f *os.File
+		f, err := os.OpenFile(testFileAlreadyExists, os.O_WRONLY|os.O_CREATE, 0666)
+		if err != nil {
+			t.Fatalf("creating test file failed: %s", err)
+		}
+		f.Sync()
+		f.Close()
+	}
+
+	watcher := newWatcher(t)
+	defer watcher.Close()
+
+	addWatch(t, watcher, testDir)
+
+	// Test that RemoveWatch can be invoked concurrently, with no data races.
+	removed1 := make(chan struct{})
+	go func() {
+		defer close(removed1)
+		watcher.Remove(testDir)
+	}()
+	removed2 := make(chan struct{})
+	go func() {
+		close(removed2)
+		watcher.Remove(testDir)
+	}()
+	<-removed1
+	<-removed2
+}
+
+func TestClose(t *testing.T) {
+	// Regression test for #59 bad file descriptor from Close
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	watcher := newWatcher(t)
+	if err := watcher.Add(testDir); err != nil {
+		t.Fatalf("Expected no error on Add, got %v", err)
+	}
+	err := watcher.Close()
+	if err != nil {
+		t.Fatalf("Expected no error on Close, got %v.", err)
+	}
+}
+
+func testRename(file1, file2 string) error {
+	switch runtime.GOOS {
+	case "windows", "plan9":
+		return os.Rename(file1, file2)
+	default:
+		cmd := exec.Command("mv", file1, file2)
+		return cmd.Run()
+	}
+}

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/kqueue.go
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/kqueue.go
@@ -1,0 +1,463 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build freebsd openbsd netbsd dragonfly darwin
+
+package fsnotify
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// Watcher watches a set of files, delivering events to a channel.
+type Watcher struct {
+	Events chan Event
+	Errors chan error
+	done   chan bool // Channel for sending a "quit message" to the reader goroutine
+
+	kq int // File descriptor (as returned by the kqueue() syscall).
+
+	mu              sync.Mutex        // Protects access to watcher data
+	watches         map[string]int    // Map of watched file descriptors (key: path).
+	externalWatches map[string]bool   // Map of watches added by user of the library.
+	dirFlags        map[string]uint32 // Map of watched directories to fflags used in kqueue.
+	paths           map[int]pathInfo  // Map file descriptors to path names for processing kqueue events.
+	fileExists      map[string]bool   // Keep track of if we know this file exists (to stop duplicate create events).
+	isClosed        bool              // Set to true when Close() is first called
+}
+
+type pathInfo struct {
+	name  string
+	isDir bool
+}
+
+// NewWatcher establishes a new watcher with the underlying OS and begins waiting for events.
+func NewWatcher() (*Watcher, error) {
+	kq, err := kqueue()
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Watcher{
+		kq:              kq,
+		watches:         make(map[string]int),
+		dirFlags:        make(map[string]uint32),
+		paths:           make(map[int]pathInfo),
+		fileExists:      make(map[string]bool),
+		externalWatches: make(map[string]bool),
+		Events:          make(chan Event),
+		Errors:          make(chan error),
+		done:            make(chan bool),
+	}
+
+	go w.readEvents()
+	return w, nil
+}
+
+// Close removes all watches and closes the events channel.
+func (w *Watcher) Close() error {
+	w.mu.Lock()
+	if w.isClosed {
+		w.mu.Unlock()
+		return nil
+	}
+	w.isClosed = true
+	w.mu.Unlock()
+
+	w.mu.Lock()
+	ws := w.watches
+	w.mu.Unlock()
+
+	var err error
+	for name := range ws {
+		if e := w.Remove(name); e != nil && err == nil {
+			err = e
+		}
+	}
+
+	// Send "quit" message to the reader goroutine:
+	w.done <- true
+
+	return nil
+}
+
+// Add starts watching the named file or directory (non-recursively).
+func (w *Watcher) Add(name string) error {
+	w.mu.Lock()
+	w.externalWatches[name] = true
+	w.mu.Unlock()
+	return w.addWatch(name, noteAllEvents)
+}
+
+// Remove stops watching the the named file or directory (non-recursively).
+func (w *Watcher) Remove(name string) error {
+	name = filepath.Clean(name)
+	w.mu.Lock()
+	watchfd, ok := w.watches[name]
+	w.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("can't remove non-existent kevent watch for: %s", name)
+	}
+
+	const registerRemove = syscall.EV_DELETE
+	if err := register(w.kq, []int{watchfd}, registerRemove, 0); err != nil {
+		return err
+	}
+
+	syscall.Close(watchfd)
+
+	w.mu.Lock()
+	isDir := w.paths[watchfd].isDir
+	delete(w.watches, name)
+	delete(w.paths, watchfd)
+	delete(w.dirFlags, name)
+	w.mu.Unlock()
+
+	// Find all watched paths that are in this directory that are not external.
+	if isDir {
+		var pathsToRemove []string
+		w.mu.Lock()
+		for _, path := range w.paths {
+			wdir, _ := filepath.Split(path.name)
+			if filepath.Clean(wdir) == name {
+				if !w.externalWatches[path.name] {
+					pathsToRemove = append(pathsToRemove, path.name)
+				}
+			}
+		}
+		w.mu.Unlock()
+		for _, name := range pathsToRemove {
+			// Since these are internal, not much sense in propagating error
+			// to the user, as that will just confuse them with an error about
+			// a path they did not explicitly watch themselves.
+			w.Remove(name)
+		}
+	}
+
+	return nil
+}
+
+// Watch all events (except NOTE_EXTEND, NOTE_LINK, NOTE_REVOKE)
+const noteAllEvents = syscall.NOTE_DELETE | syscall.NOTE_WRITE | syscall.NOTE_ATTRIB | syscall.NOTE_RENAME
+
+// keventWaitTime to block on each read from kevent
+var keventWaitTime = durationToTimespec(100 * time.Millisecond)
+
+// addWatch adds name to the watched file set.
+// The flags are interpreted as described in kevent(2).
+func (w *Watcher) addWatch(name string, flags uint32) error {
+	var isDir bool
+	// Make ./name and name equivalent
+	name = filepath.Clean(name)
+
+	w.mu.Lock()
+	if w.isClosed {
+		w.mu.Unlock()
+		return errors.New("kevent instance already closed")
+	}
+	watchfd, alreadyWatching := w.watches[name]
+	// We already have a watch, but we can still override flags.
+	if alreadyWatching {
+		isDir = w.paths[watchfd].isDir
+	}
+	w.mu.Unlock()
+
+	if !alreadyWatching {
+		fi, err := os.Lstat(name)
+		if err != nil {
+			return err
+		}
+
+		// Don't watch sockets.
+		if fi.Mode()&os.ModeSocket == os.ModeSocket {
+			return nil
+		}
+
+		// Follow Symlinks
+		// Unfortunately, Linux can add bogus symlinks to watch list without
+		// issue, and Windows can't do symlinks period (AFAIK). To  maintain
+		// consistency, we will act like everything is fine. There will simply
+		// be no file events for broken symlinks.
+		// Hence the returns of nil on errors.
+		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+			name, err = filepath.EvalSymlinks(name)
+			if err != nil {
+				return nil
+			}
+
+			fi, err = os.Lstat(name)
+			if err != nil {
+				return nil
+			}
+		}
+
+		watchfd, err = syscall.Open(name, openMode, 0700)
+		if watchfd == -1 {
+			return err
+		}
+
+		isDir = fi.IsDir()
+	}
+
+	const registerAdd = syscall.EV_ADD | syscall.EV_CLEAR | syscall.EV_ENABLE
+	if err := register(w.kq, []int{watchfd}, registerAdd, flags); err != nil {
+		syscall.Close(watchfd)
+		return err
+	}
+
+	if !alreadyWatching {
+		w.mu.Lock()
+		w.watches[name] = watchfd
+		w.paths[watchfd] = pathInfo{name: name, isDir: isDir}
+		w.mu.Unlock()
+	}
+
+	if isDir {
+		// Watch the directory if it has not been watched before,
+		// or if it was watched before, but perhaps only a NOTE_DELETE (watchDirectoryFiles)
+		w.mu.Lock()
+		watchDir := (flags&syscall.NOTE_WRITE) == syscall.NOTE_WRITE &&
+			(!alreadyWatching || (w.dirFlags[name]&syscall.NOTE_WRITE) != syscall.NOTE_WRITE)
+		// Store flags so this watch can be updated later
+		w.dirFlags[name] = flags
+		w.mu.Unlock()
+
+		if watchDir {
+			if err := w.watchDirectoryFiles(name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// readEvents reads from kqueue and converts the received kevents into
+// Event values that it sends down the Events channel.
+func (w *Watcher) readEvents() {
+	eventBuffer := make([]syscall.Kevent_t, 10)
+
+	for {
+		// See if there is a message on the "done" channel
+		select {
+		case <-w.done:
+			err := syscall.Close(w.kq)
+			if err != nil {
+				w.Errors <- err
+			}
+			close(w.Events)
+			close(w.Errors)
+			return
+		default:
+		}
+
+		// Get new events
+		kevents, err := read(w.kq, eventBuffer, &keventWaitTime)
+		// EINTR is okay, the syscall was interrupted before timeout expired.
+		if err != nil && err != syscall.EINTR {
+			w.Errors <- err
+			continue
+		}
+
+		// Flush the events we received to the Events channel
+		for len(kevents) > 0 {
+			kevent := &kevents[0]
+			watchfd := int(kevent.Ident)
+			mask := uint32(kevent.Fflags)
+			w.mu.Lock()
+			path := w.paths[watchfd]
+			w.mu.Unlock()
+			event := newEvent(path.name, mask)
+
+			if path.isDir && !(event.Op&Remove == Remove) {
+				// Double check to make sure the directory exists. This can happen when
+				// we do a rm -fr on a recursively watched folders and we receive a
+				// modification event first but the folder has been deleted and later
+				// receive the delete event
+				if _, err := os.Lstat(event.Name); os.IsNotExist(err) {
+					// mark is as delete event
+					event.Op |= Remove
+				}
+			}
+
+			if event.Op&Rename == Rename || event.Op&Remove == Remove {
+				w.Remove(event.Name)
+				w.mu.Lock()
+				delete(w.fileExists, event.Name)
+				w.mu.Unlock()
+			}
+
+			if path.isDir && event.Op&Write == Write && !(event.Op&Remove == Remove) {
+				w.sendDirectoryChangeEvents(event.Name)
+			} else {
+				// Send the event on the Events channel
+				w.Events <- event
+			}
+
+			if event.Op&Remove == Remove {
+				// Look for a file that may have overwritten this.
+				// For example, mv f1 f2 will delete f2, then create f2.
+				fileDir, _ := filepath.Split(event.Name)
+				fileDir = filepath.Clean(fileDir)
+				w.mu.Lock()
+				_, found := w.watches[fileDir]
+				w.mu.Unlock()
+				if found {
+					// make sure the directory exists before we watch for changes. When we
+					// do a recursive watch and perform rm -fr, the parent directory might
+					// have gone missing, ignore the missing directory and let the
+					// upcoming delete event remove the watch from the parent directory.
+					if _, err := os.Lstat(fileDir); os.IsExist(err) {
+						w.sendDirectoryChangeEvents(fileDir)
+						// FIXME: should this be for events on files or just isDir?
+					}
+				}
+			}
+
+			// Move to next event
+			kevents = kevents[1:]
+		}
+	}
+}
+
+// newEvent returns an platform-independent Event based on kqueue Fflags.
+func newEvent(name string, mask uint32) Event {
+	e := Event{Name: name}
+	if mask&syscall.NOTE_DELETE == syscall.NOTE_DELETE {
+		e.Op |= Remove
+	}
+	if mask&syscall.NOTE_WRITE == syscall.NOTE_WRITE {
+		e.Op |= Write
+	}
+	if mask&syscall.NOTE_RENAME == syscall.NOTE_RENAME {
+		e.Op |= Rename
+	}
+	if mask&syscall.NOTE_ATTRIB == syscall.NOTE_ATTRIB {
+		e.Op |= Chmod
+	}
+	return e
+}
+
+func newCreateEvent(name string) Event {
+	return Event{Name: name, Op: Create}
+}
+
+// watchDirectoryFiles to mimic inotify when adding a watch on a directory
+func (w *Watcher) watchDirectoryFiles(dirPath string) error {
+	// Get all files
+	files, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		return err
+	}
+
+	for _, fileInfo := range files {
+		filePath := filepath.Join(dirPath, fileInfo.Name())
+		if err := w.internalWatch(filePath, fileInfo); err != nil {
+			return err
+		}
+
+		w.mu.Lock()
+		w.fileExists[filePath] = true
+		w.mu.Unlock()
+	}
+
+	return nil
+}
+
+// sendDirectoryEvents searches the directory for newly created files
+// and sends them over the event channel. This functionality is to have
+// the BSD version of fsnotify match Linux inotify which provides a
+// create event for files created in a watched directory.
+func (w *Watcher) sendDirectoryChangeEvents(dirPath string) {
+	// Get all files
+	files, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		w.Errors <- err
+	}
+
+	// Search for new files
+	for _, fileInfo := range files {
+		filePath := filepath.Join(dirPath, fileInfo.Name())
+		w.mu.Lock()
+		_, doesExist := w.fileExists[filePath]
+		w.mu.Unlock()
+		if !doesExist {
+			// Send create event
+			w.Events <- newCreateEvent(filePath)
+		}
+
+		// like watchDirectoryFiles (but without doing another ReadDir)
+		if err := w.internalWatch(filePath, fileInfo); err != nil {
+			return
+		}
+
+		w.mu.Lock()
+		w.fileExists[filePath] = true
+		w.mu.Unlock()
+	}
+}
+
+func (w *Watcher) internalWatch(name string, fileInfo os.FileInfo) error {
+	if fileInfo.IsDir() {
+		// mimic Linux providing delete events for subdirectories
+		// but preserve the flags used if currently watching subdirectory
+		w.mu.Lock()
+		flags := w.dirFlags[name]
+		w.mu.Unlock()
+
+		flags |= syscall.NOTE_DELETE
+		return w.addWatch(name, flags)
+	}
+
+	// watch file to mimic Linux inotify
+	return w.addWatch(name, noteAllEvents)
+}
+
+// kqueue creates a new kernel event queue and returns a descriptor.
+func kqueue() (kq int, err error) {
+	kq, err = syscall.Kqueue()
+	if kq == -1 {
+		return kq, err
+	}
+	return kq, nil
+}
+
+// register events with the queue
+func register(kq int, fds []int, flags int, fflags uint32) error {
+	changes := make([]syscall.Kevent_t, len(fds))
+
+	for i, fd := range fds {
+		// SetKevent converts int to the platform-specific types:
+		syscall.SetKevent(&changes[i], fd, syscall.EVFILT_VNODE, flags)
+		changes[i].Fflags = fflags
+	}
+
+	// register the events
+	success, err := syscall.Kevent(kq, changes, nil, nil)
+	if success == -1 {
+		return err
+	}
+	return nil
+}
+
+// read retrieves pending events, or waits until an event occurs.
+// A timeout of nil blocks indefinitely, while 0 polls the queue.
+func read(kq int, events []syscall.Kevent_t, timeout *syscall.Timespec) ([]syscall.Kevent_t, error) {
+	n, err := syscall.Kevent(kq, nil, events, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return events[0:n], nil
+}
+
+// durationToTimespec prepares a timeout value
+func durationToTimespec(d time.Duration) syscall.Timespec {
+	return syscall.NsecToTimespec(d.Nanoseconds())
+}

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/open_mode_bsd.go
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/open_mode_bsd.go
@@ -1,0 +1,11 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build freebsd openbsd netbsd dragonfly
+
+package fsnotify
+
+import "syscall"
+
+const openMode = syscall.O_NONBLOCK | syscall.O_RDONLY

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/open_mode_darwin.go
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/open_mode_darwin.go
@@ -1,0 +1,12 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin
+
+package fsnotify
+
+import "syscall"
+
+// note: this constant is not defined on BSD
+const openMode = syscall.O_EVTONLY

--- a/Godeps/_workspace/src/gopkg.in/fsnotify.v1/windows.go
+++ b/Godeps/_workspace/src/gopkg.in/fsnotify.v1/windows.go
@@ -1,0 +1,561 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package fsnotify
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+// Watcher watches a set of files, delivering events to a channel.
+type Watcher struct {
+	Events   chan Event
+	Errors   chan error
+	isClosed bool           // Set to true when Close() is first called
+	mu       sync.Mutex     // Map access
+	port     syscall.Handle // Handle to completion port
+	watches  watchMap       // Map of watches (key: i-number)
+	input    chan *input    // Inputs to the reader are sent on this channel
+	quit     chan chan<- error
+}
+
+// NewWatcher establishes a new watcher with the underlying OS and begins waiting for events.
+func NewWatcher() (*Watcher, error) {
+	port, e := syscall.CreateIoCompletionPort(syscall.InvalidHandle, 0, 0, 0)
+	if e != nil {
+		return nil, os.NewSyscallError("CreateIoCompletionPort", e)
+	}
+	w := &Watcher{
+		port:    port,
+		watches: make(watchMap),
+		input:   make(chan *input, 1),
+		Events:  make(chan Event, 50),
+		Errors:  make(chan error),
+		quit:    make(chan chan<- error, 1),
+	}
+	go w.readEvents()
+	return w, nil
+}
+
+// Close removes all watches and closes the events channel.
+func (w *Watcher) Close() error {
+	if w.isClosed {
+		return nil
+	}
+	w.isClosed = true
+
+	// Send "quit" message to the reader goroutine
+	ch := make(chan error)
+	w.quit <- ch
+	if err := w.wakeupReader(); err != nil {
+		return err
+	}
+	return <-ch
+}
+
+// Add starts watching the named file or directory (non-recursively).
+func (w *Watcher) Add(name string) error {
+	if w.isClosed {
+		return errors.New("watcher already closed")
+	}
+	in := &input{
+		op:    opAddWatch,
+		path:  filepath.Clean(name),
+		flags: sys_FS_ALL_EVENTS,
+		reply: make(chan error),
+	}
+	w.input <- in
+	if err := w.wakeupReader(); err != nil {
+		return err
+	}
+	return <-in.reply
+}
+
+// Remove stops watching the the named file or directory (non-recursively).
+func (w *Watcher) Remove(name string) error {
+	in := &input{
+		op:    opRemoveWatch,
+		path:  filepath.Clean(name),
+		reply: make(chan error),
+	}
+	w.input <- in
+	if err := w.wakeupReader(); err != nil {
+		return err
+	}
+	return <-in.reply
+}
+
+const (
+	// Options for AddWatch
+	sys_FS_ONESHOT = 0x80000000
+	sys_FS_ONLYDIR = 0x1000000
+
+	// Events
+	sys_FS_ACCESS      = 0x1
+	sys_FS_ALL_EVENTS  = 0xfff
+	sys_FS_ATTRIB      = 0x4
+	sys_FS_CLOSE       = 0x18
+	sys_FS_CREATE      = 0x100
+	sys_FS_DELETE      = 0x200
+	sys_FS_DELETE_SELF = 0x400
+	sys_FS_MODIFY      = 0x2
+	sys_FS_MOVE        = 0xc0
+	sys_FS_MOVED_FROM  = 0x40
+	sys_FS_MOVED_TO    = 0x80
+	sys_FS_MOVE_SELF   = 0x800
+
+	// Special events
+	sys_FS_IGNORED    = 0x8000
+	sys_FS_Q_OVERFLOW = 0x4000
+)
+
+func newEvent(name string, mask uint32) Event {
+	e := Event{Name: name}
+	if mask&sys_FS_CREATE == sys_FS_CREATE || mask&sys_FS_MOVED_TO == sys_FS_MOVED_TO {
+		e.Op |= Create
+	}
+	if mask&sys_FS_DELETE == sys_FS_DELETE || mask&sys_FS_DELETE_SELF == sys_FS_DELETE_SELF {
+		e.Op |= Remove
+	}
+	if mask&sys_FS_MODIFY == sys_FS_MODIFY {
+		e.Op |= Write
+	}
+	if mask&sys_FS_MOVE == sys_FS_MOVE || mask&sys_FS_MOVE_SELF == sys_FS_MOVE_SELF || mask&sys_FS_MOVED_FROM == sys_FS_MOVED_FROM {
+		e.Op |= Rename
+	}
+	if mask&sys_FS_ATTRIB == sys_FS_ATTRIB {
+		e.Op |= Chmod
+	}
+	return e
+}
+
+const (
+	opAddWatch = iota
+	opRemoveWatch
+)
+
+const (
+	provisional uint64 = 1 << (32 + iota)
+)
+
+type input struct {
+	op    int
+	path  string
+	flags uint32
+	reply chan error
+}
+
+type inode struct {
+	handle syscall.Handle
+	volume uint32
+	index  uint64
+}
+
+type watch struct {
+	ov     syscall.Overlapped
+	ino    *inode            // i-number
+	path   string            // Directory path
+	mask   uint64            // Directory itself is being watched with these notify flags
+	names  map[string]uint64 // Map of names being watched and their notify flags
+	rename string            // Remembers the old name while renaming a file
+	buf    [4096]byte
+}
+
+type indexMap map[uint64]*watch
+type watchMap map[uint32]indexMap
+
+func (w *Watcher) wakeupReader() error {
+	e := syscall.PostQueuedCompletionStatus(w.port, 0, 0, nil)
+	if e != nil {
+		return os.NewSyscallError("PostQueuedCompletionStatus", e)
+	}
+	return nil
+}
+
+func getDir(pathname string) (dir string, err error) {
+	attr, e := syscall.GetFileAttributes(syscall.StringToUTF16Ptr(pathname))
+	if e != nil {
+		return "", os.NewSyscallError("GetFileAttributes", e)
+	}
+	if attr&syscall.FILE_ATTRIBUTE_DIRECTORY != 0 {
+		dir = pathname
+	} else {
+		dir, _ = filepath.Split(pathname)
+		dir = filepath.Clean(dir)
+	}
+	return
+}
+
+func getIno(path string) (ino *inode, err error) {
+	h, e := syscall.CreateFile(syscall.StringToUTF16Ptr(path),
+		syscall.FILE_LIST_DIRECTORY,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE|syscall.FILE_SHARE_DELETE,
+		nil, syscall.OPEN_EXISTING,
+		syscall.FILE_FLAG_BACKUP_SEMANTICS|syscall.FILE_FLAG_OVERLAPPED, 0)
+	if e != nil {
+		return nil, os.NewSyscallError("CreateFile", e)
+	}
+	var fi syscall.ByHandleFileInformation
+	if e = syscall.GetFileInformationByHandle(h, &fi); e != nil {
+		syscall.CloseHandle(h)
+		return nil, os.NewSyscallError("GetFileInformationByHandle", e)
+	}
+	ino = &inode{
+		handle: h,
+		volume: fi.VolumeSerialNumber,
+		index:  uint64(fi.FileIndexHigh)<<32 | uint64(fi.FileIndexLow),
+	}
+	return ino, nil
+}
+
+// Must run within the I/O thread.
+func (m watchMap) get(ino *inode) *watch {
+	if i := m[ino.volume]; i != nil {
+		return i[ino.index]
+	}
+	return nil
+}
+
+// Must run within the I/O thread.
+func (m watchMap) set(ino *inode, watch *watch) {
+	i := m[ino.volume]
+	if i == nil {
+		i = make(indexMap)
+		m[ino.volume] = i
+	}
+	i[ino.index] = watch
+}
+
+// Must run within the I/O thread.
+func (w *Watcher) addWatch(pathname string, flags uint64) error {
+	dir, err := getDir(pathname)
+	if err != nil {
+		return err
+	}
+	if flags&sys_FS_ONLYDIR != 0 && pathname != dir {
+		return nil
+	}
+	ino, err := getIno(dir)
+	if err != nil {
+		return err
+	}
+	w.mu.Lock()
+	watchEntry := w.watches.get(ino)
+	w.mu.Unlock()
+	if watchEntry == nil {
+		if _, e := syscall.CreateIoCompletionPort(ino.handle, w.port, 0, 0); e != nil {
+			syscall.CloseHandle(ino.handle)
+			return os.NewSyscallError("CreateIoCompletionPort", e)
+		}
+		watchEntry = &watch{
+			ino:   ino,
+			path:  dir,
+			names: make(map[string]uint64),
+		}
+		w.mu.Lock()
+		w.watches.set(ino, watchEntry)
+		w.mu.Unlock()
+		flags |= provisional
+	} else {
+		syscall.CloseHandle(ino.handle)
+	}
+	if pathname == dir {
+		watchEntry.mask |= flags
+	} else {
+		watchEntry.names[filepath.Base(pathname)] |= flags
+	}
+	if err = w.startRead(watchEntry); err != nil {
+		return err
+	}
+	if pathname == dir {
+		watchEntry.mask &= ^provisional
+	} else {
+		watchEntry.names[filepath.Base(pathname)] &= ^provisional
+	}
+	return nil
+}
+
+// Must run within the I/O thread.
+func (w *Watcher) remWatch(pathname string) error {
+	dir, err := getDir(pathname)
+	if err != nil {
+		return err
+	}
+	ino, err := getIno(dir)
+	if err != nil {
+		return err
+	}
+	w.mu.Lock()
+	watch := w.watches.get(ino)
+	w.mu.Unlock()
+	if watch == nil {
+		return fmt.Errorf("can't remove non-existent watch for: %s", pathname)
+	}
+	if pathname == dir {
+		w.sendEvent(watch.path, watch.mask&sys_FS_IGNORED)
+		watch.mask = 0
+	} else {
+		name := filepath.Base(pathname)
+		w.sendEvent(watch.path+"\\"+name, watch.names[name]&sys_FS_IGNORED)
+		delete(watch.names, name)
+	}
+	return w.startRead(watch)
+}
+
+// Must run within the I/O thread.
+func (w *Watcher) deleteWatch(watch *watch) {
+	for name, mask := range watch.names {
+		if mask&provisional == 0 {
+			w.sendEvent(watch.path+"\\"+name, mask&sys_FS_IGNORED)
+		}
+		delete(watch.names, name)
+	}
+	if watch.mask != 0 {
+		if watch.mask&provisional == 0 {
+			w.sendEvent(watch.path, watch.mask&sys_FS_IGNORED)
+		}
+		watch.mask = 0
+	}
+}
+
+// Must run within the I/O thread.
+func (w *Watcher) startRead(watch *watch) error {
+	if e := syscall.CancelIo(watch.ino.handle); e != nil {
+		w.Errors <- os.NewSyscallError("CancelIo", e)
+		w.deleteWatch(watch)
+	}
+	mask := toWindowsFlags(watch.mask)
+	for _, m := range watch.names {
+		mask |= toWindowsFlags(m)
+	}
+	if mask == 0 {
+		if e := syscall.CloseHandle(watch.ino.handle); e != nil {
+			w.Errors <- os.NewSyscallError("CloseHandle", e)
+		}
+		w.mu.Lock()
+		delete(w.watches[watch.ino.volume], watch.ino.index)
+		w.mu.Unlock()
+		return nil
+	}
+	e := syscall.ReadDirectoryChanges(watch.ino.handle, &watch.buf[0],
+		uint32(unsafe.Sizeof(watch.buf)), false, mask, nil, &watch.ov, 0)
+	if e != nil {
+		err := os.NewSyscallError("ReadDirectoryChanges", e)
+		if e == syscall.ERROR_ACCESS_DENIED && watch.mask&provisional == 0 {
+			// Watched directory was probably removed
+			if w.sendEvent(watch.path, watch.mask&sys_FS_DELETE_SELF) {
+				if watch.mask&sys_FS_ONESHOT != 0 {
+					watch.mask = 0
+				}
+			}
+			err = nil
+		}
+		w.deleteWatch(watch)
+		w.startRead(watch)
+		return err
+	}
+	return nil
+}
+
+// readEvents reads from the I/O completion port, converts the
+// received events into Event objects and sends them via the Events channel.
+// Entry point to the I/O thread.
+func (w *Watcher) readEvents() {
+	var (
+		n, key uint32
+		ov     *syscall.Overlapped
+	)
+	runtime.LockOSThread()
+
+	for {
+		e := syscall.GetQueuedCompletionStatus(w.port, &n, &key, &ov, syscall.INFINITE)
+		watch := (*watch)(unsafe.Pointer(ov))
+
+		if watch == nil {
+			select {
+			case ch := <-w.quit:
+				w.mu.Lock()
+				var indexes []indexMap
+				for _, index := range w.watches {
+					indexes = append(indexes, index)
+				}
+				w.mu.Unlock()
+				for _, index := range indexes {
+					for _, watch := range index {
+						w.deleteWatch(watch)
+						w.startRead(watch)
+					}
+				}
+				var err error
+				if e := syscall.CloseHandle(w.port); e != nil {
+					err = os.NewSyscallError("CloseHandle", e)
+				}
+				close(w.Events)
+				close(w.Errors)
+				ch <- err
+				return
+			case in := <-w.input:
+				switch in.op {
+				case opAddWatch:
+					in.reply <- w.addWatch(in.path, uint64(in.flags))
+				case opRemoveWatch:
+					in.reply <- w.remWatch(in.path)
+				}
+			default:
+			}
+			continue
+		}
+
+		switch e {
+		case syscall.ERROR_MORE_DATA:
+			if watch == nil {
+				w.Errors <- errors.New("ERROR_MORE_DATA has unexpectedly null lpOverlapped buffer")
+			} else {
+				// The i/o succeeded but the buffer is full.
+				// In theory we should be building up a full packet.
+				// In practice we can get away with just carrying on.
+				n = uint32(unsafe.Sizeof(watch.buf))
+			}
+		case syscall.ERROR_ACCESS_DENIED:
+			// Watched directory was probably removed
+			w.sendEvent(watch.path, watch.mask&sys_FS_DELETE_SELF)
+			w.deleteWatch(watch)
+			w.startRead(watch)
+			continue
+		case syscall.ERROR_OPERATION_ABORTED:
+			// CancelIo was called on this handle
+			continue
+		default:
+			w.Errors <- os.NewSyscallError("GetQueuedCompletionPort", e)
+			continue
+		case nil:
+		}
+
+		var offset uint32
+		for {
+			if n == 0 {
+				w.Events <- newEvent("", sys_FS_Q_OVERFLOW)
+				w.Errors <- errors.New("short read in readEvents()")
+				break
+			}
+
+			// Point "raw" to the event in the buffer
+			raw := (*syscall.FileNotifyInformation)(unsafe.Pointer(&watch.buf[offset]))
+			buf := (*[syscall.MAX_PATH]uint16)(unsafe.Pointer(&raw.FileName))
+			name := syscall.UTF16ToString(buf[:raw.FileNameLength/2])
+			fullname := watch.path + "\\" + name
+
+			var mask uint64
+			switch raw.Action {
+			case syscall.FILE_ACTION_REMOVED:
+				mask = sys_FS_DELETE_SELF
+			case syscall.FILE_ACTION_MODIFIED:
+				mask = sys_FS_MODIFY
+			case syscall.FILE_ACTION_RENAMED_OLD_NAME:
+				watch.rename = name
+			case syscall.FILE_ACTION_RENAMED_NEW_NAME:
+				if watch.names[watch.rename] != 0 {
+					watch.names[name] |= watch.names[watch.rename]
+					delete(watch.names, watch.rename)
+					mask = sys_FS_MOVE_SELF
+				}
+			}
+
+			sendNameEvent := func() {
+				if w.sendEvent(fullname, watch.names[name]&mask) {
+					if watch.names[name]&sys_FS_ONESHOT != 0 {
+						delete(watch.names, name)
+					}
+				}
+			}
+			if raw.Action != syscall.FILE_ACTION_RENAMED_NEW_NAME {
+				sendNameEvent()
+			}
+			if raw.Action == syscall.FILE_ACTION_REMOVED {
+				w.sendEvent(fullname, watch.names[name]&sys_FS_IGNORED)
+				delete(watch.names, name)
+			}
+			if w.sendEvent(fullname, watch.mask&toFSnotifyFlags(raw.Action)) {
+				if watch.mask&sys_FS_ONESHOT != 0 {
+					watch.mask = 0
+				}
+			}
+			if raw.Action == syscall.FILE_ACTION_RENAMED_NEW_NAME {
+				fullname = watch.path + "\\" + watch.rename
+				sendNameEvent()
+			}
+
+			// Move to the next event in the buffer
+			if raw.NextEntryOffset == 0 {
+				break
+			}
+			offset += raw.NextEntryOffset
+
+			// Error!
+			if offset >= n {
+				w.Errors <- errors.New("Windows system assumed buffer larger than it is, events have likely been missed.")
+				break
+			}
+		}
+
+		if err := w.startRead(watch); err != nil {
+			w.Errors <- err
+		}
+	}
+}
+
+func (w *Watcher) sendEvent(name string, mask uint64) bool {
+	if mask == 0 {
+		return false
+	}
+	event := newEvent(name, uint32(mask))
+	select {
+	case ch := <-w.quit:
+		w.quit <- ch
+	case w.Events <- event:
+	}
+	return true
+}
+
+func toWindowsFlags(mask uint64) uint32 {
+	var m uint32
+	if mask&sys_FS_ACCESS != 0 {
+		m |= syscall.FILE_NOTIFY_CHANGE_LAST_ACCESS
+	}
+	if mask&sys_FS_MODIFY != 0 {
+		m |= syscall.FILE_NOTIFY_CHANGE_LAST_WRITE
+	}
+	if mask&sys_FS_ATTRIB != 0 {
+		m |= syscall.FILE_NOTIFY_CHANGE_ATTRIBUTES
+	}
+	if mask&(sys_FS_MOVE|sys_FS_CREATE|sys_FS_DELETE) != 0 {
+		m |= syscall.FILE_NOTIFY_CHANGE_FILE_NAME | syscall.FILE_NOTIFY_CHANGE_DIR_NAME
+	}
+	return m
+}
+
+func toFSnotifyFlags(action uint32) uint64 {
+	switch action {
+	case syscall.FILE_ACTION_ADDED:
+		return sys_FS_CREATE
+	case syscall.FILE_ACTION_REMOVED:
+		return sys_FS_DELETE
+	case syscall.FILE_ACTION_MODIFIED:
+		return sys_FS_MODIFY
+	case syscall.FILE_ACTION_RENAMED_OLD_NAME:
+		return sys_FS_MOVED_FROM
+	case syscall.FILE_ACTION_RENAMED_NEW_NAME:
+		return sys_FS_MOVED_TO
+	}
+	return 0
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,7 +54,7 @@ var expectedConf = &Config{DefaultedConfig{
 
 			FileSDConfigs: []*FileSDConfig{
 				{DefaultedFileSDConfig{
-					Names:           []string{"foo/*.slow.json", "foo/*.slow.yml"},
+					Names:           []string{"foo/*.slow.json", "foo/*.slow.yml", "single/file.yml"},
 					RefreshInterval: Duration(10 * time.Minute),
 				}},
 				{DefaultedFileSDConfig{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -52,6 +52,17 @@ var expectedConf = &Config{DefaultedConfig{
 				},
 			},
 
+			FileSDConfigs: []*FileSDConfig{
+				{DefaultedFileSDConfig{
+					Names:           []string{"foo/*.slow.json", "foo/*.slow.yml"},
+					RefreshInterval: Duration(10 * time.Minute),
+				}},
+				{DefaultedFileSDConfig{
+					Names:           []string{"bar/*.yaml"},
+					RefreshInterval: Duration(30 * time.Second),
+				}},
+			},
+
 			RelabelConfigs: []*RelabelConfig{
 				{DefaultedRelabelConfig{
 					SourceLabels: clientmodel.LabelNames{"job", "__meta_dns_srv_name"},

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -28,6 +28,7 @@ scrape_configs:
       - names:
           - foo/*.slow.json
           - foo/*.slow.yml
+          - single/file.yml
         refresh_interval: 10m
       - names:
           - bar/*.yaml

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -24,6 +24,14 @@ scrape_configs:
     labels:
       foo: baz
 
+    file_sd_configs:
+      - names:
+          - foo/*.slow.json
+          - foo/*.slow.yml
+        refresh_interval: 10m
+      - names:
+          - bar/*.yaml
+
     target_groups:
       - targets: ['localhost:9090', 'localhost:9191']
         labels:

--- a/retrieval/discovery/file.go
+++ b/retrieval/discovery/file.go
@@ -1,0 +1,249 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"gopkg.in/fsnotify.v1"
+	"gopkg.in/yaml.v2"
+
+	"github.com/prometheus/prometheus/config"
+)
+
+// FileDiscovery provides service discovery functionality based
+// on files that contain target groups in JSON or YAML format. Refreshing
+// happens using file watches and periodic refreshes.
+type FileDiscovery struct {
+	paths    []string
+	watcher  *fsnotify.Watcher
+	interval time.Duration
+	done     chan struct{}
+
+	// lastRefresh stores which files were found during the last refresh
+	// and how many target groups they contained.
+	// This is used to detect deleted target groups.
+	lastRefresh map[string]int
+}
+
+// NewFileDiscovery returns a new file discovery for the given paths.
+func NewFileDiscovery(paths []string, interval time.Duration) *FileDiscovery {
+	fd := &FileDiscovery{
+		paths:    paths,
+		interval: interval,
+		done:     make(chan struct{}),
+	}
+	return fd
+}
+
+// Sources implements the TargetProvider interface.
+func (fd *FileDiscovery) Sources() []string {
+	var srcs []string
+	// As we allow multiple target groups per file we have no choice
+	// but to parse them all.
+	for _, p := range fd.listFiles() {
+		tgroups, err := readFile(p)
+		if err != nil {
+			glog.Errorf("Error reading file %q: ", p, err)
+		}
+		for _, tg := range tgroups {
+			srcs = append(srcs, tg.Source)
+		}
+	}
+	return srcs
+}
+
+// listFiles returns a list of all files that match the configured patterns.
+func (fd *FileDiscovery) listFiles() []string {
+	var paths []string
+	for _, p := range fd.paths {
+		files, err := filepath.Glob(p)
+		if err != nil {
+			glog.Errorf("Error expanding glob %q: %s", p, err)
+			continue
+		}
+		paths = append(paths, files...)
+	}
+	return paths
+}
+
+// watchFiles sets watches on all full paths or directories that were configured for
+// this file discovery.
+func (fd *FileDiscovery) watchFiles() {
+	if fd.watcher == nil {
+		panic("no watcher configured")
+	}
+	for _, p := range fd.paths {
+		if idx := strings.LastIndex(p, "/"); idx > -1 {
+			p = p[:idx]
+		} else {
+			p = "./"
+		}
+		if err := fd.watcher.Add(p); err != nil {
+			glog.Errorf("Error adding file watch for %q: %s", p, err)
+		}
+	}
+}
+
+// Run implements the TargetProvider interface.
+func (fd *FileDiscovery) Run(ch chan<- *config.TargetGroup) {
+	defer close(ch)
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		glog.Errorf("Error creating file watcher: %s", err)
+		return
+	}
+	fd.watcher = watcher
+
+	fd.refresh(ch)
+
+	ticker := time.NewTicker(fd.interval)
+	defer ticker.Stop()
+
+	for {
+		// Stopping has priority over refreshing. Thus we wrap the actual select
+		// clause to always catch done signals.
+		select {
+		case <-fd.done:
+			return
+		default:
+			select {
+			case event := <-fd.watcher.Events:
+				// fsnotify sometimes sends a bunch of events without name or operation.
+				// It's unclear what they are and why they are sent - filter them out.
+				if len(event.Name) == 0 {
+					break
+				}
+				// Everything but a chmod requires rereading.
+				if event.Op^fsnotify.Chmod == 0 {
+					break
+				}
+				// Changes to a file can spawn various sequences of events with
+				// different combinations of operations. For all practical purposes
+				// this is inaccurate.
+				// The most reliable solution is to reload everything if anything happens.
+				fd.refresh(ch)
+
+			case <-ticker.C:
+				// Setting a new watch after an update might fail. Make sure we don't lose
+				// those files forever.
+				fd.refresh(ch)
+
+			case err := <-fd.watcher.Errors:
+				if err != nil {
+					glog.Errorf("Error on file watch: %s", err)
+				}
+
+			case <-fd.done:
+				return
+			}
+		}
+	}
+}
+
+// refresh reads all files matching the discoveries patterns and sends the respective
+// updated target groups through the channel.
+func (fd *FileDiscovery) refresh(ch chan<- *config.TargetGroup) {
+	ref := map[string]int{}
+	for _, p := range fd.listFiles() {
+		tgroups, err := readFile(p)
+		if err != nil {
+			glog.Errorf("Error reading file %q: %s", p, err)
+			// Prevent deletion down below.
+			ref[p] = fd.lastRefresh[p]
+			continue
+		}
+		for _, tg := range tgroups {
+			ch <- tg
+		}
+		ref[p] = len(tgroups)
+	}
+	// Send empty updates for sources that disappeared.
+	for f, n := range fd.lastRefresh {
+		m, ok := ref[f]
+		if !ok || n > m {
+			for i := m; i < n; i++ {
+				ch <- &config.TargetGroup{Source: fileSource(f, i)}
+			}
+		}
+	}
+	fd.lastRefresh = ref
+
+	fd.watchFiles()
+}
+
+// fileSource returns a source ID for the i-th target group in the file.
+func fileSource(filename string, i int) string {
+	return fmt.Sprintf("file:%s:%d", filename, i)
+}
+
+// Stop implements the TargetProvider interface.
+func (fd *FileDiscovery) Stop() {
+	glog.V(1).Info("Stopping file discovery for %s...", fd.paths)
+
+	fd.done <- struct{}{}
+	// Closing the watcher will deadlock unless all events and errors are drained.
+	go func() {
+		for {
+			select {
+			case <-fd.watcher.Errors:
+			case <-fd.watcher.Events:
+				// Drain all events and errors.
+			case <-fd.done:
+				return
+			}
+		}
+	}()
+	fd.watcher.Close()
+
+	fd.done <- struct{}{}
+
+	glog.V(1).Info("File discovery for %s stopped.", fd.paths)
+}
+
+// readFile reads a JSON or YAML list of targets groups from the file, depending on its
+// file extension. It returns full configuration target groups.
+func readFile(filename string) ([]*config.TargetGroup, error) {
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var targetGroups []*config.TargetGroup
+
+	switch ext := filepath.Ext(filename); strings.ToLower(ext) {
+	case ".json":
+		if err := json.Unmarshal(content, &targetGroups); err != nil {
+			return nil, err
+		}
+	case ".yml", ".yaml":
+		if err := yaml.Unmarshal(content, &targetGroups); err != nil {
+			return nil, err
+		}
+	default:
+		panic(fmt.Errorf("retrieval.FileDiscovery.readFile: unhandled file extension %q", ext))
+	}
+
+	for i, tg := range targetGroups {
+		tg.Source = fileSource(filename, i)
+	}
+	return targetGroups, nil
+}

--- a/retrieval/discovery/file_test.go
+++ b/retrieval/discovery/file_test.go
@@ -1,0 +1,93 @@
+package discovery
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/config"
+)
+
+func TestFileSD(t *testing.T) {
+	testFileSD(t, ".yml")
+	testFileSD(t, ".json")
+	os.Remove("fixtures/_test.yml")
+	os.Remove("fixtures/_test.json")
+}
+
+func testFileSD(t *testing.T, ext string) {
+	// As interval refreshing is more of a fallback, we only want to test
+	// whether file watches work as expected.
+	fsd := NewFileDiscovery([]string{"fixtures/_*" + ext}, 1*time.Hour)
+
+	ch := make(chan *config.TargetGroup)
+	go fsd.Run(ch)
+	defer fsd.Stop()
+
+	select {
+	case <-time.After(25 * time.Millisecond):
+		// Expected.
+	case tg := <-ch:
+		t.Fatalf("Unexpected target group in file discovery: %s", tg)
+	}
+
+	newf, err := os.Create("fixtures/_test" + ext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer newf.Close()
+
+	f, err := os.Open("fixtures/target_groups" + ext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	_, err = io.Copy(newf, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newf.Close()
+
+	// The files contain two target groups which are read and sent in order.
+	select {
+	case <-time.After(15 * time.Second):
+		t.Fatalf("Expected new target group but got none")
+	case tg := <-ch:
+		if tg.String() != fmt.Sprintf("file:fixtures/_test%s:0", ext) {
+			t.Fatalf("Unexpected target group", tg)
+		}
+	}
+	select {
+	case <-time.After(15 * time.Second):
+		t.Fatalf("Expected new target group but got none")
+	case tg := <-ch:
+		if tg.String() != fmt.Sprintf("file:fixtures/_test%s:1", ext) {
+			t.Fatalf("Unexpected target group %s", tg)
+		}
+	}
+	// Based on unknown circumstances, sometimes fsnotify will trigger more events in
+	// some runs (which might be empty, chains of different operations etc.).
+	// We have to drain those (as the target manager would) to avoid deadlocking and must
+	// not try to make sense of it all...
+	go func() {
+		for tg := range ch {
+			// Below we will change the file to a bad syntax. Previously extracted target
+			// groups must not be deleted via sending an empty target group.
+			if len(tg.Targets) == 0 {
+				t.Fatalf("Unexpected empty target group received: %s", tg)
+			}
+		}
+	}()
+
+	newf, err = os.Create("fixtures/_test" + ext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newf.Write([]byte("]gibberish\n][")); err != nil {
+		t.Fatal(err)
+	}
+	newf.Close()
+}

--- a/retrieval/discovery/fixtures/target_groups.json
+++ b/retrieval/discovery/fixtures/target_groups.json
@@ -1,0 +1,11 @@
+[
+	{
+		"targets": ["localhost:9090", "example.org:443"],
+		"labels": {
+			"foo": "bar"
+		}
+	},
+	{
+		"targets": ["my.domain"]
+	}
+]

--- a/retrieval/discovery/fixtures/target_groups.yml
+++ b/retrieval/discovery/fixtures/target_groups.yml
@@ -1,0 +1,5 @@
+- targets: ['localhost:9090', 'example.org:443']
+  labels:
+    test: success
+
+- targets: ['my.domain']

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -210,8 +210,6 @@ func (t *target) Update(cfg *config.ScrapeConfig, baseLabels clientmodel.LabelSe
 }
 
 func (t *target) String() string {
-	t.RLock()
-	defer t.RUnlock()
 	return t.url.Host
 }
 
@@ -398,22 +396,6 @@ func (t *target) URL() string {
 
 // InstanceIdentifier implements Target.
 func (t *target) InstanceIdentifier() string {
-	// If we are given a port in the host port, use that.
-	if strings.Contains(t.url.Host, ":") {
-		return t.url.Host
-	}
-
-	t.RLock()
-	defer t.RUnlock()
-
-	// Otherwise, deduce port based on protocol.
-	if t.url.Scheme == "http" {
-		return fmt.Sprintf("%s:80", t.url.Host)
-	} else if t.url.Scheme == "https" {
-		return fmt.Sprintf("%s:443", t.url.Host)
-	}
-
-	glog.Warningf("Unknown scheme %s when generating identifier, using host without port number.", t.url.Scheme)
 	return t.url.Host
 }
 

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -34,7 +34,7 @@ func TestTargetInterface(t *testing.T) {
 }
 
 func TestBaseLabels(t *testing.T) {
-	target := newTestTarget("example.com", 0, clientmodel.LabelSet{"job": "some_job", "foo": "bar"})
+	target := newTestTarget("example.com:80", 0, clientmodel.LabelSet{"job": "some_job", "foo": "bar"})
 	want := clientmodel.LabelSet{
 		clientmodel.JobLabel:      "some_job",
 		clientmodel.InstanceLabel: "example.com:80",
@@ -89,7 +89,7 @@ func TestTargetScrapeWithFullChannel(t *testing.T) {
 }
 
 func TestTargetRecordScrapeHealth(t *testing.T) {
-	testTarget := newTestTarget("example.url", 0, clientmodel.LabelSet{clientmodel.JobLabel: "testjob"})
+	testTarget := newTestTarget("example.url:80", 0, clientmodel.LabelSet{clientmodel.JobLabel: "testjob"})
 
 	now := clientmodel.Now()
 	appender := &collectResultAppender{}


### PR DESCRIPTION
This commits adds file based service discovery which reads target
groups from specified files. It detects changes based on file watches
and regular refreshes.

We also no longer deduce ports in the target but before creating it.