### PR TITLE
Align int64s for atomic operations

### DIFF
--- a/storage/local/mapper.go
+++ b/storage/local/mapper.go
@@ -23,12 +23,14 @@ type fpMappings map[clientmodel.Fingerprint]map[string]clientmodel.Fingerprint
 // fpMapper is used to map fingerprints in order to work around fingerprint
 // collisions.
 type fpMapper struct {
+	// highestMappedFP has to be aligned for atomic operations.
+	highestMappedFP clientmodel.Fingerprint
+
 	mtx      sync.RWMutex // Protects mappings.
 	mappings fpMappings
 
-	fpToSeries      *seriesMap
-	p               *persistence
-	highestMappedFP clientmodel.Fingerprint
+	fpToSeries *seriesMap
+	p          *persistence
 }
 
 // newFPMapper loads the collision map from the persistence and

--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -79,6 +79,11 @@ const (
 type syncStrategy func() bool
 
 type memorySeriesStorage struct {
+	// numChunksToPersist has to be aligned for atomic operations.
+	numChunksToPersist int64 // The number of chunks waiting for persistence.
+	maxChunksToPersist int   // If numChunksToPersist reaches this threshold, ingestion will stall.
+	degraded           bool
+
 	fpLocker   *fingerprintLocker
 	fpToSeries *seriesMap
 
@@ -89,10 +94,6 @@ type memorySeriesStorage struct {
 	dropAfter                  time.Duration
 	checkpointInterval         time.Duration
 	checkpointDirtySeriesLimit int
-
-	numChunksToPersist int64 // The number of chunks waiting for persistence.
-	maxChunksToPersist int   // If numChunksToPersist reaches this threshold, ingestion will stall.
-	degraded           bool
 
 	persistence *persistence
 	mapper      *fpMapper


### PR DESCRIPTION
For atomic operations proper memory alignment is required on some systems.