### PR TITLE
add port support for kubernetes_sd_config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -993,6 +993,7 @@ type KubernetesSDConfig struct {
 	BearerToken     string         `yaml:"bearer_token,omitempty"`
 	BearerTokenFile string         `yaml:"bearer_token_file,omitempty"`
 	TLSConfig       TLSConfig      `yaml:"tls_config,omitempty"`
+	Port            int            `yaml:"port"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -65,6 +65,7 @@ type Discovery struct {
 	client kubernetes.Interface
 	role   config.KubernetesRole
 	logger log.Logger
+	port   int
 }
 
 func init() {
@@ -140,6 +141,7 @@ func New(l log.Logger, conf *config.KubernetesSDConfig) (*Discovery, error) {
 		client: c,
 		logger: l,
 		role:   conf.Role,
+		port:   conf.Port,
 	}, nil
 }
 
@@ -206,6 +208,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
 		node := NewNode(
 			d.logger.With("kubernetes_sd", "node"),
 			cache.NewSharedInformer(nlw, &apiv1.Node{}, resyncPeriod),
+			d.port,
 		)
 		go node.informer.Run(ctx.Done())
 

--- a/discovery/kubernetes/node_test.go
+++ b/discovery/kubernetes/node_test.go
@@ -155,7 +155,7 @@ func newFakeNodeInformer() *fakeInformer {
 
 func makeTestNodeDiscovery() (*Node, *fakeInformer) {
 	i := newFakeNodeInformer()
-	return NewNode(log.Base(), i), i
+	return NewNode(log.Base(), i, 0), i
 }
 
 func makeNode(name, address string, labels map[string]string, annotations map[string]string) *v1.Node {


### PR DESCRIPTION
port parameter can override node port from apiserver;
```
      - job_name: 'kubernetes-nodes'
        scheme: http
        kubernetes_sd_configs:
        - port: 10255
          role: node
 
```