### PR TITLE
Fix graph links when "web.path-prefix" option is set

### DIFF
--- a/console_libraries/prom.lib
+++ b/console_libraries/prom.lib
@@ -40,7 +40,7 @@ renderTemplate is the name of the template to use to render the value.
 */}}
 {{ define "prom_query_drilldown" }}
 {{ $expr := .arg0 }}{{ $suffix := (or .arg1 "") }}{{ $renderTemplate := (or .arg2 "__prom_query_drilldown_noop") }}
-<a class="prom_query_drilldown" href="{{ graphLink $expr }}">{{ with query $expr }}{{tmpl $renderTemplate ( . | first | value )}}{{ $suffix }}{{ else }}-{{ end }}</a>
+<a class="prom_query_drilldown" href="{{ pathPrefix }}{{ graphLink $expr }}">{{ with query $expr }}{{tmpl $renderTemplate ( . | first | value )}}{{ $suffix }}{{ else }}-{{ end }}</a>
 {{ end }}
 
 {{ define "prom_path" }}/consoles/{{ .Path }}?{{ range $param, $value := .Params }}{{ $param }}={{ $value }}&amp;{{ end }}{{ end }}"

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"html/template"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -213,16 +214,16 @@ func (rule *AlertingRule) String() string {
 }
 
 // HTMLSnippet returns an HTML snippet representing this alerting rule.
-func (rule *AlertingRule) HTMLSnippet() template.HTML {
+func (rule *AlertingRule) HTMLSnippet(pathPrefix string) template.HTML {
 	alertMetric := clientmodel.Metric{
 		clientmodel.MetricNameLabel: AlertMetricName,
 		AlertNameLabel:              clientmodel.LabelValue(rule.name),
 	}
 	return template.HTML(fmt.Sprintf(
 		`ALERT <a href="%s">%s</a> IF <a href="%s">%s</a> FOR %s WITH %s`,
-		utility.GraphLinkForExpression(alertMetric.String()),
+		pathPrefix+strings.TrimLeft(utility.GraphLinkForExpression(alertMetric.String()), "/"),
 		rule.name,
-		utility.GraphLinkForExpression(rule.Vector.String()),
+		pathPrefix+strings.TrimLeft(utility.GraphLinkForExpression(rule.Vector.String()), "/"),
 		rule.Vector,
 		utility.DurationToString(rule.holdDuration),
 		rule.Labels))

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"html/template"
 	"reflect"
+	"strings"
 
 	clientmodel "github.com/prometheus/client_golang/model"
 
@@ -85,13 +86,13 @@ func (rule RecordingRule) String() string {
 }
 
 // HTMLSnippet returns an HTML snippet representing this rule.
-func (rule RecordingRule) HTMLSnippet() template.HTML {
+func (rule RecordingRule) HTMLSnippet(pathPrefix string) template.HTML {
 	ruleExpr := rule.vector.String()
 	return template.HTML(fmt.Sprintf(
 		`<a href="%s">%s</a>%s = <a href="%s">%s</a>`,
-		utility.GraphLinkForExpression(rule.name),
+		pathPrefix+strings.TrimLeft(utility.GraphLinkForExpression(rule.name), "/"),
 		rule.name,
 		rule.labels,
-		utility.GraphLinkForExpression(ruleExpr),
+		pathPrefix+strings.TrimLeft(utility.GraphLinkForExpression(ruleExpr), "/"),
 		ruleExpr))
 }

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -37,5 +37,5 @@ type Rule interface {
 	String() string
 	// HTMLSnippet returns a human-readable string representation of the rule,
 	// decorated with HTML elements for use the web frontend.
-	HTMLSnippet() template.HTML
+	HTMLSnippet(pathPrefix string) template.HTML
 }

--- a/web/templates/alerts.html
+++ b/web/templates/alerts.html
@@ -17,7 +17,7 @@
       <tr class="alert_details">
         <td>
           <div class="alert_description">
-            <span class="label alert_rule">{{.HTMLSnippet}}</span>
+            <span class="label alert_rule">{{.HTMLSnippet pathPrefix}}</span>
             <a href="#" class="silence_children_link">Silence All Children&hellip;</a>
           </div>
           {{if $activeAlerts}}

--- a/web/templates/status.html
+++ b/web/templates/status.html
@@ -28,7 +28,7 @@
     <pre>{{.Config}}</pre>
 
     <h2>Rules</h2>
-    <pre>{{range .RuleManager.Rules}}{{.HTMLSnippet}}<br/>{{end}}</pre>
+    <pre>{{range .RuleManager.Rules}}{{.HTMLSnippet pathPrefix}}<br/>{{end}}</pre>
 
     <h2>Targets</h2>
       <table class="table table-condensed table-bordered table-striped table-hover">


### PR DESCRIPTION
Hi,

I notice that some graph links is broken.

Broken link:
```
http://127.0.0.1:9090/graph#...
```

Correct link (when I set "wet.path-prefix" as "/prometheus"):
```
http://127.0.0.1:9090/prometheus/graph#...
```