### PR TITLE
change deprecated maintainer to label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM        quay.io/prometheus/busybox:latest
-MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
+LABEL maintainer "The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 COPY prometheus                             /bin/prometheus
 COPY promtool                               /bin/promtool


### PR DESCRIPTION
maintainer is deprecated in release: v1.13.0
https://docs.docker.com/engine/deprecated/#repositoryshortid-image-references
Change to LABEL instead