### PR TITLE
Expose ActiveAt for use in alert rule templating as activeAt function

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -252,6 +252,9 @@ func NewTemplateExpander(ctx context.Context, text string, name string, data int
 			"externalURL": func() string {
 				return externalURL.String()
 			},
+			"activeAt": func() string {
+				return fmt.Sprintf("%d", int64(timestamp))
+			},
 		},
 	}
 }

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -209,9 +209,14 @@ func TestTemplateExpansion(t *testing.T) {
 			text:   "{{ externalURL }}",
 			output: "http://testhost:9090/path/prefix",
 		},
+		{
+			// activeAt.
+			text:   "{{ activeAt }}",
+			output: "1508315335052",
+		},
 	}
 
-	time := model.Time(0)
+	time := model.Time(1508315335052)
 
 	storage := testutil.NewStorage(t)
 	defer storage.Close()
@@ -221,9 +226,9 @@ func TestTemplateExpansion(t *testing.T) {
 		t.Fatalf("get appender: %s", err)
 	}
 
-	_, err = app.Add(labels.FromStrings(labels.MetricName, "metric", "instance", "a"), 0, 11)
+	_, err = app.Add(labels.FromStrings(labels.MetricName, "metric", "instance", "a"), 1508315335052, 11)
 	require.NoError(t, err)
-	_, err = app.Add(labels.FromStrings(labels.MetricName, "metric", "instance", "b"), 0, 21)
+	_, err = app.Add(labels.FromStrings(labels.MetricName, "metric", "instance", "b"), 1508315335052, 21)
 	require.NoError(t, err)
 
 	if err := app.Commit(); err != nil {


### PR DESCRIPTION
This exposes the ActiveAt timestamp on an alert via the activeAt template function so that it can be used to parameterize a link to a Grafana graph with start=activeAt and end=now. 