### PR TITLE
Use /x/net/context consistently.

### DIFF
--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -14,7 +14,6 @@
 package rules
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"reflect"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -14,10 +14,10 @@
 package remote
 
 import (
-	"context"
 	"sort"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/prompb"


### PR DESCRIPTION
Only two places used `"context"`, I changed that.