### PR TITLE
Ec2 sd tag filter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -909,7 +909,7 @@ type EC2SDConfig struct {
 	SecretKey       string         `yaml:"secret_key,omitempty"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
 	Port            int            `yaml:"port"`
-
+	TagFilters      []string       `yaml:"tag_filters,omitempty"`
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`
 }


### PR DESCRIPTION
taken from @pierzapin 

Although this was mentioned briefly in this issue (#1642), it looks worth revisiting as ec2 service discovery scrapes all instances in an account. As we use this feature a lot and have many servers in our AWS account, this ends up taking a lot longer and spending more resources than it has to. 
This just includes a new config setting tag_filters, which can filter by the existence of a tag key, or a certain key-tag combo. 