### PR TITLE
Rename matrix to range selector in external error messages

### DIFF
--- a/promql/parse.go
+++ b/promql/parse.go
@@ -609,19 +609,20 @@ func (p *parser) unaryExpr() Expr {
 		case *MatrixSelector:
 			s.Offset = offset
 		default:
-			p.errorf("offset modifier must be preceded by a metric or range selector, but follows a %T instead", e)
+			p.errorf("offset modifier must be preceded by an instant or range selector, but follows a %T instead", e)
 		}
 	}
 
 	return e
 }
 
-// rangeSelector parses a matrix selector based on a given vector selector.
+// rangeSelector parses a matrix (a.k.a. range) selector based on a given
+// vector selector.
 //
 //		<vector_selector> '[' <duration> ']'
 //
 func (p *parser) rangeSelector(vs *VectorSelector) *MatrixSelector {
-	const ctx = "matrix selector"
+	const ctx = "range selector"
 	p.next()
 
 	var erange time.Duration
@@ -948,7 +949,7 @@ func (p *parser) offset() time.Duration {
 	return offset
 }
 
-// vectorSelector parses a new vector selector.
+// vectorSelector parses a new (instant) vector selector.
 //
 //		<metric_identifier> [<label_matchers>]
 //		[<metric_identifier>] <label_matchers>

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -228,6 +228,10 @@ var testExpr = []struct {
 		input:  `*test`,
 		fail:   true,
 		errMsg: "no valid expression found",
+	}, {
+		input:  "1 offset 1d",
+		fail:   true,
+		errMsg: "offset modifier must be preceded by an instant or range selector",
 	},
 	// Vector binary operations.
 	{


### PR DESCRIPTION
The documentation speaks about range vectors and range vector selectors.
This change does not fix all issues, we might still expose the term
"Matrix" in error messages using %T.

@juliusv @fabxc @brian-brazil 