### PR TITLE
Fix git branch with slash as docker tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ pkgs   = $(shell $(GO) list ./... | grep -v /vendor/)
 PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_NAME       ?= prometheus
-DOCKER_IMAGE_TAG        ?= $(shell git rev-parse --abbrev-ref HEAD)
+DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 
 ifdef DEBUG
 	bindata_flags = -debug


### PR DESCRIPTION
CircleCI is naming the branch as `pull/{number}` when building PRs. `/` is not a valid character for docker tags.