### PR TITLE
Cleaner separation between ServiceAccount and custom authentication in K8S SD

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -988,6 +988,11 @@ func (c *KubernetesSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) er
 	if c.BasicAuth != nil && (len(c.BearerToken) > 0 || len(c.BearerTokenFile) > 0) {
 		return fmt.Errorf("at most one of basic_auth, bearer_token & bearer_token_file must be configured")
 	}
+	if c.APIServer.URL == nil &&
+		(c.BasicAuth != nil || c.BearerToken != "" || c.BearerTokenFile != "" ||
+			c.TLSConfig.CAFile != "" || c.TLSConfig.CertFile != "" && c.TLSConfig.KeyFile != "") {
+		return fmt.Errorf("to use custom authentication please provide the 'api_server' URL explicitly")
+	}
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -990,7 +990,7 @@ func (c *KubernetesSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) er
 	}
 	if c.APIServer.URL == nil &&
 		(c.BasicAuth != nil || c.BearerToken != "" || c.BearerTokenFile != "" ||
-			c.TLSConfig.CAFile != "" || c.TLSConfig.CertFile != "" && c.TLSConfig.KeyFile != "") {
+			c.TLSConfig.CAFile != "" || c.TLSConfig.CertFile != "" || c.TLSConfig.KeyFile != "") {
 		return fmt.Errorf("to use custom authentication please provide the 'api_server' URL explicitly")
 	}
 	return nil


### PR DESCRIPTION
**What does this do?**

It provides a clearer separation between using [ServiceAccount](https://kubernetes.io/docs/admin/service-accounts-admin/) based authentication on K8S and other authentication schemes.

It is generally accepted as best-practice for applications that need to access the Kubernetes API from inside a cluster to use service accounts for authenticating. The ServiceAccounts are a well specified identity mechanism in Kubernetes which is entirely managed by the cluster control plane.

ServiceAccounts provide the path of least resistance to authentication inside the cluster, when used according to the specification and guidelines. Kubernetes provides convenience features in the client to easily make use of ServiceAccount authentication through the [`rest.InClusterConfig()`](https://github.com/kubernetes/client-go/blob/master/rest/config.go#L274) function. It's return value is a ready-to-use client config and should be used as-is for maximum reliability.

There is very little reason for modifying the result of  [`rest.InClusterConfig()`](https://github.com/kubernetes/client-go/blob/master/rest/config.go#L274) and users should explicitly be aware when choosing to do so. Specifically, the use of basic-http, token or TLS client certs instead of ServiceAccount authentication should be a decision users make with full awareness.

This change allows to do so and prevents accidental misconfigurations that could prevent ServiceAccount auth from working as expected.

Advanced users that want full control of the authentication setup, can still conveniently do so by explicitly populating the `api_server` field along with all other relevant parameters.

Documentation around using service accounts:
* https://kubernetes.io/docs/user-guide/service-accounts/
* https://kubernetes.io/docs/admin/service-accounts-admin/
* https://kubernetes.io/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod
