### PR TITLE
Make time parameter optional in v1 query API

### DIFF
--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -35,9 +35,11 @@ func TestEndpoints(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	now := model.Now()
 	api := &API{
 		Storage:     suite.Storage(),
 		QueryEngine: suite.QueryEngine(),
+		now:         func() model.Time { return now },
 	}
 
 	start := model.Time(0)
@@ -91,6 +93,19 @@ func TestEndpoints(t *testing.T) {
 			},
 		},
 		{
+			endpoint: api.query,
+			query: url.Values{
+				"query": []string{"0.333"},
+			},
+			response: &queryData{
+				ResultType: model.ValScalar,
+				Result: &model.Scalar{
+					Value:     0.333,
+					Timestamp: now,
+				},
+			},
+		},
+		{
 			endpoint: api.queryRange,
 			query: url.Values{
 				"query": []string{"time()"},
@@ -137,14 +152,6 @@ func TestEndpoints(t *testing.T) {
 				"query": []string{"time()"},
 				"start": []string{"0"},
 				"end":   []string{"2"},
-			},
-			errType: errorBadData,
-		},
-		// Missing evaluation time.
-		{
-			endpoint: api.query,
-			query: url.Values{
-				"query": []string{"0.333"},
 			},
 			errType: errorBadData,
 		},

--- a/web/web.go
+++ b/web/web.go
@@ -138,10 +138,7 @@ func New(st local.Storage, qe *promql.Engine, rm *rules.Manager, status *Prometh
 		queryEngine: qe,
 		storage:     st,
 
-		apiV1: &v1.API{
-			QueryEngine: qe,
-			Storage:     st,
-		},
+		apiV1: v1.NewAPI(qe, st),
 		apiLegacy: &legacy.API{
 			QueryEngine: qe,
 			Storage:     st,


### PR DESCRIPTION
If no time paramter is provided, the current server timestamp is used.

Fixes #1207.

@qed- @fabxc 