### PR TITLE
add port omitted host header for scrape client

### DIFF
--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -348,6 +348,7 @@ func (t *Target) scrape(sampleAppender storage.SampleAppender) (err error) {
 		panic(err)
 	}
 	req.Header.Add("Accept", acceptHeader)
+	req.Host = t.hostHeader()
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -419,6 +420,18 @@ func (t *Target) URL() *url.URL {
 	u := &url.URL{}
 	*u = *t.url
 	return u
+}
+
+// URLHostHeader returns the Host part of an URL without ports
+func (t *Target) hostHeader() string {
+	parts := strings.SplitN(t.url.Host, ":", 2)
+
+	// If 2 parts wasn't found, return the original value
+	if len(parts) != 2 {
+		return t.url.Host
+	}
+
+	return parts[0]
 }
 
 // InstanceIdentifier returns the identifier for the target.

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -31,6 +31,38 @@ import (
 	"github.com/prometheus/prometheus/util/httputil"
 )
 
+func TestHostHeader(t *testing.T) {
+	type test struct {
+		target   *Target
+		wantHost string
+	}
+
+	tests := []test{
+		{
+			target:   newTestTarget("example.com:80", 0, nil),
+			wantHost: "example.com",
+		},
+		{
+			target:   newTestTarget("example.com:443", 0, nil),
+			wantHost: "example.com",
+		},
+		{
+			target:   newTestTarget("example.com", 0, nil),
+			wantHost: "example.com",
+		},
+		{
+			target:   newTestTarget("http://example.com:443/test", 0, nil),
+			wantHost: "example.com",
+		},
+	}
+
+	for _, test := range tests {
+		if test.target.hostHeader() != test.wantHost {
+			t.Errorf("want host header %v, got %v", test.wantHost, test.target.hostHeader)
+		}
+	}
+}
+
 func TestBaseLabels(t *testing.T) {
 	target := newTestTarget("example.com:80", 0, clientmodel.LabelSet{"job": "some_job", "foo": "bar"})
 	want := clientmodel.LabelSet{


### PR DESCRIPTION
This adds the host header for the target when scraping an url as a port
omitted host name. For example, for "example.com:80" will be "example.com".

The problem that this commit is trying to solve is when having a scrape URL
behind a proxy that uses the host header for load balancing the header will be
incorrect.

ping @juliusv 

Thanks!