### PR TITLE
storage/tsdb: check that max block duration is larger than min

### DIFF
--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -126,6 +126,10 @@ type Options struct {
 
 // Open returns a new storage backed by a TSDB database that is configured for Prometheus.
 func Open(path string, l log.Logger, r prometheus.Registerer, opts *Options) (*tsdb.DB, error) {
+	if opts.MinBlockDuration > opts.MaxBlockDuration {
+		return nil, errors.Errorf("tsdb max block duration (%v) must be larger than min block duration (%v)",
+			opts.MaxBlockDuration, opts.MinBlockDuration)
+	}
 	// Start with smallest block duration and create exponential buckets until the exceed the
 	// configured maximum block duration.
 	rngs := tsdb.ExponentialBlockRanges(int64(time.Duration(opts.MinBlockDuration).Seconds()*1000), 10, 3)


### PR DESCRIPTION
If the user accidentally sets the max block duration smaller than the min,
the current error is not informative.  This change just performs the check
earlier and improves the error message.