### PR TITLE
Don't add anchoring to exported `Value` matcher field

### DIFF
--- a/pkg/labels/matcher.go
+++ b/pkg/labels/matcher.go
@@ -59,8 +59,7 @@ func NewMatcher(t MatchType, n, v string) (*Matcher, error) {
 		Value: v,
 	}
 	if t == MatchRegexp || t == MatchNotRegexp {
-		m.Value = "^(?:" + v + ")$"
-		re, err := regexp.Compile(m.Value)
+		re, err := regexp.Compile("^(?:" + v + ")$")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/labels/matcher_test.go
+++ b/pkg/labels/matcher_test.go
@@ -1,0 +1,89 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labels
+
+import "testing"
+
+func mustNewMatcher(t *testing.T, mType MatchType, value string) *Matcher {
+	m, err := NewMatcher(mType, "", value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func TestMatcher(t *testing.T) {
+	tests := []struct {
+		matcher *Matcher
+		value   string
+		match   bool
+	}{
+		{
+			matcher: mustNewMatcher(t, MatchEqual, "bar"),
+			value:   "bar",
+			match:   true,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchEqual, "bar"),
+			value:   "foo-bar",
+			match:   false,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchNotEqual, "bar"),
+			value:   "bar",
+			match:   false,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchNotEqual, "bar"),
+			value:   "foo-bar",
+			match:   true,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchRegexp, "bar"),
+			value:   "bar",
+			match:   true,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchRegexp, "bar"),
+			value:   "foo-bar",
+			match:   false,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchRegexp, ".*bar"),
+			value:   "foo-bar",
+			match:   true,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchNotRegexp, "bar"),
+			value:   "bar",
+			match:   false,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchNotRegexp, "bar"),
+			value:   "foo-bar",
+			match:   true,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchNotRegexp, ".*bar"),
+			value:   "foo-bar",
+			match:   false,
+		},
+	}
+
+	for _, test := range tests {
+		if test.matcher.Matches(test.value) != test.match {
+			t.Fatalf("Unexpected match result for matcher %v and value %q; want %v, got %v", test.matcher, test.value, test.match, !test.match)
+		}
+	}
+}

--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -233,14 +233,14 @@ func convertMatcher(m *labels.Matcher) tsdbLabels.Matcher {
 		return tsdbLabels.Not(tsdbLabels.NewEqualMatcher(m.Name, m.Value))
 
 	case labels.MatchRegexp:
-		res, err := tsdbLabels.NewRegexpMatcher(m.Name, m.Value)
+		res, err := tsdbLabels.NewRegexpMatcher(m.Name, "^(?:"+m.Value+")$")
 		if err != nil {
 			panic(err)
 		}
 		return res
 
 	case labels.MatchNotRegexp:
-		res, err := tsdbLabels.NewRegexpMatcher(m.Name, m.Value)
+		res, err := tsdbLabels.NewRegexpMatcher(m.Name, "^(?:"+m.Value+")$")
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Instead, just make the anchoring part of the internal regex. This helps because
some users will want to read back the `Value` field and expect it to be the
same as the input value (e.g. some tests in Cortex), or use the value in
another context which is already expected to add its own anchoring, leading to
superfluous double anchoring (such as when we translate matchers into remote
read request matchers).