### PR TITLE
Make HashMod use md5 instead of fnv

### DIFF
--- a/retrieval/relabel_test.go
+++ b/retrieval/relabel_test.go
@@ -170,7 +170,7 @@ func TestRelabel(t *testing.T) {
 				"a": "foo",
 				"b": "bar",
 				"c": "baz",
-				"d": "58",
+				"d": "976",
 			},
 		},
 	}


### PR DESCRIPTION
FNV is not a crypto hash and therefor the outcome heavily depends
on the input. Move this over to a crypto hash function (md5) which
gives us a more random outcome when using hashmod.

Fixes issue  #981