### PR TITLE
Re-add multiple remote writers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -204,7 +204,7 @@ type Config struct {
 	RuleFiles      []string        `yaml:"rule_files,omitempty"`
 	ScrapeConfigs  []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
 
-	RemoteWriteConfig RemoteWriteConfig `yaml:"remote_write,omitempty"`
+	RemoteWriteConfigs []*RemoteWriteConfig `yaml:"remote_write,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,14 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+func mustParseURL(u string) *URL {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		panic(err)
+	}
+	return &URL{URL: parsed}
+}
+
 var expectedConf = &Config{
 	GlobalConfig: GlobalConfig{
 		ScrapeInterval:     model.Duration(15 * time.Second),
@@ -44,16 +52,23 @@ var expectedConf = &Config{
 		"testdata/my/*.rules",
 	},
 
-	RemoteWriteConfig: RemoteWriteConfig{
-		RemoteTimeout: model.Duration(30 * time.Second),
-		WriteRelabelConfigs: []*RelabelConfig{
-			{
-				SourceLabels: model.LabelNames{"__name__"},
-				Separator:    ";",
-				Regex:        MustNewRegexp("expensive.*"),
-				Replacement:  "$1",
-				Action:       RelabelDrop,
+	RemoteWriteConfigs: []*RemoteWriteConfig{
+		{
+			URL:           mustParseURL("http://remote1/push"),
+			RemoteTimeout: model.Duration(30 * time.Second),
+			WriteRelabelConfigs: []*RelabelConfig{
+				{
+					SourceLabels: model.LabelNames{"__name__"},
+					Separator:    ";",
+					Regex:        MustNewRegexp("expensive.*"),
+					Replacement:  "$1",
+					Action:       RelabelDrop,
+				},
 			},
+		},
+		{
+			URL:           mustParseURL("http://remote2/push"),
+			RemoteTimeout: model.Duration(30 * time.Second),
 		},
 	},
 

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -14,10 +14,12 @@ rule_files:
 - "my/*.rules"
 
 remote_write:
-  write_relabel_configs:
-  - source_labels: [__name__]
-    regex:         expensive.*
-    action:        drop
+  - url: http://remote1/push
+    write_relabel_configs:
+    - source_labels: [__name__]
+      regex:         expensive.*
+      action:        drop
+  - url: http://remote2/push
 
 scrape_configs:
 - job_name: prometheus

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -31,13 +31,14 @@ import (
 
 // Client allows sending batches of Prometheus samples to an HTTP endpoint.
 type Client struct {
+	index   int // Used to differentiate metrics.
 	url     config.URL
 	client  *http.Client
 	timeout time.Duration
 }
 
 // NewClient creates a new Client.
-func NewClient(conf config.RemoteWriteConfig) (*Client, error) {
+func NewClient(index int, conf *config.RemoteWriteConfig) (*Client, error) {
 	tlsConfig, err := httputil.NewTLSConfig(conf.TLSConfig)
 	if err != nil {
 		return nil, err
@@ -55,6 +56,7 @@ func NewClient(conf config.RemoteWriteConfig) (*Client, error) {
 	}
 
 	return &Client{
+		index:   index,
 		url:     *conf.URL,
 		client:  httputil.NewClient(rt),
 		timeout: time.Duration(conf.RemoteTimeout),
@@ -114,7 +116,7 @@ func (c *Client) Store(samples model.Samples) error {
 	return nil
 }
 
-// Name identifies the client as a generic client.
+// Name identifies the client.
 func (c Client) Name() string {
-	return "generic"
+	return fmt.Sprintf("%d:%s", c.index, c.url)
 }

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -97,7 +97,7 @@ func TestSampleDelivery(t *testing.T) {
 	c := NewTestStorageClient()
 	c.expectSamples(samples[:len(samples)/2])
 
-	m := NewStorageQueueManager(StorageQueueManagerConfig{
+	m := NewQueueManager(QueueManagerConfig{
 		Client: c,
 		Shards: 1,
 	})
@@ -134,7 +134,7 @@ func TestSampleDeliveryOrder(t *testing.T) {
 
 	c := NewTestStorageClient()
 	c.expectSamples(samples)
-	m := NewStorageQueueManager(StorageQueueManagerConfig{
+	m := NewQueueManager(QueueManagerConfig{
 		Client: c,
 		// Ensure we don't drop samples in this test.
 		QueueCapacity: n,
@@ -184,7 +184,7 @@ func (c *TestBlockingStorageClient) Name() string {
 	return "testblockingstorageclient"
 }
 
-func (t *StorageQueueManager) queueLen() int {
+func (t *QueueManager) queueLen() int {
 	queueLength := 0
 	for _, shard := range t.shards {
 		queueLength += len(shard)
@@ -211,7 +211,7 @@ func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 	}
 
 	c := NewTestBlockedStorageClient()
-	m := NewStorageQueueManager(StorageQueueManagerConfig{
+	m := NewQueueManager(QueueManagerConfig{
 		Client:        c,
 		QueueCapacity: n,
 	})
@@ -244,7 +244,7 @@ func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 	}
 
 	if m.queueLen() != defaultMaxSamplesPerSend {
-		t.Fatalf("Failed to drain StorageQueueManager queue, %d elements left",
+		t.Fatalf("Failed to drain QueueManager queue, %d elements left",
 			m.queueLen(),
 		)
 	}

--- a/storage/remote/remote.go
+++ b/storage/remote/remote.go
@@ -19,16 +19,12 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/config"
-	"github.com/prometheus/prometheus/relabel"
 )
 
 // Storage allows queueing samples for remote writes.
 type Storage struct {
-	mtx            sync.RWMutex
-	externalLabels model.LabelSet
-	conf           config.RemoteWriteConfig
-
-	queue *StorageQueueManager
+	mtx    sync.RWMutex
+	queues []*StorageQueueManager
 }
 
 // ApplyConfig updates the state as the new config requires.
@@ -36,34 +32,36 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
+	newQueues := []*StorageQueueManager{}
 	// TODO: we should only stop & recreate queues which have changes,
 	// as this can be quite disruptive.
-	var newQueue *StorageQueueManager
-
-	if conf.RemoteWriteConfig.URL != nil {
-		c, err := NewClient(conf.RemoteWriteConfig)
+	for i, rwConf := range conf.RemoteWriteConfigs {
+		c, err := NewClient(i, rwConf)
 		if err != nil {
 			return err
 		}
-		newQueue = NewStorageQueueManager(c, nil)
+		newQueues = append(newQueues, NewStorageQueueManager(StorageQueueManagerConfig{
+			Client:         c,
+			ExternalLabels: conf.GlobalConfig.ExternalLabels,
+			RelabelConfigs: rwConf.WriteRelabelConfigs,
+		}))
 	}
 
-	if s.queue != nil {
-		s.queue.Stop()
+	for _, q := range s.queues {
+		q.Stop()
 	}
-	s.queue = newQueue
-	s.conf = conf.RemoteWriteConfig
-	s.externalLabels = conf.GlobalConfig.ExternalLabels
-	if s.queue != nil {
-		s.queue.Start()
+
+	s.queues = newQueues
+	for _, q := range s.queues {
+		q.Start()
 	}
 	return nil
 }
 
 // Stop the background processing of the storage queues.
 func (s *Storage) Stop() {
-	if s.queue != nil {
-		s.queue.Stop()
+	for _, q := range s.queues {
+		q.Stop()
 	}
 }
 
@@ -72,26 +70,9 @@ func (s *Storage) Append(smpl *model.Sample) error {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 
-	if s.queue == nil {
-		return nil
+	for _, q := range s.queues {
+		q.Append(smpl)
 	}
-
-	var snew model.Sample
-	snew = *smpl
-	snew.Metric = smpl.Metric.Clone()
-
-	for ln, lv := range s.externalLabels {
-		if _, ok := smpl.Metric[ln]; !ok {
-			snew.Metric[ln] = lv
-		}
-	}
-	snew.Metric = model.Metric(
-		relabel.Process(model.LabelSet(snew.Metric), s.conf.WriteRelabelConfigs...))
-
-	if snew.Metric == nil {
-		return nil
-	}
-	s.queue.Append(&snew)
 	return nil
 }
 

--- a/storage/remote/remote.go
+++ b/storage/remote/remote.go
@@ -24,7 +24,7 @@ import (
 // Storage allows queueing samples for remote writes.
 type Storage struct {
 	mtx    sync.RWMutex
-	queues []*StorageQueueManager
+	queues []*QueueManager
 }
 
 // ApplyConfig updates the state as the new config requires.
@@ -32,7 +32,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	newQueues := []*StorageQueueManager{}
+	newQueues := []*QueueManager{}
 	// TODO: we should only stop & recreate queues which have changes,
 	// as this can be quite disruptive.
 	for i, rwConf := range conf.RemoteWriteConfigs {
@@ -40,7 +40,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		if err != nil {
 			return err
 		}
-		newQueues = append(newQueues, NewStorageQueueManager(StorageQueueManagerConfig{
+		newQueues = append(newQueues, NewQueueManager(QueueManagerConfig{
 			Client:         c,
 			ExternalLabels: conf.GlobalConfig.ExternalLabels,
 			RelabelConfigs: rwConf.WriteRelabelConfigs,

--- a/vendor/github.com/prometheus/common/model/value.go
+++ b/vendor/github.com/prometheus/common/model/value.go
@@ -129,11 +129,8 @@ func (s *Sample) Equal(o *Sample) bool {
 	if !s.Timestamp.Equal(o.Timestamp) {
 		return false
 	}
-	if s.Value.Equal(o.Value) {
-		return false
-	}
 
-	return true
+	return s.Value.Equal(o.Value)
 }
 
 func (s Sample) String() string {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -560,8 +560,8 @@
 		{
 			"checksumSHA1": "vopCLXHzYm+3l5fPKOf4/fQwrCM=",
 			"path": "github.com/prometheus/common/model",
-			"revision": "dd2f054febf4a6c00f2343686efb775948a8bff4",
-			"revisionTime": "2017-01-08T23:12:12Z"
+			"revision": "3007b6072c17c8d985734e6e19b1dea9174e13d3",
+			"revisionTime": "2017-02-19T00:35:58+01:00"
 		},
 		{
 			"checksumSHA1": "ZbbESWBHHcPUJ/A5yrzKhTHuPc8=",


### PR DESCRIPTION
Each remote write endpoint gets its own set of relabeling rules.

This is based on the (yet-to-be-merged) #2419, which removes legacy remote write implementations.