### PR TITLE
Do not force the pure Go name resolver

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -6,7 +6,7 @@ build:
           path: ./cmd/prometheus
         - name: promtool
           path: ./cmd/promtool
-    flags: -a -tags netgo
+    flags: -a
     ldflags: |
         -X {{repoPath}}/vendor/github.com/prometheus/common/version.Version={{.Version}}
         -X {{repoPath}}/vendor/github.com/prometheus/common/version.Revision={{.Revision}}


### PR DESCRIPTION
Revert to Go's default mechanism that will decide between the `netgo` pure-Go implementation and the `netcgo` cgo-based implementation depending on OS and environment variables.

This allows, among other things, to use Prometheus to scrape mDNS targets, thereby addressing #2537.



Context: I had a look at past commits and discussions, and kind of understand why it was chosen to use `netgo` by default (essentially performance concerns and compatibility). On the other hand, there are cases where the `netcgo` backend is really preferable, as with mDNS names. I think letting end users override the default via an environment variable is the most flexible solution, and it is already implemented as of Go 1.7:

>  The resolver decision can be overridden by setting the netdns value of the GODEBUG environment variable (see package runtime) to go or cgo, as in:
>
> export GODEBUG=netdns=go    # force pure Go resolver
> export GODEBUG=netdns=cgo   # force cgo resolver

 - https://golang.org/pkg/net/#hdr-Name_Resolution

Discussion welcome!