### PR TITLE
Add HTTP Basic Auth & TLS support to the generic write path.

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -206,15 +206,6 @@ func init() {
 		&cfg.remote.InfluxdbDatabase, "storage.remote.influxdb.database", "prometheus",
 		"The name of the database to use for storing samples in InfluxDB.",
 	)
-	cfg.fs.StringVar(
-		&cfg.remote.URL, "experimental.storage.remote.url", "",
-		"The URL of the remote endpoint to send samples to. None, if empty. EXPERIMENTAL.",
-	)
-
-	cfg.fs.DurationVar(
-		&cfg.remote.StorageTimeout, "storage.remote.timeout", 30*time.Second,
-		"The timeout to use when sending samples to the remote storage.",
-	)
 
 	// Alertmanager.
 	cfg.fs.Var(

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -168,13 +168,10 @@ func Main() int {
 	}()
 
 	if remoteStorage != nil {
-		prometheus.MustRegister(remoteStorage)
-
 		remoteStorage.Start()
 		defer remoteStorage.Stop()
 	}
 
-	prometheus.MustRegister(reloadableRemoteStorage)
 	defer reloadableRemoteStorage.Stop()
 
 	// The storage has to be fully initialized before registering.

--- a/config/config.go
+++ b/config/config.go
@@ -151,6 +151,11 @@ var (
 		Port:            80,
 		RefreshInterval: model.Duration(5 * time.Minute),
 	}
+
+	// DefaultRemoteWriteConfig is the default remote write configuration.
+	DefaultRemoteWriteConfig = RemoteWriteConfig{
+		RemoteTimeout: model.Duration(30 * time.Second),
+	}
 )
 
 // URL is a custom URL type that allows validation at configuration load time.
