### PR TITLE
Changes to Marathon service discovery to use the label PROMETHEUS_PORT_INDEX to configure the target

### DIFF
--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -318,6 +318,9 @@ func getPortIndex(app *App) int {
 	if err != nil {
 		portIndex = 0
 	}
+	if portIndex < 0 {
+		portIndex = 0
+	}
 	return int(portIndex)
 }
 

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -310,11 +310,11 @@ func targetsForApp(app *App) []model.LabelSet {
 }
 
 func getPortIndex(app *App) int {
-	index := app.Labels["PROMETHEUS_PORT_INDEX"]
-	if index == "" {
+	index, exists := app.Labels["PROMETHEUS_PORT_INDEX"]
+	if !exists {
 		index = "0"
 	}
-	portIndex, err := strconv.ParseUint(index, 10, 32)
+	portIndex, err := strconv.Atoi(index)
 	if err != nil {
 		portIndex = 0
 	}

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -294,11 +295,12 @@ func createTargetGroup(app *App) *config.TargetGroup {
 
 func targetsForApp(app *App) []model.LabelSet {
 	targets := make([]model.LabelSet, 0, len(app.Tasks))
+	portIndex := getPortIndex(app)
 	for _, t := range app.Tasks {
 		if len(t.Ports) == 0 {
 			continue
 		}
-		target := targetForTask(&t)
+		target := targetForTask(&t, portIndex)
 		targets = append(targets, model.LabelSet{
 			model.AddressLabel: model.LabelValue(target),
 			taskLabel:          model.LabelValue(t.ID),
@@ -307,6 +309,22 @@ func targetsForApp(app *App) []model.LabelSet {
 	return targets
 }
 
-func targetForTask(task *Task) string {
-	return net.JoinHostPort(task.Host, fmt.Sprintf("%d", task.Ports[0]))
+func getPortIndex(app *App) int {
+	index := app.Labels["PROMETHEUS_PORT_INDEX"]
+	if index == "" {
+		index = "0"
+	}
+	portIndex, err := strconv.ParseUint(index, 10, 32)
+	if err != nil {
+		portIndex = 0
+	}
+	return int(portIndex)
+}
+
+func targetForTask(task *Task, portIndex int) string {
+	// fallback: if the port index is wrong, use the first port
+	if portIndex >= len(task.Ports) {
+		portIndex = 0
+	}
+	return net.JoinHostPort(task.Host, fmt.Sprintf("%d", task.Ports[portIndex]))
 }

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -346,3 +346,33 @@ func TestMarathonZeroTaskPortIndexWrong(t *testing.T) {
 		t.Fatal("Did not get a target group.")
 	}
 }
+
+func TestMarathonZeroTaskNegativePortIndex(t *testing.T) {
+	var (
+		ch     = make(chan []*config.TargetGroup, 1)
+		labels = map[string]string{"prometheus": "yes", "PROMETHEUS_PORT_INDEX": "-1"}
+		client = func(client *http.Client, url, token string) (*AppList, error) {
+			return marathonTestTaskPortIndexAppList(labels, 1), nil
+		}
+	)
+	if err := testUpdateServices(client, ch); err != nil {
+		t.Fatalf("Got error: %s", err)
+	}
+	select {
+	case tgs := <-ch:
+		tg := tgs[0]
+
+		if tg.Source != "test-service-port-index" {
+			t.Fatalf("Wrong target group name: %s", tg.Source)
+		}
+		if len(tg.Targets) != 1 {
+			t.Fatalf("Wrong number of targets: %v", tg.Targets)
+		}
+		tgt := tg.Targets[0]
+		if tgt[model.AddressLabel] != "mesos-slave-3:31000" {
+			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
+		}
+	default:
+		t.Fatal("Did not get a target group.")
+	}
+}

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -257,11 +257,11 @@ func marathonTestTaskPortIndexAppList(labels map[string]string, runningTasks int
 	}
 }
 
-func TestMarathonTaskPortIndex0(t *testing.T) {
+func TestMarathonZeroTaskPortIndex0(t *testing.T) {
 	var (
 		ch     = make(chan []*config.TargetGroup, 1)
 		labels = map[string]string{"prometheus": "yes", "PROMETHEUS_PORT_INDEX": "0"}
-		client = func(client *http.Client, url string) (*AppList, error) {
+		client = func(client *http.Client, url, token string) (*AppList, error) {
 			return marathonTestTaskPortIndexAppList(labels, 1), nil
 		}
 	)
@@ -287,11 +287,11 @@ func TestMarathonTaskPortIndex0(t *testing.T) {
 	}
 }
 
-func TestMarathonTaskPortIndex1(t *testing.T) {
+func TestMarathonZeroTaskPortIndex1(t *testing.T) {
 	var (
 		ch     = make(chan []*config.TargetGroup, 1)
 		labels = map[string]string{"prometheus": "yes", "PROMETHEUS_PORT_INDEX": "1"}
-		client = func(client *http.Client, url string) (*AppList, error) {
+		client = func(client *http.Client, url, token string) (*AppList, error) {
 			return marathonTestTaskPortIndexAppList(labels, 1), nil
 		}
 	)
@@ -310,6 +310,36 @@ func TestMarathonTaskPortIndex1(t *testing.T) {
 		}
 		tgt := tg.Targets[0]
 		if tgt[model.AddressLabel] != "mesos-slave-3:32000" {
+			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
+		}
+	default:
+		t.Fatal("Did not get a target group.")
+	}
+}
+
+func TestMarathonZeroTaskPortIndexWrong(t *testing.T) {
+	var (
+		ch     = make(chan []*config.TargetGroup, 1)
+		labels = map[string]string{"prometheus": "yes", "PROMETHEUS_PORT_INDEX": "0"}
+		client = func(client *http.Client, url, token string) (*AppList, error) {
+			return marathonTestTaskPortIndexAppList(labels, 1), nil
+		}
+	)
+	if err := testUpdateServices(client, ch); err != nil {
+		t.Fatalf("Got error: %s", err)
+	}
+	select {
+	case tgs := <-ch:
+		tg := tgs[0]
+
+		if tg.Source != "test-service-port-index" {
+			t.Fatalf("Wrong target group name: %s", tg.Source)
+		}
+		if len(tg.Targets) != 1 {
+			t.Fatalf("Wrong number of targets: %v", tg.Targets)
+		}
+		tgt := tg.Targets[0]
+		if tgt[model.AddressLabel] != "mesos-slave-3:31000" {
 			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
 		}
 	default:

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -234,3 +234,85 @@ func TestMarathonZeroTaskPorts(t *testing.T) {
 		t.Fatal("Did not get a target group.")
 	}
 }
+
+func marathonTestTaskPortIndexAppList(labels map[string]string, runningTasks int) *AppList {
+	var (
+		task = Task{
+			ID:    "test-task-3",
+			Host:  "mesos-slave-3",
+			Ports: []uint32{31000, 32000},
+		}
+		docker    = DockerContainer{Image: "repo/image:tag"}
+		container = Container{Docker: docker}
+		app       = App{
+			ID:           "test-service-port-index",
+			Tasks:        []Task{task},
+			RunningTasks: runningTasks,
+			Labels:       labels,
+			Container:    container,
+		}
+	)
+	return &AppList{
+		Apps: []App{app},
+	}
+}
+
+func TestMarathonTaskPortIndex0(t *testing.T) {
+	var (
+		ch     = make(chan []*config.TargetGroup, 1)
+		labels = map[string]string{"prometheus": "yes", "PROMETHEUS_PORT_INDEX": "0"}
+		client = func(client *http.Client, url string) (*AppList, error) {
+			return marathonTestTaskPortIndexAppList(labels, 1), nil
+		}
+	)
+	if err := testUpdateServices(client, ch); err != nil {
+		t.Fatalf("Got error: %s", err)
+	}
+	select {
+	case tgs := <-ch:
+		tg := tgs[0]
+
+		if tg.Source != "test-service-port-index" {
+			t.Fatalf("Wrong target group name: %s", tg.Source)
+		}
+		if len(tg.Targets) != 1 {
+			t.Fatalf("Wrong number of targets: %v", tg.Targets)
+		}
+		tgt := tg.Targets[0]
+		if tgt[model.AddressLabel] != "mesos-slave-3:31000" {
+			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
+		}
+	default:
+		t.Fatal("Did not get a target group.")
+	}
+}
+
+func TestMarathonTaskPortIndex1(t *testing.T) {
+	var (
+		ch     = make(chan []*config.TargetGroup, 1)
+		labels = map[string]string{"prometheus": "yes", "PROMETHEUS_PORT_INDEX": "1"}
+		client = func(client *http.Client, url string) (*AppList, error) {
+			return marathonTestTaskPortIndexAppList(labels, 1), nil
+		}
+	)
+	if err := testUpdateServices(client, ch); err != nil {
+		t.Fatalf("Got error: %s", err)
+	}
+	select {
+	case tgs := <-ch:
+		tg := tgs[0]
+
+		if tg.Source != "test-service-port-index" {
+			t.Fatalf("Wrong target group name: %s", tg.Source)
+		}
+		if len(tg.Targets) != 1 {
+			t.Fatalf("Wrong number of targets: %v", tg.Targets)
+		}
+		tgt := tg.Targets[0]
+		if tgt[model.AddressLabel] != "mesos-slave-3:32000" {
+			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
+		}
+	default:
+		t.Fatal("Did not get a target group.")
+	}
+}


### PR DESCRIPTION
Use the app's label `PROMETHEUS_PORT_INDEX` to get the metrics port index

It's another approach to #2448 

Thanks @ShimiTaNaka for the suggestion