### PR TITLE
Remove @beorn7 from MAINTAINERS.md, promote @fabxc to storage maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,6 @@
 Maintainers of this repository with their focus areas:
 
-* Björn Rabenstein <beorn@soundcloud.com> @beorn7: Local storage; general code-level issues.
 * Brian Brazil <brian.brazil@robustperception.io> @brian-brazil: Console templates; semantics of PromQL, service discovery, and relabeling.
-* Fabian Reinartz <fabian.reinartz@coreos.com> @fabxc: PromQL parsing and evaluation; implementation of retrieval, alert notification, and service discovery.
+* Fabian Reinartz <fabian.reinartz@coreos.com> @fabxc: Local storage; PromQL parsing and evaluation; implementation of retrieval, alert notification, and service discovery.
 * Julius Volz <julius.volz@gmail.com> @juliusv: Remote storage integrations; web UI.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 Maintainers of this repository with their focus areas:
 
 * Brian Brazil <brian.brazil@robustperception.io> @brian-brazil: Console templates; semantics of PromQL, service discovery, and relabeling.
-* Fabian Reinartz <fabian.reinartz@coreos.com> @fabxc: Local storage; PromQL parsing and evaluation; implementation of retrieval, alert notification, and service discovery.
+* Fabian Reinartz <fabian.reinartz@coreos.com> @fabxc: PromQL parsing and evaluation; implementation of retrieval, alert notification, and service discovery.
 * Julius Volz <julius.volz@gmail.com> @juliusv: Remote storage integrations; web UI.
 


### PR DESCRIPTION
With the merge of dev-2.0 into master, the local storage code I used
to own has disappeared. @fabxc is the obvious most qualified person
for the new storage code.

Leaving me in just for “general code-level issues” would suggest I'm
in some overarching code custodian role, which doesn't really match
reality.

Open for other suggestions.

@fabxc @brian-brazil @juliusv