### PR TITLE
Fix SD mechanism source prefix handling.

### DIFF
--- a/retrieval/discovery/dns.go
+++ b/retrieval/discovery/dns.go
@@ -91,7 +91,7 @@ func NewDNSDiscovery(conf *config.DNSSDConfig) *DNSDiscovery {
 }
 
 // Run implements the TargetProvider interface.
-func (dd *DNSDiscovery) Run(ch chan<- *config.TargetGroup, done <-chan struct{}) {
+func (dd *DNSDiscovery) Run(ch chan<- config.TargetGroup, done <-chan struct{}) {
 	defer close(ch)
 
 	ticker := time.NewTicker(dd.interval)
@@ -119,7 +119,7 @@ func (dd *DNSDiscovery) Sources() []string {
 	return srcs
 }
 
-func (dd *DNSDiscovery) refreshAll(ch chan<- *config.TargetGroup) {
+func (dd *DNSDiscovery) refreshAll(ch chan<- config.TargetGroup) {
 	var wg sync.WaitGroup
 	wg.Add(len(dd.names))
 	for _, name := range dd.names {
@@ -133,7 +133,7 @@ func (dd *DNSDiscovery) refreshAll(ch chan<- *config.TargetGroup) {
 	wg.Wait()
 }
 
-func (dd *DNSDiscovery) refresh(name string, ch chan<- *config.TargetGroup) error {
+func (dd *DNSDiscovery) refresh(name string, ch chan<- config.TargetGroup) error {
 	response, err := lookupAll(name, dd.qtype)
 	dnsSDLookupsCount.Inc()
 	if err != nil {
@@ -141,7 +141,7 @@ func (dd *DNSDiscovery) refresh(name string, ch chan<- *config.TargetGroup) erro
 		return err
 	}
 
-	tg := &config.TargetGroup{}
+	var tg config.TargetGroup
 	for _, record := range response.Answer {
 		target := model.LabelValue("")
 		switch addr := record.(type) {

--- a/retrieval/discovery/ec2.go
+++ b/retrieval/discovery/ec2.go
@@ -62,7 +62,7 @@ func NewEC2Discovery(conf *config.EC2SDConfig) *EC2Discovery {
 }
 
 // Run implements the TargetProvider interface.
-func (ed *EC2Discovery) Run(ch chan<- *config.TargetGroup, done <-chan struct{}) {
+func (ed *EC2Discovery) Run(ch chan<- config.TargetGroup, done <-chan struct{}) {
 	defer close(ch)
 
 	ticker := time.NewTicker(ed.interval)
@@ -73,7 +73,7 @@ func (ed *EC2Discovery) Run(ch chan<- *config.TargetGroup, done <-chan struct{})
 	if err != nil {
 		log.Error(err)
 	} else {
-		ch <- tg
+		ch <- *tg
 	}
 
 	for {
@@ -83,7 +83,7 @@ func (ed *EC2Discovery) Run(ch chan<- *config.TargetGroup, done <-chan struct{})
 			if err != nil {
 				log.Error(err)
 			} else {
-				ch <- tg
+				ch <- *tg
 			}
 		case <-done:
 			return

--- a/retrieval/discovery/file.go
+++ b/retrieval/discovery/file.go
@@ -103,7 +103,7 @@ func (fd *FileDiscovery) watchFiles() {
 }
 
 // Run implements the TargetProvider interface.
-func (fd *FileDiscovery) Run(ch chan<- *config.TargetGroup, done <-chan struct{}) {
+func (fd *FileDiscovery) Run(ch chan<- config.TargetGroup, done <-chan struct{}) {
 	defer close(ch)
 	defer fd.stop()
 
@@ -188,7 +188,7 @@ func (fd *FileDiscovery) stop() {
 
 // refresh reads all files matching the discovery's patterns and sends the respective
 // updated target groups through the channel.
-func (fd *FileDiscovery) refresh(ch chan<- *config.TargetGroup) {
+func (fd *FileDiscovery) refresh(ch chan<- config.TargetGroup) {
 	ref := map[string]int{}
 	for _, p := range fd.listFiles() {
 		tgroups, err := readFile(p)
@@ -199,7 +199,7 @@ func (fd *FileDiscovery) refresh(ch chan<- *config.TargetGroup) {
 			continue
 		}
 		for _, tg := range tgroups {
-			ch <- tg
+			ch <- *tg
 		}
 		ref[p] = len(tgroups)
 	}
@@ -208,7 +208,7 @@ func (fd *FileDiscovery) refresh(ch chan<- *config.TargetGroup) {
 		m, ok := ref[f]
 		if !ok || n > m {
 			for i := m; i < n; i++ {
-				ch <- &config.TargetGroup{Source: fileSource(f, i)}
+				ch <- config.TargetGroup{Source: fileSource(f, i)}
 			}
 		}
 	}

--- a/retrieval/discovery/file_test.go
+++ b/retrieval/discovery/file_test.go
@@ -26,7 +26,7 @@ func testFileSD(t *testing.T, ext string) {
 
 	var (
 		fsd  = NewFileDiscovery(&conf)
-		ch   = make(chan *config.TargetGroup)
+		ch   = make(chan config.TargetGroup)
 		done = make(chan struct{})
 	)
 	go fsd.Run(ch, done)

--- a/retrieval/discovery/marathon.go
+++ b/retrieval/discovery/marathon.go
@@ -53,7 +53,7 @@ func (md *MarathonDiscovery) Sources() []string {
 }
 
 // Run implements the TargetProvider interface.
-func (md *MarathonDiscovery) Run(ch chan<- *config.TargetGroup, done <-chan struct{}) {
+func (md *MarathonDiscovery) Run(ch chan<- config.TargetGroup, done <-chan struct{}) {
 	defer close(ch)
 
 	for {
@@ -69,7 +69,7 @@ func (md *MarathonDiscovery) Run(ch chan<- *config.TargetGroup, done <-chan stru
 	}
 }
 
-func (md *MarathonDiscovery) updateServices(ch chan<- *config.TargetGroup) error {
+func (md *MarathonDiscovery) updateServices(ch chan<- config.TargetGroup) error {
 	targetMap, err := md.fetchTargetGroups()
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func (md *MarathonDiscovery) updateServices(ch chan<- *config.TargetGroup) error
 
 	// Update services which are still present
 	for _, tg := range targetMap {
-		ch <- tg
+		ch <- *tg
 	}
 
 	// Remove services which did disappear
@@ -85,7 +85,7 @@ func (md *MarathonDiscovery) updateServices(ch chan<- *config.TargetGroup) error
 		_, ok := targetMap[source]
 		if !ok {
 			log.Debugf("Removing group for %s", source)
-			ch <- &config.TargetGroup{Source: source}
+			ch <- config.TargetGroup{Source: source}
 		}
 	}
 

--- a/retrieval/discovery/marathon_test.go
+++ b/retrieval/discovery/marathon_test.go
@@ -26,8 +26,8 @@ import (
 
 var marathonValidLabel = map[string]string{"prometheus": "yes"}
 
-func newTestDiscovery(client marathon.AppListClient) (chan *config.TargetGroup, *MarathonDiscovery) {
-	ch := make(chan *config.TargetGroup)
+func newTestDiscovery(client marathon.AppListClient) (chan config.TargetGroup, *MarathonDiscovery) {
+	ch := make(chan config.TargetGroup)
 	md := NewMarathonDiscovery(&config.MarathonSDConfig{
 		Servers: []string{"http://localhost:8080"},
 	})

--- a/retrieval/discovery/serverset.go
+++ b/retrieval/discovery/serverset.go
@@ -67,7 +67,7 @@ type ServersetDiscovery struct {
 	conn       *zk.Conn
 	mu         sync.RWMutex
 	sources    map[string]*config.TargetGroup
-	sdUpdates  *chan<- *config.TargetGroup
+	sdUpdates  *chan<- config.TargetGroup
 	updates    chan zookeeperTreeCacheEvent
 	treeCaches []*zookeeperTreeCache
 }
@@ -124,7 +124,7 @@ func (sd *ServersetDiscovery) processUpdates() {
 		}
 		sd.mu.Unlock()
 		if sd.sdUpdates != nil {
-			*sd.sdUpdates <- tg
+			*sd.sdUpdates <- *tg
 		}
 	}
 
@@ -134,11 +134,11 @@ func (sd *ServersetDiscovery) processUpdates() {
 }
 
 // Run implements the TargetProvider interface.
-func (sd *ServersetDiscovery) Run(ch chan<- *config.TargetGroup, done <-chan struct{}) {
+func (sd *ServersetDiscovery) Run(ch chan<- config.TargetGroup, done <-chan struct{}) {
 	// Send on everything we have seen so far.
 	sd.mu.Lock()
 	for _, targetGroup := range sd.sources {
-		ch <- targetGroup
+		ch <- *targetGroup
 	}
 	// Tell processUpdates to send future updates.
 	sd.sdUpdates = &ch

--- a/retrieval/helpers_test.go
+++ b/retrieval/helpers_test.go
@@ -52,12 +52,12 @@ type fakeTargetProvider struct {
 	update  chan *config.TargetGroup
 }
 
-func (tp *fakeTargetProvider) Run(ch chan<- *config.TargetGroup, done <-chan struct{}) {
+func (tp *fakeTargetProvider) Run(ch chan<- config.TargetGroup, done <-chan struct{}) {
 	defer close(ch)
 	for {
 		select {
 		case tg := <-tp.update:
-			ch <- tg
+			ch <- *tg
 		case <-done:
 			return
 		}

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -52,7 +52,7 @@ func TestPrefixedTargetProvider(t *testing.T) {
 		t.Fatalf("expected sources %v, got %v", expSources, tp.Sources())
 	}
 
-	ch := make(chan *config.TargetGroup)
+	ch := make(chan config.TargetGroup)
 	done := make(chan struct{})
 
 	defer close(done)
@@ -64,10 +64,10 @@ func TestPrefixedTargetProvider(t *testing.T) {
 	expGroup2.Source = "job-x:static:123:1"
 
 	// The static target provider sends on the channel once per target group.
-	if tg := <-ch; !reflect.DeepEqual(tg, &expGroup1) {
+	if tg := <-ch; !reflect.DeepEqual(tg, expGroup1) {
 		t.Fatalf("expected target group %v, got %v", expGroup1, tg)
 	}
-	if tg := <-ch; !reflect.DeepEqual(tg, &expGroup2) {
+	if tg := <-ch; !reflect.DeepEqual(tg, expGroup2) {
 		t.Fatalf("expected target group %v, got %v", expGroup2, tg)
 	}
 }


### PR DESCRIPTION
The prefixed target provider changed a pointerized target group that was
reused in the wrapped target provider, causing an ever-increasing chain
of source prefixes in target groups from the Consul target provider.

We now make this bug generally impossible by switching the target group
channel from pointer to value type and thus ensuring that target groups
are copied before being passed on to other parts of the system.

I tried to not let the depointerization leak too far outside of the
channel handling (both upstream and downstream) because I tried that
initially and caused some nasty bugs, which I want to minimize.

Fixes https://github.com/prometheus/prometheus/issues/1083