### PR TITLE
cmd/prometheus: fail fast if the alertmanager.url does not have a valid scheme

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -365,6 +365,8 @@ func validateAlertmanagerURL(u string) error {
 	}
 	if url.Scheme == "" {
 		return fmt.Errorf("missing scheme in Alertmanager URL: %s", u)
+	} else if url.Scheme != "http" && url.Scheme != "https" {
+		return fmt.Errorf("unknown scheme '%s' in Alertmanager URL: %s", url.Scheme, u)
 	}
 	return nil
 }

--- a/cmd/prometheus/config_test.go
+++ b/cmd/prometheus/config_test.go
@@ -57,6 +57,10 @@ func TestParse(t *testing.T) {
 			valid: false,
 		},
 		{
+			input: []string{"-alertmanager.url", "alertmanager.company.com:80"},
+			valid: false,
+		},
+		{
 			input: []string{"-alertmanager.url", "https://double--dash.de"},
 			valid: true,
 		},
@@ -77,9 +81,9 @@ func TestParse(t *testing.T) {
 
 		err := parse(test.input)
 		if test.valid && err != nil {
-			t.Errorf("%d. expected input to be valid, got %s", i, err)
+			t.Errorf("%d. expected input '%s' to be valid, got %s", i, test.input, err)
 		} else if !test.valid && err == nil {
-			t.Errorf("%d. expected input to be invalid", i)
+			t.Errorf("%d. expected input '%s' to be invalid", i, test.input)
 		}
 	}
 }


### PR DESCRIPTION
If the alert manager url is set to a hostname with a port (i.e. example.com:8080)
it will pass the initial config validation but fail later in the startup process
when it tries to connect because of the unknown scheme 'example.com'.  This
patch adds a check to see that a valid scheme was set for the alertmanager.url and
adds a test to validate the check.  Also, prints the test input string when there
is a test failure.