### PR TITLE
Kubernetes discovery

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -174,6 +174,26 @@ var expectedConf = &Config{
 			},
 			BearerToken: "avalidtoken",
 		},
+		{
+			JobName: "service-kubernetes",
+
+			ScrapeInterval: Duration(15 * time.Second),
+			ScrapeTimeout:  DefaultGlobalConfig.ScrapeTimeout,
+
+			MetricsPath: DefaultScrapeConfig.MetricsPath,
+			Scheme:      DefaultScrapeConfig.Scheme,
+
+			KubernetesSDConfigs: []*KubernetesSDConfig{
+				{
+					Server:         "https://localhost:1234/",
+					Username:       "myusername",
+					Password:       "mypassword",
+					KubeletPort:    10255,
+					RequestTimeout: Duration(10 * time.Second),
+					RetryInterval:  Duration(1 * time.Second),
+				},
+			},
+		},
 	},
 	original: "",
 }
@@ -189,10 +209,12 @@ func TestLoadConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error parsing %s: %s", "testdata/conf.good.yml", err)
 	}
+
 	bgot, err := yaml.Marshal(c)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
+
 	bexp, err := yaml.Marshal(expectedConf)
 	if err != nil {
 		t.Fatalf("%s", err)

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -99,3 +99,10 @@ scrape_configs:
     key: valid_key_file
 
   bearer_token: avalidtoken
+
+- job_name: service-kubernetes
+
+  kubernetes_sd_configs:
+  - server: 'https://localhost:1234'
+    username: 'myusername'
+    password: 'mypassword'

--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -1,0 +1,33 @@
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 15s # By default, scrape targets every 15 seconds.
+  scrape_timeout: 10s
+
+scrape_configs:
+- job_name: 'kubernetes'
+
+  kubernetes_sd_configs:
+  - server: 'https://kubernetes.default.svc'
+    in_cluster: true
+
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_node, __meta_kubernetes_service_annotation_prometheus_io_scrape]
+    action: keep
+    regex: ^(?:.+;|;true)$
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    action: replace
+    target_label: __scheme__
+    regex: ^(https?)$
+    replacement: $1
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    action: replace
+    target_label: __metrics_path__
+    regex: ^(.+)$
+    replacement: $1
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    action: replace
+    target_label: __address__
+    regex: ^(.+)(?::\d+);(\d+)$
+    replacement: $1:$2

--- a/retrieval/discovery/kubernetes.go
+++ b/retrieval/discovery/kubernetes.go
@@ -1,0 +1,30 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/retrieval/discovery/kubernetes"
+)
+
+func NewKubernetesDiscovery(conf *config.KubernetesSDConfig) (*kubernetes.KubernetesDiscovery, error) {
+	kd := &kubernetes.KubernetesDiscovery{
+		Conf: conf,
+	}
+	err := kd.Initialize()
+	if err != nil {
+		return nil, err
+	}
+	return kd, nil
+}

