### PR TITLE
Namespace PromQL metrics with 'promql'

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -36,8 +36,7 @@ import (
 )
 
 const (
-	namespace = "prometheus"
-	subsystem = "engine"
+	namespace = "promql"
 	queryTag  = "query"
 
 	// The largest SampleValue that can be converted to an int64 without overflow.
@@ -49,20 +48,17 @@ const (
 var (
 	currentQueries = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Subsystem: subsystem,
 		Name:      "queries",
 		Help:      "The current number of queries being executed or waiting.",
 	})
 	maxConcurrentQueries = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Subsystem: subsystem,
 		Name:      "queries_concurrent_max",
 		Help:      "The max number of concurrent queries.",
 	})
 	queryPrepareTime = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace:   namespace,
-			Subsystem:   subsystem,
 			Name:        "query_duration_seconds",
 			Help:        "Query timings",
 			ConstLabels: prometheus.Labels{"slice": "prepare_time"},
@@ -71,7 +67,6 @@ var (
 	queryInnerEval = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace:   namespace,
-			Subsystem:   subsystem,
 			Name:        "query_duration_seconds",
 			Help:        "Query timings",
 			ConstLabels: prometheus.Labels{"slice": "inner_eval"},
@@ -80,7 +75,6 @@ var (
 	queryResultAppend = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace:   namespace,
-			Subsystem:   subsystem,
 			Name:        "query_duration_seconds",
 			Help:        "Query timings",
 			ConstLabels: prometheus.Labels{"slice": "result_append"},
@@ -89,7 +83,6 @@ var (
 	queryResultSort = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace:   namespace,
-			Subsystem:   subsystem,
 			Name:        "query_duration_seconds",
 			Help:        "Query timings",
 			ConstLabels: prometheus.Labels{"slice": "result_sort"},


### PR DESCRIPTION
Per discussion with @brian-brazil at PromCon 2017, metrics should be
namespaced by the library that they belong to. Since PromQL can be
imported by applications other than Prometheus, its metrics should be
namespaced with `promql`.

I've removed the `engine` subsystem as it now seems unnecessary, e.g.

    prometheus_engine_queries_concurrent_max

is now:

    promql_queries_concurrent_max