### PR TITLE
[WIP] return query samples if at least one backend has returned some data

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -546,8 +546,11 @@ func (ng *Engine) populateIterators(ctx context.Context, s *EvalStmt) (storage.Q
 			}
 			n.series, err = expandSeriesSet(set)
 			if err != nil {
-				level.Error(ng.logger).Log("msg", "error expanding series set", "err", err)
-				return false
+				if _, remoteStorageError := err.(storage.RemoteStorageError); !remoteStorageError {
+					level.Error(ng.logger).Log("msg", "error expanding series set", "err", err)
+					return false
+				}
+
 			}
 			for _, s := range n.series {
 				it := storage.NewBuffer(s.Iterator(), durationMilliseconds(n.Range))


### PR DESCRIPTION
fix for #2573

cc @brian-brazil , @tomwilkie 

when `expandSeriesSet` is called on `mergeIterator` , `mergeIterator.Err` returns an error even when not all iteratros have errored.

This change will return an error only if all iterators have errored.
This way  `expandSeriesSet` returns the remaining samples even when one backend is misbehaving.

@brian-brazil mentioned to add some extra info in the returned sample to specify that there was an error, so if you think this is needed please provide a sample with an error in it.

Tested with the `influxdb` remote read and write
It would be great if I test it with some more different config examples  to make sure I am not braking any use-case.