### PR TITLE
Export build information as metric.

### DIFF
--- a/version/info.go
+++ b/version/info.go
@@ -13,6 +13,8 @@
 
 package version
 
+import "github.com/prometheus/client_golang/prometheus"
+
 // Build information. Populated at build-time.
 var (
 	Version   string
@@ -31,4 +33,17 @@ var Map = map[string]string{
 	"buildUser": BuildUser,
 	"buildDate": BuildDate,
 	"goVersion": GoVersion,
+}
+
+func init() {
+	buildInfo := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prometheus_build_info",
+			Help: "A metric with a constant '1' value labeled by version, revision, and branch from which Prometheus was built.",
+		},
+		[]string{"version", "revision", "branch"},
+	)
+	buildInfo.WithLabelValues(Version, Revision, Branch).Set(1)
+
+	prometheus.MustRegister(buildInfo)
 }


### PR DESCRIPTION
There is more build information that could be put into labels, but
Version, Revision, and Branch seemed like the right level of detail to
me.