### PR TITLE
Increase waiting time in TestEvictAndLoadChunkDescs

### DIFF
--- a/storage/local/storage_test.go
+++ b/storage/local/storage_test.go
@@ -1200,7 +1200,7 @@ func testEvictAndLoadChunkDescs(t *testing.T, encoding chunkEncoding) {
 	// Maintain series without any dropped chunks.
 	s.maintainMemorySeries(fp, 0)
 	// Give the evict goroutine an opportunity to run.
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	// Maintain series again to trigger chunkDesc eviction
 	s.maintainMemorySeries(fp, 0)
 


### PR DESCRIPTION
The test had become flaky with Go1.5.

Theory here is that with Go1.5.x, sleeping for 10ms might not be
enough to wake up another goroutine, possibly because it is used for
GC. 50ms should always be enough due to GC pause guarantees with the
new GC.

Fixes https://github.com/prometheus/prometheus/issues/944 (hopefully...).
@juliusv @fabxc @swsnider 