### PR TITLE
Remote storage reads based on oldest timestamp in primary storage

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -225,7 +225,7 @@ func main() {
 
 	var (
 		localStorage  = &tsdb.ReadyStorage{}
-		remoteStorage = remote.NewStorage(log.With(logger, "component", "remote"))
+		remoteStorage = remote.NewStorage(log.With(logger, "component", "remote"), localStorage.StartTime)
 		fanoutStorage = storage.NewFanout(logger, localStorage, remoteStorage)
 	)
 
@@ -326,7 +326,8 @@ func main() {
 		}
 		level.Info(logger).Log("msg", "TSDB started")
 
-		localStorage.Set(db)
+		startTimeMargin := int64(time.Duration(cfg.tsdb.MinBlockDuration).Seconds() * 1000)
+		localStorage.Set(db, startTimeMargin)
 	}()
 
 	prometheus.MustRegister(configSuccess)

--- a/config/config.go
+++ b/config/config.go
@@ -197,6 +197,7 @@ var (
 	// DefaultRemoteReadConfig is the default remote read configuration.
 	DefaultRemoteReadConfig = RemoteReadConfig{
 		RemoteTimeout: model.Duration(1 * time.Minute),
+		ReadRecent:    true,
 	}
 )
 
@@ -1490,7 +1491,7 @@ type QueueConfig struct {
 type RemoteReadConfig struct {
 	URL           *URL           `yaml:"url"`
 	RemoteTimeout model.Duration `yaml:"remote_timeout,omitempty"`
-
+	ReadRecent    bool           `yaml:"read_recent,omitempty"`
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.
 	HTTPClientConfig HTTPClientConfig `yaml:",inline"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -75,6 +75,19 @@ var expectedConf = &Config{
 		},
 	},
 
+	RemoteReadConfigs: []*RemoteReadConfig{
+		{
+			URL:           mustParseURL("http://remote1/read"),
+			RemoteTimeout: model.Duration(1 * time.Minute),
+			ReadRecent:    true,
+		},
+		{
+			URL:           mustParseURL("http://remote3/read"),
+			RemoteTimeout: model.Duration(1 * time.Minute),
+			ReadRecent:    false,
+		},
+	},
+
 	ScrapeConfigs: []*ScrapeConfig{
 		{
 			JobName: "prometheus",

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -20,6 +20,12 @@ remote_write:
       action:        drop
   - url: http://remote2/push
 
+remote_read:
+  - url: http://remote1/read
+    read_recent: true
+  - url: http://remote3/read
+    read_recent: false
+
 scrape_configs:
 - job_name: prometheus
 

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -31,6 +31,9 @@ var (
 // Storage ingests and manages samples, along with various indexes. All methods
 // are goroutine-safe. Storage implements storage.SampleAppender.
 type Storage interface {
+	// StartTime returns the oldest timestamp stored in the storage.
+	StartTime() (int64, error)
+
 	// Querier returns a new Querier on the storage.
 	Querier(ctx context.Context, mint, maxt int64) (Querier, error)
 

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -37,15 +37,17 @@ const maxErrMsgLen = 256
 
 // Client allows reading and writing from/to a remote HTTP endpoint.
 type Client struct {
-	index   int // Used to differentiate metrics.
-	url     *config.URL
-	client  *http.Client
-	timeout time.Duration
+	index      int // Used to differentiate metrics.
+	url        *config.URL
+	client     *http.Client
+	timeout    time.Duration
+	readRecent bool
 }
 
 type clientConfig struct {
 	url              *config.URL
 	timeout          model.Duration
+	readRecent       bool
 	httpClientConfig config.HTTPClientConfig
 }
 
@@ -57,10 +59,11 @@ func NewClient(index int, conf *clientConfig) (*Client, error) {
 	}
 
 	return &Client{
-		index:   index,
-		url:     conf.url,
-		client:  httpClient,
-		timeout: time.Duration(conf.timeout),
+		index:      index,
+		url:        conf.url,
+		client:     httpClient,
+		timeout:    time.Duration(conf.timeout),
+		readRecent: conf.readRecent,
 	}, nil
 }
 

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -17,8 +17,10 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
@@ -121,5 +123,61 @@ func TestConcreteSeriesSet(t *testing.T) {
 	}
 	if c.Next() {
 		t.Fatalf("Expected Next() to be false.")
+	}
+}
+
+type mockMergeQuerier struct{ queriersCount int }
+
+func (*mockMergeQuerier) Select(...*labels.Matcher) storage.SeriesSet { return nil }
+func (*mockMergeQuerier) LabelValues(name string) ([]string, error)   { return nil, nil }
+func (*mockMergeQuerier) Close() error                                { return nil }
+
+func TestRemoteStorageQuerier(t *testing.T) {
+	tests := []struct {
+		localStartTime        int64
+		readRecentClients     []bool
+		mint                  int64
+		maxt                  int64
+		expectedQueriersCount int
+	}{
+		{
+			localStartTime:    int64(20),
+			readRecentClients: []bool{true, true, false},
+			mint:              int64(0),
+			maxt:              int64(50),
+			expectedQueriersCount: 3,
+		},
+		{
+			localStartTime:    int64(20),
+			readRecentClients: []bool{true, true, false},
+			mint:              int64(30),
+			maxt:              int64(50),
+			expectedQueriersCount: 2,
+		},
+	}
+
+	for i, test := range tests {
+		s := NewStorage(nil, func() (int64, error) { return test.localStartTime, nil })
+		s.clients = []*Client{}
+		for _, readRecent := range test.readRecentClients {
+			c, _ := NewClient(0, &clientConfig{
+				url:              nil,
+				timeout:          model.Duration(30 * time.Second),
+				httpClientConfig: config.HTTPClientConfig{},
+				readRecent:       readRecent,
+			})
+			s.clients = append(s.clients, c)
+		}
+		// overrides mergeQuerier to mockMergeQuerier so we can reflect its type
+		newMergeQueriers = func(queriers []storage.Querier) storage.Querier {
+			return &mockMergeQuerier{queriersCount: len(queriers)}
+		}
+
+		querier, _ := s.Querier(nil, test.mint, test.maxt)
+		actualQueriersCount := reflect.ValueOf(querier).Interface().(*mockMergeQuerier).queriersCount
+
+		if !reflect.DeepEqual(actualQueriersCount, test.expectedQueriersCount) {
+			t.Fatalf("%d. unexpected queriers count; want %v, got %v", i, test.expectedQueriersCount, actualQueriersCount)
+		}
 	}
 }

--- a/util/testutil/storage.go
+++ b/util/testutil/storage.go
@@ -40,7 +40,7 @@ func NewStorage(t T) storage.Storage {
 	if err != nil {
 		t.Fatalf("Opening test storage failed: %s", err)
 	}
-	return testStorage{Storage: tsdb.Adapter(db), dir: dir}
+	return testStorage{Storage: tsdb.Adapter(db, int64(0)), dir: dir}
 }
 
 type testStorage struct {


### PR DESCRIPTION
Currently all read queries are simply pushed to remote storage.
We need instead to compare the oldest timestamp in primary/local
storage with the query range lower boundary. If the oldest timestamp
is older than the mint parameter, then there is no need for remote
storage calls.
This commit add StartTime() in Storage interface, and logic to use it.
This also need prometheus/tsdb#134 to be merged.
Fixes #3041 