### PR TITLE
Fix issue with date and time parsers

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -875,7 +875,7 @@ func dateWrapper(ev *evaluator, args Expressions, f func(time.Time) model.Sample
 	}
 	for _, el := range v {
 		el.Metric.Del(model.MetricNameLabel)
-		t := time.Unix(int64(el.Value), 0).UTC()
+		t := time.Unix(int64(el.Timestamp)/int64(time.Second/time.Millisecond), 0).UTC()
 		el.Value = f(t)
 	}
 	return v


### PR DESCRIPTION
The date and time query functions originally parsed the time based on the value
for a metric as opposed to the timestamp. This resulted in the queries
returning unexpected results. Note that the 'el.Timestamp' value is in
milliseconds and needs to be converted to seconds for the conversion to work.

Signed-Off-By: Robert Clark <robert.d.clark@hpe.com>