### PR TITLE
storage: Evict unused chunk.Descs in crash recovery

### DIFF
--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -1587,7 +1587,7 @@ func (s *MemorySeriesStorage) maintainMemorySeries(
 		}
 		return
 	}
-	// If we are here, the series is not archived, so check for Chunk.Desc
+	// If we are here, the series is not archived, so check for chunk.Desc
 	// eviction next.
 	series.evictChunkDescs(iOldestNotEvicted)
 


### PR DESCRIPTION
This is in line with the v1.5 change in paradigm to not keep
chunk.Descs without chunks around after a series maintenance.

The code avoids to create memory time series with zero chunk.Descs as
that is prone to trigger weird effects. (Series maintenance would
archive series with zero chunk.Descs, but we cannot do that here
because the archive indices still have to be checked.)

@brian-brazil 