### PR TITLE
Make topk/bottomk prefer returning real numbers over NaN.

### DIFF
--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -193,3 +193,34 @@ eval instant at 0m clamp_max(clamp_min(test_clamp, -20), 70)
 	{src="clamp-a"}	-20
 	{src="clamp-b"}	0
 	{src="clamp-c"}	70
+
+clear
+
+# Tests for topk/bottomk.
+load 5m
+	http_requests{job="api-server", instance="0", group="production"}	0+10x10
+	http_requests{job="api-server", instance="1", group="production"}	0+20x10
+	http_requests{job="api-server", instance="0", group="canary"}		0+30x10
+	http_requests{job="api-server", instance="1", group="canary"}		0+40x10
+	http_requests{job="app-server", instance="0", group="production"}	0+50x10
+	http_requests{job="app-server", instance="1", group="production"}	0+60x10
+	http_requests{job="app-server", instance="0", group="canary"}		0+70x10
+	http_requests{job="app-server", instance="1", group="canary"}		0+80x10
+
+eval_ordered instant at 50m topk(3, http_requests)
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="production", instance="1", job="app-server"} 600
+
+eval_ordered instant at 50m topk(5, http_requests{group="canary",job="app-server"})
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="canary", instance="0", job="app-server"} 700
+
+eval_ordered instant at 50m bottomk(3, http_requests)
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="canary", instance="0", job="api-server"} 300
+
+eval_ordered instant at 50m bottomk(5, http_requests{group="canary",job="app-server"})
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="canary", instance="1", job="app-server"} 800

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -200,6 +200,7 @@ clear
 load 5m
 	http_requests{job="api-server", instance="0", group="production"}	0+10x10
 	http_requests{job="api-server", instance="1", group="production"}	0+20x10
+	http_requests{job="api-server", instance="2", group="production"}	NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
 	http_requests{job="api-server", instance="0", group="canary"}		0+30x10
 	http_requests{job="api-server", instance="1", group="canary"}		0+40x10
 	http_requests{job="app-server", instance="0", group="production"}	0+50x10
@@ -224,3 +225,14 @@ eval_ordered instant at 50m bottomk(3, http_requests)
 eval_ordered instant at 50m bottomk(5, http_requests{group="canary",job="app-server"})
 	http_requests{group="canary", instance="0", job="app-server"} 700
 	http_requests{group="canary", instance="1", job="app-server"} 800
+
+# Test NaN is sorted away from the top/bottom.
+eval_ordered instant at 50m topk(3, http_requests{job="api-server",group="production"})
+	http_requests{job="api-server", instance="1", group="production"}	200
+	http_requests{job="api-server", instance="0", group="production"}	100
+	http_requests{job="api-server", instance="2", group="production"}	NaN
+
+eval_ordered instant at 50m bottomk(3, http_requests{job="api-server",group="production"})
+	http_requests{job="api-server", instance="0", group="production"}	100
+	http_requests{job="api-server", instance="1", group="production"}	200
+	http_requests{job="api-server", instance="2", group="production"}	NaN

--- a/promql/testdata/legacy.test
+++ b/promql/testdata/legacy.test
@@ -164,23 +164,6 @@ eval_ordered instant at 50m sort_desc(http_requests)
 	http_requests{group="production", instance="1", job="api-server"} 200 
 	http_requests{group="production", instance="0", job="api-server"} 100 
 
-eval_ordered instant at 50m topk(3, http_requests)
-	http_requests{group="canary", instance="1", job="app-server"} 800 
-	http_requests{group="canary", instance="0", job="app-server"} 700 
-	http_requests{group="production", instance="1", job="app-server"} 600 
-
-eval_ordered instant at 50m topk(5, http_requests{group="canary",job="app-server"})
-	http_requests{group="canary", instance="1", job="app-server"} 800 
-	http_requests{group="canary", instance="0", job="app-server"} 700 
-
-eval_ordered instant at 50m bottomk(3, http_requests)
-	http_requests{group="production", instance="0", job="api-server"} 100 
-	http_requests{group="production", instance="1", job="api-server"} 200 
-	http_requests{group="canary", instance="0", job="api-server"} 300 
-
-eval_ordered instant at 50m bottomk(5, http_requests{group="canary",job="app-server"})
-	http_requests{group="canary", instance="0", job="app-server"} 700 
-	http_requests{group="canary", instance="1", job="app-server"} 800 
 
 
 # Single-letter label names and values.


### PR DESCRIPTION
Fixes #1215

This will always sort NaN to the bottom of a list.