### PR TITLE
Microoptimise matching

### DIFF
--- a/storage/local/test_helpers.go
+++ b/storage/local/test_helpers.go
@@ -65,3 +65,7 @@ func NewTestStorage(t testutil.T, encoding chunkEncoding) (*MemorySeriesStorage,
 
 	return storage, closer
 }
+
+func makeFingerprintSeriesPair(s *MemorySeriesStorage, fp model.Fingerprint) fingerprintSeriesPair {
+	return fingerprintSeriesPair{fp, s.seriesForRange(fp, model.Earliest, model.Latest)}
+}


### PR DESCRIPTION
Series of patches with minor matching optimizations.

ab65905 - adds BenchmarkQueryRange to measure effect of future changes
 e222d40 - avoids extra iteration over possible results, run matchers checks before adding to a result instead 
 1121364 - extracts logic which prepares candidate FPs into a separate method
9b15a3b - adds `fpsForLabelMatchers` and `seriesForLabelMatchers` methods and uses them where appropriate 

Before (as of ab65905):
```
go test -bench BenchmarkQueryRange -run none -benchtime=10s -benchmem
    1000	  14723524 ns/op	 5013534 B/op	   83059 allocs/op
```

After:
```
go test -bench BenchmarkQueryRange -run none -benchtime=10s -benchmem
    1000	  11553489 ns/op	 4688423 B/op	   82596 allocs/op
```