### PR TITLE
template: Use zero-values for missing values.

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -273,6 +273,7 @@ func (te Expander) Expand() (result string, resultErr error) {
 	}()
 
 	tmpl, err := text_template.New(te.name).Funcs(te.funcMap).Parse(te.text)
+	tmpl.Option("missingkey=zero")
 	if err != nil {
 		return "", fmt.Errorf("error parsing template %v: %v", te.name, err)
 	}
@@ -297,6 +298,7 @@ func (te Expander) ExpandHTML(templateFiles []string) (result string, resultErr 
 	}()
 
 	tmpl := html_template.New(te.name).Funcs(html_template.FuncMap(te.funcMap))
+	tmpl.Option("missingkey=zero")
 	tmpl.Funcs(html_template.FuncMap{
 		"tmpl": func(name string, data interface{}) (html_template.HTML, error) {
 			var buffer bytes.Buffer

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -85,6 +85,21 @@ func TestTemplateExpansion(t *testing.T) {
 			output: "a",
 		},
 		{
+			// Missing label is empty when using label function.
+			text:   "{{ query \"metric{instance='a'}\" | first | label \"foo\" }}",
+			output: "",
+		},
+		{
+			// Missing label is empty when not using label function.
+			text:   "{{ $x := query \"metric\" | first }}{{ $x.Labels.foo }}",
+			output: "",
+		},
+		{
+			text:   "{{ $x := query \"metric\" | first }}{{ $x.Labels.foo }}",
+			output: "",
+			html:   true,
+		},
+		{
 			// Range over query and sort by label.
 			text:   "{{ range query \"metric\" | sortByLabel \"instance\" }}{{.Labels.instance}}:{{.Value}}: {{end}}",
 			output: "a:11: b:21: ",


### PR DESCRIPTION
Currently missing values will get the value <no value>
rather than the empty string. Using the empty string is
more consistent, and should be easier for users to deal with too.

@fabxc 