### PR TITLE
Change case of alert json to initial lower letter.

### DIFF
--- a/notification/notification.go
+++ b/notification/notification.go
@@ -143,14 +143,14 @@ func (n *NotificationHandler) sendNotifications(reqs NotificationReqs) error {
 	alerts := make([]map[string]interface{}, 0, len(reqs))
 	for _, req := range reqs {
 		alerts = append(alerts, map[string]interface{}{
-			"Summary":     req.Summary,
-			"Description": req.Description,
-			"Labels":      req.Labels,
-			"Payload": map[string]interface{}{
-				"Value":        req.Value,
-				"ActiveSince":  req.ActiveSince,
-				"GeneratorURL": req.GeneratorURL,
-				"AlertingRule": req.RuleString,
+			"summary":     req.Summary,
+			"description": req.Description,
+			"labels":      req.Labels,
+			"payload": map[string]interface{}{
+				"value":        req.Value,
+				"activeSince":  req.ActiveSince,
+				"generatorURL": req.GeneratorURL,
+				"alertingRule": req.RuleString,
 			},
 		})
 	}

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -81,7 +81,7 @@ func TestNotificationHandler(t *testing.T) {
 			// Correct message.
 			summary:     "Summary",
 			description: "Description",
-			message:     `[{"Description":"Description","Labels":{"instance":"testinstance"},"Payload":{"ActiveSince":"0001-01-01T00:00:00Z","AlertingRule":"Test rule string","GeneratorURL":"prometheus_url","Value":"0.3333333333333333"},"Summary":"Summary"}]`,
+			message:     `[{"description":"Description","labels":{"instance":"testinstance"},"payload":{"activeSince":"0001-01-01T00:00:00Z","alertingRule":"Test rule string","generatorURL":"prometheus_url","value":"0.3333333333333333"},"summary":"Summary"}]`,
 		},
 	}
 


### PR DESCRIPTION
This is more in line with common practice,
and with the webhook in alertmanager this will
be more directly exposed to users.


This is a minor breaking change, in that if you have a mix of old/new alertamanger/prometheus the alertmanager UI and some notifications will be a bit less useful.