### PR TITLE
Storage: Tell users how to avoid crash recovery.

### DIFF
--- a/storage/local/crashrecovery.go
+++ b/storage/local/crashrecovery.go
@@ -37,6 +37,7 @@ import (
 func (p *persistence) recoverFromCrash(fingerprintToSeries map[clientmodel.Fingerprint]*memorySeries) error {
 	// TODO(beorn): We need proper tests for the crash recovery.
 	log.Warn("Starting crash recovery. Prometheus is inoperational until complete.")
+	log.Warn("To avoid crash recovery in future, shutdown Prometheus with SIGTERM or a HTTP POST to /-/quit.")
 
 	fpsSeen := map[clientmodel.Fingerprint]struct{}{}
 	count := 0


### PR DESCRIPTION
If users see the crash recovery error, the chances are
they aren't shutting down Prometheus correctly. Telling
them how to do so will help them debug and fix the problem.

@fabxc 