### PR TITLE
Detect code style violations in deeply nested files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ all: format build test
 
 style:
 	@echo ">> checking code style"
-	@! gofmt -d **/*.go | grep '^'
+	@! gofmt -d $(shell find . -path ./vendor -prune -o -name '*.go' -print) | grep '^'
 
 test:
 	@echo ">> running tests"


### PR DESCRIPTION
So far the style check did not recognize issues in files in deeply
nested directories, e.g. retrieval/discovery/kubernetes/discovery.go.

@jimmidyson 