### PR TITLE
Fix "go vet" errors.

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -113,7 +113,7 @@ func TestQueryCancel(t *testing.T) {
 		t.Fatalf("expected cancellation error for query1 but got none")
 	}
 	if ee := ErrQueryCanceled("test statement execution"); res.Err != ee {
-		t.Fatalf("expected error %q, got %q")
+		t.Fatalf("expected error %q, got %q", ee, res.Err)
 	}
 
 	// Canceling a query before starting it must have no effect.
@@ -198,12 +198,15 @@ func TestRecoverEvaluatorRuntime(t *testing.T) {
 func TestRecoverEvaluatorError(t *testing.T) {
 	var ev *evaluator
 	var err error
-	defer ev.recover(&err)
 
 	e := fmt.Errorf("custom error")
-	panic(e)
 
-	if err.Error() != e.Error() {
-		t.Fatalf("wrong error message: %q, expected %q", err, e)
-	}
+	defer func() {
+		if err.Error() != e.Error() {
+			t.Fatalf("wrong error message: %q, expected %q", err, e)
+		}
+	}()
+	defer ev.recover(&err)
+
+	panic(e)
 }

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -535,7 +535,6 @@ func (p *parser) expr() Expr {
 			}
 		}
 	}
-	return nil
 }
 
 // unaryExpr parses a unary expression.

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -1456,12 +1456,15 @@ func TestRecoverParserRuntime(t *testing.T) {
 func TestRecoverParserError(t *testing.T) {
 	var p *parser
 	var err error
-	defer p.recover(&err)
 
 	e := fmt.Errorf("custom error")
-	panic(e)
 
-	if err.Error() != e.Error() {
-		t.Fatalf("wrong error message: %q, expected %q", err, e)
-	}
+	defer func() {
+		if err.Error() != e.Error() {
+			t.Fatalf("wrong error message: %q, expected %q", err, e)
+		}
+	}()
+	defer p.recover(&err)
+
+	panic(e)
 }

--- a/retrieval/discovery/file.go
+++ b/retrieval/discovery/file.go
@@ -61,7 +61,7 @@ func (fd *FileDiscovery) Sources() []string {
 	for _, p := range fd.listFiles() {
 		tgroups, err := readFile(p)
 		if err != nil {
-			log.Errorf("Error reading file %q: ", p, err)
+			log.Errorf("Error reading file %q: %s", p, err)
 		}
 		for _, tg := range tgroups {
 			srcs = append(srcs, tg.Source)

--- a/retrieval/discovery/file_test.go
+++ b/retrieval/discovery/file_test.go
@@ -66,7 +66,7 @@ func testFileSD(t *testing.T, ext string) {
 			t.Fatalf("Label not parsed")
 		}
 		if tg.String() != fmt.Sprintf("fixtures/_test%s:0", ext) {
-			t.Fatalf("Unexpected target group", tg)
+			t.Fatalf("Unexpected target group %s", tg)
 		}
 	}
 	select {

--- a/retrieval/discovery/kubernetes/discovery.go
+++ b/retrieval/discovery/kubernetes/discovery.go
@@ -271,7 +271,7 @@ func (kd *KubernetesDiscovery) watchNodes(events chan interface{}, done <-chan s
 			return
 		}
 		if res.StatusCode != http.StatusOK {
-			log.Errorf("Failed to watch nodes: %s", res.StatusCode)
+			log.Errorf("Failed to watch nodes: %d", res.StatusCode)
 			return
 		}
 
@@ -312,7 +312,7 @@ func (kd *KubernetesDiscovery) watchServices(events chan interface{}, done <-cha
 			return
 		}
 		if res.StatusCode != http.StatusOK {
-			log.Errorf("Failed to watch services: %s", res.StatusCode)
+			log.Errorf("Failed to watch services: %d", res.StatusCode)
 			return
 		}
 
@@ -382,7 +382,7 @@ func (kd *KubernetesDiscovery) addService(service *Service) *config.TargetGroup 
 		return nil
 	}
 	if res.StatusCode != http.StatusOK {
-		log.Errorf("Failed to get service endpoints: %s", res.StatusCode)
+		log.Errorf("Failed to get service endpoints: %d", res.StatusCode)
 		return nil
 	}
 
@@ -453,7 +453,7 @@ func (kd *KubernetesDiscovery) watchServiceEndpoints(events chan interface{}, do
 			return
 		}
 		if res.StatusCode != http.StatusOK {
-			log.Errorf("Failed to watch service endpoints: %s", res.StatusCode)
+			log.Errorf("Failed to watch service endpoints: %d", res.StatusCode)
 			return
 		}
 

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -623,7 +623,7 @@ func newTLSConfig(t *testing.T) *tls.Config {
 	tlsConfig.ServerName = "127.0.0.1"
 	cert, err := tls.LoadX509KeyPair("testdata/server.cer", "testdata/server.key")
 	if err != nil {
-		t.Errorf("Unable to use specified server cert (%s) & key (%v): %s", "testdata/server.cer", "testdata/server.key")
+		t.Errorf("Unable to use specified server cert (%s) & key (%v): %s", "testdata/server.cer", "testdata/server.key", err)
 	}
 	tlsConfig.Certificates = []tls.Certificate{cert}
 	tlsConfig.BuildNameToCertificate()

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -178,7 +178,7 @@ func TestTargetManagerChan(t *testing.T) {
 		<-time.After(1 * time.Millisecond)
 
 		if len(targetManager.targets) != len(step.expected) {
-			t.Fatalf("step %d: sources mismatch %v, %v", targetManager.targets, step.expected)
+			t.Fatalf("step %d: sources mismatch %v, %v", i, targetManager.targets, step.expected)
 		}
 
 		for source, actTargets := range targetManager.targets {

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -46,7 +46,7 @@ func (c *TestStorageClient) Store(s model.Samples) error {
 	return nil
 }
 
-func (c TestStorageClient) Name() string {
+func (c *TestStorageClient) Name() string {
 	return "teststorageclient"
 }
 


### PR DESCRIPTION
I ignored all errors of the type "composite literal uses unkeyed
fields". Most of them are wrong because of
https://github.com/golang/go/issues/9171.