### PR TITLE
Anchor regexes in vector matching

### DIFF
--- a/promql/testdata/legacy.test
+++ b/promql/testdata/legacy.test
@@ -226,20 +226,20 @@ eval instant at 50m http_requests{group!="canary"}
 	http_requests{group="production", instance="1", job="api-server"} 200 
 	http_requests{group="production", instance="0", job="api-server"} 100 
 
-eval instant at 50m http_requests{job=~"server",group!="canary"}
+eval instant at 50m http_requests{job=~".+-server",group!="canary"}
 	http_requests{group="production", instance="1", job="app-server"} 600 
 	http_requests{group="production", instance="0", job="app-server"} 500 
 	http_requests{group="production", instance="1", job="api-server"} 200 
 	http_requests{group="production", instance="0", job="api-server"} 100 
 
-eval instant at 50m http_requests{job!~"api",group!="canary"}
+eval instant at 50m http_requests{job!~"api-.+",group!="canary"}
 	http_requests{group="production", instance="1", job="app-server"} 600 
 	http_requests{group="production", instance="0", job="app-server"} 500 
 
-eval instant at 50m count_scalar(http_requests{job=~"^server$"})
+eval instant at 50m count_scalar(http_requests{job=~"server"})
 	0
 
-eval instant at 50m http_requests{group="production",job=~"^api"}
+eval instant at 50m http_requests{group="production",job=~"api-.+"}
 	http_requests{group="production", instance="0", job="api-server"} 100 
 	http_requests{group="production", instance="1", job="api-server"} 200 
 
@@ -357,7 +357,7 @@ eval instant at 50m {__name__=~".+"}
 	cpu_count{instance="0", type="numa"} 300 
 
 
-eval instant at 50m {job=~"server", job!~"api"}
+eval instant at 50m {job=~".+-server", job!~"api-.+"}
 	http_requests{group="canary", instance="0", job="app-server"} 700 
 	http_requests{group="canary", instance="1", job="app-server"} 800 
 	http_requests{group="production", instance="0", job="app-server"} 500 

--- a/storage/metric/matcher.go
+++ b/storage/metric/matcher.go
@@ -63,7 +63,7 @@ func NewLabelMatcher(matchType MatchType, name model.LabelName, value model.Labe
 		Value: value,
 	}
 	if matchType == RegexMatch || matchType == RegexNoMatch {
-		re, err := regexp.Compile(string(value))
+		re, err := regexp.Compile("^(?:" + string(value) + ")$")
 		if err != nil {
 			return nil, err
 		}

--- a/storage/metric/matcher_test.go
+++ b/storage/metric/matcher_test.go
@@ -1,0 +1,32 @@
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import (
+	"testing"
+)
+
+func TestAnchoredMatcher(t *testing.T) {
+	m, err := NewLabelMatcher(RegexMatch, "", "foo|bar|baz")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !m.Match("foo") {
+		t.Errorf("Expected match for %q but got none", "foo")
+	}
+	if m.Match("fooo") {
+		t.Errorf("Unexpected match for %q", "fooo")
+	}
+}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -210,7 +210,7 @@ func TestEndpoints(t *testing.T) {
 		{
 			endpoint: api.series,
 			query: url.Values{
-				"match[]": []string{`test_metric1{foo=~"o$"}`},
+				"match[]": []string{`test_metric1{foo=~".+o"}`},
 			},
 			response: []model.Metric{
 				{
@@ -222,7 +222,7 @@ func TestEndpoints(t *testing.T) {
 		{
 			endpoint: api.series,
 			query: url.Values{
-				"match[]": []string{`test_metric1{foo=~"o$"}`, `test_metric1{foo=~"o$"}`},
+				"match[]": []string{`test_metric1{foo=~"o$"}`, `test_metric1{foo=~".+o"}`},
 			},
 			response: []model.Metric{
 				{
@@ -234,7 +234,7 @@ func TestEndpoints(t *testing.T) {
 		{
 			endpoint: api.series,
 			query: url.Values{
-				"match[]": []string{`test_metric1{foo=~"o$"}`, `none`},
+				"match[]": []string{`test_metric1{foo=~".+o"}`, `none`},
 			},
 			response: []model.Metric{
 				{
@@ -257,7 +257,7 @@ func TestEndpoints(t *testing.T) {
 		{
 			endpoint: api.dropSeries,
 			query: url.Values{
-				"match[]": []string{`test_metric1{foo=~"o$"}`},
+				"match[]": []string{`test_metric1{foo=~".+o"}`},
 			},
 			response: struct {
 				NumDeleted int `json:"numDeleted"`


### PR DESCRIPTION
This commit makes the regex behavior of vector matching consistent with
configuration and label_replace() by anchoring it.

Fixes #1200