### PR TITLE
Move ProvidersFromConfig out of discovery package

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -18,20 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/prometheus/config"
-	"github.com/prometheus/prometheus/discovery/azure"
-	"github.com/prometheus/prometheus/discovery/consul"
-	"github.com/prometheus/prometheus/discovery/dns"
-	"github.com/prometheus/prometheus/discovery/ec2"
-	"github.com/prometheus/prometheus/discovery/file"
-	"github.com/prometheus/prometheus/discovery/gce"
-	"github.com/prometheus/prometheus/discovery/kubernetes"
-	"github.com/prometheus/prometheus/discovery/marathon"
-	"github.com/prometheus/prometheus/discovery/openstack"
-	"github.com/prometheus/prometheus/discovery/triton"
-	"github.com/prometheus/prometheus/discovery/zookeeper"
 	"golang.org/x/net/context"
 )
 
@@ -49,88 +36,6 @@ type TargetProvider interface {
 	// Must returns if the context gets canceled. It should not close the update
 	// channel on returning.
 	Run(ctx context.Context, up chan<- []*config.TargetGroup)
-}
-
-// ProvidersFromConfig returns all TargetProviders configured in cfg.
-func ProvidersFromConfig(cfg config.ServiceDiscoveryConfig, logger log.Logger) map[string]TargetProvider {
-	providers := map[string]TargetProvider{}
-
-	app := func(mech string, i int, tp TargetProvider) {
-		providers[fmt.Sprintf("%s/%d", mech, i)] = tp
-	}
-
-	for i, c := range cfg.DNSSDConfigs {
-		app("dns", i, dns.NewDiscovery(c, log.With(logger, "discovery", "dns")))
-	}
-	for i, c := range cfg.FileSDConfigs {
-		app("file", i, file.NewDiscovery(c, log.With(logger, "discovery", "file")))
-	}
-	for i, c := range cfg.ConsulSDConfigs {
-		k, err := consul.NewDiscovery(c, log.With(logger, "discovery", "consul"))
-		if err != nil {
-			level.Error(logger).Log("msg", "Cannot create Consul discovery", "err", err)
-			continue
-		}
-		app("consul", i, k)
-	}
-	for i, c := range cfg.MarathonSDConfigs {
-		m, err := marathon.NewDiscovery(c, log.With(logger, "discovery", "marathon"))
-		if err != nil {
-			level.Error(logger).Log("msg", "Cannot create Marathon discovery", "err", err)
-			continue
-		}
-		app("marathon", i, m)
-	}
-	for i, c := range cfg.KubernetesSDConfigs {
-		k, err := kubernetes.New(log.With(logger, "discovery", "k8s"), c)
-		if err != nil {
-			level.Error(logger).Log("msg", "Cannot create Kubernetes discovery", "err", err)
-			continue
-		}
-		app("kubernetes", i, k)
-	}
-	for i, c := range cfg.ServersetSDConfigs {
-		app("serverset", i, zookeeper.NewServersetDiscovery(c, log.With(logger, "discovery", "zookeeper")))
-	}
-	for i, c := range cfg.NerveSDConfigs {
-		app("nerve", i, zookeeper.NewNerveDiscovery(c, log.With(logger, "discovery", "nerve")))
-	}
-	for i, c := range cfg.EC2SDConfigs {
-		app("ec2", i, ec2.NewDiscovery(c, log.With(logger, "discovery", "ec2")))
-	}
-	for i, c := range cfg.OpenstackSDConfigs {
-		openstackd, err := openstack.NewDiscovery(c, log.With(logger, "discovery", "openstack"))
-		if err != nil {
-			level.Error(logger).Log("msg", "Cannot initialize OpenStack discovery", "err", err)
-			continue
-		}
-		app("openstack", i, openstackd)
-	}
-
-	for i, c := range cfg.GCESDConfigs {
-		gced, err := gce.NewDiscovery(c, log.With(logger, "discovery", "gce"))
-		if err != nil {
-			level.Error(logger).Log("msg", "Cannot initialize GCE discovery", "err", err)
-			continue
-		}
-		app("gce", i, gced)
-	}
-	for i, c := range cfg.AzureSDConfigs {
-		app("azure", i, azure.NewDiscovery(c, log.With(logger, "discovery", "azure")))
-	}
-	for i, c := range cfg.TritonSDConfigs {
-		t, err := triton.New(log.With(logger, "discovery", "trition"), c)
-		if err != nil {
-			level.Error(logger).Log("msg", "Cannot create Triton discovery", "err", err)
-			continue
-		}
-		app("triton", i, t)
-	}
-	if len(cfg.StaticConfigs) > 0 {
-		app("static", 0, NewStaticProvider(cfg.StaticConfigs))
-	}
-
-	return providers
 }
 
 // StaticProvider holds a list of target groups that never change.
