### PR TITLE
notifier: increase notification batch size to 256

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -140,7 +140,7 @@ func (n *Notifier) ApplyConfig(conf *config.Config) bool {
 	return true
 }
 
-const maxBatchSize = 64
+const maxBatchSize = 256
 
 func (n *Notifier) queueLen() int {
 	n.mtx.RLock()


### PR DESCRIPTION
The previous limit of 64 was rather small and might not accomodate
use cases where we are dealing with thousands of simultanious alerts.

@brian-brazil I suppose you want this to be a configuration flag – I think this generally fine though.