### PR TITLE
Improve display of target labels on status page.

### DIFF
--- a/web/static/css/prometheus.css
+++ b/web/static/css/prometheus.css
@@ -17,3 +17,7 @@ th.job_header {
 .literal_output td {
   font-family: monospace;
 }
+
+.cursor-pointer {
+  cursor: pointer;
+}

--- a/web/templates/status.html
+++ b/web/templates/status.html
@@ -56,9 +56,16 @@
                 </span>
               </td>
               <td>
-                <a href="#" data-toggle="tooltip" title="" data-original-title="Before Relabel: {{.MetaLabels}}">
-                  {{or (stripLabels .BaseLabels "job" "instance") "{}"}}
-                </a>
+                <span class="cursor-pointer" data-toggle="tooltip" title="" data-original-title="Before relabeling: {{.MetaLabels}}">
+                  {{$baseLabels := stripLabels .BaseLabels "job" "instance"}}
+                  {{if $baseLabels}}
+                    {{range $label, $value := $baseLabels}}
+                      <span class="label label-primary">{{$label}}="{{$value}}"</span>
+                    {{end}}
+                  {{else}}
+                    <span class="label label-default">none</span>
+                  {{end}}
+                </span>
               </td>
               <td>
                 {{if .Status.LastScrape.IsZero}}Never{{else}}{{since .Status.LastScrape}} ago{{end}}


### PR DESCRIPTION
Instead of a "{...}"-style list, show key/value pairs as Bootstrap
labels.