### PR TITLE
Add guard against non-monotonic samples in series

### DIFF
--- a/storage/local/series.go
+++ b/storage/local/series.go
@@ -14,6 +14,7 @@
 package local
 
 import (
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -495,6 +496,10 @@ func (s *memorySeries) preloadChunksForRange(
 	}
 	if throughIdx == len(s.chunkDescs) {
 		throughIdx--
+	}
+	if fromIdx > throughIdx {
+		// Guard against nonsensical result. The caller will quarantine the series with a meaningful log entry.
+		return nopIter, fmt.Errorf("fromIdx=%d is greater than throughIdx=%d, likely caused by data corruption", fromIdx, throughIdx)
 	}
 
 	pinIndexes := make([]int, 0, throughIdx-fromIdx+1)


### PR DESCRIPTION
This can only happen due to data corruption.

Fixes #2115 .

@juliusv @fabxc @stamm