### PR TITLE
Added overview of network throughput to console templates

### DIFF
--- a/consoles/node-network.html
+++ b/consoles/node-network.html
@@ -1,0 +1,80 @@
+{{ template "head" . }}
+
+{{ template "prom_right_table_head" }}
+  <th colspan="2">Disks</th>
+</tr>
+{{ range printf "node_disk_io_time_ms{job='node',instance='%s'}" .Params.instance | query | sortByLabel "device" }}
+  <th colspan="2">{{ .Labels.device }}</th>
+  <tr>
+    <td>Utilization</td>
+    <td>{{ template "prom_query_drilldown" (args (printf "rate(node_disk_io_time_ms{job='node',instance='%s',device='%s'}[5m]) / 1000 * 100" .Labels.instance .Labels.device) "%" "printf.1f") }}</td>
+  </tr>
+  <tr>
+    <td>Throughput</td>
+    <td>{{ template "prom_query_drilldown" (args (printf "rate(node_disk_sectors_read{job='node',instance='%s',device='%s'}[5m]) * 512 + rate(node_disk_sectors_written{job='node',instance='%s',device='%s'}[5m]) * 512" .Labels.instance .Labels.device .Labels.instance .Labels.device) "B/s" "humanize") }}</td>
+  </tr>
+  <tr>
+    <td>Avg Read Time</td>
+    <td>{{ template "prom_query_drilldown" (args (printf "rate(node_disk_read_time_ms{job='node',instance='%s',device='%s'}[5m]) / 1000 / rate(node_disk_reads_completed{job='node',instance='%s',device='%s'}[5m])" .Labels.instance .Labels.device .Labels.instance .Labels.device) "s" "humanize") }}</td>
+  </tr>
+  <tr>
+    <td>Avg Write Time</td>
+    <td>{{ template "prom_query_drilldown" (args (printf "rate(node_disk_write_time_ms{job='node',instance='%s',device='%s'}[5m]) / 1000 / rate(node_disk_writes_completed{job='node',instance='%s',device='%s'}[5m])" .Labels.instance .Labels.device .Labels.instance .Labels.device) "s" "humanize") }}</td>
+  </tr>
+{{ end }}
+  <th colspan="2">Filesystem Fullness</th>
+</tr>
+{{ define "roughlyNearZero" }}
+{{ if gt .1 . }}~0{{ else }}{{ printf "%.1f" . }}{{ end }}
+{{ end }}
+{{ range printf "node_filesystem_size{job='node',instance='%s'}" .Params.instance | query | sortByLabel "filesystem" }}
+  <tr>
+    <td>{{ .Labels.filesystem }}</td>
+    <td>{{ template "prom_query_drilldown" (args (printf "100 - node_filesystem_free{job='node',instance='%s',filesystem='%s'} / node_filesystem_size{job='node'} * 100" .Labels.instance .Labels.filesystem) "%" "roughlyNearZero") }}</td>
+  </tr>
+{{ end }}
+<tr>
+</tr>
+{{ template "prom_right_table_tail" }}
+
+{{ template "prom_content_head" . }}
+  <h1>Node Network - {{ reReplaceAll "(.*?://)([^:/]+?)(:\\d+)?/.*" "$2" .Params.instance }}</h1>
+
+  <h3>Network Received IO</h3>
+  <div id="networkreceiveioGraph"></div>
+  <script>
+  new PromConsole.Graph({
+    node: document.querySelector("#networkreceiveioGraph"),
+    expr: [
+      "rate(node_network_receive_bytes{job='node',instance='{{ .Params.instance }}'}[5m])",
+    ],
+    min: 0,
+    name: '[[ device ]]',
+    yUnits: "B",
+    renderer: 'area',
+    yAxisFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
+    yHoverFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
+    yTitle: 'Bytes Received'
+  })
+  </script>
+
+  <h3>Network Transmitted IO</h3>
+  <div id="networktransmitioGraph"></div>
+  <script>
+  new PromConsole.Graph({
+    node: document.querySelector("#networktransmitioGraph"),
+    expr: [
+      "rate(node_network_transmit_bytes{job='node',instance='{{ .Params.instance }}'}[5m])",
+    ],
+    min: 0,
+    name: '[[ device ]]',
+    yUnits: "B",
+    renderer: 'area',
+    yAxisFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
+    yHoverFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
+    yTitle: 'Bytes Transmitted'
+  })
+  </script>
+{{ template "prom_content_tail" . }}
+
+{{ template "tail" }}

--- a/consoles/node.html
+++ b/consoles/node.html
@@ -16,6 +16,7 @@
   <th>Up</th>
   <th>CPU<br/>Used</th>
   <th>Memory<br/> Available</th>
+  <th>Network<br/> Tx/Rx</th>
 </tr>
 {{ range query "up{job='node'}" | sortByLabel "instance" }}
 <tr>
@@ -23,6 +24,7 @@
   <td{{ if eq (. | value) 1.0 }}>Yes{{ else }} class="alert-danger">No{{ end }}</td>
   <td>{{ template "prom_query_drilldown" (args (printf "100 * (1 - avg by(instance)(rate(node_cpu{job='node',mode='idle',instance='%s'}[5m])))" .Labels.instance) "%" "printf.1f") }}</td>
   <td>{{ template "prom_query_drilldown" (args (printf "node_memory_MemFree{job='node',instance='%s'} + node_memory_Cached{job='node',instance='%s'} + node_memory_Buffers{job='node',instance='%s'}" .Labels.instance .Labels.instance .Labels.instance) "B" "humanize1024") }}</td>
+  <td>{{ template "prom_query_drilldown" (args (printf "rate(node_network_transmit_bytes{job='node',instance='%s'}[5m])" .Labels.instance ) "B/s" "humanize1024")}} / {{ template "prom_query_drilldown" (args (printf "rate(node_network_receive_bytes{job='node',instance='%s'}[5m])" .Labels.instance) "B/s" "humanize1024")}} </td>
 </tr>
 {{ else }}
 <tr><td colspan=4>No nodes found.</td></tr>


### PR DESCRIPTION
It would be nice if the example templates included some very basic network throughput overviews. Perhaps one or two more graphs on dropped packets or errors would be other good examples.