### PR TITLE
cmd/promtool: fix missing builddate in version info

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -145,7 +145,7 @@ func checkRules(t cli.Term, filename string) (int, error) {
 var versionInfoTmpl = `
 prometheus, version {{.version}} (branch: {{.branch}}, revision: {{.revision}})
   build user:       {{.buildUser}}
-  build date:       {{.builDate}}
+  build date:       {{.buildDate}}
   go version:       {{.goVersion}}
 `
 


### PR DESCRIPTION
@juliusv 