### PR TITLE
Use fingerprint for target identity comparison

### DIFF
--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -265,7 +265,7 @@ func (tm *TargetManager) updateTargetGroup(tgroup *config.TargetGroup, cfg *conf
 				if told == nil {
 					continue
 				}
-				if tnew.InstanceIdentifier() == told.InstanceIdentifier() {
+				if tnew.fingerprint() == told.fingerprint() {
 					match = told
 					oldTargets[j] = nil
 					break


### PR DESCRIPTION
So far we were using the InstanceIdentifier to compare equality of targets.
This is not always accurate, for example for the blackbox exporter where the 
actual target is in the parameter.

@brian-brazil 