### PR TITLE
storage: Mark storage as dirty if indexing fails

### DIFF
--- a/storage/local/persistence.go
+++ b/storage/local/persistence.go
@@ -1381,9 +1381,11 @@ func (p *persistence) processIndexingQueue() {
 
 		if err := p.labelPairToFingerprints.IndexBatch(pairToFPs); err != nil {
 			log.Error("Error indexing label pair to fingerprints batch: ", err)
+			p.setDirty(err)
 		}
 		if err := p.labelNameToLabelValues.IndexBatch(nameToValues); err != nil {
 			log.Error("Error indexing label name to label values batch: ", err)
+			p.setDirty(err)
 		}
 		batchSize = 0
 		nameToValues = index.LabelNameLabelValuesMapping{}


### PR DESCRIPTION
@mattbostock This should at least flag the problem you have encountered (and it will lead to crashrecovery after the next restart, which should rebuild the inconsistent indices).