### PR TITLE
Make path-prefixing of served HTTP routes optional.

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -78,6 +78,10 @@ func init() {
 		&cfg.prometheusURL, "web.external-url", "",
 		"The URL under which Prometheus is externally reachable (for example, if Prometheus is served via a reverse proxy). Used for generating relative and absolute links back to Prometheus itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Prometheus. If omitted, relevant URL components will be derived automatically.",
 	)
+	cfg.fs.BoolVar(
+		&cfg.web.PrefixRoutes, "web.prefix-routes", true,
+		"Whether to prefix all HTTP routes with the path part of the URL specified by -web.external-url. Turning this off allows for proxies which pass only a trailing part of the path on to the Prometheus backend.",
+	)
 	cfg.fs.StringVar(
 		&cfg.web.MetricsPath, "web.telemetry-path", "/metrics",
 		"Path under which to expose metrics.",

--- a/web/web.go
+++ b/web/web.go
@@ -113,6 +113,7 @@ func (s *PrometheusStatus) ApplyConfig(conf *config.Config) bool {
 type Options struct {
 	ListenAddress        string
 	ExternalURL          *url.URL
+	PrefixRoutes         bool
 	MetricsPath          string
 	UseLocalAssets       bool
 	UserAssetsPath       string
@@ -148,7 +149,7 @@ func New(st local.Storage, qe *promql.Engine, rm *rules.Manager, status *Prometh
 		},
 	}
 
-	if o.ExternalURL.Path != "" {
+	if o.ExternalURL.Path != "" && o.PrefixRoutes {
 		// If the prefix is missing for the root path, prepend it.
 		router.Get("/", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, o.ExternalURL.Path, http.StatusFound)


### PR DESCRIPTION
This allows use cases where one wants to use the Prometheus UI through a
proxy which maps only a trailing part of the proxied path to the backend
path.

Fixes https://github.com/prometheus/prometheus/issues/1191