--- a/retrieval/discovery/kubernetes/types.go
+++ b/retrieval/discovery/kubernetes/types.go
@@ -1,0 +1,210 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+type EventType string
+
+const (
+	added    EventType = "ADDED"
+	modified EventType = "MODIFIED"
+	deleted  EventType = "DELETED"
+)
+
+type nodeEvent struct {
+	EventType EventType `json:"type"`
+	Node      *Node     `json:"object"`
+}
+
+type serviceEvent struct {
+	EventType EventType `json:"type"`
+	Service   *Service  `json:"object"`
+}
+
+type endpointsEvent struct {
+	EventType EventType  `json:"type"`
+	Endpoints *Endpoints `json:"object"`
+}
+
+// From here down types are copied from
+// https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/api/v1/types.go
+// with all currently irrelevant types/fields stripped out. This removes the
+// need for any kubernetes dependencies, with the drawback of having to keep
+// this file up to date.
+
+// ListMeta describes metadata that synthetic resources must have, including lists and
+// various status objects.
+type ListMeta struct {
+	// An opaque value that represents the version of this response for use with optimistic
+	// concurrency and change monitoring endpoints.  Clients must treat these values as opaque
+	// and values may only be valid for a particular resource or set of resources. Only servers
+	// will generate resource versions.
+	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"`
+}
+
+// ObjectMeta is metadata that all persisted resources must have, which includes all objects
+// users must create.
+type ObjectMeta struct {
+	// Name is unique within a namespace.  Name is required when creating resources, although
+	// some resources may allow a client to request the generation of an appropriate name
+	// automatically. Name is primarily intended for creation idempotence and configuration
+	// definition.
+	Name string `json:"name,omitempty" description:"string that identifies an object. Must be unique within a namespace; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"`
+
+	// Namespace defines the space within which name must be unique. An empty namespace is
+	// equivalent to the "default" namespace, but "default" is the canonical representation.
+	// Not all objects are required to be scoped to a namespace - the value of this field for
+	// those objects will be empty.
+	Namespace string `json:"namespace,omitempty" description:"namespace of the object; must be a DNS_LABEL; cannot be updated; see http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md"`
+
+	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"`
+
+	// TODO: replace map[string]string with labels.LabelSet type
+	Labels map[string]string `json:"labels,omitempty" description:"map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services; see http://releases.k8s.io/HEAD/docs/user-guide/labels.md"`
+
+	// Annotations are unstructured key value data stored with a resource that may be set by
+	// external tooling. They are not queryable and should be preserved when modifying
+	// objects.
+	Annotations map[string]string `json:"annotations,omitempty" description:"map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects; see http://releases.k8s.io/HEAD/docs/user-guide/annotations.md"`
+}
+
+// Protocol defines network protocols supported for things like conatiner ports.
+type Protocol string
+
+const (
+	// ProtocolTCP is the TCP protocol.
+	ProtocolTCP Protocol = "TCP"
+	// ProtocolUDP is the UDP protocol.
+	ProtocolUDP Protocol = "UDP"
+)
+
+const (
+	// NamespaceAll is the default argument to specify on a context when you want to list or filter resources across all namespaces
+	NamespaceAll string = ""
+)
+
+// Container represents a single container that is expected to be run on the host.
+type Container struct {
+	// Required: This must be a DNS_LABEL.  Each container in a pod must
+	// have a unique name.
+	Name string `json:"name" description:"name of the container; must be a DNS_LABEL and unique within the pod; cannot be updated"`
+	// Optional.
+	Image string `json:"image,omitempty" description:"Docker image name; see http://releases.k8s.io/HEAD/docs/user-guide/images.md"`
+}
+
+// Service is a named abstraction of software service (for example, mysql) consisting of local port
+// (for example 3306) that the proxy listens on, and the selector that determines which pods
+// will answer requests sent through the proxy.
+type Service struct {
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
+}
+
+// ServiceList holds a list of services.
+type ServiceList struct {
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
+
+	Items []Service `json:"items" description:"list of services"`
+}
+
+// Endpoints is a collection of endpoints that implement the actual service.  Example:
+//   Name: "mysvc",
+//   Subsets: [
+//     {
+//       Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+//       Ports: [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+//     },
+//     {
+//       Addresses: [{"ip": "10.10.3.3"}],
+//       Ports: [{"name": "a", "port": 93}, {"name": "b", "port": 76}]
+//     },
+//  ]
+type Endpoints struct {
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
+
+	// The set of all endpoints is the union of all subsets.
+	Subsets []EndpointSubset `json:"subsets" description:"sets of addresses and ports that comprise a service"`
+}
+
+// EndpointSubset is a group of addresses with a common set of ports.  The
+// expanded set of endpoints is the Cartesian product of Addresses x Ports.
+// For example, given:
+//   {
+//     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+//     Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+//   }
+// The resulting set of endpoints can be viewed as:
+//     a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],
+//     b: [ 10.10.1.1:309, 10.10.2.2:309 ]
+type EndpointSubset struct {
+	Addresses []EndpointAddress `json:"addresses,omitempty" description:"IP addresses which offer the related ports"`
+	Ports     []EndpointPort    `json:"ports,omitempty" description:"port numbers available on the related IP addresses"`
+}
+
+// EndpointAddress is a tuple that describes single IP address.
+type EndpointAddress struct {
+	// The IP of this endpoint.
+	// TODO: This should allow hostname or IP, see #4447.
+	IP string `json:"ip" description:"IP address of the endpoint"`
+}
+
+// EndpointPort is a tuple that describes a single port.
+type EndpointPort struct {
+	// The port number.
+	Port int `json:"port" description:"port number of the endpoint"`
+
+	// The IP protocol for this port.
+	Protocol Protocol `json:"protocol,omitempty" description:"protocol for this port; must be UDP or TCP; TCP if unspecified"`
+}
+
+// EndpointsList is a list of endpoints.
+type EndpointsList struct {
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
+
+	Items []Endpoints `json:"items" description:"list of endpoints"`
+}
+
+// NodeStatus is information about the current status of a node.
+type NodeStatus struct {
+	// Queried from cloud provider, if available.
+	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node; see http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses" patchStrategy:"merge" patchMergeKey:"type"`
+}
+
+type NodeAddressType string
+
+// These are valid address type of node.
+const (
+	NodeHostName   NodeAddressType = "Hostname"
+	NodeExternalIP NodeAddressType = "ExternalIP"
+	NodeInternalIP NodeAddressType = "InternalIP"
+)
+
+type NodeAddress struct {
+	Type    NodeAddressType `json:"type" description:"node address type, one of Hostname, ExternalIP or InternalIP"`
+	Address string          `json:"address" description:"the node address"`
+}
+
+// Node is a worker node in Kubernetes, formerly known as minion.
+// Each node will have a unique identifier in the cache (i.e. in etcd).
+type Node struct {
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
+
+	// Status describes the current status of a Node
+	Status NodeStatus `json:"status,omitempty" description:"most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"`
+}
+
+// NodeList is the whole list of all Nodes which have been registered with master.
+type NodeList struct {
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
+
+	Items []Node `json:"items" description:"list of nodes"`
+}

