### PR TITLE
Refactor scraperLoop/scraper to allow reuse of TargetManage code outside of Prometheus.

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -98,7 +98,7 @@ func Main() int {
 
 	var (
 		notifier       = notifier.New(&cfg.notifier)
-		targetManager  = retrieval.NewTargetManager(sampleAppender)
+		targetManager  = retrieval.NewTargetManager(retrieval.NewTargetScraperFn(sampleAppender))
 		queryEngine    = promql.NewEngine(localStorage, &cfg.queryEngine)
 		ctx, cancelCtx = context.WithCancel(context.Background())
 	)

--- a/retrieval/scrape.go
+++ b/retrieval/scrape.go
@@ -337,12 +337,13 @@ func (sl *scrapeLoop) stop() {
 	<-sl.done
 }
 
-// A Scraper retrieves samples and accepts a status report at the end.
+// A Scraper scrapes a Target.
 type Scraper interface {
 	Scrape(ctx context.Context) error
 	Offset(time.Duration) time.Duration
 }
 
+// ScraperFn returns a new Scraper for a given Target.
 type ScraperFn func(*Target, *http.Client, model.LabelSet, *config.ScrapeConfig) Scraper
 
 // targetScraper implements the scraper interface for a target.
@@ -360,6 +361,7 @@ type targetScraper struct {
 	last     time.Time
 }
 
+// NewTargetScraperFn makes a new ScraperFn, which makes Scrapers that appends samples to the supplied appender.
 func NewTargetScraperFn(appender storage.SampleAppender) ScraperFn {
 	return func(target *Target, client *http.Client, targetLabels model.LabelSet, config *config.ScrapeConfig) Scraper {
 		return &targetScraper{


### PR DESCRIPTION
Instead of passing an appender to TargetManager (and ScrapePool, and ScrapeLoop), pass a ScrapeFn which captures the appender in main.go, and returns a Scraper.  Also, move a lot of the sample-specific handling into Scraper, and out of ScrapeLoop.

This results in a lot less parsing around of configuration but also means the TargetManager can be used to scrape things other than metrics.  I use it to scrape traces in Loki.