### PR TITLE
Next iteration of retrieval refactoring

### DIFF
--- a/retrieval/discovery/dns.go
+++ b/retrieval/discovery/dns.go
@@ -113,6 +113,7 @@ func (dd *DNSDiscovery) Run(ctx context.Context, ch chan<- []*config.TargetGroup
 
 func (dd *DNSDiscovery) refreshAll(ch chan<- []*config.TargetGroup) {
 	var wg sync.WaitGroup
+
 	wg.Add(len(dd.names))
 	for _, name := range dd.names {
 		go func(n string) {
@@ -122,6 +123,7 @@ func (dd *DNSDiscovery) refreshAll(ch chan<- []*config.TargetGroup) {
 			wg.Done()
 		}(name)
 	}
+
 	wg.Wait()
 }
 

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -185,40 +185,25 @@ type Target struct {
 
 // NewTarget creates a reasonably configured target for querying.
 func NewTarget(cfg *config.ScrapeConfig, labels, metaLabels model.LabelSet) (*Target, error) {
+	client, err := newHTTPClient(cfg)
+	if err != nil {
+		return nil, err
+	}
 	t := &Target{
 		status:          &TargetStatus{},
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
+		scrapeConfig:    cfg,
+		labels:          labels,
+		metaLabels:      metaLabels,
+		httpClient:      client,
 	}
-	err := t.Update(cfg, labels, metaLabels)
-	return t, err
+	return t, nil
 }
 
 // Status returns the status of the target.
 func (t *Target) Status() *TargetStatus {
 	return t.status
-}
-
-// Update overwrites settings in the target that are derived from the job config
-// it belongs to.
-func (t *Target) Update(cfg *config.ScrapeConfig, labels, metaLabels model.LabelSet) error {
-	t.Lock()
-
-	t.scrapeConfig = cfg
-	t.labels = labels
-	t.metaLabels = metaLabels
-
-	t.Unlock()
-
-	httpClient, err := t.client()
-	if err != nil {
-		return fmt.Errorf("cannot create HTTP client: %s", err)
-	}
-	t.Lock()
-	t.httpClient = httpClient
-	t.Unlock()
-
-	return nil
 }
 
 func newHTTPClient(cfg *config.ScrapeConfig) (*http.Client, error) {
@@ -291,13 +276,6 @@ func (t *Target) offset(interval time.Duration) time.Duration {
 		next -= int64(interval)
 	}
 	return time.Duration(next)
-}
-
-func (t *Target) client() (*http.Client, error) {
-	t.RLock()
-	defer t.RUnlock()
-
-	return newHTTPClient(t.scrapeConfig)
 }
 
 func (t *Target) interval() time.Duration {

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -167,6 +167,7 @@ type Target struct {
 	scraperStopping chan struct{}
 	// Closing scraperStopped signals that scraping has been stopped.
 	scraperStopped chan struct{}
+	running        bool
 
 	// Mutex protects the members below.
 	sync.RWMutex
@@ -409,9 +410,11 @@ func (t *Target) InstanceIdentifier() string {
 func (t *Target) RunScraper(sampleAppender storage.SampleAppender) {
 	defer close(t.scraperStopped)
 
-	lastScrapeInterval := t.interval()
+	t.Lock()
+	t.running = true
+	t.Unlock()
 
-	log.Debugf("Starting scraper for target %v...", t)
+	lastScrapeInterval := t.interval()
 
 	select {
 	case <-time.After(t.offset(lastScrapeInterval)):
@@ -469,6 +472,14 @@ func (t *Target) RunScraper(sampleAppender storage.SampleAppender) {
 
 // StopScraper implements Target.
 func (t *Target) StopScraper() {
+	t.Lock()
+	if !t.running {
+		t.Unlock()
+		return
+	}
+	t.running = false
+	t.Unlock()
+
 	log.Debugf("Stopping scraper for target %v...", t)
 
 	close(t.scraperStopping)

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -167,7 +167,6 @@ type Target struct {
 	scraperStopping chan struct{}
 	// Closing scraperStopped signals that scraping has been stopped.
 	scraperStopped chan struct{}
-	running        bool
 
 	// Mutex protects the members below.
 	sync.RWMutex
@@ -386,11 +385,9 @@ func (t *Target) InstanceIdentifier() string {
 
 // RunScraper implements Target.
 func (t *Target) RunScraper(sampleAppender storage.SampleAppender) {
-	defer close(t.scraperStopped)
+	log.Debugf("Running scraper for %v", t)
 
-	t.Lock()
-	t.running = true
-	t.Unlock()
+	defer close(t.scraperStopped)
 
 	lastScrapeInterval := t.interval()
 
@@ -450,14 +447,6 @@ func (t *Target) RunScraper(sampleAppender storage.SampleAppender) {
 
 // StopScraper implements Target.
 func (t *Target) StopScraper() {
-	t.Lock()
-	if !t.running {
-		t.Unlock()
-		return
-	}
-	t.running = false
-	t.Unlock()
-
 	log.Debugf("Stopping scraper for target %v...", t)
 
 	close(t.scraperStopping)

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -578,7 +578,7 @@ func newTestTarget(targetURL string, deadline time.Duration, labels model.LabelS
 	labels[model.AddressLabel] = model.LabelValue(strings.TrimLeft(targetURL, "http://"))
 	labels[model.MetricsPathLabel] = "/metrics"
 
-	t := &Target{
+	return &Target{
 		scrapeConfig: &config.ScrapeConfig{
 			ScrapeInterval: model.Duration(time.Millisecond),
 			ScrapeTimeout:  model.Duration(deadline),
@@ -588,13 +588,6 @@ func newTestTarget(targetURL string, deadline time.Duration, labels model.LabelS
 		scraperStopping: make(chan struct{}),
 		scraperStopped:  make(chan struct{}),
 	}
-
-	var err error
-	if t.httpClient, err = t.client(); err != nil {
-		panic(err)
-	}
-
-	return t
 }
 
 func TestNewHTTPBearerToken(t *testing.T) {


### PR DESCRIPTION
We wait up to 5 seconds for the initial full set of target when starting a new target provider. Only then we will update and thus avoid clearing out targets that remain across reloads.

TargetSets run providers and consume their updates. They hold a ScrapePool which takes care of scraping. In this iteration this simply takes the target groups and starts/stops the scrapers of the targets.
In the next step the ScrapePools will deduplicate the targets they receive.

@brian-brazil 