### PR TITLE
Rework the way to communicate backpressure (AKA suspended ingestion)

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -107,7 +107,7 @@ func init() {
 	)
 	cfg.fs.IntVar(
 		&cfg.storage.MemoryChunks, "storage.local.memory-chunks", 1024*1024,
-		"How many chunks to keep in memory. While the size of a chunk is 1kiB, the total memory usage will be significantly higher than this value * 1kiB. Furthermore, for various reasons, more chunks might have to be kept in memory temporarily.",
+		"How many chunks to keep in memory. While the size of a chunk is 1kiB, the total memory usage will be significantly higher than this value * 1kiB. Furthermore, for various reasons, more chunks might have to be kept in memory temporarily. Sample ingestion will be throttled if the configured value is exceeded by more than 10%.",
 	)
 	cfg.fs.DurationVar(
 		&cfg.storage.PersistenceRetentionPeriod, "storage.local.retention", 15*24*time.Hour,
@@ -115,7 +115,7 @@ func init() {
 	)
 	cfg.fs.IntVar(
 		&cfg.storage.MaxChunksToPersist, "storage.local.max-chunks-to-persist", 512*1024,
-		"How many chunks can be waiting for persistence before sample ingestion will stop. Many chunks waiting to be persisted will increase the checkpoint size.",
+		"How many chunks can be waiting for persistence before sample ingestion will be throttled. Many chunks waiting to be persisted will increase the checkpoint size.",
 	)
 	cfg.fs.DurationVar(
 		&cfg.storage.CheckpointInterval, "storage.local.checkpoint-interval", 5*time.Minute,

--- a/retrieval/helpers_test.go
+++ b/retrieval/helpers_test.go
@@ -14,8 +14,6 @@
 package retrieval
 
 import (
-	"time"
-
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/config"
@@ -26,14 +24,13 @@ type nopAppender struct{}
 func (a nopAppender) Append(*model.Sample) {
 }
 
-type slowAppender struct{}
-
-func (a slowAppender) Append(*model.Sample) {
-	time.Sleep(time.Millisecond)
+func (a nopAppender) NeedsThrottling() bool {
+	return false
 }
 
 type collectResultAppender struct {
-	result model.Samples
+	result    model.Samples
+	throttled bool
 }
 
 func (a *collectResultAppender) Append(s *model.Sample) {
@@ -43,6 +40,10 @@ func (a *collectResultAppender) Append(s *model.Sample) {
 		}
 	}
 	a.result = append(a.result, s)
+}
+
+func (a *collectResultAppender) NeedsThrottling() bool {
+	return a.throttled
 }
 
 // fakeTargetProvider implements a TargetProvider and allows manual injection

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -165,6 +165,7 @@ func (tm *TargetManager) Run() {
 	})
 
 	tm.running = true
+	log.Info("Target manager started.")
 }
 
 // handleUpdates receives target group updates and handles them in the

--- a/storage/local/interface.go
+++ b/storage/local/interface.go
@@ -34,6 +34,9 @@ type Storage interface {
 	// from the provided Sample as those labels are considered equivalent to
 	// a label not present at all.
 	Append(*model.Sample)
+	// NeedsThrottling returns true if the Storage has too many chunks in memory
+	// already or has too many chunks waiting for persistence.
+	NeedsThrottling() bool
 	// NewPreloader returns a new Preloader which allows preloading and pinning
 	// series data into memory for use within a query.
 	NewPreloader() Preloader

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -132,8 +132,7 @@ func NewStorageQueueManager(tsdb StorageClient, queueCapacity int) *StorageQueue
 }
 
 // Append queues a sample to be sent to the remote storage. It drops the
-// sample on the floor if the queue is full. It implements
-// storage.SampleAppender.
+// sample on the floor if the queue is full.
 func (t *StorageQueueManager) Append(s *model.Sample) {
 	select {
 	case t.queue <- s:

--- a/storage/remote/remote.go
+++ b/storage/remote/remote.go
@@ -124,6 +124,13 @@ func (s *Storage) Append(smpl *model.Sample) {
 	}
 }
 
+// NeedsThrottling implements storage.SampleAppender. It will always return
+// false as a remote storage drops samples on the floor if backlogging instead
+// of asking for throttling.
+func (s *Storage) NeedsThrottling() bool {
+	return false
+}
+
 // Describe implements prometheus.Collector.
 func (s *Storage) Describe(ch chan<- *prometheus.Desc) {
 	for _, q := range s.queues {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -18,9 +18,32 @@ import (
 )
 
 // SampleAppender is the interface to append samples to both, local and remote
-// storage.
+// storage. All methods are goroutine-safe.
 type SampleAppender interface {
+	// Append appends a sample to the underlying storage. Depending on the
+	// storage implementation, there are different guarantees for the fate
+	// of the sample after Append has returned. Remote storage
+	// implementation will simply drop samples if they cannot keep up with
+	// sending samples. Local storage implementations will only drop metrics
+	// upon unrecoverable errors. Reporting any errors is done via metrics
+	// and logs and not the concern of the caller.
 	Append(*model.Sample)
+	// NeedsThrottling returns true if the underlying storage wishes to not
+	// receive any more samples. Append will still work but might lead to
+	// undue resource usage. It is recommended to call NeedsThrottling once
+	// before an upcoming batch of Append calls (e.g. a full scrape of a
+	// target or the evaluation of a rule group) and only proceed with the
+	// batch if NeedsThrottling returns false. In that way, the result of a
+	// scrape or of an evaluation of a rule group will always be appended
+	// completely or not at all, and the work of scraping or evaluation will
+	// not be performed in vain. Also, a call of NeedsThrottling is
+	// potentially expensive, so limiting the number of calls is reasonable.
+	//
+	// Only SampleAppenders for which it is considered critical to receive
+	// each and every sample should ever return true. SampleAppenders that
+	// tolerate not receiving all samples should always return false and
+	// instead drop samples as they see fit to avoid overload.
+	NeedsThrottling() bool
 }
 
 // Fanout is a SampleAppender that appends every sample to each SampleAppender
@@ -34,4 +57,15 @@ func (f Fanout) Append(s *model.Sample) {
 	for _, a := range f {
 		a.Append(s)
 	}
+}
+
+// NeedsThrottling returns true if at least one of the SampleAppenders in the
+// Fanout slice is throttled.
+func (f Fanout) NeedsThrottling() bool {
+	for _, a := range f {
+		if a.NeedsThrottling() {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This gives up on the idea to communicate throuh the Append() call (by
either not returning as it is now or returning an error as
suggested/explored elsewhere). Here I have added a Throttled() call,
which has the advantage that it can be called before a whole _batch_
of Append()'s. Scrapes will happen completely or not at all. Same for
rule group evaluations. That's a highly desired behavior (as discussed
elsewhere). The code is even simpler now as the whole ingestion buffer
could be removed.

Logging of throttled mode has been streamlined and will create at most
one message per minute.

Fixes #1319 .

@fabxc This is a sneak preview. Still needs to be benchmarked.