### PR TITLE
retrieval/discovery/kubernetes: fix cache state unknown behavior

### DIFF
--- a/retrieval/discovery/kubernetes/endpoints.go
+++ b/retrieval/discovery/kubernetes/endpoints.go
@@ -83,31 +83,38 @@ func (e *Endpoints) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
 
 	e.endpointsInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o interface{}) {
-			send(e.buildEndpoints(o.(*apiv1.Endpoints)))
+			eps, err := convertToEndpoints(o)
+			if err != nil {
+				e.logger.With("err", err).Errorln("converting to Endpoints object failed")
+				return
+			}
+			send(e.buildEndpoints(eps))
 		},
 		UpdateFunc: func(_, o interface{}) {
-			send(e.buildEndpoints(o.(*apiv1.Endpoints)))
+			eps, err := convertToEndpoints(o)
+			if err != nil {
+				e.logger.With("err", err).Errorln("converting to Endpoints object failed")
+				return
+			}
+			send(e.buildEndpoints(eps))
 		},
 		DeleteFunc: func(o interface{}) {
-			endpoints, isEndpoints := o.(*apiv1.Endpoints)
-			if !isEndpoints {
-				deletedState, ok := o.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					e.logger.Errorln("Received unexpected object: %v", o)
-					return
-				}
-				endpoints, ok = deletedState.Obj.(*apiv1.Endpoints)
-				if !ok {
-					e.logger.Errorln("DeletedFinalStateUnknown contained non-Endpoints object: %v", deletedState.Obj)
-					return
-				}
+			eps, err := convertToEndpoints(o)
+			if err != nil {
+				e.logger.With("err", err).Errorln("converting to Endpoints object failed")
+				return
 			}
-
-			send(&config.TargetGroup{Source: endpointsSource(endpoints.ObjectMeta)})
+			send(&config.TargetGroup{Source: endpointsSource(eps)})
 		},
 	})
 
-	serviceUpdate := func(svc *apiv1.Service) {
+	serviceUpdate := func(o interface{}) {
+		svc, err := convertToService(o)
+		if err != nil {
+			e.logger.With("err", err).Errorln("converting to Service object failed")
+			return
+		}
+
 		ep := &apiv1.Endpoints{}
 		ep.Namespace = svc.Namespace
 		ep.Name = svc.Name
@@ -122,33 +129,33 @@ func (e *Endpoints) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
 	e.serviceInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		// TODO(fabxc): potentially remove add and delete event handlers. Those should
 		// be triggered via the endpoint handlers already.
-		AddFunc:    func(o interface{}) { serviceUpdate(o.(*apiv1.Service)) },
-		UpdateFunc: func(_, o interface{}) { serviceUpdate(o.(*apiv1.Service)) },
-		DeleteFunc: func(o interface{}) {
-			service, isService := o.(*apiv1.Service)
-			if !isService {
-				deletedState, ok := o.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					e.logger.Errorln("Received unexpected object: %v", o)
-					return
-				}
-				service, ok = deletedState.Obj.(*apiv1.Service)
-				if !ok {
-					e.logger.Errorln("DeletedFinalStateUnknown contained non-Service object: %v", deletedState.Obj)
-					return
-				}
-			}
-
-			serviceUpdate(service)
-		},
+		AddFunc:    func(o interface{}) { serviceUpdate(o) },
+		UpdateFunc: func(_, o interface{}) { serviceUpdate(o) },
+		DeleteFunc: func(o interface{}) { serviceUpdate(o) },
 	})
 
 	// Block until the target provider is explicitly canceled.
 	<-ctx.Done()
 }
 
