### PR TITLE
Forbid invalid relabel configurations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -963,6 +963,9 @@ func (c *RelabelConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if c.Modulus == 0 && c.Action == RelabelHashMod {
 		return fmt.Errorf("relabel configuration for hashmod requires non-zero modulus")
 	}
+	if (c.Action == RelabelReplace || c.Action == RelabelHashMod) && c.TargetLabel == "" {
+		return fmt.Errorf("relabel configuration for %s action requires 'target_label' value", c.Action)
+	}
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -397,6 +397,12 @@ var expectedErrors = []struct {
 	}, {
 		filename: "url_in_targetgroup.bad.yml",
 		errMsg:   "\"http://bad\" is not a valid hostname",
+	}, {
+		filename: "target_label_missing.bad.yml",
+		errMsg:   "relabel configuration for replace action requires 'target_label' value",
+	}, {
+		filename: "target_label_hashmod_missing.bad.yml",
+		errMsg:   "relabel configuration for hashmod action requires 'target_label' value",
 	},
 }
 

--- a/config/testdata/target_label_hashmod_missing.bad.yml
+++ b/config/testdata/target_label_hashmod_missing.bad.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: prometheus
+    relabel_configs:
+      - source_labels: [__address__]
+        modulus:       8
+        action:        hashmod

--- a/config/testdata/target_label_missing.bad.yml
+++ b/config/testdata/target_label_missing.bad.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - job_name: prometheus
+    relabel_configs:
+      - regex: abcdef


### PR DESCRIPTION
This fix adds check if target_label value is set in case if action is replace or
hashmod
Issue [#1900]