### PR TITLE
At ListMatch syntax to promql

### DIFF
--- a/promql/lex.go
+++ b/promql/lex.go
@@ -162,6 +162,8 @@ const (
 	itemGTR
 	itemEQLRegex
 	itemNEQRegex
+	itemEQLList
+	itemNEQList
 	itemPOW
 	operatorsEnd
 
@@ -261,6 +263,8 @@ var itemTypeStr = map[itemType]string{
 	itemGTR:      ">",
 	itemEQLRegex: "=~",
 	itemNEQRegex: "!~",
+	itemEQLList: "=|",
+	itemNEQList: "!|",
 	itemPOW:      "^",
 }
 
@@ -579,8 +583,17 @@ func lexInsideBraces(l *lexer) stateFn {
 		l.stringOpen = r
 		return lexRawString
 	case r == '=':
-		if l.next() == '~' {
+		toBreak := false
+		switch l.next() {
+		case '~':
 			l.emit(itemEQLRegex)
+			toBreak = true
+		case '|':
+			l.emit(itemEQLList)
+			toBreak = true
+		}
+		// TODO: use label break
+		if toBreak {
 			break
 		}
 		l.backup()
@@ -589,6 +602,8 @@ func lexInsideBraces(l *lexer) stateFn {
 		switch nr := l.next(); {
 		case nr == '~':
 			l.emit(itemNEQRegex)
+		case nr == '|':
+			l.emit(itemNEQList)
 		case nr == '=':
 			l.emit(itemNEQ)
 		default:

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -854,6 +854,10 @@ func (p *parser) labelMatchers(operators ...itemType) []*labels.Matcher {
 			matchType = labels.MatchRegexp
 		case itemNEQRegex:
 			matchType = labels.MatchNotRegexp
+		case itemEQLList:
+			matchType = labels.MatchList
+		case itemNEQList:
+			matchType = labels.MatchNotList
 		default:
 			p.errorf("item %q is not a metric match type", op)
 		}
@@ -940,7 +944,7 @@ func (p *parser) VectorSelector(name string) *VectorSelector {
 	var matchers []*labels.Matcher
 	// Parse label matching if any.
 	if t := p.peek(); t.typ == itemLeftBrace {
-		matchers = p.labelMatchers(itemEQL, itemNEQ, itemEQLRegex, itemNEQRegex)
+		matchers = p.labelMatchers(itemEQL, itemNEQ, itemEQLRegex, itemNEQRegex, itemEQLList, itemNEQList)
 	}
 	// Metric name must not be set in the label matchers and before at the same time.
 	if name != "" {

--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -245,6 +245,12 @@ func convertMatcher(m *labels.Matcher) tsdbLabels.Matcher {
 			panic(err)
 		}
 		return tsdbLabels.Not(res)
+
+	case labels.MatchList:
+		return tsdbLabels.NewListMatcher(m.Name, m.Value)
+
+	case labels.MatchNotList:
+		return tsdbLabels.Not(tsdbLabels.NewListMatcher(m.Name, m.Value))
 	}
 	panic("storage.convertMatcher: invalid matcher type")
 }

--- a/vendor/github.com/prometheus/tsdb/labels/selector.go
+++ b/vendor/github.com/prometheus/tsdb/labels/selector.go
@@ -106,3 +106,27 @@ func (m *PrefixMatcher) Prefix() string { return m.prefix }
 
 // Matches implements Matcher interface.
 func (m *PrefixMatcher) Matches(v string) bool { return strings.HasPrefix(v, m.prefix) }
+
+// ListMatcher implements Matcher for labels which values are within a list of values
+type ListMatcher struct {
+	name string
+	set map[string]struct{}
+}
+
+// NewListMatcher returns new Matcher for labels which values are within a list of values
+func NewListMatcher(name, sets string) Matcher {
+	set := make(map[string]struct{})
+	for _, s := range strings.Split(sets, ",") {
+		set[s] = struct{}{}
+	}
+	return &ListMatcher{name: name, set: set}
+}
+
+// Name implements Matcher interface.
+func (m *ListMatcher) Name() string { return m.name }
+
+// Matches implements Matcher interface.
+func (m *ListMatcher) Matches(v string) bool {
+	_, ok := m.set[v]
+	return ok
+}


### PR DESCRIPTION
In usage of promql its quite common to want to target a specific label by a known set of values (the canonical example being the `node` label with a list of known hostnames). In the current promql language the only mechanism you have to do a multi-select is to use a regex which would look something like:

`metric_name{node=~"(host1|host1)"}`

The downside of this being that I have to take my nicely structured data (a list) and put it into a regex. This causes a variety of performance problems. There is an issue up right now (#2651) to "optimize queries using regex matchers for set lookups". In my experience writing code to parse things out of regexes to do smarter things is *significantly* harder than just keeping the data structured to begin with. Although there may be other use-cases that would want "smarter regex" the "match a list of values" seems like a common-enough case to warrant a new matcher.

I have (in my fork) new matchers to do a valueSet comparison. With this feature the above query becomes:

`metric_name{node=|"host1,host1"}`

I originally was planning on doing `metric_name{node=["host1","host1"]}` but that seemed to cause quite the pain with the lexer/parser (as there aren't any other matchers with trailing characters.

I have the change staged in my fork of tsdb (https://github.com/prometheus/tsdb/compare/master...jacksontj:master) before this would be merged I'll get that in and then update the vendor normally. 