### PR TITLE
Staleness for rules

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -230,7 +230,7 @@ func (b *Builder) Set(n, v string) *Builder {
 }
 
 // Labels returns the labels from the builder. If no modifications
-// were made, the originl labels are returned.
+// were made, the original labels are returned.
 func (b *Builder) Labels() Labels {
 	if len(b.del) == 0 && len(b.add) == 0 {
 		return b.base

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -75,23 +75,18 @@ func TestAlertingRule(t *testing.T) {
 		}, {
 			time: 5 * time.Minute,
 			result: []string{
-				`{__name__="ALERTS", alertname="HTTPRequestRateLow", alertstate="pending", group="canary", instance="0", job="app-server", severity="critical"} => 0 @[%v]`,
 				`{__name__="ALERTS", alertname="HTTPRequestRateLow", alertstate="firing", group="canary", instance="0", job="app-server", severity="critical"} => 1 @[%v]`,
-				`{__name__="ALERTS", alertname="HTTPRequestRateLow", alertstate="pending", group="canary", instance="1", job="app-server", severity="critical"} => 0 @[%v]`,
 				`{__name__="ALERTS", alertname="HTTPRequestRateLow", alertstate="firing", group="canary", instance="1", job="app-server", severity="critical"} => 1 @[%v]`,
 			},
 		}, {
 			time: 10 * time.Minute,
 			result: []string{
 				`{__name__="ALERTS", alertname="HTTPRequestRateLow", alertstate="firing", group="canary", instance="0", job="app-server", severity="critical"} => 1 @[%v]`,
-				`{__name__="ALERTS", alertname="HTTPRequestRateLow", alertstate="firing", group="canary", instance="1", job="app-server", severity="critical"} => 0 @[%v]`,
 			},
 		},
 		{
-			time: 15 * time.Minute,
-			result: []string{
-				`{__name__="ALERTS", alertname="HTTPRequestRateLow", alertstate="firing", group="canary", instance="0", job="app-server", severity="critical"} => 0 @[%v]`,
-			},
+			time:   15 * time.Minute,
+			result: []string{},
 		},
 		{
 			time:   20 * time.Minute,
@@ -106,7 +101,6 @@ func TestAlertingRule(t *testing.T) {
 		{
 			time: 30 * time.Minute,
 			result: []string{
-				`{__name__="ALERTS", alertname="HTTPRequestRateLow", alertstate="pending", group="canary", instance="0", job="app-server", severity="critical"} => 0 @[%v]`,
 				`{__name__="ALERTS", alertname="HTTPRequestRateLow", alertstate="firing", group="canary", instance="0", job="app-server", severity="critical"} => 1 @[%v]`,
 			},
 		},


### PR DESCRIPTION
This should work with no changes once we have rule groups. If a rule is deleted we don't add stale markers, but that's okay as it no longer exists (or is in another group now) so if it's stale for a bit that's fine.

Note there's a semantic change in the last commit.

@fabxc 