### PR TITLE
Preserve Alertmanager URLs as *url.URL.

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -316,13 +316,13 @@ func (n *Notifier) setMore() {
 	}
 }
 
-// Alertmanagers returns a list Alertmanager URLs.
-func (n *Notifier) Alertmanagers() []string {
+// Alertmanagers returns a slice of Alertmanager URLs.
+func (n *Notifier) Alertmanagers() []*url.URL {
 	n.mtx.RLock()
 	amSets := n.alertmanagers
 	n.mtx.RUnlock()
 
-	var res []string
+	var res []*url.URL
 
 	for _, ams := range amSets {
 		ams.mtx.RLock()
@@ -364,7 +364,7 @@ func (n *Notifier) sendAll(alerts ...*model.Alert) bool {
 			defer cancel()
 
 			go func(am alertmanager) {
-				u := am.url()
+				u := am.url().String()
 
 				if err := n.sendOne(ctx, ams.client, u, b); err != nil {
 					log.With("alertmanager", u).With("count", len(alerts)).Errorf("Error sending alerts: %s", err)
@@ -412,20 +412,19 @@ func (n *Notifier) Stop() {
 
 // alertmanager holds Alertmanager endpoint information.
 type alertmanager interface {
-	url() string
+	url() *url.URL
 }
 
 type alertmanagerLabels model.LabelSet
 
 const pathLabel = "__alerts_path__"
 
-func (a alertmanagerLabels) url() string {
-	u := &url.URL{
+func (a alertmanagerLabels) url() *url.URL {
+	return &url.URL{
 		Scheme: string(a[model.SchemeLabel]),
 		Host:   string(a[model.AddressLabel]),
 		Path:   string(a[pathLabel]),
 	}
-	return u.String()
 }
 
 // alertmanagerSet contains a set of Alertmanagers discovered via a group of service
@@ -476,7 +475,7 @@ func (s *alertmanagerSet) Sync(tgs []*config.TargetGroup) {
 	seen := map[string]struct{}{}
 
 	for _, am := range all {
-		us := am.url()
+		us := am.url().String()
 		if _, ok := seen[us]; ok {
 			continue
 		}

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -415,6 +416,10 @@ type alertmanagerMock struct {
 	urlf func() string
 }
 
-func (a alertmanagerMock) url() string {
-	return a.urlf()
+func (a alertmanagerMock) url() *url.URL {
+	u, err := url.Parse(a.urlf())
+	if err != nil {
+		panic(err)
+	}
+	return u
 }

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"time"
@@ -74,7 +75,7 @@ type targetRetriever interface {
 }
 
 type alertmanagerRetriever interface {
-	Alertmanagers() []string
+	Alertmanagers() []*url.URL
 }
 
 type response struct {
@@ -430,8 +431,8 @@ func (api *API) alertmanagers(r *http.Request) (interface{}, *apiError) {
 	urls := api.alertmanagerRetriever.Alertmanagers()
 	ams := &AlertmanagerDiscovery{ActiveAlertmanagers: make([]*AlertmanagerTarget, len(urls))}
 
-	for i := range urls {
-		ams.ActiveAlertmanagers[i] = &AlertmanagerTarget{URL: urls[i]}
+	for i, url := range urls {
+		ams.ActiveAlertmanagers[i] = &AlertmanagerTarget{URL: url.String()}
 	}
 
 	return ams, nil

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -39,9 +39,9 @@ func (f targetRetrieverFunc) Targets() []*retrieval.Target {
 	return f()
 }
 
-type alertmanagerRetrieverFunc func() []string
+type alertmanagerRetrieverFunc func() []*url.URL
 
-func (f alertmanagerRetrieverFunc) Alertmanagers() []string {
+func (f alertmanagerRetrieverFunc) Alertmanagers() []*url.URL {
 	return f()
 }
 
@@ -77,8 +77,12 @@ func TestEndpoints(t *testing.T) {
 		}
 	})
 
-	ar := alertmanagerRetrieverFunc(func() []string {
-		return []string{"http://alertmanager.example.com:8080/api/v1/alerts"}
+	ar := alertmanagerRetrieverFunc(func() []*url.URL {
+		return []*url.URL{{
+			Scheme: "http",
+			Host:   "alertmanager.example.com:8080",
+			Path:   "/api/v1/alerts",
+		}}
 	})
 
 	api := &API{

--- a/web/ui/bindata.go
+++ b/web/ui/bindata.go
@@ -121,7 +121,7 @@ func webUiTemplates_baseHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/_base.html", size: 2858, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/_base.html", size: 2858, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -141,7 +141,7 @@ func webUiTemplatesAlertsHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/alerts.html", size: 1837, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/alerts.html", size: 1837, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -161,7 +161,7 @@ func webUiTemplatesConfigHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/config.html", size: 175, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/config.html", size: 175, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -181,7 +181,7 @@ func webUiTemplatesFlagsHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/flags.html", size: 433, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/flags.html", size: 433, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -201,7 +201,7 @@ func webUiTemplatesGraphHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/graph.html", size: 1941, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/graph.html", size: 1941, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -221,12 +221,12 @@ func webUiTemplatesRulesHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/rules.html", size: 209, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/rules.html", size: 209, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
-var _webUiTemplatesStatusHtml = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xcc\x54\xc1\x8e\xda\x30\x10\xbd\xe7\x2b\x5c\xdf\x43\xa4\x3d\x1b\x4b\x65\xa9\xaa\x5e\x57\xa5\x7b\x36\xf1\x80\x47\x0d\x63\x34\x36\xb4\x2b\xcb\xff\x5e\x25\x10\x48\xa4\x65\xa1\xca\xa1\xbd\x40\x5e\xe6\xe9\xbd\xf1\x73\x66\x52\xb2\xb0\x41\x02\x21\x1d\x18\x2b\x73\x56\x9f\xca\x52\x10\xfe\x16\x65\xa9\x53\x02\xb2\x39\x17\xc5\x95\x55\x7b\x8a\x40\x51\xe6\x5c\x08\xa1\x2c\x1e\x45\xdd\x98\x10\xe6\x5d\xc1\x20\x01\x97\x9b\xe6\x80\x56\xea\x42\x08\x21\x94\x7b\x12\x68\xe7\x92\x0f\x14\x71\x07\x52\xbf\x9c\x1e\xc4\x37\xda\x78\xde\x99\x88\x9e\x54\xe5\x9e\xce\xec\x68\xd6\x0d\xf4\x8a\x27\xd0\xfd\x96\xb5\x27\x0b\x14\xc0\x9e\xf1\xda\xb3\x05\xbe\xc0\x10\x19\xf7\x17\xe4\xfc\x11\xf8\xdc\x40\x2b\xba\xf6\xf6\xad\x47\x2d\xe6\x2b\x68\xa1\xd3\xab\x7d\xdb\x93\xaa\xa2\x1b\x57\xac\x4e\x69\xb6\x40\x8e\x6e\xb6\xfa\xfe\x9c\xb3\xaa\xa2\x1d\x08\x55\x43\xa5\x77\x64\x5f\x3d\xff\x44\xda\x8a\x25\x32\xd4\xd1\xf3\xdb\x0d\x87\xe7\xd7\xe5\x47\xda\xaa\x1a\x9c\x40\x55\xdd\x19\x75\x31\x8a\x77\x7d\xc0\xc6\xe2\x35\x52\xa9\x17\xed\x9b\xff\x2a\x65\x11\x6a\xbf\x87\xb9\x64\xff\x4b\xea\x1f\xc0\xa1\x6b\xea\xdd\x40\xce\xd5\xfe\xff\x6f\x83\x1f\x39\xbd\xc0\x11\x1f\xb0\xea\x69\x93\xbc\x16\x6c\xa8\x76\x77\x9c\x4e\xa4\x69\x3e\xed\xe5\xae\x02\xf0\x3d\xab\x9e\x37\xdd\x6d\x69\xe2\xad\x01\x19\xb9\xb5\xbc\x49\x6e\x5f\xfd\x63\xdf\xc6\x85\x37\x71\x74\x4c\x03\x1c\x77\x86\xcc\x16\x38\x48\xfd\x79\x08\xff\xed\xcc\x74\x3b\xe4\x0b\xd9\xbd\x47\x8a\xe3\x34\xc6\x89\xa6\xc4\x86\xb6\x20\x66\xa3\xe6\xbb\x0d\x7d\x23\xf2\x2e\xc9\x8f\xaf\xa9\xdf\xfd\x77\x82\x54\x95\xc5\xa3\x2e\x7a\xf6\x9f\x00\x00\x00\xff\xff\x94\xfe\x26\xaf\x4f\x06\x00\x00")
+var _webUiTemplatesStatusHtml = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xcc\x55\xc1\x8e\xdb\x20\x14\xbc\xfb\x2b\x5e\x39\xae\xea\x20\xed\xb1\x22\x48\xcd\xa6\x6a\x2b\xf5\x50\xa5\x4d\xf7\x4c\xcc\x4b\x40\x75\x20\x02\x92\x6d\x84\xf8\xf7\x0a\x27\x76\x6c\x29\xbb\xd9\xca\x87\xee\x25\x61\x60\x34\xf3\x98\x07\x38\x46\x89\x6b\x6d\x10\x88\x42\x21\x49\x4a\xec\x5d\x59\x82\xd1\x7f\xa0\x2c\x79\x8c\x68\x64\x4a\x45\x71\x61\x55\xd6\x04\x34\x81\xa4\x54\x00\x30\xa9\x0f\x50\xd5\xc2\xfb\x69\xb3\x20\xb4\x41\x57\xae\xeb\xbd\x96\x84\x17\x00\x00\x4c\xdd\x83\x96\x53\xe2\xf6\x26\xe8\x2d\x12\xbe\x38\x0d\xe0\xab\x59\x5b\xb7\x15\x41\x5b\xc3\xa8\xba\x3f\xb3\x83\x58\xd5\xd8\x2a\x9e\x40\xf3\x5b\x56\xd6\x48\x34\x1e\xe5\x19\xaf\xac\x93\xe8\x3a\xe8\x83\xd3\xbb\x0e\x29\x7b\x40\x77\x2e\x20\x8b\xae\xac\x3c\xb6\x28\x63\x77\x01\x19\x2a\xbe\xdc\xe5\x9a\x18\x0d\x6a\xb8\x22\x79\x8c\x93\x99\x76\x41\x4d\x96\x3f\x1f\x52\x62\x34\xc8\x9e\x10\xed\x2b\x5d\x91\x7d\xb4\xee\xb7\x36\x1b\x98\x6b\x87\x55\xb0\xee\xf8\x8c\xc3\xc3\xe3\xfc\x25\x6d\x46\x7b\x3b\x60\xb4\xd9\x23\x2f\x06\xf1\xae\xf6\xba\x96\xfa\x12\x29\xe1\xb3\x3c\xf3\xa6\x52\x06\x5f\xd9\x1d\x4e\x89\xb3\x4f\x84\xff\x42\xe7\x9b\xa2\xae\x06\x72\x5e\x6d\xff\xff\x35\xf8\x81\xd3\x02\x0f\xfa\x15\x56\x2d\x6d\x94\xd7\xcc\x09\x53\xa9\x1b\x4e\x27\xd2\x38\x9f\xdc\xdc\xa5\x47\x77\xcb\xaa\xe5\x8d\x77\x9b\x8b\xf0\xdc\x05\x19\xb8\x65\xde\x28\xb7\xcf\xf6\x75\x67\xa3\xe3\x8d\xbc\x3a\xa2\x46\x17\xb6\xc2\x88\x0d\x3a\x4f\xf8\xc7\x3e\xfc\xbf\x77\xa6\x79\x43\x3e\x19\xb9\xb3\xda\x84\x61\x1a\xc3\x44\x63\x74\xc2\x6c\x10\x26\x83\xe2\x9b\x17\xfa\xaa\x70\x8c\xf4\x0e\xfa\x5c\x58\x2e\xbe\x79\x10\xf5\x93\x38\x7a\x50\xe2\x80\xf0\xa3\x52\xb8\xc5\xf7\xf0\xc5\xfa\x00\xc2\x48\xf8\x2e\x72\x9f\x30\xc0\x1d\xed\x09\x77\x5d\x39\xf1\x53\xfa\x40\x29\x13\xa0\x1c\xae\xa7\x64\x38\x1d\xe3\x24\x8b\xa5\x44\x78\x37\x64\x54\x64\x90\xb5\x5f\x3e\x33\xed\x87\xe8\x46\x57\x19\x95\xfa\xc0\x8b\x96\xfd\x37\x00\x00\xff\xff\x3e\x79\x94\x2b\xdc\x06\x00\x00")
 
 func webUiTemplatesStatusHtmlBytes() ([]byte, error) {
 	return bindataRead(
@@ -241,7 +241,7 @@ func webUiTemplatesStatusHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/status.html", size: 1615, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/status.html", size: 1756, mode: os.FileMode(420), modTime: time.Unix(1493101048, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -261,7 +261,7 @@ func webUiTemplatesTargetsHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/targets.html", size: 2271, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/targets.html", size: 2271, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -281,7 +281,7 @@ func webUiStaticCssAlertsCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/css/alerts.css", size: 74, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/css/alerts.css", size: 74, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -301,7 +301,7 @@ func webUiStaticCssGraphCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/css/graph.css", size: 2710, mode: os.FileMode(420), modTime: time.Unix(1491495065, 0)}
+	info := bindataFileInfo{name: "web/ui/static/css/graph.css", size: 2710, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -321,7 +321,7 @@ func webUiStaticCssProm_consoleCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/css/prom_console.css", size: 2883, mode: os.FileMode(420), modTime: time.Unix(1491488441, 0)}
+	info := bindataFileInfo{name: "web/ui/static/css/prom_console.css", size: 2883, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -341,7 +341,7 @@ func webUiStaticCssPrometheusCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/css/prometheus.css", size: 405, mode: os.FileMode(420), modTime: time.Unix(1491488230, 0)}
+	info := bindataFileInfo{name: "web/ui/static/css/prometheus.css", size: 405, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -361,7 +361,7 @@ func webUiStaticImgAjaxLoaderGif() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/img/ajax-loader.gif", size: 847, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/img/ajax-loader.gif", size: 847, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -381,7 +381,7 @@ func webUiStaticImgFaviconIco() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/img/favicon.ico", size: 15086, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/img/favicon.ico", size: 15086, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -401,7 +401,7 @@ func webUiStaticJsAlertsJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/js/alerts.js", size: 445, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/js/alerts.js", size: 445, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -421,7 +421,7 @@ func webUiStaticJsGraphJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/js/graph.js", size: 26293, mode: os.FileMode(420), modTime: time.Unix(1493026986, 0)}
+	info := bindataFileInfo{name: "web/ui/static/js/graph.js", size: 26293, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -441,7 +441,7 @@ func webUiStaticJsGraph_templateHandlebar() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/js/graph_template.handlebar", size: 6337, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/js/graph_template.handlebar", size: 6337, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -461,7 +461,7 @@ func webUiStaticJsProm_consoleJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/js/prom_console.js", size: 21632, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/js/prom_console.js", size: 21632, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -481,7 +481,7 @@ func webUiStaticVendorBootstrap331CssBootstrapThemeMinCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/css/bootstrap-theme.min.css", size: 19835, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/css/bootstrap-theme.min.css", size: 19835, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -501,7 +501,7 @@ func webUiStaticVendorBootstrap331CssBootstrapMinCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/css/bootstrap.min.css", size: 113498, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/css/bootstrap.min.css", size: 113498, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -521,7 +521,7 @@ func webUiStaticVendorBootstrap331FontsGlyphiconsHalflingsRegularEot() (*asset, 
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.eot", size: 20335, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.eot", size: 20335, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -541,7 +541,7 @@ func webUiStaticVendorBootstrap331FontsGlyphiconsHalflingsRegularSvg() (*asset, 
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.svg", size: 62926, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.svg", size: 62926, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -561,7 +561,7 @@ func webUiStaticVendorBootstrap331FontsGlyphiconsHalflingsRegularTtf() (*asset, 
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.ttf", size: 41280, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.ttf", size: 41280, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -581,7 +581,7 @@ func webUiStaticVendorBootstrap331FontsGlyphiconsHalflingsRegularWoff() (*asset,
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.woff", size: 23320, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.woff", size: 23320, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -601,7 +601,7 @@ func webUiStaticVendorBootstrap331JsBootstrapMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/js/bootstrap.min.js", size: 35601, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/js/bootstrap.min.js", size: 35601, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -621,7 +621,7 @@ func webUiStaticVendorBootstrap331JsNpmJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/js/npm.js", size: 484, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/js/npm.js", size: 484, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -641,7 +641,7 @@ func webUiStaticVendorBootstrap3TypeaheadBootstrap3TypeaheadMinJs() (*asset, err
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap3-typeahead/bootstrap3-typeahead.min.js", size: 7856, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap3-typeahead/bootstrap3-typeahead.min.js", size: 7856, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -661,7 +661,7 @@ func webUiStaticVendorEonasdanBootstrapDatetimepickerBootstrapDatetimepickerMinC
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/eonasdan-bootstrap-datetimepicker/bootstrap-datetimepicker.min.css", size: 7771, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/eonasdan-bootstrap-datetimepicker/bootstrap-datetimepicker.min.css", size: 7771, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -681,7 +681,7 @@ func webUiStaticVendorEonasdanBootstrapDatetimepickerBootstrapDatetimepickerMinJ
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/eonasdan-bootstrap-datetimepicker/bootstrap-datetimepicker.min.js", size: 48881, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/eonasdan-bootstrap-datetimepicker/bootstrap-datetimepicker.min.js", size: 48881, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -701,7 +701,7 @@ func webUiStaticVendorFuzzyFuzzyJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/fuzzy/fuzzy.js", size: 5669, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/fuzzy/fuzzy.js", size: 5669, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -721,7 +721,7 @@ func webUiStaticVendorJsJqueryHotkeysJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/js/jquery.hotkeys.js", size: 3283, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/js/jquery.hotkeys.js", size: 3283, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -741,7 +741,7 @@ func webUiStaticVendorJsJqueryMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/js/jquery.min.js", size: 95935, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/js/jquery.min.js", size: 95935, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -761,7 +761,7 @@ func webUiStaticVendorJsJquerySelectionJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/js/jquery.selection.js", size: 13320, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/js/jquery.selection.js", size: 13320, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -781,7 +781,7 @@ func webUiStaticVendorMomentMomentMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/moment/moment.min.js", size: 61281, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/moment/moment.min.js", size: 61281, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -801,7 +801,7 @@ func webUiStaticVendorMustacheMustacheMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/mustache/mustache.min.js", size: 9528, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/mustache/mustache.min.js", size: 9528, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -821,7 +821,7 @@ func webUiStaticVendorRickshawRickshawMinCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/rickshaw.min.css", size: 6102, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/rickshaw.min.css", size: 6102, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -841,7 +841,7 @@ func webUiStaticVendorRickshawRickshawMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/rickshaw.min.js", size: 76322, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/rickshaw.min.js", size: 76322, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -861,7 +861,7 @@ func webUiStaticVendorRickshawVendorD3LayoutMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/vendor/d3.layout.min.js", size: 17514, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/vendor/d3.layout.min.js", size: 17514, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -881,7 +881,7 @@ func webUiStaticVendorRickshawVendorD3V3Js() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/vendor/d3.v3.js", size: 144718, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/vendor/d3.v3.js", size: 144718, mode: os.FileMode(420), modTime: time.Unix(1493096326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/web/ui/templates/status.html
+++ b/web/ui/templates/status.html
@@ -54,7 +54,8 @@
         </tr>
         {{range .Alertmanagers}}
         <tr>
-          <td>{{.}}</td>
+          {{/* Alertmanager URLs always have Scheme, Host and Path set */}}
+          <td>{{.Scheme}}://<a href="{{.Scheme}}://{{.Host}}">{{.Host}}</a>{{.Path}}</td>
         </tr>
         {{end}}
       </tbody>

--- a/web/web.go
+++ b/web/web.go
@@ -347,7 +347,7 @@ func (h *Handler) status(w http.ResponseWriter, r *http.Request) {
 		Birth         time.Time
 		CWD           string
 		Version       *PrometheusVersion
-		Alertmanagers []string
+		Alertmanagers []*url.URL
 	}{
 		Birth:         h.birth,
 		CWD:           h.cwd,


### PR DESCRIPTION
Render a nicer link in the web UI.