### PR TITLE
Ensure ewma int64s are always aligned.

### DIFF
--- a/storage/remote/ewma.go
+++ b/storage/remote/ewma.go
@@ -29,8 +29,10 @@ type ewmaRate struct {
 	mutex     sync.Mutex
 }
 
-func newEWMARate(alpha float64, interval time.Duration) ewmaRate {
-	return ewmaRate{
+// newEWMARate always allocates a new ewmaRate, as this guarantees the atomically
+// accessed int64 will be aligned on ARM.  See prometheus#2666.
+func newEWMARate(alpha float64, interval time.Duration) *ewmaRate {
+	return &ewmaRate{
 		alpha:    alpha,
 		interval: interval,
 	}

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -185,7 +185,7 @@ type QueueManager struct {
 	quit        chan struct{}
 	wg          sync.WaitGroup
 
-	samplesIn, samplesOut, samplesOutDuration ewmaRate
+	samplesIn, samplesOut, samplesOutDuration *ewmaRate
 	integralAccumulator                       float64
 }
 


### PR DESCRIPTION
Fixes #2666 

~Not super happy with this solution, but I've confirmed the extra alignment in the ewma struct is necessary.~