### PR TITLE
storage: enhance Querier interface usage

### DIFF
--- a/storage/local/interface.go
+++ b/storage/local/interface.go
@@ -26,7 +26,8 @@ import (
 // Storage ingests and manages samples, along with various indexes. All methods
 // are goroutine-safe. Storage implements storage.SampleAppender.
 type Storage interface {
-	Querier
+	// Querier returns a new Querier on the storage.
+	Querier() (Querier, error)
 
 	// This SampleAppender needs multiple samples for the same fingerprint to be
 	// submitted in chronological order, from oldest to newest. When Append has
@@ -57,6 +58,9 @@ type Storage interface {
 
 // Querier allows querying a time series storage.
 type Querier interface {
+	// Close closes the querier. Behavior for subsequent calls to Querier methods
+	// is undefined.
+	Close() error
 	// QueryRange returns a list of series iterators for the selected
 	// time range and label matchers. The iterators need to be closed
 	// after usage.

--- a/storage/local/noop_storage.go
+++ b/storage/local/noop_storage.go
@@ -40,23 +40,35 @@ func (s *NoopStorage) Stop() error {
 func (s *NoopStorage) WaitForIndexing() {
 }
 
-// LastSampleForLabelMatchers implements Storage.
-func (s *NoopStorage) LastSampleForLabelMatchers(ctx context.Context, cutoff model.Time, matcherSets ...metric.LabelMatchers) (model.Vector, error) {
+// Querier implements Storage.
+func (s *NoopStorage) Querier() (Querier, error) {
+	return &NoopQuerier{}, nil
+}
+
+type NoopQuerier struct{}
+
+// Close implements Querier.
+func (s *NoopQuerier) Close() error {
+	return nil
+}
+
+// LastSampleForLabelMatchers implements Querier.
+func (s *NoopQuerier) LastSampleForLabelMatchers(ctx context.Context, cutoff model.Time, matcherSets ...metric.LabelMatchers) (model.Vector, error) {
 	return nil, nil
 }
 
-// QueryRange implements Storage.
-func (s *NoopStorage) QueryRange(ctx context.Context, from, through model.Time, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error) {
+// QueryRange implements Querier
+func (s *NoopQuerier) QueryRange(ctx context.Context, from, through model.Time, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error) {
 	return nil, nil
 }
 
-// QueryInstant implements Storage.
-func (s *NoopStorage) QueryInstant(ctx context.Context, ts model.Time, stalenessDelta time.Duration, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error) {
+// QueryInstant implements Querier.
+func (s *NoopQuerier) QueryInstant(ctx context.Context, ts model.Time, stalenessDelta time.Duration, matchers ...*metric.LabelMatcher) ([]SeriesIterator, error) {
 	return nil, nil
 }
 
-// MetricsForLabelMatchers implements Storage.
-func (s *NoopStorage) MetricsForLabelMatchers(
+// MetricsForLabelMatchers implements Querier.
+func (s *NoopQuerier) MetricsForLabelMatchers(
 	ctx context.Context,
 	from, through model.Time,
 	matcherSets ...metric.LabelMatchers,
@@ -64,8 +76,8 @@ func (s *NoopStorage) MetricsForLabelMatchers(
 	return nil, nil
 }
 
-// LabelValuesForLabelName implements Storage.
-func (s *NoopStorage) LabelValuesForLabelName(ctx context.Context, labelName model.LabelName) (model.LabelValues, error) {
+// LabelValuesForLabelName implements Querier.
+func (s *NoopQuerier) LabelValuesForLabelName(ctx context.Context, labelName model.LabelName) (model.LabelValues, error) {
 	return nil, nil
 }
 

--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -403,6 +403,19 @@ func (s *MemorySeriesStorage) Stop() error {
 	return nil
 }
 
+type memorySeriesStorageQuerier struct {
+	*MemorySeriesStorage
+}
+
+func (memorySeriesStorageQuerier) Close() error {
+	return nil
+}
+
+// Querier implements the storage interface.
+func (s *MemorySeriesStorage) Querier() (Querier, error) {
+	return memorySeriesStorageQuerier{s}, nil
+}
+
 // WaitForIndexing implements Storage.
 func (s *MemorySeriesStorage) WaitForIndexing() {
 	s.persistence.waitForIndexing()

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -226,7 +226,13 @@ func (api *API) labelValues(r *http.Request) (interface{}, *apiError) {
 	if !model.LabelNameRE.MatchString(name) {
 		return nil, &apiError{errorBadData, fmt.Errorf("invalid label name: %q", name)}
 	}
-	vals, err := api.Storage.LabelValuesForLabelName(api.context(r), model.LabelName(name))
+	q, err := api.Storage.Querier()
+	if err != nil {
+		return nil, &apiError{errorExec, err}
+	}
+	defer q.Close()
+
+	vals, err := q.LabelValuesForLabelName(api.context(r), model.LabelName(name))
 	if err != nil {
 		return nil, &apiError{errorExec, err}
 	}
@@ -272,7 +278,13 @@ func (api *API) series(r *http.Request) (interface{}, *apiError) {
 		matcherSets = append(matcherSets, matchers)
 	}
 
-	res, err := api.Storage.MetricsForLabelMatchers(api.context(r), start, end, matcherSets...)
+	q, err := api.Storage.Querier()
+	if err != nil {
+		return nil, &apiError{errorExec, err}
+	}
+	defer q.Close()
+
+	res, err := q.MetricsForLabelMatchers(api.context(r), start, end, matcherSets...)
 	if err != nil {
 		return nil, &apiError{errorExec, err}
 	}

--- a/web/federate.go
+++ b/web/federate.go
@@ -50,7 +50,14 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 	)
 	w.Header().Set("Content-Type", string(format))
 
-	vector, err := h.storage.LastSampleForLabelMatchers(h.context, minTimestamp, matcherSets...)
+	q, err := h.storage.Querier()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer q.Close()
+
+	vector, err := q.LastSampleForLabelMatchers(h.context, minTimestamp, matcherSets...)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
This extracts Querier as an instantiateable and closeable object
rather than just defining extending methods of the storage interface.
This improves composability and allows abstracting query transactions,
which can be useful for transaction-level caches, consistent data views,
and encapsulating teardown.

@beorn7 @juliusv 

This has no immediate use for the MemorySeriesStorage, but as there are now external implementers, this is conceptually more powerful and flexible.