### PR TITLE
Changed target to point to the service address

### DIFF
--- a/retrieval/discovery/consul.go
+++ b/retrieval/discovery/consul.go
@@ -264,7 +264,7 @@ func (cd *ConsulDiscovery) watchService(srv *consulService, ch chan<- config.Tar
 		srv.tgroup.Targets = make([]model.LabelSet, 0, len(nodes))
 
 		for _, node := range nodes {
-			addr := fmt.Sprintf("%s:%d", node.Address, node.ServicePort)
+			addr := fmt.Sprintf("%s:%d", node.ServiceAddress, node.ServicePort)
 			// We surround the separated list with the separator as well. This way regular expressions
 			// in relabeling rules don't have to consider tag positions.
 			tags := cd.tagSeparator + strings.Join(node.ServiceTags, cd.tagSeparator) + cd.tagSeparator


### PR DESCRIPTION
It seems that Prometheus is using consul node address as scrapper target; however, it should use service address.
If I'm wrong please excuse the noise.