### PR TITLE
Remove `assets` target from default `make` execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ifdef DEBUG
 endif
 
 
-all: assets format build test
+all: format build test
 
 style:
 	@echo ">> checking code style"


### PR DESCRIPTION
go-bindata constantly attempts to update timestamps even though
the file data didn't change.

Fixes #1326 

@RichiH