### PR TITLE
Contextify storage and PromQL interfaces.

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -26,6 +26,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/version"
+	"golang.org/x/net/context"
+
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/promql"
@@ -102,15 +104,17 @@ func Main() int {
 	}
 
 	var (
-		notifier      = notifier.New(&cfg.notifier)
-		targetManager = retrieval.NewTargetManager(sampleAppender)
-		queryEngine   = promql.NewEngine(localStorage, &cfg.queryEngine)
+		notifier                = notifier.New(&cfg.notifier)
+		targetManager           = retrieval.NewTargetManager(sampleAppender)
+		queryEngine             = promql.NewEngine(localStorage, &cfg.queryEngine)
+		queryCtx, cancelQueries = context.WithCancel(context.Background())
 	)
 
 	ruleManager := rules.NewManager(&rules.ManagerOptions{
 		SampleAppender: sampleAppender,
 		Notifier:       notifier,
 		QueryEngine:    queryEngine,
+		QueryCtx:       queryCtx,
 		ExternalURL:    cfg.web.ExternalURL,
 	})
 
@@ -128,7 +132,7 @@ func Main() int {
 		GoVersion: version.GoVersion,
 	}
 
-	webHandler := web.New(localStorage, queryEngine, targetManager, ruleManager, version, flags, &cfg.web)
+	webHandler := web.New(localStorage, queryEngine, queryCtx, targetManager, ruleManager, version, flags, &cfg.web)
 
 	reloadables = append(reloadables, targetManager, ruleManager, webHandler, notifier)
 
