### PR TITLE
Add Chunk.Utilization() methods

### DIFF
--- a/storage/local/chunk/chunk.go
+++ b/storage/local/chunk/chunk.go
@@ -273,6 +273,7 @@ type Chunk interface {
 	Unmarshal(io.Reader) error
 	UnmarshalFromBuf([]byte) error
 	Encoding() Encoding
+	Utilization() float64
 }
 
 // Iterator enables efficient access to the content of a chunk. It is

--- a/storage/local/chunk/delta.go
+++ b/storage/local/chunk/delta.go
@@ -267,6 +267,11 @@ func (c *deltaEncodedChunk) UnmarshalFromBuf(buf []byte) error {
 // encoding implements chunk.
 func (c deltaEncodedChunk) Encoding() Encoding { return Delta }
 
+// Utilization implements chunk.
+func (c deltaEncodedChunk) Utilization() float64 {
+	return float64(len(c)) / float64(cap(c))
+}
+
 func (c deltaEncodedChunk) timeBytes() deltaBytes {
 	return deltaBytes(c[deltaHeaderTimeBytesOffset])
 }

--- a/storage/local/chunk/doubledelta.go
+++ b/storage/local/chunk/doubledelta.go
@@ -277,6 +277,11 @@ func (c *doubleDeltaEncodedChunk) UnmarshalFromBuf(buf []byte) error {
 // encoding implements chunk.
 func (c doubleDeltaEncodedChunk) Encoding() Encoding { return DoubleDelta }
 
+// Utilization implements chunk.
+func (c doubleDeltaEncodedChunk) Utilization() float64 {
+	return float64(len(c)) / float64(cap(c))
+}
+
 func (c doubleDeltaEncodedChunk) baseTime() model.Time {
 	return model.Time(
 		binary.LittleEndian.Uint64(

--- a/storage/local/chunk/varbit.go
+++ b/storage/local/chunk/varbit.go
@@ -322,6 +322,12 @@ func (c varbitChunk) UnmarshalFromBuf(buf []byte) error {
 // encoding implements chunk.
 func (c varbitChunk) Encoding() Encoding { return Varbit }
 
+// Utilization implements chunk.
+func (c varbitChunk) Utilization() float64 {
+	// 15 bytes is the length of the chunk footer.
+	return math.Min(float64(c.nextSampleOffset()/8+15)/float64(cap(c)), 1)
+}
+
 // FirstTime implements chunk.
 func (c varbitChunk) FirstTime() model.Time {
 	return model.Time(


### PR DESCRIPTION
When using the chunking code in other projects (both Weave Prism and
ChronixDB ingester), you sometimes want to know how well you are
utilizing your chunks when closing/storing them.