### PR TITLE
Fast path the merge querier 

### DIFF
--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -197,9 +197,26 @@ type mergeQuerier struct {
 }
 
 // NewMergeQuerier returns a new Querier that merges results of input queriers.
+// NB will return nil if no queriers are passed to it, and will filter nil
+// queriers from its arguments, in order to reduce overhead when only one
+// querier is passed.
 func NewMergeQuerier(queriers []Querier) Querier {
-	return &mergeQuerier{
-		queriers: queriers,
+	filtered := make([]Querier, 0, len(queriers))
+	for _, querier := range queriers {
+		if querier != nil {
+			filtered = append(filtered, querier)
+		}
+	}
+
+	switch len(filtered) {
+	case 0:
+		return nil
+	case 1:
+		return filtered[0]
+	default:
+		return &mergeQuerier{
+			queriers: filtered,
+		}
 	}
 }
 

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -202,14 +202,14 @@ type mergeQuerier struct {
 func NewMergeQuerier(queriers []Querier) Querier {
 	filtered := make([]Querier, 0, len(queriers))
 	for _, querier := range queriers {
-		if querier != NoopQuerier {
+		if querier != NoopQuerier() {
 			filtered = append(filtered, querier)
 		}
 	}
 
 	switch len(filtered) {
 	case 0:
-		return NoopQuerier
+		return NoopQuerier()
 	case 1:
 		return filtered[0]
 	default:

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -67,27 +67,26 @@ func (f *fanout) StartTime() (int64, error) {
 }
 
 func (f *fanout) Querier(ctx context.Context, mint, maxt int64) (Querier, error) {
-	queriers := mergeQuerier{
-		queriers: make([]Querier, 0, 1+len(f.secondaries)),
-	}
+	queriers := make([]Querier, 0, 1+len(f.secondaries))
 
 	// Add primary querier
 	querier, err := f.primary.Querier(ctx, mint, maxt)
 	if err != nil {
 		return nil, err
 	}
-	queriers.queriers = append(queriers.queriers, querier)
+	queriers = append(queriers, querier)
 
 	// Add secondary queriers
 	for _, storage := range f.secondaries {
 		querier, err := storage.Querier(ctx, mint, maxt)
 		if err != nil {
-			queriers.Close()
+			NewMergeQuerier(queriers).Close()
 			return nil, err
 		}
-		queriers.queriers = append(queriers.queriers, querier)
+		queriers = append(queriers, querier)
 	}
-	return &queriers, nil
+
+	return NewMergeQuerier(queriers), nil
 }
 
 func (f *fanout) Appender() (Appender, error) {
@@ -197,20 +196,20 @@ type mergeQuerier struct {
 }
 
 // NewMergeQuerier returns a new Querier that merges results of input queriers.
-// NB will return nil if no queriers are passed to it, and will filter nil
-// queriers from its arguments, in order to reduce overhead when only one
-// querier is passed.
+// NB NewMergeQuerier will return NoopQuerier if no queriers are passed to it,
+// and will filter NoopQueriers from its arguments, in order to reduce overhead
+// when only one querier is passed.
 func NewMergeQuerier(queriers []Querier) Querier {
 	filtered := make([]Querier, 0, len(queriers))
 	for _, querier := range queriers {
-		if querier != nil {
+		if querier != NoopQuerier {
 			filtered = append(filtered, querier)
 		}
 	}
 
 	switch len(filtered) {
 	case 0:
-		return nil
+		return NoopQuerier
 	case 1:
 		return filtered[0]
 	default:

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -1,3 +1,16 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package storage
 
 import "github.com/prometheus/prometheus/pkg/labels"

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -18,10 +18,12 @@ import "github.com/prometheus/prometheus/pkg/labels"
 type noopQuerier struct{}
 
 // NoopQuerier is a Querier that does nothing.
-var NoopQuerier Querier = noopQuerier{}
+func NoopQuerier() Querier {
+	return noopQuerier{}
+}
 
 func (noopQuerier) Select(...*labels.Matcher) SeriesSet {
-	return NoopSeriesSet
+	return NoopSeriesSet()
 }
 
 func (noopQuerier) LabelValues(name string) ([]string, error) {
@@ -35,7 +37,9 @@ func (noopQuerier) Close() error {
 type noopSeriesSet struct{}
 
 // NoopSeriesSet is a SeriesSet that does nothing.
-var NoopSeriesSet = noopSeriesSet{}
+func NoopSeriesSet() SeriesSet {
+	return noopSeriesSet{}
+}
 
 func (noopSeriesSet) Next() bool {
 	return false

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -1,0 +1,37 @@
+package storage
+
+import "github.com/prometheus/prometheus/pkg/labels"
+
+type noopQuerier struct{}
+
+// NoopQuerier is a Querier that does nothing.
+var NoopQuerier Querier = noopQuerier{}
+
+func (noopQuerier) Select(...*labels.Matcher) SeriesSet {
+	return NoopSeriesSet
+}
+
+func (noopQuerier) LabelValues(name string) ([]string, error) {
+	return nil, nil
+}
+
+func (noopQuerier) Close() error {
+	return nil
+}
+
+type noopSeriesSet struct{}
+
+// NoopSeriesSet is a SeriesSet that does nothing.
+var NoopSeriesSet = noopSeriesSet{}
+
+func (noopSeriesSet) Next() bool {
+	return false
+}
+
+func (noopSeriesSet) At() Series {
+	return nil
+}
+
+func (noopSeriesSet) Err() error {
+	return nil
+}


### PR DESCRIPTION
Such that it is completely removed from query path when there is no remote storage.

See #3357, actually fix #3065.