### PR TITLE
Expose ec2_instance_state

### DIFF
--- a/retrieval/discovery/ec2.go
+++ b/retrieval/discovery/ec2.go
@@ -32,16 +32,17 @@ import (
 )
 
 const (
-	ec2Label           = model.MetaLabelPrefix + "ec2_"
-	ec2LabelAZ         = ec2Label + "availability_zone"
-	ec2LabelInstanceID = ec2Label + "instance_id"
-	ec2LabelPublicDNS  = ec2Label + "public_dns_name"
-	ec2LabelPublicIP   = ec2Label + "public_ip"
-	ec2LabelPrivateIP  = ec2Label + "private_ip"
-	ec2LabelSubnetID   = ec2Label + "subnet_id"
-	ec2LabelTag        = ec2Label + "tag_"
-	ec2LabelVPCID      = ec2Label + "vpc_id"
-	subnetSeparator    = ","
+	ec2Label              = model.MetaLabelPrefix + "ec2_"
+	ec2LabelAZ            = ec2Label + "availability_zone"
+	ec2LabelInstanceID    = ec2Label + "instance_id"
+	ec2LabelInstanceState = ec2Label + "instance_state"
+	ec2LabelPublicDNS     = ec2Label + "public_dns_name"
+	ec2LabelPublicIP      = ec2Label + "public_ip"
+	ec2LabelPrivateIP     = ec2Label + "private_ip"
+	ec2LabelSubnetID      = ec2Label + "subnet_id"
+	ec2LabelTag           = ec2Label + "tag_"
+	ec2LabelVPCID         = ec2Label + "vpc_id"
+	subnetSeparator       = ","
 )
 
 // EC2Discovery periodically performs EC2-SD requests. It implements
@@ -122,6 +123,7 @@ func (ed *EC2Discovery) refresh() (*config.TargetGroup, error) {
 				}
 
 				labels[ec2LabelAZ] = model.LabelValue(*inst.Placement.AvailabilityZone)
+				labels[ec2LabelInstanceState] = model.LabelValue(*inst.State.Name)
 
 				if inst.VpcId != nil {
 					labels[ec2LabelVPCID] = model.LabelValue(*inst.VpcId)


### PR DESCRIPTION
In order to reduce false alerts in our prometheus setup we need to have the instance state (esp. "stopped") available during relabeling.

This trivial change (only two lines added) adds the Instance State as a meta label during discovery.

@juliusv Please consider merging this.