### PR TITLE
Add count_values() aggregator.

### DIFF
--- a/promql/lex.go
+++ b/promql/lex.go
@@ -60,7 +60,9 @@ func (i itemType) isAggregator() bool { return i > aggregatorsStart && i < aggre
 
 // isAggregator returns true if the item is an aggregator that takes a parameter.
 // Returns false otherwise
-func (i itemType) isAggregatorWithParam() bool { return i == itemTopK || i == itemBottomK }
+func (i itemType) isAggregatorWithParam() bool {
+	return i == itemTopK || i == itemBottomK || i == itemCountValues
+}
 
 // isKeyword returns true if the item corresponds to a keyword.
 // Returns false otherwise.
@@ -176,6 +178,7 @@ const (
 	itemStdvar
 	itemTopK
 	itemBottomK
+	itemCountValues
 	aggregatorsEnd
 
 	keywordsStart
@@ -209,15 +212,16 @@ var key = map[string]itemType{
 	"unless": itemLUnless,
 
 	// Aggregators.
-	"sum":     itemSum,
-	"avg":     itemAvg,
-	"count":   itemCount,
-	"min":     itemMin,
-	"max":     itemMax,
-	"stddev":  itemStddev,
-	"stdvar":  itemStdvar,
-	"topk":    itemTopK,
-	"bottomk": itemBottomK,
+	"sum":          itemSum,
+	"avg":          itemAvg,
+	"count":        itemCount,
+	"min":          itemMin,
+	"max":          itemMax,
+	"stddev":       itemStddev,
+	"stdvar":       itemStdvar,
+	"topk":         itemTopK,
+	"bottomk":      itemBottomK,
+	"count_values": itemCountValues,
 
 	// Keywords.
 	"alert":       itemAlert,

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -1052,6 +1052,9 @@ func (p *parser) checkType(node Node) (typ model.ValueType) {
 		if n.Op == itemTopK || n.Op == itemBottomK {
 			p.expectType(n.Param, model.ValScalar, "aggregation parameter")
 		}
+		if n.Op == itemCountValues {
+			p.expectType(n.Param, model.ValString, "aggregation parameter")
+		}
 
 	case *BinaryExpr:
 		lt := p.checkType(n.LHS)

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -1214,6 +1214,18 @@ var testExpr = []struct {
 			Param: &NumberLiteral{5},
 		},
 	}, {
+		input: "count_values(\"value\", some_metric)",
+		expected: &AggregateExpr{
+			Op: itemCountValues,
+			Expr: &VectorSelector{
+				Name: "some_metric",
+				LabelMatchers: metric.LabelMatchers{
+					{Type: metric.Equal, Name: model.MetricNameLabel, Value: "some_metric"},
+				},
+			},
+			Param: &StringLiteral{"value"},
+		},
+	}, {
 		input:  `sum some_metric by (test)`,
 		fail:   true,
 		errMsg: "unexpected identifier \"some_metric\" in aggregation, expected \"(\"",
@@ -1257,6 +1269,10 @@ var testExpr = []struct {
 		input:  `topk(some_metric, other_metric)`,
 		fail:   true,
 		errMsg: "parse error at char 32: expected type scalar in aggregation parameter, got vector",
+	}, {
+		input:  `count_values(5, other_metric)`,
+		fail:   true,
+		errMsg: "parse error at char 30: expected type string in aggregation parameter, got scalar",
 	},
 	// Test function calls.
 	{

--- a/promql/printer_test.go
+++ b/promql/printer_test.go
@@ -75,6 +75,9 @@ func TestExprString(t *testing.T) {
 			in: `topk(5, task:errors:rate10s{job="s"})`,
 		},
 		{
+			in: `count_values("value", task:errors:rate10s{job="s"})`,
+		},
+		{
 			in: `a - ON(b) c`,
 		},
 		{

--- a/promql/testdata/aggregators.test
+++ b/promql/testdata/aggregators.test
@@ -183,3 +183,40 @@ eval_ordered instant at 50m bottomk(3, http_requests{job="api-server",group="pro
 	http_requests{job="api-server", instance="0", group="production"}	100
 	http_requests{job="api-server", instance="1", group="production"}	200
 	http_requests{job="api-server", instance="2", group="production"}	NaN
+
+clear
+
+# Tests for count_values.
+load 5m
+	version{job="api-server", instance="0", group="production"}	6
+	version{job="api-server", instance="1", group="production"}	6
+	version{job="api-server", instance="2", group="production"}	6
+	version{job="api-server", instance="0", group="canary"}		8
+	version{job="api-server", instance="1", group="canary"}		8
+	version{job="app-server", instance="0", group="production"}	6
+	version{job="app-server", instance="1", group="production"}	6
+	version{job="app-server", instance="0", group="canary"}		7
+	version{job="app-server", instance="1", group="canary"}		7
+
+eval instant at 5m count_values("version", version)
+	{version="6"} 5
+	{version="7"} 2
+	{version="8"} 2
+
+eval instant at 5m count_values without (instance)("version", version)
+	{job="api-server", group="production", version="6"} 3
+	{job="api-server", group="canary", version="8"} 2
+	{job="app-server", group="production", version="6"} 2
+	{job="app-server", group="canary", version="7"} 2
+
+# Overwrite label with output. Don't do this.
+eval instant at 5m count_values without (instance)("job", version)
+	{job="6", group="production"} 5
+	{job="8", group="canary"} 2
+	{job="7", group="canary"} 2
+
+# Overwrite label with output. Don't do this.
+eval instant at 5m count_values by (job, group)("job", version)
+	{job="6", group="production"} 5
+	{job="8", group="canary"} 2
+	{job="7", group="canary"} 2


### PR DESCRIPTION
This is useful for counting how many instances
of a job are running a particular version/build.

Fixes #622