### PR TITLE
Make copying alerting state safer.

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -110,6 +110,10 @@ func (rule *AlertingRule) Name() string {
 	return rule.name
 }
 
+func (r *AlertingRule) equal(o *AlertingRule) bool {
+	return r.name == o.name && r.labels.Equal(o.labels)
+}
+
 func (r *AlertingRule) sample(alert *Alert, ts model.Time, set bool) *model.Sample {
 	metric := model.Metric(r.labels.Clone())
 

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -212,8 +212,12 @@ func (g *Group) copyState(from *Group) {
 			if !ok {
 				continue
 			}
-			if far.Name() == ar.Name() {
-				ar.active = far.active
+			// TODO(fabxc): forbid same alert definitions that are not unique by
+			// at least on static label or alertname?
+			if far.equal(ar) {
+				for fp, a := range far.active {
+					ar.active[fp] = a
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This considers static labels in the equality of alerts to
avoid falsely copying state from a different alert definition with
the same name across reloads.

To be safe, it also copies the state map rather than just its pointer
so that remaining collisions disappear after one evaluation interval.

More of a hotfix. Fixes #1433 