### PR TITLE
Fix 'access denied' error on Windows

### DIFF
--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -812,6 +812,9 @@ func (p *persistence) dropAndPersistChunks(
 		}
 		_, err = io.ReadFull(f, headerBuf)
 		if err == io.EOF {
+			// Close the file before trying to delete it. This is necessary on Windows
+			// (this will cause the defer f.Close to fail, but the error is silently ignored)
+			f.Close()
 			// We ran into the end of the file without finding any chunks that should
 			// be kept. Remove the whole file.
 			if numDropped, err = p.deleteSeriesFile(fp); err != nil {
@@ -875,6 +878,9 @@ func (p *persistence) dropAndPersistChunks(
 		return
 	}
 	defer func() {
+		// Close the file before trying to rename to it. This is necessary on Windows
+		// (this will cause the defer f.Close to fail, but the error is silently ignored)
+		f.Close()
 		p.closeChunkFile(temp)
 		if err == nil {
 			err = os.Rename(p.tempFileNameForFingerprint(fp), p.fileNameForFingerprint(fp))


### PR DESCRIPTION
On Windows, it is not possible to rename or delete a file that is
currerntly open. This change closes the file in dropAndPersistChunks
before it tries to delete it, or rename the temporary file to it.

I repro'd this on my Windows machine, and verified that this fixes the problem.

Fixes #1628 