### PR TITLE
Fix go version hint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Prometheus will now be reachable at http://localhost:9090/.
 ### Building from source
 
 To build Prometheus from the source code yourself you need to have a working
-Go environment with [version 1.5 or greater installed](http://golang.org/doc/install).
+Go environment with [version 1.8 or greater installed](http://golang.org/doc/install).
 
 You can directly use the `go` tool to download and install the `prometheus`
 and `promtool` binaries into your `GOPATH`. We use Go 1.5's experimental


### PR DESCRIPTION
As #2698 said, we should update the go version requirement, since the dependencies are all needed equal or greater than go 1.8.