### PR TITLE
Fix cache maintenance on changing metric representations

### DIFF
--- a/vendor/github.com/prometheus/tsdb/block.go
+++ b/vendor/github.com/prometheus/tsdb/block.go
@@ -64,11 +64,6 @@ type Appendable interface {
 	Appender() Appender
 }
 
-// Queryable defines an entity which provides a Querier.
-type Queryable interface {
-	Querier(mint, maxt int64) Querier
-}
-
 // BlockMeta provides meta information about a block.
 type BlockMeta struct {
 	// Unique identifier for the block and its contents. Changes on compaction.

--- a/vendor/github.com/prometheus/tsdb/db.go
+++ b/vendor/github.com/prometheus/tsdb/db.go
@@ -165,8 +165,7 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 		return nil, err
 	}
 	if l == nil {
-		l = log.NewLogfmtLogger(os.Stdout)
-		l = log.With(l, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
+		l = log.NewNopLogger()
 	}
 	if opts == nil {
 		opts = DefaultOptions

--- a/vendor/github.com/prometheus/tsdb/index.go
+++ b/vendor/github.com/prometheus/tsdb/index.go
@@ -570,6 +570,9 @@ var (
 	errInvalidFlag = fmt.Errorf("invalid flag")
 )
 
+// NewIndexReader returns a new IndexReader on the given directory.
+func NewIndexReader(dir string) (IndexReader, error) { return newIndexReader(dir) }
+
 // newIndexReader returns a new indexReader on the given directory.
 func newIndexReader(dir string) (*indexReader, error) {
 	f, err := openMmapFile(filepath.Join(dir, "index"))

--- a/vendor/github.com/prometheus/tsdb/wal.go
+++ b/vendor/github.com/prometheus/tsdb/wal.go
@@ -99,9 +99,6 @@ type WALReader interface {
 type RefSeries struct {
 	Ref    uint64
 	Labels labels.Labels
-
-	// hash for the label set. This field is not generally populated.
-	hash uint64
 }
 
 // RefSample is a timestamp/value pair associated with a reference to a series.
@@ -827,7 +824,9 @@ func (r *walReader) Read(seriesf SeriesCB, samplesf SamplesCB, deletesf DeletesC
 			if err != nil {
 				return errors.Wrap(err, "decode series entry")
 			}
-			seriesf(series)
+			if err := seriesf(series); err != nil {
+				return err
+			}
 
 			cf := r.current()
 
@@ -842,7 +841,9 @@ func (r *walReader) Read(seriesf SeriesCB, samplesf SamplesCB, deletesf DeletesC
 			if err != nil {
 				return errors.Wrap(err, "decode samples entry")
 			}
-			samplesf(samples)
+			if err := samplesf(samples); err != nil {
+				return err
+			}
 
 			// Update the times for the WAL segment file.
 			cf := r.current()
@@ -858,7 +859,9 @@ func (r *walReader) Read(seriesf SeriesCB, samplesf SamplesCB, deletesf DeletesC
 			if err != nil {
 				return errors.Wrap(err, "decode delete entry")
 			}
-			deletesf(stones)
+			if err := deletesf(stones); err != nil {
+				return err
+			}
 			// Update the times for the WAL segment file.
 
 			cf := r.current()

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -871,22 +871,22 @@
 			"revisionTime": "2016-04-11T19:08:41Z"
 		},
 		{
-			"checksumSHA1": "mDKxPAubVLTWW/Gar13m7YDHSek=",
+			"checksumSHA1": "B5ndMoK8lqgFJ8xUZ/0V4zCpUw0=",
 			"path": "github.com/prometheus/tsdb",
-			"revision": "3870ec285c4640d462a0ad80e7acbcdf1e939563",
-			"revisionTime": "2017-09-11T08:41:33Z"
+			"revision": "162a48e4f2c6e486a0ebf61cf9cea73a8023ef0a",
+			"revisionTime": "2017-09-19T08:20:19Z"
 		},
 		{
 			"checksumSHA1": "Gua979gmISm4cJP/fR2hL8m5To8=",
 			"path": "github.com/prometheus/tsdb/chunks",
-			"revision": "3870ec285c4640d462a0ad80e7acbcdf1e939563",
-			"revisionTime": "2017-09-11T08:41:33Z"
+			"revision": "162a48e4f2c6e486a0ebf61cf9cea73a8023ef0a",
+			"revisionTime": "2017-09-19T08:20:19Z"
 		},
 		{
 			"checksumSHA1": "zhmlvc322RH1L3l9DaA9d/HVVWs=",
 			"path": "github.com/prometheus/tsdb/labels",
-			"revision": "3870ec285c4640d462a0ad80e7acbcdf1e939563",
-			"revisionTime": "2017-09-11T08:41:33Z"
+			"revision": "162a48e4f2c6e486a0ebf61cf9cea73a8023ef0a",
+			"revisionTime": "2017-09-19T08:20:19Z"
 		},
 		{
 			"checksumSHA1": "5SYLEhADhdBVZAGPVHWggQl7H8k=",


### PR DESCRIPTION
We were not properly maintaining the scrape cache when the same metric was exposed with a different string representation. This overall reduces the scraping cache's complexity, which fixes the issue and saves about 10% of memory in a scraping-only Prometheus instance.

Test is added but I'd still like some of the commenters of #2955 confirm that this fixes it.

We now wait 3 iterations before purging cache items. That should help to sustain performance when exposed metrics are heavily flapping as in cAdvisor most recently.

@Gouthamve @brian-brazil 
