### PR TITLE
cmd/prometheus: Fix capitalisation in log line

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -331,7 +331,7 @@ func main() {
 
 	// Set web server to ready.
 	webHandler.Ready()
-	log.Info("Server is Ready to receive requests.")
+	log.Info("Server is ready to receive requests.")
 
 	term := make(chan os.Signal)
 	signal.Notify(term, os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
Change 'Ready' to 'ready'.