### PR TITLE
Add triton zone brand metadata

### DIFF
--- a/discovery/triton/triton.go
+++ b/discovery/triton/triton.go
@@ -32,6 +32,7 @@ const (
 	tritonLabel             = model.MetaLabelPrefix + "triton_"
 	tritonLabelMachineId    = tritonLabel + "machine_id"
 	tritonLabelMachineAlias = tritonLabel + "machine_alias"
+	tritonLabelMachineBrand = tritonLabel + "machine_brand"
 	tritonLabelMachineImage = tritonLabel + "machine_image"
 	tritonLabelServerId     = tritonLabel + "server_id"
 	namespace               = "prometheus"
@@ -59,6 +60,7 @@ type DiscoveryResponse struct {
 	Containers []struct {
 		ServerUUID  string `json:"server_uuid"`
 		VMAlias     string `json:"vm_alias"`
+		VMBrand     string `json:"vm_brand"`
 		VMImageUUID string `json:"vm_image_uuid"`
 		VMUUID      string `json:"vm_uuid"`
 	} `json:"containers"`
@@ -157,6 +159,7 @@ func (d *Discovery) refresh() (tg *config.TargetGroup, err error) {
 		labels := model.LabelSet{
 			tritonLabelMachineId:    model.LabelValue(container.VMUUID),
 			tritonLabelMachineAlias: model.LabelValue(container.VMAlias),
+			tritonLabelMachineBrand: model.LabelValue(container.VMBrand),
 			tritonLabelMachineImage: model.LabelValue(container.VMImageUUID),
 			tritonLabelServerId:     model.LabelValue(container.ServerUUID),
 		}

--- a/discovery/triton/triton_test.go
+++ b/discovery/triton/triton_test.go
@@ -111,12 +111,14 @@ func TestTritonSDRefreshMultipleTargets(t *testing.T) {
 		 	{
 				"server_uuid":"44454c4c-5000-104d-8037-b7c04f5a5131",
 				"vm_alias":"server01",
+				"vm_brand":"lx",
 				"vm_image_uuid":"7b27a514-89d7-11e6-bee6-3f96f367bee7",
 				"vm_uuid":"ad466fbf-46a2-4027-9b64-8d3cdb7e9072"
 			},
 			{
 				"server_uuid":"a5894692-bd32-4ca1-908a-e2dda3c3a5e6",
 				"vm_alias":"server02",
+				"vm_brand":"kvm",
 				"vm_image_uuid":"a5894692-bd32-4ca1-908a-e2dda3c3a5e6",
 				"vm_uuid":"7b27a514-89d7-11e6-bee6-3f96f367bee7"
 			}]


### PR DESCRIPTION
This commit enables Triton users to re-label and/or filter based on the type of vm.