### PR TITLE
Web: Add pre-relabel labels to status page.

### DIFF
--- a/web/templates/_base.html
+++ b/web/templates/_base.html
@@ -4,11 +4,17 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Prometheus Time Series Collection and Processing Server</title>
     <script src="{{ pathPrefix }}/static/vendor/js/jquery.min.js"></script>
+    <script src="{{ pathPrefix }}/static/vendor/bootstrap-3.3.1/js/bootstrap.min.js"></script>
 
     <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/bootstrap-3.3.1/css/bootstrap.min.css">
     <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/css/prometheus.css">
 
-    <script>var PATH_PREFIX = "{{ pathPrefix }}";</script>
+    <script>
+      var PATH_PREFIX = "{{ pathPrefix }}";
+      $(function () {
+        $('[data-toggle="tooltip"]').tooltip()
+      })
+    </script>
 
     {{template "head" .}}
   </head>

--- a/web/templates/status.html
+++ b/web/templates/status.html
@@ -56,7 +56,9 @@
                 </span>
               </td>
               <td>
-                {{stripLabels .BaseLabels "job" "instance"}}
+                <a href="#" data-toggle="tooltip" title="" data-original-title="Before Relabel: {{.MetaLabels}}">
+                  {{or (stripLabels .BaseLabels "job" "instance") "{}"}}
+                </a>
               </td>
               <td>
                 {{if .Status.LastScrape.IsZero}}Never{{else}}{{since .Status.LastScrape}} ago{{end}}


### PR DESCRIPTION
Figuring out what's going on with the new service discovery
and labels is difficult. Add a popover with the labels
to the target table to make things simpler, and help
discovery of potentially useful labels.

@fabxc 