### PR TITLE
testutil: simplify code

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -63,7 +63,7 @@ func TestComputeExternalURL(t *testing.T) {
 		if test.valid {
 			testutil.Ok(t, err)
 		} else {
-			testutil.NotOk(t, err, "input=%q: ", test.input)
+			testutil.NotOk(t, err, "input=%q", test.input)
 		}
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -673,7 +673,7 @@ var expectedErrors = []struct {
 func TestBadConfigs(t *testing.T) {
 	for _, ee := range expectedErrors {
 		_, err := LoadFile("testdata/" + ee.filename)
-		testutil.NotOk(t, err, "%s: ", ee.filename)
+		testutil.NotOk(t, err, "%s", ee.filename)
 		testutil.Assert(t, strings.Contains(err.Error(), ee.errMsg),
 			"Expected error for %s to contain %q but got: %s", ee.filename, ee.errMsg, err)
 	}
@@ -684,7 +684,7 @@ func TestBadStaticConfigs(t *testing.T) {
 	testutil.Ok(t, err)
 	var tg TargetGroup
 	err = json.Unmarshal(content, &tg)
-	testutil.NotOk(t, err, "", nil)
+	testutil.NotOk(t, err, "")
 }
 
 func TestEmptyConfig(t *testing.T) {

--- a/util/testutil/testing.go
+++ b/util/testutil/testing.go
@@ -23,45 +23,41 @@
 package testutil
 
 import (
-	"fmt"
-	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 )
 
 // Assert fails the test if the condition is false.
-func Assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+func Assert(tb testing.TB, condition bool, format string, a ...interface{}) {
+	tb.Helper()
 	if !condition {
-		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
-		tb.FailNow()
+		tb.Fatalf("\033[31m"+format+"\033[39m\n", a...)
 	}
 }
 
 // Ok fails the test if an err is not nil.
 func Ok(tb testing.TB, err error) {
+	tb.Helper()
 	if err != nil {
-		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
-		tb.FailNow()
+		tb.Fatalf("\033[31munexpected error: %v\033[39m\n", err)
 	}
 }
 
 // NotOk fails the test if an err is nil.
-func NotOk(tb testing.TB, err error, msg string, v ...interface{}) {
+func NotOk(tb testing.TB, err error, format string, a ...interface{}) {
+	tb.Helper()
 	if err == nil {
-		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d: "+msg+"expected error, got nothing\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
-		tb.FailNow()
+		if len(a) != 0 {
+			tb.Fatalf("\033[31m"+format+": expected error, got none\033[39m", a...)
+		}
+		tb.Fatalf("\033[31mexpected error, got none\033[39m")
 	}
 }
 
 // Equals fails the test if exp is not equal to act.
 func Equals(tb testing.TB, exp, act interface{}) {
+	tb.Helper()
 	if !reflect.DeepEqual(exp, act) {
-		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
-		tb.FailNow()
+		tb.Fatalf("\033[31m\nexp: %#v\n\ngot: %#v\033[39m\n", exp, act)
 	}
 }


### PR DESCRIPTION
Simplify package `testutils` testing functions by using `testing.Helper()` and `testing.Fatal()` rather than hardcoding their behaviour in every function.