### PR TITLE
Close HTTP connections on HTTP errors too.

### DIFF
--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -437,6 +437,8 @@ func (t *Target) scrape(appender storage.SampleAppender) (err error) {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("server returned HTTP status %s", resp.Status)
 	}
@@ -445,7 +447,6 @@ func (t *Target) scrape(appender storage.SampleAppender) (err error) {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	sdec := expfmt.SampleDecoder{
 		Dec: dec,


### PR DESCRIPTION
Move defer resp.Body.Close() up to make sure it's called even when the
HTTP request returns something other than 200 or Decoder construction
fails. This avoids leaking and eventually running out of file descriptors.

@fabxc 