### PR TITLE
Update remote storage APIs from 1.8 branch

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -55,7 +55,7 @@ type ClientConfig struct {
 
 // NewClient creates a new Client.
 func NewClient(index int, conf *ClientConfig) (*Client, error) {
-	httpClient, err := httputil.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage")
+	httpClient, err := httputil.NewClientFromConfigAndOptions(conf.HTTPClientConfig, "remote_storage", false)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -54,7 +54,7 @@ type ClientConfig struct {
 
 // NewClient creates a new Client.
 func NewClient(index int, conf *ClientConfig) (*Client, error) {
-	httpClient, err := httputil.NewClientFromConfigAndOptions(conf.HTTPClientConfig, "remote_storage", false)
+	httpClient, err := httputil.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage")
 	if err != nil {
 		return nil, err
 	}

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -45,26 +45,27 @@ type Client struct {
 	readRecent bool
 }
 
-type clientConfig struct {
-	url              *config.URL
-	timeout          model.Duration
-	readRecent       bool
-	httpClientConfig config.HTTPClientConfig
+// ClientConfig configures a Client.
+type ClientConfig struct {
+	URL              *config.URL
+	Timeout          model.Duration
+	ReadRecent       bool
+	HTTPClientConfig config.HTTPClientConfig
 }
 
 // NewClient creates a new Client.
-func NewClient(index int, conf *clientConfig) (*Client, error) {
-	httpClient, err := httputil.NewClientFromConfig(conf.httpClientConfig, "remote_storage")
+func NewClient(index int, conf *ClientConfig) (*Client, error) {
+	httpClient, err := httputil.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage")
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
 		index:      index,
-		url:        conf.url,
+		url:        conf.URL,
 		client:     httpClient,
-		timeout:    time.Duration(conf.timeout),
-		readRecent: conf.readRecent,
+		timeout:    time.Duration(conf.Timeout),
+		readRecent: conf.ReadRecent,
 	}, nil
 }
 
@@ -129,6 +130,8 @@ func (c *Client) Read(ctx context.Context, from, through int64, matchers []*labe
 	}
 
 	req := &prompb.ReadRequest{
+		// TODO: Support batching multiple queries into one read request,
+		// as the protobuf interface allows for it.
 		Queries: []*prompb.Query{
 			query,
 		},

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/prompb"
 )
 
 var longErrMessage = strings.Repeat("error message", maxErrMsgLen)
@@ -65,14 +66,14 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 		}
 
 		c, err := NewClient(0, &ClientConfig{
-			URL:     &config.URL{serverURL},
+			URL:     &config.URL{URL: serverURL},
 			Timeout: model.Duration(time.Second),
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = c.Store(nil)
+		err = c.Store(&prompb.WriteRequest{})
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("%d. Unexpected error; want %v, got %v", i, test.err, err)
 		}

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -64,9 +64,9 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		c, err := NewClient(0, &clientConfig{
-			url:     &config.URL{serverURL},
-			timeout: model.Duration(time.Second),
+		c, err := NewClient(0, &ClientConfig{
+			URL:     &config.URL{serverURL},
+			Timeout: model.Duration(time.Second),
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -321,6 +321,9 @@ func MetricToLabelProtos(metric model.Metric) []*prompb.Label {
 			Value: string(v),
 		})
 	}
+	sort.Slice(labels, func(i int, j int) bool {
+		return labels[i].Name < labels[j].Name
+	})
 	return labels
 }
 

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -1,0 +1,218 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/prompb"
+)
+
+// DecodeReadRequest reads a remote.Request from a http.Request.
+func DecodeReadRequest(r *http.Request) (*prompb.ReadRequest, error) {
+	compressed, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	reqBuf, err := snappy.Decode(nil, compressed)
+	if err != nil {
+		return nil, err
+	}
+
+	var req prompb.ReadRequest
+	if err := proto.Unmarshal(reqBuf, &req); err != nil {
+		return nil, err
+	}
+
+	return &req, nil
+}
+
+// EncodeReadResponse writes a remote.Response to a http.ResponseWriter.
+func EncodeReadResponse(resp *prompb.ReadResponse, w http.ResponseWriter) error {
+	data, err := proto.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	w.Header().Set("Content-Type", "application/x-protobuf")
+	w.Header().Set("Content-Encoding", "snappy")
+
+	compressed := snappy.Encode(nil, data)
+	_, err = w.Write(compressed)
+	return err
+}
+
+// ToWriteRequest converts an array of samples into a WriteRequest proto.
+func ToWriteRequest(samples []*model.Sample) *prompb.WriteRequest {
+	req := &prompb.WriteRequest{
+		Timeseries: make([]*prompb.TimeSeries, 0, len(samples)),
+	}
+
+	for _, s := range samples {
+		ts := prompb.TimeSeries{
+			Labels: ToLabelPairs(s.Metric),
+			Samples: []*prompb.Sample{
+				{
+					Value:     float64(s.Value),
+					Timestamp: int64(s.Timestamp),
+				},
+			},
+		}
+		req.Timeseries = append(req.Timeseries, &ts)
+	}
+
+	return req
+}
+
+// ToQuery builds a Query proto.
+func ToQuery(from, to int64, matchers []*labels.Matcher) (*prompb.Query, error) {
+	ms, err := toLabelMatchers(matchers)
+	if err != nil {
+		return nil, err
+	}
+
+	return &prompb.Query{
+		StartTimestampMs: from,
+		EndTimestampMs:   to,
+		Matchers:         ms,
+	}, nil
+}
+
+// FromQuery unpacks a Query proto.
+func FromQuery(req *prompb.Query) (model.Time, model.Time, []*labels.Matcher, error) {
+	matchers, err := fromLabelMatchers(req.Matchers)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+	from := model.Time(req.StartTimestampMs)
+	to := model.Time(req.EndTimestampMs)
+	return from, to, matchers, nil
+}
+
+// ToQueryResult builds a QueryResult proto.
+func ToQueryResult(matrix model.Matrix) *prompb.QueryResult {
+	resp := &prompb.QueryResult{}
+	for _, ss := range matrix {
+		ts := prompb.TimeSeries{
+			Labels:  ToLabelPairs(ss.Metric),
+			Samples: make([]*prompb.Sample, 0, len(ss.Values)),
+		}
+		for _, s := range ss.Values {
+			ts.Samples = append(ts.Samples, &prompb.Sample{
+				Value:     float64(s.Value),
+				Timestamp: int64(s.Timestamp),
+			})
+		}
+		resp.Timeseries = append(resp.Timeseries, &ts)
+	}
+	return resp
+}
+
+// FromQueryResult unpacks a QueryResult proto.
+func FromQueryResult(resp *prompb.QueryResult) model.Matrix {
+	m := make(model.Matrix, 0, len(resp.Timeseries))
+	for _, ts := range resp.Timeseries {
+		var ss model.SampleStream
+		ss.Metric = FromLabelPairs(ts.Labels)
+		ss.Values = make([]model.SamplePair, 0, len(ts.Samples))
+		for _, s := range ts.Samples {
+			ss.Values = append(ss.Values, model.SamplePair{
+				Value:     model.SampleValue(s.Value),
+				Timestamp: model.Time(s.Timestamp),
+			})
+		}
+		m = append(m, &ss)
+	}
+
+	return m
+}
+
+func toLabelMatchers(matchers []*labels.Matcher) ([]*prompb.LabelMatcher, error) {
+	pbMatchers := make([]*prompb.LabelMatcher, 0, len(matchers))
+	for _, m := range matchers {
+		var mType prompb.LabelMatcher_Type
+		switch m.Type {
+		case labels.MatchEqual:
+			mType = prompb.LabelMatcher_EQ
+		case labels.MatchNotEqual:
+			mType = prompb.LabelMatcher_NEQ
+		case labels.MatchRegexp:
+			mType = prompb.LabelMatcher_RE
+		case labels.MatchNotRegexp:
+			mType = prompb.LabelMatcher_NRE
+		default:
+			return nil, fmt.Errorf("invalid matcher type")
+		}
+		pbMatchers = append(pbMatchers, &prompb.LabelMatcher{
+			Type:  mType,
+			Name:  m.Name,
+			Value: m.Value,
+		})
+	}
+	return pbMatchers, nil
+}
+
+func fromLabelMatchers(matchers []*prompb.LabelMatcher) ([]*labels.Matcher, error) {
+	result := make([]*labels.Matcher, 0, len(matchers))
+	for _, matcher := range matchers {
+		var mtype labels.MatchType
+		switch matcher.Type {
+		case prompb.LabelMatcher_EQ:
+			mtype = labels.MatchEqual
+		case prompb.LabelMatcher_NEQ:
+			mtype = labels.MatchNotEqual
+		case prompb.LabelMatcher_RE:
+			mtype = labels.MatchRegexp
+		case prompb.LabelMatcher_NRE:
+			mtype = labels.MatchNotRegexp
+		default:
+			return nil, fmt.Errorf("invalid matcher type")
+		}
+		matcher, err := labels.NewMatcher(mtype, matcher.Name, matcher.Value)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, matcher)
+	}
+	return result, nil
+}
+
+// ToLabelPairs builds a []LabelPair from a model.Metric
+func ToLabelPairs(metric model.Metric) []*prompb.Label {
+	labelPairs := make([]*prompb.Label, 0, len(metric))
+	for k, v := range metric {
+		labelPairs = append(labelPairs, &prompb.Label{
+			Name:  string(k),
+			Value: string(v),
+		})
+	}
+	return labelPairs
+}
+
+// FromLabelPairs unpack a []LabelPair to a model.Metric
+func FromLabelPairs(labelPairs []*prompb.Label) model.Metric {
+	metric := make(model.Metric, len(labelPairs))
+	for _, l := range labelPairs {
+		metric[model.LabelName(l.Name)] = model.LabelValue(l.Value)
+	}
+	return metric
+}

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -1,0 +1,113 @@
+package remote
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/storage"
+)
+
+func TestValidateLabelsAndMetricName(t *testing.T) {
+	tests := []struct {
+		input       labels.Labels
+		expectedErr string
+		shouldPass  bool
+	}{
+		{
+			input: labels.FromStrings(
+				"__name__", "name",
+				"labelName", "labelValue",
+			),
+			expectedErr: "",
+			shouldPass:  true,
+		},
+		{
+			input: labels.FromStrings(
+				"__name__", "name",
+				"_labelName", "labelValue",
+			),
+			expectedErr: "",
+			shouldPass:  true,
+		},
+		{
+			input: labels.FromStrings(
+				"__name__", "name",
+				"@labelName", "labelValue",
+			),
+			expectedErr: "Invalid label name: @labelName",
+			shouldPass:  false,
+		},
+		{
+			input: labels.FromStrings(
+				"__name__", "name",
+				"123labelName", "labelValue",
+			),
+			expectedErr: "Invalid label name: 123labelName",
+			shouldPass:  false,
+		},
+		{
+			input: labels.FromStrings(
+				"__name__", "name",
+				"", "labelValue",
+			),
+			expectedErr: "Invalid label name: ",
+			shouldPass:  false,
+		},
+		{
+			input: labels.FromStrings(
+				"__name__", "name",
+				"labelName", string([]byte{0xff}),
+			),
+			expectedErr: "Invalid label value: " + string([]byte{0xff}),
+			shouldPass:  false,
+		},
+		{
+			input: labels.FromStrings(
+				"__name__", "@invalid_name",
+			),
+			expectedErr: "Invalid metric name: @invalid_name",
+			shouldPass:  false,
+		},
+	}
+
+	for _, test := range tests {
+		err := validateLabelsAndMetricName(test.input)
+		if test.shouldPass != (err == nil) {
+			if test.shouldPass {
+				t.Fatalf("Test should pass, got unexpected error: %v", err)
+			} else {
+				t.Fatalf("Test should fail, unexpected error, got: %v, expected: %v", err, test.expectedErr)
+			}
+		}
+	}
+}
+
+func TestConcreteSeriesSet(t *testing.T) {
+	series1 := &concreteSeries{
+		labels:  labels.FromStrings("foo", "bar"),
+		samples: []*prompb.Sample{&prompb.Sample{Value: 1, Timestamp: 2}},
+	}
+	series2 := &concreteSeries{
+		labels:  labels.FromStrings("foo", "baz"),
+		samples: []*prompb.Sample{&prompb.Sample{Value: 3, Timestamp: 4}},
+	}
+	c := &concreteSeriesSet{
+		series: []storage.Series{series1, series2},
+	}
+	if !c.Next() {
+		t.Fatalf("Expected Next() to be true.")
+	}
+	if c.At() != series1 {
+		t.Fatalf("Unexpected series returned.")
+	}
+	if !c.Next() {
+		t.Fatalf("Expected Next() to be true.")
+	}
+	if c.At() != series2 {
+		t.Fatalf("Unexpected series returned.")
+	}
+	if c.Next() {
+		t.Fatalf("Expected Next() to be false.")
+	}
+}

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -1,3 +1,16 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package remote
 
 import (

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -183,6 +183,12 @@ func NewQueueManager(logger log.Logger, cfg config.QueueConfig, externalLabels m
 	numShards.WithLabelValues(t.queueName).Set(float64(t.numShards))
 	queueCapacity.WithLabelValues(t.queueName).Set(float64(t.cfg.Capacity))
 
+	// Initialise counter labels to zero.
+	sentBatchDuration.WithLabelValues(t.queueName)
+	succeededSamplesTotal.WithLabelValues(t.queueName)
+	failedSamplesTotal.WithLabelValues(t.queueName)
+	droppedSamplesTotal.WithLabelValues(t.queueName)
+
 	return t
 }
 

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -124,42 +124,6 @@ func init() {
 	prometheus.MustRegister(numShards)
 }
 
-// QueueManagerConfig is the configuration for the queue used to write to remote
-// storage.
-type QueueManagerConfig struct {
-	// Number of samples to buffer per shard before we start dropping them.
-	QueueCapacity int
-	// Max number of shards, i.e. amount of concurrency.
-	MaxShards int
-	// Maximum number of samples per send.
-	MaxSamplesPerSend int
-	// Maximum time sample will wait in buffer.
-	BatchSendDeadline time.Duration
-	// Max number of times to retry a batch on recoverable errors.
-	MaxRetries int
-	// On recoverable errors, backoff exponentially.
-	MinBackoff time.Duration
-	MaxBackoff time.Duration
-}
-
-// defaultQueueManagerConfig is the default remote queue configuration.
-var defaultQueueManagerConfig = QueueManagerConfig{
-	// With a maximum of 1000 shards, assuming an average of 100ms remote write
-	// time and 100 samples per batch, we will be able to push 1M samples/s.
-	MaxShards:         1000,
-	MaxSamplesPerSend: 100,
-
-	// By default, buffer 1000 batches, which at 100ms per batch is 1:40mins. At
-	// 1000 shards, this will buffer 100M samples total.
-	QueueCapacity:     100 * 1000,
-	BatchSendDeadline: 5 * time.Second,
-
-	// Max number of times to retry a batch on recoverable errors.
-	MaxRetries: 10,
-	MinBackoff: 30 * time.Millisecond,
-	MaxBackoff: 100 * time.Millisecond,
-}
-
 // StorageClient defines an interface for sending a batch of samples to an
 // external timeseries database.
 type StorageClient interface {
@@ -174,7 +138,7 @@ type StorageClient interface {
 type QueueManager struct {
 	logger log.Logger
 
-	cfg            QueueManagerConfig
+	cfg            config.QueueConfig
 	externalLabels model.LabelSet
 	relabelConfigs []*config.RelabelConfig
 	client         StorageClient
@@ -193,7 +157,7 @@ type QueueManager struct {
 }
 
 // NewQueueManager builds a new QueueManager.
-func NewQueueManager(logger log.Logger, cfg QueueManagerConfig, externalLabels model.LabelSet, relabelConfigs []*config.RelabelConfig, client StorageClient) *QueueManager {
+func NewQueueManager(logger log.Logger, cfg config.QueueConfig, externalLabels model.LabelSet, relabelConfigs []*config.RelabelConfig, client StorageClient) *QueueManager {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -216,7 +180,7 @@ func NewQueueManager(logger log.Logger, cfg QueueManagerConfig, externalLabels m
 	}
 	t.shards = t.newShards(t.numShards)
 	numShards.WithLabelValues(t.queueName).Set(float64(t.numShards))
-	queueCapacity.WithLabelValues(t.queueName).Set(float64(t.cfg.QueueCapacity))
+	queueCapacity.WithLabelValues(t.queueName).Set(float64(t.cfg.Capacity))
 
 	return t
 }
@@ -408,7 +372,7 @@ type shards struct {
 func (t *QueueManager) newShards(numShards int) *shards {
 	queues := make([]chan *model.Sample, numShards)
 	for i := 0; i < numShards; i++ {
-		queues[i] = make(chan *model.Sample, t.cfg.QueueCapacity)
+		queues[i] = make(chan *model.Sample, t.cfg.Capacity)
 	}
 	s := &shards{
 		qm:     t,

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -15,6 +15,7 @@ package remote
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -22,19 +23,20 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/prompb"
 )
 
 type TestStorageClient struct {
-	receivedSamples map[string]model.Samples
-	expectedSamples map[string]model.Samples
+	receivedSamples map[string][]*prompb.Sample
+	expectedSamples map[string][]*prompb.Sample
 	wg              sync.WaitGroup
 	mtx             sync.Mutex
 }
 
 func NewTestStorageClient() *TestStorageClient {
 	return &TestStorageClient{
-		receivedSamples: map[string]model.Samples{},
-		expectedSamples: map[string]model.Samples{},
+		receivedSamples: map[string][]*prompb.Sample{},
+		expectedSamples: map[string][]*prompb.Sample{},
 	}
 }
 
@@ -43,8 +45,11 @@ func (c *TestStorageClient) expectSamples(ss model.Samples) {
 	defer c.mtx.Unlock()
 
 	for _, s := range ss {
-		ts := s.Metric.String()
-		c.expectedSamples[ts] = append(c.expectedSamples[ts], s)
+		ts := labelProtosToLabels(MetricToLabelProtos(s.Metric)).String()
+		c.expectedSamples[ts] = append(c.expectedSamples[ts], &prompb.Sample{
+			Timestamp: int64(s.Timestamp),
+			Value:     float64(s.Value),
+		})
 	}
 	c.wg.Add(len(ss))
 }
@@ -55,23 +60,24 @@ func (c *TestStorageClient) waitForExpectedSamples(t *testing.T) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 	for ts, expectedSamples := range c.expectedSamples {
-		for i, expected := range expectedSamples {
-			if !expected.Equal(c.receivedSamples[ts][i]) {
-				t.Fatalf("%d. Expected %v, got %v", i, expected, c.receivedSamples[ts][i])
-			}
+		if !reflect.DeepEqual(expectedSamples, c.receivedSamples[ts]) {
+			t.Fatalf("%s: Expected %v, got %v", ts, expectedSamples, c.receivedSamples[ts])
 		}
 	}
 }
 
-func (c *TestStorageClient) Store(ss model.Samples) error {
+func (c *TestStorageClient) Store(req *prompb.WriteRequest) error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
-
-	for _, s := range ss {
-		ts := s.Metric.String()
-		c.receivedSamples[ts] = append(c.receivedSamples[ts], s)
+	count := 0
+	for _, ts := range req.Timeseries {
+		labels := labelProtosToLabels(ts.Labels).String()
+		for _, sample := range ts.Samples {
+			count++
+			c.receivedSamples[labels] = append(c.receivedSamples[labels], sample)
+		}
 	}
-	c.wg.Add(-len(ss))
+	c.wg.Add(-count)
 	return nil
 }
 
@@ -162,7 +168,7 @@ func NewTestBlockedStorageClient() *TestBlockingStorageClient {
 	}
 }
 
-func (c *TestBlockingStorageClient) Store(s model.Samples) error {
+func (c *TestBlockingStorageClient) Store(_ *prompb.WriteRequest) error {
 	atomic.AddUint64(&c.numCalls, 1)
 	<-c.block
 	return nil

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
 )
 
 type TestStorageClient struct {
@@ -81,7 +82,7 @@ func (c *TestStorageClient) Name() string {
 func TestSampleDelivery(t *testing.T) {
 	// Let's create an even number of send batches so we don't run into the
 	// batch timeout case.
-	n := defaultQueueManagerConfig.QueueCapacity * 2
+	n := config.DefaultQueueConfig.Capacity * 2
 
 	samples := make(model.Samples, 0, n)
 	for i := 0; i < n; i++ {
@@ -97,7 +98,7 @@ func TestSampleDelivery(t *testing.T) {
 	c := NewTestStorageClient()
 	c.expectSamples(samples[:len(samples)/2])
 
-	cfg := defaultQueueManagerConfig
+	cfg := config.DefaultQueueConfig
 	cfg.MaxShards = 1
 	m := NewQueueManager(nil, cfg, nil, nil, c)
 
@@ -117,7 +118,7 @@ func TestSampleDelivery(t *testing.T) {
 
 func TestSampleDeliveryOrder(t *testing.T) {
 	ts := 10
-	n := defaultQueueManagerConfig.MaxSamplesPerSend * ts
+	n := config.DefaultQueueConfig.MaxSamplesPerSend * ts
 
 	samples := make(model.Samples, 0, n)
 	for i := 0; i < n; i++ {
@@ -133,7 +134,7 @@ func TestSampleDeliveryOrder(t *testing.T) {
 
 	c := NewTestStorageClient()
 	c.expectSamples(samples)
-	m := NewQueueManager(nil, defaultQueueManagerConfig, nil, nil, c)
+	m := NewQueueManager(nil, config.DefaultQueueConfig, nil, nil, c)
 
 	// These should be received by the client.
 	for _, s := range samples {
@@ -194,7 +195,7 @@ func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 	// `MaxSamplesPerSend*Shards` samples should be consumed by the
 	// per-shard goroutines, and then another `MaxSamplesPerSend`
 	// should be left on the queue.
-	n := defaultQueueManagerConfig.MaxSamplesPerSend * 2
+	n := config.DefaultQueueConfig.MaxSamplesPerSend * 2
 
 	samples := make(model.Samples, 0, n)
 	for i := 0; i < n; i++ {
@@ -208,9 +209,9 @@ func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 	}
 
 	c := NewTestBlockedStorageClient()
-	cfg := defaultQueueManagerConfig
+	cfg := config.DefaultQueueConfig
 	cfg.MaxShards = 1
-	cfg.QueueCapacity = n
+	cfg.Capacity = n
 	m := NewQueueManager(nil, cfg, nil, nil, c)
 
 	m.Start()
@@ -240,7 +241,7 @@ func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	if m.queueLen() != defaultQueueManagerConfig.MaxSamplesPerSend {
+	if m.queueLen() != config.DefaultQueueConfig.MaxSamplesPerSend {
 		t.Fatalf("Failed to drain QueueManager queue, %d elements left",
 			m.queueLen(),
 		)

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -76,7 +76,7 @@ func (q *querier) Select(matchers ...*labels.Matcher) storage.SeriesSet {
 
 	series := make([]storage.Series, 0, len(res))
 	for _, ts := range res {
-		labels := labelPairsToLabels(ts.Labels)
+		labels := labelProtosToLabels(ts.Labels)
 		removeLabels(&labels, added)
 		if err := validateLabelsAndMetricName(labels); err != nil {
 			return errSeriesSet{err: err}
@@ -91,18 +91,6 @@ func (q *querier) Select(matchers ...*labels.Matcher) storage.SeriesSet {
 	return &concreteSeriesSet{
 		series: series,
 	}
-}
-
-func labelPairsToLabels(labelPairs []*prompb.Label) labels.Labels {
-	result := make(labels.Labels, 0, len(labelPairs))
-	for _, l := range labelPairs {
-		result = append(result, labels.Label{
-			Name:  l.Name,
-			Value: l.Value,
-		})
-	}
-	sort.Sort(result)
-	return result
 }
 
 type byLabel []storage.Series

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -98,7 +98,7 @@ func TestAddExternalLabels(t *testing.T) {
 	}
 }
 
-func TestRemoveLabels(t *testing.T) {
+func TestSeriesSetFilter(t *testing.T) {
 	tests := []struct {
 		in       *prompb.QueryResult
 		toRemove model.LabelSet

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -184,11 +184,11 @@ func TestRemoteStorageQuerier(t *testing.T) {
 		s := NewStorage(nil, func() (int64, error) { return test.localStartTime, nil })
 		s.clients = []*Client{}
 		for _, readRecent := range test.readRecentClients {
-			c, _ := NewClient(0, &clientConfig{
-				url:              nil,
-				timeout:          model.Duration(30 * time.Second),
-				httpClientConfig: config.HTTPClientConfig{},
-				readRecent:       readRecent,
+			c, _ := NewClient(0, &ClientConfig{
+				URL:              nil,
+				Timeout:          model.Duration(30 * time.Second),
+				HTTPClientConfig: config.HTTPClientConfig{},
+				ReadRecent:       readRecent,
 			})
 			s.clients = append(s.clients, c)
 		}

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -68,7 +68,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		}
 		newQueues = append(newQueues, NewQueueManager(
 			s.logger,
-			defaultQueueManagerConfig,
+			config.DefaultQueueConfig,
 			conf.GlobalConfig.ExternalLabels,
 			rwConf.WriteRelabelConfigs,
 			c,

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -58,10 +58,10 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 	// TODO: we should only stop & recreate queues which have changes,
 	// as this can be quite disruptive.
 	for i, rwConf := range conf.RemoteWriteConfigs {
-		c, err := NewClient(i, &clientConfig{
-			url:              rwConf.URL,
-			timeout:          rwConf.RemoteTimeout,
-			httpClientConfig: rwConf.HTTPClientConfig,
+		c, err := NewClient(i, &ClientConfig{
+			URL:              rwConf.URL,
+			Timeout:          rwConf.RemoteTimeout,
+			HTTPClientConfig: rwConf.HTTPClientConfig,
 		})
 		if err != nil {
 			return err
@@ -88,11 +88,11 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 
 	clients := []*Client{}
 	for i, rrConf := range conf.RemoteReadConfigs {
-		c, err := NewClient(i, &clientConfig{
-			url:              rrConf.URL,
-			timeout:          rrConf.RemoteTimeout,
-			httpClientConfig: rrConf.HTTPClientConfig,
-			readRecent:       rrConf.ReadRecent,
+		c, err := NewClient(i, &ClientConfig{
+			URL:              rrConf.URL,
+			Timeout:          rrConf.RemoteTimeout,
+			HTTPClientConfig: rrConf.HTTPClientConfig,
+			ReadRecent:       rrConf.ReadRecent,
 		})
 		if err != nil {
 			return err

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -38,15 +38,6 @@ func (s *Storage) Add(l labels.Labels, t int64, v float64) (uint64, error) {
 	return 0, nil
 }
 
-func labelsToMetric(ls labels.Labels) model.Metric {
-	metric := make(model.Metric, len(ls))
-	for _, l := range ls {
-		metric[model.LabelName(l.Name)] = model.LabelValue(l.Value)
-	}
-	return metric
-}
-
-// AddFast implements storage.Appender.
 func (s *Storage) AddFast(l labels.Labels, _ uint64, t int64, v float64) error {
 	_, err := s.Add(l, t, v)
 	return err

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -38,6 +38,7 @@ func (s *Storage) Add(l labels.Labels, t int64, v float64) (uint64, error) {
 	return 0, nil
 }
 
+// AddFast implements storage.Appender.
 func (s *Storage) AddFast(l labels.Labels, _ uint64, t int64, v float64) error {
 	_, err := s.Add(l, t, v)
 	return err

--- a/util/httputil/client.go
+++ b/util/httputil/client.go
@@ -34,6 +34,12 @@ func newClient(rt http.RoundTripper) *http.Client {
 // NewClientFromConfig returns a new HTTP client configured for the
 // given config.HTTPClientConfig. The name is used as go-conntrack metric label.
 func NewClientFromConfig(cfg config.HTTPClientConfig, name string) (*http.Client, error) {
+	return NewClientFromConfigAndOptions(cfg, name, true)
+}
+
+// NewClientFromConfigAndOptions returns a new HTTP client configured for the
+// given config.HTTPClientConfig. The name is used as go-conntrack metric label.
+func NewClientFromConfigAndOptions(cfg config.HTTPClientConfig, name string, disableKeepAlives bool) (*http.Client, error) {
 	tlsConfig, err := NewTLSConfig(cfg.TLSConfig)
 	if err != nil {
 		return nil, err
@@ -43,7 +49,7 @@ func NewClientFromConfig(cfg config.HTTPClientConfig, name string) (*http.Client
 	var rt http.RoundTripper = &http.Transport{
 		Proxy:              http.ProxyURL(cfg.ProxyURL.URL),
 		MaxIdleConns:       20000,
-		DisableKeepAlives:  false,
+		DisableKeepAlives:  disableKeepAlives,
 		TLSClientConfig:    tlsConfig,
 		DisableCompression: true,
 		// 5 minutes is typically above the maximum sane scrape interval. So we can

--- a/util/httputil/client.go
+++ b/util/httputil/client.go
@@ -34,12 +34,6 @@ func newClient(rt http.RoundTripper) *http.Client {
 // NewClientFromConfig returns a new HTTP client configured for the
 // given config.HTTPClientConfig. The name is used as go-conntrack metric label.
 func NewClientFromConfig(cfg config.HTTPClientConfig, name string) (*http.Client, error) {
-	return NewClientFromConfigAndOptions(cfg, name, true)
-}
-
-// NewClientFromConfigAndOptions returns a new HTTP client configured for the
-// given config.HTTPClientConfig. The name is used as go-conntrack metric label.
-func NewClientFromConfigAndOptions(cfg config.HTTPClientConfig, name string, disableKeepAlives bool) (*http.Client, error) {
 	tlsConfig, err := NewTLSConfig(cfg.TLSConfig)
 	if err != nil {
 		return nil, err
@@ -49,7 +43,7 @@ func NewClientFromConfigAndOptions(cfg config.HTTPClientConfig, name string, dis
 	var rt http.RoundTripper = &http.Transport{
 		Proxy:              http.ProxyURL(cfg.ProxyURL.URL),
 		MaxIdleConns:       20000,
-		DisableKeepAlives:  disableKeepAlives,
+		DisableKeepAlives:  false,
 		TLSClientConfig:    tlsConfig,
 		DisableCompression: true,
 		// 5 minutes is typically above the maximum sane scrape interval. So we can

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -563,10 +563,10 @@ func TestReadEndpoint(t *testing.T) {
 			{
 				Labels: []*prompb.Label{
 					{Name: "__name__", Value: "test_metric1"},
-					{Name: "baz", Value: "qux"},
-					{Name: "foo", Value: "bar"},
 					{Name: "b", Value: "c"},
+					{Name: "baz", Value: "qux"},
 					{Name: "d", Value: "e"},
+					{Name: "foo", Value: "bar"},
 				},
 				Samples: []*prompb.Sample{{Value: 1, Timestamp: 0}},
 			},

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/golang/snappy"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
-	"github.com/weaveworks/common/test"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -574,7 +573,6 @@ func TestReadEndpoint(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(result, expected) {
-		t.Fatalf(test.Diff(expected, result))
 		t.Fatalf("Expected response \n%v\n but got \n%v\n", result, expected)
 	}
 }

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -14,6 +14,7 @@
 package v1
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -26,14 +27,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
+	"github.com/weaveworks/common/test"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/retrieval"
+	"github.com/prometheus/prometheus/storage/remote"
 )
 
 type targetRetrieverFunc func() []*retrieval.Target
@@ -473,6 +479,103 @@ func TestEndpoints(t *testing.T) {
 		if !reflect.DeepEqual(resp, test.response) {
 			t.Fatalf("Response does not match, expected:\n%+v\ngot:\n%+v", test.response, resp)
 		}
+	}
+}
+
+func TestReadEndpoint(t *testing.T) {
+	suite, err := promql.NewTest(t, `
+		load 1m
+			test_metric1{foo="bar",baz="qux"} 1
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer suite.Close()
+
+	if err := suite.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	api := &API{
+		Queryable:   suite.Storage(),
+		QueryEngine: suite.QueryEngine(),
+		config: func() config.Config {
+			return config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ExternalLabels: model.LabelSet{
+						"baz": "a",
+						"b":   "c",
+						"d":   "e",
+					},
+				},
+			}
+		},
+	}
+
+	// Encode the request.
+	matcher1, err := labels.NewMatcher(labels.MatchEqual, "__name__", "test_metric1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	matcher2, err := labels.NewMatcher(labels.MatchEqual, "d", "e")
+	if err != nil {
+		t.Fatal(err)
+	}
+	query, err := remote.ToQuery(0, 1, []*labels.Matcher{matcher1, matcher2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &prompb.ReadRequest{Queries: []*prompb.Query{query}}
+	data, err := proto.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compressed := snappy.Encode(nil, data)
+	request, err := http.NewRequest("POST", "", bytes.NewBuffer(compressed))
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	api.remoteRead(recorder, request)
+
+	// Decode the response.
+	compressed, err = ioutil.ReadAll(recorder.Result().Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	uncompressed, err := snappy.Decode(nil, compressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var resp prompb.ReadResponse
+	err = proto.Unmarshal(uncompressed, &resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(resp.Results) != 1 {
+		t.Fatalf("Expected 1 result, got %d", len(resp.Results))
+	}
+
+	result := resp.Results[0]
+	expected := &prompb.QueryResult{
+		Timeseries: []*prompb.TimeSeries{
+			{
+				Labels: []*prompb.Label{
+					{Name: "__name__", Value: "test_metric1"},
+					{Name: "baz", Value: "qux"},
+					{Name: "foo", Value: "bar"},
+					{Name: "b", Value: "c"},
+					{Name: "d", Value: "e"},
+				},
+				Samples: []*prompb.Sample{{Value: 1, Timestamp: 0}},
+			},
+		},
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf(test.Diff(expected, result))
+		t.Fatalf("Expected response \n%v\n but got \n%v\n", result, expected)
 	}
 }
 


### PR DESCRIPTION
This PR brings over to master a bunch of work that happened to the remote storage APIs during 1.7/1.8:
- Port codec.go over form 1.8 branch (groundwork for Prom2.0 supporting remote read)
- remote: Expose ClientConfig type (see #3165)
- Port 'Make queue manager configurable.' to 2.0, (see #2991), fixes #3095
- Port Metric name validation to 2.0 (see #2975), fixes #2996
- Port 'Don't disable HTTP keep-alives for remote storage connections.' to 2.0 (see #3173)
- Port remote read server API to 2.0, includes #3263 and #3325

~I'm still going through the code / PRs to ensure I've got everything, as its not a straight forward port.~

Includes a bunch of refactoring so we're not doing two conversions on the read path.  Write path is still suboptimal mind you.
