### PR TITLE
[storage/remote] cleanup ticker in QueueManager

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -249,12 +249,13 @@ func (t *QueueManager) Stop() {
 func (t *QueueManager) updateShardsLoop() {
 	defer t.wg.Done()
 
-	ticker := time.Tick(shardUpdateDuration)
+	ticker := time.NewTicker(shardUpdateDuration)
 	for {
 		select {
 		case <-ticker:
 			t.calculateDesiredShards()
 		case <-t.quit:
+			ticker.Stop()
 			return
 		}
 	}


### PR DESCRIPTION
It's not a big deal but might affect tests.
Also, it's useful to cleanup all goroutines if you'd decide to check for
goroutine leaks in future.