### PR TITLE
Target deduplication and deterministic scraping times

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -255,6 +255,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if scfg.ScrapeTimeout == 0 {
 			scfg.ScrapeTimeout = c.GlobalConfig.ScrapeTimeout
 		}
+		if scfg.ScrapeTimeout > scfg.ScrapeInterval {
+			return fmt.Errorf("scrape timeout greater than scrape interval for scrape config with job name %q", scfg.JobName)
+		}
 
 		if _, ok := jobNames[scfg.JobName]; ok {
 			return fmt.Errorf("found multiple scrape configs with job name %q", scfg.JobName)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -274,6 +274,9 @@ var expectedErrors = []struct {
 		filename: "jobname_dup.bad.yml",
 		errMsg:   `found multiple scrape configs with job name "prometheus"`,
 	}, {
+		filename: "scrape_interval.bad.yml",
+		errMsg:   `scrape timeout greater than scrape interval`,
+	}, {
 		filename: "labelname.bad.yml",
 		errMsg:   `"not$allowed" is not a valid label name`,
 	}, {

--- a/config/testdata/scrape_interval.bad.yml
+++ b/config/testdata/scrape_interval.bad.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - job_name: prometheus
+    scrape_interval: 5s
+    scrape_timeout:  6s

--- a/retrieval/helpers_test.go
+++ b/retrieval/helpers_test.go
@@ -33,17 +33,17 @@ func (a slowAppender) Append(*model.Sample) {
 	return
 }
 
-type collectResultAppender struct {
-	result model.Samples
+type collectAppender struct {
+	samples model.Samples
 }
 
-func (a *collectResultAppender) Append(s *model.Sample) {
+func (a *collectAppender) Append(s *model.Sample) {
 	for ln, lv := range s.Metric {
 		if len(lv) == 0 {
 			delete(s.Metric, ln)
 		}
 	}
-	a.result = append(a.result, s)
+	a.samples = append(a.samples, s)
 }
 
 // fakeTargetProvider implements a TargetProvider and allows manual injection

--- a/retrieval/relabel.go
+++ b/retrieval/relabel.go
@@ -55,10 +55,12 @@ func relabel(labels model.LabelSet, cfg *config.RelabelConfig) (model.LabelSet, 
 		if cfg.Regex.MatchString(val) {
 			return nil, nil
 		}
+
 	case config.RelabelKeep:
 		if !cfg.Regex.MatchString(val) {
 			return nil, nil
 		}
+
 	case config.RelabelReplace:
 		indexes := cfg.Regex.FindStringSubmatchIndex(val)
 		// If there is no match no replacement must take place.
@@ -71,9 +73,11 @@ func relabel(labels model.LabelSet, cfg *config.RelabelConfig) (model.LabelSet, 
 		} else {
 			labels[cfg.TargetLabel] = model.LabelValue(res)
 		}
+
 	case config.RelabelHashMod:
 		mod := sum64(md5.Sum([]byte(val))) % cfg.Modulus
 		labels[cfg.TargetLabel] = model.LabelValue(fmt.Sprintf("%d", mod))
+
 	case config.RelabelLabelMap:
 		out := make(model.LabelSet, len(labels))
 		// Take a copy to avoid infinite loops.
@@ -87,6 +91,7 @@ func relabel(labels model.LabelSet, cfg *config.RelabelConfig) (model.LabelSet, 
 			}
 		}
 		labels = out
+
 	default:
 		panic(fmt.Errorf("retrieval.relabel: unknown relabel action type %q", cfg.Action))
 	}

--- a/retrieval/scrape.go
+++ b/retrieval/scrape.go
@@ -1,0 +1,273 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retrieval
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/log"
+	"golang.org/x/net/context"
+
+	"github.com/prometheus/prometheus/storage"
+)
+
+// Scraper retrieves samples.
+type Scraper interface {
+	// Sends samples to ch until an error occurrs, the context is canceled
+	// or no further samples can be retrieved. The channel is closed before returning.
+	Scrape(ctx context.Context, ch chan<- *model.Sample) error
+}
+
+// Scrape pools runs scrapers for a set of targets where a target, identified by
+// a label set is scraped exactly once.
+type ScrapePool struct {
+	appender storage.SampleAppender
+
+	ctx     context.Context
+	cancel  func()
+	newLoop func(storage.SampleAppender, *Target, *TargetStatus) loop
+
+	mtx    sync.RWMutex
+	loops  map[model.Fingerprint]loop
+	states map[model.Fingerprint]*TargetStatus
+
+	// running keeps track of running loops.
+	running sync.WaitGroup
+}
+
+func NewScrapePool(app storage.SampleAppender) *ScrapePool {
+	sp := &ScrapePool{
+		appender: app,
+		states:   map[model.Fingerprint]*TargetStatus{},
+		newLoop:  newScrapeLoop,
+	}
+	sp.ctx, sp.cancel = context.WithCancel(context.Background())
+
+	return sp
+}
+
+func (sp *ScrapePool) Stop() {
+	if sp.cancel != nil {
+		sp.cancel()
+	}
+	sp.running.Wait()
+}
+
+// Sync the running scrapers with the provided list of targets.
+func (sp *ScrapePool) Sync(targets []*Target) {
+	sp.mtx.Lock()
+	defer sp.mtx.Unlock()
+
+	// Shutdown all running loops after their current scrape
+	// is finished.
+	for _, l := range sp.loops {
+		go l.stop()
+	}
+
+	// Old loops are shutting down, create new from the targets.
+	sp.loops = map[model.Fingerprint]loop{}
+
+	for _, t := range targets {
+		fp := t.fingerprint()
+
+		// Create states for new targets.
+		state, ok := sp.states[fp]
+		if !ok {
+			state = &TargetStatus{}
+			sp.states[fp] = state
+		}
+
+		// Create and start loops the first time we see a target.
+		if _, ok := sp.loops[fp]; !ok {
+			loop := sp.newLoop(sp.appender, t, state)
+			sp.loops[fp] = loop
+
+			sp.running.Add(1)
+			go func(t *Target) {
+				loop.run(sp.ctx, t.interval(), t.timeout(), nil)
+				sp.running.Done()
+			}(t)
+		}
+	}
+
+	// Drop states of targets that no longer exist.
+	for fp := range sp.states {
+		if _, ok := sp.loops[fp]; !ok {
+			delete(sp.states, fp)
+		}
+	}
+}
+
+type loop interface {
+	run(ctx context.Context, interval, timeout time.Duration, errc chan<- error)
+	stop()
+}
+
+// scrapeLoop manages scraping cycles.
+type scrapeLoop struct {
+	scraper  Scraper
+	state    *TargetStatus
+	appender storage.SampleAppender
+
+	cancel      func()
+	stopc, done chan struct{}
+	mtx         sync.RWMutex
+}
+
+func newScrapeLoop(app storage.SampleAppender, target *Target, state *TargetStatus) loop {
+	return &scrapeLoop{
+		scraper:  target,
+		appender: target.wrapAppender(app),
+		state:    state,
+	}
+}
+
+func (sl *scrapeLoop) active() bool {
+	return sl.cancel != nil
+}
+
+func (sl *scrapeLoop) run(ctx context.Context, interval, timeout time.Duration, errc chan<- error) {
+	if sl.active() {
+		return
+	}
+
+	ctx, sl.cancel = context.WithCancel(ctx)
+
+	sl.stopc = make(chan struct{})
+	sl.done = make(chan struct{})
+
+	defer func() {
+		close(sl.done)
+		sl.cancel = nil
+	}()
+
+	select {
+	case <-time.After(time.Duration(float64(interval) * rand.Float64())):
+		// Continue after random scraping offset.
+	case <-ctx.Done():
+		return
+	case <-sl.stopc:
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		start := time.Now()
+
+		err := sl.scrape(ctx, timeout)
+		if err != nil {
+			log.Debugf("Scraping error: %s", err)
+		}
+
+		sl.report(start, time.Since(start), err)
+		if errc != nil {
+			errc <- err
+		}
+
+		select {
+		case <-sl.stopc:
+			return
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		<-ticker.C
+	}
+}
+
+// kill terminates the scraping loop immediately.
+func (sl *scrapeLoop) kill() {
+	if !sl.active() {
+		return
+	}
+	sl.cancel()
+}
+
+// stop finishes any pending scrapes and then kills the loop.
+func (sl *scrapeLoop) stop() {
+	if !sl.active() {
+		return
+	}
+	close(sl.stopc)
+	<-sl.done
+
+	sl.kill()
+}
+
+// scrape executes a single Scrape and appends the retrieved samples.
+func (sl *scrapeLoop) scrape(ctx context.Context, timeout time.Duration) error {
+	ch := make(chan *model.Sample, ingestedSamplesCap)
+
+	// Receive and append all the samples retrieved by the scraper.
+	go func() {
+		var (
+			smpl *model.Sample
+			ok   bool
+		)
+		for {
+			select {
+			case smpl, ok = <-ch:
+				if !ok {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+			// TODO(fabxc): Change the SampleAppender interface to return an error
+			// so we can proceed based on the status and don't leak goroutines trying
+			// to append a single sample after dropping all the other ones.
+			sl.appender.Append(smpl)
+		}
+	}()
+
+	ctx, _ = context.WithTimeout(ctx, timeout)
+
+	return sl.scraper.Scrape(ctx, ch)
+}
+
+func (sl *scrapeLoop) report(start time.Time, duration time.Duration, err error) {
+	sl.state.setLastScrape(start)
+	sl.state.setLastError(err)
+
+	ts := model.TimeFromUnixNano(start.UnixNano())
+
+	var health model.SampleValue
+	if err == nil {
+		health = 1
+	}
+
+	healthSample := &model.Sample{
+		Metric: model.Metric{
+			model.MetricNameLabel: scrapeHealthMetricName,
+		},
+		Timestamp: ts,
+		Value:     health,
+	}
+	durationSample := &model.Sample{
+		Metric: model.Metric{
+			model.MetricNameLabel: scrapeDurationMetricName,
+		},
+		Timestamp: ts,
+		Value:     model.SampleValue(float64(duration) / float64(time.Second)),
+	}
+
+	sl.appender.Append(healthSample)
+	sl.appender.Append(durationSample)
+}

--- a/retrieval/scrape.go
+++ b/retrieval/scrape.go
@@ -120,9 +120,10 @@ type loop interface {
 
 // scrapeLoop manages scraping cycles.
 type scrapeLoop struct {
-	scraper  scraper
-	state    *TargetStatus
-	appender storage.SampleAppender
+	scraper        scraper
+	state          *TargetStatus
+	appender       storage.SampleAppender
+	reportAppender storage.SampleAppender
 
 	// A function to calculate an initial offset for a given
 	// scrape interval.
@@ -135,10 +136,11 @@ type scrapeLoop struct {
 
 func newScrapeLoop(app storage.SampleAppender, target *Target, state *TargetStatus) loop {
 	return &scrapeLoop{
-		scraper:  target,
-		appender: target.wrapAppender(app),
-		state:    state,
-		offset:   target.offset,
+		scraper:        target,
+		appender:       target.wrapAppender(app, true),
+		reportAppender: target.wrapAppender(app, false),
+		state:          state,
+		offset:         target.offset,
 	}
 }
 
@@ -295,6 +297,6 @@ func (sl *scrapeLoop) report(start time.Time, duration time.Duration, err error)
 		Value:     model.SampleValue(float64(duration) / float64(time.Second)),
 	}
 
-	sl.appender.Append(healthSample)
-	sl.appender.Append(durationSample)
+	sl.reportAppender.Append(healthSample)
+	sl.reportAppender.Append(durationSample)
 }

--- a/retrieval/scrape_test.go
+++ b/retrieval/scrape_test.go
@@ -1,0 +1,541 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retrieval
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
+
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/storage"
+)
+
+func TestNewScrapePool(t *testing.T) {
+	app := &nopAppender{}
+	sp := NewScrapePool(app)
+
+	if !reflect.DeepEqual(app, sp.appender) {
+		t.Fatalf("Wrong sample appender")
+	}
+
+	if sp.ctx == nil || sp.cancel == nil {
+		t.Fatalf("Context not initialized")
+	}
+
+	if sp.newLoop == nil {
+		t.Fatalf("newLoop function not initializated")
+	}
+}
+
+func TestScrapePoolStop(t *testing.T) {
+	sp := NewScrapePool(&nopAppender{})
+
+	sp.Stop()
+
+	select {
+	case <-sp.ctx.Done():
+	default:
+		t.Fatalf("Context was not canceled")
+	}
+}
+
+type testLoop struct {
+	target           *Target
+	status           *TargetStatus
+	started, stopped int
+}
+
+func newTestLoop(app storage.SampleAppender, t *Target, s *TargetStatus) loop {
+	return &testLoop{target: t, status: s}
+}
+
+func (l *testLoop) run(ctx context.Context, interval, timeout time.Duration, errc chan<- error) {
+	l.started++
+}
+
+func (l *testLoop) stop() {
+	l.stopped++
+}
+
+func TestScrapePoolSync(t *testing.T) {
+	cfg := &config.ScrapeConfig{
+		ScrapeInterval: config.Duration(1 * time.Hour),
+		ScrapeTimeout:  config.Duration(1 * time.Hour),
+	}
+	targets := []Target{
+		{
+			labels: model.LabelSet{
+				model.MetricsPathLabel: "/metrics",
+				model.AddressLabel:     "example.com:8888",
+				model.SchemeLabel:      "http",
+			},
+			scrapeConfig: cfg,
+		}, {
+			labels: model.LabelSet{
+				model.MetricsPathLabel: "/metrics",
+				model.AddressLabel:     "example.com:8889",
+				model.SchemeLabel:      "http",
+			},
+			scrapeConfig: cfg,
+		},
+	}
+
+	suite := []struct {
+		all    []*Target
+		unique []*Target
+	}{
+		{
+			all:    []*Target{},
+			unique: []*Target{},
+		},
+		{
+			all:    []*Target{&targets[0], &targets[1]},
+			unique: []*Target{&targets[0], &targets[1]},
+		},
+		{
+			all:    []*Target{&targets[0], &targets[1], &targets[0]},
+			unique: []*Target{&targets[0], &targets[1]},
+		},
+		{
+			all:    []*Target{&targets[0]},
+			unique: []*Target{&targets[0]},
+		},
+		{
+			all:    nil,
+			unique: nil,
+		},
+	}
+
+	sp := NewScrapePool(&nopAppender{})
+	sp.newLoop = newTestLoop
+
+	var (
+		lastLoops  map[model.Fingerprint]loop
+		lastStates map[model.Fingerprint]*TargetStatus
+	)
+
+	for i, step := range suite {
+		sp.Sync(step.all)
+
+		// Let loops stop and start and Sync is not blocking until this is done.
+		time.Sleep(5 * time.Millisecond)
+
+		if len(sp.loops) != len(step.unique) {
+			t.Fatalf("step %d: wrong number of unique targets: want %d, got %d", i, len(step.unique), len(sp.loops))
+		}
+		if len(sp.states) != len(step.unique) {
+			t.Fatalf("step %d: wrong number of scrape states: want %d, got %d", i, len(step.unique), len(sp.states))
+		}
+
+		for _, l := range sp.loops {
+			tl, ok := l.(*testLoop)
+			if !ok {
+				t.Fatalf("step %d: wrong loop type instantiated", i)
+			}
+
+			if tl.started != 1 {
+				t.Fatalf("step %d: loop was not started exactly once, got %d", i, tl.started)
+			}
+			if tl.stopped != 0 {
+				t.Fatalf("step %d: loop stopped unexpectedly", i)
+			}
+
+			found := false
+			for _, target := range step.unique {
+				if target.fingerprint() != tl.target.fingerprint() {
+					continue
+				}
+				found = true
+
+				// Check whether the loop is instantiated with the correct state.
+				if tl.status != sp.states[target.fingerprint()] {
+					t.Fatalf("step %d: unexpected status in loop: got %p, want %p", i, tl.status, sp.states[target.fingerprint()])
+				}
+				break
+			}
+			if !found {
+				t.Fatalf("step %d: unexpected target %q")
+			}
+		}
+
+		for _, l := range lastLoops {
+			tl := l.(*testLoop)
+
+			if tl.stopped != 1 || tl.started != 1 {
+				t.Fatalf("step %d: removed loop not stopped properly", i)
+			}
+		}
+
+		for fp, oldState := range lastStates {
+			if newState, ok := sp.states[fp]; ok {
+				if oldState != newState {
+					t.Fatalf("step %d: state was not kept for target", i)
+				}
+			}
+		}
+
+		lastLoops = sp.loops
+		lastStates = sp.states
+	}
+}
+
+type testScraper struct {
+	block, active chan struct{}
+	samples       []*model.Sample
+}
+
+func newTestScraper() *testScraper {
+	return &testScraper{
+		block:  make(chan struct{}, 1),
+		active: make(chan struct{}),
+	}
+}
+
+func (s *testScraper) Scrape(ctx context.Context, ch chan<- *model.Sample) error {
+	defer close(ch)
+
+	s.active <- struct{}{}
+
+	for _, smpl := range s.samples {
+		select {
+		case ch <- smpl:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	select {
+	case <-s.block:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	return nil
+}
+
+func TestScrapeLoopRun(t *testing.T) {
+	var (
+		scraper  = newTestScraper()
+		interval = 1 * time.Microsecond
+		timeout  = 1 * time.Second
+		errc     = make(chan error)
+	)
+
+	sl := &scrapeLoop{
+		scraper:  scraper,
+		appender: nopAppender{},
+		state:    &TargetStatus{},
+	}
+
+	checkStatus := func(h TargetHealth) {
+		if sl.state.health != h {
+			if h == HealthGood {
+				t.Errorf("Unexpected scrape error: %q", sl.state.LastError())
+			}
+			t.Fatalf("Expected target health %q, got %q", h, sl.state.Health())
+		}
+		if sl.state.health != HealthUnknown && sl.state.LastScrape().IsZero() {
+			t.Fatalf("Missing timestamp for scrape")
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start the loop but cancel the base context before.
+	// It must exit immediately.
+	t.Log("Test loop on canceled context")
+
+	cancel()
+
+	exited := make(chan struct{})
+	go func() {
+		sl.run(ctx, interval, timeout, errc)
+		close(exited)
+	}()
+
+	select {
+	case <-scraper.active:
+		t.Fatalf("Scraper called unexpectedly")
+	case <-time.After(timeout):
+		t.Fatalf("Expected scrape loop to exit")
+	case <-exited:
+	}
+
+	checkStatus(HealthUnknown)
+
+	// Perform regular scrapes.
+	t.Log("Test loop for regular scrapes")
+
+	ctx, cancel = context.WithCancel(context.Background())
+	go sl.run(ctx, interval, timeout, errc)
+
+	for i := 0; i < 100; i++ {
+		select {
+		case <-scraper.active:
+		case <-time.After(timeout):
+			t.Fatalf("Expected scrape was not initiated")
+		}
+		scraper.block <- struct{}{}
+
+		// The error of a scrape (including nil) is sent on errc
+		// after the scrape status was updated.
+		<-errc
+		checkStatus(HealthGood)
+	}
+
+	// Start loop again but hard-kill it, the scraper should be signaled to
+	// exit. The test scraper returns without us unblocking it in that case.
+	t.Log("Test hard-killing scraper")
+
+	select {
+	case <-scraper.active:
+	case <-time.After(timeout):
+		t.Fatalf("Expected scrape was not initiated")
+	}
+
+	sl.kill()
+
+	select {
+	case err := <-errc:
+		if err != context.Canceled {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+	case <-time.After(timeout):
+		t.Fatalf("Scrape was not canceled")
+	}
+
+	checkStatus(HealthBad)
+
+	select {
+	case <-sl.done:
+	case <-time.After(timeout):
+		t.Fatalf("Loop did not terminate for canceled context")
+	}
+
+	// Start loop again and stop, the scraper should be signaled to
+	// exit but finish its scrape.
+	t.Log("Test soft-killing scraper")
+
+	ctx, cancel = context.WithCancel(context.Background())
+	go sl.run(ctx, interval, timeout, errc)
+
+	select {
+	case <-scraper.active:
+	case <-time.After(timeout):
+		t.Fatalf("Expected scrape was not initiated")
+	}
+
+	go sl.stop()
+	// Wait for stop signal to be sent.
+	<-sl.stopc
+
+	scraper.block <- struct{}{}
+
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+	case <-time.After(timeout):
+		t.Fatalf("Expected scraper to exit on kill")
+	}
+
+	checkStatus(HealthGood)
+}
+
+func TestScrapeLoopReport(t *testing.T) {
+	sl := &scrapeLoop{
+		scraper: &testScraper{},
+		state:   &TargetStatus{},
+	}
+
+	suite := []struct {
+		start    model.Time
+		duration time.Duration
+		err      error
+	}{
+		{
+			start:    model.TimeFromUnix(time.Now().Unix()),
+			duration: 3 * time.Second,
+		},
+		{
+			start:    model.TimeFromUnix(time.Now().Unix()),
+			duration: 5 * time.Second,
+			err:      fmt.Errorf("error"),
+		},
+	}
+
+	for _, test := range suite {
+		appender := &collectAppender{}
+		sl.appender = appender
+
+		sl.report(test.start.Time(), test.duration, test.err)
+
+		if sl.state.LastError() != test.err {
+			t.Fatalf("Expected error %q but got %q", test.err, sl.state.LastError())
+		}
+
+		if sl.state.LastScrape() != test.start.Time() {
+			t.Fatalf("Expeceted test start at %v but got %v", test.start.Time(), sl.state.LastScrape())
+		}
+
+		if len(appender.samples) != 2 {
+			t.Fatalf("Expected two samples, got %d", len(appender.samples))
+		}
+
+		expHealth := model.SampleValue(0)
+		if test.err == nil {
+			expHealth = 1
+		}
+
+		expected := &model.Sample{
+			Metric: model.Metric{
+				model.MetricNameLabel: scrapeHealthMetricName,
+			},
+			Timestamp: test.start,
+			Value:     expHealth,
+		}
+
+		actual := appender.samples[0]
+
+		if !actual.Equal(expected) {
+			t.Fatalf("Expected and actual samples not equal, want: %v, got: %v", expected, actual)
+		}
+
+		expected = &model.Sample{
+			Metric: model.Metric{
+				model.MetricNameLabel: scrapeDurationMetricName,
+			},
+			Timestamp: test.start,
+			Value:     model.SampleValue(test.duration.Seconds()),
+		}
+
+		actual = appender.samples[1]
+
+		if !actual.Equal(expected) {
+			t.Fatalf("Expected and actual samples not equal, want: %v, got %v", expected, actual)
+		}
+	}
+}
+
+type redirectAppender struct {
+	ch chan *model.Sample
+}
+
+func newRedirectAppender() *redirectAppender {
+	return &redirectAppender{ch: make(chan *model.Sample)}
+}
+
+func (a *redirectAppender) Append(s *model.Sample) {
+	a.ch <- s
+}
+
+func TestScrapeLoopScrape(t *testing.T) {
+	var (
+		scraper  = newTestScraper()
+		appender = newRedirectAppender()
+		timeout  = 1 * time.Second
+		errc     = make(chan error)
+	)
+	sl := &scrapeLoop{
+		scraper:  scraper,
+		appender: appender,
+		state:    &TargetStatus{},
+	}
+
+	scraper.samples = make([]*model.Sample, 2*ingestedSamplesCap)
+
+	// Perform a regular scrape where all appends succeed immediately.
+	t.Log("Test regular scraping")
+
+	go func() {
+		errc <- sl.scrape(context.Background(), timeout)
+	}()
+
+	<-scraper.active
+	// Receive all samples.
+	for i := 0; i < 2*ingestedSamplesCap; i++ {
+		select {
+		case <-appender.ch:
+		case <-time.After(timeout):
+			t.Fatalf("Timeout on expecting sample %d", i)
+		}
+	}
+
+	select {
+	case <-appender.ch:
+		t.Fatalf("Received more sample than sent by the scraper")
+	default:
+	}
+	scraper.block <- struct{}{}
+
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("Unexpected scrape error: %s", err)
+		}
+	case <-time.After(3 * timeout):
+		t.Fatalf("Timeout on scrape")
+	}
+
+	// Test appending with context being canceled at random points in time.
+	t.Log("Test scraping with context cancelation")
+
+	for numIngested := 0; numIngested < 2*ingestedSamplesCap; numIngested += 8 {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go func() {
+			errc <- sl.scrape(ctx, timeout)
+		}()
+
+		<-scraper.active
+		//
+		for i := 0; i < numIngested; i++ {
+			select {
+			case <-appender.ch:
+			case <-time.After(timeout):
+				t.Fatalf("Timeout on expecting sample %d", i)
+			}
+		}
+		cancel()
+
+		// With the current SampleAppender behavior we cannot terminate
+		// mid-appending. We may have to consume one more sample before the
+		// cancelation takes effect.
+		select {
+		case <-appender.ch:
+		default:
+		}
+
+		select {
+		case <-appender.ch:
+			t.Fatalf("Received more samples after context cancelation")
+		default:
+		}
+
+		select {
+		case err := <-errc:
+			if err != context.Canceled {
+				t.Fatalf("Unexpected scrape error: %s", err)
+			}
+		case <-time.After(3 * timeout):
+			t.Fatalf("Timeout on scrape")
+		}
+	}
+}

--- a/retrieval/scrape_test.go
+++ b/retrieval/scrape_test.go
@@ -39,7 +39,7 @@ func TestNewScrapePool(t *testing.T) {
 	}
 
 	if sp.newLoop == nil {
-		t.Fatalf("newLoop function not initializated")
+		t.Fatalf("newLoop function not initialized")
 	}
 }
 
@@ -245,9 +245,10 @@ func TestScrapeLoopRun(t *testing.T) {
 	)
 
 	sl := &scrapeLoop{
-		scraper:  scraper,
-		appender: nopAppender{},
-		state:    &TargetStatus{},
+		scraper:        scraper,
+		appender:       nopAppender{},
+		reportAppender: nopAppender{},
+		state:          &TargetStatus{},
 	}
 
 	checkStatus := func(h TargetHealth) {
@@ -390,7 +391,7 @@ func TestScrapeLoopReport(t *testing.T) {
 
 	for _, test := range suite {
 		appender := &collectAppender{}
-		sl.appender = appender
+		sl.reportAppender = appender
 
 		sl.report(test.start.Time(), test.duration, test.err)
 
@@ -399,7 +400,7 @@ func TestScrapeLoopReport(t *testing.T) {
 		}
 
 		if sl.state.LastScrape() != test.start.Time() {
-			t.Fatalf("Expeceted test start at %v but got %v", test.start.Time(), sl.state.LastScrape())
+			t.Fatalf("Expected test start at %v but got %v", test.start.Time(), sl.state.LastScrape())
 		}
 
 		if len(appender.samples) != 2 {
@@ -489,7 +490,7 @@ func TestScrapeLoopScrape(t *testing.T) {
 
 	select {
 	case <-appender.ch:
-		t.Fatalf("Received more sample than sent by the scraper")
+		t.Fatalf("Received more samples than sent by the scraper")
 	default:
 	}
 	scraper.block <- struct{}{}

--- a/retrieval/scrape_test.go
+++ b/retrieval/scrape_test.go
@@ -170,7 +170,7 @@ func TestScrapePoolSync(t *testing.T) {
 				break
 			}
 			if !found {
-				t.Fatalf("step %d: unexpected target %q")
+				t.Fatalf("step %d: expected target %q not found", i, tl.target)
 			}
 		}
 

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -94,7 +94,7 @@ type TargetStatus struct {
 	mu sync.RWMutex
 }
 
-func (ts TargetStatus) String() string {
+func (ts *TargetStatus) String() string {
 	if ts.LastError() != nil {
 		return fmt.Sprintf("<status %s:%q>", ts.Health(), ts.LastError())
 	}

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -206,10 +206,10 @@ func (t *Target) offset(interval time.Duration) time.Duration {
 	return time.Duration(next - now)
 }
 
-func (t *Target) wrapAppender(app storage.SampleAppender) storage.SampleAppender {
+func (t *Target) wrapAppender(app storage.SampleAppender, relabel bool) storage.SampleAppender {
 	// The relabelAppender has to be inside the label-modifying appenders
 	// so the relabeling rules are applied to the correct label set.
-	if mrc := t.scrapeConfig.MetricRelabelConfigs; len(mrc) > 0 {
+	if mrc := t.scrapeConfig.MetricRelabelConfigs; relabel && len(mrc) > 0 {
 		app = relabelAppender{
 			app:         app,
 			relabelings: mrc,

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -1,632 +1,632 @@
-// Copyright 2013 The Prometheus Authors
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// // Copyright 2013 The Prometheus Authors
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// // http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
 
 package retrieval
 
-import (
-	"crypto/tls"
-	"crypto/x509"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"reflect"
-	"strings"
-	"testing"
-	"time"
+// import (
+// 	"crypto/tls"
+// 	"crypto/x509"
+// 	"errors"
+// 	"fmt"
+// 	"io/ioutil"
+// 	"net/http"
+// 	"net/http/httptest"
+// 	"net/url"
+// 	"reflect"
+// 	"strings"
+// 	"testing"
+// 	"time"
 
-	"github.com/prometheus/common/model"
+// 	"github.com/prometheus/common/model"
 
-	"github.com/prometheus/prometheus/config"
-)
+// 	"github.com/prometheus/prometheus/config"
+// )
 
-func TestBaseLabels(t *testing.T) {
-	target := newTestTarget("example.com:80", 0, model.LabelSet{"job": "some_job", "foo": "bar"})
-	want := model.LabelSet{
-		model.JobLabel:      "some_job",
-		model.InstanceLabel: "example.com:80",
-		"foo":               "bar",
-	}
-	got := target.BaseLabels()
-	if !reflect.DeepEqual(want, got) {
-		t.Errorf("want base labels %v, got %v", want, got)
-	}
-}
+// func TestBaseLabels(t *testing.T) {
+// 	target := newTestTarget("example.com:80", 0, model.LabelSet{"job": "some_job", "foo": "bar"})
+// 	want := model.LabelSet{
+// 		model.JobLabel:      "some_job",
+// 		model.InstanceLabel: "example.com:80",
+// 		"foo":               "bar",
+// 	}
+// 	got := target.BaseLabels()
+// 	if !reflect.DeepEqual(want, got) {
+// 		t.Errorf("want base labels %v, got %v", want, got)
+// 	}
+// }
 
-func TestOverwriteLabels(t *testing.T) {
-	type test struct {
-		metric       string
-		resultNormal model.Metric
-		resultHonor  model.Metric
-	}
-	var tests []test
+// func TestOverwriteLabels(t *testing.T) {
+// 	type test struct {
+// 		metric       string
+// 		resultNormal model.Metric
+// 		resultHonor  model.Metric
+// 	}
+// 	var tests []test
 
-	server := httptest.NewServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-				for _, test := range tests {
-					w.Write([]byte(test.metric))
-					w.Write([]byte(" 1\n"))
-				}
-			},
-		),
-	)
-	defer server.Close()
-	addr := model.LabelValue(strings.Split(server.URL, "://")[1])
+// 	server := httptest.NewServer(
+// 		http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+// 				for _, test := range tests {
+// 					w.Write([]byte(test.metric))
+// 					w.Write([]byte(" 1\n"))
+// 				}
+// 			},
+// 		),
+// 	)
+// 	defer server.Close()
+// 	addr := model.LabelValue(strings.Split(server.URL, "://")[1])
 
-	tests = []test{
-		{
-			metric: `foo{}`,
-			resultNormal: model.Metric{
-				model.MetricNameLabel: "foo",
-				model.InstanceLabel:   addr,
-			},
-			resultHonor: model.Metric{
-				model.MetricNameLabel: "foo",
-				model.InstanceLabel:   addr,
-			},
-		},
-		{
-			metric: `foo{instance=""}`,
-			resultNormal: model.Metric{
-				model.MetricNameLabel: "foo",
-				model.InstanceLabel:   addr,
-			},
-			resultHonor: model.Metric{
-				model.MetricNameLabel: "foo",
-			},
-		},
-		{
-			metric: `foo{instance="other_instance"}`,
-			resultNormal: model.Metric{
-				model.MetricNameLabel:                           "foo",
-				model.InstanceLabel:                             addr,
-				model.ExportedLabelPrefix + model.InstanceLabel: "other_instance",
-			},
-			resultHonor: model.Metric{
-				model.MetricNameLabel: "foo",
-				model.InstanceLabel:   "other_instance",
-			},
-		},
-	}
+// 	tests = []test{
+// 		{
+// 			metric: `foo{}`,
+// 			resultNormal: model.Metric{
+// 				model.MetricNameLabel: "foo",
+// 				model.InstanceLabel:   addr,
+// 			},
+// 			resultHonor: model.Metric{
+// 				model.MetricNameLabel: "foo",
+// 				model.InstanceLabel:   addr,
+// 			},
+// 		},
+// 		{
+// 			metric: `foo{instance=""}`,
+// 			resultNormal: model.Metric{
+// 				model.MetricNameLabel: "foo",
+// 				model.InstanceLabel:   addr,
+// 			},
+// 			resultHonor: model.Metric{
+// 				model.MetricNameLabel: "foo",
+// 			},
+// 		},
+// 		{
+// 			metric: `foo{instance="other_instance"}`,
+// 			resultNormal: model.Metric{
+// 				model.MetricNameLabel:                           "foo",
+// 				model.InstanceLabel:                             addr,
+// 				model.ExportedLabelPrefix + model.InstanceLabel: "other_instance",
+// 			},
+// 			resultHonor: model.Metric{
+// 				model.MetricNameLabel: "foo",
+// 				model.InstanceLabel:   "other_instance",
+// 			},
+// 		},
+// 	}
 
-	target := newTestTarget(server.URL, 10*time.Millisecond, nil)
+// 	target := newTestTarget(server.URL, 10*time.Millisecond, nil)
 
-	target.honorLabels = false
-	app := &collectResultAppender{}
-	if err := target.scrape(app); err != nil {
-		t.Fatal(err)
-	}
+// 	target.honorLabels = false
+// 	app := &collectResultAppender{}
+// 	if err := target.scrape(app); err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	for i, test := range tests {
-		if !reflect.DeepEqual(app.result[i].Metric, test.resultNormal) {
-			t.Errorf("Error comparing %q:\nExpected:\n%s\nGot:\n%s\n", test.metric, test.resultNormal, app.result[i].Metric)
-		}
-	}
+// 	for i, test := range tests {
+// 		if !reflect.DeepEqual(app.result[i].Metric, test.resultNormal) {
+// 			t.Errorf("Error comparing %q:\nExpected:\n%s\nGot:\n%s\n", test.metric, test.resultNormal, app.result[i].Metric)
+// 		}
+// 	}
 
-	target.honorLabels = true
-	app = &collectResultAppender{}
-	if err := target.scrape(app); err != nil {
-		t.Fatal(err)
-	}
+// 	target.honorLabels = true
+// 	app = &collectResultAppender{}
+// 	if err := target.scrape(app); err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	for i, test := range tests {
-		if !reflect.DeepEqual(app.result[i].Metric, test.resultHonor) {
-			t.Errorf("Error comparing %q:\nExpected:\n%s\nGot:\n%s\n", test.metric, test.resultHonor, app.result[i].Metric)
-		}
+// 	for i, test := range tests {
+// 		if !reflect.DeepEqual(app.result[i].Metric, test.resultHonor) {
+// 			t.Errorf("Error comparing %q:\nExpected:\n%s\nGot:\n%s\n", test.metric, test.resultHonor, app.result[i].Metric)
+// 		}
 
-	}
-}
-func TestTargetScrapeUpdatesState(t *testing.T) {
-	testTarget := newTestTarget("bad schema", 0, nil)
+// 	}
+// }
+// func TestTargetScrapeUpdatesState(t *testing.T) {
+// 	testTarget := newTestTarget("bad schema", 0, nil)
 
-	testTarget.scrape(nopAppender{})
-	if testTarget.status.Health() != HealthBad {
-		t.Errorf("Expected target state %v, actual: %v", HealthBad, testTarget.status.Health())
-	}
-}
+// 	testTarget.scrape(nopAppender{})
+// 	if testTarget.status.Health() != HealthBad {
+// 		t.Errorf("Expected target state %v, actual: %v", HealthBad, testTarget.status.Health())
+// 	}
+// }
 
-func TestTargetScrapeWithFullChannel(t *testing.T) {
-	server := httptest.NewServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-				for i := 0; i < 2*ingestedSamplesCap; i++ {
-					w.Write([]byte(
-						fmt.Sprintf("test_metric_%d{foo=\"bar\"} 123.456\n", i),
-					))
-				}
-			},
-		),
-	)
-	defer server.Close()
+// func TestTargetScrapeWithFullChannel(t *testing.T) {
+// 	server := httptest.NewServer(
+// 		http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+// 				for i := 0; i < 2*ingestedSamplesCap; i++ {
+// 					w.Write([]byte(
+// 						fmt.Sprintf("test_metric_%d{foo=\"bar\"} 123.456\n", i),
+// 					))
+// 				}
+// 			},
+// 		),
+// 	)
+// 	defer server.Close()
 
-	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{"dings": "bums"})
+// 	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{"dings": "bums"})
 
-	testTarget.scrape(slowAppender{})
-	if testTarget.status.Health() != HealthBad {
-		t.Errorf("Expected target state %v, actual: %v", HealthBad, testTarget.status.Health())
-	}
-	if testTarget.status.LastError() != errIngestChannelFull {
-		t.Errorf("Expected target error %q, actual: %q", errIngestChannelFull, testTarget.status.LastError())
-	}
-}
+// 	testTarget.scrape(slowAppender{})
+// 	if testTarget.status.Health() != HealthBad {
+// 		t.Errorf("Expected target state %v, actual: %v", HealthBad, testTarget.status.Health())
+// 	}
+// 	if testTarget.status.LastError() != errIngestChannelFull {
+// 		t.Errorf("Expected target error %q, actual: %q", errIngestChannelFull, testTarget.status.LastError())
+// 	}
+// }
 
-func TestTargetScrapeMetricRelabelConfigs(t *testing.T) {
-	server := httptest.NewServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-				w.Write([]byte("test_metric_drop 0\n"))
-				w.Write([]byte("test_metric_relabel 1\n"))
-			},
-		),
-	)
-	defer server.Close()
-	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{})
-	testTarget.metricRelabelConfigs = []*config.RelabelConfig{
-		{
-			SourceLabels: model.LabelNames{"__name__"},
-			Regex:        config.MustNewRegexp(".*drop.*"),
-			Action:       config.RelabelDrop,
-		},
-		{
-			SourceLabels: model.LabelNames{"__name__"},
-			Regex:        config.MustNewRegexp(".*(relabel|up).*"),
-			TargetLabel:  "foo",
-			Replacement:  "bar",
-			Action:       config.RelabelReplace,
-		},
-	}
+// func TestTargetScrapeMetricRelabelConfigs(t *testing.T) {
+// 	server := httptest.NewServer(
+// 		http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+// 				w.Write([]byte("test_metric_drop 0\n"))
+// 				w.Write([]byte("test_metric_relabel 1\n"))
+// 			},
+// 		),
+// 	)
+// 	defer server.Close()
+// 	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{})
+// 	testTarget.metricRelabelConfigs = []*config.RelabelConfig{
+// 		{
+// 			SourceLabels: model.LabelNames{"__name__"},
+// 			Regex:        config.MustNewRegexp(".*drop.*"),
+// 			Action:       config.RelabelDrop,
+// 		},
+// 		{
+// 			SourceLabels: model.LabelNames{"__name__"},
+// 			Regex:        config.MustNewRegexp(".*(relabel|up).*"),
+// 			TargetLabel:  "foo",
+// 			Replacement:  "bar",
+// 			Action:       config.RelabelReplace,
+// 		},
+// 	}
 
-	appender := &collectResultAppender{}
-	testTarget.scrape(appender)
+// 	appender := &collectResultAppender{}
+// 	testTarget.scrape(appender)
 
-	// Remove variables part of result.
-	for _, sample := range appender.result {
-		sample.Timestamp = 0
-		sample.Value = 0
-	}
+// 	// Remove variables part of result.
+// 	for _, sample := range appender.result {
+// 		sample.Timestamp = 0
+// 		sample.Value = 0
+// 	}
 
-	expected := []*model.Sample{
-		{
-			Metric: model.Metric{
-				model.MetricNameLabel: "test_metric_relabel",
-				"foo":               "bar",
-				model.InstanceLabel: model.LabelValue(testTarget.url.Host),
-			},
-			Timestamp: 0,
-			Value:     0,
-		},
-		// The metrics about the scrape are not affected.
-		{
-			Metric: model.Metric{
-				model.MetricNameLabel: scrapeHealthMetricName,
-				model.InstanceLabel:   model.LabelValue(testTarget.url.Host),
-			},
-			Timestamp: 0,
-			Value:     0,
-		},
-		{
-			Metric: model.Metric{
-				model.MetricNameLabel: scrapeDurationMetricName,
-				model.InstanceLabel:   model.LabelValue(testTarget.url.Host),
-			},
-			Timestamp: 0,
-			Value:     0,
-		},
-	}
+// 	expected := []*model.Sample{
+// 		{
+// 			Metric: model.Metric{
+// 				model.MetricNameLabel: "test_metric_relabel",
+// 				"foo":               "bar",
+// 				model.InstanceLabel: model.LabelValue(testTarget.url.Host),
+// 			},
+// 			Timestamp: 0,
+// 			Value:     0,
+// 		},
+// 		// The metrics about the scrape are not affected.
+// 		{
+// 			Metric: model.Metric{
+// 				model.MetricNameLabel: scrapeHealthMetricName,
+// 				model.InstanceLabel:   model.LabelValue(testTarget.url.Host),
+// 			},
+// 			Timestamp: 0,
+// 			Value:     0,
+// 		},
+// 		{
+// 			Metric: model.Metric{
+// 				model.MetricNameLabel: scrapeDurationMetricName,
+// 				model.InstanceLabel:   model.LabelValue(testTarget.url.Host),
+// 			},
+// 			Timestamp: 0,
+// 			Value:     0,
+// 		},
+// 	}
 
-	if !appender.result.Equal(expected) {
-		t.Fatalf("Expected and actual samples not equal. Expected: %s, actual: %s", expected, appender.result)
-	}
+// 	if !appender.result.Equal(expected) {
+// 		t.Fatalf("Expected and actual samples not equal. Expected: %s, actual: %s", expected, appender.result)
+// 	}
 
-}
+// }
 
-func TestTargetRecordScrapeHealth(t *testing.T) {
-	testTarget := newTestTarget("example.url:80", 0, model.LabelSet{model.JobLabel: "testjob"})
+// func TestTargetRecordScrapeHealth(t *testing.T) {
+// 	testTarget := newTestTarget("example.url:80", 0, model.LabelSet{model.JobLabel: "testjob"})
 
-	now := model.Now()
-	appender := &collectResultAppender{}
-	testTarget.status.setLastError(nil)
-	recordScrapeHealth(appender, now.Time(), testTarget.BaseLabels(), testTarget.status.Health(), 2*time.Second)
+// 	now := model.Now()
+// 	appender := &collectResultAppender{}
+// 	testTarget.status.setLastError(nil)
+// 	recordScrapeHealth(appender, now.Time(), testTarget.BaseLabels(), testTarget.status.Health(), 2*time.Second)
 
-	result := appender.result
+// 	result := appender.result
 
-	if len(result) != 2 {
-		t.Fatalf("Expected two samples, got %d", len(result))
-	}
+// 	if len(result) != 2 {
+// 		t.Fatalf("Expected two samples, got %d", len(result))
+// 	}
 
-	actual := result[0]
-	expected := &model.Sample{
-		Metric: model.Metric{
-			model.MetricNameLabel: scrapeHealthMetricName,
-			model.InstanceLabel:   "example.url:80",
-			model.JobLabel:        "testjob",
-		},
-		Timestamp: now,
-		Value:     1,
-	}
+// 	actual := result[0]
+// 	expected := &model.Sample{
+// 		Metric: model.Metric{
+// 			model.MetricNameLabel: scrapeHealthMetricName,
+// 			model.InstanceLabel:   "example.url:80",
+// 			model.JobLabel:        "testjob",
+// 		},
+// 		Timestamp: now,
+// 		Value:     1,
+// 	}
 
-	if !actual.Equal(expected) {
-		t.Fatalf("Expected and actual samples not equal. Expected: %v, actual: %v", expected, actual)
-	}
+// 	if !actual.Equal(expected) {
+// 		t.Fatalf("Expected and actual samples not equal. Expected: %v, actual: %v", expected, actual)
+// 	}
 
-	actual = result[1]
-	expected = &model.Sample{
-		Metric: model.Metric{
-			model.MetricNameLabel: scrapeDurationMetricName,
-			model.InstanceLabel:   "example.url:80",
-			model.JobLabel:        "testjob",
-		},
-		Timestamp: now,
-		Value:     2.0,
-	}
+// 	actual = result[1]
+// 	expected = &model.Sample{
+// 		Metric: model.Metric{
+// 			model.MetricNameLabel: scrapeDurationMetricName,
+// 			model.InstanceLabel:   "example.url:80",
+// 			model.JobLabel:        "testjob",
+// 		},
+// 		Timestamp: now,
+// 		Value:     2.0,
+// 	}
 
-	if !actual.Equal(expected) {
-		t.Fatalf("Expected and actual samples not equal. Expected: %v, actual: %v", expected, actual)
-	}
-}
+// 	if !actual.Equal(expected) {
+// 		t.Fatalf("Expected and actual samples not equal. Expected: %v, actual: %v", expected, actual)
+// 	}
+// }
 
-func TestTargetScrapeTimeout(t *testing.T) {
-	signal := make(chan bool, 1)
-	server := httptest.NewServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				<-signal
-				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-				w.Write([]byte{})
-			},
-		),
-	)
-	defer server.Close()
+// func TestTargetScrapeTimeout(t *testing.T) {
+// 	signal := make(chan bool, 1)
+// 	server := httptest.NewServer(
+// 		http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				<-signal
+// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+// 				w.Write([]byte{})
+// 			},
+// 		),
+// 	)
+// 	defer server.Close()
 
-	testTarget := newTestTarget(server.URL, 50*time.Millisecond, model.LabelSet{})
+// 	testTarget := newTestTarget(server.URL, 50*time.Millisecond, model.LabelSet{})
 
-	appender := nopAppender{}
+// 	appender := nopAppender{}
 
-	// scrape once without timeout
-	signal <- true
-	if err := testTarget.scrape(appender); err != nil {
-		t.Fatal(err)
-	}
+// 	// scrape once without timeout
+// 	signal <- true
+// 	if err := testTarget.scrape(appender); err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	// let the deadline lapse
-	time.Sleep(55 * time.Millisecond)
+// 	// let the deadline lapse
+// 	time.Sleep(55 * time.Millisecond)
 
-	// now scrape again
-	signal <- true
-	if err := testTarget.scrape(appender); err != nil {
-		t.Fatal(err)
-	}
+// 	// now scrape again
+// 	signal <- true
+// 	if err := testTarget.scrape(appender); err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	// now timeout
-	if err := testTarget.scrape(appender); err == nil {
-		t.Fatal("expected scrape to timeout")
-	} else {
-		signal <- true // let handler continue
-	}
+// 	// now timeout
+// 	if err := testTarget.scrape(appender); err == nil {
+// 		t.Fatal("expected scrape to timeout")
+// 	} else {
+// 		signal <- true // let handler continue
+// 	}
 
-	// now scrape again without timeout
-	signal <- true
-	if err := testTarget.scrape(appender); err != nil {
-		t.Fatal(err)
-	}
-}
+// 	// now scrape again without timeout
+// 	signal <- true
+// 	if err := testTarget.scrape(appender); err != nil {
+// 		t.Fatal(err)
+// 	}
+// }
 
-func TestTargetScrape404(t *testing.T) {
-	server := httptest.NewServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusNotFound)
-			},
-		),
-	)
-	defer server.Close()
+// func TestTargetScrape404(t *testing.T) {
+// 	server := httptest.NewServer(
+// 		http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				w.WriteHeader(http.StatusNotFound)
+// 			},
+// 		),
+// 	)
+// 	defer server.Close()
 
