### PR TITLE
Add maintainers' GitHub usernames to MAINTAINERS.md.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,7 @@
 Maintainers of this repository with their focus areas:
 
-* Björn Rabenstein <beorn@soundcloud.com>: Local storage; general code-level issues.
-* Brian Brazil <brian.brazil@robustperception.io>: Console templates; semantics of PromQL, service discovery, and relabeling.
-* Fabian Reinartz <fabian.reinartz@coreos.com>: PromQL parsing and evaluation; implementation of retrieval, alert notification, and service discovery.
-* Julius Volz <julius.volz@gmail.com>: Remote storage integrations; web UI.
+* Björn Rabenstein <beorn@soundcloud.com> @beorn7: Local storage; general code-level issues.
+* Brian Brazil <brian.brazil@robustperception.io> @brian-brazil: Console templates; semantics of PromQL, service discovery, and relabeling.
+* Fabian Reinartz <fabian.reinartz@coreos.com> @fabxc: PromQL parsing and evaluation; implementation of retrieval, alert notification, and service discovery.
+* Julius Volz <julius.volz@gmail.com> @juliusv: Remote storage integrations; web UI.
 


### PR DESCRIPTION
CONTRIBUTING.md instructs people to loop them in using that mechanism,
but nothing lists the right username.

@fabxc