### PR TITLE
Allow labelmap action

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -687,7 +687,7 @@ func (a *RelabelAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	switch act := RelabelAction(strings.ToLower(s)); act {
-	case RelabelReplace, RelabelKeep, RelabelDrop, RelabelHashMod:
+	case RelabelReplace, RelabelKeep, RelabelDrop, RelabelHashMod, RelabelLabelMap:
 		*a = act
 		return nil
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -143,6 +143,11 @@ var expectedConf = &Config{
 					Separator:    ";",
 					Action:       RelabelKeep,
 				},
+				{
+					Regex:     MustNewRegexp("1"),
+					Separator: ";",
+					Action:    RelabelLabelMap,
+				},
 			},
 			MetricRelabelConfigs: []*RelabelConfig{
 				{

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -80,6 +80,8 @@ scrape_configs:
   - source_labels: [__tmp_hash]
     regex:         1
     action:        keep
+  - action:        labelmap
+    regex:         1
 
   metric_relabel_configs:
   - source_labels: [__name__]


### PR DESCRIPTION
`action: labelmap` currently has a parse error due to a missing item in a case.