-	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{})
-	appender := nopAppender{}
+// 	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{})
+// 	appender := nopAppender{}
 
-	want := errors.New("server returned HTTP status 404 Not Found")
-	got := testTarget.scrape(appender)
-	if got == nil || want.Error() != got.Error() {
-		t.Fatalf("want err %q, got %q", want, got)
-	}
-}
+// 	want := errors.New("server returned HTTP status 404 Not Found")
+// 	got := testTarget.scrape(appender)
+// 	if got == nil || want.Error() != got.Error() {
+// 		t.Fatalf("want err %q, got %q", want, got)
+// 	}
+// }
 
-func TestTargetRunScraperScrapes(t *testing.T) {
-	testTarget := newTestTarget("bad schema", 0, nil)
+// func TestTargetRunScraperScrapes(t *testing.T) {
+// 	testTarget := newTestTarget("bad schema", 0, nil)
 
-	go testTarget.RunScraper(nopAppender{})
+// 	go testTarget.RunScraper(nopAppender{})
 
-	// Enough time for a scrape to happen.
-	time.Sleep(10 * time.Millisecond)
-	if testTarget.status.LastScrape().IsZero() {
-		t.Errorf("Scrape hasn't occured.")
-	}
+// 	// Enough time for a scrape to happen.
+// 	time.Sleep(10 * time.Millisecond)
+// 	if testTarget.status.LastScrape().IsZero() {
+// 		t.Errorf("Scrape hasn't occured.")
+// 	}
 
-	testTarget.StopScraper()
-	// Wait for it to take effect.
-	time.Sleep(5 * time.Millisecond)
-	last := testTarget.status.LastScrape()
-	// Enough time for a scrape to happen.
-	time.Sleep(10 * time.Millisecond)
-	if testTarget.status.LastScrape() != last {
-		t.Errorf("Scrape occured after it was stopped.")
-	}
-}
+// 	testTarget.StopScraper()
+// 	// Wait for it to take effect.
+// 	time.Sleep(5 * time.Millisecond)
+// 	last := testTarget.status.LastScrape()
+// 	// Enough time for a scrape to happen.
+// 	time.Sleep(10 * time.Millisecond)
+// 	if testTarget.status.LastScrape() != last {
+// 		t.Errorf("Scrape occured after it was stopped.")
+// 	}
+// }
 
