### PR TITLE
Add basic test for TargetManager.targetSet

### DIFF
--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -12,3 +12,63 @@
 // limitations under the License.
 
 package retrieval
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+	"gopkg.in/yaml.v2"
+
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/storage/local"
+)
+
+func TestTargetSetRecreatesTargetGroupsEveryRun(t *testing.T) {
+	scrapeConfig := &config.ScrapeConfig{}
+
+	sOne := `
+job_name: "foo"
+dns_sd_configs:
+- names:
+  - "srv.name.one.example.org"
+`
+	if err := yaml.Unmarshal([]byte(sOne), scrapeConfig); err != nil {
+		t.Fatalf("Unable to load YAML config sOne: %s", err)
+	}
+
+	// Not properly setting it up, but that seems okay
+	mss := &local.MemorySeriesStorage{}
+
+	ts := newTargetSet(scrapeConfig, mss)
+
+	ts.runProviders(context.Background(), providersFromConfig(scrapeConfig))
+
+	verifyPresence(t, ts.tgroups, "dns/0/srv.name.one.example.org", true)
+
+	sTwo := `
+job_name: "foo"
+dns_sd_configs:
+- names:
+  - "srv.name.two.example.org"
+`
+	if err := yaml.Unmarshal([]byte(sTwo), scrapeConfig); err != nil {
+		t.Fatalf("Unable to load YAML config sTwo: %s", err)
+	}
+
+	ts.runProviders(context.Background(), providersFromConfig(scrapeConfig))
+
+	verifyPresence(t, ts.tgroups, "dns/0/srv.name.one.example.org", false)
+	verifyPresence(t, ts.tgroups, "dns/0/srv.name.two.example.org", true)
+
+}
+
+func verifyPresence(t *testing.T, tgroups map[string][]*Target, name string, present bool) {
+	if _, ok := tgroups[name]; ok != present {
+		msg := ""
+		if !present {
+			msg = "not "
+		}
+		t.Fatalf("'%s' should %sbe present in TargetSet.tgroups: %s", name, msg, tgroups)
+	}
+
+}

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -24,6 +24,18 @@ import (
 )
 
 func TestTargetSetRecreatesTargetGroupsEveryRun(t *testing.T) {
+
+	verifyPresence := func(tgroups map[string][]*Target, name string, present bool) {
+		if _, ok := tgroups[name]; ok != present {
+			msg := ""
+			if !present {
+				msg = "not "
+			}
+			t.Fatalf("'%s' should %sbe present in TargetSet.tgroups: %s", name, msg, tgroups)
+		}
+
+	}
+
 	scrapeConfig := &config.ScrapeConfig{}
 
 	sOne := `
@@ -43,7 +55,7 @@ dns_sd_configs:
 
 	ts.runProviders(context.Background(), providersFromConfig(scrapeConfig))
 
-	verifyPresence(t, ts.tgroups, "dns/0/srv.name.one.example.org", true)
+	verifyPresence(ts.tgroups, "dns/0/srv.name.one.example.org", true)
 
 	sTwo := `
 job_name: "foo"
@@ -57,18 +69,6 @@ dns_sd_configs:
 
 	ts.runProviders(context.Background(), providersFromConfig(scrapeConfig))
 
-	verifyPresence(t, ts.tgroups, "dns/0/srv.name.one.example.org", false)
-	verifyPresence(t, ts.tgroups, "dns/0/srv.name.two.example.org", true)
-
-}
-
-func verifyPresence(t *testing.T, tgroups map[string][]*Target, name string, present bool) {
-	if _, ok := tgroups[name]; ok != present {
-		msg := ""
-		if !present {
-			msg = "not "
-		}
-		t.Fatalf("'%s' should %sbe present in TargetSet.tgroups: %s", name, msg, tgroups)
-	}
-
+	verifyPresence(ts.tgroups, "dns/0/srv.name.one.example.org", false)
+	verifyPresence(ts.tgroups, "dns/0/srv.name.two.example.org", true)
 }


### PR DESCRIPTION
Verify that if the configs change, target groups are cleaned out on TargetManager.reload (rather than having old ones linger around, even if they are no longer present in the configs).

This covers the bug fixed in #1907 -- I verified that by checking out source from before that commit.

This is a start on #1906

@beorn7 @fabxc 