### PR TITLE
rules: Allow recorded rules expressions to be scalars.

### DIFF
--- a/promql/parse.go
+++ b/promql/parse.go
@@ -1009,7 +1009,10 @@ func (p *parser) checkType(node Node) (typ ExprType) {
 		}
 
 	case *RecordStmt:
-		p.expectType(n.Expr, ExprVector, "record statement")
+		ty := p.checkType(n.Expr)
+		if ty != ExprVector && ty != ExprScalar {
+			p.errorf("record statement must have a valid expression of type vector or scalar but got %s", ty)
+		}
 
 	case Expressions:
 		for _, e := range n {

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -1207,10 +1207,20 @@ var testStatement = []struct {
 		expected: Statements{},
 	}, {
 		input: "foo = time()",
-		fail:  true,
+		expected: Statements{
+			&RecordStmt{
+				Name:   "foo",
+				Expr:   &Call{Func: mustGetFunction("time")},
+				Labels: nil,
+			}},
 	}, {
 		input: "foo = 1",
-		fail:  true,
+		expected: Statements{
+			&RecordStmt{
+				Name:   "foo",
+				Expr:   &NumberLiteral{1},
+				Labels: nil,
+			}},
 	}, {
 		input: "foo = bar[5m]",
 		fail:  true,


### PR DESCRIPTION
This is useful if you want to build up a constant metric,
such as a set of alert thresholds that vary by label value.

Closes #1007 