### PR TITLE
Return error on sample appending

### DIFF
--- a/retrieval/helpers_test.go
+++ b/retrieval/helpers_test.go
@@ -21,7 +21,8 @@ import (
 
 type nopAppender struct{}
 
-func (a nopAppender) Append(*model.Sample) {
+func (a nopAppender) Append(*model.Sample) error {
+	return nil
 }
 
 func (a nopAppender) NeedsThrottling() bool {
@@ -33,13 +34,14 @@ type collectResultAppender struct {
 	throttled bool
 }
 
-func (a *collectResultAppender) Append(s *model.Sample) {
+func (a *collectResultAppender) Append(s *model.Sample) error {
 	for ln, lv := range s.Metric {
 		if len(lv) == 0 {
 			delete(s.Metric, ln)
 		}
 	}
 	a.result = append(a.result, s)
+	return nil
 }
 
 func (a *collectResultAppender) NeedsThrottling() bool {

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -453,6 +453,7 @@ func (t *Target) scrape(appender storage.SampleAppender) (err error) {
 	var (
 		samples       model.Vector
 		numOutOfOrder int
+		logger        = log.With("target", t.InstanceIdentifier())
 	)
 	for {
 		if err = sdec.Decode(&samples); err != nil {
@@ -464,14 +465,14 @@ func (t *Target) scrape(appender storage.SampleAppender) (err error) {
 				if err == local.ErrOutOfOrderSample {
 					numOutOfOrder++
 				} else {
-					log.Warnf("Error inserting sample %v: %s", s, err)
+					logger.With("sample", s).Warnf("Error inserting sample: %s", err)
 				}
 			}
 
 		}
 	}
 	if numOutOfOrder > 0 {
-		log.Warnf("Error on ingesting %d out-of-order samples")
+		logger.With("numDropped", numOutOfOrder).Warn("Error on ingesting out-of-order samples")
 	}
 
 	if err == io.EOF {

--- a/storage/local/interface.go
+++ b/storage/local/interface.go
@@ -33,7 +33,7 @@ type Storage interface {
 	// processing.) The implementation might remove labels with empty value
 	// from the provided Sample as those labels are considered equivalent to
 	// a label not present at all.
-	Append(*model.Sample)
+	Append(*model.Sample) error
 	// NeedsThrottling returns true if the Storage has too many chunks in memory
 	// already or has too many chunks waiting for persistence.
 	NeedsThrottling() bool

--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -591,6 +591,7 @@ func (s *memorySeriesStorage) Append(sample *model.Sample) error {
 	series := s.getOrCreateSeries(fp, sample.Metric)
 
 	if sample.Timestamp <= series.lastTime {
+		s.fpLocker.Unlock(fp)
 		// Don't log and track equal timestamps, as they are a common occurrence
 		// when using client-side timestamps (e.g. Pushgateway or federation).
 		// It would be even better to also compare the sample values here, but
@@ -599,7 +600,6 @@ func (s *memorySeriesStorage) Append(sample *model.Sample) error {
 			s.outOfOrderSamplesCount.Inc()
 			return ErrOutOfOrderSample
 		}
-		s.fpLocker.Unlock(fp)
 		return nil
 	}
 	completedChunksCount := series.add(&model.SamplePair{

--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -567,8 +567,10 @@ func (s *memorySeriesStorage) DropMetricsForFingerprints(fps ...model.Fingerprin
 	}
 }
 
+var ErrOutOfOrderSample = fmt.Errorf("sample timestamp out of order")
+
 // Append implements Storage.
-func (s *memorySeriesStorage) Append(sample *model.Sample) {
+func (s *memorySeriesStorage) Append(sample *model.Sample) error {
 	for ln, lv := range sample.Metric {
 		if len(lv) == 0 {
 			delete(sample.Metric, ln)
@@ -594,11 +596,11 @@ func (s *memorySeriesStorage) Append(sample *model.Sample) {
 		// It would be even better to also compare the sample values here, but
 		// we don't have efficient access to a series's last value.
 		if sample.Timestamp != series.lastTime {
-			log.Warnf("Ignoring sample with out-of-order timestamp for fingerprint %v (%v): %v is not after %v", fp, series.metric, sample.Timestamp, series.lastTime)
 			s.outOfOrderSamplesCount.Inc()
+			return ErrOutOfOrderSample
 		}
 		s.fpLocker.Unlock(fp)
-		return
+		return nil
 	}
 	completedChunksCount := series.add(&model.SamplePair{
 		Value:     sample.Value,
@@ -607,6 +609,8 @@ func (s *memorySeriesStorage) Append(sample *model.Sample) {
 	s.fpLocker.Unlock(fp)
 	s.ingestedSamplesCount.Inc()
 	s.incNumChunksToPersist(completedChunksCount)
+
+	return nil
 }
 
 // NeedsThrottling implements Storage.

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -133,13 +133,15 @@ func NewStorageQueueManager(tsdb StorageClient, queueCapacity int) *StorageQueue
 
 // Append queues a sample to be sent to the remote storage. It drops the
 // sample on the floor if the queue is full.
-func (t *StorageQueueManager) Append(s *model.Sample) {
+// Always returns nil.
+func (t *StorageQueueManager) Append(s *model.Sample) error {
 	select {
 	case t.queue <- s:
 	default:
 		t.samplesCount.WithLabelValues(dropped).Inc()
 		log.Warn("Remote storage queue full, discarding sample.")
 	}
+	return nil
 }
 
 // Stop stops sending samples to the remote storage and waits for pending

--- a/storage/remote/remote.go
+++ b/storage/remote/remote.go
@@ -104,8 +104,8 @@ func (s *Storage) Stop() {
 	}
 }
 
-// Append implements storage.SampleAppender.
-func (s *Storage) Append(smpl *model.Sample) {
+// Append implements storage.SampleAppender. Always returns nil.
+func (s *Storage) Append(smpl *model.Sample) error {
 	s.mtx.RLock()
 
 	var snew model.Sample
@@ -122,6 +122,7 @@ func (s *Storage) Append(smpl *model.Sample) {
 	for _, q := range s.queues {
 		q.Append(&snew)
 	}
+	return nil
 }
 
 // NeedsThrottling implements storage.SampleAppender. It will always return

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -25,8 +25,7 @@ type SampleAppender interface {
 	// of the sample after Append has returned. Remote storage
 	// implementation will simply drop samples if they cannot keep up with
 	// sending samples. Local storage implementations will only drop metrics
-	// upon unrecoverable errors. Reporting any errors is done via metrics
-	// and logs and not the concern of the caller.
+	// upon unrecoverable errors.
 	Append(*model.Sample) error
 	// NeedsThrottling returns true if the underlying storage wishes to not
 	// receive any more samples. Append will still work but might lead to


### PR DESCRIPTION
Not happy about the error-dropping for remotes and only returning the first error on the fanout appender.
But that's aligned with the idea that we only have one client that will ever return an error anyway and the assumption that we are do not care about success on all other clients.

This will reduce the out-of-order spam several users have reported.

@beorn7 