### PR TITLE
Add a "reload configurations" button on status page.

### DIFF
--- a/web/blob/static/js/status.js
+++ b/web/blob/static/js/status.js
@@ -1,0 +1,26 @@
+/* globals PATH_PREFIX, jQuery */
+(function ($, undefined) {
+    'use strict';
+
+    $('#reload-conf-btn').on('click', function () {
+        var elBtn;
+        $(this).promise().then(function (btn) {
+            elBtn = btn;
+            elBtn.text('Waiting...').prop('disabled', true);
+            return $.post(PATH_PREFIX + '/-/reload');
+        }).then(function () {
+            elBtn.text('Loaded Successfully!')
+                .prop('disabled', false)
+                .addClass('btn-success');
+        }, function() {
+            elBtn.text('Failed to load!')
+                .prop('disabled', false)
+                .addClass('btn-danger');
+        }).always(function () {
+            setTimeout(function () {
+                elBtn.removeClass('btn-danger btn-success')
+                    .text('Reload Configurations');
+            }, 1000);
+        });
+    });
+}(jQuery));

--- a/web/blob/static/js/status.js
+++ b/web/blob/static/js/status.js
@@ -1,26 +1,26 @@
-/* globals PATH_PREFIX, jQuery */
-(function ($, undefined) {
+/* globals PATH_PREFIX, $ */
+$(function () {
     'use strict';
 
-    $('#reload-conf-btn').on('click', function () {
+    $('#reload_conf_btn').on('click', function () {
         var elBtn;
         $(this).promise().then(function (btn) {
             elBtn = btn;
             elBtn.text('Waiting...').prop('disabled', true);
             return $.post(PATH_PREFIX + '/-/reload');
         }).then(function () {
-            elBtn.text('Loaded Successfully!')
+            elBtn.text('Triggered Reload!')
                 .prop('disabled', false)
                 .addClass('btn-success');
         }, function() {
-            elBtn.text('Failed to load!')
+            elBtn.text('Triggered Reload Failed!')
                 .prop('disabled', false)
                 .addClass('btn-danger');
         }).always(function () {
             setTimeout(function () {
                 elBtn.removeClass('btn-danger btn-success')
-                    .text('Reload Configurations');
-            }, 1000);
+                    .text('Reload Configuration');
+            }, 1400);
         });
     });
-}(jQuery));
+});

--- a/web/blob/templates/_base.html
+++ b/web/blob/templates/_base.html
@@ -49,5 +49,7 @@
     </nav>
 
     {{template "content" .}}
+
+    {{ template "js" .}}
   </body>
 </html>

--- a/web/blob/templates/_base.html
+++ b/web/blob/templates/_base.html
@@ -3,18 +3,9 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Prometheus Time Series Collection and Processing Server</title>
-    <script src="{{ pathPrefix }}/static/vendor/js/jquery.min.js"></script>
-    <script src="{{ pathPrefix }}/static/vendor/bootstrap-3.3.1/js/bootstrap.min.js"></script>
 
     <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/bootstrap-3.3.1/css/bootstrap.min.css">
     <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/css/prometheus.css">
-
-    <script>
-      var PATH_PREFIX = "{{ pathPrefix }}";
-      $(function () {
-        $('[data-toggle="tooltip"]').tooltip()
-      })
-    </script>
 
     {{template "head" .}}
   </head>
@@ -50,6 +41,14 @@
 
     {{template "content" .}}
 
+    <script src="{{ pathPrefix }}/static/vendor/js/jquery.min.js"></script>
+    <script src="{{ pathPrefix }}/static/vendor/bootstrap-3.3.1/js/bootstrap.min.js"></script>
+    <script>
+      var PATH_PREFIX = "{{ pathPrefix }}";
+      $(function () {
+        $('[data-toggle="tooltip"]').tooltip()
+      })
+    </script>
     {{ template "js" .}}
   </body>
 </html>

--- a/web/blob/templates/alerts.html
+++ b/web/blob/templates/alerts.html
@@ -1,7 +1,10 @@
 {{define "head"}}
   <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/css/alerts.css">
-  <script src="{{ pathPrefix }}/static/js/alerts.js"></script>
 {{end}}
+
+{{ define "js" }}
+  <script src="{{ pathPrefix }}/static/js/alerts.js"></script>
+{{ end }}
 
 {{define "content"}}
 <div class="container-fluid">
