### PR TITLE
Prevent number of remote write shards from going negative.

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -339,6 +339,8 @@ func (t *QueueManager) calculateDesiredShards() {
 	numShards := int(math.Ceil(desiredShards))
 	if numShards > t.cfg.MaxShards {
 		numShards = t.cfg.MaxShards
+	} else if numShards < 1 {
+		numShards = 1
 	}
 	if numShards == t.numShards {
 		return


### PR DESCRIPTION
This can happen in the situation where the system scales up the number of shards massively (to deal with some backlog), then scales it down again as the number of samples sent during the time period is less than the number received.

(Cherry pick of 1d94eb8d into 1.7, see #2969)