### PR TITLE
Make index queue bigger.

### DIFF
--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -68,7 +68,7 @@ const (
 
 	indexingMaxBatchSize  = 1024 * 1024
 	indexingBatchTimeout  = 500 * time.Millisecond // Commit batch when idle for that long.
-	indexingQueueCapacity = 1024 * 16
+	indexingQueueCapacity = 1024 * 256
 )
 
 var fpLen = len(model.Fingerprint(0).String()) // Length of a fingerprint as string.


### PR DESCRIPTION
When a large Prometheus starts up fresh it can take many minutes
to warmup and clear out the index queue. A larger queue means less
blocking, bigger batches and cuts down startup time by ~50%.

This will knock off 4-5m per 10M timeseries.

@beorn7 