### PR TITLE
Fix loopback address for REST API gateway (v2)

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -391,7 +391,14 @@ func (h *Handler) Run(ctx context.Context) error {
 	)
 	av2.RegisterGRPC(grpcSrv)
 
-	hh, err := av2.HTTPHandler(grpcl.Addr().String())
+	lAddr := grpcl.Addr().String()
+	host, port, _ := net.SplitHostPort(lAddr)
+	ip := net.ParseIP(host)
+	if ip.Equal(net.IPv4zero) || ip.Equal(net.IPv6zero) {
+		lAddr = net.JoinHostPort("localhost", port)
+	}
+
+	hh, err := av2.HTTPHandler(lAddr)
 	if err != nil {
 		return err
 	}

--- a/web/web.go
+++ b/web/web.go
@@ -398,6 +398,10 @@ func (h *Handler) Run(ctx context.Context) error {
 	}
 	ip := net.ParseIP(host)
 	if ip.Equal(net.IPv4zero) || ip.Equal(net.IPv6zero) {
+		// The gRPC server is listening on an empty/wildcard address (0.0.0.0 or ::).
+		// We should be able to connect to an empty IP just fine, but as there were
+		// some issues with this in the past (#3004, #3149), we explicitly tell
+		// the REST API gateway to connect to localhost.
 		lAddr = net.JoinHostPort("localhost", port)
 	}
 

--- a/web/web.go
+++ b/web/web.go
@@ -392,7 +392,10 @@ func (h *Handler) Run(ctx context.Context) error {
 	av2.RegisterGRPC(grpcSrv)
 
 	lAddr := grpcl.Addr().String()
-	host, port, _ := net.SplitHostPort(lAddr)
+	host, port, err := net.SplitHostPort(lAddr)
+	if err != nil {
+		return err
+	}
 	ip := net.ParseIP(host)
 	if ip.Equal(net.IPv4zero) || ip.Equal(net.IPv6zero) {
 		lAddr = net.JoinHostPort("localhost", port)


### PR DESCRIPTION
This pull request for `dev-2.0` (not `master`) resolves #3149 and resolves #3004 by replacing zero listen-addresses (`0.0.0.0`, `::`, `""`) with `localhost` before passing it to the client for the REST API gateway.

CC: @fabxc