### PR TITLE
Expose rule & group evaluation

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -146,9 +146,9 @@ func (r *AlertingRule) sample(alert *Alert, ts model.Time, set bool) *model.Samp
 // is kept in memory state and consequentally repeatedly sent to the AlertManager.
 const resolvedRetention = 15 * time.Minute
 
-// eval evaluates the rule expression and then creates pending alerts and fires
+// Eval evaluates the rule expression and then creates pending alerts and fires
 // or removes previously pending alerts accordingly.
-func (r *AlertingRule) eval(ctx context.Context, ts model.Time, engine *promql.Engine, externalURLPath string) (model.Vector, error) {
+func (r *AlertingRule) Eval(ctx context.Context, ts model.Time, engine *promql.Engine, externalURLPath string) (model.Vector, error) {
 	query, err := engine.NewInstantQuery(r.vector.String(), ts)
 	if err != nil {
 		return nil, err

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -106,7 +106,7 @@ const (
 type Rule interface {
 	Name() string
 	// eval evaluates the rule, including any associated recording or alerting actions.
-	eval(context.Context, model.Time, *promql.Engine, string) (model.Vector, error)
+	Eval(context.Context, model.Time, *promql.Engine, string) (model.Vector, error)
 	// String returns a human-readable string representation of the rule.
 	String() string
 	// HTMLSnippet returns a human-readable string representation of the rule,
@@ -257,7 +257,7 @@ func (g *Group) eval() {
 
 			evalTotal.WithLabelValues(rtyp).Inc()
 
-			vector, err := rule.eval(g.opts.Context, now, g.opts.QueryEngine, g.opts.ExternalURL.Path)
+			vector, err := rule.Eval(g.opts.Context, now, g.opts.QueryEngine, g.opts.ExternalURL.Path)
 			if err != nil {
 				// Canceled queries are intentional termination of queries. This normally
 				// happens on shutdown and thus we skip logging of any errors here.

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -105,7 +105,7 @@ func TestAlertingRule(t *testing.T) {
 	for i, test := range tests {
 		evalTime := model.Time(0).Add(test.time)
 
-		res, err := rule.eval(suite.Context(), evalTime, suite.QueryEngine(), "")
+		res, err := rule.Eval(suite.Context(), evalTime, suite.QueryEngine(), "")
 		if err != nil {
 			t.Fatalf("Error during alerting rule evaluation: %s", err)
 		}

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -45,8 +45,8 @@ func (rule RecordingRule) Name() string {
 	return rule.name
 }
 
-// eval evaluates the rule and then overrides the metric names and labels accordingly.
-func (rule RecordingRule) eval(ctx context.Context, timestamp model.Time, engine *promql.Engine, _ string) (model.Vector, error) {
+// Eval evaluates the rule and then overrides the metric names and labels accordingly.
+func (rule RecordingRule) Eval(ctx context.Context, timestamp model.Time, engine *promql.Engine, _ string) (model.Vector, error) {
 	query, err := engine.NewInstantQuery(rule.vector.String(), timestamp)
 	if err != nil {
 		return nil, err

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -63,7 +63,7 @@ func TestRuleEval(t *testing.T) {
 
 	for _, test := range suite {
 		rule := NewRecordingRule(test.name, test.expr, test.labels)
-		result, err := rule.eval(ctx, now, engine, "")
+		result, err := rule.Eval(ctx, now, engine, "")
 		if err != nil {
 			t.Fatalf("Error evaluating %s", test.name)
 		}


### PR DESCRIPTION
Exposes rule & group evaluation from rules package, so other Go code can evaluate parsed rules.

Context: I'm looking at doing multi-tenant recording rules for https://github.com/weaveworks/cortex. While we could get something extremely kludgey working with the existing public methods, exporting a bit more will probably help us.

I haven't yet experimented with actually _using_ the changes in this PR, but intend to do so immediately after submitting it.

I spoke a bit with @fabxc about this on IRC today. Summary:
1. rules implementations parse queries on each evaluation, which is less than ideal
2. implementing #1595 and #1095 could help quite a lot

I don't think either of those ought to prevent this PR, but would be happy to learn otherwise.