### PR TITLE
Add a Peacewise Aggregate Approximation function

### DIFF
--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -71,3 +71,18 @@ eval instant at 1d changes(http_requests[1d])
 	bench := NewBenchmark(b, input)
 	bench.Run()
 }
+
+func BenchmarkPAA1Day1Min(b *testing.B) {
+	input := `
+clear
+load 1m
+    http_requests{path="/foo"}    0+10x1440
+
+eval instant at 1d paa(http_requests[1d])
+    {path="/foo"} 2406775
+`
+
+	bench := NewBenchmark(b, input)
+	bench.Run()
+
+}

--- a/promql/paa.go
+++ b/promql/paa.go
@@ -1,0 +1,171 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"fmt"
+	"math"
+)
+
+func paaStdDevAvg(samples []float64) (float64, float64) {
+	var sum, squaredSum, count float64
+	for _, v := range samples {
+		if float64(v) != math.NaN() {
+			sum += v
+			squaredSum += v * v
+		}
+		count += 1
+	}
+	avg := sum / count
+	return math.Sqrt(float64(squaredSum/count - avg*avg)), float64(avg)
+}
+
+// zNorm aero normalizes a set of floats.
+func zNorm(samples []float64) []float64 {
+	stddev, mean := paaStdDevAvg(samples)
+	res := make([]float64, len(samples))
+	for i, v := range samples {
+		if stddev == 0 {
+			res[i] = 1.0
+		} else {
+			res[i] = (v - mean) / stddev
+		}
+	}
+	return res
+}
+
+// float64ToBits unpack a single uint64 PAA from
+// a float64
+func float64ToBits(f float64) uint64 {
+	//	return *(*uint64)(unsafe.Pointer(&f))
+	return uint64(f)
+}
+
+// bitsToFloat64bits packs a single uint64 PAA into
+// a float (in reality, if we stick to an 8 x 3bit PAA
+// we can fit this in 54 bit int portion of the float
+func bitsToFloat64bits(u uint64) float64 {
+	//	return *(*float64)(unsafe.Pointer(&u))
+	return float64(u)
+}
+
+var saxBuckets = []float64{-1.5, -0.67, -0.32, 0.0, 0.32, 0.67, 1.5}
+
+// quantize  converts a zNorm'd float64 slice to a uint64 with
+// 3 bits for each value. The quotients are taken from the ISAX2
+// paper.
+func quantize(values []float64) uint64 {
+	out := uint64(0)
+	for _, v := range values {
+		switch {
+		case v < saxBuckets[0]:
+			out = (out << 3) | 0
+		case v >= saxBuckets[0] && v < saxBuckets[1]:
+			out = (out << 3) | 1
+		case v >= saxBuckets[1] && v < saxBuckets[2]:
+			out = (out << 3) | 2
+		case v >= saxBuckets[2] && v < saxBuckets[3]:
+			out = (out << 3) | 3
+		case v >= saxBuckets[3] && v < saxBuckets[4]:
+			out = (out << 3) | 4
+		case v >= saxBuckets[4] && v < saxBuckets[5]:
+			out = (out << 3) | 5
+		case v >= saxBuckets[5] && v < saxBuckets[6]:
+			out = (out << 3) | 6
+		case v >= saxBuckets[6]:
+			out = (out << 3) | 7
+		case math.IsNaN(v):
+			out = (out << 3) | 0
+		default:
+			panic(fmt.Errorf("paa failed, unquantizable value %#v", v))
+		}
+	}
+
+	return out
+}
+
+// lttb is an implementation of Largest-Triangle-Three-Buckets downsampling
+// which atempts to preserve the visual repsentation of a time series
+func lttb(samples *sampleStream, t int) []float64 {
+	sampled := []float64{}
+	if t >= len(samples.Values) || t == 0 {
+		for _, v := range samples.Values {
+			sampled = append(sampled, float64(v.Value))
+		}
+		return sampled
+	}
+
+	// Bucket size. Leave room for start and end data points
+	bsize := float64((len(samples.Values) - 2)) / float64(t-2)
+	a, nexta := 0, 0
+
+	sampled = append(sampled, float64(samples.Values[0].Value))
+
+	for i := 0; i < t-2; i++ {
+		avgRangeStart := (int)(math.Floor((float64(i+1) * bsize)) + 1)
+		avgRangeEnd := (int)(math.Floor((float64(i+2))*bsize) + 1)
+
+		if avgRangeEnd >= len(samples.Values) {
+			avgRangeEnd = len(samples.Values)
+		}
+
+		avgRangeLength := (avgRangeEnd - avgRangeStart)
+
+		avgX, avgY := 0.0, 0.0
+
+		for {
+			if avgRangeStart >= avgRangeEnd {
+				break
+			}
+			avgX += float64(samples.Values[avgRangeStart].Timestamp)
+			avgY += float64(samples.Values[avgRangeStart].Value)
+			avgRangeStart++
+		}
+
+		avgX /= float64(avgRangeLength)
+		avgY /= float64(avgRangeLength)
+
+		rangeOffs := (int)(math.Floor((float64(i)+0)*bsize) + 1)
+		rangeTo := (int)(math.Floor((float64(i)+1)*bsize) + 1)
+
+		pointAx := float64(samples.Values[a].Timestamp)
+		pointAy := float64(samples.Values[a].Value)
+
+		maxArea := -1.0
+
+		maxAreaPoint := 0.0
+
+		for {
+			if rangeOffs >= rangeTo {
+				break
+			}
+
+			area := math.Abs((pointAx-avgX)*(float64(samples.Values[rangeOffs].Value)-pointAy)-(pointAx-float64(samples.Values[rangeOffs].Timestamp))*(avgY-pointAy)) * 0.5
+
+			if area > maxArea {
+				maxArea = area
+				maxAreaPoint = float64(samples.Values[rangeOffs].Value)
+				nexta = rangeOffs
+			}
+			rangeOffs++
+		}
+
+		sampled = append(sampled, maxAreaPoint)
+		a = nexta
+	}
+
+	sampled = append(sampled, float64(samples.Values[len(samples.Values)-1].Value))
+
+	return sampled
+}

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -427,3 +427,43 @@ eval instant at 0m days_in_month(vector(1454284800))
 # Febuary 1st 2017 not in leap year.
 eval instant at 0m days_in_month(vector(1485907200))
   {} 28
