### PR TITLE
Clean up some doc comments

### DIFF
--- a/storage/local/chunk/delta.go
+++ b/storage/local/chunk/delta.go
@@ -72,7 +72,7 @@ func newDeltaEncodedChunk(tb, vb deltaBytes, isInt bool, length int) *deltaEncod
 	return &c
 }
 
-// add implements chunk.
+// Add implements chunk.
 func (c deltaEncodedChunk) Add(s model.SamplePair) ([]Chunk, error) {
 	// TODO(beorn7): Since we return &c, this method might cause an unnecessary allocation.
 	if c.len() == 0 {
@@ -177,7 +177,7 @@ func (c deltaEncodedChunk) Add(s model.SamplePair) ([]Chunk, error) {
 	return []Chunk{&c}, nil
 }
 
-// clone implements chunk.
+// Clone implements chunk.
 func (c deltaEncodedChunk) Clone() Chunk {
 	clone := make(deltaEncodedChunk, len(c), cap(c))
 	copy(clone, c)
@@ -201,7 +201,7 @@ func (c *deltaEncodedChunk) NewIterator() Iterator {
 	})
 }
 
-// marshal implements chunk.
+// Marshal implements chunk.
 func (c deltaEncodedChunk) Marshal(w io.Writer) error {
 	if len(c) > math.MaxUint16 {
 		panic("chunk buffer length would overflow a 16 bit uint.")
@@ -232,7 +232,7 @@ func (c deltaEncodedChunk) MarshalToBuf(buf []byte) error {
 	return nil
 }
 
-// unmarshal implements chunk.
+// Unmarshal implements chunk.
 func (c *deltaEncodedChunk) Unmarshal(r io.Reader) error {
 	*c = (*c)[:cap(*c)]
 	if _, err := io.ReadFull(r, *c); err != nil {
@@ -249,7 +249,7 @@ func (c *deltaEncodedChunk) Unmarshal(r io.Reader) error {
 	return nil
 }
 
-// unmarshalFromBuf implements chunk.
+// UnmarshalFromBuf implements chunk.
 func (c *deltaEncodedChunk) UnmarshalFromBuf(buf []byte) error {
 	*c = (*c)[:cap(*c)]
 	copy(*c, buf)
@@ -264,7 +264,7 @@ func (c *deltaEncodedChunk) UnmarshalFromBuf(buf []byte) error {
 	return nil
 }
 
-// encoding implements chunk.
+// Encoding implements chunk.
 func (c deltaEncodedChunk) Encoding() Encoding { return Delta }
 
 // Utilization implements chunk.

--- a/storage/local/chunk/doubledelta.go
+++ b/storage/local/chunk/doubledelta.go
@@ -80,7 +80,7 @@ func newDoubleDeltaEncodedChunk(tb, vb deltaBytes, isInt bool, length int) *doub
 	return &c
 }
 
-// add implements chunk.
+// Add implements chunk.
 func (c doubleDeltaEncodedChunk) Add(s model.SamplePair) ([]Chunk, error) {
 	// TODO(beorn7): Since we return &c, this method might cause an unnecessary allocation.
 	if c.len() == 0 {
@@ -184,7 +184,7 @@ func (c doubleDeltaEncodedChunk) Add(s model.SamplePair) ([]Chunk, error) {
 	return []Chunk{&c}, nil
 }
 
-// clone implements chunk.
+// Clone implements chunk.
 func (c doubleDeltaEncodedChunk) Clone() Chunk {
 	clone := make(doubleDeltaEncodedChunk, len(c), cap(c))
 	copy(clone, c)
@@ -210,7 +210,7 @@ func (c *doubleDeltaEncodedChunk) NewIterator() Iterator {
 	})
 }
 
-// marshal implements chunk.
+// Marshal implements chunk.
 func (c doubleDeltaEncodedChunk) Marshal(w io.Writer) error {
 	if len(c) > math.MaxUint16 {
 		panic("chunk buffer length would overflow a 16 bit uint")
@@ -241,7 +241,7 @@ func (c doubleDeltaEncodedChunk) MarshalToBuf(buf []byte) error {
 	return nil
 }
 
-// unmarshal implements chunk.
+// Unmarshal implements chunk.
 func (c *doubleDeltaEncodedChunk) Unmarshal(r io.Reader) error {
 	*c = (*c)[:cap(*c)]
 	if _, err := io.ReadFull(r, *c); err != nil {
@@ -259,7 +259,7 @@ func (c *doubleDeltaEncodedChunk) Unmarshal(r io.Reader) error {
 	return nil
 }
 
-// unmarshalFromBuf implements chunk.
+// UnmarshalFromBuf implements chunk.
 func (c *doubleDeltaEncodedChunk) UnmarshalFromBuf(buf []byte) error {
 	*c = (*c)[:cap(*c)]
 	copy(*c, buf)
@@ -274,7 +274,7 @@ func (c *doubleDeltaEncodedChunk) UnmarshalFromBuf(buf []byte) error {
 	return nil
 }
 
-// encoding implements chunk.
+// Encoding implements chunk.
 func (c doubleDeltaEncodedChunk) Encoding() Encoding { return DoubleDelta }
 
 // Utilization implements chunk.

--- a/storage/local/chunk/varbit.go
+++ b/storage/local/chunk/varbit.go
@@ -256,7 +256,7 @@ func newVarbitChunk(enc varbitValueEncoding) *varbitChunk {
 	return &c
 }
 
-// add implements chunk.
+// Add implements chunk.
 func (c *varbitChunk) Add(s model.SamplePair) ([]Chunk, error) {
 	offset := c.nextSampleOffset()
 	switch {
@@ -272,7 +272,7 @@ func (c *varbitChunk) Add(s model.SamplePair) ([]Chunk, error) {
 	return c.addLaterSample(s, offset)
 }
 
-// clone implements chunk.
+// Clone implements chunk.
 func (c varbitChunk) Clone() Chunk {
 	clone := make(varbitChunk, len(c))
 	copy(clone, c)
@@ -284,7 +284,7 @@ func (c varbitChunk) NewIterator() Iterator {
 	return newVarbitChunkIterator(c)
 }
 
-// marshal implements chunk.
+// Marshal implements chunk.
 func (c varbitChunk) Marshal(w io.Writer) error {
 	n, err := w.Write(c)
 	if err != nil {
@@ -296,7 +296,7 @@ func (c varbitChunk) Marshal(w io.Writer) error {
 	return nil
 }
 
-// marshalToBuf implements chunk.
+// MarshalToBuf implements chunk.
 func (c varbitChunk) MarshalToBuf(buf []byte) error {
 	n := copy(buf, c)
 	if n != len(c) {
@@ -305,13 +305,13 @@ func (c varbitChunk) MarshalToBuf(buf []byte) error {
 	return nil
 }
 
-// unmarshal implements chunk.
+// Unmarshal implements chunk.
 func (c varbitChunk) Unmarshal(r io.Reader) error {
 	_, err := io.ReadFull(r, c)
 	return err
 }
 
-// unmarshalFromBuf implements chunk.
+// UnmarshalFromBuf implements chunk.
 func (c varbitChunk) UnmarshalFromBuf(buf []byte) error {
 	if copied := copy(c, buf); copied != cap(c) {
 		return fmt.Errorf("insufficient bytes copied from buffer during unmarshaling, want %d, got %d", cap(c), copied)
@@ -319,7 +319,7 @@ func (c varbitChunk) UnmarshalFromBuf(buf []byte) error {
 	return nil
 }
 
-// encoding implements chunk.
+// Encoding implements chunk.
 func (c varbitChunk) Encoding() Encoding { return Varbit }
 
 // Utilization implements chunk.


### PR DESCRIPTION
Even though they don't trigger golint warnings because they are for methods on unexported types.