### PR TITLE
Run scrape loop with interval 1 instead of 0

### DIFF
--- a/retrieval/scrape_test.go
+++ b/retrieval/scrape_test.go
@@ -329,7 +329,7 @@ func TestScrapeLoopStop(t *testing.T) {
 
 	runDone := make(chan struct{})
 	go func() {
-		sl.run(0, 0, nil)
+		sl.run(1, 0, nil)
 		close(runDone)
 	}()
 


### PR DESCRIPTION
0 is considered an invalid interval by time.NewTicker() and will cause a
panic if control reaches that point. Given the vagaries of timekeeping,
this may occasionally happen and makes scrape_test.go unstable on Go 1.7.

This stabilizes tests on Go1.7 for me. I haven't actually run the binary yet, though. =)
@fabxc, again, sorry to pester you with these trivial reviews, but when fly-swatting
is all I need to do to fix the problems I encounter, swatted flies is all I have to offer. ;)