### PR TITLE
Improve handling of series file truncation

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -128,6 +128,10 @@ func init() {
 		&cfg.storage.SyncStrategy, "storage.local.series-sync-strategy",
 		"When to sync series files after modification. Possible values: 'never', 'always', 'adaptive'. Sync'ing slows down storage performance but reduces the risk of data loss in case of an OS crash. With the 'adaptive' strategy, series files are sync'd for as long as the storage is not too much behind on chunk persistence.",
 	)
+	cfg.fs.Float64Var(
+		&cfg.storage.MinShrinkRatio, "storage.local.series-file-shrink-ratio", 0.1,
+		"A series file is only truncated (to delete samples that have exceeded the retention period) if it shrinks by at least the provided ratio. This saves I/O operations while causing only a limited storage space overhead. If 0 or smaller, truncation will be performed even for a single dropped chunk, while 1 or larger will effectively prevent any truncation.",
+	)
 	cfg.fs.BoolVar(
 		&cfg.storage.Dirty, "storage.local.dirty", false,
 		"If set, the local storage layer will perform crash recovery even if the last shutdown appears to be clean.",

--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -152,6 +152,7 @@ type MemorySeriesStorageOptions struct {
 	Dirty                      bool          // Force the storage to consider itself dirty on startup.
 	PedanticChecks             bool          // If dirty, perform crash-recovery checks on each series file.
 	SyncStrategy               SyncStrategy  // Which sync strategy to apply to series files.
+	MinShrinkRatio             float64       // Minimum ratio a series file has to shrink during truncation.
 }
 
 // NewMemorySeriesStorage returns a newly allocated Storage. Storage.Serve still
@@ -243,7 +244,12 @@ func (s *memorySeriesStorage) Start() (err error) {
 	}
 
 	var p *persistence
-	p, err = newPersistence(s.options.PersistenceStoragePath, s.options.Dirty, s.options.PedanticChecks, syncStrategy)
+	p, err = newPersistence(
+		s.options.PersistenceStoragePath,
+		s.options.Dirty, s.options.PedanticChecks,
+		syncStrategy,
+		s.options.MinShrinkRatio,
+	)
 	if err != nil {
 		return err
 	}

--- a/storage/local/storage_test.go
+++ b/storage/local/storage_test.go
@@ -563,6 +563,7 @@ func TestLoop(t *testing.T) {
 		PersistenceStoragePath:     directory.Path(),
 		CheckpointInterval:         250 * time.Millisecond,
 		SyncStrategy:               Adaptive,
+		MinShrinkRatio:             0.1,
 	}
 	storage := NewMemorySeriesStorage(o)
 	if err := storage.Start(); err != nil {
@@ -1320,6 +1321,7 @@ func benchmarkFuzz(b *testing.B, encoding chunkEncoding) {
 		PersistenceStoragePath:     directory.Path(),
 		CheckpointInterval:         time.Second,
 		SyncStrategy:               Adaptive,
+		MinShrinkRatio:             0.1,
 	}
 	s := NewMemorySeriesStorage(o)
 	if err := s.Start(); err != nil {


### PR DESCRIPTION
If only very few chunks are to be truncated from a very large series
file, the rewrite of the file is a lorge overhead. With this change, a
certain ratio of the file has to be dropped to make it happen. While
only causing disk overhead at about the same ratio (by default 10%),
it will cut down I/O by a lot in above scenario.

@fabxc @matthiasr 

Fixes https://github.com/prometheus/prometheus/issues/1296