### PR TITLE
azure service fabric service discovery

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1549,7 +1549,7 @@ type AzureServiceFabricSDConfig struct {
 	Endpoints            map[string]struct{} `yaml:"endpoints"`
 	RefreshInterval      model.Duration      `yaml:"refresh_interval,omitempty"`
 	ClientCertAndKeyFile string              `yaml:"client_cert_and_key_file"` // populate only for secure clusters. Comma separated
-	TlsSkipVerify        bool                `yaml:"tls_skip_verify"`
+	TLSSkipVerify        bool                `yaml:"tls_skip_verify"`
 
 	XXX map[string]interface{} `yaml:",inline"` // Catches all undefined fields and must be empty after parsing.
 }

--- a/config/config.go
+++ b/config/config.go
@@ -201,7 +201,6 @@ var (
 
 	// DefaultAzureServiceFabricSDConfig is the default Azure Service Fabric SD configuration.
 	DefaultAzureServiceFabricSDConfig = AzureServiceFabricSDConfig{
-		Endpoints:       map[string]struct{}{},
 		RefreshInterval: model.Duration(time.Minute),
 	}
 )
@@ -1558,8 +1557,7 @@ type AzureServiceFabricSDConfig struct {
 func (c *AzureServiceFabricSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultAzureServiceFabricSDConfig
 	type plain AzureServiceFabricSDConfig
-	err := unmarshal((*plain)(c))
-	if err != nil {
+	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
 

--- a/discovery/azuresf/azuresf.go
+++ b/discovery/azuresf/azuresf.go
@@ -1,0 +1,311 @@
+package azuresf
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+)
+
+const (
+	azureSFLabel            = model.MetaLabelPrefix + "azure_sf_"
+	azureSFLabelApplication = azureSFLabel + "application"
+	azureSFLabelService     = azureSFLabel + "service"
+	azureSFLabelPartition   = azureSFLabel + "partition"
+	azureSFLabelNode        = azureSFLabel + "node"
+	azureSFLabelEndpoint    = azureSFLabel + "endpoint_"
+
+	refreshTimeout = time.Second * 15
+)
+
+var (
+	azureSFSDRefreshFailuresCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "prometheus_sd_azure_sf_refresh_failures_total",
+			Help: "Number of Azure Service Fabric SD refresh failures.",
+		})
+	azureSFSDRefreshDuration = prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Name: "prometheus_sd_azure_sf_refresh_duration_seconds",
+			Help: "The duration of Azure Service Fabric SD refresh in seconds.",
+		})
+)
+
+func init() {
+	prometheus.MustRegister(azureSFSDRefreshFailuresCount)
+	prometheus.MustRegister(azureSFSDRefreshDuration)
+}
+
+// Discovery periodically performs Azure Service Fabric SD requests.
+// It implements the TargetProvider interface.
+type Discovery struct {
+	cfg      *config.AzureServiceFabricSDConfig
+	interval time.Duration
+	sfClient *sfClient
+}
+
+func NewDiscovery(cfg *config.AzureServiceFabricSDConfig) (*Discovery, error) {
+	var sfc *sfClient
+
+	if cfg.ClientCertAndKeyFile == "" {
+		sfc = &sfClient{
+			origin: fmt.Sprintf("http://%s", cfg.ClusterHost),
+			client: http.DefaultClient,
+		}
+	} else {
+		fileNames := strings.Split(cfg.ClientCertAndKeyFile, ",")
+		if len(fileNames) != 2 {
+			return nil, errors.New("expecting 'certFile,keyFile', comma-separated")
+		}
+
+		cert, err := tls.LoadX509KeyPair(fileNames[0], fileNames[1])
+		if err != nil {
+			return nil, err
+		}
+
+		tlsConfig := &tls.Config{
+			Certificates:       []tls.Certificate{cert},
+			Renegotiation:      tls.RenegotiateOnceAsClient,
+			InsecureSkipVerify: true, // cfg.TlsSkipVerify,
+		}
+		tlsConfig.BuildNameToCertificate()
+
+		sfc = &sfClient{
+			origin: fmt.Sprintf("https://%s", cfg.ClusterHost),
+			client: &http.Client{
+				Transport: &http.Transport{TLSClientConfig: tlsConfig},
+			},
+		}
+	}
+
+	return &Discovery{
+		cfg:      cfg,
+		interval: time.Duration(cfg.RefreshInterval),
+		sfClient: sfc,
+	}, nil
+}
+
+// Run implements the TargetProvider interface.
+func (d *Discovery) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
+	ticker := time.NewTicker(d.interval)
+	defer ticker.Stop()
+
+	select {
+	case <-ctx.Done():
+		// context is already closed, do not even perform one discovery
+		return
+	default:
+	}
+
+	for {
+		tg, err := d.refresh()
+		if err != nil {
+			log.Errorf("unable to refresh during Azure Sevice Fabric discovery: %s", err)
+		} else {
+			select {
+			case <-ctx.Done():
+			case ch <- []*config.TargetGroup{tg}:
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+	}
+}
+
+func (d *Discovery) refresh() (tg *config.TargetGroup, err error) {
+	defer func(start time.Time) {
+		azureSFSDRefreshDuration.Observe(time.Since(start).Seconds())
+		if err != nil {
+			azureSFSDRefreshFailuresCount.Inc()
+		}
+	}(time.Now())
+
+	// ctx with cancel after a given timeout
+	ctx, cancel := context.WithTimeout(context.Background(), refreshTimeout)
+	defer cancel() // stops the timer
+
+	applicationEntries, err := getApplicationEntries(ctx, d.sfClient)
+	if err != nil {
+		return nil, err
+	}
+
+	targets := d.makeTargets(applicationEntries)
+
+	log.Debugf("Azure Service Fabric discovery completed.")
+
+	return &config.TargetGroup{
+		Targets: targets,
+	}, nil
+}
+
+type applicationEntry struct {
+	application    string
+	serviceEntries []serviceEntry
+	err            error
+}
+
+func getApplicationEntries(ctx context.Context, client *sfClient) ([]applicationEntry, error) {
+	applications, err := client.getApplications(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get applications: %s", err)
+	}
+
+	applicationEntries := make([]applicationEntry, len(applications))
+	wg := sync.WaitGroup{}
+	wg.Add(len(applications))
+
+	for i, application := range applications {
+		go func(i int, application string) {
+			serviceEntries, err := getServiceEntries(ctx, client, application)
+			applicationEntries[i] = applicationEntry{
+				err:            err,
+				application:    application,
+				serviceEntries: serviceEntries,
+			}
+			wg.Done()
+		}(i, application)
+	}
+
+	wg.Wait()
+
+	// check for errors
+	for _, entry := range applicationEntries {
+		if entry.err != nil {
+			return nil, entry.err
+		}
+		applicationEntries = append(applicationEntries, entry)
+	}
+
+	return applicationEntries, nil
+}
+
+type serviceEntry struct {
+	service           string
+	partitionsEntries []partitionEntry
+	err               error
+}
+
+func getServiceEntries(ctx context.Context, client *sfClient, application string) ([]serviceEntry, error) {
+	services, err := client.getServices(ctx, application)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get services: %s", err)
+	}
+
+	serviceEntries := make([]serviceEntry, len(services))
+	wg := sync.WaitGroup{}
+	wg.Add(len(services))
+
+	for i, service := range services {
+		go func(i int, service string) {
+			partitionEntries, err := getPartitionsEntries(ctx, client, application, service)
+			serviceEntries[i] = serviceEntry{
+				err:               err,
+				service:           service,
+				partitionsEntries: partitionEntries,
+			}
+			wg.Done()
+		}(i, service)
+	}
+
+	wg.Wait()
+
+	// check for errors
+	for _, entry := range serviceEntries {
+		if entry.err != nil {
+			return nil, entry.err
+		}
+	}
+
+	return serviceEntries, nil
+}
+
+type partitionEntry struct {
+	partition     string
+	nodeEndpoints []nodeAndEndpoints
+	err           error
+}
+
+func getPartitionsEntries(ctx context.Context, client *sfClient, application, service string) ([]partitionEntry, error) {
+	partitions, err := client.getPartitions(ctx, application, service)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get partitions: %s", err)
+	}
+
+	partitionEntries := make([]partitionEntry, len(partitions))
+	wg := sync.WaitGroup{}
+	wg.Add(len(partitions))
+
+	for i, partition := range partitions {
+		go func(i int, partition string) {
+			nodeEndpoints, err := client.getReplicaEndpoints(ctx, application, service, partition)
+			partitionEntries[i] = partitionEntry{
+				err:           err,
+				partition:     partition,
+				nodeEndpoints: nodeEndpoints,
+			}
+			wg.Done()
+		}(i, partition)
+	}
+
+	wg.Wait()
+
+	// check for errors
+	for _, entry := range partitionEntries {
+		if entry.err != nil {
+			return nil, entry.err
+		}
+		partitionEntries = append(partitionEntries, entry)
+	}
+
+	return partitionEntries, nil
+}
+
+func (d *Discovery) makeTargets(applicationEntries []applicationEntry) []model.LabelSet {
+	// TODO - any clever way to pre-calculate the size of this slice?
+	var targets []model.LabelSet
+
+	for _, applicationEntry := range applicationEntries {
+		for _, serviceEntry := range applicationEntry.serviceEntries {
+			for _, partitionEntry := range serviceEntry.partitionsEntries {
+				for _, nodeEndpoints := range partitionEntry.nodeEndpoints {
+					for endpointName, endpointValue := range nodeEndpoints.endpoints {
+						if _, ok := d.cfg.Endpoints[endpointName]; !ok {
+							// endpoint is not to be scrapped
+							continue
+						}
+
+						targets = append(targets, model.LabelSet{
+							azureSFLabelApplication: model.LabelValue(applicationEntry.application),
+							azureSFLabelService:     model.LabelValue(serviceEntry.service),
+							azureSFLabelPartition:   model.LabelValue(partitionEntry.partition),
+							azureSFLabelNode:        model.LabelValue(nodeEndpoints.node),
+
+							// the default scrape target, __address__
+							model.AddressLabel: model.LabelValue(endpointValue),
+
+							// captures de endpoint name, so relabel_configs may filter if appropriate
+							azureSFLabelEndpoint + model.LabelName(endpointName): model.LabelValue(endpointValue),
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return targets
+}

--- a/discovery/azuresf/azuresf.go
+++ b/discovery/azuresf/azuresf.go
@@ -1,3 +1,16 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package azuresf
 
 import (
@@ -54,6 +67,7 @@ type Discovery struct {
 	sfClient *sfClient
 }
 
+// NewDiscovery returns a new Azure Service Fabric discovery which periodically refreshes its targets.
 func NewDiscovery(cfg *config.AzureServiceFabricSDConfig) (*Discovery, error) {
 	var sfc *sfClient
 

--- a/discovery/azuresf/client.go
+++ b/discovery/azuresf/client.go
@@ -1,0 +1,183 @@
+package azuresf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	apiVersion = "api-version=2.0"
+)
+
+type sfClient struct {
+	origin string
+	client *http.Client
+}
+
+func httpNotOKError(method string, code int) error {
+	return fmt.Errorf("%s: expecting 200, got %d", method, code)
+}
+
+type getApplicationsResponse struct {
+	Items []struct {
+		ID string `json:"Id"`
+	} `json:"Items"`
+}
+
+func (c *sfClient) getApplications(ctx context.Context) ([]string, error) {
+	url := fmt.Sprintf("%s/Applications/?"+apiVersion, c.origin)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpNotOKError("getApplications", resp.StatusCode)
+	}
+
+	var appResp getApplicationsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&appResp); err != nil {
+		return nil, err
+	}
+
+	apps := make([]string, 0, len(appResp.Items))
+	for _, item := range appResp.Items {
+		apps = append(apps, item.ID)
+	}
+
+	return apps, nil
+}
+
+type getServicesResponse struct {
+	Items []struct {
+		ID string `json:"Id"`
+	} `json:"Items"`
+}
+
+func (c *sfClient) getServices(ctx context.Context, application string) ([]string, error) {
+	url := fmt.Sprintf("%s/Applications/%s/$/GetServices?"+apiVersion, c.origin, application)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpNotOKError("getServices", resp.StatusCode)
+	}
+
+	var servicesResp getServicesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&servicesResp); err != nil {
+		return nil, err
+	}
+
+	services := make([]string, 0, len(servicesResp.Items))
+	for _, item := range servicesResp.Items {
+		services = append(services, item.ID)
+	}
+
+	return services, nil
+}
+
+type getPartitionsResponse struct {
+	Items []struct {
+		Info struct {
+			ID string `json:"Id"`
+		} `json:"PartitionInformation"`
+	} `json:"Items"`
+}
+
+func (c *sfClient) getPartitions(ctx context.Context, application, service string) ([]string, error) {
+	url := fmt.Sprintf("%s/Applications/%s/$/GetServices/%s/$/GetPartitions?"+apiVersion, c.origin, application, url.QueryEscape(service))
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req.WithContext(ctx))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpNotOKError("getPartitions", resp.StatusCode)
+	}
+
+	var partitionsResp getPartitionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&partitionsResp); err != nil {
+		return nil, err
+	}
+
+	partitions := make([]string, 0, len(partitionsResp.Items))
+	for _, item := range partitionsResp.Items {
+		partitions = append(partitions, item.Info.ID)
+	}
+
+	return partitions, nil
+}
+
+type getReplicaResponse struct {
+	Items []struct {
+		NodeName string `json:"NodeName"`
+		Address  string `json:"Address"`
+	} `json:"Items"`
+}
+
+type getReplicaResponseEndpoints struct {
+	Endpoints map[string]string `json:"Endpoints"`
+}
+
+type nodeAndEndpoints struct {
+	node      string
+	endpoints map[string]string
+}
+
+func (c *sfClient) getReplicaEndpoints(ctx context.Context, application, service, partition string) ([]nodeAndEndpoints, error) {
+	url := fmt.Sprintf("%s/Applications/%s/$/GetServices/%s/$/GetPartitions/%s/$/GetReplicas?"+apiVersion, c.origin, application, url.QueryEscape(service), partition)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req.WithContext(ctx))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpNotOKError("getReplicaEndpoints", resp.StatusCode)
+	}
+
+	var replicaResp getReplicaResponse
+	if err := json.NewDecoder(resp.Body).Decode(&replicaResp); err != nil {
+		return nil, err
+	}
+
+	nodeEndpoints := make([]nodeAndEndpoints, 0, len(replicaResp.Items))
+	for _, item := range replicaResp.Items {
+		var endpoints getReplicaResponseEndpoints
+		if err := json.Unmarshal([]byte(item.Address), &endpoints); err != nil {
+			// there are other valid formats for endpoints (such as containers). Ignore this endpoint and move on
+			// TODO - support additional formats
+			continue
+		}
+
+		nodeEndpoints = append(nodeEndpoints, nodeAndEndpoints{node: item.NodeName, endpoints: endpoints.Endpoints})
+	}
+
+	return nodeEndpoints, nil
+}

