### PR TITLE
Unset GOBIN in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ensure GOBIN is not set during build so that promu is installed to the correct path
+unexport GOBIN
+
 GO           ?= go
 GOFMT        ?= $(GO)fmt
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))


### PR DESCRIPTION
Prevents issue where promu is built into the wrong location

If GOBIN is set to a non-default location relative to GOPATH, then the build will fail because it can't find the promu binary.
Looks like this issue was fixed previously in #492, but the fix was removed in build refactoring.