### PR TITLE
Remove fullLabels method and fix target updating

### DIFF
--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -405,18 +405,6 @@ func (t *Target) InstanceIdentifier() string {
 	return t.host()
 }
 
-func (t *Target) fullLabels() model.LabelSet {
-	t.RLock()
-	defer t.RUnlock()
-
-	lset := t.labels.Clone()
-
-	if _, ok := lset[model.InstanceLabel]; !ok {
-		lset[model.InstanceLabel] = t.labels[model.AddressLabel]
-	}
-	return lset
-}
-
 // RunScraper implements Target.
 func (t *Target) RunScraper(sampleAppender storage.SampleAppender) {
 	defer close(t.scraperStopped)

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -278,7 +278,7 @@ func (tm *TargetManager) updateTargetGroup(tgroup *config.TargetGroup, cfg *conf
 				// to build up.
 				wg.Add(1)
 				go func(t *Target) {
-					if err := match.Update(cfg, t.fullLabels(), t.metaLabels); err != nil {
+					if err := match.Update(cfg, t.labels, t.metaLabels); err != nil {
 						log.Errorf("Error updating target %v: %v", t, err)
 					}
 					wg.Done()


### PR DESCRIPTION
With recent changes to a Target's internal data representation
updating by fullLabels() assigns the additional default
instance label. This breaks target identity comparison and causes
identical targets from service discovery to be constantly swapped.

@brian-brazil 
This bit of code will be gone soon anyway. But this will make it easier to track down potential issues from the refactoring.