### PR TITLE
check if file_sd files exists in checkConfig

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -152,6 +152,21 @@ func checkConfig(filename string) ([]string, error) {
 				return nil, err
 			}
 		}
+
+		for _, filesd := range scfg.ServiceDiscoveryConfig.FileSDConfigs {
+			for _, file := range filesd.Files {
+				files, err := filepath.Glob(file)
+				if err != nil {
+					return nil, err
+				}
+				if len(files) != 0 {
+					// There was at least one match for the glob and we can assume checkFileExists
+					// for all matches would pass, we can continue the loop.
+					continue
+				}
+				fmt.Printf("  WARNING: file %q for file_sd in scrape job %q does not exist\n", file, scfg.JobName)
+			}
+		}
 	}
 
 	return ruleFiles, nil


### PR DESCRIPTION
for issue #1553 

There was no check in `checkConfig` for files in a file_sd config. The issue mentions that the output should be WARNING rather than FAILURE. I can make that change if there's still agreement around that being the desired behaviour.

At the moment, output would look like:  

    Checking prometheus-missing.yml
    FAILED: error checking for file SD &{["not-there.yml" "not-there2.yml"] "5m" map[]}: stat not-there.yml: no such file or directory

cc: @grobie @Gouthamve  