### PR TITLE
Clarify error message when Prometheus data dir finds unexpected files

### DIFF
--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -161,7 +161,7 @@ func newPersistence(
 			return nil, err
 		}
 		if len(fis) > 0 && !(len(fis) == 1 && fis[0].Name() == "lost+found" && fis[0].IsDir()) {
-			return nil, fmt.Errorf("could not detect storage version on disk, assuming version 0, need version %d - please wipe storage or run a version of Prometheus compatible with storage version 0", Version)
+			return nil, fmt.Errorf("found existing files in storage path that do not look like storage files compatible with this version of Prometheus; please delete the files in the storage path or choose a different storage path")
 		}
 		// Finally we can write our own version into a new version file.
 		file, err := os.Create(versionPath)


### PR DESCRIPTION
While trying to work with remote storage, I kept hitting the error
referenced on line 161. I assumed that the remote volume was empty, but ended
up finding a test file when I mounted it manually. The current error
does mention that it is potentially necessary to wipe the storage, but
I thought presenting an additional note about the potential number of
files might clarify what an operator needs to remove.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/1794)

<!-- Reviewable:end -->