-func BenchmarkScrape(b *testing.B) {
-	server := httptest.NewServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-				w.Write([]byte("test_metric{foo=\"bar\"} 123.456\n"))
-			},
-		),
-	)
-	defer server.Close()
+// func BenchmarkScrape(b *testing.B) {
+// 	server := httptest.NewServer(
+// 		http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+// 				w.Write([]byte("test_metric{foo=\"bar\"} 123.456\n"))
+// 			},
+// 		),
+// 	)
+// 	defer server.Close()
 
-	testTarget := newTestTarget(server.URL, 100*time.Millisecond, model.LabelSet{"dings": "bums"})
-	appender := nopAppender{}
+// 	testTarget := newTestTarget(server.URL, 100*time.Millisecond, model.LabelSet{"dings": "bums"})
+// 	appender := nopAppender{}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if err := testTarget.scrape(appender); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
+// 	b.ResetTimer()
+// 	for i := 0; i < b.N; i++ {
+// 		if err := testTarget.scrape(appender); err != nil {
+// 			b.Fatal(err)
+// 		}
+// 	}
+// }
 
-func TestURLParams(t *testing.T) {
-	server := httptest.NewServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-				w.Write([]byte{})
-				r.ParseForm()
-				if r.Form["foo"][0] != "bar" {
-					t.Fatalf("URL parameter 'foo' had unexpected first value '%v'", r.Form["foo"][0])
-				}
-				if r.Form["foo"][1] != "baz" {
-					t.Fatalf("URL parameter 'foo' had unexpected second value '%v'", r.Form["foo"][1])
-				}
-			},
-		),
-	)
-	defer server.Close()
-	serverURL, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
+// func TestURLParams(t *testing.T) {
+// 	server := httptest.NewServer(
+// 		http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+// 				w.Write([]byte{})
+// 				r.ParseForm()
+// 				if r.Form["foo"][0] != "bar" {
+// 					t.Fatalf("URL parameter 'foo' had unexpected first value '%v'", r.Form["foo"][0])
+// 				}
+// 				if r.Form["foo"][1] != "baz" {
+// 					t.Fatalf("URL parameter 'foo' had unexpected second value '%v'", r.Form["foo"][1])
+// 				}
+// 			},
+// 		),
+// 	)
+// 	defer server.Close()
+// 	serverURL, err := url.Parse(server.URL)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	target := NewTarget(
-		&config.ScrapeConfig{
-			JobName:        "test_job1",
-			ScrapeInterval: config.Duration(1 * time.Minute),
-			ScrapeTimeout:  config.Duration(1 * time.Second),
-			Scheme:         serverURL.Scheme,
-			Params: url.Values{
-				"foo": []string{"bar", "baz"},
-			},
-		},
-		model.LabelSet{
-			model.SchemeLabel:  model.LabelValue(serverURL.Scheme),
-			model.AddressLabel: model.LabelValue(serverURL.Host),
-			"__param_foo":      "bar",
-		},
-		nil)
-	app := &collectResultAppender{}
-	if err = target.scrape(app); err != nil {
-		t.Fatal(err)
-	}
-}
+// 	target := NewTarget(
+// 		&config.ScrapeConfig{
+// 			JobName:        "test_job1",
+// 			ScrapeInterval: config.Duration(1 * time.Minute),
+// 			ScrapeTimeout:  config.Duration(1 * time.Second),
+// 			Scheme:         serverURL.Scheme,
+// 			Params: url.Values{
+// 				"foo": []string{"bar", "baz"},
+// 			},
+// 		},
+// 		model.LabelSet{
+// 			model.SchemeLabel:  model.LabelValue(serverURL.Scheme),
+// 			model.AddressLabel: model.LabelValue(serverURL.Host),
+// 			"__param_foo":      "bar",
+// 		},
+// 		nil)
+// 	app := &collectResultAppender{}
+// 	if err = target.scrape(app); err != nil {
+// 		t.Fatal(err)
+// 	}
+// }
 
-func newTestTarget(targetURL string, deadline time.Duration, baseLabels model.LabelSet) *Target {
-	cfg := &config.ScrapeConfig{
-		ScrapeTimeout: config.Duration(deadline),
-	}
-	c, _ := newHTTPClient(cfg)
-	t := &Target{
-		url: &url.URL{
-			Scheme: "http",
-			Host:   strings.TrimLeft(targetURL, "http://"),
-			Path:   "/metrics",
-		},
-		deadline:        deadline,
-		status:          &TargetStatus{},
-		scrapeInterval:  1 * time.Millisecond,
-		httpClient:      c,
-		scraperStopping: make(chan struct{}),
-		scraperStopped:  make(chan struct{}),
-	}
-	t.baseLabels = model.LabelSet{
-		model.InstanceLabel: model.LabelValue(t.InstanceIdentifier()),
-	}
-	for baseLabel, baseValue := range baseLabels {
-		t.baseLabels[baseLabel] = baseValue
-	}
-	return t
-}
+// func newTestTarget(targetURL string, deadline time.Duration, baseLabels model.LabelSet) *Target {
+// 	cfg := &config.ScrapeConfig{
+// 		ScrapeTimeout: config.Duration(deadline),
+// 	}
+// 	c, _ := newHTTPClient(cfg)
+// 	t := &Target{
+// 		url: &url.URL{
+// 			Scheme: "http",
+// 			Host:   strings.TrimLeft(targetURL, "http://"),
+// 			Path:   "/metrics",
+// 		},
+// 		deadline:        deadline,
+// 		status:          &TargetStatus{},
+// 		scrapeInterval:  1 * time.Millisecond,
+// 		httpClient:      c,
+// 		scraperStopping: make(chan struct{}),
+// 		scraperStopped:  make(chan struct{}),
+// 	}
+// 	t.baseLabels = model.LabelSet{
+// 		model.InstanceLabel: model.LabelValue(t.InstanceIdentifier()),
+// 	}
+// 	for baseLabel, baseValue := range baseLabels {
+// 		t.baseLabels[baseLabel] = baseValue
+// 	}
+// 	return t
+// }
 
-func TestNewHTTPBearerToken(t *testing.T) {
-	server := httptest.NewServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				expected := "Bearer 1234"
-				received := r.Header.Get("Authorization")
-				if expected != received {
-					t.Fatalf("Authorization header was not set correctly: expected '%v', got '%v'", expected, received)
-				}
-			},
-		),
-	)
-	defer server.Close()
+// func TestNewHTTPBearerToken(t *testing.T) {
+// 	server := httptest.NewServer(
+// 		http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				expected := "Bearer 1234"
+// 				received := r.Header.Get("Authorization")
+// 				if expected != received {
+// 					t.Fatalf("Authorization header was not set correctly: expected '%v', got '%v'", expected, received)
+// 				}
+// 			},
+// 		),
+// 	)
+// 	defer server.Close()
 