+
+
+# Tests for paa().
+clear
+
+load 1m
+	paa_test{path="/foo"}	1 2 3 0 1 0 0 1 2 0 1 2 3 0 1 0 0 1 2 0
+	paa_test{path="/boo"}	11 12 13 10 11 10 10 11 12 10 11 12 13 10 11 10 10 11 12 10
+	paa_test{path="/bao"}	20 40 60 00 20 00 00 20 40 00 20 40 60 00 20 00 00 20 40 00
+	paa_test{path="/bar"}	1 2 3 4 5 1 2 3 4 5 1 2 3 4 5 1 2 3 4 5
+	paa_test{path="/buz"}	1 1 1 1 0 0 0 0 1 1 1 1 0 0 0 0 1 1 1 1
+	paa_test{path="/biz"}	0 0 0 0 0 1 1 1 1 1 0 0 0 0 0 1 1 1 1 1
+	paa_test{path="/bun"}	0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1
+
+eval instant at 20m paa(paa_test[8m])
+	{path="/foo"} 15078193
+	{path="/boo"} 15078193
+	{path="/bao"} 15078193
+	{path="/bar"} 7799534
+	{path="/buz"} 2399670
+	{path="/biz"} 2420150
+	{path="/bun"} 14380470
+
+eval instant at 20m paa(paa_test[10m])
+	{path="/foo"} 10195569
+	{path="/boo"} 10195569
+	{path="/bao"} 10195569
+	{path="/bar"} 2781863
+	{path="/buz"} 14193590
+	{path="/biz"} 2399670
+	{path="/bun"} 14380470
+
+eval instant at 20m paa(paa_test[20m])
+	{path="/foo"} 7904369
+	{path="/boo"} 7904369
+	{path="/bao"} 7904369
+	{path="/bar"} 3466134
+	{path="/buz"} 11819565
+	{path="/biz"} 2581110
+	{path="/bun"} 2399670


### PR DESCRIPTION
This is a preliminary attempt at implementing a peace-wise aggregate
approximation function for prometheus. This can be used to search for
time series with overall visual similarity.

This was mostly just an exploratory attempt to reimplement something I
have found useful (and interesting) previously, in prometheus.

If there is any interest in this, there is considerable room for
improvement and optimization. In particular:

- The downsampling technique is fun, but expensive
- There is no handling of NaNs in the raw data.

If not, then I fully understand. It has least been fun. I'm going to
write up a blog post about it, just to have it written up somewhere.
I'll make it clear that it's not in, and probably never will be in,
prometheus.