### PR TITLE
#1618 support the credentials file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1139,6 +1139,7 @@ type EC2SDConfig struct {
 	AccessKey       string         `yaml:"access_key,omitempty"`
 	SecretKey       Secret         `yaml:"secret_key,omitempty"`
 	Profile         string         `yaml:"profile,omitempty"`
+	CredentialPath  string         `yaml:"credential_path,omitempty"`
 	RoleARN         string         `yaml:"role_arn,omitempty"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
 	Port            int            `yaml:"port"`

--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -72,6 +72,7 @@ type Discovery struct {
 	aws      *aws.Config
 	interval time.Duration
 	profile  string
+	path     string
 	roleARN  string
 	port     int
 	logger   log.Logger
@@ -79,9 +80,11 @@ type Discovery struct {
 
 // NewDiscovery returns a new EC2Discovery which periodically refreshes its targets.
 func NewDiscovery(conf *config.EC2SDConfig, logger log.Logger) *Discovery {
-	creds := credentials.NewStaticCredentials(conf.AccessKey, string(conf.SecretKey), "")
-	if conf.AccessKey == "" && conf.SecretKey == "" {
-		creds = nil
+	var creds *credentials.Credentials
+	if conf.AccessKey != "" && string(conf.SecretKey) !="" {
+		creds = credentials.NewStaticCredentials(conf.AccessKey, string(conf.SecretKey), "")
+	} else {
+		creds = credentials.NewSharedCredentials(conf.CredentialPath, conf.Profile)
 	}
 	return &Discovery{
 		aws: &aws.Config{
@@ -89,6 +92,7 @@ func NewDiscovery(conf *config.EC2SDConfig, logger log.Logger) *Discovery {
 			Credentials: creds,
 		},
 		profile:  conf.Profile,
+		path:     conf.CredentialPath,
 		roleARN:  conf.RoleARN,
 		interval: time.Duration(conf.RefreshInterval),
 		port:     conf.Port,

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/chain_provider.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/chain_provider.go
@@ -13,7 +13,7 @@ var (
 	//
 	// @readonly
 	ErrNoValidProvidersFoundInChain = awserr.New("NoCredentialProviders",
-		`no valid providers in chain. Deprecated. 
+		`no valid providers in chain. Deprecated.
 	For verbose messaging see aws.Config.CredentialsChainVerboseErrors`,
 		nil)
 )
