### PR TITLE
Avoid blocking in the logThrottling loop

### DIFF
--- a/storage/local/storage.go
+++ b/storage/local/storage.go
@@ -999,7 +999,10 @@ func (s *MemorySeriesStorage) logThrottling() {
 		select {
 		case <-s.throttled:
 			if !timer.Stop() {
-				<-timer.C
+				select {
+				case <-timer.C:
+				default:
+				}
 				score, _ := s.getPersistenceUrgencyScore()
 				log.
 					With("urgencyScore", score).


### PR DESCRIPTION
The timer semantics is really hard. The simple pattern as given in the
godoc for the time package assumes we are not elsewhere consuming from
the timer's channel. However, exactly that can happen here with the
right sequence of events. Thus, we have to drain the channel only if
it has something to drain.

@grobie (who caught this issue in the first place).