### PR TITLE
Clone lset before relabelling.

### DIFF
--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -305,6 +305,7 @@ func (app *countingAppender) Append(s *model.Sample) error {
 // It returns a label set before relabeling was applied as the second return value.
 // Returns a nil label set if the target is dropped during relabeling.
 func populateLabels(lset model.LabelSet, cfg *config.ScrapeConfig) (res, orig model.LabelSet, err error) {
+	lset = lset.Clone()
 	if _, ok := lset[model.AddressLabel]; !ok {
 		return nil, nil, fmt.Errorf("no address")
 	}

--- a/retrieval/targetmanager_test.go
+++ b/retrieval/targetmanager_test.go
@@ -140,9 +140,13 @@ func TestPopulateLabels(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
+		in := c.in.Clone()
 		res, orig, err := populateLabels(c.in, c.cfg)
 		if err != nil {
 			t.Fatalf("case %d: %s", i, err)
+		}
+		if !reflect.DeepEqual(c.in, in) {
+			t.Errorf("case %d: input lset was changed was\n\t%+v\n now\n\t%+v", i, in, c.in)
 		}
 		if !reflect.DeepEqual(res, c.res) {
 			t.Errorf("case %d: expected res\n\t%+v\n got\n\t%+v", i, c.res, res)


### PR DESCRIPTION
We need to not change the lset passed into populateLabels, as that
is kept around by the SDs.

Fixes 2377