### PR TITLE
add volume /etc/prometheus to change from default configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY consoles/                              /usr/share/prometheus/consoles/
 RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
 
 EXPOSE     9090
-VOLUME     [ "/prometheus" ]
+VOLUME     [ "/prometheus", "/etc/prometheus" ]
 WORKDIR    /prometheus
 ENTRYPOINT [ "/bin/prometheus" ]
 CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \


### PR DESCRIPTION
In oder to use multiple docker, it's best to permit the modification of the configuration file with a volume.

I hope it's the good way to do it and there is not another best solution (I could'nt find it).

Thanks,