### PR TITLE
Only clone the metric in the one place relabelling needs it.

### DIFF
--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -304,7 +304,7 @@ func populateLabels(lset model.LabelSet, cfg *config.ScrapeConfig) (res, orig mo
 		}
 	}
 
-	preRelabelLabels := lset
+	preRelabelLabels := lset.Clone()
 	lset = relabel.Process(lset, cfg.RelabelConfigs...)
 
 	// Check if the target was dropped.


### PR DESCRIPTION
This cuts ~17% off memory allocations related to ingesting data
in a basic setup.