### PR TITLE
Fix unstable fanin test

### DIFF
--- a/storage/fanin/fanin_test.go
+++ b/storage/fanin/fanin_test.go
@@ -698,6 +698,9 @@ func TestMetricsForLabelMatchersIgnoresRemoteData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	sort.Slice(got, func(i, j int) bool {
+		return got[i].Metric.Before(got[j].Metric)
+	})
 
 	want := []metric.Metric{
 		{


### PR DESCRIPTION
As far as I understand, the local storage `MetricsForLabelMatchers()` implementation will create a few new maps along the way with fingerprints as the key. Therefore, we can't rely on any order and getting the two time series back in the expected order is a 50/50 chance. Or am I missing something here?

@juliusv 

OT: I was surprised to see that fanin calls local storage and each remote storage sequentially. What's the reason for that?