### PR TITLE
Allow disabling local storage.

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -43,11 +43,12 @@ var cfg = struct {
 	printVersion bool
 	configFile   string
 
-	storage     local.MemorySeriesStorageOptions
-	notifier    notifier.Options
-	queryEngine promql.EngineOptions
-	web         web.Options
-	remote      remote.Options
+	storage            local.MemorySeriesStorageOptions
+	localStorageEngine string
+	notifier           notifier.Options
+	queryEngine        promql.EngineOptions
+	web                web.Options
+	remote             remote.Options
 
 	alertmanagerURLs stringset
 	prometheusURL    string
@@ -171,6 +172,10 @@ func init() {
 	cfg.fs.IntVar(
 		&cfg.storage.NumMutexes, "storage.local.num-fingerprint-mutexes", 4096,
 		"The number of mutexes used for fingerprint locking.",
+	)
+	cfg.fs.StringVar(
+		&cfg.localStorageEngine, "storage.local.engine", "persisted",
+		"Local storage engine. Supported values are: 'persisted' (full local storage with on-disk persistence) and 'none' (no local storage).",
 	)
 
 	// Remote storage.

--- a/storage/local/noop_storage.go
+++ b/storage/local/noop_storage.go
@@ -1,0 +1,82 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage/metric"
+)
+
+// NoopStorage is a dummy storage for use when Prometheus's local storage is
+// disabled. It throws away any appended samples and returns empty results.
+type NoopStorage struct{}
+
+// Start implements Storage.
+func (s *NoopStorage) Start() (err error) {
+	return nil
+}
+
+// Stop implements Storage.
+func (s *NoopStorage) Stop() error {
+	return nil
+}
+
+// WaitForIndexing implements Storage.
+func (s *NoopStorage) WaitForIndexing() {
+}
+
+// LastSampleForLabelMatchers implements Storage.
+func (s *NoopStorage) LastSampleForLabelMatchers(cutoff model.Time, matcherSets ...metric.LabelMatchers) (model.Vector, error) {
+	return nil, nil
+}
+
+// QueryRange implements Storage.
+func (s *NoopStorage) QueryRange(from, through model.Time, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error) {
+	return nil, nil
+}
+
+// QueryInstant implements Storage.
+func (s *NoopStorage) QueryInstant(ts model.Time, stalenessDelta time.Duration, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error) {
+	return nil, nil
+}
+
+// MetricsForLabelMatchers implements Storage.
+func (s *NoopStorage) MetricsForLabelMatchers(
+	from, through model.Time,
+	matcherSets ...metric.LabelMatchers,
+) ([]metric.Metric, error) {
+	return nil, nil
+}
+
+// LabelValuesForLabelName implements Storage.
+func (s *NoopStorage) LabelValuesForLabelName(labelName model.LabelName) (model.LabelValues, error) {
+	return nil, nil
+}
+
+// DropMetricsForLabelMatchers implements Storage.
+func (s *NoopStorage) DropMetricsForLabelMatchers(matchers ...*metric.LabelMatcher) (int, error) {
+	return 0, nil
+}
+
+// Append implements Storage.
+func (s *NoopStorage) Append(sample *model.Sample) error {
+	return nil
+}
+
+// NeedsThrottling implements Storage.
+func (s *NoopStorage) NeedsThrottling() bool {
+	return false
+}


### PR DESCRIPTION
This adds a flag -storage.local.disable which allows turning off local
storage in Prometheus. Instead of adding if-conditions and nil checks to
all parts of Prometheus that deal with Prometheus's local storage
(including the web interface), disabling local storage simply means
replacing the normal local storage with a noop version that throws
samples away and returns empty query results. We also don't add the noop
storage to the fanout appender to decrease internal overhead.

Instead of returning empty results, an alternate behavior could be to
return errors on any query that point out that the local storage is
disabled. Not sure which one is more preferable, so I went with the
empty result option for now.