### PR TITLE
Integrate tsdb with main logger, indicate components

### DIFF
--- a/util/testutil/storage.go
+++ b/util/testutil/storage.go
@@ -36,7 +36,7 @@ func NewStorage(t T) storage.Storage {
 
 	// Tests just load data for a series sequentially. Thus we
 	// need a long appendable window.
-	db, err := tsdb.Open(dir, nil, &tsdb.Options{
+	db, err := tsdb.Open(dir, nil, nil, &tsdb.Options{
 		MinBlockDuration: model.Duration(24 * time.Hour),
 		MaxBlockDuration: model.Duration(24 * time.Hour),
 	})


### PR DESCRIPTION
I was annoyed tonight (again) that the TSDB logged in a different way than the rest of Prometheus, so I was curious to see what an integration with the main logger would look like. And yeah, it was more complicated than I thought due to the wildly incompatible interfaces of logrus and go-kit for logging :)

I don't have any context on this, nor does there seem to be an issue about it yet, so this is kind of a stab in the dark. Not sure if @fabxc has a totally different vision for this, so maybe best to let him judge when he's back.

In general, I hope we intend to keep logrus, as its colors and format are so nice (especially when testing or during workshops, errors are spotted easily). I realize that the colors go away when not logging to a terminal, but still...

Another question (happy to separate out) is whether we want to add a `component` key to all the sub loggers, as I did here.