### PR TITLE
Compress remote storage requests and responses with unframed/raw snappy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ benchmark.txt
 !/.travis.yml
 !/.promu.yml
 /documentation/examples/remote_storage/remote_storage_adapter/remote_storage_adapter
+/documentation/examples/remote_storage/example_write_adapter/example_writer_adapter

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ benchmark.txt
 !/circle.yml
 !/.travis.yml
 !/.promu.yml
+/documentation/examples/remote_storage/remote_storage_adapter/remote_storage_adapter

--- a/documentation/examples/remote_storage/example_write_adapter/server.go
+++ b/documentation/examples/remote_storage/example_write_adapter/server.go
@@ -27,7 +27,13 @@ import (
 
 func main() {
 	http.HandleFunc("/receive", func(w http.ResponseWriter, r *http.Request) {
-		reqBuf, err := ioutil.ReadAll(snappy.NewReader(r.Body))
+		compressed, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		reqBuf, err := snappy.Decode(nil, compressed)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/documentation/examples/remote_storage/remote_storage_adapter/main.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/main.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
@@ -184,7 +185,8 @@ func buildClients(cfg *config) ([]writer, []reader) {
 
 func serve(addr string, writers []writer, readers []reader) error {
 	http.HandleFunc("/write", func(w http.ResponseWriter, r *http.Request) {
-		reqBuf, err := ioutil.ReadAll(snappy.NewReader(r.Body))
+		shouldUseRawSnappy := shouldUseRawSnappy(r.Header.Get("X-Prometheus-Remote-Write-Version"))
+		reqBuf, err := decompressSnappyRequest(shouldUseRawSnappy, r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -211,7 +213,8 @@ func serve(addr string, writers []writer, readers []reader) error {
 	})
 
 	http.HandleFunc("/read", func(w http.ResponseWriter, r *http.Request) {
-		reqBuf, err := ioutil.ReadAll(snappy.NewReader(r.Body))
+		shouldUseRawSnappy := shouldUseRawSnappy(r.Header.Get("X-Prometheus-Remote-Read-Version"))
+		reqBuf, err := decompressSnappyRequest(shouldUseRawSnappy, r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -244,14 +247,50 @@ func serve(addr string, writers []writer, readers []reader) error {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/x-protobuf")
-		if _, err := snappy.NewWriter(w).Write(data); err != nil {
+		if err := compressSnappyResponse(shouldUseRawSnappy, w, data); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 	})
 
 	return http.ListenAndServe(addr, nil)
+}
+
+func decompressSnappyRequest(shouldUseRawSnappy bool, r *http.Request) ([]byte, error) {
+	if !shouldUseRawSnappy {
+		return ioutil.ReadAll(snappy.NewReader(r.Body))
+	}
+
+	compressed, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Decode(nil, compressed)
+}
+
+func compressSnappyResponse(shouldUseRawSnappy bool, w http.ResponseWriter, data []byte) error {
+	w.Header().Set("Content-Type", "application/x-protobuf")
+	w.Header().Set("Content-Encoding", "snappy")
+
+	if !shouldUseRawSnappy {
+		_, err := snappy.NewWriter(w).Write(data)
+		return err
+	}
+
+	compressed := snappy.Encode(nil, data)
+	_, err := w.Write(compressed)
+	return err
+}
+
+var rawSnappyFromVersion = semver.MustParse("0.1.0")
+
+func shouldUseRawSnappy(version string) bool {
+	ver, err := semver.Make(version)
+	if err != nil {
+		return true
+	}
+
+	return ver.GTE(rawSnappyFromVersion)
 }
 
 func protoToSamples(req *remote.WriteRequest) model.Samples {

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -94,12 +94,8 @@ func (c *Client) Store(samples model.Samples) error {
 		return err
 	}
 
-	buf := bytes.Buffer{}
-	if _, err := snappy.NewWriter(&buf).Write(data); err != nil {
-		return err
-	}
-
-	httpReq, err := http.NewRequest("POST", c.url.String(), &buf)
+	compressed := snappy.Encode(nil, data)
+	httpReq, err := http.NewRequest("POST", c.url.String(), bytes.NewBuffer(compressed))
 	if err != nil {
 		// Errors from NewRequest are from unparseable URLs, so are not
 		// recoverable.
@@ -107,7 +103,7 @@ func (c *Client) Store(samples model.Samples) error {
 	}
 	httpReq.Header.Add("Content-Encoding", "snappy")
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
-	httpReq.Header.Set("X-Prometheus-Remote-Write-Version", "0.0.1")
+	httpReq.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
 
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
@@ -151,17 +147,14 @@ func (c *Client) Read(ctx context.Context, from, through model.Time, matchers me
 		return nil, fmt.Errorf("unable to marshal read request: %v", err)
 	}
 
-	buf := bytes.Buffer{}
-	if _, err := snappy.NewWriter(&buf).Write(data); err != nil {
-		return nil, err
-	}
-
-	httpReq, err := http.NewRequest("POST", c.url.String(), &buf)
+	compressed := snappy.Encode(nil, data)
+	httpReq, err := http.NewRequest("POST", c.url.String(), bytes.NewBuffer(compressed))
 	if err != nil {
 		return nil, fmt.Errorf("unable to create request: %v", err)
 	}
+	httpReq.Header.Add("Content-Encoding", "snappy")
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
-	httpReq.Header.Set("X-Prometheus-Remote-Read-Version", "0.0.1")
+	httpReq.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
 
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
@@ -175,12 +168,18 @@ func (c *Client) Read(ctx context.Context, from, through model.Time, matchers me
 		return nil, fmt.Errorf("server returned HTTP status %s", httpResp.Status)
 	}
 
-	if data, err = ioutil.ReadAll(snappy.NewReader(httpResp.Body)); err != nil {
+	compressed, err = ioutil.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response: %v", err)
+	}
+
+	uncompressed, err := snappy.Decode(nil, compressed)
+	if err != nil {
 		return nil, fmt.Errorf("error reading response: %v", err)
 	}
 
 	var resp ReadResponse
-	err = proto.Unmarshal(data, &resp)
+	err = proto.Unmarshal(uncompressed, &resp)
 	if err != nil {
 		return nil, fmt.Errorf("unable to unmarshal response body: %v", err)
 	}


### PR DESCRIPTION
For compatibility with other languages.  Fixes #2692.

It turns out snappy framing is not part of the standard, so the use of `snappy.New{Reader,Writer}` makes Prometheus remote storage APIs hard to consume in other languages.

This change:
- Makes Prometheus use `snappy.{Encode,Decode}`, which should work across languages (confirmed here: https://github.com/weaveworks-experiments/prometheus-benchmarks/tree/master/cmd/snappy). 
- Bumps the `X-Prometheus-Remote-{Read,Write}-Version` headers from `0.0.1` to `0.1.0`, to allow existing implementations to detect the change (*cough* Cortex *cough*)
- Update the example remote storage adapter so it can accept both encodings and return the correctly encoded response to older Prometheus'.
- Makes the remote storage adapter return the `Content-Encoding: snappy` header for read responses.

I haven't made the response side of read requests backwards compatible in the Prometheus code - I reasoned that people running bleeding edge Prometheus can probably run bleeding edge storage adapter.  This means new Prometheus will fail to talk to old storage adapter for reads, buts thats the case anyway, as they won't understand the raw snappy encoding.