### PR TITLE
Add support for go-nerve's labels

### DIFF
--- a/discovery/zookeeper/zookeeper.go
+++ b/discovery/zookeeper/zookeeper.go
@@ -172,9 +172,10 @@ const (
 )
 
 type nerveMember struct {
-	Host string `json:"host"`
-	Port int    `json:"port"`
-	Name string `json:"name"`
+	Host   string                     `json:"host"`
+	Port   int                        `json:"port"`
+	Name   string                     `json:"name"`
+	Labels map[model.LabelName]string `json:"labels"`
 }
 
 func parseNerveMember(data []byte, path string) (model.LabelSet, error) {
@@ -192,6 +193,10 @@ func parseNerveMember(data []byte, path string) (model.LabelSet, error) {
 	labels[nerveEndpointLabelPrefix+"_host"] = model.LabelValue(member.Host)
 	labels[nerveEndpointLabelPrefix+"_port"] = model.LabelValue(fmt.Sprintf("%d", member.Port))
 	labels[nerveEndpointLabelPrefix+"_name"] = model.LabelValue(member.Name)
+
+	for k, v := range member.Labels {
+		labels[nerveEndpointLabelPrefix+"_labels_"+k] = model.LabelValue(v)
+	}
 
 	return labels, nil
 }


### PR DESCRIPTION
go-nerve is a rewrite of AirBnB's nerve for service discovery.
https://github.com/blablacar/go-nerve

You can add tags in the discovery process, that can be used for relabeling.
This is useful for SD to be able to push tags directly to prometheus.

This commit is backwards compatible with the original Nerve without the labels feature.
