### PR TITLE
promql: Add vector function.

### DIFF
--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -146,3 +146,18 @@ eval_fail instant at 0m label_replace(testmetric, "invalid-label-name", "", "src
 
 # label_replace fails when there would be duplicated identical output label sets.
 eval_fail instant at 0m label_replace(testmetric, "src", "", "", "")
+
+clear
+
+# Tests for vector.
+eval instant at 0m vector(1)
+  {} 1
+
+eval instant at 60m vector(time())
+  {} 3600
+
+eval instant at 0m vector(1, {a="b"})
+  {a="b"} 1
+
+eval instant at 0m vector(1, {a="b", c=~"d", e!="f", g!~"h", a="z"})
+  {a="z"} 1


### PR DESCRIPTION
Currently the only way to convert a scalar to a vector is to
use absent(), which isn't very clean. This adds a vector()
function that's the inverse of scalar() and lets your optionally
set labels.

Example usage would be
vector(time() % 86400) < 3600
to filter to only the first hour of the day.



After some thought, this is the more generic and useful way to provide a `unity()` or `one()` function to convert scalars to vectors.

@fabxc 