### PR TITLE
promql: Add 'bool' modifier to comparison functions

### DIFF
--- a/promql/ast.go
+++ b/promql/ast.go
@@ -117,6 +117,9 @@ type BinaryExpr struct {
 	// The matching behavior for the operation if both operands are vectors.
 	// If they are not this field is nil.
 	VectorMatching *VectorMatching
+
+	// If a comparison operator, return 0/1 rather than filtering.
+	ReturnBool bool
 }
 
 // Call represents a function call.

--- a/promql/lex.go
+++ b/promql/lex.go
@@ -151,6 +151,7 @@ const (
 	itemOn
 	itemGroupLeft
 	itemGroupRight
+	itemBool
 	keywordsEnd
 )
 
@@ -183,6 +184,7 @@ var key = map[string]itemType{
 	"on":            itemOn,
 	"group_left":    itemGroupLeft,
 	"group_right":   itemGroupRight,
+	"bool":          itemBool,
 }
 
 // These are the default string representations for common items. It does not

--- a/promql/lex_test.go
+++ b/promql/lex_test.go
@@ -264,6 +264,9 @@ var tests = []struct {
 	}, {
 		input:    "group_right",
 		expected: []item{{itemGroupRight, 0, "group_right"}},
+	}, {
+		input:    "bool",
+		expected: []item{{itemBool, 0, "bool"}},
 	},
 	// Test Selector.
 	{

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -485,6 +485,19 @@ func (p *parser) expr() Expr {
 			vecMatching.Card = CardManyToMany
 		}
 
+		returnBool := false
+		// Parse bool modifier.
+		if p.peek().typ == itemBool {
+			switch op {
+			case itemEQL, itemNEQ, itemLTE, itemLSS, itemGTE, itemGTR:
+				break
+			default:
+				p.errorf("bool modifier can only be used on comparison operators")
+			}
+			p.next()
+			returnBool = true
+		}
+
 		// Parse ON clause.
 		if p.peek().typ == itemOn {
 			p.next()
@@ -523,6 +536,7 @@ func (p *parser) expr() Expr {
 					LHS:            lhs.RHS,
 					RHS:            rhs,
 					VectorMatching: vecMatching,
+					ReturnBool:     returnBool,
 				},
 				VectorMatching: lhs.VectorMatching,
 			}
@@ -532,6 +546,7 @@ func (p *parser) expr() Expr {
 				LHS:            expr,
 				RHS:            rhs,
 				VectorMatching: vecMatching,
+				ReturnBool:     returnBool,
 			}
 		}
 	}

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -71,37 +71,40 @@ var testExpr = []struct {
 		expected: &NumberLiteral{-493},
 	}, {
 		input:    "1 + 1",
-		expected: &BinaryExpr{itemADD, &NumberLiteral{1}, &NumberLiteral{1}, nil},
+		expected: &BinaryExpr{itemADD, &NumberLiteral{1}, &NumberLiteral{1}, nil, false},
 	}, {
 		input:    "1 - 1",
-		expected: &BinaryExpr{itemSUB, &NumberLiteral{1}, &NumberLiteral{1}, nil},
+		expected: &BinaryExpr{itemSUB, &NumberLiteral{1}, &NumberLiteral{1}, nil, false},
 	}, {
 		input:    "1 * 1",
-		expected: &BinaryExpr{itemMUL, &NumberLiteral{1}, &NumberLiteral{1}, nil},
+		expected: &BinaryExpr{itemMUL, &NumberLiteral{1}, &NumberLiteral{1}, nil, false},
 	}, {
 		input:    "1 % 1",
-		expected: &BinaryExpr{itemMOD, &NumberLiteral{1}, &NumberLiteral{1}, nil},
+		expected: &BinaryExpr{itemMOD, &NumberLiteral{1}, &NumberLiteral{1}, nil, false},
 	}, {
 		input:    "1 / 1",
-		expected: &BinaryExpr{itemDIV, &NumberLiteral{1}, &NumberLiteral{1}, nil},
+		expected: &BinaryExpr{itemDIV, &NumberLiteral{1}, &NumberLiteral{1}, nil, false},
 	}, {
 		input:    "1 == 1",
-		expected: &BinaryExpr{itemEQL, &NumberLiteral{1}, &NumberLiteral{1}, nil},
+		expected: &BinaryExpr{itemEQL, &NumberLiteral{1}, &NumberLiteral{1}, nil, false},
 	}, {
 		input:    "1 != 1",
-		expected: &BinaryExpr{itemNEQ, &NumberLiteral{1}, &NumberLiteral{1}, nil},
+		expected: &BinaryExpr{itemNEQ, &NumberLiteral{1}, &NumberLiteral{1}, nil, false},
 	}, {
 		input:    "1 > 1",
-		expected: &BinaryExpr{itemGTR, &NumberLiteral{1}, &NumberLiteral{1}, nil},
+		expected: &BinaryExpr{itemGTR, &NumberLiteral{1}, &NumberLiteral{1}, nil, false},
 	}, {
 		input:    "1 >= 1",
-		expected: &BinaryExpr{itemGTE, &NumberLiteral{1}, &NumberLiteral{1}, nil},
+		expected: &BinaryExpr{itemGTE, &NumberLiteral{1}, &NumberLiteral{1}, nil, false},
 	}, {
 		input:    "1 < 1",
-		expected: &BinaryExpr{itemLSS, &NumberLiteral{1}, &NumberLiteral{1}, nil},
+		expected: &BinaryExpr{itemLSS, &NumberLiteral{1}, &NumberLiteral{1}, nil, false},
 	}, {
 		input:    "1 <= 1",
-		expected: &BinaryExpr{itemLTE, &NumberLiteral{1}, &NumberLiteral{1}, nil},
+		expected: &BinaryExpr{itemLTE, &NumberLiteral{1}, &NumberLiteral{1}, nil, false},
+	}, {
+		input:    "1 <= bool 1",
+		expected: &BinaryExpr{itemLTE, &NumberLiteral{1}, &NumberLiteral{1}, nil, true},
 	}, {
 		input: "+1 + -2 * 1",
 		expected: &BinaryExpr{
@@ -255,6 +258,19 @@ var testExpr = []struct {
 				},
 			},
 			RHS: &NumberLiteral{1},
+		},
+	}, {
+		input: "foo == bool 1",
+		expected: &BinaryExpr{
+			Op: itemEQL,
+			LHS: &VectorSelector{
+				Name: "foo",
+				LabelMatchers: metric.LabelMatchers{
+					{Type: metric.Equal, Name: model.MetricNameLabel, Value: "foo"},
+				},
+			},
+			RHS:        &NumberLiteral{1},
+			ReturnBool: true,
 		},
 	}, {
 		input: "2.5 / bar",
@@ -513,6 +529,18 @@ var testExpr = []struct {
 		input:  `http_requests{group="production"} + on(instance) group_left(job,instance) cpu_count{type="smp"}`,
 		fail:   true,
 		errMsg: "label \"instance\" must not occur in ON and INCLUDE clause at once",
+	}, {
+		input:  "foo + bool bar",
+		fail:   true,
+		errMsg: "bool modifier can only be used on comparison operators",
+	}, {
+		input:  "foo + bool 10",
+		fail:   true,
+		errMsg: "bool modifier can only be used on comparison operators",
+	}, {
+		input:  "foo and bool 10",
+		fail:   true,
+		errMsg: "bool modifier can only be used on comparison operators",
 	},
 	// Test vector selector.
 	{

--- a/promql/testdata/comparison.test
+++ b/promql/testdata/comparison.test
@@ -1,0 +1,53 @@
+load 5m
+	http_requests{job="api-server", instance="0", group="production"}	0+10x10
+	http_requests{job="api-server", instance="1", group="production"}	0+20x10
+	http_requests{job="api-server", instance="0", group="canary"}		0+30x10
+	http_requests{job="api-server", instance="1", group="canary"}		0+40x10
+	http_requests{job="app-server", instance="0", group="production"}	0+50x10
+	http_requests{job="app-server", instance="1", group="production"}	0+60x10
+	http_requests{job="app-server", instance="0", group="canary"}		0+70x10
+	http_requests{job="app-server", instance="1", group="canary"}		0+80x10
+
+eval instant at 50m SUM(http_requests) BY (job) > 1000
+	{job="app-server"} 2600 
+
+
+eval instant at 50m 1000 < SUM(http_requests) BY (job)
+	{job="app-server"} 1000 
+
+
+eval instant at 50m SUM(http_requests) BY (job) <= 1000
+	{job="api-server"} 1000 
+
+
+eval instant at 50m SUM(http_requests) BY (job) != 1000
+	{job="app-server"} 2600 
+
+
+eval instant at 50m SUM(http_requests) BY (job) == 1000
+	{job="api-server"} 1000 
+
+eval instant at 50m SUM(http_requests) BY (job) == bool 1000
+	{job="api-server"} 1
+	{job="app-server"} 0
+
+eval instant at 50m SUM(http_requests) BY (job) == bool SUM(http_requests) BY (job)
+	{job="api-server"} 1
+	{job="app-server"} 1
+
+eval instant at 50m SUM(http_requests) BY (job) != bool SUM(http_requests) BY (job)
+	{job="api-server"} 0
+	{job="app-server"} 0
+
+
+eval instant at 50m 0 == 1
+	0
+
+eval instant at 50m 1 == 1
+	1
+
+eval instant at 50m 0 == bool 1
+	0
+
+eval instant at 50m 1 == bool 1
+	1

--- a/promql/testdata/legacy.test
+++ b/promql/testdata/legacy.test
@@ -108,26 +108,6 @@ eval instant at 50m SUM(http_requests) BY (job) / 0
 	{job="app-server"} +Inf 
 
 
-eval instant at 50m SUM(http_requests) BY (job) > 1000
-	{job="app-server"} 2600 
-
-
-eval instant at 50m 1000 < SUM(http_requests) BY (job)
-	{job="app-server"} 1000 
-
-
-eval instant at 50m SUM(http_requests) BY (job) <= 1000
-	{job="api-server"} 1000 
-
-
-eval instant at 50m SUM(http_requests) BY (job) != 1000
-	{job="app-server"} 2600 
-
-
-eval instant at 50m SUM(http_requests) BY (job) == 1000
-	{job="api-server"} 1000 
-
-
 eval instant at 50m SUM(http_requests) BY (job) + SUM(http_requests) BY (job)
 	{job="api-server"} 2000 
 	{job="app-server"} 5200 


### PR DESCRIPTION
When doing comparison operations on vectors, filtering
sometimes gets in the way and you have to go to a fair bit of
effort to workaround it in order to always return a result.
The 'bool' modifier instead of filtering returns 0/1 depending
on the result of the compairson.

This is also a prerequisite to removing plain scalar/scalar comparisons,
as it maintains the current behaviour under a new syntax.


This is related to #482, but also generally useful. Does `bool` sound like a good name for this?