### PR TITLE
Add missing logging of out-of-order samples

### DIFF
--- a/retrieval/scrape.go
+++ b/retrieval/scrape.go
@@ -496,6 +496,10 @@ func (sl *scrapeLoop) report(start time.Time, duration time.Duration, err error)
 		Value:     model.SampleValue(float64(duration) / float64(time.Second)),
 	}
 
-	sl.reportAppender.Append(healthSample)
-	sl.reportAppender.Append(durationSample)
+	if err := sl.reportAppender.Append(healthSample); err != nil {
+		log.With("sample", healthSample).With("error", err).Warn("Scrape health sample discarded")
+	}
+	if err := sl.reportAppender.Append(durationSample); err != nil {
+		log.With("sample", durationSample).With("error", err).Warn("Scrape duration sample discarded")
+	}
 }


### PR DESCRIPTION
So far, out-of-order samples during rule evaluation were not logged,
and neither scrape health samples. The latter are unlikely to cause
any errors. That's why I'm logging them always now. (It's alway highly
irregular should it happen.) For rules, I have used the same plumbing
as for samples, just with a different wording in the message to mark
them as a result of rule evaluation.

@fabxc 