### PR TITLE
Allow for consul tag filtering

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -659,6 +659,7 @@ type ConsulSDConfig struct {
 	// The list of services for which targets are discovered.
 	// Defaults to all services if empty.
 	Services []string `yaml:"services"`
+	Tags     []string `yaml:"tags"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/documentation/examples/prometheus-consul.yml
+++ b/documentation/examples/prometheus-consul.yml
@@ -1,0 +1,19 @@
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's services registered in consul.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'consul-services'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: "services-with-metrics-tag"
+    consul_sd_configs:
+    - server:   '127.0.0.1:8500'
+      tags: ["metrics"]

--- a/retrieval/discovery/consul/consul_test.go
+++ b/retrieval/discovery/consul/consul_test.go
@@ -1,0 +1,76 @@
+package consul
+
+import (
+	"github.com/prometheus/prometheus/config"
+	"testing"
+)
+
+var configuredServiceName = "configuredService"
+var nonConfiguredServiceName = "nonConfiguredService"
+var configuredTagName = "configuredTag"
+var nonConfiguredTagName = "nonConfiguredTag"
+
+func TestConfiguredService(t *testing.T) {
+	conf := &config.ConsulSDConfig{
+		Services: []string{configuredServiceName}}
+
+	consulDiscovery, _ := NewDiscovery(conf)
+
+	if !consulDiscovery.shouldWatch(configuredServiceName) {
+		t.Errorf("Expected service %s to be watched", configuredServiceName)
+	}
+	nonConfiguredServiceName := "nonConfiguredService"
+	if consulDiscovery.shouldWatch(nonConfiguredServiceName) {
+		t.Errorf("Expected service %s to not be watched", nonConfiguredServiceName)
+	}
+}
+
+func TestNoConfiguredServices(t *testing.T) {
+	conf := &config.ConsulSDConfig{}
+
+	consulDiscovery, _ := NewDiscovery(conf)
+
+	if !consulDiscovery.shouldWatch(nonConfiguredServiceName) {
+		t.Errorf("Expected service %s to be watched", nonConfiguredServiceName)
+	}
+}
+
+func TestConfiguredTag(t *testing.T) {
+	conf := &config.ConsulSDConfig{
+		Tags: []string{configuredTagName}}
+
+	consulDiscovery, _ := NewDiscovery(conf)
+
+	if !consulDiscovery.shouldWatchTags([]string{configuredTagName}) {
+		t.Errorf("Expected tag %s to be watched", configuredTagName)
+	}
+	nonConfiguredTagName := "nonConfiguredTag"
+	if consulDiscovery.shouldWatchTags([]string{nonConfiguredTagName}) {
+		t.Errorf("Expected tag %s to be watched", nonConfiguredTagName)
+	}
+}
+
+func TestNoConfiguredTags(t *testing.T) {
+	conf := &config.ConsulSDConfig{}
+
+	consulDiscovery, _ := NewDiscovery(conf)
+
+	if !consulDiscovery.shouldWatchTags([]string{nonConfiguredTagName}) {
+		t.Errorf("Expected tag %s to be watched", nonConfiguredTagName)
+	}
+}
+
+func TestConfiguredTagAndService(t *testing.T) {
+	conf := &config.ConsulSDConfig{
+		Tags:     []string{configuredTagName},
+		Services: []string{configuredServiceName}}
+
+	consulDiscovery, _ := NewDiscovery(conf)
+
+	if !consulDiscovery.shouldWatchTags([]string{configuredTagName}) {
+		t.Errorf("Expected tag %s to be watched", configuredTagName)
+	}
+	if consulDiscovery.shouldWatchTags([]string{nonConfiguredTagName}) {
+		t.Errorf("Expected tag %s to be watched", nonConfiguredTagName)
+	}
+}


### PR DESCRIPTION
Services to be scraped from consul are currently configured by a list of
servicenames. We extend this by allowing filtering by tags in addition.

The following configs are now allowed:

- job_name: "scrapeserviceswithtag"
    consul_sd_configs:
    - server:   '127.0.0.1:8500'
      tags: ["tagName"]

This will scrape all services registered in consul with the given tag
"tagName."

- job_name: "scrapeserviceswithserviceandtag"
    consul_sd_configs:
    - server:   '127.0.0.1:8500'
      services: ["serviceName"]
      tags: ["tagName"]

This will scrape all services with name "serviceName" *and* tag "tagName."

I added some tests for the methods that actually compare the lists, but
not for the consul discovery as a whole because they were missing from
before.