### PR TITLE
Fix pprof endpoints when -web.route-prefix or -web.external-url is used

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	_ "net/http/pprof" // Comment this line to disable pprof endpoint.
 	"os"
 	"os/signal"
 	"runtime/debug"


### PR DESCRIPTION
Whenever a route prefix is applied, the router prepends the prefix to
the URL path on the request. For most handlers, this is not an issue
because the request's path is only used for routing and is not actually
needed by the handler itself. However, Prometheus delegates the handling
of the `/debug/*` endpoints to the `http.DefaultServeMux` which has it's own
routing logic that depends on the url.Path. As a result, whenever a
prefix is applied, the prefixed URL is passed to the `DefaultServeMux`
which has no awareness of the prefix and returns a 404.

The issue could be fixed either by manually attaching the pprof
endpoints to the router (basically duplicating pprof.Init) or by
creating a new handler to construct the proper non-prefixed path to be
passed to `http.DefaultServeMux`. This change implements the latter to
avoid having to maintain a list of pprof endpoints.

Fixes #2183.