### PR TITLE
Add labeldrop and labelkeep actions.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1100,6 +1100,10 @@ const (
 	RelabelHashMod RelabelAction = "hashmod"
 	// RelabelLabelMap copies labels to other labelnames based on a regex.
 	RelabelLabelMap RelabelAction = "labelmap"
+	// RelabelLabelDrop drops any label matching the regex.
+	RelabelLabelDrop RelabelAction = "labeldrop"
+	// RelabelLabelKeep drops any label not matching the regex.
+	RelabelLabelKeep RelabelAction = "labelkeep"
 )
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -1109,7 +1113,7 @@ func (a *RelabelAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	switch act := RelabelAction(strings.ToLower(s)); act {
-	case RelabelReplace, RelabelKeep, RelabelDrop, RelabelHashMod, RelabelLabelMap:
+	case RelabelReplace, RelabelKeep, RelabelDrop, RelabelHashMod, RelabelLabelMap, RelabelLabelDrop, RelabelLabelKeep:
 		*a = act
 		return nil
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -193,6 +193,18 @@ var expectedConf = &Config{
 					Replacement: DefaultRelabelConfig.Replacement,
 					Action:      RelabelLabelMap,
 				},
+				{
+					Regex:       MustNewRegexp("d"),
+					Separator:   ";",
+					Replacement: DefaultRelabelConfig.Replacement,
+					Action:      RelabelLabelDrop,
+				},
+				{
+					Regex:       MustNewRegexp("k"),
+					Separator:   ";",
+					Replacement: DefaultRelabelConfig.Replacement,
+					Action:      RelabelLabelKeep,
+				},
 			},
 			MetricRelabelConfigs: []*RelabelConfig{
 				{

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -95,6 +95,10 @@ scrape_configs:
     action:        keep
   - action:        labelmap
     regex:         1
+  - action:        labeldrop
+    regex:         d
+  - action:        labelkeep
+    regex:         k
 
   metric_relabel_configs:
   - source_labels: [__name__]

--- a/relabel/relabel.go
+++ b/relabel/relabel.go
@@ -88,6 +88,22 @@ func relabel(labels model.LabelSet, cfg *config.RelabelConfig) model.LabelSet {
 			}
 		}
 		labels = out
+	case config.RelabelLabelDrop:
+		out := make(model.LabelSet, len(labels))
+		for ln, lv := range labels {
+			if !cfg.Regex.MatchString(string(ln)) {
+				out[ln] = lv
+			}
+		}
+		labels = out
+	case config.RelabelLabelKeep:
+		out := make(model.LabelSet, len(labels))
+		for ln, lv := range labels {
+			if cfg.Regex.MatchString(string(ln)) {
+				out[ln] = lv
+			}
+		}
+		labels = out
 	default:
 		panic(fmt.Errorf("retrieval.relabel: unknown relabel action type %q", cfg.Action))
 	}

--- a/relabel/relabel_test.go
+++ b/relabel/relabel_test.go
@@ -377,6 +377,39 @@ func TestRelabel(t *testing.T) {
 				"foo":              "bar",
 			},
 		},
+		{
+			input: model.LabelSet{
+				"a":  "foo",
+				"b1": "bar",
+				"b2": "baz",
+			},
+			relabel: []*config.RelabelConfig{
+				{
+					Regex:  config.MustNewRegexp("(b.*)"),
+					Action: config.RelabelLabelKeep,
+				},
+			},
+			output: model.LabelSet{
+				"b1": "bar",
+				"b2": "baz",
+			},
+		},
+		{
+			input: model.LabelSet{
+				"a":  "foo",
+				"b1": "bar",
+				"b2": "baz",
+			},
+			relabel: []*config.RelabelConfig{
+				{
+					Regex:  config.MustNewRegexp("(b.*)"),
+					Action: config.RelabelLabelDrop,
+				},
+			},
+			output: model.LabelSet{
+				"a": "foo",
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Introduce two new relabel actions. labeldrop, and labelkeep.
These can be used to filter the set of labels by matching regex

- labeldrop: drops all labels that match the regex
- labelkeep: drops all labels that do not match the regex