### PR TITLE
Use lexicographic order to sort alerts by name.

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -274,7 +274,7 @@ func (h *Handler) Run() {
 
 func (h *Handler) alerts(w http.ResponseWriter, r *http.Request) {
 	alerts := h.ruleManager.AlertingRules()
-	alertsSorter := byAlertStateSorter{alerts: alerts}
+	alertsSorter := byAlertStateAndNameSorter{alerts: alerts}
 	sort.Sort(alertsSorter)
 
 	alertStatus := AlertStatus{
@@ -541,18 +541,20 @@ type AlertStatus struct {
 	AlertStateToRowClass map[rules.AlertState]string
 }
 
-type byAlertStateSorter struct {
+type byAlertStateAndNameSorter struct {
 	alerts []*rules.AlertingRule
 }
 
-func (s byAlertStateSorter) Len() int {
+func (s byAlertStateAndNameSorter) Len() int {
 	return len(s.alerts)
 }
 
-func (s byAlertStateSorter) Less(i, j int) bool {
-	return s.alerts[i].State() > s.alerts[j].State()
+func (s byAlertStateAndNameSorter) Less(i, j int) bool {
+	return s.alerts[i].State() > s.alerts[j].State() ||
+		(s.alerts[i].State() == s.alerts[j].State() &&
+			s.alerts[i].Name() < s.alerts[j].Name())
 }
 
-func (s byAlertStateSorter) Swap(i, j int) {
+func (s byAlertStateAndNameSorter) Swap(i, j int) {
 	s.alerts[i], s.alerts[j] = s.alerts[j], s.alerts[i]
 }


### PR DESCRIPTION
Right now the /alerts page of Prometheus sorts alerts by severity
(firing, pending, inactive). Once multiple alerts have the same
severity, their order seems to correlate to how they are placed in the
configuration files, but not always. Looking at the code, we make use of
sort.Sort(), which is documented not to provide a stable sort. The
Less() function also only takes the alert state into account.

This change extends the Less() function to provide a lexicographic order
on both the alert state and the name. This means I can finally find the
alerts I'm looking for without using my browser's search feature.