### PR TITLE
Kubernetes SD: Add labels for all node addresses and discover node port

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -129,7 +129,6 @@ var (
 
 	// DefaultKubernetesSDConfig is the default Kubernetes SD configuration
 	DefaultKubernetesSDConfig = KubernetesSDConfig{
-		KubeletPort:    10255,
 		RequestTimeout: model.Duration(10 * time.Second),
 		RetryInterval:  model.Duration(1 * time.Second),
 	}
@@ -752,7 +751,6 @@ func (c *MarathonSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) erro
 // KubernetesSDConfig is the configuration for Kubernetes service discovery.
 type KubernetesSDConfig struct {
 	APIServers      []URL          `yaml:"api_servers"`
-	KubeletPort     int            `yaml:"kubelet_port,omitempty"`
 	InCluster       bool           `yaml:"in_cluster,omitempty"`
 	BasicAuth       *BasicAuth     `yaml:"basic_auth,omitempty"`
 	BearerToken     string         `yaml:"bearer_token,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -227,7 +227,6 @@ var expectedConf = &Config{
 						Username: "myusername",
 						Password: "mypassword",
 					},
-					KubeletPort:    10255,
 					RequestTimeout: model.Duration(10 * time.Second),
 					RetryInterval:  model.Duration(1 * time.Second),
 				},

--- a/retrieval/discovery/kubernetes/discovery.go
+++ b/retrieval/discovery/kubernetes/discovery.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode"
 
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
@@ -304,9 +303,6 @@ func (kd *Discovery) updateNodesTargetGroup() *config.TargetGroup {
 		}
 
 		kubeletPort := int(node.Status.DaemonEndpoints.KubeletEndpoint.Port)
-		if kubeletPort == 0 {
-			kubeletPort = kd.Conf.KubeletPort
-		}
 
 		address := fmt.Sprintf("%s:%d", defaultNodeAddress.String(), kubeletPort)
 
@@ -316,7 +312,7 @@ func (kd *Discovery) updateNodesTargetGroup() *config.TargetGroup {
 		}
 
 		for addrType, ip := range nodeAddressMap {
-			labelName := strutil.SanitizeLabelName(nodeAddressPrefix + toSnake(string(addrType)))
+			labelName := strutil.SanitizeLabelName(nodeAddressPrefix + string(addrType))
 			t[model.LabelName(labelName)] = model.LabelValue(ip[0].String())
 		}
 
@@ -1063,21 +1059,4 @@ func (kd *Discovery) updatePodsTargetGroup() *config.TargetGroup {
 	}
 
 	return tg
-}
-
-// toSnake convert the given string to snake case following the Golang format:
-// acronyms are converted to lower-case and preceded by an underscore.
-func toSnake(in string) string {
-	runes := []rune(in)
-	length := len(runes)
-
-	var out []rune
-	for i := 0; i < length; i++ {
-		if i > 0 && unicode.IsUpper(runes[i]) && ((i+1 < length && unicode.IsLower(runes[i+1])) || unicode.IsLower(runes[i-1])) {
-			out = append(out, '_')
-		}
-		out = append(out, unicode.ToLower(runes[i]))
-	}
-
-	return string(out)
 }

--- a/retrieval/discovery/kubernetes/types.go
+++ b/retrieval/discovery/kubernetes/types.go
@@ -208,6 +208,26 @@ type EndpointsList struct {
 type NodeStatus struct {
 	// Queried from cloud provider, if available.
 	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node; see http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses" patchStrategy:"merge" patchMergeKey:"type"`
+	// Endpoints of daemons running on the Node.
+	DaemonEndpoints NodeDaemonEndpoints `json:"daemonEndpoints,omitempty"`
+}
+
+// NodeDaemonEndpoints lists ports opened by daemons running on the Node.
+type NodeDaemonEndpoints struct {
+	// Endpoint on which Kubelet is listening.
+	KubeletEndpoint DaemonEndpoint `json:"kubeletEndpoint,omitempty"`
+}
+
+// DaemonEndpoint contains information about a single Daemon endpoint.
+type DaemonEndpoint struct {
+	/*
+		The port tag was not properly in quotes in earlier releases, so it must be
+		uppercased for backwards compat (since it was falling back to var name of
+		'Port').
+	*/
+
+	// Port number of the given endpoint.
+	Port int32 `json:"Port"`
 }
 
 // NodeAddressType can legally only have the values defined as constants below.


### PR DESCRIPTION
Fixes #1680 by allowing relabelling to any discovered node IP.

Also switches to discovered node port if available via API, overriding default configured node port.