### PR TITLE
Fix double redirect if there is a route-prefix in 2.0

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -185,7 +185,7 @@ func New(o *Options) *Handler {
 	readyf := h.testReady
 
 	router.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		router.Redirect(w, r, path.Join(o.ExternalURL.Path, "/graph"), http.StatusFound)
+		http.Redirect(w, r, path.Join(o.ExternalURL.Path, "/graph"), http.StatusFound)
 	})
 
 	router.Get("/alerts", readyf(instrf("alerts", h.alerts)))


### PR DESCRIPTION
@juliusv

Fixes #3082 

I'm not sure what's the procedure since it was already fixed in v1. If it will be brought back from v1 to v2, feel free to close this PR. 

Thanks!