### PR TITLE
Add timestamp() function.

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -739,7 +739,7 @@ func (ev *evaluator) vectorSelector(node *VectorSelector) Vector {
 		}
 		vec = append(vec, Sample{
 			Metric: node.series[i].Labels(),
-			Point:  Point{V: v, T: ev.Timestamp},
+			Point:  Point{V: v, T: t},
 		})
 	}
 	return vec

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -650,6 +650,18 @@ func funcLog10(ev *evaluator, args Expressions) Value {
 	return vec
 }
 
+// === timestamp(Vector ValueTypeVector) Vector ===
+func funcTimestamp(ev *evaluator, args Expressions) Value {
+	vec := ev.evalVector(args[0])
+	for i := range vec {
+		el := &vec[i]
+
+		el.Metric = dropMetricName(el.Metric)
+		el.V = float64(el.T) / 1000.0
+	}
+	return vec
+}
+
 // linearRegression performs a least-square linear regression analysis on the
 // provided SamplePairs. It returns the slope, and the intercept value at the
 // provided time.
@@ -1207,6 +1219,12 @@ var functions = map[string]*Function{
 		ArgTypes:   []ValueType{},
 		ReturnType: ValueTypeScalar,
 		Call:       funcTime,
+	},
+	"timestamp": {
+		Name:       "timestamp",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcTimestamp,
 	},
 	"vector": {
 		Name:       "vector",

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -223,14 +223,31 @@ eval_fail instant at 0m label_replace(testmetric, "src", "", "", "")
 
 clear
 
-# Tests for vector.
+# Tests for vector, time and timestamp.
+load 10s
+  metric 1 1
+
+eval instant at 0s timestamp(metric)
+  {} 0
+
+eval instant at 5s timestamp(metric)
+  {} 0
+
+eval instant at 10s timestamp(metric)
+  {} 10
+
 eval instant at 0m vector(1)
   {} 1
+
+eval instant at 0s vector(time())
+  {} 0
+
+eval instant at 5s vector(time())
+  {} 5
 
 eval instant at 60m vector(time())
   {} 3600
 
-clear
 
 # Tests for clamp_max and clamp_min().
 load 5m
@@ -436,3 +453,4 @@ eval instant at 0m days_in_month(vector(1454284800))
 # Febuary 1st 2017 not in leap year.
 eval instant at 0m days_in_month(vector(1485907200))
   {} 28
+


### PR DESCRIPTION
Make the timestamp of instant vectors be the timestamp of the sample
rather than the evaluation. We were not using this anywhere, so this is
safe.

Add a function to return the timestamp of samples in an instant vector.

Fixes #1557


This may expose inconsistent behaviour in how our functions output timestamps that'll need cleanup, but we can at least now do `node_time - timestamp(node_time)` to better detect NTP drift.