### PR TITLE
Add in default port after relabelling.

### DIFF
--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -446,19 +446,6 @@ func (tm *TargetManager) targetsFromGroup(tg *config.TargetGroup, cfg *config.Sc
 
 	targets := make([]*Target, 0, len(tg.Targets))
 	for i, labels := range tg.Targets {
-		addr := string(labels[model.AddressLabel])
-		// If no port was provided, infer it based on the used scheme.
-		if !strings.Contains(addr, ":") {
-			switch cfg.Scheme {
-			case "http":
-				addr = fmt.Sprintf("%s:80", addr)
-			case "https":
-				addr = fmt.Sprintf("%s:443", addr)
-			default:
-				panic(fmt.Errorf("targetsFromGroup: invalid scheme %q", cfg.Scheme))
-			}
-			labels[model.AddressLabel] = model.LabelValue(addr)
-		}
 		for k, v := range cfg.Params {
 			if len(v) > 0 {
 				labels[model.LabelName(model.ParamLabelPrefix+k)] = model.LabelValue(v[0])
@@ -495,6 +482,19 @@ func (tm *TargetManager) targetsFromGroup(tg *config.TargetGroup, cfg *config.Sc
 		// Check if the target was dropped.
 		if labels == nil {
 			continue
+		}
+		// If no port was provided, infer it based on the used scheme.
+		addr := string(labels[model.AddressLabel])
+		if !strings.Contains(addr, ":") {
+			switch labels[model.SchemeLabel] {
+			case "http", "":
+				addr = fmt.Sprintf("%s:80", addr)
+			case "https":
+				addr = fmt.Sprintf("%s:443", addr)
+			default:
+				panic(fmt.Errorf("targetsFromGroup: invalid scheme %q", cfg.Scheme))
+			}
+			labels[model.AddressLabel] = model.LabelValue(addr)
 		}
 		if err = config.CheckTargetAddress(labels[model.AddressLabel]); err != nil {
 			return nil, err

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -211,7 +211,7 @@ func TestTargetManagerConfigUpdate(t *testing.T) {
 		TargetGroups: []*config.TargetGroup{{
 			Targets: []model.LabelSet{
 				{model.AddressLabel: "example.org:80"},
-				{model.AddressLabel: "example.com:80"},
+				{model.AddressLabel: "example.com"},
 			},
 		}},
 		RelabelConfigs: []*config.RelabelConfig{
@@ -222,6 +222,13 @@ func TestTargetManagerConfigUpdate(t *testing.T) {
 				TargetLabel:  "testParam",
 				Replacement:  "$1",
 				Action:       config.RelabelReplace,
+			},
+			{
+				// The port number is added after relabeling, so
+				// this relabel rule should have no effect.
+				SourceLabels: model.LabelNames{model.AddressLabel},
+				Regex:        config.MustNewRegexp("example.com:80"),
+				Action:       config.RelabelDrop,
 			},
 		},
 	}


### PR DESCRIPTION
For the SNMP and blackbox exporters where
the ports tends to not be 80/443 and indeed
there may not be a port this makes the relabelling
a bit simpler as you don't have to figure out this
logic exists and strip off the :80.

This is a breaking change for the example configs of
those exporters.

@fabxc 