### PR TITLE
Fix flakey FileSD test.

### DIFF
--- a/retrieval/discovery/file.go
+++ b/retrieval/discovery/file.go
@@ -160,7 +160,7 @@ func (fd *FileDiscovery) Run(ch chan<- *config.TargetGroup, done <-chan struct{}
 	}
 }
 
-// refresh reads all files matching the discoveries patterns and sends the respective
+// refresh reads all files matching the discovery's patterns and sends the respective
 // updated target groups through the channel.
 func (fd *FileDiscovery) refresh(ch chan<- *config.TargetGroup) {
 	ref := map[string]int{}


### PR DESCRIPTION
When the test ends, all files matching the watcher's glob are removed
via defer. In that moment, the draining goroutine may still be running
and then detect no files matching the configured glob just before the
test exits.

This is now solved by waiting for the draining goroutine to finish
before leaving the test function and thus causing the deferred file
removal.