### PR TITLE
Use go1.5.1

### DIFF
--- a/Makefile.INCLUDE
+++ b/Makefile.INCLUDE
@@ -30,14 +30,8 @@ MAKEFILE_DIR ?= $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 BUILD_PATH = $(MAKEFILE_DIR)/.build
 
-GO_VERSION := 1.4.2
+GO_VERSION := 1.5.1
 GOOS ?= $(subst Darwin,darwin,$(subst Linux,linux,$(subst FreeBSD,freebsd,$(OS))))
-
-ifeq ($(GOOS),darwin)
-RELEASE_SUFFIX ?= -osx$(MAC_OS_X_VERSION)
-else
-RELEASE_SUFFIX ?=
-endif
 
 # Never honor GOBIN, should it be set at all.
 unexport GOBIN

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -429,7 +429,7 @@ func (t *Target) scrape(appender storage.SampleAppender) (err error) {
 
 	req, err := http.NewRequest("GET", t.URL().String(), nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	req.Header.Add("Accept", acceptHeader)
 


### PR DESCRIPTION
The benchmarks are looking very good.
I don't think they cover the slowdown coming with concurrent GC but seems to be well worth it anyway.

```
benchmark                                old ns/op      new ns/op      delta
BenchmarkScrape-8                        258791         224605         -13.21%
BenchmarkFingerprintLockerParallel-8     832            790            -5.05%
BenchmarkFingerprintLockerSerial-8       40.4           36.7           -9.16%
BenchmarkLoadChunksSequentially-8        217354         84845          -60.96%
BenchmarkLoadChunksRandomly-8            125422         70660          -43.66%
BenchmarkLoadChunkDescs-8                188935         181914         -3.72%
BenchmarkLabelMatching-8                 1465243350     1403976589     -4.18%
BenchmarkValueAtTimeChunkType0-8         3805751        3102526        -18.48%
BenchmarkValueAtTimeChunkType1-8         3745618        3603184        -3.80%
BenchmarkRangeValuesChunkType0-8         11408070       10191329       -10.67%
BenchmarkRangeValuesChunkType1-8         11321398       9373008        -17.21%
BenchmarkAppendType0-8                   1925           1590           -17.40%
BenchmarkAppendType1-8                   1646           1550           -5.83%
BenchmarkFuzzChunkType0-8                1633572908     1545326812     -5.40%
BenchmarkFuzzChunkType1-8                1729309026     1535153195     -11.23%

benchmark                                old allocs     new allocs     delta
BenchmarkScrape-8                        181            163            -9.94%
BenchmarkFingerprintLockerParallel-8     0              0              +0.00%
BenchmarkFingerprintLockerSerial-8       0              0              +0.00%
BenchmarkLoadChunksSequentially-8        315            312            -0.95%
BenchmarkLoadChunksRandomly-8            103            102            -0.97%
BenchmarkLoadChunkDescs-8                192            192            +0.00%
BenchmarkLabelMatching-8                 3499747        901203         -74.25%
BenchmarkValueAtTimeChunkType0-8         20095          20094          -0.00%
BenchmarkValueAtTimeChunkType1-8         20051          20050          -0.00%
BenchmarkRangeValuesChunkType0-8         23700          23697          -0.01%
BenchmarkRangeValuesChunkType1-8         21896          21893          -0.01%
BenchmarkAppendType0-8                   3              3              +0.00%
BenchmarkAppendType1-8                   3              3              +0.00%
BenchmarkFuzzChunkType0-8                530738         523095         -1.44%
BenchmarkFuzzChunkType1-8                547035         539678         -1.34%

benchmark                                old bytes     new bytes     delta
BenchmarkScrape-8                        33118         30526         -7.83%
BenchmarkFingerprintLockerParallel-8     0             0             +0.00%
BenchmarkFingerprintLockerSerial-8       0             0             +0.00%
BenchmarkLoadChunksSequentially-8        153520        152806        -0.47%
BenchmarkLoadChunksRandomly-8            39837         39380         -1.15%
BenchmarkLoadChunkDescs-8                12704         12638         -0.52%
BenchmarkLabelMatching-8                 344468592     230607272     -33.05%
BenchmarkValueAtTimeChunkType0-8         489385        489355        -0.01%
BenchmarkValueAtTimeChunkType1-8         485616        485613        -0.00%
BenchmarkRangeValuesChunkType0-8         7463933       7463645       -0.00%
BenchmarkRangeValuesChunkType1-8         7256081       7255433       -0.01%
BenchmarkAppendType0-8                   112           112           +0.00%
BenchmarkAppendType1-8                   83            83            +0.00%
BenchmarkFuzzChunkType0-8                395866536     395669808     -0.05%
BenchmarkFuzzChunkType1-8                458708240     458449920     -0.06%
```

@beorn7 @juliusv 