### PR TITLE
Retrieval: Show error message for failed test scrape

### DIFF
--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -195,7 +195,9 @@ func TestTargetScrapeMetricRelabelConfigs(t *testing.T) {
 	}
 
 	appender := &collectResultAppender{}
-	testTarget.scrape(appender)
+	if err := testTarget.scrape(appender); err != nil {
+		t.Fatal(err)
+	}
 
 	// Remove variables part of result.
 	for _, sample := range appender.result {


### PR DESCRIPTION
This is flaky, and I suspect it was due the to I/O timeout that I've
already fixed. In case that wasn't it, display the error should it
happen again.

@fabxc 