### PR TITLE
Add a humanizeTimestamp to prom.lib.

### DIFF
--- a/console_libraries/prom.lib
+++ b/console_libraries/prom.lib
@@ -30,6 +30,7 @@
 {{ define "humanizeNoSmallPrefix" }}{{ if and (lt . 1.0) (gt . -1.0) }}{{ printf "%.3g" . }}{{ else }}{{ humanize . }}{{ end }}{{ end }}
 {{ define "humanize1024" }}{{ humanize1024 . }}{{ end }}
 {{ define "humanizeDuration" }}{{ humanizeDuration . }}{{ end }}
+{{ define "humanizeTimestamp" }}{{ humanizeTimestamp . }}{{ end }}
 {{ define "printf.1f" }}{{ printf "%.1f" . }}{{ end }}
 {{ define "printf.3g" }}{{ printf "%.3g" . }}{{ end }}
 


### PR DESCRIPTION
Useful for `prom_query_drilldown` calls for instance.