### PR TITLE
use a timeout in the HTTP client used for consul sd

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -114,7 +114,10 @@ func NewDiscovery(conf *config.ConsulSDConfig, logger log.Logger) (*Discovery, e
 			conntrack.DialWithName("consul_sd"),
 		),
 	}
-	wrapper := &http.Client{Transport: transport}
+	wrapper := &http.Client{
+		Transport: transport,
+		Timeout:   30 * time.Second,
+	}
 
 	clientConf := &consul.Config{
 		Address:    conf.Server,


### PR DESCRIPTION
cc: @fabxc @grobie 
To address #3096 

I still don't entirely understand how just a client timeout is the fix, but this seems to work relatively well. 30s seems to be a reasonable timeout period to me, but I'm unsure if we'd want a config option as well. Probably not.

As I said, I don't entirely understand how a timeout is the fix. I thought the HTTP client, and it's connections, should be closed if their goroutine ends. If the reload sends ctx.Close properly then those goroutines should end? A timeout ending the client connections seems like it's just obscuring the real cause to me, though I haven't been able to find any other cause. My understanding of how the various components interact and communicate is very limited. If anyone has time to walk me through this I'd appreciate it :)