### PR TITLE
Let code format style errors fail CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ go:
 - 1.5
 
 script:
-- make -f Makefile
+- make style test

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ endif
 
 all: assets format build test
 
+style:
+	@echo ">> checking code style"
+	@! gofmt -d **/*.go | grep '^'
+
 test:
 	@echo ">> running tests"
 	@$(GO) test -short $(pkgs)
@@ -46,4 +50,4 @@ assets:
 	@go-bindata $(bindata_flags) -pkg ui -o web/ui/bindata.go -ignore '(.*\.map|bootstrap\.js|bootstrap-theme\.css|bootstrap\.css)'  web/ui/templates/... web/ui/static/...
 
 
-.PHONY: all format build test vet docker assets
+.PHONY: all style format build test vet docker assets


### PR DESCRIPTION
Example output

```
>> checking code style
diff promql/lex.go gofmt/promql/lex.go
--- /tmp/gofmt809685273 2016-01-06 18:28:33.000161101 -0500
+++ /tmp/gofmt043863460 2016-01-06 18:28:33.000161101 -0500
@@ -14,7 +14,7 @@
 package promql
 
 import (
-               "fmt"
+       "fmt"
        "strings"
        "unicode"
        "unicode/utf8"
Makefile:25: recipe for target 'style' failed
make: *** [style] Error 1
```

@fabxc @juliusv 