### PR TITLE
Fix missing console template buildVersion() func

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -191,7 +191,6 @@ func (r *AlertingRule) Eval(ctx context.Context, ts model.Time, engine *promql.E
 				tmplData,
 				ts,
 				engine,
-				externalURLPath,
 			)
 			result, err := tmpl.Expand()
 			if err != nil {

--- a/template/template.go
+++ b/template/template.go
@@ -111,7 +111,7 @@ type Expander struct {
 }
 
 // NewTemplateExpander returns a template expander ready to use.
-func NewTemplateExpander(ctx context.Context, text string, name string, data interface{}, timestamp model.Time, queryEngine *promql.Engine, pathPrefix string) *Expander {
+func NewTemplateExpander(ctx context.Context, text string, name string, data interface{}, timestamp model.Time, queryEngine *promql.Engine) *Expander {
 	return &Expander{
 		text: text,
 		name: name,
@@ -245,9 +245,6 @@ func NewTemplateExpander(ctx context.Context, text string, name string, data int
 				}
 				t := model.TimeFromUnixNano(int64(v * 1e9)).Time().UTC()
 				return fmt.Sprint(t)
-			},
-			"pathPrefix": func() string {
-				return pathPrefix
 			},
 		},
 	}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -221,7 +221,7 @@ func TestTemplateExpansion(t *testing.T) {
 	for i, s := range scenarios {
 		var result string
 		var err error
-		expander := NewTemplateExpander(context.Background(), s.text, "test", s.input, time, engine, "")
+		expander := NewTemplateExpander(context.Background(), s.text, "test", s.input, time, engine)
 		if s.html {
 			result, err = expander.ExpandHTML(nil)
 		} else {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -59,7 +59,7 @@ func TestGlobalURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%d. Error parsing input URL: %s", i, err)
 		}
-		globalURL := tmplFuncs("", opts)["globalURL"].(func(u *url.URL) *url.URL)
+		globalURL := uiTmplFuncs("", opts)["globalURL"].(func(u *url.URL) *url.URL)
 		outURL := globalURL(inURL)
 
 		if outURL.String() != test.outURL {


### PR DESCRIPTION
As a side effect, this removes the pathPrefix() function from alert
templates, but that function was never externally documented, nor meant
to be available in alert templates.