### PR TITLE
Guard against tags being nil in EC2 discovery

### DIFF
--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -200,6 +200,9 @@ func (d *Discovery) refresh() (tg *config.TargetGroup, err error) {
 				}
 
 				for _, t := range inst.Tags {
+					if t == nil || t.Key == nil || t.Value == nil {
+						continue
+					}
 					name := strutil.SanitizeLabelName(*t.Key)
 					labels[ec2LabelTag+model.LabelName(name)] = model.LabelValue(*t.Value)
 				}


### PR DESCRIPTION
This PR tries to fix the issue reported, but in fact I think we should check all pointers against nil.
Unfortunately this would make the code a lot harder to read.

Any thoughts?

Fixes #3001