### PR TITLE
Give TestEvictAndLoadChunkDescs more time to actually evict

### DIFF
--- a/storage/local/storage_test.go
+++ b/storage/local/storage_test.go
@@ -1205,7 +1205,7 @@ func testEvictAndLoadChunkDescs(t *testing.T, encoding chunkEncoding) {
 	// Maintain series without any dropped chunks.
 	s.maintainMemorySeries(fp, 0)
 	// Give the evict goroutine an opportunity to run.
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 	// Maintain series again to trigger chunkDesc eviction
 	s.maintainMemorySeries(fp, 0)
 


### PR DESCRIPTION
Obviously, it's really bad to depend on timing here. The proper fix
would be to have something like WaitForIndexing for other things to
wait for, too.

For now, let's see if the wait time increase fixes the issue.

@RichiH This should fix the last flaky test you reported in https://github.com/prometheus/prometheus/issues/1337 . Since It's not flaky in my environment, could you try if it helps for you?
