### PR TITLE
Make the number of fingerprint mutexes configurable

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -162,6 +162,10 @@ func init() {
 		&index.LabelPairFingerprintsCacheSize, "storage.local.index-cache-size.label-pair-to-fingerprints", index.LabelPairFingerprintsCacheSize,
 		"The size in bytes for the label pair to fingerprints index cache.",
 	)
+	cfg.fs.IntVar(
+		&cfg.storage.NumMutexes, "storage.local.num-fingerprint-mutexes", 4096,
+		"The number of mutexes used for fingerprint locking.",
+	)
 
 	// Remote storage.
 	cfg.fs.StringVar(

--- a/storage/local/locker.go
+++ b/storage/local/locker.go
@@ -22,16 +22,13 @@ import (
 // fingerprintLocker allows locking individual fingerprints. To limit the number
 // of mutexes needed for that, only a fixed number of mutexes are
 // allocated. Fingerprints to be locked are assigned to those pre-allocated
-// mutexes by their value. (Note that fingerprints are calculated by a hash
-// function, so that an approximately equal distribution over the mutexes is
-// expected, even without additional hashing of the fingerprint value.)
-// Collisions are not detected. If two fingerprints get assigned to the same
-// mutex, only one of them can be locked at the same time. As long as the number
-// of pre-allocated mutexes is much larger than the number of goroutines
-// requiring a fingerprint lock concurrently, the loss in efficiency is
-// small. However, a goroutine must never lock more than one fingerprint at the
-// same time. (In that case a collision would try to acquire the same mutex
-// twice).
+// mutexes by their value. Collisions are not detected. If two fingerprints get
+// assigned to the same mutex, only one of them can be locked at the same
+// time. As long as the number of pre-allocated mutexes is much larger than the
+// number of goroutines requiring a fingerprint lock concurrently, the loss in
+// efficiency is small. However, a goroutine must never lock more than one
+// fingerprint at the same time. (In that case a collision would try to acquire
+// the same mutex twice).
 type fingerprintLocker struct {
 	fpMtxs    []sync.Mutex
 	numFpMtxs uint
@@ -59,6 +56,13 @@ func (l *fingerprintLocker) Unlock(fp model.Fingerprint) {
 	l.fpMtxs[hashFP(fp)%l.numFpMtxs].Unlock()
 }
 
+// hashFP simply moves entropy from the most significant 48 bits of the
+// fingerprint into the least significant 16 bits (by XORing) so that a simple
+// MOD on the result can be used to pick a mutex while still making use of
+// changes in more significant bits of the fingerprint. (The fast fingerprinting
+// function we use is prone to only change a few bits for similar metrics. We
+// really want to make use of every change in the fingerprint to vary mutex
+// selection.)
 func hashFP(fp model.Fingerprint) uint {
 	return uint(fp ^ (fp >> 32) ^ (fp >> 16))
 }

--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -184,13 +184,14 @@ type MemorySeriesStorageOptions struct {
 	PedanticChecks             bool          // If dirty, perform crash-recovery checks on each series file.
 	SyncStrategy               SyncStrategy  // Which sync strategy to apply to series files.
 	MinShrinkRatio             float64       // Minimum ratio a series file has to shrink during truncation.
+	NumMutexes                 int           // Number of mutexes used for stochastic fingerprint locking.
 }
 
 // NewMemorySeriesStorage returns a newly allocated Storage. Storage.Serve still
 // has to be called to start the storage.
 func NewMemorySeriesStorage(o *MemorySeriesStorageOptions) Storage {
 	s := &memorySeriesStorage{
-		fpLocker: newFingerprintLocker(1024),
+		fpLocker: newFingerprintLocker(o.NumMutexes),
 
 		options: o,
 


### PR DESCRIPTION
With a lot of series accessed in a short timeframe (by a query, a
large scrape, checkpointing, ...), there is actually quite a
significant amount of lock contention if something similar is running
at the same time.

In those cases, the number of locks needs to be increased.

On the same front, as our fingerprints don't have a lot of entropy, I
introduced some additional shuffling. With the current state, anly
changes in the least singificant bits of a FP would matter.

@bitfehler @SuperQ FYI
@fabxc for review.

I'll write some documentation for this in the `next` doc branch.