### PR TITLE
Re-enable http keepalive on remote storage

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -505,7 +505,7 @@ type HTTPClientConfig struct {
 	ProxyURL URL `yaml:"proxy_url,omitempty"`
 	// TLSConfig to use to connect to the targets.
 	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
-	// If set, override whether to use HTTP KeepAlive - defaults OFF
+	// If set, override whether to use HTTP KeepAlive - scraping defaults OFF, remote read/write defaults ON
 	KeepAlive *bool `yaml:"keep_alive,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.

--- a/config/config.go
+++ b/config/config.go
@@ -505,6 +505,8 @@ type HTTPClientConfig struct {
 	ProxyURL URL `yaml:"proxy_url,omitempty"`
 	// TLSConfig to use to connect to the targets.
 	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
+	// If set, override whether to use HTTP KeepAlive - defaults OFF
+	KeepAlive *bool `yaml:"keep_alive,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -51,6 +51,11 @@ type clientConfig struct {
 
 // NewClient creates a new Client.
 func NewClient(index int, conf *clientConfig) (*Client, error) {
+	// If not specified in config, allow HTTP connections for remote API to use keep-alive
+	if conf.httpClientConfig.KeepAlive == nil {
+		val := true
+		conf.httpClientConfig.KeepAlive = &val
+	}
 	httpClient, err := httputil.NewClientFromConfig(conf.httpClientConfig)
 	if err != nil {
 		return nil, err

--- a/util/httputil/client.go
+++ b/util/httputil/client.go
@@ -39,11 +39,15 @@ func NewClientFromConfig(cfg config.HTTPClientConfig) (*http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	disableKeepAlives := true // hard-coded default unless overridden in config
+	if cfg.KeepAlive != nil {
+		disableKeepAlives = !*cfg.KeepAlive
+	}
 	// The only timeout we care about is the configured scrape timeout.
 	// It is applied on request. So we leave out any timings here.
 	var rt http.RoundTripper = &http.Transport{
 		Proxy:             http.ProxyURL(cfg.ProxyURL.URL),
-		DisableKeepAlives: true,
+		DisableKeepAlives: disableKeepAlives,
 		TLSClientConfig:   tlsConfig,
 	}
 


### PR DESCRIPTION
Cherry-pick of #3160 as candidate for the 1.7.2 release

Allow HTTP keep-alive setting to be overridden in config, and default it ON for remote storage read/write
