### PR TITLE
Fix MOD binop for scalars and vectors

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1012,7 +1012,7 @@ func scalarBinop(op itemType, lhs, rhs model.SampleValue) model.SampleValue {
 	case itemPOW:
 		return model.SampleValue(math.Pow(float64(lhs), float64(rhs)))
 	case itemMOD:
-		if rhs != 0 {
+		if int(rhs) != 0 {
 			return model.SampleValue(int(lhs) % int(rhs))
 		}
 		return model.SampleValue(math.NaN())
@@ -1046,7 +1046,7 @@ func vectorElemBinop(op itemType, lhs, rhs model.SampleValue) (model.SampleValue
 	case itemPOW:
 		return model.SampleValue(math.Pow(float64(lhs), float64(rhs))), true
 	case itemMOD:
-		if rhs != 0 {
+		if int(rhs) != 0 {
 			return model.SampleValue(int(lhs) % int(rhs)), true
 		}
 		return model.SampleValue(math.NaN()), true

--- a/promql/testdata/operators.test
+++ b/promql/testdata/operators.test
@@ -34,6 +34,10 @@ eval instant at 50m SUM(http_requests) BY (job) % 3
 	{job="api-server"} 1
 	{job="app-server"} 2
 
+eval instant at 50m SUM(http_requests) BY (job) % 0.3
+	{job="api-server"} NaN
+	{job="app-server"} NaN
+
 eval instant at 50m SUM(http_requests) BY (job) ^ 2
 	{job="api-server"} 1000000
 	{job="app-server"} 6760000
@@ -347,3 +351,13 @@ eval instant at 5m metricA + ignoring() metricB
 
 eval instant at 5m metricA + metricB
   {baz="meh"} 7
+
+clear
+
+load 5m
+  finite{foo="bar"} 42
+  almost_zero{foo="bar"} 0.123
+
+# MOD by "almost zero" with vector.
+eval instant at 5m finite % almost_zero
+  {foo="bar"} NaN


### PR DESCRIPTION
Previously, a floating point number that would round down to 0 would
cause a "division by zero" panic.

@TheTincho fixes #2058 

@fabxc as Mr Parser
@brian-brazil in case @fabxc is not available