### PR TITLE
remove the api data point limit queryRange method

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -207,13 +207,6 @@ func (api *API) queryRange(r *http.Request) (interface{}, *apiError) {
 		return nil, &apiError{errorBadData, err}
 	}
 
-	// For safety, limit the number of returned points per timeseries.
-	// This is sufficient for 60s resolution for a week or 1h resolution for a year.
-	if end.Sub(start)/step > 11000 {
-		err := errors.New("exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)")
-		return nil, &apiError{errorBadData, err}
-	}
-
 	qry, err := api.QueryEngine.NewRangeQuery(r.FormValue("query"), start, end, step)
 	if err != nil {
 		return nil, &apiError{errorBadData, err}


### PR DESCRIPTION
I thought to remove this limitation because, most of the times you probably need less than that, but, sometimes you need more, and I don't think default global configuration is good for this. From performance point, api user need to check that the ranges is not too match large, tell me if you think we need to add log info when the peeked range is big. 