### PR TITLE
Use testutil assertion helpers in cmd package

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -13,7 +13,11 @@
 
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/util/testutil"
+)
 
 func TestComputeExternalURL(t *testing.T) {
 	tests := []struct {
@@ -54,13 +58,12 @@ func TestComputeExternalURL(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
-		r, err := computeExternalURL(test.input, "0.0.0.0:9090")
-		if test.valid && err != nil {
-			t.Errorf("%d. expected input to be valid, got %s", i, err)
-		} else if !test.valid && err == nil {
-			t.Logf("%+v", test, r)
-			t.Errorf("%d. expected input to be invalid", i)
+	for _, test := range tests {
+		_, err := computeExternalURL(test.input, "0.0.0.0:9090")
+		if test.valid {
+			testutil.Ok(t, err)
+		} else {
+			testutil.NotOk(t, err)
 		}
 	}
 }

--- a/util/testutil/testing.go
+++ b/util/testutil/testing.go
@@ -48,6 +48,15 @@ func Ok(tb testing.TB, err error) {
 	}
 }
 
+// NotOk fails the test if an err is nil.
+func NotOk(tb testing.TB, err error) {
+	if err == nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: expected error, got nothing \033[39m\n\n", filepath.Base(file), line)
+		tb.FailNow()
+	}
+}
+
 // Equals fails the test if exp is not equal to act.
 func Equals(tb testing.TB, exp, act interface{}) {
 	if !reflect.DeepEqual(exp, act) {


### PR DESCRIPTION
Related to #3242,

In this pull request I:

- [x] Add a test helper `testing.NotOk` asserting the existence of an error
- [x] Use testutil assertions in the `cmd` package

Actually I re-did the job for the package `config`, but I noticed it was already done in #3269. This is why I added the `NotOk` helper, I thought it had some value. 