### PR TITLE
Adds execution timer stats to the range query

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -330,7 +330,7 @@ func (ng *Engine) exec(ctx context.Context, q *query) (Value, error) {
 
 	const env = "query execution"
 
-	evalTimer := q.stats.GetTimer(stats.TotalEvalTime).Start()
+	evalTimer := q.stats.GetTimer(stats.EvalTotalTime).Start()
 	defer evalTimer.Stop()
 
 	// The base context might already be canceled on the first iteration (e.g. during shutdown).

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -314,6 +314,8 @@ func (ng *Engine) exec(ctx context.Context, q *query) (Value, error) {
 	ctx, cancel := context.WithTimeout(ctx, ng.options.Timeout)
 	q.cancel = cancel
 
+	execTimer := q.stats.GetTimer(stats.ExecTotalTime).Start()
+	defer execTimer.Stop()
 	queueTimer := q.stats.GetTimer(stats.ExecQueueTime).Start()
 
 	if err := ng.gate.Start(ctx); err != nil {

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -50,7 +50,7 @@ func (s QueryTiming) String() string {
 	}
 }
 
-// QueryTimings with all query timers mapped to durations.
+// queryTimings with all query timers mapped to durations.
 type queryTimings struct {
 	EvalTotalTime        float64 `json:"evalTotalTime"`
 	ResultSortTime       float64 `json:"resultSortTime"`
@@ -61,7 +61,7 @@ type queryTimings struct {
 	ExecTotalTime        float64 `json:"execTotalTime"`
 }
 
-// QueryStats currently only holding query timings
+// QueryStats currently only holding query timings.
 type QueryStats struct {
 	Timings queryTimings `json:"timings,omitempty"`
 }

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -19,7 +19,7 @@ type QueryTiming int
 
 // Query timings.
 const (
-	TotalEvalTime QueryTiming = iota
+	EvalTotalTime QueryTiming = iota
 	ResultSortTime
 	QueryPreparationTime
 	InnerEvalTime
@@ -31,8 +31,8 @@ const (
 // Return a string representation of a QueryTiming identifier.
 func (s QueryTiming) String() string {
 	switch s {
-	case TotalEvalTime:
-		return "Total eval time"
+	case EvalTotalTime:
+		return "Eval total time"
 	case ResultSortTime:
 		return "Result sorting time"
 	case QueryPreparationTime:
@@ -52,7 +52,7 @@ func (s QueryTiming) String() string {
 
 // QueryStats with all query timers mapped to durations.
 type QueryStats struct {
-	TotalEvalTime        float64 `json:"totalEvalTime"`
+	EvalTotalTime        float64 `json:"evalTotalTime"`
 	ResultSortTime       float64 `json:"resultSortTime"`
 	QueryPreparationTime float64 `json:"queryPreparationTime"`
 	InnerEvalTime        float64 `json:"innerEvalTime"`
@@ -68,8 +68,8 @@ func NewQueryStats(tg *TimerGroup) *QueryStats {
 
 	for s, timer := range tg.timers {
 		switch s {
-		case TotalEvalTime:
-			qs.TotalEvalTime = timer.Duration()
+		case EvalTotalTime:
+			qs.EvalTotalTime = timer.Duration()
 		case ResultSortTime:
 			qs.ResultSortTime = timer.Duration()
 		case QueryPreparationTime:

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -25,6 +25,7 @@ const (
 	InnerEvalTime
 	ResultAppendTime
 	ExecQueueTime
+	ExecTotalTime
 )
 
 // Return a string representation of a QueryTiming identifier.
@@ -42,7 +43,47 @@ func (s QueryTiming) String() string {
 		return "Result append time"
 	case ExecQueueTime:
 		return "Exec queue wait time"
+	case ExecTotalTime:
+		return "Exec total time"
 	default:
 		return "Unknown query timing"
 	}
+}
+
+// QueryStats with all query timers mapped to durations.
+type QueryStats struct {
+	TotalEvalTime        float64 `json:"totalEvalTime"`
+	ResultSortTime       float64 `json:"resultSortTime"`
+	QueryPreparationTime float64 `json:"queryPreparationTime"`
+	InnerEvalTime        float64 `json:"innerEvalTime"`
+	ResultAppendTime     float64 `json:"resultAppendTime"`
+	ExecQueueTime        float64 `json:"execQueueTime"`
+	ExecTotalTime        float64 `json:"execTotalTime"`
+}
+
+// MakeQueryStats makes a QueryStats struct with all QueryTimings found in the
+// given TimerGroup.
+func MakeQueryStats(tg *TimerGroup) *QueryStats {
+	var qs QueryStats
+
+	for s, timer := range tg.timers {
+		switch s {
+		case TotalEvalTime:
+			qs.TotalEvalTime = timer.Duration()
+		case ResultSortTime:
+			qs.ResultSortTime = timer.Duration()
+		case QueryPreparationTime:
+			qs.QueryPreparationTime = timer.Duration()
+		case InnerEvalTime:
+			qs.InnerEvalTime = timer.Duration()
+		case ResultAppendTime:
+			qs.ResultAppendTime = timer.Duration()
+		case ExecQueueTime:
+			qs.ExecQueueTime = timer.Duration()
+		case ExecTotalTime:
+			qs.ExecTotalTime = timer.Duration()
+		}
+	}
+
+	return &qs
 }

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -61,9 +61,9 @@ type QueryStats struct {
 	ExecTotalTime        float64 `json:"execTotalTime"`
 }
 
-// MakeQueryStats makes a QueryStats struct with all QueryTimings found in the
+// NewQueryStats makes a QueryStats struct with all QueryTimings found in the
 // given TimerGroup.
-func MakeQueryStats(tg *TimerGroup) *QueryStats {
+func NewQueryStats(tg *TimerGroup) *QueryStats {
 	var qs QueryStats
 
 	for s, timer := range tg.timers {

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -50,8 +50,8 @@ func (s QueryTiming) String() string {
 	}
 }
 
-// QueryStats with all query timers mapped to durations.
-type QueryStats struct {
+// QueryTimings with all query timers mapped to durations.
+type queryTimings struct {
 	EvalTotalTime        float64 `json:"evalTotalTime"`
 	ResultSortTime       float64 `json:"resultSortTime"`
 	QueryPreparationTime float64 `json:"queryPreparationTime"`
@@ -61,29 +61,35 @@ type QueryStats struct {
 	ExecTotalTime        float64 `json:"execTotalTime"`
 }
 
+// QueryStats currently only holding query timings
+type QueryStats struct {
+	Timings queryTimings `json:"timings,omitempty"`
+}
+
 // NewQueryStats makes a QueryStats struct with all QueryTimings found in the
 // given TimerGroup.
 func NewQueryStats(tg *TimerGroup) *QueryStats {
-	var qs QueryStats
+	var qt queryTimings
 
 	for s, timer := range tg.timers {
 		switch s {
 		case EvalTotalTime:
-			qs.EvalTotalTime = timer.Duration()
+			qt.EvalTotalTime = timer.Duration()
 		case ResultSortTime:
-			qs.ResultSortTime = timer.Duration()
+			qt.ResultSortTime = timer.Duration()
 		case QueryPreparationTime:
-			qs.QueryPreparationTime = timer.Duration()
+			qt.QueryPreparationTime = timer.Duration()
 		case InnerEvalTime:
-			qs.InnerEvalTime = timer.Duration()
+			qt.InnerEvalTime = timer.Duration()
 		case ResultAppendTime:
-			qs.ResultAppendTime = timer.Duration()
+			qt.ResultAppendTime = timer.Duration()
 		case ExecQueueTime:
-			qs.ExecQueueTime = timer.Duration()
+			qt.ExecQueueTime = timer.Duration()
 		case ExecTotalTime:
-			qs.ExecTotalTime = timer.Duration()
+			qt.ExecTotalTime = timer.Duration()
 		}
 	}
 
+	qs := QueryStats{Timings: qt}
 	return &qs
 }

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Prometheus Authors
+// Copyright 2017 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -47,9 +47,15 @@ func TestQueryStatsWithTimers(t *testing.T) {
 
 	var qs *QueryStats
 	qs = NewQueryStats(tg)
-	actual, _ := json.Marshal(qs)
+	actual, err := json.Marshal(qs)
+	if err != nil {
+		t.Fatalf("Unexpected error during serialization: %v", err)
+	}
 	// Timing value is one of multiple fields, unit is seconds (float).
-	match, _ := regexp.MatchString(`[,{]"execTotalTime":\d+\.\d+[,}]`, string(actual))
+	match, err := regexp.MatchString(`[,{]"execTotalTime":\d+\.\d+[,}]`, string(actual))
+	if err != nil {
+		t.Fatalf("Unexpected error while matching string: %v", err)
+	}
 	if !match {
 		t.Fatalf("Expected timings with one non-zero entry, but got %s.", actual)
 	}

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -24,17 +24,17 @@ func TestTimerGroupNewTimer(t *testing.T) {
 	tg := NewTimerGroup()
 	timer := tg.GetTimer(ExecTotalTime)
 	if duration := timer.Duration(); duration != 0 {
-		t.Errorf("Expected duration of 0, but it was %f instead.", duration)
+		t.Fatalf("Expected duration of 0, but it was %f instead.", duration)
 	}
 	minimum := 2 * time.Millisecond
 	timer.Start()
 	time.Sleep(minimum)
 	timer.Stop()
 	if duration := timer.Duration(); duration == 0 {
-		t.Errorf("Expected duration greater than 0, but it was %f instead.", duration)
+		t.Fatalf("Expected duration greater than 0, but it was %f instead.", duration)
 	}
 	if elapsed := timer.ElapsedTime(); elapsed < minimum {
-		t.Errorf("Expected elapsed time to be greater than time slept, elapsed was %d, and time slept was %d.", elapsed.Nanoseconds(), minimum)
+		t.Fatalf("Expected elapsed time to be greater than time slept, elapsed was %d, and time slept was %d.", elapsed.Nanoseconds(), minimum)
 	}
 }
 
@@ -48,8 +48,9 @@ func TestQueryStatsWithTimers(t *testing.T) {
 	var qs *QueryStats
 	qs = NewQueryStats(tg)
 	actual, _ := json.Marshal(qs)
+	// Timing value is one of multiple fields, unit is seconds (float).
 	match, _ := regexp.MatchString(`[,{]"execTotalTime":\d+\.\d+[,}]`, string(actual))
 	if !match {
-		t.Errorf("Expected timings with one non-zero entry, but got %s.", actual)
+		t.Fatalf("Expected timings with one non-zero entry, but got %s.", actual)
 	}
 }

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -1,0 +1,55 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+	"time"
+)
+
+func TestTimerGroupNewTimer(t *testing.T) {
+	tg := NewTimerGroup()
+	timer := tg.GetTimer(ExecTotalTime)
+	if duration := timer.Duration(); duration != 0 {
+		t.Errorf("Expected duration of 0, but it was %f instead.", duration)
+	}
+	minimum := 2 * time.Millisecond
+	timer.Start()
+	time.Sleep(minimum)
+	timer.Stop()
+	if duration := timer.Duration(); duration == 0 {
+		t.Errorf("Expected duration greater than 0, but it was %f instead.", duration)
+	}
+	if elapsed := timer.ElapsedTime(); elapsed < minimum {
+		t.Errorf("Expected elapsed time to be greater than time slept, elapsed was %d, and time slept was %d.", elapsed.Nanoseconds(), minimum)
+	}
+}
+
+func TestQueryStatsWithTimers(t *testing.T) {
+	tg := NewTimerGroup()
+	timer := tg.GetTimer(ExecTotalTime)
+	timer.Start()
+	time.Sleep(2 * time.Millisecond)
+	timer.Stop()
+
+	var qs *QueryStats
+	qs = NewQueryStats(tg)
+	actual, _ := json.Marshal(qs)
+	match, _ := regexp.MatchString(`[,{]"execTotalTime":\d+\.\d+[,}]`, string(actual))
+	if !match {
+		t.Errorf("Expected timings with one non-zero entry, but got %s.", actual)
+	}
+}

--- a/util/stats/timer.go
+++ b/util/stats/timer.go
@@ -45,6 +45,11 @@ func (t *Timer) ElapsedTime() time.Duration {
 	return time.Since(t.start)
 }
 
+// Duration returns the duration value of the timer in seconds.
+func (t *Timer) Duration() float64 {
+	return t.duration.Seconds()
+}
+
 // Return a string representation of the Timer.
 func (t *Timer) String() string {
 	return fmt.Sprintf("%s: %s", t.name, t.duration)

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -171,8 +171,8 @@ func (api *API) Register(r *route.Router) {
 }
 
 type queryData struct {
-	ResultType promql.ValueType `json:"resultType"`
-	Result     promql.Value     `json:"result"`
+	ResultType promql.ValueType  `json:"resultType"`
+	Result     promql.Value      `json:"result"`
 	Stats      *stats.QueryStats `json:"stats,omitempty"`
 }
 
@@ -221,9 +221,17 @@ func (api *API) query(r *http.Request) (interface{}, *apiError) {
 		}
 		return nil, &apiError{errorExec, res.Err}
 	}
+
+	// Optional stats field in response if parameter "stats" is not empty.
+	var qs *stats.QueryStats
+	if r.FormValue("stats") != "" {
+		qs = stats.NewQueryStats(qry.Stats())
+	}
+
 	return &queryData{
 		ResultType: res.Value.Type(),
 		Result:     res.Value,
+		Stats:      qs,
 	}, nil
 }
 
@@ -289,7 +297,7 @@ func (api *API) queryRange(r *http.Request) (interface{}, *apiError) {
 	// Optional stats field in response if parameter "stats" is not empty.
 	var qs *stats.QueryStats
 	if r.FormValue("stats") != "" {
-		qs = stats.MakeQueryStats(qry.Stats())
+		qs = stats.NewQueryStats(qry.Stats())
 	}
 
 	return &queryData{


### PR DESCRIPTION
API consumers should be able to get insight into the query run times.
The UI currently measures total roundtrip times. This PR allows for more
fine grained metrics to be exposed.

* adds new timer for total execution time (queue + eval)

* expose new timer, queue timer, and eval timer in stats field of the
 range query response:
```json
{
  "status": "success",
  "data": {
    "resultType": "matrix",
    "result": [],
    "stats": {
      "execQueueTimeNs": 4683,
      "execTotalTimeNs": 2086587,
      "totalEvalTimeNs": 2077851
    }
  }
}
```

* stats field is optional, only set when query parameter `stats` is not
empty

Try it via
```sh
curl 'http://localhost:9090/api/v1/query_range?query=up&start=1486480279&end=1486483879&step=14000&stats=true'
```