### PR TITLE
Consul: Add regexp filter option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -677,6 +677,9 @@ type ConsulSDConfig struct {
 	// The list of services for which targets are discovered.
 	// Defaults to all services if empty.
 	Services []string `yaml:"services"`
+	// An optional filter regexp that will be checked
+	// if none of the Services match
+	Filter string `yaml:"filter,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/retrieval/discovery/consul/consul.go
+++ b/retrieval/discovery/consul/consul.go
@@ -16,6 +16,7 @@ package consul
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -58,6 +59,7 @@ type Discovery struct {
 	clientDatacenter string
 	tagSeparator     string
 	watchedServices  []string // Set of services which will be discovered.
+	filter           string
 }
 
 // NewDiscovery returns a new Discovery for the given config.
@@ -81,6 +83,7 @@ func NewDiscovery(conf *config.ConsulSDConfig) (*Discovery, error) {
 		clientConf:       clientConf,
 		tagSeparator:     conf.TagSeparator,
 		watchedServices:  conf.Services,
+		filter:           conf.Filter,
 		clientDatacenter: clientConf.Datacenter,
 	}
 	return cd, nil
@@ -95,6 +98,11 @@ func (cd *Discovery) shouldWatch(name string) bool {
 	for _, sn := range cd.watchedServices {
 		if sn == name {
 			return true
+		}
+	}
+	if cd.filter != "" {
+		if match, _ := regexp.MatchString("^"+cd.filter+"$", name); !match {
+			return false
 		}
 	}
 	return false

--- a/retrieval/discovery/consul/consul.go
+++ b/retrieval/discovery/consul/consul.go
@@ -92,7 +92,7 @@ func NewDiscovery(conf *config.ConsulSDConfig) (*Discovery, error) {
 // shouldWatch returns whether the service of the given name should be watched.
 func (cd *Discovery) shouldWatch(name string) bool {
 	// If there's no fixed set of watched services, we watch everything.
-	if len(cd.watchedServices) == 0 {
+	if len(cd.watchedServices) == 0 && cd.filter == "" {
 		return true
 	}
 	for _, sn := range cd.watchedServices {
@@ -101,8 +101,8 @@ func (cd *Discovery) shouldWatch(name string) bool {
 		}
 	}
 	if cd.filter != "" {
-		if match, _ := regexp.MatchString("^"+cd.filter+"$", name); !match {
-			return false
+		if match, _ := regexp.MatchString("^"+cd.filter+"$", name); match {
+			return true
 		}
 	}
 	return false

--- a/retrieval/discovery/consul/consul_test.go
+++ b/retrieval/discovery/consul/consul_test.go
@@ -1,3 +1,16 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package consul
 
 import "testing"

--- a/retrieval/discovery/consul/consul_test.go
+++ b/retrieval/discovery/consul/consul_test.go
@@ -1,0 +1,49 @@
+package consul
+
+import "testing"
+
+func TestShouldWatch(t *testing.T) {
+	for _, tc := range []struct {
+		Discovery      *Discovery
+		ShouldMatch    []string
+		ShouldNotMatch []string
+	}{
+		{ // empty rules match everything
+			Discovery:   &Discovery{},
+			ShouldMatch: []string{"foo", "bar", "baz"},
+		},
+		{ // exact matches
+			Discovery: &Discovery{
+				watchedServices: []string{"foo", "bar", "baz"},
+			},
+			ShouldMatch:    []string{"foo", "bar", "baz"},
+			ShouldNotMatch: []string{"zab", "aar"},
+		},
+		{ // regexp matches
+			Discovery: &Discovery{
+				filter: ".*a.*",
+			},
+			ShouldMatch:    []string{"bar", "baz", "zab"},
+			ShouldNotMatch: []string{"foo"},
+		},
+		{ // exact matches and regexp
+			Discovery: &Discovery{
+				watchedServices: []string{"foo", "oof"},
+				filter:          "ba.+",
+			},
+			ShouldMatch:    []string{"foo", "oof", "bar", "baz"},
+			ShouldNotMatch: []string{"zab", "ba"},
+		},
+	} {
+		for _, svc := range tc.ShouldMatch {
+			if !tc.Discovery.shouldWatch(svc) {
+				t.Errorf("Should watch service %s", svc)
+			}
+		}
+		for _, svc := range tc.ShouldNotMatch {
+			if tc.Discovery.shouldWatch(svc) {
+				t.Errorf("Should not watch service %s", svc)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a regexp filter to reduce the number of services discovered. It aims to be fully backward-compatible.

See also https://github.com/prometheus/prometheus/pull/2028

I can change it to pre-compile the filter on instantiation if anyone thinks it's worth the extra code.
