### PR TITLE
Correct notifications_dropped description

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -118,7 +118,7 @@ func New(o *Options) *Notifier {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "dropped_total",
-			Help:      "Total number of alerts dropped due to alert manager missing in configuration.",
+			Help:      "Total number of alerts dropped due to errors when sending to Alertmanager.",
 		}),
 		queueLength: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,


### PR DESCRIPTION
The current description does not accurately describe when the metric is incremented.

Aside from Alertmanger missing from the configuration, `prometheus_notifications_dropped_total` is incremented when errors occur while sending alert notifications to Alertmanager, or because the notifications queue is full, or because the number of notifications to be sent exceeds the queue capacity.

I think calling these cases 'errors' in a generic sense is more useful than the current description.

/cc @fabxc 