### PR TITLE
allow a binary name to be passed to make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ vet:
 
 build: promu
 	@echo ">> building binaries"
-	@$(PROMU) build --prefix $(PREFIX)
+	@$(PROMU) build --prefix $(PREFIX) $(BINARIES)
 
 tarball: promu
 	@echo ">> building release tarball"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ You can also clone the repository yourself and build using `make`:
     $ make build
     $ ./prometheus -config.file=your_config.yml
 
+You can also build just one of the binaries in this repo by passing a name to the build function:
+    $ make build BINARIES=promtool
+
 The Makefile provides several targets:
 
   * *build*: build the `prometheus` and `promtool` binaries


### PR DESCRIPTION
While working on promtool and prometheus I often went back and forth commenting out binaries in the `.promu.yml` file in order to only rebuild the binary I wanted to rebuild.

In this pr: https://github.com/prometheus/promu/pull/77 I added the option to pass a binary name to promu's build function. This is controlled by setting the `BINARIES` var.

For example: 
```
$make build BINARIES=promtool  
>> building binaries
 >   promtool
```

In this PR we simply pass `BINARIES` to promu. If it's not set, promu will build all binaries from the YAML file as normal.
```
$make build                  
>> building binaries
 >   prometheus
 >   promtool

```
