### PR TITLE
Populate first and last time in the chunk descriptor earlier

### DIFF
--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -856,7 +856,7 @@ func (p *persistence) loadSeriesMapAndHeads() (sm *seriesMap, chunksToPersist in
 					p.dirty = true
 					return sm, chunksToPersist, nil
 				}
-				chunkDescs[i] = newChunkDesc(chunk)
+				chunkDescs[i] = newChunkDesc(chunk, chunk.firstTime())
 				chunksToPersist++
 			}
 		}


### PR DESCRIPTION
The First time is kind of trivial as we always know it when we create
a new chunkDesc.

The last time is only know when the chunk is closed, so we have to set
it at that time.

The change saves a lot of digging down into the chunk
itself. Especially the last time is relative expensive as it involves
the creation of an iterator. The first time access now doesn't require
locking, which is also a nice gain.

@fabxc 
This is kind of risky and more than a bug fix / clean-up, so it should _not_ go into 0.17.0.