@@ -201,7 +205,7 @@ func Main() int {
 
 	// Shutting down the query engine before the rule manager will cause pending queries
 	// to be canceled and ensures a quick shutdown of the rule manager.
-	defer queryEngine.Stop()
+	defer cancelQueries()
 
 	go webHandler.Run()
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -23,7 +23,8 @@ import (
 
 func TestQueryConcurrency(t *testing.T) {
 	engine := NewEngine(nil, nil)
-	defer engine.Stop()
+	ctx, cancelQueries := context.WithCancel(context.Background())
+	defer cancelQueries()
 
 	block := make(chan struct{})
 	processing := make(chan struct{})
@@ -36,7 +37,7 @@ func TestQueryConcurrency(t *testing.T) {
 
 	for i := 0; i < DefaultEngineOptions.MaxConcurrentQueries; i++ {
 		q := engine.newTestQuery(f)
-		go q.Exec()
+		go q.Exec(ctx)
 		select {
 		case <-processing:
 			// Expected.
@@ -46,7 +47,7 @@ func TestQueryConcurrency(t *testing.T) {
 	}
 
 	q := engine.newTestQuery(f)
-	go q.Exec()
+	go q.Exec(ctx)
 
 	select {
 	case <-processing:
@@ -76,14 +77,15 @@ func TestQueryTimeout(t *testing.T) {
 		Timeout:              5 * time.Millisecond,
 		MaxConcurrentQueries: 20,
 	})
-	defer engine.Stop()
+	ctx, cancelQueries := context.WithCancel(context.Background())
+	defer cancelQueries()
 
 	query := engine.newTestQuery(func(ctx context.Context) error {
 		time.Sleep(50 * time.Millisecond)
 		return contextDone(ctx, "test statement execution")
 	})
 
-	res := query.Exec()
+	res := query.Exec(ctx)
 	if res.Err == nil {
 		t.Fatalf("expected timeout error but got none")
 	}
@@ -94,7 +96,8 @@ func TestQueryTimeout(t *testing.T) {
 
 func TestQueryCancel(t *testing.T) {
 	engine := NewEngine(nil, nil)
-	defer engine.Stop()
+	ctx, cancelQueries := context.WithCancel(context.Background())
+	defer cancelQueries()
 
 	// Cancel a running query before it completes.
 	block := make(chan struct{})
@@ -109,7 +112,7 @@ func TestQueryCancel(t *testing.T) {
 	var res *Result
 
 	go func() {
-		res = query1.Exec()
+		res = query1.Exec(ctx)
 		processing <- struct{}{}
 	}()
 
@@ -131,14 +134,15 @@ func TestQueryCancel(t *testing.T) {
 	})
 
 	query2.Cancel()
-	res = query2.Exec()
+	res = query2.Exec(ctx)
 	if res.Err != nil {
-		t.Fatalf("unexpeceted error on executing query2: %s", res.Err)
+		t.Fatalf("unexpected error on executing query2: %s", res.Err)
 	}
 }
 
 func TestEngineShutdown(t *testing.T) {
 	engine := NewEngine(nil, nil)
+	ctx, cancelQueries := context.WithCancel(context.Background())
 
 	block := make(chan struct{})
 	processing := make(chan struct{})
@@ -158,12 +162,12 @@ func TestEngineShutdown(t *testing.T) {
 
 	var res *Result
 	go func() {
-		res = query1.Exec()
+		res = query1.Exec(ctx)
 		processing <- struct{}{}
 	}()
 
 	<-processing
-	engine.Stop()
+	cancelQueries()
 	block <- struct{}{}
 	<-processing
 
@@ -181,9 +185,9 @@ func TestEngineShutdown(t *testing.T) {
 
 	// The second query is started after the engine shut down. It must
 	// be canceled immediately.
-	res2 := query2.Exec()
+	res2 := query2.Exec(ctx)
 	if res2.Err == nil {
-		t.Fatalf("expected error on querying shutdown engine but got none")
+		t.Fatalf("expected error on querying with canceled context but got none")
 	}
 	if _, ok := res2.Err.(ErrQueryCanceled); !ok {
 		t.Fatalf("expected cancelation error, got %q", res2.Err)

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -23,8 +23,8 @@ import (
 
 func TestQueryConcurrency(t *testing.T) {
 	engine := NewEngine(nil, nil)
-	ctx, cancelQueries := context.WithCancel(context.Background())
-	defer cancelQueries()
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
 
 	block := make(chan struct{})
 	processing := make(chan struct{})
@@ -77,8 +77,8 @@ func TestQueryTimeout(t *testing.T) {
 		Timeout:              5 * time.Millisecond,
 		MaxConcurrentQueries: 20,
 	})
-	ctx, cancelQueries := context.WithCancel(context.Background())
-	defer cancelQueries()
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
 
 	query := engine.newTestQuery(func(ctx context.Context) error {
 		time.Sleep(50 * time.Millisecond)
@@ -96,8 +96,8 @@ func TestQueryTimeout(t *testing.T) {
 
 func TestQueryCancel(t *testing.T) {
 	engine := NewEngine(nil, nil)
-	ctx, cancelQueries := context.WithCancel(context.Background())
-	defer cancelQueries()
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
 
 	// Cancel a running query before it completes.
 	block := make(chan struct{})
@@ -142,7 +142,7 @@ func TestQueryCancel(t *testing.T) {
 
 func TestEngineShutdown(t *testing.T) {
 	engine := NewEngine(nil, nil)
-	ctx, cancelQueries := context.WithCancel(context.Background())
+	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	block := make(chan struct{})
 	processing := make(chan struct{})
@@ -167,7 +167,7 @@ func TestEngineShutdown(t *testing.T) {
 	}()
 
 	<-processing
-	cancelQueries()
+	cancelCtx()
 	block <- struct{}{}
 	<-processing
 

--- a/promql/test.go
+++ b/promql/test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/local"
@@ -49,9 +50,11 @@ type Test struct {
 
 	cmds []testCommand
 
-	storage      local.Storage
-	closeStorage func()
-	queryEngine  *Engine
+	storage       local.Storage
+	closeStorage  func()
+	queryEngine   *Engine
+	queryCtx      context.Context
+	cancelQueries context.CancelFunc
 }
 
 // NewTest returns an initialized empty Test.
@@ -77,6 +80,11 @@ func newTestFromFile(t testutil.T, filename string) (*Test, error) {
 // QueryEngine returns the test's query engine.
 func (t *Test) QueryEngine() *Engine {
 	return t.queryEngine
+}
+
+// Context returns the test's query context.
+func (t *Test) Context() context.Context {
+	return t.queryCtx
 }
 
 // Storage returns the test's storage.
@@ -463,7 +471,7 @@ func (t *Test) exec(tc testCommand) error {
 
 	case *evalCmd:
 		q := t.queryEngine.newQuery(cmd.expr, cmd.start, cmd.end, cmd.interval)
-		res := q.Exec()
+		res := q.Exec(t.queryCtx)
 		if res.Err != nil {
 			if cmd.fail {
 				return nil
@@ -490,8 +498,8 @@ func (t *Test) clear() {
 	if t.closeStorage != nil {
 		t.closeStorage()
 	}
-	if t.queryEngine != nil {
-		t.queryEngine.Stop()
+	if t.cancelQueries != nil {
+		t.cancelQueries()
 	}
 
 	var closer testutil.Closer
@@ -499,11 +507,12 @@ func (t *Test) clear() {
 
 	t.closeStorage = closer.Close
 	t.queryEngine = NewEngine(t.storage, nil)
+	t.queryCtx, t.cancelQueries = context.WithCancel(context.Background())
 }
 
 // Close closes resources associated with the Test.
 func (t *Test) Close() {
-	t.queryEngine.Stop()
+	t.cancelQueries()
 	t.closeStorage()
 }
 

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/context"
+
 	html_template "html/template"
 
 	"github.com/prometheus/common/log"
@@ -146,12 +148,12 @@ const resolvedRetention = 15 * time.Minute
 
 // eval evaluates the rule expression and then creates pending alerts and fires
 // or removes previously pending alerts accordingly.
-func (r *AlertingRule) eval(ts model.Time, engine *promql.Engine, externalURLPath string) (model.Vector, error) {
+func (r *AlertingRule) eval(ts model.Time, engine *promql.Engine, queryCtx context.Context, externalURLPath string) (model.Vector, error) {
 	query, err := engine.NewInstantQuery(r.vector.String(), ts)
 	if err != nil {
 		return nil, err
 	}
-	res, err := query.Exec().Vector()
+	res, err := query.Exec(queryCtx).Vector()
 	if err != nil {
 		return nil, err
 	}
@@ -188,6 +190,7 @@ func (r *AlertingRule) eval(ts model.Time, engine *promql.Engine, externalURLPat
 				tmplData,
 				ts,
 				engine,
+				queryCtx,
 				externalURLPath,
 			)
 			result, err := tmpl.Expand()

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -148,12 +148,12 @@ const resolvedRetention = 15 * time.Minute
 
 // eval evaluates the rule expression and then creates pending alerts and fires
 // or removes previously pending alerts accordingly.
-func (r *AlertingRule) eval(ts model.Time, engine *promql.Engine, queryCtx context.Context, externalURLPath string) (model.Vector, error) {
+func (r *AlertingRule) eval(ctx context.Context, ts model.Time, engine *promql.Engine, externalURLPath string) (model.Vector, error) {
 	query, err := engine.NewInstantQuery(r.vector.String(), ts)
 	if err != nil {
 		return nil, err
 	}
-	res, err := query.Exec(queryCtx).Vector()
+	res, err := query.Exec(ctx).Vector()
 	if err != nil {
 		return nil, err
 	}
@@ -185,12 +185,12 @@ func (r *AlertingRule) eval(ts model.Time, engine *promql.Engine, queryCtx conte
 
 		expand := func(text model.LabelValue) model.LabelValue {
 			tmpl := template.NewTemplateExpander(
+				ctx,
 				defs+string(text),
 				"__alert_"+r.Name(),
 				tmplData,
 				ts,
 				engine,
-				queryCtx,
 				externalURLPath,
 			)
 			result, err := tmpl.Expand()

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -21,13 +21,12 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
-
 	html_template "html/template"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/notifier"
@@ -107,7 +106,7 @@ const (
 type Rule interface {
 	Name() string
 	// eval evaluates the rule, including any associated recording or alerting actions.
-	eval(model.Time, *promql.Engine, context.Context, string) (model.Vector, error)
+	eval(context.Context, model.Time, *promql.Engine, string) (model.Vector, error)
 	// String returns a human-readable string representation of the rule.
 	String() string
 	// HTMLSnippet returns a human-readable string representation of the rule,
@@ -258,7 +257,7 @@ func (g *Group) eval() {
 
 			evalTotal.WithLabelValues(rtyp).Inc()
 
-			vector, err := rule.eval(now, g.opts.QueryEngine, g.opts.QueryCtx, g.opts.ExternalURL.Path)
+			vector, err := rule.eval(g.opts.Context, now, g.opts.QueryEngine, g.opts.ExternalURL.Path)
 			if err != nil {
 				// Canceled queries are intentional termination of queries. This normally
 				// happens on shutdown and thus we skip logging of any errors here.
@@ -343,7 +342,7 @@ type Manager struct {
 type ManagerOptions struct {
 	ExternalURL    *url.URL
 	QueryEngine    *promql.Engine
-	QueryCtx       context.Context
+	Context        context.Context
 	Notifier       *notifier.Notifier
 	SampleAppender storage.SampleAppender
 }

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -105,7 +105,7 @@ func TestAlertingRule(t *testing.T) {
 	for i, test := range tests {
 		evalTime := model.Time(0).Add(test.time)
 
-		res, err := rule.eval(evalTime, suite.QueryEngine(), "")
+		res, err := rule.eval(evalTime, suite.QueryEngine(), suite.Context(), "")
 		if err != nil {
 			t.Fatalf("Error during alerting rule evaluation: %s", err)
 		}

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -105,7 +105,7 @@ func TestAlertingRule(t *testing.T) {
 	for i, test := range tests {
 		evalTime := model.Time(0).Add(test.time)
 
-		res, err := rule.eval(evalTime, suite.QueryEngine(), suite.Context(), "")
+		res, err := rule.eval(suite.Context(), evalTime, suite.QueryEngine(), "")
 		if err != nil {
 			t.Fatalf("Error during alerting rule evaluation: %s", err)
 		}

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -46,14 +46,14 @@ func (rule RecordingRule) Name() string {
 }
 
 // eval evaluates the rule and then overrides the metric names and labels accordingly.
-func (rule RecordingRule) eval(timestamp model.Time, engine *promql.Engine, queryCtx context.Context, _ string) (model.Vector, error) {
+func (rule RecordingRule) eval(ctx context.Context, timestamp model.Time, engine *promql.Engine, _ string) (model.Vector, error) {
 	query, err := engine.NewInstantQuery(rule.vector.String(), timestamp)
 	if err != nil {
 		return nil, err
 	}
 
 	var (
-		result = query.Exec(queryCtx)
+		result = query.Exec(ctx)
 		vector model.Vector
 	)
 	if result.Err != nil {

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -18,6 +18,7 @@ import (
 	"html/template"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/util/strutil"
@@ -45,14 +46,14 @@ func (rule RecordingRule) Name() string {
 }
 
 // eval evaluates the rule and then overrides the metric names and labels accordingly.
-func (rule RecordingRule) eval(timestamp model.Time, engine *promql.Engine, _ string) (model.Vector, error) {
+func (rule RecordingRule) eval(timestamp model.Time, engine *promql.Engine, queryCtx context.Context, _ string) (model.Vector, error) {
 	query, err := engine.NewInstantQuery(rule.vector.String(), timestamp)
 	if err != nil {
 		return nil, err
 	}
 
 	var (
-		result = query.Exec()
+		result = query.Exec(queryCtx)
 		vector model.Vector
 	)
 	if result.Err != nil {

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage/local"
@@ -27,6 +28,9 @@ func TestRuleEval(t *testing.T) {
 	storage, closer := local.NewTestStorage(t, 2)
 	defer closer.Close()
 	engine := promql.NewEngine(storage, nil)
+	queryCtx, cancelQueries := context.WithCancel(context.Background())
+	defer cancelQueries()
+
 	now := model.Now()
 
 	suite := []struct {
@@ -59,7 +63,7 @@ func TestRuleEval(t *testing.T) {
 
 	for _, test := range suite {
 		rule := NewRecordingRule(test.name, test.expr, test.labels)
-		result, err := rule.eval(now, engine, "")
+		result, err := rule.eval(now, engine, queryCtx, "")
 		if err != nil {
 			t.Fatalf("Error evaluating %s", test.name)
 		}

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -28,8 +28,8 @@ func TestRuleEval(t *testing.T) {
 	storage, closer := local.NewTestStorage(t, 2)
 	defer closer.Close()
 	engine := promql.NewEngine(storage, nil)
-	queryCtx, cancelQueries := context.WithCancel(context.Background())
-	defer cancelQueries()
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
 
 	now := model.Now()
 
@@ -63,7 +63,7 @@ func TestRuleEval(t *testing.T) {
 
 	for _, test := range suite {
 		rule := NewRecordingRule(test.name, test.expr, test.labels)
-		result, err := rule.eval(now, engine, queryCtx, "")
+		result, err := rule.eval(ctx, now, engine, "")
 		if err != nil {
 			t.Fatalf("Error evaluating %s", test.name)
 		}

--- a/storage/local/interface.go
+++ b/storage/local/interface.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/metric"
@@ -40,7 +41,7 @@ type Storage interface {
 
 	// Drop all time series associated with the given label matchers. Returns
 	// the number series that were dropped.
-	DropMetricsForLabelMatchers(...*metric.LabelMatcher) (int, error)
+	DropMetricsForLabelMatchers(context.Context, ...*metric.LabelMatcher) (int, error)
 	// Run the various maintenance loops in goroutines. Returns when the
 	// storage is ready to use. Keeps everything running in the background
 	// until Stop is called.
@@ -59,10 +60,10 @@ type Querier interface {
 	// QueryRange returns a list of series iterators for the selected
 	// time range and label matchers. The iterators need to be closed
 	// after usage.
-	QueryRange(from, through model.Time, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error)
+	QueryRange(ctx context.Context, from, through model.Time, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error)
 	// QueryInstant returns a list of series iterators for the selected
 	// instant and label matchers. The iterators need to be closed after usage.
-	QueryInstant(ts model.Time, stalenessDelta time.Duration, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error)
+	QueryInstant(ctx context.Context, ts model.Time, stalenessDelta time.Duration, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error)
 	// MetricsForLabelMatchers returns the metrics from storage that satisfy
 	// the given sets of label matchers. Each set of matchers must contain at
 	// least one label matcher that does not match the empty string. Otherwise,
@@ -72,14 +73,14 @@ type Querier interface {
 	// storage to optimize the search. The storage MAY exclude metrics that
 	// have no samples in the specified interval from the returned map. In
 	// doubt, specify model.Earliest for from and model.Latest for through.
-	MetricsForLabelMatchers(from, through model.Time, matcherSets ...metric.LabelMatchers) ([]metric.Metric, error)
+	MetricsForLabelMatchers(ctx context.Context, from, through model.Time, matcherSets ...metric.LabelMatchers) ([]metric.Metric, error)
 	// LastSampleForLabelMatchers returns the last samples that have been
 	// ingested for the time series matching the given set of label matchers.
 	// The label matching behavior is the same as in MetricsForLabelMatchers.
 	// All returned samples are between the specified cutoff time and now.
-	LastSampleForLabelMatchers(cutoff model.Time, matcherSets ...metric.LabelMatchers) (model.Vector, error)
+	LastSampleForLabelMatchers(ctx context.Context, cutoff model.Time, matcherSets ...metric.LabelMatchers) (model.Vector, error)
 	// Get all of the label values that are associated with a given label name.
-	LabelValuesForLabelName(model.LabelName) (model.LabelValues, error)
+	LabelValuesForLabelName(context.Context, model.LabelName) (model.LabelValues, error)
 }
 
 // SeriesIterator enables efficient access of sample values in a series. Its

--- a/storage/local/noop_storage.go
+++ b/storage/local/noop_storage.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
+
 	"github.com/prometheus/prometheus/storage/metric"
 )
 
@@ -39,22 +41,23 @@ func (s *NoopStorage) WaitForIndexing() {
 }
 
 // LastSampleForLabelMatchers implements Storage.
-func (s *NoopStorage) LastSampleForLabelMatchers(cutoff model.Time, matcherSets ...metric.LabelMatchers) (model.Vector, error) {
+func (s *NoopStorage) LastSampleForLabelMatchers(ctx context.Context, cutoff model.Time, matcherSets ...metric.LabelMatchers) (model.Vector, error) {
 	return nil, nil
 }
 
 // QueryRange implements Storage.
-func (s *NoopStorage) QueryRange(from, through model.Time, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error) {
+func (s *NoopStorage) QueryRange(ctx context.Context, from, through model.Time, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error) {
 	return nil, nil
 }
 
 // QueryInstant implements Storage.
-func (s *NoopStorage) QueryInstant(ts model.Time, stalenessDelta time.Duration, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error) {
+func (s *NoopStorage) QueryInstant(ctx context.Context, ts model.Time, stalenessDelta time.Duration, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error) {
 	return nil, nil
 }
 
 // MetricsForLabelMatchers implements Storage.
 func (s *NoopStorage) MetricsForLabelMatchers(
+	ctx context.Context,
 	from, through model.Time,
 	matcherSets ...metric.LabelMatchers,
 ) ([]metric.Metric, error) {
@@ -62,12 +65,12 @@ func (s *NoopStorage) MetricsForLabelMatchers(
 }
 
 // LabelValuesForLabelName implements Storage.
-func (s *NoopStorage) LabelValuesForLabelName(labelName model.LabelName) (model.LabelValues, error) {
+func (s *NoopStorage) LabelValuesForLabelName(ctx context.Context, labelName model.LabelName) (model.LabelValues, error) {
 	return nil, nil
 }
 
 // DropMetricsForLabelMatchers implements Storage.
-func (s *NoopStorage) DropMetricsForLabelMatchers(matchers ...*metric.LabelMatcher) (int, error) {
+func (s *NoopStorage) DropMetricsForLabelMatchers(ctx context.Context, matchers ...*metric.LabelMatcher) (int, error) {
 	return 0, nil
 }
 

--- a/storage/local/storage_test.go
+++ b/storage/local/storage_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/storage/metric"
 	"github.com/prometheus/prometheus/util/testutil"
@@ -194,6 +195,7 @@ func TestMatches(t *testing.T) {
 
 	for _, mt := range matcherTests {
 		metrics, err := storage.MetricsForLabelMatchers(
+			context.Background(),
 			model.Earliest, model.Latest,
 			mt.matchers,
 		)
@@ -218,6 +220,7 @@ func TestMatches(t *testing.T) {
 		}
 		// Smoketest for from/through.
 		metrics, err = storage.MetricsForLabelMatchers(
+			context.Background(),
 			model.Earliest, -10000,
 			mt.matchers,
 		)
@@ -228,6 +231,7 @@ func TestMatches(t *testing.T) {
 			t.Error("expected no matches with 'through' older than any sample")
 		}
 		metrics, err = storage.MetricsForLabelMatchers(
+			context.Background(),
 			10000, model.Latest,
 			mt.matchers,
 		)
@@ -243,6 +247,7 @@ func TestMatches(t *testing.T) {
 			through model.Time = 75
 		)
 		metrics, err = storage.MetricsForLabelMatchers(
+			context.Background(),
 			from, through,
 			mt.matchers,
 		)
@@ -451,6 +456,7 @@ func BenchmarkLabelMatching(b *testing.B) {
 		benchLabelMatchingRes = []metric.Metric{}
 		for _, mt := range matcherTests {
 			benchLabelMatchingRes, err = s.MetricsForLabelMatchers(
+				context.Background(),
 				model.Earliest, model.Latest,
 				mt,
 			)
@@ -493,7 +499,7 @@ func TestRetentionCutoff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating label matcher: %s", err)
 	}
-	its, err := s.QueryRange(insertStart, now, lm)
+	its, err := s.QueryRange(context.Background(), insertStart, now, lm)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -581,7 +587,7 @@ func TestDropMetrics(t *testing.T) {
 
 	fpList := model.Fingerprints{m1.FastFingerprint(), m2.FastFingerprint(), fpToBeArchived}
 
-	n, err := s.DropMetricsForLabelMatchers(lm1)
+	n, err := s.DropMetricsForLabelMatchers(context.Background(), lm1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -614,7 +620,7 @@ func TestDropMetrics(t *testing.T) {
 		t.Errorf("chunk file does not exist for fp=%v", fpList[2])
 	}
 
-	n, err = s.DropMetricsForLabelMatchers(lmAll)
+	n, err = s.DropMetricsForLabelMatchers(context.Background(), lmAll)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/template/template.go
+++ b/template/template.go
@@ -111,14 +111,14 @@ type Expander struct {
 }
 
 // NewTemplateExpander returns a template expander ready to use.
-func NewTemplateExpander(text string, name string, data interface{}, timestamp model.Time, queryEngine *promql.Engine, queryCtx context.Context, pathPrefix string) *Expander {
+func NewTemplateExpander(ctx context.Context, text string, name string, data interface{}, timestamp model.Time, queryEngine *promql.Engine, pathPrefix string) *Expander {
 	return &Expander{
 		text: text,
 		name: name,
 		data: data,
 		funcMap: text_template.FuncMap{
 			"query": func(q string) (queryResult, error) {
-				return query(queryCtx, q, timestamp, queryEngine)
+				return query(ctx, q, timestamp, queryEngine)
 			},
 			"first": func(v queryResult) (*sample, error) {
 				if len(v) > 0 {

--- a/template/template.go
+++ b/template/template.go
@@ -26,6 +26,7 @@ import (
 	text_template "text/template"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/util/strutil"
@@ -55,12 +56,12 @@ func (q queryResultByLabelSorter) Swap(i, j int) {
 	q.results[i], q.results[j] = q.results[j], q.results[i]
 }
 
-func query(q string, timestamp model.Time, queryEngine *promql.Engine) (queryResult, error) {
+func query(ctx context.Context, q string, timestamp model.Time, queryEngine *promql.Engine) (queryResult, error) {
 	query, err := queryEngine.NewInstantQuery(q, timestamp)
 	if err != nil {
 		return nil, err
 	}
-	res := query.Exec()
+	res := query.Exec(ctx)
 	if res.Err != nil {
 		return nil, res.Err
 	}
@@ -110,14 +111,14 @@ type Expander struct {
 }
 
 // NewTemplateExpander returns a template expander ready to use.
-func NewTemplateExpander(text string, name string, data interface{}, timestamp model.Time, queryEngine *promql.Engine, pathPrefix string) *Expander {
+func NewTemplateExpander(text string, name string, data interface{}, timestamp model.Time, queryEngine *promql.Engine, queryCtx context.Context, pathPrefix string) *Expander {
 	return &Expander{
 		text: text,
 		name: name,
 		data: data,
 		funcMap: text_template.FuncMap{
 			"query": func(q string) (queryResult, error) {
-				return query(q, timestamp, queryEngine)
+				return query(queryCtx, q, timestamp, queryEngine)
 			},
 			"first": func(v queryResult) (*sample, error) {
 				if len(v) > 0 {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage/local"
@@ -220,7 +221,7 @@ func TestTemplateExpansion(t *testing.T) {
 	for i, s := range scenarios {
 		var result string
 		var err error
-		expander := NewTemplateExpander(s.text, "test", s.input, time, engine, "")
+		expander := NewTemplateExpander(s.text, "test", s.input, time, engine, context.Background(), "")
 		if s.html {
 			result, err = expander.ExpandHTML(nil)
 		} else {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -221,7 +221,7 @@ func TestTemplateExpansion(t *testing.T) {
 	for i, s := range scenarios {
 		var result string
 		var err error
-		expander := NewTemplateExpander(s.text, "test", s.input, time, engine, context.Background(), "")
+		expander := NewTemplateExpander(context.Background(), s.text, "test", s.input, time, engine, "")
 		if s.html {
 			result, err = expander.ExpandHTML(nil)
 		} else {

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -85,19 +85,19 @@ type apiFunc func(r *http.Request) (interface{}, *apiError)
 // API can register a set of endpoints in a router and handle
 // them using the provided storage and query engine.
 type API struct {
+	Context     context.Context
 	Storage     local.Storage
 	QueryEngine *promql.Engine
-	QueryCtx    context.Context
 
 	context func(r *http.Request) context.Context
 	now     func() model.Time
 }
 
 // NewAPI returns an initialized API type.
-func NewAPI(qe *promql.Engine, qc context.Context, st local.Storage) *API {
+func NewAPI(ctx context.Context, qe *promql.Engine, st local.Storage) *API {
 	return &API{
+		Context:     ctx,
 		QueryEngine: qe,
-		QueryCtx:    qc,
 		Storage:     st,
 		context:     route.Context,
 		now:         model.Now,
@@ -159,7 +159,7 @@ func (api *API) query(r *http.Request) (interface{}, *apiError) {
 		return nil, &apiError{errorBadData, err}
 	}
 
-	res := qry.Exec(api.QueryCtx)
+	res := qry.Exec(api.Context)
 	if res.Err != nil {
 		switch res.Err.(type) {
 		case promql.ErrQueryCanceled:
@@ -206,7 +206,7 @@ func (api *API) queryRange(r *http.Request) (interface{}, *apiError) {
 		return nil, &apiError{errorBadData, err}
 	}
 
-	res := qry.Exec(api.QueryCtx)
+	res := qry.Exec(api.Context)
 	if res.Err != nil {
 		switch res.Err.(type) {
 		case promql.ErrQueryCanceled:
@@ -228,7 +228,7 @@ func (api *API) labelValues(r *http.Request) (interface{}, *apiError) {
 	if !model.LabelNameRE.MatchString(name) {
 		return nil, &apiError{errorBadData, fmt.Errorf("invalid label name: %q", name)}
 	}
-	vals, err := api.Storage.LabelValuesForLabelName(model.LabelName(name))
+	vals, err := api.Storage.LabelValuesForLabelName(api.Context, model.LabelName(name))
 	if err != nil {
 		return nil, &apiError{errorExec, err}
 	}
@@ -274,7 +274,7 @@ func (api *API) series(r *http.Request) (interface{}, *apiError) {
 		matcherSets = append(matcherSets, matchers)
 	}
 
-	res, err := api.Storage.MetricsForLabelMatchers(start, end, matcherSets...)
+	res, err := api.Storage.MetricsForLabelMatchers(api.Context, start, end, matcherSets...)
 	if err != nil {
 		return nil, &apiError{errorExec, err}
 	}
@@ -298,7 +298,7 @@ func (api *API) dropSeries(r *http.Request) (interface{}, *apiError) {
 		if err != nil {
 			return nil, &apiError{errorBadData, err}
 		}
-		n, err := api.Storage.DropMetricsForLabelMatchers(matchers...)
+		n, err := api.Storage.DropMetricsForLabelMatchers(context.TODO(), matchers...)
 		if err != nil {
 			return nil, &apiError{errorExec, err}
 		}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -52,7 +52,7 @@ func TestEndpoints(t *testing.T) {
 	api := &API{
 		Storage:     suite.Storage(),
 		QueryEngine: suite.QueryEngine(),
-		QueryCtx:    suite.Context(),
+		Context:     suite.Context(),
 		now:         func() model.Time { return now },
 	}
 

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -52,6 +52,7 @@ func TestEndpoints(t *testing.T) {
 	api := &API{
 		Storage:     suite.Storage(),
 		QueryEngine: suite.QueryEngine(),
+		QueryCtx:    suite.Context(),
 		now:         func() model.Time { return now },
 	}
 

--- a/web/federate.go
+++ b/web/federate.go
@@ -50,7 +50,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 	)
 	w.Header().Set("Content-Type", string(format))
 
-	vector, err := h.storage.LastSampleForLabelMatchers(minTimestamp, matcherSets...)
+	vector, err := h.storage.LastSampleForLabelMatchers(h.context, minTimestamp, matcherSets...)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/web/web.go
+++ b/web/web.go
@@ -36,6 +36,7 @@ import (
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/promql"
@@ -55,6 +56,7 @@ type Handler struct {
 	targetManager *retrieval.TargetManager
 	ruleManager   *rules.Manager
 	queryEngine   *promql.Engine
+	queryCtx      context.Context
 	storage       local.Storage
 
 	apiV1 *api_v1.API
@@ -112,6 +114,7 @@ type Options struct {
 func New(
 	st local.Storage,
 	qe *promql.Engine,
+	qc context.Context,
 	tm *retrieval.TargetManager,
 	rm *rules.Manager,
 	version *PrometheusVersion,
@@ -133,9 +136,10 @@ func New(
 		targetManager: tm,
 		ruleManager:   rm,
 		queryEngine:   qe,
+		queryCtx:      qc,
 		storage:       st,
 
-		apiV1: api_v1.NewAPI(qe, st),
+		apiV1: api_v1.NewAPI(qe, qc, st),
 		now:   model.Now,
 	}
 
@@ -293,7 +297,7 @@ func (h *Handler) consoles(w http.ResponseWriter, r *http.Request) {
 		Path:      strings.TrimLeft(name, "/"),
 	}
 
-	tmpl := template.NewTemplateExpander(string(text), "__console_"+name, data, h.now(), h.queryEngine, h.options.ExternalURL.Path)
+	tmpl := template.NewTemplateExpander(string(text), "__console_"+name, data, h.now(), h.queryEngine, h.queryCtx, h.options.ExternalURL.Path)
 	filenames, err := filepath.Glob(h.options.ConsoleLibrariesPath + "/*.lib")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -466,7 +470,7 @@ func (h *Handler) executeTemplate(w http.ResponseWriter, name string, data inter
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 
-	tmpl := template.NewTemplateExpander(text, name, data, h.now(), h.queryEngine, h.options.ExternalURL.Path)
+	tmpl := template.NewTemplateExpander(text, name, data, h.now(), h.queryEngine, h.queryCtx, h.options.ExternalURL.Path)
 	tmpl.Funcs(tmplFuncs(h.consolesPath(), h.options))
 
 	result, err := tmpl.ExpandHTML(nil)


### PR DESCRIPTION
This is based on https://github.com/prometheus/prometheus/pull/1997.

This adds contexts to the relevant Storage methods and already passes
PromQL's new per-query context into the storage's query methods.
The immediate motivation supporting multi-tenancy in Frankenstein, but
this could also be used by Prometheus's normal local storage to support
cancellations and timeouts at some point.