### PR TITLE
retrieval: Reduce flakiness of TestTargetManagerChan

### DIFF
--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -174,7 +174,7 @@ func TestTargetManagerChan(t *testing.T) {
 	for i, step := range sequence {
 		prov1.update <- step.tgroup
 
-		<-time.After(1 * time.Millisecond)
+		time.Sleep(20 * time.Millisecond)
 
 		if len(targetManager.targets) != len(step.expected) {
 			t.Fatalf("step %d: sources mismatch %v, %v", i, targetManager.targets, step.expected)


### PR DESCRIPTION
This will increase test time by a few hundred ms,
this is the 2nd most common cause of flakiness.

@fabxc 