### PR TITLE
Limit retrievable samples to retention window.

### DIFF
--- a/storage/local/interface.go
+++ b/storage/local/interface.go
@@ -44,6 +44,8 @@ type Storage interface {
 	// Get the metric associated with the provided fingerprint.
 	MetricForFingerprint(clientmodel.Fingerprint) clientmodel.COWMetric
 	// Construct an iterator for a given fingerprint.
+	// The iterator will never return samples older than retention time,
+	// relative to the time NewIterator was called.
 	NewIterator(clientmodel.Fingerprint) SeriesIterator
 	// Run the various maintenance loops in goroutines. Returns when the
 	// storage is ready to use. Keeps everything running in the background


### PR DESCRIPTION
The storage does not delete data immediately after the retention period.
We don't want to retrieve this data as it causes artifacts.

@beorn7 This seemed like a non-invasive approach. Does the added layer have any performance implications?

We could also prevent preloading data out of range. Is it a relevant performance concern?
