### PR TITLE
Convert tsdb.ErrOutOfBounds to a storage error

### DIFF
--- a/retrieval/scrape.go
+++ b/retrieval/scrape.go
@@ -852,7 +852,7 @@ loop:
 		sl.l.With("numDropped", numDuplicates).Warn("Error on ingesting samples with different value but same timestamp")
 	}
 	if numOutOfBounds > 0 {
-		sl.l.With("numOutOfBounds", numOutOfBounds).Warn("Error on ingesting samples that are too old")
+		sl.l.With("numOutOfBounds", numOutOfBounds).Warn("Error on ingesting samples that are too old or are too far into the future")
 	}
 	if err == nil {
 		sl.cache.forEachStale(func(lset labels.Labels) bool {

--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -125,6 +125,8 @@ func (a appender) Add(lset labels.Labels, t int64, v float64) (string, error) {
 		return "", storage.ErrOutOfOrderSample
 	case tsdb.ErrAmendSample:
 		return "", storage.ErrDuplicateSampleForTimestamp
+	case tsdb.ErrOutOfBounds:
+		return "", storage.ErrOutOfBounds
 	}
 	return ref, err
 }
@@ -139,6 +141,8 @@ func (a appender) AddFast(ref string, t int64, v float64) error {
 		return storage.ErrOutOfOrderSample
 	case tsdb.ErrAmendSample:
 		return storage.ErrDuplicateSampleForTimestamp
+	case tsdb.ErrOutOfBounds:
+		return storage.ErrOutOfBounds
 	}
 	return err
 }


### PR DESCRIPTION
storage.Err* cannot be compared to tsdb.Err* as errors.New() returns
pointers

Fixes #2894 for good. Tested on a target which failed previously but now works.

/cc @johrstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/2906)
<!-- Reviewable:end -->
