### PR TITLE
readme: direct link to Prometheus docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Debian packages [are available](https://packages.debian.org/sid/net/prometheus).
 
 ### Container images
 
-Container images are available on [Quay.io](https://quay.io/organization/prometheus).
+Container images are available on [Quay.io](https://quay.io/repository/prometheus/prometheus).
 
 ### Building from source
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ There are various ways of installing Prometheus.
 ### Precompiled binaries
 
 Precompiled binaries for released versions are available in the
-[*releases* section](https://github.com/prometheus/prometheus/releases)
-of the GitHub repository. Using the latest production release binary
+[*download* section](https://prometheus.io/download/)
+on [prometheus.io](https://prometheus.io). Using the latest production release binary
 is the recommended way of installing Prometheus. 
 See the [Installing](https://prometheus.io/docs/introduction/install/) 
 chapter in the documentation for all the details.
 
 Debian packages [are available](https://packages.debian.org/sid/net/prometheus).
 
-### Container images
+### Docker images
 
-Container images are available on [Quay.io](https://quay.io/repository/prometheus/prometheus).
+Docker images are available on [Quay.io](https://quay.io/repository/prometheus/prometheus).
 
 ### Building from source
 


### PR DESCRIPTION
There are quite a few repositories already, so we don't have to make people search.