### PR TITLE
prefix redirect with external url path

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -170,7 +171,7 @@ func New(o *Options) *Handler {
 	instrf := prometheus.InstrumentHandlerFunc
 
 	router.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		router.Redirect(w, r, "/graph", http.StatusFound)
+		router.Redirect(w, r, path.Join(o.ExternalURL.Path, "/graph"), http.StatusFound)
 	})
 
 	router.Get("/alerts", instrf("alerts", h.alerts))


### PR DESCRIPTION
We're trying to run Prometheus behind an Nginx Ingress in Kubernetes. We have `-external-url` set to `https://www.example.com/prometheus` and `-route-prefix` to `/` because we have the `rewrite-target` option set to `/`, basically what this does is it truncates the path prefix on actual requests, and makes requests look like they came from root. This causes the current redirect to redirect to `https://www.example.com/graph`, whereas it should be redirecting to `https://www.example.com/prometheus/graph`. Which is exactly what this PR implements.

There are many cases that could happen with `-external-url` and `-route-prefix` combinations that this should be reviewed carefully.

@fabxc @brian-brazil @juliusv @beorn7 @grobie @mxinden