### PR TITLE
Additional targetScrapeSample metrics

### DIFF
--- a/retrieval/scrape.go
+++ b/retrieval/scrape.go
@@ -86,6 +86,24 @@ var (
 			Help: "Total number of scrapes that hit the sample limit and were rejected.",
 		},
 	)
+	targetScrapeSampleDuplicate = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "prometheus_target_scrapes_sample_duplicate_timestamp_total",
+			Help: "Total number of samples ingested with different values but the same timestamp",
+		},
+	)
+	targetScrapeSampleOutOfOrder = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "prometheus_target_scrapes_sample_out_of_order_total",
+			Help: "Total number of samples ingested out of the expected order",
+		},
+	)
+	targetScrapeSampleOutOfBounds = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "prometheus_target_scrapes_sample_out_of_bounds_total",
+			Help: "Total number of samples ingested out of bounds",
+		},
+	)
 )
 
 func init() {
@@ -94,6 +112,9 @@ func init() {
 	prometheus.MustRegister(targetSyncIntervalLength)
 	prometheus.MustRegister(targetScrapePoolSyncsCounter)
 	prometheus.MustRegister(targetScrapeSampleLimit)
+	prometheus.MustRegister(targetScrapeSampleDuplicate)
+	prometheus.MustRegister(targetScrapeSampleOutOfOrder)
+	prometheus.MustRegister(targetScrapeSampleOutOfBounds)
 }
 
 // scrapePool manages scrapes for sets of targets.
@@ -770,6 +791,7 @@ loop:
 			case storage.ErrDuplicateSampleForTimestamp:
 				numDuplicates++
 				sl.l.With("timeseries", string(met)).Debug("Duplicate sample for timestamp")
+				targetScrapeSampleDuplicate.Inc()
 				continue
 			case storage.ErrOutOfBounds:
 				numOutOfBounds++
@@ -810,18 +832,21 @@ loop:
 				continue
 			case storage.ErrOutOfOrderSample:
 				err = nil
-				sl.l.With("timeseries", string(met)).Debug("Out of order sample")
 				numOutOfOrder++
+				sl.l.With("timeseries", string(met)).Debug("Out of order sample")
+				targetScrapeSampleOutOfOrder.Inc()
 				continue
 			case storage.ErrDuplicateSampleForTimestamp:
 				err = nil
 				numDuplicates++
 				sl.l.With("timeseries", string(met)).Debug("Duplicate sample for timestamp")
+				targetScrapeSampleDuplicate.Inc()
 				continue
 			case storage.ErrOutOfBounds:
 				err = nil
 				numOutOfBounds++
 				sl.l.With("timeseries", string(met)).Debug("Out of bounds metric")
+				targetScrapeSampleOutOfBounds.Inc()
 				continue
 			case errSampleLimit:
 				sampleLimitErr = err


### PR DESCRIPTION
Added three additional metrics to cover monitoring metrics that fall foul of expected rules. 
Originally did this due to issues i saw when faced with metrics with duplicate timestamps. @brian-brazil suggested the fixes may be more appropriate to the `dev-2.0` branch due to the changes around these functions. 

Points for discussion: 
* Three separate errors, considered having a more generic error and using dimensions but feel the metric help text would be lost. 
* Metric names, my best guesses for what would fit given the context of the surrounding code. Happy to update based on feedback of course. 
* Metric name could in theory be used as a dimension to make the metrics more usable, i'm worried about the cardinality in some situations that could cause this to become expensive.