### PR TITLE
retrieval: Bump timeout beyond 256ms of test

### DIFF
--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -154,7 +154,7 @@ func TestTargetScrapeWithFullChannel(t *testing.T) {
 	)
 	defer server.Close()
 
-	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{"dings": "bums"})
+	testTarget := newTestTarget(server.URL, time.Second, model.LabelSet{"dings": "bums"})
 
 	testTarget.scrape(slowAppender{})
 	if testTarget.status.Health() != HealthBad {


### PR DESCRIPTION
Fixes #1081 

Another test that flakes sometimes, this should prevent this particular failure mode anyway 

@fabxc 