### PR TITLE
web: round last scrape timestamp to milliseconds

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -377,7 +377,9 @@ func (h *Handler) consolesPath() string {
 
 func tmplFuncs(consolesPath string, opts *Options) template_text.FuncMap {
 	return template_text.FuncMap{
-		"since":        time.Since,
+		"since": func(t time.Time) time.Duration {
+			return time.Since(t) / time.Millisecond * time.Millisecond
+		},
 		"consolesPath": func() string { return consolesPath },
 		"pathPrefix":   func() string { return opts.ExternalURL.Path },
 		"stripLabels": func(lset model.LabelSet, labels ...model.LabelName) model.LabelSet {


### PR DESCRIPTION
The excessive precision causes the table to jump around on refreshes. This has been bothering me for a while. I don't think we need sub-millisecond precision.