### PR TITLE
notifier: expose metric for number of discovered alertmanagers

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -79,15 +79,16 @@ type Options struct {
 }
 
 type alertMetrics struct {
-	latency       *prometheus.SummaryVec
-	errors        *prometheus.CounterVec
-	sent          *prometheus.CounterVec
-	dropped       prometheus.Counter
-	queueLength   prometheus.GaugeFunc
-	queueCapacity prometheus.Gauge
+	latency                 *prometheus.SummaryVec
+	errors                  *prometheus.CounterVec
+	sent                    *prometheus.CounterVec
+	dropped                 prometheus.Counter
+	queueLength             prometheus.GaugeFunc
+	queueCapacity           prometheus.Gauge
+	alertmanagersDiscovered prometheus.GaugeFunc
 }
 
-func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen func() float64) *alertMetrics {
+func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanagersDiscovered func() float64) *alertMetrics {
 	m := &alertMetrics{
 		latency: prometheus.NewSummaryVec(prometheus.SummaryOpts{
 			Namespace: namespace,
@@ -131,6 +132,10 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen func() floa
 			Name:      "queue_capacity",
 			Help:      "The capacity of the alert notifications queue.",
 		}),
+		alertmanagersDiscovered: prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "prometheus_notifications_alertmanagers_discovered",
+			Help: "The number of alertmanagers discovered and active.",
+		}, alertmanagersDiscovered),
 	}
 
 	m.queueCapacity.Set(float64(queueCap))
@@ -143,6 +148,7 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen func() floa
 			m.dropped,
 			m.queueLength,
 			m.queueCapacity,
+			m.alertmanagersDiscovered,
 		)
 	}
 
@@ -166,7 +172,8 @@ func New(o *Options) *Notifier {
 	}
 
 	queueLenFunc := func() float64 { return float64(n.queueLen()) }
-	n.metrics = newAlertMetrics(o.Registerer, o.QueueCapacity, queueLenFunc)
+	alertmanagersDiscoveredFunc := func() float64 { return float64(len(n.Alertmanagers())) }
+	n.metrics = newAlertMetrics(o.Registerer, o.QueueCapacity, queueLenFunc, alertmanagersDiscoveredFunc)
 	return n
 }
 


### PR DESCRIPTION
I'm currently debugging an odd behavior where the Alertmanager discovery seems to loose Alertmanager targets and thought it would be helpful to have a metric representing this. So far I have not been able to figure out a pattern for the described behavior, but the metric seemed worth it to contribute.

@brian-brazil @fabxc @beorn7 @juliusv @mxinden