### PR TITLE
Call SD metrics refresh rather than scrape.

### DIFF
--- a/retrieval/discovery/azure.go
+++ b/retrieval/discovery/azure.go
@@ -43,23 +43,23 @@ const (
 )
 
 var (
-	azureSDScrapeFailuresCount = prometheus.NewCounter(
+	azureSDRefreshFailuresCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
-			Name:      "sd_azure_scrape_failures_total",
-			Help:      "Number of Azure-SD scrape failures.",
+			Name:      "sd_azure_refresh_failures_total",
+			Help:      "Number of Azure-SD refresh failures.",
 		})
-	azureSDScrapeDuration = prometheus.NewSummary(
+	azureSDRefreshDuration = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace: namespace,
-			Name:      "sd_azure_scrape_duration_seconds",
-			Help:      "The duration of a Azure-SD scrape in seconds.",
+			Name:      "sd_azure_refresh_duration_seconds",
+			Help:      "The duration of a Azure-SD refresh in seconds.",
 		})
 )
 
 func init() {
-	prometheus.MustRegister(azureSDScrapeDuration)
-	prometheus.MustRegister(azureSDScrapeFailuresCount)
+	prometheus.MustRegister(azureSDRefreshDuration)
+	prometheus.MustRegister(azureSDRefreshFailuresCount)
 }
 
 // AzureDiscovery periodically performs Azure-SD requests. It implements
@@ -159,9 +159,9 @@ func newAzureResourceFromID(id string) (azureResource, error) {
 func (ad *AzureDiscovery) refresh() (tg *config.TargetGroup, err error) {
 	t0 := time.Now()
 	defer func() {
-		azureSDScrapeDuration.Observe(time.Since(t0).Seconds())
+		azureSDRefreshDuration.Observe(time.Since(t0).Seconds())
 		if err != nil {
-			azureSDScrapeFailuresCount.Inc()
+			azureSDRefreshFailuresCount.Inc()
 		}
 	}()
 	tg = &config.TargetGroup{}

--- a/retrieval/discovery/ec2.go
+++ b/retrieval/discovery/ec2.go
@@ -48,23 +48,23 @@ const (
 )
 
 var (
-	ec2SDScrapeFailuresCount = prometheus.NewCounter(
+	ec2SDRefreshFailuresCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
-			Name:      "sd_ec2_scrape_failures_total",
+			Name:      "sd_ec2_refresh_failures_total",
 			Help:      "The number of EC2-SD scrape failures.",
 		})
-	ec2SDScrapeDuration = prometheus.NewSummary(
+	ec2SDRefreshDuration = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace: namespace,
-			Name:      "sd_ec2_scrape_duration_seconds",
-			Help:      "The duration of a EC2-SD scrape in seconds.",
+			Name:      "sd_ec2_refresh_duration_seconds",
+			Help:      "The duration of a EC2-SD refresh in seconds.",
 		})
 )
 
 func init() {
-	prometheus.MustRegister(ec2SDScrapeFailuresCount)
-	prometheus.MustRegister(ec2SDScrapeDuration)
+	prometheus.MustRegister(ec2SDRefreshFailuresCount)
+	prometheus.MustRegister(ec2SDRefreshDuration)
 }
 
 // EC2Discovery periodically performs EC2-SD requests. It implements