-	cfg := &config.ScrapeConfig{
-		ScrapeTimeout: config.Duration(1 * time.Second),
-		BearerToken:   "1234",
-	}
-	c, err := newHTTPClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = c.Get(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
+// 	cfg := &config.ScrapeConfig{
+// 		ScrapeTimeout: config.Duration(1 * time.Second),
+// 		BearerToken:   "1234",
+// 	}
+// 	c, err := newHTTPClient(cfg)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	_, err = c.Get(server.URL)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// }
 
-func TestNewHTTPBearerTokenFile(t *testing.T) {
-	server := httptest.NewServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				expected := "Bearer 12345"
-				received := r.Header.Get("Authorization")
-				if expected != received {
-					t.Fatalf("Authorization header was not set correctly: expected '%v', got '%v'", expected, received)
-				}
-			},
-		),
-	)
-	defer server.Close()
+// func TestNewHTTPBearerTokenFile(t *testing.T) {
+// 	server := httptest.NewServer(
+// 		http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				expected := "Bearer 12345"
+// 				received := r.Header.Get("Authorization")
+// 				if expected != received {
+// 					t.Fatalf("Authorization header was not set correctly: expected '%v', got '%v'", expected, received)
+// 				}
+// 			},
+// 		),
+// 	)
+// 	defer server.Close()
 
-	cfg := &config.ScrapeConfig{
-		ScrapeTimeout:   config.Duration(1 * time.Second),
-		BearerTokenFile: "testdata/bearertoken.txt",
-	}
-	c, err := newHTTPClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = c.Get(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
+// 	cfg := &config.ScrapeConfig{
+// 		ScrapeTimeout:   config.Duration(1 * time.Second),
+// 		BearerTokenFile: "testdata/bearertoken.txt",
+// 	}
+// 	c, err := newHTTPClient(cfg)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	_, err = c.Get(server.URL)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// }
 
-func TestNewHTTPBasicAuth(t *testing.T) {
-	server := httptest.NewServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				username, password, ok := r.BasicAuth()
-				if !(ok && username == "user" && password == "password123") {
-					t.Fatalf("Basic authorization header was not set correctly: expected '%v:%v', got '%v:%v'", "user", "password123", username, password)
-				}
-			},
-		),
-	)
-	defer server.Close()
+// func TestNewHTTPBasicAuth(t *testing.T) {
+// 	server := httptest.NewServer(
+// 		http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				username, password, ok := r.BasicAuth()
+// 				if !(ok && username == "user" && password == "password123") {
+// 					t.Fatalf("Basic authorization header was not set correctly: expected '%v:%v', got '%v:%v'", "user", "password123", username, password)
+// 				}
+// 			},
+// 		),
+// 	)
+// 	defer server.Close()
 
-	cfg := &config.ScrapeConfig{
-		ScrapeTimeout: config.Duration(1 * time.Second),
-		BasicAuth: &config.BasicAuth{
-			Username: "user",
-			Password: "password123",
-		},
-	}
-	c, err := newHTTPClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = c.Get(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
+// 	cfg := &config.ScrapeConfig{
+// 		ScrapeTimeout: config.Duration(1 * time.Second),
+// 		BasicAuth: &config.BasicAuth{
+// 			Username: "user",
+// 			Password: "password123",
+// 		},
+// 	}
+// 	c, err := newHTTPClient(cfg)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	_, err = c.Get(server.URL)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// }
 
-func TestNewHTTPCACert(t *testing.T) {
-	server := httptest.NewUnstartedServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-				w.Write([]byte{})
-			},
-		),
-	)
-	server.TLS = newTLSConfig(t)
-	server.StartTLS()
-	defer server.Close()
+// func TestNewHTTPCACert(t *testing.T) {
+// 	server := httptest.NewUnstartedServer(
+// 		http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+// 				w.Write([]byte{})
+// 			},
+// 		),
+// 	)
+// 	server.TLS = newTLSConfig(t)
+// 	server.StartTLS()
+// 	defer server.Close()
 
-	cfg := &config.ScrapeConfig{
-		ScrapeTimeout: config.Duration(1 * time.Second),
-		TLSConfig: config.TLSConfig{
-			CAFile: "testdata/ca.cer",
-		},
-	}
-	c, err := newHTTPClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = c.Get(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
+// 	cfg := &config.ScrapeConfig{
+// 		ScrapeTimeout: config.Duration(1 * time.Second),
+// 		TLSConfig: config.TLSConfig{
+// 			CAFile: "testdata/ca.cer",
+// 		},
+// 	}
+// 	c, err := newHTTPClient(cfg)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	_, err = c.Get(server.URL)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// }
 
-func TestNewHTTPClientCert(t *testing.T) {
-	server := httptest.NewUnstartedServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-				w.Write([]byte{})
-			},
-		),
-	)
-	tlsConfig := newTLSConfig(t)
-	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-	tlsConfig.ClientCAs = tlsConfig.RootCAs
-	tlsConfig.BuildNameToCertificate()
-	server.TLS = tlsConfig
-	server.StartTLS()
-	defer server.Close()
+// func TestNewHTTPClientCert(t *testing.T) {
+// 	server := httptest.NewUnstartedServer(
+// 		http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+// 				w.Write([]byte{})
+// 			},
+// 		),
+// 	)
+// 	tlsConfig := newTLSConfig(t)
+// 	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+// 	tlsConfig.ClientCAs = tlsConfig.RootCAs
+// 	tlsConfig.BuildNameToCertificate()
+// 	server.TLS = tlsConfig
+// 	server.StartTLS()
+// 	defer server.Close()
 
-	cfg := &config.ScrapeConfig{
-		ScrapeTimeout: config.Duration(1 * time.Second),
-		TLSConfig: config.TLSConfig{
-			CAFile:   "testdata/ca.cer",
-			CertFile: "testdata/client.cer",
-			KeyFile:  "testdata/client.key",
-		},
-	}
-	c, err := newHTTPClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = c.Get(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
+// 	cfg := &config.ScrapeConfig{
+// 		ScrapeTimeout: config.Duration(1 * time.Second),
+// 		TLSConfig: config.TLSConfig{
+// 			CAFile:   "testdata/ca.cer",
+// 			CertFile: "testdata/client.cer",
+// 			KeyFile:  "testdata/client.key",
+// 		},
+// 	}
+// 	c, err := newHTTPClient(cfg)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	_, err = c.Get(server.URL)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// }
 
-func newTLSConfig(t *testing.T) *tls.Config {
-	tlsConfig := &tls.Config{}
-	caCertPool := x509.NewCertPool()
-	caCert, err := ioutil.ReadFile("testdata/ca.cer")
-	if err != nil {
-		t.Fatalf("Couldn't set up TLS server: %v", err)
-	}
-	caCertPool.AppendCertsFromPEM(caCert)
-	tlsConfig.RootCAs = caCertPool
-	tlsConfig.ServerName = "127.0.0.1"
-	cert, err := tls.LoadX509KeyPair("testdata/server.cer", "testdata/server.key")
-	if err != nil {
-		t.Errorf("Unable to use specified server cert (%s) & key (%v): %s", "testdata/server.cer", "testdata/server.key", err)
-	}
-	tlsConfig.Certificates = []tls.Certificate{cert}
-	tlsConfig.BuildNameToCertificate()
-	return tlsConfig
-}
+// func newTLSConfig(t *testing.T) *tls.Config {
+// 	tlsConfig := &tls.Config{}
+// 	caCertPool := x509.NewCertPool()
+// 	caCert, err := ioutil.ReadFile("testdata/ca.cer")
+// 	if err != nil {
+// 		t.Fatalf("Couldn't set up TLS server: %v", err)
+// 	}
+// 	caCertPool.AppendCertsFromPEM(caCert)
+// 	tlsConfig.RootCAs = caCertPool
+// 	tlsConfig.ServerName = "127.0.0.1"
+// 	cert, err := tls.LoadX509KeyPair("testdata/server.cer", "testdata/server.key")
+// 	if err != nil {
+// 		t.Errorf("Unable to use specified server cert (%s) & key (%v): %s", "testdata/server.cer", "testdata/server.key", err)
+// 	}
+// 	tlsConfig.Certificates = []tls.Certificate{cert}
+// 	tlsConfig.BuildNameToCertificate()
+// 	return tlsConfig
+// }

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -13,620 +13,394 @@
 
 package retrieval
 
-// import (
-// 	"crypto/tls"
-// 	"crypto/x509"
-// 	"errors"
-// 	"fmt"
-// 	"io/ioutil"
-// 	"net/http"
-// 	"net/http/httptest"
-// 	"net/url"
-// 	"reflect"
-// 	"strings"
-// 	"testing"
-// 	"time"
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
 
-// 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
-// 	"github.com/prometheus/prometheus/config"
-// )
+	"github.com/prometheus/prometheus/config"
+)
 
-// func TestBaseLabels(t *testing.T) {
-// 	target := newTestTarget("example.com:80", 0, model.LabelSet{"job": "some_job", "foo": "bar"})
-// 	want := model.LabelSet{
-// 		model.JobLabel:      "some_job",
-// 		model.InstanceLabel: "example.com:80",
-// 		"foo":               "bar",
-// 	}
-// 	got := target.BaseLabels()
-// 	if !reflect.DeepEqual(want, got) {
-// 		t.Errorf("want base labels %v, got %v", want, got)
-// 	}
-// }
+func TestTargetBaseLabels(t *testing.T) {
+	target := newTestTarget("example.com:80", 0, model.LabelSet{
+		model.JobLabel: "some_job",
+		"foo":          "bar",
+	})
 
-// func TestOverwriteLabels(t *testing.T) {
-// 	type test struct {
-// 		metric       string
-// 		resultNormal model.Metric
-// 		resultHonor  model.Metric
-// 	}
-// 	var tests []test
+	want := model.LabelSet{
+		model.JobLabel:      "some_job",
+		model.InstanceLabel: "example.com:80",
+		"foo":               "bar",
+	}
+	got := target.BaseLabels()
 
-// 	server := httptest.NewServer(
-// 		http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-// 				for _, test := range tests {
-// 					w.Write([]byte(test.metric))
-// 					w.Write([]byte(" 1\n"))
-// 				}
-// 			},
-// 		),
-// 	)
-// 	defer server.Close()
-// 	addr := model.LabelValue(strings.Split(server.URL, "://")[1])
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("want base labels %v, got %v", want, got)
+	}
 
-// 	tests = []test{
-// 		{
-// 			metric: `foo{}`,
-// 			resultNormal: model.Metric{
-// 				model.MetricNameLabel: "foo",
-// 				model.InstanceLabel:   addr,
-// 			},
-// 			resultHonor: model.Metric{
-// 				model.MetricNameLabel: "foo",
-// 				model.InstanceLabel:   addr,
-// 			},
-// 		},
-// 		{
-// 			metric: `foo{instance=""}`,
-// 			resultNormal: model.Metric{
-// 				model.MetricNameLabel: "foo",
-// 				model.InstanceLabel:   addr,
-// 			},
-// 			resultHonor: model.Metric{
-// 				model.MetricNameLabel: "foo",
-// 			},
-// 		},
-// 		{
-// 			metric: `foo{instance="other_instance"}`,
-// 			resultNormal: model.Metric{
-// 				model.MetricNameLabel:                           "foo",
-// 				model.InstanceLabel:                             addr,
-// 				model.ExportedLabelPrefix + model.InstanceLabel: "other_instance",
-// 			},
-// 			resultHonor: model.Metric{
-// 				model.MetricNameLabel: "foo",
-// 				model.InstanceLabel:   "other_instance",
-// 			},
-// 		},
-// 	}
+	// Ensure it is a copy.
+	delete(got, "foo")
+	if _, ok := target.BaseLabels()["foo"]; !ok {
+		t.Fatalf("Targets internal label set was modified")
+	}
+}
 
-// 	target := newTestTarget(server.URL, 10*time.Millisecond, nil)
+func newTestTarget(host string, timeout time.Duration, baseLabels model.LabelSet) *Target {
+	cfg := &config.ScrapeConfig{
+		ScrapeTimeout:  config.Duration(timeout),
+		ScrapeInterval: config.Duration(1 * time.Millisecond),
+	}
+	host = strings.TrimLeft(host, "http://")
 
-// 	target.honorLabels = false
-// 	app := &collectResultAppender{}
-// 	if err := target.scrape(app); err != nil {
-// 		t.Fatal(err)
-// 	}
+	labels := model.LabelSet{
+		model.SchemeLabel:      "http",
+		model.AddressLabel:     model.LabelValue(host),
+		model.MetricsPathLabel: "/metrics",
+	}
+	for ln, lv := range baseLabels {
+		labels[ln] = lv
+	}
+	return NewTarget(cfg, labels, labels)
+}
 
-// 	for i, test := range tests {
-// 		if !reflect.DeepEqual(app.result[i].Metric, test.resultNormal) {
-// 			t.Errorf("Error comparing %q:\nExpected:\n%s\nGot:\n%s\n", test.metric, test.resultNormal, app.result[i].Metric)
-// 		}
-// 	}
+func TestTargetURL(t *testing.T) {
+	tests := []struct {
+		labels model.LabelSet
+		url    string
+		cfg    *config.ScrapeConfig
+	}{
+		{
+			labels: model.LabelSet{
+				model.SchemeLabel:      "http",
+				model.AddressLabel:     "example.org:8999",
+				model.MetricsPathLabel: "/metrics",
+			},
+			url: "http://example.org:8999/metrics",
+			cfg: &config.ScrapeConfig{},
+		},
+		{
+			labels: model.LabelSet{
+				model.SchemeLabel:      "https",
+				model.AddressLabel:     "example.org:8999",
+				model.MetricsPathLabel: "/federate",
+				"random_label":         "value",
+			},
+			url: "https://example.org:8999/federate",
+			cfg: &config.ScrapeConfig{},
+		},
+		{
+			labels: model.LabelSet{
+				model.SchemeLabel:      "https",
+				model.AddressLabel:     "example.org:8999",
+				model.MetricsPathLabel: "/federate",
+				"random_label":         "value",
+				"__param_first":        "x",
+				"__param_second":       "y",
+			},
+			url: "https://example.org:8999/federate?first=x&second=y&baseparam=z",
+			cfg: &config.ScrapeConfig{
+				Params: url.Values{
+					"baseparam": []string{"z"},
+				},
+			},
+		},
+		{
+			labels: model.LabelSet{
+				model.SchemeLabel:      "https",
+				model.AddressLabel:     "example.org:8999",
+				model.MetricsPathLabel: "/federate",
+				"random_label":         "value",
+				"__param_first":        "x",
+				"__param_second":       "y",
+				"__param_baseparam":    "rule",
+			},
+			url: "https://example.org:8999/federate?first=x&second=y&baseparam=rule",
+			cfg: &config.ScrapeConfig{
+				Params: url.Values{
+					"baseparam": []string{"z"},
+				},
+			},
+		},
+	}
 
-// 	target.honorLabels = true
-// 	app = &collectResultAppender{}
-// 	if err := target.scrape(app); err != nil {
-// 		t.Fatal(err)
-// 	}
+	for _, test := range tests {
+		target := NewTarget(test.cfg, test.labels, nil)
 
-// 	for i, test := range tests {
-// 		if !reflect.DeepEqual(app.result[i].Metric, test.resultHonor) {
-// 			t.Errorf("Error comparing %q:\nExpected:\n%s\nGot:\n%s\n", test.metric, test.resultHonor, app.result[i].Metric)
-// 		}
+		exp, err := url.Parse(test.url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		res := target.URL()
 
-// 	}
-// }
-// func TestTargetScrapeUpdatesState(t *testing.T) {
-// 	testTarget := newTestTarget("bad schema", 0, nil)
+		if res.Scheme != exp.Scheme {
+			t.Fatalf("Wrong URL scheme: want %q, got %q", exp.Scheme, res.Scheme)
+		}
+		if res.Host != exp.Host {
+			t.Fatalf("Wrong URL host: want %q, got %q", exp.Host, res.Host)
+		}
+		if res.Path != exp.Path {
+			t.Fatalf("Wrong URL path: want %q, got %q", exp.Path, res.Path)
+		}
+		if !reflect.DeepEqual(res.Query(), exp.Query()) {
+			t.Fatalf("Wrong URL query: want %q, got %q", exp.Query(), res.Query())
+		}
+	}
+}
 
-// 	testTarget.scrape(nopAppender{})
-// 	if testTarget.status.Health() != HealthBad {
-// 		t.Errorf("Expected target state %v, actual: %v", HealthBad, testTarget.status.Health())
-// 	}
-// }
+func TestTargetScrape(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+			w.Write([]byte("test_metric{a=\"b\"} 0\n"))
+			w.Write([]byte("test_metric{a=\"c\"} 1\n"))
+		},
+	))
 
-// func TestTargetScrapeWithFullChannel(t *testing.T) {
-// 	server := httptest.NewServer(
-// 		http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-// 				for i := 0; i < 2*ingestedSamplesCap; i++ {
-// 					w.Write([]byte(
-// 						fmt.Sprintf("test_metric_%d{foo=\"bar\"} 123.456\n", i),
-// 					))
-// 				}
-// 			},
-// 		),
-// 	)
-// 	defer server.Close()
+	target := newTestTarget(server.URL, 10*time.Millisecond, nil)
 
-// 	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{"dings": "bums"})
+	ch := make(chan model.Vector, 1)
 
-// 	testTarget.scrape(slowAppender{})
-// 	if testTarget.status.Health() != HealthBad {
-// 		t.Errorf("Expected target state %v, actual: %v", HealthBad, testTarget.status.Health())
-// 	}
-// 	if testTarget.status.LastError() != errIngestChannelFull {
-// 		t.Errorf("Expected target error %q, actual: %q", errIngestChannelFull, testTarget.status.LastError())
-// 	}
-// }
+	start := time.Now()
+	err := target.Scrape(context.Background(), ch)
+	if err != nil {
+		t.Fatalf("Unexpected scrape error: %s", err)
+	}
 
-// func TestTargetScrapeMetricRelabelConfigs(t *testing.T) {
-// 	server := httptest.NewServer(
-// 		http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-// 				w.Write([]byte("test_metric_drop 0\n"))
-// 				w.Write([]byte("test_metric_relabel 1\n"))
-// 			},
-// 		),
-// 	)
-// 	defer server.Close()
-// 	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{})
-// 	testTarget.metricRelabelConfigs = []*config.RelabelConfig{
-// 		{
-// 			SourceLabels: model.LabelNames{"__name__"},
-// 			Regex:        config.MustNewRegexp(".*drop.*"),
-// 			Action:       config.RelabelDrop,
-// 		},
-// 		{
-// 			SourceLabels: model.LabelNames{"__name__"},
-// 			Regex:        config.MustNewRegexp(".*(relabel|up).*"),
-// 			TargetLabel:  "foo",
-// 			Replacement:  "bar",
-// 			Action:       config.RelabelReplace,
-// 		},
-// 	}
+	expect := func(smpl *model.Sample, m model.Metric, value model.SampleValue) {
+		if !reflect.DeepEqual(smpl.Metric, m) {
+			t.Fatalf("Unexpected sample metric: want %v, got %v", m, smpl.Metric)
+		}
+		if smpl.Value != value {
+			t.Fatalf("Unexpected sample value: want %v, got %v", value, smpl.Value)
+		}
+		ts := smpl.Timestamp.Time()
+		if ts.Before(start.Add(-1*time.Millisecond)) || ts.After(time.Now().Add(1*time.Millisecond)) {
+			t.Fatalf("Unexpected timestamp: %v", ts, start)
+		}
+	}
 
