### PR TITLE
consoles: Remove federation example.

### DIFF
--- a/consoles/federation_template_example.txt
+++ b/consoles/federation_template_example.txt
@@ -1,3 +1,0 @@
-{{/* Adjust the query below to select the samples to expose. */}}
-{{ range query "{__name__=~'^job:.*'}" }}
-{{ .Labels.__name__ }}{{ "{" }}{{ range $k, $v := .Labels }}{{ if ne "__name__" $k }}{{ $k }}="{{ $v | reReplaceAll "([\\\\\"])" "\\$1" | reReplaceAll "\n" "\\n"| safeHtml }}",{{ end }}{{ end }}{{ "}" }} {{ print .Value | safeHtml }}{{ end }}


### PR DESCRIPTION
Now that federation is a 1st class feature, there's
no reason to keep this around.

@juliusv 