### PR TITLE
Docker: Move console dirs to /usr/share/prometheus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 COPY prometheus                             /bin/prometheus
 COPY promtool                               /bin/promtool
 COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
-COPY console_libraries/                     /etc/prometheus/console_libraries/
-COPY consoles/                              /etc/prometheus/consoles/
+COPY console_libraries/                     /usr/share/prometheus/console_libraries/
+COPY consoles/                              /usr/share/prometheus/consoles/
+
+RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
 
 EXPOSE     9090
 VOLUME     [ "/prometheus" ]
@@ -13,5 +15,5 @@ WORKDIR    /prometheus
 ENTRYPOINT [ "/bin/prometheus" ]
 CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
              "-storage.local.path=/prometheus", \
-             "-web.console.libraries=/etc/prometheus/console_libraries", \
-             "-web.console.templates=/etc/prometheus/consoles" ]
+             "-web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "-web.console.templates=/usr/share/prometheus/consoles" ]


### PR DESCRIPTION
Fixes #1845. Used symlinks as suggested by @brian-brazil in https://github.com/prometheus/prometheus/issues/1845#issuecomment-235857299. This works nicely for me, not having to change flags when bind mounting config dir over /etc/prometheus, while at the same time retaining backwards compatibility.