### PR TITLE
Kubernetes SD: Use first TCP service port as target port & clean up example config

### DIFF
--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -60,7 +60,6 @@ scrape_configs:
     regex: (https?)
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
     action: replace
-    regex: (.+)
     target_label: __metrics_path__
   - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
     action: replace
@@ -100,21 +99,17 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_role, __meta_kubernetes_service_annotation_prometheus_io_probe]
     action: keep
     regex: service;true
-  - target_label: __address__
-    replacement: blackbox.default.svc:9115
   - source_labels: [__address__]
-    regex: (.*)(:80)?
     target_label: __param_target
+  - target_label: __address__
+    replacement: blackbox
   - source_labels: [__param_target]
     target_label: instance
   - action: labelmap
     regex: __meta_kubernetes_service_label_(.+)
   - source_labels: [__meta_kubernetes_role]
-    action: replace
     target_label: kubernetes_role
   - source_labels: [__meta_kubernetes_service_namespace]
-    action: replace
     target_label: kubernetes_namespace
   - source_labels: [__meta_kubernetes_service_name]
-    action: replace
     target_label: kubernetes_name

--- a/retrieval/discovery/kubernetes/discovery.go
+++ b/retrieval/discovery/kubernetes/discovery.go
@@ -514,8 +514,18 @@ func (kd *Discovery) updateServiceTargetGroup(service *Service, eps *Endpoints) 
 		tg.Labels[model.LabelName(labelName)] = model.LabelValue(v)
 	}
 
+	serviceAddress := service.ObjectMeta.Name + "." + service.ObjectMeta.Namespace + ".svc"
+
+	// Append the first TCP service port if one exists.
+	for _, port := range service.Spec.Ports {
+		if port.Protocol == ProtocolTCP {
+			serviceAddress += fmt.Sprintf(":%d", port.Port)
+			break
+		}
+	}
+
 	t := model.LabelSet{
-		model.AddressLabel: model.LabelValue(service.ObjectMeta.Name + "." + service.ObjectMeta.Namespace + ".svc"),
+		model.AddressLabel: model.LabelValue(serviceAddress),
 		roleLabel:          model.LabelValue("service"),
 	}
 	tg.Targets = append(tg.Targets, t)

--- a/retrieval/discovery/kubernetes/types.go
+++ b/retrieval/discovery/kubernetes/types.go
@@ -107,6 +107,27 @@ type Container struct {
 // will answer requests sent through the proxy.
 type Service struct {
 	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
+
+	// Spec defines the behavior of a service.
+	// http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status
+	Spec ServiceSpec `json:"spec,omitempty"`
+}
+
+// ServiceSpec describes the attributes that a user creates on a service.
+type ServiceSpec struct {
+	// The list of ports that are exposed by this service.
+	// More info: http://releases.k8s.io/HEAD/docs/user-guide/services.md#virtual-ips-and-service-proxies
+	Ports []ServicePort `json:"ports"`
+}
+
+// ServicePort conatins information on service's port.
+type ServicePort struct {
+	// The IP protocol for this port. Supports "TCP" and "UDP".
+	// Default is TCP.
+	Protocol Protocol `json:"protocol,omitempty"`
+
+	// The port that will be exposed by this service.
+	Port int32 `json:"port"`
 }
 
 // ServiceList holds a list of services.


### PR DESCRIPTION
Fixes #1256

/cc @SuperQ @fabxc @iancoffey