### PR TITLE
Feature: Use MultiStage Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,18 @@
-FROM        quay.io/prometheus/busybox:latest
+FROM quay.io/prometheus/golang-builder:1.9.0-base AS sbuilder
 LABEL maintainer "The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-COPY prometheus                             /bin/prometheus
-COPY promtool                               /bin/promtool
+WORKDIR /go/src/github.com/prometheus/prometheus
+
+ADD . .
+RUN make build
+RUN mv prometheus /prometheus && mv promtool /promtool
+
+
+FROM  quay.io/prometheus/busybox:latest
+LABEL maintainer "The Prometheus Authors <prometheus-developers@googlegroups.com>"
+
+COPY --from=sbuilder /prometheus            /bin/prometheus
+COPY --from=sbuilder /promtool              /bin/promtool
 COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
 COPY console_libraries/                     /usr/share/prometheus/console_libraries/
 COPY consoles/                              /usr/share/prometheus/consoles/


### PR DESCRIPTION
A multi stage docker image affords us the ability to compile prometheus
the same way regardless of host.  The alternative is cross compiling to
linux/amd64 prior to running `make docker`.

This PR closes #3109

@discordianfish 