### PR TITLE
config: simplify some returns

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -463,10 +463,7 @@ func (c *TLSConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if err := checkOverflow(c.XXX, "TLS config"); err != nil {
-		return err
-	}
-	return nil
+	return checkOverflow(c.XXX, "TLS config")
 }
 
 // ServiceDiscoveryConfig configures lists of different service discovery mechanisms.
@@ -508,10 +505,7 @@ func (c *ServiceDiscoveryConfig) UnmarshalYAML(unmarshal func(interface{}) error
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if err := checkOverflow(c.XXX, "service discovery config"); err != nil {
-		return err
-	}
-	return nil
+	return checkOverflow(c.XXX, "service discovery config")
 }
 
 // HTTPClientConfig configures an HTTP client.
@@ -630,10 +624,7 @@ func (c *AlertingConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if err := checkOverflow(c.XXX, "alerting config"); err != nil {
-		return err
-	}
-	return nil
+	return checkOverflow(c.XXX, "alerting config")
 }
 
 // AlertmanagerConfig configures how Alertmanagers can be discovered and communicated with.
@@ -1085,10 +1076,7 @@ func (c *KubernetesNamespaceDiscovery) UnmarshalYAML(unmarshal func(interface{})
 	if err != nil {
 		return err
 	}
-	if err := checkOverflow(c.XXX, "namespaces"); err != nil {
-		return err
-	}
-	return nil
+	return checkOverflow(c.XXX, "namespaces")
 }
 
 // GCESDConfig is the configuration for GCE based service discovery.
@@ -1469,10 +1457,7 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 		return err
 	}
 
-	if err := checkOverflow(c.XXX, "remote_write"); err != nil {
-		return err
-	}
-	return nil
+	return checkOverflow(c.XXX, "remote_write")
 }
 
 // QueueConfig is the configuration for the queue used to write to remote
@@ -1529,8 +1514,5 @@ func (c *RemoteReadConfig) UnmarshalYAML(unmarshal func(interface{}) error) erro
 		return err
 	}
 
-	if err := checkOverflow(c.XXX, "remote_read"); err != nil {
-		return err
-	}
-	return nil
+	return checkOverflow(c.XXX, "remote_read")
 }


### PR DESCRIPTION
@fabxc @alileza 

This patch rewords some returns at the end of several UnmarshalYAML methods, hoping to make them simpler and more similar to other implementations of the same method, see: https://github.com/prometheus/prometheus/blob/398fa4fd028372fe9c280e4719e9cabbab094f45/config/config.go#L726, https://github.com/prometheus/prometheus/blob/398fa4fd028372fe9c280e4719e9cabbab094f45/config/config.go#L762 or https://github.com/prometheus/prometheus/blob/398fa4fd028372fe9c280e4719e9cabbab094f45/config/config.go#L1232