### PR TITLE
Point help to docs, not main Prometheus website

### DIFF
--- a/web/ui/templates/_base.html
+++ b/web/ui/templates/_base.html
@@ -52,7 +52,7 @@
               </ul>
             </li>
             <li>
-              <a href="https://prometheus.io" target="_blank">Help</a>
+              <a href="https://prometheus.io/docs" target="_blank">Help</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
No matter how we refactor docs, `/docs/` will stay the prefix, so there's not long-term risk in changing this.

One we version docs, we should probably try and keep link & version in sync.