### PR TITLE
vendoring: Do not ignore appengine build tags

### DIFF
--- a/vendor/github.com/miekg/dns/udp_other.go
+++ b/vendor/github.com/miekg/dns/udp_other.go
@@ -1,0 +1,15 @@
+// +build !linux appengine
+
+package dns
+
+import (
+	"net"
+)
+
+// These do nothing. See udp_linux.go for an example of how to implement this.
+
+// We tried to adhire to some kind of naming scheme.
+func setUDPSocketOptions(conn *net.UDPConn) error                  { return nil }
+func setUDPSocketOptions4(conn *net.UDPConn) error                 { return nil }
+func setUDPSocketOptions6(conn *net.UDPConn) error                 { return nil }
+func getUDPSocketOptions6Only(conn *net.UDPConn) (bool, error)     { return false, nil }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,6 +1,6 @@
 {
 	"comment": "",
-	"ignore": "test appengine",
+	"ignore": "test",
 	"package": [
 		{
 			"checksumSHA1": "Cslv4/ITyQmgjSUhNXFu8q5bqOU=",
@@ -508,7 +508,7 @@
 			"revisionTime": "2015-04-06T19:39:34+02:00"
 		},
 		{
-			"checksumSHA1": "wJxkqZ80Ux6+klKr1+3erSZjVnQ=",
+			"checksumSHA1": "UoQnBcZrj1gvLAK+MGNB+E7+AIE=",
 			"path": "github.com/miekg/dns",
 			"revision": "672033dedc09500ca4d340760d0b80b9c0b198bd",
 			"revisionTime": "2017-02-13T20:16:50Z"


### PR DESCRIPTION
For weird reasons, this excluded github.com/miekg/dns/udp_other.go
from vendoring.

@fastest963 @grobie 