### PR TITLE
notifier: dispatch to multiple Alertmanagers

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"text/template"
 	"time"
@@ -48,9 +49,12 @@ var cfg = struct {
 	web         web.Options
 	remote      remote.Options
 
-	prometheusURL string
-	influxdbURL   string
-}{}
+	alertmanagerURLs stringset
+	prometheusURL    string
+	influxdbURL      string
+}{
+	alertmanagerURLs: stringset{},
+}
 
 func init() {
 	flag.CommandLine.Init(os.Args[0], flag.ContinueOnError)
@@ -202,9 +206,9 @@ func init() {
 	)
 
 	// Alertmanager.
-	cfg.fs.StringVar(
-		&cfg.notifier.AlertmanagerURL, "alertmanager.url", "",
-		"The URL of the alert manager to send notifications to.",
+	cfg.fs.Var(
+		&cfg.alertmanagerURLs, "alertmanager.url",
+		"Comma-separated list of Alertmanager URLs to send notifications to.",
 	)
 	cfg.fs.IntVar(
 		&cfg.notifier.QueueCapacity, "alertmanager.notification-queue-capacity", 10000,
@@ -245,8 +249,11 @@ func parse(args []string) error {
 	if err := parseInfluxdbURL(); err != nil {
 		return err
 	}
-	if err := validateAlertmanagerURL(); err != nil {
-		return err
+	for u := range cfg.alertmanagerURLs {
+		if err := validateAlertmanagerURL(u); err != nil {
+			return err
+		}
+		cfg.notifier.AlertmanagerURLs = cfg.alertmanagerURLs.slice()
 	}
 
 	cfg.remote.InfluxdbPassword = os.Getenv("INFLUXDB_PW")
@@ -303,19 +310,19 @@ func parseInfluxdbURL() error {
 	return nil
 }
 
-func validateAlertmanagerURL() error {
-	if cfg.notifier.AlertmanagerURL == "" {
+func validateAlertmanagerURL(u string) error {
+	if u == "" {
 		return nil
 	}
-	if ok := govalidator.IsURL(cfg.notifier.AlertmanagerURL); !ok {
-		return fmt.Errorf("invalid Alertmanager URL: %s", cfg.notifier.AlertmanagerURL)
+	if ok := govalidator.IsURL(u); !ok {
+		return fmt.Errorf("invalid Alertmanager URL: %s", u)
 	}
-	url, err := url.Parse(cfg.notifier.AlertmanagerURL)
+	url, err := url.Parse(u)
 	if err != nil {
 		return err
 	}
 	if url.Scheme == "" {
-		return fmt.Errorf("missing scheme in Alertmanager URL: %s", cfg.notifier.AlertmanagerURL)
+		return fmt.Errorf("missing scheme in Alertmanager URL: %s", u)
 	}
 	return nil
 }
@@ -379,4 +386,29 @@ func usage() {
 	if err := t.Execute(os.Stdout, groups); err != nil {
 		panic(fmt.Errorf("error executing usage template: %s", err))
 	}
+}
+
+type stringset map[string]struct{}
+
+func (ss stringset) Set(s string) error {
+	for _, v := range strings.Split(s, ",") {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			ss[v] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func (ss stringset) String() string {
+	return strings.Join(ss.slice(), ",")
+}
+
+func (ss stringset) slice() []string {
+	slice := make([]string, 0, len(ss))
+	for k := range ss {
+		slice = append(slice, k)
+	}
+	sort.Strings(slice)
+	return slice
 }


### PR DESCRIPTION
This commit extends the notifier to dispatch alert batches to multiple Alertmanagers concurrently.
It changes the `-alertmanager.url` flag to accept a comma separated list of URLs and/or to be set multiple times.

Metrics are extended by an `alertmanager` dimension. The `dropped` metric is incremented if dispatching to all Alertmanagers failed or alerts did not reach that stage.

@brian-brazil 