### PR TITLE
promql: Fix (and simplify) populating iterators

### DIFF
--- a/promql/bench.go
+++ b/promql/bench.go
@@ -39,7 +39,9 @@ func (b *Benchmark) Run() {
 	b.b.ReportAllocs()
 	b.b.ResetTimer()
 	for i := 0; i < b.b.N; i++ {
-		b.t.RunAsBenchmark(b)
+		if err := b.t.RunAsBenchmark(b); err != nil {
+			b.b.Error(err)
+		}
 		b.iterCount++
 	}
 }

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -522,7 +522,7 @@ func funcStddevOverTime(ev *evaluator, args Expressions) model.Value {
 		for _, v := range values {
 			sum += v.Value
 			squaredSum += v.Value * v.Value
-			count += 1
+			count++
 		}
 		avg := sum / count
 		return model.SampleValue(math.Sqrt(float64(squaredSum/count - avg*avg)))
@@ -536,7 +536,7 @@ func funcStdvarOverTime(ev *evaluator, args Expressions) model.Value {
 		for _, v := range values {
 			sum += v.Value
 			squaredSum += v.Value * v.Value
-			count += 1
+			count++
 		}
 		avg := sum / count
 		return squaredSum/count - avg*avg

--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -22,7 +22,7 @@ load 5m
     http_requests{path="/foo"}    0+10x8064
 
 eval instant at 4w holt_winters(http_requests[4w], 0.3, 0.3)
-    {path="/foo"} 20160
+    {path="/foo"} 80640
 `
 
 	bench := NewBenchmark(b, input)
@@ -51,7 +51,7 @@ load 1m
     http_requests{path="/foo"}    0+10x1440
 
 eval instant at 1d holt_winters(http_requests[1d], 0.3, 0.3)
-    {path="/foo"} 20160
+    {path="/foo"} 14400
 `
 
 	bench := NewBenchmark(b, input)
@@ -65,7 +65,7 @@ load 1m
     http_requests{path="/foo"}    0+10x1440
 
 eval instant at 1d changes(http_requests[1d])
-    {path="/foo"} 20160
+    {path="/foo"} 1440
 `
 
 	bench := NewBenchmark(b, input)


### PR DESCRIPTION
This was only relevant so far for the benchmark suite as it would
recycle Expr for repetitions. However, the append is unnecessary as
each node is only inspected once when populating iterators, and
population must always start from scratch.

This also introduces error checking during benchmarks and fixes the so
far undetected test errors during benchmarking.

Also, remove a style nit (two golint warnings less…).

Fixes #1912 and #1784 .

@grobie @juliusv @fabxc @tcolgate