### PR TITLE
Add Start/Wait to targetmanager make it easier to consume

### DIFF
--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -60,15 +60,23 @@ func NewTargetManager(app storage.SampleAppender, logger log.Logger) *TargetMana
 
 // Run starts background processing to handle target updates.
 func (tm *TargetManager) Run() {
+	tm.Start()
+	tm.Wait()
+}
+
+// Start loads initial target updates
+func (tm *TargetManager) Start() {
 	tm.logger.Info("Starting target manager...")
 
 	tm.mtx.Lock()
+	defer tm.mtx.Unlock()
 
 	tm.ctx, tm.cancel = context.WithCancel(context.Background())
 	tm.reload()
+}
 
-	tm.mtx.Unlock()
-
+// Wait blocks until Stop
+func (tm *TargetManager) Wait() {
 	tm.wg.Wait()
 }
 


### PR DESCRIPTION
Hello! Here is a small PR to break out `Wait` from TargetManager's `Run`. 

I was having deadlock issues during tests if I had called `Stop` before the go routine to run`Run` had received the lock. 

It's possible that https://github.com/prometheus/prometheus/blob/master/cmd/prometheus/main.go#L218-L219  has this issue if the program receives a SIGTERM running the deferred `Stop` before `go targetManager.Run()` has begun executing.

In this PR I kept the `Run` function, but, if is an ok change, I can fix the defer issue in `cmd/prometheus/main.go` as well !

