### PR TITLE
rewrite operator balancing to be recursive

### DIFF
--- a/promql/parse.go
+++ b/promql/parse.go
@@ -530,35 +530,34 @@ func (p *parser) expr() Expr {
 		rhs := p.unaryExpr()
 
 		// Assign the new root based on the precedence of the LHS and RHS operators.
-		if lhs, ok := expr.(*BinaryExpr); ok && lhs.Op.precedence() < op.precedence() {
-			expr = &BinaryExpr{
-				Op:  lhs.Op,
-				LHS: lhs.LHS,
-				RHS: &BinaryExpr{
-					Op:             op,
-					LHS:            lhs.RHS,
-					RHS:            rhs,
-					VectorMatching: vecMatching,
-					ReturnBool:     returnBool,
-				},
-				VectorMatching: lhs.VectorMatching,
-			}
-			if op.isComparisonOperator() && !returnBool && rhs.Type() == model.ValScalar && lhs.RHS.Type() == model.ValScalar {
-				p.errorf("comparisons between scalars must use BOOL modifier")
-			}
-		} else {
-			expr = &BinaryExpr{
-				Op:             op,
-				LHS:            expr,
-				RHS:            rhs,
-				VectorMatching: vecMatching,
-				ReturnBool:     returnBool,
-			}
-			if op.isComparisonOperator() && !returnBool && rhs.Type() == model.ValScalar && expr.Type() == model.ValScalar {
-				p.errorf("comparisons between scalars must use BOOL modifier")
-			}
-		}
+		expr = p.balance(expr, op, rhs, vecMatching, returnBool)
+	}
+}
 
+func (p *parser) balance(lhs Expr, op itemType, rhs Expr, vecMatching *VectorMatching, returnBool bool) *BinaryExpr {
+	if lhsBE, ok := lhs.(*BinaryExpr); ok && lhsBE.Op.precedence() < op.precedence() {
+		var balanced = p.balance(lhsBE.RHS, op, rhs, vecMatching, returnBool)
+		if lhsBE.Op.isComparisonOperator() && !lhsBE.ReturnBool && balanced.Type() == model.ValScalar && lhsBE.LHS.Type() == model.ValScalar {
+			p.errorf("comparisons between scalars must use BOOL modifier")
+		}
+		return &BinaryExpr{
+			Op:             lhsBE.Op,
+			LHS:            lhsBE.LHS,
+			RHS:            balanced,
+			VectorMatching: lhsBE.VectorMatching,
+			ReturnBool:     lhsBE.ReturnBool,
+		}
+	} else {
+		if op.isComparisonOperator() && !returnBool && rhs.Type() == model.ValScalar && lhs.Type() == model.ValScalar {
+			p.errorf("comparisons between scalars must use BOOL modifier")
+		}
+		return &BinaryExpr{
+			Op:             op,
+			LHS:            lhs,
+			RHS:            rhs,
+			VectorMatching: vecMatching,
+			ReturnBool:     returnBool,
+		}
 	}
 }
 

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -536,7 +536,7 @@ func (p *parser) expr() Expr {
 
 func (p *parser) balance(lhs Expr, op itemType, rhs Expr, vecMatching *VectorMatching, returnBool bool) *BinaryExpr {
 	if lhsBE, ok := lhs.(*BinaryExpr); ok && lhsBE.Op.precedence() < op.precedence() {
-		var balanced = p.balance(lhsBE.RHS, op, rhs, vecMatching, returnBool)
+		balanced := p.balance(lhsBE.RHS, op, rhs, vecMatching, returnBool)
 		if lhsBE.Op.isComparisonOperator() && !lhsBE.ReturnBool && balanced.Type() == model.ValScalar && lhsBE.LHS.Type() == model.ValScalar {
 			p.errorf("comparisons between scalars must use BOOL modifier")
 		}

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -125,6 +125,20 @@ var testExpr = []struct {
 			},
 		},
 	}, {
+		input: "1 < bool 2 - 1 * 2",
+		expected: &BinaryExpr{
+			Op:         itemLSS,
+			ReturnBool: true,
+			LHS:        &NumberLiteral{1},
+			RHS: &BinaryExpr{
+				Op:  itemSUB,
+				LHS: &NumberLiteral{2},
+				RHS: &BinaryExpr{
+					Op: itemMUL, LHS: &NumberLiteral{1}, RHS: &NumberLiteral{2},
+				},
+			},
+		},
+	}, {
 		input: "-some_metric", expected: &UnaryExpr{
 			Op: itemSUB,
 			Expr: &VectorSelector{


### PR DESCRIPTION
Includes a new test covering the bad behavior, which the change satisfies, without breaking old tests. Closes #1446.