### PR TITLE
Fix /debug/pprof endpoint with new web router.

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -171,6 +171,8 @@ func New(st local.Storage, qe *promql.Engine, rm *rules.Manager, status *Prometh
 		router.Post("/-/quit", h.quit)
 	}
 
+	router.Get("/debug/*subpath", http.DefaultServeMux.ServeHTTP)
+
 	return h
 }
 


### PR DESCRIPTION
This got broken in
https://github.com/prometheus/prometheus/commit/78047326b487fcfccb25fbaaa2fb5c13397ad97b
since it stopped using the DefaultServeMux.

This approach will defer pprof requests to the DefaultServeMux, which
may or may not have pprof enabled (in Prometheus, it gets it included in
main.go). An alternative approach would be to duplicate the four lines in
https://golang.org/src/net/http/pprof/pprof.go#L62. When choosing that
approach though, we would not automatically gain any new endpoints added
by net/http/pprof in the future.