### PR TITLE
Restore default ScrapeInterval of 1 minute instead of 10 seconds

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,7 +50,7 @@ var (
 
 	// The default global configuration.
 	DefaultGlobalConfig = DefaultedGlobalConfig{
-		ScrapeInterval:     Duration(10 * time.Second),
+		ScrapeInterval:     Duration(1 * time.Minute),
 		ScrapeTimeout:      Duration(10 * time.Second),
 		EvaluationInterval: Duration(1 * time.Minute),
 	}


### PR DESCRIPTION
I noticed that in #680 the [`ScrapeInterval` was changed](https://github.com/prometheus/prometheus/pull/680/files#diff-3baf47c64847a8fb8aaa8cc2e088513bR49) from 1 minute to 10 seconds, which seemed like an accidental change since the [Configuration file](http://prometheus.io/docs/operating/configuration/#configuration-file) documentation still refers to the default as 1 minute as did the previous [generated configuration](https://github.com/prometheus/prometheus/pull/680/files#diff-b99949919153473f6385c0ce70762f88L130).

In case this was unintentional, this PR restores the previous value, but if it wasn't then this can just be closed out.