### PR TITLE
Fix file SD test

### DIFF
--- a/retrieval/discovery/file_test.go
+++ b/retrieval/discovery/file_test.go
@@ -81,17 +81,24 @@ func testFileSD(t *testing.T, ext string) {
 			// Below we will change the file to a bad syntax. Previously extracted target
 			// groups must not be deleted via sending an empty target group.
 			if len(tg.Targets) == 0 {
-				t.Fatalf("Unexpected empty target group received: %s", tg)
+				t.Errorf("Unexpected empty target group received: %s", tg)
 			}
 		}
 	}()
 
-	newf, err = os.Create("fixtures/_test" + ext)
+	newf, err = os.Create("fixtures/_test.new")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.Remove(newf.Name())
+
 	if _, err := newf.Write([]byte("]gibberish\n][")); err != nil {
 		t.Fatal(err)
 	}
 	newf.Close()
+
+	os.Rename(newf.Name(), "fixtures/_test"+ext)
+
+	// Give notifcations some time to arrive.
+	time.Sleep(50 * time.Millisecond)
 }


### PR DESCRIPTION
The original plan was to be able to handle bad formatted files and basically we still are.
For actual file SD bridges (i.e. not using file SD as user-editable files outside of config) atomic renaming should be advertised as best practice, though.

The occasional testing deadlock happened due to a chain of reasons which are of no concern for the actual code.

Hopefully this fixes it - I could no longer reproduce it.

@juliusv 