### PR TITLE
Removing external_labels from example conf file

### DIFF
--- a/documentation/examples/prometheus.yml
+++ b/documentation/examples/prometheus.yml
@@ -4,11 +4,6 @@ global:
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
   # scrape_timeout is set to the global default (10s).
 
-  # Attach these labels to any time series or alerts when communicating with
-  # external systems (federation, remote storage, Alertmanager).
-  external_labels:
-      monitor: 'codelab-monitor'
-
 # Alertmanager configuration
 alerting:
   alertmanagers:


### PR DESCRIPTION
It's unclear why this is in the example configuration file. Probably best to keep that super simple, c.f. https://github.com/prometheus/docs/pull/895#discussion_r148924390