### PR TITLE
Don't disable HTTP keep-alives for remote storage connections.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -520,8 +520,6 @@ type HTTPClientConfig struct {
 	ProxyURL URL `yaml:"proxy_url,omitempty"`
 	// TLSConfig to use to connect to the targets.
 	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
-	// If set, override whether to use HTTP KeepAlive - scraping defaults OFF, remote read/write defaults ON
-	KeepAlive *bool `yaml:"keep_alive,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -52,12 +52,7 @@ type ClientConfig struct {
 
 // NewClient creates a new Client.
 func NewClient(index int, conf *ClientConfig) (*Client, error) {
-	// If not specified in config, allow HTTP connections for remote API to use keep-alive
-	if conf.HTTPClientConfig.KeepAlive == nil {
-		val := true
-		conf.HTTPClientConfig.KeepAlive = &val
-	}
-	httpClient, err := httputil.NewClientFromConfig(conf.HTTPClientConfig)
+	httpClient, err := httputil.NewClientFromConfigAndOptions(conf.HTTPClientConfig, false)
 	if err != nil {
 		return nil, err
 	}

--- a/util/httputil/client.go
+++ b/util/httputil/client.go
@@ -32,13 +32,15 @@ func NewClient(rt http.RoundTripper) *http.Client {
 // NewClientFromConfig returns a new HTTP client configured for the
 // given config.HTTPClientConfig.
 func NewClientFromConfig(cfg config.HTTPClientConfig) (*http.Client, error) {
+	return NewClientFromConfigAndOptions(cfg, true)
+}
+
+// NewClientFromConfigAndOptions returns a new HTTP client configured for the
+// given config.HTTPClientConfig, optionally disabling HTTP keepalive.
+func NewClientFromConfigAndOptions(cfg config.HTTPClientConfig, disableKeepAlives bool) (*http.Client, error) {
 	tlsConfig, err := NewTLSConfig(cfg.TLSConfig)
 	if err != nil {
 		return nil, err
-	}
-	disableKeepAlives := true // hard-coded default unless overridden in config
-	if cfg.KeepAlive != nil {
-		disableKeepAlives = !*cfg.KeepAlive
 	}
 	// The only timeout we care about is the configured scrape timeout.
 	// It is applied on request. So we leave out any timings here.


### PR DESCRIPTION
Removes configurability introduced in #3160 in favour of hard-coding, per [advice from @brian-brazil](https://github.com/prometheus/prometheus/pull/3171#discussion_r138852915).

The slightly unwieldy `NewClientFromConfigAndOptions()` is introduced to avoid changing the 13+ other calls to `NewClientFromConfig()` in this repo and presumably more downstream.