### PR TITLE
PromQL: Add minute() function

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -909,6 +909,13 @@ func funcHour(ev *evaluator, args Expressions) model.Value {
 	})
 }
 
+// === minute(v vector) scalar ===
+func funcMinute(ev *evaluator, args Expressions) model.Value {
+	return dateWrapper(ev, args, func(t time.Time) model.SampleValue {
+		return model.SampleValue(t.Minute())
+	})
+}
+
 // === month(v vector) scalar ===
 func funcMonth(ev *evaluator, args Expressions) model.Value {
 	return dateWrapper(ev, args, func(t time.Time) model.SampleValue {
@@ -1101,6 +1108,13 @@ var functions = map[string]*Function{
 		ArgTypes:   []model.ValueType{model.ValMatrix},
 		ReturnType: model.ValVector,
 		Call:       funcMinOverTime,
+	},
+	"minute": {
+		Name:         "minute",
+		ArgTypes:     []model.ValueType{model.ValVector},
+		OptionalArgs: 1,
+		ReturnType:   model.ValVector,
+		Call:         funcMinute,
 	},
 	"month": {
 		Name:         "month",

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -383,6 +383,9 @@ eval instant at 0m day_of_week()
 eval instant at 0m hour()
   {} 0
 
+eval instant at 0m minute()
+  {} 0
+
 # 2008-12-31 23:59:59 just before leap second.
 eval instant at 0m year(vector(1230767999))
   {} 2008

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -370,21 +370,39 @@ clear
 eval instant at 0m year()
   {} 1970
 
+eval instant at 0m year(vector(1136239445))
+  {} 2006
+
 eval instant at 0m month()
+  {} 1
+
+eval instant at 0m month(vector(1136239445))
   {} 1
 
 eval instant at 0m day_of_month()
   {} 1
 
+eval instant at 0m day_of_month(vector(1136239445))
+  {} 2
+
 # Thursday.
 eval instant at 0m day_of_week()
   {} 4
 
+eval instant at 0m day_of_week(vector(1136239445))
+  {} 1
+
 eval instant at 0m hour()
   {} 0
 
+eval instant at 0m hour(vector(1136239445))
+  {} 22
+
 eval instant at 0m minute()
   {} 0
+
+eval instant at 0m minute(vector(1136239445))
+  {} 4
 
 # 2008-12-31 23:59:59 just before leap second.
 eval instant at 0m year(vector(1230767999))


### PR DESCRIPTION
Returns the minutes from the current time in UTC. Related to the
`hour()` function.

Fixes #1983.