### PR TITLE
Remove logging output from test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,6 @@ race_condition_binary: build
 race_condition_run: race_condition_binary
 	./prometheus.race $(ARGUMENTS)
 
-run: binary
-	./prometheus -alsologtostderr -stderrthreshold=0 $(ARGUMENTS)
-
 search_index:
 	godoc -index -write_index -index_files='search_index'
 

--- a/Makefile.INCLUDE
+++ b/Makefile.INCLUDE
@@ -58,7 +58,7 @@ export PREFIX=$(BUILD_PATH)/root
 
 export PATH := $(GOPATH)/bin:$(GOROOT)/bin:$(PATH)
 
-export GO_TEST_FLAGS ?= -v -short
+export GO_TEST_FLAGS ?= -short
 
 GO_GET := $(GO) get -u -v -x
 


### PR DESCRIPTION
Passing `-log.level=panic` makes tests of packages that do not import our logging package fail.
When we don't pass `-v` to the tests, logs are silenced by default. 

I see no immediate benefit in using `-v`. We just want to ensure all tests pass. If tests fail during development we are rerunning the tests on package level anyway.