### PR TITLE
k8s: Use versioned struct for ingress discovery

### DIFF
--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
-	"k8s.io/client-go/pkg/apis/extensions"
+	extensionsv1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )
@@ -244,7 +244,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*config.TargetGroup) {
 			ilw := cache.NewListWatchFromClient(reclient, "ingresses", namespace, nil)
 			ingress := NewIngress(
 				d.logger.With("kubernetes_sd", "ingress"),
-				cache.NewSharedInformer(ilw, &extensions.Ingress{}, resyncPeriod),
+				cache.NewSharedInformer(ilw, &extensionsv1beta1.Ingress{}, resyncPeriod),
 			)
 			go ingress.informer.Run(ctx.Done())
 


### PR DESCRIPTION
This closes #3141

This works on my clusters too, so I assume it's the right thing to do. But I also opened https://github.com/kubernetes/client-go/issues/289 to get clarification in how this versioning works. I think this here can be merged already though.