### PR TITLE
Add support for remote write relabelling.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -192,7 +192,7 @@ type Config struct {
 	RuleFiles      []string        `yaml:"rule_files,omitempty"`
 	ScrapeConfigs  []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
 
-	RemoteWriteConfig []RemoteWriteConfig `yaml:"remote_write,omitempty"`
+	RemoteWriteConfig RemoteWriteConfig `yaml:"remote_write,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`
@@ -1075,11 +1075,12 @@ func (re Regexp) MarshalYAML() (interface{}, error) {
 
 // RemoteWriteConfig is the configuration for remote storage.
 type RemoteWriteConfig struct {
-	URL           URL            `yaml:"url,omitempty"`
-	RemoteTimeout model.Duration `yaml:"remote_timeout,omitempty"`
-	BasicAuth     *BasicAuth     `yaml:"basic_auth,omitempty"`
-	TLSConfig     TLSConfig      `yaml:"tls_config,omitempty"`
-	ProxyURL      URL            `yaml:"proxy_url,omitempty"`
+	URL                 *URL             `yaml:"url,omitempty"`
+	RemoteTimeout       model.Duration   `yaml:"remote_timeout,omitempty"`
+	BasicAuth           *BasicAuth       `yaml:"basic_auth,omitempty"`
+	TLSConfig           TLSConfig        `yaml:"tls_config,omitempty"`
+	ProxyURL            URL              `yaml:"proxy_url,omitempty"`
+	WriteRelabelConfigs []*RelabelConfig `yaml:"write_relabel_configs,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,6 +44,19 @@ var expectedConf = &Config{
 		"testdata/my/*.rules",
 	},
 
+	RemoteWriteConfig: RemoteWriteConfig{
+		RemoteTimeout: model.Duration(30 * time.Second),
+		WriteRelabelConfigs: []*RelabelConfig{
+			{
+				SourceLabels: model.LabelNames{"__name__"},
+				Separator:    ";",
+				Regex:        MustNewRegexp("expensive.*"),
+				Replacement:  "$1",
+				Action:       RelabelDrop,
+			},
+		},
+	},
+
 	ScrapeConfigs: []*ScrapeConfig{
 		{
 			JobName: "prometheus",

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -13,6 +13,12 @@ rule_files:
 - "/absolute/second.rules"
 - "my/*.rules"
 
+remote_write:
+  write_relabel_configs:
+  - source_labels: [__name__]
+    regex:         expensive.*
+    action:        drop
+
 scrape_configs:
 - job_name: prometheus
 

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -31,14 +31,13 @@ import (
 
 // Client allows sending batches of Prometheus samples to an HTTP endpoint.
 type Client struct {
-	index   int // Used to differentiate metrics
 	url     config.URL
 	client  *http.Client
 	timeout time.Duration
 }
 
 // NewClient creates a new Client.
-func NewClient(index int, conf config.RemoteWriteConfig) (*Client, error) {
+func NewClient(conf config.RemoteWriteConfig) (*Client, error) {
 	tlsConfig, err := httputil.NewTLSConfig(conf.TLSConfig)
 	if err != nil {
 		return nil, err
@@ -56,8 +55,7 @@ func NewClient(index int, conf config.RemoteWriteConfig) (*Client, error) {
 	}
 
 	return &Client{
-		index:   index,
-		url:     conf.URL,
+		url:     *conf.URL,
 		client:  httputil.NewClient(rt),
 		timeout: time.Duration(conf.RemoteTimeout),
 	}, nil
@@ -117,10 +115,6 @@ func (c *Client) Store(samples model.Samples) error {
 }
 
 // Name identifies the client as a generic client.
-//
-// TODO: This client is going to be the only one soon - then this method
-// will simply be removed in the restructuring and the whole "generic" naming
-// will be gone for good.
 func (c Client) Name() string {
-	return fmt.Sprintf("generic:%d:%s", c.index, c.url)
+	return "generic"
 }


### PR DESCRIPTION
Switch back to a single remote writer, as we were only ever meant to
have one and the relabel semantics are clearer that way.

Fixed #1955 

@juliusv 