### PR TITLE
Add promu installation logging to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ assets:
 	@$(GO) fmt ./web/ui
 
 promu:
+	@echo ">> fetching promu"
 	@GOOS=$(shell uname -s | tr A-Z a-z) \
 	GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
 	$(GO) get -u github.com/prometheus/promu


### PR DESCRIPTION
Due to bad GitHub connectivity, "make" frequently got stuck at the promu
step for me, and I was thinking that "format" was taking a long time
because the promu step wasn't logged. All other Makefile targets have
log statements...