-func endpointsSource(ep apiv1.ObjectMeta) string {
-	return "endpoints/" + ep.Namespace + "/" + ep.Name
+func convertToEndpoints(o interface{}) (*apiv1.Endpoints, error) {
+	endpoints, isEndpoints := o.(*apiv1.Endpoints)
+	if !isEndpoints {
+		deletedState, ok := o.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return nil, fmt.Errorf("Received unexpected object: %v", o)
+		}
+		endpoints, ok = deletedState.Obj.(*apiv1.Endpoints)
+		if !ok {
+			return nil, fmt.Errorf("DeletedFinalStateUnknown contained non-Endpoints object: %v", deletedState.Obj)
+		}
+	}
+
+	return endpoints, nil
+}
+
+func endpointsSource(ep *apiv1.Endpoints) string {
+	return "endpoints/" + ep.ObjectMeta.Namespace + "/" + ep.ObjectMeta.Name
 }
 
 const (
@@ -164,7 +171,7 @@ func (e *Endpoints) buildEndpoints(eps *apiv1.Endpoints) *config.TargetGroup {
 	}
 
 	tg := &config.TargetGroup{
-		Source: endpointsSource(eps.ObjectMeta),
+		Source: endpointsSource(eps),
 	}
 	tg.Labels = model.LabelSet{
 		namespaceLabel:     lv(eps.Namespace),

--- a/retrieval/discovery/kubernetes/node.go
+++ b/retrieval/discovery/kubernetes/node.go
@@ -63,32 +63,49 @@ func (n *Node) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
 	}
 	n.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o interface{}) {
-			send(n.buildNode(o.(*apiv1.Node)))
+			node, err := convertToNode(o)
+			if err != nil {
+				n.logger.With("err", err).Errorln("converting to Node object failed")
+				return
+			}
+			send(n.buildNode(node))
 		},
 		DeleteFunc: func(o interface{}) {
-			node, isNode := o.(*apiv1.Node)
-			if !isNode {
-				deletedState, ok := o.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					n.logger.Errorln("Received unexpected object: %v", o)
-					return
-				}
-				node, ok = deletedState.Obj.(*apiv1.Node)
-				if !ok {
-					n.logger.Errorln("DeletedFinalStateUnknown contained non-Node object: %v", deletedState.Obj)
-					return
-				}
+			node, err := convertToNode(o)
+			if err != nil {
+				n.logger.With("err", err).Errorln("converting to Node object failed")
+				return
 			}
-
 			send(&config.TargetGroup{Source: nodeSource(node)})
 		},
 		UpdateFunc: func(_, o interface{}) {
-			send(n.buildNode(o.(*apiv1.Node)))
+			node, err := convertToNode(o)
+			if err != nil {
+				n.logger.With("err", err).Errorln("converting to Node object failed")
+				return
+			}
+			send(n.buildNode(node))
 		},
 	})
 
 	// Block until the target provider is explicitly canceled.
 	<-ctx.Done()
