### PR TITLE
Improve unique target group sources.

### DIFF
--- a/retrieval/discovery/consul.go
+++ b/retrieval/discovery/consul.go
@@ -30,7 +30,6 @@ import (
 )
 
 const (
-	consulSourcePrefix  = "consul"
 	consulWatchTimeout  = 30 * time.Second
 	consulRetryInterval = 15 * time.Second
 
@@ -127,7 +126,7 @@ func (cd *ConsulDiscovery) Sources() []string {
 	srcs := make([]string, 0, len(srvs))
 	for name := range srvs {
 		if _, ok := cd.scrapedServices[name]; ok {
-			srcs = append(srcs, consulSourcePrefix+":"+name)
+			srcs = append(srcs, name)
 		}
 	}
 	return srcs
@@ -146,7 +145,7 @@ func (cd *ConsulDiscovery) Run(ch chan<- *config.TargetGroup) {
 			return
 		case srv := <-update:
 			if srv.removed {
-				ch <- &config.TargetGroup{Source: consulSourcePrefix + ":" + srv.name}
+				ch <- &config.TargetGroup{Source: srv.name}
 				break
 			}
 			// Launch watcher for the service.
@@ -221,7 +220,7 @@ func (cd *ConsulDiscovery) watchServices(update chan<- *consulService) {
 					tgroup: &config.TargetGroup{},
 					done:   make(chan struct{}, 1),
 				}
-				srv.tgroup.Source = consulSourcePrefix + ":" + name
+				srv.tgroup.Source = name
 				cd.services[name] = srv
 			}
 			srv.tgroup.Labels = clientmodel.LabelSet{

--- a/retrieval/discovery/dns.go
+++ b/retrieval/discovery/dns.go
@@ -32,8 +32,7 @@ import (
 const (
 	resolvConf = "/etc/resolv.conf"
 
-	dnsSourcePrefix = "dns"
-	DNSNameLabel    = clientmodel.MetaLabelPrefix + "dns_srv_name"
+	DNSNameLabel = clientmodel.MetaLabelPrefix + "dns_srv_name"
 
 	// Constants for instrumentation.
 	namespace = "prometheus"
@@ -123,7 +122,7 @@ func (dd *DNSDiscovery) Stop() {
 func (dd *DNSDiscovery) Sources() []string {
 	var srcs []string
 	for _, name := range dd.names {
-		srcs = append(srcs, dnsSourcePrefix+":"+name)
+		srcs = append(srcs, name)
 	}
 	return srcs
 }
@@ -174,7 +173,7 @@ func (dd *DNSDiscovery) refresh(name string, ch chan<- *config.TargetGroup) erro
 		})
 	}
 
-	tg.Source = dnsSourcePrefix + ":" + name
+	tg.Source = name
 	ch <- tg
 
 	return nil

--- a/retrieval/discovery/file.go
+++ b/retrieval/discovery/file.go
@@ -195,7 +195,7 @@ func (fd *FileDiscovery) refresh(ch chan<- *config.TargetGroup) {
 
 // fileSource returns a source ID for the i-th target group in the file.
 func fileSource(filename string, i int) string {
-	return fmt.Sprintf("file:%s:%d", filename, i)
+	return fmt.Sprintf("%s:%d", filename, i)
 }
 
 // Stop implements the TargetProvider interface.

--- a/retrieval/discovery/file_test.go
+++ b/retrieval/discovery/file_test.go
@@ -63,7 +63,7 @@ func testFileSD(t *testing.T, ext string) {
 		if _, ok := tg.Labels["foo"]; !ok {
 			t.Fatalf("Label not parsed")
 		}
-		if tg.String() != fmt.Sprintf("file:fixtures/_test%s:0", ext) {
+		if tg.String() != fmt.Sprintf("fixtures/_test%s:0", ext) {
 			t.Fatalf("Unexpected target group", tg)
 		}
 	}
@@ -71,7 +71,7 @@ func testFileSD(t *testing.T, ext string) {
 	case <-time.After(15 * time.Second):
 		t.Fatalf("Expected new target group but got none")
 	case tg := <-ch:
-		if tg.String() != fmt.Sprintf("file:fixtures/_test%s:1", ext) {
+		if tg.String() != fmt.Sprintf("fixtures/_test%s:1", ext) {
 			t.Fatalf("Unexpected target group %s", tg)
 		}
 	}

--- a/retrieval/discovery/marathon/conversion.go
+++ b/retrieval/discovery/marathon/conversion.go
@@ -67,7 +67,7 @@ func isValidApp(app *App) bool {
 }
 
 func targetGroupName(app *App) string {
-	return fmt.Sprintf("marathon:%s", sanitizeName(app.ID))
+	return sanitizeName(app.ID)
 }
 
 func sanitizeName(id string) string {

--- a/retrieval/discovery/marathon/url.go
+++ b/retrieval/discovery/marathon/url.go
@@ -7,9 +7,10 @@ import (
 
 const appListPath string = "/v2/apps/?embed=apps.tasks"
 
-// RandomAppsURL randomly selects a server from an array and creates an URL pointing to the app list.
+// RandomAppsURL randomly selects a server from an array and creates
+// an URL pointing to the app list.
 func RandomAppsURL(servers []string) string {
-	// TODO If possible update server list from Marathon at some point
+	// TODO: If possible update server list from Marathon at some point.
 	server := servers[rand.Intn(len(servers))]
 	return fmt.Sprintf("%s%s", server, appListPath)
 }

--- a/retrieval/discovery/marathon_test.go
+++ b/retrieval/discovery/marathon_test.go
@@ -84,7 +84,7 @@ func TestMarathonSDSendGroup(t *testing.T) {
 	go func() {
 		select {
 		case tg := <-ch:
-			if tg.Source != "marathon:test-service" {
+			if tg.Source != "test-service" {
 				t.Fatalf("Wrong target group name: %s", tg.Source)
 			}
 			if len(tg.Targets) != 1 {

--- a/retrieval/discovery/serverset.go
+++ b/retrieval/discovery/serverset.go
@@ -31,8 +31,6 @@ import (
 )
 
 const (
-	serversetSourcePrefix = "serverset"
-
 	serversetNodePrefix = "member_"
 
 	serversetLabelPrefix         = clientmodel.MetaLabelPrefix + "serverset_"
@@ -112,7 +110,7 @@ func (sd *ServersetDiscovery) processUpdates() {
 	defer sd.conn.Close()
 	for event := range sd.updates {
 		tg := &config.TargetGroup{
-			Source: serversetSourcePrefix + event.Path,
+			Source: event.Path,
 		}
 		sd.mu.Lock()
 		if event.Data != nil {


### PR DESCRIPTION
This includes the position of the SD mechanism into the unique source string. Logic for ensuring uniqueness was removed from the SD implementations (they now only have to ensure uniqueness within the target groups they expose themselves). It was also removed from the target manager which now assumes uniqueness across the target providers.

The behavior is now encapsulated in the `prefixedTargetProvider` and the `providersFromConfig`.

@juliusv 

Will be rebased on top of #902 