### PR TITLE
Trim stray whitespace from bearer token file

### DIFF
--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -98,7 +98,7 @@ func newHTTPClient(cfg *config.ScrapeConfig) (*http.Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to read bearer token file %s: %s", cfg.BearerTokenFile, err)
 		}
-		bearerToken = string(b)
+		bearerToken = strings.TrimSpace(string(b))
 	}
 
 	if len(bearerToken) > 0 {


### PR DESCRIPTION
Apart from not trying to send a newline in a HTTP header,
this also allows Prometheus to build and pass tests with Go 1.7,
which features stricter checking of HTTP headers.

This is the minimal change in behavior that allows tests to pass.
It could be argued that we should `strings.TrimSpace(strings(b))` instead.
I'm open to opinions. =)

@fabxc, I see you've touched this file a bit before. Please take a look? =)

Thanks,
-@M