### PR TITLE
Add the ability to assume a role for ec2 discovery

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1137,6 +1137,7 @@ type EC2SDConfig struct {
 	AccessKey       string         `yaml:"access_key,omitempty"`
 	SecretKey       Secret         `yaml:"secret_key,omitempty"`
 	Profile         string         `yaml:"profile,omitempty"`
+	RoleARN         string         `yaml:"role_arn,omitempty"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
 	Port            int            `yaml:"port"`
 


### PR DESCRIPTION
Adds the option to assume a role during ec2 discovery.  Unlike using a profile this does not require a static set of credentials.

Add the following to your ec2 discovery config if you would like use the feature.
`rolearn: 'arn:aws:iam::account-id:role/role-name'`

@brian-brazil Please let me know if you would like any more information or require any changes.
