### PR TITLE
proposal: export duration in templates

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -295,15 +295,17 @@ func (g *Group) sendAlerts(rule *AlertingRule, timestamp model.Time) error {
 		}
 
 		tmplData := struct {
-			Labels map[string]string
-			Value  float64
+			Labels   map[string]string
+			Value    float64
+			Duration float64
 		}{
-			Labels: l,
-			Value:  float64(alert.Value),
+			Labels:   l,
+			Value:    float64(alert.Value),
+			Duration: timestamp.Sub(alert.ActiveAt).Seconds(),
 		}
 		// Inject some convenience variables that are easier to remember for users
 		// who are not used to Go's templating system.
-		defs := "{{$labels := .Labels}}{{$value := .Value}}"
+		defs := "{{$labels := .Labels}}{{$value := .Value}}{{$duration := .Duration}}"
 
 		expand := func(text model.LabelValue) model.LabelValue {
 			tmpl := template.NewTemplateExpander(


### PR DESCRIPTION
This is just for discussion for now. I will prepare a better CL with tests and doc changes if required.

I've recently started to write some nice annotations for my alerting rules (e.g. "The filesystem /srv/mysql (ext4) at myhost will fill in 3h 13m based on the growth rate of the last 1h. Please clean up or increase the volume size.").

Now I would like to display the downtime in some of those texts (e.g. "The node/service/etc. foobar is down for 3h 15m."). Unfortunately it is not possible to access the duration since the alert is active within templates. Is this intentional?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/1568)

<!-- Reviewable:end -->
