### PR TITLE
Fixing Discovery File Tests

### DIFF
--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -92,7 +92,12 @@ retry:
 			}
 		case tgs := <-ch:
 			if !expect {
-				t.Fatalf("Unexpected target groups %s, we expected a failure here.", tgs)
+				for _, tg := range tgs {
+					if tg.Targets != nil {
+						t.Fatalf("Unexpected target groups %s, we expected a failure here.",
+							tgs)
+					}
+				}
 			}
 
 			if len(tgs) != 2 {


### PR DESCRIPTION
According to discovery/README.md:
_If all the targets in a group go away, we need to send the target groups
with empty `Targets` down the channel._
For this reason a extra check were added to the Targets received in the
channel for some Discover File tests.