### PR TITLE
retrieval: make scrape timeout header consistent with others

### DIFF
--- a/retrieval/scrape.go
+++ b/retrieval/scrape.go
@@ -307,7 +307,7 @@ func (s *targetScraper) scrape(ctx context.Context, ts time.Time) (model.Samples
 	}
 	req.Header.Add("Accept", acceptHeader)
 	req.Header.Set("User-Agent", userAgentHeader)
-	req.Header.Set("Scrape-Timeout-Seconds", fmt.Sprintf("%f", s.timeout.Seconds()))
+	req.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", fmt.Sprintf("%f", s.timeout.Seconds()))
 
 	resp, err := ctxhttp.Do(ctx, s.client, req)
 	if err != nil {

--- a/retrieval/scrape_test.go
+++ b/retrieval/scrape_test.go
@@ -588,7 +588,7 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			timeout := r.Header.Get("Scrape-Timeout-Seconds")
+			timeout := r.Header.Get("X-Prometheus-Scrape-Timeout-Seconds")
 			if timeout != expectedTimeout {
 				t.Errorf("Scrape timeout did not match expected timeout")
 				t.Errorf("Expected: %v", expectedTimeout)


### PR DESCRIPTION
Fixes #2581 .

r: @juliusv 