@@ -124,9 +124,9 @@ func (ed *EC2Discovery) Run(ctx context.Context, ch chan<- []*config.TargetGroup
 func (ed *EC2Discovery) refresh() (tg *config.TargetGroup, err error) {
 	t0 := time.Now()
 	defer func() {
-		ec2SDScrapeDuration.Observe(time.Since(t0).Seconds())
+		ec2SDRefreshDuration.Observe(time.Since(t0).Seconds())
 		if err != nil {
-			ec2SDScrapeFailuresCount.Inc()
+			ec2SDRefreshFailuresCount.Inc()
 		}
 	}()
 

--- a/retrieval/discovery/gce.go
+++ b/retrieval/discovery/gce.go
@@ -50,23 +50,23 @@ const (
 )
 
 var (
-	gceSDScrapeFailuresCount = prometheus.NewCounter(
+	gceSDRefreshFailuresCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
-			Name:      "sd_gce_scrape_failures_total",
-			Help:      "The number of GCE-SD scrape failures.",
+			Name:      "sd_gce_refresh_failures_total",
+			Help:      "The number of GCE-SD refresh failures.",
 		})
-	gceSDScrapeDuration = prometheus.NewSummary(
+	gceSDRefreshDuration = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace: namespace,
-			Name:      "sd_gce_scrape_duration",
-			Help:      "The duration of a GCE-SD scrape in seconds.",
+			Name:      "sd_gce_refresh_duration",
+			Help:      "The duration of a GCE-SD refresh in seconds.",
 		})
 )
 
 func init() {
-	prometheus.MustRegister(gceSDScrapeFailuresCount)
-	prometheus.MustRegister(gceSDScrapeDuration)
+	prometheus.MustRegister(gceSDRefreshFailuresCount)
+	prometheus.MustRegister(gceSDRefreshDuration)
 }
 
 // GCEDiscovery periodically performs GCE-SD requests. It implements
@@ -139,9 +139,9 @@ func (gd *GCEDiscovery) Run(ctx context.Context, ch chan<- []*config.TargetGroup
 func (gd *GCEDiscovery) refresh() (tg *config.TargetGroup, err error) {
 	t0 := time.Now()
 	defer func() {
-		gceSDScrapeDuration.Observe(time.Since(t0).Seconds())
+		gceSDRefreshDuration.Observe(time.Since(t0).Seconds())
 		if err != nil {
-			gceSDScrapeFailuresCount.Inc()
+			gceSDRefreshFailuresCount.Inc()
 		}
 	}()
 
@@ -202,7 +202,7 @@ func (gd *GCEDiscovery) refresh() (tg *config.TargetGroup, err error) {
 		return nil
 	})
 	if err != nil {
-		return tg, fmt.Errorf("error retrieving scrape targets from gce: %s", err)
+		return tg, fmt.Errorf("error retrieving refresh targets from gce: %s", err)
 	}
 	return tg, nil
 }

--- a/retrieval/discovery/marathon/marathon.go
+++ b/retrieval/discovery/marathon/marathon.go
@@ -49,23 +49,23 @@ const (
 )
 
 var (
-	scrapeFailuresCount = prometheus.NewCounter(
+	refreshFailuresCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
-			Name:      "sd_marathon_scrape_failures_total",
-			Help:      "The number of Marathon-SD scrape failures.",
+			Name:      "sd_marathon_refresh_failures_total",
+			Help:      "The number of Marathon-SD refresh failures.",
 		})
-	scrapeDuration = prometheus.NewSummary(
+	refreshDuration = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace: namespace,
-			Name:      "sd_marathon_scrape_duration_seconds",
-			Help:      "The duration of a Marathon-SD scrape in seconds.",
+			Name:      "sd_marathon_refresh_duration_seconds",
+			Help:      "The duration of a Marathon-SD refresh in seconds.",
 		})
 )
 
 func init() {
-	prometheus.MustRegister(scrapeFailuresCount)
-	prometheus.MustRegister(scrapeDuration)
+	prometheus.MustRegister(refreshFailuresCount)
+	prometheus.MustRegister(refreshDuration)
 }
 
 const appListPath string = "/v2/apps/?embed=apps.tasks"
@@ -121,9 +121,9 @@ func (md *Discovery) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
 func (md *Discovery) updateServices(ctx context.Context, ch chan<- []*config.TargetGroup) (err error) {
 	t0 := time.Now()
 	defer func() {
-		scrapeDuration.Observe(time.Since(t0).Seconds())
+		refreshDuration.Observe(time.Since(t0).Seconds())
 		if err != nil {
-			scrapeFailuresCount.Inc()
+			refreshFailuresCount.Inc()
 		}
 	}()
 


### PR DESCRIPTION
This avoids confusion with scrape_duration_seconds, and
is more in line with the API naming.

@dominikschulz 