### PR TITLE
query_range: Validate that start comes before end

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -182,6 +182,11 @@ func (api *API) queryRange(r *http.Request) (interface{}, *apiError) {
 	if err != nil {
 		return nil, &apiError{errorBadData, err}
 	}
+	if end.Before(start) {
+		err := errors.New("end timestamp must not be before start time")
+		return nil, &apiError{errorBadData, err}
+	}
+
 	step, err := parseDuration(r.FormValue("step"))
 	if err != nil {
 		return nil, &apiError{errorBadData, err}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -198,6 +198,17 @@ func TestEndpoints(t *testing.T) {
 			},
 			errType: errorBadData,
 		},
+		// Start after end
+		{
+			endpoint: api.queryRange,
+			query: url.Values{
+				"query": []string{"time()"},
+				"start": []string{"2"},
+				"end":   []string{"1"},
+				"step":  []string{"1"},
+			},
+			errType: errorBadData,
+		},
 		{
 			endpoint: api.labelValues,
 			params: map[string]string{


### PR DESCRIPTION
This should take care of https://github.com/prometheus/prometheus/issues/2140