### PR TITLE
gitignore: clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,10 @@
 *#
-*.[568ao]
-*.a[568o]
-*.cgo*.c
-*.cgo*.go
+.#*
+*-stamp
 /*.yaml
 /*.yml
 /*.rules
 *.exe
-*.orig
-*.pyc
-*.rej
-*.so
 
 # Editor files #
 ################
@@ -20,12 +14,6 @@
 *.iml
 .idea
 
-.DS_Store
-.nfs.*
-[568a].out
-core
-
-*-stamp
 /prometheus
 /promtool
 benchmark.txt
@@ -33,12 +21,6 @@ benchmark.txt
 /.build
 /.release
 /.tarballs
-
-.#*
-command-line-arguments.test
-*BACKUP*
-*LOCAL*
-*REMOTE*
 
 !/circle.yml
 !/.travis.yml


### PR DESCRIPTION
This removes several outdated or unnecessary ignore patterns.
Especially those that match random words such as 'local' or 'core',
which repeatedly caused weird behavior that's hard to debug, e.g.
invisble vendored files.

I'd even argue for removing all the editor files as these patterns belong into a users own .gitignore – we cannot add ignores for all possible editors.