### PR TITLE
notifier: clone and not reuse LabelSet in AM discovery

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -500,6 +500,7 @@ func alertmanagerFromGroup(tg *config.TargetGroup, cfg *config.AlertmanagerConfi
 	var res []alertmanager
 
 	for _, lset := range tg.Targets {
+		lset = lset.Clone()
 		// Set configured scheme as the initial scheme label for overwrite.
 		lset[model.SchemeLabel] = model.LabelValue(cfg.Scheme)
 		lset[pathLabel] = model.LabelValue(postPath(cfg.PathPrefix))
@@ -510,7 +511,8 @@ func alertmanagerFromGroup(tg *config.TargetGroup, cfg *config.AlertmanagerConfi
 				lset[ln] = lv
 			}
 		}
-		lset := relabel.Process(lset, cfg.RelabelConfigs...)
+
+		lset = relabel.Process(lset, cfg.RelabelConfigs...)
 		if lset == nil {
 			continue
 		}

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -418,3 +418,30 @@ type alertmanagerMock struct {
 func (a alertmanagerMock) url() string {
 	return a.urlf()
 }
+
+func TestLabelSetNotReused(t *testing.T) {
+	tg := makeInputTargetGroup()
+	_, err := alertmanagerFromGroup(tg, &config.AlertmanagerConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(tg, makeInputTargetGroup()) {
+		t.Fatal("Target modified during alertmanager extraction")
+	}
+}
+
+func makeInputTargetGroup() *config.TargetGroup {
+	return &config.TargetGroup{
+		Targets: []model.LabelSet{
+			model.LabelSet{
+				model.AddressLabel:            model.LabelValue("1.1.1.1:9090"),
+				model.LabelName("notcommon1"): model.LabelValue("label"),
+			},
+		},
+		Labels: model.LabelSet{
+			model.LabelName("common"): model.LabelValue("label"),
+		},
+		Source: "testsource",
+	}
+}


### PR DESCRIPTION
Not cloning and re-defining the `lset` variable in the Alertmanager discovery caused unpredictable behavior and made Alertmanager targets appear and reappear regularly. I noticed this using Kubernetes SD to discover Alertmanagers.

Before the fix the `prometheus_notifications_alertmanagers_discovered` metric looks like this. The `prometheus-c-0` instance has constant number of Alertmanagers as them configured statically, whereas `prometheus-b-0` fluctuates a lot and on every Kubernetes resync interval (when all the maps are re-instantiated from scratch) the Alertmangers are discovered for a short period and then get scrambled again:

![screenshot from 2017-05-15 18-52-11](https://cloud.githubusercontent.com/assets/4546722/26159077/e7ca0ce6-3b1d-11e7-8adf-64ce54ddfd3a.png)

I haven't been running this fix for very long but so far it seems to now be stable:

![screenshot from 2017-05-17 16-34-19](https://cloud.githubusercontent.com/assets/4546722/26159374/baf26c8a-3b1e-11e7-8555-9ebd8f4d4336.png)

@fabxc @brian-brazil @beorn7 @juliusv @mxinden