### PR TITLE
Fixed int64 overflow for timestamp in v1/api parseDuration and parseTime

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -479,7 +479,7 @@ func respondError(w http.ResponseWriter, apiErr *apiError, data interface{}) {
 func parseTime(s string) (model.Time, error) {
 	if t, err := strconv.ParseFloat(s, 64); err == nil {
 		ts := t * float64(time.Second)
-		if ts >= float64(math.MaxInt64) || ts <= float64(math.MinInt64) {
+		if ts > float64(math.MaxInt64) || ts < float64(math.MinInt64) {
 			return 0, fmt.Errorf("cannot parse %q to a valid timestamp. It overflows int64", s)
 		}
 		return model.TimeFromUnixNano(int64(ts)), nil
@@ -493,7 +493,7 @@ func parseTime(s string) (model.Time, error) {
 func parseDuration(s string) (time.Duration, error) {
 	if d, err := strconv.ParseFloat(s, 64); err == nil {
 		ts := d * float64(time.Second)
-		if ts >= float64(math.MaxInt64) || ts <= float64(math.MinInt64) {
+		if ts > float64(math.MaxInt64) || ts < float64(math.MinInt64) {
 			return 0, fmt.Errorf("cannot parse %q to a valid duration. It overflows int64", s)
 		}
 		return time.Duration(ts), nil

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -221,7 +221,7 @@ func TestEndpoints(t *testing.T) {
 			},
 			errType: errorBadData,
 		},
-		// Invalid step
+		// Invalid step.
 		{
 			endpoint: api.queryRange,
 			query: url.Values{
@@ -232,7 +232,7 @@ func TestEndpoints(t *testing.T) {
 			},
 			errType: errorBadData,
 		},
-		// Start after end
+		// Start after end.
 		{
 			endpoint: api.queryRange,
 			query: url.Values{
@@ -243,7 +243,7 @@ func TestEndpoints(t *testing.T) {
 			},
 			errType: errorBadData,
 		},
-		// Start overflows int64 internally
+		// Start overflows int64 internally.
 		{
 			endpoint: api.queryRange,
 			query: url.Values{
@@ -605,11 +605,11 @@ func TestParseTime(t *testing.T) {
 			input: "30s",
 			fail:  true,
 		}, {
-			// Internal int64 overflow
+			// Internal int64 overflow.
 			input: "-148966367200.372",
 			fail:  true,
 		}, {
-			// Internal int64 overflow
+			// Internal int64 overflow.
 			input: "148966367200.372",
 			fail:  true,
 		}, {
@@ -660,11 +660,11 @@ func TestParseDuration(t *testing.T) {
 			input: "2015-06-03T13:21:58.555Z",
 			fail:  true,
 		}, {
-			// Internal int64 overflow
+			// Internal int64 overflow.
 			input: "-148966367200.372",
 			fail:  true,
 		}, {
-			// Internal int64 overflow
+			// Internal int64 overflow.
 			input: "148966367200.372",
 			fail:  true,
 		}, {

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -243,6 +243,17 @@ func TestEndpoints(t *testing.T) {
 			},
 			errType: errorBadData,
 		},
+		// Start overflows int64 internally
+		{
+			endpoint: api.queryRange,
+			query: url.Values{
+				"query": []string{"time()"},
+				"start": []string{"148966367200.372"},
+				"end":   []string{"1489667272.372"},
+				"step":  []string{"1"},
+			},
+			errType: errorBadData,
+		},
 		{
 			endpoint: api.labelValues,
 			params: map[string]string{
@@ -594,11 +605,16 @@ func TestParseTime(t *testing.T) {
 			input: "30s",
 			fail:  true,
 		}, {
+			// Internal int64 overflow
+			input: "-148966367200.372",
+			fail:  true,
+		}, {
+			// Internal int64 overflow
+			input: "148966367200.372",
+			fail:  true,
+		}, {
 			input:  "123",
 			result: time.Unix(123, 0),
-		}, {
-			input:  "123.123",
-			result: time.Unix(123, 123000000),
 		}, {
 			input:  "123.123",
 			result: time.Unix(123, 123000000),
@@ -642,6 +658,14 @@ func TestParseDuration(t *testing.T) {
 			fail:  true,
 		}, {
 			input: "2015-06-03T13:21:58.555Z",
+			fail:  true,
+		}, {
+			// Internal int64 overflow
+			input: "-148966367200.372",
+			fail:  true,
+		}, {
+			// Internal int64 overflow
+			input: "148966367200.372",
 			fail:  true,
 		}, {
 			input:  "123",


### PR DESCRIPTION
This led to unexpected results on wrong query with `(...)&start=148966367200.372&end=1489667272.372` fields. (additional `00` at the end of start)
That query is wrong because now `start > end`, but actually internal int64 overflow caused start to be something around `MinInt64` (huge negative number) and was passing the `end.Before(start)` validation.

In my opinion it should return error on API.

Changes:
- Added int64 overflow validation inside `ParseTime` and `ParseDuration`, stictly on `ParseFloat` path.
- Added mentioned values as test cases for endpoint, ParseTime and ParseDuration tests

Any feedback welcome!
 @brian-brazil @fabxc 

BTW: Not sure if negative timestamp makes sense even.. But `model.Earliest` is actually `MinInt64` (https://github.com/prometheus/common/blob/master/model/time.go#L36) 
Can someone explain me why Prometheus time model supports negative timestamps?

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>