### PR TITLE
Fix data race in lexer and lexer test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ check_license:
 
 test:
 	@echo ">> running tests"
-	@$(GO) test -short $(pkgs)
+	@$(GO) test -race -short $(pkgs)
 
 format:
 	@echo ">> formatting code"

--- a/promql/lex.go
+++ b/promql/lex.go
@@ -428,9 +428,16 @@ func (l *lexer) nextItem() item {
 
 // lex creates a new scanner for the input string.
 func lex(input string) *lexer {
+	return lexWithSeriesDesc(input, false)
+}
+
+// lexWithSeriesDesc creates a  new scanner for the input string
+// and specify seriesDesc to prevent data race in tests
+func lexWithSeriesDesc(input string, seriesDesc bool) *lexer {
 	l := &lexer{
-		input: input,
-		items: make(chan item),
+		input:      input,
+		items:      make(chan item),
+		seriesDesc: seriesDesc,
 	}
 	go l.run()
 	return l

--- a/promql/lex.go
+++ b/promql/lex.go
@@ -428,16 +428,9 @@ func (l *lexer) nextItem() item {
 
 // lex creates a new scanner for the input string.
 func lex(input string) *lexer {
-	return lexWithSeriesDesc(input, false)
-}
-
-// lexWithSeriesDesc creates a  new scanner for the input string
-// and specify seriesDesc to prevent data race in tests
-func lexWithSeriesDesc(input string, seriesDesc bool) *lexer {
 	l := &lexer{
-		input:      input,
-		items:      make(chan item),
-		seriesDesc: seriesDesc,
+		input: input,
+		items: make(chan item),
 	}
 	go l.run()
 	return l

--- a/promql/lex_test.go
+++ b/promql/lex_test.go
@@ -438,7 +438,13 @@ var tests = []struct {
 // for the parser to avoid duplicated effort.
 func TestLexer(t *testing.T) {
 	for i, test := range tests {
-		l := lexWithSeriesDesc(test.input, test.seriesDesc)
+		l := &lexer{
+			input:      test.input,
+			items:      make(chan item),
+			seriesDesc: test.seriesDesc,
+		}
+		go l.run()
+
 		out := []item{}
 		for it := range l.items {
 			out = append(out, it)

--- a/promql/lex_test.go
+++ b/promql/lex_test.go
@@ -438,9 +438,7 @@ var tests = []struct {
 // for the parser to avoid duplicated effort.
 func TestLexer(t *testing.T) {
 	for i, test := range tests {
-		l := lex(test.input)
-		l.seriesDesc = test.seriesDesc
-
+		l := lexWithSeriesDesc(test.input, test.seriesDesc)
 		out := []item{}
 		for it := range l.items {
 			out = append(out, it)


### PR DESCRIPTION
As described in #1898 'go test -race' detects a race in lexer code. This
pacth fixes it and also add '-race' option to test target to prevent
regression.