### PR TITLE
Simplify and fix remote write example

### DIFF
--- a/documentation/examples/remote_storage/README.md
+++ b/documentation/examples/remote_storage/README.md
@@ -7,11 +7,18 @@ To use it:
 
 ```
 go build
-remote_storage
+./remote_storage
 ```
 
-...and then run Prometheus as:
+...and then add the following to your `prometheus.yml`:
+
+```yaml
+remote_write:
+  url: "http://localhost:1234/receive"
+```
+
+Then start Prometheus:
 
 ```
-./prometheus -storage.remote.address=localhost:1234
+./prometheus
 ```


### PR DESCRIPTION
After removing gRPC, this can be simplified again. Also, the
configuration for the remote storage moved from flags to the config
file.