### PR TITLE
Added support for tags to consul discovery

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -834,6 +834,9 @@ type ConsulSDConfig struct {
 	// The list of services for which targets are discovered.
 	// Defaults to all services if empty.
 	Services []string `yaml:"services"`
+	// The list of tags for which targets are discovered.
+	// Defaults to all services if empty.
+	Tags []string `yaml:"tags"`
 
 	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
 	// Catches all undefined fields and must be empty after parsing.


### PR DESCRIPTION
Hi @brian-brazil,

We are using Consul for the service discovery. We cannot maintain a static configuration file with all the services since they are dynamically added or removed. The services which need to be monitored typically are tagged in consul with the tag "metrics".

We have extended the consul-discovery module in prometheus, so you can add `tags` to the configuration. All the services with this tag will be scraped. This greatly simplifies our setup and scraping process. Up til now, we had a job which rewrites the `prometheus.yml` and reload this configuration.

An example of the new configuration looks like:

    consul_sd_configs:
    - server: 'consul:8500'
      services:
      - 'cadvisor'
      - 'node-exporter'
      - 'consul-exporter'
      tags:
      - 'metrics'

The combination of `services` and `tags` works in an "OR"-fashion.