### PR TITLE
Make relative links in README.md absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ The Makefile provides several targets:
 
 ## Contributing
 
-Refer to [CONTRIBUTING.md](CONTRIBUTING.md)
+Refer to [CONTRIBUTING.md](https://github.com/prometheus/prometheus/blob/master/CONTRIBUTING.md)
 
 ## License
 
-Apache License 2.0, see [LICENSE](LICENSE).
+Apache License 2.0, see [LICENSE](https://github.com/prometheus/prometheus/blob/master/LICENSE).
 
 
 [travis]: https://travis-ci.org/prometheus/prometheus


### PR DESCRIPTION
The relative links don't work in other pages that render the README (for example https://hub.docker.com/r/prom/prometheus/). As the links are (hopefully) not due to change any time soon, I think using absolute links is better.

Note: Future forks will link back to this repo. Is that a bad thing?