### PR TITLE
Fix parsing Marathon SD config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -626,6 +626,10 @@ type KubernetesSDConfig struct {
 func (c *MarathonSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultMarathonSDConfig
 	type plain MarathonSDConfig
+	err := unmarshal((*plain)(c))
+	if err != nil {
+		return err
+	}
 	if len(c.Servers) == 0 {
 		return fmt.Errorf("Marathon SD config must contain at least one Marathon server")
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -205,6 +205,24 @@ var expectedConf = &Config{
 				},
 			},
 		},
+		{
+			JobName: "service-marathon",
+
+			ScrapeInterval: Duration(15 * time.Second),
+			ScrapeTimeout:  DefaultGlobalConfig.ScrapeTimeout,
+
+			MetricsPath: DefaultScrapeConfig.MetricsPath,
+			Scheme:      DefaultScrapeConfig.Scheme,
+
+			MarathonSDConfigs: []*MarathonSDConfig{
+				{
+					Servers: []string{
+						"http://marathon.example.com:8080",
+					},
+					RefreshInterval: Duration(30 * time.Second),
+				},
+			},
+		},
 	},
 	original: "",
 }
@@ -280,6 +298,9 @@ var expectedErrors = []struct {
 	}, {
 		filename: "bearertoken_basicauth.bad.yml",
 		errMsg:   "at most one of basic_auth, bearer_token & bearer_token_file must be configured",
+	}, {
+		filename: "marathon_no_servers.bad.yml",
+		errMsg:   "Marathon SD config must contain at least one Marathon server",
 	},
 }
 

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -106,3 +106,8 @@ scrape_configs:
   - server: 'https://localhost:1234'
     username: 'myusername'
     password: 'mypassword'
+
+- job_name: service-marathon
+  marathon_sd_configs:
+  - servers:
+    - 'http://marathon.example.com:8080'

--- a/config/testdata/marathon_no_servers.bad.yml
+++ b/config/testdata/marathon_no_servers.bad.yml
@@ -1,0 +1,10 @@
+# my global config
+global:
+  scrape_interval:     15s
+  evaluation_interval: 30s
+
+scrape_configs:
+
+- job_name: service-marathon
+  marathon_sd_configs:
+  - servers:


### PR DESCRIPTION
Parsing the Marathon SD configuration is currently broken as the actual `unmarshal` call is missing in the function.