### PR TITLE
Kubernetes port annotations - match addresses with or without declared ports

### DIFF
--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -108,7 +108,7 @@ scrape_configs:
   - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
     action: replace
     target_label: __address__
-    regex: (.+)(?::\d+);(\d+)
+    regex: (.+)(?::\d+)?;(\d+)
     replacement: $1:$2
   - action: labelmap
     regex: __meta_kubernetes_service_label_(.+)
@@ -174,8 +174,8 @@ scrape_configs:
     regex: (.+)
   - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
     action: replace
-    regex: (.+):(?:\d+);(\d+)
-    replacement: ${1}:${2}
+    regex: (.+)(?::\d+)?;(\d+)
+    replacement: $1:$2
     target_label: __address__
   - action: labelmap
     regex: __meta_kubernetes_pod_label_(.+)


### PR DESCRIPTION
This change updates port relabeling for pod and service discovery so the
port relabeling regex matches addresses with or without declared ports.
As well, this change uses a consistent style in the replacement pattern
for the two expressions.

Previously, for both services or pods that did not have declared ports, the
relabel config regex would fail to match:

    __meta_kubernetes_service_annotation_prometheus_io_port
    regex: (.+)(?::\d+);(\d+)

    __meta_kubernetes_pod_annotation_prometheus_io_port
    regex: (.+):(?:\d+);(\d+)

Both regexes expected a <host>:<port> pattern.

The new regex matches addresses with or without declared ports by making
the :<port> pattern optional.

    __meta_kubernetes_service_annotation_prometheus_io_port
    __meta_kubernetes_pod_annotation_prometheus_io_port
    regex: (.+)(?::\d+)?;(\d+)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/2427)
<!-- Reviewable:end -->
