### PR TITLE
web: Fix regression in .Path

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -244,7 +245,7 @@ func (h *Handler) consoles(w http.ResponseWriter, r *http.Request) {
 	}{
 		RawParams: rawParams,
 		Params:    params,
-		Path:      name,
+		Path:      strings.TrimLeft(name, "/"),
 	}
 
 	tmpl := template.NewTemplateExpander(string(text), "__console_"+name, data, clientmodel.Now(), h.queryEngine, h.options.ExternalURL.Path)


### PR DESCRIPTION
.Path is documented as removing /consoles/,
recent changes added in a leading / which broke
the provided console templates menu system.