### PR TITLE
Add FOSSA License scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/prometheus/prometheus)](https://goreportcard.com/report/github.com/prometheus/prometheus)
 [![Code Climate](https://codeclimate.com/github/prometheus/prometheus/badges/gpa.svg)](https://codeclimate.com/github/prometheus/prometheus)
 [![Issue Count](https://codeclimate.com/github/prometheus/prometheus/badges/issue_count.svg)](https://codeclimate.com/github/prometheus/prometheus)
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fprometheus%2Fprometheus.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fprometheus%2Fprometheus?ref=badge_shield)
 
 Visit [prometheus.io](https://prometheus.io) for the full documentation,
 examples and guides.


### PR DESCRIPTION
CNCF is beta testing FOSSA for licensing compliance. Using
FOSSA ensures all CNCF projects are compliant with the CNCF
IP Policy in a fairly painless way.

https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fprometheus%2Fprometheus

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>