### PR TITLE
Add max concurrent and current queries engine metrics

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -204,6 +204,7 @@ func Main() int {
 	prometheus.MustRegister(notifier)
 	prometheus.MustRegister(configSuccess)
 	prometheus.MustRegister(configSuccessTime)
+	prometheus.MustRegister(queryEngine)
 
 	// The notifier is a dependency of the rule manager. It has to be
 	// started before and torn down afterwards.

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -204,7 +204,6 @@ func Main() int {
 	prometheus.MustRegister(notifier)
 	prometheus.MustRegister(configSuccess)
 	prometheus.MustRegister(configSuccessTime)
-	prometheus.MustRegister(queryEngine)
 
 	// The notifier is a dependency of the rule manager. It has to be
 	// started before and torn down afterwards.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -271,7 +271,7 @@ func NewEngine(queryable Queryable, o *EngineOptions) *Engine {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "queries",
-			Help:      "The current number of queries.",
+			Help:      "The current number of queries being executed or waiting.",
 		}),
 	}
 }

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -51,7 +51,7 @@ var (
 	maxConcurrentQueries = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Subsystem: subsystem,
-		Name:      "max_concurrent_queries",
+		Name:      "queries_concurrent_max",
 		Help:      "The max number of concurrent queries.",
 	})
 )


### PR DESCRIPTION
This PR adds two metrics to the promql/engine: the number of max concurrent queries, as configured by the flag, and the number of current queries being served+blocked in the engine.

Related to #2325.