### PR TITLE
make: do not call go-bindata on building.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ advice: $(GOCC)
 
 binary: build
 
-build: tools web $(GOPATH)
+build: tools $(GOPATH)
 	$(GO) build -o prometheus $(BUILDFLAGS) .
 
 docker: build
@@ -49,7 +49,7 @@ tag:
 $(BUILD_PATH)/cache/$(GOPKG):
 	$(CURL) -o $@ -L $(GOURL)/$(GOPKG)
 
-benchmark: dependencies tools web
+benchmark: dependencies tools
 	$(GO) test $(GO_TEST_FLAGS) -test.run='NONE' -test.bench='.*' -test.benchmem ./... | tee benchmark.txt
 
 clean:
@@ -84,7 +84,7 @@ race_condition_run: race_condition_binary
 search_index:
 	godoc -index -write_index -index_files='search_index'
 
-test: dependencies tools web
+test: dependencies tools
 	$(GO) test $(GO_TEST_FLAGS) ./...
 
 tools: dependencies

--- a/web/Makefile
+++ b/web/Makefile
@@ -21,6 +21,6 @@ blob/files.go: go-bindata $(shell find blob/templates/ blob/static/ -type f)
 	$(GO) generate ./blob
 
 go-bindata:
-	$(GO) get -u github.com/jteeuwen/go-bindata/...
+	$(GO) get github.com/jteeuwen/go-bindata/...
 
 .PHONY: go-bindata


### PR DESCRIPTION
go-generate is meant to be invoked by the developer when coding and not at build time. 
It is sufficient if the Makefile in `web/` is called once by the person who modified the assets.

Problems in our case:
- As the Makefile `go get`s go-bindata make terminates when building with no internet connection.
- As go-bindata writes the modification time into the generated code, each build will change `web/blob/files.go` to the time of the last checkout.

During development you have to set the `-debug` flag in your `go:generate` line. So you have to manually call `make -C web` twice, once when starting to make changes and once more before finishing the PR.
 Still better than before, as you had to rebuild for every change to a template file.