### PR TITLE
Raise error on unknown non-flag arguments

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -242,6 +242,13 @@ func init() {
 
 func parse(args []string) error {
 	err := cfg.fs.Parse(args)
+
+	unkown_args := cfg.fs.Args()
+
+	if len(unkown_args) != 0 {
+		return fmt.Errorf("Unknown non-flag command line arguments: %s", unkown_args)
+	}
+
 	if err != nil {
 		if err != flag.ErrHelp {
 			log.Errorf("Invalid command line arguments. Help: %s -h", os.Args[0])


### PR DESCRIPTION
Fixes: #1821 

Error is raised if any non-flags parameters are added, even alongside with valid flags. Also, it reports the non-flags that caused the error.

@juliusv you may take a look

