### PR TITLE
Remote writes: retry on recoverable errors.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -173,6 +173,7 @@ var (
 		RemoteTimeout: model.Duration(1 * time.Minute),
 	}
 
+	// DefaultRemoteQueueConfig is the default remote queue configuration.
 	DefaultRemoteQueueConfig = RemoteQueueConfig{
 		// With a maximum of 1000 shards, assuming an average of 100ms remote write
 		// time and 100 samples per batch, we will be able to push 1M samples/s.
@@ -1319,6 +1320,8 @@ func (re Regexp) MarshalYAML() (interface{}, error) {
 	return nil, nil
 }
 
+// RemoteQueueConfig is the configuration for the queue used to write to remote
+// storage.
 type RemoteQueueConfig struct {
 	// Number of samples to buffer per shard before we start dropping them.
 	QueueCapacity int

--- a/config/config.go
+++ b/config/config.go
@@ -172,24 +172,6 @@ var (
 	DefaultRemoteReadConfig = RemoteReadConfig{
 		RemoteTimeout: model.Duration(1 * time.Minute),
 	}
-
-	// DefaultRemoteQueueConfig is the default remote queue configuration.
-	DefaultRemoteQueueConfig = RemoteQueueConfig{
-		// With a maximum of 1000 shards, assuming an average of 100ms remote write
-		// time and 100 samples per batch, we will be able to push 1M samples/s.
-		MaxShards:         1000,
-		MaxSamplesPerSend: 100,
-
-		// By default, buffer 1000 batches, which at 100ms per batch is 1:40mins. At
-		// 1000 shards, this will buffer 100M samples total.
-		QueueCapacity:     100 * 1000,
-		BatchSendDeadline: 5 * time.Second,
-
-		// Max number of times to retry a batch on recoverable errors.
-		MaxRetries: 10,
-		MinBackoff: 30 * time.Second,
-		MaxBackoff: 100 * time.Millisecond,
-	}
 )
 
 // URL is a custom URL type that allows validation at configuration load time.
@@ -1320,40 +1302,6 @@ func (re Regexp) MarshalYAML() (interface{}, error) {
 	return nil, nil
 }
 
-// RemoteQueueConfig is the configuration for the queue used to write to remote
-// storage.
-type RemoteQueueConfig struct {
-	// Number of samples to buffer per shard before we start dropping them.
-	QueueCapacity int
-	// Max number of shards, i.e. amount of concurrency.
-	MaxShards int
-	// Maximum number of samples per send.
-	MaxSamplesPerSend int
-	// Maximum time sample will wait in buffer.
-	BatchSendDeadline time.Duration
-	// Max number of times to retry a batch on recoverable errors.
-	MaxRetries int
-	// On recoverable errors, backoff exponentially.
-	MinBackoff time.Duration
-	MaxBackoff time.Duration
-
-	// Catches all undefined fields and must be empty after parsing.
-	XXX map[string]interface{} `yaml:",inline"`
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *RemoteQueueConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	*c = DefaultRemoteQueueConfig
-	type plain RemoteQueueConfig
-	if err := unmarshal((*plain)(c)); err != nil {
-		return err
-	}
-	if err := checkOverflow(c.XXX, "remote_queue"); err != nil {
-		return err
-	}
-	return nil
-}
-
 // RemoteWriteConfig is the configuration for writing to remote storage.
 type RemoteWriteConfig struct {
 	URL                 *URL             `yaml:"url,omitempty"`
@@ -1363,8 +1311,6 @@ type RemoteWriteConfig struct {
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.
 	HTTPClientConfig HTTPClientConfig `yaml:",inline"`
-
-	RemoteQueueConfig RemoteQueueConfig `yaml:",inline"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -60,7 +60,7 @@ func NewClient(index int, conf *clientConfig) (*Client, error) {
 	}, nil
 }
 
-type recorerableError struct {
+type recoverableError struct {
 	error
 }
 
@@ -116,7 +116,7 @@ func (c *Client) Store(samples model.Samples) error {
 	if err != nil {
 		// Errors from client.Do are from (for example) network errors, so are
 		// recoverable.
-		return recorerableError{err}
+		return recoverableError{err}
 	}
 	defer httpResp.Body.Close()
 
@@ -124,7 +124,7 @@ func (c *Client) Store(samples model.Samples) error {
 		err = fmt.Errorf("server returned HTTP status %s", httpResp.Status)
 	}
 	if httpResp.StatusCode/100 == 5 {
-		return recorerableError{err}
+		return recoverableError{err}
 	}
 	return nil
 }

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -60,6 +60,10 @@ func NewClient(index int, conf *clientConfig) (*Client, error) {
 	}, nil
 }
 
+type recorerableError struct {
+	error
+}
+
 // Store sends a batch of samples to the HTTP endpoint.
 func (c *Client) Store(samples model.Samples) error {
 	req := &WriteRequest{
@@ -97,6 +101,8 @@ func (c *Client) Store(samples model.Samples) error {
 
 	httpReq, err := http.NewRequest("POST", c.url.String(), &buf)
 	if err != nil {
+		// Errors from NewRequest are from unparseable URLs, so are not
+		// recoverable.
 		return err
 	}
 	httpReq.Header.Add("Content-Encoding", "snappy")
@@ -108,11 +114,17 @@ func (c *Client) Store(samples model.Samples) error {
 
 	httpResp, err := ctxhttp.Do(ctx, c.client, httpReq)
 	if err != nil {
-		return err
+		// Errors from client.Do are from (for example) network errors, so are
+		// recoverable.
+		return recorerableError{err}
 	}
 	defer httpResp.Body.Close()
+
 	if httpResp.StatusCode/100 != 2 {
-		return fmt.Errorf("server returned HTTP status %s", httpResp.Status)
+		err = fmt.Errorf("server returned HTTP status %s", httpResp.Status)
+	}
+	if httpResp.StatusCode/100 == 5 {
+		return recorerableError{err}
 	}
 	return nil
 }

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -123,7 +123,7 @@ func init() {
 	prometheus.MustRegister(numShards)
 }
 
-// RemoteQueueConfig is the configuration for the queue used to write to remote
+// QueueManagerConfig is the configuration for the queue used to write to remote
 // storage.
 type QueueManagerConfig struct {
 	// Number of samples to buffer per shard before we start dropping them.
@@ -141,7 +141,7 @@ type QueueManagerConfig struct {
 	MaxBackoff time.Duration
 }
 
-// DefaultRemoteQueueConfig is the default remote queue configuration.
+// defaultQueueManagerConfig is the default remote queue configuration.
 var defaultQueueManagerConfig = QueueManagerConfig{
 	// With a maximum of 1000 shards, assuming an average of 100ms remote write
 	// time and 100 samples per batch, we will be able to push 1M samples/s.

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -478,7 +478,7 @@ func (s *shards) sendSamples(samples model.Samples) {
 	begin := time.Now()
 	s.sendSamplesWithBackoff(samples)
 
-	// These counters are used to caclulate the dynamic sharding, as as such
+	// These counters are used to caclulate the dynamic sharding, and as such
 	// should be maintained irrespective of success or failure.
 	s.qm.samplesOut.incr(int64(len(samples)))
 	s.qm.samplesOutDuration.incr(int64(time.Since(begin)))
@@ -499,7 +499,7 @@ func (s *shards) sendSamplesWithBackoff(samples model.Samples) {
 
 		log.Warnf("Error sending %d samples to remote storage: %s", len(samples), err)
 		if _, ok := err.(recoverableError); !ok {
-			return
+			break
 		}
 		time.Sleep(backoff)
 		backoff = backoff * 2

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
 )
 
 type TestStorageClient struct {
@@ -81,7 +82,7 @@ func (c *TestStorageClient) Name() string {
 func TestSampleDelivery(t *testing.T) {
 	// Let's create an even number of send batches so we don't run into the
 	// batch timeout case.
-	n := defaultQueueCapacity * 2
+	n := config.DefaultRemoteQueueConfig.QueueCapacity * 2
 
 	samples := make(model.Samples, 0, n)
 	for i := 0; i < n; i++ {
@@ -97,10 +98,9 @@ func TestSampleDelivery(t *testing.T) {
 	c := NewTestStorageClient()
 	c.expectSamples(samples[:len(samples)/2])
 
-	m := NewQueueManager(QueueManagerConfig{
-		Client:    c,
-		MaxShards: 1,
-	})
+	cfg := config.DefaultRemoteQueueConfig
+	cfg.MaxShards = 1
+	m := NewQueueManager(config.DefaultRemoteQueueConfig, nil, nil, c)
 
 	// These should be received by the client.
 	for _, s := range samples[:len(samples)/2] {
@@ -118,7 +118,7 @@ func TestSampleDelivery(t *testing.T) {
 
 func TestSampleDeliveryOrder(t *testing.T) {
 	ts := 10
-	n := defaultMaxSamplesPerSend * ts
+	n := config.DefaultRemoteQueueConfig.MaxSamplesPerSend * ts
 
 	samples := make(model.Samples, 0, n)
 	for i := 0; i < n; i++ {
@@ -134,11 +134,7 @@ func TestSampleDeliveryOrder(t *testing.T) {
 
 	c := NewTestStorageClient()
 	c.expectSamples(samples)
-	m := NewQueueManager(QueueManagerConfig{
-		Client: c,
-		// Ensure we don't drop samples in this test.
-		QueueCapacity: n,
-	})
+	m := NewQueueManager(config.DefaultRemoteQueueConfig, nil, nil, c)
 
 	// These should be received by the client.
 	for _, s := range samples {
@@ -199,7 +195,7 @@ func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 	// `MaxSamplesPerSend*Shards` samples should be consumed by the
 	// per-shard goroutines, and then another `MaxSamplesPerSend`
 	// should be left on the queue.
-	n := defaultMaxSamplesPerSend*1 + defaultMaxSamplesPerSend
+	n := config.DefaultRemoteQueueConfig.MaxSamplesPerSend * 2
 
 	samples := make(model.Samples, 0, n)
 	for i := 0; i < n; i++ {
@@ -213,11 +209,10 @@ func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 	}
 
 	c := NewTestBlockedStorageClient()
-	m := NewQueueManager(QueueManagerConfig{
-		Client:        c,
-		QueueCapacity: n,
-		MaxShards:     1,
-	})
+	cfg := config.DefaultRemoteQueueConfig
+	cfg.MaxShards = 1
+	cfg.QueueCapacity = n
+	m := NewQueueManager(cfg, nil, nil, c)
 
 	m.Start()
 
@@ -246,7 +241,7 @@ func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	if m.queueLen() != defaultMaxSamplesPerSend {
+	if m.queueLen() != config.DefaultRemoteQueueConfig.MaxSamplesPerSend {
 		t.Fatalf("Failed to drain QueueManager queue, %d elements left",
 			m.queueLen(),
 		)

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -44,11 +44,12 @@ func (w *Writer) ApplyConfig(conf *config.Config) error {
 		if err != nil {
 			return err
 		}
-		newQueues = append(newQueues, NewQueueManager(QueueManagerConfig{
-			Client:         c,
-			ExternalLabels: conf.GlobalConfig.ExternalLabels,
-			RelabelConfigs: rwConf.WriteRelabelConfigs,
-		}))
+		newQueues = append(newQueues, NewQueueManager(
+			rwConf.RemoteQueueConfig,
+			conf.GlobalConfig.ExternalLabels,
+			rwConf.WriteRelabelConfigs,
+			c,
+		))
 	}
 
 	for _, q := range w.queues {

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -45,7 +45,7 @@ func (w *Writer) ApplyConfig(conf *config.Config) error {
 			return err
 		}
 		newQueues = append(newQueues, NewQueueManager(
-			rwConf.RemoteQueueConfig,
+			defaultQueueManagerConfig,
 			conf.GlobalConfig.ExternalLabels,
 			rwConf.WriteRelabelConfigs,
 			c,


### PR DESCRIPTION
Fixes #2512 

Certain errors in the remote write path should be retried, so we don't unnecessarily drop samples on transient network errors.  I've marked errors from `ctxhttp.Do` and HTTP 500's as retry-able, and do exponential backoff between failed pushes.

Also, move the `QueueManagerConfig` struct to `config.RemoteQueueConfig`, and specify defaults in the usual way.

Some open questions / notes:
- I made the client identify 'recoverable' errors by wrapping them in a `recoverableError` struct and then doing some type inspection in the caller.  In hindsight, a simple bool return param would probably be cleaner - WDYT?
- I didn't move the sharding parameters into the `config` struct yet, I think thats still too experimental.
