### PR TITLE
Add go_import_path to travis so it works on a fork.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ go:
 
 script:
 - make check_license style test
+
+go_import_path: github.com/prometheus/prometheus

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ language: go
 go:
 - 1.6.3
 
+go_import_path: github.com/prometheus/prometheus
+
 script:
 - make check_license style test
 
-go_import_path: github.com/prometheus/prometheus
+


### PR DESCRIPTION
By default, travis checkout out go code in github.com/{user}/{repo}, which means forks of Prometheus won't build on travis.  See https://docs.travis-ci.com/user/languages/go