+}
+
+func convertToNode(o interface{}) (*apiv1.Node, error) {
+	node, isNode := o.(*apiv1.Node)
+	if !isNode {
+		deletedState, ok := o.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return nil, fmt.Errorf("Received unexpected object: %v", o)
+		}
+		node, ok = deletedState.Obj.(*apiv1.Node)
+		if !ok {
+			return nil, fmt.Errorf("DeletedFinalStateUnknown contained non-Node object: %v", deletedState.Obj)
+		}
+	}
+
+	return node, nil
 }
 
 func nodeSource(n *apiv1.Node) string {

--- a/retrieval/discovery/kubernetes/pod_test.go
+++ b/retrieval/discovery/kubernetes/pod_test.go
@@ -14,13 +14,13 @@
 package kubernetes
 
 import (
-	//"fmt"
 	"testing"
 
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"k8s.io/client-go/1.5/pkg/api/v1"
+	"k8s.io/client-go/1.5/tools/cache"
 )
 
 func podStoreKeyFunc(obj interface{}) (string, error) {
@@ -196,6 +196,43 @@ func TestPodDiscoveryDelete(t *testing.T) {
 	k8sDiscoveryTest{
 		discovery:  n,
 		afterStart: func() { go func() { i.Delete(makePod()) }() },
+		expectedInitial: []*config.TargetGroup{
+			&config.TargetGroup{
+				Targets: []model.LabelSet{
+					model.LabelSet{
+						"__address__":                                   "1.2.3.4:9000",
+						"__meta_kubernetes_pod_container_name":          "testcontainer",
+						"__meta_kubernetes_pod_container_port_name":     "testport",
+						"__meta_kubernetes_pod_container_port_number":   "9000",
+						"__meta_kubernetes_pod_container_port_protocol": "TCP",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_namespace":     "default",
+					"__meta_kubernetes_pod_node_name": "testnode",
+					"__meta_kubernetes_pod_ip":        "1.2.3.4",
+					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
+					"__meta_kubernetes_pod_ready":     "true",
+				},
+				Source: "pod/default/testpod",
+			},
+		},
+		expectedRes: []*config.TargetGroup{
+			&config.TargetGroup{
+				Source: "pod/default/testpod",
+			},
+		},
+	}.Run(t)
+}
+
+func TestPodDiscoveryDeleteUnknownCacheState(t *testing.T) {
+	n, i := makeTestPodDiscovery()
+	i.GetStore().Add(makePod())
+
+	k8sDiscoveryTest{
+		discovery:  n,
+		afterStart: func() { go func() { i.Delete(cache.DeletedFinalStateUnknown{Obj: makePod()}) }() },
 		expectedInitial: []*config.TargetGroup{
 			&config.TargetGroup{
 				Targets: []model.LabelSet{

--- a/retrieval/discovery/kubernetes/service.go
+++ b/retrieval/discovery/kubernetes/service.go
@@ -14,6 +14,7 @@
 package kubernetes
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 
@@ -61,32 +62,49 @@ func (s *Service) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
 	}
 	s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o interface{}) {
-			send(s.buildService(o.(*apiv1.Service)))
+			svc, err := convertToService(o)
+			if err != nil {
+				s.logger.With("err", err).Errorln("converting to Service object failed")
+				return
+			}
+			send(s.buildService(svc))
 		},
 		DeleteFunc: func(o interface{}) {
-			service, isService := o.(*apiv1.Service)
-			if !isService {
-				deletedState, ok := o.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					s.logger.Errorln("Received unexpected object: %v", o)
-					return
-				}
-				service, ok = deletedState.Obj.(*apiv1.Service)
-				if !ok {
-					s.logger.Errorln("DeletedFinalStateUnknown contained non-Service object: %v", deletedState.Obj)
-					return
-				}
+			svc, err := convertToService(o)
+			if err != nil {
+				s.logger.With("err", err).Errorln("converting to Service object failed")
+				return
 			}
-
-			send(&config.TargetGroup{Source: serviceSource(service)})
+			send(&config.TargetGroup{Source: serviceSource(svc)})
 		},
 		UpdateFunc: func(_, o interface{}) {
-			send(s.buildService(o.(*apiv1.Service)))
+			svc, err := convertToService(o)
+			if err != nil {
+				s.logger.With("err", err).Errorln("converting to Service object failed")
+				return
+			}
+			send(s.buildService(svc))
 		},
 	})
 
 	// Block until the target provider is explicitly canceled.
 	<-ctx.Done()
+}
+
+func convertToService(o interface{}) (*apiv1.Service, error) {
+	service, isService := o.(*apiv1.Service)
+	if !isService {
+		deletedState, ok := o.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return nil, fmt.Errorf("Received unexpected object: %v", o)
+		}
+		service, ok = deletedState.Obj.(*apiv1.Service)
+		if !ok {
+			return nil, fmt.Errorf("DeletedFinalStateUnknown contained non-Service object: %v", deletedState.Obj)
+		}
+	}
+
+	return service, nil
 }
 
 func serviceSource(s *apiv1.Service) string {


### PR DESCRIPTION
The `OnDelete` handler can under certain circumstances [return a `DeletedFinalStateUnknown`](https://github.com/kubernetes/client-go/blob/843f7c4f28b1f647f664f883697107d5c02c5acc/1.5/tools/cache/controller.go#L146-L149) object. In that case we have a stale cache, but will only return to a correct cache once the refresh period has passed, so we keep our cache and use it on a best effort basis until then, without `panic`ing here.

@fabxc @brian-brazil 

Fixes #2178 