### PR TITLE
consul port label

### DIFF
--- a/retrieval/discovery/consul.go
+++ b/retrieval/discovery/consul.go
@@ -16,6 +16,7 @@ package discovery
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -275,7 +276,7 @@ func (cd *ConsulDiscovery) watchService(srv *consulService, ch chan<- *config.Ta
 				ConsulNodeLabel:           clientmodel.LabelValue(node.Node),
 				ConsulTagsLabel:           clientmodel.LabelValue(tags),
 				ConsulServiceAddressLabel: clientmodel.LabelValue(node.ServiceAddress),
-				ConsulServicePortLabel:    clientmodel.LabelValue(node.ServicePort),
+				ConsulServicePortLabel:    clientmodel.LabelValue(strconv.Itoa(node.ServicePort)),
 			})
 		}
 


### PR DESCRIPTION
I found a problem while trying to relabel a target from consul. The port seem to be some random string and not the numeric port (see attached screenshot).
![screenshot 2015-07-31 18 17 05](https://cloud.githubusercontent.com/assets/199681/9011946/3791f88c-37b1-11e5-9c84-de7f61746e85.png)

My config:

```yaml
scrape_configs:
- job_name: cadvisor
  consul_sd_configs:
  - server: 'consul:8500'
    services: ['cadvisor']

  # relabel address to use ServiceAddress instead of Address
  relabel_configs:
  - target_label: __address__
    source_labels: ['__meta_consul_service_address', '__meta_consul_service_port']
    separator: ':'
    regex: '.*'
    replacement: '${0}'
```

I tried to fix it with a simple int to string conversion and it works for me. I hope it doesn't break things this time ;)