### PR TITLE
promql: add MarshalJSON method for ExprType.

### DIFF
--- a/promql/ast.go
+++ b/promql/ast.go
@@ -14,6 +14,7 @@
 package promql
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -96,6 +97,11 @@ const (
 	ExprMatrix
 	ExprString
 )
+
+// MarshalJSON implements json.Marshaler.
+func (et ExprType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(et.String())
+}
 
 func (e ExprType) String() string {
 	switch e {


### PR DESCRIPTION
@juliusv 

Regarding `resultType`: I changed it in the design doc. Basically how it is done is consistent how we do it one level further up for `error`, `errorType`. I think it's more convenient to use as it reduces one level of nesting.