### PR TITLE
discovery: If SRV results returned no port, use supplied port

### DIFF
--- a/discovery/dns/dns.go
+++ b/discovery/dns/dns.go
@@ -141,8 +141,12 @@ func (dd *Discovery) refresh(ctx context.Context, name string, ch chan<- []*conf
 		case *dns.SRV:
 			// Remove the final dot from rooted DNS names to make them look more usual.
 			addr.Target = strings.TrimRight(addr.Target, ".")
-
-			target = hostPort(addr.Target, int(addr.Port))
+			p := int(addr.Port)
+			// Fill in the port if results had no port, but config has one.
+			if p == 0 {
+				p = dd.port
+			}
+			target = hostPort(addr.Target, p)
 		case *dns.A:
 			target = hostPort(addr.A.String(), dd.port)
 		case *dns.AAAA:


### PR DESCRIPTION
Currently, if a config is specified as:
```
  - job_name: 'node_exporter'
    dns_sd_configs:
      - names:
          - 'nodes'
        type: SRV
        port: 9100
```

The `port` will not be used for SRV results if the SRV results return a port of 0. This PR adds a fallback to the configured port if the results return a 0 port.