### PR TITLE
Fix example prometheus.yml to use "external_labels" instead of "labels"

### DIFF
--- a/documentation/examples/prometheus.yml
+++ b/documentation/examples/prometheus.yml
@@ -4,8 +4,9 @@ global:
   evaluation_interval: 15s # By default, scrape targets every 15 seconds.
   # scrape_timeout is set to the global default (10s).
 
-  # Attach these extra labels to all timeseries collected by this Prometheus instance.
-  labels:
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
       monitor: 'codelab-monitor'
 
 # Load and evaluate rules in this file every 'evaluation_interval' seconds.


### PR DESCRIPTION
The file /documentation/examples/prometheus.yml is invalid after commit db382b4570bd7ca3135ead21914d5538b7f5a3e5. This is a simple fix to change "labels" to "external_labels".