### PR TITLE
Implement relative complement set operator "unless"

### DIFF
--- a/promql/lex.go
+++ b/promql/lex.go
@@ -48,7 +48,7 @@ func (i item) String() string {
 	return fmt.Sprintf("%q", i.val)
 }
 
-// isOperator returns true if the item corresponds to a logical or arithmetic operator.
+// isOperator returns true if the item corresponds to a arithmetic or set operator.
 // Returns false otherwise.
 func (i itemType) isOperator() bool { return i > operatorsStart && i < operatorsEnd }
 
@@ -71,6 +71,15 @@ func (i itemType) isComparisonOperator() bool {
 	}
 }
 
+// isSetOperator returns whether the item corresponds to a set operator.
+func (i itemType) isSetOperator() bool {
+	switch i {
+	case itemLAND, itemLOR, itemLUnless:
+		return true
+	}
+	return false
+}
+
 // Constants for operator precedence in expressions.
 //
 const LowestPrec = 0 // Non-operators.
@@ -82,7 +91,7 @@ func (i itemType) precedence() int {
 	switch i {
 	case itemLOR:
 		return 1
-	case itemLAND:
+	case itemLAND, itemLUnless:
 		return 2
 	case itemEQL, itemNEQ, itemLTE, itemLSS, itemGTE, itemGTR:
 		return 3
@@ -127,6 +136,7 @@ const (
 	itemDIV
 	itemLAND
 	itemLOR
+	itemLUnless
 	itemEQL
 	itemNEQ
 	itemLTE
@@ -168,8 +178,9 @@ const (
 
 var key = map[string]itemType{
 	// Operators.
-	"and": itemLAND,
-	"or":  itemLOR,
+	"and":    itemLAND,
+	"or":     itemLOR,
+	"unless": itemLUnless,
 
 	// Aggregators.
 	"sum":    itemSum,

--- a/promql/lex_test.go
+++ b/promql/lex_test.go
@@ -217,6 +217,9 @@ var tests = []struct {
 	}, {
 		input:    `or`,
 		expected: []item{{itemLOR, 0, `or`}},
+	}, {
+		input:    `unless`,
+		expected: []item{{itemLUnless, 0, `unless`}},
 	},
 	// Test aggregators.
 	{

--- a/promql/testdata/operators.test
+++ b/promql/testdata/operators.test
@@ -109,6 +109,16 @@ eval instant at 50m (http_requests{group="canary"} + 1) or on(instance) (http_re
 	vector_matching_a{l="x"} 10
 	vector_matching_a{l="y"} 20
 
+eval instant at 50m http_requests{group="canary"} unless http_requests{instance="0"}
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
+
+eval instant at 50m http_requests{group="canary"} unless on(job) http_requests{instance="0"}
+
+eval instant at 50m http_requests{group="canary"} unless on(job, instance) http_requests{instance="0"}
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
+
 eval instant at 50m http_requests{group="canary"} / on(instance,job) http_requests{group="production"}
 	{instance="0", job="api-server"} 3
 	{instance="0", job="app-server"} 1.4


### PR DESCRIPTION
The `unless` set operator can be used to return all vector elements from
the LHS which do not match the elements on the RHS. A use case is to
return all metrics for nodes which do not have a specific role:

    node_load1 unless on(instance) chef_role{role="app"}

Fixes #1286.