### PR TITLE
Build static binaries when using make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ vet:
 
 build: promu
 	@echo ">> building binaries"
-	@$(PROMU) build --prefix $(PREFIX)
+	@CGO_ENABLED=0 $(PROMU) build --prefix $(PREFIX)
 
 tarball: promu
 	@echo ">> building release tarball"


### PR DESCRIPTION
This makes sure the binaries produced by `make build` are static and the images built via `make docker` work

cc @sdurrheimer 