@@ -316,4 +221,11 @@ func (ts *TargetSet) setTargetGroup(name string, tg *config.TargetGroup) {
 		return
 	}
 	ts.tgroups[name+"/"+tg.Source] = tg
+}
+
+func (ts *TargetSet) ContainsTargetGroup(name string) bool {
+	ts.mtx.RLock()
+	_, ok := ts.tgroups[name]
+	ts.mtx.RUnlock()
+	return ok
 }

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -37,6 +37,7 @@ import (
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
+	"github.com/prometheus/prometheus/util/discoveryutil"
 	"github.com/prometheus/prometheus/util/httputil"
 )
 
@@ -264,7 +265,7 @@ func (n *Notifier) ApplyConfig(conf *config.Config) error {
 	// old ones.
 	for _, ams := range amSets {
 		go ams.ts.Run(ctx)
-		ams.ts.UpdateProviders(discovery.ProvidersFromConfig(ams.cfg.ServiceDiscoveryConfig, n.logger))
+		ams.ts.UpdateProviders(discoveryutil.ProvidersFromConfig(ams.cfg.ServiceDiscoveryConfig, n.logger))
 	}
 	if n.cancelDiscovery != nil {
 		n.cancelDiscovery()

--- a/retrieval/targetmanager.go
+++ b/retrieval/targetmanager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/discoveryutil"
 )
 
 // TargetManager maintains a set of targets, starts and stops their scraping and
@@ -125,7 +126,7 @@ func (tm *TargetManager) reload() {
 		} else {
 			ts.sp.reload(scfg)
 		}
-		ts.ts.UpdateProviders(discovery.ProvidersFromConfig(scfg.ServiceDiscoveryConfig, tm.logger))
+		ts.ts.UpdateProviders(discoveryutil.ProvidersFromConfig(scfg.ServiceDiscoveryConfig, tm.logger))
 	}
 
 	// Remove old target sets. Waiting for scrape pools to complete pending