-// 	appender := &collectResultAppender{}
-// 	testTarget.scrape(appender)
+	select {
+	case samples := <-ch:
+		expect(samples[0], model.Metric{model.MetricNameLabel: "test_metric", "a": "b"}, 0)
+		expect(samples[1], model.Metric{model.MetricNameLabel: "test_metric", "a": "c"}, 1)
 
-// 	// Remove variables part of result.
-// 	for _, sample := range appender.result {
-// 		sample.Timestamp = 0
-// 		sample.Value = 0
-// 	}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("No sample received")
+	}
+}
 
-// 	expected := []*model.Sample{
-// 		{
-// 			Metric: model.Metric{
-// 				model.MetricNameLabel: "test_metric_relabel",
-// 				"foo":               "bar",
-// 				model.InstanceLabel: model.LabelValue(testTarget.url.Host),
-// 			},
-// 			Timestamp: 0,
-// 			Value:     0,
-// 		},
-// 		// The metrics about the scrape are not affected.
-// 		{
-// 			Metric: model.Metric{
-// 				model.MetricNameLabel: scrapeHealthMetricName,
-// 				model.InstanceLabel:   model.LabelValue(testTarget.url.Host),
-// 			},
-// 			Timestamp: 0,
-// 			Value:     0,
-// 		},
-// 		{
-// 			Metric: model.Metric{
-// 				model.MetricNameLabel: scrapeDurationMetricName,
-// 				model.InstanceLabel:   model.LabelValue(testTarget.url.Host),
-// 			},
-// 			Timestamp: 0,
-// 			Value:     0,
-// 		},
-// 	}
+func TestTargetScrapeTimeout(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
 
-// 	if !appender.result.Equal(expected) {
-// 		t.Fatalf("Expected and actual samples not equal. Expected: %s, actual: %s", expected, appender.result)
-// 	}
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			<-block
+		},
+	))
 
-// }
+	target := newTestTarget(server.URL, 10*time.Millisecond, nil)
 
-// func TestTargetRecordScrapeHealth(t *testing.T) {
-// 	testTarget := newTestTarget("example.url:80", 0, model.LabelSet{model.JobLabel: "testjob"})
+	ctx, _ := context.WithTimeout(context.Background(), target.timeout())
+	ch := make(chan model.Vector)
 
-// 	now := model.Now()
-// 	appender := &collectResultAppender{}
-// 	testTarget.status.setLastError(nil)
-// 	recordScrapeHealth(appender, now.Time(), testTarget.BaseLabels(), testTarget.status.Health(), 2*time.Second)
+	err := target.Scrape(ctx, ch)
+	if !strings.Contains(err.Error(), "timeout") && !strings.Contains(err.Error(), "deadline") {
+		t.Fatalf("Expected timeout error but got %q", err)
+	}
+}
 
-// 	result := appender.result
+func TestTargetScrapeErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(http.NotFound))
 
-// 	if len(result) != 2 {
-// 		t.Fatalf("Expected two samples, got %d", len(result))
-// 	}
+	target := newTestTarget(server.URL, 10*time.Millisecond, nil)
 
-// 	actual := result[0]
-// 	expected := &model.Sample{
-// 		Metric: model.Metric{
-// 			model.MetricNameLabel: scrapeHealthMetricName,
-// 			model.InstanceLabel:   "example.url:80",
-// 			model.JobLabel:        "testjob",
-// 		},
-// 		Timestamp: now,
-// 		Value:     1,
-// 	}
+	err := target.Scrape(context.Background(), make(chan model.Vector))
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+}
 
-// 	if !actual.Equal(expected) {
-// 		t.Fatalf("Expected and actual samples not equal. Expected: %v, actual: %v", expected, actual)
-// 	}
+func TestNewHTTPBearerToken(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expected := "Bearer 1234"
+				received := r.Header.Get("Authorization")
+				if expected != received {
+					t.Fatalf("Authorization header was not set correctly: expected '%v', got '%v'", expected, received)
+				}
+			},
+		),
+	)
+	defer server.Close()
 
-// 	actual = result[1]
-// 	expected = &model.Sample{
-// 		Metric: model.Metric{
-// 			model.MetricNameLabel: scrapeDurationMetricName,
-// 			model.InstanceLabel:   "example.url:80",
-// 			model.JobLabel:        "testjob",
-// 		},
-// 		Timestamp: now,
-// 		Value:     2.0,
-// 	}
+	cfg := &config.ScrapeConfig{
+		ScrapeTimeout: config.Duration(1 * time.Second),
+		BearerToken:   "1234",
+	}
+	c, err := newHTTPClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
-// 	if !actual.Equal(expected) {
-// 		t.Fatalf("Expected and actual samples not equal. Expected: %v, actual: %v", expected, actual)
-// 	}
-// }
+func TestNewHTTPBearerTokenFile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			var (
+				expected = "Bearer 12345"
+				received = r.Header.Get("Authorization")
+			)
+			if expected != received {
+				t.Fatalf("Authorization header was not set correctly: expected %q', got %q", expected, received)
+			}
+		},
+	))
+	defer server.Close()
 
-// func TestTargetScrapeTimeout(t *testing.T) {
-// 	signal := make(chan bool, 1)
-// 	server := httptest.NewServer(
-// 		http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				<-signal
-// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-// 				w.Write([]byte{})
-// 			},
-// 		),
-// 	)
-// 	defer server.Close()
+	cfg := &config.ScrapeConfig{
+		ScrapeTimeout:   config.Duration(1 * time.Second),
+		BearerTokenFile: "testdata/bearertoken.txt",
+	}
 
-// 	testTarget := newTestTarget(server.URL, 50*time.Millisecond, model.LabelSet{})
+	c, err := newHTTPClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	appender := nopAppender{}
+	_, err = c.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
-// 	// scrape once without timeout
-// 	signal <- true
-// 	if err := testTarget.scrape(appender); err != nil {
-// 		t.Fatal(err)
-// 	}
+func TestNewHTTPBasicAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			username, password, ok := r.BasicAuth()
+			if !(ok && username == "user" && password == "password123") {
+				t.Fatalf("Basic authorization header was not set correctly: expected \"%s:%s\", got \"%s:%s\"", "user", "password123", username, password)
+			}
+		},
+	))
+	defer server.Close()
 
-// 	// let the deadline lapse
-// 	time.Sleep(55 * time.Millisecond)
+	cfg := &config.ScrapeConfig{
+		ScrapeTimeout: config.Duration(1 * time.Second),
+		BasicAuth: &config.BasicAuth{
+			Username: "user",
+			Password: "password123",
+		},
+	}
+	c, err := newHTTPClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
-// 	// now scrape again
-// 	signal <- true
-// 	if err := testTarget.scrape(appender); err != nil {
-// 		t.Fatal(err)
-// 	}
+func TestNewHTTPCACert(t *testing.T) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+			w.Write([]byte{})
+		},
+	))
 
-// 	// now timeout
-// 	if err := testTarget.scrape(appender); err == nil {
-// 		t.Fatal("expected scrape to timeout")
-// 	} else {
-// 		signal <- true // let handler continue
-// 	}
+	server.TLS = newTLSConfig(t)
+	server.StartTLS()
 
-// 	// now scrape again without timeout
-// 	signal <- true
-// 	if err := testTarget.scrape(appender); err != nil {
-// 		t.Fatal(err)
-// 	}
-// }
+	defer server.Close()
 
-// func TestTargetScrape404(t *testing.T) {
-// 	server := httptest.NewServer(
-// 		http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				w.WriteHeader(http.StatusNotFound)
-// 			},
-// 		),
-// 	)
-// 	defer server.Close()
+	cfg := &config.ScrapeConfig{
+		ScrapeTimeout: config.Duration(1 * time.Second),
+		TLSConfig: config.TLSConfig{
+			CAFile: "testdata/ca.cer",
+		},
+	}
+	c, err := newHTTPClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
-// 	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{})
-// 	appender := nopAppender{}
+func TestNewHTTPClientCert(t *testing.T) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+			w.Write([]byte{})
+		},
+	))
 
-// 	want := errors.New("server returned HTTP status 404 Not Found")
-// 	got := testTarget.scrape(appender)
-// 	if got == nil || want.Error() != got.Error() {
-// 		t.Fatalf("want err %q, got %q", want, got)
-// 	}
-// }
+	tlsConfig := newTLSConfig(t)
+	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	tlsConfig.ClientCAs = tlsConfig.RootCAs
+	tlsConfig.BuildNameToCertificate()
 
-// func TestTargetRunScraperScrapes(t *testing.T) {
-// 	testTarget := newTestTarget("bad schema", 0, nil)
+	server.TLS = tlsConfig
+	server.StartTLS()
 
-// 	go testTarget.RunScraper(nopAppender{})
+	defer server.Close()
 
