### PR TITLE
Allow all instance labels in target groups

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -335,6 +335,9 @@ var expectedErrors = []struct {
 	}, {
 		filename: "marathon_no_servers.bad.yml",
 		errMsg:   "Marathon SD config must contain at least one Marathon server",
+	}, {
+		filename: "url_in_targetgroup.bad.yml",
+		errMsg:   "\"http://bad\" is not a valid hostname",
 	},
 }
 

--- a/config/testdata/url_in_targetgroup.bad.yml
+++ b/config/testdata/url_in_targetgroup.bad.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+- job_name: prometheus
+  target_groups:
+  - targets:
+    - http://bad

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -496,6 +496,9 @@ func (tm *TargetManager) targetsFromGroup(tg *config.TargetGroup, cfg *config.Sc
 		if labels == nil {
 			continue
 		}
+		if err = config.CheckTargetAddress(labels[model.AddressLabel]); err != nil {
+			return nil, err
+		}
 
 		for ln := range labels {
 			// Meta labels are deleted after relabelling. Other internal labels propagate to


### PR DESCRIPTION
With the blackbox exporter, the instance label will commonly
be used for things other than hostnames so remove this restriction.
https://example.com or https://example.com/probe/me are some examples.

@fabxc 