### PR TITLE
Small changes to the example configuration

### DIFF
--- a/documentation/examples/prometheus.yml
+++ b/documentation/examples/prometheus.yml
@@ -27,4 +27,5 @@ scrape_configs:
     # scheme defaults to 'http'.
 
     static_configs:
-      - targets: ['localhost:9090']
+      - targets: 
+        - 'localhost:9090'

--- a/documentation/examples/prometheus.yml
+++ b/documentation/examples/prometheus.yml
@@ -29,3 +29,15 @@ scrape_configs:
     static_configs:
       - targets: 
         - 'localhost:9090'
+
+  # An example for relabeling an instance
+  # see https://prometheus.io/docs/operating/configuration/#<relabel_config>
+  - job_name: 'node'
+    static_configs:
+      - targets:
+        - '172.17.0.1:9100'
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: (172\.17\.0\.1:9100)
+        target_label: instance
+        replacement: my.node.local

--- a/documentation/examples/prometheus.yml
+++ b/documentation/examples/prometheus.yml
@@ -40,4 +40,4 @@ scrape_configs:
       - source_labels: [__address__]
         regex: (172\.17\.0\.1:9100)
         target_label: instance
-        replacement: my.node.local
+        replacement: my.node.local:9100


### PR DESCRIPTION
The old way of specifying the target list doesn't seem to work with static_configs.
Since it is something i was looking for during testing, and people asked for it on irc, I added an example on how to relabel an instance.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/1809)

<!-- Reviewable:end -->
