### PR TITLE
config: set default region for EC2 SD

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1128,7 +1128,10 @@ func (c *EC2SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	if c.Region == "" {
-		sess := session.Must(session.NewSession())
+		sess, err := session.NewSession()
+		if err != nil {
+			return err
+		}
 		metadata := ec2metadata.New(sess)
 		region, err := metadata.Region()
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
 )
@@ -1126,7 +1128,13 @@ func (c *EC2SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	if c.Region == "" {
-		return fmt.Errorf("EC2 SD configuration requires a region")
+		sess := session.Must(session.NewSession())
+		metadata := ec2metadata.New(sess)
+		region, err := metadata.Region()
+		if err != nil {
+			return fmt.Errorf("EC2 SD configuration requires a region")
+		}
+		c.Region = region
 	}
 	return nil
 }


### PR DESCRIPTION
If Prometheus is running on EC2, most of the case `region` might be same region where Prometheus is running.
I want to set default region for the case.