### PR TITLE
storage: Fix linter issue

### DIFF
--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -154,11 +154,10 @@ func newPersistence(
 		// empty. If not, we have found an old storage directory without
 		// version file, so we have to bail out.
 		if err := os.MkdirAll(basePath, 0700); err != nil {
-			if abspath, e := filepath.Abs(basePath); e != nil {
-				return nil, fmt.Errorf("cannot create persistent directory %s: %s", basePath, err)
-			} else {
+			if abspath, e := filepath.Abs(basePath); e == nil {
 				return nil, fmt.Errorf("cannot create persistent directory %s: %s", abspath, err)
 			}
+			return nil, fmt.Errorf("cannot create persistent directory %s: %s", basePath, err)
 		}
 		fis, err := ioutil.ReadDir(basePath)
 		if err != nil {


### PR DESCRIPTION
Go style tries to avoid indented `else` blocks.

@tattsun