### PR TITLE
Unpublish accidentally published series methods

### DIFF
--- a/storage/local/persistence_test.go
+++ b/storage/local/persistence_test.go
@@ -462,16 +462,16 @@ func testCheckpointAndLoadSeriesMapAndHeads(t *testing.T, encoding chunk.Encodin
 	s3, _ := newMemorySeries(m3, nil, time.Time{})
 	s4, _ := newMemorySeries(m4, nil, time.Time{})
 	s5, _ := newMemorySeries(m5, nil, time.Time{})
-	s1.Add(model.SamplePair{Timestamp: 1, Value: 3.14})
-	s3.Add(model.SamplePair{Timestamp: 2, Value: 2.7})
+	s1.add(model.SamplePair{Timestamp: 1, Value: 3.14})
+	s3.add(model.SamplePair{Timestamp: 2, Value: 2.7})
 	s3.headChunkClosed = true
 	s3.persistWatermark = 1
 	for i := 0; i < 10000; i++ {
-		s4.Add(model.SamplePair{
+		s4.add(model.SamplePair{
 			Timestamp: model.Time(i),
 			Value:     model.SampleValue(i) / 2,
 		})
-		s5.Add(model.SamplePair{
+		s5.add(model.SamplePair{
 			Timestamp: model.Time(i),
 			Value:     model.SampleValue(i * i),
 		})

--- a/storage/local/series.go
+++ b/storage/local/series.go
@@ -219,7 +219,7 @@ func newMemorySeries(m model.Metric, chunkDescs []*chunk.Desc, modTime time.Time
 // completed chunks (which are now eligible for persistence).
 //
 // The caller must have locked the fingerprint of the series.
-func (s *memorySeries) Add(v model.SamplePair) (int, error) {
+func (s *memorySeries) add(v model.SamplePair) (int, error) {
 	if len(s.chunkDescs) == 0 || s.headChunkClosed {
 		newHead := chunk.NewDesc(chunk.New(), v.Timestamp)
 		s.chunkDescs = append(s.chunkDescs, newHead)
@@ -383,18 +383,18 @@ func (s *memorySeries) preloadChunks(
 	}
 
 	iter := &boundedIterator{
-		it:    s.NewIterator(pinnedChunkDescs, curriedQuarantineSeries, mss.evictRequests),
+		it:    s.newIterator(pinnedChunkDescs, curriedQuarantineSeries, mss.evictRequests),
 		start: model.Now().Add(-mss.dropAfter),
 	}
 
 	return iter, nil
 }
 
-// NewIterator( returns a new SeriesIterator for the provided chunkDescs (which
+// newIterator returns a new SeriesIterator for the provided chunkDescs (which
 // must be pinned).
 //
 // The caller must have locked the fingerprint of the memorySeries.
-func (s *memorySeries) NewIterator(
+func (s *memorySeries) newIterator(
 	pinnedChunkDescs []*chunk.Desc,
 	quarantine func(error),
 	evictRequests chan<- chunk.EvictRequest,

--- a/storage/local/series_test.go
+++ b/storage/local/series_test.go
@@ -26,11 +26,11 @@ func TestDropChunks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.Add(model.SamplePair{
+	s.add(model.SamplePair{
 		Timestamp: 100,
 		Value:     42,
 	})
-	s.Add(model.SamplePair{
+	s.add(model.SamplePair{
 		Timestamp: 110,
 		Value:     4711,
 	})

--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -757,7 +757,7 @@ func (s *MemorySeriesStorage) Append(sample *model.Sample) error {
 		s.discardedSamplesCount.WithLabelValues(outOfOrderTimestamp).Inc()
 		return ErrOutOfOrderSample // Caused by the caller.
 	}
-	completedChunksCount, err := series.Add(model.SamplePair{
+	completedChunksCount, err := series.add(model.SamplePair{
 		Value:     sample.Value,
 		Timestamp: sample.Timestamp,
 	})


### PR DESCRIPTION
There were some more accidentally published methods of the memorySeries
type which I didn't notice when reviewing https://github.com/prometheus/prometheus/pull/2011