### PR TITLE
Allow URLs in targets defined via a JSON file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -580,9 +580,6 @@ func (tg *TargetGroup) UnmarshalJSON(b []byte) error {
 	}
 	tg.Targets = make([]model.LabelSet, 0, len(g.Targets))
 	for _, t := range g.Targets {
-		if strings.Contains(t, "/") {
-			return fmt.Errorf("%q is not a valid hostname", t)
-		}
 		tg.Targets = append(tg.Targets, model.LabelSet{
 			model.AddressLabel: model.LabelValue(t),
 		})


### PR DESCRIPTION
This enables defining `blackbox_exporter` targets (which can be URLs,
because of relabeling) in a JSON file.

Not sure if this is the best approach, but current behaviour is
inconsistent (`UnmarshalYAML` does not have this check) and breaks
officially documented way to use `blackbox_exporter`.