### PR TITLE
remote: Expose ClientConfig type

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -43,29 +43,30 @@ type Client struct {
 	timeout time.Duration
 }
 
-type clientConfig struct {
-	url              *config.URL
-	timeout          model.Duration
-	httpClientConfig config.HTTPClientConfig
+// ClientConfig configures a Client.
+type ClientConfig struct {
+	URL              *config.URL
+	Timeout          model.Duration
+	HTTPClientConfig config.HTTPClientConfig
 }
 
 // NewClient creates a new Client.
-func NewClient(index int, conf *clientConfig) (*Client, error) {
+func NewClient(index int, conf *ClientConfig) (*Client, error) {
 	// If not specified in config, allow HTTP connections for remote API to use keep-alive
-	if conf.httpClientConfig.KeepAlive == nil {
+	if conf.HTTPClientConfig.KeepAlive == nil {
 		val := true
-		conf.httpClientConfig.KeepAlive = &val
+		conf.HTTPClientConfig.KeepAlive = &val
 	}
-	httpClient, err := httputil.NewClientFromConfig(conf.httpClientConfig)
+	httpClient, err := httputil.NewClientFromConfig(conf.HTTPClientConfig)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
 		index:   index,
-		url:     conf.url,
+		url:     conf.URL,
 		client:  httpClient,
-		timeout: time.Duration(conf.timeout),
+		timeout: time.Duration(conf.Timeout),
 	}, nil
 }
 

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -64,9 +64,9 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 			panic(err)
 		}
 
-		c, err := NewClient(0, &clientConfig{
-			url:     &config.URL{serverURL},
-			timeout: model.Duration(time.Second),
+		c, err := NewClient(0, &ClientConfig{
+			URL:     &config.URL{serverURL},
+			Timeout: model.Duration(time.Second),
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -37,10 +37,10 @@ type Reader struct {
 func (r *Reader) ApplyConfig(conf *config.Config) error {
 	clients := []*Client{}
 	for i, rrConf := range conf.RemoteReadConfigs {
-		c, err := NewClient(i, &clientConfig{
-			url:              rrConf.URL,
-			timeout:          rrConf.RemoteTimeout,
-			httpClientConfig: rrConf.HTTPClientConfig,
+		c, err := NewClient(i, &ClientConfig{
+			URL:              rrConf.URL,
+			Timeout:          rrConf.RemoteTimeout,
+			HTTPClientConfig: rrConf.HTTPClientConfig,
 		})
 		if err != nil {
 			return err

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -36,10 +36,10 @@ func (w *Writer) ApplyConfig(conf *config.Config) error {
 	// TODO: we should only stop & recreate queues which have changes,
 	// as this can be quite disruptive.
 	for i, rwConf := range conf.RemoteWriteConfigs {
-		c, err := NewClient(i, &clientConfig{
-			url:              rwConf.URL,
-			timeout:          rwConf.RemoteTimeout,
-			httpClientConfig: rwConf.HTTPClientConfig,
+		c, err := NewClient(i, &ClientConfig{
+			URL:              rwConf.URL,
+			Timeout:          rwConf.RemoteTimeout,
+			HTTPClientConfig: rwConf.HTTPClientConfig,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
The Client type is already exposed, but can't be used without the config for it
also being exposed. Using the remote.Client from other programs is useful to do
full end-to-end tests of Prometheus's remote protocol against adapter
implementations.