### PR TITLE
Handle NaN for min/max.

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1084,11 +1084,11 @@ func (ev *evaluator) aggregation(op itemType, grouping model.LabelNames, keepExt
 			groupedResult.value += sample.Value
 			groupedResult.groupCount++
 		case itemMax:
-			if groupedResult.value < sample.Value {
+			if groupedResult.value < sample.Value || math.IsNaN(float64(groupedResult.value)) {
 				groupedResult.value = sample.Value
 			}
 		case itemMin:
-			if groupedResult.value > sample.Value {
+			if groupedResult.value > sample.Value || math.IsNaN(float64(groupedResult.value)) {
 				groupedResult.value = sample.Value
 			}
 		case itemCount:

--- a/promql/testdata/operators.test
+++ b/promql/testdata/operators.test
@@ -1,0 +1,22 @@
+# Tests for min/max.
+clear
+load 5m
+  http_requests{job="api-server", instance="0", group="production"}	1
+  http_requests{job="api-server", instance="1", group="production"}	2
+  http_requests{job="api-server", instance="0", group="canary"}		NaN
+  http_requests{job="api-server", instance="1", group="canary"}		3
+  http_requests{job="api-server", instance="2", group="canary"}		4
+
+eval instant at 0m max(http_requests)
+  {} 4
+
+eval instant at 0m min(http_requests)
+  {} 1
+
+eval instant at 0m max by (group) (http_requests)
+  {group="production"} 2
+  {group="canary"} 4
+
+eval instant at 0m min by (group) (http_requests)
+  {group="production"} 1
+  {group="canary"} 3


### PR DESCRIPTION
Similar to topk and sort, prefer not returning NaN
where possible.

Fixed #1289 