### PR TITLE
Handle building without git.

### DIFF
--- a/Makefile.INCLUDE
+++ b/Makefile.INCLUDE
@@ -15,7 +15,9 @@
 
 .SUFFIXES:
 
-VERSION?=$(shell cat `git rev-parse --show-toplevel`/VERSION)
+current_dir := $(patsubst %/,%, $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+
+VERSION=$(shell cat $(current_dir)/VERSION)
 
 OS=$(shell uname)
 ARCH=$(shell uname -m)
@@ -62,8 +64,8 @@ export GO_TEST_FLAGS ?= -short
 
 GO_GET := $(GO) get -u -v -x
 
-REV        := $(shell git rev-parse --short HEAD)
-BRANCH     := $(shell git rev-parse --abbrev-ref HEAD)
+REV        := $(shell git rev-parse --short HEAD 2> /dev/null  || echo 'unknown')
+BRANCH     := $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null  || echo 'unknown')
 HOSTNAME   := $(shell hostname -f)
 BUILD_DATE := $(shell date +%Y%m%d-%H:%M:%S)
 BUILDFLAGS := -ldflags \


### PR DESCRIPTION
Resolves #609 by removing two dependencies on git.
  - Use the Makefile to find the current directory.
  - In the case of building from an archive fall back to fixed REV
and BRANCH values.

Related to #707.  @matthiasr and @juliusv I made a couple of assumptions I'm happy to change. 
- In the case of the current_path it seemed that finding the root was important (over just using say PWD or CURDIR). So I'm pulling that out of the Makefile. This would find the project root regardless of where make was called from.
- For REV and BRANCH I picked 'archive' and 'none' respectively for the built from archive. This should allow folks to understand the provenance of these builds from  `--version` clearly. For example:

```
$ prometheus --version
prometheus, version 0.14.0 (branch: none, revision: archive)
  build user:       metcalfc@transtainer.local
  build date:       20150614-13:01:10
  go version:       1.4.2
```