### PR TITLE
Only checkpoint chunkdescs and series that need persisting.

### DIFF
--- a/storage/local/persistence_test.go
+++ b/storage/local/persistence_test.go
@@ -493,8 +493,8 @@ func testCheckpointAndLoadSeriesMapAndHeads(t *testing.T, encoding chunk.Encodin
 	if err != nil {
 		t.Fatal(err)
 	}
-	if loadedSM.length() != 4 {
-		t.Errorf("want 4 series in map, got %d", loadedSM.length())
+	if loadedSM.length() != 3 {
+		t.Errorf("want 3 series in map, got %d", loadedSM.length())
 	}
 	if loadedS1, ok := loadedSM.get(m1.FastFingerprint()); ok {
 		if !reflect.DeepEqual(loadedS1.metric, m1) {
@@ -517,28 +517,6 @@ func testCheckpointAndLoadSeriesMapAndHeads(t *testing.T, encoding chunk.Encodin
 		}
 	} else {
 		t.Errorf("couldn't find %v in loaded map", m1)
-	}
-	if loadedS3, ok := loadedSM.get(m3.FastFingerprint()); ok {
-		if !reflect.DeepEqual(loadedS3.metric, m3) {
-			t.Errorf("want metric %v, got %v", m3, loadedS3.metric)
-		}
-		if loadedS3.head().C != nil {
-			t.Error("head chunk not evicted")
-		}
-		if loadedS3.chunkDescsOffset != 0 {
-			t.Errorf("want chunkDescsOffset 0, got %d", loadedS3.chunkDescsOffset)
-		}
-		if !loadedS3.headChunkClosed {
-			t.Error("headChunkClosed is false")
-		}
-		if loadedS3.head().ChunkFirstTime != 2 {
-			t.Errorf("want ChunkFirstTime in head chunk to be 2, got %d", loadedS3.head().ChunkFirstTime)
-		}
-		if loadedS3.head().ChunkLastTime != 2 {
-			t.Errorf("want ChunkLastTime in head chunk to be 2, got %d", loadedS3.head().ChunkLastTime)
-		}
-	} else {
-		t.Errorf("couldn't find %v in loaded map", m3)
 	}
 	if loadedS4, ok := loadedSM.get(m4.FastFingerprint()); ok {
 		if !reflect.DeepEqual(loadedS4.metric, m4) {
@@ -594,20 +572,17 @@ func testCheckpointAndLoadSeriesMapAndHeads(t *testing.T, encoding chunk.Encodin
 		if !reflect.DeepEqual(loadedS5.metric, m5) {
 			t.Errorf("want metric %v, got %v", m5, loadedS5.metric)
 		}
-		if got, want := len(loadedS5.chunkDescs), chunkCountS5; got != want {
+		if got, want := len(loadedS5.chunkDescs), chunkCountS5-3; got != want {
 			t.Errorf("got %d chunkDescs, want %d", got, want)
 		}
-		if got, want := loadedS5.persistWatermark, 3; got != want {
+		if got, want := loadedS5.persistWatermark, 0; got != want {
 			t.Errorf("got persistWatermark %d, want %d", got, want)
 		}
-		if !loadedS5.chunkDescs[2].IsEvicted() {
-			t.Error("3rd chunk not evicted")
+		if loadedS5.chunkDescs[0].IsEvicted() {
+			t.Error("1st chunk evicted")
 		}
-		if loadedS5.chunkDescs[3].IsEvicted() {
-			t.Error("4th chunk evicted")
-		}
-		if loadedS5.chunkDescsOffset != 0 {
-			t.Errorf("want chunkDescsOffset 0, got %d", loadedS5.chunkDescsOffset)
+		if loadedS5.chunkDescsOffset != 3 {
+			t.Errorf("want chunkDescsOffset 3, got %d", loadedS5.chunkDescsOffset)
 		}
 		if loadedS5.headChunkClosed {
 			t.Error("headChunkClosed is true")


### PR DESCRIPTION
This decreases checkpoint size by not checkpointing things
that don't actually need checkpointing.

This is fully compatible with the v2 checkpoint format,
as it makes series appear as though the only chunksdescs
in memory are those that need persisting.


@beorn7 

Very preliminary numbers from my home Prometheus indicate a 5-10% drop in checkpoint size and ~25% drop in checkpoint time. Benefits will be larger/smaller depending on how many chunks you have to persist vs. chunks in memory (my home Prometheus is around 2-3% to persist).