### PR TITLE
promql: Remove deprecated 2nd argument to delta()

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -44,8 +44,9 @@ func funcTime(ev *evaluator, args Expressions) model.Value {
 	}
 }
 
-// === delta(matrix model.ValMatrix, isCounter=0 model.ValScalar) Vector ===
+// === delta(matrix model.ValMatrix) Vector ===
 func funcDelta(ev *evaluator, args Expressions) model.Value {
+	// This function still takes a 2nd argument for use by rate() and increase().
 	isCounter := len(args) >= 2 && ev.evalInt(args[1]) > 0
 	resultVector := vector{}
 
@@ -763,11 +764,10 @@ var functions = map[string]*Function{
 		Call:       funcCountScalar,
 	},
 	"delta": {
-		Name:         "delta",
-		ArgTypes:     []model.ValueType{model.ValMatrix, model.ValScalar},
-		OptionalArgs: 1, // The 2nd argument is deprecated.
-		ReturnType:   model.ValVector,
-		Call:         funcDelta,
+		Name:       "delta",
+		ArgTypes:   []model.ValueType{model.ValMatrix},
+		ReturnType: model.ValVector,
+		Call:       funcDelta,
 	},
 	"deriv": {
 		Name:       "deriv",

--- a/promql/testdata/legacy.test
+++ b/promql/testdata/legacy.test
@@ -133,16 +133,6 @@ eval instant at 50m rate(http_requests[25m]) * 25 * 60
 	{group="production", instance="1", job="api-server"} 100 
 	{group="production", instance="1", job="app-server"} 300 
 
-eval instant at 50m delta(http_requests[25m], 1)
-	{group="canary", instance="0", job="api-server"} 150 
-	{group="canary", instance="0", job="app-server"} 350 
-	{group="canary", instance="1", job="api-server"} 200 
-	{group="canary", instance="1", job="app-server"} 400 
-	{group="production", instance="0", job="api-server"} 50 
-	{group="production", instance="0", job="app-server"} 250 
-	{group="production", instance="1", job="api-server"} 100 
-	{group="production", instance="1", job="app-server"} 300 
-
 eval_ordered instant at 50m sort(http_requests)
 	http_requests{group="production", instance="0", job="api-server"} 100 
 	http_requests{group="production", instance="1", job="api-server"} 200 
@@ -206,11 +196,6 @@ eval instant at 50m sum(http_requests) by (job) + min(http_requests) by (job) + 
 
 # Deltas should be adjusted for target interval vs. samples under target interval.
 eval instant at 50m delta(http_requests{group="canary", instance="1", job="app-server"}[18m])
-	{group="canary", instance="1", job="app-server"} 288
-
-
-# Deltas should perform the same operation when 2nd argument is 0.
-eval instant at 50m delta(http_requests{group="canary", instance="1", job="app-server"}[18m], 0)
 	{group="canary", instance="1", job="app-server"} 288
 
 


### PR DESCRIPTION
This change is breaking, use increase() instead.

I'm not cleaning up the function in this PR, as my solution to #581 will
rewrite and simplify increase/rate/delta.

@juliusv @fabxc 