### PR TITLE
Retrieval: Make it possible to relabel query params

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -44,23 +44,19 @@
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/extraction",
-			"Comment": "0.7.0",
-			"Rev": "6dbab8106ed3ed77359ac85d9cf08e30290df864"
+			"Rev": "3a499bf7fc46bc58337ce612d0cbb29c550b8118"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/model",
-			"Comment": "0.7.0",
-			"Rev": "6dbab8106ed3ed77359ac85d9cf08e30290df864"
+			"Rev": "3a499bf7fc46bc58337ce612d0cbb29c550b8118"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/prometheus",
-			"Comment": "0.7.0",
-			"Rev": "6dbab8106ed3ed77359ac85d9cf08e30290df864"
+			"Rev": "3a499bf7fc46bc58337ce612d0cbb29c550b8118"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/text",
-			"Comment": "0.7.0",
-			"Rev": "6dbab8106ed3ed77359ac85d9cf08e30290df864"
+			"Rev": "3a499bf7fc46bc58337ce612d0cbb29c550b8118"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_model/go",

--- a/Godeps/_workspace/src/github.com/prometheus/client_golang/model/labelname.go
+++ b/Godeps/_workspace/src/github.com/prometheus/client_golang/model/labelname.go
@@ -46,6 +46,10 @@ const (
 	// will not be attached to time series.
 	MetaLabelPrefix = "__meta_"
 
+	// ParamLabelPrefix is a prefix for labels that provide URL parameters
+	// used to scrape a target.
+	ParamLabelPrefix = "__param_"
+
 	// JobLabel is the label name indicating the job from which a timeseries
 	// was scraped.
 	JobLabel LabelName = "job"

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -197,10 +197,24 @@ func (t *Target) Update(cfg *config.ScrapeConfig, baseLabels, metaLabels clientm
 
 	t.url.Scheme = cfg.Scheme
 	t.url.Path = string(baseLabels[clientmodel.MetricsPathLabel])
+	params := url.Values{}
+	for k, v := range cfg.Params {
+		params[k] = make([]string, len(v))
+		copy(params[k], v)
+	}
+	for k, v := range baseLabels {
+		if strings.HasPrefix(string(k), clientmodel.ParamLabelPrefix) {
+			if len(params[string(k[len(clientmodel.ParamLabelPrefix):])]) > 0 {
+				params[string(k[len(clientmodel.ParamLabelPrefix):])][0] = string(v)
+			} else {
+				params[string(k[len(clientmodel.ParamLabelPrefix):])] = []string{string(v)}
+			}
+		}
+	}
+	t.url.RawQuery = params.Encode()
 	if cfg.BasicAuth != nil {
 		t.url.User = url.UserPassword(cfg.BasicAuth.Username, cfg.BasicAuth.Password)
 	}
-	t.url.RawQuery = cfg.Params.Encode()
 
 	t.scrapeInterval = time.Duration(cfg.ScrapeInterval)
 	t.deadline = time.Duration(cfg.ScrapeTimeout)

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -329,6 +329,11 @@ func (tm *TargetManager) targetsFromGroup(tg *config.TargetGroup, cfg *config.Sc
 			}
 			labels[clientmodel.AddressLabel] = clientmodel.LabelValue(addr)
 		}
+		for k, v := range cfg.Params {
+			if len(v) > 0 {
+				labels[clientmodel.LabelName(clientmodel.ParamLabelPrefix+k)] = clientmodel.LabelValue(v[0])
+			}
+		}
 		// Copy labels into the labelset for the target if they are not
 		// set already. Apply the labelsets in order of decreasing precedence.
 		labelsets := []clientmodel.LabelSet{


### PR DESCRIPTION
This is breaking in that:
a) it's no longer possible to specify multiple query params
for the same name, which also means a config format change
b) query param names must be valid label names
Neither of these are expected to be issues in practice.