### PR TITLE
Increase notification test timeouts

### DIFF
--- a/notification/notification.go
+++ b/notification/notification.go
@@ -274,7 +274,6 @@ func (n *Handler) send(alerts ...*model.Alert) error {
 func (n *Handler) Stop() {
 	log.Info("Stopping notification handler...")
 
-	close(n.more)
 	n.cancel()
 }
 

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -192,7 +192,7 @@ func TestHandlerFull(t *testing.T) {
 		case <-called:
 			expected = alerts[i*maxBatchSize : (i+1)*maxBatchSize]
 			unblock <- struct{}{}
-		case <-time.After(time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatalf("Alerts were not pushed")
 		}
 	}
@@ -218,7 +218,7 @@ func TestHandlerFull(t *testing.T) {
 		case <-called:
 			expected = alerts[i*maxBatchSize : (i+1)*maxBatchSize]
 			unblock <- struct{}{}
-		case <-time.After(time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatalf("Alerts were not pushed")
 		}
 	}


### PR DESCRIPTION
Fixes the notification part of #1337

The timeout is significantly increased so that the test passes for slow machines.
The closing of the `n.more` channel was essentially not necessary and not doing it avoids panics with shutting down the notification handler while async calls to `Send` are still happening (as it did in the test that timed out early).

@RichiH