### PR TITLE
sample config for a mesos cluster

### DIFF
--- a/documentation/examples/prometheus-mesos-cluster.yml
+++ b/documentation/examples/prometheus-mesos-cluster.yml
@@ -1,0 +1,40 @@
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'mesos-cluster'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  - job_name: 'slaves'
+    # if you have mesos dns configured on the machine running 
+    # prometheus you can use dns to find all nodes to pull from
+    dns_sd_configs:
+      - 
+       names:
+        - slave.mesos
+       type: 'A'
+       # port to pull from
+       # default port for node exporter
+       port: 9100
+  
+  # find the master nodes
+  - job_name: 'masters'
+    dns_sd_configs:
+     - 
+      names:
+        - master.mesos
+      type: 'A'
+      port: 9100
+
+  # pull in apps from marathon
+  - job_name: 'marathon-apps'
+    marathon_sd_configs:
+     -
+      servers:
+        # mesos dns will resolve the marathon master
+        # 8080 is the default port for marathon
+        - 'http://marathon.mesos:8080'

--- a/documentation/examples/prometheus-mesos-cluster.yml
+++ b/documentation/examples/prometheus-mesos-cluster.yml
@@ -21,6 +21,8 @@ scrape_configs:
       port: 9100
   
   # Find the master nodes
+  # If using mesos dns this will return an A record for all masters
+  # If you are just looking for the leader use leader.mesos
   - job_name: 'mesos_masters'
     dns_sd_configs:
     - names:
@@ -29,7 +31,7 @@ scrape_configs:
       port: 9100
 
   # Pull in apps from marathon
-  - job_name: 'marathon_apps'
+  - job_name: 'sample_app'
     marathon_sd_configs:
     - servers:
       # Mesos dns will resolve the marathon master
@@ -42,9 +44,15 @@ scrape_configs:
     - source_labels: [__meta_marathon_app_label_MONITOR]
       action: keep
       regex: prometheus
-    # Add marathon_app label
+    # Only pull an app with a name of sample_app
     - source_labels: [__meta_marathon_app]
-      target_label: marathon_app
+      action: keep
+      regex: sample_app
+    # Set target path via a label assigned to app in marathon
+    - source_labels: [__meta_marathon_app_label_PROMETHEUS_METRICS]
+      action: replace
+      target_label: __metrics_path__
+      regex: (.+)
     # Add a label that detects docker image
     - target_label: __meta_marathon_image
       replacement: docker_image

--- a/documentation/examples/prometheus-mesos-cluster.yml
+++ b/documentation/examples/prometheus-mesos-cluster.yml
@@ -4,37 +4,47 @@ global:
   # Attach these labels to any time series or alerts when communicating with
   # external systems (federation, remote storage, Alertmanager).
   external_labels:
-    monitor: 'mesos-cluster'
+    monitor: 'mesos_cluster'
 
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  - job_name: 'slaves'
-    # if you have mesos dns configured on the machine running 
+  - job_name: 'mesos_nodes'
+    # If you have mesos dns configured on the machine running 
     # prometheus you can use dns to find all nodes to pull from
     dns_sd_configs:
-      - 
-       names:
-        - slave.mesos
-       type: 'A'
-       # port to pull from
-       # default port for node exporter
-       port: 9100
+    - names:
+      - slave.mesos
+      type: 'A'
+      # Port to pull from
+      # Default port for node exporter
+      port: 9100
   
-  # find the master nodes
-  - job_name: 'masters'
+  # Find the master nodes
+  - job_name: 'mesos_masters'
     dns_sd_configs:
-     - 
-      names:
-        - master.mesos
+    - names:
+      - master.mesos
       type: 'A'
       port: 9100
 
-  # pull in apps from marathon
-  - job_name: 'marathon-apps'
+  # Pull in apps from marathon
+  - job_name: 'marathon_apps'
     marathon_sd_configs:
-     -
-      servers:
-        # mesos dns will resolve the marathon master
-        # 8080 is the default port for marathon
-        - 'http://marathon.mesos:8080'
+    - servers:
+      # Mesos dns will resolve the marathon master
+      # 8080 is the default port for marathon
+      - 'http://marathon.mesos:8080'
+
+    relabel_configs:
+    # Only scrape apps that have a label of 'MONITOR' set to 'prometheus'
+    # in the marathon app definition
+    - source_labels: [__meta_marathon_app_label_MONITOR]
+      action: keep
+      regex: prometheus
+    # Add marathon_app label
+    - source_labels: [__meta_marathon_app]
+      target_label: marathon_app
+    # Add a label that detects docker image
+    - target_label: __meta_marathon_image
+      replacement: docker_image


### PR DESCRIPTION
Added a sample config for a mesos cluster.
-Uses mesos-dns to find nodes to pull from
-Uses marathon_ds_config to find applications

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/1846)

<!-- Reviewable:end -->
