### PR TITLE
Explicitely add alertmanager to example config

### DIFF
--- a/documentation/examples/prometheus.yml
+++ b/documentation/examples/prometheus.yml
@@ -9,10 +9,17 @@ global:
   external_labels:
       monitor: 'codelab-monitor'
 
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+  - static_config:
+    - targets:
+      # - alertmanager:9093
+
 # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
 rule_files:
-  # - "first.rules"
-  # - "second.rules"
+  # - "first_rules.yml"
+  # - "second_rules.yml"
 
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.


### PR DESCRIPTION
As alertmanager needs to be configured in the config file in Prometheus 2, I think it is useful to have it in the example config.

Also renamed the rules in the example config so they are explicitely yml files.