### PR TITLE
Fix consoles and console_libraries path in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 COPY prometheus                             /bin/prometheus
 COPY promtool                               /bin/promtool
 COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
-COPY console_libraries/                     /etc/prometheus/
-COPY consoles/                              /etc/prometheus/
+COPY console_libraries/                     /etc/prometheus/console_libraries/
+COPY consoles/                              /etc/prometheus/consoles/
 
 EXPOSE     9090
 VOLUME     [ "/prometheus" ]


### PR DESCRIPTION
Hello, thanks for your work on Prometheus!

In your docker image, consoles and console_libraries files are inside `/etc/prometheus` instead of `/etc/prometheus/consoles` and `/etc/prometheus/console_libraries`. Thus your docker image doesn't offer the consoles' functionality.

According to [docker's COPY function documentation](https://docs.docker.com/engine/reference/builder/#copy), only the contents and not the src directory itself are copied to the image:
> If \<src\> is a directory, the entire contents of the directory are copied, including filesystem metadata.
> Note: The directory itself is not copied, just its contents.