### PR TITLE
Clean storage shutdown on startup errors, require initial config

### DIFF
--- a/main.go
+++ b/main.go
@@ -237,27 +237,35 @@ func (p *prometheus) reloadConfig() bool {
 // down. The method installs an interrupt handler, allowing to trigger a
 // shutdown by sending SIGTERM to the process.
 func (p *prometheus) Serve() {
+	// Start all components.
 	if err := p.storage.Start(); err != nil {
 		glog.Error("Error opening memory series storage: ", err)
 		os.Exit(1)
 	}
+	defer p.storage.Stop()
+
+	// The storage has to be fully initialized before registering Prometheus.
+	registry.MustRegister(p)
+
 	for _, q := range p.remoteStorageQueues {
 		go q.Run()
+		defer q.Stop()
 	}
 
 	go p.ruleManager.Run()
+	defer p.ruleManager.Stop()
+
 	go p.notificationHandler.Run()
+	defer p.notificationHandler.Stop()
+
 	go p.targetManager.Run()
+	defer p.targetManager.Stop()
 
-	registry.MustRegister(p)
+	defer p.queryEngine.Stop()
 
-	go func() {
-		err := p.webService.ServeForever(*pathPrefix)
-		if err != nil {
-			glog.Fatal(err)
-		}
-	}()
+	go p.webService.ServeForever(*pathPrefix)
 
+	// Wait for reload or termination signals.
 	hup := make(chan os.Signal)
 	signal.Notify(hup, syscall.SIGHUP)
 	go func() {
@@ -277,19 +285,6 @@ func (p *prometheus) Serve() {
 
 	close(hup)
 
-	p.targetManager.Stop()
-	p.ruleManager.Stop()
-	p.queryEngine.Stop()
-
-	if err := p.storage.Stop(); err != nil {
-		glog.Error("Error stopping local storage: ", err)
-	}
-
-	for _, q := range p.remoteStorageQueues {
-		q.Stop()
-	}
-
-	p.notificationHandler.Stop()
 	glog.Info("See you next time!")
 }
 

--- a/storage/local/interface.go
+++ b/storage/local/interface.go
@@ -48,7 +48,7 @@ type Storage interface {
 	// Run the various maintenance loops in goroutines. Returns when the
 	// storage is ready to use. Keeps everything running in the background
 	// until Stop is called.
-	Start()
+	Start() error
 	// Stop shuts down the Storage gracefully, flushes all pending
 	// operations, stops all maintenance loops,and frees all resources.
 	Stop() error

--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -268,8 +268,11 @@ func newPersistence(basePath string, dirty, pedanticChecks bool, shouldSync sync
 	p.labelPairToFingerprints = labelPairToFingerprints
 	p.labelNameToLabelValues = labelNameToLabelValues
 
-	go p.processIndexingQueue()
 	return p, nil
+}
+
+func (p *persistence) run() {
+	p.processIndexingQueue()
 }
 
 // Describe implements prometheus.Collector.

--- a/storage/local/persistence_test.go
+++ b/storage/local/persistence_test.go
@@ -42,6 +42,7 @@ func newTestPersistence(t *testing.T, encoding chunkEncoding) (*persistence, tes
 		dir.Close()
 		t.Fatal(err)
 	}
+	go p.run()
 	return p, test.NewCallbackCloser(func() {
 		p.close()
 		dir.Close()

--- a/storage/local/storage_test.go
+++ b/storage/local/storage_test.go
@@ -163,9 +163,9 @@ func TestLoop(t *testing.T) {
 		CheckpointInterval:         250 * time.Millisecond,
 		SyncStrategy:               Adaptive,
 	}
-	storage, err := NewMemorySeriesStorage(o)
-	if err != nil {
-		t.Fatalf("Error creating storage: %s", err)
+	storage := NewMemorySeriesStorage(o)
+	if err := storage.Start; err != nil {
+		t.Fatalf("Error starting storage: %s", err)
 	}
 	storage.Start()
 	for _, s := range samples {
@@ -731,9 +731,9 @@ func benchmarkFuzz(b *testing.B, encoding chunkEncoding) {
 		CheckpointInterval:         time.Second,
 		SyncStrategy:               Adaptive,
 	}
-	s, err := NewMemorySeriesStorage(o)
-	if err != nil {
-		b.Fatalf("Error creating storage: %s", err)
+	s := NewMemorySeriesStorage(o)
+	if err := s.Start(); err != nil {
+		b.Fatalf("Error starting storage: %s", err)
 	}
 	s.Start()
 	defer s.Stop()

--- a/storage/local/test_helpers.go
+++ b/storage/local/test_helpers.go
@@ -48,13 +48,11 @@ func NewTestStorage(t test.T, encoding chunkEncoding) (*memorySeriesStorage, tes
 		CheckpointInterval:         time.Hour,
 		SyncStrategy:               Adaptive,
 	}
-	storage, err := NewMemorySeriesStorage(o)
-	if err != nil {
+	storage := NewMemorySeriesStorage(o)
+	if err := storage.Start(); err != nil {
 		directory.Close()
 		t.Fatalf("Error creating storage: %s", err)
 	}
-
-	storage.Start()
 
 	closer := &testStorageCloser{
 		storage:   storage,

--- a/web/web.go
+++ b/web/web.go
@@ -54,7 +54,7 @@ type WebService struct {
 }
 
 // ServeForever serves the HTTP endpoints and only returns upon errors.
-func (ws WebService) ServeForever(pathPrefix string) error {
+func (ws WebService) ServeForever(pathPrefix string) {
 
 	http.Handle("/favicon.ico", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "", 404)
@@ -104,9 +104,16 @@ func (ws WebService) ServeForever(pathPrefix string) error {
 		}))
 	}
 
-	glog.Info("listening on ", *listenAddress)
+	glog.Infof("Listening on %s", *listenAddress)
 
-	return http.ListenAndServe(*listenAddress, nil)
+	// If we cannot bind to a port, retry after 30 seconds.
+	for {
+		err := http.ListenAndServe(*listenAddress, nil)
+		if err != nil {
+			glog.Errorf("Could not listen on %s: %s", *listenAddress, err)
+		}
+		time.Sleep(30 * time.Second)
+	}
 }
 
 func (ws WebService) quitHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This attempts to fix the storage bootstrapping issue for good (#504).
The storage does no longer start any background processing unless `Start()` returned without an error.

An initial configuration file is now required (again).

@beorn7 