### PR TITLE
Allow custom ldflags for go build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -34,7 +34,8 @@ ldflags="
   -X ${repo_path}/version.Branch=${branch}
   -X ${repo_path}/version.BuildUser=${USER}@${host}
   -X ${repo_path}/version.BuildDate=${build_date}
-  -X ${repo_path}/version.GoVersion=${go_version}"
+  -X ${repo_path}/version.GoVersion=${go_version}
+  ${EXTRA_LDFLAGS}"
 
 export GO15VENDOREXPERIMENT="1"
 


### PR DESCRIPTION
This allows users to use CGO and external linker when building Prometheus.