@@ -187,6 +192,8 @@ type Config struct {
 	AlertingConfig AlertingConfig  `yaml:"alerting,omitempty"`
 	RuleFiles      []string        `yaml:"rule_files,omitempty"`
 	ScrapeConfigs  []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
+
+	RemoteWriteConfig []RemoteWriteConfig `yaml:"remote_write,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`
@@ -1065,4 +1072,29 @@ func (re Regexp) MarshalYAML() (interface{}, error) {
 		return re.original, nil
 	}
 	return nil, nil
+}
+
+// RemoteWriteConfig is the configuration for remote storage.
+type RemoteWriteConfig struct {
+	URL           URL            `yaml:"url,omitempty"`
+	RemoteTimeout model.Duration `yaml:"remote_timeout,omitempty"`
+	BasicAuth     *BasicAuth     `yaml:"basic_auth,omitempty"`
+	TLSConfig     TLSConfig      `yaml:"tls_config,omitempty"`
+	ProxyURL      URL            `yaml:"proxy_url,omitempty"`
+
+	// Catches all undefined fields and must be empty after parsing.
+	XXX map[string]interface{} `yaml:",inline"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultRemoteWriteConfig
+	type plain RemoteWriteConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	if err := checkOverflow(c.XXX, "remote_write"); err != nil {
+		return err
+	}
+	return nil
 }

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -68,18 +68,7 @@ func NewTarget(labels, metaLabels model.LabelSet, params url.Values) *Target {
 
 // NewHTTPClient returns a new HTTP client configured for the given scrape configuration.
 func NewHTTPClient(cfg *config.ScrapeConfig) (*http.Client, error) {
-	tlsOpts := httputil.TLSOptions{
-		InsecureSkipVerify: cfg.TLSConfig.InsecureSkipVerify,
-		CAFile:             cfg.TLSConfig.CAFile,
-	}
-	if len(cfg.TLSConfig.CertFile) > 0 && len(cfg.TLSConfig.KeyFile) > 0 {
-		tlsOpts.CertFile = cfg.TLSConfig.CertFile
-		tlsOpts.KeyFile = cfg.TLSConfig.KeyFile
-	}
-	if len(cfg.TLSConfig.ServerName) > 0 {
-		tlsOpts.ServerName = cfg.TLSConfig.ServerName
-	}
-	tlsConfig, err := httputil.NewTLSConfig(tlsOpts)
+	tlsConfig, err := httputil.TLSConfig(cfg.TLSConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -68,7 +68,7 @@ func NewTarget(labels, metaLabels model.LabelSet, params url.Values) *Target {
 
 // NewHTTPClient returns a new HTTP client configured for the given scrape configuration.
 func NewHTTPClient(cfg *config.ScrapeConfig) (*http.Client, error) {
-	tlsConfig, err := httputil.TLSConfig(cfg.TLSConfig)
+	tlsConfig, err := httputil.NewTLSConfig(cfg.TLSConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -21,22 +21,43 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
+	"golang.org/x/net/context"
+	"golang.org/x/net/context/ctxhttp"
+
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/util/httputil"
 )
 
 // Client allows sending batches of Prometheus samples to an HTTP endpoint.
 type Client struct {
-	url    string
-	client http.Client
+	url     config.URL
+	client  *http.Client
+	timeout time.Duration
 }
 
 // NewClient creates a new Client.
-func NewClient(url string, timeout time.Duration) (*Client, error) {
+func NewClient(conf config.RemoteWriteConfig) (*Client, error) {
+	tlsConfig, err := httputil.TLSConfig(conf.TLSConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// The only timeout we care about is the configured push timeout.
+	// It is applied on request. So we leave out any timings here.
+	var rt http.RoundTripper = &http.Transport{
+		Proxy:           http.ProxyURL(conf.ProxyURL.URL),
+		TLSClientConfig: tlsConfig,
+	}
+
+	if conf.BasicAuth != nil {
+		rt = httputil.NewBasicAuthRoundTripper(conf.BasicAuth.Username, conf.BasicAuth.Password, rt)
+	}
+
 	return &Client{
-		url: url,
-		client: http.Client{
-			Timeout: timeout,
-		},
+		url:     conf.URL,
+		client:  httputil.NewClient(rt),
+		timeout: time.Duration(conf.RemoteTimeout),
 	}, nil
 }
 
@@ -75,12 +96,14 @@ func (c *Client) Store(samples model.Samples) error {
 		return err
 	}
 
-	httpReq, err := http.NewRequest("POST", c.url, &buf)
+	httpReq, err := http.NewRequest("POST", c.url.String(), &buf)
 	if err != nil {
 		return err
 	}
 	httpReq.Header.Add("Content-Encoding", "snappy")
-	httpResp, err := c.client.Do(httpReq)
+
+	ctx, _ := context.WithTimeout(context.Background(), c.timeout)
+	httpResp, err := ctxhttp.Do(ctx, c.client, httpReq)
 	if err != nil {
 		return err
 	}
@@ -97,5 +120,5 @@ func (c *Client) Store(samples model.Samples) error {
 // will simply be removed in the restructuring and the whole "generic" naming
 // will be gone for good.
 func (c Client) Name() string {
-	return "generic"
+	return fmt.Sprintf("generic:%s", c.url)
 }

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -31,13 +31,14 @@ import (
 
 // Client allows sending batches of Prometheus samples to an HTTP endpoint.
 type Client struct {
+	index   int // Used to differentiate metrics
 	url     config.URL
 	client  *http.Client
 	timeout time.Duration
 }
 
 // NewClient creates a new Client.
-func NewClient(conf config.RemoteWriteConfig) (*Client, error) {
+func NewClient(index int, conf config.RemoteWriteConfig) (*Client, error) {
 	tlsConfig, err := httputil.NewTLSConfig(conf.TLSConfig)
 	if err != nil {
 		return nil, err
@@ -55,6 +56,7 @@ func NewClient(conf config.RemoteWriteConfig) (*Client, error) {
 	}
 
 	return &Client{
+		index:   index,
 		url:     conf.URL,
 		client:  httputil.NewClient(rt),
 		timeout: time.Duration(conf.RemoteTimeout),
@@ -120,5 +122,5 @@ func (c *Client) Store(samples model.Samples) error {
 // will simply be removed in the restructuring and the whole "generic" naming
 // will be gone for good.
 func (c Client) Name() string {
-	return fmt.Sprintf("generic:%s", c.url)
+	return fmt.Sprintf("generic:%d:%s", c.index, c.url)
 }

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -38,7 +38,7 @@ type Client struct {
 
 // NewClient creates a new Client.
 func NewClient(conf config.RemoteWriteConfig) (*Client, error) {
-	tlsConfig, err := httputil.TLSConfig(conf.TLSConfig)
+	tlsConfig, err := httputil.NewTLSConfig(conf.TLSConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -185,12 +185,12 @@ func (t *StorageQueueManager) Collect(ch chan<- prometheus.Metric) {
 	ch <- t.queueCapacity
 }
 
-// Run continuously sends samples to the remote storage.
-func (t *StorageQueueManager) Run() {
+// Start the queue manager sending samples to the remote storage.
+// Does not block.
+func (t *StorageQueueManager) Start() {
 	for i := 0; i < t.cfg.Shards; i++ {
 		go t.runShard(i)
 	}
-	t.wg.Wait()
 }
 
 // Stop stops sending samples to the remote storage and waits for pending

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -244,9 +244,9 @@ func (t *StorageQueueManager) sendSamples(s model.Samples) {
 
 	if err != nil {
 		log.Warnf("error sending %d samples to remote storage: %s", len(s), err)
-		sentSamplesTotal.WithLabelValues(t.queueName).Add(float64(len(s)))
+		failedSamplesTotal.WithLabelValues(t.queueName).Add(float64(len(s)))
 	} else {
-		droppedSamplesTotal.WithLabelValues(t.queueName).Add(float64(len(s)))
+		sentSamplesTotal.WithLabelValues(t.queueName).Add(float64(len(s)))
 	}
 	sentBatchDuration.WithLabelValues(t.queueName).Observe(duration)
 }

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -108,7 +108,7 @@ func TestSampleDelivery(t *testing.T) {
 	for _, s := range samples[len(samples)/2:] {
 		m.Append(s)
 	}
-	go m.Run()
+	m.Start()
 	defer m.Stop()
 
 	c.waitForExpectedSamples(t)
@@ -141,7 +141,7 @@ func TestSampleDeliveryOrder(t *testing.T) {
 	for _, s := range samples {
 		m.Append(s)
 	}
-	go m.Run()
+	m.Start()
 	defer m.Stop()
 
 	c.waitForExpectedSamples(t)
@@ -204,7 +204,7 @@ func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 	c := NewTestBlockedStorageClient()
 	m := NewStorageQueueManager(c, &cfg)
 
-	go m.Run()
+	m.Start()
 
 	defer func() {
 		c.unlock()

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -181,6 +181,14 @@ func (c *TestBlockingStorageClient) Name() string {
 	return "testblockingstorageclient"
 }
 
+func (t *StorageQueueManager) queueLen() int {
+	queueLength := 0
+	for _, shard := range t.shards {
+		queueLength += len(shard)
+	}
+	return queueLength
+}
+
 func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 	// Our goal is to fully empty the queue:
 	// `MaxSamplesPerSend*Shards` samples should be consumed by the

--- a/storage/remote/remote.go
+++ b/storage/remote/remote.go
@@ -130,17 +130,3 @@ func (s *Storage) Append(smpl *model.Sample) error {
 func (s *Storage) NeedsThrottling() bool {
 	return false
 }
-
-// Describe implements prometheus.Collector.
-func (s *Storage) Describe(ch chan<- *prometheus.Desc) {
-	for _, q := range s.queues {
-		q.Describe(ch)
-	}
-}
-
-// Collect implements prometheus.Collector.
-func (s *Storage) Collect(ch chan<- prometheus.Metric) {
-	for _, q := range s.queues {
-		q.Collect(ch)
-	}
-}

--- a/storage/remote/remote.go
+++ b/storage/remote/remote.go
@@ -69,13 +69,6 @@ func New(o *Options) (*Storage, error) {
 		prometheus.MustRegister(c)
 		s.queues = append(s.queues, NewStorageQueueManager(c, nil))
 	}
-	if o.URL != "" {
-		c, err := NewClient(o.URL, o.StorageTimeout)
-		if err != nil {
-			return nil, err
-		}
-		s.queues = append(s.queues, NewStorageQueueManager(c, nil))
-	}
 	if len(s.queues) == 0 {
 		return nil, nil
 	}
@@ -94,15 +87,12 @@ type Options struct {
 	GraphiteAddress         string
 	GraphiteTransport       string
 	GraphitePrefix          string
-	// TODO: This just being called "URL" will make more sense once the
-	// other remote storage mechanisms are removed.
-	URL string
 }
 
 // Run starts the background processing of the storage queues.
-func (s *Storage) Run() {
+func (s *Storage) Start() {
 	for _, q := range s.queues {
-		go q.Run()
+		q.Start()
 	}
 }
 

--- a/storage/remote/remote_reloadable.go
+++ b/storage/remote/remote_reloadable.go
@@ -1,0 +1,116 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/config"
+)
+
+// Storage collects multiple remote storage queues.
+type ReloadableStorage struct {
+	mtx            sync.RWMutex
+	externalLabels model.LabelSet
+	conf           []config.RemoteWriteConfig
+
+	queues []*StorageQueueManager
+}
+
+// New returns a new remote Storage.
+func NewConfigurable() *ReloadableStorage {
+	return &ReloadableStorage{}
+}
+
+// ApplyConfig updates the state as the new config requires.
+func (s *ReloadableStorage) ApplyConfig(conf *config.Config) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	newQueues := []*StorageQueueManager{}
+	for _, c := range conf.RemoteWriteConfig {
+		c, err := NewClient(c)
+		if err != nil {
+			return err
+		}
+		newQueues = append(newQueues, NewStorageQueueManager(c, nil))
+	}
+
+	for _, q := range s.queues {
+		q.Stop()
+	}
+	s.queues = newQueues
+	s.externalLabels = conf.GlobalConfig.ExternalLabels
+	s.conf = conf.RemoteWriteConfig
+	for _, q := range s.queues {
+		q.Start()
+	}
+	return nil
+}
+
+// Stop the background processing of the storage queues.
+func (s *ReloadableStorage) Stop() {
+	for _, q := range s.queues {
+		q.Stop()
+	}
+}
+
+// Append implements storage.SampleAppender. Always returns nil.
+func (s *ReloadableStorage) Append(smpl *model.Sample) error {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	var snew model.Sample
+	snew = *smpl
+	snew.Metric = smpl.Metric.Clone()
+
+	for ln, lv := range s.externalLabels {
+		if _, ok := smpl.Metric[ln]; !ok {
+			snew.Metric[ln] = lv
+		}
+	}
+
+	for _, q := range s.queues {
+		q.Append(&snew)
+	}
+	return nil
+}
+
+// NeedsThrottling implements storage.SampleAppender. It will always return
+// false as a remote storage drops samples on the floor if backlogging instead
+// of asking for throttling.
+func (s *ReloadableStorage) NeedsThrottling() bool {
+	return false
+}
+
+// Describe implements prometheus.Collector.
+func (s *ReloadableStorage) Describe(ch chan<- *prometheus.Desc) {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	for _, q := range s.queues {
+		q.Describe(ch)
+	}
+}
+
+// Collect implements prometheus.Collector.
+func (s *ReloadableStorage) Collect(ch chan<- prometheus.Metric) {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	for _, q := range s.queues {
+		q.Collect(ch)
+	}
+}

--- a/storage/remote/remote_reloadable.go
+++ b/storage/remote/remote_reloadable.go
@@ -16,7 +16,6 @@ package remote
 import (
 	"sync"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/config"
@@ -97,22 +96,4 @@ func (s *ReloadableStorage) Append(smpl *model.Sample) error {
 // of asking for throttling.
 func (s *ReloadableStorage) NeedsThrottling() bool {
 	return false
-}
-
-// Describe implements prometheus.Collector.
-func (s *ReloadableStorage) Describe(ch chan<- *prometheus.Desc) {
-	s.mtx.RLock()
-	defer s.mtx.RUnlock()
-	for _, q := range s.queues {
-		q.Describe(ch)
-	}
-}
-
-// Collect implements prometheus.Collector.
-func (s *ReloadableStorage) Collect(ch chan<- prometheus.Metric) {
-	s.mtx.RLock()
-	defer s.mtx.RUnlock()
-	for _, q := range s.queues {
-		q.Collect(ch)
-	}
 }

--- a/storage/remote/remote_reloadable.go
+++ b/storage/remote/remote_reloadable.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Prometheus Authors
+// Copyright 2016 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -41,9 +41,11 @@ func (s *ReloadableStorage) ApplyConfig(conf *config.Config) error {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
+	// TODO: we should only stop & recreate queues which have changes,
+	// as this can be quite disruptive.
 	newQueues := []*StorageQueueManager{}
-	for _, c := range conf.RemoteWriteConfig {
-		c, err := NewClient(c)
+	for i, c := range conf.RemoteWriteConfig {
+		c, err := NewClient(i, c)
 		if err != nil {
 			return err
 		}

--- a/util/httputil/client.go
+++ b/util/httputil/client.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/prometheus/prometheus/config"
 )
 
 // NewClient returns a http.Client using the specified http.RoundTripper.
@@ -123,6 +125,21 @@ type TLSOptions struct {
 	CertFile           string
 	KeyFile            string
 	ServerName         string
+}
+
+func TLSConfig(cfg config.TLSConfig) (*tls.Config, error) {
+	tlsOpts := TLSOptions{
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		CAFile:             cfg.CAFile,
+	}
+	if len(cfg.CertFile) > 0 && len(cfg.KeyFile) > 0 {
+		tlsOpts.CertFile = cfg.CertFile
+		tlsOpts.KeyFile = cfg.KeyFile
+	}
+	if len(cfg.ServerName) > 0 {
+		tlsOpts.ServerName = cfg.ServerName
+	}
+	return NewTLSConfig(tlsOpts)
 }
 
 func NewTLSConfig(opts TLSOptions) (*tls.Config, error) {

--- a/util/httputil/client.go
+++ b/util/httputil/client.go
@@ -119,53 +119,30 @@ func cloneRequest(r *http.Request) *http.Request {
 	return r2
 }
 
-type TLSOptions struct {
-	InsecureSkipVerify bool
-	CAFile             string
-	CertFile           string
-	KeyFile            string
-	ServerName         string
-}
-
-func TLSConfig(cfg config.TLSConfig) (*tls.Config, error) {
-	tlsOpts := TLSOptions{
-		InsecureSkipVerify: cfg.InsecureSkipVerify,
-		CAFile:             cfg.CAFile,
-	}
-	if len(cfg.CertFile) > 0 && len(cfg.KeyFile) > 0 {
-		tlsOpts.CertFile = cfg.CertFile
-		tlsOpts.KeyFile = cfg.KeyFile
-	}
-	if len(cfg.ServerName) > 0 {
-		tlsOpts.ServerName = cfg.ServerName
-	}
-	return NewTLSConfig(tlsOpts)
-}
-
-func NewTLSConfig(opts TLSOptions) (*tls.Config, error) {
-	tlsConfig := &tls.Config{InsecureSkipVerify: opts.InsecureSkipVerify}
+func NewTLSConfig(cfg config.TLSConfig) (*tls.Config, error) {
+	tlsConfig := &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify}
 
 	// If a CA cert is provided then let's read it in so we can validate the
 	// scrape target's certificate properly.
-	if len(opts.CAFile) > 0 {
+	if len(cfg.CAFile) > 0 {
 		caCertPool := x509.NewCertPool()
 		// Load CA cert.
-		caCert, err := ioutil.ReadFile(opts.CAFile)
+		caCert, err := ioutil.ReadFile(cfg.CAFile)
 		if err != nil {
-			return nil, fmt.Errorf("unable to use specified CA cert %s: %s", opts.CAFile, err)
+			return nil, fmt.Errorf("unable to use specified CA cert %s: %s", cfg.CAFile, err)
 		}
 		caCertPool.AppendCertsFromPEM(caCert)
 		tlsConfig.RootCAs = caCertPool
 	}
 
-	if len(opts.ServerName) > 0 {
-		tlsConfig.ServerName = opts.ServerName
+	if len(cfg.ServerName) > 0 {
+		tlsConfig.ServerName = cfg.ServerName
 	}
 	// If a client cert & key is provided then configure TLS config accordingly.
-	if len(opts.CertFile) > 0 && len(opts.KeyFile) > 0 {
-		cert, err := tls.LoadX509KeyPair(opts.CertFile, opts.KeyFile)
+	if len(cfg.CertFile) > 0 && len(cfg.KeyFile) > 0 {
+		cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
 		if err != nil {
-			return nil, fmt.Errorf("unable to use specified client cert (%s) & key (%s): %s", opts.CertFile, opts.KeyFile, err)
+			return nil, fmt.Errorf("unable to use specified client cert (%s) & key (%s): %s", cfg.CertFile, cfg.KeyFile, err)
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
 	}


### PR DESCRIPTION
(/cc @brian-brazil, @juliusv)

This PR adds support for HTTP basic auth to the new generic write path.  I've opened mainly to trigger the discussion of what auth support we want here, not that I think this necessarily is the correct way forward (although it works quite nicely).

NB this PR doesn't address the use of SSL, but this something I intend to handle next.

Part of #1934 