### PR TITLE
Fix staticcheck issue in test

### DIFF
--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -14,6 +14,7 @@
 package remote
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
@@ -196,7 +197,7 @@ func TestRemoteStorageQuerier(t *testing.T) {
 			return &mockMergeQuerier{queriersCount: len(queriers)}
 		}
 
-		querier, _ := s.Querier(nil, test.mint, test.maxt)
+		querier, _ := s.Querier(context.Background(), test.mint, test.maxt)
 		actualQueriersCount := reflect.ValueOf(querier).Interface().(*mockMergeQuerier).queriersCount
 
 		if !reflect.DeepEqual(actualQueriersCount, test.expectedQueriersCount) {


### PR DESCRIPTION
`staticcheck` fails for me locally with:

```
storage/remote/read_test.go:199:27: do not pass a nil Context, even if a function permits it; pass context.TODO if you are unsure about which Context to use (SA1012)
```