### PR TITLE
Fix kubernetes SD crash

### DIFF
--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -288,6 +288,9 @@ func (ts *targetSet) runProviders(ctx context.Context, providers map[string]Targ
 				}
 				// First set of all targets the provider knows.
 				for _, tgroup := range initial {
+					if tgroup == nil {
+						continue
+					}
 					targets, err := targetsFromGroup(tgroup, ts.config)
 					if err != nil {
 						log.With("target_group", tgroup).Errorf("Target update failed: %s", err)
@@ -333,6 +336,9 @@ func (ts *targetSet) runProviders(ctx context.Context, providers map[string]Targ
 
 // update handles a target group update from a target provider identified by the name.
 func (ts *targetSet) update(name string, tgroup *config.TargetGroup) error {
+	if tgroup == nil {
+		return nil
+	}
 	targets, err := targetsFromGroup(tgroup, ts.config)
 	if err != nil {
 		return err

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -404,6 +404,7 @@ func providersFromConfig(cfg *config.ScrapeConfig) map[string]TargetProvider {
 }
 
 // targetsFromGroup builds targets based on the given TargetGroup and config.
+// Panics if target group is nil.
 func targetsFromGroup(tg *config.TargetGroup, cfg *config.ScrapeConfig) ([]*Target, error) {
 	targets := make([]*Target, 0, len(tg.Targets))
 


### PR DESCRIPTION
`nil` target groups sent to the SD update channel caused panics.
 `nil` values should not be sent in the first place but given the state of SD implementation it's safer to catch and handle this in the target manager.

This will trigger a 0.19.1 release.