### PR TITLE
Fix typo in AM config field static_configs 

### DIFF
--- a/documentation/examples/prometheus.yml
+++ b/documentation/examples/prometheus.yml
@@ -12,7 +12,7 @@ global:
 # Alertmanager configuration
 alerting:
   alertmanagers:
-  - static_config:
+  - static_configs:
     - targets:
       # - alertmanager:9093
 


### PR DESCRIPTION
* the presence of this field causes prometheus to throw an error
* commented out the field for now

Fixes #3414