### PR TITLE
Fix kubernetes host:port relabel regex.

### DIFF
--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -108,7 +108,7 @@ scrape_configs:
   - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
     action: replace
     target_label: __address__
-    regex: (.+)(?::\d+)?;(\d+)
+    regex: ([^:]+)(?::\d+)?;(\d+)
     replacement: $1:$2
   - action: labelmap
     regex: __meta_kubernetes_service_label_(.+)
@@ -174,7 +174,7 @@ scrape_configs:
     regex: (.+)
   - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
     action: replace
-    regex: (.+)(?::\d+)?;(\d+)
+    regex: ([^:]+)(?::\d+)?;(\d+)
     replacement: $1:$2
     target_label: __address__
   - action: labelmap


### PR DESCRIPTION
This change corrects a bug introduced by PR https://github.com/prometheus/prometheus/pull/2427

The regex uses three groups: the hostname, an optional port, and the
prefered port from a kubernetes annotation.

Previously, the second group should have been ignored if a :port was not
present in the input. However, making the port group optional with the
"?" had the unintended side-effect of allowing the hostname regex "(.+)"
to match greedily, which included the ":port" patterns up to the ";"
separating the hostname from the kubernetes port annotation.

This change updates the regex for the hostname to match any non-":"
characters. This forces the regex to stop if a ":port" is present and
allow the second group to match the optional port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/2434)
<!-- Reviewable:end -->
