### PR TITLE
added docker run command to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Debian packages [are available](https://packages.debian.org/sid/net/prometheus).
 
 Docker images are available on [Quay.io](https://quay.io/repository/prometheus/prometheus).
 
+You can launch a Prometheus container for trying it out with
+```
+docker run --name prometheus -d -p 127.0.0.1:9090:9090 quay.io/prometheus/prometheus
+```
+and you can reach it at http://127.0.0.1:9090
+
+
 ### Building from source
 
 To build Prometheus from the source code yourself you need to have a working

--- a/README.md
+++ b/README.md
@@ -50,11 +50,10 @@ Debian packages [are available](https://packages.debian.org/sid/net/prometheus).
 Docker images are available on [Quay.io](https://quay.io/repository/prometheus/prometheus).
 
 You can launch a Prometheus container for trying it out with
-```
-docker run --name prometheus -d -p 127.0.0.1:9090:9090 quay.io/prometheus/prometheus
-```
-and you can reach it at http://127.0.0.1:9090
 
+    $ docker run --name prometheus -d -p 127.0.0.1:9090:9090 quay.io/prometheus/prometheus
+
+Prometheus will now be reachable at http://localhost:9090/.
 
 ### Building from source
 


### PR DESCRIPTION
I think it'd be nice to put this command into the readme to provide a quick 'try it out' example.