### PR TITLE
Proposal: Try to reverse lookup dns name if it is IP address.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -738,6 +738,7 @@ type DNSSDConfig struct {
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
 	Type            string         `yaml:"type"`
 	Port            int            `yaml:"port"` // Ignored for SRV records
+	Lookup          bool           `yaml:"lookup"`
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/discovery/dns/dns.go
+++ b/discovery/dns/dns.go
@@ -136,26 +136,33 @@ func (dd *Discovery) refresh(ctx context.Context, name string, ch chan<- []*conf
 	}
 
 	for _, record := range response.Answer {
-		target := model.LabelValue("")
+		host, port := "", 0
 		switch addr := record.(type) {
 		case *dns.SRV:
 			// Remove the final dot from rooted DNS names to make them look more usual.
 			addr.Target = strings.TrimRight(addr.Target, ".")
 
-			target = hostPort(addr.Target, int(addr.Port))
+			host, port = addr.Target, int(addr.Port)
 		case *dns.A:
-			target = hostPort(addr.A.String(), dd.port)
+			host, port = addr.A.String(), dd.port
 		case *dns.AAAA:
-			target = hostPort(addr.AAAA.String(), dd.port)
+			host, port = addr.AAAA.String(), dd.port
 		default:
 			log.Warnf("%q is not a valid SRV record", record)
 			continue
 
 		}
-		tg.Targets = append(tg.Targets, model.LabelSet{
-			model.AddressLabel: target,
+
+		// Try to reverse lookup for the host if it is ip addr.
+		names, err := net.LookupAddr(host)
+		if err == nil && len(names) > 0 {
+			name = strings.TrimRight(names[0], ".")
+		}
+		target := model.LabelSet{
+			model.AddressLabel: hostPort(host, port),
 			dnsNameLabel:       model.LabelValue(name),
-		})
+		}
+		tg.Targets = append(tg.Targets, target)
 	}
 
 	tg.Source = name


### PR DESCRIPTION
Using prometheus with docker services, there is a difficulty of which it is hard to discover the right instance labels of jobs while dns service discovery. Discovered instance labels tend to be dynamic local IP address and port number, for example, "10.0.0.41:8080", "10.0.0.63:8080" and so on.

This pull request provides a way to solve the problem by taking reverse lookup the "__meta_dns_name" of which it seemed IP address, so that relabelling can replace it with the instance label that is unique service task name, such as "nginx.1".

Here's an example of relabel_configs to aschive it:

```
    relabel_configs:
    - source_labels: ['__meta_dns_name']
      target_label: 'instance'
      regex: '([^.]+.[^.]+).*'
```