### PR TITLE
Increase default retry interval for file SD

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -91,7 +91,7 @@ var (
 
 	// The default file SD configuration.
 	DefaultFileSDConfig = FileSDConfig{
-		RefreshInterval: Duration(30 * time.Second),
+		RefreshInterval: Duration(5 * time.Minute),
 	}
 
 	// The default Consul SD configuration.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -65,7 +65,7 @@ var expectedConf = &Config{
 				},
 				{
 					Names:           []string{"bar/*.yaml"},
-					RefreshInterval: Duration(30 * time.Second),
+					RefreshInterval: Duration(5 * time.Minute),
 				},
 			},
 


### PR DESCRIPTION
The automatic refresh is a safety mechanism in case
file watches fail. As they seem to be working well the
interval can be increased.

@brian-brazil 