### PR TITLE
Bugfix: Avoid divide-by-zero panic on query_range?step=0

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -187,6 +187,11 @@ func (api *API) queryRange(r *http.Request) (interface{}, *apiError) {
 		return nil, &apiError{errorBadData, err}
 	}
 
+	if step <= 0 {
+		err := errors.New("zero or negative query resolution step widths are not accepted. Try a positive integer")
+		return nil, &apiError{errorBadData, err}
+	}
+
 	// For safety, limit the number of returned points per timeseries.
 	// This is sufficient for 60s resolution for a week or 1h resolution for a year.
 	if end.Sub(start)/step > 11000 {

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -187,6 +187,17 @@ func TestEndpoints(t *testing.T) {
 			},
 			errType: errorBadData,
 		},
+		// Invalid step
+		{
+			endpoint: api.queryRange,
+			query: url.Values{
+				"query": []string{"time()"},
+				"start": []string{"1"},
+				"end":   []string{"2"},
+				"step":  []string{"0"},
+			},
+			errType: errorBadData,
+		},
 		{
 			endpoint: api.labelValues,
 			params: map[string]string{


### PR DESCRIPTION
Turns out that for every possible nonsensical input value there exists a silly user that provides such an input value - in this case personified by me. This panics the Prometheus process.

@fabxc , you "he"'d on IRC, so here's the PR. =)