### PR TITLE
config: simplify default config handling.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,7 +46,7 @@ func LoadFromFile(filename string) (*Config, error) {
 var (
 	// The default top-level configuration.
 	DefaultConfig = Config{
-		GlobalConfig: &DefaultGlobalConfig,
+		GlobalConfig: DefaultGlobalConfig,
 	}
 
 	// The default global configuration.
@@ -56,7 +56,7 @@ var (
 		EvaluationInterval: Duration(1 * time.Minute),
 	}
 
-	// Te default scrape configuration.
+	// The default scrape configuration.
 	DefaultScrapeConfig = ScrapeConfig{
 		// ScrapeTimeout and ScrapeInterval default to the
 		// configured globals.
@@ -89,7 +89,7 @@ var (
 
 // Config is the top-level configuration for Prometheus's config files.
 type Config struct {
-	GlobalConfig  *GlobalConfig   `yaml:"global"`
+	GlobalConfig  GlobalConfig    `yaml:"global"`
 	RuleFiles     []string        `yaml:"rule_files,omitempty"`
 	ScrapeConfigs []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var expectedConf = &Config{
-	GlobalConfig: &GlobalConfig{
+	GlobalConfig: GlobalConfig{
 		ScrapeInterval:     Duration(15 * time.Second),
 		ScrapeTimeout:      DefaultGlobalConfig.ScrapeTimeout,
 		EvaluationInterval: Duration(30 * time.Second),
@@ -118,6 +118,12 @@ var expectedConf = &Config{
 }
 
 func TestLoadConfig(t *testing.T) {
+	// Parse a valid file that sets a global scrape timeout. This tests whether parsing
+	// an overwritten default field in the global config permanently changes the default.
+	if _, err := LoadFromFile("testdata/global_timeout.good.yml"); err != nil {
+		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
+	}
+
 	c, err := LoadFromFile("testdata/conf.good.yml")
 	if err != nil {
 		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,8 +12,8 @@ import (
 	clientmodel "github.com/prometheus/client_golang/model"
 )
 
-var expectedConf = &Config{DefaultedConfig{
-	GlobalConfig: &GlobalConfig{DefaultedGlobalConfig{
+var expectedConf = &Config{
+	GlobalConfig: &GlobalConfig{
 		ScrapeInterval:     Duration(15 * time.Second),
 		ScrapeTimeout:      DefaultGlobalConfig.ScrapeTimeout,
 		EvaluationInterval: Duration(30 * time.Second),
@@ -22,7 +22,7 @@ var expectedConf = &Config{DefaultedConfig{
 			"monitor": "codelab",
 			"foo":     "bar",
 		},
-	}},
+	},
 
 	RuleFiles: []string{
 		"first.rules",
@@ -31,7 +31,7 @@ var expectedConf = &Config{DefaultedConfig{
 	},
 
 	ScrapeConfigs: []*ScrapeConfig{
-		{DefaultedScrapeConfig{
+		{
 			JobName: "prometheus",
 
 			ScrapeInterval: Duration(15 * time.Second),
@@ -54,28 +54,28 @@ var expectedConf = &Config{DefaultedConfig{
 			},
 
 			FileSDConfigs: []*FileSDConfig{
-				{DefaultedFileSDConfig{
+				{
 					Names:           []string{"foo/*.slow.json", "foo/*.slow.yml", "single/file.yml"},
 					RefreshInterval: Duration(10 * time.Minute),
-				}},
-				{DefaultedFileSDConfig{
+				},
+				{
 					Names:           []string{"bar/*.yaml"},
 					RefreshInterval: Duration(30 * time.Second),
-				}},
+				},
 			},
 
 			RelabelConfigs: []*RelabelConfig{
-				{DefaultedRelabelConfig{
+				{
 					SourceLabels: clientmodel.LabelNames{"job", "__meta_dns_srv_name"},
 					TargetLabel:  "job",
 					Separator:    ";",
 					Regex:        &Regexp{*regexp.MustCompile("(.*)some-[regex]$")},
 					Replacement:  "foo-${1}",
 					Action:       RelabelReplace,
-				}},
+				},
 			},
-		}},
-		{DefaultedScrapeConfig{
+		},
+		{
 			JobName: "service-x",
 
 			ScrapeInterval: Duration(50 * time.Second),
@@ -89,32 +89,33 @@ var expectedConf = &Config{DefaultedConfig{
 			Scheme:      "https",
 
 			DNSSDConfigs: []*DNSSDConfig{
-				{DefaultedDNSSDConfig{
+				{
 					Names: []string{
 						"first.dns.address.domain.com",
 						"second.dns.address.domain.com",
 					},
 					RefreshInterval: Duration(15 * time.Second),
-				}},
-				{DefaultedDNSSDConfig{
+				},
+				{
 					Names: []string{
 						"first.dns.address.domain.com",
 					},
 					RefreshInterval: Duration(30 * time.Second),
-				}},
+				},
 			},
 
 			RelabelConfigs: []*RelabelConfig{
-				{DefaultedRelabelConfig{
+				{
 					SourceLabels: clientmodel.LabelNames{"job"},
 					Regex:        &Regexp{*regexp.MustCompile("(.*)some-[regex]$")},
 					Separator:    ";",
 					Action:       RelabelDrop,
-				}},
+				},
 			},
-		}},
+		},
 	},
-}, ""}
+	original: "",
+}
 
 func TestLoadConfig(t *testing.T) {
 	c, err := LoadFromFile("testdata/conf.good.yml")

--- a/config/testdata/global_timeout.good.yml
+++ b/config/testdata/global_timeout.good.yml
@@ -1,0 +1,2 @@
+global:
+  scrape_timeout: 1h

--- a/retrieval/relabel_test.go
+++ b/retrieval/relabel_test.go
@@ -13,7 +13,7 @@ import (
 func TestRelabel(t *testing.T) {
 	tests := []struct {
 		input   clientmodel.LabelSet
-		relabel []config.DefaultedRelabelConfig
+		relabel []*config.RelabelConfig
 		output  clientmodel.LabelSet
 	}{
 		{
@@ -22,7 +22,7 @@ func TestRelabel(t *testing.T) {
 				"b": "bar",
 				"c": "baz",
 			},
-			relabel: []config.DefaultedRelabelConfig{
+			relabel: []*config.RelabelConfig{
 				{
 					SourceLabels: clientmodel.LabelNames{"a"},
 					Regex:        &config.Regexp{*regexp.MustCompile("f(.*)")},
@@ -45,7 +45,7 @@ func TestRelabel(t *testing.T) {
 				"b": "bar",
 				"c": "baz",
 			},
-			relabel: []config.DefaultedRelabelConfig{
+			relabel: []*config.RelabelConfig{
 				{
 					SourceLabels: clientmodel.LabelNames{"a", "b"},
 					Regex:        &config.Regexp{*regexp.MustCompile("^f(.*);(.*)r$")},
@@ -74,7 +74,7 @@ func TestRelabel(t *testing.T) {
 			input: clientmodel.LabelSet{
 				"a": "foo",
 			},
-			relabel: []config.DefaultedRelabelConfig{
+			relabel: []*config.RelabelConfig{
 				{
 					SourceLabels: clientmodel.LabelNames{"a"},
 					Regex:        &config.Regexp{*regexp.MustCompile("o$")},
@@ -94,7 +94,7 @@ func TestRelabel(t *testing.T) {
 			input: clientmodel.LabelSet{
 				"a": "foo",
 			},
-			relabel: []config.DefaultedRelabelConfig{
+			relabel: []*config.RelabelConfig{
 				{
 					SourceLabels: clientmodel.LabelNames{"a"},
 					Regex:        &config.Regexp{*regexp.MustCompile("no-match")},
@@ -109,7 +109,7 @@ func TestRelabel(t *testing.T) {
 			input: clientmodel.LabelSet{
 				"a": "foo",
 			},
-			relabel: []config.DefaultedRelabelConfig{
+			relabel: []*config.RelabelConfig{
 				{
 					SourceLabels: clientmodel.LabelNames{"a"},
 					Regex:        &config.Regexp{*regexp.MustCompile("no-match")},
@@ -122,7 +122,7 @@ func TestRelabel(t *testing.T) {
 			input: clientmodel.LabelSet{
 				"a": "foo",
 			},
-			relabel: []config.DefaultedRelabelConfig{
+			relabel: []*config.RelabelConfig{
 				{
 					SourceLabels: clientmodel.LabelNames{"a"},
 					Regex:        &config.Regexp{*regexp.MustCompile("^f")},
@@ -138,7 +138,7 @@ func TestRelabel(t *testing.T) {
 			input: clientmodel.LabelSet{
 				"a": "boo",
 			},
-			relabel: []config.DefaultedRelabelConfig{
+			relabel: []*config.RelabelConfig{
 				{
 					SourceLabels: clientmodel.LabelNames{"a"},
 					Regex:        &config.Regexp{*regexp.MustCompile("^f")},
@@ -154,11 +154,7 @@ func TestRelabel(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		var relabel []*config.RelabelConfig
-		for _, rl := range test.relabel {
-			relabel = append(relabel, &config.RelabelConfig{rl})
-		}
-		res, err := Relabel(test.input, relabel...)
+		res, err := Relabel(test.input, test.relabel...)
 		if err != nil {
 			t.Errorf("Test %d: error relabeling: %s", i+1, err)
 		}

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestTargetManagerChan(t *testing.T) {
-	testJob1 := &config.ScrapeConfig{config.DefaultedScrapeConfig{
+	testJob1 := &config.ScrapeConfig{
 		JobName:        "test_job1",
 		ScrapeInterval: config.Duration(1 * time.Minute),
 		TargetGroups: []*config.TargetGroup{{
@@ -34,7 +34,7 @@ func TestTargetManagerChan(t *testing.T) {
 				{clientmodel.AddressLabel: "example.com:80"},
 			},
 		}},
-	}}
+	}
 	prov1 := &fakeTargetProvider{
 		sources: []string{"src1", "src2"},
 		update:  make(chan *config.TargetGroup),
@@ -154,7 +154,7 @@ func TestTargetManagerChan(t *testing.T) {
 }
 
 func TestTargetManagerConfigUpdate(t *testing.T) {
-	testJob1 := &config.ScrapeConfig{config.DefaultedScrapeConfig{
+	testJob1 := &config.ScrapeConfig{
 		JobName:        "test_job1",
 		ScrapeInterval: config.Duration(1 * time.Minute),
 		TargetGroups: []*config.TargetGroup{{
@@ -163,8 +163,8 @@ func TestTargetManagerConfigUpdate(t *testing.T) {
 				{clientmodel.AddressLabel: "example.com:80"},
 			},
 		}},
-	}}
-	testJob2 := &config.ScrapeConfig{config.DefaultedScrapeConfig{
+	}
+	testJob2 := &config.ScrapeConfig{
 		JobName:        "test_job2",
 		ScrapeInterval: config.Duration(1 * time.Minute),
 		TargetGroups: []*config.TargetGroup{
@@ -191,14 +191,14 @@ func TestTargetManagerConfigUpdate(t *testing.T) {
 			},
 		},
 		RelabelConfigs: []*config.RelabelConfig{
-			{config.DefaultedRelabelConfig{
+			{
 				SourceLabels: clientmodel.LabelNames{clientmodel.AddressLabel},
 				Regex:        &config.Regexp{*regexp.MustCompile(`^test\.(.*?):(.*)`)},
 				Replacement:  "foo.${1}:${2}",
 				TargetLabel:  clientmodel.AddressLabel,
 				Action:       config.RelabelReplace,
-			}},
-			{config.DefaultedRelabelConfig{
+			},
+			{
 				// Add a new label for example.* targets.
 				SourceLabels: clientmodel.LabelNames{clientmodel.AddressLabel, "boom", "foo"},
 				Regex:        &config.Regexp{*regexp.MustCompile("^example.*?-b([a-z-]+)r$")},
@@ -206,17 +206,17 @@ func TestTargetManagerConfigUpdate(t *testing.T) {
 				Replacement:  "$1",
 				Separator:    "-",
 				Action:       config.RelabelReplace,
-			}},
-			{config.DefaultedRelabelConfig{
+			},
+			{
 				// Drop an existing label.
 				SourceLabels: clientmodel.LabelNames{"boom"},
 				Regex:        &config.Regexp{*regexp.MustCompile(".*")},
 				TargetLabel:  "boom",
 				Replacement:  "",
 				Action:       config.RelabelReplace,
-			}},
+			},
 		},
-	}}
+	}
 
 	sequence := []struct {
 		scrapeConfigs []*config.ScrapeConfig
@@ -275,7 +275,8 @@ func TestTargetManagerConfigUpdate(t *testing.T) {
 			},
 		},
 	}
-	conf := &config.Config{DefaultedConfig: config.DefaultConfig}
+	conf := &config.Config{}
+	*conf = config.DefaultConfig
 
 	targetManager := NewTargetManager(nopAppender{})
 	targetManager.ApplyConfig(conf)


### PR DESCRIPTION
As suggested by @neelance, this makes default configuration handling more transparent.
Thanks again @neelance, I like it.