### PR TITLE
config: raise error on unknown config parameters

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -146,20 +146,20 @@ func TestLoadConfig(t *testing.T) {
 
 	c, err := LoadFromFile("testdata/conf.good.yml")
 	if err != nil {
-		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
+		t.Fatalf("Error parsing %s: %s", "testdata/conf.good.yml", err)
 	}
 	bgot, err := yaml.Marshal(c)
 	if err != nil {
-		t.Errorf("%s", err)
+		t.Fatalf("%s", err)
 	}
 	bexp, err := yaml.Marshal(expectedConf)
 	if err != nil {
-		t.Errorf("%s", err)
+		t.Fatalf("%s", err)
 	}
 	expectedConf.original = c.original
 
 	if !reflect.DeepEqual(c, expectedConf) {
-		t.Errorf("%s: unexpected config result: \n\n%s\n expected\n\n%s", "testdata/conf.good.yml", bgot, bexp)
+		t.Fatalf("%s: unexpected config result: \n\n%s\n expected\n\n%s", "testdata/conf.good.yml", bgot, bexp)
 	}
 }
 
@@ -188,6 +188,9 @@ var expectedErrors = []struct {
 	}, {
 		filename: "rules.bad.yml",
 		errMsg:   "invalid rule file path",
+	}, {
+		filename: "unknown_attr.bad.yml",
+		errMsg:   "unknown fields in scrape_config: consult_sd_configs",
 	},
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -115,6 +115,24 @@ var expectedConf = &Config{
 				},
 			},
 		},
+		{
+			JobName: "service-y",
+
+			ScrapeInterval: Duration(15 * time.Second),
+			ScrapeTimeout:  DefaultGlobalConfig.ScrapeTimeout,
+
+			MetricsPath: DefaultScrapeConfig.MetricsPath,
+			Scheme:      DefaultScrapeConfig.Scheme,
+
+			ConsulSDConfigs: []*ConsulSDConfig{
+				{
+					Server:       "localhost:1234",
+					Services:     []string{"nginx", "cache", "mysql"},
+					TagSeparator: DefaultConsulSDConfig.TagSeparator,
+					Scheme:       DefaultConsulSDConfig.Scheme,
+				},
+			},
+		},
 	},
 	original: "",
 }

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -5,71 +5,75 @@ global:
   # scrape_timeout is set to the global default (10s).
 
   labels:
-      monitor: codelab
-      foo:     bar
+    monitor: codelab
+    foo:     bar
 
 rule_files:
-  - "first.rules"
-  - "second.rules"
-  - "my/*.rules"
+- "first.rules"
+- "second.rules"
+- "my/*.rules"
 
 scrape_configs:
-  - job_name: prometheus
+- job_name: prometheus
 
-    # scrape_interval is defined by the configured global (15s).
-    # scrape_timeout is defined by the global default (10s).
+  # scrape_interval is defined by the configured global (15s).
+  # scrape_timeout is defined by the global default (10s).
 
-    # metrics_path defaults to '/metrics'
-    # scheme defaults to 'http'.
+  # metrics_path defaults to '/metrics'
+  # scheme defaults to 'http'.
 
+  file_sd_configs:
+    - names:
+      - foo/*.slow.json
+      - foo/*.slow.yml
+      - single/file.yml
+      refresh_interval: 10m
+    - names:
+      - bar/*.yaml
+
+  target_groups:
+  - targets: ['localhost:9090', 'localhost:9191']
     labels:
-      foo: baz
+      my:   label
+      your: label
 
-    file_sd_configs:
-      - names:
-          - foo/*.slow.json
-          - foo/*.slow.yml
-          - single/file.yml
-        refresh_interval: 10m
-      - names:
-          - bar/*.yaml
-
-    target_groups:
-      - targets: ['localhost:9090', 'localhost:9191']
-        labels:
-          my:   label
-          your: label
-
-    relabel_configs:
-      - source_labels: [job, __meta_dns_srv_name]
-        regex:         (.*)some-[regex]$
-        target_label:  job
-        replacement:   foo-${1}
-        # action defaults to 'replace'
+  relabel_configs:
+  - source_labels: [job, __meta_dns_srv_name]
+    regex:         (.*)some-[regex]$
+    target_label:  job
+    replacement:   foo-${1}
+    # action defaults to 'replace'
 
 
-  - job_name: service-x
+- job_name: service-x
 
-    basic_auth:
-      username: admin
-      password: password
+  basic_auth:
+    username: admin
+    password: password
 
-    scrape_interval: 50s
-    scrape_timeout:  5s
+  scrape_interval: 50s
+  scrape_timeout:  5s
 
-    metrics_path: /my_path
-    scheme: https
+  metrics_path: /my_path
+  scheme: https
 
-    dns_sd_configs:
-      - refresh_interval: 15s
-        names:
-          - first.dns.address.domain.com
-          - second.dns.address.domain.com
-      - names:
-          - first.dns.address.domain.com
-        # refresh_interval defaults to 30s.
+  dns_sd_configs:
+  - refresh_interval: 15s
+    names:
+    - first.dns.address.domain.com
+    - second.dns.address.domain.com
+  - names:
+    - first.dns.address.domain.com
+    # refresh_interval defaults to 30s.
 
-    relabel_configs:
-      - source_labels: [job]
-        regex:         (.*)some-[regex]$
-        action:        drop
+  relabel_configs:
+  - source_labels: [job]
+    regex:         (.*)some-[regex]$
+    action:        drop
+
+
+- job_name: service-y
+
+  consul_sd_configs:
+  - server: 'localhost:1234'
+    services: ['nginx', 'cache', 'mysql']

--- a/config/testdata/unknown_attr.bad.yml
+++ b/config/testdata/unknown_attr.bad.yml
@@ -1,0 +1,20 @@
+# my global config
+global:
+  scrape_interval:     15s
+  evaluation_interval: 30s
+  # scrape_timeout is set to the global default (10s).
+
+  labels:
+      monitor: codelab
+      foo:     bar
+
+rule_files:
+  - "first.rules"
+  - "second.rules"
+  - "my/*.rules"
+
+scrape_configs:
+  - job_name: prometheus
+
+    consult_sd_configs:
+    - server: 'localhost:1234'


### PR DESCRIPTION
The YAML parser ignores additional parameters on unmarshaling. This causes
frequent confusion with bad configs that pass parsing.

These changes raise errors on additional parameters.