### PR TITLE
Fix 'remote_write' config example

### DIFF
--- a/documentation/examples/remote_storage/example_write_adapter/README.md
+++ b/documentation/examples/remote_storage/example_write_adapter/README.md
@@ -14,7 +14,7 @@ go build
 
 ```yaml
 remote_write:
-  url: "http://localhost:1234/receive"
+  - url: "http://localhost:1234/receive"
 ```
 
 Then start Prometheus:


### PR DESCRIPTION
When the contents of `remote_write` are a map, as it currently is in this README, Prometheus 1.6.3 fails to start with error message:
```
Error loading config: couldn't load configuration (-config.file=/etc/prometheus/prometheus.yml): yaml: unmarshal errors:\n  line 14: cannot unmarshal !!map into []*config.RemoteWriteConfig" source="main.go:159"
```
Changing it to a list of keyword: value pairs, fixes the error.