### PR TITLE
Fix small copy and paste error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -891,7 +891,7 @@ func (c *GCESDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err != nil {
 		return err
 	}
-	if err := checkOverflow(c.XXX, "ec2_sd_config"); err != nil {
+	if err := checkOverflow(c.XXX, "gce_sd_config"); err != nil {
 		return err
 	}
 	if c.Project == "" {


### PR DESCRIPTION
This PR corrects the error output in case of an parsing error in the gce_sd_config.