### PR TITLE
discovery: Add __meta_kubernetes_pod_uid to K8S labels

### DIFF
--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -125,6 +125,7 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 	pods.GetStore().Add(&v1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "testpod",
+			UID:       "e4c35dec-836e-4931-83c6-13b9dbf39b18",
 			Namespace: "default",
 		},
 		Spec: v1.PodSpec{
@@ -202,6 +203,7 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 						"__meta_kubernetes_endpoint_port_protocol":      "TCP",
 						"__meta_kubernetes_endpoint_ready":              "true",
 						"__meta_kubernetes_pod_name":                    "testpod",
+						"__meta_kubernetes_pod_uid":                     "e4c35dec-836e-4931-83c6-13b9dbf39b18",
 						"__meta_kubernetes_pod_ip":                      "1.2.3.4",
 						"__meta_kubernetes_pod_ready":                   "unknown",
 						"__meta_kubernetes_pod_node_name":               "testnode",
@@ -214,6 +216,7 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 					model.LabelSet{
 						"__address__":                                   "1.2.3.4:9001",
 						"__meta_kubernetes_pod_name":                    "testpod",
+						"__meta_kubernetes_pod_uid":                     "e4c35dec-836e-4931-83c6-13b9dbf39b18",
 						"__meta_kubernetes_pod_ip":                      "1.2.3.4",
 						"__meta_kubernetes_pod_ready":                   "unknown",
 						"__meta_kubernetes_pod_node_name":               "testnode",

--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -124,6 +124,7 @@ func convertToPod(o interface{}) (*apiv1.Pod, error) {
 
 const (
 	podNameLabel                  = metaLabelPrefix + "pod_name"
+	podUIDLabel                   = metaLabelPrefix + "pod_uid"
 	podIPLabel                    = metaLabelPrefix + "pod_ip"
 	podContainerNameLabel         = metaLabelPrefix + "pod_container_name"
 	podContainerPortNameLabel     = metaLabelPrefix + "pod_container_port_name"
@@ -139,6 +140,7 @@ const (
 func podLabels(pod *apiv1.Pod) model.LabelSet {
 	ls := model.LabelSet{
 		podNameLabel:     lv(pod.ObjectMeta.Name),
+		podUIDLabel:      lv(string(pod.ObjectMeta.UID)),
 		podIPLabel:       lv(pod.Status.PodIP),
 		podReadyLabel:    podReady(pod),
 		podNodeNameLabel: lv(pod.Spec.NodeName),

--- a/discovery/kubernetes/pod_test.go
+++ b/discovery/kubernetes/pod_test.go
@@ -40,6 +40,7 @@ func makeMultiPortPod() *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "testpod",
+			UID:         "e4c35dec-836e-4931-83c6-13b9dbf39b18",
 			Namespace:   "default",
 			Labels:      map[string]string{"testlabel": "testvalue"},
 			Annotations: map[string]string{"testannotation": "testannotationvalue"},
@@ -84,6 +85,7 @@ func makePod() *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "testpod",
+			UID:       "e4c35dec-836e-4931-83c6-13b9dbf39b18",
 			Namespace: "default",
 		},
 		Spec: v1.PodSpec{
@@ -144,6 +146,7 @@ func TestPodDiscoveryInitial(t *testing.T) {
 				},
 				Labels: model.LabelSet{
 					"__meta_kubernetes_pod_name":                      "testpod",
+					"__meta_kubernetes_pod_uid":                       "e4c35dec-836e-4931-83c6-13b9dbf39b18",
 					"__meta_kubernetes_namespace":                     "default",
 					"__meta_kubernetes_pod_label_testlabel":           "testvalue",
 					"__meta_kubernetes_pod_annotation_testannotation": "testannotationvalue",
@@ -177,6 +180,7 @@ func TestPodDiscoveryAdd(t *testing.T) {
 				},
 				Labels: model.LabelSet{
 					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_pod_uid":       "e4c35dec-836e-4931-83c6-13b9dbf39b18",
 					"__meta_kubernetes_namespace":     "default",
 					"__meta_kubernetes_pod_node_name": "testnode",
 					"__meta_kubernetes_pod_ip":        "1.2.3.4",
@@ -209,6 +213,7 @@ func TestPodDiscoveryDelete(t *testing.T) {
 				},
 				Labels: model.LabelSet{
 					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_pod_uid":       "e4c35dec-836e-4931-83c6-13b9dbf39b18",
 					"__meta_kubernetes_namespace":     "default",
 					"__meta_kubernetes_pod_node_name": "testnode",
 					"__meta_kubernetes_pod_ip":        "1.2.3.4",
@@ -246,6 +251,7 @@ func TestPodDiscoveryDeleteUnknownCacheState(t *testing.T) {
 				},
 				Labels: model.LabelSet{
 					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_pod_uid":       "e4c35dec-836e-4931-83c6-13b9dbf39b18",
 					"__meta_kubernetes_namespace":     "default",
 					"__meta_kubernetes_pod_node_name": "testnode",
 					"__meta_kubernetes_pod_ip":        "1.2.3.4",
@@ -268,6 +274,7 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 	i.GetStore().Add(&v1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "testpod",
+			UID:       "e4c35dec-836e-4931-83c6-13b9dbf39b18",
 			Namespace: "default",
 		},
 		Spec: v1.PodSpec{
@@ -307,6 +314,7 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 				},
 				Labels: model.LabelSet{
 					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_pod_uid":       "e4c35dec-836e-4931-83c6-13b9dbf39b18",
 					"__meta_kubernetes_namespace":     "default",
 					"__meta_kubernetes_pod_node_name": "testnode",
 					"__meta_kubernetes_pod_ip":        "1.2.3.4",
@@ -329,6 +337,7 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 				},
 				Labels: model.LabelSet{
 					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_pod_uid":       "e4c35dec-836e-4931-83c6-13b9dbf39b18",
 					"__meta_kubernetes_namespace":     "default",
 					"__meta_kubernetes_pod_node_name": "testnode",
 					"__meta_kubernetes_pod_ip":        "1.2.3.4",


### PR DESCRIPTION
Prometheus already records the `__meta_kubernetes_pod_name` label, but a pod might be deleted and recreated with the same name. So it's useful to have a unique identifier, i.e., `__meta_kubernetes_pod_uid`, to differentiate.