### PR TITLE
Add support for interpolating target_label

### DIFF
--- a/relabel/relabel.go
+++ b/relabel/relabel.go
@@ -64,9 +64,14 @@ func relabel(labels model.LabelSet, cfg *config.RelabelConfig) model.LabelSet {
 		res := cfg.Regex.ExpandString([]byte{}, cfg.Replacement, val, indexes)
 		if len(res) == 0 {
 			delete(labels, cfg.TargetLabel)
-		} else {
-			labels[cfg.TargetLabel] = model.LabelValue(res)
+			break
 		}
+		target := cfg.Regex.ExpandString([]byte{}, string(cfg.TargetLabel), val, indexes)
+		if len(target) == 0 {
+			delete(labels, cfg.TargetLabel)
+			break
+		}
+		labels[model.LabelName(target)] = model.LabelValue(res)
 	case config.RelabelHashMod:
 		mod := sum64(md5.Sum([]byte(val))) % cfg.Modulus
 		labels[cfg.TargetLabel] = model.LabelValue(fmt.Sprintf("%d", mod))

--- a/relabel/relabel.go
+++ b/relabel/relabel.go
@@ -61,17 +61,17 @@ func relabel(labels model.LabelSet, cfg *config.RelabelConfig) model.LabelSet {
 		if indexes == nil {
 			break
 		}
+		target := model.LabelName(cfg.Regex.ExpandString([]byte{}, string(cfg.TargetLabel), val, indexes))
+		if !target.IsValid() {
+			delete(labels, cfg.TargetLabel)
+			break
+		}
 		res := cfg.Regex.ExpandString([]byte{}, cfg.Replacement, val, indexes)
 		if len(res) == 0 {
 			delete(labels, cfg.TargetLabel)
 			break
 		}
-		target := cfg.Regex.ExpandString([]byte{}, string(cfg.TargetLabel), val, indexes)
-		if len(target) == 0 {
-			delete(labels, cfg.TargetLabel)
-			break
-		}
-		labels[model.LabelName(target)] = model.LabelValue(res)
+		labels[target] = model.LabelValue(res)
 	case config.RelabelHashMod:
 		mod := sum64(md5.Sum([]byte(val))) % cfg.Modulus
 		labels[cfg.TargetLabel] = model.LabelValue(fmt.Sprintf("%d", mod))

--- a/relabel/relabel_test.go
+++ b/relabel/relabel_test.go
@@ -350,21 +350,21 @@ func TestRelabel(t *testing.T) {
 			relabel: []*config.RelabelConfig{
 				{
 					SourceLabels: model.LabelNames{"__meta_sd_tags"},
-					Regex:        config.MustNewRegexp(".*?(?:,|^)path:(/[^,]+).*"),
+					Regex:        config.MustNewRegexp("(?:.+,|^)path:(/[^,]+).*"),
 					Action:       config.RelabelReplace,
 					Replacement:  "${1}",
 					TargetLabel:  model.LabelName("__metrics_path__"),
 				},
 				{
 					SourceLabels: model.LabelNames{"__meta_sd_tags"},
-					Regex:        config.MustNewRegexp(".*?(?:,|^)job:([^,]+).*"),
+					Regex:        config.MustNewRegexp("(?:.+,|^)job:([^,]+).*"),
 					Action:       config.RelabelReplace,
 					Replacement:  "${1}",
 					TargetLabel:  model.LabelName("job"),
 				},
 				{
 					SourceLabels: model.LabelNames{"__meta_sd_tags"},
-					Regex:        config.MustNewRegexp(".*?(?:,|^)label:([^=]+)=([^,]+).*"),
+					Regex:        config.MustNewRegexp("(?:.+,|^)label:([^=]+)=([^,]+).*"),
 					Action:       config.RelabelReplace,
 					Replacement:  "${2}",
 					TargetLabel:  model.LabelName("${1}"),

--- a/relabel/relabel_test.go
+++ b/relabel/relabel_test.go
@@ -312,7 +312,7 @@ func TestRelabel(t *testing.T) {
 				"a": "some-name-value",
 			},
 		},
-		{ // invalid target_label ""
+		{ // invalid target_labels
 			input: model.LabelSet{
 				"a": "some-name-value",
 			},
@@ -323,6 +323,20 @@ func TestRelabel(t *testing.T) {
 					Action:       config.RelabelReplace,
 					Replacement:  "${1}",
 					TargetLabel:  model.LabelName("${3}"),
+				},
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        config.MustNewRegexp("some-([^-]+)-([^,]+)"),
+					Action:       config.RelabelReplace,
+					Replacement:  "${1}",
+					TargetLabel:  model.LabelName("0${3}"),
+				},
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        config.MustNewRegexp("some-([^-]+)-([^,]+)"),
+					Action:       config.RelabelReplace,
+					Replacement:  "${1}",
+					TargetLabel:  model.LabelName("-${3}"),
 				},
 			},
 			output: model.LabelSet{
@@ -353,20 +367,14 @@ func TestRelabel(t *testing.T) {
 					Regex:        config.MustNewRegexp(".*?(?:,|^)label:([^=]+)=([^,]+).*"),
 					Action:       config.RelabelReplace,
 					Replacement:  "${2}",
-					TargetLabel:  model.LabelName("__meta_sd_add_label_${1}"),
-				},
-				{
-					Regex:       config.MustNewRegexp("__meta_sd_add_label_(.*)"),
-					Replacement: "${1}",
-					Action:      config.RelabelLabelMap,
+					TargetLabel:  model.LabelName("${1}"),
 				},
 			},
 			output: model.LabelSet{
 				"__meta_sd_tags":   "path:/secret,job:some-job,label:foo=bar",
 				"__metrics_path__": "/secret",
 				"job":              "some-job",
-				"__meta_sd_add_label_foo": "bar",
-				"foo": "bar",
+				"foo":              "bar",
 			},
 		},
 	}


### PR DESCRIPTION
Adds support for interpolating regexp match group names in target_label variable in relabel replace action.

ref: #1099 

Why:

We currently schedule service and batch jobs using nomad scheduler (nomadproject.io), the scheduler registers jobs to consul as services. We would like to expose some details of the nomad scheduling as labels via consul tags and would like freedom to map data from the service tags to arbitrary labels resolved from the tags, so that prometheus reconfiguration is not necessary when introducing new target_labels.

A perhaps better solution to our problem would be to implement nomad discovery instead and expose the jobs metadata as labels instead but I feel that this feature adds to the power of relabeling even on its own.

Below are example prometheus config and nomad job that illustrate what can be done with this PR. It propagates nomad jobs allocation name  (ie. "example-service.api[0]") and version of the running service via consul tags to 'job' and 'version' labels.

```yaml
scrape_configs:
  - job_name: "overwritten-default"
    consul_sd_configs:
    - server:   '127.0.0.1:8500'
    relabel_configs:
    # only scrape services with prometheus tag 
    - source_labels: ['__meta_consul_tags']
      regex:         '(?:^|.+,)prometheus,?.*'
      action:        keep

    # .. set instance and job from consul __meta

    # map any label:k=v tags to labels
    - source_labels: ['__meta_consul_tags']
      regex:         '(?:.+,|^)label:([^=]+)=([^,]+).*'
      target_label: '${1}'
      replacement:  '${2}'
```

```hcl
job "example-service" {
  group "api" {
    count = 5
    task "http" {
      driver = "docker"
      service {
        name = "example"
        port = "http"
        tags = [
          "prometheus",
           # add some prometheus labels.
          "label:version=bdaf0ec6a2210ac93e0addc7b67d524ce5e1c182",
          "label:job=${NOMAD_ALLOC_NAME}"
        ]
      }
      config {
        image = "registry/image:bdaf0ec6a2210ac93e0addc7b67d524ce5e1c182"
      }
      resources {
        network {
          port "http" { }
        }
      }
    }
  }
}
```