### PR TITLE
storage: Fix float->uint conversions on some compilers.

### DIFF
--- a/storage/local/delta.go
+++ b/storage/local/delta.go
@@ -156,11 +156,11 @@ func (c deltaEncodedChunk) add(s *metric.SamplePair) []chunk {
 		case d0:
 			// No-op. Constant value is stored as base value.
 		case d1:
-			c[offset] = byte(dv)
+			c[offset] = byte(int8(dv))
 		case d2:
-			binary.LittleEndian.PutUint16(c[offset:], uint16(dv))
+			binary.LittleEndian.PutUint16(c[offset:], uint16(int16(dv)))
 		case d4:
-			binary.LittleEndian.PutUint32(c[offset:], uint32(dv))
+			binary.LittleEndian.PutUint32(c[offset:], uint32(int32(dv)))
 		// d8 must not happen. Those samples are encoded as float64.
 		default:
 			panic("invalid number of bytes for integer delta")

--- a/storage/local/doubledelta.go
+++ b/storage/local/doubledelta.go
@@ -164,11 +164,11 @@ func (c doubleDeltaEncodedChunk) add(s *metric.SamplePair) []chunk {
 		case d0:
 			// No-op. Constant delta is stored as base value.
 		case d1:
-			c[offset] = byte(ddv)
+			c[offset] = byte(int8(ddv))
 		case d2:
-			binary.LittleEndian.PutUint16(c[offset:], uint16(ddv))
+			binary.LittleEndian.PutUint16(c[offset:], uint16(int16(ddv)))
 		case d4:
-			binary.LittleEndian.PutUint32(c[offset:], uint32(ddv))
+			binary.LittleEndian.PutUint32(c[offset:], uint32(int32(ddv)))
 		// d8 must not happen. Those samples are encoded as float64.
 		default:
 			panic("invalid number of bytes for integer delta")


### PR DESCRIPTION
See https://github.com/prometheus/prometheus/issues/887, which will at
least be partially fixed by this.

From the spec https://golang.org/ref/spec#Conversions:

"In all non-constant conversions involving floating-point or complex
values, if the result type cannot represent the value the conversion
succeeds but the result value is implementation-dependent."

This ended up setting the converted values to 0 on Debian's Go 1.4.2
compiler, at least on 32-bit Debians.