### PR TITLE
Expose PromConsole.Graph.buildQueryUrl, refactor dispatch to use

### DIFF
--- a/web/ui/static/js/prom_console.js
+++ b/web/ui/static/js/prom_console.js
@@ -523,6 +523,16 @@ PromConsole.Graph.prototype._clearGraph = function() {
 
 PromConsole.Graph.prototype._xhrs = [];
 
+// Enable a user to build a query in the context of this graph
+// e.g. relevant annotations
+PromConsole.Graph.prototype.buildQueryUrl = function(expr) {
+  var p = this.params;
+  return PATH_PREFIX + "/api/v1/query_range?query=" +
+    encodeURIComponent(expr) +
+    "&step=" + p.duration / this.graphTd.offsetWidth +
+    "&start=" + (p.endTime - p.duration) + "&end=" + p.endTime;
+};
+
 PromConsole.Graph.prototype.dispatch = function() {
   for (var j = 0; j < this._xhrs.length; j++) {
     this._xhrs[j].abort();
@@ -532,9 +542,7 @@ PromConsole.Graph.prototype.dispatch = function() {
   var pending_requests = this.params.expr.length;
   for (var i = 0; i < this.params.expr.length; ++i) {
     var endTime = this.params.endTime;
-    var url = PATH_PREFIX + "/api/v1/query_range?query=" + encodeURIComponent(this.params.expr[i]) +
-      "&step=" + this.params.duration / this.graphTd.offsetWidth + 
-      "&start=" + (endTime - this.params.duration) + "&end=" + endTime;
+    var url = this.buildQueryUrl(this.params.expr[i]);
     var xhr = new XMLHttpRequest();
     xhr.open('get', url, true);
     xhr.responseType = 'json';

--- a/web/ui/static/js/prom_console.js
+++ b/web/ui/static/js/prom_console.js
@@ -523,8 +523,6 @@ PromConsole.Graph.prototype._clearGraph = function() {
 
 PromConsole.Graph.prototype._xhrs = [];
 
-// Enable a user to build a query in the context of this graph
-// e.g. relevant annotations
 PromConsole.Graph.prototype.buildQueryUrl = function(expr) {
   var p = this.params;
   return PATH_PREFIX + "/api/v1/query_range?query=" +


### PR DESCRIPTION
buildQueryUrl will allow users to execute queries over the range of an
existing graph.  This will be helpful to select data series they wish to
annotate the graph with, for example.