### PR TITLE
validates that the recording name to  include only allowed characters.

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -128,6 +128,12 @@ func (r *Rule) Validate() (errs []error) {
 			errs = append(errs, errors.Errorf("invalid field 'for' in recording rule"))
 		}
 	}
+	for i, b := range r.Record {
+		if !((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || b == ':' || (b >= '0' && b <= '9' && i > 0)) {
+			errs = append(errs, errors.Errorf("record name includes invalid character: '%v'", string(b)))
+			break
+		}
+	}
 
 	for k, v := range r.Labels {
 		if !model.LabelName(k).IsValid() {

--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -127,11 +127,8 @@ func (r *Rule) Validate() (errs []error) {
 		if r.For != 0 {
 			errs = append(errs, errors.Errorf("invalid field 'for' in recording rule"))
 		}
-	}
-	for i, b := range r.Record {
-		if !((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || b == ':' || (b >= '0' && b <= '9' && i > 0)) {
-			errs = append(errs, errors.Errorf("record name includes invalid character: '%v'", string(b)))
-			break
+		if !model.IsValidMetricName(model.LabelValue(r.Record)) {
+			errs = append(errs, errors.Errorf("invalid recording rule name"))
 		}
 	}
 

--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -128,7 +128,7 @@ func (r *Rule) Validate() (errs []error) {
 			errs = append(errs, errors.Errorf("invalid field 'for' in recording rule"))
 		}
 		if !model.IsValidMetricName(model.LabelValue(r.Record)) {
-			errs = append(errs, errors.Errorf("invalid recording rule name"))
+			errs = append(errs, errors.Errorf("invalid recording rule name: %s", r.Record))
 		}
 	}
 

--- a/pkg/rulefmt/rulefmt_test.go
+++ b/pkg/rulefmt/rulefmt_test.go
@@ -61,6 +61,10 @@ func TestParseFileFailure(t *testing.T) {
 			filename: "bad_annotation.bad.yaml",
 			errMsg:   "invalid annotation name",
 		},
+		{
+			filename: "invalid_record_name.bad.yaml",
+			errMsg:   "record name includes invalid character: '{'",
+		},
 	}
 
 	for _, c := range table {

--- a/pkg/rulefmt/rulefmt_test.go
+++ b/pkg/rulefmt/rulefmt_test.go
@@ -63,7 +63,7 @@ func TestParseFileFailure(t *testing.T) {
 		},
 		{
 			filename: "invalid_record_name.bad.yaml",
-			errMsg:   "record name includes invalid character: '{'",
+			errMsg:   "invalid recording rule name",
 		},
 	}
 

--- a/pkg/rulefmt/testdata/invalid_record_name.bad.yaml
+++ b/pkg/rulefmt/testdata/invalid_record_name.bad.yaml
@@ -1,0 +1,5 @@
+groups:
+  - name: yolo
+    rules:
+    - record: strawberry{flavor="sweet"}
+      expr: 1


### PR DESCRIPTION
fixes https://github.com/prometheus/prometheus/issues/3290

allowed characters for the record name are `a-z A-Z 0-9  :   _ `
