### PR TITLE
Fix function names in comments

### DIFF
--- a/notification/notification.go
+++ b/notification/notification.go
@@ -69,7 +69,7 @@ type HandlerOptions struct {
 	ExternalLabels  model.LabelSet
 }
 
-// NewHandler constructs a new Handler.
+// New constructs a new Handler.
 func New(o *HandlerOptions) *Handler {
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -200,7 +200,7 @@ func (n *Handler) Run() {
 	}
 }
 
-// SubmitReqs queues the given notification requests for processing.
+// Send queues the given notification requests for processing.
 // Panics if called on a handler that is not running.
 func (n *Handler) Send(alerts ...*model.Alert) {
 	n.mtx.Lock()


### PR DESCRIPTION
Hi,

Fixed these two functions names in the comments. About `New` (previously named `NewNotificationHandler`), is there any reason not to name it `NewHandler`?. The places where it is used inside the repo are `notification_test.go` and `cmd/prometheus/main.go`, but it could be used outside of the repo too so maybe you want to leave it as it is. Hope it helps...

Cheers