### PR TITLE
expose max memory chunks metrics

### DIFF
--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -89,7 +89,7 @@ var (
 	)
 	maxMemChunksDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "max_memory_chunks"),
-		"The maximum number of chunks that can be holding in the memory",
+		"The configured maximum number of chunks that can be held in memory",
 		nil, nil,
 	)
 )

--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -87,6 +87,11 @@ var (
 		"The maximum number of chunks that can be waiting for persistence before sample ingestion will stop.",
 		nil, nil,
 	)
+	maxMemChunksDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystem, "max_memory_chunks"),
+		"The maximum number of chunks that can be holding in the memory",
+		nil, nil,
+	)
 )
 
 type quarantineRequest struct {
@@ -1763,6 +1768,11 @@ func (s *MemorySeriesStorage) Collect(ch chan<- prometheus.Metric) {
 	ch <- s.ingestedSamplesCount
 	s.discardedSamplesCount.Collect(ch)
 	ch <- s.nonExistentSeriesMatchesCount
+	ch <- prometheus.MustNewConstMetric(
+		maxMemChunksDesc,
+		prometheus.GaugeValue,
+		float64(s.maxMemoryChunks),
+	)
 	ch <- prometheus.MustNewConstMetric(
 		chunk.NumMemChunksDesc,
 		prometheus.GaugeValue,


### PR DESCRIPTION
By using this, we can estimate how much additional memory the Prometheus will use (when the chunks is not full).

I'm not sure this is reasonable change, if the Prometheus already provides alternative metrics, please tell me.