### PR TITLE
storage: fix struct alignment issue in test

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -152,8 +152,8 @@ func TestSampleDeliveryOrder(t *testing.T) {
 // the `numCalls` property will contain a count of how many times Store() was
 // called.
 type TestBlockingStorageClient struct {
-	block    chan bool
 	numCalls uint64
+	block    chan bool
 }
 
 func NewTestBlockedStorageClient() *TestBlockingStorageClient {


### PR DESCRIPTION
The uint64 `numCalls` ends up being not word-aligned on certain architectures,
which makes atomic reads/writes panic.

As reported on IRC by @TheTincho