### PR TITLE
Add various time and date functions

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -924,12 +924,6 @@ var functions = map[string]*Function{
 		ReturnType: model.ValVector,
 		Call:       funcAbsent,
 	},
-	"increase": {
-		Name:       "increase",
-		ArgTypes:   []model.ValueType{model.ValMatrix},
-		ReturnType: model.ValVector,
-		Call:       funcIncrease,
-	},
 	"avg_over_time": {
 		Name:       "avg_over_time",
 		ArgTypes:   []model.ValueType{model.ValMatrix},
@@ -1032,17 +1026,23 @@ var functions = map[string]*Function{
 		ReturnType: model.ValVector,
 		Call:       funcHourOfDay,
 	},
-	"irate": {
-		Name:       "irate",
-		ArgTypes:   []model.ValueType{model.ValMatrix},
-		ReturnType: model.ValVector,
-		Call:       funcIrate,
-	},
 	"idelta": {
 		Name:       "idelta",
 		ArgTypes:   []model.ValueType{model.ValMatrix},
 		ReturnType: model.ValVector,
 		Call:       funcIdelta,
+	},
+	"increase": {
+		Name:       "increase",
+		ArgTypes:   []model.ValueType{model.ValMatrix},
+		ReturnType: model.ValVector,
+		Call:       funcIncrease,
+	},
+	"irate": {
+		Name:       "irate",
+		ArgTypes:   []model.ValueType{model.ValMatrix},
+		ReturnType: model.ValVector,
+		Call:       funcIrate,
 	},
 	"label_replace": {
 		Name:       "label_replace",

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -892,8 +892,8 @@ func funcDayOfWeek(ev *evaluator, args Expressions) model.Value {
 	return vector
 }
 
-// === hour_of_day(v vector) scalar ===
-func funcHourOfDay(ev *evaluator, args Expressions) model.Value {
+// === hour(v vector) scalar ===
+func funcHour(ev *evaluator, args Expressions) model.Value {
 	vector := ev.evalVector(args[0])
 	for _, el := range vector {
 		el.Metric.Del(model.MetricNameLabel)
@@ -902,8 +902,8 @@ func funcHourOfDay(ev *evaluator, args Expressions) model.Value {
 	return vector
 }
 
-// === month_of_year(v vector) scalar ===
-func funcMonthOfYear(ev *evaluator, args Expressions) model.Value {
+// === month(v vector) scalar ===
+func funcMonth(ev *evaluator, args Expressions) model.Value {
 	vector := ev.evalVector(args[0])
 	for _, el := range vector {
 		el.Metric.Del(model.MetricNameLabel)
@@ -1037,11 +1037,11 @@ var functions = map[string]*Function{
 		ReturnType: model.ValVector,
 		Call:       funcHoltWinters,
 	},
-	"hour_of_day": {
-		Name:       "hour_of_day",
+	"hour": {
+		Name:       "hour",
 		ArgTypes:   []model.ValueType{model.ValVector},
 		ReturnType: model.ValVector,
-		Call:       funcHourOfDay,
+		Call:       funcHour,
 	},
 	"idelta": {
 		Name:       "idelta",
@@ -1097,11 +1097,11 @@ var functions = map[string]*Function{
 		ReturnType: model.ValVector,
 		Call:       funcMinOverTime,
 	},
-	"month_of_year": {
-		Name:       "month_of_year",
+	"month": {
+		Name:       "month",
 		ArgTypes:   []model.ValueType{model.ValVector},
 		ReturnType: model.ValVector,
-		Call:       funcMonthOfYear,
+		Call:       funcMonth,
 	},
 	"predict_linear": {
 		Name:       "predict_linear",

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -860,6 +860,17 @@ func funcVector(ev *evaluator, args Expressions) model.Value {
 	}
 }
 
+// === days_in_month(v vector) scalar ===
+func funcDaysInMonth(ev *evaluator, args Expressions) model.Value {
+	vector := ev.evalVector(args[0])
+	for _, el := range vector {
+		el.Metric.Del(model.MetricNameLabel)
+		t := time.Unix(int64(el.Value), 0)
+		el.Value = model.SampleValue(32 - time.Date(t.Year(), t.Month(), 32, 0, 0, 0, 0, time.UTC).Day())
+	}
+	return vector
+}
+
 // === day_of_month(v vector) scalar ===
 func funcDayOfMonth(ev *evaluator, args Expressions) model.Value {
 	vector := ev.evalVector(args[0])
@@ -965,6 +976,12 @@ var functions = map[string]*Function{
 		ArgTypes:   []model.ValueType{model.ValVector},
 		ReturnType: model.ValScalar,
 		Call:       funcCountScalar,
+	},
+	"days_in_month": {
+		Name:       "days_in_month",
+		ArgTypes:   []model.ValueType{model.ValVector},
+		ReturnType: model.ValVector,
+		Call:       funcDaysInMonth,
 	},
 	"day_of_month": {
 		Name:       "day_of_month",

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/prometheus/common/model"
 
@@ -859,6 +860,57 @@ func funcVector(ev *evaluator, args Expressions) model.Value {
 	}
 }
 
+// === day_of_month(v vector) scalar ===
+func funcDayOfMonth(ev *evaluator, args Expressions) model.Value {
+	vector := ev.evalVector(args[0])
+	for _, el := range vector {
+		el.Metric.Del(model.MetricNameLabel)
+		el.Value = model.SampleValue(time.Unix(int64(el.Value), 0).UTC().Day())
+	}
+	return vector
+}
+
+// === day_of_week(v vector) scalar ===
+func funcDayOfWeek(ev *evaluator, args Expressions) model.Value {
+	vector := ev.evalVector(args[0])
+	for _, el := range vector {
+		el.Metric.Del(model.MetricNameLabel)
+		// Sunday = 0.
+		el.Value = model.SampleValue(time.Unix(int64(el.Value), 0).UTC().Weekday())
+	}
+	return vector
+}
+
+// === hour_of_day(v vector) scalar ===
+func funcHourOfDay(ev *evaluator, args Expressions) model.Value {
+	vector := ev.evalVector(args[0])
+	for _, el := range vector {
+		el.Metric.Del(model.MetricNameLabel)
+		el.Value = model.SampleValue(time.Unix(int64(el.Value), 0).UTC().Hour())
+	}
+	return vector
+}
+
+// === month_of_year(v vector) scalar ===
+func funcMonthOfYear(ev *evaluator, args Expressions) model.Value {
+	vector := ev.evalVector(args[0])
+	for _, el := range vector {
+		el.Metric.Del(model.MetricNameLabel)
+		el.Value = model.SampleValue(time.Unix(int64(el.Value), 0).UTC().Month())
+	}
+	return vector
+}
+
+// === year(v vector) scalar ===
+func funcYear(ev *evaluator, args Expressions) model.Value {
+	vector := ev.evalVector(args[0])
+	for _, el := range vector {
+		el.Metric.Del(model.MetricNameLabel)
+		el.Value = model.SampleValue(time.Unix(int64(el.Value), 0).UTC().Year())
+	}
+	return vector
+}
+
 var functions = map[string]*Function{
 	"abs": {
 		Name:       "abs",
@@ -920,6 +972,18 @@ var functions = map[string]*Function{
 		ReturnType: model.ValScalar,
 		Call:       funcCountScalar,
 	},
+	"day_of_month": {
+		Name:       "day_of_month",
+		ArgTypes:   []model.ValueType{model.ValVector},
+		ReturnType: model.ValVector,
+		Call:       funcDayOfMonth,
+	},
+	"day_of_week": {
+		Name:       "day_of_week",
+		ArgTypes:   []model.ValueType{model.ValVector},
+		ReturnType: model.ValVector,
+		Call:       funcDayOfWeek,
+	},
 	"delta": {
 		Name:       "delta",
 		ArgTypes:   []model.ValueType{model.ValMatrix},
@@ -961,6 +1025,12 @@ var functions = map[string]*Function{
 		ArgTypes:   []model.ValueType{model.ValMatrix, model.ValScalar, model.ValScalar},
 		ReturnType: model.ValVector,
 		Call:       funcHoltWinters,
+	},
+	"hour_of_day": {
+		Name:       "hour_of_day",
+		ArgTypes:   []model.ValueType{model.ValVector},
+		ReturnType: model.ValVector,
+		Call:       funcHourOfDay,
 	},
 	"irate": {
 		Name:       "irate",
@@ -1009,6 +1079,12 @@ var functions = map[string]*Function{
 		ArgTypes:   []model.ValueType{model.ValMatrix},
 		ReturnType: model.ValVector,
 		Call:       funcMinOverTime,
+	},
+	"month_of_year": {
+		Name:       "month_of_year",
+		ArgTypes:   []model.ValueType{model.ValVector},
+		ReturnType: model.ValVector,
+		Call:       funcMonthOfYear,
 	},
 	"predict_linear": {
 		Name:       "predict_linear",
@@ -1094,6 +1170,12 @@ var functions = map[string]*Function{
 		ArgTypes:   []model.ValueType{model.ValScalar},
 		ReturnType: model.ValVector,
 		Call:       funcVector,
+	},
+	"year": {
+		Name:       "year",
+		ArgTypes:   []model.ValueType{model.ValVector},
+		ReturnType: model.ValVector,
+		Call:       funcYear,
 	},
 }
 

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -398,3 +398,11 @@ eval instant at 0m month_of_year(vector(1456790399)) + day_of_month(vector(14567
 # 2016-03-01 00:00:00 March 1st in leap year.
 eval instant at 0m month_of_year(vector(1456790400)) + day_of_month(vector(1456790400)) / 100
   {} 3.01
+
+# Febuary 1st 2016 in leap year.
+eval instant at 0m days_in_month(vector(1454284800))
+  {} 29
+
+# Febuary 1st 2017 not in leap year.
+eval instant at 0m days_in_month(vector(1485907200))
+  {} 28

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -367,20 +367,20 @@ eval instant at 1m quantile_over_time(2, data[1m])
 clear
 
 # Test time-related functions.
-eval instant at 0m year(vector(0))
+eval instant at 0m year()
   {} 1970
 
-eval instant at 0m month(vector(0))
+eval instant at 0m month()
   {} 1
 
-eval instant at 0m day_of_month(vector(0))
+eval instant at 0m day_of_month()
   {} 1
 
 # Thursday.
-eval instant at 0m day_of_week(vector(0))
+eval instant at 0m day_of_week()
   {} 4
 
-eval instant at 0m hour(vector(0))
+eval instant at 0m hour()
   {} 0
 
 # 2008-12-31 23:59:59 just before leap second.

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -370,7 +370,7 @@ clear
 eval instant at 0m year(vector(0))
   {} 1970
 
-eval instant at 0m month_of_year(vector(0))
+eval instant at 0m month(vector(0))
   {} 1
 
 eval instant at 0m day_of_month(vector(0))
@@ -380,7 +380,7 @@ eval instant at 0m day_of_month(vector(0))
 eval instant at 0m day_of_week(vector(0))
   {} 4
 
-eval instant at 0m hour_of_day(vector(0))
+eval instant at 0m hour(vector(0))
   {} 0
 
 # 2008-12-31 23:59:59 just before leap second.
@@ -392,11 +392,11 @@ eval instant at 0m year(vector(1230768000))
   {} 2009
 
 # 2016-02-29 23:59:59 Febuary 29th in leap year.
-eval instant at 0m month_of_year(vector(1456790399)) + day_of_month(vector(1456790399)) / 100
+eval instant at 0m month(vector(1456790399)) + day_of_month(vector(1456790399)) / 100
   {} 2.29
 
 # 2016-03-01 00:00:00 March 1st in leap year.
-eval instant at 0m month_of_year(vector(1456790400)) + day_of_month(vector(1456790400)) / 100
+eval instant at 0m month(vector(1456790400)) + day_of_month(vector(1456790400)) / 100
   {} 3.01
 
 # Febuary 1st 2016 in leap year.

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -363,3 +363,38 @@ eval instant at 1m quantile_over_time(2, data[1m])
 	{test="two samples"} +Inf
 	{test="three samples"} +Inf
 	{test="uneven samples"} +Inf
+
+clear
+
+# Test time-related functions.
+eval instant at 0m year(vector(0))
+  {} 1970
+
+eval instant at 0m month_of_year(vector(0))
+  {} 1
+
+eval instant at 0m day_of_month(vector(0))
+  {} 1
+
+# Thursday.
+eval instant at 0m day_of_week(vector(0))
+  {} 4
+
+eval instant at 0m hour_of_day(vector(0))
+  {} 0
+
+# 2008-12-31 23:59:59 just before leap second.
+eval instant at 0m year(vector(1230767999))
+  {} 2008
+
+# 2009-01-01 00:00:00 just after leap second.
+eval instant at 0m year(vector(1230768000))
+  {} 2009
+
+# 2016-02-29 23:59:59 Febuary 29th in leap year.
+eval instant at 0m month_of_year(vector(1456790399)) + day_of_month(vector(1456790399)) / 100
+  {} 2.29
+
+# 2016-03-01 00:00:00 March 1st in leap year.
+eval instant at 0m month_of_year(vector(1456790400)) + day_of_month(vector(1456790400)) / 100
+  {} 3.01


### PR DESCRIPTION
Adds day_of_month, day_of_week, hour_of_day, month_of_year, year and days_in_month.

This all take in unix timestamps as a vector, and return the answer as a vector.
All results are in UTC.

Fixes #1545 