### PR TITLE
storage: fix error message

### DIFF
--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/storage/local/chunk"
 	"github.com/prometheus/prometheus/storage/local/codable"
 	"github.com/prometheus/prometheus/storage/local/index"
@@ -154,7 +155,11 @@ func newPersistence(
 		// empty. If not, we have found an old storage directory without
 		// version file, so we have to bail out.
 		if err := os.MkdirAll(basePath, 0700); err != nil {
-			return nil, err
+			if abspath, e := filepath.Abs(basePath); e != nil {
+				return nil, errors.Wrapf(err, "cannot create parsistent path %s", basePath)
+			} else {
+				return nil, errors.Wrapf(err, "cannot create persistent path %s", abspath)
+			}
 		}
 		fis, err := ioutil.ReadDir(basePath)
 		if err != nil {

--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -31,7 +31,6 @@ import (
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/storage/local/chunk"
 	"github.com/prometheus/prometheus/storage/local/codable"
 	"github.com/prometheus/prometheus/storage/local/index"
@@ -156,9 +155,9 @@ func newPersistence(
 		// version file, so we have to bail out.
 		if err := os.MkdirAll(basePath, 0700); err != nil {
 			if abspath, e := filepath.Abs(basePath); e != nil {
-				return nil, errors.Wrapf(err, "cannot create parsistent path %s", basePath)
+				return nil, fmt.Errorf("cannot create persistent directory %s: %s", basePath, err)
 			} else {
-				return nil, errors.Wrapf(err, "cannot create persistent path %s", abspath)
+				return nil, fmt.Errorf("cannot create persistent directory %s: %s", abspath, err)
 			}
 		}
 		fis, err := ioutil.ReadDir(basePath)


### PR DESCRIPTION
Issue: https://github.com/prometheus/prometheus/issues/2264
When executing `mkdir` the storage directory failed on startup(e.g. permission denied), it prints a too simple error message.

[Changed]
- Wrapping error messages of `mkdir`, I added (detailed) path information.