### PR TITLE
Allow reloading via webhandler

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -104,7 +104,11 @@ func Main() int {
 	signal.Notify(hup, syscall.SIGHUP)
 	go func() {
 		<-hupReady
-		for range hup {
+		for {
+			select {
+			case <-hup:
+			case <-webHandler.Reload():
+			}
 			reloadConfig(cfg.configFile, status, targetManager, ruleManager)
 		}
 	}()

--- a/web/web.go
+++ b/web/web.go
@@ -61,7 +61,7 @@ type Handler struct {
 
 	router     *route.Router
 	quitCh     chan struct{}
-	reloadCh   chan bool // boolean saves as placeholder, actual value does not matter
+	reloadCh   chan struct{}
 	options    *Options
 	statusInfo *PrometheusStatus
 
@@ -112,7 +112,7 @@ func New(st local.Storage, qe *promql.Engine, rm *rules.Manager, status *Prometh
 	h := &Handler{
 		router:     router,
 		quitCh:     make(chan struct{}),
-		reloadCh: make(chan bool),
+		reloadCh:   make(chan struct{}),
 		options:    o,
 		statusInfo: status,
 
@@ -173,7 +173,7 @@ func New(st local.Storage, qe *promql.Engine, rm *rules.Manager, status *Prometh
 		router.Post("/-/quit", h.quit)
 	}
 
-	router.Post("/reload", h.reload)
+	router.Post("/-/reload", h.reload)
 	router.Get("/debug/*subpath", http.DefaultServeMux.ServeHTTP)
 
 	return h
@@ -184,8 +184,7 @@ func (h *Handler) Quit() <-chan struct{} {
 	return h.quitCh
 }
 
-
-func (h *Handler) Reload() <-chan bool {
+func (h *Handler) Reload() <-chan struct{} {
 	return h.reloadCh
 }
 
@@ -303,7 +302,7 @@ func (h *Handler) quit(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) reload(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Reloading configuration file...")
-	h.reloadCh <- true
+	h.reloadCh <- struct{}{}
 }
 
 func (h *Handler) getTemplateFile(name string) (string, error) {


### PR DESCRIPTION
Targeting issue #923 @juliusv 

Implemented changes allow a reload of the configuration file by POST'ing to http://server:port/reload.

Communication between the web module and main.go has been realised using an exposed channel in order to align with the implementation of the [quit channel](https://github.com/prometheus/prometheus/blob/master/web/web.go#L291).