### PR TITLE
Allow web.external-url to be relative

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -333,10 +333,6 @@ func parsePrometheusURL() error {
 		cfg.prometheusURL = fmt.Sprintf("http://%s:%s/", hostname, port)
 	}
 
-	if ok := govalidator.IsURL(cfg.prometheusURL); !ok {
-		return fmt.Errorf("invalid Prometheus URL: %s", cfg.prometheusURL)
-	}
-
 	promURL, err := url.Parse(cfg.prometheusURL)
 	if err != nil {
 		return err


### PR DESCRIPTION
This closes #1583 
This is all that is needed to make prometheus work well with the kubernetes apiserver proxy: If set to the proxy endpoint (`/api/v1/namespaces/default/services/prometheus/proxy/`), the apiserver won't prefix the path as it does when the external url is absolute.