### PR TITLE
Use timestamp of a sample in deriv() to avoid FP issues

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -678,7 +678,10 @@ func funcDeriv(ev *evaluator, args Expressions) model.Value {
 		if len(samples.Values) < 2 {
 			continue
 		}
-		slope, _ := linearRegression(samples.Values, 0)
+		// We pass in an arbitrary timestamp that is near the values in use
+		// to avoid floating point accuracy issues, see
+		// https://github.com/prometheus/prometheus/issues/2674
+		slope, _ := linearRegression(samples.Values, samples.Values[0].Timestamp)
 		resultSample := &sample{
 			Metric:    samples.Metric,
 			Value:     slope,


### PR DESCRIPTION
With the squaring of the timestamp, we run into the
precision limitations of the 53bit mantissa for a 64bit float.

By subtracting away a timestamp of one of the samples (which is how the
intercept is used) we avoid this issue in practice as it's unlikely
that it is used over a very long time range.

Fixes #2674

@marcan