### PR TITLE
updated-gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,11 +14,15 @@
 *.iml
 .idea
 tags
+.history
+.vscode
 
 /prometheus
 /promtool
 benchmark.txt
 /data
+/cmd/prometheus/data
+/cmd/prometheus/debug
 /.build
 /.release
 /.tarballs


### PR DESCRIPTION
some more temp files generated by vscode
`/cmd/prometheus/data` - when I run prometheus as  go run main.go.... from within cmd/ptometheus
`/cmd/prometheus/debug` - when I start a debug session from vscode
`.history` - generated by the local-hstory addon for vscode 