### PR TITLE
keep  existing alert rules state on config reload.

### DIFF
--- a/config/testdata/first.rules
+++ b/config/testdata/first.rules
@@ -7,4 +7,4 @@ groups:
     labels:
       severity: critical
     annotations:
-      description: "stuff's happening with {{ $labels.service }}"  
+      description: "stuff's happening with {{ $labels.service }}"

--- a/config/testdata/first.rules
+++ b/config/testdata/first.rules
@@ -1,0 +1,10 @@
+groups:
+- name: my-group-name
+  rules:
+  - alert: InstanceDown
+    expr: up == 0
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      description: "stuff's happening with {{ $labels.service }}"  

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -494,9 +494,9 @@ func (m *Manager) ApplyConfig(conf *config.Config) error {
 
 		// If there is an old group with the same identifier, stop it and wait for
 		// it to finish the current iteration. Then copy it into the new group.
-		groupName := newg.name + ";" + newg.file
-		oldg, ok := m.groups[groupName]
-		delete(m.groups, groupName)
+		gn := groupName(newg.name, newg.file)
+		oldg, ok := m.groups[gn]
+		delete(m.groups, gn)
 
 		go func(newg *Group) {
 			if ok {
@@ -568,12 +568,16 @@ func (m *Manager) loadGroups(interval time.Duration, filenames ...string) (map[s
 				))
 			}
 
-			// Group names need not be unique across filenames.
-			groups[rg.Name+";"+fn] = NewGroup(rg.Name, fn, itv, rules, m.opts)
+			groups[groupName(rg.Name, fn)] = NewGroup(rg.Name, fn, itv, rules, m.opts)
 		}
 	}
 
 	return groups, nil
+}
+
+// Group names need not be unique across filenames.
+func groupName(name, file string) string {
+	return name + ";" + file
 }
 
 // RuleGroups returns the list of manager's rule groups.

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -494,8 +494,9 @@ func (m *Manager) ApplyConfig(conf *config.Config) error {
 
 		// If there is an old group with the same identifier, stop it and wait for
 		// it to finish the current iteration. Then copy it into the new group.
-		oldg, ok := m.groups[newg.name]
-		delete(m.groups, newg.name)
+		groupName := newg.name + ";" + newg.file
+		oldg, ok := m.groups[groupName]
+		delete(m.groups, groupName)
 
 		go func(newg *Group) {
 			if ok {

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -494,7 +494,7 @@ func (m *Manager) ApplyConfig(conf *config.Config) error {
 
 		// If there is an old group with the same identifier, stop it and wait for
 		// it to finish the current iteration. Then copy it into the new group.
-		gn := groupName(newg.name, newg.file)
+		gn := groupKey(newg.name, newg.file)
 		oldg, ok := m.groups[gn]
 		delete(m.groups, gn)
 
@@ -568,7 +568,7 @@ func (m *Manager) loadGroups(interval time.Duration, filenames ...string) (map[s
 				))
 			}
 
-			groups[groupName(rg.Name, fn)] = NewGroup(rg.Name, fn, itv, rules, m.opts)
+			groups[groupKey(rg.Name, fn)] = NewGroup(rg.Name, fn, itv, rules, m.opts)
 		}
 	}
 
@@ -576,7 +576,7 @@ func (m *Manager) loadGroups(interval time.Duration, filenames ...string) (map[s
 }
 
 // Group names need not be unique across filenames.
-func groupName(name, file string) string {
+func groupKey(name, file string) string {
 	return name + ";" + file
 }
 

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/common/model"
 
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/pkg/value"
@@ -284,5 +285,49 @@ func TestCopyState(t *testing.T) {
 	}
 	if !reflect.DeepEqual(oldGroup.rules[0], newGroup.rules[3]) {
 		t.Fatalf("Active alerts not as expected. Wanted: %+v Got: %+v", oldGroup.rules[0], oldGroup.rules[3])
+	}
+}
+
+func TestApplyConfig(t *testing.T) {
+	expected := map[string]labels.Labels{
+		"test": labels.Labels{
+			labels.Label{
+				Name:  "name",
+				Value: "value",
+			},
+		},
+	}
+	conf, err := config.LoadFile("../config/testdata/conf.good.yml")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	ruleManager := NewManager(&ManagerOptions{
+		Appendable:  nil,
+		Notifier:    nil,
+		QueryEngine: nil,
+		Context:     context.Background(),
+		Logger:      log.NewNopLogger(),
+	})
+	ruleManager.Run()
+
+	if err := ruleManager.ApplyConfig(conf); err != nil {
+		t.Fatalf(err.Error())
+	}
+	for _, g := range ruleManager.groups {
+		g.seriesInPreviousEval = []map[string]labels.Labels{
+			expected,
+		}
+	}
+
+	if err := ruleManager.ApplyConfig(conf); err != nil {
+		t.Fatalf(err.Error())
+	}
+	for _, g := range ruleManager.groups {
+		for _, actual := range g.seriesInPreviousEval {
+
+			if !reflect.DeepEqual(expected, actual) {
+				t.Fatalf("Rule groups state lost after config reload. Expected: %+v Got: %+v", expected, actual)
+			}
+		}
 	}
 }


### PR DESCRIPTION
fix for #3376 
groups are saved in a map as
`groups[groupName+";"+fileName]`

but when reload is triggered they are  matched using only the groupName so marked as non existing and `copyState` is never called.
`groups[groupName]`

cc: @brian-brazil @fabxc 