### PR TITLE
Use an RW lock to checkpoint fingerprint mappings.

### DIFF
--- a/storage/local/mapper.go
+++ b/storage/local/mapper.go
@@ -141,10 +141,10 @@ func (m *fpMapper) maybeAddMapping(
 		// A new mapping has to be created.
 		mappedFP = m.nextMappedFP()
 		mappedFPs[ms] = mappedFP
-		m.mtx.RLock()
+		m.mtx.Lock()
 		// Checkpoint mappings after each change.
 		err := m.p.checkpointFPMappings(m.mappings)
-		m.mtx.RUnlock()
+		m.mtx.Unlock()
 		log.Infof(
 			"Collision detected for fingerprint %v, metric %v, mapping to new fingerprint %v.",
 			fp, collidingMetric, mappedFP,


### PR DESCRIPTION
This has to be backported to 0.13.x.

@fabxc @juliusv 