### PR TITLE
Remote write: read first line of response and include it in the error.

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -14,6 +14,7 @@
 package remote
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io/ioutil"
@@ -117,7 +118,12 @@ func (c *Client) Store(samples model.Samples) error {
 	defer httpResp.Body.Close()
 
 	if httpResp.StatusCode/100 != 2 {
-		err = fmt.Errorf("server returned HTTP status %s", httpResp.Status)
+		scanner := bufio.NewScanner(httpResp.Body)
+		line := ""
+		if scanner.Scan() {
+			line = scanner.Text()
+		}
+		err = fmt.Errorf("server returned HTTP status %s: %s", httpResp.Status, line)
 	}
 	if httpResp.StatusCode/100 == 5 {
 		return recoverableError{err}

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -31,6 +32,8 @@ import (
 	"github.com/prometheus/prometheus/storage/metric"
 	"github.com/prometheus/prometheus/util/httputil"
 )
+
+const maxErrMsgLen = 256
 
 // Client allows reading and writing from/to a remote HTTP endpoint.
 type Client struct {
@@ -118,7 +121,7 @@ func (c *Client) Store(samples model.Samples) error {
 	defer httpResp.Body.Close()
 
 	if httpResp.StatusCode/100 != 2 {
-		scanner := bufio.NewScanner(httpResp.Body)
+		scanner := bufio.NewScanner(io.LimitReader(httpResp.Body, maxErrMsgLen))
 		line := ""
 		if scanner.Scan() {
 			line = scanner.Text()

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -19,12 +19,15 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 )
+
+var longErrMessage = strings.Repeat("error message", maxErrMsgLen)
 
 func TestStoreHTTPErrorHandling(t *testing.T) {
 	tests := []struct {
@@ -37,22 +40,22 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 		},
 		{
 			code: 300,
-			err:  fmt.Errorf("server returned HTTP status 300 Multiple Choices: test error"),
+			err:  fmt.Errorf("server returned HTTP status 300 Multiple Choices: " + longErrMessage[:maxErrMsgLen]),
 		},
 		{
 			code: 404,
-			err:  fmt.Errorf("server returned HTTP status 404 Not Found: test error"),
+			err:  fmt.Errorf("server returned HTTP status 404 Not Found: " + longErrMessage[:maxErrMsgLen]),
 		},
 		{
 			code: 500,
-			err:  recoverableError{fmt.Errorf("server returned HTTP status 500 Internal Server Error: test error")},
+			err:  recoverableError{fmt.Errorf("server returned HTTP status 500 Internal Server Error: " + longErrMessage[:maxErrMsgLen])},
 		},
 	}
 
 	for i, test := range tests {
 		server := httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				http.Error(w, "test error", test.code)
+				http.Error(w, longErrMessage, test.code)
 			}),
 		)
 

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -37,15 +37,15 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 		},
 		{
 			code: 300,
-			err:  fmt.Errorf("server returned HTTP status 300 Multiple Choices"),
+			err:  fmt.Errorf("server returned HTTP status 300 Multiple Choices: test error"),
 		},
 		{
 			code: 404,
-			err:  fmt.Errorf("server returned HTTP status 404 Not Found"),
+			err:  fmt.Errorf("server returned HTTP status 404 Not Found: test error"),
 		},
 		{
 			code: 500,
-			err:  recoverableError{fmt.Errorf("server returned HTTP status 500 Internal Server Error")},
+			err:  recoverableError{fmt.Errorf("server returned HTTP status 500 Internal Server Error: test error")},
 		},
 	}
 
@@ -68,7 +68,7 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 
 		err = c.Store(nil)
 		if !reflect.DeepEqual(err, test.err) {
-			t.Fatalf("%d. Unexpected error; want %v, got %v", i, test.err, err)
+			t.Errorf("%d. Unexpected error; want %v, got %v", i, test.err, err)
 		}
 
 		server.Close()


### PR DESCRIPTION
Fixes #2768

Cortex returns quite meaningful error messages - for instance, when a user has gone over their samples/s limit, or when the cardinality of a metric is too high, or when samples are coming out of order.

It would help users self-diagnose if these messages were included in the Prometheus logs.