### PR TITLE
Fix loop-reloading on shutdown

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -159,8 +159,6 @@ func Main() int {
 		log.Warn("Received termination request via web service, exiting gracefully...")
 	}
 
-	close(hup)
-
 	log.Info("See you next time!")
 	return 0
 }


### PR DESCRIPTION
This was introduced via https://github.com/prometheus/prometheus/commit/2bf7048dbb1a60e36b0e41fc3a7ad58ecb3a8c4e

A range loop terminates on a closing channel. Switching to select thus caused `case <-hup` to succeed every time after closing the channel.

@jimmidyson 