### PR TITLE
Add test to prove redundant calls to identical target providers

### DIFF
--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -15,6 +15,7 @@ package discovery
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/prometheus/prometheus/config"
@@ -81,5 +82,50 @@ type mockSyncer struct {
 func (s *mockSyncer) Sync(tgs []*config.TargetGroup) {
 	if s.sync != nil {
 		s.sync(tgs)
+	}
+}
+
+type mockTargetProvider struct {
+	callCount *int
+}
+
+func (tp mockTargetProvider) Run(ctx context.Context, up chan<- []*config.TargetGroup) {
+	*tp.callCount = *tp.callCount + 1
+	up <- []*config.TargetGroup{{Source: "dummySource"}}
+}
+
+func TestTargetSetRunsSameTargetProviderMultipleTimes(t *testing.T) {
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	ts1 := NewTargetSet(&mockSyncer{
+		sync: func([]*config.TargetGroup) { wg.Done() },
+	})
+
+	ts2 := NewTargetSet(&mockSyncer{
+		sync: func([]*config.TargetGroup) { wg.Done() },
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tp := mockTargetProvider{}
+	callCount := 0
+	tp.callCount = &callCount
+
+	targetProviders := map[string]TargetProvider{}
+	targetProviders["testProvider"] = tp
+
+	go ts1.Run(ctx)
+	go ts2.Run(ctx)
+
+	ts1.UpdateProviders(targetProviders)
+	ts2.UpdateProviders(targetProviders)
+	wg.Wait()
+
+	if callCount != 2 {
+		t.Errorf("Was expecting 2 calls received %v", callCount)
 	}
 }

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -16,6 +16,7 @@ package discovery
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/prometheus/prometheus/config"
@@ -86,11 +87,11 @@ func (s *mockSyncer) Sync(tgs []*config.TargetGroup) {
 }
 
 type mockTargetProvider struct {
-	callCount *int
+	callCount *uint32
 }
 
 func (tp mockTargetProvider) Run(ctx context.Context, up chan<- []*config.TargetGroup) {
-	*tp.callCount = *tp.callCount + 1
+	atomic.AddUint32(tp.callCount, 1)
 	up <- []*config.TargetGroup{{Source: "dummySource"}}
 }
 
@@ -112,7 +113,7 @@ func TestTargetSetRunsSameTargetProviderMultipleTimes(t *testing.T) {
 	defer cancel()
 
 	tp := mockTargetProvider{}
-	callCount := 0
+	var callCount uint32
 	tp.callCount = &callCount
 
 	targetProviders := map[string]TargetProvider{}


### PR DESCRIPTION
This test proves that service discovery creates multiple instances for identical target providers. 

I am working on https://github.com/prometheus/prometheus/issues/2191, as a starter I wanted to write a test that proves the behavior that we want to modify.

I am planning to follow this up with changes in the discovery package that reuses the TargetProvider instances when they are identical.

cc @brian-brazil  @fabxc 