### PR TITLE
Expose ec2_instance_type

### DIFF
--- a/retrieval/discovery/ec2.go
+++ b/retrieval/discovery/ec2.go
@@ -37,6 +37,7 @@ const (
 	ec2LabelAZ            = ec2Label + "availability_zone"
 	ec2LabelInstanceID    = ec2Label + "instance_id"
 	ec2LabelInstanceState = ec2Label + "instance_state"
+	ec2LabelInstanceType  = ec2Label + "instance_type"
 	ec2LabelPublicDNS     = ec2Label + "public_dns_name"
 	ec2LabelPublicIP      = ec2Label + "public_ip"
 	ec2LabelPrivateIP     = ec2Label + "private_ip"
@@ -153,6 +154,7 @@ func (ed *EC2Discovery) refresh() (tg *config.TargetGroup, err error) {
 
 				labels[ec2LabelAZ] = model.LabelValue(*inst.Placement.AvailabilityZone)
 				labels[ec2LabelInstanceState] = model.LabelValue(*inst.State.Name)
+				labels[ec2LabelInstanceType] = model.LabelValue(*inst.InstanceType)
 
 				if inst.VpcId != nil {
 					labels[ec2LabelVPCID] = model.LabelValue(*inst.VpcId)


### PR DESCRIPTION
To calculate resource utilization per instance type, I want to get instance type from ec2_sd.

ref. Datadog has such feature.
http://docs.datadoghq.com/guides/hostmap/

I'm not sure this is popular use case, please consider to add this.