### PR TITLE
Improve 0.17.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-## 0.17.0 / 2016-01-27
+## 0.17.0 / unreleased
 
-This version no longer works with Alertmanager 0.4.0 and earlier!
+This version no longer works with Alertmanager 0.0.4 and earlier!
 The alerting rule syntax has changed as well but the old syntax is supported
 up until version 0.18.
+
+All regular expressions in PromQL are anchored now, matching the behavior of
+regular expressions in config files. Expressions in rules, alerts or dashboards
+need to be changed if they don't match the full value so far (for example
+`http_requests_total{status=~"^5"}` won't match anything anymore and needs to
+be changed to `http_requests_total{status=~"5.."}`).
 
 * [CHANGE] Integrate with Alertmanager 0.1.0 and higher
 * [CHANGE] Degraded storage mode renamed to rushed mode


### PR DESCRIPTION
* remove wrong release date until 0.17.0 gets actually released
* fix wrong alertmanager version number
* add example for regex anchor change

@beorn7 @fabxc 