### PR TITLE
Initial API v1 implementation

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,8 @@ import (
 	"github.com/prometheus/prometheus/storage/remote/influxdb"
 	"github.com/prometheus/prometheus/storage/remote/opentsdb"
 	"github.com/prometheus/prometheus/web"
-	"github.com/prometheus/prometheus/web/api"
+	"github.com/prometheus/prometheus/web/api/legacy"
+	"github.com/prometheus/prometheus/web/api/v1"
 )
 
 const deletionBatchSize = 100
@@ -184,8 +185,13 @@ func NewPrometheus() *prometheus {
 		PathPrefix: *pathPrefix,
 	}
 
-	metricsService := &api.MetricsService{
+	apiLegacy := &legacy.API{
 		Now:         clientmodel.Now,
+		Storage:     memStorage,
+		QueryEngine: queryEngine,
+	}
+
+	apiv1 := &v1.API{
 		Storage:     memStorage,
 		QueryEngine: queryEngine,
 	}
@@ -193,7 +199,8 @@ func NewPrometheus() *prometheus {
 	webService := web.NewWebService(&web.WebServiceOptions{
 		PathPrefix:      *pathPrefix,
 		StatusHandler:   prometheusStatus,
-		MetricsHandler:  metricsService,
+		APILegacy:       apiLegacy,
+		APIv1:           apiv1,
 		ConsolesHandler: consolesHandler,
 		AlertsHandler:   alertsHandler,
 		GraphsHandler:   graphsHandler,

--- a/promql/lex.go
+++ b/promql/lex.go
@@ -666,7 +666,7 @@ func lexNumberOrDuration(l *lexer) stateFn {
 // not necessarily a valid number. This case is caught by the parser.
 func (l *lexer) scanNumber() bool {
 	digits := "0123456789"
-	// Disallow hexal in series descriptions as the syntax is ambiguous.
+	// Disallow hexadecimal in series descriptions as the syntax is ambiguous.
 	if !l.seriesDesc && l.accept("0") && l.accept("xX") {
 		digits = "0123456789abcdefABCDEF"
 	}

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -1275,6 +1275,13 @@ var testSeries = []struct {
 		},
 		expectedValues: newSeq(1, 2, 3, -7, -17, -27, -37),
 	}, {
+		input: `my_metric{a="b"} 1 2 3-0x4`,
+		expectedMetric: clientmodel.Metric{
+			clientmodel.MetricNameLabel: "my_metric",
+			"a": "b",
+		},
+		expectedValues: newSeq(1, 2, 3, 3, 3, 3, 3),
+	}, {
 		input: `my_metric{a="b"} 1 3 _ 5 _x4`,
 		expectedMetric: clientmodel.Metric{
 			clientmodel.MetricNameLabel: "my_metric",

--- a/promql/test.go
+++ b/promql/test.go
@@ -77,6 +77,16 @@ func NewTestFromFile(t testutil.T, filename string) (*Test, error) {
 	return NewTest(t, string(content))
 }
 
+// QueryEngine returns the test's query engine.
+func (t *Test) QueryEngine() *Engine {
+	return t.queryEngine
+}
+
+// Storage returns the test's storage.
+func (t *Test) Storage() local.Storage {
+	return t.storage
+}
+
 func raise(line int, format string, v ...interface{}) error {
 	return &ParseErr{
 		Line: line + 1,

--- a/web/api/legacy/api.go
+++ b/web/api/legacy/api.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package api
+package legacy
 
 import (
 	"net/http"
@@ -26,18 +26,18 @@ import (
 	"github.com/prometheus/prometheus/util/route"
 )
 
-// MetricsService manages the /api HTTP endpoint.
-type MetricsService struct {
+// API manages the /api HTTP endpoint.
+type API struct {
 	Now         func() clientmodel.Timestamp
 	Storage     local.Storage
 	QueryEngine *promql.Engine
 }
 
 // RegisterHandler registers the handler for the various endpoints below /api.
-func (msrv *MetricsService) RegisterHandler(router *route.Router) {
-	router.Get("/query", handle("query", msrv.Query))
-	router.Get("/query_range", handle("query_range", msrv.QueryRange))
-	router.Get("/metrics", handle("metrics", msrv.Metrics))
+func (api *API) Register(router *route.Router) {
+	router.Get("/query", handle("query", api.Query))
+	router.Get("/query_range", handle("query_range", api.QueryRange))
+	router.Get("/metrics", handle("metrics", api.Metrics))
 }
 
 func handle(name string, f http.HandlerFunc) http.HandlerFunc {

--- a/web/api/legacy/api_test.go
+++ b/web/api/legacy/api_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package api
+package legacy
 
 import (
 	"io/ioutil"
@@ -93,13 +93,13 @@ func TestQuery(t *testing.T) {
 	})
 	storage.WaitForIndexing()
 
-	api := MetricsService{
+	api := &API{
 		Now:         testNow,
 		Storage:     storage,
 		QueryEngine: promql.NewEngine(storage),
 	}
 	rtr := route.New()
-	api.RegisterHandler(rtr.WithPrefix("/api"))
+	api.Register(rtr.WithPrefix("/api"))
 
 	server := httptest.NewServer(rtr)
 	defer server.Close()

--- a/web/api/legacy/query_test.go
+++ b/web/api/legacy/query_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package api
+package legacy
 
 import (
 	"testing"

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1,0 +1,213 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	clientmodel "github.com/prometheus/client_golang/model"
+
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage/local"
+	"github.com/prometheus/prometheus/util/route"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+type status string
+
+const (
+	statusSuccess status = "success"
+	statusError          = "error"
+)
+
+type errorType string
+
+const (
+	errorTimeout  errorType = "timeout"
+	errorCanceled           = "canceled"
+	errorExec               = "execution"
+	errorBadData            = "bad_data"
+)
+
+type apiError struct {
+	typ errorType
+	err error
+}
+
+func (e *apiError) Error() string {
+	return fmt.Sprintf("%s: %s", e.typ, e.err)
+}
+
+type response struct {
+	Status    status      `json:"status"`
+	Data      interface{} `json:"data,omitempty"`
+	ErrorType errorType   `json:"errorType,omitempty"`
+	Error     string      `json:"error,omitempty"`
+}
+
+// API can register a set of endpoints in a router and handle
+// them using the provided storage and query engine.
+type API struct {
+	Storage     local.Storage
+	QueryEngine *promql.Engine
+}
+
+// Enables cross-site script calls.
+func setCORS(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, Origin")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Expose-Headers", "Date")
+}
+
+type apiFunc func(r *http.Request) (interface{}, *apiError)
+
+// Register the API's endpoints in the given router.
+func (api *API) Register(r *route.Router) {
+	instr := func(name string, f apiFunc) http.HandlerFunc {
+		return prometheus.InstrumentHandlerFunc(name, func(w http.ResponseWriter, r *http.Request) {
+			setCORS(w)
+			if data, err := f(r); err != nil {
+				respondError(w, err, data)
+			} else {
+				respond(w, data)
+			}
+		})
+	}
+
+	r.Get("/query", instr("query", api.query))
+	r.Get("/query_range", instr("query_range", api.queryRange))
+
+	r.Get("/metrics/names", instr("metric_names", api.metricNames))
+}
+
+type queryData struct {
+	ResultType promql.ExprType `json:"resultType"`
+	Result     promql.Value    `json:"result"`
+}
+
+func (api *API) query(r *http.Request) (interface{}, *apiError) {
+	ts, err := parseTime(r.FormValue("time"))
+	if err != nil {
+		return nil, &apiError{errorBadData, err}
+	}
+	qry, err := api.QueryEngine.NewInstantQuery(r.FormValue("query"), ts)
+	if err != nil {
+		return nil, &apiError{errorBadData, err}
+	}
+
+	res := qry.Exec()
+	if res.Err != nil {
+		return nil, &apiError{errorBadData, res.Err}
+	}
+	return &queryData{
+		ResultType: res.Value.Type(),
+		Result:     res.Value,
+	}, nil
+}
+
+func (api *API) queryRange(r *http.Request) (interface{}, *apiError) {
+	start, err := parseTime(r.FormValue("start"))
+	if err != nil {
+		return nil, &apiError{errorBadData, err}
+	}
+	end, err := parseTime(r.FormValue("end"))
+	if err != nil {
+		return nil, &apiError{errorBadData, err}
+	}
+	step, err := parseDuration(r.FormValue("step"))
+	if err != nil {
+		return nil, &apiError{errorBadData, err}
+	}
+
+	// For safety, limit the number of returned points per timeseries.
+	// This is sufficient for 60s resolution for a week or 1h resolution for a year.
+	if end.Sub(start)/step > 11000 {
+		err := errors.New("exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)")
+		return nil, &apiError{errorBadData, err}
+	}
+
+	qry, err := api.QueryEngine.NewRangeQuery(r.FormValue("query"), start, end, step)
+	if err != nil {
+		switch err.(type) {
+		case promql.ErrQueryCanceled:
+			return nil, &apiError{errorCanceled, err}
+		case promql.ErrQueryTimeout:
+			return nil, &apiError{errorTimeout, err}
+		}
+		return nil, &apiError{errorExec, err}
+	}
+
+	res := qry.Exec()
+	if res.Err != nil {
+		return nil, &apiError{errorBadData, err}
+	}
+	return &queryData{
+		ResultType: res.Value.Type(),
+		Result:     res.Value,
+	}, nil
+}
+
+func (api *API) metricNames(r *http.Request) (interface{}, *apiError) {
+	metricNames := api.Storage.LabelValuesForLabelName(clientmodel.MetricNameLabel)
+	sort.Sort(metricNames)
+
+	return metricNames, nil
+}
+
+func respond(w http.ResponseWriter, data interface{}) {
+	w.WriteHeader(200)
+	w.Header().Set("Content-Type", "application/json")
+
+	b, err := json.Marshal(&response{
+		Status: statusSuccess,
+		Data:   data,
+	})
+	if err != nil {
+		return
+	}
+	w.Write(b)
+}
+
+func respondError(w http.ResponseWriter, apiErr *apiError, data interface{}) {
+	w.WriteHeader(422)
+	w.Header().Set("Content-Type", "application/json")
+
+	b, err := json.Marshal(&response{
+		Status:    statusError,
+		ErrorType: apiErr.typ,
+		Error:     apiErr.err.Error(),
+		Data:      data,
+	})
+	if err != nil {
+		return
+	}
+	w.Write(b)
+}
+
+func parseTime(s string) (clientmodel.Timestamp, error) {
+	if t, err := strconv.ParseFloat(s, 64); err == nil {
+		ts := int64(t * float64(time.Second))
+		return clientmodel.TimestampFromUnixNano(ts), nil
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return clientmodel.TimestampFromTime(t), nil
+	}
+	return 0, fmt.Errorf("cannot parse %q to a valid timestamp", s)
+}
+
+func parseDuration(s string) (time.Duration, error) {
+	if d, err := strconv.ParseFloat(s, 64); err == nil {
+		return time.Duration(d * float64(time.Second)), nil
+	}
+	if d, err := strutil.StringToDuration(s); err == nil {
+		return d, nil
+	}
+	return 0, fmt.Errorf("cannot parse %q to a valid duration", s)
+}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1,0 +1,275 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	clientmodel "github.com/prometheus/client_golang/model"
+
+	"github.com/prometheus/prometheus/promql"
+)
+
+func TestEndpoints(t *testing.T) {
+	suite, err := promql.NewTest(t, `
+		load 1m
+			test_metric1{foo="bar"} 0+100x100
+			test_metric1{foo="boo"} 1+0x100
+			test_metric2{foo="boo"} 1+0x100
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer suite.Close()
+
+	if err := suite.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	api := &API{
+		Storage:     suite.Storage(),
+		QueryEngine: suite.QueryEngine(),
+	}
+
+	start := clientmodel.Timestamp(0)
+	var tests = []struct {
+		endpoint apiFunc
+		query    url.Values
+		response interface{}
+		errType  errorType
+	}{
+		{
+			endpoint: api.query,
+			query: url.Values{
+				"query": []string{"2"},
+				"time":  []string{"123.3"},
+			},
+			response: &queryData{
+				ResultType: promql.ExprScalar,
+				Result: &promql.Scalar{
+					Value:     2,
+					Timestamp: start.Add(123*time.Second + 300*time.Millisecond),
+				},
+			},
+		},
+		{
+			endpoint: api.query,
+			query: url.Values{
+				"query": []string{"0.333"},
+				"time":  []string{"1970-01-01T00:02:03Z"},
+			},
+			response: &queryData{
+				ResultType: promql.ExprScalar,
+				Result: &promql.Scalar{
+					Value:     0.333,
+					Timestamp: start.Add(123 * time.Second),
+				},
+			},
+		},
+		{
+			endpoint: api.query,
+			query: url.Values{
+				"query": []string{"0.333"},
+				"time":  []string{"1970-01-01T01:02:03+01:00"},
+			},
+			response: &queryData{
+				ResultType: promql.ExprScalar,
+				Result: &promql.Scalar{
+					Value:     0.333,
+					Timestamp: start.Add(123 * time.Second),
+				},
+			},
+		},
+		{
+			endpoint: api.metricNames,
+			response: clientmodel.LabelValues{
+				"test_metric1",
+				"test_metric2",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		req, err := http.NewRequest("ANY", fmt.Sprintf("http://example.com?%s", test.query.Encode()), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, apierr := test.endpoint(req)
+		if apierr != nil {
+			if test.errType == "" {
+				t.Fatalf("Unexpected error: %s", apierr)
+			}
+			if test.errType != apierr.typ {
+				t.Fatalf("Expected error of type %q but got type %q", test.errType, apierr.typ)
+			}
+			continue
+		}
+		if apierr == nil && test.errType != "" {
+			t.Fatalf("Expected error of type %q but got none", test.errType)
+		}
+		if !reflect.DeepEqual(resp, test.response) {
+			t.Fatalf("Response does not match, expected:\n%v\ngot:\n%v", test.response, resp)
+		}
+	}
+}
+
+func TestRespondSuccess(t *testing.T) {
+	w := httptest.NewRecorder()
+	respond(w, "test")
+
+	if w.Code != 200 {
+		t.Fatalf("Return code %d expected in success response but got %d", 200, w.Code)
+	}
+	var res response
+	err := json.Unmarshal([]byte(w.Body.String()), &res)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if h := w.Header().Get("Content-Type"); h != "application/json" {
+		t.Fatalf("expected Content-Type %q but got %q", "application/json", h)
+	}
+
+	exp := &response{
+		Status: statusSuccess,
+		Data:   "test",
+	}
+	if !reflect.DeepEqual(&res, exp) {
+		t.Fatalf("Expected response \n%v\n but got \n%v\n", res, exp)
+	}
+}
+
+func TestRespondError(t *testing.T) {
+	w := httptest.NewRecorder()
+	respondError(w, &apiError{errorTimeout, errors.New("message")}, "test")
+
+	if w.Code != 422 {
+		t.Fatalf("Return code %d expected in success response but got %d", 422, w.Code)
+	}
+	var res response
+	err := json.Unmarshal([]byte(w.Body.String()), &res)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if h := w.Header().Get("Content-Type"); h != "application/json" {
+		t.Fatalf("expected Content-Type %q but got %q", "application/json", h)
+	}
+
+	exp := &response{
+		Status:    statusError,
+		Data:      "test",
+		ErrorType: errorTimeout,
+		Error:     "message",
+	}
+	if !reflect.DeepEqual(&res, exp) {
+		t.Fatalf("Expected response \n%v\n but got \n%v\n", res, exp)
+	}
+}
+
+func TestParseTime(t *testing.T) {
+	ts, err := time.Parse(time.RFC3339Nano, "2015-06-03T13:21:58.555Z")
+	if err != nil {
+		panic(err)
+	}
+
+	var tests = []struct {
+		input  string
+		fail   bool
+		result time.Time
+	}{
+		{
+			input: "",
+			fail:  true,
+		}, {
+			input: "abc",
+			fail:  true,
+		}, {
+			input: "30s",
+			fail:  true,
+		}, {
+			input:  "123",
+			result: time.Unix(123, 0),
+		}, {
+			input:  "123.123",
+			result: time.Unix(123, 123000000),
+		}, {
+			input:  "123.123",
+			result: time.Unix(123, 123000000),
+		}, {
+			input:  "2015-06-03T13:21:58.555Z",
+			result: ts,
+		}, {
+			input:  "2015-06-03T14:21:58.555+01:00",
+			result: ts,
+		},
+	}
+
+	for _, test := range tests {
+		ts, err := parseTime(test.input)
+		if err != nil && !test.fail {
+			t.Errorf("Unexpected error for %q: %s", test.input, err)
+			continue
+		}
+		if err == nil && test.fail {
+			t.Errorf("Expected error for %q but got none", test.input)
+			continue
+		}
+		res := clientmodel.TimestampFromTime(test.result)
+		if !test.fail && ts != res {
+			t.Errorf("Expected time %v for input %q but got %v", res, test.input, ts)
+		}
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+	var tests = []struct {
+		input  string
+		fail   bool
+		result time.Duration
+	}{
+		{
+			input: "",
+			fail:  true,
+		}, {
+			input: "abc",
+			fail:  true,
+		}, {
+			input: "2015-06-03T13:21:58.555Z",
+			fail:  true,
+		}, {
+			input:  "123",
+			result: 123 * time.Second,
+		}, {
+			input:  "123.333",
+			result: 123*time.Second + 333*time.Millisecond,
+		}, {
+			input:  "15s",
+			result: 15 * time.Second,
+		}, {
+			input:  "5m",
+			result: 5 * time.Minute,
+		},
+	}
+
+	for _, test := range tests {
+		d, err := parseDuration(test.input)
+		if err != nil && !test.fail {
+			t.Errorf("Unexpected error for %q: %s", test.input, err)
+			continue
+		}
+		if err == nil && test.fail {
+			t.Errorf("Expected error for %q but got none", test.input)
+			continue
+		}
+		if !test.fail && d != test.result {
+			t.Errorf("Expected duration %v for input %q but got %v", test.result, test.input, d)
+		}
+	}
+}


### PR DESCRIPTION
These commits add an initial API v1 that provides the equivalent endpoint to the old API accepting unix or RFC3339 timestamps.
Both APIs are running in parallel.