### PR TITLE
Remove mentions of GO15VENDOREXPERIMENT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GO           ?= GO15VENDOREXPERIMENT=1 go
+GO           ?= go
 GOFMT        ?= $(GO)fmt
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 PROMU        := $(FIRST_GOPATH)/bin/promu


### PR DESCRIPTION
Since #2750[1] prometheus depends on go 1.8. go 1.7 enables vendoring by
default and removes the corresponding variable[2], simplifying things a bit.

[1] https://github.com/prometheus/prometheus/pull/2750
[2] https://blog.golang.org/go1.7