### PR TITLE
Fix order of log msgs on shutdown

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -332,6 +332,8 @@ func main() {
 	prometheus.MustRegister(configSuccess)
 	prometheus.MustRegister(configSuccessTime)
 
+	defer level.Info(logger).Log("msg", "See you next time!")
+
 	// The notifier is a dependency of the rule manager. It has to be
 	// started before and torn down afterwards.
 	go notifier.Run()
@@ -380,8 +382,6 @@ func main() {
 	case err := <-errc:
 		level.Error(logger).Log("msg", "Error starting web server, exiting gracefully", "err", err)
 	}
-
-	level.Info(logger).Log("msg", "See you next time!")
 }
 
 // Reloadable things can change their internal state to match a new config

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -481,6 +481,7 @@ func (n *Notifier) sendOne(ctx context.Context, c *http.Client, url string, b []
 func (n *Notifier) Stop() {
 	level.Info(n.logger).Log("msg", "Stopping notification handler...")
 	n.cancel()
+	level.Info(n.logger).Log("msg", "Notification handler stopped")
 }
 
 // alertmanager holds Alertmanager endpoint information.


### PR DESCRIPTION
Closes #3232 

Added missing "notification handler stopped" log message as well. 