### PR TITLE
retrieval: Reduce flakiness of target tests

### DIFF
--- a/retrieval/helpers_test.go
+++ b/retrieval/helpers_test.go
@@ -30,7 +30,6 @@ type slowAppender struct{}
 
 func (a slowAppender) Append(*model.Sample) {
 	time.Sleep(time.Millisecond)
-	return
 }
 
 type collectResultAppender struct {

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -103,7 +103,7 @@ func TestOverwriteLabels(t *testing.T) {
 		},
 	}
 
-	target := newTestTarget(server.URL, 10*time.Millisecond, nil)
+	target := newTestTarget(server.URL, time.Second, nil)
 
 	target.honorLabels = false
 	app := &collectResultAppender{}
@@ -154,7 +154,9 @@ func TestTargetScrapeWithFullChannel(t *testing.T) {
 	)
 	defer server.Close()
 
-	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{"dings": "bums"})
+	testTarget := newTestTarget(server.URL, time.Second, model.LabelSet{"dings": "bums"})
+	// Affects full channel but not HTTP fetch
+	testTarget.deadline = 0
 
 	testTarget.scrape(slowAppender{})
 	if testTarget.status.Health() != HealthBad {
@@ -176,7 +178,7 @@ func TestTargetScrapeMetricRelabelConfigs(t *testing.T) {
 		),
 	)
 	defer server.Close()
-	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{})
+	testTarget := newTestTarget(server.URL, time.Second, model.LabelSet{})
 	testTarget.metricRelabelConfigs = []*config.RelabelConfig{
 		{
 			SourceLabels: model.LabelNames{"__name__"},
@@ -337,7 +339,7 @@ func TestTargetScrape404(t *testing.T) {
 	)
 	defer server.Close()
 
-	testTarget := newTestTarget(server.URL, 10*time.Millisecond, model.LabelSet{})
+	testTarget := newTestTarget(server.URL, time.Second, model.LabelSet{})
 	appender := nopAppender{}
 
 	want := errors.New("server returned HTTP status 404 Not Found")
@@ -380,7 +382,7 @@ func BenchmarkScrape(b *testing.B) {
 	)
 	defer server.Close()
 
-	testTarget := newTestTarget(server.URL, 100*time.Millisecond, model.LabelSet{"dings": "bums"})
+	testTarget := newTestTarget(server.URL, time.Second, model.LabelSet{"dings": "bums"})
 	appender := nopAppender{}
 
 	b.ResetTimer()


### PR DESCRIPTION
Bump timeouts of tests where we don't want I/O timeouts.

Adjust the full channel test to be much more reliable,
by reducing the ingestion timeout from 1ms to 0.

Fixes #1081

@fabxc 