### PR TITLE
web/api: add alertmanager api

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -71,6 +71,10 @@ type targetRetriever interface {
 	Targets() []*retrieval.Target
 }
 
+type alertmanagerRetriever interface {
+	Alertmanagers() []string
+}
+
 type response struct {
 	Status    status      `json:"status"`
 	Data      interface{} `json:"data,omitempty"`
@@ -93,20 +97,22 @@ type API struct {
 	Storage     local.Storage
 	QueryEngine *promql.Engine
 
-	targetRetriever targetRetriever
+	targetRetriever       targetRetriever
+	alertmanagerRetriever alertmanagerRetriever
 
 	context func(r *http.Request) context.Context
 	now     func() model.Time
 }
 
 // NewAPI returns an initialized API type.
-func NewAPI(qe *promql.Engine, st local.Storage, tr targetRetriever) *API {
+func NewAPI(qe *promql.Engine, st local.Storage, tr targetRetriever, ar alertmanagerRetriever) *API {
 	return &API{
-		QueryEngine:     qe,
-		Storage:         st,
-		targetRetriever: tr,
-		context:         route.Context,
-		now:             model.Now,
+		QueryEngine:           qe,
+		Storage:               st,
+		targetRetriever:       tr,
+		alertmanagerRetriever: ar,
+		context:               route.Context,
+		now:                   model.Now,
 	}
 }
 
@@ -139,6 +145,7 @@ func (api *API) Register(r *route.Router) {
 	r.Del("/series", instr("drop_series", api.dropSeries))
 
 	r.Get("/targets", instr("targets", api.targets))
+	r.Get("/alertmanagers", instr("alertmanagers", api.alertmanagers))
 }
 
 type queryData struct {
@@ -373,6 +380,25 @@ func (api *API) targets(r *http.Request) (interface{}, *apiError) {
 	}
 
 	return res, nil
+}
+
+type AlertmanagerDiscovery struct {
+	ActiveAlertmanagers []*AlertmanagerTarget `json:"activeAlertmanagers"`
+}
+
+type AlertmanagerTarget struct {
+	URL string `json:"url"`
+}
+
+func (api *API) alertmanagers(r *http.Request) (interface{}, *apiError) {
+	urls := api.alertmanagerRetriever.Alertmanagers()
+	ams := &AlertmanagerDiscovery{ActiveAlertmanagers: make([]*AlertmanagerTarget, len(urls))}
+
+	for i := range urls {
+		ams.ActiveAlertmanagers[i] = &AlertmanagerTarget{URL: urls[i]}
+	}
+
+	return ams, nil
 }
 
 func respond(w http.ResponseWriter, data interface{}) {

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -351,16 +351,20 @@ type Target struct {
 	// Any labels that are added to this target and its metrics.
 	Labels model.LabelSet `json:"labels"`
 
-	ScrapeUrl string `json:"scrapeUrl"`
+	ScrapeURL string `json:"scrapeUrl"`
 
 	LastError  string                 `json:"lastError"`
 	LastScrape time.Time              `json:"lastScrape"`
 	Health     retrieval.TargetHealth `json:"health"`
 }
 
+type TargetDiscovery struct {
+	ActiveTargets []*Target `json:"activeTargets"`
+}
+
 func (api *API) targets(r *http.Request) (interface{}, *apiError) {
 	targets := api.targetRetriever.Targets()
-	res := make([]*Target, len(targets))
+	res := &TargetDiscovery{ActiveTargets: make([]*Target, len(targets))}
 
 	for i, t := range targets {
 		lastErrStr := ""
@@ -369,10 +373,10 @@ func (api *API) targets(r *http.Request) (interface{}, *apiError) {
 			lastErrStr = lastErr.Error()
 		}
 
-		res[i] = &Target{
+		res.ActiveTargets[i] = &Target{
 			DiscoveredLabels: t.DiscoveredLabels(),
 			Labels:           t.Labels(),
-			ScrapeUrl:        t.URL().String(),
+			ScrapeURL:        t.URL().String(),
 			LastError:        lastErrStr,
 			LastScrape:       t.LastScrape(),
 			Health:           t.Health(),

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -440,12 +440,14 @@ func TestEndpoints(t *testing.T) {
 			}{2},
 		}, {
 			endpoint: api.targets,
-			response: []*Target{
-				&Target{
-					DiscoveredLabels: model.LabelSet{},
-					Labels:           model.LabelSet{},
-					ScrapeUrl:        "http://example.com:8080/metrics",
-					Health:           "unknown",
+			response: &TargetDiscovery{
+				ActiveTargets: []*Target{
+					&Target{
+						DiscoveredLabels: model.LabelSet{},
+						Labels:           model.LabelSet{},
+						ScrapeURL:        "http://example.com:8080/metrics",
+						Health:           "unknown",
+					},
 				},
 			},
 		}, {

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -39,6 +39,12 @@ func (f targetRetrieverFunc) Targets() []*retrieval.Target {
 	return f()
 }
 
+type alertmanagerRetrieverFunc func() []string
+
+func (f alertmanagerRetrieverFunc) Alertmanagers() []string {
+	return f()
+}
+
 func TestEndpoints(t *testing.T) {
 	suite, err := promql.NewTest(t, `
 		load 1m
@@ -71,11 +77,16 @@ func TestEndpoints(t *testing.T) {
 		}
 	})
 
+	ar := alertmanagerRetrieverFunc(func() []string {
+		return []string{"http://alertmanager.example.com:8080/api/v1/alerts"}
+	})
+
 	api := &API{
-		Storage:         suite.Storage(),
-		QueryEngine:     suite.QueryEngine(),
-		targetRetriever: tr,
-		now:             func() model.Time { return now },
+		Storage:               suite.Storage(),
+		QueryEngine:           suite.QueryEngine(),
+		targetRetriever:       tr,
+		alertmanagerRetriever: ar,
+		now: func() model.Time { return now },
 	}
 
 	start := model.Time(0)
@@ -435,6 +446,15 @@ func TestEndpoints(t *testing.T) {
 					Labels:           model.LabelSet{},
 					ScrapeUrl:        "http://example.com:8080/metrics",
 					Health:           "unknown",
+				},
+			},
+		}, {
+			endpoint: api.alertmanagers,
+			response: &AlertmanagerDiscovery{
+				ActiveAlertmanagers: []*AlertmanagerTarget{
+					&AlertmanagerTarget{
+						URL: "http://alertmanager.example.com:8080/api/v1/alerts",
+					},
 				},
 			},
 		},

--- a/web/web.go
+++ b/web/web.go
@@ -155,7 +155,7 @@ func New(o *Options) *Handler {
 		storage:       o.Storage,
 		notifier:      o.Notifier,
 
-		apiV1: api_v1.NewAPI(o.QueryEngine, o.Storage, o.TargetManager),
+		apiV1: api_v1.NewAPI(o.QueryEngine, o.Storage, o.TargetManager, o.Notifier),
 		now:   model.Now,
 	}
 


### PR DESCRIPTION
Similar to the Targets API that was recently added in #2234. We would like to test whether a Prometheus instance has been setup correctly and is properly discovering Alertmanagers. The particular case is for the [prometheus-operator](https://github.com/coreos/promethesu-operator)'s end-to-end tests. Ultimately this as well as the Targets API introduced in #2234 should be exposing dropped targets as well, which would help a lot when debugging a configuration, for that however, some more ground work and refactoring in the retrievel/discovery mechanisms need to be made. That is also the reason that some of this code is very similar to the Targets API, as I did not want to introduce a premature abstraction that is too tightly coupled and won't allow those changes to be easily made.

If possible when releasing these two APIs I would like to release them in beta status as due to the above reasons they are likely to be subject to change in the future.

@alexsomesan @brian-brazil @fabxc 