@@ -39,16 +39,18 @@ var (
 // does not return any credentials ChainProvider will return the error
 // ErrNoValidProvidersFoundInChain
 //
-//     creds := NewChainCredentials(
-//         []Provider{
-//             &EnvProvider{},
-//             &EC2RoleProvider{
+//     creds := credentials.NewChainCredentials(
+//         []credentials.Provider{
+//             &credentials.EnvProvider{},
+//             &ec2rolecreds.EC2RoleProvider{
 //                 Client: ec2metadata.New(sess),
 //             },
 //         })
 //
 //     // Usage of ChainCredentials with aws.Config
-//     svc := ec2.New(&aws.Config{Credentials: creds})
+//     svc := ec2.New(session.Must(session.NewSession(&aws.Config{
+//       Credentials: creds,
+//     })))
 //
 type ChainProvider struct {
 	Providers     []Provider

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds/ec2_role_provider.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds/ec2_role_provider.go
@@ -111,7 +111,7 @@ func (m *EC2RoleProvider) Retrieve() (credentials.Value, error) {
 	}, nil
 }
 
-// A ec2RoleCredRespBody provides the shape for unmarshalling credential
+// A ec2RoleCredRespBody provides the shape for unmarshaling credential
 // request responses.
 type ec2RoleCredRespBody struct {
 	// Success State

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/env_provider.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/env_provider.go
@@ -29,6 +29,7 @@ var (
 // Environment variables used:
 //
 // * Access Key ID:     AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY
+//
 // * Secret Access Key: AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY
 type EnvProvider struct {
 	retrieved bool

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/shared_credentials_provider.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/shared_credentials_provider.go
@@ -3,11 +3,11 @@ package credentials
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/go-ini/ini"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/internal/shareddefaults"
 )
 
 // SharedCredsProviderName provides a name of SharedCreds provider
@@ -15,8 +15,6 @@ const SharedCredsProviderName = "SharedCredentialsProvider"
 
 var (
 	// ErrSharedCredentialsHomeNotFound is emitted when the user directory cannot be found.
-	//
-	// @readonly
 	ErrSharedCredentialsHomeNotFound = awserr.New("UserHomeNotFound", "user home directory not found.", nil)
 )
 
@@ -117,21 +115,22 @@ func loadProfile(filename, profile string) (Value, error) {
 //
 // Will return an error if the user's home directory path cannot be found.
 func (p *SharedCredentialsProvider) filename() (string, error) {
-	if p.Filename == "" {
-		if p.Filename = os.Getenv("AWS_SHARED_CREDENTIALS_FILE"); p.Filename != "" {
-			return p.Filename, nil
-		}
-
-		homeDir := os.Getenv("HOME") // *nix
-		if homeDir == "" {           // Windows
-			homeDir = os.Getenv("USERPROFILE")
-		}
-		if homeDir == "" {
-			return "", ErrSharedCredentialsHomeNotFound
-		}
-
-		p.Filename = filepath.Join(homeDir, ".aws", "credentials")
+	if len(p.Filename) != 0 {
+		return p.Filename, nil
 	}
+
+	if p.Filename = os.Getenv("AWS_SHARED_CREDENTIALS_FILE"); len(p.Filename) != 0 {
+		return p.Filename, nil
+	}
+
+	if home := shareddefaults.UserHomeDir(); len(home) == 0 {
+		// Backwards compatibility of home directly not found error being returned.
+		// This error is too verbose, failure when opening the file would of been
+		// a better error to return.
+		return "", ErrSharedCredentialsHomeNotFound
+	}
+
+	p.Filename = shareddefaults.SharedCredentialsFilename()
 
 	return p.Filename, nil
 }

--- a/vendor/github.com/aws/aws-sdk-go/internal/shareddefaults/shared_config.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/shareddefaults/shared_config.go
@@ -1,0 +1,40 @@
+package shareddefaults
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// SharedCredentialsFilename returns the SDK's default file path
+// for the shared credentials file.
+//
+// Builds the shared config file path based on the OS's platform.
+//
+//   - Linux/Unix: $HOME/.aws/credentials
+//   - Windows: %USERPROFILE%\.aws\credentials
+func SharedCredentialsFilename() string {
+	return filepath.Join(UserHomeDir(), ".aws", "credentials")
+}
+
+// SharedConfigFilename returns the SDK's default file path for
+// the shared config file.
+//
+// Builds the shared config file path based on the OS's platform.
+//
+//   - Linux/Unix: $HOME/.aws/config
+//   - Windows: %USERPROFILE%\.aws\config
+func SharedConfigFilename() string {
+	return filepath.Join(UserHomeDir(), ".aws", "config")
+}
+
+// UserHomeDir returns the home directory for the user the process is
+// running under.
+func UserHomeDir() string {
+	if runtime.GOOS == "windows" { // Windows
+		return os.Getenv("USERPROFILE")
+	}
+
+	// *nix
+	return os.Getenv("HOME")
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -107,28 +107,28 @@
 			"revisionTime": "2016-11-02T21:59:28Z"
 		},
 		{
-			"checksumSHA1": "zu5C95rmCZff6NYZb62lEaT5ibE=",
+			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "707203bc55114ed114446bf57949c5c211d8b7c0",
-			"revisionTime": "2016-11-02T21:59:28Z"
+			"revision": "4c984c1f412ef5c5cdbb1a3f1c6ce5e3155ca9ab",
+			"revisionTime": "2017-09-22T21:25:34Z"
 		},
 		{
-			"checksumSHA1": "KQiUK/zr3mqnAXD7x/X55/iNme0=",
+			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "707203bc55114ed114446bf57949c5c211d8b7c0",
-			"revisionTime": "2016-11-02T21:59:28Z"
+			"revision": "4c984c1f412ef5c5cdbb1a3f1c6ce5e3155ca9ab",
+			"revisionTime": "2017-09-22T21:25:34Z"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "707203bc55114ed114446bf57949c5c211d8b7c0",
-			"revisionTime": "2016-11-02T21:59:28Z"
+			"revision": "4c984c1f412ef5c5cdbb1a3f1c6ce5e3155ca9ab",
+			"revisionTime": "2017-09-22T21:25:34Z"
 		},
 		{
-			"checksumSHA1": "4Ipx+5xN0gso+cENC2MHMWmQlR4=",
+			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "707203bc55114ed114446bf57949c5c211d8b7c0",
-			"revisionTime": "2016-11-02T21:59:28Z"
+			"revision": "4c984c1f412ef5c5cdbb1a3f1c6ce5e3155ca9ab",
+			"revisionTime": "2017-09-22T21:25:34Z"
 		},
 		{
 			"checksumSHA1": "DwhFsNluCFEwqzyp3hbJR3q2Wqs=",
@@ -159,6 +159,12 @@
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
 			"revision": "707203bc55114ed114446bf57949c5c211d8b7c0",
 			"revisionTime": "2016-11-02T21:59:28Z"
+		},
+		{
+			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
+			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
+			"revision": "4c984c1f412ef5c5cdbb1a3f1c6ce5e3155ca9ab",
+			"revisionTime": "2017-09-22T21:25:34Z"
 		},
 		{
 			"checksumSHA1": "Esab5F8KswqkTdB4TtjSvZgs56k=",


### PR DESCRIPTION
#1618 

This PR is supported for AWS Credential File.

* I have to update aws-sdk-go/credential, because of [aws-sdk-go/credentials](https://github.com/aws/aws-sdk-go/commits/master/aws/credentials/shared_credentials_provider.go) update for credential file at 2 Jun 2017.
* when CredentialPath is empty, sdk automatically search
  * sdk [ref](https://github.com/aws/aws-sdk-go/blob/master/aws/credentials/shared_credentials_provider.go#L26)
* when profile is empty, sdk automatically search
  * sdk [ref](https://github.com/aws/aws-sdk-go/blob/master/aws/credentials/shared_credentials_provider.go#L34)

@brian-brazil 