### PR TITLE
Support compiling prometheus on ARM architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ assets:
 
 promu:
 	@GOOS=$(shell uname -s | tr A-Z a-z) \
-	GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
+	GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(patsubst arm%,arm,$(shell uname -m)))) \
 	$(GO) get -u github.com/prometheus/promu
 
 


### PR DESCRIPTION
This fixes an issue where the golang compiler requires GOARCH="arm" to be set when compiling on ARM architectures, whereas uname may produce something like "armv7l".

r: @juliusv @fabxc @beorn7 
