### PR TITLE
storage: Fix chunkIndexToStartSeek calculation

### DIFF
--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -932,8 +932,9 @@ func (p *persistence) dropAndPersistChunks(
 	chunkIndexToStartSeek := 0
 	if p.minShrinkRatio < 1 {
 		chunkIndexToStartSeek = int(math.Floor(float64(totalChunks) * p.minShrinkRatio))
-	} else {
-		chunkIndexToStartSeek = totalChunks - 1
+	}
+	if chunkIndexToStartSeek >= chunksInFile {
+		chunkIndexToStartSeek = chunksInFile - 1
 	}
 	numDropped = chunkIndexToStartSeek
 


### PR DESCRIPTION
With a high enough shrink ratio and enough chunks to persist, the
cutoff point could be _outside_ of the file, which wreaks havoc in the
storage.

@mtanda