### PR TITLE
AUTHORS.md: Replace explicit list of authors with reference to git log

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,5 +7,7 @@ Maintainers of this repository:
 * Fabian Reinartz <fabian.reinartz@coreos.com>
 * Julius Volz <julius.volz@gmail.com>
 
-More than 100 individuals have contributed to this repository.
-Please refer to the Git commit log for a complete list.
+More than [100 individuals][1] have contributed to this repository. Please
+refer to the Git commit log for a complete list.
+
+[1]: https://github.com/prometheus/prometheus/graphs/contributors

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,49 +7,5 @@ Maintainers of this repository:
 * Fabian Reinartz <fabian.reinartz@coreos.com>
 * Julius Volz <julius.volz@gmail.com>
 
-The following individuals have contributed code to this repository
-(listed in alphabetical order):
-
-* Alan Braithwaite <asbraithwaite@gmail.com>
-* Alexander Staubo <alex@bengler.no>
-* Andres Suarez <andres@soundcloud.com>
-* Bernerd Schaefer <bj.schaefer@gmail.com>
-* Björn Rabenstein <beorn@soundcloud.com>
-* Brian Brazil <brian.brazil@robustperception.io>
-* Ceesjan Luiten <ceesjan@ytec.nl>
-* Chad Metcalf <metcalfc@gmail.com>
-* Conor Hennessy <conor@soundcloud.com>
-* Deomid Ryabkov <rojer@rojer.me>
-* Dan Williams <me@deedubs.com>
-* Daniel Bornkessel <daniel@soundcloud.com>
-* Fabian Reinartz <fabian.reinartz@coreos.com>
-* Florian Pfitzer <pfitzer@w3p.cc>
-* Jimmi Dyson <jimmidyson@gmail.com>
-* Johannes 'fish' Ziemke <fish@freigeist.org>
-* Joonas Bergius <joonas@digitalocean.com>
-* Joseph Wilk <joe@josephwilk.net>
-* Julius Volz <julius.volz@gmail.com>
-* Laurie Malau <laurie.malau@gmail.com>
-* Marko Mikulicic <mkm@cesanta.com>
-* Matt T. Proud <matt.proud@gmail.com>
-* Miek Gieben <miek@improbable.io>
-* Miquel Sabaté <mikisabate@gmail.com>
-* Mitsuhiro Tanda <mitsuhiro.tanda@gmail.com>
-* Peter Bourgon <peter@bourgon.org>
-* Robey Pointer <robeypointer@gmail.com>
-* Sabra Melamed <yosabra@gmail.com>
-* Sam McLeod <sammcj@users.noreply.github.com>
-* Scott Worley <scottworley@scottworley.com>
-* Sergiusz 'q3k' Bazański <q3k@q3k.org>
-* Sharif Nassar <mrwacky42@gmail.com>
-* Sindre Myren <smyrman@gmail.com>
-* Stephan Erb <github@stephanerb.eu>
-* Stephen Shirley <kormat@gmail.com>
-* Steve Durrheimer <s.durrheimer@gmail.com>
-* Stuart Nelson <stuart.nelson@soundcloud.com>
-* Tobias Gesellchen <tobias@gesellix.de>
-* Tobias Schmidt <ts@soundcloud.com>
-* Tom Prince <tom.prince@twistedmatrix.com>
-* Tomás Senart <tsenart@gmail.com>
-* Ursula Kallio <ursula@soundcloud.com>
-* Will Rouesnel <w.rouesnel@gmail.com>
+More than 100 individuals have contributed to this repository.
+Please refer to the Git commit log for a complete list.


### PR DESCRIPTION
Given the many contributors to the repository, maintaining a dedup'd
list of contributors is infeasible.

@brian-brazil @fabxc @juliusv 