### PR TITLE
Trivial spelling corrections

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -910,6 +910,7 @@ type EC2SDConfig struct {
 	SecretKey       string         `yaml:"secret_key,omitempty"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
 	Port            int            `yaml:"port"`
+
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`
 }
@@ -939,6 +940,7 @@ type AzureSDConfig struct {
 	ClientID        string         `yaml:"client_id,omitempty"`
 	ClientSecret    string         `yaml:"client_secret,omitempty"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
+
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -362,7 +362,7 @@ func TestLoadConfig(t *testing.T) {
 	// Parse a valid file that sets a global scrape timeout. This tests whether parsing
 	// an overwritten default field in the global config permanently changes the default.
 	if _, err := LoadFile("testdata/global_timeout.good.yml"); err != nil {
-		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
+		t.Errorf("Error parsing %s: %s", "testdata/global_timeout.good.yml", err)
 	}
 
 	c, err := LoadFile("testdata/conf.good.yml")

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -290,6 +290,7 @@ func (n *Notifier) sendAll(alerts ...*model.Alert) int {
 		}
 		defer resp.Body.Close()
 
+		// Any HTTP status 2xx is OK.
 		if resp.StatusCode/100 != 2 {
 			return fmt.Errorf("bad response status %v", resp.Status)
 		}

--- a/storage/local/chunk/varbit.go
+++ b/storage/local/chunk/varbit.go
@@ -518,7 +518,7 @@ func (c *varbitChunk) addSecondSample(s model.SamplePair) ([]Chunk, error) {
 	return []Chunk{c}, nil
 }
 
-// addLastSample isa a helper method only used by c.add() and in other helper
+// addLastSample is a helper method only used by c.add() and in other helper
 // methods called by c.add(). It simply sets the given sample as the last sample
 // in the heador and declares the chunk closed. In other words, addLastSample
 // adds the very last sample added to this chunk ever, while setLastSample sets


### PR DESCRIPTION
This PR fixes some spelling inconsistencies and adds a short comment that may save two seconds when reading the code.