### PR TITLE
Read from indexing queue during crash recovery.

### DIFF
--- a/main.go
+++ b/main.go
@@ -239,10 +239,14 @@ func (p *prometheus) reloadConfig() bool {
 func (p *prometheus) Serve() {
 	// Start all components.
 	if err := p.storage.Start(); err != nil {
-		log.Error("Error opening memory series storage: ", err)
+		log.Errorln("Error opening memory series storage:", err)
 		os.Exit(1)
 	}
-	defer p.storage.Stop()
+	defer func() {
+		if err := p.storage.Stop(); err != nil {
+			log.Errorln("Error stopping storage:", err)
+		}
+	}()
 
 	// The storage has to be fully initialized before registering Prometheus.
 	registry.MustRegister(p)


### PR DESCRIPTION
Change #704 introduced a regression that started reading the queue only
after potential crash recovery. When more than the queue capacity was
indexed, Prometheus deadlocked.

@beorn7 @juliusv 

This attempts to preserve that you don't have to call `Storage.Stop()` if `Storage.Start()` failed.

#721 