### PR TITLE
storage: Catch data corruption that leads to division by zero

### DIFF
--- a/storage/local/chunk/chunk_test.go
+++ b/storage/local/chunk/chunk_test.go
@@ -39,7 +39,10 @@ func TestLen(t *testing.T) {
 				t.Errorf("chunk type %s should have %d samples, had %d", c.Encoding(), i, c.Len())
 			}
 
-			cs, _ := c.Add(model.SamplePair{model.Time(i), model.SampleValue(i)})
+			cs, _ := c.Add(model.SamplePair{
+				Timestamp: model.Time(i),
+				Value:     model.SampleValue(i),
+			})
 			c = cs[0]
 		}
 	}

--- a/storage/local/chunk/doubledelta.go
+++ b/storage/local/chunk/doubledelta.go
@@ -247,28 +247,36 @@ func (c *doubleDeltaEncodedChunk) Unmarshal(r io.Reader) error {
 	if _, err := io.ReadFull(r, *c); err != nil {
 		return err
 	}
-	l := binary.LittleEndian.Uint16((*c)[doubleDeltaHeaderBufLenOffset:])
-	if int(l) > cap(*c) {
-		return fmt.Errorf("chunk length exceeded during unmarshaling: %d", l)
-	}
-	if int(l) < doubleDeltaHeaderMinBytes {
-		return fmt.Errorf("chunk length less than header size: %d < %d", l, doubleDeltaHeaderMinBytes)
-	}
-
-	*c = (*c)[:l]
-	return nil
+	return c.setLen()
 }
 
 // UnmarshalFromBuf implements chunk.
 func (c *doubleDeltaEncodedChunk) UnmarshalFromBuf(buf []byte) error {
 	*c = (*c)[:cap(*c)]
 	copy(*c, buf)
+	return c.setLen()
+}
+
+// setLen sets the length of the underlying slice and performs some sanity checks.
+func (c *doubleDeltaEncodedChunk) setLen() error {
 	l := binary.LittleEndian.Uint16((*c)[doubleDeltaHeaderBufLenOffset:])
 	if int(l) > cap(*c) {
-		return fmt.Errorf("chunk length exceeded during unmarshaling: %d", l)
+		return fmt.Errorf("doubledelta chunk length exceeded during unmarshaling: %d", l)
 	}
 	if int(l) < doubleDeltaHeaderMinBytes {
-		return fmt.Errorf("chunk length less than header size: %d < %d", l, doubleDeltaHeaderMinBytes)
+		return fmt.Errorf("doubledelta chunk length less than header size: %d < %d", l, doubleDeltaHeaderMinBytes)
+	}
+	switch c.timeBytes() {
+	case d1, d2, d4, d8:
+		// Pass.
+	default:
+		return fmt.Errorf("invalid number of time bytes in doubledelta chunk: %d", c.timeBytes())
+	}
+	switch c.valueBytes() {
+	case d0, d1, d2, d4, d8:
+		// Pass.
+	default:
+		return fmt.Errorf("invalid number of value bytes in doubledelta chunk: %d", c.valueBytes())
 	}
 	*c = (*c)[:l]
 	return nil

--- a/storage/local/noop_storage.go
+++ b/storage/local/noop_storage.go
@@ -45,6 +45,9 @@ func (s *NoopStorage) Querier() (Querier, error) {
 	return &NoopQuerier{}, nil
 }
 
+// NoopQuerier is a dummy Querier for use when Prometheus's local storage is
+// disabled. It is returned by the NoopStorage Querier method and always returns
+// empty results.
 type NoopQuerier struct{}
 
 // Close implements Querier.

--- a/storage/local/storage_test.go
+++ b/storage/local/storage_test.go
@@ -319,31 +319,31 @@ func TestFingerprintsForLabels(t *testing.T) {
 		expected model.Fingerprints
 	}{
 		{
-			pairs:    []model.LabelPair{{"label1", "x"}},
+			pairs:    []model.LabelPair{{Name: "label1", Value: "x"}},
 			expected: fingerprints[:0],
 		},
 		{
-			pairs:    []model.LabelPair{{"label1", "test_0"}},
+			pairs:    []model.LabelPair{{Name: "label1", Value: "test_0"}},
 			expected: fingerprints[:10],
 		},
 		{
 			pairs: []model.LabelPair{
-				{"label1", "test_0"},
-				{"label1", "test_1"},
+				{Name: "label1", Value: "test_0"},
+				{Name: "label1", Value: "test_1"},
 			},
 			expected: fingerprints[:0],
 		},
 		{
 			pairs: []model.LabelPair{
-				{"label1", "test_0"},
-				{"label2", "test_1"},
+				{Name: "label1", Value: "test_0"},
+				{Name: "label2", Value: "test_1"},
 			},
 			expected: fingerprints[5:10],
 		},
 		{
 			pairs: []model.LabelPair{
-				{"label1", "test_1"},
-				{"label2", "test_2"},
+				{Name: "label1", Value: "test_1"},
+				{Name: "label2", Value: "test_2"},
 			},
 			expected: fingerprints[15:20],
 		},


### PR DESCRIPTION
@brancz 
Fixes #2273 

Sorry for also throwing in go-vet and golint fixes. They always throw me off during coding when I want to find my own violations.