### PR TITLE
promu: don't build openbsd/arm

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -21,3 +21,30 @@ tarball:
         - documentation/examples/prometheus.yml
         - LICENSE
         - NOTICE
+crossbuild:
+    platforms:
+        - linux/amd64
+        - linux/386
+        - darwin/amd64
+        - darwin/386
+        - windows/amd64
+        - windows/386
+        - freebsd/amd64
+        - freebsd/386
+        - openbsd/amd64
+        - openbsd/386
+        - netbsd/amd64
+        - netbsd/386
+        - dragonfly/amd64
+        - linux/arm
+        - linux/arm64
+        - freebsd/arm
+        # Temporarily deactivated as golang.org/x/sys does not have syscalls
+        # implemented for that os/platform combination.
+        #- openbsd/arm
+        #- linux/mips64
+        #- linux/mips64le
+        - netbsd/arm
+        - linux/ppc64
+        - linux/ppc64le
+


### PR DESCRIPTION
Deactivate crossbuilding for openbsd/arm as golang.org/x/sys
does not have the necessary syscalls implemented.

@sdurrheimer 