### PR TITLE
Improve target discovery pipeline

### DIFF
--- a/retrieval/discovery/file_test.go
+++ b/retrieval/discovery/file_test.go
@@ -24,11 +24,13 @@ func testFileSD(t *testing.T, ext string) {
 	conf.Names = []string{"fixtures/_*" + ext}
 	conf.RefreshInterval = config.Duration(1 * time.Hour)
 
-	fsd := NewFileDiscovery(&conf)
-
-	ch := make(chan *config.TargetGroup)
-	go fsd.Run(ch)
-	defer fsd.Stop()
+	var (
+		fsd  = NewFileDiscovery(&conf)
+		ch   = make(chan *config.TargetGroup)
+		done = make(chan struct{})
+	)
+	go fsd.Run(ch, done)
+	defer close(done)
 
 	select {
 	case <-time.After(25 * time.Millisecond):

--- a/retrieval/discovery/marathon.go
+++ b/retrieval/discovery/marathon.go
@@ -40,13 +40,12 @@ func (md *MarathonDiscovery) Sources() []string {
 }
 
 // Run implements the TargetProvider interface.
-func (md *MarathonDiscovery) Run(ch chan<- *config.TargetGroup) {
+func (md *MarathonDiscovery) Run(ch chan<- *config.TargetGroup, done <-chan struct{}) {
 	defer close(ch)
 
 	for {
 		select {
-		case <-md.done:
-			log.Debug("Shutting down marathon discovery.")
+		case <-done:
 			return
 		case <-time.After(md.refreshInterval):
 			err := md.updateServices(ch)
@@ -55,11 +54,6 @@ func (md *MarathonDiscovery) Run(ch chan<- *config.TargetGroup) {
 			}
 		}
 	}
-}
-
-// Stop implements the TargetProvider interface.
-func (md *MarathonDiscovery) Stop() {
-	md.done <- struct{}{}
 }
 
 func (md *MarathonDiscovery) updateServices(ch chan<- *config.TargetGroup) error {

--- a/retrieval/discovery/marathon_test.go
+++ b/retrieval/discovery/marathon_test.go
@@ -181,17 +181,18 @@ func TestMarathonSDRunAndStop(t *testing.T) {
 		return marathonTestAppList(marathonValidLabel, 1), nil
 	})
 	md.refreshInterval = time.Millisecond * 10
+	done := make(chan struct{})
 
 	go func() {
 		select {
 		case <-ch:
-			md.Stop()
+			close(done)
 		case <-time.After(md.refreshInterval * 3):
-			md.Stop()
+			close(done)
 			t.Fatalf("Update took too long.")
 		}
 	}()
-	md.Run(ch)
+	md.Run(ch, done)
 	select {
 	case <-ch:
 	default:

--- a/retrieval/helpers_test.go
+++ b/retrieval/helpers_test.go
@@ -53,15 +53,16 @@ type fakeTargetProvider struct {
 	update  chan *config.TargetGroup
 }
 
-func (tp *fakeTargetProvider) Run(ch chan<- *config.TargetGroup) {
+func (tp *fakeTargetProvider) Run(ch chan<- *config.TargetGroup, done <-chan struct{}) {
 	defer close(ch)
-	for tg := range tp.update {
-		ch <- tg
+	for {
+		select {
+		case tg := <-tp.update:
+			ch <- tg
+		case <-done:
+			return
+		}
 	}
-}
-
-func (tp *fakeTargetProvider) Stop() {
-	close(tp.update)
 }
 
 func (tp *fakeTargetProvider) Sources() []string {

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -54,7 +54,10 @@ func TestPrefixedTargetProvider(t *testing.T) {
 	}
 
 	ch := make(chan *config.TargetGroup)
-	go tp.Run(ch)
+	done := make(chan struct{})
+
+	defer close(done)
+	go tp.Run(ch, done)
 
 	expGroup1 := *targetGroups[0]
 	expGroup2 := *targetGroups[1]
@@ -347,10 +350,10 @@ func TestTargetManagerConfigUpdate(t *testing.T) {
 		conf.ScrapeConfigs = step.scrapeConfigs
 		targetManager.ApplyConfig(conf)
 
-		<-time.After(1 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 
 		if len(targetManager.targets) != len(step.expected) {
-			t.Fatalf("step %d: sources mismatch %v, %v", targetManager.targets, step.expected)
+			t.Fatalf("step %d: sources mismatch: expected %v, got %v", i, step.expected, targetManager.targets)
 		}
 
 		for source, actTargets := range targetManager.targets {


### PR DESCRIPTION
Replace the TargetProvider Stop method with done channels
that ensure properly broadcasted shutdown of the whole pipeline.

This is without a doubt a fairly invasive change into a component that
has always been problematic. So I would like to get this into master as
soon as possible so we get timely feedback.
There is a prerequisite for further changes.

@juliusv 