### PR TITLE
allow relabeling of alerts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -176,10 +176,10 @@ func (u URL) MarshalYAML() (interface{}, error) {
 
 // Config is the top-level configuration for Prometheus's config files.
 type Config struct {
-	GlobalConfig        GlobalConfig     `yaml:"global"`
-	AlertRelabelConfigs []*RelabelConfig `yaml:"alert_relabel_configs,omitempty"`
-	RuleFiles           []string         `yaml:"rule_files,omitempty"`
-	ScrapeConfigs       []*ScrapeConfig  `yaml:"scrape_configs,omitempty"`
+	GlobalConfig   GlobalConfig    `yaml:"global"`
+	AlertingConfig AlertingConfig  `yaml:"alerting,omitempty"`
+	RuleFiles      []string        `yaml:"rule_files,omitempty"`
+	ScrapeConfigs  []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`
@@ -291,6 +291,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		jobNames[scfg.JobName] = struct{}{}
 	}
 	return nil
+}
+
+// AlertingConfig configures alerting and alertmanager related configs
+type AlertingConfig struct {
+	AlertRelabelConfigs []*RelabelConfig `yaml:"alert_relabel_configs,omitempty"`
 }
 
 // GlobalConfig configures values that are used across other configuration

--- a/config/config.go
+++ b/config/config.go
@@ -176,9 +176,10 @@ func (u URL) MarshalYAML() (interface{}, error) {
 
 // Config is the top-level configuration for Prometheus's config files.
 type Config struct {
-	GlobalConfig  GlobalConfig    `yaml:"global"`
-	RuleFiles     []string        `yaml:"rule_files,omitempty"`
-	ScrapeConfigs []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
+	GlobalConfig        GlobalConfig     `yaml:"global"`
+	AlertRelabelConfigs []*RelabelConfig `yaml:"alert_relabel_configs,omitempty"`
+	RuleFiles           []string         `yaml:"rule_files,omitempty"`
+	ScrapeConfigs       []*ScrapeConfig  `yaml:"scrape_configs,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/prometheus/prometheus/config"
-	"github.com/prometheus/prometheus/retrieval"
+	"github.com/prometheus/prometheus/relabel"
 )
 
 const (
@@ -239,7 +239,7 @@ func (n *Notifier) Send(alerts ...*model.Alert) {
 func (n *Notifier) relabelAlerts(alerts []*model.Alert) []*model.Alert {
 	var relabeledAlerts []*model.Alert
 	for _, alert := range alerts {
-		labels, _ := retrieval.Relabel(alert.Labels, n.opts.RelabelConfigs...)
+		labels := relabel.Process(alert.Labels, n.opts.RelabelConfigs...)
 		if labels != nil {
 			alert.Labels = labels
 			relabeledAlerts = append(relabeledAlerts, alert)

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -138,7 +138,7 @@ func (n *Notifier) ApplyConfig(conf *config.Config) error {
 	defer n.mtx.Unlock()
 
 	n.opts.ExternalLabels = conf.GlobalConfig.ExternalLabels
-	n.opts.RelabelConfigs = conf.AlertRelabelConfigs
+	n.opts.RelabelConfigs = conf.AlertingConfig.AlertRelabelConfigs
 	return nil
 }
 

--- a/relabel/relabel_test.go
+++ b/relabel/relabel_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package retrieval
+package relabel
 
 import (
 	"reflect"
@@ -280,10 +280,7 @@ func TestRelabel(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		res, err := Relabel(test.input, test.relabel...)
-		if err != nil {
-			t.Errorf("Test %d: error relabeling: %s", i+1, err)
-		}
+		res := Process(test.input, test.relabel...)
 
 		if !reflect.DeepEqual(res, test.output) {
 			t.Errorf("Test %d: relabel output mismatch: expected %#v, got %#v", i+1, test.output, res)

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/relabel"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/httputil"
 )
@@ -275,10 +276,8 @@ type relabelAppender struct {
 }
 
 func (app relabelAppender) Append(s *model.Sample) error {
-	labels, err := Relabel(model.LabelSet(s.Metric), app.relabelings...)
-	if err != nil {
-		return fmt.Errorf("metric relabeling error %s: %s", s.Metric, err)
-	}
+	labels := relabel.Process(model.LabelSet(s.Metric), app.relabelings...)
+
 	// Check if the timeseries was dropped.
 	if labels == nil {
 		return nil

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/relabel"
 	"github.com/prometheus/prometheus/retrieval/discovery"
 	"github.com/prometheus/prometheus/storage"
 )
@@ -448,10 +449,8 @@ func targetsFromGroup(tg *config.TargetGroup, cfg *config.ScrapeConfig) ([]*Targ
 
 		preRelabelLabels := labels
 
-		labels, err := Relabel(labels, cfg.RelabelConfigs...)
-		if err != nil {
-			return nil, fmt.Errorf("error while relabeling instance %d in target group %s: %s", i, tg, err)
-		}
+		labels := relabel.Process(labels, cfg.RelabelConfigs...)
+
 		// Check if the target was dropped.
 		if labels == nil {
 			continue
@@ -469,7 +468,7 @@ func targetsFromGroup(tg *config.TargetGroup, cfg *config.ScrapeConfig) ([]*Targ
 			}
 			labels[model.AddressLabel] = model.LabelValue(addr)
 		}
-		if err = config.CheckTargetAddress(labels[model.AddressLabel]); err != nil {
+		if err := config.CheckTargetAddress(labels[model.AddressLabel]); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
Regarding #1744

In case of dropping don't even enqueue them, that way dropped alerts don't interfere with the max batch size.

Tagging @brian-brazil as he originally created the issue.