### PR TITLE
Change SD metric names to make logical grouping more visible.

### DIFF
--- a/retrieval/discovery/azure.go
+++ b/retrieval/discovery/azure.go
@@ -46,13 +46,13 @@ var (
 	azureSDScrapeFailuresCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
-			Name:      "azure_sd_scrape_failures_total",
+			Name:      "sd_azure_scrape_failures_total",
 			Help:      "Number of Azure-SD scrape failures.",
 		})
 	azureSDScrapeDuration = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace: namespace,
-			Name:      "azure_sd_scrape_duration_seconds",
+			Name:      "sd_azure_scrape_duration_seconds",
 			Help:      "The duration of a Azure-SD scrape in seconds.",
 		})
 )

--- a/retrieval/discovery/dns/dns.go
+++ b/retrieval/discovery/dns/dns.go
@@ -42,13 +42,13 @@ var (
 	dnsSDLookupsCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
-			Name:      "dns_sd_lookups_total",
+			Name:      "sd_dns_lookups_total",
 			Help:      "The number of DNS-SD lookups.",
 		})
 	dnsSDLookupFailuresCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
-			Name:      "dns_sd_lookup_failures_total",
+			Name:      "sd_dns_lookup_failures_total",
 			Help:      "The number of DNS-SD lookup failures.",
 		})
 )

--- a/retrieval/discovery/ec2.go
+++ b/retrieval/discovery/ec2.go
@@ -50,13 +50,13 @@ var (
 	ec2SDScrapeFailuresCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
-			Name:      "ec2_sd_scrape_failures_total",
+			Name:      "sd_ec2_scrape_failures_total",
 			Help:      "The number of EC2-SD scrape failures.",
 		})
 	ec2SDScrapeDuration = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace: namespace,
-			Name:      "ec2_sd_scrape_duration_seconds",
+			Name:      "sd_ec2_scrape_duration_seconds",
 			Help:      "The duration of a EC2-SD scrape in seconds.",
 		})
 )

--- a/retrieval/discovery/gce.go
+++ b/retrieval/discovery/gce.go
@@ -50,28 +50,21 @@ const (
 )
 
 var (
-	gceSDScrapesCount = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "gce_sd_scrapes_total",
-			Help:      "The number of GCE-SD scrapes.",
-		})
 	gceSDScrapeFailuresCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
-			Name:      "gce_sd_scrape_failures_total",
+			Name:      "sd_gce_scrape_failures_total",
 			Help:      "The number of GCE-SD scrape failures.",
 		})
 	gceSDScrapeDuration = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace: namespace,
-			Name:      "gce_sd_scrape_duration",
+			Name:      "sd_gce_scrape_duration",
 			Help:      "The duration of a GCE-SD scrape in seconds.",
 		})
 )
 
 func init() {
-	prometheus.MustRegister(gceSDScrapesCount)
 	prometheus.MustRegister(gceSDScrapeFailuresCount)
 	prometheus.MustRegister(gceSDScrapeDuration)
 }
@@ -147,7 +140,6 @@ func (gd *GCEDiscovery) refresh() (tg *config.TargetGroup, err error) {
 	t0 := time.Now()
 	defer func() {
 		gceSDScrapeDuration.Observe(time.Since(t0).Seconds())
-		gceSDScrapesCount.Inc()
 		if err != nil {
 			gceSDScrapeFailuresCount.Inc()
 		}


### PR DESCRIPTION
This PR renames the SD metrics as per @brian-brazil suggestion in https://github.com/prometheus/prometheus/pull/2097#discussion_r84091338

It also removes a redundant metric from the GCE-SD. The number of scrapes is available in `sd_gce_scrape_duration_count` anyway. No need to a separate counter.