### PR TITLE
use filepath.Glob(pat) only when the rule path is a pattern

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -470,12 +471,16 @@ func (m *Manager) ApplyConfig(conf *config.Config) error {
 	// Get all rule files and load the groups they define.
 	var files []string
 	for _, pat := range conf.RuleFiles {
-		fs, err := filepath.Glob(pat)
-		if err != nil {
-			// The only error can be a bad pattern.
-			return fmt.Errorf("error retrieving rule files for %s: %s", pat, err)
+		if strings.Contains(pat, "*") {
+			fs, err := filepath.Glob(pat)
+			if err != nil {
+				// The only error can be a bad pattern.
+				return fmt.Errorf("error retrieving rule files for %s: %s", pat, err)
+			}
+			files = append(files, fs...)
+		} else {
+			files = append(files, pat)
 		}
-		files = append(files, fs...)
 	}
 
 	// To be replaced with a configurable per-group interval.


### PR DESCRIPTION
```
rule_files:
   "./rulexxx.yaml" - error if doesn't exist
   "second*.rules" - load all files matching the pattern.
```

I think it would be  a good idea to add a test case, so let me know if this fix looks ok  and I will add it.