### PR TITLE
web: fix double prefix redirect

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -171,7 +171,7 @@ func New(o *Options) *Handler {
 	instrf := prometheus.InstrumentHandlerFunc
 
 	router.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		router.Redirect(w, r, path.Join(o.ExternalURL.Path, "/graph"), http.StatusFound)
+		http.Redirect(w, r, path.Join(o.ExternalURL.Path, "/graph"), http.StatusFound)
 	})
 
 	router.Get("/alerts", instrf("alerts", h.alerts))


### PR DESCRIPTION
Fixes #2825 and #2817.

The problem was that when using the `.Redirect` method of the router after is has been prefixed, it will use the route prefix and external url path joined with the graph path, ending up with being redirected to `/prometheus/prometheus/graph`, when `-web.external-url` is set to a URL with `/prometheus` as the path and no `-web.route-prefix` (which makes it default to the same path).

The bug was previously introduced by #2755.

@brian-brazil @fabxc @grobie 