### PR TITLE
Add formal governance structure

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -100,7 +100,7 @@ Votes may take the form of a single proposal, with the option to vote yes or no;
 
 A vote on a single proposal is considered successful if more vote in favour than against.
 
-A vote on multiple alternatives is considered decided in favour of one alternative if any alternative receives more than half of the total votes cast. Members may vote against all alternatives by voting "no". Should no alternative reach a majority, another vote on a reduced number of options may be called separately.
+If there are multiple alternatives, members may vote for one or more alternative, or vote "no" to object to all alternatives. A vote on multiple alternatives is considered decided in favour of one alternative if it has received the most votes in favour, and a vote from least half of those voting. Should no alternative reach this quorum, another vote on a reduced number of options may be called separately.
 
 ### Supermajority vote
 
@@ -112,7 +112,7 @@ Votes may take the form of a single proposal, with the option to vote yes or no;
 
 A vote on a single proposal is considered successful if at least two thirds of those eligible to vote vote in favour.
 
-A vote on multiple alternatives is considered decided in favour of one alternative if any alternative receives more than two thirds of those eligible to vote vote for it. Members may vote against all alternatives by voting "no". Should no alternative reach a majority, another vote on a reduced number of options may be called separately.
+If there are multiple alternatives, members may vote for one or more alternative, or vote "no" to object to all alternatives. A vote on multiple alternatives is considered decided in favour of one alternative if it has received the most votes in favour, and a vote from least two thirds of those eligible to vote. Should no alternative reach this quorum, another vote on a reduced number of options may be called separately.
 
 ## Releases
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -22,7 +22,7 @@ Each project must have a MAINTAINERS.md file with at least one maintainer. Where
 
 ### Team members 
 
