### PR TITLE
(trivial) fix several minor golint style issues

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -42,7 +42,7 @@ const (
 	subsystem = "notifications"
 )
 
-// Handler is responsible for dispatching alert notifications to an
+// Notifier is responsible for dispatching alert notifications to an
 // alert manager service.
 type Notifier struct {
 	queue model.Alerts
@@ -61,7 +61,7 @@ type Notifier struct {
 	queueCapacity prometheus.Metric
 }
 
-// HandlerOptions are the configurable parameters of a Handler.
+// Options are the configurable parameters of a Handler.
 type Options struct {
 	AlertmanagerURL string
 	QueueCapacity   int

--- a/promql/lex.go
+++ b/promql/lex.go
@@ -82,8 +82,7 @@ func (i itemType) isSetOperator() bool {
 	return false
 }
 
-// Constants for operator precedence in expressions.
-//
+// LowestPrec is a constant for operator precedence in expressions.
 const LowestPrec = 0 // Non-operators.
 
 // Precedence returns the operator precedence of the binary

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -512,17 +512,16 @@ func (p *parser) balance(lhs Expr, op itemType, rhs Expr, vecMatching *VectorMat
 			VectorMatching: lhsBE.VectorMatching,
 			ReturnBool:     lhsBE.ReturnBool,
 		}
-	} else {
-		if op.isComparisonOperator() && !returnBool && rhs.Type() == model.ValScalar && lhs.Type() == model.ValScalar {
-			p.errorf("comparisons between scalars must use BOOL modifier")
-		}
-		return &BinaryExpr{
-			Op:             op,
-			LHS:            lhs,
-			RHS:            rhs,
-			VectorMatching: vecMatching,
-			ReturnBool:     returnBool,
-		}
+	}
+	if op.isComparisonOperator() && !returnBool && rhs.Type() == model.ValScalar && lhs.Type() == model.ValScalar {
+		p.errorf("comparisons between scalars must use BOOL modifier")
+	}
+	return &BinaryExpr{
+		Op:             op,
+		LHS:            lhs,
+		RHS:            rhs,
+		VectorMatching: vecMatching,
+		ReturnBool:     returnBool,
 	}
 }
 

--- a/storage/remote/graphite/client.go
+++ b/storage/remote/graphite/client.go
@@ -51,7 +51,7 @@ func pathFromMetric(m model.Metric, prefix string) string {
 
 	// We want to sort the labels.
 	labels := make(model.LabelNames, 0, len(m))
-	for l, _ := range m {
+	for l := range m {
 		labels = append(labels, l)
 	}
 	sort.Sort(labels)


### PR DESCRIPTION
A list of golint issues fixed - 

notifier:
```
notifier.go:45:1: comment on exported type Notifier should be of the form "Notifier ..." (with optional leading article)
notifier.go:64:1: comment on exported type Options should be of the form "Options ..." (with optional leading article)
```

promql:
```
lex.go:85:1: comment on exported const LowestPrec should be of the form "LowestPrec ..."
parse.go:515:9: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
```

storage/remote/graphite:
```
client.go:54:9: should omit 2nd value from range; this loop is equivalent to `for l := range ...`
```

@fabxc 