### PR TITLE
Add support to multiple ports in Marathon

### DIFF
--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -46,10 +46,10 @@ const (
 	// taskLabel contains the mesos task name of the app instance.
 	taskLabel model.LabelName = metaLabelPrefix + "task"
 
-	// portMappingsLabelPrefix is the prefix for the application portMappings labels.
-	portMappingsLabelPrefix = metaLabelPrefix + "port_mappings_label_"
-	// portDefinitionsLabelPrefix is the prefix for the application portDefinitions labels.
-	portDefinitionsLabelPrefix = metaLabelPrefix + "port_definitions_label_"
+	// portMappingLabelPrefix is the prefix for the application portMappings labels.
+	portMappingLabelPrefix = metaLabelPrefix + "port_mapping_label_"
+	// portDefinitionLabelPrefix is the prefix for the application portDefinitions labels.
+	portDefinitionLabelPrefix = metaLabelPrefix + "port_definition_label_"
 
 	// Constants for instrumentation.
 	namespace = "prometheus"
@@ -324,13 +324,13 @@ func targetsForApp(app *App) []model.LabelSet {
 			}
 			if i < len(app.PortDefinitions) {
 				for ln, lv := range app.PortDefinitions[i].Labels {
-					ln = portDefinitionsLabelPrefix + strutil.SanitizeLabelName(ln)
+					ln = portDefinitionLabelPrefix + strutil.SanitizeLabelName(ln)
 					target[model.LabelName(ln)] = model.LabelValue(lv)
 				}
 			}
 			if i < len(app.Container.Docker.PortMappings) {
 				for ln, lv := range app.Container.Docker.PortMappings[i].Labels {
-					ln = portMappingsLabelPrefix + strutil.SanitizeLabelName(ln)
+					ln = portMappingLabelPrefix + strutil.SanitizeLabelName(ln)
 					target[model.LabelName(ln)] = model.LabelValue(lv)
 				}
 			}

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -321,13 +321,17 @@ func targetsForApp(app *App) []model.LabelSet {
 				model.AddressLabel: model.LabelValue(targetAddress),
 				taskLabel:          model.LabelValue(t.ID),
 			}
-			for ln, lv := range app.PortDefinitions[i].Labels {
-				ln = portDefinitionsLabelPrefix + ln
-				target[model.LabelName(ln)] = model.LabelValue(lv)
+			if i < len(app.PortDefinitions) {
+				for ln, lv := range app.PortDefinitions[i].Labels {
+					ln = portDefinitionsLabelPrefix + ln
+					target[model.LabelName(ln)] = model.LabelValue(lv)
+				}
 			}
-			for ln, lv := range app.Container.Docker.PortMappings[i].Labels {
-				ln = portMappingsLabelPrefix + ln
-				target[model.LabelName(ln)] = model.LabelValue(lv)
+			if i < len(app.Container.Docker.PortMappings) {
+				for ln, lv := range app.Container.Docker.PortMappings[i].Labels {
+					ln = portMappingsLabelPrefix + ln
+					target[model.LabelName(ln)] = model.LabelValue(lv)
+				}
 			}
 			targets = append(targets, target)
 		}

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -47,9 +47,9 @@ const (
 	taskLabel model.LabelName = metaLabelPrefix + "task"
 
 	// portMappingsLabelPrefix is the prefix for the application portMappings labels.
-	portMappingsLabelPrefix = metaLabelPrefix + "port_mappings_"
+	portMappingsLabelPrefix = metaLabelPrefix + "port_mappings_label_"
 	// portDefinitionsLabelPrefix is the prefix for the application portDefinitions labels.
-	portDefinitionsLabelPrefix = metaLabelPrefix + "port_definitions_"
+	portDefinitionsLabelPrefix = metaLabelPrefix + "port_definitions_label_"
 
 	// Constants for instrumentation.
 	namespace = "prometheus"

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -193,7 +193,7 @@ type Task struct {
 	Ports []uint32 `json:"ports"`
 }
 
-// PortMappings describes in which port the process are binding inside the docker container
+// PortMappings describes in which port the process are binding inside the docker container.
 type PortMappings struct {
 	Labels map[string]string `json:"labels"`
 }
@@ -209,7 +209,7 @@ type Container struct {
 	Docker DockerContainer `json:"docker"`
 }
 
-// PortDefinitions describes which load balancer port you should access to access the service
+// PortDefinitions describes which load balancer port you should access to access the service.
 type PortDefinitions struct {
 	Labels map[string]string `json:"labels"`
 }

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/util/httputil"
+	"github.com/prometheus/prometheus/util/strutil"
 )
 
 const (
@@ -302,7 +303,7 @@ func createTargetGroup(app *App) *config.TargetGroup {
 	}
 
 	for ln, lv := range app.Labels {
-		ln = appLabelPrefix + ln
+		ln = appLabelPrefix + strutil.SanitizeLabelName(ln)
 		tg.Labels[model.LabelName(ln)] = model.LabelValue(lv)
 	}
 
@@ -323,13 +324,13 @@ func targetsForApp(app *App) []model.LabelSet {
 			}
 			if i < len(app.PortDefinitions) {
 				for ln, lv := range app.PortDefinitions[i].Labels {
-					ln = portDefinitionsLabelPrefix + ln
+					ln = portDefinitionsLabelPrefix + strutil.SanitizeLabelName(ln)
 					target[model.LabelName(ln)] = model.LabelValue(lv)
 				}
 			}
 			if i < len(app.Container.Docker.PortMappings) {
 				for ln, lv := range app.Container.Docker.PortMappings[i].Labels {
-					ln = portMappingsLabelPrefix + ln
+					ln = portMappingsLabelPrefix + strutil.SanitizeLabelName(ln)
 					target[model.LabelName(ln)] = model.LabelValue(lv)
 				}
 			}

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -326,3 +326,76 @@ func TestMarathonZeroTaskPorts(t *testing.T) {
 		t.Fatal("Did not get a target group.")
 	}
 }
+
+func marathonTestAppListWithoutPortMappings(labels map[string]string, runningTasks int) *AppList {
+	var (
+		task = Task{
+			ID:    "test-task-1",
+			Host:  "mesos-slave1",
+			Ports: []uint32{31000, 32000},
+		}
+		docker = DockerContainer{
+			Image: "repo/image:tag",
+		}
+		container = Container{Docker: docker}
+		app       = App{
+			ID:           "test-service",
+			Tasks:        []Task{task},
+			RunningTasks: runningTasks,
+			Labels:       labels,
+			Container:    container,
+			PortDefinitions: []PortDefinitions{
+				{Labels: make(map[string]string)},
+				{Labels: labels},
+			},
+		}
+	)
+	return &AppList{
+		Apps: []App{app},
+	}
+}
+
+func TestMarathonSDSendGroupWithoutPortMappings(t *testing.T) {
+	var (
+		ch     = make(chan []*config.TargetGroup, 1)
+		client = func(client *http.Client, url, token string) (*AppList, error) {
+			return marathonTestAppListWithoutPortMappings(marathonValidLabel, 1), nil
+		}
+	)
+	if err := testUpdateServices(client, ch); err != nil {
+		t.Fatalf("Got error: %s", err)
+	}
+	select {
+	case tgs := <-ch:
+		tg := tgs[0]
+
+		if tg.Source != "test-service" {
+			t.Fatalf("Wrong target group name: %s", tg.Source)
+		}
+		if len(tg.Targets) != 2 {
+			t.Fatalf("Wrong number of targets: %v", tg.Targets)
+		}
+		tgt := tg.Targets[0]
+		if tgt[model.AddressLabel] != "mesos-slave1:31000" {
+			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
+		}
+		if tgt[model.LabelName(portMappingsLabelPrefix+"prometheus")] != "" {
+			t.Fatalf("Wrong first portMappings label from the first port: %s", tgt[model.AddressLabel])
+		}
+		if tgt[model.LabelName(portDefinitionsLabelPrefix+"prometheus")] != "" {
+			t.Fatalf("Wrong first portDefinitions label from the first port: %s", tgt[model.AddressLabel])
+		}
+		tgt = tg.Targets[1]
+		if tgt[model.AddressLabel] != "mesos-slave1:32000" {
+			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
+		}
+		if tgt[model.LabelName(portMappingsLabelPrefix+"prometheus")] != "" {
+			t.Fatalf("Wrong portMappings label from the second port: %s", tgt[model.AddressLabel])
+		}
+		if tgt[model.LabelName(portDefinitionsLabelPrefix+"prometheus")] != "yes" {
+			t.Fatalf("Wrong portDefinitions label from the second port: %s", tgt[model.AddressLabel])
+		}
+	default:
+		t.Fatal("Did not get a target group.")
+	}
+}

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -399,3 +399,76 @@ func TestMarathonSDSendGroupWithoutPortMappings(t *testing.T) {
 		t.Fatal("Did not get a target group.")
 	}
 }
+
+func marathonTestAppListWithoutPortDefinitions(labels map[string]string, runningTasks int) *AppList {
+	var (
+		task = Task{
+			ID:    "test-task-1",
+			Host:  "mesos-slave1",
+			Ports: []uint32{31000, 32000},
+		}
+		docker = DockerContainer{
+			Image: "repo/image:tag",
+			PortMappings: []PortMappings{
+				{Labels: labels},
+				{Labels: make(map[string]string)},
+			},
+		}
+		container = Container{Docker: docker}
+		app       = App{
+			ID:           "test-service",
+			Tasks:        []Task{task},
+			RunningTasks: runningTasks,
+			Labels:       labels,
+			Container:    container,
+		}
+	)
+	return &AppList{
+		Apps: []App{app},
+	}
+}
+
+func TestMarathonSDSendGroupWithoutPortDefinitions(t *testing.T) {
+	var (
+		ch     = make(chan []*config.TargetGroup, 1)
+		client = func(client *http.Client, url, token string) (*AppList, error) {
+			return marathonTestAppListWithoutPortDefinitions(marathonValidLabel, 1), nil
+		}
+	)
+	if err := testUpdateServices(client, ch); err != nil {
+		t.Fatalf("Got error: %s", err)
+	}
+	select {
+	case tgs := <-ch:
+		tg := tgs[0]
+
+		if tg.Source != "test-service" {
+			t.Fatalf("Wrong target group name: %s", tg.Source)
+		}
+		if len(tg.Targets) != 2 {
+			t.Fatalf("Wrong number of targets: %v", tg.Targets)
+		}
+		tgt := tg.Targets[0]
+		if tgt[model.AddressLabel] != "mesos-slave1:31000" {
+			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
+		}
+		if tgt[model.LabelName(portMappingsLabelPrefix+"prometheus")] != "yes" {
+			t.Fatalf("Wrong first portMappings label from the first port: %s", tgt[model.AddressLabel])
+		}
+		if tgt[model.LabelName(portDefinitionsLabelPrefix+"prometheus")] != "" {
+			t.Fatalf("Wrong first portDefinitions label from the first port: %s", tgt[model.AddressLabel])
+		}
+		tgt = tg.Targets[1]
+		if tgt[model.AddressLabel] != "mesos-slave1:32000" {
+			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
+		}
+		if tgt[model.LabelName(portMappingsLabelPrefix+"prometheus")] != "" {
+			t.Fatalf("Wrong portMappings label from the second port: %s", tgt[model.AddressLabel])
+		}
+		if tgt[model.LabelName(portDefinitionsLabelPrefix+"prometheus")] != "" {
+			t.Fatalf("Wrong portDefinitions label from the second port: %s", tgt[model.AddressLabel])
+		}
+	default:
+		t.Fatal("Did not get a target group.")
+	}
+}

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -127,10 +127,10 @@ func TestMarathonSDSendGroup(t *testing.T) {
 		if tgt[model.AddressLabel] != "mesos-slave1:31000" {
 			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portMappingsLabelPrefix+"prometheus")] != "yes" {
+		if tgt[model.LabelName(portMappingLabelPrefix+"prometheus")] != "yes" {
 			t.Fatalf("Wrong first portMappings label from the first port: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portDefinitionsLabelPrefix+"prometheus")] != "" {
+		if tgt[model.LabelName(portDefinitionLabelPrefix+"prometheus")] != "" {
 			t.Fatalf("Wrong first portDefinitions label from the first port: %s", tgt[model.AddressLabel])
 		}
 	default:
@@ -259,20 +259,20 @@ func TestMarathonSDSendGroupWithMutiplePort(t *testing.T) {
 		if tgt[model.AddressLabel] != "mesos-slave1:31000" {
 			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portMappingsLabelPrefix+"prometheus")] != "yes" {
+		if tgt[model.LabelName(portMappingLabelPrefix+"prometheus")] != "yes" {
 			t.Fatalf("Wrong first portMappings label from the first port: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portDefinitionsLabelPrefix+"prometheus")] != "" {
+		if tgt[model.LabelName(portDefinitionLabelPrefix+"prometheus")] != "" {
 			t.Fatalf("Wrong first portDefinitions label from the first port: %s", tgt[model.AddressLabel])
 		}
 		tgt = tg.Targets[1]
 		if tgt[model.AddressLabel] != "mesos-slave1:32000" {
 			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portMappingsLabelPrefix+"prometheus")] != "" {
+		if tgt[model.LabelName(portMappingLabelPrefix+"prometheus")] != "" {
 			t.Fatalf("Wrong portMappings label from the second port: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portDefinitionsLabelPrefix+"prometheus")] != "yes" {
+		if tgt[model.LabelName(portDefinitionLabelPrefix+"prometheus")] != "yes" {
 			t.Fatalf("Wrong portDefinitions label from the second port: %s", tgt[model.AddressLabel])
 		}
 	default:
@@ -379,20 +379,20 @@ func TestMarathonSDSendGroupWithoutPortMappings(t *testing.T) {
 		if tgt[model.AddressLabel] != "mesos-slave1:31000" {
 			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portMappingsLabelPrefix+"prometheus")] != "" {
+		if tgt[model.LabelName(portMappingLabelPrefix+"prometheus")] != "" {
 			t.Fatalf("Wrong first portMappings label from the first port: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portDefinitionsLabelPrefix+"prometheus")] != "" {
+		if tgt[model.LabelName(portDefinitionLabelPrefix+"prometheus")] != "" {
 			t.Fatalf("Wrong first portDefinitions label from the first port: %s", tgt[model.AddressLabel])
 		}
 		tgt = tg.Targets[1]
 		if tgt[model.AddressLabel] != "mesos-slave1:32000" {
 			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portMappingsLabelPrefix+"prometheus")] != "" {
+		if tgt[model.LabelName(portMappingLabelPrefix+"prometheus")] != "" {
 			t.Fatalf("Wrong portMappings label from the second port: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portDefinitionsLabelPrefix+"prometheus")] != "yes" {
+		if tgt[model.LabelName(portDefinitionLabelPrefix+"prometheus")] != "yes" {
 			t.Fatalf("Wrong portDefinitions label from the second port: %s", tgt[model.AddressLabel])
 		}
 	default:
@@ -452,20 +452,20 @@ func TestMarathonSDSendGroupWithoutPortDefinitions(t *testing.T) {
 		if tgt[model.AddressLabel] != "mesos-slave1:31000" {
 			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portMappingsLabelPrefix+"prometheus")] != "yes" {
+		if tgt[model.LabelName(portMappingLabelPrefix+"prometheus")] != "yes" {
 			t.Fatalf("Wrong first portMappings label from the first port: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portDefinitionsLabelPrefix+"prometheus")] != "" {
+		if tgt[model.LabelName(portDefinitionLabelPrefix+"prometheus")] != "" {
 			t.Fatalf("Wrong first portDefinitions label from the first port: %s", tgt[model.AddressLabel])
 		}
 		tgt = tg.Targets[1]
 		if tgt[model.AddressLabel] != "mesos-slave1:32000" {
 			t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portMappingsLabelPrefix+"prometheus")] != "" {
+		if tgt[model.LabelName(portMappingLabelPrefix+"prometheus")] != "" {
 			t.Fatalf("Wrong portMappings label from the second port: %s", tgt[model.AddressLabel])
 		}
-		if tgt[model.LabelName(portDefinitionsLabelPrefix+"prometheus")] != "" {
+		if tgt[model.LabelName(portDefinitionLabelPrefix+"prometheus")] != "" {
 			t.Fatalf("Wrong portDefinitions label from the second port: %s", tgt[model.AddressLabel])
 		}
 	default:


### PR DESCRIPTION
- create a target for every port
- add labels from portMappings and portDefinitions for each port
 * it is useful to filter ports

Please @grobie, review it.

refer: #2448, #2450, #2503 