### PR TITLE
Re-enable http keepalive on remote storage

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -526,7 +526,7 @@ type HTTPClientConfig struct {
 	ProxyURL URL `yaml:"proxy_url,omitempty"`
 	// TLSConfig to use to connect to the targets.
 	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
-	// If set, override whether to use HTTP KeepAlive - defaults OFF
+	// If set, override whether to use HTTP KeepAlive - scraping defaults OFF, remote read/write defaults ON
 	KeepAlive *bool `yaml:"keep_alive,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.

--- a/config/config.go
+++ b/config/config.go
@@ -526,6 +526,8 @@ type HTTPClientConfig struct {
 	ProxyURL URL `yaml:"proxy_url,omitempty"`
 	// TLSConfig to use to connect to the targets.
 	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
+	// If set, override whether to use HTTP KeepAlive - defaults OFF
+	KeepAlive *bool `yaml:"keep_alive,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -51,6 +51,11 @@ type clientConfig struct {
 
 // NewClient creates a new Client.
 func NewClient(index int, conf *clientConfig) (*Client, error) {
+	// If not specified in config, allow HTTP connections for remote API to use keep-alive
+	if conf.httpClientConfig.KeepAlive == nil {
+		val := true
+		conf.httpClientConfig.KeepAlive = &val
+	}
 	httpClient, err := httputil.NewClientFromConfig(conf.httpClientConfig)
 	if err != nil {
 		return nil, err

--- a/util/httputil/client.go
+++ b/util/httputil/client.go
@@ -36,11 +36,15 @@ func NewClientFromConfig(cfg config.HTTPClientConfig) (*http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	disableKeepAlives := true // hard-coded default unless overridden in config
+	if cfg.KeepAlive != nil {
+		disableKeepAlives = !*cfg.KeepAlive
+	}
 	// The only timeout we care about is the configured scrape timeout.
 	// It is applied on request. So we leave out any timings here.
 	var rt http.RoundTripper = &http.Transport{
 		Proxy:             http.ProxyURL(cfg.ProxyURL.URL),
-		DisableKeepAlives: true,
+		DisableKeepAlives: disableKeepAlives,
 		TLSClientConfig:   tlsConfig,
 	}
 


### PR DESCRIPTION
As discussed at https://groups.google.com/d/msg/prometheus-users/CMyMtPC-Co4/vDfrsOXVAAAJ

Without this change, Prometheus is doing a DNS lookup, opening/closing a socket, etc., on every remote read or write, which may be many times per second.

I felt I should give users the option, and since I did this at the lower level this ends up relevant to #2498 
