### PR TITLE
Remove duplicated bootstrap js on the graph template

### DIFF
--- a/web/blob/templates/graph.html
+++ b/web/blob/templates/graph.html
@@ -1,6 +1,4 @@
 {{define "head"}}
-    <script src="{{ pathPrefix }}/static/vendor/bootstrap-3.3.1/js/bootstrap.min.js"></script>
-
     <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/css/graph.css">
 
     <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/rickshaw/rickshaw.min.css">


### PR DESCRIPTION
It's already included on the base template.