### PR TITLE
Expose current Prometheus config via /status/config

### DIFF
--- a/web/federate.go
+++ b/web/federate.go
@@ -74,7 +74,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 	}
 	sort.Sort(byName(vector))
 
-	externalLabels := h.externalLabels.Clone()
+	externalLabels := h.config.GlobalConfig.ExternalLabels.Clone()
 	if _, ok := externalLabels[model.InstanceLabel]; !ok {
 		externalLabels[model.InstanceLabel] = ""
 	}

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/promql"
 )
 
@@ -178,10 +179,13 @@ func TestFederation(t *testing.T) {
 		storage:     suite.Storage(),
 		queryEngine: suite.QueryEngine(),
 		now:         func() model.Time { return 101 * 60 * 1000 }, // 101min after epoch.
+		config: &config.Config{
+			GlobalConfig: config.GlobalConfig{},
+		},
 	}
 
 	for name, scenario := range scenarios {
-		h.externalLabels = scenario.externalLabels
+		h.config.GlobalConfig.ExternalLabels = scenario.externalLabels
 		req, err := http.ReadRequest(bufio.NewReader(strings.NewReader(
 			"GET http://example.org/federate?" + scenario.params + " HTTP/1.0\r\n\r\n",
 		)))


### PR DESCRIPTION
This PR adds the `/status/config` endpoint which exposes the currently
loaded Prometheus config. This is the same config that is displayed on
`/config` in the UI. The response payload looks like such:
```
{
  "status": "success",
  "data": {
    "yaml": "<CONFIG>"
  }
}
```

Related to PR #2600 and issue #2467 