--- a/retrieval/discovery/serverset.go
+++ b/retrieval/discovery/serverset.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -28,6 +27,7 @@ import (
 	clientmodel "github.com/prometheus/client_golang/model"
 
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/util/strutil"
 )
 
 const (
@@ -37,10 +37,6 @@ const (
 	serversetStatusLabel         = serversetLabelPrefix + "status"
 	serversetPathLabel           = serversetLabelPrefix + "path"
 	serversetEndpointLabelPrefix = serversetLabelPrefix + "endpoint"
-)
-
-var (
-	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 )
 
 type serversetMember struct {
@@ -176,7 +172,7 @@ func parseServersetMember(data []byte, path string) (*clientmodel.LabelSet, erro
 	labels[serversetEndpointLabelPrefix+"_port"] = clientmodel.LabelValue(fmt.Sprintf("%d", member.ServiceEndpoint.Port))
 
 	for name, endpoint := range member.AdditionalEndpoints {
-		cleanName := clientmodel.LabelName(invalidLabelCharRE.ReplaceAllString(name, "_"))
+		cleanName := clientmodel.LabelName(strutil.SanitizeLabelName(name))
 		labels[serversetEndpointLabelPrefix+"_host_"+cleanName] = clientmodel.LabelValue(
 			endpoint.Host)
 		labels[serversetEndpointLabelPrefix+"_port_"+cleanName] = clientmodel.LabelValue(

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -223,9 +223,6 @@ func (t *Target) Update(cfg *config.ScrapeConfig, baseLabels, metaLabels clientm
 		}
 	}
 	t.url.RawQuery = params.Encode()
-	if cfg.BasicAuth != nil {
-		t.url.User = url.UserPassword(cfg.BasicAuth.Username, cfg.BasicAuth.Password)
-	}
 
 	t.scrapeInterval = time.Duration(cfg.ScrapeInterval)
 	t.deadline = time.Duration(cfg.ScrapeTimeout)
@@ -290,6 +287,10 @@ func newHTTPClient(cfg *config.ScrapeConfig) (*http.Client, error) {
 	}
 	if len(bearerToken) > 0 {
 		rt = httputil.NewBearerAuthRoundTripper(bearerToken, rt)
+	}
+
+	if cfg.BasicAuth != nil {
+		rt = httputil.NewBasicAuthRoundTripper(cfg.BasicAuth.Username, cfg.BasicAuth.Password, rt)
 	}
 
 	// Return a new client with the configured round tripper.

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -359,6 +359,14 @@ func providersFromConfig(cfg *config.ScrapeConfig) []TargetProvider {
 	for i, c := range cfg.MarathonSDConfigs {
 		app("marathon", i, discovery.NewMarathonDiscovery(c))
 	}
+	for i, c := range cfg.KubernetesSDConfigs {
+		k, err := discovery.NewKubernetesDiscovery(c)
+		if err != nil {
+			log.Errorf("Cannot create Kubernetes discovery: %s", err)
+			continue
+		}
+		app("kubernetes", i, k)
+	}
 	for i, c := range cfg.ServersetSDConfigs {
 		app("serverset", i, discovery.NewServersetDiscovery(c))
 	}

--- a/util/httputil/client.go
+++ b/util/httputil/client.go
@@ -74,6 +74,27 @@ func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 	return rt.rt.RoundTrip(req)
 }
 
+type basicAuthRoundTripper struct {
+	username string
+	password string
+	rt       http.RoundTripper
+}
+
+// NewBasicAuthRoundTripper will apply a BASIC auth authorization header to a request unless it has
+// already been set.
+func NewBasicAuthRoundTripper(username, password string, rt http.RoundTripper) http.RoundTripper {
+	return &basicAuthRoundTripper{username, password, rt}
+}
+
+func (rt *basicAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(req.Header.Get("Authorization")) != 0 {
+		return rt.rt.RoundTrip(req)
+	}
+	req = cloneRequest(req)
+	req.SetBasicAuth(rt.username, rt.password)
+	return rt.rt.RoundTrip(req)
+}
+
 // cloneRequest returns a clone of the provided *http.Request.
 // The clone is a shallow copy of the struct and its Header map.
 func cloneRequest(r *http.Request) *http.Request {

--- a/util/strutil/strconv.go
+++ b/util/strutil/strconv.go
@@ -22,7 +22,10 @@ import (
 	"time"
 )
 
-var durationRE = regexp.MustCompile("^([0-9]+)([ywdhms]+)$")
+var (
+	durationRE         = regexp.MustCompile("^([0-9]+)([ywdhms]+)$")
+	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+)
 
 // DurationToString formats a time.Duration as a string with the assumption that
 // a year always has 365 days and a day always has 24h. (The former doesn't work
@@ -102,4 +105,10 @@ func TableLinkForExpression(expr string) string {
 func GraphLinkForExpression(expr string) string {
 	urlData := url.QueryEscape(fmt.Sprintf(`[{"expr":%q,"tab":0}]`, expr))
 	return fmt.Sprintf("/graph#%s", strings.Replace(urlData, "+", "%20", -1))
+}
+
+// SanitizeLabelName replaces anything that doesn't match
+// client_label.LabelNameRE with an underscore.
+func SanitizeLabelName(name string) string {
+	return invalidLabelCharRE.ReplaceAllString(name, "_")
 }


### PR DESCRIPTION
As discussed in #904. This initial implementation adds in node discovery which scrapes pod/container metrics from all nodes in the cluster.

Would love feedback please. Missing tests, although I guess only place that I can add them easily is to the config parsing? Oh & documentation.

Sorry about the amount of godeps required - not sure of how to avoid that if that's a problem? Certainly makes the PR harder to review. If you have a better way to add these deps in please let me know.