### PR TITLE
Crash recovery: Fix an edge case.

### DIFF
--- a/storage/local/crashrecovery.go
+++ b/storage/local/crashrecovery.go
@@ -362,6 +362,10 @@ func (p *persistence) sanitizeSeries(
 		)
 		numMemChunkDescs.Sub(float64(keepIdx))
 		atomic.AddInt64(&numMemChunks, int64(-keepIdx))
+		if keepIdx == len(s.chunkDescs) {
+			// No chunks from series file left, head chunk is evicted, so declare it closed.
+			s.headChunkClosed = true
+		}
 		s.chunkDescs = append(cds, s.chunkDescs[keepIdx:]...)
 		return fp, true
 	}


### PR DESCRIPTION
If the chunks of a series in the checkpoint are all older then the
latest chunk on disk, the head chunk is persisted and therefore has to
be declared closed.

It would be great to have a test for this, but that would require more
plumbing, subject of #447.

Fixes #1790 
@fabxc @PrFalken 