### PR TITLE
Add flag to get OpenStack auth from the environment

### DIFF
--- a/discovery/openstack/openstack.go
+++ b/discovery/openstack/openstack.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 
@@ -52,15 +53,24 @@ type Discovery interface {
 
 // NewDiscovery returns a new OpenStackDiscovery which periodically refreshes its targets.
 func NewDiscovery(conf *config.OpenstackSDConfig, l log.Logger) (Discovery, error) {
-	opts := gophercloud.AuthOptions{
-		IdentityEndpoint: conf.IdentityEndpoint,
-		Username:         conf.Username,
-		UserID:           conf.UserID,
-		Password:         string(conf.Password),
-		TenantName:       conf.ProjectName,
-		TenantID:         conf.ProjectID,
-		DomainName:       conf.DomainName,
-		DomainID:         conf.DomainID,
+	var opts gophercloud.AuthOptions
+	if conf.IdentityEndpoint == "" {
+		var err error
+		opts, err = openstack.AuthOptionsFromEnv()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		opts = gophercloud.AuthOptions{
+			IdentityEndpoint: conf.IdentityEndpoint,
+			Username:         conf.Username,
+			UserID:           conf.UserID,
+			Password:         string(conf.Password),
+			TenantName:       conf.ProjectName,
+			TenantID:         conf.ProjectID,
+			DomainName:       conf.DomainName,
+			DomainID:         conf.DomainID,
+		}
 	}
 	switch conf.Role {
 	case config.OpenStackRoleHypervisor:


### PR DESCRIPTION
This change adds a new flag 'auth_options_from_env' to the OpenStack
service discovery. When enabled, the OpenStack provider will get the
authentication credentials from the OS_* environment variables instead
of the Prometheus configuration file.