### PR TITLE
Enable statitcheck at build time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 GO           := GO15VENDOREXPERIMENT=1 go
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 PROMU        := $(FIRST_GOPATH)/bin/promu
+STATICCHECK  := $(FIRST_GOPATH)/bin/staticcheck
 pkgs          = $(shell $(GO) list ./... | grep -v /vendor/)
 
 PREFIX                  ?= $(shell pwd)
@@ -25,8 +26,15 @@ ifdef DEBUG
 	bindata_flags = -debug
 endif
 
+STATICCHECK_IGNORE = \
+  github.com/prometheus/prometheus/discovery/kubernetes/node.go:SA1019 \
+  github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter/main.go:SA1019 \
+  github.com/prometheus/prometheus/storage/local/codable/codable.go:SA6002 \
+  github.com/prometheus/prometheus/storage/local/persistence.go:SA6002 \
+  github.com/prometheus/prometheus/storage/remote/queue_manager.go:SA1015 \
+  github.com/prometheus/prometheus/web/web.go:SA1019
 
-all: format build test
+all: format staticcheck build test
 
 style:
 	@echo ">> checking code style"
@@ -52,6 +60,10 @@ vet:
 	@echo ">> vetting code"
 	@$(GO) vet $(pkgs)
 
+staticcheck: $(STATICCHECK)
+	@echo ">> running staticcheck"
+	@$(STATICCHECK) -ignore "$(STATICCHECK_IGNORE)" $(pkgs)
+
 build: promu
 	@echo ">> building binaries"
 	@$(PROMU) build --prefix $(PREFIX)
@@ -76,5 +88,7 @@ promu:
 	GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
 	$(GO) get -u github.com/prometheus/promu
 
+$(FIRST_GOPATH)/bin/staticcheck:
+	@GOOS= GOARCH= $(GO) get -u honnef.co/go/tools/cmd/staticcheck
 
-.PHONY: all style check_license format build test vet assets tarball docker promu
+.PHONY: all style check_license format build test vet assets tarball docker promu staticcheck $(FIRST_GOPATH)/bin/staticcheck

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -229,7 +229,7 @@ func Main() int {
 	webHandler.Ready()
 	log.Info("Server is Ready to receive requests.")
 
-	term := make(chan os.Signal)
+	term := make(chan os.Signal, 1)
 	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
 	select {
 	case <-term:

--- a/retrieval/target_test.go
+++ b/retrieval/target_test.go
@@ -130,7 +130,7 @@ func TestTargetURL(t *testing.T) {
 func newTestTarget(targetURL string, deadline time.Duration, labels model.LabelSet) *Target {
 	labels = labels.Clone()
 	labels[model.SchemeLabel] = "http"
-	labels[model.AddressLabel] = model.LabelValue(strings.TrimLeft(targetURL, "http://"))
+	labels[model.AddressLabel] = model.LabelValue(strings.TrimPrefix(targetURL, "http://"))
 	labels[model.MetricsPathLabel] = "/metrics"
 
 	return &Target{

--- a/storage/local/mapper_test.go
+++ b/storage/local/mapper_test.go
@@ -63,6 +63,9 @@ func TestFPMapper(t *testing.T) {
 	defer closer.Close()
 
 	mapper, err := newFPMapper(sm, p)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Everything is empty, resolving a FP should do nothing.
 	gotFP := mapper.mapFP(fp1, cm11)

--- a/storage/local/persistence_test.go
+++ b/storage/local/persistence_test.go
@@ -136,6 +136,9 @@ func testPersistLoadDropChunks(t *testing.T, encoding chunk.Encoding) {
 		}
 		// Load all chunk descs.
 		actualChunkDescs, err := p.loadChunkDescs(fp, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if len(actualChunkDescs) != 10 {
 			t.Errorf("Got %d chunkDescs, want %d.", len(actualChunkDescs), 10)
 		}

--- a/storage/local/storage_test.go
+++ b/storage/local/storage_test.go
@@ -1420,7 +1420,7 @@ func testEvictAndPurgeSeries(t *testing.T, encoding chunk.Encoding) {
 	// Unarchive metrics.
 	s.getOrCreateSeries(fp, model.Metric{})
 
-	series, ok = s.fpToSeries.get(fp)
+	_, ok = s.fpToSeries.get(fp)
 	if !ok {
 		t.Fatal("could not find series")
 	}

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -68,6 +68,9 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 			url:     &config.URL{serverURL},
 			timeout: model.Duration(time.Second),
 		})
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		err = c.Store(nil)
 		if !reflect.DeepEqual(err, test.err) {


### PR DESCRIPTION
* Add `staticcheck` to the Makefile.
* Fix `staticcheck` errors.
* Ignore deprecated function in kubernetes API.

Closes: https://github.com/prometheus/prometheus/issues/3124