### PR TITLE
storage: optimize dropping chunks by using minShrinkRatio

### DIFF
--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -886,8 +886,8 @@ func (p *persistence) dropAndPersistChunks(
 	}
 	totalChunks := int(fi.Size())/chunkLenWithHeader + len(chunks)
 
-	// Calculate chunk index from minShrinkRatio, to skip unnecessary chunk header reading
-	var chunkIndexToStartSeek int
+	// Calculate chunk index from minShrinkRatio, to skip unnecessary chunk header reading.
+	chunkIndexToStartSeek := 0
 	if p.minShrinkRatio < 1 {
 		chunkIndexToStartSeek = int(math.Floor(float64(totalChunks) * p.minShrinkRatio))
 	} else {
@@ -900,7 +900,6 @@ func (p *persistence) dropAndPersistChunks(
 	for ; ; numDropped++ {
 		_, err = f.Seek(offsetForChunkIndex(numDropped), os.SEEK_SET)
 		if err != nil {
-			numDropped = -1
 			return
 		}
 		_, err = io.ReadFull(f, headerBuf)
@@ -921,7 +920,6 @@ func (p *persistence) dropAndPersistChunks(
 			return
 		}
 		if err != nil {
-			numDropped = -1
 			return
 		}
 		lastTime := model.Time(

--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -879,15 +880,22 @@ func (p *persistence) dropAndPersistChunks(
 	}
 	defer f.Close()
 
-	// Calculate total chunks
 	fi, err := f.Stat()
 	if err != nil {
 		return
 	}
 	totalChunks := int(fi.Size())/chunkLenWithHeader + len(chunks)
 
+	// Calculate chunk index from minShrinkRatio, to skip unnecessary chunk header reading
+	var chunkIndexToStartSeek int
+	if p.minShrinkRatio < 1 {
+		chunkIndexToStartSeek = int(math.Floor(float64(totalChunks) * p.minShrinkRatio))
+	} else {
+		chunkIndexToStartSeek = totalChunks - 1
+	}
+	numDropped = chunkIndexToStartSeek
+
 	headerBuf := make([]byte, chunkHeaderLen)
-	var firstTimeInFile model.Time
 	// Find the first chunk in the file that should be kept.
 	for ; ; numDropped++ {
 		_, err = f.Seek(offsetForChunkIndex(numDropped), os.SEEK_SET)
@@ -914,11 +922,6 @@ func (p *persistence) dropAndPersistChunks(
 		if err != nil {
 			return
 		}
-		if numDropped == 0 {
-			firstTimeInFile = model.Time(
-				binary.LittleEndian.Uint64(headerBuf[chunkHeaderFirstTimeOffset:]),
-			)
-		}
 		lastTime := model.Time(
 			binary.LittleEndian.Uint64(headerBuf[chunkHeaderLastTimeOffset:]),
 		)
@@ -927,10 +930,21 @@ func (p *persistence) dropAndPersistChunks(
 		}
 	}
 
-	if numDropped == 0 || float64(numDropped)/float64(totalChunks) < p.minShrinkRatio {
+	// If numDropped isn't incremented, the minShrinkRatio condition isn't satisfied.
+	if numDropped == chunkIndexToStartSeek {
 		// Nothing to drop. Just adjust the return values and append the chunks (if any).
 		numDropped = 0
-		firstTimeNotDropped = firstTimeInFile
+		_, err = f.Seek(offsetForChunkIndex(0), os.SEEK_SET)
+		if err != nil {
+			return
+		}
+		_, err = io.ReadFull(f, headerBuf)
+		if err != nil {
+			return
+		}
+		firstTimeNotDropped = model.Time(
+			binary.LittleEndian.Uint64(headerBuf[chunkHeaderFirstTimeOffset:]),
+		)
 		if len(chunks) > 0 {
 			offset, err = p.persistChunks(fp, chunks)
 		}

--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -900,6 +900,7 @@ func (p *persistence) dropAndPersistChunks(
 	for ; ; numDropped++ {
 		_, err = f.Seek(offsetForChunkIndex(numDropped), os.SEEK_SET)
 		if err != nil {
+			numDropped = -1
 			return
 		}
 		_, err = io.ReadFull(f, headerBuf)
@@ -920,6 +921,7 @@ func (p *persistence) dropAndPersistChunks(
 			return
 		}
 		if err != nil {
+			numDropped = -1
 			return
 		}
 		lastTime := model.Time(


### PR DESCRIPTION
If `minShrinkRatio` > 0, I think we can skip to read the beginning part of chunks, because, we are interested with the chunk index which satisfy `minShrinkRatio`, not first chunk index before `beforeTime`.