@@ -49,6 +52,3 @@
   </table>
 </div>
 {{end}}
-
-{{ define "js" }}
-{{ end }}

--- a/web/blob/templates/alerts.html
+++ b/web/blob/templates/alerts.html
@@ -49,3 +49,6 @@
   </table>
 </div>
 {{end}}
+
+{{ define "js" }}
+{{ end }}

--- a/web/blob/templates/graph.html
+++ b/web/blob/templates/graph.html
@@ -3,7 +3,9 @@
 
     <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/rickshaw/rickshaw.min.css">
     <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/bootstrap-datetimepicker/bootstrap-datetimepicker.min.css">
+{{end}}
 
+{{ define "js" }}
     <script src="{{ pathPrefix }}/static/vendor/rickshaw/vendor/d3.v3.js"></script>
     <script src="{{ pathPrefix }}/static/vendor/rickshaw/vendor/d3.layout.min.js"></script>
     <script src="{{ pathPrefix }}/static/vendor/rickshaw/rickshaw.min.js"></script>
@@ -17,7 +19,7 @@
     <script src="{{ pathPrefix }}/static/js/graph.js"></script>
 
     <script id="graph_template" type="text/x-handlebars-template"></script>
-{{end}}
+{{ end }}
 
 {{define "content"}}
     <div id="graph_container" class="container-fluid">
@@ -26,6 +28,3 @@
       <div><input class="btn btn-primary" type="submit" value="Add Graph" id="add_graph"></div>
     </div>
 {{end}}
-
-{{ define "js" }}
-{{ end }}

--- a/web/blob/templates/graph.html
+++ b/web/blob/templates/graph.html
@@ -26,3 +26,6 @@
       <div><input class="btn btn-primary" type="submit" value="Add Graph" id="add_graph"></div>
     </div>
 {{end}}
+
+{{ define "js" }}
+{{ end }}

--- a/web/blob/templates/status.html
+++ b/web/blob/templates/status.html
@@ -26,6 +26,7 @@
 
     <h2 id="configuration">Configuration</h2>
     <pre>{{.Status.Config}}</pre>
+    <button class="btn btn-primary" id="reload-conf-btn">Reload Configurations</button>
 
     <h2 id="rules">Rules</h2>
     <pre>{{range call .Status.Rules}}{{.HTMLSnippet pathPrefix}}<br/>{{end}}</pre>
@@ -98,3 +99,7 @@
     </table>
   </div>
 {{end}}
+
+{{ define "js" }}
+<script src="{{ pathPrefix }}/static/js/status.js"></script>
+{{ end }}

--- a/web/blob/templates/status.html
+++ b/web/blob/templates/status.html
@@ -1,5 +1,9 @@
 {{define "head"}}<!-- nix -->{{end}}
 
+{{ define "js" }}
+  <script src="{{ pathPrefix }}/static/js/status.js"></script>
+{{ end }}
+
 {{define "content"}}
   <div class="container-fluid">
     <h2 id="runtime">Runtime Information</h2>
@@ -26,7 +30,7 @@
 
     <h2 id="configuration">Configuration</h2>
     <pre>{{.Status.Config}}</pre>
-    <button class="btn btn-primary" id="reload-conf-btn">Reload Configurations</button>
+    <button class="btn btn-primary" id="reload_conf_btn">Reload Configuration</button>
 
     <h2 id="rules">Rules</h2>
     <pre>{{range call .Status.Rules}}{{.HTMLSnippet pathPrefix}}<br/>{{end}}</pre>
@@ -99,7 +103,3 @@
     </table>
   </div>
 {{end}}
-
-{{ define "js" }}
-<script src="{{ pathPrefix }}/static/js/status.js"></script>
-{{ end }}


### PR DESCRIPTION
Currently the route always returns 200, due independent gorotine which reloads the configurations.

Should we have another channel that signals the caller goroutine when [`reloadConfig`](https://github.com/prometheus/prometheus/blob/master/cmd/prometheus/main.go#L131) terminates?

I'll appreciate it if someone with permissions creates a new branch for that feature so I can work with.

P.S I've also created a new section for js files (at the end of the body, [it's better](http://stackoverflow.com/a/24070373)), not used yet but in status page.