### PR TITLE
Allow number to be the first letter as well for `job_name`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,6 @@ import (
 )
 
 var (
-	patJobName    = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_-]*$`)
 	patFileSDName = regexp.MustCompile(`^[^*]*(\*[^/]*)?\.(json|yml|yaml|JSON|YML|YAML)$`)
 	patRulePath   = regexp.MustCompile(`^[^*]*(\*[^/]*)?$`)
 	patAuthLine   = regexp.MustCompile(`((?:password|bearer_token|secret_key|client_secret):\s+)(".+"|'.+'|[^\s]+)`)
@@ -454,8 +453,8 @@ func (c *ScrapeConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := checkOverflow(c.XXX, "scrape_config"); err != nil {
 		return err
 	}
-	if !patJobName.MatchString(c.JobName) {
-		return fmt.Errorf("%q is not a valid job name", c.JobName)
+	if len(c.JobName) == 0 {
+		return fmt.Errorf("job_name is empty")
 	}
 	if len(c.BearerToken) > 0 && len(c.BearerTokenFile) > 0 {
 		return fmt.Errorf("at most one of bearer_token & bearer_token_file must be configured")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -307,6 +307,40 @@ var expectedConf = &Config{
 				},
 			},
 		},
+		{
+			JobName: "0123service-xxx",
+
+			ScrapeInterval: model.Duration(15 * time.Second),
+			ScrapeTimeout:  DefaultGlobalConfig.ScrapeTimeout,
+
+			MetricsPath: DefaultScrapeConfig.MetricsPath,
+			Scheme:      DefaultScrapeConfig.Scheme,
+
+			StaticConfigs: []*TargetGroup{
+				{
+					Targets: []model.LabelSet{
+						{model.AddressLabel: "localhost:9090"},
+					},
+				},
+			},
+		},
+		{
+			JobName: "測試",
+
+			ScrapeInterval: model.Duration(15 * time.Second),
+			ScrapeTimeout:  DefaultGlobalConfig.ScrapeTimeout,
+
+			MetricsPath: DefaultScrapeConfig.MetricsPath,
+			Scheme:      DefaultScrapeConfig.Scheme,
+
+			StaticConfigs: []*TargetGroup{
+				{
+					Targets: []model.LabelSet{
+						{model.AddressLabel: "localhost:9090"},
+					},
+				},
+			},
+		},
 	},
 	original: "",
 }
@@ -351,7 +385,7 @@ var expectedErrors = []struct {
 }{
 	{
 		filename: "jobname.bad.yml",
-		errMsg:   `"prom^etheus" is not a valid job name`,
+		errMsg:   `job_name is empty`,
 	}, {
 		filename: "jobname_dup.bad.yml",
 		errMsg:   `found multiple scrape configs with job name "prometheus"`,

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -142,3 +142,15 @@ scrape_configs:
       - localhost
       paths:
       - /monitoring
+
+- job_name: 0123service-xxx
+  metrics_path: /metrics
+  static_configs:
+    - targets:
+      - localhost:9090
+
+- job_name: 測試
+  metrics_path: /metrics
+  static_configs:
+    - targets:
+      - localhost:9090

--- a/config/testdata/jobname.bad.yml
+++ b/config/testdata/jobname.bad.yml
@@ -1,2 +1,2 @@
 scrape_configs:
-  - job_name: prom^etheus
+  - job_name:


### PR DESCRIPTION
Allow number to be the first letter as well for `job_name`. 

```
Sep 15 11:00:26 us-imm-prometheus1.example.io prometheus[22999]: time="2016-09-15T11:00:26Z" level=error msg="Error loading config: couldn't load configuration (-config.file=/opt/prometheus/prometheus.yml): \"000backend\" is not a valid job name" source="main.go:126"
```
@juliusv or is there any real reason why not allow the number as first?