### PR TITLE
retrieval/discovery: surround __meta_consul_tags value with tag seperators.

### DIFF
--- a/retrieval/discovery/consul.go
+++ b/retrieval/discovery/consul.go
@@ -1,3 +1,16 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package discovery
+
 package discovery
 
 import (
@@ -245,7 +258,9 @@ func (cd *ConsulDiscovery) watchService(srv *consulService, ch chan<- *config.Ta
 
 		for _, node := range nodes {
 			addr := fmt.Sprintf("%s:%d", node.Address, node.ServicePort)
-			tags := strings.Join(node.ServiceTags, cd.tagSeparator)
+			// We surround the separated list with the separator as well. This way regular expressions
+			// in relabeling rules don't have to consider tag positions.
+			tags := cd.tagSeparator + strings.Join(node.ServiceTags, cd.tagSeparator) + cd.tagSeparator
 
 			srv.tgroup.Targets = append(srv.tgroup.Targets, clientmodel.LabelSet{
 				clientmodel.AddressLabel: clientmodel.LabelValue(addr),


### PR DESCRIPTION
@brian-brazil 