### PR TITLE
Use Consul ServiceAddress instead of Address when set

### DIFF
--- a/retrieval/discovery/consul.go
+++ b/retrieval/discovery/consul.go
@@ -258,6 +258,10 @@ func (cd *ConsulDiscovery) watchService(srv *consulService, ch chan<- *config.Ta
 
 		for _, node := range nodes {
 			addr := fmt.Sprintf("%s:%d", node.Address, node.ServicePort)
+			// Use ServiceAddress instead of Address if not empty.
+			if len(node.ServiceAddress) > 0 {
+				addr = fmt.Sprintf("%s:%d", node.ServiceAddress, node.ServicePort)
+			}
 			// We surround the separated list with the separator as well. This way regular expressions
 			// in relabeling rules don't have to consider tag positions.
 			tags := cd.tagSeparator + strings.Join(node.ServiceTags, cd.tagSeparator) + cd.tagSeparator


### PR DESCRIPTION
I'm using consul and registrator with the internal flag, so it adds the container ip as ServiceAddress in consul.
Prometheus currently only respects the Address, which is in my case the ip of the consul server and not the real service ip:

```javascript
  {
    "ServicePort": 4041,
    "ServiceAddress": "10.123.2.34",
    "ServiceTags": null,
    "ServiceName": "foo-service",
    "ServiceID": "node02.cluster-test.local:foo-service:4041",
    "Address": "172.17.8.102",
    "Node": "node02"
  }
```
Would result in prometheus fetching 172.17.8.102:4041 instead of 10.123.2.34:4041