### PR TITLE
Simplify runtime version code more

### DIFF
--- a/version/info.go
+++ b/version/info.go
@@ -26,7 +26,6 @@ var (
 	Branch    string
 	BuildUser string
 	BuildDate string
-	GoVersion = runtime.Version()
 )
 
 // Map provides the iterable version information.
@@ -36,7 +35,7 @@ var Map = map[string]string{
 	"branch":    Branch,
 	"buildUser": BuildUser,
 	"buildDate": BuildDate,
-	"goVersion": GoVersion,
+	"goVersion": runtime.Version(),
 }
 
 func init() {


### PR DESCRIPTION
It's no longer a build-time injected variable (as the comment above its
block indicates), so move it to the map below.