### PR TITLE
storage: Guard against appending to evicted chunk

### DIFF
--- a/storage/local/chunk/chunk.go
+++ b/storage/local/chunk/chunk.go
@@ -33,7 +33,10 @@ const ChunkLen = 1024
 // DefaultEncoding can be changed via a flag.
 var DefaultEncoding = DoubleDelta
 
-var errChunkBoundsExceeded = errors.New("attempted access outside of chunk boundaries")
+var (
+	errChunkBoundsExceeded = errors.New("attempted access outside of chunk boundaries")
+	errAddedToEvictedChunk = errors.New("attempted to add sample to evicted chunk")
+)
 
 // EvictRequest is a request to evict a chunk from memory.
 type EvictRequest struct {
@@ -133,6 +136,9 @@ func NewDesc(c Chunk, firstTime model.Time) *Desc {
 // The chunk must be pinned, and the caller must have locked the fingerprint of
 // the series.
 func (d *Desc) Add(s model.SamplePair) ([]Chunk, error) {
+	if d.C == nil {
+		return nil, errAddedToEvictedChunk
+	}
 	return d.C.Add(s)
 }
 


### PR DESCRIPTION
Fixes #2480. For certain definition of "fixes".

This is something that should never happen. Sadly, it does happen,
albeit extremely rarely. This could be some weird cornercase we
haven't covered yet. Or it happens as a consequesnce of data
corruption or a crash recovery gone bad.

This is not a "real" fix as we don't know the root cause of the
incident reported in #2480. However, this makes sure the server does
not crash, but deals gracefully with the problem: The series in
question is quarantined, which even makes it available for forensics.

@stuartnelson3 @ichekrygin