### PR TITLE
API endpoint to evaluate arbitrary ALERT rules

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -207,7 +207,7 @@ func (r *AlertingRule) Eval(ts model.Time, engine *promql.Engine) (model.Vector,
 }
 
 // Expand fills out templated detail for an evaluated alert.
-func (rule *AlertingRule) Expand(opts *ManagerOptions, timestamp model.Time) model.Alerts {
+func (rule *AlertingRule) Expand(timestamp model.Time, queryEngine *promql.Engine, pathPrefix string) model.Alerts {
 	var alerts model.Alerts
 
 	for _, alert := range rule.currentAlerts() {
@@ -239,8 +239,8 @@ func (rule *AlertingRule) Expand(opts *ManagerOptions, timestamp model.Time) mod
 				"__alert_"+rule.Name(),
 				tmplData,
 				timestamp,
-				opts.QueryEngine,
-				opts.ExternalURL.Path,
+				queryEngine,
+				pathPrefix,
 			)
 			result, err := tmpl.Expand()
 			if err != nil {
@@ -265,7 +265,7 @@ func (rule *AlertingRule) Expand(opts *ManagerOptions, timestamp model.Time) mod
 			StartsAt:     alert.ActiveAt.Add(rule.holdDuration).Time(),
 			Labels:       labels,
 			Annotations:  annotations,
-			GeneratorURL: opts.ExternalURL.String() + strutil.GraphLinkForExpression(rule.vector.String()),
+			GeneratorURL: pathPrefix + strutil.GraphLinkForExpression(rule.vector.String()),
 		}
 		if alert.ResolvedAt != 0 {
 			a.EndsAt = alert.ResolvedAt.Time()

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -136,9 +136,9 @@ func (r *AlertingRule) sample(alert *Alert, ts model.Time, set bool) *model.Samp
 // is kept in memory state and consequentally repeatedly sent to the AlertManager.
 const resolvedRetention = 15 * time.Minute
 
-// eval evaluates the rule expression and then creates pending alerts and fires
+// Eval evaluates the rule expression and then creates pending alerts and fires
 // or removes previously pending alerts accordingly.
-func (r *AlertingRule) eval(ts model.Time, engine *promql.Engine) (model.Vector, error) {
+func (r *AlertingRule) Eval(ts model.Time, engine *promql.Engine) (model.Vector, error) {
 	query, err := engine.NewInstantQuery(r.vector.String(), ts)
 	if err != nil {
 		return nil, err

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -105,7 +105,7 @@ const (
 type Rule interface {
 	Name() string
 	// eval evaluates the rule, including any associated recording or alerting actions.
-	eval(model.Time, *promql.Engine) (model.Vector, error)
+	Eval(model.Time, *promql.Engine) (model.Vector, error)
 	// String returns a human-readable string representation of the rule.
 	String() string
 	// HTMLSnippet returns a human-readable string representation of the rule,
@@ -252,7 +252,7 @@ func (g *Group) eval() {
 
 			evalTotal.WithLabelValues(rtyp).Inc()
 
-			vector, err := rule.eval(now, g.opts.QueryEngine)
+			vector, err := rule.Eval(now, g.opts.QueryEngine)
 			if err != nil {
 				// Canceled queries are intentional termination of queries. This normally
 				// happens on shutdown and thus we skip logging of any errors here.

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -262,7 +262,7 @@ func (g *Group) eval() {
 			}
 
 			if ar, ok := rule.(*AlertingRule); ok {
-				alerts := ar.Expand(g.opts, now)
+				alerts := ar.Expand(now, g.opts.QueryEngine, g.opts.ExternalURL.Path)
 				if len(alerts) > 0 {
 					g.opts.NotificationHandler.Send(alerts...)
 				}

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -96,7 +96,7 @@ func TestAlertingRule(t *testing.T) {
 	for i, test := range tests {
 		evalTime := model.Time(0).Add(test.time)
 
-		res, err := rule.eval(evalTime, suite.QueryEngine())
+		res, err := rule.Eval(evalTime, suite.QueryEngine())
 		if err != nil {
 			t.Fatalf("Error during alerting rule evaluation: %s", err)
 		}

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -44,8 +44,8 @@ func (rule RecordingRule) Name() string {
 	return rule.name
 }
 
-// eval evaluates the rule and then overrides the metric names and labels accordingly.
-func (rule RecordingRule) eval(timestamp model.Time, engine *promql.Engine) (model.Vector, error) {
+// Eval evaluates the rule and then overrides the metric names and labels accordingly.
+func (rule RecordingRule) Eval(timestamp model.Time, engine *promql.Engine) (model.Vector, error) {
 	query, err := engine.NewInstantQuery(rule.vector.String(), timestamp)
 	if err != nil {
 		return nil, err

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -59,7 +59,7 @@ func TestRuleEval(t *testing.T) {
 
 	for _, test := range suite {
 		rule := NewRecordingRule(test.name, test.expr, test.labels)
-		result, err := rule.eval(now, engine)
+		result, err := rule.Eval(now, engine)
 		if err != nil {
 			t.Fatalf("Error evaluating %s", test.name)
 		}

--- a/web/web.go
+++ b/web/web.go
@@ -138,7 +138,7 @@ func New(st local.Storage, qe *promql.Engine, rm *rules.Manager, status *Prometh
 		queryEngine: qe,
 		storage:     st,
 
-		apiV1: v1.NewAPI(qe, st),
+		apiV1: v1.NewAPI(qe, st, o.ExternalURL.Path),
 		apiLegacy: &legacy.API{
 			QueryEngine: qe,
 			Storage:     st,


### PR DESCRIPTION
This adds the ability to paste an entire ALERT rule definition into Prometheus, have it evaluate the rule, and show the full resulting alerts -- and templated data -- that would fire.

This serves as a rapid way of developing new alert rules with live data, and perhaps brings things in the direction of being able to write tests for alerts.

A little bit of refactoring was necessary, see the individual commits.

More thought needs to be put into how the `/query_rule` endpoint works.  I plan to add a tab in the UI with a large textarea and an "Evaluate" button.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/1369)

<!-- Reviewable:end -->
