### PR TITLE
Fix Map Race by Moving Locking closer to the Write

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -217,11 +217,6 @@ func (ts *TargetSet) UpdateProviders(p map[string]TargetProvider) {
 }
 
 func (ts *TargetSet) updateProviders(ctx context.Context, providers map[string]TargetProvider) {
-	// Lock for the entire time. This may mean up to 5 seconds until the full initial set
-	// is retrieved and applied.
-	// We could release earlier with some tweaks, but this is easier to reason about.
-	ts.mtx.Lock()
-	defer ts.mtx.Unlock()
 
 	// Stop all previous target providers of the target set.
 	if ts.cancelProviders != nil {
@@ -292,9 +287,6 @@ func (ts *TargetSet) updateProviders(ctx context.Context, providers map[string]T
 
 // update handles a target group update from a target provider identified by the name.
 func (ts *TargetSet) update(name string, tgroup *config.TargetGroup) {
-	ts.mtx.Lock()
-	defer ts.mtx.Unlock()
-
 	ts.setTargetGroup(name, tgroup)
 
 	select {
@@ -304,6 +296,9 @@ func (ts *TargetSet) update(name string, tgroup *config.TargetGroup) {
 }
 
 func (ts *TargetSet) setTargetGroup(name string, tg *config.TargetGroup) {
+	ts.mtx.Lock()
+	defer ts.mtx.Unlock()
+
 	if tg == nil {
 		return
 	}

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -257,9 +257,8 @@ func (ts *TargetSet) updateProviders(ctx context.Context, providers map[string]T
 
 			// Start listening for further updates.
 			for {
-				done := ctx.Done()
 				select {
-				case <-done:
+				case <-ctx.Done():
 					return
 				case tgs, ok := <-updates:
 					// Handle the case that a target provider exits and closes the channel
@@ -268,14 +267,8 @@ func (ts *TargetSet) updateProviders(ctx context.Context, providers map[string]T
 						return
 					}
 					for _, tg := range tgs {
-						select {
-						case <-done:
-							return
-						default:
-							ts.update(name, tg)
-						}
+						ts.update(name, tg)
 					}
-
 				}
 			}
 		}(name, prov)

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -228,7 +228,9 @@ func (ts *TargetSet) updateProviders(ctx context.Context, providers map[string]T
 	// (Re-)create a fresh tgroups map to not keep stale targets around. We
 	// will retrieve all targets below anyway, so cleaning up everything is
 	// safe and doesn't inflict any additional cost.
+	ts.mtx.Lock()
 	ts.tgroups = map[string]*config.TargetGroup{}
+	ts.mtx.Unlock()
 
 	for name, prov := range providers {
 		wg.Add(1)


### PR DESCRIPTION
Fixes #2444 

I think we are protecting only the map as mentioned in the above issue. This is much cleaner and will avoid the race when there are multiple providers (We are launching a go routine per provider and not serializing access there).

The only question I have is whether this line needs to be protected: https://github.com/prometheus/prometheus/blob/master/discovery/discovery.go#L236