### PR TITLE
rules/ cleanup

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -16,7 +16,6 @@ package rules
 import (
 	"fmt"
 	"html/template"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -187,21 +186,6 @@ func (rule *AlertingRule) Eval(timestamp clientmodel.Timestamp, engine *promql.E
 	}
 
 	return vector, nil
-}
-
-// DotGraph returns the text representation of a dot graph.
-func (rule *AlertingRule) DotGraph() string {
-	graph := fmt.Sprintf(
-		`digraph "Rules" {
-	  %#p[shape="box",label="ALERT %s IF FOR %s"];
-		%#p -> %x;
-		%s
-	}`,
-		&rule, rule.name, utility.DurationToString(rule.holdDuration),
-		&rule, reflect.ValueOf(rule.Vector).Pointer(),
-		rule.Vector.DotGraph(),
-	)
-	return graph
 }
 
 func (rule *AlertingRule) String() string {

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -127,19 +127,14 @@ func (rule *AlertingRule) Name() string {
 	return rule.name
 }
 
-// EvalRaw returns the raw value of the rule expression, without creating alerts.
-func (rule *AlertingRule) EvalRaw(timestamp clientmodel.Timestamp, engine *promql.Engine) (promql.Vector, error) {
+// Eval evaluates the rule expression and then creates pending alerts and fires
+// or removes previously pending alerts accordingly.
+func (rule *AlertingRule) Eval(timestamp clientmodel.Timestamp, engine *promql.Engine) (promql.Vector, error) {
 	query, err := engine.NewInstantQuery(rule.Vector.String(), timestamp)
 	if err != nil {
 		return nil, err
 	}
-	return query.Exec().Vector()
-}
-
-// Eval evaluates the rule expression and then creates pending alerts and fires
-// or removes previously pending alerts accordingly.
-func (rule *AlertingRule) Eval(timestamp clientmodel.Timestamp, engine *promql.Engine) (promql.Vector, error) {
-	exprResult, err := rule.EvalRaw(timestamp, engine)
+	exprResult, err := query.Exec().Vector()
 	if err != nil {
 		return nil, err
 	}

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -28,12 +28,12 @@ import (
 
 const (
 	// AlertMetricName is the metric name for synthetic alert timeseries.
-	AlertMetricName clientmodel.LabelValue = "ALERTS"
+	alertMetricName clientmodel.LabelValue = "ALERTS"
 
 	// AlertNameLabel is the label name indicating the name of an alert.
-	AlertNameLabel clientmodel.LabelName = "alertname"
+	alertNameLabel clientmodel.LabelName = "alertname"
 	// AlertStateLabel is the label name indicating the state of an alert.
-	AlertStateLabel clientmodel.LabelName = "alertstate"
+	alertStateLabel clientmodel.LabelName = "alertstate"
 )
 
 // AlertState denotes the state of an active alert.
@@ -41,11 +41,11 @@ type AlertState int
 
 func (s AlertState) String() string {
 	switch s {
-	case Inactive:
+	case StateInactive:
 		return "inactive"
-	case Pending:
+	case StatePending:
 		return "pending"
-	case Firing:
+	case StateFiring:
 		return "firing"
 	default:
 		panic("undefined")
@@ -54,13 +54,13 @@ func (s AlertState) String() string {
 
 const (
 	// Inactive alerts are neither firing nor pending.
-	Inactive AlertState = iota
+	StateInactive AlertState = iota
 	// Pending alerts have been active for less than the configured
 	// threshold duration.
-	Pending
+	StatePending
 	// Firing alerts have been active for longer than the configured
 	// threshold duration.
-	Firing
+	StateFiring
 )
 
 // Alert is used to track active (pending/firing) alerts over time.
@@ -84,9 +84,9 @@ func (a Alert) sample(timestamp clientmodel.Timestamp, value clientmodel.SampleV
 		recordedMetric[label] = value
 	}
 
-	recordedMetric[clientmodel.MetricNameLabel] = AlertMetricName
-	recordedMetric[AlertNameLabel] = clientmodel.LabelValue(a.Name)
-	recordedMetric[AlertStateLabel] = clientmodel.LabelValue(a.State.String())
+	recordedMetric[clientmodel.MetricNameLabel] = alertMetricName
+	recordedMetric[alertNameLabel] = clientmodel.LabelValue(a.Name)
+	recordedMetric[alertStateLabel] = clientmodel.LabelValue(a.State.String())
 
 	return &promql.Sample{
 		Metric: clientmodel.COWMetric{
@@ -103,16 +103,16 @@ type AlertingRule struct {
 	// The name of the alert.
 	name string
 	// The vector expression from which to generate alerts.
-	Vector promql.Expr
+	vector promql.Expr
 	// The duration for which a labelset needs to persist in the expression
 	// output vector before an alert transitions from Pending to Firing state.
 	holdDuration time.Duration
 	// Extra labels to attach to the resulting alert sample vectors.
-	Labels clientmodel.LabelSet
+	labels clientmodel.LabelSet
 	// Short alert summary, suitable for email subjects.
-	Summary string
+	summary string
 	// More detailed alert description.
-	Description string
+	description string
 
 	// Protects the below.
 	mutex sync.Mutex
@@ -121,15 +121,36 @@ type AlertingRule struct {
 	activeAlerts map[clientmodel.Fingerprint]*Alert
 }
 
+// NewAlertingRule constructs a new AlertingRule.
+func NewAlertingRule(
+	name string,
+	vector promql.Expr,
+	holdDuration time.Duration,
+	labels clientmodel.LabelSet,
+	summary string,
+	description string,
+) *AlertingRule {
+	return &AlertingRule{
+		name:         name,
+		vector:       vector,
+		holdDuration: holdDuration,
+		labels:       labels,
+		summary:      summary,
+		description:  description,
+
+		activeAlerts: map[clientmodel.Fingerprint]*Alert{},
+	}
+}
+
 // Name returns the name of the alert.
 func (rule *AlertingRule) Name() string {
 	return rule.name
 }
 
-// Eval evaluates the rule expression and then creates pending alerts and fires
+// eval evaluates the rule expression and then creates pending alerts and fires
 // or removes previously pending alerts accordingly.
-func (rule *AlertingRule) Eval(timestamp clientmodel.Timestamp, engine *promql.Engine) (promql.Vector, error) {
-	query, err := engine.NewInstantQuery(rule.Vector.String(), timestamp)
+func (rule *AlertingRule) eval(timestamp clientmodel.Timestamp, engine *promql.Engine) (promql.Vector, error) {
+	query, err := engine.NewInstantQuery(rule.vector.String(), timestamp)
 	if err != nil {
 		return nil, err
 	}
@@ -151,14 +172,14 @@ func (rule *AlertingRule) Eval(timestamp clientmodel.Timestamp, engine *promql.E
 		if alert, ok := rule.activeAlerts[fp]; !ok {
 			labels := clientmodel.LabelSet{}
 			labels.MergeFromMetric(sample.Metric.Metric)
-			labels = labels.Merge(rule.Labels)
+			labels = labels.Merge(rule.labels)
 			if _, ok := labels[clientmodel.MetricNameLabel]; ok {
 				delete(labels, clientmodel.MetricNameLabel)
 			}
 			rule.activeAlerts[fp] = &Alert{
 				Name:        rule.name,
 				Labels:      labels,
-				State:       Pending,
+				State:       StatePending,
 				ActiveSince: timestamp,
 				Value:       sample.Value,
 			}
@@ -177,9 +198,9 @@ func (rule *AlertingRule) Eval(timestamp clientmodel.Timestamp, engine *promql.E
 			continue
 		}
 
-		if activeAlert.State == Pending && timestamp.Sub(activeAlert.ActiveSince) >= rule.holdDuration {
+		if activeAlert.State == StatePending && timestamp.Sub(activeAlert.ActiveSince) >= rule.holdDuration {
 			vector = append(vector, activeAlert.sample(timestamp, 0))
-			activeAlert.State = Firing
+			activeAlert.State = StateFiring
 		}
 
 		vector = append(vector, activeAlert.sample(timestamp, 1))
@@ -189,23 +210,23 @@ func (rule *AlertingRule) Eval(timestamp clientmodel.Timestamp, engine *promql.E
 }
 
 func (rule *AlertingRule) String() string {
-	return fmt.Sprintf("ALERT %s IF %s FOR %s WITH %s", rule.name, rule.Vector, utility.DurationToString(rule.holdDuration), rule.Labels)
+	return fmt.Sprintf("ALERT %s IF %s FOR %s WITH %s", rule.name, rule.vector, utility.DurationToString(rule.holdDuration), rule.labels)
 }
 
 // HTMLSnippet returns an HTML snippet representing this alerting rule.
 func (rule *AlertingRule) HTMLSnippet(pathPrefix string) template.HTML {
 	alertMetric := clientmodel.Metric{
-		clientmodel.MetricNameLabel: AlertMetricName,
-		AlertNameLabel:              clientmodel.LabelValue(rule.name),
+		clientmodel.MetricNameLabel: alertMetricName,
+		alertNameLabel:              clientmodel.LabelValue(rule.name),
 	}
 	return template.HTML(fmt.Sprintf(
 		`ALERT <a href="%s">%s</a> IF <a href="%s">%s</a> FOR %s WITH %s`,
 		pathPrefix+strings.TrimLeft(utility.GraphLinkForExpression(alertMetric.String()), "/"),
 		rule.name,
-		pathPrefix+strings.TrimLeft(utility.GraphLinkForExpression(rule.Vector.String()), "/"),
-		rule.Vector,
+		pathPrefix+strings.TrimLeft(utility.GraphLinkForExpression(rule.vector.String()), "/"),
+		rule.vector,
 		utility.DurationToString(rule.holdDuration),
-		rule.Labels))
+		rule.labels))
 }
 
 // State returns the "maximum" state: firing > pending > inactive.
@@ -213,7 +234,7 @@ func (rule *AlertingRule) State() AlertState {
 	rule.mutex.Lock()
 	defer rule.mutex.Unlock()
 
-	maxState := Inactive
+	maxState := StateInactive
 	for _, activeAlert := range rule.activeAlerts {
 		if activeAlert.State > maxState {
 			maxState = activeAlert.State
@@ -232,18 +253,4 @@ func (rule *AlertingRule) ActiveAlerts() []Alert {
 		alerts = append(alerts, *alert)
 	}
 	return alerts
-}
-
-// NewAlertingRule constructs a new AlertingRule.
-func NewAlertingRule(name string, vector promql.Expr, holdDuration time.Duration, labels clientmodel.LabelSet, summary string, description string) *AlertingRule {
-	return &AlertingRule{
-		name:         name,
-		Vector:       vector,
-		holdDuration: holdDuration,
-		Labels:       labels,
-		Summary:      summary,
-		Description:  description,
-
-		activeAlerts: map[clientmodel.Fingerprint]*Alert{},
-	}
 }

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -16,7 +16,6 @@ package rules
 import (
 	"fmt"
 	"html/template"
-	"reflect"
 	"strings"
 
 	clientmodel "github.com/prometheus/client_golang/model"
@@ -59,21 +58,6 @@ func (rule RecordingRule) Eval(timestamp clientmodel.Timestamp, engine *promql.E
 	}
 
 	return vector, nil
-}
-
-// DotGraph returns the text representation of a dot graph.
-func (rule RecordingRule) DotGraph() string {
-	graph := fmt.Sprintf(
-		`digraph "Rules" {
-	  %#p[shape="box",label="%s = "];
-		%#p -> %x;
-		%s
-	}`,
-		&rule, rule.name,
-		&rule, reflect.ValueOf(rule.vector).Pointer(),
-		rule.vector.DotGraph(),
-	)
-	return graph
 }
 
 func (rule RecordingRule) String() string {

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -31,11 +31,20 @@ type RecordingRule struct {
 	labels clientmodel.LabelSet
 }
 
+// NewRecordingRule returns a new recording rule.
+func NewRecordingRule(name string, vector promql.Expr, labels clientmodel.LabelSet) *RecordingRule {
+	return &RecordingRule{
+		name:   name,
+		vector: vector,
+		labels: labels,
+	}
+}
+
 // Name returns the rule name.
 func (rule RecordingRule) Name() string { return rule.name }
 
-// Eval evaluates the rule and then overrides the metric names and labels accordingly.
-func (rule RecordingRule) Eval(timestamp clientmodel.Timestamp, engine *promql.Engine) (promql.Vector, error) {
+// eval evaluates the rule and then overrides the metric names and labels accordingly.
+func (rule RecordingRule) eval(timestamp clientmodel.Timestamp, engine *promql.Engine) (promql.Vector, error) {
 	query, err := engine.NewInstantQuery(rule.vector.String(), timestamp)
 	if err != nil {
 		return nil, err

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -35,18 +35,13 @@ type RecordingRule struct {
 // Name returns the rule name.
 func (rule RecordingRule) Name() string { return rule.name }
 
-// EvalRaw returns the raw value of the rule expression.
-func (rule RecordingRule) EvalRaw(timestamp clientmodel.Timestamp, engine *promql.Engine) (promql.Vector, error) {
+// Eval evaluates the rule and then overrides the metric names and labels accordingly.
+func (rule RecordingRule) Eval(timestamp clientmodel.Timestamp, engine *promql.Engine) (promql.Vector, error) {
 	query, err := engine.NewInstantQuery(rule.vector.String(), timestamp)
 	if err != nil {
 		return nil, err
 	}
-	return query.Exec().Vector()
-}
-
-// Eval evaluates the rule and then overrides the metric names and labels accordingly.
-func (rule RecordingRule) Eval(timestamp clientmodel.Timestamp, engine *promql.Engine) (promql.Vector, error) {
-	vector, err := rule.EvalRaw(timestamp, engine)
+	vector, err := query.Exec().Vector()
 	if err != nil {
 		return nil, err
 	}

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -28,8 +28,6 @@ type Rule interface {
 	Name() string
 	// Eval evaluates the rule, including any associated recording or alerting actions.
 	Eval(clientmodel.Timestamp, *promql.Engine) (promql.Vector, error)
-	// DotGraph returns a Graphviz dot graph of the rule.
-	DotGraph() string
 	// String returns a human-readable string representation of the rule.
 	String() string
 	// HTMLSnippet returns a human-readable string representation of the rule,

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -26,9 +26,6 @@ import (
 type Rule interface {
 	// Name returns the name of the rule.
 	Name() string
-	// EvalRaw evaluates the rule's vector expression without triggering any
-	// other actions, like recording or alerting.
-	EvalRaw(clientmodel.Timestamp, *promql.Engine) (promql.Vector, error)
 	// Eval evaluates the rule, including any associated recording or alerting actions.
 	Eval(clientmodel.Timestamp, *promql.Engine) (promql.Vector, error)
 	// DotGraph returns a Graphviz dot graph of the rule.

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -27,7 +27,7 @@ type Rule interface {
 	// Name returns the name of the rule.
 	Name() string
 	// Eval evaluates the rule, including any associated recording or alerting actions.
-	Eval(clientmodel.Timestamp, *promql.Engine) (promql.Vector, error)
+	eval(clientmodel.Timestamp, *promql.Engine) (promql.Vector, error)
 	// String returns a human-readable string representation of the rule.
 	String() string
 	// HTMLSnippet returns a human-readable string representation of the rule,

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -186,7 +186,7 @@ func TestAlertingRule(t *testing.T) {
 	for i, expectedLines := range evalOutputs {
 		evalTime := testStartTime.Add(testSampleInterval * time.Duration(i))
 
-		res, err := rule.Eval(evalTime, engine)
+		res, err := rule.eval(evalTime, engine)
 		if err != nil {
 			t.Fatalf("Error during alerting rule evaluation: %s", err)
 		}

--- a/web/alerts.go
+++ b/web/alerts.go
@@ -63,9 +63,9 @@ func (h *AlertsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	alertStatus := AlertStatus{
 		AlertingRules: alertsSorter.alerts,
 		AlertStateToRowClass: map[rules.AlertState]string{
-			rules.Inactive: "success",
-			rules.Pending:  "warning",
-			rules.Firing:   "danger",
+			rules.StateInactive: "success",
+			rules.StatePending:  "warning",
+			rules.StateFiring:   "danger",
 		},
 	}
 	executeTemplate(w, "alerts", alertStatus, h.PathPrefix)


### PR DESCRIPTION
@juliusv as we've discussed before, the `DotGraph` methods are unused and can be removed. Restoring possible, should we ever want them back.

The `EvalRaw` methods were unused from the outside and had no real value. Should we ever want a raw evaluation from the outside, we'd rather export the AST to let the caller evaluate on its own terms (timeout, cancel, ...).

There were several inconsistencies regarding what's exported and what not. Both rule types now have a constructor but are fully immutable. As in other places const enums are now recognized by a common prefix.

@beorn7 

This merges into a `0.14.1` branch that should be merged into `master` once `0.14.0` is released.