### PR TITLE
promql: fix printing annotations of an *AlertStmt

### DIFF
--- a/promql/printer.go
+++ b/promql/printer.go
@@ -109,7 +109,7 @@ func (node *AlertStmt) String() string {
 		s += fmt.Sprintf("\n\tLABELS %s", node.Labels)
 	}
 	if len(node.Annotations) > 0 {
-		s += fmt.Sprintf("\n\tANNOTATIONS %s", node.Labels)
+		s += fmt.Sprintf("\n\tANNOTATIONS %s", node.Annotations)
 	}
 	return s
 }

--- a/promql/printer_test.go
+++ b/promql/printer_test.go
@@ -79,3 +79,35 @@ func TestExprString(t *testing.T) {
 		}
 	}
 }
+
+func TestStmtsString(t *testing.T) {
+	// A list of valid statements that are expected to be returned as out when
+	// calling String(). If out is empty the output is expected to equal the
+	// input.
+	inputs := []struct {
+		in, out string
+	}{
+		{
+			in:  `ALERT foo IF up == 0 FOR 1m`,
+			out: "ALERT foo\n\tIF up == 0\n\tFOR 1m",
+		},
+		{
+			in:  `ALERT foo IF up == 0 FOR 1m ANNOTATIONS {summary="foo"}`,
+			out: "ALERT foo\n\tIF up == 0\n\tFOR 1m\n\tANNOTATIONS {summary=\"foo\"}",
+		},
+	}
+
+	for _, test := range inputs {
+		expr, err := ParseStmts(test.in)
+		if err != nil {
+			t.Fatalf("parsing error for %q: %s", test.in, err)
+		}
+		exp := test.in
+		if test.out != "" {
+			exp = test.out
+		}
+		if expr.String() != exp {
+			t.Fatalf("expected %q to be returned as:\n%s\ngot:\n%s\n", test.in, exp, expr.String())
+		}
+	}
+}


### PR DESCRIPTION
Currently the printer doesn't print the annotations of an `*AlertStmt`
declaration. I've added a test case as well, which fails for the current
master.