### PR TITLE
Bypass the fanout storage merging if no remote storage is configured.

### DIFF
--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -34,6 +34,10 @@ type fanout struct {
 // NewFanout returns a new fan-out Storage, which proxies reads and writes
 // through to multiple underlying storages.
 func NewFanout(logger log.Logger, primary Storage, secondaries ...Storage) Storage {
+	if len(secondaries) == 0 {
+		return primary
+	}
+
 	return &fanout{
 		logger:      logger,
 		primary:     primary,


### PR DESCRIPTION
Quick and dirty fix for #3065 

I'd like to do a little benchmarking of the merging code too, ideally it should be a no-op with only one storage, but its not the case right now.