### PR TITLE
Follow golang naming conventions in discovery packages

### DIFF
--- a/discovery/gce/gce.go
+++ b/discovery/gce/gce.go
@@ -44,9 +44,6 @@ const (
 	gceLabelInstanceStatus = gceLabel + "instance_status"
 	gceLabelTags           = gceLabel + "tags"
 	gceLabelMetadata       = gceLabel + "metadata_"
-
-	// Constants for instrumentation.
-	namespace = "prometheus"
 )
 
 var (
@@ -67,9 +64,9 @@ func init() {
 	prometheus.MustRegister(gceSDRefreshDuration)
 }
 
-// GCEDiscovery periodically performs GCE-SD requests. It implements
+// Discovery periodically performs GCE-SD requests. It implements
 // the TargetProvider interface.
-type GCEDiscovery struct {
+type Discovery struct {
 	project      string
 	zone         string
 	filter       string
@@ -81,9 +78,9 @@ type GCEDiscovery struct {
 	tagSeparator string
 }
 
-// NewGCEDiscovery returns a new GCEDiscovery which periodically refreshes its targets.
-func NewDiscovery(conf *config.GCESDConfig) (*GCEDiscovery, error) {
-	gd := &GCEDiscovery{
+// NewDiscovery returns a new Discovery which periodically refreshes its targets.
+func NewDiscovery(conf *config.GCESDConfig) (*Discovery, error) {
+	gd := &Discovery{
 		project:      conf.Project,
 		zone:         conf.Zone,
 		filter:       conf.Filter,
@@ -105,9 +102,9 @@ func NewDiscovery(conf *config.GCESDConfig) (*GCEDiscovery, error) {
 }
 
 // Run implements the TargetProvider interface.
-func (gd *GCEDiscovery) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
+func (d *Discovery) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
 	// Get an initial set right away.
-	tg, err := gd.refresh()
+	tg, err := d.refresh()
 	if err != nil {
 		log.Error(err)
 	} else {
@@ -117,13 +114,13 @@ func (gd *GCEDiscovery) Run(ctx context.Context, ch chan<- []*config.TargetGroup
 		}
 	}
 
-	ticker := time.NewTicker(gd.interval)
+	ticker := time.NewTicker(d.interval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			tg, err := gd.refresh()
+			tg, err := d.refresh()
 			if err != nil {
 				log.Error(err)
 				continue
@@ -138,7 +135,7 @@ func (gd *GCEDiscovery) Run(ctx context.Context, ch chan<- []*config.TargetGroup
 	}
 }
 
-func (gd *GCEDiscovery) refresh() (tg *config.TargetGroup, err error) {
+func (d *Discovery) refresh() (tg *config.TargetGroup, err error) {
 	t0 := time.Now()
 	defer func() {
 		gceSDRefreshDuration.Observe(time.Since(t0).Seconds())
@@ -148,12 +145,12 @@ func (gd *GCEDiscovery) refresh() (tg *config.TargetGroup, err error) {
 	}()
 
 	tg = &config.TargetGroup{
-		Source: fmt.Sprintf("GCE_%s_%s", gd.project, gd.zone),
+		Source: fmt.Sprintf("GCE_%s_%s", d.project, d.zone),
 	}
 
-	ilc := gd.isvc.List(gd.project, gd.zone)
-	if len(gd.filter) > 0 {
-		ilc = ilc.Filter(gd.filter)
+	ilc := d.isvc.List(d.project, d.zone)
+	if len(d.filter) > 0 {
+		ilc = ilc.Filter(d.filter)
 	}
 	err = ilc.Pages(nil, func(l *compute.InstanceList) error {
 		for _, inst := range l.Items {
@@ -161,7 +158,7 @@ func (gd *GCEDiscovery) refresh() (tg *config.TargetGroup, err error) {
 				continue
 			}
 			labels := model.LabelSet{
-				gceLabelProject:        model.LabelValue(gd.project),
+				gceLabelProject:        model.LabelValue(d.project),
 				gceLabelZone:           model.LabelValue(inst.Zone),
 				gceLabelInstanceName:   model.LabelValue(inst.Name),
 				gceLabelInstanceStatus: model.LabelValue(inst.Status),
@@ -170,14 +167,14 @@ func (gd *GCEDiscovery) refresh() (tg *config.TargetGroup, err error) {
 			labels[gceLabelNetwork] = model.LabelValue(priIface.Network)
 			labels[gceLabelSubnetwork] = model.LabelValue(priIface.Subnetwork)
 			labels[gceLabelPrivateIP] = model.LabelValue(priIface.NetworkIP)
-			addr := fmt.Sprintf("%s:%d", priIface.NetworkIP, gd.port)
+			addr := fmt.Sprintf("%s:%d", priIface.NetworkIP, d.port)
 			labels[model.AddressLabel] = model.LabelValue(addr)
 
 			// Tags in GCE are usually only used for networking rules.
 			if inst.Tags != nil && len(inst.Tags.Items) > 0 {
 				// We surround the separated list with the separator as well. This way regular expressions
 				// in relabeling rules don't have to consider tag positions.
-				tags := gd.tagSeparator + strings.Join(inst.Tags.Items, gd.tagSeparator) + gd.tagSeparator
+				tags := d.tagSeparator + strings.Join(inst.Tags.Items, d.tagSeparator) + d.tagSeparator
 				labels[gceLabelTags] = model.LabelValue(tags)
 			}
 

--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -45,33 +45,33 @@ func makeEndpoints() *v1.Endpoints {
 			Namespace: "default",
 		},
 		Subsets: []v1.EndpointSubset{
-			v1.EndpointSubset{
+			{
 				Addresses: []v1.EndpointAddress{
-					v1.EndpointAddress{
+					{
 						IP: "1.2.3.4",
 					},
 				},
 				Ports: []v1.EndpointPort{
-					v1.EndpointPort{
+					{
 						Name:     "testport",
 						Port:     9000,
 						Protocol: v1.ProtocolTCP,
 					},
 				},
 			},
-			v1.EndpointSubset{
+			{
 				Addresses: []v1.EndpointAddress{
-					v1.EndpointAddress{
+					{
 						IP: "2.3.4.5",
 					},
 				},
 				NotReadyAddresses: []v1.EndpointAddress{
-					v1.EndpointAddress{
+					{
 						IP: "2.3.4.5",
 					},
 				},
 				Ports: []v1.EndpointPort{
-					v1.EndpointPort{
+					{
 						Name:     "testport",
 						Port:     9001,
 						Protocol: v1.ProtocolTCP,
@@ -89,21 +89,21 @@ func TestEndpointsDiscoveryInitial(t *testing.T) {
 	k8sDiscoveryTest{
 		discovery: n,
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__":                              "1.2.3.4:9000",
 						"__meta_kubernetes_endpoint_port_name":     "testport",
 						"__meta_kubernetes_endpoint_port_protocol": "TCP",
 						"__meta_kubernetes_endpoint_ready":         "true",
 					},
-					model.LabelSet{
+					{
 						"__address__":                              "2.3.4.5:9001",
 						"__meta_kubernetes_endpoint_port_name":     "testport",
 						"__meta_kubernetes_endpoint_port_protocol": "TCP",
 						"__meta_kubernetes_endpoint_ready":         "true",
 					},
-					model.LabelSet{
+					{
 						"__address__":                              "2.3.4.5:9001",
 						"__meta_kubernetes_endpoint_port_name":     "testport",
 						"__meta_kubernetes_endpoint_port_protocol": "TCP",
@@ -130,20 +130,20 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 		Spec: v1.PodSpec{
 			NodeName: "testnode",
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name: "c1",
 					Ports: []v1.ContainerPort{
-						v1.ContainerPort{
+						{
 							Name:          "mainport",
 							ContainerPort: 9000,
 							Protocol:      v1.ProtocolTCP,
 						},
 					},
 				},
-				v1.Container{
+				{
 					Name: "c2",
 					Ports: []v1.ContainerPort{
-						v1.ContainerPort{
+						{
 							Name:          "sideport",
 							ContainerPort: 9001,
 							Protocol:      v1.ProtocolTCP,
@@ -169,9 +169,9 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 							Namespace: "default",
 						},
 						Subsets: []v1.EndpointSubset{
-							v1.EndpointSubset{
+							{
 								Addresses: []v1.EndpointAddress{
-									v1.EndpointAddress{
+									{
 										IP: "4.3.2.1",
 										TargetRef: &v1.ObjectReference{
 											Kind:      "Pod",
@@ -181,7 +181,7 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 									},
 								},
 								Ports: []v1.EndpointPort{
-									v1.EndpointPort{
+									{
 										Name:     "testport",
 										Port:     9000,
 										Protocol: v1.ProtocolTCP,
@@ -194,9 +194,9 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 			}()
 		},
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__":                                   "4.3.2.1:9000",
 						"__meta_kubernetes_endpoint_port_name":          "testport",
 						"__meta_kubernetes_endpoint_port_protocol":      "TCP",
@@ -211,7 +211,7 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 						"__meta_kubernetes_pod_container_port_number":   "9000",
 						"__meta_kubernetes_pod_container_port_protocol": "TCP",
 					},
-					model.LabelSet{
+					{
 						"__address__":                                   "1.2.3.4:9001",
 						"__meta_kubernetes_pod_name":                    "testpod",
 						"__meta_kubernetes_pod_ip":                      "1.2.3.4",
@@ -242,7 +242,7 @@ func TestEndpointsDiscoveryDelete(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { eps.Delete(makeEndpoints()) }() },
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Source: "endpoints/default/testendpoints",
 			},
 		},
@@ -257,7 +257,7 @@ func TestEndpointsDiscoveryDeleteUnknownCacheState(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { eps.Delete(cache.DeletedFinalStateUnknown{Obj: makeEndpoints()}) }() },
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Source: "endpoints/default/testendpoints",
 			},
 		},
@@ -278,28 +278,28 @@ func TestEndpointsDiscoveryUpdate(t *testing.T) {
 						Namespace: "default",
 					},
 					Subsets: []v1.EndpointSubset{
-						v1.EndpointSubset{
+						{
 							Addresses: []v1.EndpointAddress{
-								v1.EndpointAddress{
+								{
 									IP: "1.2.3.4",
 								},
 							},
 							Ports: []v1.EndpointPort{
-								v1.EndpointPort{
+								{
 									Name:     "testport",
 									Port:     9000,
 									Protocol: v1.ProtocolTCP,
 								},
 							},
 						},
-						v1.EndpointSubset{
+						{
 							Addresses: []v1.EndpointAddress{
-								v1.EndpointAddress{
+								{
 									IP: "2.3.4.5",
 								},
 							},
 							Ports: []v1.EndpointPort{
-								v1.EndpointPort{
+								{
 									Name:     "testport",
 									Port:     9001,
 									Protocol: v1.ProtocolTCP,
@@ -311,15 +311,15 @@ func TestEndpointsDiscoveryUpdate(t *testing.T) {
 			}()
 		},
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__":                              "1.2.3.4:9000",
 						"__meta_kubernetes_endpoint_port_name":     "testport",
 						"__meta_kubernetes_endpoint_port_protocol": "TCP",
 						"__meta_kubernetes_endpoint_ready":         "true",
 					},
-					model.LabelSet{
+					{
 						"__address__":                              "2.3.4.5:9001",
 						"__meta_kubernetes_endpoint_port_name":     "testport",
 						"__meta_kubernetes_endpoint_port_protocol": "TCP",

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -59,9 +59,9 @@ func init() {
 	}
 }
 
-// Kubernetes implements the TargetProvider interface for discovering
+// Discovery implements the TargetProvider interface for discovering
 // targets from Kubernetes.
-type Kubernetes struct {
+type Discovery struct {
 	client kubernetes.Interface
 	role   config.KubernetesRole
 	logger log.Logger
@@ -76,7 +76,7 @@ func init() {
 }
 
 // New creates a new Kubernetes discovery for the given role.
-func New(l log.Logger, conf *config.KubernetesSDConfig) (*Kubernetes, error) {
+func New(l log.Logger, conf *config.KubernetesSDConfig) (*Discovery, error) {
 	var (
 		kcfg *rest.Config
 		err  error
@@ -136,7 +136,7 @@ func New(l log.Logger, conf *config.KubernetesSDConfig) (*Kubernetes, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Kubernetes{
+	return &Discovery{
 		client: c,
 		logger: l,
 		role:   conf.Role,
@@ -146,16 +146,16 @@ func New(l log.Logger, conf *config.KubernetesSDConfig) (*Kubernetes, error) {
 const resyncPeriod = 10 * time.Minute
 
 // Run implements the TargetProvider interface.
-func (k *Kubernetes) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
-	rclient := k.client.Core().GetRESTClient()
+func (d *Discovery) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
+	rclient := d.client.Core().GetRESTClient()
 
-	switch k.role {
+	switch d.role {
 	case "endpoints":
 		elw := cache.NewListWatchFromClient(rclient, "endpoints", api.NamespaceAll, nil)
 		slw := cache.NewListWatchFromClient(rclient, "services", api.NamespaceAll, nil)
 		plw := cache.NewListWatchFromClient(rclient, "pods", api.NamespaceAll, nil)
 		eps := NewEndpoints(
-			k.logger.With("kubernetes_sd", "endpoint"),
+			d.logger.With("kubernetes_sd", "endpoint"),
 			cache.NewSharedInformer(slw, &apiv1.Service{}, resyncPeriod),
 			cache.NewSharedInformer(elw, &apiv1.Endpoints{}, resyncPeriod),
 			cache.NewSharedInformer(plw, &apiv1.Pod{}, resyncPeriod),
@@ -178,7 +178,7 @@ func (k *Kubernetes) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
 	case "pod":
 		plw := cache.NewListWatchFromClient(rclient, "pods", api.NamespaceAll, nil)
 		pod := NewPod(
-			k.logger.With("kubernetes_sd", "pod"),
+			d.logger.With("kubernetes_sd", "pod"),
 			cache.NewSharedInformer(plw, &apiv1.Pod{}, resyncPeriod),
 		)
 		go pod.informer.Run(ctx.Done())
@@ -191,7 +191,7 @@ func (k *Kubernetes) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
 	case "service":
 		slw := cache.NewListWatchFromClient(rclient, "services", api.NamespaceAll, nil)
 		svc := NewService(
-			k.logger.With("kubernetes_sd", "service"),
+			d.logger.With("kubernetes_sd", "service"),
 			cache.NewSharedInformer(slw, &apiv1.Service{}, resyncPeriod),
 		)
 		go svc.informer.Run(ctx.Done())
@@ -204,7 +204,7 @@ func (k *Kubernetes) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
 	case "node":
 		nlw := cache.NewListWatchFromClient(rclient, "nodes", api.NamespaceAll, nil)
 		node := NewNode(
-			k.logger.With("kubernetes_sd", "node"),
+			d.logger.With("kubernetes_sd", "node"),
 			cache.NewSharedInformer(nlw, &apiv1.Node{}, resyncPeriod),
 		)
 		go node.informer.Run(ctx.Done())
@@ -215,7 +215,7 @@ func (k *Kubernetes) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
 		node.Run(ctx, ch)
 
 	default:
-		k.logger.Errorf("unknown Kubernetes discovery kind %q", k.role)
+		d.logger.Errorf("unknown Kubernetes discovery kind %q", d.role)
 	}
 
 	<-ctx.Done()

--- a/discovery/kubernetes/node_test.go
+++ b/discovery/kubernetes/node_test.go
@@ -167,7 +167,7 @@ func makeNode(name, address string, labels map[string]string, annotations map[st
 		},
 		Status: v1.NodeStatus{
 			Addresses: []v1.NodeAddress{
-				v1.NodeAddress{
+				{
 					Type:    v1.NodeInternalIP,
 					Address: address,
 				},
@@ -197,9 +197,9 @@ func TestNodeDiscoveryInitial(t *testing.T) {
 	k8sDiscoveryTest{
 		discovery: n,
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__": "1.2.3.4:10250",
 						"instance":    "test",
 						"__meta_kubernetes_node_address_InternalIP": "1.2.3.4",
@@ -223,9 +223,9 @@ func TestNodeDiscoveryAdd(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { i.Add(makeEnumeratedNode(1)) }() },
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__": "1.2.3.4:10250",
 						"instance":    "test1",
 						"__meta_kubernetes_node_address_InternalIP": "1.2.3.4",
@@ -248,9 +248,9 @@ func TestNodeDiscoveryDelete(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { i.Delete(makeEnumeratedNode(0)) }() },
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__": "1.2.3.4:10250",
 						"instance":    "test0",
 						"__meta_kubernetes_node_address_InternalIP": "1.2.3.4",
@@ -263,7 +263,7 @@ func TestNodeDiscoveryDelete(t *testing.T) {
 			},
 		},
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Source: "node/test0",
 			},
 		},
@@ -278,9 +278,9 @@ func TestNodeDiscoveryDeleteUnknownCacheState(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { i.Delete(cache.DeletedFinalStateUnknown{Obj: makeEnumeratedNode(0)}) }() },
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__": "1.2.3.4:10250",
 						"instance":    "test0",
 						"__meta_kubernetes_node_address_InternalIP": "1.2.3.4",
@@ -293,7 +293,7 @@ func TestNodeDiscoveryDeleteUnknownCacheState(t *testing.T) {
 			},
 		},
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Source: "node/test0",
 			},
 		},
@@ -319,9 +319,9 @@ func TestNodeDiscoveryUpdate(t *testing.T) {
 			}()
 		},
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__": "1.2.3.4:10250",
 						"instance":    "test0",
 						"__meta_kubernetes_node_address_InternalIP": "1.2.3.4",
@@ -334,9 +334,9 @@ func TestNodeDiscoveryUpdate(t *testing.T) {
 			},
 		},
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__": "1.2.3.4:10250",
 						"instance":    "test0",
 						"__meta_kubernetes_node_address_InternalIP": "1.2.3.4",

--- a/discovery/kubernetes/pod_test.go
+++ b/discovery/kubernetes/pod_test.go
@@ -47,22 +47,22 @@ func makeMultiPortPod() *v1.Pod {
 		Spec: v1.PodSpec{
 			NodeName: "testnode",
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name: "testcontainer0",
 					Ports: []v1.ContainerPort{
-						v1.ContainerPort{
+						{
 							Name:          "testport0",
 							Protocol:      v1.ProtocolTCP,
 							ContainerPort: int32(9000),
 						},
-						v1.ContainerPort{
+						{
 							Name:          "testport1",
 							Protocol:      v1.ProtocolUDP,
 							ContainerPort: int32(9001),
 						},
 					},
 				},
-				v1.Container{
+				{
 					Name: "testcontainer1",
 				},
 			},
@@ -71,7 +71,7 @@ func makeMultiPortPod() *v1.Pod {
 			PodIP:  "1.2.3.4",
 			HostIP: "2.3.4.5",
 			Conditions: []v1.PodCondition{
-				v1.PodCondition{
+				{
 					Type:   v1.PodReady,
 					Status: v1.ConditionTrue,
 				},
@@ -89,10 +89,10 @@ func makePod() *v1.Pod {
 		Spec: v1.PodSpec{
 			NodeName: "testnode",
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name: "testcontainer",
 					Ports: []v1.ContainerPort{
-						v1.ContainerPort{
+						{
 							Name:          "testport",
 							Protocol:      v1.ProtocolTCP,
 							ContainerPort: int32(9000),
@@ -105,7 +105,7 @@ func makePod() *v1.Pod {
 			PodIP:  "1.2.3.4",
 			HostIP: "2.3.4.5",
 			Conditions: []v1.PodCondition{
-				v1.PodCondition{
+				{
 					Type:   v1.PodReady,
 					Status: v1.ConditionTrue,
 				},
@@ -121,23 +121,23 @@ func TestPodDiscoveryInitial(t *testing.T) {
 	k8sDiscoveryTest{
 		discovery: n,
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__":                                   "1.2.3.4:9000",
 						"__meta_kubernetes_pod_container_name":          "testcontainer0",
 						"__meta_kubernetes_pod_container_port_name":     "testport0",
 						"__meta_kubernetes_pod_container_port_number":   "9000",
 						"__meta_kubernetes_pod_container_port_protocol": "TCP",
 					},
-					model.LabelSet{
+					{
 						"__address__":                                   "1.2.3.4:9001",
 						"__meta_kubernetes_pod_container_name":          "testcontainer0",
 						"__meta_kubernetes_pod_container_port_name":     "testport1",
 						"__meta_kubernetes_pod_container_port_number":   "9001",
 						"__meta_kubernetes_pod_container_port_protocol": "UDP",
 					},
-					model.LabelSet{
+					{
 						"__address__":                          "1.2.3.4",
 						"__meta_kubernetes_pod_container_name": "testcontainer1",
 					},
@@ -165,9 +165,9 @@ func TestPodDiscoveryAdd(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { i.Add(makePod()) }() },
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__":                                   "1.2.3.4:9000",
 						"__meta_kubernetes_pod_container_name":          "testcontainer",
 						"__meta_kubernetes_pod_container_port_name":     "testport",
@@ -197,9 +197,9 @@ func TestPodDiscoveryDelete(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { i.Delete(makePod()) }() },
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__":                                   "1.2.3.4:9000",
 						"__meta_kubernetes_pod_container_name":          "testcontainer",
 						"__meta_kubernetes_pod_container_port_name":     "testport",
@@ -219,7 +219,7 @@ func TestPodDiscoveryDelete(t *testing.T) {
 			},
 		},
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Source: "pod/default/testpod",
 			},
 		},
@@ -234,9 +234,9 @@ func TestPodDiscoveryDeleteUnknownCacheState(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { i.Delete(cache.DeletedFinalStateUnknown{Obj: makePod()}) }() },
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__":                                   "1.2.3.4:9000",
 						"__meta_kubernetes_pod_container_name":          "testcontainer",
 						"__meta_kubernetes_pod_container_port_name":     "testport",
@@ -256,7 +256,7 @@ func TestPodDiscoveryDeleteUnknownCacheState(t *testing.T) {
 			},
 		},
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Source: "pod/default/testpod",
 			},
 		},
@@ -273,10 +273,10 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 		Spec: v1.PodSpec{
 			NodeName: "testnode",
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name: "testcontainer",
 					Ports: []v1.ContainerPort{
-						v1.ContainerPort{
+						{
 							Name:          "testport",
 							Protocol:      v1.ProtocolTCP,
 							ContainerPort: int32(9000),
@@ -295,9 +295,9 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { i.Update(makePod()) }() },
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__":                                   "1.2.3.4:9000",
 						"__meta_kubernetes_pod_container_name":          "testcontainer",
 						"__meta_kubernetes_pod_container_port_name":     "testport",
@@ -317,9 +317,9 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 			},
 		},
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__address__":                                   "1.2.3.4:9000",
 						"__meta_kubernetes_pod_container_name":          "testcontainer",
 						"__meta_kubernetes_pod_container_port_name":     "testport",

--- a/discovery/kubernetes/service_test.go
+++ b/discovery/kubernetes/service_test.go
@@ -47,12 +47,12 @@ func makeMultiPortService() *v1.Service {
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Name:     "testport0",
 					Protocol: v1.ProtocolTCP,
 					Port:     int32(30900),
 				},
-				v1.ServicePort{
+				{
 					Name:     "testport1",
 					Protocol: v1.ProtocolUDP,
 					Port:     int32(30901),
@@ -70,7 +70,7 @@ func makeSuffixedService(suffix string) *v1.Service {
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Name:     "testport",
 					Protocol: v1.ProtocolTCP,
 					Port:     int32(30900),
@@ -91,14 +91,14 @@ func TestServiceDiscoveryInitial(t *testing.T) {
 	k8sDiscoveryTest{
 		discovery: n,
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
 						"__address__":                             "testservice.default.svc:30900",
 						"__meta_kubernetes_service_port_name":     "testport0",
 					},
-					model.LabelSet{
+					{
 						"__meta_kubernetes_service_port_protocol": "UDP",
 						"__address__":                             "testservice.default.svc:30901",
 						"__meta_kubernetes_service_port_name":     "testport1",
@@ -123,9 +123,9 @@ func TestServiceDiscoveryAdd(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { i.Add(makeService()) }() },
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
 						"__address__":                             "testservice.default.svc:30900",
 						"__meta_kubernetes_service_port_name":     "testport",
@@ -149,9 +149,9 @@ func TestServiceDiscoveryDelete(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { i.Delete(makeService()) }() },
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
 						"__address__":                             "testservice.default.svc:30900",
 						"__meta_kubernetes_service_port_name":     "testport",
@@ -165,7 +165,7 @@ func TestServiceDiscoveryDelete(t *testing.T) {
 			},
 		},
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Source: "svc/default/testservice",
 			},
 		},
@@ -180,9 +180,9 @@ func TestServiceDiscoveryDeleteUnknownCacheState(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { i.Delete(cache.DeletedFinalStateUnknown{Obj: makeService()}) }() },
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
 						"__address__":                             "testservice.default.svc:30900",
 						"__meta_kubernetes_service_port_name":     "testport",
@@ -196,7 +196,7 @@ func TestServiceDiscoveryDeleteUnknownCacheState(t *testing.T) {
 			},
 		},
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Source: "svc/default/testservice",
 			},
 		},
@@ -211,9 +211,9 @@ func TestServiceDiscoveryUpdate(t *testing.T) {
 		discovery:  n,
 		afterStart: func() { go func() { i.Update(makeMultiPortService()) }() },
 		expectedInitial: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
 						"__address__":                             "testservice.default.svc:30900",
 						"__meta_kubernetes_service_port_name":     "testport",
@@ -227,14 +227,14 @@ func TestServiceDiscoveryUpdate(t *testing.T) {
 			},
 		},
 		expectedRes: []*config.TargetGroup{
-			&config.TargetGroup{
+			{
 				Targets: []model.LabelSet{
-					model.LabelSet{
+					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
 						"__address__":                             "testservice.default.svc:30900",
 						"__meta_kubernetes_service_port_name":     "testport0",
 					},
-					model.LabelSet{
+					{
 						"__meta_kubernetes_service_port_protocol": "UDP",
 						"__address__":                             "testservice.default.svc:30901",
 						"__meta_kubernetes_service_port_name":     "testport1",

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -125,33 +125,33 @@ func TestMarathonSDSendGroup(t *testing.T) {
 }
 
 func TestMarathonSDRemoveApp(t *testing.T) {
-	var ch = make(chan []*config.TargetGroup)
+	var ch = make(chan []*config.TargetGroup, 1)
 	md, err := NewDiscovery(&conf)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
+
 	md.appsClient = func(client *http.Client, url, token string) (*AppList, error) {
 		return marathonTestAppList(marathonValidLabel, 1), nil
 	}
-	go func() {
-		up1 := (<-ch)[0]
-		up2 := (<-ch)[0]
-		if up2.Source != up1.Source {
-			t.Fatalf("Source is different: %s", up2)
-			if len(up2.Targets) > 0 {
-				t.Fatalf("Got a non-empty target set: %s", up2.Targets)
-			}
-		}
-	}()
 	if err := md.updateServices(context.Background(), ch); err != nil {
 		t.Fatalf("Got error on first update: %s", err)
 	}
+	up1 := (<-ch)[0]
 
 	md.appsClient = func(client *http.Client, url, token string) (*AppList, error) {
 		return marathonTestAppList(marathonValidLabel, 0), nil
 	}
 	if err := md.updateServices(context.Background(), ch); err != nil {
 		t.Fatalf("Got error on second update: %s", err)
+	}
+	up2 := (<-ch)[0]
+
+	if up2.Source != up1.Source {
+		t.Fatalf("Source is different: %s", up2)
+		if len(up2.Targets) > 0 {
+			t.Fatalf("Got a non-empty target set: %s", up2.Targets)
+		}
 	}
 }
 
@@ -160,6 +160,7 @@ func TestMarathonSDRunAndStop(t *testing.T) {
 		refreshInterval = model.Duration(time.Millisecond * 10)
 		conf            = config.MarathonSDConfig{Servers: testServers, RefreshInterval: refreshInterval}
 		ch              = make(chan []*config.TargetGroup)
+		doneCh          = make(chan error)
 	)
 	md, err := NewDiscovery(&conf)
 	if err != nil {
@@ -171,21 +172,21 @@ func TestMarathonSDRunAndStop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
-		for {
-			select {
-			case _, ok := <-ch:
-				if !ok {
-					return
-				}
-				cancel()
-			case <-time.After(md.refreshInterval * 3):
-				cancel()
-				t.Fatalf("Update took too long.")
-			}
-		}
+		md.Run(ctx, ch)
+		close(doneCh)
 	}()
 
-	md.Run(ctx, ch)
+	timeout := time.After(md.refreshInterval * 3)
+	for {
+		select {
+		case <-ch:
+			cancel()
+		case <-doneCh:
+			return
+		case <-timeout:
+			t.Fatalf("Update took too long.")
+		}
+	}
 }
 
 func marathonTestZeroTaskPortAppList(labels map[string]string, runningTasks int) *AppList {


### PR DESCRIPTION
While opening the discovery packages in my IDE, all kinds of go naming warnings were shown. So I fixed them, `gorename` to the rescue.

@fabxc 