### PR TITLE
Set timestamp for date functions

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -914,8 +914,9 @@ func dateWrapper(ev *evaluator, args Expressions, f func(time.Time) model.Sample
 	if len(args) == 0 {
 		v = vector{
 			&sample{
-				Metric: metric.Metric{},
-				Value:  model.SampleValue(ev.Timestamp.Unix()),
+				Metric:    metric.Metric{},
+				Value:     model.SampleValue(ev.Timestamp.Unix()),
+				Timestamp: ev.Timestamp,
 			},
 		}
 	} else {


### PR DESCRIPTION


This is only really a noticeable bug in 1.x, but the function required to add unittests for it is only in 2.0.