### PR TITLE
Use '.' instead of '=' to separate labels from their values in Graphite

### DIFF
--- a/storage/remote/graphite/client.go
+++ b/storage/remote/graphite/client.go
@@ -63,11 +63,11 @@ func pathFromMetric(m model.Metric, prefix string) string {
 		if l == model.MetricNameLabel || len(l) == 0 {
 			continue
 		}
-		// Here we use '=' instead of '.' to be able
-		// to later read back the value correctly. Using '.' would
-		// not allow to distinguish labels from values.
+		// Since we use '.' instead of '=' to separate label and values
+		// it means that we can't have an '.' in the metric name. Fortunately
+		// this is prohibited in prometheus metrics.
 		buffer.WriteString(fmt.Sprintf(
-			".%s=%s", string(l), escape(v)))
+			".%s.%s", string(l), escape(v)))
 	}
 	return buffer.String()
 }

--- a/storage/remote/graphite/client_test.go
+++ b/storage/remote/graphite/client_test.go
@@ -48,8 +48,8 @@ func TestEscape(t *testing.T) {
 func TestPathFromMetric(t *testing.T) {
 	expected := ("prefix." +
 		"test:metric" +
-		".many_chars=abc!ABC:012-3!45%C3%B667~89%2E%2F\\(\\)\\{\\}\\,%3D%2E\\\"\\\\" +
-		".testlabel=test:value")
+		".many_chars.abc!ABC:012-3!45%C3%B667~89%2E%2F\\(\\)\\{\\}\\,%3D%2E\\\"\\\\" +
+		".testlabel.test:value")
 	actual := pathFromMetric(metric, "prefix.")
 	if expected != actual {
 		t.Errorf("Expected %s, got %s", expected, actual)


### PR DESCRIPTION
Using .label=value. was weird to use in Graphite and didn't bring much value.