### PR TITLE
Fix error where we look into the future.

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -253,12 +253,22 @@ load 10s
 		{
 			Query: "metric",
 			Result: Matrix{Series{
-				Points: []Point{{V: 1, T: 0}, {V: 1, T: 1000}, {V: 2, T: 2000}},
+				Points: []Point{{V: 1, T: 0}, {V: 1, T: 1000}, {V: 1, T: 2000}},
 				Metric: labels.FromStrings("__name__", "metric")},
 			},
 			Start:    time.Unix(0, 0),
 			End:      time.Unix(2, 0),
 			Interval: time.Second,
+		},
+		{
+			Query: "metric",
+			Result: Matrix{Series{
+				Points: []Point{{V: 1, T: 0}, {V: 1, T: 5000}, {V: 2, T: 10000}},
+				Metric: labels.FromStrings("__name__", "metric")},
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(10, 0),
+			Interval: 5 * time.Second,
 		},
 	}
 

--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -80,10 +80,12 @@ func (b *BufferedSeriesIterator) Seek(t int64) bool {
 
 // Next advances the iterator to the next element.
 func (b *BufferedSeriesIterator) Next() bool {
-	// Add current element to buffer before advancing.
-	if !b.done {
-		b.buf.add(b.it.At())
+	if b.done {
+		return false
 	}
+
+	// Add current element to buffer before advancing.
+	b.buf.add(b.it.At())
 
 	ok := b.it.Next()
 	if ok {

--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -13,7 +13,9 @@
 
 package storage
 
-import "math"
+import (
+	"math"
+)
 
 // BufferedSeriesIterator wraps an iterator with a look-back buffer.
 type BufferedSeriesIterator struct {
@@ -21,6 +23,7 @@ type BufferedSeriesIterator struct {
 	buf *sampleRing
 
 	lastTime int64
+	done     bool
 }
 
 // NewBuffer returns a new iterator that buffers the values within the time range
@@ -78,12 +81,17 @@ func (b *BufferedSeriesIterator) Seek(t int64) bool {
 // Next advances the iterator to the next element.
 func (b *BufferedSeriesIterator) Next() bool {
 	// Add current element to buffer before advancing.
-	b.buf.add(b.it.At())
+	if !b.done {
+		b.buf.add(b.it.At())
+	}
 
 	ok := b.it.Next()
 	if ok {
 		b.lastTime, _ = b.Values()
+	} else {
+		b.done = true
 	}
+
 	return ok
 }
 

--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -61,6 +61,7 @@ func (b *BufferedSeriesIterator) Seek(t int64) bool {
 
 		ok := b.it.Seek(t0)
 		if !ok {
+			b.done = true
 			return false
 		}
 		b.lastTime, _ = b.Values()


### PR DESCRIPTION
So if we are requesting the values from `ts to te`, we are looking beyond `te` and returning those values too. For example if we have [(1, 1), (15000, 10)] and we ask for values at t = 1 and t = 2, we will be returning [(1, 1), (2, 10)].

The changed test should make it clear.


Further, It is not advisable to call .At() after Next() returns false. The erroneous final values seen in: https://youtu.be/jDuWoOlyljM are due to this.

cc @fabxc @brian-brazil

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/2829)
<!-- Reviewable:end -->
