### PR TITLE
storage: One more persist error code path discovered

### DIFF
--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -1513,7 +1513,8 @@ func (s *MemorySeriesStorage) writeMemorySeries(
 		series.chunkDescsOffset -= numDroppedFromPersistence
 		if series.chunkDescsOffset < 0 {
 			persistErr = errors.New("dropped more chunks from persistence than from memory")
-			series.chunkDescsOffset = -1
+			series.chunkDescsOffset = 0
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
@brian-brazil Found one more code path that creates a persistErr, but was still returning false in writeMemorySeries.

The weird thing is: This codepath should never really happen, only upon obscure data corruption. I'll let this fix run on my high-load test server again. The (only) one server where I could observe #2409 so far.