### PR TITLE
promql: Bump sleep in query timeout test

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -70,7 +70,7 @@ func TestQueryTimeout(t *testing.T) {
 	defer engine.Stop()
 
 	query := engine.newTestQuery(func(ctx context.Context) error {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		return contextDone(ctx, "test statement execution")
 	})
 


### PR DESCRIPTION
This test is flaky, I'm presuming the time.AfterFunc
call is being delayed so the evaluation isn't getting
cancelled.

This isn't repeatable enough to verify if this fixes it, but I think it should do the trick.

@fabxc 
