### PR TITLE
[WIP/RFC]Adding a simple Basic Authentication mechanism.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -91,6 +91,10 @@
 		{
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "7ad95dd0798a40da1ccdff6dff35fd177b5edf40"
-		}
+		},
+                {
+                        "ImportPath": "github.com/abbot/go-http-auth",
+                        "Rev": "46b96277a30605aa35da613039628d71eab707d2"
+                }
 	]
 }

--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -73,6 +73,17 @@ func init() {
 		&cfg.web.ListenAddress, "web.listen-address", ":9090",
 		"Address to listen on for the web interface, API, and telemetry.",
 	)
+
+	cfg.fs.BoolVar(
+		&cfg.web.AuthEnabled, "web.auth-enabled", false,
+		"Enable simple Authentication for web")
+
+	cfg.fs.StringVar(&cfg.web.BasicAuthUsername, "web.basicauth.username", "",
+		"Username to allow")
+
+	cfg.fs.StringVar(&cfg.web.BasicAuthPassword, "web.basicauth.password", "",
+		"Password to allow")
+
 	cfg.fs.StringVar(
 		&cfg.prometheusURL, "web.external-url", "",
 		"The URL under which Prometheus is externally reachable (for example, if Prometheus is served via a reverse proxy). Used for generating relative and absolute links back to Prometheus itself. If omitted, relevant URL components will be derived automatically.",

--- a/web/web.go
+++ b/web/web.go
@@ -28,12 +28,12 @@ import (
 	"sync"
 	"time"
 
-	pprof_runtime "runtime/pprof"
-	template_text "text/template"
-
+	auth "github.com/abbot/go-http-auth"
 	clientmodel "github.com/prometheus/client_golang/model"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/log"
+	pprof_runtime "runtime/pprof"
+	template_text "text/template"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/promql"
@@ -49,6 +49,7 @@ import (
 )
 
 var localhostRepresentations = []string{"127.0.0.1", "localhost"}
+var authenticate = false
 
 // Handler serves various HTTP endpoints of the Prometheus server
 type Handler struct {
@@ -102,6 +103,25 @@ type Options struct {
 	ConsoleTemplatesPath string
 	ConsoleLibrariesPath string
 	EnableQuit           bool
+	AuthEnabled          bool
+	BasicAuthUsername    string
+	BasicAuthPassword    string
+}
+
+// Using this as the nil SecretProvider
+func Secret(user, realm string) string {
+	return ""
+}
+
+func OptionalAuthCheck(au auth.AuthenticatorInterface, wrapped http.HandlerFunc) http.HandlerFunc {
+	if authenticate == true {
+		return au.Wrap(func(w http.ResponseWriter, ar *auth.AuthenticatedRequest) {
+			ar.Header.Set("X-Authenticated-Username", ar.Username)
+			wrapped(w, &ar.Request)
+		})
+	} else {
+		return wrapped
+	}
 }
 
 // New initializes a new web Handler.
@@ -138,16 +158,27 @@ func New(st local.Storage, qe *promql.Engine, rm *rules.Manager, status *Prometh
 		})
 		router = router.WithPrefix(o.ExternalURL.Path)
 	}
+	var authenticator = auth.NewBasicAuthenticator("Prometheus", Secret)
+
+	if o.AuthEnabled == true {
+		authenticate = true
+		authenticator = auth.NewBasicAuthenticator("Prometheus", func(user string, realm string) string {
+			if user == o.BasicAuthUsername {
+				return o.BasicAuthPassword
+			}
+			return ""
+		})
+	}
 
 	instrf := prometheus.InstrumentHandlerFunc
 	instrh := prometheus.InstrumentHandler
 
-	router.Get("/", instrf("status", h.status))
-	router.Get("/alerts", instrf("alerts", h.alerts))
-	router.Get("/graph", instrf("graph", h.graph))
+	router.Get("/", OptionalAuthCheck(authenticator, instrf("status", h.status)))
+	router.Get("/alerts", OptionalAuthCheck(authenticator, instrf("alerts", h.alerts)))
+	router.Get("/graph", OptionalAuthCheck(authenticator, instrf("graph", h.graph)))
 	router.Get("/version", instrf("version", h.version))
 
-	router.Get("/heap", instrf("heap", dumpHeap))
+	router.Get("/heap", OptionalAuthCheck(authenticator, instrf("heap", dumpHeap)))
 
 	router.Get("/federate", instrh("federate", h.federation))
 	router.Get(o.MetricsPath, prometheus.Handler().ServeHTTP)
@@ -155,7 +186,7 @@ func New(st local.Storage, qe *promql.Engine, rm *rules.Manager, status *Prometh
 	h.apiLegacy.Register(router.WithPrefix("/api"))
 	h.apiV1.Register(router.WithPrefix("/api/v1"))
 
-	router.Get("/consoles/*filepath", instrf("consoles", h.consoles))
+	router.Get("/consoles/*filepath", OptionalAuthCheck(authenticator, instrf("consoles", h.consoles)))
 
 	if o.UseLocalAssets {
 		router.Get("/static/*filepath", instrf("static", route.FileServe("web/blob/static")))


### PR DESCRIPTION
I noticed that both AuthManager and Prometheus web endpoints are wide open. They include configuration information including service keys for various web services like PagerDuty. Securing these web endpoints would require additional service/reverse_proxy to add some kind of authentication. My goal with this fix was to add a very simple bare-minimum, optional authentication mechanism. I didn't find anything accessible in the mailing lists that implied someone was working on this.

How to use it:

- Caveat: I tried adding the config in the config.yml but the way the web struct is initialized I only get the string form of config and would have to parse again. 

./prometheus -config.file=./prometheus.yml -web.auth-enabled=true -web.basicauth.username test -web.basicauth.password '$1$dlPL2MqE$oQmn16q49SqdmhenQuNgs1'

where the password is the digest generated by htpasswd for "hello"

I'm sure there are many stylistic changes that could be made but I'm neither expert on prometheus or Go, so I'm open to any criticisms and improvements to the code. I do think at least having basic authentication for web endpoints is warranted. If there are better ideas in motion, I'd be curious when they'd be implemented.
