### PR TITLE
Fix busylooping in case of no target providers.

### DIFF
--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -171,12 +171,15 @@ func (tm *TargetManager) Run() {
 	tm.running = true
 }
 
-// handleTargetUpdates receives target group updates and handles them in the
+// handleUpdates receives target group updates and handles them in the
 // context of the given job config.
 func (tm *TargetManager) handleUpdates(ch <-chan targetGroupUpdate, done <-chan struct{}) {
 	for {
 		select {
-		case update := <-ch:
+		case update, ok := <-ch:
+			if !ok {
+				return
+			}
 			if update.tg == nil {
 				break
 			}

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -376,3 +376,10 @@ func TestTargetManagerConfigUpdate(t *testing.T) {
 		}
 	}
 }
+
+func TestHandleUpdatesReturnsWhenUpdateChanIsClosed(t *testing.T) {
+	tm := NewTargetManager(nopAppender{})
+	ch := make(chan targetGroupUpdate)
+	close(ch)
+	tm.handleUpdates(ch, make(chan struct{}))
+}


### PR DESCRIPTION
merge() closes the channel that handleUpdates() reads from when there
are zero configured target providers in the configuration. In that case,
the for-select loop in handleUpdates() entered a busy loop. It should
exit when the upstream channel is closed.