### PR TITLE
Log failure to send NaN values to remote store as Debug

### DIFF
--- a/documentation/examples/remote_storage/remote_storage_adapter/graphite/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/graphite/client.go
@@ -86,7 +86,7 @@ func (c *Client) Write(samples model.Samples) error {
 		t := float64(s.Timestamp.UnixNano()) / 1e9
 		v := float64(s.Value)
 		if math.IsNaN(v) || math.IsInf(v, 0) {
-			log.Warnf("cannot send value %f to Graphite,"+
+			log.Debugf("cannot send value %f to Graphite,"+
 				"skipping sample %#v", v, s)
 			continue
 		}

--- a/documentation/examples/remote_storage/remote_storage_adapter/opentsdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/opentsdb/client.go
@@ -75,7 +75,7 @@ func (c *Client) Write(samples model.Samples) error {
 	for _, s := range samples {
 		v := float64(s.Value)
 		if math.IsNaN(v) || math.IsInf(v, 0) {
-			log.Warnf("cannot send value %f to OpenTSDB, skipping sample %#v", v, s)
+			log.Debugf("cannot send value %f to OpenTSDB, skipping sample %#v", v, s)
 			continue
 		}
 		metric := TagValue(s.Metric[model.MetricNameLabel])


### PR DESCRIPTION
This was a warning and can be a frequent occurrence.  Let's not fill up
logs unless we are asked to.

The InfluxDB driver has a similar condition and log message but is already at the Debug level.