### PR TITLE
fix build with multi-part $GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GO    := GO15VENDOREXPERIMENT=1 go
-PROMU := $(GOPATH)/bin/promu
-pkgs   = $(shell $(GO) list ./... | grep -v /vendor/)
+GO           := GO15VENDOREXPERIMENT=1 go
+FIRST_GOPATH := $(firstword $(subst :, ,$(GOPATH)))
+PROMU        := $(FIRST_GOPATH)/bin/promu
+pkgs          = $(shell $(GO) list ./... | grep -v /vendor/)
 
 PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)


### PR DESCRIPTION
`$GOPATH` can have multiple, `:` separated, parts (just like `$PATH`). The `go` command will automatically use the first part for `go get`. This patch fixes a build failure for those with a multi-part `$GOPATH`.