-Team member status is given to those who have made ongoing contributions for at least 3 months to the Prometheus Project. This is usually in the form of code improvements and/or notable work on documentation, but organizing events or user support could also be taken into account. 
+Team member status may be given to those who have made ongoing contributions for at least 3 months to the Prometheus Project. This is usually in the form of code improvements and/or notable work on documentation, but organizing events or user support could also be taken into account. 
 
 New members may be proposed by any existing member by email to [prometheus-team][team] and voted on by [consensus](#consensus). If no consensus is reached, the new member is not accepted.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -62,7 +62,7 @@ Changes to this document are discussed publicly on the [developer mailing mailin
 
 ### Other matters
 
-Any matter that needs a decision, including but not limited to financial matters, may be called to a vote by any member if they deem it necessary. For private or personal matters discussion and voting takes place on the [team mailing list][team], otherwise on the [developer mailing list][devs].
+Any matter that needs a decision, including but not limited to financial matters, may be called to a vote by any member if they deem it necessary. For financial, private or personnel matters discussion and voting takes place on the [team mailing list][team], otherwise on the [developer mailing list][devs].
 
 ## Voting
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,66 +2,157 @@
 
 This document describes the rules and governance of the project. It is meant to be followed by all the developers of the project and the Prometheus community. Common terminology used in this governance document are listed below:
 
-* **Core Developers**: The stewards of the Prometheus community
+* **Team members**: Any members of the private [prometheus-team][team] Google group.
 
-* **Committers**: Developers who have write access to a project
+* **Maintainers**: Team members who are leads on an individual project ([MAINTAINERS.md][maintainers.md]).
 
-* **Maintainers**: Committers who are leads on an individual project (MAINTAINERS.md)
+* **Projects**: Any repository in the Prometheus [GitHub organization][gh].
 
-* **Projects**: Any repository in the Prometheus [GitHub organization](https://github.com/prometheus)
+* **The Prometheus Project**: The sum of all activities performed under this governance, concerning one or more Repositories or the community.
 
 ## Values
 
-The Prometheus developers and community are expected to follow the values defined in the [CNCF charter](https://www.cncf.io/about/charter/), including the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). Furthermore, the Prometheus community strives for kindness, giving feedback effectively and building a welcoming environment. The Prometheus developer community strives to operate by rough consensus for the majority of decisions and only resort to conflict resolution through a motion if consensus cannot be reached.
-
-## Core Developers
-
-As stewards of the project, Core Developers have additional duties beyond that of a maintainer. They are expected to represent the best interests of the project, above any employer or other company/organisational ties. The current Core Developers are:
-
-* Brian Brazil, Fabian Reinartz, Julius Volz
-
-New Core Developers are proposed by Core Developers on the prometheus-team@ mailing list, and voted on using the rules discussed in the voting section below. The current Core Developers are recognized as leaders of the Prometheus project as a whole, through their sustained and significant contributions across the project.
-
-## Core Developer Lead
-
-Core Developers are allowed to elect a Core Developer Lead who serves as the final say in any deadlock situation that can’t be resolved via a vote of the Core Developers or any maintainers. Instead of calling a vote, Core Developers and maintainers may always delegate a decision to the Core Developer Lead. However, if a vote is called, it takes precedence over the decision of the Core Developer Lead.
+The Prometheus developers and community are expected to follow the values defined in the [CNCF charter][charter], including the [CNCF Code of Conduct][coc]. Furthermore, the Prometheus community strives for kindness, giving feedback effectively and building a welcoming environment. The Prometheus developer community strives to operate by rough consensus for the majority of decisions and only resort to conflict resolution through a motion if consensus cannot be reached.
 
 ## Projects
 
 Each project must have a MAINTAINERS.md file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the prometheus-users mailing list. Any new repositories should be first proposed on prometheus-team@ and following the voting procedures listed below. When a repository is no longer relevant, it should be moved to the prometheus-junkyard Github organization.
 
-## Committers and Maintainers
+## Decisionmaking
 
-Committer status (commit bit) is given to those who have made ongoing contributions to a given project. This is usually in the form of code improvements, notable work on documentation, organizing events or user support could also be taken into account. 
+### Team members 
 
-Maintainers are committers who are expected to lead the project and serve as a point of conflict resolution amongst the committers.
+Team member status is given to those who have made ongoing contributions for at least 3 months to the Prometheus Project. This is usually in the form of code improvements and/or notable work on documentation, but organizing events or user support could also be taken into account. 
 
-In order to become a committer or maintainer, an existing maintainer must nominate you on the public prometheus-developers@ mailing list. Once another maintainer (or core developer) seconds and there are no objections within a week, a core developer will add the nominee to the prometheus-team@ mailing list and give appropriate other access rights. If there is an objection which can't be resolved via consensus, a formal [vote](#heading=h.x907eu6orfvp) will occur. A maintainer or committer may resign by notifying the prometheus-team@ mailing list. A maintainer with no project activity for a year will be deemed to have resigned.
+New members may be proposed by any existing member by email to [prometheus-team][team] and voted on by [consensus](#consensus). If no consensus is reached, the new member is not accepted.
+
+Team members are added to the [GitHub organization][gh] and have commit rights to all projects. They should however respect the maintainers of each project.
+
+Team members may retire at any time by emailing [the team][team].
+
+Team members can be removed by [supermajority vote](#supermajority-vote) on [the team mailing list][team]. For this vote, the member in question is not eligible to vote and does not count towards the quorum.
+
+Upon death of a member, their team membership ends automatically.
+
+Unless voted upon otherwise, membership changes take effect immediately. Unless voted upon otherwise, any membership change is announced to [the public developer mailing list][devs] as soon as it is in effect.
+
+### Maintainers
+
+Maintainers are team members who are lead one or more project(s) and serve as a point of conflict resolution amongst the contributors to this project.
+
+A maintainer or committer may resign by notifying the [team mailing list][team]. A maintainer with no project activity for a year is considered to have resigned. Maintainers who wish to resign are encouraged to propose another team member to take over the project.
+
+An extraordinary change of maintainership of any project may be proposed on the [team mailing list][team] and is voted on by [consensus](#consensus). If no consensus can be reached, the matter is resolved by [majority vote](#majority-vote).
+
+A project may have more multiple maintainers, as long as the responsibilities are clearly agreed upon between them. This includes coordinating who handles which issues and pull requests.
+
+Any maintainership change is performed by changing the project's MAINTAINERS.md on the main branch of the repository, and should be announced on the [developers mailing list][devs].
+
+### Technical decisions
+
+Technical decisions that only affect a single project are made informally by the maintainer of this project, and [lazy consensus](#consensus) is assumed.
+
+Technical decisions that span multiple parts of the Prometheus Project are discussed and made on the [Prometheus developer mailing list][devs]. Decisions are usually made by [consensus](#consensus). If no consensus can be reached, the matter may be resolved by [majority vote](#majority-vote).
+
+### New projects
+
+New projects under the Prometheus Project must be proposed to the [developer mailing list][devs] and are subject to [lazy consensus](#consensus).
+
+### Governance changes
+
+Changes to this document are discussed publicly on the [developer mailing mailing list][devs]. Any change requires a [supermajority](#supermajority-vote) in favour.
+
+### Other matters
+
+Any matter that needs a decision, including but not limited to financial matters, may be called to a vote by any member if they deem it necessary. For private or personal matters discussion and voting takes place on the [team mailing list][team], otherwise on the [developer mailing list][devs].
 
 ## Voting
 
-The Prometheus project usually runs by informal consensus, however sometimes a formal decision must be made. All votes MUST be done on the prometheus-developers@ mailing list, and generally at least a week given for discussion between maintainers and for votes to take place. A majority of Core Developers must vote in favor for a vote to pass.
+The Prometheus Project usually runs by informal consensus, however sometimes a formal decision must be made.
 
-Formal votes must happen for the following: major changes to this document or the project structure, financial matters, adding core developers, removing committers or core developers.
+Depending on the subject matter, as laid out in [Decisionmaking](#decisionmaking), different methods of voting are used.
+
+For all votes, voting must be open for at least one week. A vote may be called and closed early if enough votes have come in one way that further votes cannot change the final decision.
+
+In all cases, all and only [team members](#team-members) are eligible to vote, with the sole exception of the forced removal of a team member, in which said member is not eligible to vote.
+
+Discussion and votes on personal matters (including but not limited to team membership and maintainership) are held in private on the [team mailing list][team]. All other discussion and votes are held in public on the [developer mailing list][team].
+
+For public discussions, anyone interested is encouraged to participate. Formal power to object or vote is limited to [team members](#team-members).
+
+### Consensus
+
+The default decision making mechanism for the Prometheus Project is [lazy consensus](https://rave.apache.org/docs/governance/lazyConsensus.html). This means that any decision on technical issues is considered supported by the [team][team] as long as nobody objects.
+
+Silence on any consensus decision is implicit agreement and equivalent to explicit agreement. Explicit agreement may be stated at will. Decisions may, but do not need to be called out and put up for decision on the [developers mailing list][devs] at any time and by anyone.
+
+Consensus decisions can never override or go against the spirit of an earlier explicit vote.
+
+If any [team member](#team-members) raises objections, we work together towards a solution that all involved can accept. This solution is again subject to lazy consensus.
+
+In case no consensus can be found, but a decision one way or the other must be made, any [team member](#team-members) may call a formal [majority vote](#majority-vote).
+
+### Majority vote
+
+Majority votes must be called explicitly in a separate thread on the appropriate mailing list. The subject must be prefixed with `[VOTE]`. In the body, the call to vote must state the proposal being voted on. It should reference any discussion leading up to this point.
+
+Voting must be open for at least 1 week (7 days from the beginning of the vote). The end date should be clearly stated in the call to vote.
+
+Votes may take the form of a single proposal, with the option to vote yes or no; or the form of multiple alternatives.
+
+A vote on a single proposal is considered successful if more vote in favour than against.
+
+A vote on multiple alternatives is considered decided in favour of one alternative if any alternative receives more than half of the total votes cast. Members may vote against all alternatives by voting "no". Should no alternative reach a majority, another vote on a reduced number of options may be called separately.
+
+### Supermajority vote
+
+Supermajority votes must be called explicitly in a separate thread on the appropriate mailing list. The subject must be prefixed with `[VOTE]`. In the body, the call to vote must state the proposal being voted on. It should reference any discussion leading up to this point.
+
+Voting must be open for at least 1 week (7 days from the beginning of the vote). The end date should be clearly stated in the call to vote.
+
+Votes may take the form of a single proposal, with the option to vote yes or no; or the form of multiple alternatives.
+
+A vote on a single proposal is considered successful if at least two thirds of those eligible to vote vote in favour.
+
+A vote on multiple alternatives is considered decided in favour of one alternative if any alternative receives more than two thirds of those eligible to vote vote for it. Members may vote against all alternatives by voting "no". Should no alternative reach a majority, another vote on a reduced number of options may be called separately.
 
 ## Releases
 
-The release process hopes to encourage early, consistent consensus-building during project development. The mechanisms used are regular community communication on the mailing list about progress, scheduled meetings for issue resolution and release triage, and regularly paced and communicated releases. Each project within Prometheus can define their own release process if there’s consensus amongst the maintainers.
+The release process hopes to encourage early, consistent consensus-building during project development. The mechanisms used are regular community communication on the mailing list about progress, scheduled meetings for issue resolution and release triage, and regularly paced and communicated releases. Each project within Prometheus can define their own release process if there is consensus amongst the maintainers.
 
 ## FAQ
 
-**How do I propose a vote?**
+This section is informational. In case of disagreement, the rules above overrule any FAQ.
 
-Send an email to prometheus-dev with your motion. A majority of Core Developers must vote in favor (+1 or LGTM) for a vote to pass.
+### How do I propose a decision?
 
-**How do I add a project or committer?**
+Send an email to [the developer mailing list](devs) with your motion. If there is no objection within a reasonable amount of time, consider the decision made. If there are objections and no consensus can be found, a vote may be called by a team member.
 
-In order to become a committer or maintainer, an existing maintainer must nominate you on the public prometheus-dev@ mailing list. Once another maintainer (or core developer) seconds and there are no objections within a week, a core developer will add the nominee to the prometheus-team@ mailing list and give appropriate other access rights. If there is an objection which can't be resolved via consensus, a formal [vote](#heading=h.x907eu6orfvp) will occur. 
+### How do I become a team member?
 
-**How do I remove a committer or maintainer?**
+To become an official team member, you should make ongoing contributions to one or more project(s) for at least three months. At that point, a team member (typically the maintainer of the project) may propose you for membership. The discussion about this will be held in private, and you will be informed privately when a decision has been made.
 
-A maintainer or committer may resign by notifying the prometheus-team@ mailing list. A maintainer with no project activity for a year will be deemed to have resigned.
+Should the decision be in favour, your new membership will also be announced on the [developers mailing list][devs].
 
-**How do I archive or remove a project?**
+### How do I add a project?
 
-Send an email to prometheus-dev stating that a repository is no longer relevant, then it should be moved to the prometheus-junkyard Github organization.
+As a team member, propose the new project on the [developer mailing list][devs]. If nobody objects, create the project in the Github organization. Add at least a README.md explaining the goal of the project, and a MAINTAINERS.md with the maintainers of the project (at this point, this probably means you).
+
+### How do I archive or remove a project?
+
+Send an email to the [developer mailing list][devs] proposing the retirement of a repository. If nobody objects, move it to the prometheus-junkyard Github organization.
+
+### How do I remove an inactive maintainer?
+
+A maintainer may resign by notifying the [team mailing list][team]. A maintainer with no project activity for a year will be treated as if they had resigned. If there is an urgent need to replace a maintainer, discuss this on the [team mailing list][team].
+
+### How do I remove a team member?
+
+Team members may resign by notifying the [team mailing list][team]. If you think a team member should be removed against their will, propose this to the [team mailing list][team]. Discussions will be held there in private.
+
+[team]: https://groups.google.com/forum/#!forum/prometheus-team
+[gh]: https://github.com/prometheus
+[devs]: https://groups.google.com/forum/#!forum/prometheus-developers
+[maintainers.md]: https://github.com/search?l=&q=org%3Aprometheus+filename%3AMAINTAINERS.md&ref=advsearch&type=Code&utf8=%E2%9C%93
+[charter]: https://www.cncf.io/about/charter/
+[coc]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -44,7 +44,7 @@ Maintainers are team members who are lead one or more project(s) and serve as a 
 
 A maintainer or committer may resign by notifying the [team mailing list][team]. A maintainer with no project activity for a year is considered to have resigned. Maintainers who wish to resign are encouraged to propose another team member to take over the project.
 
-An extraordinary change of maintainership of any project may be proposed on the [team mailing list][team] and is voted on by [consensus](#consensus). If no consensus can be reached, the matter is resolved by [majority vote](#majority-vote).
+An extraordinary change of maintainership of any project may be proposed on the [team mailing list][team] and is voted on by [majority vote](#majority-vote).
 
 A project may have more multiple maintainers, as long as the responsibilities are clearly agreed upon between them. This includes coordinating who handles which issues and pull requests.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -114,10 +114,6 @@ A vote on a single proposal is considered successful if at least two thirds of t
 
 If there are multiple alternatives, members may vote for one or more alternative, or vote "no" to object to all alternatives. A vote on multiple alternatives is considered decided in favour of one alternative if it has received the most votes in favour, and a vote from least two thirds of those eligible to vote. Should no alternative reach this quorum, another vote on a reduced number of options may be called separately.
 
-## Releases
-
-The release process hopes to encourage early, consistent consensus-building during project development. The mechanisms used are regular community communication on the mailing list about progress, scheduled meetings for issue resolution and release triage, and regularly paced and communicated releases. Each project within Prometheus can define their own release process if there is consensus amongst the maintainers.
-
 ## FAQ
 
 This section is informational. In case of disagreement, the rules above overrule any FAQ.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,7 +12,7 @@ This document describes the rules and governance of the project. It is meant to 
 
 ## Values
 
-The Prometheus developers and community are expected to follow the values defined in the [CNCF charter][charter], including the [CNCF Code of Conduct][coc]. Furthermore, the Prometheus community strives for kindness, giving feedback effectively and building a welcoming environment. The Prometheus developer community strives to operate by rough consensus for the majority of decisions and only resort to conflict resolution through a motion if consensus cannot be reached.
+The Prometheus developers and community are expected to follow the values defined in the [CNCF charter][charter], including the [CNCF Code of Conduct][coc]. Furthermore, the Prometheus community strives for kindness, giving feedback effectively, and building a welcoming environment. The Prometheus developer community strives to operate by rough consensus for the majority of decisions and only resort to conflict resolution through a motion if consensus cannot be reached.
 
 ## Projects
 
@@ -24,9 +24,9 @@ Each project must have a MAINTAINERS.md file with at least one maintainer. Where
 
 Team member status may be given to those who have made ongoing contributions for at least 3 months to the Prometheus Project. This is usually in the form of code improvements and/or notable work on documentation, but organizing events or user support could also be taken into account. 
 
-New members may be proposed by any existing member by email to [prometheus-team][team] and voted on by [lazy consensus](#consensus). If no consensus is reached, the new member is not accepted.
+New members may be proposed by any existing member by email to [prometheus-team][team]. It is highly desired to reach consensus about acceptance of a new member. However, the proposal is ultimately voted on by a formal [supermajority vote](#supermajority-vote).
 
-Team members are added to the [GitHub organization][gh] and have commit rights to all projects. They should however respect the maintainers of each project.
+Team members are added to the [GitHub organization][gh] as _Owner_. They should however respect the maintainers of each project.
 
 Team members may retire at any time by emailing [the team][team].
 
@@ -40,11 +40,13 @@ A public list of team members is kept on the [community page][community] or link
 
 ### Maintainers
 
-Maintainers are team members who lead one or more project(s) and serve as a point of conflict resolution amongst the contributors to this project.
+Maintainers lead one or more project(s) or parts thereof and serve as a point of conflict resolution amongst the contributors to this project. Ideally, maintainers are also team members, but exceptions are possible for suitable maintainers that, for whatever reason, are not or not yet team members.
+
+Changes in maintainership have to be announced on the [developers mailing list][devs]. They are decided by [lazy consensus](#consensus) and formalized by changing the `MAINTAINERS.md` file of the respective repository.
+
+Maintainers are granted commit rights to all projects in the [GitHub organization][gh].
 
 A maintainer or committer may resign by notifying the [team mailing list][team]. A maintainer with no project activity for a year is considered to have resigned. Maintainers who wish to resign are encouraged to propose another team member to take over the project.
-
-An extraordinary change of maintainership of any project may be proposed on the [team mailing list][team] and is voted on by [majority vote](#majority-vote).
 
 A project may have multiple maintainers, as long as the responsibilities are clearly agreed upon between them. This includes coordinating who handles which issues and pull requests.
 
@@ -58,11 +60,11 @@ Technical decisions that span multiple parts of the Prometheus Project can be di
 
 ### Governance changes
 
-Material changes to this document are discussed publicly on the [developer mailing mailing list][devs]. Any change requires a [supermajority](#supermajority-vote) in favour. Editorial changes may be made by [lazy consensus](#consensus) unless challenged.
+Material changes to this document are discussed publicly on the [developer mailing mailing list][devs]. Any change requires a [supermajority](#supermajority-vote) in favor. Editorial changes may be made by [lazy consensus](#consensus) unless challenged.
 
 ### Other matters
 
-Any matter that needs a decision, including but not limited to financial matters, may be called to a vote by any member if they deem it necessary. For financial, private or personnel matters discussion and voting takes place on the [team mailing list][team], otherwise on the [developer mailing list][devs].
+Any matter that needs a decision, including but not limited to financial matters, may be called to a vote by any member if they deem it necessary. For financial, private, or personnel matters, discussion and voting takes place on the [team mailing list][team], otherwise on the [developer mailing list][devs].
 
 ## Voting
 
@@ -96,9 +98,9 @@ Majority votes must be called explicitly in a separate thread on the appropriate
 
 Votes may take the form of a single proposal, with the option to vote yes or no; or the form of multiple alternatives.
 
-A vote on a single proposal is considered successful if more vote in favour than against.
+A vote on a single proposal is considered successful if more vote in favor than against.
 
-If there are multiple alternatives, members may vote for one or more alternative, or vote "no" to object to all alternatives. A vote on multiple alternatives is considered decided in favour of one alternative if it has received the most votes in favour, and a vote from least half of those voting. Should no alternative reach this quorum, another vote on a reduced number of options may be called separately.
+If there are multiple alternatives, members may vote for one or more alternative, or vote “no” to object to all alternatives. It is not possible to cast an “abstain” vote. A vote on multiple alternatives is considered decided in favor of one alternative if it has received the most votes in favor, and a vote from more than half of those voting. Should no alternative reach this quorum, another vote on a reduced number of options may be called separately.
 
 ### Supermajority vote
 
@@ -106,9 +108,9 @@ Supermajority votes must be called explicitly in a separate thread on the approp
 
 Votes may take the form of a single proposal, with the option to vote yes or no; or the form of multiple alternatives.
 
-A vote on a single proposal is considered successful if at least two thirds of those eligible to vote vote in favour.
+A vote on a single proposal is considered successful if at least two thirds of those eligible to vote vote in favor.
 
-If there are multiple alternatives, members may vote for one or more alternative, or vote "no" to object to all alternatives. A vote on multiple alternatives is considered decided in favour of one alternative if it has received the most votes in favour, and a vote from least two thirds of those eligible to vote. Should no alternative reach this quorum, another vote on a reduced number of options may be called separately.
+If there are multiple alternatives, members may vote for one or more alternative, or vote “no” to object to all alternatives. A vote on multiple alternatives is considered decided in favor of one alternative if it has received the most votes in favor, and a vote from at least two thirds of those eligible to vote. Should no alternative reach this quorum, another vote on a reduced number of options may be called separately.
 
 ## FAQ
 
@@ -120,9 +122,9 @@ Send an email to [the developer mailing list](devs) with your motion. If there i
 
 ### How do I become a team member?
 
-To become an official team member, you should make ongoing contributions to one or more project(s) for at least three months. At that point, a team member (typically a maintainer of the project) may propose you for membership. The discussion about this will be held in private, and you will be informed privately when a decision has been made.
+To become an official team member, you should make ongoing contributions to one or more project(s) for at least three months. At that point, a team member (typically a maintainer of the project) may propose you for membership. The discussion about this will be held in private, and you will be informed privately when a decision has been made. A possible, but not required, graduation path is to become a maintainer first.
 
-Should the decision be in favour, your new membership will also be announced on the [developers mailing list][devs].
+Should the decision be in favor, your new membership will also be announced on the [developers mailing list][devs].
 
 ### How do I add a project?
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,7 +34,7 @@ Team members can be removed by [supermajority vote](#supermajority-vote) on [the
 
 Upon death of a member, their team membership ends automatically.
 
-Unless voted upon otherwise, membership changes take effect immediately. Unless voted upon otherwise, any membership change is announced to [the public developer mailing list][devs] as soon as it is in effect.
+Unless voted upon otherwise, membership changes take effect immediately.
 
 ### Maintainers
 
@@ -46,7 +46,7 @@ An extraordinary change of maintainership of any project may be proposed on the 
 
 A project may have more multiple maintainers, as long as the responsibilities are clearly agreed upon between them. This includes coordinating who handles which issues and pull requests.
 
-Any maintainership change is performed by changing the project's MAINTAINERS.md on the main branch of the repository, and should be announced on the [developers mailing list][devs].
+Any maintainership change is performed by changing the project's MAINTAINERS.md on the main branch of the repository.
 
 ### Technical decisions
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -154,5 +154,5 @@ Team members may resign by notifying the [team mailing list][team]. If you think
 [maintainers.md]: https://github.com/search?l=&q=org%3Aprometheus+filename%3AMAINTAINERS.md&ref=advsearch&type=Code&utf8=%E2%9C%93
 [charter]: https://www.cncf.io/about/charter/
 [coc]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
-[lazy]: https://rave.apache.org/docs/governance/lazyConsensus.html
+[lazy]: https://couchdb.apache.org/bylaws.html#lazy
 [community]: https://prometheus.io/community/

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -36,6 +36,8 @@ Upon death of a member, their team membership ends automatically.
 
 Unless voted upon otherwise, membership changes take effect immediately.
 
+A public list of team members is kept on the [community page][community] or linked from it.
+
 ### Maintainers
 
 Maintainers are team members who are lead one or more project(s) and serve as a point of conflict resolution amongst the contributors to this project.
@@ -157,3 +159,4 @@ Team members may resign by notifying the [team mailing list][team]. If you think
 [charter]: https://www.cncf.io/about/charter/
 [coc]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
 [lazy]: https://rave.apache.org/docs/governance/lazyConsensus.html
+[community]: https://prometheus.io/community/

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,7 +16,7 @@ The Prometheus developers and community are expected to follow the values define
 
 ## Projects
 
-Each project must have a MAINTAINERS.md file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the prometheus-users mailing list. Any new repositories should be first proposed on prometheus-team@ and following the voting procedures listed below. When a repository is no longer relevant, it should be moved to the prometheus-junkyard Github organization.
+Each project must have a MAINTAINERS.md file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the prometheus-users mailing list. Any new repositories should be first proposed on the [developers mailing list][devs] and following the voting procedures listed below. When a repository is no longer relevant, it should be moved to the prometheus-junkyard Github organization.
 
 ## Decisionmaking
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -24,7 +24,7 @@ Each project must have a MAINTAINERS.md file with at least one maintainer. Where
 
 Team member status may be given to those who have made ongoing contributions for at least 3 months to the Prometheus Project. This is usually in the form of code improvements and/or notable work on documentation, but organizing events or user support could also be taken into account. 
 
-New members may be proposed by any existing member by email to [prometheus-team][team] and voted on by [consensus](#consensus). If no consensus is reached, the new member is not accepted.
+New members may be proposed by any existing member by email to [prometheus-team][team] and voted on by [lazy consensus](#consensus). If no consensus is reached, the new member is not accepted.
 
 Team members are added to the [GitHub organization][gh] and have commit rights to all projects. They should however respect the maintainers of each project.
 
@@ -40,7 +40,7 @@ A public list of team members is kept on the [community page][community] or link
 
 ### Maintainers
 
-Maintainers are team members who are lead one or more project(s) and serve as a point of conflict resolution amongst the contributors to this project.
+Maintainers are team members who lead one or more project(s) and serve as a point of conflict resolution amongst the contributors to this project.
 
 A maintainer or committer may resign by notifying the [team mailing list][team]. A maintainer with no project activity for a year is considered to have resigned. Maintainers who wish to resign are encouraged to propose another team member to take over the project.
 
@@ -54,7 +54,7 @@ Any maintainership change is performed by changing the project's MAINTAINERS.md 
 
 Technical decisions that only affect a single project are made informally by the maintainer of this project, and [lazy consensus](#consensus) is assumed.
 
-Technical decisions that span multiple parts of the Prometheus Project are discussed and made on the [Prometheus developer mailing list][devs]. Decisions are usually made by [consensus](#consensus). If no consensus can be reached, the matter may be resolved by [majority vote](#majority-vote).
+Technical decisions that span multiple parts of the Prometheus Project are discussed and made on the [Prometheus developer mailing list][devs]. Decisions are usually made by [lazy consensus](#consensus). If no consensus can be reached, the matter may be resolved by [majority vote](#majority-vote).
 
 ### Governance changes
 
@@ -74,7 +74,7 @@ For all votes, voting must be open for at least one week. A vote may be called a
 
 In all cases, all and only [team members](#team-members) are eligible to vote, with the sole exception of the forced removal of a team member, in which said member is not eligible to vote.
 
-Discussion and votes on personal matters (including but not limited to team membership and maintainership) are held in private on the [team mailing list][team]. All other discussion and votes are held in public on the [developer mailing list][team].
+Discussion and votes on personal matters (including but not limited to team membership and maintainership) are held in private on the [team mailing list][team]. All other discussion and votes are held in public on the [developer mailing list][devs].
 
 For public discussions, anyone interested is encouraged to participate. Formal power to object or vote is limited to [team members](#team-members).
 
@@ -124,7 +124,7 @@ Send an email to [the developer mailing list](devs) with your motion. If there i
 
 ### How do I become a team member?
 
-To become an official team member, you should make ongoing contributions to one or more project(s) for at least three months. At that point, a team member (typically the maintainer of the project) may propose you for membership. The discussion about this will be held in private, and you will be informed privately when a decision has been made.
+To become an official team member, you should make ongoing contributions to one or more project(s) for at least three months. At that point, a team member (typically a maintainer of the project) may propose you for membership. The discussion about this will be held in private, and you will be informed privately when a decision has been made.
 
 Should the decision be in favour, your new membership will also be announced on the [developers mailing list][devs].
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,9 +16,9 @@ The Prometheus developers and community are expected to follow the values define
 
 ## Projects
 
-Each project must have a MAINTAINERS.md file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the prometheus-users mailing list. Any new repositories should be first proposed on the [developers mailing list][devs] and following the voting procedures listed below. When a repository is no longer relevant, it should be moved to the prometheus-junkyard Github organization.
+Each project must have a MAINTAINERS.md file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the prometheus-users mailing list. Any new projects should be first proposed on the [developers mailing list][devs] following the voting procedures listed below. When a project is no longer relevant, it should be moved to the prometheus-junkyard Github organization.
 
-## Decisionmaking
+## Decision Making
 
 ### Team members 
 
@@ -48,17 +48,13 @@ An extraordinary change of maintainership of any project may be proposed on the 
 
 A project may have more multiple maintainers, as long as the responsibilities are clearly agreed upon between them. This includes coordinating who handles which issues and pull requests.
 
-Any maintainership change is performed by changing the project's MAINTAINERS.md on the main branch of the repository.
+Any maintainership change is performed by changing the project's MAINTAINERS.md on the main branch of the project.
 
 ### Technical decisions
 
 Technical decisions that only affect a single project are made informally by the maintainer of this project, and [lazy consensus](#consensus) is assumed.
 
 Technical decisions that span multiple parts of the Prometheus Project are discussed and made on the [Prometheus developer mailing list][devs]. Decisions are usually made by [consensus](#consensus). If no consensus can be reached, the matter may be resolved by [majority vote](#majority-vote).
-
-### New projects
-
-New projects under the Prometheus Project must be proposed to the [developer mailing list][devs] and are subject to [lazy consensus](#consensus).
 
 ### Governance changes
 
@@ -72,7 +68,7 @@ Any matter that needs a decision, including but not limited to financial matters
 
 The Prometheus Project usually runs by informal consensus, however sometimes a formal decision must be made.
 
-Depending on the subject matter, as laid out in [Decisionmaking](#decisionmaking), different methods of voting are used.
+Depending on the subject matter, as laid out in [Decision Making](#decision-making), different methods of voting are used.
 
 For all votes, voting must be open for at least one week. A vote may be called and closed early if enough votes have come in one way that further votes cannot change the final decision.
 
@@ -142,7 +138,7 @@ As a team member, propose the new project on the [developer mailing list][devs].
 
 ### How do I archive or remove a project?
 
-Send an email to the [developer mailing list][devs] proposing the retirement of a repository. If nobody objects, move it to the prometheus-junkyard Github organization.
+Send an email to the [developer mailing list][devs] proposing the retirement of a project. If nobody objects, move it to the prometheus-junkyard Github organization.
 
 ### How do I remove an inactive maintainer?
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -70,7 +70,7 @@ The Prometheus Project usually runs by informal consensus, however sometimes a f
 
 Depending on the subject matter, as laid out [above](#decision-making), different methods of voting are used.
 
-For all votes, voting must be open for at least one week. A vote may be called and closed early if enough votes have come in one way that further votes cannot change the final decision.
+For all votes, voting must be open for at least one week. The end date should be clearly stated in the call to vote. A vote may be called and closed early if enough votes have come in one way that further votes cannot change the final decision.
 
 In all cases, all and only [team members](#team-members) are eligible to vote, with the sole exception of the forced removal of a team member, in which said member is not eligible to vote.
 
@@ -94,8 +94,6 @@ In case no consensus can be found, but a decision one way or the other must be m
 
 Majority votes must be called explicitly in a separate thread on the appropriate mailing list. The subject must be prefixed with `[VOTE]`. In the body, the call to vote must state the proposal being voted on. It should reference any discussion leading up to this point.
 
-Voting must be open for at least 1 week (7 days from the beginning of the vote). The end date should be clearly stated in the call to vote.
-
 Votes may take the form of a single proposal, with the option to vote yes or no; or the form of multiple alternatives.
 
 A vote on a single proposal is considered successful if more vote in favour than against.
@@ -105,8 +103,6 @@ If there are multiple alternatives, members may vote for one or more alternative
 ### Supermajority vote
 
 Supermajority votes must be called explicitly in a separate thread on the appropriate mailing list. The subject must be prefixed with `[VOTE]`. In the body, the call to vote must state the proposal being voted on. It should reference any discussion leading up to this point.
-
-Voting must be open for at least 1 week (7 days from the beginning of the vote). The end date should be clearly stated in the call to vote.
 
 Votes may take the form of a single proposal, with the option to vote yes or no; or the form of multiple alternatives.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -22,7 +22,7 @@ Each project must have a MAINTAINERS.md file with at least one maintainer. Where
 
 ### Team members 
 
-Team member status may be given to those who have made ongoing contributions for at least 3 months to the Prometheus Project. This is usually in the form of code improvements, but work on documentation, organizing events, or user support could also be taken into account. 
+Team member status may be given to those who have made ongoing contributions for at least 3 months to the Prometheus Project. This is usually in the form of code improvements and/or notable work on documentation, but organizing events or user support could also be taken into account. 
 
 New members may be proposed by any existing member by email to [prometheus-team][team] and voted on by [lazy consensus](#consensus). If no consensus is reached, the new member is not accepted.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -18,7 +18,7 @@ The Prometheus developers and community are expected to follow the values define
 
 Each project must have a MAINTAINERS.md file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the prometheus-users mailing list. Any new projects should be first proposed on the [developers mailing list][devs] following the voting procedures listed below. When a project is no longer relevant, it should be moved to the prometheus-junkyard Github organization.
 
-## Decision Making
+## Decision making
 
 ### Team members 
 
@@ -68,7 +68,7 @@ Any matter that needs a decision, including but not limited to financial matters
 
 The Prometheus Project usually runs by informal consensus, however sometimes a formal decision must be made.
 
-Depending on the subject matter, as laid out in [Decision Making](#decision-making), different methods of voting are used.
+Depending on the subject matter, as laid out [above](#decision-making), different methods of voting are used.
 
 For all votes, voting must be open for at least one week. A vote may be called and closed early if enough votes have come in one way that further votes cannot change the final decision.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -46,7 +46,7 @@ A maintainer or committer may resign by notifying the [team mailing list][team].
 
 An extraordinary change of maintainership of any project may be proposed on the [team mailing list][team] and is voted on by [majority vote](#majority-vote).
 
-A project may have more multiple maintainers, as long as the responsibilities are clearly agreed upon between them. This includes coordinating who handles which issues and pull requests.
+A project may have multiple maintainers, as long as the responsibilities are clearly agreed upon between them. This includes coordinating who handles which issues and pull requests.
 
 Any maintainership change is performed by changing the project's MAINTAINERS.md on the main branch of the project.
 
@@ -74,7 +74,7 @@ For all votes, voting must be open for at least one week. A vote may be called a
 
 In all cases, all and only [team members](#team-members) are eligible to vote, with the sole exception of the forced removal of a team member, in which said member is not eligible to vote.
 
-Discussion and votes on personal matters (including but not limited to team membership and maintainership) are held in private on the [team mailing list][team]. All other discussion and votes are held in public on the [developer mailing list][devs].
+Discussion and votes on personnel matters (including but not limited to team membership and maintainership) are held in private on the [team mailing list][team]. All other discussion and votes are held in public on the [developer mailing list][devs].
 
 For public discussions, anyone interested is encouraged to participate. Formal power to object or vote is limited to [team members](#team-members).
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -82,7 +82,7 @@ For public discussions, anyone interested is encouraged to participate. Formal p
 
 ### Consensus
 
-The default decision making mechanism for the Prometheus Project is [lazy consensus](https://rave.apache.org/docs/governance/lazyConsensus.html). This means that any decision on technical issues is considered supported by the [team][team] as long as nobody objects.
+The default decision making mechanism for the Prometheus Project is [lazy consensus][lazy]. This means that any decision on technical issues is considered supported by the [team][team] as long as nobody objects.
 
 Silence on any consensus decision is implicit agreement and equivalent to explicit agreement. Explicit agreement may be stated at will. Decisions may, but do not need to be called out and put up for decision on the [developers mailing list][devs] at any time and by anyone.
 
@@ -156,3 +156,4 @@ Team members may resign by notifying the [team mailing list][team]. If you think
 [maintainers.md]: https://github.com/search?l=&q=org%3Aprometheus+filename%3AMAINTAINERS.md&ref=advsearch&type=Code&utf8=%E2%9C%93
 [charter]: https://www.cncf.io/about/charter/
 [coc]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
+[lazy]: https://rave.apache.org/docs/governance/lazyConsensus.html

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,7 +4,7 @@ This document describes the rules and governance of the project. It is meant to 
 
 * **Team members**: Any members of the private [prometheus-team][team] Google group.
 
-* **Maintainers**: Team members who are leads on an individual project ([MAINTAINERS.md][maintainers.md]).
+* **Maintainers**: Maintainers lead an individual project or parts thereof ([MAINTAINERS.md][maintainers.md]).
 
 * **Projects**: Any repository in the Prometheus [GitHub organization][gh].
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -22,7 +22,7 @@ Each project must have a MAINTAINERS.md file with at least one maintainer. Where
 
 ### Team members 
 
-Team member status may be given to those who have made ongoing contributions for at least 3 months to the Prometheus Project. This is usually in the form of code improvements and/or notable work on documentation, but organizing events or user support could also be taken into account. 
+Team member status may be given to those who have made ongoing contributions for at least 3 months to the Prometheus Project. This is usually in the form of code improvements, but work on documentation, organizing events, or user support could also be taken into account. 
 
 New members may be proposed by any existing member by email to [prometheus-team][team] and voted on by [lazy consensus](#consensus). If no consensus is reached, the new member is not accepted.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -58,7 +58,7 @@ Technical decisions that span multiple parts of the Prometheus Project are discu
 
 ### Governance changes
 
-Changes to this document are discussed publicly on the [developer mailing mailing list][devs]. Any change requires a [supermajority](#supermajority-vote) in favour.
+Material changes to this document are discussed publicly on the [developer mailing mailing list][devs]. Any change requires a [supermajority](#supermajority-vote) in favour. Editorial changes may be made by [lazy consensus](#consensus) unless challenged.
 
 ### Other matters
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,67 @@
+# Prometheus Governance v1.0
+
+This document describes the rules and governance of the project. It is meant to be followed by all the developers of the project and the Prometheus community. Common terminology used in this governance document are listed below:
+
+* **Core Developers**: The stewards of the Prometheus community
+
+* **Committers**: Developers who have write access to a project
+
+* **Maintainers**: Committers who are leads on an individual project (MAINTAINERS.md)
+
+* **Projects**: Any repository in the Prometheus GitHub organization
+
+## Values
+
+The Prometheus developers and community are expected to follow the values defined in the CNCF [charter](https://www.cncf.io/about/charter/), including the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). Furthermore, the Prometheus community strives for kindness, giving feedback effectively and building a welcoming environment.The Prometheus developer community also strives to operate by rough consensus for the majority of decisions and only resort to conflict resolution through a motion if consensus can’t be reached.
+
+## Core Developers
+
+As stewards of the project, Core Developers have additional duties beyond that of a maintainer. They are expected to represent the best interests of the project, above any employer or other company/organisational ties. The current Core Developers are:
+
+* Brian Brazil, Fabian Reinartz, Julius Volz
+
+New Core Developers are proposed by Core Developers on the prometheus-team@ mailing list, and voted on using the rules discussed in the voting section below. The current Core Developers are recognized as leaders of the Prometheus project as a whole, through their sustained and significant contributions across the project.
+
+## Core Developer Lead
+
+Core Developers are allowed to elect a Core Developer Lead who serves as the final say in any deadlock situation that can’t be resolved via a vote of the Core Developers or any maintainers. Instead of calling a vote, Core Developers and maintainers may always delegate a decision to the Core Developer Lead. However, if a vote is called, it takes precedence over the decision of the Core Developer Lead.
+
+## Projects
+
+Each project must have a MAINTAINERS.md file with at least one maintainer. Where a project has a release process, access and documentation should be such that more than one person can perform a release. Releases should be announced on the prometheus-users mailing list. Any new repositories should be first proposed on prometheus-team@ and following the voting procedures listed below. When a repository is no longer relevant, it should be moved to the prometheus-junkyard Github organization.
+
+## Committers and Maintainers
+
+Committer status (commit bit) is given to those who have made ongoing contributions to a given project. This is usually in the form of code improvements, notable work on documentation, organizing events or user support could also be taken into account. 
+
+Maintainers are committers who are expected to lead the project and serve as a point of conflict resolution amongst the committers.
+
+In order to become a committer or maintainer, an existing maintainer must nominate you on the public prometheus-developers@ mailing list. Once another maintainer (or core developer) seconds and there are no objections within a week, a core developer will add the nominee to the prometheus-team@ mailing list and give appropriate other access rights. If there is an objection which can't be resolved via consensus, a formal [vote](#heading=h.x907eu6orfvp) will occur. A maintainer or committer may resign by notifying the prometheus-team@ mailing list. A maintainer with no project activity for a year will be deemed to have resigned.
+
+## Voting
+
+The Prometheus project usually runs by informal consensus, however sometimes a formal decision must be made. All votes MUST be done on the prometheus-developers@ mailing list, and generally at least a week given for discussion between maintainers and for votes to take place. A majority of Core Developers must vote in favor for a vote to pass.
+
+Formal votes must happen for the following: major changes to this document or the project structure, financial matters, adding core developers, removing committers or core developers.
+
+## Releases
+
+The release process hopes to encourage early, consistent consensus-building during project development. The mechanisms used are regular community communication on the mailing list about progress, scheduled meetings for issue resolution and release triage, and regularly paced and communicated releases. Each project within Prometheus can define their own release process if there’s consensus amongst the maintainers.
+
+## FAQ
+
+**How do I propose a vote?**
+
+Send an email to prometheus-dev with your motion. A majority of Core Developers must vote in favor (+1 or LGTM) for a vote to pass.
+
+**How do I add a project or committer?**
+
+In order to become a committer or maintainer, an existing maintainer must nominate you on the public prometheus-dev@ mailing list. Once another maintainer (or core developer) seconds and there are no objections within a week, a core developer will add the nominee to the prometheus-team@ mailing list and give appropriate other access rights. If there is an objection which can't be resolved via consensus, a formal [vote](#heading=h.x907eu6orfvp) will occur. 
+
+**How do I remove a committer or maintainer?**
+
+A maintainer or committer may resign by notifying the prometheus-team@ mailing list. A maintainer with no project activity for a year will be deemed to have resigned.
+
+**How do I archive or remove a project?**
+
+Send an email to prometheus-dev stating that a repository is no longer relevant, then it should be moved to the prometheus-junkyard Github organization.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -54,7 +54,7 @@ Any maintainership change is performed by changing the project's MAINTAINERS.md 
 
 Technical decisions that only affect a single project are made informally by the maintainer of this project, and [lazy consensus](#consensus) is assumed.
 
-Technical decisions that span multiple parts of the Prometheus Project are discussed and made on the [Prometheus developer mailing list][devs]. Decisions are usually made by [lazy consensus](#consensus). If no consensus can be reached, the matter may be resolved by [majority vote](#majority-vote).
+Technical decisions that span multiple parts of the Prometheus Project can be discussed and made on the [Prometheus developer mailing list][devs]. Decisions are usually made by [lazy consensus](#consensus). If no consensus can be reached, the matter may be resolved by [majority vote](#majority-vote).
 
 ### Governance changes
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,11 +8,11 @@ This document describes the rules and governance of the project. It is meant to 
 
 * **Maintainers**: Committers who are leads on an individual project (MAINTAINERS.md)
 
-* **Projects**: Any repository in the Prometheus GitHub organization
+* **Projects**: Any repository in the Prometheus [GitHub organization](https://github.com/prometheus)
 
 ## Values
 
-The Prometheus developers and community are expected to follow the values defined in the CNCF [charter](https://www.cncf.io/about/charter/), including the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). Furthermore, the Prometheus community strives for kindness, giving feedback effectively and building a welcoming environment.The Prometheus developer community also strives to operate by rough consensus for the majority of decisions and only resort to conflict resolution through a motion if consensus can’t be reached.
+The Prometheus developers and community are expected to follow the values defined in the [CNCF charter](https://www.cncf.io/about/charter/), including the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). Furthermore, the Prometheus community strives for kindness, giving feedback effectively and building a welcoming environment. The Prometheus developer community strives to operate by rough consensus for the majority of decisions and only resort to conflict resolution through a motion if consensus cannot be reached.
 
 ## Core Developers
 


### PR DESCRIPTION
Per the formal CNCF graduation criteria (https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc) projects are expected to have a governance structured documented. Here's a stab at the governance after months of discussion with the core prometheus team.

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>