### PR TITLE
bump consul HTTP client timeout by 5s

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -116,7 +116,7 @@ func NewDiscovery(conf *config.ConsulSDConfig, logger log.Logger) (*Discovery, e
 	}
 	wrapper := &http.Client{
 		Transport: transport,
-		Timeout:   30 * time.Second,
+		Timeout:   35 * time.Second,
 	}
 
 	clientConf := &consul.Config{


### PR DESCRIPTION
Bump consul HTTP client timeout by 5s so it doesn't match up exactly with the consul SD watch timeout. I don't see the log spam at all with this change. I bumped the timeout only by a small amount so that hopefully in situations where config refreshes happen frequently we still clean up unneeded connections to consul quickly.

addresses #3353
@fabxc @zemek