### PR TITLE
Only truncate buildVersion if it's set

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -425,7 +425,7 @@ func tmplFuncs(consolesPath string, opts *Options) template_text.FuncMap {
 		},
 		"consolesPath": func() string { return consolesPath },
 		"pathPrefix":   func() string { return opts.ExternalURL.Path },
-		"buildVersion": func() string { return opts.Version.Revision[:7] },
+		"buildVersion": func() string { return opts.Version.Revision },
 		"stripLabels": func(lset model.LabelSet, labels ...model.LabelName) model.LabelSet {
 			for _, ln := range labels {
 				delete(lset, ln)


### PR DESCRIPTION
Without this, the web interface templates fail to execute on non-promu builds.