### PR TITLE
config: Don't hide username, it's not secret.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,7 @@ var (
 	patJobName    = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_-]*$`)
 	patFileSDName = regexp.MustCompile(`^[^*]*(\*[^/]*)?\.(json|yml|yaml|JSON|YML|YAML)$`)
 	patRulePath   = regexp.MustCompile(`^[^*]*(\*[^/]*)?$`)
-	patAuthLine   = regexp.MustCompile(`((?:username|password|bearer_token|secret_key):\s+)(".+"|'.+'|[^\s]+)`)
+	patAuthLine   = regexp.MustCompile(`((?:password|bearer_token|secret_key):\s+)(".+"|'.+'|[^\s]+)`)
 )
 
 // Load parses the YAML input s into a Config.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -282,7 +282,7 @@ func TestLoadConfig(t *testing.T) {
 
 	// String method must not reveal authentication credentials.
 	s := c.String()
-	if strings.Contains(s, "admin_name") || strings.Contains(s, "admin_password") {
+	if strings.Contains(s, "admin_password") {
 		t.Fatalf("config's String method reveals authentication credentials.")
 	}
 }


### PR DESCRIPTION
Usernames are not generally considered to be secrets,
and treating them as secrets may lead to confusion
as to how secure they are. Obscuring them also makes
debugging harder.

@fabxc 