### PR TITLE
Remove multi-statement queries

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -1,7 +1,6 @@
 package promql
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -18,14 +17,15 @@ func TestQueryConcurreny(t *testing.T) {
 
 	block := make(chan struct{})
 	processing := make(chan struct{})
-	f1 := testStmt(func(context.Context) error {
+
+	f := func(context.Context) error {
 		processing <- struct{}{}
 		<-block
 		return nil
-	})
+	}
 
 	for i := 0; i < DefaultEngineOptions.MaxConcurrentQueries; i++ {
-		q := engine.newTestQuery(f1)
+		q := engine.newTestQuery(f)
 		go q.Exec()
 		select {
 		case <-processing:
@@ -35,7 +35,7 @@ func TestQueryConcurreny(t *testing.T) {
 		}
 	}
 
-	q := engine.newTestQuery(f1)
+	q := engine.newTestQuery(f)
 	go q.Exec()
 
 	select {
@@ -68,14 +68,10 @@ func TestQueryTimeout(t *testing.T) {
 	})
 	defer engine.Stop()
 
-	f1 := testStmt(func(context.Context) error {
+	query := engine.newTestQuery(func(ctx context.Context) error {
 		time.Sleep(10 * time.Millisecond)
-		return nil
+		return contextDone(ctx, "test statement execution")
 	})
-
-	// Timeouts are not exact but checked in designated places. For example between
-	// invoking test statements.
-	query := engine.newTestQuery(f1, f1)
 
 	res := query.Exec()
 	if res.Err == nil {
@@ -90,37 +86,40 @@ func TestQueryCancel(t *testing.T) {
 	engine := NewEngine(nil, nil)
 	defer engine.Stop()
 
-	// As for timeouts, cancellation is only checked at designated points. We ensure
-	// that we reach one of those points using the same method.
-	f1 := testStmt(func(context.Context) error {
-		time.Sleep(2 * time.Millisecond)
-		return nil
+	// Cancel a running query before it completes.
+	block := make(chan struct{})
+	processing := make(chan struct{})
+
+	query1 := engine.newTestQuery(func(ctx context.Context) error {
+		processing <- struct{}{}
+		<-block
+		return contextDone(ctx, "test statement execution")
 	})
 
-	query1 := engine.newTestQuery(f1, f1)
-	query2 := engine.newTestQuery(f1, f1)
-
-	// Cancel query after starting it.
-	var wg sync.WaitGroup
 	var res *Result
 
-	wg.Add(1)
 	go func() {
 		res = query1.Exec()
-		wg.Done()
+		processing <- struct{}{}
 	}()
-	time.Sleep(1 * time.Millisecond)
+
+	<-processing
 	query1.Cancel()
-	wg.Wait()
+	block <- struct{}{}
+	<-processing
 
 	if res.Err == nil {
 		t.Fatalf("expected cancellation error for query1 but got none")
 	}
-	if _, ok := res.Err.(ErrQueryCanceled); res.Err != nil && !ok {
-		t.Fatalf("expected cancellation error for query1 but got: %s", res.Err)
+	if ee := ErrQueryCanceled("test statement execution"); res.Err != ee {
+		t.Fatalf("expected error %q, got %q")
 	}
 
-	// Canceling query before starting it must have no effect.
+	// Canceling a query before starting it must have no effect.
+	query2 := engine.newTestQuery(func(ctx context.Context) error {
+		return contextDone(ctx, "test statement execution")
+	})
+
 	query2.Cancel()
 	res = query2.Exec()
 	if res.Err != nil {
@@ -131,36 +130,52 @@ func TestQueryCancel(t *testing.T) {
 func TestEngineShutdown(t *testing.T) {
 	engine := NewEngine(nil, nil)
 
-	handlerExecutions := 0
+	block := make(chan struct{})
+	processing := make(chan struct{})
+
 	// Shutdown engine on first handler execution. Should handler execution ever become
 	// concurrent this test has to be adjusted accordingly.
-	f1 := testStmt(func(context.Context) error {
-		handlerExecutions++
-		engine.Stop()
-		time.Sleep(10 * time.Millisecond)
-		return nil
-	})
-	query1 := engine.newTestQuery(f1, f1)
-	query2 := engine.newTestQuery(f1, f1)
+	f := func(ctx context.Context) error {
+		processing <- struct{}{}
+		<-block
+		return contextDone(ctx, "test statement execution")
+	}
+	query1 := engine.newTestQuery(f)
 
 	// Stopping the engine must cancel the base context. While executing queries is
 	// still possible, their context is canceled from the beginning and execution should
 	// terminate immediately.
 
-	res := query1.Exec()
+	var res *Result
+	go func() {
+		res = query1.Exec()
+		processing <- struct{}{}
+	}()
+
+	<-processing
+	engine.Stop()
+	block <- struct{}{}
+	<-processing
+
 	if res.Err == nil {
 		t.Fatalf("expected error on shutdown during query but got none")
 	}
-	if handlerExecutions != 1 {
-		t.Fatalf("expected only one handler to be executed before query cancellation but got %d executions", handlerExecutions)
+	if ee := ErrQueryCanceled("test statement execution"); res.Err != ee {
+		t.Fatalf("expected error %q, got %q", ee, res.Err)
 	}
 
+	query2 := engine.newTestQuery(func(context.Context) error {
+		t.Fatalf("reached query execution unexpectedly")
+		return nil
+	})
+
+	// The second query is started after the engine shut down. It must
+	// be canceled immediately.
 	res2 := query2.Exec()
 	if res2.Err == nil {
 		t.Fatalf("expected error on querying shutdown engine but got none")
 	}
-	if handlerExecutions != 1 {
-		t.Fatalf("expected no handler execution for query after engine shutdown")
+	if _, ok := res2.Err.(ErrQueryCanceled); !ok {
+		t.Fatalf("expected cancelation error, got %q", res2.Err)
 	}
-
 }


### PR DESCRIPTION
This commit removes the possibility to have multi-statement queries
which had no full support anyway. This makes the caller responsible
for multi-statement semantics.
Multiple tests are no longer timing-dependent.

Should we need some convenience later on I have some ideas. This
however allows for a clearer separation and simplifies the core semantics.

This is a prerequisite to allow sane query engine instrumentation.

@juliusv 