### PR TITLE
Update two more __meta_dns_srv_name references.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -83,7 +83,7 @@ var expectedConf = &Config{
 
 			RelabelConfigs: []*RelabelConfig{
 				{
-					SourceLabels: model.LabelNames{"job", "__meta_dns_srv_name"},
+					SourceLabels: model.LabelNames{"job", "__meta_dns_name"},
 					TargetLabel:  "job",
 					Separator:    ";",
 					Regex:        MustNewRegexp("(.*)some-[regex]"),

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -39,7 +39,7 @@ scrape_configs:
       your: label
 
   relabel_configs:
-  - source_labels: [job, __meta_dns_srv_name]
+  - source_labels: [job, __meta_dns_name]
     regex:         (.*)some-[regex]
     target_label:  job
     replacement:   foo-${1}


### PR DESCRIPTION
Although they are only in examples/tests and don't affect anything, they
could be confusing (the label has been renamed in the rest of the code a
while ago).