### PR TITLE
Kubernetes SD: Fix namespace meta label in example config

### DIFF
--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -146,7 +146,7 @@ scrape_configs:
     target_label: instance
   - action: labelmap
     regex: __meta_kubernetes_service_label_(.+)
-  - source_labels: [__meta_kubernetes_service_namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     target_label: kubernetes_namespace
   - source_labels: [__meta_kubernetes_service_name]
     target_label: kubernetes_name


### PR DESCRIPTION
Replace one more instance of `__meta_kubernetes_service_namespace` with
`__meta_kubernetes_namespace`.