### PR TITLE
discovery/marathon: Fix race conditions in test

### DIFF
--- a/retrieval/discovery/marathon/marathon_test.go
+++ b/retrieval/discovery/marathon/marathon_test.go
@@ -27,7 +27,7 @@ import (
 var marathonValidLabel = map[string]string{"prometheus": "yes"}
 
 func newTestDiscovery(client AppListClient) (chan []*config.TargetGroup, *Discovery) {
-	ch := make(chan []*config.TargetGroup)
+	ch := make(chan []*config.TargetGroup, 1)
 	md := &Discovery{
 		Servers: []string{"http://localhost:8080"},
 		Client:  client,
@@ -40,16 +40,14 @@ func TestMarathonSDHandleError(t *testing.T) {
 	ch, md := newTestDiscovery(func(url string) (*AppList, error) {
 		return nil, errTesting
 	})
-	go func() {
-		select {
-		case tg := <-ch:
-			t.Fatalf("Got group: %s", tg)
-		default:
-		}
-	}()
 	err := md.updateServices(context.Background(), ch)
 	if err != errTesting {
 		t.Fatalf("Expected error: %s", err)
+	}
+	select {
+	case tg := <-ch:
+		t.Fatalf("Got group: %s", tg)
+	default:
 	}
 }
 
@@ -57,18 +55,16 @@ func TestMarathonSDEmptyList(t *testing.T) {
 	ch, md := newTestDiscovery(func(url string) (*AppList, error) {
 		return &AppList{}, nil
 	})
-	go func() {
-		select {
-		case tg := <-ch:
-			if len(tg) > 0 {
-				t.Fatalf("Got group: %v", tg)
-			}
-		default:
-		}
-	}()
 	err := md.updateServices(context.Background(), ch)
 	if err != nil {
 		t.Fatalf("Got error: %s", err)
+	}
+	select {
+	case tg := <-ch:
+		if len(tg) > 0 {
+			t.Fatalf("Got group: %v", tg)
+		}
+	default:
 	}
 }
 
@@ -96,28 +92,26 @@ func TestMarathonSDSendGroup(t *testing.T) {
 	ch, md := newTestDiscovery(func(url string) (*AppList, error) {
 		return marathonTestAppList(marathonValidLabel, 1), nil
 	})
-	go func() {
-		select {
-		case tgs := <-ch:
-			tg := tgs[0]
-
-			if tg.Source != "test-service" {
-				t.Fatalf("Wrong target group name: %s", tg.Source)
-			}
-			if len(tg.Targets) != 1 {
-				t.Fatalf("Wrong number of targets: %v", tg.Targets)
-			}
-			tgt := tg.Targets[0]
-			if tgt[model.AddressLabel] != "mesos-slave1:31000" {
-				t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
-			}
-		default:
-			t.Fatal("Did not get a target group.")
-		}
-	}()
 	err := md.updateServices(context.Background(), ch)
 	if err != nil {
 		t.Fatalf("Got error: %s", err)
+	}
+	select {
+	case tgs := <-ch:
+		tg := tgs[0]
+
+		if tg.Source != "test-service" {
+			t.Fatalf("Wrong target group name: %s", tg.Source)
+		}
+		if len(tg.Targets) != 1 {
+			t.Fatalf("Wrong number of targets: %v", tg.Targets)
+		}
+		tgt := tg.Targets[0]
+		if tgt[model.AddressLabel] != "mesos-slave1:31000" {
+			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
+		}
+	default:
+		t.Fatal("Did not get a target group.")
 	}
 }
 
@@ -158,22 +152,21 @@ func TestMarathonSDRunAndStop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
-		select {
-		case <-ch:
-			cancel()
-		case <-time.After(md.RefreshInterval * 3):
-			cancel()
-			t.Fatalf("Update took too long.")
+		for {
+			select {
+			case _, ok := <-ch:
+				if !ok {
+					return
+				}
+				cancel()
+			case <-time.After(md.RefreshInterval * 3):
+				cancel()
+				t.Fatalf("Update took too long.")
+			}
 		}
 	}()
 
 	md.Run(ctx, ch)
-
-	select {
-	case <-ch:
-	default:
-		t.Fatalf("Channel not closed.")
-	}
 }
 
 func marathonTestZeroTaskPortAppList(labels map[string]string, runningTasks int) *AppList {
@@ -201,23 +194,21 @@ func TestMarathonZeroTaskPorts(t *testing.T) {
 		return marathonTestZeroTaskPortAppList(marathonValidLabel, 1), nil
 	})
 
-	go func() {
-		select {
-		case tgs := <-ch:
-			tg := tgs[0]
-
-			if tg.Source != "test-service-zero-ports" {
-				t.Fatalf("Wrong target group name: %s", tg.Source)
-			}
-			if len(tg.Targets) != 0 {
-				t.Fatalf("Wrong number of targets: %v", tg.Targets)
-			}
-		default:
-			t.Fatal("Did not get a target group.")
-		}
-	}()
 	err := md.updateServices(context.Background(), ch)
 	if err != nil {
 		t.Fatalf("Got error: %s", err)
+	}
+	select {
+	case tgs := <-ch:
+		tg := tgs[0]
+
+		if tg.Source != "test-service-zero-ports" {
+			t.Fatalf("Wrong target group name: %s", tg.Source)
+		}
+		if len(tg.Targets) != 0 {
+			t.Fatalf("Wrong number of targets: %v", tg.Targets)
+		}
+	default:
+		t.Fatal("Did not get a target group.")
 	}
 }


### PR DESCRIPTION
The concurrency applied before is in most cases not even needed. With
a cap=1 channel, most tests are much cleaner.

TestMarathonSDRunAndStop was trickier. It could even have blocked
before.

@fabxc 

Fixes #1733 