### PR TITLE
Use the default go version for the crossbuilt process

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,4 +1,3 @@
-go: 1.6.2
 repository:
     path: github.com/prometheus/prometheus
 build:


### PR DESCRIPTION
The current default go version in promu is `1.6.3`.