### PR TITLE
BasicAuth support In Marathon

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -766,6 +766,7 @@ func (c *NerveSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type MarathonSDConfig struct {
 	Servers         []string       `yaml:"servers,omitempty"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
+	BasicAuth       *BasicAuth     `yaml:"basic_auth,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -243,8 +243,10 @@ var expectedConf = &Config{
 
 			MarathonSDConfigs: []*MarathonSDConfig{
 				{
-					Servers: []string{
-						"http://marathon.example.com:8080",
+					Servers: []string{"http://marathon.example.com:8080"},
+					BasicAuth: &BasicAuth{
+						Username: "myusername",
+						Password: "mypassword",
 					},
 					RefreshInterval: model.Duration(30 * time.Second),
 				},

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -121,6 +121,10 @@ scrape_configs:
   - servers:
     - 'http://marathon.example.com:8080'
 
+    basic_auth:
+      username: 'myusername'
+      password: 'mypassword'
+
 - job_name: service-ec2
   ec2_sd_configs:
     - region: us-east-1

--- a/retrieval/discovery/marathon.go
+++ b/retrieval/discovery/marathon.go
@@ -24,6 +24,7 @@ import (
 func NewMarathon(conf *config.MarathonSDConfig) *marathon.Discovery {
 	return &marathon.Discovery{
 		Servers:         conf.Servers,
+		Auth:            conf.BasicAuth,
 		RefreshInterval: time.Duration(conf.RefreshInterval),
 		Client:          marathon.FetchApps,
 	}

--- a/retrieval/discovery/marathon/marathon_test.go
+++ b/retrieval/discovery/marathon/marathon_test.go
@@ -41,7 +41,7 @@ func TestMarathonSDHandleError(t *testing.T) {
 	var (
 		errTesting = errors.New("testing failure")
 		ch         = make(chan []*config.TargetGroup, 1)
-		client     = func(url string) (*AppList, error) { return nil, errTesting }
+		client     = func(url string, auth *config.BasicAuth) (*AppList, error) { return nil, errTesting }
 	)
 	if err := testUpdateServices(client, ch); err != errTesting {
 		t.Fatalf("Expected error: %s", err)
@@ -56,7 +56,7 @@ func TestMarathonSDHandleError(t *testing.T) {
 func TestMarathonSDEmptyList(t *testing.T) {
 	var (
 		ch     = make(chan []*config.TargetGroup, 1)
-		client = func(url string) (*AppList, error) { return &AppList{}, nil }
+		client = func(url string, auth *config.BasicAuth) (*AppList, error) { return &AppList{}, nil }
 	)
 	if err := testUpdateServices(client, ch); err != nil {
 		t.Fatalf("Got error: %s", err)
@@ -95,7 +95,7 @@ func marathonTestAppList(labels map[string]string, runningTasks int) *AppList {
 func TestMarathonSDSendGroup(t *testing.T) {
 	var (
 		ch     = make(chan []*config.TargetGroup, 1)
-		client = func(url string) (*AppList, error) {
+		client = func(url string, auth *config.BasicAuth) (*AppList, error) {
 			return marathonTestAppList(marathonValidLabel, 1), nil
 		}
 	)
@@ -124,7 +124,7 @@ func TestMarathonSDSendGroup(t *testing.T) {
 func TestMarathonSDRemoveApp(t *testing.T) {
 	var (
 		ch     = make(chan []*config.TargetGroup)
-		client = func(url string) (*AppList, error) {
+		client = func(url string, auth *config.BasicAuth) (*AppList, error) {
 			return marathonTestAppList(marathonValidLabel, 1), nil
 		}
 		md = Discovery{
@@ -147,7 +147,7 @@ func TestMarathonSDRemoveApp(t *testing.T) {
 		t.Fatalf("Got error on first update: %s", err)
 	}
 
-	md.Client = func(url string) (*AppList, error) {
+	md.Client = func(url string, auth *config.BasicAuth) (*AppList, error) {
 		return marathonTestAppList(marathonValidLabel, 0), nil
 	}
 	err = md.updateServices(context.Background(), ch)
@@ -159,7 +159,7 @@ func TestMarathonSDRemoveApp(t *testing.T) {
 func TestMarathonSDRunAndStop(t *testing.T) {
 	var (
 		ch     = make(chan []*config.TargetGroup)
-		client = func(url string) (*AppList, error) {
+		client = func(url string, auth *config.BasicAuth) (*AppList, error) {
 			return marathonTestAppList(marathonValidLabel, 1), nil
 		}
 		md = Discovery{
@@ -213,7 +213,7 @@ func marathonTestZeroTaskPortAppList(labels map[string]string, runningTasks int)
 func TestMarathonZeroTaskPorts(t *testing.T) {
 	var (
 		ch     = make(chan []*config.TargetGroup, 1)
-		client = func(url string) (*AppList, error) {
+		client = func(url string, auth *config.BasicAuth) (*AppList, error) {
 			return marathonTestZeroTaskPortAppList(marathonValidLabel, 1), nil
 		}
 	)


### PR DESCRIPTION
@beorn7 @juliusv @fabxc 

This is a simple enhancement to support BasicAuth in Marathon.  I also added this to the good config as a part of the test suite.

Our Marathon cluster used LDAP authentication frontend by BasicAuth which also allowed me to test at runtime.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/1745)

<!-- Reviewable:end -->
