### PR TITLE
Fix mutation of active alert elements by notifier

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -301,6 +301,8 @@ func (r *AlertingRule) currentAlerts() []*Alert {
 
 	for _, a := range r.active {
 		anew := *a
+		anew.Labels = anew.Labels.Clone()
+		anew.Annotations = anew.Annotations.Clone()
 		alerts = append(alerts, &anew)
 	}
 	return alerts

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -37,3 +37,26 @@ func TestAlertingRuleHTMLSnippet(t *testing.T) {
 		t.Fatalf("incorrect HTML snippet; want:\n\n|%v|\n\ngot:\n\n|%v|", want, got)
 	}
 }
+
+func TestCurrentAlertsClonesLabelsAndAnnotations(t *testing.T) {
+	r := AlertingRule{
+		active: map[model.Fingerprint]*Alert{
+			0: &Alert{
+				Labels:      model.LabelSet{"test_label": "test_label_value"},
+				Annotations: model.LabelSet{"test_annotation": "test_annotation_value"},
+			},
+		},
+	}
+
+	alerts := r.currentAlerts()
+	alerts[0].Labels["test_label"] = "new_label_value"
+	alerts[0].Annotations["test_annotation"] = "new_annotation_value"
+
+	alerts = r.currentAlerts()
+	if want, got := model.LabelValue("test_label_value"), alerts[0].Labels["test_label"]; want != got {
+		t.Fatalf("unexpected label value; want %q, got %q", want, got)
+	}
+	if want, got := model.LabelValue("test_annotation_value"), alerts[0].Annotations["test_annotation"]; want != got {
+		t.Fatalf("unexpected annotation value; want %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
This caused the external label application in the notifier to bleed back
into the rule manager's active alerting elements.