### PR TITLE
Remove old superfluous calls to setLastScrape().

### DIFF
--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -433,7 +433,6 @@ func (t *Target) RunScraper(sampleAppender storage.SampleAppender) {
 	ticker := time.NewTicker(lastScrapeInterval)
 	defer ticker.Stop()
 
-	t.status.setLastScrape(time.Now())
 	t.scrape(sampleAppender)
 
 	// Explanation of the contraption below:
@@ -453,7 +452,6 @@ func (t *Target) RunScraper(sampleAppender storage.SampleAppender) {
 				return
 			case <-ticker.C:
 				took := time.Since(t.status.LastScrape())
-				t.status.setLastScrape(time.Now())
 
 				intervalStr := lastScrapeInterval.String()
 


### PR DESCRIPTION
This is called from within the scrape()->report() flow now.

See https://github.com/prometheus/prometheus/pull/1394/files#r52945817