### PR TITLE
Increment dirty counter only if setDirty(true) is called.

### DIFF
--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -316,7 +316,9 @@ func (p *persistence) isDirty() bool {
 // dirty during our runtime, there is no way back. If we were dirty from the
 // start, a clean-up might make us clean again.)
 func (p *persistence) setDirty(dirty bool) {
-	p.dirtyCounter.Inc()
+	if dirty {
+		p.dirtyCounter.Inc()
+	}
 	p.dirtyMtx.Lock()
 	defer p.dirtyMtx.Unlock()
 	if p.becameDirty {


### PR DESCRIPTION
Currently, we increment the counter even if setDirty(false) is called,
which sets the storage clean.

@juliusv 