### PR TITLE
Improve iterator performance.

### DIFF
--- a/promql/analyzer.go
+++ b/promql/analyzer.go
@@ -73,7 +73,7 @@ func (a *Analyzer) Analyze(ctx context.Context) error {
 		switch n := node.(type) {
 		case *VectorSelector:
 			pt := getPreloadTimes(n.Offset)
-			fpts := a.Storage.GetFingerprintsForLabelMatchers(n.LabelMatchers)
+			fpts := a.Storage.FingerprintsForLabelMatchers(n.LabelMatchers)
 			n.fingerprints = fpts
 			n.metrics = map[clientmodel.Fingerprint]clientmodel.COWMetric{}
 			n.iterators = map[clientmodel.Fingerprint]local.SeriesIterator{}
@@ -84,11 +84,11 @@ func (a *Analyzer) Analyze(ctx context.Context) error {
 				if _, alreadyInRanges := pt.ranges[fp]; !alreadyInRanges {
 					pt.instants[fp] = struct{}{}
 				}
-				n.metrics[fp] = a.Storage.GetMetricForFingerprint(fp)
+				n.metrics[fp] = a.Storage.MetricForFingerprint(fp)
 			}
 		case *MatrixSelector:
 			pt := getPreloadTimes(n.Offset)
-			fpts := a.Storage.GetFingerprintsForLabelMatchers(n.LabelMatchers)
+			fpts := a.Storage.FingerprintsForLabelMatchers(n.LabelMatchers)
 			n.fingerprints = fpts
 			n.metrics = map[clientmodel.Fingerprint]clientmodel.COWMetric{}
 			n.iterators = map[clientmodel.Fingerprint]local.SeriesIterator{}
@@ -100,7 +100,7 @@ func (a *Analyzer) Analyze(ctx context.Context) error {
 					// an instant for the same fingerprint, should we have one.
 					delete(pt.instants, fp)
 				}
-				n.metrics[fp] = a.Storage.GetMetricForFingerprint(fp)
+				n.metrics[fp] = a.Storage.MetricForFingerprint(fp)
 			}
 		}
 		return true

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -644,7 +644,7 @@ func (ev *evaluator) eval(expr Expr) Value {
 func (ev *evaluator) vectorSelector(node *VectorSelector) Vector {
 	vec := Vector{}
 	for fp, it := range node.iterators {
-		sampleCandidates := it.GetValueAtTime(ev.Timestamp.Add(-node.Offset))
+		sampleCandidates := it.ValueAtTime(ev.Timestamp.Add(-node.Offset))
 		samplePair := chooseClosestSample(sampleCandidates, ev.Timestamp.Add(-node.Offset))
 		if samplePair != nil {
 			vec = append(vec, &Sample{
@@ -666,7 +666,7 @@ func (ev *evaluator) matrixSelector(node *MatrixSelector) Matrix {
 
 	sampleStreams := make([]*SampleStream, 0, len(node.iterators))
 	for fp, it := range node.iterators {
-		samplePairs := it.GetRangeValues(interval)
+		samplePairs := it.RangeValues(interval)
 		if len(samplePairs) == 0 {
 			continue
 		}
@@ -695,7 +695,7 @@ func (ev *evaluator) matrixSelectorBounds(node *MatrixSelector) Matrix {
 
 	sampleStreams := make([]*SampleStream, 0, len(node.iterators))
 	for fp, it := range node.iterators {
-		samplePairs := it.GetBoundaryValues(interval)
+		samplePairs := it.BoundaryValues(interval)
 		if len(samplePairs) == 0 {
 			continue
 		}

--- a/storage/local/crashrecovery.go
+++ b/storage/local/crashrecovery.go
@@ -318,7 +318,7 @@ func (p *persistence) sanitizeSeries(
 		return fp, true
 	}
 	// This series is supposed to be archived.
-	metric, err := p.getArchivedMetric(fp)
+	metric, err := p.archivedMetric(fp)
 	if err != nil {
 		glog.Errorf(
 			"Fingerprint %v assumed archived but couldn't be looked up in archived index: %s",

--- a/storage/local/delta.go
+++ b/storage/local/delta.go
@@ -188,18 +188,19 @@ func (c deltaEncodedChunk) clone() chunk {
 
 // firstTime implements chunk.
 func (c deltaEncodedChunk) firstTime() clientmodel.Timestamp {
-	return c.valueAtIndex(0).Timestamp
-}
-
-// lastTime implements chunk.
-func (c deltaEncodedChunk) lastTime() clientmodel.Timestamp {
-	return c.valueAtIndex(c.len() - 1).Timestamp
+	return c.baseTime()
 }
 
 // newIterator implements chunk.
 func (c *deltaEncodedChunk) newIterator() chunkIterator {
 	return &deltaEncodedChunkIterator{
-		chunk: c,
+		c:      *c,
+		len:    c.len(),
+		baseT:  c.baseTime(),
+		baseV:  c.baseValue(),
+		tBytes: c.timeBytes(),
+		vBytes: c.valueBytes(),
+		isInt:  c.isInt(),
 	}
 }
 
@@ -237,19 +238,6 @@ func (c *deltaEncodedChunk) unmarshalFromBuf(buf []byte) {
 	*c = (*c)[:binary.LittleEndian.Uint16((*c)[deltaHeaderBufLenOffset:])]
 }
 
-// values implements chunk.
-func (c deltaEncodedChunk) values() <-chan *metric.SamplePair {
-	n := c.len()
-	valuesChan := make(chan *metric.SamplePair)
-	go func() {
-		for i := 0; i < n; i++ {
-			valuesChan <- c.valueAtIndex(i)
-		}
-		close(valuesChan)
-	}()
-	return valuesChan
-}
-
 // encoding implements chunk.
 func (c deltaEncodedChunk) encoding() chunkEncoding { return delta }
 
@@ -284,106 +272,157 @@ func (c deltaEncodedChunk) len() int {
 	return (len(c) - deltaHeaderBytes) / c.sampleSize()
 }
 
-func (c deltaEncodedChunk) valueAtIndex(idx int) *metric.SamplePair {
-	offset := deltaHeaderBytes + idx*c.sampleSize()
-
-	var ts clientmodel.Timestamp
-	switch c.timeBytes() {
-	case d1:
-		ts = c.baseTime() + clientmodel.Timestamp(uint8(c[offset]))
-	case d2:
-		ts = c.baseTime() + clientmodel.Timestamp(binary.LittleEndian.Uint16(c[offset:]))
-	case d4:
-		ts = c.baseTime() + clientmodel.Timestamp(binary.LittleEndian.Uint32(c[offset:]))
-	case d8:
-		// Take absolute value for d8.
-		ts = clientmodel.Timestamp(binary.LittleEndian.Uint64(c[offset:]))
-	default:
-		panic("Invalid number of bytes for time delta")
-	}
-
-	offset += int(c.timeBytes())
-
-	var v clientmodel.SampleValue
-	if c.isInt() {
-		switch c.valueBytes() {
-		case d0:
-			v = c.baseValue()
-		case d1:
-			v = c.baseValue() + clientmodel.SampleValue(int8(c[offset]))
-		case d2:
-			v = c.baseValue() + clientmodel.SampleValue(int16(binary.LittleEndian.Uint16(c[offset:])))
-		case d4:
-			v = c.baseValue() + clientmodel.SampleValue(int32(binary.LittleEndian.Uint32(c[offset:])))
-		// No d8 for ints.
-		default:
-			panic("Invalid number of bytes for integer delta")
-		}
-	} else {
-		switch c.valueBytes() {
-		case d4:
-			v = c.baseValue() + clientmodel.SampleValue(math.Float32frombits(binary.LittleEndian.Uint32(c[offset:])))
-		case d8:
-			// Take absolute value for d8.
-			v = clientmodel.SampleValue(math.Float64frombits(binary.LittleEndian.Uint64(c[offset:])))
-		default:
-			panic("Invalid number of bytes for floating point delta")
-		}
-	}
-	return &metric.SamplePair{
-		Timestamp: ts,
-		Value:     v,
-	}
-}
-
 // deltaEncodedChunkIterator implements chunkIterator.
 type deltaEncodedChunkIterator struct {
-	chunk *deltaEncodedChunk
-	// TODO: add more fields here to keep track of last position.
+	c              deltaEncodedChunk
+	len            int
+	baseT          clientmodel.Timestamp
+	baseV          clientmodel.SampleValue
+	tBytes, vBytes deltaBytes
+	isInt          bool
 }
+
+// length implements chunkIterator.
+func (it *deltaEncodedChunkIterator) length() int { return it.len }
 
 // getValueAtTime implements chunkIterator.
 func (it *deltaEncodedChunkIterator) getValueAtTime(t clientmodel.Timestamp) metric.Values {
-	i := sort.Search(it.chunk.len(), func(i int) bool {
-		return !it.chunk.valueAtIndex(i).Timestamp.Before(t)
+	i := sort.Search(it.len, func(i int) bool {
+		return !it.getTimestampAtIndex(i).Before(t)
 	})
 
 	switch i {
 	case 0:
-		return metric.Values{*it.chunk.valueAtIndex(0)}
-	case it.chunk.len():
-		return metric.Values{*it.chunk.valueAtIndex(it.chunk.len() - 1)}
+		return metric.Values{metric.SamplePair{
+			Timestamp: it.getTimestampAtIndex(0),
+			Value:     it.getSampleValueAtIndex(0),
+		}}
+	case it.len:
+		return metric.Values{metric.SamplePair{
+			Timestamp: it.getTimestampAtIndex(it.len - 1),
+			Value:     it.getSampleValueAtIndex(it.len - 1),
+		}}
 	default:
-		v := it.chunk.valueAtIndex(i)
-		if v.Timestamp.Equal(t) {
-			return metric.Values{*v}
+		ts := it.getTimestampAtIndex(i)
+		if ts.Equal(t) {
+			return metric.Values{metric.SamplePair{
+				Timestamp: ts,
+				Value:     it.getSampleValueAtIndex(i),
+			}}
 		}
-		return metric.Values{*it.chunk.valueAtIndex(i - 1), *v}
+		return metric.Values{
+			metric.SamplePair{
+				Timestamp: it.getTimestampAtIndex(i - 1),
+				Value:     it.getSampleValueAtIndex(i - 1),
+			},
+			metric.SamplePair{
+				Timestamp: ts,
+				Value:     it.getSampleValueAtIndex(i),
+			},
+		}
 	}
 }
 
 // getRangeValues implements chunkIterator.
 func (it *deltaEncodedChunkIterator) getRangeValues(in metric.Interval) metric.Values {
-	oldest := sort.Search(it.chunk.len(), func(i int) bool {
-		return !it.chunk.valueAtIndex(i).Timestamp.Before(in.OldestInclusive)
+	oldest := sort.Search(it.len, func(i int) bool {
+		return !it.getTimestampAtIndex(i).Before(in.OldestInclusive)
 	})
 
-	newest := sort.Search(it.chunk.len(), func(i int) bool {
-		return it.chunk.valueAtIndex(i).Timestamp.After(in.NewestInclusive)
+	newest := sort.Search(it.len, func(i int) bool {
+		return it.getTimestampAtIndex(i).After(in.NewestInclusive)
 	})
 
-	if oldest == it.chunk.len() {
+	if oldest == it.len {
 		return nil
 	}
 
 	result := make(metric.Values, 0, newest-oldest)
 	for i := oldest; i < newest; i++ {
-		result = append(result, *it.chunk.valueAtIndex(i))
+		result = append(result, metric.SamplePair{
+			Timestamp: it.getTimestampAtIndex(i),
+			Value:     it.getSampleValueAtIndex(i),
+		})
 	}
 	return result
 }
 
 // contains implements chunkIterator.
 func (it *deltaEncodedChunkIterator) contains(t clientmodel.Timestamp) bool {
-	return !t.Before(it.chunk.firstTime()) && !t.After(it.chunk.lastTime())
+	return !t.Before(it.baseT) && !t.After(it.getTimestampAtIndex(it.len-1))
+}
+
+// values implements chunkIterator.
+func (it *deltaEncodedChunkIterator) values() <-chan *metric.SamplePair {
+	valuesChan := make(chan *metric.SamplePair)
+	go func() {
+		for i := 0; i < it.len; i++ {
+			valuesChan <- &metric.SamplePair{
+				Timestamp: it.getTimestampAtIndex(i),
+				Value:     it.getSampleValueAtIndex(i),
+			}
+		}
+		close(valuesChan)
+	}()
+	return valuesChan
+}
+
+// getTimestampAtIndex implements chunkIterator.
+func (it *deltaEncodedChunkIterator) getTimestampAtIndex(idx int) clientmodel.Timestamp {
+	offset := deltaHeaderBytes + idx*int(it.tBytes+it.vBytes)
+
+	switch it.tBytes {
+	case d1:
+		return it.baseT + clientmodel.Timestamp(uint8(it.c[offset]))
+	case d2:
+		return it.baseT + clientmodel.Timestamp(binary.LittleEndian.Uint16(it.c[offset:]))
+	case d4:
+		return it.baseT + clientmodel.Timestamp(binary.LittleEndian.Uint32(it.c[offset:]))
+	case d8:
+		// Take absolute value for d8.
+		return clientmodel.Timestamp(binary.LittleEndian.Uint64(it.c[offset:]))
+	default:
+		panic("Invalid number of bytes for time delta")
+	}
+}
+
+// getLastTimestamp implements chunkIterator.
+func (it *deltaEncodedChunkIterator) getLastTimestamp() clientmodel.Timestamp {
+	return it.getTimestampAtIndex(it.len - 1)
+}
+
+// getSampleValueAtIndex implements chunkIterator.
+func (it *deltaEncodedChunkIterator) getSampleValueAtIndex(idx int) clientmodel.SampleValue {
+	offset := deltaHeaderBytes + idx*int(it.tBytes+it.vBytes) + int(it.tBytes)
+
+	if it.isInt {
+		switch it.vBytes {
+		case d0:
+			return it.baseV
+		case d1:
+			return it.baseV + clientmodel.SampleValue(int8(it.c[offset]))
+		case d2:
+			return it.baseV + clientmodel.SampleValue(int16(binary.LittleEndian.Uint16(it.c[offset:])))
+		case d4:
+			return it.baseV + clientmodel.SampleValue(int32(binary.LittleEndian.Uint32(it.c[offset:])))
+		// No d8 for ints.
+		default:
+			panic("Invalid number of bytes for integer delta")
+		}
+	} else {
+		switch it.vBytes {
+		case d4:
+			return it.baseV + clientmodel.SampleValue(math.Float32frombits(binary.LittleEndian.Uint32(it.c[offset:])))
+		case d8:
+			// Take absolute value for d8.
+			return clientmodel.SampleValue(math.Float64frombits(binary.LittleEndian.Uint64(it.c[offset:])))
+		default:
+			panic("Invalid number of bytes for floating point delta")
+		}
+	}
+}
+
+// getLastSampleValue implements chunkIterator.
+func (it *deltaEncodedChunkIterator) getLastSampleValue() clientmodel.SampleValue {
+	return it.getSampleValueAtIndex(it.len - 1)
 }

--- a/storage/local/doubledelta.go
+++ b/storage/local/doubledelta.go
@@ -199,15 +199,18 @@ func (c doubleDeltaEncodedChunk) firstTime() clientmodel.Timestamp {
 	return c.baseTime()
 }
 
-// lastTime implements chunk.
-func (c doubleDeltaEncodedChunk) lastTime() clientmodel.Timestamp {
-	return c.valueAtIndex(c.len() - 1).Timestamp
-}
-
 // newIterator implements chunk.
 func (c *doubleDeltaEncodedChunk) newIterator() chunkIterator {
 	return &doubleDeltaEncodedChunkIterator{
-		chunk: c,
+		c:      *c,
+		len:    c.len(),
+		baseT:  c.baseTime(),
+		baseΔT: c.baseTimeDelta(),
+		baseV:  c.baseValue(),
+		baseΔV: c.baseValueDelta(),
+		tBytes: c.timeBytes(),
+		vBytes: c.valueBytes(),
+		isInt:  c.isInt(),
 	}
 }
 
@@ -245,19 +248,6 @@ func (c *doubleDeltaEncodedChunk) unmarshalFromBuf(buf []byte) {
 	*c = (*c)[:binary.LittleEndian.Uint16((*c)[doubleDeltaHeaderBufLenOffset:])]
 }
 
-// values implements chunk.
-func (c doubleDeltaEncodedChunk) values() <-chan *metric.SamplePair {
-	n := c.len()
-	valuesChan := make(chan *metric.SamplePair)
-	go func() {
-		for i := 0; i < n; i++ {
-			valuesChan <- c.valueAtIndex(i)
-		}
-		close(valuesChan)
-	}()
-	return valuesChan
-}
-
 // encoding implements chunk.
 func (c doubleDeltaEncodedChunk) encoding() chunkEncoding { return doubleDelta }
 
@@ -280,6 +270,9 @@ func (c doubleDeltaEncodedChunk) baseValue() clientmodel.SampleValue {
 }
 
 func (c doubleDeltaEncodedChunk) baseTimeDelta() clientmodel.Timestamp {
+	if len(c) < doubleDeltaHeaderBaseTimeDeltaOffset+8 {
+		return 0
+	}
 	return clientmodel.Timestamp(
 		binary.LittleEndian.Uint64(
 			c[doubleDeltaHeaderBaseTimeDeltaOffset:],
@@ -288,6 +281,9 @@ func (c doubleDeltaEncodedChunk) baseTimeDelta() clientmodel.Timestamp {
 }
 
 func (c doubleDeltaEncodedChunk) baseValueDelta() clientmodel.SampleValue {
+	if len(c) < doubleDeltaHeaderBaseValueDeltaOffset+8 {
+		return 0
+	}
 	return clientmodel.SampleValue(
 		math.Float64frombits(
 			binary.LittleEndian.Uint64(
@@ -387,120 +383,56 @@ func (c doubleDeltaEncodedChunk) addSecondSample(s *metric.SamplePair, tb, vb de
 	return []chunk{&c}
 }
 
-func (c doubleDeltaEncodedChunk) valueAtIndex(idx int) *metric.SamplePair {
-	if idx == 0 {
-		return &metric.SamplePair{
-			Timestamp: c.baseTime(),
-			Value:     c.baseValue(),
-		}
-	}
-	if idx == 1 {
-		// If time and/or value bytes are at d8, the time and value is
-		// saved directly rather than as a difference.
-		timestamp := c.baseTimeDelta()
-		if c.timeBytes() < d8 {
-			timestamp += c.baseTime()
-		}
-		value := c.baseValueDelta()
-		if c.valueBytes() < d8 {
-			value += c.baseValue()
-		}
-		return &metric.SamplePair{
-			Timestamp: timestamp,
-			Value:     value,
-		}
-	}
-	offset := doubleDeltaHeaderBytes + (idx-2)*c.sampleSize()
-
-	var ts clientmodel.Timestamp
-	switch c.timeBytes() {
-	case d1:
-		ts = c.baseTime() +
-			clientmodel.Timestamp(idx)*c.baseTimeDelta() +
-			clientmodel.Timestamp(int8(c[offset]))
-	case d2:
-		ts = c.baseTime() +
-			clientmodel.Timestamp(idx)*c.baseTimeDelta() +
-			clientmodel.Timestamp(int16(binary.LittleEndian.Uint16(c[offset:])))
-	case d4:
-		ts = c.baseTime() +
-			clientmodel.Timestamp(idx)*c.baseTimeDelta() +
-			clientmodel.Timestamp(int32(binary.LittleEndian.Uint32(c[offset:])))
-	case d8:
-		// Take absolute value for d8.
-		ts = clientmodel.Timestamp(binary.LittleEndian.Uint64(c[offset:]))
-	default:
-		panic("Invalid number of bytes for time delta")
-	}
-
-	offset += int(c.timeBytes())
-
-	var v clientmodel.SampleValue
-	if c.isInt() {
-		switch c.valueBytes() {
-		case d0:
-			v = c.baseValue() +
-				clientmodel.SampleValue(idx)*c.baseValueDelta()
-		case d1:
-			v = c.baseValue() +
-				clientmodel.SampleValue(idx)*c.baseValueDelta() +
-				clientmodel.SampleValue(int8(c[offset]))
-		case d2:
-			v = c.baseValue() +
-				clientmodel.SampleValue(idx)*c.baseValueDelta() +
-				clientmodel.SampleValue(int16(binary.LittleEndian.Uint16(c[offset:])))
-		case d4:
-			v = c.baseValue() +
-				clientmodel.SampleValue(idx)*c.baseValueDelta() +
-				clientmodel.SampleValue(int32(binary.LittleEndian.Uint32(c[offset:])))
-		// No d8 for ints.
-		default:
-			panic("Invalid number of bytes for integer delta")
-		}
-	} else {
-		switch c.valueBytes() {
-		case d4:
-			v = c.baseValue() +
-				clientmodel.SampleValue(idx)*c.baseValueDelta() +
-				clientmodel.SampleValue(math.Float32frombits(binary.LittleEndian.Uint32(c[offset:])))
-		case d8:
-			// Take absolute value for d8.
-			v = clientmodel.SampleValue(math.Float64frombits(binary.LittleEndian.Uint64(c[offset:])))
-		default:
-			panic("Invalid number of bytes for floating point delta")
-		}
-	}
-	return &metric.SamplePair{
-		Timestamp: ts,
-		Value:     v,
-	}
-}
-
 // doubleDeltaEncodedChunkIterator implements chunkIterator.
 type doubleDeltaEncodedChunkIterator struct {
-	chunk *doubleDeltaEncodedChunk
-	// TODO(beorn7): add more fields here to keep track of last position.
+	c              doubleDeltaEncodedChunk
+	len            int
+	baseT, baseΔT  clientmodel.Timestamp
+	baseV, baseΔV  clientmodel.SampleValue
+	tBytes, vBytes deltaBytes
+	isInt          bool
 }
+
+// length implements chunkIterator.
+func (it *doubleDeltaEncodedChunkIterator) length() int { return it.len }
 
 // getValueAtTime implements chunkIterator.
 func (it *doubleDeltaEncodedChunkIterator) getValueAtTime(t clientmodel.Timestamp) metric.Values {
 	// TODO(beorn7): Implement in a more efficient way making use of the
 	// state of the iterator and internals of the doubleDeltaChunk.
-	i := sort.Search(it.chunk.len(), func(i int) bool {
-		return !it.chunk.valueAtIndex(i).Timestamp.Before(t)
+	i := sort.Search(it.len, func(i int) bool {
+		return !it.getTimestampAtIndex(i).Before(t)
 	})
 
 	switch i {
 	case 0:
-		return metric.Values{*it.chunk.valueAtIndex(0)}
-	case it.chunk.len():
-		return metric.Values{*it.chunk.valueAtIndex(it.chunk.len() - 1)}
+		return metric.Values{metric.SamplePair{
+			Timestamp: it.getTimestampAtIndex(0),
+			Value:     it.getSampleValueAtIndex(0),
+		}}
+	case it.len:
+		return metric.Values{metric.SamplePair{
+			Timestamp: it.getTimestampAtIndex(it.len - 1),
+			Value:     it.getSampleValueAtIndex(it.len - 1),
+		}}
 	default:
-		v := it.chunk.valueAtIndex(i)
-		if v.Timestamp.Equal(t) {
-			return metric.Values{*v}
+		ts := it.getTimestampAtIndex(i)
+		if ts.Equal(t) {
+			return metric.Values{metric.SamplePair{
+				Timestamp: ts,
+				Value:     it.getSampleValueAtIndex(i),
+			}}
 		}
-		return metric.Values{*it.chunk.valueAtIndex(i - 1), *v}
+		return metric.Values{
+			metric.SamplePair{
+				Timestamp: it.getTimestampAtIndex(i - 1),
+				Value:     it.getSampleValueAtIndex(i - 1),
+			},
+			metric.SamplePair{
+				Timestamp: ts,
+				Value:     it.getSampleValueAtIndex(i),
+			},
+		}
 	}
 }
 
@@ -508,26 +440,143 @@ func (it *doubleDeltaEncodedChunkIterator) getValueAtTime(t clientmodel.Timestam
 func (it *doubleDeltaEncodedChunkIterator) getRangeValues(in metric.Interval) metric.Values {
 	// TODO(beorn7): Implement in a more efficient way making use of the
 	// state of the iterator and internals of the doubleDeltaChunk.
-	oldest := sort.Search(it.chunk.len(), func(i int) bool {
-		return !it.chunk.valueAtIndex(i).Timestamp.Before(in.OldestInclusive)
+	oldest := sort.Search(it.len, func(i int) bool {
+		return !it.getTimestampAtIndex(i).Before(in.OldestInclusive)
 	})
 
-	newest := sort.Search(it.chunk.len(), func(i int) bool {
-		return it.chunk.valueAtIndex(i).Timestamp.After(in.NewestInclusive)
+	newest := sort.Search(it.len, func(i int) bool {
+		return it.getTimestampAtIndex(i).After(in.NewestInclusive)
 	})
 
-	if oldest == it.chunk.len() {
+	if oldest == it.len {
 		return nil
 	}
 
 	result := make(metric.Values, 0, newest-oldest)
 	for i := oldest; i < newest; i++ {
-		result = append(result, *it.chunk.valueAtIndex(i))
+		result = append(result, metric.SamplePair{
+			Timestamp: it.getTimestampAtIndex(i),
+			Value:     it.getSampleValueAtIndex(i),
+		})
 	}
 	return result
 }
 
 // contains implements chunkIterator.
 func (it *doubleDeltaEncodedChunkIterator) contains(t clientmodel.Timestamp) bool {
-	return !t.Before(it.chunk.firstTime()) && !t.After(it.chunk.lastTime())
+	return !t.Before(it.baseT) && !t.After(it.getTimestampAtIndex(it.len-1))
+}
+
+// values implements chunkIterator.
+func (it *doubleDeltaEncodedChunkIterator) values() <-chan *metric.SamplePair {
+	valuesChan := make(chan *metric.SamplePair)
+	go func() {
+		for i := 0; i < it.len; i++ {
+			valuesChan <- &metric.SamplePair{
+				Timestamp: it.getTimestampAtIndex(i),
+				Value:     it.getSampleValueAtIndex(i),
+			}
+		}
+		close(valuesChan)
+	}()
+	return valuesChan
+}
+
+// getTimestampAtIndex implements chunkIterator.
+func (it *doubleDeltaEncodedChunkIterator) getTimestampAtIndex(idx int) clientmodel.Timestamp {
+	if idx == 0 {
+		return it.baseT
+	}
+	if idx == 1 {
+		// If time bytes are at d8, the time is saved directly rather
+		// than as a difference.
+		if it.tBytes == d8 {
+			return it.baseΔT
+		}
+		return it.baseT + it.baseΔT
+	}
+
+	offset := doubleDeltaHeaderBytes + (idx-2)*int(it.tBytes+it.vBytes)
+
+	switch it.tBytes {
+	case d1:
+		return it.baseT +
+			clientmodel.Timestamp(idx)*it.baseΔT +
+			clientmodel.Timestamp(int8(it.c[offset]))
+	case d2:
+		return it.baseT +
+			clientmodel.Timestamp(idx)*it.baseΔT +
+			clientmodel.Timestamp(int16(binary.LittleEndian.Uint16(it.c[offset:])))
+	case d4:
+		return it.baseT +
+			clientmodel.Timestamp(idx)*it.baseΔT +
+			clientmodel.Timestamp(int32(binary.LittleEndian.Uint32(it.c[offset:])))
+	case d8:
+		// Take absolute value for d8.
+		return clientmodel.Timestamp(binary.LittleEndian.Uint64(it.c[offset:]))
+	default:
+		panic("Invalid number of bytes for time delta")
+	}
+}
+
+// getLastTimestamp implements chunkIterator.
+func (it *doubleDeltaEncodedChunkIterator) getLastTimestamp() clientmodel.Timestamp {
+	return it.getTimestampAtIndex(it.len - 1)
+}
+
+// getSampleValueAtIndex implements chunkIterator.
+func (it *doubleDeltaEncodedChunkIterator) getSampleValueAtIndex(idx int) clientmodel.SampleValue {
+	if idx == 0 {
+		return it.baseV
+	}
+	if idx == 1 {
+		// If value bytes are at d8, the value is saved directly rather
+		// than as a difference.
+		if it.vBytes == d8 {
+			return it.baseΔV
+		}
+		return it.baseV + it.baseΔV
+	}
+
+	offset := doubleDeltaHeaderBytes + (idx-2)*int(it.tBytes+it.vBytes) + int(it.tBytes)
+
+	if it.isInt {
+		switch it.vBytes {
+		case d0:
+			return it.baseV +
+				clientmodel.SampleValue(idx)*it.baseΔV
+		case d1:
+			return it.baseV +
+				clientmodel.SampleValue(idx)*it.baseΔV +
+				clientmodel.SampleValue(int8(it.c[offset]))
+		case d2:
+			return it.baseV +
+				clientmodel.SampleValue(idx)*it.baseΔV +
+				clientmodel.SampleValue(int16(binary.LittleEndian.Uint16(it.c[offset:])))
+		case d4:
+			return it.baseV +
+				clientmodel.SampleValue(idx)*it.baseΔV +
+				clientmodel.SampleValue(int32(binary.LittleEndian.Uint32(it.c[offset:])))
+		// No d8 for ints.
+		default:
+			panic("Invalid number of bytes for integer delta")
+		}
+	} else {
+		switch it.vBytes {
+		case d4:
+			return it.baseV +
+				clientmodel.SampleValue(idx)*it.baseΔV +
+				clientmodel.SampleValue(math.Float32frombits(binary.LittleEndian.Uint32(it.c[offset:])))
+		case d8:
+			// Take absolute value for d8.
+			return clientmodel.SampleValue(math.Float64frombits(binary.LittleEndian.Uint64(it.c[offset:])))
+		default:
+			panic("Invalid number of bytes for floating point delta")
+		}
+	}
+}
+
+// getLastSampleValue implements chunkIterator.
+func (it *doubleDeltaEncodedChunkIterator) getLastSampleValue() clientmodel.SampleValue {
+	return it.getSampleValueAtIndex(it.len - 1)
 }

--- a/storage/local/doubledelta.go
+++ b/storage/local/doubledelta.go
@@ -398,8 +398,6 @@ func (it *doubleDeltaEncodedChunkIterator) length() int { return it.len }
 
 // getValueAtTime implements chunkIterator.
 func (it *doubleDeltaEncodedChunkIterator) getValueAtTime(t clientmodel.Timestamp) metric.Values {
-	// TODO(beorn7): Implement in a more efficient way making use of the
-	// state of the iterator and internals of the doubleDeltaChunk.
 	i := sort.Search(it.len, func(i int) bool {
 		return !it.getTimestampAtIndex(i).Before(t)
 	})
@@ -438,8 +436,6 @@ func (it *doubleDeltaEncodedChunkIterator) getValueAtTime(t clientmodel.Timestam
 
 // getRangeValues implements chunkIterator.
 func (it *doubleDeltaEncodedChunkIterator) getRangeValues(in metric.Interval) metric.Values {
-	// TODO(beorn7): Implement in a more efficient way making use of the
-	// state of the iterator and internals of the doubleDeltaChunk.
 	oldest := sort.Search(it.len, func(i int) bool {
 		return !it.getTimestampAtIndex(i).Before(in.OldestInclusive)
 	})

--- a/storage/local/doubledelta.go
+++ b/storage/local/doubledelta.go
@@ -396,52 +396,52 @@ type doubleDeltaEncodedChunkIterator struct {
 // length implements chunkIterator.
 func (it *doubleDeltaEncodedChunkIterator) length() int { return it.len }
 
-// getValueAtTime implements chunkIterator.
-func (it *doubleDeltaEncodedChunkIterator) getValueAtTime(t clientmodel.Timestamp) metric.Values {
+// valueAtTime implements chunkIterator.
+func (it *doubleDeltaEncodedChunkIterator) valueAtTime(t clientmodel.Timestamp) metric.Values {
 	i := sort.Search(it.len, func(i int) bool {
-		return !it.getTimestampAtIndex(i).Before(t)
+		return !it.timestampAtIndex(i).Before(t)
 	})
 
 	switch i {
 	case 0:
 		return metric.Values{metric.SamplePair{
-			Timestamp: it.getTimestampAtIndex(0),
-			Value:     it.getSampleValueAtIndex(0),
+			Timestamp: it.timestampAtIndex(0),
+			Value:     it.sampleValueAtIndex(0),
 		}}
 	case it.len:
 		return metric.Values{metric.SamplePair{
-			Timestamp: it.getTimestampAtIndex(it.len - 1),
-			Value:     it.getSampleValueAtIndex(it.len - 1),
+			Timestamp: it.timestampAtIndex(it.len - 1),
+			Value:     it.sampleValueAtIndex(it.len - 1),
 		}}
 	default:
-		ts := it.getTimestampAtIndex(i)
+		ts := it.timestampAtIndex(i)
 		if ts.Equal(t) {
 			return metric.Values{metric.SamplePair{
 				Timestamp: ts,
-				Value:     it.getSampleValueAtIndex(i),
+				Value:     it.sampleValueAtIndex(i),
 			}}
 		}
 		return metric.Values{
 			metric.SamplePair{
-				Timestamp: it.getTimestampAtIndex(i - 1),
-				Value:     it.getSampleValueAtIndex(i - 1),
+				Timestamp: it.timestampAtIndex(i - 1),
+				Value:     it.sampleValueAtIndex(i - 1),
 			},
 			metric.SamplePair{
 				Timestamp: ts,
-				Value:     it.getSampleValueAtIndex(i),
+				Value:     it.sampleValueAtIndex(i),
 			},
 		}
 	}
 }
 
-// getRangeValues implements chunkIterator.
-func (it *doubleDeltaEncodedChunkIterator) getRangeValues(in metric.Interval) metric.Values {
+// rangeValues implements chunkIterator.
+func (it *doubleDeltaEncodedChunkIterator) rangeValues(in metric.Interval) metric.Values {
 	oldest := sort.Search(it.len, func(i int) bool {
-		return !it.getTimestampAtIndex(i).Before(in.OldestInclusive)
+		return !it.timestampAtIndex(i).Before(in.OldestInclusive)
 	})
 
 	newest := sort.Search(it.len, func(i int) bool {
-		return it.getTimestampAtIndex(i).After(in.NewestInclusive)
+		return it.timestampAtIndex(i).After(in.NewestInclusive)
 	})
 
 	if oldest == it.len {
@@ -451,8 +451,8 @@ func (it *doubleDeltaEncodedChunkIterator) getRangeValues(in metric.Interval) me
 	result := make(metric.Values, 0, newest-oldest)
 	for i := oldest; i < newest; i++ {
 		result = append(result, metric.SamplePair{
-			Timestamp: it.getTimestampAtIndex(i),
-			Value:     it.getSampleValueAtIndex(i),
+			Timestamp: it.timestampAtIndex(i),
+			Value:     it.sampleValueAtIndex(i),
 		})
 	}
 	return result
@@ -460,7 +460,7 @@ func (it *doubleDeltaEncodedChunkIterator) getRangeValues(in metric.Interval) me
 
 // contains implements chunkIterator.
 func (it *doubleDeltaEncodedChunkIterator) contains(t clientmodel.Timestamp) bool {
-	return !t.Before(it.baseT) && !t.After(it.getTimestampAtIndex(it.len-1))
+	return !t.Before(it.baseT) && !t.After(it.timestampAtIndex(it.len-1))
 }
 
 // values implements chunkIterator.
@@ -469,8 +469,8 @@ func (it *doubleDeltaEncodedChunkIterator) values() <-chan *metric.SamplePair {
 	go func() {
 		for i := 0; i < it.len; i++ {
 			valuesChan <- &metric.SamplePair{
-				Timestamp: it.getTimestampAtIndex(i),
-				Value:     it.getSampleValueAtIndex(i),
+				Timestamp: it.timestampAtIndex(i),
+				Value:     it.sampleValueAtIndex(i),
 			}
 		}
 		close(valuesChan)
@@ -478,8 +478,8 @@ func (it *doubleDeltaEncodedChunkIterator) values() <-chan *metric.SamplePair {
 	return valuesChan
 }
 
-// getTimestampAtIndex implements chunkIterator.
-func (it *doubleDeltaEncodedChunkIterator) getTimestampAtIndex(idx int) clientmodel.Timestamp {
+// timestampAtIndex implements chunkIterator.
+func (it *doubleDeltaEncodedChunkIterator) timestampAtIndex(idx int) clientmodel.Timestamp {
 	if idx == 0 {
 		return it.baseT
 	}
@@ -515,13 +515,13 @@ func (it *doubleDeltaEncodedChunkIterator) getTimestampAtIndex(idx int) clientmo
 	}
 }
 
-// getLastTimestamp implements chunkIterator.
-func (it *doubleDeltaEncodedChunkIterator) getLastTimestamp() clientmodel.Timestamp {
-	return it.getTimestampAtIndex(it.len - 1)
+// lastTimestamp implements chunkIterator.
+func (it *doubleDeltaEncodedChunkIterator) lastTimestamp() clientmodel.Timestamp {
+	return it.timestampAtIndex(it.len - 1)
 }
 
-// getSampleValueAtIndex implements chunkIterator.
-func (it *doubleDeltaEncodedChunkIterator) getSampleValueAtIndex(idx int) clientmodel.SampleValue {
+// sampleValueAtIndex implements chunkIterator.
+func (it *doubleDeltaEncodedChunkIterator) sampleValueAtIndex(idx int) clientmodel.SampleValue {
 	if idx == 0 {
 		return it.baseV
 	}
@@ -572,7 +572,7 @@ func (it *doubleDeltaEncodedChunkIterator) getSampleValueAtIndex(idx int) client
 	}
 }
 
-// getLastSampleValue implements chunkIterator.
-func (it *doubleDeltaEncodedChunkIterator) getLastSampleValue() clientmodel.SampleValue {
-	return it.getSampleValueAtIndex(it.len - 1)
+// lastSampleValue implements chunkIterator.
+func (it *doubleDeltaEncodedChunkIterator) lastSampleValue() clientmodel.SampleValue {
+	return it.sampleValueAtIndex(it.len - 1)
 }

--- a/storage/local/interface.go
+++ b/storage/local/interface.go
@@ -58,11 +58,11 @@ type Storage interface {
 	WaitForIndexing()
 }
 
-// SeriesIterator enables efficient access of sample values in a series. All
-// methods are goroutine-safe. A SeriesIterator iterates over a snapshot of a
-// series, i.e. it is safe to continue using a SeriesIterator after modifying
-// the corresponding series, but the iterator will represent the state of the
-// series prior the modification.
+// SeriesIterator enables efficient access of sample values in a series. Its
+// methods are not goroutine-safe. A SeriesIterator iterates over a snapshot of
+// a series, i.e. it is safe to continue using a SeriesIterator after or during
+// modifying the corresponding series, but the iterator will represent the state
+// of the series prior the modification.
 type SeriesIterator interface {
 	// Gets the two values that are immediately adjacent to a given time. In
 	// case a value exist at precisely the given time, only that single

--- a/storage/local/interface.go
+++ b/storage/local/interface.go
@@ -38,11 +38,11 @@ type Storage interface {
 	NewPreloader() Preloader
 	// Get all of the metric fingerprints that are associated with the
 	// provided label matchers.
-	GetFingerprintsForLabelMatchers(metric.LabelMatchers) clientmodel.Fingerprints
+	FingerprintsForLabelMatchers(metric.LabelMatchers) clientmodel.Fingerprints
 	// Get all of the label values that are associated with a given label name.
-	GetLabelValuesForLabelName(clientmodel.LabelName) clientmodel.LabelValues
+	LabelValuesForLabelName(clientmodel.LabelName) clientmodel.LabelValues
 	// Get the metric associated with the provided fingerprint.
-	GetMetricForFingerprint(clientmodel.Fingerprint) clientmodel.COWMetric
+	MetricForFingerprint(clientmodel.Fingerprint) clientmodel.COWMetric
 	// Construct an iterator for a given fingerprint.
 	NewIterator(clientmodel.Fingerprint) SeriesIterator
 	// Run the various maintenance loops in goroutines. Returns when the
@@ -53,8 +53,8 @@ type Storage interface {
 	// operations, stops all maintenance loops,and frees all resources.
 	Stop() error
 	// WaitForIndexing returns once all samples in the storage are
-	// indexed. Indexing is needed for GetFingerprintsForLabelMatchers and
-	// GetLabelValuesForLabelName and may lag behind.
+	// indexed. Indexing is needed for FingerprintsForLabelMatchers and
+	// LabelValuesForLabelName and may lag behind.
 	WaitForIndexing()
 }
 
@@ -69,12 +69,12 @@ type SeriesIterator interface {
 	// value is returned. Only the first or last value is returned (as a
 	// single value), if the given time is before or after the first or last
 	// value, respectively.
-	GetValueAtTime(clientmodel.Timestamp) metric.Values
+	ValueAtTime(clientmodel.Timestamp) metric.Values
 	// Gets the boundary values of an interval: the first and last value
 	// within a given interval.
-	GetBoundaryValues(metric.Interval) metric.Values
+	BoundaryValues(metric.Interval) metric.Values
 	// Gets all values contained within a given interval.
-	GetRangeValues(metric.Interval) metric.Values
+	RangeValues(metric.Interval) metric.Values
 }
 
 // A Preloader preloads series data necessary for a query into memory and pins

--- a/storage/local/mapper.go
+++ b/storage/local/mapper.go
@@ -91,7 +91,7 @@ func (r *fpMapper) mapFP(fp clientmodel.Fingerprint, m clientmodel.Metric) (clie
 	// If we are here, FP does not exist in memory and is either not mapped
 	// at all, or existing mappings for FP are not for m. Check if we have
 	// something for FP in the archive.
-	archivedMetric, err := r.p.getArchivedMetric(fp)
+	archivedMetric, err := r.p.archivedMetric(fp)
 	if err != nil {
 		return fp, err
 	}

--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -880,7 +880,7 @@ func (p *persistence) dropAndPersistChunks(
 		// too old. If that's the case, the chunks in the series file
 		// are all too old, too.
 		i := 0
-		for ; i < len(chunks) && chunks[i].lastTime().Before(beforeTime); i++ {
+		for ; i < len(chunks) && chunks[i].newIterator().getLastTimestamp().Before(beforeTime); i++ {
 		}
 		if i < len(chunks) {
 			firstTimeNotDropped = chunks[i].firstTime()
@@ -1567,8 +1567,14 @@ func chunkIndexForOffset(offset int64) (int, error) {
 func writeChunkHeader(w io.Writer, c chunk) error {
 	header := make([]byte, chunkHeaderLen)
 	header[chunkHeaderTypeOffset] = byte(c.encoding())
-	binary.LittleEndian.PutUint64(header[chunkHeaderFirstTimeOffset:], uint64(c.firstTime()))
-	binary.LittleEndian.PutUint64(header[chunkHeaderLastTimeOffset:], uint64(c.lastTime()))
+	binary.LittleEndian.PutUint64(
+		header[chunkHeaderFirstTimeOffset:],
+		uint64(c.firstTime()),
+	)
+	binary.LittleEndian.PutUint64(
+		header[chunkHeaderLastTimeOffset:],
+		uint64(c.newIterator().getLastTimestamp()),
+	)
 	_, err := w.Write(header)
 	return err
 }

--- a/storage/local/persistence_test.go
+++ b/storage/local/persistence_test.go
@@ -70,8 +70,8 @@ func buildTestChunks(encoding chunkEncoding) map[clientmodel.Fingerprint][]chunk
 }
 
 func chunksEqual(c1, c2 chunk) bool {
-	values2 := c2.values()
-	for v1 := range c1.values() {
+	values2 := c2.newIterator().values()
+	for v1 := range c1.newIterator().values() {
 		v2 := <-values2
 		if !v1.Equal(v2) {
 			return false

--- a/storage/local/persistence_test.go
+++ b/storage/local/persistence_test.go
@@ -397,7 +397,7 @@ func testCheckpointAndLoadSeriesMapAndHeads(t *testing.T, encoding chunkEncoding
 		if !reflect.DeepEqual(loadedS1.metric, m1) {
 			t.Errorf("want metric %v, got %v", m1, loadedS1.metric)
 		}
-		if !reflect.DeepEqual(loadedS1.head().chunk, s1.head().chunk) {
+		if !reflect.DeepEqual(loadedS1.head().c, s1.head().c) {
 			t.Error("head chunks differ")
 		}
 		if loadedS1.chunkDescsOffset != 0 {
@@ -413,7 +413,7 @@ func testCheckpointAndLoadSeriesMapAndHeads(t *testing.T, encoding chunkEncoding
 		if !reflect.DeepEqual(loadedS3.metric, m3) {
 			t.Errorf("want metric %v, got %v", m3, loadedS3.metric)
 		}
-		if loadedS3.head().chunk != nil {
+		if loadedS3.head().c != nil {
 			t.Error("head chunk not evicted")
 		}
 		if loadedS3.chunkDescsOffset != -1 {
@@ -515,7 +515,7 @@ func TestCheckpointAndLoadFPMappings(t *testing.T) {
 	}
 }
 
-func testGetFingerprintsModifiedBefore(t *testing.T, encoding chunkEncoding) {
+func testFingerprintsModifiedBefore(t *testing.T, encoding chunkEncoding) {
 	p, closer := newTestPersistence(t, encoding)
 	defer closer.Close()
 
@@ -537,7 +537,7 @@ func testGetFingerprintsModifiedBefore(t *testing.T, encoding chunkEncoding) {
 	}
 
 	for ts, want := range expectedFPs {
-		got, err := p.getFingerprintsModifiedBefore(ts)
+		got, err := p.fingerprintsModifiedBefore(ts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -575,7 +575,7 @@ func testGetFingerprintsModifiedBefore(t *testing.T, encoding chunkEncoding) {
 	}
 
 	for ts, want := range expectedFPs {
-		got, err := p.getFingerprintsModifiedBefore(ts)
+		got, err := p.fingerprintsModifiedBefore(ts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -585,12 +585,12 @@ func testGetFingerprintsModifiedBefore(t *testing.T, encoding chunkEncoding) {
 	}
 }
 
-func TestGetFingerprintsModifiedBeforeChunkType0(t *testing.T) {
-	testGetFingerprintsModifiedBefore(t, 0)
+func TestFingerprintsModifiedBeforeChunkType0(t *testing.T) {
+	testFingerprintsModifiedBefore(t, 0)
 }
 
-func TestGetFingerprintsModifiedBeforeChunkType1(t *testing.T) {
-	testGetFingerprintsModifiedBefore(t, 1)
+func TestFingerprintsModifiedBeforeChunkType1(t *testing.T) {
+	testFingerprintsModifiedBefore(t, 1)
 }
 
 func testDropArchivedMetric(t *testing.T, encoding chunkEncoding) {
@@ -605,7 +605,7 @@ func testDropArchivedMetric(t *testing.T, encoding chunkEncoding) {
 	p.indexMetric(2, m2)
 	p.waitForIndexing()
 
-	outFPs, err := p.getFingerprintsForLabelPair(metric.LabelPair{Name: "n1", Value: "v1"})
+	outFPs, err := p.fingerprintsForLabelPair(metric.LabelPair{Name: "n1", Value: "v1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -613,7 +613,7 @@ func testDropArchivedMetric(t *testing.T, encoding chunkEncoding) {
 	if !reflect.DeepEqual(outFPs, want) {
 		t.Errorf("want %#v, got %#v", want, outFPs)
 	}
-	outFPs, err = p.getFingerprintsForLabelPair(metric.LabelPair{Name: "n2", Value: "v2"})
+	outFPs, err = p.fingerprintsForLabelPair(metric.LabelPair{Name: "n2", Value: "v2"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -637,7 +637,7 @@ func testDropArchivedMetric(t *testing.T, encoding chunkEncoding) {
 	}
 	p.waitForIndexing()
 
-	outFPs, err = p.getFingerprintsForLabelPair(metric.LabelPair{Name: "n1", Value: "v1"})
+	outFPs, err = p.fingerprintsForLabelPair(metric.LabelPair{Name: "n1", Value: "v1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -645,7 +645,7 @@ func testDropArchivedMetric(t *testing.T, encoding chunkEncoding) {
 	if !reflect.DeepEqual(outFPs, want) {
 		t.Errorf("want %#v, got %#v", want, outFPs)
 	}
-	outFPs, err = p.getFingerprintsForLabelPair(metric.LabelPair{Name: "n2", Value: "v2"})
+	outFPs, err = p.fingerprintsForLabelPair(metric.LabelPair{Name: "n2", Value: "v2"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -858,7 +858,7 @@ func verifyIndexedState(i int, t *testing.T, b incrementalBatch, indexedFpsToMet
 	p.waitForIndexing()
 	for fp, m := range indexedFpsToMetrics {
 		// Compare archived metrics with input metrics.
-		mOut, err := p.getArchivedMetric(fp)
+		mOut, err := p.archivedMetric(fp)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -884,7 +884,7 @@ func verifyIndexedState(i int, t *testing.T, b incrementalBatch, indexedFpsToMet
 
 	// Compare label name -> label values mappings.
 	for ln, lvs := range b.expectedLnToLvs {
-		outLvs, err := p.getLabelValuesForLabelName(ln)
+		outLvs, err := p.labelValuesForLabelName(ln)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -901,7 +901,7 @@ func verifyIndexedState(i int, t *testing.T, b incrementalBatch, indexedFpsToMet
 
 	// Compare label pair -> fingerprints mappings.
 	for lp, fps := range b.expectedLpToFps {
-		outFPs, err := p.getFingerprintsForLabelPair(lp)
+		outFPs, err := p.fingerprintsForLabelPair(lp)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/local/preload.go
+++ b/storage/local/preload.go
@@ -40,8 +40,8 @@ func (p *memorySeriesPreloader) PreloadRange(
 }
 
 /*
-// GetMetricAtTime implements Preloader.
-func (p *memorySeriesPreloader) GetMetricAtTime(fp clientmodel.Fingerprint, t clientmodel.Timestamp) error {
+// MetricAtTime implements Preloader.
+func (p *memorySeriesPreloader) MetricAtTime(fp clientmodel.Fingerprint, t clientmodel.Timestamp) error {
 	cds, err := p.storage.preloadChunks(fp, &timeSelector{
 		from:    t,
 		through: t,
@@ -53,8 +53,8 @@ func (p *memorySeriesPreloader) GetMetricAtTime(fp clientmodel.Fingerprint, t cl
 	return nil
 }
 
-// GetMetricAtInterval implements Preloader.
-func (p *memorySeriesPreloader) GetMetricAtInterval(fp clientmodel.Fingerprint, from, through clientmodel.Timestamp, interval time.Duration) error {
+// MetricAtInterval implements Preloader.
+func (p *memorySeriesPreloader) MetricAtInterval(fp clientmodel.Fingerprint, from, through clientmodel.Timestamp, interval time.Duration) error {
 	cds, err := p.storage.preloadChunks(fp, &timeSelector{
 		from:     from,
 		through:  through,
@@ -67,8 +67,8 @@ func (p *memorySeriesPreloader) GetMetricAtInterval(fp clientmodel.Fingerprint, 
 	return
 }
 
-// GetMetricRange implements Preloader.
-func (p *memorySeriesPreloader) GetMetricRange(fp clientmodel.Fingerprint, t clientmodel.Timestamp, rangeDuration time.Duration) error {
+// MetricRange implements Preloader.
+func (p *memorySeriesPreloader) MetricRange(fp clientmodel.Fingerprint, t clientmodel.Timestamp, rangeDuration time.Duration) error {
 	cds, err := p.storage.preloadChunks(fp, &timeSelector{
 		from:          t,
 		through:       t,
@@ -81,8 +81,8 @@ func (p *memorySeriesPreloader) GetMetricRange(fp clientmodel.Fingerprint, t cli
 	return
 }
 
-// GetMetricRangeAtInterval implements Preloader.
-func (p *memorySeriesPreloader) GetMetricRangeAtInterval(fp clientmodel.Fingerprint, from, through clientmodel.Timestamp, interval, rangeDuration time.Duration) error {
+// MetricRangeAtInterval implements Preloader.
+func (p *memorySeriesPreloader) MetricRangeAtInterval(fp clientmodel.Fingerprint, from, through clientmodel.Timestamp, interval, rangeDuration time.Duration) error {
 	cds, err := p.storage.preloadChunks(fp, &timeSelector{
 		from:          from,
 		through:       through,

--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -277,10 +277,7 @@ func (s *memorySeriesStorage) NewIterator(fp clientmodel.Fingerprint) SeriesIter
 		// return any values.
 		return nopSeriesIterator{}
 	}
-	return series.newIterator(
-		func() { s.fpLocker.Lock(fp) },
-		func() { s.fpLocker.Unlock(fp) },
-	)
+	return series.newIterator()
 }
 
 // NewPreloader implements Storage.

--- a/storage/local/storage_test.go
+++ b/storage/local/storage_test.go
@@ -208,7 +208,7 @@ func testChunk(t *testing.T, encoding chunkEncoding) {
 			if cd.isEvicted() {
 				continue
 			}
-			for sample := range cd.chunk.values() {
+			for sample := range cd.chunk.newIterator().values() {
 				values = append(values, *sample)
 			}
 		}

--- a/web/api/query.go
+++ b/web/api/query.go
@@ -156,7 +156,7 @@ func (serv MetricsService) Metrics(w http.ResponseWriter, r *http.Request) {
 	setAccessControlHeaders(w)
 	w.Header().Set("Content-Type", "application/json")
 
-	metricNames := serv.Storage.GetLabelValuesForLabelName(clientmodel.MetricNameLabel)
+	metricNames := serv.Storage.LabelValuesForLabelName(clientmodel.MetricNameLabel)
 	sort.Sort(metricNames)
 	resultBytes, err := json.Marshal(metricNames)
 	if err != nil {


### PR DESCRIPTION
Finally... I was working in increments on this for an eternity...

```
benchmark                             old ns/op     new ns/op     delta
BenchmarkGetValueAtTimeChunkType1     23514417      3806180       -83.81%
BenchmarkGetValueAtTimeChunkType0     17600036      3945522       -77.58%
BenchmarkGetRangeValuesChunkType1     46013168      12004930      -73.91%
BenchmarkGetRangeValuesChunkType0     36569615      12893927      -64.74%

benchmark                             old allocs     new allocs     delta
BenchmarkGetRangeValuesChunkType1     472130         21893          -95.36%
BenchmarkGetRangeValuesChunkType0     493789         23697          -95.20%
BenchmarkGetValueAtTimeChunkType0     230743         20094          -91.29%
BenchmarkGetValueAtTimeChunkType1     230191         20049          -91.29%

benchmark                             old bytes     new bytes     delta
BenchmarkGetValueAtTimeChunkType1     3844556       485557        -87.37%
BenchmarkGetValueAtTimeChunkType0     3851663       489308        -87.30%
BenchmarkGetRangeValuesChunkType0     14887560      7463797       -49.87%
BenchmarkGetRangeValuesChunkType1     14371182      7255937       -49.51%
```