### PR TITLE
Resolve relative paths on configuration loading

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -170,7 +170,7 @@ type Reloadable interface {
 func reloadConfig(filename string, rls ...Reloadable) bool {
 	log.Infof("Loading configuration file %s", filename)
 
-	conf, err := config.LoadFromFile(filename)
+	conf, err := config.LoadFile(filename)
 	if err != nil {
 		log.Errorf("Couldn't load configuration (-config.file=%s): %v", filename, err)
 		log.Errorf("Note: The configuration format has changed with version 0.14. Please see the documentation (http://prometheus.io/docs/operating/configuration/) and the provided configuration migration tool (https://github.com/prometheus/migrate).")

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -21,7 +21,6 @@ import (
 	_ "net/http/pprof" // Comment this line to disable pprof endpoint.
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"text/template"
@@ -77,7 +76,6 @@ func Main() int {
 		NotificationHandler: notificationHandler,
 		QueryEngine:         queryEngine,
 		ExternalURL:         cfg.web.ExternalURL,
-		BaseDir:             filepath.Dir(cfg.configFile),
 	})
 
 	flags := map[string]string{}

--- a/config/config.go
+++ b/config/config.go
@@ -40,8 +40,8 @@ func Load(s string) (*Config, error) {
 	return cfg, nil
 }
 
-// LoadFromFile parses the given YAML file into a Config.
-func LoadFromFile(filename string) (*Config, error) {
+// LoadFile parses the given YAML file into a Config.
+func LoadFile(filename string) (*Config, error) {
 	content, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -181,11 +181,11 @@ var expectedConf = &Config{
 func TestLoadConfig(t *testing.T) {
 	// Parse a valid file that sets a global scrape timeout. This tests whether parsing
 	// an overwritten default field in the global config permanently changes the default.
-	if _, err := LoadFromFile("testdata/global_timeout.good.yml"); err != nil {
+	if _, err := LoadFile("testdata/global_timeout.good.yml"); err != nil {
 		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
 	}
 
-	c, err := LoadFromFile("testdata/conf.good.yml")
+	c, err := LoadFile("testdata/conf.good.yml")
 	if err != nil {
 		t.Fatalf("Error parsing %s: %s", "testdata/conf.good.yml", err)
 	}
@@ -252,7 +252,7 @@ var expectedErrors = []struct {
 
 func TestBadConfigs(t *testing.T) {
 	for _, ee := range expectedErrors {
-		_, err := LoadFromFile("testdata/" + ee.filename)
+		_, err := LoadFile("testdata/" + ee.filename)
 		if err == nil {
 			t.Errorf("Expected error parsing %s but got none", ee.filename)
 			continue

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,9 +27,9 @@ var expectedConf = &Config{
 	},
 
 	RuleFiles: []string{
-		"first.rules",
-		"second.rules",
-		"my/*.rules",
+		"testdata/first.rules",
+		"/absolute/second.rules",
+		"testdata/my/*.rules",
 	},
 
 	ScrapeConfigs: []*ScrapeConfig{
@@ -42,6 +42,8 @@ var expectedConf = &Config{
 
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
+
+			BearerTokenFile: "testdata/valid_token_file",
 
 			TargetGroups: []*TargetGroup{
 				{
@@ -167,8 +169,8 @@ var expectedConf = &Config{
 			Scheme:      "http",
 
 			ClientCert: &ClientCert{
-				Cert: "valid_cert_file",
-				Key:  "valid_key_file",
+				Cert: "testdata/valid_cert_file",
+				Key:  "testdata/valid_key_file",
 			},
 			BearerToken: "avalidtoken",
 		},

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -10,7 +10,7 @@ global:
 
 rule_files:
 - "first.rules"
-- "second.rules"
+- "/absolute/second.rules"
 - "my/*.rules"
 
 scrape_configs:
@@ -44,6 +44,8 @@ scrape_configs:
     target_label:  job
     replacement:   foo-${1}
     # action defaults to 'replace'
+
+  bearer_token_file: valid_token_file
 
 
 - job_name: service-x

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -104,7 +104,6 @@ type Manager struct {
 	notificationHandler *notification.NotificationHandler
 
 	externalURL *url.URL
-	baseDir     string
 }
 
 // ManagerOptions bundles options for the Manager.
@@ -116,7 +115,6 @@ type ManagerOptions struct {
 	SampleAppender      storage.SampleAppender
 
 	ExternalURL *url.URL
-	BaseDir     string
 }
 
 // NewManager returns an implementation of Manager, ready to be started
@@ -131,7 +129,6 @@ func NewManager(o *ManagerOptions) *Manager {
 		queryEngine:         o.QueryEngine,
 		notificationHandler: o.NotificationHandler,
 		externalURL:         o.ExternalURL,
-		baseDir:             o.BaseDir,
 	}
 	return manager
 }
@@ -330,10 +327,6 @@ func (m *Manager) ApplyConfig(conf *config.Config) bool {
 
 	var files []string
 	for _, pat := range conf.RuleFiles {
-		if !filepath.IsAbs(pat) {
-			pat = filepath.Join(m.baseDir, pat)
-		}
-
 		fs, err := filepath.Glob(pat)
 		if err != nil {
 			// The only error can be a bad pattern.


### PR DESCRIPTION
This moves the concern of resolving the files relative to the config
file into the configuration loading itself.
It also fixes #921 which did not load the cert and token files relatively.

@jimmidyson I missed the relative loading in my review, you could hardly know. Just be aware that this might break your setup.

@juliusv 