### PR TITLE
Add 'hashmod' relabel action.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -114,6 +114,19 @@ var expectedConf = &Config{
 					Separator:    ";",
 					Action:       RelabelDrop,
 				},
+				{
+					SourceLabels: clientmodel.LabelNames{"__address__"},
+					TargetLabel:  "__hash",
+					Modulus:      8,
+					Separator:    ";",
+					Action:       RelabelHashMod,
+				},
+				{
+					SourceLabels: clientmodel.LabelNames{"__hash"},
+					Regex:        &Regexp{*regexp.MustCompile("^1$")},
+					Separator:    ";",
+					Action:       RelabelKeep,
+				},
 			},
 			MetricRelabelConfigs: []*RelabelConfig{
 				{
@@ -194,6 +207,9 @@ var expectedErrors = []struct {
 	}, {
 		filename: "regex_missing.bad.yml",
 		errMsg:   "relabel configuration requires a regular expression",
+	}, {
+		filename: "modulus_missing.bad.yml",
+		errMsg:   "relabel configuration for hashmod requires non-zero modulus",
 	}, {
 		filename: "rules.bad.yml",
 		errMsg:   "invalid rule file path",

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -71,6 +71,13 @@ scrape_configs:
   - source_labels: [job]
     regex:         (.*)some-[regex]$
     action:        drop
+  - source_labels: [__address__]
+    modulus:       8
+    target_label:  __hash
+    action:        hashmod
+  - source_labels: [__hash]
+    regex:         ^1$
+    action:        keep
 
   metric_relabel_configs:
   - source_labels: [__name__]

--- a/config/testdata/modulus_missing.bad.yml
+++ b/config/testdata/modulus_missing.bad.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: prometheus
+    relabel_configs:
+      - regex: abcdef
+        action: hashmod

--- a/retrieval/relabel.go
+++ b/retrieval/relabel.go
@@ -2,6 +2,7 @@ package retrieval
 
 import (
 	"fmt"
+	"hash/fnv"
 	"strings"
 
 	clientmodel "github.com/prometheus/client_golang/model"
@@ -56,6 +57,11 @@ func relabel(labels clientmodel.LabelSet, cfg *config.RelabelConfig) (clientmode
 		} else {
 			labels[cfg.TargetLabel] = clientmodel.LabelValue(res)
 		}
+	case config.RelabelHashMod:
+		hasher := fnv.New64a()
+		hasher.Write([]byte(val))
+		mod := hasher.Sum64() % cfg.Modulus
+		labels[cfg.TargetLabel] = clientmodel.LabelValue(fmt.Sprintf("%d", mod))
 	default:
 		panic(fmt.Errorf("retrieval.relabel: unknown relabel action type %q", cfg.Action))
 	}

--- a/retrieval/relabel_test.go
+++ b/retrieval/relabel_test.go
@@ -151,6 +151,28 @@ func TestRelabel(t *testing.T) {
 				"a": "boo",
 			},
 		},
+		{
+			input: clientmodel.LabelSet{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+			},
+			relabel: []*config.RelabelConfig{
+				{
+					SourceLabels: clientmodel.LabelNames{"c"},
+					TargetLabel:  clientmodel.LabelName("d"),
+					Separator:    ";",
+					Action:       config.RelabelHashMod,
+					Modulus:      1000,
+				},
+			},
+			output: clientmodel.LabelSet{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+				"d": "58",
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
This takes the modulus of a hash of some labels.
Combined with a keep relabel action, this allows
for sharding of targets across multiple prometheus
servers.