### PR TITLE
added absolute_increase function

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -144,6 +144,31 @@ func funcIncrease(ev *evaluator, args Expressions) model.Value {
 	return extrapolatedRate(ev, args[0], true, false)
 }
 
+// === abolute_increase(matrix model.ValMatrix) Vector ===
+func funcAbsoluteIncrease(ev *evaluator, args Expressions) model.Value {
+	return aggrOverTime(ev, args, func(values []model.SamplePair) model.SampleValue {
+		count := 0.0
+		start := math.Inf(1)
+		got_start := false
+		for _, v := range values {
+			// get the first value if we don't already have it
+			if !got_start {
+				start = float64(v.Value)
+				got_start = true
+			}
+			// if the count resets, add it to what was there before
+			if count > float64(v.Value) {
+				count += float64(v.Value)
+			} else { // if the count is going up, let it
+				count = float64(v.Value)
+			}
+		}
+		// subtract the starting value from the final value
+		count -= start
+		return model.SampleValue(count)
+	})
+}
+
 // === irate(node model.ValMatrix) Vector ===
 func funcIrate(ev *evaluator, args Expressions) model.Value {
 	return instantValue(ev, args[0], true)
@@ -1066,6 +1091,12 @@ var functions = map[string]*Function{
 		ArgTypes:   []model.ValueType{model.ValMatrix},
 		ReturnType: model.ValVector,
 		Call:       funcIncrease,
+	},
+	"absolute_increase": {
+		Name:       "absolute_increase",
+		ArgTypes:   []model.ValueType{model.ValMatrix},
+		ReturnType: model.ValVector,
+		Call:       funcAbsoluteIncrease,
 	},
 	"irate": {
 		Name:       "irate",


### PR DESCRIPTION
I needed a way to see how many events happened during a particular time frame, as accurate as possible.  increase() seems to work well if the rate is pretty constant and if there are samples over the entire window that is requested, and not so much otherwise.  This seems to work better for my needs and might be useful to others. 
The count is off by -1 for the first event after the service is started, but seems to be accurate after that.  Improvements welcome!
