### PR TITLE
Re-add counting of evict chunk ops and decrementing NumMemChunks

### DIFF
--- a/storage/local/chunk/chunk.go
+++ b/storage/local/chunk/chunk.go
@@ -252,6 +252,8 @@ func (d *Desc) MaybeEvict() bool {
 		panic("ChunkLastTime not populated for evicted chunk")
 	}
 	d.C = nil
+	Ops.WithLabelValues(Evict).Inc()
+	atomic.AddInt64(&NumMemChunks, -1)
 	return true
 }
 


### PR DESCRIPTION
Also, modify test to expose the regression.

@juliusv That happened during your refactoring, and I didn't spot the oversight.

This needs to be released quickly. @fabxc @brian-brazil Whoever is there, please have a look.