### PR TITLE
Instrument query engine timings

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -58,7 +58,7 @@ var (
 		prometheus.SummaryOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
-			Name:      "query_time",
+			Name:      "query_duration_seconds",
 			Help:      "Query timmings",
 		},
 		[]string{"slice"},
@@ -389,7 +389,7 @@ func (ng *Engine) exec(ctx context.Context, q *query) (model.Value, error) {
 	defer func() {
 		evalTimer.Stop()
 		queryTimingStats.WithLabelValues("eval_total").
-			Observe(float64(evalTimer.ElapsedTime()) / float64(time.Millisecond))
+			Observe(evalTimer.ElapsedTime().Seconds())
 	}()
 
 	// The base context might already be canceled on the first iteration (e.g. during shutdown).
@@ -419,7 +419,7 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *EvalStmt) (
 	err = ng.populateIterators(ctx, querier, s)
 	prepareTimer.Stop()
 	queryTimingStats.WithLabelValues("prepare_time").
-		Observe(float64(prepareTimer.ElapsedTime()) / float64(time.Millisecond))
+		Observe(prepareTimer.ElapsedTime().Seconds())
 
 	if err != nil {
 		return nil, err
@@ -449,7 +449,7 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *EvalStmt) (
 
 		evalTimer.Stop()
 		queryTimingStats.WithLabelValues("inner_eval").
-			Observe(float64(evalTimer.ElapsedTime()) / float64(time.Millisecond))
+			Observe(evalTimer.ElapsedTime().Seconds())
 
 		return val, nil
 	}
@@ -507,7 +507,7 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *EvalStmt) (
 	}
 	evalTimer.Stop()
 	queryTimingStats.WithLabelValues("inner_eval").
-		Observe(float64(evalTimer.ElapsedTime()) / float64(time.Millisecond))
+		Observe(evalTimer.ElapsedTime().Seconds())
 
 	if err := contextDone(ctx, "expression evaluation"); err != nil {
 		return nil, err
@@ -520,7 +520,7 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *EvalStmt) (
 	}
 	appendTimer.Stop()
 	queryTimingStats.WithLabelValues("result_append").
-		Observe(float64(appendTimer.ElapsedTime()) / float64(time.Millisecond))
+		Observe(appendTimer.ElapsedTime().Seconds())
 
 	if err := contextDone(ctx, "expression evaluation"); err != nil {
 		return nil, err
@@ -533,7 +533,7 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *EvalStmt) (
 	sort.Sort(resMatrix)
 	sortTimer.Stop()
 	queryTimingStats.WithLabelValues("result_sort").
-		Observe(float64(sortTimer.ElapsedTime()) / float64(time.Millisecond))
+		Observe(sortTimer.ElapsedTime().Seconds())
 	return resMatrix, nil
 }
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -577,18 +577,15 @@ func (ng *Engine) populateIterators(ctx context.Context, querier local.Querier, 
 }
 
 func (ng *Engine) closeIterators(s *EvalStmt) {
-	var countv float64
 	Inspect(s.Expr, func(node Node) bool {
 		switch n := node.(type) {
 		case *VectorSelector:
 			for _, it := range n.iterators {
 				it.Close()
-				countv++
 			}
 		case *MatrixSelector:
 			for _, it := range n.iterators {
 				it.Close()
-				countv++
 			}
 		}
 		return true

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -386,11 +386,7 @@ func (ng *Engine) exec(ctx context.Context, q *query) (model.Value, error) {
 	const env = "query execution"
 
 	evalTimer := q.stats.GetTimer(stats.TotalEvalTime).Start()
-	defer func() {
-		evalTimer.Stop()
-		queryTimingStats.WithLabelValues("eval_total").
-			Observe(evalTimer.ElapsedTime().Seconds())
-	}()
+	defer evalTimer.Stop()
 
 	// The base context might already be canceled on the first iteration (e.g. during shutdown).
 	if err := contextDone(ctx, env); err != nil {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -99,7 +99,6 @@ func init() {
 	prometheus.MustRegister(queryInnerEval)
 	prometheus.MustRegister(queryResultAppend)
 	prometheus.MustRegister(queryResultSort)
-
 }
 
 // convertibleToInt64 returns true if v does not over-/underflow an int64.


### PR DESCRIPTION
This exposes the already collected statistics on query engine performance.
Adds a series of summaries labeled according to corresponding query engine step.

A typical graph should look like this:
<img width="1239" alt="screen shot 2017-02-10 at 15 34 35" src="https://cloud.githubusercontent.com/assets/1097371/22848163/4fe7b444-efa7-11e6-857a-0bec580e74ac.png">
