### PR TITLE
main.go: Set GOGC to 40 by default

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -20,6 +20,7 @@ import (
 	_ "net/http/pprof" // Comment this line to disable pprof endpoint.
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"syscall"
 	"time"
 
@@ -42,6 +43,13 @@ import (
 func main() {
 	os.Exit(Main())
 }
+
+// defaultGCPercent is the value used to to call SetGCPercent if the GOGC
+// environment variable is not set or empty. The value here is intended to hit
+// the sweet spot between memory utilization and GC effort. It is lower than the
+// usual default of 100 as a lot of the heap in Prometheus is used to cache
+// memory chunks, which have a lifetime of hours if not days or weeks.
+const defaultGCPercent = 40
 
 var (
 	configSuccess = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -70,6 +78,10 @@ func Main() int {
 	if cfg.printVersion {
 		fmt.Fprintln(os.Stdout, version.Print("prometheus"))
 		return 0
+	}
+
+	if os.Getenv("GOGC") == "" {
+		debug.SetGCPercent(defaultGCPercent)
 	}
 
 	log.Infoln("Starting prometheus", version.Info())


### PR DESCRIPTION
@juliusv @rtreffer @stuartnelson3 Discussed with each of you at various opportunities. I'll add some graphs later to show the effect.

Rationale: The default value for GOGC is 100, i.e. a garbage collected
is initialized once as many heap space has been allocated as was in
use after the last GC was done. This ratio doesn't make a lot of sense
in Prometheus, as typically about 60% of the heap is allocated for
long-lived memory chunks (most of which are around for many hours if
not days). Thus, short-lived heap objects are accumulated for quite
some time until they finally match the large amount of memory used by
bulk memory chunks and a gigantic GC cyle is invoked. With GOGC=40, we
are essentially reinstating "normal" GC behavior by acknowledging that
about 60% of the heap are used for long-term bulk storage.

The median Prometheus production server at SoundCloud runs a GC cycle
every 90 seconds. With GOGC=40, a GC cycle is run every 35 seconds
(which is still not very often). However, the effective RAM usage is
now reduced by about 30%. If settings are updated to utilize more RAM,
the time between GC cycles goes up again (as the heap size is larger
with more long-lived memory chunks, but the frequency of creating
short-lived heap objects does not change). On a quite busy large
Prometheus server, the timing changed from one GC run every 20s to one
GC run every 12s.

In the former case (just changing GOGC, leave everything else as it
is), the CPU usage increases by about 10% (on a mid-size referenc
server from 8.1 to 8.9). If settings are adjusted, the CPU
consumptions increases more drastically (from 8 cores to 13 cores on a
large reference server), despite GCs happening more rarely, presumably
because a 50% larger set of memory chunks is managed now. Having more
memory chunks is good in many regards, and most servers are running
out of memory long before they run out of CPU cycles, so the tradeoff
is overwhelmingly positive in most cases.

Power users can still set the GOGC environment variable as usual, as
the implementation in this commit honors an explicitly set variable.