### PR TITLE
Correctly stringify GROUP_x modifiers without labels

### DIFF
--- a/promql/printer.go
+++ b/promql/printer.go
@@ -165,11 +165,16 @@ func (node *BinaryExpr) String() string {
 		} else {
 			matching = fmt.Sprintf(" ON(%s)", vm.MatchingLabels)
 		}
-		if vm.Card == CardManyToOne {
-			matching += fmt.Sprintf(" GROUP_LEFT(%s)", vm.Include)
-		}
-		if vm.Card == CardOneToMany {
-			matching += fmt.Sprintf(" GROUP_RIGHT(%s)", vm.Include)
+		if vm.Card == CardManyToOne || vm.Card == CardManyToMany {
+			matching += " GROUP_"
+			if vm.Card == CardManyToOne {
+				matching += "LEFT"
+			} else {
+				matching += "RIGHT"
+			}
+			if len(vm.Include) > 0 {
+				matching += fmt.Sprintf("(%s)", vm.Include)
+			}
 		}
 	}
 	return fmt.Sprintf("%s %s%s%s %s", node.LHS, node.Op, returnBool, matching, node.RHS)

--- a/promql/printer_test.go
+++ b/promql/printer_test.go
@@ -40,6 +40,15 @@ func TestExprString(t *testing.T) {
 			in: `a - ON(b) c`,
 		},
 		{
+			in: `a - ON(b) GROUP_LEFT(x) c`,
+		},
+		{
+			in: `a - ON(b) GROUP_LEFT(x, y) c`,
+		},
+		{
+			in: `a - ON(b) GROUP_LEFT c`,
+		},
+		{
 			in: `a - IGNORING(b) c`,
 		},
 		{


### PR DESCRIPTION
Since rule evaluations work via String(), this fixes evaluation of
rules containing GROUP_x modifiers without labels. This change is the
minimal bugfix (so that we can release a fixed version without
risk). It does not intend to implement any additional features (like
allowing `GROUP_LEFT()` or `ON()` or even `ON` - see discussion in
https://github.com/prometheus/prometheus/issues/1597 ).

Fixes https://github.com/prometheus/prometheus/issues/1676

@brian-brazil @fabxc 