### PR TITLE
promu: Use default Go version again

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,5 +1,3 @@
-go:
-    version: 1.7.1
 repository:
     path: github.com/prometheus/prometheus
 build:


### PR DESCRIPTION
The default is Go1.7.1 now.

@grobie @sdurrheimer 