### PR TITLE
Dockerfile: use busybox with glibc for better dns lookup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        quay.io/prometheus/busybox:latest
+FROM        quay.io/prometheus/busybox:glibc
 MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 
 COPY prometheus                             /bin/prometheus


### PR DESCRIPTION
While testing with docker-compose i discovered an problem with the base docker image busybox, the libc does not support resolving from /etc/hosts (localhost seems broken as well).
When using docker links, it writes the linked hosts to /etc/hosts which is ignored in the default busybox image. 

There was an early issue which addressed this: #897.
Due some changes in the Dockerfile the problem was triggered again ;-)

This is just an simple MR to use the prometheus busybox image with glibc. 