-// 	// Enough time for a scrape to happen.
-// 	time.Sleep(10 * time.Millisecond)
-// 	if testTarget.status.LastScrape().IsZero() {
-// 		t.Errorf("Scrape hasn't occured.")
-// 	}
+	cfg := &config.ScrapeConfig{
+		ScrapeTimeout: config.Duration(1 * time.Second),
+		TLSConfig: config.TLSConfig{
+			CAFile:   "testdata/ca.cer",
+			CertFile: "testdata/client.cer",
+			KeyFile:  "testdata/client.key",
+		},
+	}
+	c, err := newHTTPClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
-// 	testTarget.StopScraper()
-// 	// Wait for it to take effect.
-// 	time.Sleep(5 * time.Millisecond)
-// 	last := testTarget.status.LastScrape()
-// 	// Enough time for a scrape to happen.
-// 	time.Sleep(10 * time.Millisecond)
-// 	if testTarget.status.LastScrape() != last {
-// 		t.Errorf("Scrape occured after it was stopped.")
-// 	}
-// }
+func newTLSConfig(t *testing.T) *tls.Config {
+	tlsConfig := &tls.Config{}
 
-// func BenchmarkScrape(b *testing.B) {
-// 	server := httptest.NewServer(
-// 		http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-// 				w.Write([]byte("test_metric{foo=\"bar\"} 123.456\n"))
-// 			},
-// 		),
-// 	)
-// 	defer server.Close()
+	caCertPool := x509.NewCertPool()
+	caCert, err := ioutil.ReadFile("testdata/ca.cer")
+	if err != nil {
+		t.Fatalf("Couldn't set up TLS server: %v", err)
+	}
 
-// 	testTarget := newTestTarget(server.URL, 100*time.Millisecond, model.LabelSet{"dings": "bums"})
-// 	appender := nopAppender{}
+	caCertPool.AppendCertsFromPEM(caCert)
+	tlsConfig.RootCAs = caCertPool
+	tlsConfig.ServerName = "127.0.0.1"
 
-// 	b.ResetTimer()
-// 	for i := 0; i < b.N; i++ {
-// 		if err := testTarget.scrape(appender); err != nil {
-// 			b.Fatal(err)
-// 		}
-// 	}
-// }
+	cert, err := tls.LoadX509KeyPair("testdata/server.cer", "testdata/server.key")
+	if err != nil {
+		t.Errorf("Unable to use specified server cert (%s) and key (%v): %s", "testdata/server.cer", "testdata/server.key", err)
+	}
+	tlsConfig.Certificates = []tls.Certificate{cert}
+	tlsConfig.BuildNameToCertificate()
 
-// func TestURLParams(t *testing.T) {
-// 	server := httptest.NewServer(
-// 		http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-// 				w.Write([]byte{})
-// 				r.ParseForm()
-// 				if r.Form["foo"][0] != "bar" {
-// 					t.Fatalf("URL parameter 'foo' had unexpected first value '%v'", r.Form["foo"][0])
-// 				}
-// 				if r.Form["foo"][1] != "baz" {
-// 					t.Fatalf("URL parameter 'foo' had unexpected second value '%v'", r.Form["foo"][1])
-// 				}
-// 			},
-// 		),
-// 	)
-// 	defer server.Close()
-// 	serverURL, err := url.Parse(server.URL)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-
-// 	target := NewTarget(
-// 		&config.ScrapeConfig{
-// 			JobName:        "test_job1",
-// 			ScrapeInterval: config.Duration(1 * time.Minute),
-// 			ScrapeTimeout:  config.Duration(1 * time.Second),
-// 			Scheme:         serverURL.Scheme,
-// 			Params: url.Values{
-// 				"foo": []string{"bar", "baz"},
-// 			},
-// 		},
-// 		model.LabelSet{
-// 			model.SchemeLabel:  model.LabelValue(serverURL.Scheme),
-// 			model.AddressLabel: model.LabelValue(serverURL.Host),
-// 			"__param_foo":      "bar",
-// 		},
-// 		nil)
-// 	app := &collectResultAppender{}
-// 	if err = target.scrape(app); err != nil {
-// 		t.Fatal(err)
-// 	}
-// }
-
-// func newTestTarget(targetURL string, deadline time.Duration, baseLabels model.LabelSet) *Target {
-// 	cfg := &config.ScrapeConfig{
-// 		ScrapeTimeout: config.Duration(deadline),
-// 	}
-// 	c, _ := newHTTPClient(cfg)
-// 	t := &Target{
-// 		url: &url.URL{
-// 			Scheme: "http",
-// 			Host:   strings.TrimLeft(targetURL, "http://"),
-// 			Path:   "/metrics",
-// 		},
-// 		deadline:        deadline,
-// 		status:          &TargetStatus{},
-// 		scrapeInterval:  1 * time.Millisecond,
-// 		httpClient:      c,
-// 		scraperStopping: make(chan struct{}),
-// 		scraperStopped:  make(chan struct{}),
-// 	}
-// 	t.baseLabels = model.LabelSet{
-// 		model.InstanceLabel: model.LabelValue(t.InstanceIdentifier()),
-// 	}
-// 	for baseLabel, baseValue := range baseLabels {
-// 		t.baseLabels[baseLabel] = baseValue
-// 	}
-// 	return t
-// }
-
-// func TestNewHTTPBearerToken(t *testing.T) {
-// 	server := httptest.NewServer(
-// 		http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				expected := "Bearer 1234"
-// 				received := r.Header.Get("Authorization")
-// 				if expected != received {
-// 					t.Fatalf("Authorization header was not set correctly: expected '%v', got '%v'", expected, received)
-// 				}
-// 			},
-// 		),
-// 	)
-// 	defer server.Close()
-
-// 	cfg := &config.ScrapeConfig{
-// 		ScrapeTimeout: config.Duration(1 * time.Second),
-// 		BearerToken:   "1234",
-// 	}
-// 	c, err := newHTTPClient(cfg)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	_, err = c.Get(server.URL)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// }
-
-// func TestNewHTTPBearerTokenFile(t *testing.T) {
-// 	server := httptest.NewServer(
-// 		http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				expected := "Bearer 12345"
-// 				received := r.Header.Get("Authorization")
-// 				if expected != received {
-// 					t.Fatalf("Authorization header was not set correctly: expected '%v', got '%v'", expected, received)
-// 				}
-// 			},
-// 		),
-// 	)
-// 	defer server.Close()
-
-// 	cfg := &config.ScrapeConfig{
-// 		ScrapeTimeout:   config.Duration(1 * time.Second),
-// 		BearerTokenFile: "testdata/bearertoken.txt",
-// 	}
-// 	c, err := newHTTPClient(cfg)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	_, err = c.Get(server.URL)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// }
-
-// func TestNewHTTPBasicAuth(t *testing.T) {
-// 	server := httptest.NewServer(
-// 		http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				username, password, ok := r.BasicAuth()
-// 				if !(ok && username == "user" && password == "password123") {
-// 					t.Fatalf("Basic authorization header was not set correctly: expected '%v:%v', got '%v:%v'", "user", "password123", username, password)
-// 				}
-// 			},
-// 		),
-// 	)
-// 	defer server.Close()
-
-// 	cfg := &config.ScrapeConfig{
-// 		ScrapeTimeout: config.Duration(1 * time.Second),
-// 		BasicAuth: &config.BasicAuth{
-// 			Username: "user",
-// 			Password: "password123",
-// 		},
-// 	}
-// 	c, err := newHTTPClient(cfg)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	_, err = c.Get(server.URL)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// }
-
-// func TestNewHTTPCACert(t *testing.T) {
-// 	server := httptest.NewUnstartedServer(
-// 		http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-// 				w.Write([]byte{})
-// 			},
-// 		),
-// 	)
-// 	server.TLS = newTLSConfig(t)
-// 	server.StartTLS()
-// 	defer server.Close()
-
-// 	cfg := &config.ScrapeConfig{
-// 		ScrapeTimeout: config.Duration(1 * time.Second),
-// 		TLSConfig: config.TLSConfig{
-// 			CAFile: "testdata/ca.cer",
-// 		},
-// 	}
-// 	c, err := newHTTPClient(cfg)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	_, err = c.Get(server.URL)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// }
-
-// func TestNewHTTPClientCert(t *testing.T) {
-// 	server := httptest.NewUnstartedServer(
-// 		http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
-// 				w.Write([]byte{})
-// 			},
-// 		),
-// 	)
-// 	tlsConfig := newTLSConfig(t)
-// 	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-// 	tlsConfig.ClientCAs = tlsConfig.RootCAs
-// 	tlsConfig.BuildNameToCertificate()
-// 	server.TLS = tlsConfig
-// 	server.StartTLS()
-// 	defer server.Close()
-
-// 	cfg := &config.ScrapeConfig{
-// 		ScrapeTimeout: config.Duration(1 * time.Second),
-// 		TLSConfig: config.TLSConfig{
-// 			CAFile:   "testdata/ca.cer",
-// 			CertFile: "testdata/client.cer",
-// 			KeyFile:  "testdata/client.key",
-// 		},
-// 	}
-// 	c, err := newHTTPClient(cfg)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	_, err = c.Get(server.URL)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// }
-
-// func newTLSConfig(t *testing.T) *tls.Config {
-// 	tlsConfig := &tls.Config{}
-// 	caCertPool := x509.NewCertPool()
-// 	caCert, err := ioutil.ReadFile("testdata/ca.cer")
-// 	if err != nil {
-// 		t.Fatalf("Couldn't set up TLS server: %v", err)
-// 	}
-// 	caCertPool.AppendCertsFromPEM(caCert)
-// 	tlsConfig.RootCAs = caCertPool
-// 	tlsConfig.ServerName = "127.0.0.1"
-// 	cert, err := tls.LoadX509KeyPair("testdata/server.cer", "testdata/server.key")
-// 	if err != nil {
-// 		t.Errorf("Unable to use specified server cert (%s) & key (%v): %s", "testdata/server.cer", "testdata/server.key", err)
-// 	}
-// 	tlsConfig.Certificates = []tls.Certificate{cert}
-// 	tlsConfig.BuildNameToCertificate()
-// 	return tlsConfig
-// }
+	return tlsConfig
+}

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -212,7 +212,7 @@ func TestTargetScrape(t *testing.T) {
 		}
 		ts := smpl.Timestamp.Time()
 		if ts.Before(start.Add(-1*time.Millisecond)) || ts.After(time.Now().Add(1*time.Millisecond)) {
-			t.Fatalf("Unexpected timestamp: %v", ts, start)
+			t.Fatalf("Unexpected timestamp: want %v, got %v", start, ts)
 		}
 	}
 

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -206,7 +206,7 @@ func (tm *TargetManager) Run() {
 func (tm *TargetManager) handleUpdates(ch <-chan targetGroupUpdate, done <-chan struct{}) {
 	// To not sync constantly on a stream of updates, attempt a sync every second
 	// if an update has been received.
-	syncTicker := time.NewTicker(1 * time.Second)
+	syncTicker := time.NewTicker(2 * time.Second)
 	defer syncTicker.Stop()
 
 	dirty := false

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -349,7 +349,7 @@ func TestTargetManagerConfigUpdate(t *testing.T) {
 		conf.ScrapeConfigs = step.scrapeConfigs
 		targetManager.ApplyConfig(conf)
 
-		time.Sleep(150 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 
 		if len(targetManager.targets) != len(step.expected) {
 			t.Fatalf("step %d: sources mismatch: expected %v, got %v", i, step.expected, targetManager.targets)

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -1,384 +1,396 @@
-// // Copyright 2013 The Prometheus Authors
-// // Licensed under the Apache License, Version 2.0 (the "License");
-// // you may not use this file except in compliance with the License.
-// // You may obtain a copy of the License at
-// //
-// // http://www.apache.org/licenses/LICENSE-2.0
-// //
-// // Unless required by applicable law or agreed to in writing, software
-// // distributed under the License is distributed on an "AS IS" BASIS,
-// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// // See the License for the specific language governing permissions and
-// // limitations under the License.
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package retrieval
 
-// import (
-// 	"net/url"
-// 	"reflect"
-// 	"testing"
-// 	"time"
+import (
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
 
-// 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/model"
 
-// 	"github.com/prometheus/prometheus/config"
-// )
+	"github.com/prometheus/prometheus/config"
+)
 
-// func TestPrefixedTargetProvider(t *testing.T) {
-// 	targetGroups := []*config.TargetGroup{
-// 		{
-// 			Targets: []model.LabelSet{
-// 				{model.AddressLabel: "test-1:1234"},
-// 			},
-// 		}, {
-// 			Targets: []model.LabelSet{
-// 				{model.AddressLabel: "test-1:1235"},
-// 			},
-// 		},
-// 	}
+func TestPrefixedTargetProvider(t *testing.T) {
+	targetGroups := []*config.TargetGroup{
+		{
+			Targets: []model.LabelSet{
+				{model.AddressLabel: "test-1:1234"},
+			},
+		}, {
+			Targets: []model.LabelSet{
+				{model.AddressLabel: "test-1:1235"},
+			},
+		},
+	}
 
-// 	tp := &prefixedTargetProvider{
-// 		job:            "job-x",
-// 		mechanism:      "static",
-// 		idx:            123,
-// 		TargetProvider: NewStaticProvider(targetGroups),
-// 	}
+	tp := &prefixedTargetProvider{
+		job:            "job-x",
+		mechanism:      "static",
+		idx:            123,
+		TargetProvider: NewStaticProvider(targetGroups),
+	}
 
-// 	expSources := []string{
-// 		"job-x:static:123:0",
-// 		"job-x:static:123:1",
-// 	}
-// 	if !reflect.DeepEqual(tp.Sources(), expSources) {
-// 		t.Fatalf("expected sources %v, got %v", expSources, tp.Sources())
-// 	}
+	expSources := []string{
+		"job-x:static:123:0",
+		"job-x:static:123:1",
+	}
+	if !reflect.DeepEqual(tp.Sources(), expSources) {
+		t.Fatalf("expected sources %v, got %v", expSources, tp.Sources())
+	}
 
-// 	ch := make(chan *config.TargetGroup)
-// 	done := make(chan struct{})
+	ch := make(chan *config.TargetGroup)
+	done := make(chan struct{})
 
-// 	defer close(done)
-// 	go tp.Run(ch, done)
+	defer close(done)
+	go tp.Run(ch, done)
 
-// 	expGroup1 := *targetGroups[0]
-// 	expGroup2 := *targetGroups[1]
-// 	expGroup1.Source = "job-x:static:123:0"
-// 	expGroup2.Source = "job-x:static:123:1"
+	expGroup1 := *targetGroups[0]
+	expGroup2 := *targetGroups[1]
+	expGroup1.Source = "job-x:static:123:0"
+	expGroup2.Source = "job-x:static:123:1"
 
-// 	// The static target provider sends on the channel once per target group.
-// 	if tg := <-ch; !reflect.DeepEqual(tg, &expGroup1) {
-// 		t.Fatalf("expected target group %v, got %v", expGroup1, tg)
-// 	}
-// 	if tg := <-ch; !reflect.DeepEqual(tg, &expGroup2) {
-// 		t.Fatalf("expected target group %v, got %v", expGroup2, tg)
-// 	}
-// }
+	// The static target provider sends on the channel once per target group.
+	if tg := <-ch; !reflect.DeepEqual(tg, &expGroup1) {
+		t.Fatalf("expected target group %v, got %v", expGroup1, tg)
+	}
+	if tg := <-ch; !reflect.DeepEqual(tg, &expGroup2) {
+		t.Fatalf("expected target group %v, got %v", expGroup2, tg)
+	}
+}
 
-// func TestTargetManagerChan(t *testing.T) {
-// 	testJob1 := &config.ScrapeConfig{
-// 		JobName:        "test_job1",
-// 		ScrapeInterval: config.Duration(1 * time.Minute),
-// 		TargetGroups: []*config.TargetGroup{{
-// 			Targets: []model.LabelSet{
-// 				{model.AddressLabel: "example.org:80"},
-// 				{model.AddressLabel: "example.com:80"},
-// 			},
-// 		}},
-// 	}
-// 	prov1 := &fakeTargetProvider{
-// 		sources: []string{"src1", "src2"},
-// 		update:  make(chan *config.TargetGroup),
-// 	}
+func TestTargetManagerChan(t *testing.T) {
+	testJob1 := &config.ScrapeConfig{
+		JobName:        "test_job1",
+		ScrapeInterval: config.Duration(1 * time.Minute),
+		TargetGroups: []*config.TargetGroup{{
+			Targets: []model.LabelSet{
+				{model.AddressLabel: "example.org:80"},
+				{model.AddressLabel: "example.com:80"},
+			},
+		}},
+	}
+	prov1 := &fakeTargetProvider{
+		sources: []string{"src1", "src2"},
+		update:  make(chan *config.TargetGroup),
+	}
 
-// 	targetManager := &TargetManager{
-// 		sampleAppender: nopAppender{},
-// 		providers: map[*config.ScrapeConfig][]TargetProvider{
-// 			testJob1: {prov1},
-// 		},
-// 		targets: make(map[string][]*Target),
-// 	}
-// 	go targetManager.Run()
-// 	defer targetManager.Stop()
+	targetManager := &TargetManager{
+		pool: NewScrapePool(nopAppender{}),
+		providers: map[*config.ScrapeConfig][]TargetProvider{
+			testJob1: {prov1},
+		},
+		targets: make(map[string][]*Target),
+	}
+	go targetManager.Run()
+	defer targetManager.Stop()
 
-// 	sequence := []struct {
-// 		tgroup   *config.TargetGroup
-// 		expected map[string][]model.LabelSet
-// 	}{
-// 		{
-// 			tgroup: &config.TargetGroup{
-// 				Source: "src1",
-// 				Targets: []model.LabelSet{
-// 					{model.AddressLabel: "test-1:1234"},
-// 					{model.AddressLabel: "test-2:1234", "label": "set"},
-// 					{model.AddressLabel: "test-3:1234"},
-// 				},
-// 			},
-// 			expected: map[string][]model.LabelSet{
-// 				"src1": {
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1234", "label": "set"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
-// 				},
-// 			},
-// 		}, {
-// 			tgroup: &config.TargetGroup{
-// 				Source: "src2",
-// 				Targets: []model.LabelSet{
-// 					{model.AddressLabel: "test-1:1235"},
-// 					{model.AddressLabel: "test-2:1235"},
-// 					{model.AddressLabel: "test-3:1235"},
-// 				},
-// 				Labels: model.LabelSet{"group": "label"},
-// 			},
-// 			expected: map[string][]model.LabelSet{
-// 				"src1": {
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1234", "label": "set"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
-// 				},
-// 				"src2": {
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1235", "group": "label"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1235", "group": "label"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1235", "group": "label"},
-// 				},
-// 			},
-// 		}, {
-// 			tgroup: &config.TargetGroup{
-// 				Source:  "src2",
-// 				Targets: []model.LabelSet{},
-// 			},
-// 			expected: map[string][]model.LabelSet{
-// 				"src1": {
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1234", "label": "set"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
-// 				},
-// 			},
-// 		}, {
-// 			tgroup: &config.TargetGroup{
-// 				Source: "src1",
-// 				Targets: []model.LabelSet{
-// 					{model.AddressLabel: "test-1:1234", "added": "label"},
-// 					{model.AddressLabel: "test-3:1234"},
-// 					{model.AddressLabel: "test-4:1234", "fancy": "label"},
-// 				},
-// 			},
-// 			expected: map[string][]model.LabelSet{
-// 				"src1": {
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234", "added": "label"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-4:1234", "fancy": "label"},
-// 				},
-// 			},
-// 		},
-// 	}
+	sequence := []struct {
+		tgroup   *config.TargetGroup
+		expected map[string][]model.LabelSet
+	}{
+		{
+			tgroup: &config.TargetGroup{
+				Source: "src1",
+				Targets: []model.LabelSet{
+					{model.AddressLabel: "test-1:1234"},
+					{model.AddressLabel: "test-2:1234", "label": "set"},
+					{model.AddressLabel: "test-3:1234"},
+				},
+			},
+			expected: map[string][]model.LabelSet{
+				"src1": {
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1234", "label": "set"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
+				},
+			},
+		}, {
+			tgroup: &config.TargetGroup{
+				Source: "src2",
+				Targets: []model.LabelSet{
+					{model.AddressLabel: "test-1:1235"},
+					{model.AddressLabel: "test-2:1235"},
+					{model.AddressLabel: "test-3:1235"},
+				},
+				Labels: model.LabelSet{"group": "label"},
+			},
+			expected: map[string][]model.LabelSet{
+				"src1": {
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1234", "label": "set"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
+				},
+				"src2": {
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1235", "group": "label"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1235", "group": "label"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1235", "group": "label"},
+				},
+			},
+		}, {
+			tgroup: &config.TargetGroup{
+				Source:  "src2",
+				Targets: []model.LabelSet{},
+			},
+			expected: map[string][]model.LabelSet{
+				"src1": {
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1234", "label": "set"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
+				},
+			},
+		}, {
+			tgroup: &config.TargetGroup{
+				Source: "src1",
+				Targets: []model.LabelSet{
+					{model.AddressLabel: "test-1:1234", "added": "label"},
+					{model.AddressLabel: "test-3:1234"},
+					{model.AddressLabel: "test-4:1234", "fancy": "label"},
+				},
+			},
+			expected: map[string][]model.LabelSet{
+				"src1": {
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234", "added": "label"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "test-4:1234", "fancy": "label"},
+				},
+			},
+		},
+	}
 
-// 	for i, step := range sequence {
-// 		prov1.update <- step.tgroup
+	for i, step := range sequence {
+		prov1.update <- step.tgroup
 
-// 		<-time.After(1 * time.Millisecond)
+		time.Sleep(1 * time.Millisecond)
 
-// 		if len(targetManager.targets) != len(step.expected) {
-// 			t.Fatalf("step %d: sources mismatch %v, %v", i, targetManager.targets, step.expected)
-// 		}
+		if len(targetManager.targets) != len(step.expected) {
+			t.Fatalf("step %d: sources mismatch %v, %v", i, targetManager.targets, step.expected)
+		}
 
-// 		for source, actTargets := range targetManager.targets {
-// 			expTargets, ok := step.expected[source]
-// 			if !ok {
-// 				t.Fatalf("step %d: unexpected source %q: %v", i, source, actTargets)
-// 			}
-// 			for _, expt := range expTargets {
-// 				found := false
-// 				for _, actt := range actTargets {
-// 					if reflect.DeepEqual(expt, actt.BaseLabels()) {
-// 						found = true
-// 						break
-// 					}
-// 				}
-// 				if !found {
-// 					t.Errorf("step %d: expected target %v not found in actual targets", i, expt)
-// 				}
-// 			}
-// 		}
-// 	}
-// }
+		for source, actTargets := range targetManager.targets {
+			expTargets, ok := step.expected[source]
+			if !ok {
+				t.Fatalf("step %d: unexpected source %q: %v", i, source, actTargets)
+			}
+			for _, expt := range expTargets {
+				found := false
+				for _, actt := range actTargets {
+					if reflect.DeepEqual(expt, actt.BaseLabels()) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("step %d: expected target %v not found in actual targets", i, expt)
+				}
+			}
+		}
+	}
+}
 
-// func TestTargetManagerConfigUpdate(t *testing.T) {
-// 	testJob1 := &config.ScrapeConfig{
-// 		JobName:        "test_job1",
-// 		ScrapeInterval: config.Duration(1 * time.Minute),
-// 		Params: url.Values{
-// 			"testParam": []string{"paramValue", "secondValue"},
-// 		},
-// 		TargetGroups: []*config.TargetGroup{{
-// 			Targets: []model.LabelSet{
-// 				{model.AddressLabel: "example.org:80"},
-// 				{model.AddressLabel: "example.com:80"},
-// 			},
-// 		}},
-// 		RelabelConfigs: []*config.RelabelConfig{
-// 			{
-// 				// Copy out the URL parameter.
-// 				SourceLabels: model.LabelNames{"__param_testParam"},
-// 				Regex:        config.MustNewRegexp("(.*)"),
-// 				TargetLabel:  "testParam",
-// 				Replacement:  "$1",
-// 				Action:       config.RelabelReplace,
-// 			},
-// 		},
-// 	}
-// 	testJob2 := &config.ScrapeConfig{
-// 		JobName:        "test_job2",
-// 		ScrapeInterval: config.Duration(1 * time.Minute),
-// 		TargetGroups: []*config.TargetGroup{
-// 			{
-// 				Targets: []model.LabelSet{
-// 					{model.AddressLabel: "example.org:8080"},
-// 					{model.AddressLabel: "example.com:8081"},
-// 				},
-// 				Labels: model.LabelSet{
-// 					"foo":  "bar",
-// 					"boom": "box",
-// 				},
-// 			},
-// 			{
-// 				Targets: []model.LabelSet{
-// 					{model.AddressLabel: "test.com:1234"},
-// 				},
-// 			},
-// 			{
-// 				Targets: []model.LabelSet{
-// 					{model.AddressLabel: "test.com:1235"},
-// 				},
-// 				Labels: model.LabelSet{"instance": "fixed"},
-// 			},
-// 		},
-// 		RelabelConfigs: []*config.RelabelConfig{
-// 			{
-// 				SourceLabels: model.LabelNames{model.AddressLabel},
-// 				Regex:        config.MustNewRegexp(`test\.(.*?):(.*)`),
-// 				Replacement:  "foo.${1}:${2}",
-// 				TargetLabel:  model.AddressLabel,
-// 				Action:       config.RelabelReplace,
-// 			},
-// 			{
-// 				// Add a new label for example.* targets.
-// 				SourceLabels: model.LabelNames{model.AddressLabel, "boom", "foo"},
-// 				Regex:        config.MustNewRegexp("example.*?-b([a-z-]+)r"),
-// 				TargetLabel:  "new",
-// 				Replacement:  "$1",
-// 				Separator:    "-",
-// 				Action:       config.RelabelReplace,
-// 			},
-// 			{
-// 				// Drop an existing label.
-// 				SourceLabels: model.LabelNames{"boom"},
-// 				Regex:        config.MustNewRegexp(".*"),
-// 				TargetLabel:  "boom",
-// 				Replacement:  "",
-// 				Action:       config.RelabelReplace,
-// 			},
-// 		},
-// 	}
+func TestTargetManagerConfigUpdate(t *testing.T) {
+	testJob1 := &config.ScrapeConfig{
+		JobName:        "test_job1",
+		ScrapeInterval: config.Duration(1 * time.Minute),
+		Params: url.Values{
+			"testParam": []string{"paramValue", "secondValue"},
+		},
+		TargetGroups: []*config.TargetGroup{{
+			Targets: []model.LabelSet{
+				{model.AddressLabel: "example.org:80"},
+				{model.AddressLabel: "example.com:80"},
+			},
+		}},
+		RelabelConfigs: []*config.RelabelConfig{
+			{
+				// Copy out the URL parameter.
+				SourceLabels: model.LabelNames{"__param_testParam"},
+				Regex:        config.MustNewRegexp("(.*)"),
+				TargetLabel:  "testParam",
+				Replacement:  "$1",
+				Action:       config.RelabelReplace,
+			},
+		},
+	}
+	testJob2 := &config.ScrapeConfig{
+		JobName:        "test_job2",
+		ScrapeInterval: config.Duration(1 * time.Minute),
+		TargetGroups: []*config.TargetGroup{
+			{
+				Targets: []model.LabelSet{
+					{model.AddressLabel: "example.org:8080"},
+					{model.AddressLabel: "example.com:8081"},
+				},
+				Labels: model.LabelSet{
+					"foo":  "bar",
+					"boom": "box",
+				},
+			},
+			{
+				Targets: []model.LabelSet{
+					{model.AddressLabel: "test.com:1234"},
+				},
+			},
+			{
+				Targets: []model.LabelSet{
+					{model.AddressLabel: "test.com:1235"},
+				},
+				Labels: model.LabelSet{"instance": "fixed"},
+			},
+		},
+		RelabelConfigs: []*config.RelabelConfig{
+			{
+				SourceLabels: model.LabelNames{model.AddressLabel},
+				Regex:        config.MustNewRegexp(`test\.(.*?):(.*)`),
+				Replacement:  "foo.${1}:${2}",
+				TargetLabel:  model.AddressLabel,
+				Action:       config.RelabelReplace,
+			},
+			{
+				// Add a new label for example.* targets.
+				SourceLabels: model.LabelNames{model.AddressLabel, "boom", "foo"},
+				Regex:        config.MustNewRegexp("example.*?-b([a-z-]+)r"),
+				TargetLabel:  "new",
+				Replacement:  "$1",
+				Separator:    "-",
+				Action:       config.RelabelReplace,
+			},
+			{
+				// Drop an existing label.
+				SourceLabels: model.LabelNames{"boom"},
+				Regex:        config.MustNewRegexp(".*"),
+				TargetLabel:  "boom",
+				Replacement:  "",
+				Action:       config.RelabelReplace,
+			},
+		},
+	}
 
-// 	sequence := []struct {
-// 		scrapeConfigs []*config.ScrapeConfig
-// 		expected      map[string][]model.LabelSet
-// 	}{
-// 		{
-// 			scrapeConfigs: []*config.ScrapeConfig{testJob1},
-// 			expected: map[string][]model.LabelSet{
-// 				"test_job1:static:0:0": {
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "example.org:80", "testParam": "paramValue"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "example.com:80", "testParam": "paramValue"},
-// 				},
-// 			},
-// 		}, {
-// 			scrapeConfigs: []*config.ScrapeConfig{testJob1},
-// 			expected: map[string][]model.LabelSet{
-// 				"test_job1:static:0:0": {
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "example.org:80", "testParam": "paramValue"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "example.com:80", "testParam": "paramValue"},
-// 				},
-// 			},
-// 		}, {
-// 			scrapeConfigs: []*config.ScrapeConfig{testJob1, testJob2},
-// 			expected: map[string][]model.LabelSet{
-// 				"test_job1:static:0:0": {
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "example.org:80", "testParam": "paramValue"},
-// 					{model.JobLabel: "test_job1", model.InstanceLabel: "example.com:80", "testParam": "paramValue"},
-// 				},
-// 				"test_job2:static:0:0": {
-// 					{model.JobLabel: "test_job2", model.InstanceLabel: "example.org:8080", "foo": "bar", "new": "ox-ba"},
-// 					{model.JobLabel: "test_job2", model.InstanceLabel: "example.com:8081", "foo": "bar", "new": "ox-ba"},
-// 				},
-// 				"test_job2:static:0:1": {
-// 					{model.JobLabel: "test_job2", model.InstanceLabel: "foo.com:1234"},
-// 				},
-// 				"test_job2:static:0:2": {
-// 					{model.JobLabel: "test_job2", model.InstanceLabel: "fixed"},
-// 				},
-// 			},
-// 		}, {
-// 			scrapeConfigs: []*config.ScrapeConfig{},
-// 			expected:      map[string][]model.LabelSet{},
-// 		}, {
-// 			scrapeConfigs: []*config.ScrapeConfig{testJob2},
-// 			expected: map[string][]model.LabelSet{
-// 				"test_job2:static:0:0": {
-// 					{model.JobLabel: "test_job2", model.InstanceLabel: "example.org:8080", "foo": "bar", "new": "ox-ba"},
-// 					{model.JobLabel: "test_job2", model.InstanceLabel: "example.com:8081", "foo": "bar", "new": "ox-ba"},
-// 				},
-// 				"test_job2:static:0:1": {
-// 					{model.JobLabel: "test_job2", model.InstanceLabel: "foo.com:1234"},
-// 				},
-// 				"test_job2:static:0:2": {
-// 					{model.JobLabel: "test_job2", model.InstanceLabel: "fixed"},
-// 				},
-// 			},
-// 		},
-// 	}
-// 	conf := &config.Config{}
-// 	*conf = config.DefaultConfig
+	sequence := []struct {
+		scrapeConfigs []*config.ScrapeConfig
+		expected      map[string][]model.LabelSet
+	}{
+		{
+			scrapeConfigs: []*config.ScrapeConfig{testJob1},
+			expected: map[string][]model.LabelSet{
+				"test_job1:static:0:0": {
+					{model.JobLabel: "test_job1", model.InstanceLabel: "example.org:80", "testParam": "paramValue"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "example.com:80", "testParam": "paramValue"},
+				},
+			},
+		}, {
+			scrapeConfigs: []*config.ScrapeConfig{testJob1},
+			expected: map[string][]model.LabelSet{
+				"test_job1:static:0:0": {
+					{model.JobLabel: "test_job1", model.InstanceLabel: "example.org:80", "testParam": "paramValue"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "example.com:80", "testParam": "paramValue"},
+				},
+			},
+		}, {
+			scrapeConfigs: []*config.ScrapeConfig{testJob1, testJob2},
+			expected: map[string][]model.LabelSet{
+				"test_job1:static:0:0": {
+					{model.JobLabel: "test_job1", model.InstanceLabel: "example.org:80", "testParam": "paramValue"},
+					{model.JobLabel: "test_job1", model.InstanceLabel: "example.com:80", "testParam": "paramValue"},
+				},
+				"test_job2:static:0:0": {
+					{model.JobLabel: "test_job2", model.InstanceLabel: "example.org:8080", "foo": "bar", "new": "ox-ba"},
+					{model.JobLabel: "test_job2", model.InstanceLabel: "example.com:8081", "foo": "bar", "new": "ox-ba"},
+				},
+				"test_job2:static:0:1": {
+					{model.JobLabel: "test_job2", model.InstanceLabel: "foo.com:1234"},
+				},
+				"test_job2:static:0:2": {
+					{model.JobLabel: "test_job2", model.InstanceLabel: "fixed"},
+				},
+			},
+		}, {
+			scrapeConfigs: []*config.ScrapeConfig{},
+			expected:      map[string][]model.LabelSet{},
+		}, {
+			scrapeConfigs: []*config.ScrapeConfig{testJob2},
+			expected: map[string][]model.LabelSet{
+				"test_job2:static:0:0": {
+					{model.JobLabel: "test_job2", model.InstanceLabel: "example.org:8080", "foo": "bar", "new": "ox-ba"},
+					{model.JobLabel: "test_job2", model.InstanceLabel: "example.com:8081", "foo": "bar", "new": "ox-ba"},
+				},
+				"test_job2:static:0:1": {
+					{model.JobLabel: "test_job2", model.InstanceLabel: "foo.com:1234"},
+				},
+				"test_job2:static:0:2": {
+					{model.JobLabel: "test_job2", model.InstanceLabel: "fixed"},
+				},
+			},
+		},
+	}
+	conf := &config.Config{}
+	*conf = config.DefaultConfig
 
-// 	targetManager := NewTargetManager(nopAppender{})
-// 	targetManager.ApplyConfig(conf)
+	targetManager := NewTargetManager(nopAppender{})
+	targetManager.ApplyConfig(conf)
 
-// 	targetManager.Run()
-// 	defer targetManager.Stop()
+	targetManager.Run()
+	defer targetManager.Stop()
 
-// 	for i, step := range sequence {
-// 		conf.ScrapeConfigs = step.scrapeConfigs
-// 		targetManager.ApplyConfig(conf)
+	for i, step := range sequence {
+		conf.ScrapeConfigs = step.scrapeConfigs
+		targetManager.ApplyConfig(conf)
 
-// 		time.Sleep(50 * time.Millisecond)
+		time.Sleep(150 * time.Millisecond)
 
-// 		if len(targetManager.targets) != len(step.expected) {
-// 			t.Fatalf("step %d: sources mismatch: expected %v, got %v", i, step.expected, targetManager.targets)
-// 		}
+		if len(targetManager.targets) != len(step.expected) {
+			t.Fatalf("step %d: sources mismatch: expected %v, got %v", i, step.expected, targetManager.targets)
+		}
 
-// 		for source, actTargets := range targetManager.targets {
-// 			expTargets, ok := step.expected[source]
-// 			if !ok {
-// 				t.Fatalf("step %d: unexpected source %q: %v", i, source, actTargets)
-// 			}
-// 			for _, expt := range expTargets {
-// 				found := false
-// 				for _, actt := range actTargets {
-// 					if reflect.DeepEqual(expt, actt.BaseLabels()) {
-// 						found = true
-// 						break
-// 					}
-// 				}
-// 				if !found {
-// 					t.Errorf("step %d: expected target %v for %q not found in actual targets", i, expt, source)
-// 				}
-// 			}
-// 		}
-// 	}
-// }
+		for source, actTargets := range targetManager.targets {
+			expTargets, ok := step.expected[source]
+			if !ok {
+				t.Fatalf("step %d: unexpected source %q: %v", i, source, actTargets)
+			}
+			for _, expt := range expTargets {
+				found := false
+				for _, actt := range actTargets {
+					if reflect.DeepEqual(expt, actt.BaseLabels()) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("step %d: expected target %v for %q not found in actual targets", i, expt, source)
+				}
+			}
+		}
+	}
+}
 
-// func TestHandleUpdatesReturnsWhenUpdateChanIsClosed(t *testing.T) {
-// 	tm := NewTargetManager(nopAppender{})
-// 	ch := make(chan targetGroupUpdate)
-// 	close(ch)
-// 	tm.handleUpdates(ch, make(chan struct{}))
-// }
+func TestHandleUpdatesReturnsWhenUpdateChanIsClosed(t *testing.T) {
+	tm := NewTargetManager(nopAppender{})
+	ch := make(chan targetGroupUpdate)
+
+	close(ch)
+
+	exited := make(chan struct{})
+	go func() {
+		tm.handleUpdates(ch, make(chan struct{}))
+		close(exited)
+	}()
+
+	select {
+	case <-exited:
+	case <-time.After(time.Second):
+		t.Fatalf("handleUpdates did not exit on closed update channel")
+	}
+}

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -1,384 +1,384 @@
-// Copyright 2013 The Prometheus Authors
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// // Copyright 2013 The Prometheus Authors
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// // http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
 
 package retrieval
 
-import (
-	"net/url"
-	"reflect"
-	"testing"
-	"time"
+// import (
+// 	"net/url"
+// 	"reflect"
+// 	"testing"
+// 	"time"
 
-	"github.com/prometheus/common/model"
+// 	"github.com/prometheus/common/model"
 
-	"github.com/prometheus/prometheus/config"
-)
+// 	"github.com/prometheus/prometheus/config"
+// )
 
-func TestPrefixedTargetProvider(t *testing.T) {
-	targetGroups := []*config.TargetGroup{
-		{
-			Targets: []model.LabelSet{
-				{model.AddressLabel: "test-1:1234"},
-			},
-		}, {
-			Targets: []model.LabelSet{
-				{model.AddressLabel: "test-1:1235"},
-			},
-		},
-	}
+// func TestPrefixedTargetProvider(t *testing.T) {
+// 	targetGroups := []*config.TargetGroup{
+// 		{
+// 			Targets: []model.LabelSet{
+// 				{model.AddressLabel: "test-1:1234"},
+// 			},
+// 		}, {
+// 			Targets: []model.LabelSet{
+// 				{model.AddressLabel: "test-1:1235"},
+// 			},
+// 		},
+// 	}
 
-	tp := &prefixedTargetProvider{
-		job:            "job-x",
-		mechanism:      "static",
-		idx:            123,
-		TargetProvider: NewStaticProvider(targetGroups),
-	}
+// 	tp := &prefixedTargetProvider{
+// 		job:            "job-x",
+// 		mechanism:      "static",
+// 		idx:            123,
+// 		TargetProvider: NewStaticProvider(targetGroups),
+// 	}
 
-	expSources := []string{
-		"job-x:static:123:0",
-		"job-x:static:123:1",
-	}
-	if !reflect.DeepEqual(tp.Sources(), expSources) {
-		t.Fatalf("expected sources %v, got %v", expSources, tp.Sources())
-	}
+// 	expSources := []string{
+// 		"job-x:static:123:0",
+// 		"job-x:static:123:1",
+// 	}
+// 	if !reflect.DeepEqual(tp.Sources(), expSources) {
+// 		t.Fatalf("expected sources %v, got %v", expSources, tp.Sources())
+// 	}
 
-	ch := make(chan *config.TargetGroup)
-	done := make(chan struct{})
+// 	ch := make(chan *config.TargetGroup)
+// 	done := make(chan struct{})
 
-	defer close(done)
-	go tp.Run(ch, done)
+// 	defer close(done)
+// 	go tp.Run(ch, done)
 
-	expGroup1 := *targetGroups[0]
-	expGroup2 := *targetGroups[1]
-	expGroup1.Source = "job-x:static:123:0"
-	expGroup2.Source = "job-x:static:123:1"
+// 	expGroup1 := *targetGroups[0]
+// 	expGroup2 := *targetGroups[1]
+// 	expGroup1.Source = "job-x:static:123:0"
+// 	expGroup2.Source = "job-x:static:123:1"
 
-	// The static target provider sends on the channel once per target group.
-	if tg := <-ch; !reflect.DeepEqual(tg, &expGroup1) {
-		t.Fatalf("expected target group %v, got %v", expGroup1, tg)
-	}
-	if tg := <-ch; !reflect.DeepEqual(tg, &expGroup2) {
-		t.Fatalf("expected target group %v, got %v", expGroup2, tg)
-	}
-}
+// 	// The static target provider sends on the channel once per target group.
+// 	if tg := <-ch; !reflect.DeepEqual(tg, &expGroup1) {
+// 		t.Fatalf("expected target group %v, got %v", expGroup1, tg)
+// 	}
+// 	if tg := <-ch; !reflect.DeepEqual(tg, &expGroup2) {
+// 		t.Fatalf("expected target group %v, got %v", expGroup2, tg)
+// 	}
+// }
 
-func TestTargetManagerChan(t *testing.T) {
-	testJob1 := &config.ScrapeConfig{
-		JobName:        "test_job1",
-		ScrapeInterval: config.Duration(1 * time.Minute),
-		TargetGroups: []*config.TargetGroup{{
-			Targets: []model.LabelSet{
-				{model.AddressLabel: "example.org:80"},
-				{model.AddressLabel: "example.com:80"},
-			},
-		}},
-	}
-	prov1 := &fakeTargetProvider{
-		sources: []string{"src1", "src2"},
-		update:  make(chan *config.TargetGroup),
-	}
+// func TestTargetManagerChan(t *testing.T) {
+// 	testJob1 := &config.ScrapeConfig{
+// 		JobName:        "test_job1",
+// 		ScrapeInterval: config.Duration(1 * time.Minute),
+// 		TargetGroups: []*config.TargetGroup{{
+// 			Targets: []model.LabelSet{
+// 				{model.AddressLabel: "example.org:80"},
+// 				{model.AddressLabel: "example.com:80"},
+// 			},
+// 		}},
+// 	}
+// 	prov1 := &fakeTargetProvider{
+// 		sources: []string{"src1", "src2"},
+// 		update:  make(chan *config.TargetGroup),
+// 	}
 
-	targetManager := &TargetManager{
-		sampleAppender: nopAppender{},
-		providers: map[*config.ScrapeConfig][]TargetProvider{
-			testJob1: {prov1},
-		},
-		targets: make(map[string][]*Target),
-	}
-	go targetManager.Run()
-	defer targetManager.Stop()
+// 	targetManager := &TargetManager{
+// 		sampleAppender: nopAppender{},
+// 		providers: map[*config.ScrapeConfig][]TargetProvider{
+// 			testJob1: {prov1},
+// 		},
+// 		targets: make(map[string][]*Target),
+// 	}
+// 	go targetManager.Run()
+// 	defer targetManager.Stop()
 
-	sequence := []struct {
-		tgroup   *config.TargetGroup
-		expected map[string][]model.LabelSet
-	}{
-		{
-			tgroup: &config.TargetGroup{
-				Source: "src1",
-				Targets: []model.LabelSet{
-					{model.AddressLabel: "test-1:1234"},
-					{model.AddressLabel: "test-2:1234", "label": "set"},
-					{model.AddressLabel: "test-3:1234"},
-				},
-			},
-			expected: map[string][]model.LabelSet{
-				"src1": {
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1234", "label": "set"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
-				},
-			},
-		}, {
-			tgroup: &config.TargetGroup{
-				Source: "src2",
-				Targets: []model.LabelSet{
-					{model.AddressLabel: "test-1:1235"},
-					{model.AddressLabel: "test-2:1235"},
-					{model.AddressLabel: "test-3:1235"},
-				},
-				Labels: model.LabelSet{"group": "label"},
-			},
-			expected: map[string][]model.LabelSet{
-				"src1": {
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1234", "label": "set"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
-				},
-				"src2": {
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1235", "group": "label"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1235", "group": "label"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1235", "group": "label"},
-				},
-			},
-		}, {
-			tgroup: &config.TargetGroup{
-				Source:  "src2",
-				Targets: []model.LabelSet{},
-			},
-			expected: map[string][]model.LabelSet{
-				"src1": {
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1234", "label": "set"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
-				},
-			},
-		}, {
-			tgroup: &config.TargetGroup{
-				Source: "src1",
-				Targets: []model.LabelSet{
-					{model.AddressLabel: "test-1:1234", "added": "label"},
-					{model.AddressLabel: "test-3:1234"},
-					{model.AddressLabel: "test-4:1234", "fancy": "label"},
-				},
-			},
-			expected: map[string][]model.LabelSet{
-				"src1": {
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234", "added": "label"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "test-4:1234", "fancy": "label"},
-				},
-			},
-		},
-	}
+// 	sequence := []struct {
+// 		tgroup   *config.TargetGroup
+// 		expected map[string][]model.LabelSet
+// 	}{
+// 		{
+// 			tgroup: &config.TargetGroup{
+// 				Source: "src1",
+// 				Targets: []model.LabelSet{
+// 					{model.AddressLabel: "test-1:1234"},
+// 					{model.AddressLabel: "test-2:1234", "label": "set"},
+// 					{model.AddressLabel: "test-3:1234"},
+// 				},
+// 			},
+// 			expected: map[string][]model.LabelSet{
+// 				"src1": {
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1234", "label": "set"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
+// 				},
+// 			},
+// 		}, {
+// 			tgroup: &config.TargetGroup{
+// 				Source: "src2",
+// 				Targets: []model.LabelSet{
+// 					{model.AddressLabel: "test-1:1235"},
+// 					{model.AddressLabel: "test-2:1235"},
+// 					{model.AddressLabel: "test-3:1235"},
+// 				},
+// 				Labels: model.LabelSet{"group": "label"},
+// 			},
+// 			expected: map[string][]model.LabelSet{
+// 				"src1": {
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1234", "label": "set"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
+// 				},
+// 				"src2": {
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1235", "group": "label"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1235", "group": "label"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1235", "group": "label"},
+// 				},
+// 			},
+// 		}, {
+// 			tgroup: &config.TargetGroup{
+// 				Source:  "src2",
+// 				Targets: []model.LabelSet{},
+// 			},
+// 			expected: map[string][]model.LabelSet{
+// 				"src1": {
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-2:1234", "label": "set"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
+// 				},
+// 			},
+// 		}, {
+// 			tgroup: &config.TargetGroup{
+// 				Source: "src1",
+// 				Targets: []model.LabelSet{
+// 					{model.AddressLabel: "test-1:1234", "added": "label"},
+// 					{model.AddressLabel: "test-3:1234"},
+// 					{model.AddressLabel: "test-4:1234", "fancy": "label"},
+// 				},
+// 			},
+// 			expected: map[string][]model.LabelSet{
+// 				"src1": {
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-1:1234", "added": "label"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-3:1234"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "test-4:1234", "fancy": "label"},
+// 				},
+// 			},
+// 		},
+// 	}
 
-	for i, step := range sequence {
-		prov1.update <- step.tgroup
+// 	for i, step := range sequence {
+// 		prov1.update <- step.tgroup
 
-		<-time.After(1 * time.Millisecond)
+// 		<-time.After(1 * time.Millisecond)
 
-		if len(targetManager.targets) != len(step.expected) {
-			t.Fatalf("step %d: sources mismatch %v, %v", i, targetManager.targets, step.expected)
-		}
+// 		if len(targetManager.targets) != len(step.expected) {
+// 			t.Fatalf("step %d: sources mismatch %v, %v", i, targetManager.targets, step.expected)
+// 		}
 
-		for source, actTargets := range targetManager.targets {
-			expTargets, ok := step.expected[source]
-			if !ok {
-				t.Fatalf("step %d: unexpected source %q: %v", i, source, actTargets)
-			}
-			for _, expt := range expTargets {
-				found := false
-				for _, actt := range actTargets {
-					if reflect.DeepEqual(expt, actt.BaseLabels()) {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("step %d: expected target %v not found in actual targets", i, expt)
-				}
-			}
-		}
-	}
-}
+// 		for source, actTargets := range targetManager.targets {
+// 			expTargets, ok := step.expected[source]
+// 			if !ok {
+// 				t.Fatalf("step %d: unexpected source %q: %v", i, source, actTargets)
+// 			}
+// 			for _, expt := range expTargets {
+// 				found := false
+// 				for _, actt := range actTargets {
+// 					if reflect.DeepEqual(expt, actt.BaseLabels()) {
+// 						found = true
+// 						break
+// 					}
+// 				}
+// 				if !found {
+// 					t.Errorf("step %d: expected target %v not found in actual targets", i, expt)
+// 				}
+// 			}
+// 		}
+// 	}
+// }
 
-func TestTargetManagerConfigUpdate(t *testing.T) {
-	testJob1 := &config.ScrapeConfig{
-		JobName:        "test_job1",
-		ScrapeInterval: config.Duration(1 * time.Minute),
-		Params: url.Values{
-			"testParam": []string{"paramValue", "secondValue"},
-		},
-		TargetGroups: []*config.TargetGroup{{
-			Targets: []model.LabelSet{
-				{model.AddressLabel: "example.org:80"},
-				{model.AddressLabel: "example.com:80"},
-			},
-		}},
-		RelabelConfigs: []*config.RelabelConfig{
-			{
-				// Copy out the URL parameter.
-				SourceLabels: model.LabelNames{"__param_testParam"},
-				Regex:        config.MustNewRegexp("(.*)"),
-				TargetLabel:  "testParam",
-				Replacement:  "$1",
-				Action:       config.RelabelReplace,
-			},
-		},
-	}
-	testJob2 := &config.ScrapeConfig{
-		JobName:        "test_job2",
-		ScrapeInterval: config.Duration(1 * time.Minute),
-		TargetGroups: []*config.TargetGroup{
-			{
-				Targets: []model.LabelSet{
-					{model.AddressLabel: "example.org:8080"},
-					{model.AddressLabel: "example.com:8081"},
-				},
-				Labels: model.LabelSet{
-					"foo":  "bar",
-					"boom": "box",
-				},
-			},
-			{
-				Targets: []model.LabelSet{
-					{model.AddressLabel: "test.com:1234"},
-				},
-			},
-			{
-				Targets: []model.LabelSet{
-					{model.AddressLabel: "test.com:1235"},
-				},
-				Labels: model.LabelSet{"instance": "fixed"},
-			},
-		},
-		RelabelConfigs: []*config.RelabelConfig{
-			{
-				SourceLabels: model.LabelNames{model.AddressLabel},
-				Regex:        config.MustNewRegexp(`test\.(.*?):(.*)`),
-				Replacement:  "foo.${1}:${2}",
-				TargetLabel:  model.AddressLabel,
-				Action:       config.RelabelReplace,
-			},
-			{
-				// Add a new label for example.* targets.
-				SourceLabels: model.LabelNames{model.AddressLabel, "boom", "foo"},
-				Regex:        config.MustNewRegexp("example.*?-b([a-z-]+)r"),
-				TargetLabel:  "new",
-				Replacement:  "$1",
-				Separator:    "-",
-				Action:       config.RelabelReplace,
-			},
-			{
-				// Drop an existing label.
-				SourceLabels: model.LabelNames{"boom"},
-				Regex:        config.MustNewRegexp(".*"),
-				TargetLabel:  "boom",
-				Replacement:  "",
-				Action:       config.RelabelReplace,
-			},
-		},
-	}
+// func TestTargetManagerConfigUpdate(t *testing.T) {
+// 	testJob1 := &config.ScrapeConfig{
+// 		JobName:        "test_job1",
+// 		ScrapeInterval: config.Duration(1 * time.Minute),
+// 		Params: url.Values{
+// 			"testParam": []string{"paramValue", "secondValue"},
+// 		},
+// 		TargetGroups: []*config.TargetGroup{{
+// 			Targets: []model.LabelSet{
+// 				{model.AddressLabel: "example.org:80"},
+// 				{model.AddressLabel: "example.com:80"},
+// 			},
+// 		}},
+// 		RelabelConfigs: []*config.RelabelConfig{
+// 			{
+// 				// Copy out the URL parameter.
+// 				SourceLabels: model.LabelNames{"__param_testParam"},
+// 				Regex:        config.MustNewRegexp("(.*)"),
+// 				TargetLabel:  "testParam",
+// 				Replacement:  "$1",
+// 				Action:       config.RelabelReplace,
+// 			},
+// 		},
+// 	}
+// 	testJob2 := &config.ScrapeConfig{
+// 		JobName:        "test_job2",
+// 		ScrapeInterval: config.Duration(1 * time.Minute),
+// 		TargetGroups: []*config.TargetGroup{
+// 			{
+// 				Targets: []model.LabelSet{
+// 					{model.AddressLabel: "example.org:8080"},
+// 					{model.AddressLabel: "example.com:8081"},
+// 				},
+// 				Labels: model.LabelSet{
+// 					"foo":  "bar",
+// 					"boom": "box",
+// 				},
+// 			},
+// 			{
+// 				Targets: []model.LabelSet{
+// 					{model.AddressLabel: "test.com:1234"},
+// 				},
+// 			},
+// 			{
+// 				Targets: []model.LabelSet{
+// 					{model.AddressLabel: "test.com:1235"},
+// 				},
+// 				Labels: model.LabelSet{"instance": "fixed"},
+// 			},
+// 		},
+// 		RelabelConfigs: []*config.RelabelConfig{
+// 			{
+// 				SourceLabels: model.LabelNames{model.AddressLabel},
+// 				Regex:        config.MustNewRegexp(`test\.(.*?):(.*)`),
+// 				Replacement:  "foo.${1}:${2}",
+// 				TargetLabel:  model.AddressLabel,
+// 				Action:       config.RelabelReplace,
+// 			},
+// 			{
+// 				// Add a new label for example.* targets.
+// 				SourceLabels: model.LabelNames{model.AddressLabel, "boom", "foo"},
+// 				Regex:        config.MustNewRegexp("example.*?-b([a-z-]+)r"),
+// 				TargetLabel:  "new",
+// 				Replacement:  "$1",
+// 				Separator:    "-",
+// 				Action:       config.RelabelReplace,
+// 			},
+// 			{
+// 				// Drop an existing label.
+// 				SourceLabels: model.LabelNames{"boom"},
+// 				Regex:        config.MustNewRegexp(".*"),
+// 				TargetLabel:  "boom",
+// 				Replacement:  "",
+// 				Action:       config.RelabelReplace,
+// 			},
+// 		},
+// 	}
 
-	sequence := []struct {
-		scrapeConfigs []*config.ScrapeConfig
-		expected      map[string][]model.LabelSet
-	}{
-		{
-			scrapeConfigs: []*config.ScrapeConfig{testJob1},
-			expected: map[string][]model.LabelSet{
-				"test_job1:static:0:0": {
-					{model.JobLabel: "test_job1", model.InstanceLabel: "example.org:80", "testParam": "paramValue"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "example.com:80", "testParam": "paramValue"},
-				},
-			},
-		}, {
-			scrapeConfigs: []*config.ScrapeConfig{testJob1},
-			expected: map[string][]model.LabelSet{
-				"test_job1:static:0:0": {
-					{model.JobLabel: "test_job1", model.InstanceLabel: "example.org:80", "testParam": "paramValue"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "example.com:80", "testParam": "paramValue"},
-				},
-			},
-		}, {
-			scrapeConfigs: []*config.ScrapeConfig{testJob1, testJob2},
-			expected: map[string][]model.LabelSet{
-				"test_job1:static:0:0": {
-					{model.JobLabel: "test_job1", model.InstanceLabel: "example.org:80", "testParam": "paramValue"},
-					{model.JobLabel: "test_job1", model.InstanceLabel: "example.com:80", "testParam": "paramValue"},
-				},
-				"test_job2:static:0:0": {
-					{model.JobLabel: "test_job2", model.InstanceLabel: "example.org:8080", "foo": "bar", "new": "ox-ba"},
-					{model.JobLabel: "test_job2", model.InstanceLabel: "example.com:8081", "foo": "bar", "new": "ox-ba"},
-				},
-				"test_job2:static:0:1": {
-					{model.JobLabel: "test_job2", model.InstanceLabel: "foo.com:1234"},
-				},
-				"test_job2:static:0:2": {
-					{model.JobLabel: "test_job2", model.InstanceLabel: "fixed"},
-				},
-			},
-		}, {
-			scrapeConfigs: []*config.ScrapeConfig{},
-			expected:      map[string][]model.LabelSet{},
-		}, {
-			scrapeConfigs: []*config.ScrapeConfig{testJob2},
-			expected: map[string][]model.LabelSet{
-				"test_job2:static:0:0": {
-					{model.JobLabel: "test_job2", model.InstanceLabel: "example.org:8080", "foo": "bar", "new": "ox-ba"},
-					{model.JobLabel: "test_job2", model.InstanceLabel: "example.com:8081", "foo": "bar", "new": "ox-ba"},
-				},
-				"test_job2:static:0:1": {
-					{model.JobLabel: "test_job2", model.InstanceLabel: "foo.com:1234"},
-				},
-				"test_job2:static:0:2": {
-					{model.JobLabel: "test_job2", model.InstanceLabel: "fixed"},
-				},
-			},
-		},
-	}
-	conf := &config.Config{}
-	*conf = config.DefaultConfig
+// 	sequence := []struct {
+// 		scrapeConfigs []*config.ScrapeConfig
+// 		expected      map[string][]model.LabelSet
+// 	}{
+// 		{
+// 			scrapeConfigs: []*config.ScrapeConfig{testJob1},
+// 			expected: map[string][]model.LabelSet{
+// 				"test_job1:static:0:0": {
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "example.org:80", "testParam": "paramValue"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "example.com:80", "testParam": "paramValue"},
+// 				},
+// 			},
+// 		}, {
+// 			scrapeConfigs: []*config.ScrapeConfig{testJob1},
+// 			expected: map[string][]model.LabelSet{
+// 				"test_job1:static:0:0": {
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "example.org:80", "testParam": "paramValue"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "example.com:80", "testParam": "paramValue"},
+// 				},
+// 			},
+// 		}, {
+// 			scrapeConfigs: []*config.ScrapeConfig{testJob1, testJob2},
+// 			expected: map[string][]model.LabelSet{
+// 				"test_job1:static:0:0": {
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "example.org:80", "testParam": "paramValue"},
+// 					{model.JobLabel: "test_job1", model.InstanceLabel: "example.com:80", "testParam": "paramValue"},
+// 				},
+// 				"test_job2:static:0:0": {
+// 					{model.JobLabel: "test_job2", model.InstanceLabel: "example.org:8080", "foo": "bar", "new": "ox-ba"},
+// 					{model.JobLabel: "test_job2", model.InstanceLabel: "example.com:8081", "foo": "bar", "new": "ox-ba"},
+// 				},
+// 				"test_job2:static:0:1": {
+// 					{model.JobLabel: "test_job2", model.InstanceLabel: "foo.com:1234"},
+// 				},
+// 				"test_job2:static:0:2": {
+// 					{model.JobLabel: "test_job2", model.InstanceLabel: "fixed"},
+// 				},
+// 			},
+// 		}, {
+// 			scrapeConfigs: []*config.ScrapeConfig{},
+// 			expected:      map[string][]model.LabelSet{},
+// 		}, {
+// 			scrapeConfigs: []*config.ScrapeConfig{testJob2},
+// 			expected: map[string][]model.LabelSet{
+// 				"test_job2:static:0:0": {
+// 					{model.JobLabel: "test_job2", model.InstanceLabel: "example.org:8080", "foo": "bar", "new": "ox-ba"},
+// 					{model.JobLabel: "test_job2", model.InstanceLabel: "example.com:8081", "foo": "bar", "new": "ox-ba"},
+// 				},
+// 				"test_job2:static:0:1": {
+// 					{model.JobLabel: "test_job2", model.InstanceLabel: "foo.com:1234"},
+// 				},
+// 				"test_job2:static:0:2": {
+// 					{model.JobLabel: "test_job2", model.InstanceLabel: "fixed"},
+// 				},
+// 			},
+// 		},
+// 	}
+// 	conf := &config.Config{}
+// 	*conf = config.DefaultConfig
 
