### PR TITLE
Make all rule links link to the "Console" tab rather than "Graph"

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -332,8 +332,8 @@ func (r *AlertingRule) HTMLSnippet(pathPrefix string) html_template.HTML {
 		model.MetricNameLabel: alertMetricName,
 		alertNameLabel:        model.LabelValue(r.name),
 	}
-	s := fmt.Sprintf("ALERT <a href=%q>%s</a>", pathPrefix+strutil.GraphLinkForExpression(alertMetric.String()), r.name)
-	s += fmt.Sprintf("\n  IF <a href=%q>%s</a>", pathPrefix+strutil.GraphLinkForExpression(r.vector.String()), html_template.HTMLEscapeString(r.vector.String()))
+	s := fmt.Sprintf("ALERT <a href=%q>%s</a>", pathPrefix+strutil.TableLinkForExpression(alertMetric.String()), r.name)
+	s += fmt.Sprintf("\n  IF <a href=%q>%s</a>", pathPrefix+strutil.TableLinkForExpression(r.vector.String()), html_template.HTMLEscapeString(r.vector.String()))
 	if r.holdDuration > 0 {
 		s += fmt.Sprintf("\n  FOR %s", model.Duration(r.holdDuration))
 	}

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -27,8 +27,8 @@ func TestAlertingRuleHTMLSnippet(t *testing.T) {
 	}
 	rule := NewAlertingRule("testrule", expr, 0, model.LabelSet{"html": "<b>BOLD</b>"}, model.LabelSet{"html": "<b>BOLD</b>"})
 
-	const want = `ALERT <a href="/test/prefix/graph?g0.expr=ALERTS%7Balertname%3D%22testrule%22%7D&g0.tab=0">testrule</a>
-  IF <a href="/test/prefix/graph?g0.expr=foo%7Bhtml%3D%22%3Cb%3EBOLD%3Cb%3E%22%7D&g0.tab=0">foo{html=&#34;&lt;b&gt;BOLD&lt;b&gt;&#34;}</a>
+	const want = `ALERT <a href="/test/prefix/graph?g0.expr=ALERTS%7Balertname%3D%22testrule%22%7D&g0.tab=1">testrule</a>
+  IF <a href="/test/prefix/graph?g0.expr=foo%7Bhtml%3D%22%3Cb%3EBOLD%3Cb%3E%22%7D&g0.tab=1">foo{html=&#34;&lt;b&gt;BOLD&lt;b&gt;&#34;}</a>
   LABELS {html=&#34;&lt;b&gt;BOLD&lt;/b&gt;&#34;}
   ANNOTATIONS {html=&#34;&lt;b&gt;BOLD&lt;/b&gt;&#34;}`
 

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -331,7 +331,7 @@ func (g *Group) sendAlerts(rule *AlertingRule, timestamp model.Time) error {
 			StartsAt:     alert.ActiveAt.Add(rule.holdDuration).Time(),
 			Labels:       alert.Labels,
 			Annotations:  alert.Annotations,
-			GeneratorURL: g.opts.ExternalURL.String() + strutil.GraphLinkForExpression(rule.vector.String()),
+			GeneratorURL: g.opts.ExternalURL.String() + strutil.TableLinkForExpression(rule.vector.String()),
 		}
 		if alert.ResolvedAt != 0 {
 			a.EndsAt = alert.ResolvedAt.Time()

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -106,9 +106,9 @@ func (rule RecordingRule) HTMLSnippet(pathPrefix string) template.HTML {
 	ruleExpr := rule.vector.String()
 	return template.HTML(fmt.Sprintf(
 		`<a href="%s">%s</a>%s = <a href="%s">%s</a>`,
-		pathPrefix+strutil.GraphLinkForExpression(rule.name),
+		pathPrefix+strutil.TableLinkForExpression(rule.name),
 		rule.name,
 		template.HTMLEscapeString(rule.labels.String()),
-		pathPrefix+strutil.GraphLinkForExpression(ruleExpr),
+		pathPrefix+strutil.TableLinkForExpression(ruleExpr),
 		template.HTMLEscapeString(ruleExpr)))
 }

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -80,7 +80,7 @@ func TestRecordingRuleHTMLSnippet(t *testing.T) {
 	}
 	rule := NewRecordingRule("testrule", expr, model.LabelSet{"html": "<b>BOLD</b>"})
 
-	const want = `<a href="/test/prefix/graph?g0.expr=testrule&g0.tab=0">testrule</a>{html=&#34;&lt;b&gt;BOLD&lt;/b&gt;&#34;} = <a href="/test/prefix/graph?g0.expr=foo%7Bhtml%3D%22%3Cb%3EBOLD%3Cb%3E%22%7D&g0.tab=0">foo{html=&#34;&lt;b&gt;BOLD&lt;b&gt;&#34;}</a>`
+	const want = `<a href="/test/prefix/graph?g0.expr=testrule&g0.tab=1">testrule</a>{html=&#34;&lt;b&gt;BOLD&lt;/b&gt;&#34;} = <a href="/test/prefix/graph?g0.expr=foo%7Bhtml%3D%22%3Cb%3EBOLD%3Cb%3E%22%7D&g0.tab=1">foo{html=&#34;&lt;b&gt;BOLD&lt;b&gt;&#34;}</a>`
 
 	got := rule.HTMLSnippet("/test/prefix")
 	if got != want {


### PR DESCRIPTION
Clicking on a rule, either the name or the expression, opens the rule
result (or the corresponding expression, repsectively) in the
expression browser. This should by default happen in the console tab,
as, more often than not, displaying it in the graph tab runs into a
timeout.

@grobie we talked about this. I wanted to fix it for ages, and finally it should go into the bug fix release.
IIRC @brian-brazil said he thought this has been fixed long ago. Thus, it's definitely the expected behavior, and what we have now is a bug.