### PR TITLE
Separate query interface out of local.Storage.

### DIFF
--- a/promql/analyzer.go
+++ b/promql/analyzer.go
@@ -27,7 +27,7 @@ import (
 // from the storage. It is bound to a context that allows cancellation and timing out.
 type Analyzer struct {
 	// The storage from which to query data.
-	Storage local.Storage
+	Storage local.Querier
 	// The expression being analyzed.
 	Expr Expr
 	// The time range for evaluation of Expr.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -218,7 +218,7 @@ func contextDone(ctx context.Context, env string) error {
 // It is connected to a storage.
 type Engine struct {
 	// The storage on which the engine operates.
-	storage local.Storage
+	storage local.Querier
 
 	// The base context for all queries and its cancellation function.
 	baseCtx       context.Context
@@ -230,7 +230,7 @@ type Engine struct {
 }
 
 // NewEngine returns a new engine.
-func NewEngine(storage local.Storage, o *EngineOptions) *Engine {
+func NewEngine(storage local.Querier, o *EngineOptions) *Engine {
 	if o == nil {
 		o = DefaultEngineOptions
 	}

--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -189,7 +189,7 @@ type MemorySeriesStorageOptions struct {
 
 // NewMemorySeriesStorage returns a newly allocated Storage. Storage.Serve still
 // has to be called to start the storage.
-func NewMemorySeriesStorage(o *MemorySeriesStorageOptions) Storage {
+func NewMemorySeriesStorage(o *MemorySeriesStorageOptions) *memorySeriesStorage {
 	s := &memorySeriesStorage{
 		fpLocker: newFingerprintLocker(o.NumMutexes),
 

--- a/storage/local/storage_test.go
+++ b/storage/local/storage_test.go
@@ -718,7 +718,7 @@ func TestLoop(t *testing.T) {
 		storage.Append(s)
 	}
 	storage.WaitForIndexing()
-	series, _ := storage.(*memorySeriesStorage).fpToSeries.get(model.Metric{}.FastFingerprint())
+	series, _ := storage.fpToSeries.get(model.Metric{}.FastFingerprint())
 	cdsBefore := len(series.chunkDescs)
 	time.Sleep(fpMaxWaitDuration + time.Second) // TODO(beorn7): Ugh, need to wait for maintenance to kick in.
 	cdsAfter := len(series.chunkDescs)
@@ -1497,12 +1497,12 @@ func benchmarkFuzz(b *testing.B, encoding chunkEncoding) {
 		for _, sample := range samples[start:middle] {
 			s.Append(sample)
 		}
-		verifyStorageRandom(b, s.(*memorySeriesStorage), samples[:middle])
+		verifyStorageRandom(b, s, samples[:middle])
 		for _, sample := range samples[middle:end] {
 			s.Append(sample)
 		}
-		verifyStorageRandom(b, s.(*memorySeriesStorage), samples[:end])
-		verifyStorageSequential(b, s.(*memorySeriesStorage), samples)
+		verifyStorageRandom(b, s, samples[:end])
+		verifyStorageSequential(b, s, samples)
 	}
 }
 

--- a/storage/local/test_helpers.go
+++ b/storage/local/test_helpers.go
@@ -52,7 +52,7 @@ func NewTestStorage(t testutil.T, encoding chunkEncoding) (*memorySeriesStorage,
 		SyncStrategy:               Adaptive,
 	}
 	storage := NewMemorySeriesStorage(o)
-	storage.(*memorySeriesStorage).archiveHighWatermark = model.Latest
+	storage.archiveHighWatermark = model.Latest
 	if err := storage.Start(); err != nil {
 		directory.Close()
 		t.Fatalf("Error creating storage: %s", err)
@@ -63,5 +63,5 @@ func NewTestStorage(t testutil.T, encoding chunkEncoding) (*memorySeriesStorage,
 		directory: directory,
 	}
 
-	return storage.(*memorySeriesStorage), closer
+	return storage, closer
 }


### PR DESCRIPTION
PromQL only requires a much narrower interface than local.Storage in
order to run queries. Narrower interfaces are easier to replace and
test, too.

We could also change the web interface to use local.Querier, except that
we'll probably use appending functions from there in the future.