### PR TITLE
Add POST handler for /debug to fix CPU profiling.

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -176,7 +176,9 @@ func New(st local.Storage, qe *promql.Engine, rm *rules.Manager, status *Prometh
 	}
 
 	router.Post("/-/reload", h.reload)
+
 	router.Get("/debug/*subpath", http.DefaultServeMux.ServeHTTP)
+	router.Post("/debug/*subpath", http.DefaultServeMux.ServeHTTP)
 
 	return h
 }


### PR DESCRIPTION
`go tool pprof` sends a POST request to enable CPU profiling, so we also
need to handle that method.