### PR TITLE
k8s: Use secrets in example scrape_config

### DIFF
--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -5,13 +5,14 @@
 scrape_configs:
 - job_name: 'kubernetes'
 
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
   kubernetes_sd_configs:
   - masters:
     - 'https://kubernetes.default.svc'
     in_cluster: true
-    tls_config:
-      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
   relabel_configs:
   - source_labels: [__meta_kubernetes_role, __meta_kubernetes_service_annotation_prometheus_io_scrape]


### PR DESCRIPTION
e633b1dc moved the config into the `kubernetes_sd_configs`, but this caused
scraping of kubernetes endpoints behind HTTPS to fail. The values under
`kubernetes_sd_configs` are the defaults and do not need to be specified.