### PR TITLE
Revert "Use Consul ServiceAddress instead of Address when set"

### DIFF
--- a/retrieval/discovery/consul.go
+++ b/retrieval/discovery/consul.go
@@ -259,10 +259,6 @@ func (cd *ConsulDiscovery) watchService(srv *consulService, ch chan<- *config.Ta
 
 		for _, node := range nodes {
 			addr := fmt.Sprintf("%s:%d", node.Address, node.ServicePort)
-			// Use ServiceAddress instead of Address if not empty.
-			if len(node.ServiceAddress) > 0 {
-				addr = fmt.Sprintf("%s:%d", node.ServiceAddress, node.ServicePort)
-			}
 			// We surround the separated list with the separator as well. This way regular expressions
 			// in relabeling rules don't have to consider tag positions.
 			tags := cd.tagSeparator + strings.Join(node.ServiceTags, cd.tagSeparator) + cd.tagSeparator


### PR DESCRIPTION
This reverts commit 0ac7e7217e28dd165787b80219f6085c8d97f814.

See discussion on https://github.com/prometheus/prometheus/pull/812 for
reasoning. While fixing one use case, it breaks others, and we need a
more generic way of handling this.