### PR TITLE
Get pprof handlers working again

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -246,6 +246,11 @@ func serveDebug(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	subpath := route.Param(ctx, "subpath")
 
+	if subpath == "/pprof" {
+		http.Redirect(w, req, req.URL.Path+"/", http.StatusMovedPermanently)
+		return
+	}
+
 	if !strings.HasPrefix(subpath, "/pprof/") {
 		http.NotFound(w, req)
 		return
@@ -262,6 +267,7 @@ func serveDebug(w http.ResponseWriter, req *http.Request) {
 	case "trace":
 		pprof.Trace(w, req)
 	default:
+		req.URL.Path = "/debug/pprof/" + subpath
 		pprof.Index(w, req)
 	}
 }


### PR DESCRIPTION
Debug handlers like `/debug/pprof/goroutine` were broken by #3054; its not particularly obvious how they are supposed to work, as the calls to `http.Handle` in [net/http/pprof/pprof.go](https://golang.org/src/net/http/pprof/pprof.go) actually do longest-prefix matching, so paths like `/debug/pprof/goroutine` are actually handled by `Index()`.

/cc @juliusv @mark-adams 