### PR TITLE
promql: Add support for predict(my_timeseries[1h], 2h)

### DIFF
--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -62,3 +62,33 @@ load 5m
 eval instant at 50m increase(http_requests[50m])
 	{path="/foo"} 100
 	{path="/bar"}  90
+
+
+clear
+
+# Tests for deriv() and predict_linear().
+load 5m
+	testcounter_reset_middle	0+10x4 0+10x5
+	http_requests{job="app-server", instance="1", group="canary"}		0+80x10
+
+# Deriv should return the same as rate in simple cases.
+eval instant at 50m rate(http_requests{group="canary", instance="1", job="app-server"}[60m])
+	{group="canary", instance="1", job="app-server"} 0.26666666666666666
+
+eval instant at 50m deriv(http_requests{group="canary", instance="1", job="app-server"}[60m])
+	{group="canary", instance="1", job="app-server"} 0.26666666666666666
+
+# Deriv should return correct result.
+eval instant at 50m deriv(testcounter_reset_middle[100m])
+	{} 0.010606060606060607
+
+# Predict_linear should return correct result.
+eval instant at 50m predict_linear(testcounter_reset_middle[100m], 3600)
+	{} 88.181818181818185200
+
+# Predict_linear is syntactic sugar around deriv.
+eval instant at 50m predict_linear(http_requests[50m], 3600) - (http_requests + deriv(http_requests[50m]) * 3600)
+	{group="canary", instance="1", job="app-server"} 0
+
+eval instant at 50m predict_linear(testcounter_reset_middle[100m], 3600) - (testcounter_reset_middle + deriv(testcounter_reset_middle[100m]) * 3600)
+	{} 0

--- a/promql/testdata/legacy.test
+++ b/promql/testdata/legacy.test
@@ -238,10 +238,6 @@ eval instant at 50m delta(http_requests{group="canary", instance="1", job="app-s
 eval instant at 50m rate(http_requests{group="canary", instance="1", job="app-server"}[60m])
 	{group="canary", instance="1", job="app-server"} 0.26666666666666666
 
-# Deriv should return the same as rate in simple cases.
-eval instant at 50m deriv(http_requests{group="canary", instance="1", job="app-server"}[60m])
-	{group="canary", instance="1", job="app-server"} 0.26666666666666666
-
 # Counter resets at in the middle of range are handled correctly by rate().
 eval instant at 50m rate(testcounter_reset_middle[60m])
 	{} 0.03
@@ -250,10 +246,6 @@ eval instant at 50m rate(testcounter_reset_middle[60m])
 # Counter resets at end of range are ignored by rate().
 eval instant at 50m rate(testcounter_reset_end[5m])
 	{} 0
-
-# Deriv should return correct result.
-eval instant at 50m deriv(testcounter_reset_middle[100m])
-	{} 0.010606060606060607
 
 # count_scalar for a non-empty vector should return scalar element count.
 eval instant at 50m count_scalar(http_requests)


### PR DESCRIPTION
This will give a prediction for the value of my_timeseries in 2 hours,
based on the last hour of data.

@juliusv 