### PR TITLE
Relabel: Document whole label set is dropped

### DIFF
--- a/retrieval/relabel_test.go
+++ b/retrieval/relabel_test.go
@@ -104,6 +104,20 @@ func TestRelabel(t *testing.T) {
 		},
 		{
 			input: model.LabelSet{
+				"a": "foo",
+				"b": "bar",
+			},
+			relabel: []*config.RelabelConfig{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        config.MustNewRegexp(".*o.*"),
+					Action:       config.RelabelDrop,
+				},
+			},
+			output: nil,
+		},
+		{
+			input: model.LabelSet{
 				"a": "abc",
 			},
 			relabel: []*config.RelabelConfig{


### PR DESCRIPTION
From the documentation and current tests, it wasn't immediately clear to
me whether the `target` being dropped as the result of a 'drop' action
was a label key-value pair or the entire labelset.

Add a test that documents this behaviour.

Documentation: https://prometheus.io/docs/operating/configuration/