### PR TITLE
storage: Evict chunks and calculate persistence pressure...

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -54,6 +54,10 @@ var cfg = struct {
 
 	alertmanagerURLs stringset
 	prometheusURL    string
+
+	// Deprecated storage flags, kept for backwards compatibility.
+	deprecatedMemoryChunks       uint64
+	deprecatedMaxChunksToPersist uint64
 }{
 	alertmanagerURLs: stringset{},
 }
@@ -145,17 +149,21 @@ func init() {
 		&cfg.storage.PersistenceStoragePath, "storage.local.path", "data",
 		"Base path for metrics storage.",
 	)
-	cfg.fs.IntVar(
-		&cfg.storage.MemoryChunks, "storage.local.memory-chunks", 1024*1024,
-		"How many chunks to keep in memory. While the size of a chunk is 1kiB, the total memory usage will be significantly higher than this value * 1kiB. Furthermore, for various reasons, more chunks might have to be kept in memory temporarily. Sample ingestion will be throttled if the configured value is exceeded by more than 10%.",
+	cfg.fs.Uint64Var(
+		&cfg.storage.TargetHeapSize, "storage.local.target-heap-size", 2*1024*1024*1024,
+		"The metrics storage attempts to limit its own memory usage such that the total heap size approaches this value. Note that this is not a hard limit. Actual heap size might be temporarily or permanently higher for a variety of reasons. The default value is a relatively safe setting to not use more than 3 GiB physical memory.",
+	)
+	cfg.fs.Uint64Var(
+		&cfg.deprecatedMemoryChunks, "storage.local.memory-chunks", 0,
+		"Deprecated. If set, -storage.local.target-heap-size will be set to this value times 3072.",
 	)
 	cfg.fs.DurationVar(
 		&cfg.storage.PersistenceRetentionPeriod, "storage.local.retention", 15*24*time.Hour,
 		"How long to retain samples in the local storage.",
 	)
-	cfg.fs.IntVar(
-		&cfg.storage.MaxChunksToPersist, "storage.local.max-chunks-to-persist", 512*1024,
-		"How many chunks can be waiting for persistence before sample ingestion will be throttled. Many chunks waiting to be persisted will increase the checkpoint size.",
+	cfg.fs.Uint64Var(
+		&cfg.deprecatedMaxChunksToPersist, "storage.local.max-chunks-to-persist", 0,
+		"Deprecated. This flag has no effect anymore.",
 	)
 	cfg.fs.DurationVar(
 		&cfg.storage.CheckpointInterval, "storage.local.checkpoint-interval", 5*time.Minute,
@@ -276,6 +284,10 @@ func parse(args []string) error {
 	// don't expose it as a separate flag but set it here.
 	cfg.storage.HeadChunkTimeout = promql.StalenessDelta
 
+	if cfg.storage.TargetHeapSize < 1024*1024 {
+		return fmt.Errorf("target heap size smaller than %d: %d", 1024*1024, cfg.storage.TargetHeapSize)
+	}
+
 	if err := parsePrometheusURL(); err != nil {
 		return err
 	}
@@ -290,6 +302,15 @@ func parse(args []string) error {
 		if err := validateAlertmanagerURL(u); err != nil {
 			return err
 		}
+	}
+
+	// Deal with deprecated storage flags.
+	if cfg.deprecatedMaxChunksToPersist > 0 {
+		log.Warn("Flag -storage.local.max-chunks-to-persist is deprecated. It has no effect.")
+	}
+	if cfg.deprecatedMemoryChunks > 0 {
+		cfg.storage.TargetHeapSize = cfg.deprecatedMemoryChunks * 3072
+		log.Warnf("Flag -storage.local.memory-chunks is deprecated. Its value %d is used to override -storage.local.target-heap-size to %d.", cfg.deprecatedMemoryChunks, cfg.storage.TargetHeapSize)
 	}
 
 	return nil

--- a/storage/local/chunk/instrumentation.go
+++ b/storage/local/chunk/instrumentation.go
@@ -83,18 +83,8 @@ func init() {
 	prometheus.MustRegister(NumMemDescs)
 }
 
-var (
-	// NumMemChunks is the total number of chunks in memory. This is a
-	// global counter, also used internally, so not implemented as
-	// metrics. Collected in MemorySeriesStorage.Collect.
-	// TODO(beorn7): As it is used internally, it is actually very bad style
-	// to have it as a global variable.
-	NumMemChunks int64
-
-	// NumMemChunksDesc is the metric descriptor for the above.
-	NumMemChunksDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, subsystem, "memory_chunks"),
-		"The current number of chunks in memory, excluding cloned chunks (i.e. chunks without a descriptor).",
-		nil, nil,
-	)
-)
+// NumMemChunks is the total number of chunks in memory. This is a global
+// counter, also used internally, so not implemented as metrics. Collected in
+// MemorySeriesStorage.
+// TODO(beorn7): Having this as an exported global variable is really bad.
+var NumMemChunks int64

--- a/storage/local/persistence_test.go
+++ b/storage/local/persistence_test.go
@@ -176,7 +176,7 @@ func testPersistLoadDropChunks(t *testing.T, encoding chunk.Encoding) {
 	// Try to drop one chunk, which must be prevented by the shrink
 	// ratio. Since we do not pass in any chunks to persist, the offset
 	// should be the number of chunks in the file.
-	for fp, _ := range fpToChunks {
+	for fp := range fpToChunks {
 		firstTime, offset, numDropped, allDropped, err := p.dropAndPersistChunks(fp, 1, nil)
 		if err != nil {
 			t.Fatal(err)

--- a/storage/local/storage_test.go
+++ b/storage/local/storage_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"runtime"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -824,8 +825,7 @@ func TestLoop(t *testing.T) {
 	directory := testutil.NewTemporaryDirectory("test_storage", t)
 	defer directory.Close()
 	o := &MemorySeriesStorageOptions{
-		MemoryChunks:               50,
-		MaxChunksToPersist:         1000000,
+		TargetHeapSize:             100000,
 		PersistenceRetentionPeriod: 24 * 7 * time.Hour,
 		PersistenceStoragePath:     directory.Path(),
 		HeadChunkTimeout:           5 * time.Minute,
@@ -877,7 +877,6 @@ func testChunk(t *testing.T, encoding chunk.Encoding) {
 
 	for m := range s.fpToSeries.iter() {
 		s.fpLocker.Lock(m.fp)
-		defer s.fpLocker.Unlock(m.fp) // TODO remove, see below
 		var values []model.SamplePair
 		for _, cd := range m.series.chunkDescs {
 			if cd.IsEvicted() {
@@ -900,7 +899,7 @@ func testChunk(t *testing.T, encoding chunk.Encoding) {
 				t.Errorf("%d. Got %v; want %v", i, v.Value, samples[i].Value)
 			}
 		}
-		//s.fpLocker.Unlock(m.fp)
+		s.fpLocker.Unlock(m.fp)
 	}
 	log.Info("test done, closing")
 }
@@ -1459,8 +1458,8 @@ func testEvictAndLoadChunkDescs(t *testing.T, encoding chunk.Encoding) {
 	s, closer := NewTestStorage(t, encoding)
 	defer closer.Close()
 
-	// Adjust memory chunks to lower value to see evictions.
-	s.maxMemoryChunks = 1
+	// Adjust target heap size to lower value to see evictions.
+	s.targetHeapSize = 1000000
 
 	for _, sample := range samples {
 		s.Append(sample)
@@ -1478,7 +1477,7 @@ func testEvictAndLoadChunkDescs(t *testing.T, encoding chunk.Encoding) {
 	// Maintain series without any dropped chunks.
 	s.maintainMemorySeries(fp, 0)
 	// Give the evict goroutine an opportunity to run.
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(1250 * time.Millisecond)
 	// Maintain series again to trigger chunk.Desc eviction.
 	s.maintainMemorySeries(fp, 0)
 
@@ -1605,8 +1604,7 @@ func benchmarkFuzz(b *testing.B, encoding chunk.Encoding) {
 	directory := testutil.NewTemporaryDirectory("test_storage", b)
 	defer directory.Close()
 	o := &MemorySeriesStorageOptions{
-		MemoryChunks:               100,
-		MaxChunksToPersist:         1000000,
+		TargetHeapSize:             200000,
 		PersistenceRetentionPeriod: time.Hour,
 		PersistenceStoragePath:     directory.Path(),
 		HeadChunkTimeout:           5 * time.Minute,
@@ -2007,6 +2005,242 @@ func TestAppendOutOfOrder(t *testing.T) {
 		wantSamplePair := want[i]
 		if !wantSamplePair.Equal(&gotSamplePair) {
 			t.Fatalf("want %v, got %v", wantSamplePair, gotSamplePair)
+		}
+	}
+}
+
+func TestCalculatePersistUrgency(t *testing.T) {
+	tests := map[string]struct {
+		persistUrgency                        int32
+		lenEvictList                          int
+		numChunksToPersist                    int64
+		targetHeapSize, msNextGC, msHeapAlloc uint64
+		msNumGC, lastNumGC                    uint32
+
+		wantPersistUrgency int32
+		wantChunksToEvict  int
+		wantLastNumGC      uint32
+	}{
+		"all zeros": {
+			persistUrgency:     0,
+			lenEvictList:       0,
+			numChunksToPersist: 0,
+			targetHeapSize:     0,
+			msNextGC:           0,
+			msHeapAlloc:        0,
+			msNumGC:            0,
+			lastNumGC:          0,
+
+			wantPersistUrgency: 0,
+			wantChunksToEvict:  0,
+			wantLastNumGC:      0,
+		},
+		"far from target heap size, plenty of chunks to persist, GC has happened": {
+			persistUrgency:     500,
+			lenEvictList:       1000,
+			numChunksToPersist: 100,
+			targetHeapSize:     1000000,
+			msNextGC:           500000,
+			msHeapAlloc:        400000,
+			msNumGC:            42,
+			lastNumGC:          41,
+
+			wantPersistUrgency: 45,
+			wantChunksToEvict:  0,
+			wantLastNumGC:      42,
+		},
+		"far from target heap size, plenty of chunks to persist, GC hasn't happened, urgency must not decrease": {
+			persistUrgency:     500,
+			lenEvictList:       1000,
+			numChunksToPersist: 100,
+			targetHeapSize:     1000000,
+			msNextGC:           500000,
+			msHeapAlloc:        400000,
+			msNumGC:            42,
+			lastNumGC:          42,
+
+			wantPersistUrgency: 500,
+			wantChunksToEvict:  0,
+			wantLastNumGC:      42,
+		},
+		"far from target heap size but no chunks to persist": {
+			persistUrgency:     50,
+			lenEvictList:       0,
+			numChunksToPersist: 100,
+			targetHeapSize:     1000000,
+			msNextGC:           500000,
+			msHeapAlloc:        400000,
+			msNumGC:            42,
+			lastNumGC:          41,
+
+			wantPersistUrgency: 500,
+			wantChunksToEvict:  0,
+			wantLastNumGC:      42,
+		},
+		"far from target heap size but no chunks to persist, HeapAlloc > NextGC": {
+			persistUrgency:     50,
+			lenEvictList:       0,
+			numChunksToPersist: 100,
+			targetHeapSize:     1000000,
+			msNextGC:           500000,
+			msHeapAlloc:        600000,
+			msNumGC:            42,
+			lastNumGC:          41,
+
+			wantPersistUrgency: 600,
+			wantChunksToEvict:  0,
+			wantLastNumGC:      42,
+		},
+		"target heap size exceeded but GC hasn't happened": {
+			persistUrgency:     50,
+			lenEvictList:       3000,
+			numChunksToPersist: 1000,
+			targetHeapSize:     1000000,
+			msNextGC:           1100000,
+			msHeapAlloc:        900000,
+			msNumGC:            42,
+			lastNumGC:          42,
+
+			wantPersistUrgency: 275,
+			wantChunksToEvict:  0,
+			wantLastNumGC:      42,
+		},
+		"target heap size exceeded, GC has happened": {
+			persistUrgency:     50,
+			lenEvictList:       3000,
+			numChunksToPersist: 1000,
+			targetHeapSize:     1000000,
+			msNextGC:           1100000,
+			msHeapAlloc:        900000,
+			msNumGC:            42,
+			lastNumGC:          41,
+
+			wantPersistUrgency: 275,
+			wantChunksToEvict:  97,
+			wantLastNumGC:      42,
+		},
+		"target heap size exceeded, GC has happened, urgency bumped due to low number of evictable chunks": {
+			persistUrgency:     50,
+			lenEvictList:       300,
+			numChunksToPersist: 100,
+			targetHeapSize:     1000000,
+			msNextGC:           1100000,
+			msHeapAlloc:        900000,
+			msNumGC:            42,
+			lastNumGC:          41,
+
+			wantPersistUrgency: 323,
+			wantChunksToEvict:  97,
+			wantLastNumGC:      42,
+		},
+		"target heap size exceeded but no evictable chunks and GC hasn't happened": {
+			persistUrgency:     50,
+			lenEvictList:       0,
+			numChunksToPersist: 1000,
+			targetHeapSize:     1000000,
+			msNextGC:           1100000,
+			msHeapAlloc:        900000,
+			msNumGC:            42,
+			lastNumGC:          42,
+
+			wantPersistUrgency: 1000,
+			wantChunksToEvict:  0,
+			wantLastNumGC:      42,
+		},
+		"target heap size exceeded but no evictable chunks and GC has happened": {
+			persistUrgency:     50,
+			lenEvictList:       0,
+			numChunksToPersist: 1000,
+			targetHeapSize:     1000000,
+			msNextGC:           1100000,
+			msHeapAlloc:        900000,
+			msNumGC:            42,
+			lastNumGC:          41,
+
+			wantPersistUrgency: 1000,
+			wantChunksToEvict:  0,
+			wantLastNumGC:      42,
+		},
+		"target heap size exceeded, very few evictable chunks, GC hasn't happened": {
+			persistUrgency:     50,
+			lenEvictList:       10,
+			numChunksToPersist: 1000,
+			targetHeapSize:     1000000,
+			msNextGC:           1100000,
+			msHeapAlloc:        900000,
+			msNumGC:            42,
+			lastNumGC:          42,
+
+			wantPersistUrgency: 1000,
+			wantChunksToEvict:  0,
+			wantLastNumGC:      42,
+		},
+		"target heap size exceeded, some evictable chunks (but not enough), GC hasn't happened": {
+			persistUrgency:     50,
+			lenEvictList:       50,
+			numChunksToPersist: 250,
+			targetHeapSize:     1000000,
+			msNextGC:           1100000,
+			msHeapAlloc:        900000,
+			msNumGC:            42,
+			lastNumGC:          42,
+
+			wantPersistUrgency: 916,
+			wantChunksToEvict:  0,
+			wantLastNumGC:      42,
+		},
+		"target heap size exceeded, some evictable chunks (but not enough), GC has happened": {
+			persistUrgency:     50,
+			lenEvictList:       50,
+			numChunksToPersist: 250,
+			targetHeapSize:     1000000,
+			msNextGC:           1100000,
+			msHeapAlloc:        900000,
+			msNumGC:            42,
+			lastNumGC:          41,
+
+			wantPersistUrgency: 1000,
+			wantChunksToEvict:  50,
+			wantLastNumGC:      42,
+		},
+	}
+
+	s, closer := NewTestStorage(t, 1)
+	defer closer.Close()
+
+	for scenario, test := range tests {
+		s.persistUrgency = test.persistUrgency
+		s.numChunksToPersist = test.numChunksToPersist
+		s.targetHeapSize = test.targetHeapSize
+		s.lastNumGC = test.lastNumGC
+		s.evictList.Init()
+		for i := 0; i < test.lenEvictList; i++ {
+			s.evictList.PushBack(&struct{}{})
+		}
+		ms := runtime.MemStats{
+			NextGC:    test.msNextGC,
+			HeapAlloc: test.msHeapAlloc,
+			NumGC:     test.msNumGC,
+		}
+		chunksToEvict := s.calculatePersistUrgency(&ms)
+
+		if chunksToEvict != test.wantChunksToEvict {
+			t.Errorf(
+				"scenario %q: got %d chunks to evict, want %d",
+				scenario, chunksToEvict, test.wantChunksToEvict,
+			)
+		}
+		if s.persistUrgency != test.wantPersistUrgency {
+			t.Errorf(
+				"scenario %q: got persist urgency %d, want %d",
+				scenario, s.persistUrgency, test.wantPersistUrgency,
+			)
+		}
+		if s.lastNumGC != test.wantLastNumGC {
+			t.Errorf(
+				"scenario %q: got lastNumGC %d , want %d",
+				scenario, s.lastNumGC, test.wantLastNumGC,
+			)
 		}
 	}
 }

--- a/storage/local/test_helpers.go
+++ b/storage/local/test_helpers.go
@@ -45,8 +45,7 @@ func NewTestStorage(t testutil.T, encoding chunk.Encoding) (*MemorySeriesStorage
 	chunk.DefaultEncoding = encoding
 	directory := testutil.NewTemporaryDirectory("test_storage", t)
 	o := &MemorySeriesStorageOptions{
-		MemoryChunks:               1000000,
-		MaxChunksToPersist:         1000000,
+		TargetHeapSize:             1000000000,
 		PersistenceRetentionPeriod: 24 * time.Hour * 365 * 100, // Enough to never trigger purging.
 		PersistenceStoragePath:     directory.Path(),
 		HeadChunkTimeout:           5 * time.Minute,


### PR DESCRIPTION
…based on target heap size

@rtreffer @stuartnelson3 This is "the memory hack" running on selected servers at SC for a while. Now finally in reviewable and tested form.

@juliusv @brian-brazil @fabxc you were interested in this.

I'll add a few graphs to this PR to demonstrate the effects.


This is a fairly easy attempt to dynamically evict chunks based on the
heap size. A target heap size has to be set as a command line flage,
so that users can essentially say "utilize 4GiB of RAM, and please
don't OOM".

The -storage.local.max-chunks-to-persist and
-storage.local.memory-chunks flags are deprecated by this
change. Backwards compatibility is provided by ignoring
-storage.local.max-chunks-to-persist and use
-storage.local.memory-chunks to set the new
-storage.local.target-heap-size to a reasonable (and conservative)
value (both with a warning).

This also makes the metrics intstrumentation more consistent (in
naming and implementation) and cleans up a few quirks in the tests.

Answers to anticipated comments:

There is a chance that Go 1.9 will allow programs better control over
the Go memory management. I don't expect those changes to be in
contradiction with the approach here, but I do expect them to
complement them and allow them to be more precise and controlled. In
any case, once those Go changes are available, this code has to be
revisted.

One might be tempted to let the user specify an estimated value for
the RSS usage, and then internall set a target heap size of a certain
fraction of that. (In my experience, 2/3 is a fairly safe bet.)
However, investigations have shown that RSS size and its relation to
the heap size is really really complicated. It depends on so many
factors that I wouldn't even start listing them in a commit
description. It depends on many circumstances and not at least on the
risk trade-off of each individual user between RAM utilization and
probability of OOMing during a RAM usage peak. To not add even more to
the confusion, we need to stick to the well-defined number we also use
in the targeting here, the sum of the sizes of heap objects.