### PR TITLE
Adding remote_storage example for KairosDB

### DIFF
--- a/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client.go
@@ -83,7 +83,7 @@ func (c *Client) Write(samples model.Samples) error {
 	reqs := make([]StoreSamplesRequest, 0, len(samples))
 	for _, s := range samples {
 		v := float64(s.Value)
-		
+
 		if math.IsNaN(v) || math.IsInf(v, 0) {
 			level.Debug(c.logger).Log("msg", "cannot send value to KairosDB, skipping sample", "value", v, "sample", s)
 			continue
@@ -123,7 +123,6 @@ func (c *Client) Write(samples model.Samples) error {
 		return nil
 	}
 
-
 	// API returns status code 400 on error, encoding error details in the
 	// response content in JSON.
 	buf, err = ioutil.ReadAll(resp.Body)
@@ -136,7 +135,7 @@ func (c *Client) Write(samples model.Samples) error {
 	if err := json.Unmarshal(buf, &r); err != nil {
 		return err
 	}
-	return fmt.Errorf("failed to write %d samples to KairosDB, %d succeeded", len(r["errors"]), totalRequests - len(r["errors"]))
+	return fmt.Errorf("failed to write %d samples to KairosDB, %d succeeded", len(r["errors"]), totalRequests-len(r["errors"]))
 }
 
 // Name identifies the client as an KairosDB client.

--- a/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client.go
@@ -55,7 +55,7 @@ func NewClient(logger log.Logger, url string, timeout time.Duration) *Client {
 // StoreSamplesRequest is used for building a JSON request for storing samples
 // via the KairosDB.
 type StoreSamplesRequest struct {
-	Name      TagValue          `json:"name"`
+	Name      string            `json:"name"`
 	Timestamp int64             `json:"timestamp"`
 	Value     float64           `json:"value"`
 	Tags      map[string]string `json:"tags"`
@@ -82,7 +82,7 @@ func (c *Client) Write(samples model.Samples) error {
 			level.Debug(c.logger).Log("msg", "cannot send value to KairosDB, skipping sample", "value", v, "sample", s)
 			continue
 		}
-		metric := TagValue(s.Metric[model.MetricNameLabel])
+		metric := s.Metric[model.MetricNameLabel]
 		reqs = append(reqs, StoreSamplesRequest{
 			Name:      metric,
 			Timestamp: s.Timestamp.Unix() / int64(time.Millisecond),

--- a/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client.go
@@ -1,0 +1,135 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kairosdb
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"bytes"
+	"context"
+	"encoding/json"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/common/model"
+	"golang.org/x/net/context/ctxhttp"
+	"math"
+	"net/url"
+	"time"
+)
+
+const (
+	postEndpoint    = "/api/v1/datapoints"
+	contentTypeJSON = "application/json"
+)
+
+// Client allows sending batches of Prometheus samples to KairosDB.
+type Client struct {
+	logger log.Logger
+
+	url     string
+	timeout time.Duration
+}
+
+// NewClient creates a new Client.
+func NewClient(logger log.Logger, url string, timeout time.Duration) *Client {
+	return &Client{
+		logger:  logger,
+		url:     url,
+		timeout: timeout,
+	}
+}
+
+// StoreSamplesRequest is used for building a JSON request for storing samples
+// via the KairosDB.
+type StoreSamplesRequest struct {
+	Name      TagValue          `json:"name"`
+	Timestamp int64             `json:"timestamp"`
+	Value     float64           `json:"value"`
+	Tags      map[string]string `json:"tags"`
+}
+
+// tagsFromMetric translates Prometheus metric into KairosDB tags.
+func tagsFromMetric(m model.Metric) map[string]string {
+	tags := make(map[string]string, len(m)-1)
+	for l, v := range m {
+		if l == model.MetricNameLabel {
+			continue
+		}
+		tags[string(l)] = string(v)
+	}
+	return tags
+}
+
+// Write sends a batch of samples to KairosDB via its HTTP API.
+func (c *Client) Write(samples model.Samples) error {
+	reqs := make([]StoreSamplesRequest, 0, len(samples))
+	for _, s := range samples {
+		v := float64(s.Value)
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			level.Debug(c.logger).Log("msg", "cannot send value to KairosDB, skipping sample", "value", v, "sample", s)
+			continue
+		}
+		metric := TagValue(s.Metric[model.MetricNameLabel])
+		reqs = append(reqs, StoreSamplesRequest{
+			Name:      metric,
+			Timestamp: s.Timestamp.Unix() / int64(time.Millisecond),
+			Value:     v,
+			Tags:      tagsFromMetric(s.Metric),
+		})
+	}
+
+	u, err := url.Parse(c.url)
+	if err != nil {
+		return err
+	}
+
+	u.Path = postEndpoint
+	buf, err := json.Marshal(reqs)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	resp, err := ctxhttp.Post(ctx, http.DefaultClient, u.String(), contentTypeJSON, bytes.NewBuffer(buf))
+
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	// API returns status code 400 on error, encoding error details in the
+	// response content in JSON.
+	buf, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var r map[string]int
+	if err := json.Unmarshal(buf, &r); err != nil {
+		return err
+	}
+	return fmt.Errorf("failed to write %d samples to KairosDB, %d succeeded", r["failed"], r["success"])
+}
+
+// Name identifies the client as an KairosDB client.
+func (c Client) Name() string {
+	return "kairosdb"
+}

--- a/documentation/examples/remote_storage/remote_storage_adapter/main.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter/graphite"
 	"github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter/influxdb"
+	"github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter/kairosdb"
 	"github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter/opentsdb"
 	"github.com/prometheus/prometheus/prompb"
 )
@@ -54,6 +55,7 @@ type config struct {
 	remoteTimeout           time.Duration
 	listenAddr              string
 	telemetryPath           string
+	kairosdbURL             string
 }
 
 var (
@@ -136,6 +138,9 @@ func parseFlags() *config {
 	flag.StringVar(&cfg.influxdbDatabase, "influxdb.database", "prometheus",
 		"The name of the database to use for storing samples in InfluxDB.",
 	)
+	flag.StringVar(&cfg.kairosdbURL, "kairosdb-url", "",
+		"The URL of the remote KairosDB server to send samples to. None, if empty.",
+	)
 	flag.DurationVar(&cfg.remoteTimeout, "send-timeout", 30*time.Second,
 		"The timeout to use when sending samples to the remote storage.",
 	)
@@ -196,6 +201,14 @@ func buildClients(logger log.Logger, cfg *config) ([]writer, []reader) {
 		prometheus.MustRegister(c)
 		writers = append(writers, c)
 		readers = append(readers, c)
+	}
+	if cfg.kairosdbURL != "" {
+		c := kairosdb.NewClient(
+			log.With(logger, "storage", "KairosDB"),
+			cfg.kairosdbURL,
+			cfg.remoteTimeout,
+		)
+		writers = append(writers, c)
 	}
 	level.Info(logger).Log("Starting up...")
 	return writers, readers


### PR DESCRIPTION
Adding an example for KairosDB as remote storage. Will be useful for people using KairosDB as remote storage with Prometheus. 

Kindly let me know if more work is needed for this request to be approved and merged.