### PR TITLE
promql: Allow per-query contexts.

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -23,7 +23,8 @@ import (
 
 func TestQueryConcurrency(t *testing.T) {
 	engine := NewEngine(nil, nil)
-	defer engine.Stop()
+	ctx, cancelQueries := context.WithCancel(context.Background())
+	defer cancelQueries()
 
 	block := make(chan struct{})
 	processing := make(chan struct{})
@@ -36,7 +37,7 @@ func TestQueryConcurrency(t *testing.T) {
 
 	for i := 0; i < DefaultEngineOptions.MaxConcurrentQueries; i++ {
 		q := engine.newTestQuery(f)
-		go q.Exec()
+		go q.Exec(ctx)
 		select {
 		case <-processing:
 			// Expected.
@@ -46,7 +47,7 @@ func TestQueryConcurrency(t *testing.T) {
 	}
 
 	q := engine.newTestQuery(f)
-	go q.Exec()
+	go q.Exec(ctx)
 
 	select {
 	case <-processing:
@@ -76,14 +77,15 @@ func TestQueryTimeout(t *testing.T) {
 		Timeout:              5 * time.Millisecond,
 		MaxConcurrentQueries: 20,
 	})
-	defer engine.Stop()
+	ctx, cancelQueries := context.WithCancel(context.Background())
+	defer cancelQueries()
 
 	query := engine.newTestQuery(func(ctx context.Context) error {
 		time.Sleep(50 * time.Millisecond)
 		return contextDone(ctx, "test statement execution")
 	})
 
-	res := query.Exec()
+	res := query.Exec(ctx)
 	if res.Err == nil {
 		t.Fatalf("expected timeout error but got none")
 	}
@@ -94,7 +96,8 @@ func TestQueryTimeout(t *testing.T) {
 
 func TestQueryCancel(t *testing.T) {
 	engine := NewEngine(nil, nil)
-	defer engine.Stop()
+	ctx, cancelQueries := context.WithCancel(context.Background())
+	defer cancelQueries()
 
 	// Cancel a running query before it completes.
 	block := make(chan struct{})
@@ -109,7 +112,7 @@ func TestQueryCancel(t *testing.T) {
 	var res *Result
 
 	go func() {
-		res = query1.Exec()
+		res = query1.Exec(ctx)
 		processing <- struct{}{}
 	}()
 
@@ -131,14 +134,15 @@ func TestQueryCancel(t *testing.T) {
 	})
 
 	query2.Cancel()
-	res = query2.Exec()
+	res = query2.Exec(ctx)
 	if res.Err != nil {
-		t.Fatalf("unexpeceted error on executing query2: %s", res.Err)
+		t.Fatalf("unexpected error on executing query2: %s", res.Err)
 	}
 }
 
 func TestEngineShutdown(t *testing.T) {
 	engine := NewEngine(nil, nil)
+	ctx, cancelQueries := context.WithCancel(context.Background())
 
 	block := make(chan struct{})
 	processing := make(chan struct{})
@@ -158,12 +162,12 @@ func TestEngineShutdown(t *testing.T) {
 
 	var res *Result
 	go func() {
-		res = query1.Exec()
+		res = query1.Exec(ctx)
 		processing <- struct{}{}
 	}()
 
 	<-processing
-	engine.Stop()
+	cancelQueries()
 	block <- struct{}{}
 	<-processing
 
@@ -181,9 +185,9 @@ func TestEngineShutdown(t *testing.T) {
 
 	// The second query is started after the engine shut down. It must
 	// be canceled immediately.
-	res2 := query2.Exec()
+	res2 := query2.Exec(ctx)
 	if res2.Err == nil {
-		t.Fatalf("expected error on querying shutdown engine but got none")
+		t.Fatalf("expected error on querying with canceled context but got none")
 	}
 	if _, ok := res2.Err.(ErrQueryCanceled); !ok {
 		t.Fatalf("expected cancelation error, got %q", res2.Err)

--- a/promql/test.go
+++ b/promql/test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/local"
@@ -49,9 +50,11 @@ type Test struct {
 
 	cmds []testCommand
 
-	storage      local.Storage
-	closeStorage func()
-	queryEngine  *Engine
+	storage       local.Storage
+	closeStorage  func()
+	queryEngine   *Engine
+	queryCtx      context.Context
+	cancelQueries context.CancelFunc
 }
 
 // NewTest returns an initialized empty Test.
@@ -77,6 +80,11 @@ func newTestFromFile(t testutil.T, filename string) (*Test, error) {
 // QueryEngine returns the test's query engine.
 func (t *Test) QueryEngine() *Engine {
 	return t.queryEngine
+}
+
+// Context returns the test's query context.
+func (t *Test) Context() context.Context {
+	return t.queryCtx
 }
 
 // Storage returns the test's storage.
@@ -463,7 +471,7 @@ func (t *Test) exec(tc testCommand) error {
 
 	case *evalCmd:
 		q := t.queryEngine.newQuery(cmd.expr, cmd.start, cmd.end, cmd.interval)
-		res := q.Exec()
+		res := q.Exec(t.queryCtx)
 		if res.Err != nil {
 			if cmd.fail {
 				return nil
@@ -490,8 +498,8 @@ func (t *Test) clear() {
 	if t.closeStorage != nil {
 		t.closeStorage()
 	}
-	if t.queryEngine != nil {
-		t.queryEngine.Stop()
+	if t.cancelQueries != nil {
+		t.cancelQueries()
 	}
 
 	var closer testutil.Closer
@@ -499,11 +507,12 @@ func (t *Test) clear() {
 
 	t.closeStorage = closer.Close
 	t.queryEngine = NewEngine(t.storage, nil)
+	t.queryCtx, t.cancelQueries = context.WithCancel(context.Background())
 }
 
 // Close closes resources associated with the Test.
 func (t *Test) Close() {
-	t.queryEngine.Stop()
+	t.cancelQueries()
 	t.closeStorage()
 }
 

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/context"
+
 	html_template "html/template"
 
 	"github.com/prometheus/common/log"
@@ -146,12 +148,12 @@ const resolvedRetention = 15 * time.Minute
 
 // eval evaluates the rule expression and then creates pending alerts and fires
 // or removes previously pending alerts accordingly.
-func (r *AlertingRule) eval(ts model.Time, engine *promql.Engine, externalURLPath string) (model.Vector, error) {
+func (r *AlertingRule) eval(ts model.Time, engine *promql.Engine, queryCtx context.Context, externalURLPath string) (model.Vector, error) {
 	query, err := engine.NewInstantQuery(r.vector.String(), ts)
 	if err != nil {
 		return nil, err
 	}
-	res, err := query.Exec().Vector()
+	res, err := query.Exec(queryCtx).Vector()
 	if err != nil {
 		return nil, err
 	}
@@ -188,6 +190,7 @@ func (r *AlertingRule) eval(ts model.Time, engine *promql.Engine, externalURLPat
 				tmplData,
 				ts,
 				engine,
+				queryCtx,
 				externalURLPath,
 			)
 			result, err := tmpl.Expand()

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -105,7 +105,7 @@ func TestAlertingRule(t *testing.T) {
 	for i, test := range tests {
 		evalTime := model.Time(0).Add(test.time)
 
-		res, err := rule.eval(evalTime, suite.QueryEngine(), "")
+		res, err := rule.eval(evalTime, suite.QueryEngine(), suite.Context(), "")
 		if err != nil {
 			t.Fatalf("Error during alerting rule evaluation: %s", err)
 		}

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -18,6 +18,7 @@ import (
 	"html/template"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/util/strutil"
@@ -45,14 +46,14 @@ func (rule RecordingRule) Name() string {
 }
 
 // eval evaluates the rule and then overrides the metric names and labels accordingly.
-func (rule RecordingRule) eval(timestamp model.Time, engine *promql.Engine, _ string) (model.Vector, error) {
+func (rule RecordingRule) eval(timestamp model.Time, engine *promql.Engine, queryCtx context.Context, _ string) (model.Vector, error) {
 	query, err := engine.NewInstantQuery(rule.vector.String(), timestamp)
 	if err != nil {
 		return nil, err
 	}
 
 	var (
-		result = query.Exec()
+		result = query.Exec(queryCtx)
 		vector model.Vector
 	)
 	if result.Err != nil {

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage/local"
@@ -27,6 +28,9 @@ func TestRuleEval(t *testing.T) {
 	storage, closer := local.NewTestStorage(t, 2)
 	defer closer.Close()
 	engine := promql.NewEngine(storage, nil)
+	queryCtx, cancelQueries := context.WithCancel(context.Background())
+	defer cancelQueries()
+
 	now := model.Now()
 
 	suite := []struct {
@@ -59,7 +63,7 @@ func TestRuleEval(t *testing.T) {
 
 	for _, test := range suite {
 		rule := NewRecordingRule(test.name, test.expr, test.labels)
-		result, err := rule.eval(now, engine, "")
+		result, err := rule.eval(now, engine, queryCtx, "")
 		if err != nil {
 			t.Fatalf("Error evaluating %s", test.name)
 		}

--- a/template/template.go
+++ b/template/template.go
@@ -26,6 +26,7 @@ import (
 	text_template "text/template"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/util/strutil"
@@ -55,12 +56,12 @@ func (q queryResultByLabelSorter) Swap(i, j int) {
 	q.results[i], q.results[j] = q.results[j], q.results[i]
 }
 
-func query(q string, timestamp model.Time, queryEngine *promql.Engine) (queryResult, error) {
+func query(ctx context.Context, q string, timestamp model.Time, queryEngine *promql.Engine) (queryResult, error) {
 	query, err := queryEngine.NewInstantQuery(q, timestamp)
 	if err != nil {
 		return nil, err
 	}
-	res := query.Exec()
+	res := query.Exec(ctx)
 	if res.Err != nil {
 		return nil, res.Err
 	}
@@ -110,14 +111,14 @@ type Expander struct {
 }
 
 // NewTemplateExpander returns a template expander ready to use.
-func NewTemplateExpander(text string, name string, data interface{}, timestamp model.Time, queryEngine *promql.Engine, pathPrefix string) *Expander {
+func NewTemplateExpander(text string, name string, data interface{}, timestamp model.Time, queryEngine *promql.Engine, queryCtx context.Context, pathPrefix string) *Expander {
 	return &Expander{
 		text: text,
 		name: name,
 		data: data,
 		funcMap: text_template.FuncMap{
 			"query": func(q string) (queryResult, error) {
-				return query(q, timestamp, queryEngine)
+				return query(queryCtx, q, timestamp, queryEngine)
 			},
 			"first": func(v queryResult) (*sample, error) {
 				if len(v) > 0 {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage/local"
@@ -220,7 +221,7 @@ func TestTemplateExpansion(t *testing.T) {
 	for i, s := range scenarios {
 		var result string
 		var err error
-		expander := NewTemplateExpander(s.text, "test", s.input, time, engine, "")
+		expander := NewTemplateExpander(s.text, "test", s.input, time, engine, context.Background(), "")
 		if s.html {
 			result, err = expander.ExpandHTML(nil)
 		} else {

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -52,6 +52,7 @@ func TestEndpoints(t *testing.T) {
 	api := &API{
 		Storage:     suite.Storage(),
 		QueryEngine: suite.QueryEngine(),
+		QueryCtx:    suite.Context(),
 		now:         func() model.Time { return now },
 	}
 


### PR DESCRIPTION
For Weaveworks' Frankenstein, we need to support multitenancy. In
Frankenstein, we initially solved this without modifying the promql
package at all: we constructed a new promql.Engine for every
query and injected a storage implementation into that engine which would
be primed to only collect data for a given user.

This is problematic to upstream, however. Prometheus assumes that there
is only one engine: the query concurrency gate is part of the engine,
and the engine contains one central cancellable context to shut down all
queries. Also, creating a new engine for every query seems like overkill.

Thus, we want to be able to pass per-query contexts into a single engine.

This change gets rid of the promql.Engine's built-in base context and
allows passing in a per-query context instead. Central cancellation of
all queries is still possible by deriving all passed-in contexts from
one central one, but this is now the responsibility of the caller. The
central query context is now created in main() and passed into the
relevant components (web handler / API, rule manager).

In a next step, the per-query context would have to be passed to the
storage implementation, so that the storage can implement multi-tenancy
or other features based on the contextual information.