### PR TITLE
Docker image support for ppc64le

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,0 +1,17 @@
+FROM ppc64le/busybox:latest
+COPY prometheus                             /bin/prometheus
+COPY promtool                               /bin/promtool
+COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
+COPY console_libraries/                     /usr/share/prometheus/console_libraries/
+COPY consoles/                              /usr/share/prometheus/consoles/
+
+RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
+
+EXPOSE     9090
+VOLUME     [ "/prometheus" ]
+WORKDIR    /prometheus
+ENTRYPOINT [ "/bin/prometheus" ]
+CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
+             "-storage.local.path=/prometheus", \
+             "-web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "-web.console.templates=/usr/share/prometheus/consoles" ]

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_NAME       ?= prometheus
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
+MACH                    ?= $(shell uname -m)
 
 ifdef DEBUG
 	bindata_flags = -debug
@@ -61,8 +62,14 @@ tarball: promu
 	@$(PROMU) tarball --prefix $(PREFIX) $(BIN_DIR)
 
 docker:
+ifeq ($(MACH), ppc64le)
+	@echo ">> building docker image for ppc64le"
+	$(eval FILE_SUFFIX=.ppc64le)
+else
 	@echo ">> building docker image"
-	@docker build -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+	$(eval FILE_SUFFIX=)
+endif
+	@docker build --file Dockerfile$(FILE_SUFFIX) -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
 
 assets:
 	@echo ">> writing assets"

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_NAME       ?= prometheus
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 MACH                    ?= $(shell uname -m)
+DOCKERFILE              ?= Dockerfile
 
 ifdef DEBUG
 	bindata_flags = -debug
@@ -63,13 +64,10 @@ tarball: promu
 
 docker:
 ifeq ($(MACH), ppc64le)
-	@echo ">> building docker image for ppc64le"
-	$(eval FILE_SUFFIX=.ppc64le)
-else
-	@echo ">> building docker image"
-	$(eval FILE_SUFFIX=)
+	$(eval DOCKERFILE=Dockerfile.ppc64le)
 endif
-	@docker build --file Dockerfile$(FILE_SUFFIX) -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+	@echo ">> building docker image from $(DOCKERFILE)"
+	@docker build --file $(DOCKERFILE) -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
 
 assets:
 	@echo ">> writing assets"


### PR DESCRIPTION
This PR adds support for a Dockerfile for ppc64le and relevant changes in the Makefile to select the correct Dockerfile for the specified architecture. The Dockerfile for ppc64le is almost the same as x86 except for the base image.