### PR TITLE
add groupByLabel template function

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -179,6 +179,9 @@ func NewTemplateExpander(text string, name string, data interface{}, timestamp m
 					return nil, fmt.Errorf("Query result has no label: '%s' to group by", label)
 				}
 
+				sorter := queryResultByLabelSorter{newResults[:], label}
+				sort.Stable(sorter)
+
 				return newResults, nil
 			},
 			"humanize": func(v float64) string {

--- a/template/template.go
+++ b/template/template.go
@@ -157,6 +157,30 @@ func NewTemplateExpander(text string, name string, data interface{}, timestamp m
 				sort.Stable(sorter)
 				return v
 			},
+			"groupByLabel": func(label string, v queryResult) (queryResult, error) {
+				m := make(map[string]*sample)
+
+				for _, r := range v {
+					if s, ok := m[r.Labels[label]]; ok {
+						s.Value = s.Value + 1
+					} else {
+						r.Value = 1
+						m[r.Labels[label]] = r
+
+					}
+				}
+
+				var newResults queryResult
+				for _, g := range m {
+					newResults = append(newResults, g)
+				}
+
+				if len(newResults) == 0 {
+					return nil, fmt.Errorf("Query result has no label: '%s' to group by", label)
+				}
+
+				return newResults, nil
+			},
 			"humanize": func(v float64) string {
 				if v == 0 || math.IsNaN(v) || math.IsInf(v, 0) {
 					return fmt.Sprintf("%.4g", v)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -107,7 +107,7 @@ func TestTemplateExpansion(t *testing.T) {
 		{
 			// Range over query and group by label.
 			text:   "{{ range query \"metric\" | groupByLabel \"instance\" }}{{.Labels.instance}}:{{.Value}}: {{end}}",
-			output: "b:1: a:1: ",
+			output: "a:1: b:1: ",
 		},
 		{
 			// Unparsable template.

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -105,6 +105,11 @@ func TestTemplateExpansion(t *testing.T) {
 			output: "a:11: b:21: ",
 		},
 		{
+			// Range over query and group by label.
+			text:   "{{ range query \"metric\" | groupByLabel \"instance\" }}{{.Labels.instance}}:{{.Value}}: {{end}}",
+			output: "b:1: a:1: ",
+		},
+		{
 			// Unparsable template.
 			text:       "{{",
 			shouldFail: true,


### PR DESCRIPTION
When using groupByLabel in the query it returns the count of the original results grouped by the given label name.

ex. Given output of up:
up{instance="localhost:9101",job="a"}	1
up{instance="localhost:9101",job="a"}	1
up{instance="localhost:9101",job="b"}	1
up{instance="localhost:9101",job="b"}	1
up{instance="localhost:9101",job="b"}	1

{{ range query "up" | groupByLabel "job }} yields:
a: 2 b: 3