### PR TITLE
Fix available memory computation in node.html

### DIFF
--- a/consoles/node.html
+++ b/consoles/node.html
@@ -22,7 +22,7 @@
   <td><a href="node-overview.html?instance={{ .Labels.instance }}">{{ reReplaceAll "(.*?://)([^:/]+?)(:\\d+)?/.*" "$2" .Labels.instance }}</a></td>
   <td{{ if eq (. | value) 1.0 }}>Yes{{ else }} class="alert-danger">No{{ end }}</td>
   <td>{{ template "prom_query_drilldown" (args (printf "100 * (1 - avg by(instance)(irate(node_cpu{job='node',mode='idle',instance='%s'}[5m])))" .Labels.instance) "%" "printf.1f") }}</td>
-  <td>{{ template "prom_query_drilldown" (args (printf "node_memory_MemFree{job='node',instance='%s'} + node_memory_Cached{job='node',instance='%s'} + node_memory_Buffers{job='node',instance='%s'}" .Labels.instance .Labels.instance .Labels.instance) "B" "humanize1024") }}</td>
+  <td>{{ template "prom_query_drilldown" (args (printf "node_memory_MemAvailable{job='node',instance='%s'}" .Labels.instance) "B" "humanize1024") }}</td>
 </tr>
 {{ else }}
 <tr><td colspan=4>No nodes found.</td></tr>


### PR DESCRIPTION
Available memory as it is computed in `node.html` has been wrong since kernel version `3.14`.

`/proc/meminfo` provides the correct value as `MemAvailable`.

Future changes  in the available memory algorithm are supposed to remain transparent to the user by way of this metric.

Here's the commit detailing this: https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773

As a side effect, `node.html` renders more quickly with the simplified metric.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/1830)

<!-- Reviewable:end -->