--- a/util/discoveryutil/discovery.go
+++ b/util/discoveryutil/discovery.go
@@ -1,0 +1,103 @@
+package discoveryutil
+
+import (
+	"fmt"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/azure"
+	"github.com/prometheus/prometheus/discovery/consul"
+	"github.com/prometheus/prometheus/discovery/dns"
+	"github.com/prometheus/prometheus/discovery/ec2"
+	"github.com/prometheus/prometheus/discovery/file"
+	"github.com/prometheus/prometheus/discovery/gce"
+	"github.com/prometheus/prometheus/discovery/kubernetes"
+	"github.com/prometheus/prometheus/discovery/marathon"
+	"github.com/prometheus/prometheus/discovery/openstack"
+	"github.com/prometheus/prometheus/discovery/triton"
+	"github.com/prometheus/prometheus/discovery/zookeeper"
+)
+
+// ProvidersFromConfig returns all TargetProviders configured in cfg.
+func ProvidersFromConfig(cfg config.ServiceDiscoveryConfig, logger log.Logger) map[string]discovery.TargetProvider {
+	providers := map[string]discovery.TargetProvider{}
+
+	app := func(mech string, i int, tp discovery.TargetProvider) {
+		providers[fmt.Sprintf("%s/%d", mech, i)] = tp
+	}
+
+	for i, c := range cfg.DNSSDConfigs {
+		app("dns", i, dns.NewDiscovery(c, log.With(logger, "discovery", "dns")))
+	}
+	for i, c := range cfg.FileSDConfigs {
+		app("file", i, file.NewDiscovery(c, log.With(logger, "discovery", "file")))
+	}
+	for i, c := range cfg.ConsulSDConfigs {
+		k, err := consul.NewDiscovery(c, log.With(logger, "discovery", "consul"))
+		if err != nil {
+			level.Error(logger).Log("msg", "Cannot create Consul discovery", "err", err)
+			continue
+		}
+		app("consul", i, k)
+	}
+	for i, c := range cfg.MarathonSDConfigs {
+		m, err := marathon.NewDiscovery(c, log.With(logger, "discovery", "marathon"))
+		if err != nil {
+			level.Error(logger).Log("msg", "Cannot create Marathon discovery", "err", err)
+			continue
+		}
+		app("marathon", i, m)
+	}
+	for i, c := range cfg.KubernetesSDConfigs {
+		k, err := kubernetes.New(log.With(logger, "discovery", "k8s"), c)
+		if err != nil {
+			level.Error(logger).Log("msg", "Cannot create Kubernetes discovery", "err", err)
+			continue
+		}
+		app("kubernetes", i, k)
+	}
+	for i, c := range cfg.ServersetSDConfigs {
+		app("serverset", i, zookeeper.NewServersetDiscovery(c, log.With(logger, "discovery", "zookeeper")))
+	}
+	for i, c := range cfg.NerveSDConfigs {
+		app("nerve", i, zookeeper.NewNerveDiscovery(c, log.With(logger, "discovery", "nerve")))
+	}
+	for i, c := range cfg.EC2SDConfigs {
+		app("ec2", i, ec2.NewDiscovery(c, log.With(logger, "discovery", "ec2")))
+	}
+	for i, c := range cfg.OpenstackSDConfigs {
+		openstackd, err := openstack.NewDiscovery(c, log.With(logger, "discovery", "openstack"))
+		if err != nil {
+			level.Error(logger).Log("msg", "Cannot initialize OpenStack discovery", "err", err)
+			continue
+		}
+		app("openstack", i, openstackd)
+	}
+
+	for i, c := range cfg.GCESDConfigs {
+		gced, err := gce.NewDiscovery(c, log.With(logger, "discovery", "gce"))
+		if err != nil {
+			level.Error(logger).Log("msg", "Cannot initialize GCE discovery", "err", err)
+			continue
+		}
+		app("gce", i, gced)
+	}
+	for i, c := range cfg.AzureSDConfigs {
+		app("azure", i, azure.NewDiscovery(c, log.With(logger, "discovery", "azure")))
+	}
+	for i, c := range cfg.TritonSDConfigs {
+		t, err := triton.New(log.With(logger, "discovery", "trition"), c)
+		if err != nil {
+			level.Error(logger).Log("msg", "Cannot create Triton discovery", "err", err)
+			continue
+		}
+		app("triton", i, t)
+	}
+	if len(cfg.StaticConfigs) > 0 {
+		app("static", 0, discovery.NewStaticProvider(cfg.StaticConfigs))
+	}
+
+	return providers
+}


### PR DESCRIPTION
This PR adresses #3014. In details it :
* Moves ProvidersFromConfig to a new package util/discoveryutils
* Moves discovery package tests to discovery_test package
* Introduces a new method for TargetSet

Discovery package doesn't have any dependencies from SD clients, which
makes dependency graph of new SD client much simpler.

cc @fabxc