### PR TITLE
config: simplify tests by using testutil.NotOk

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -63,7 +63,7 @@ func TestComputeExternalURL(t *testing.T) {
 		if test.valid {
 			testutil.Ok(t, err)
 		} else {
-			testutil.NotOk(t, err)
+			testutil.NotOk(t, err, "input=%q: ", test.input)
 		}
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -59,7 +59,7 @@ func LoadFile(filename string) (*Config, error) {
 	}
 	cfg, err := Load(string(content))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing YAML file %s: %v", filename, err)
 	}
 	resolveFilepaths(filepath.Dir(filename), cfg)
 	return cfg, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -659,8 +659,7 @@ var expectedErrors = []struct {
 func TestBadConfigs(t *testing.T) {
 	for _, ee := range expectedErrors {
 		_, err := LoadFile("testdata/" + ee.filename)
-		testutil.Assert(t, err != nil,
-			"Expected error parsing %s but got none", ee.filename)
+		testutil.NotOk(t, err, "%s: ", ee.filename)
 		testutil.Assert(t, strings.Contains(err.Error(), ee.errMsg),
 			"Expected error for %s to contain %q but got: %s", ee.filename, ee.errMsg, err)
 	}
@@ -671,7 +670,7 @@ func TestBadStaticConfigs(t *testing.T) {
 	testutil.Ok(t, err)
 	var tg TargetGroup
 	err = json.Unmarshal(content, &tg)
-	testutil.Assert(t, err != nil, "Expected unmarshal error but got none.")
+	testutil.NotOk(t, err, "", nil)
 }
 
 func TestEmptyConfig(t *testing.T) {

--- a/util/testutil/testing.go
+++ b/util/testutil/testing.go
@@ -49,10 +49,10 @@ func Ok(tb testing.TB, err error) {
 }
 
 // NotOk fails the test if an err is nil.
-func NotOk(tb testing.TB, err error) {
+func NotOk(tb testing.TB, err error, msg string, v ...interface{}) {
 	if err == nil {
 		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d: expected error, got nothing \033[39m\n\n", filepath.Base(file), line)
+		fmt.Printf("\033[31m%s:%d: "+msg+"expected error, got nothing\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
 		tb.FailNow()
 	}
 }


### PR DESCRIPTION
Simplify package config tests by using `testutil.NotOk`.

When a "table driven test" fails due to `testuitl.NotOk`, there is no way to know which entry in the table is actually failing, because, as opposed to `testutil.Ok`, `testutil.NotOk` does not receive any information from the test (its input is nil when the test fails). To fix this I have added a formatted message to `testuitl.NotOk`.

Also, I have guaranteed all `config.LoadFile` errors include the filename so people can know what file is not loading correctly.