### PR TITLE
Cast value to float, as that's what the console templates expect.

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -198,10 +198,10 @@ func (m *Manager) queueAlertNotifications(rule *AlertingRule, timestamp model.Ti
 		}
 		tmplData := struct {
 			Labels map[string]string
-			Value  model.SampleValue
+			Value  float64
 		}{
 			Labels: l,
-			Value:  aa.Value,
+			Value:  float64(aa.Value),
 		}
 		// Inject some convenience variables that are easier to remember for users
 		// who are not used to Go's templating system.

--- a/storage/local/series.go
+++ b/storage/local/series.go
@@ -533,7 +533,7 @@ func (it *memorySeriesIterator) ValueAtTime(t model.Time) []model.SamplePair {
 		it.chunkIt = it.chunkIterator(l - i + 1)
 		return []model.SamplePair{
 			sp1,
-			model.SamplePair{
+			{
 				Timestamp: it.chunkIt.timestampAtIndex(0),
 				Value:     it.chunkIt.sampleValueAtIndex(0),
 			},


### PR DESCRIPTION
Fixes #556 

This whole function needs unittests, though it wouldn't help much with this particular case.