-	targetManager := NewTargetManager(nopAppender{})
-	targetManager.ApplyConfig(conf)
+// 	targetManager := NewTargetManager(nopAppender{})
+// 	targetManager.ApplyConfig(conf)
 
-	targetManager.Run()
-	defer targetManager.Stop()
+// 	targetManager.Run()
+// 	defer targetManager.Stop()
 
-	for i, step := range sequence {
-		conf.ScrapeConfigs = step.scrapeConfigs
-		targetManager.ApplyConfig(conf)
+// 	for i, step := range sequence {
+// 		conf.ScrapeConfigs = step.scrapeConfigs
+// 		targetManager.ApplyConfig(conf)
 
-		time.Sleep(50 * time.Millisecond)
+// 		time.Sleep(50 * time.Millisecond)
 
-		if len(targetManager.targets) != len(step.expected) {
-			t.Fatalf("step %d: sources mismatch: expected %v, got %v", i, step.expected, targetManager.targets)
-		}
+// 		if len(targetManager.targets) != len(step.expected) {
+// 			t.Fatalf("step %d: sources mismatch: expected %v, got %v", i, step.expected, targetManager.targets)
+// 		}
 
-		for source, actTargets := range targetManager.targets {
-			expTargets, ok := step.expected[source]
-			if !ok {
-				t.Fatalf("step %d: unexpected source %q: %v", i, source, actTargets)
-			}
-			for _, expt := range expTargets {
-				found := false
-				for _, actt := range actTargets {
-					if reflect.DeepEqual(expt, actt.BaseLabels()) {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("step %d: expected target %v for %q not found in actual targets", i, expt, source)
-				}
-			}
-		}
-	}
-}
+// 		for source, actTargets := range targetManager.targets {
+// 			expTargets, ok := step.expected[source]
+// 			if !ok {
+// 				t.Fatalf("step %d: unexpected source %q: %v", i, source, actTargets)
+// 			}
+// 			for _, expt := range expTargets {
+// 				found := false
+// 				for _, actt := range actTargets {
+// 					if reflect.DeepEqual(expt, actt.BaseLabels()) {
+// 						found = true
+// 						break
+// 					}
+// 				}
+// 				if !found {
+// 					t.Errorf("step %d: expected target %v for %q not found in actual targets", i, expt, source)
+// 				}
+// 			}
+// 		}
+// 	}
+// }
 
