### PR TITLE
Explicitly add logging flags to our custom flag set

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -239,7 +239,7 @@ func init() {
 		"Maximum number of queries executed concurrently.",
 	)
 
-	// Copy the flags from the log package into our own flag set.
+	// Flags from the log package have to be added explicitly to our custom flag set.
 	log.AddFlags(cfg.fs)
 }
 

--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -238,6 +238,9 @@ func init() {
 		&cfg.queryEngine.MaxConcurrentQueries, "query.max-concurrency", 20,
 		"Maximum number of queries executed concurrently.",
 	)
+
+	// Copy the flags from the log package into our own flag set.
+	log.AddFlags(cfg.fs)
 }
 
 func parse(args []string) error {

--- a/vendor/github.com/prometheus/common/log/log.go
+++ b/vendor/github.com/prometheus/common/log/log.go
@@ -91,10 +91,16 @@ func (f logFormatFlag) Set(format string) error {
 }
 
 func init() {
-	// In order for these flags to take effect, the user of the package must call
-	// flag.Parse() before logging anything.
-	flag.Var(levelFlag{}, "log.level", "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal].")
-	flag.Var(logFormatFlag{}, "log.format", "If set use a syslog logger or JSON logging. Example: logger:syslog?appname=bob&local=7 or logger:stdout?json=true. Defaults to stderr.")
+	AddFlags(flag.CommandLine)
+}
+
+// AddFlags adds the flags used by this package to the given FlagSet. That's
+// useful if working with a custom FlagSet. The init function of this package
+// adds the flags to flag.CommandLine anyway. Thus, it's usually enough to call
+// flag.Parse() to make the logging flags take effect.
+func AddFlags(fs *flag.FlagSet) {
+	fs.Var(levelFlag{}, "log.level", "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal].")
+	fs.Var(logFormatFlag{}, "log.format", "If set use a syslog logger or JSON logging. Example: logger:syslog?appname=bob&local=7 or logger:stdout?json=true. Defaults to stderr.")
 }
 
 type Logger interface {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -175,10 +175,10 @@
 			"revisionTime": "2016-06-23T15:14:27Z"
 		},
 		{
-			"checksumSHA1": "qHoBp/PVBcLedTNZrF3toV9QGa0=",
+			"checksumSHA1": "fKMoxZehNhXbklRQy7lpFAVH0XY=",
 			"path": "github.com/prometheus/common/log",
-			"revision": "4402f4e5ea79ec15f3c574773b6a5198fbea215f",
-			"revisionTime": "2016-06-23T15:14:27Z"
+			"revision": "610701b0cb96fe82d0166b8e07979b174b6f06ae",
+			"revisionTime": "2016-07-20T15:23:54Z"
 		},
 		{
 			"checksumSHA1": "Jx0GXl5hGnO25s3ryyvtdWHdCpw=",


### PR DESCRIPTION
In https://github.com/prometheus/prometheus/pull/1782 , we moved to a
custom flag set to avoid getting test flags into the main prometheus
binary. However, that removed the logging flags, too. This commit
updates the vendoring to a version of the log package that allows
adding the log flags to our flag set explicitly.

@juliusv @fabxc 

Fixes https://github.com/prometheus/prometheus/issues/1826