### PR TITLE
Strip default port from http host header for alert manager url

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -399,6 +399,15 @@ func (n *Notifier) sendOne(ctx context.Context, c *http.Client, url string, b []
 	if err != nil {
 		return err
 	}
+
+	host, port, err := net.SplitHostPort(req.Host)
+	if err != nil {
+		return err
+	}
+	if port == "80" || port == "443" {
+		req.Host = host
+	}
+
 	req.Header.Set("Content-Type", contentTypeJSON)
 	resp, err := n.opts.Do(ctx, c, req)
 	if err != nil {

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -197,7 +197,7 @@ func TestHandlerSendAll(t *testing.T) {
 }
 
 func TestCustomDo(t *testing.T) {
-	const testURL = "http://testurl.com/"
+	const testURL = "http://testurl.com:80/"
 	const testBody = "testbody"
 
 	var received bool


### PR DESCRIPTION
Hello,
We setup alert manager behind our proxy which is not behaving correctly with port included in the host header of the http request.

By lookup, I found generally http clients, browsers strip off port from Host header and similar fix in other libraries.

Example:
https://github.com/websocket-client/websocket-client/pull/248