--- a/discovery/azuresf/client.go
+++ b/discovery/azuresf/client.go
@@ -1,3 +1,16 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package azuresf
 
 import (

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/azure"
+	"github.com/prometheus/prometheus/discovery/azuresf"
 	"github.com/prometheus/prometheus/discovery/consul"
 	"github.com/prometheus/prometheus/discovery/dns"
 	"github.com/prometheus/prometheus/discovery/ec2"
@@ -127,6 +128,14 @@ func ProvidersFromConfig(cfg config.ServiceDiscoveryConfig, logger log.Logger) m
 	}
 	if len(cfg.StaticConfigs) > 0 {
 		app("static", 0, NewStaticProvider(cfg.StaticConfigs))
+	}
+	for i, c := range cfg.AzureServiceFabricSDConfigs {
+		sf, err := azuresf.NewDiscovery(c)
+		if err != nil {
+			log.Errorf("Cannot create Azure Service Fabric discovery: %s", err)
+			continue
+		}
+		app("azuresf", i, sf)
 	}
 
 	return providers


### PR DESCRIPTION
Adding service discovery support for [Azure Service Fabric](https://docs.microsoft.com/en-us/azure/service-fabric/)

Uses the config `AzureServiceFabricSDConfig` to find [registered endpoints](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-service-manifest-resources#endpoints) contained in 
`Endpoints            map[string]struct{}`
and scrapes them. 

If monitoring a secure cluster, client authentication requires `ClientCertAndKeyFile` with a [client certificate](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-cluster-security-update-certs-azure#add-a-secondary-cluster-certificate-using-the-portal). Certificates with read-only access are enough and recommended.

Does not support discovery of containers yet.

Example scrape config: 

```
scrape_configs:
- job_name: service_fabric
  azure_sf_sd_configs:
  - cluster_url: "127.0.0.1:19080" # set to the desired cluster
    endpoints: {'Debug'}
    client_cert_and_key_file: "read-only.crt,read-only.key" # path to certs

  relabel_configs:
  - source_labels: ['__meta_azure_sf_service']
    regex:         "(.*)/(.*)"
    target_label:  "service"
    replacement:   "${1}"
  - source_labels: ['__meta_azure_sf_service']
    regex:         "(.*)/(.*)"
    target_label:  "component"
replacement: "${2}"
```

@brian-brazil 