### PR TITLE
retrieval: Don't include unmatched source of regex in replacement.

### DIFF
--- a/retrieval/relabel.go
+++ b/retrieval/relabel.go
@@ -47,12 +47,13 @@ func relabel(labels clientmodel.LabelSet, cfg *config.RelabelConfig) (clientmode
 			return nil, nil
 		}
 	case config.RelabelReplace:
+		indexes := cfg.Regex.FindStringSubmatchIndex(val)
 		// If there is no match no replacement must take place.
-		if !cfg.Regex.MatchString(val) {
+		if indexes == nil {
 			break
 		}
-		res := cfg.Regex.ReplaceAllString(val, cfg.Replacement)
-		if res == "" {
+		res := cfg.Regex.ExpandString([]byte{}, cfg.Replacement, val, indexes)
+		if len(res) == 0 {
 			delete(labels, cfg.TargetLabel)
 		} else {
 			labels[cfg.TargetLabel] = clientmodel.LabelValue(res)

--- a/retrieval/relabel_test.go
+++ b/retrieval/relabel_test.go
@@ -92,6 +92,25 @@ func TestRelabel(t *testing.T) {
 		},
 		{
 			input: clientmodel.LabelSet{
+				"a": "abc",
+			},
+			relabel: []*config.RelabelConfig{
+				{
+					SourceLabels: clientmodel.LabelNames{"a"},
+					Regex:        &config.Regexp{*regexp.MustCompile("(b)")},
+					TargetLabel:  clientmodel.LabelName("d"),
+					Separator:    ";",
+					Replacement:  "$1",
+					Action:       config.RelabelReplace,
+				},
+			},
+			output: clientmodel.LabelSet{
+				"a": "abc",
+				"d": "b",
+			},
+		},
+		{
+			input: clientmodel.LabelSet{
 				"a": "foo",
 			},
 			relabel: []*config.RelabelConfig{


### PR DESCRIPTION
ReplaceAllString only replaces the matching part of the regex,
the unmatched bits around it are left in place. This is not the
expected or desired behaviour as the replacement string should
be everything.

@fabxc 