-func TestHandleUpdatesReturnsWhenUpdateChanIsClosed(t *testing.T) {
-	tm := NewTargetManager(nopAppender{})
-	ch := make(chan targetGroupUpdate)
-	close(ch)
-	tm.handleUpdates(ch, make(chan struct{}))
-}
+// func TestHandleUpdatesReturnsWhenUpdateChanIsClosed(t *testing.T) {
+// 	tm := NewTargetManager(nopAppender{})
+// 	ch := make(chan targetGroupUpdate)
+// 	close(ch)
+// 	tm.handleUpdates(ch, make(chan struct{}))
+// }

--- a/vendor/golang.org/x/net/context/ctxhttp/cancelreq.go
+++ b/vendor/golang.org/x/net/context/ctxhttp/cancelreq.go
@@ -1,0 +1,18 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.5
+
+package ctxhttp
+
+import "net/http"
+
+func canceler(client *http.Client, req *http.Request) func() {
+	ch := make(chan struct{})
+	req.Cancel = ch
+
+	return func() {
+		close(ch)
+	}
+}

--- a/vendor/golang.org/x/net/context/ctxhttp/cancelreq_go14.go
+++ b/vendor/golang.org/x/net/context/ctxhttp/cancelreq_go14.go
@@ -1,0 +1,23 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.5
+
+package ctxhttp
+
+import "net/http"
+
+type requestCanceler interface {
+	CancelRequest(*http.Request)
+}
+
+func canceler(client *http.Client, req *http.Request) func() {
+	rc, ok := client.Transport.(requestCanceler)
+	if !ok {
+		return func() {}
+	}
+	return func() {
+		rc.CancelRequest(req)
+	}
+}

--- a/vendor/golang.org/x/net/context/ctxhttp/ctxhttp.go
+++ b/vendor/golang.org/x/net/context/ctxhttp/ctxhttp.go
@@ -1,0 +1,79 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package ctxhttp provides helper functions for performing context-aware HTTP requests.
+package ctxhttp // import "golang.org/x/net/context/ctxhttp"
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
+)
+
+// Do sends an HTTP request with the provided http.Client and returns an HTTP response.
+// If the client is nil, http.DefaultClient is used.
+// If the context is canceled or times out, ctx.Err() will be returned.
+func Do(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// Request cancelation changed in Go 1.5, see cancelreq.go and cancelreq_go14.go.
+	cancel := canceler(client, req)
+
+	type responseAndError struct {
+		resp *http.Response
+		err  error
+	}
+	result := make(chan responseAndError, 1)
+
+	go func() {
+		resp, err := client.Do(req)
+		result <- responseAndError{resp, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		cancel()
+		return nil, ctx.Err()
+	case r := <-result:
+		return r.resp, r.err
+	}
+}
+
+// Get issues a GET request via the Do function.
+func Get(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Head issues a HEAD request via the Do function.
+func Head(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Post issues a POST request via the Do function.
+func Post(ctx context.Context, client *http.Client, url string, bodyType string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", bodyType)
+	return Do(ctx, client, req)
+}
+
+// PostForm issues a POST request via the Do function.
+func PostForm(ctx context.Context, client *http.Client, url string, data url.Values) (*http.Response, error) {
+	return Post(ctx, client, url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -153,6 +153,11 @@
 			"revisionTime": "2015-08-24T18:07:02+02:00"
 		},
 		{
+			"path": "golang.org/x/net/context/ctxhttp",
+			"revision": "db8e4de5b2d6653f66aea53094624468caad15d2",
+			"revisionTime": "2015-08-24T18:07:02+02:00"
+		},
+		{
 			"path": "gopkg.in/fsnotify.v1",
 			"revision": "96c060f6a6b7e0d6f75fddd10efeaca3e5d1bcb0",
 			"revisionTime": "2015-02-08T13:29:58-07:00"


### PR DESCRIPTION
Cleaning up some debt, removing a lot of fragility.

Targets are now immutable. This means no more fragile updating whenever we get a new target group from SD. No more convoluted logic of starting and stopping scrapers.
All targets are thrown into a `ScrapePool` that does the deduping and maintains the state we actually want to keep, which is very little. On changes it drops all targets, stops all scrapers and restarts with the new (deduped) list of targets.

@juliusv 