### PR TITLE
Document what ports are scraped by default in k8s example

### DIFF
--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -158,7 +158,8 @@ scrape_configs:
 #
 # * `prometheus.io/scrape`: Only scrape pods that have a value of `true`
 # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
-# * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
+# * `prometheus.io/port`: Scrape the pod on the indicated port instead of the
+# pod's declared ports (default is a port-free target if none are declared).
 - job_name: 'kubernetes-pods'
 
   kubernetes_sd_configs:


### PR DESCRIPTION
The Kubernetes pod SD creates a target for each declared port, as documented:

https://prometheus.io/docs/operating/configuration/#pod

> The pod role discovers all pods and exposes their containers as targets. For
> each declared port of a container, a single target is generated. If a
> container has no specified ports, a port-free target per container is created
> for manually adding a port via relabeling.

This results in the default port being the declared port, or no port if none are
declared.