### PR TITLE
fixes #3080  - remote writes not sending job label when using AddFast method

### DIFF
--- a/retrieval/target.go
+++ b/retrieval/target.go
@@ -274,6 +274,24 @@ func (app ruleLabelsAppender) Add(lset labels.Labels, t int64, v float64) (uint6
 	return app.Appender.Add(lb.Labels(), t, v)
 }
 
+func (app ruleLabelsAppender) AddFast(lset labels.Labels, ref uint64, t int64, v float64) error {
+
+	lb := labels.NewBuilder(lset)
+
+	for _, l := range app.labels {
+		lv := lset.Get(l.Name)
+		if lv != "" {
+			lb.Set(model.ExportedLabelPrefix+l.Name, lv)
+		}
+		lb.Set(l.Name, l.Value)
+	}
+
+	if err := app.Appender.AddFast(lb.Labels(), ref, t, v); err != nil {
+		return err
+	}
+	return nil
+}
+
 type honorLabelsAppender struct {
 	storage.Appender
 	labels labels.Labels

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -121,10 +121,11 @@ func (f *fanoutAppender) AddFast(l labels.Labels, ref uint64, t int64, v float64
 	}
 
 	for _, appender := range f.secondaries {
-		if _, err := appender.Add(l, t, v); err != nil {
+		if err := appender.AddFast(l, ref, t, v); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
implemented AddFast method for the rule appender so that it adds the default labels on every sample

For the local storage the default labels(`job`,`instance`) are only used with the Add method as it needs to writes them only once at the beginning of every chunk , but when writing to a remote storage needs to send the default labels with all samples

I am also thinking to add a test to check that the default labels are always set for every sample

Signed-off-by: Krasi Georgiev <krasi.root@gmail.com>