### PR TITLE
Avoid inter-component blocking if ingestion/scraping blocks

### DIFF
--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -44,13 +44,6 @@ func TestBaseLabels(t *testing.T) {
 	if !reflect.DeepEqual(want, got) {
 		t.Errorf("want base labels %v, got %v", want, got)
 	}
-	delete(want, clientmodel.JobLabel)
-	delete(want, clientmodel.InstanceLabel)
-
-	got = target.BaseLabelsWithoutJobAndInstance()
-	if !reflect.DeepEqual(want, got) {
-		t.Errorf("want base labels %v, got %v", want, got)
-	}
 }
 
 func TestTargetScrapeUpdatesState(t *testing.T) {

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -215,7 +215,7 @@ func (tm *TargetManager) updateTargetGroup(tgroup *config.TargetGroup, cfg *conf
 				// to build up.
 				wg.Add(1)
 				go func(t Target) {
-					match.Update(cfg, t.Labels())
+					match.Update(cfg, t.fullLabels())
 					wg.Done()
 				}(tnew)
 				newTargets[i] = match

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -56,7 +56,7 @@ type TargetManager struct {
 	running        bool
 
 	// Targets by their source ID.
-	targets map[string][]Target
+	targets map[string][]*Target
 	// Providers by the scrape configs they are derived from.
 	providers map[*config.ScrapeConfig][]TargetProvider
 }
@@ -65,7 +65,7 @@ type TargetManager struct {
 func NewTargetManager(sampleAppender storage.SampleAppender) *TargetManager {
 	tm := &TargetManager{
 		sampleAppender: sampleAppender,
-		targets:        make(map[string][]Target),
+		targets:        make(map[string][]*Target),
 	}
 	return tm
 }
@@ -165,7 +165,7 @@ func (tm *TargetManager) removeTargets(f func(string) bool) {
 		}
 		wg.Add(len(targets))
 		for _, target := range targets {
-			go func(t Target) {
+			go func(t *Target) {
 				t.StopScraper()
 				wg.Done()
 			}(target)
@@ -197,7 +197,7 @@ func (tm *TargetManager) updateTargetGroup(tgroup *config.TargetGroup, cfg *conf
 		// Replace the old targets with the new ones while keeping the state
 		// of intersecting targets.
 		for i, tnew := range newTargets {
-			var match Target
+			var match *Target
 			for j, told := range oldTargets {
 				if told == nil {
 					continue
@@ -214,7 +214,7 @@ func (tm *TargetManager) updateTargetGroup(tgroup *config.TargetGroup, cfg *conf
 				// Updating is blocked during a scrape. We don't want those wait times
 				// to build up.
 				wg.Add(1)
-				go func(t Target) {
+				go func(t *Target) {
 					match.Update(cfg, t.fullLabels())
 					wg.Done()
 				}(tnew)
@@ -227,7 +227,7 @@ func (tm *TargetManager) updateTargetGroup(tgroup *config.TargetGroup, cfg *conf
 		for _, told := range oldTargets {
 			if told != nil {
 				wg.Add(1)
-				go func(t Target) {
+				go func(t *Target) {
 					t.StopScraper()
 					wg.Done()
 				}(told)
@@ -250,11 +250,11 @@ func (tm *TargetManager) updateTargetGroup(tgroup *config.TargetGroup, cfg *conf
 }
 
 // Pools returns the targets currently being scraped bucketed by their job name.
-func (tm *TargetManager) Pools() map[string][]Target {
+func (tm *TargetManager) Pools() map[string][]*Target {
 	tm.m.RLock()
 	defer tm.m.RUnlock()
 
-	pools := map[string][]Target{}
+	pools := map[string][]*Target{}
 
 	for _, ts := range tm.targets {
 		for _, t := range ts {
@@ -287,11 +287,11 @@ func (tm *TargetManager) ApplyConfig(cfg *config.Config) {
 }
 
 // targetsFromGroup builds targets based on the given TargetGroup and config.
-func (tm *TargetManager) targetsFromGroup(tg *config.TargetGroup, cfg *config.ScrapeConfig) ([]Target, error) {
+func (tm *TargetManager) targetsFromGroup(tg *config.TargetGroup, cfg *config.ScrapeConfig) ([]*Target, error) {
 	tm.m.RLock()
 	defer tm.m.RUnlock()
 
-	targets := make([]Target, 0, len(tg.Targets))
+	targets := make([]*Target, 0, len(tg.Targets))
 	for i, labels := range tg.Targets {
 		addr := string(labels[clientmodel.AddressLabel])
 		// If no port was provided, infer it based on the used scheme.

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -45,7 +45,7 @@ func TestTargetManagerChan(t *testing.T) {
 		providers: map[*config.ScrapeConfig][]TargetProvider{
 			testJob1: []TargetProvider{prov1},
 		},
-		targets: make(map[string][]Target),
+		targets: make(map[string][]*Target),
 	}
 	go targetManager.Run()
 	defer targetManager.Stop()

--- a/web/status.go
+++ b/web/status.go
@@ -32,18 +32,18 @@ type PrometheusStatusHandler struct {
 	Flags     map[string]string
 
 	RuleManager *rules.Manager
-	TargetPools func() map[string][]retrieval.Target
+	TargetPools func() map[string][]*retrieval.Target
 
 	Birth      time.Time
 	PathPrefix string
 }
 
-// TargetStateToClass returns a map of TargetState to the name of a Bootstrap CSS class.
-func (h *PrometheusStatusHandler) TargetStateToClass() map[retrieval.TargetState]string {
-	return map[retrieval.TargetState]string{
-		retrieval.Unknown:   "warning",
-		retrieval.Healthy:   "success",
-		retrieval.Unhealthy: "danger",
+// TargetHealthToClass returns a map of TargetHealth to the name of a Bootstrap CSS class.
+func (h *PrometheusStatusHandler) TargetHealthToClass() map[retrieval.TargetHealth]string {
+	return map[retrieval.TargetHealth]string{
+		retrieval.HealthUnknown: "warning",
+		retrieval.HealthBad:     "success",
+		retrieval.HealthGood:    "danger",
 	}
 }
 

--- a/web/templates/status.html
+++ b/web/templates/status.html
@@ -48,7 +48,7 @@
           {{range $pool}}
             <tr>
               <td>
-                <a href="{{.GlobalURL}}">{{.URL}}</a>
+                <a href="{{.URL | globalURL}}">{{.URL}}</a>
               </td>
               <td>
                 <span class="alert alert-{{index $stateToClass .Status.State}} target_status_alert">
@@ -56,7 +56,7 @@
                 </span>
               </td>
               <td>
-                {{.BaseLabelsWithoutJobAndInstance}}
+                {{stripLabels .BaseLabels "job" "instance"}}
               </td>
               <td>
                 {{if .Status.LastScrape.IsZero}}Never{{else}}{{since .Status.LastScrape}} ago{{end}}

--- a/web/templates/status.html
+++ b/web/templates/status.html
@@ -51,19 +51,19 @@
                 <a href="{{.GlobalURL}}">{{.URL}}</a>
               </td>
               <td>
-                <span class="alert alert-{{index $stateToClass .State}} target_status_alert">
-                  {{.State}}
+                <span class="alert alert-{{index $stateToClass .Status.State}} target_status_alert">
+                  {{.Status.State}}
                 </span>
               </td>
               <td>
                 {{.BaseLabelsWithoutJobAndInstance}}
               </td>
               <td>
-                {{if .LastScrape.IsZero}}Never{{else}}{{since .LastScrape}} ago{{end}}
+                {{if .Status.LastScrape.IsZero}}Never{{else}}{{since .Status.LastScrape}} ago{{end}}
               </td>
               <td>
-                {{if .LastError}}
-                <span class="alert alert-danger target_status_alert">{{.LastError}}</span>
+                {{if .Status.LastError}}
+                <span class="alert alert-danger target_status_alert">{{.Status.LastError}}</span>
                 {{end}}
               </td>
             </tr>

--- a/web/templates/status.html
+++ b/web/templates/status.html
@@ -32,7 +32,6 @@
 
     <h2>Targets</h2>
       <table class="table table-condensed table-bordered table-striped table-hover">
-        {{$stateToClass := .TargetStateToClass}}
         {{range $job, $pool := call .TargetPools}}
           <thead>
             <tr><th colspan="5" class="job_header">{{$job}}</th></tr>
@@ -51,7 +50,7 @@
                 <a href="{{.URL | globalURL}}">{{.URL}}</a>
               </td>
               <td>
-                <span class="alert alert-{{index $stateToClass .Status.State}} target_status_alert">
+                <span class="alert alert-{{index .TargetHealthToClass .Status.State}} target_status_alert">
                   {{.Status.State}}
                 </span>
               </td>

--- a/web/web.go
+++ b/web/web.go
@@ -193,7 +193,7 @@ func getTemplate(name string, pathPrefix string) (*template.Template, error) {
 
 	file, err = getTemplateFile(name)
 	if err != nil {
-		glog.Error("Could not read template %d: ", name, err)
+		glog.Error("Could not read template %s: %s", name, err)
 		return nil, err
 	}
 	t, err = t.Parse(file)

--- a/web/web.go
+++ b/web/web.go
@@ -29,9 +29,13 @@ import (
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 
+	clientmodel "github.com/prometheus/client_golang/model"
+
 	"github.com/prometheus/prometheus/web/api"
 	"github.com/prometheus/prometheus/web/blob"
 )
+
+var localhostRepresentations = []string{"127.0.0.1", "localhost"}
 
 // Commandline flags.
 var (
@@ -150,28 +154,53 @@ func getConsoles(pathPrefix string) string {
 	return ""
 }
 
-func getTemplate(name string, pathPrefix string) (t *template.Template, err error) {
-	t = template.New("_base")
+func getTemplate(name string, pathPrefix string) (*template.Template, error) {
+	t := template.New("_base")
+	var err error
 
 	t.Funcs(template.FuncMap{
 		"since":       time.Since,
 		"getConsoles": func() string { return getConsoles(pathPrefix) },
 		"pathPrefix":  func() string { return pathPrefix },
+		"stripLabels": func(lset clientmodel.LabelSet, labels ...clientmodel.LabelName) clientmodel.LabelSet {
+			for _, ln := range labels {
+				delete(lset, ln)
+			}
+			return lset
+		},
+		"globalURL": func(url string) string {
+			hostname, err := os.Hostname()
+			if err != nil {
+				glog.Warningf("Couldn't get hostname: %s, returning target.URL()", err)
+				return url
+			}
+			for _, localhostRepresentation := range localhostRepresentations {
+				url = strings.Replace(url, "//"+localhostRepresentation, "//"+hostname, 1)
+			}
+			return url
+		},
 	})
+
 	file, err := getTemplateFile("_base")
 	if err != nil {
-		glog.Error("Could not read base template: ", err)
+		glog.Errorln("Could not read base template:", err)
 		return nil, err
 	}
-	t.Parse(file)
+	t, err = t.Parse(file)
+	if err != nil {
+		glog.Errorln("Could not parse base template:", err)
+	}
 
 	file, err = getTemplateFile(name)
 	if err != nil {
-		glog.Error("Could not read base template: ", err)
+		glog.Error("Could not read template %d: ", name, err)
 		return nil, err
 	}
-	t.Parse(file)
-	return
+	t, err = t.Parse(file)
+	if err != nil {
+		glog.Errorf("Could not parse template %s: %s", name, err)
+	}
+	return t, err
 }
 
 func executeTemplate(w http.ResponseWriter, name string, data interface{}, pathPrefix string) {


### PR DESCRIPTION
Appending to the storage can block for a long time. Timing out
scrapes can also cause longer blocks. This commit avoids that those
blocks affect other compnents than the target itself.

Also the Target interface was removed. Methods created specifically to modify
output for the templates were moved to the templates.