### PR TITLE
Discovery tests for updating target groups

### DIFF
--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -28,216 +28,172 @@ import (
 
 func TestSingleTargetSetWithSingleProviderOnlySendsNewTargetGroups(t *testing.T) {
 
-	testCases := `
-# No updates.
-- []
-
-# Empty initials.
-- - target_groups: []
-    interval: 5
-
-# Empty initials with a delay.
-- - target_groups: []
-    interval: 6000
-
-# Initials only.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: 10.11.122.11:6001
-    - source: initial2
-      targets:
-      - instance: 10.11.122.12:6001
-    interval: 0
-
-# Initials only but after a delay.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: 10.11.122.11:6001
-    - source: initial2
-      targets:
-      - instance: 10.11.122.12:6001
-    interval: 6000
-
-# Initials and new groups.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: 10.11.122.11:6001
-    - source: initial2
-      targets:
-      - instance: 10.11.122.12:6001
-    interval: 0
-
-  - target_groups:
-    - source: update1
-      targets:
-      - instance: 10.11.122.13:6001
-    - source: update2
-      targets:
-      - instance: 10.11.122.14:6001
-    interval: 5
-
-# Initials and new groups after a delay.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: 10.11.122.11:6001
-    - source: initial2
-      targets:
-      - instance: 10.11.122.12:6001
-    interval: 6000
-
-  - target_groups:
-    - source: update1
-      targets:
-      - instance: 10.11.122.13:6001
-    - source: update2
-      targets:
-      - instance: 10.11.122.14:6001
-    interval: 500
-
-# Next test case.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: 10.11.122.11:6001
-    interval: 100
-
-  - target_groups:
-    - source: update1
-      targets:
-      - instance: 10.11.122.12:6001
-    interval: 100
-
-  - target_groups:
-    - source: update2
-      targets:
-      - instance: 10.11.122.13:6001
-    interval: 100
-
-# Next test case.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: 10.11.122.11:6001
-    - source: initial2
-      targets:
-      - instance: 10.11.122.12:6001
-    interval: 100
-
-  - target_groups:
-    - source: update1
-      targets:
-      - instance: 10.11.122.13:6001
-    - source: update2
-      targets:
-      - instance: 10.11.122.14:6001
-    - source: update3
-      targets:
-      - instance: 10.11.122.15:6001
-    - source: update4
-      targets:
-      - instance: 10.11.122.16:6001
-    - source: update5
-      targets:
-      - instance: 10.11.122.17:6001
-    - source: update6
-      targets:
-      - instance: 10.11.122.18:6001
-    interval: 100
-
-# Next test case.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: 10.11.122.11:6001
-    interval: 10
-
-  - target_groups:
-    - source: update1
-      targets:
-      - instance: 10.11.122.13:6001
-    interval: 45
-
-  - target_groups:
-    - source: update2
-      targets:
-      - instance: 10.11.122.14:6001
-    - source: update3
-      targets:
-      - instance: 10.11.122.15:6001
-    - source: update4
-      targets:
-      - instance: 10.11.122.16:6001
-    interval: 0
-
-  - target_groups:
-    - source: update5
-      targets:
-      - instance: 10.11.122.17:6001
-    interval: 10
-
-  - target_groups:
-    - source: update6
-      targets:
-      - instance: 10.11.122.18:6001
-    - source: update7
-      targets:
-      - instance: 10.11.122.19:6001
-    - source: update8
-      targets:
-      - instance: 10.11.122.20:6001
-    interval: 70
-
-# Next test case.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: 10.11.122.11:6001
-    - source: initial2
-      targets:
-      - instance: 10.11.122.12:6001
-    interval: 5
-
-  - target_groups: []
-    interval: 100
-
-  - target_groups:
-    - source: update1
-      targets:
-      - instance: 10.11.122.13:6001
-    - source: update2
-      targets:
-      - instance: 10.11.122.14:6001
-    interval: 100
-
-  - target_groups:
-    - source: update3
-      targets:
-      - instance: 10.11.122.15:6001
-    - source: update4
-      targets:
-      - instance: 10.11.122.16:6001
-    - source: update5
-      targets:
-      - instance: 10.11.122.17:6001
-    interval: 70
-`
-
-	parsedTestCases := [][]update{}
-
-	err := yaml.Unmarshal([]byte(testCases), &parsedTestCases)
-	if err != nil {
-		t.Fatalf("error while parsing test cases: %v", err)
+	testCases := []struct {
+		title   string
+		updates []update
+	}{
+		{
+			title:   "No updates",
+			updates: []update{},
+		},
+		{
+			title: "Empty initials",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{},
+					interval:     5,
+				},
+			},
+		},
+		{
+			title: "Empty initials with a delay",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{},
+					interval:     6000,
+				},
+			},
+		},
+		{
+			title: "Initials only",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+					interval:     0,
+				},
+			},
+		},
+		{
+			title: "Initials only but after a delay",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+					interval:     6000,
+				},
+			},
+		},
+		{
+			title: "Initials followed by empty updates",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+					interval:     0,
+				},
+				{
+					targetGroups: []config.TargetGroup{},
+					interval:     10,
+				},
+			},
+		},
+		{
+			title: "Initials and new groups",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+					interval:     0,
+				},
+				{
+					targetGroups: []config.TargetGroup{{Source: "update1"}, {Source: "update2"}},
+					interval:     10,
+				},
+			},
+		},
+		{
+			title: "Initials and new groups after a delay",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+					interval:     6000,
+				},
+				{
+					targetGroups: []config.TargetGroup{{Source: "update1"}, {Source: "update2"}},
+					interval:     10,
+				},
+			},
+		},
+		{
+			title: "Next test case",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{{Source: "initial1"}},
+					interval:     100,
+				},
+				{
+					targetGroups: []config.TargetGroup{{Source: "update1"}},
+					interval:     100,
+				},
+				{
+					targetGroups: []config.TargetGroup{{Source: "update2"}},
+					interval:     10,
+				},
+			},
+		},
+		{
+			title: "Next test case",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+					interval:     100,
+				},
+				{
+					targetGroups: []config.TargetGroup{{Source: "update1"}, {Source: "update2"}, {Source: "update3"}, {Source: "update4"}, {Source: "update5"}, {Source: "update6"}},
+					interval:     30,
+				},
+			},
+		},
+		{
+			title: "Next test case",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{{Source: "initial1"}},
+					interval:     10,
+				},
+				{
+					targetGroups: []config.TargetGroup{{Source: "update1"}},
+					interval:     25,
+				},
+				{
+					targetGroups: []config.TargetGroup{{Source: "update2"}, {Source: "update3"}, {Source: "update4"}},
+					interval:     10,
+				},
+				{
+					targetGroups: []config.TargetGroup{{Source: "update5"}},
+					interval:     0,
+				},
+				{
+					targetGroups: []config.TargetGroup{{Source: "update6"}, {Source: "update7"}, {Source: "update8"}},
+					interval:     70,
+				},
+			},
+		},
+		{
+			title: "Empty update in between",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+					interval:     30,
+				},
+				{
+					targetGroups: []config.TargetGroup{{Source: "update1"}, {Source: "update2"}},
+					interval:     30,
+				},
+				{
+					targetGroups: []config.TargetGroup{},
+					interval:     10,
+				},
+				{
+					targetGroups: []config.TargetGroup{{Source: "update3"}, {Source: "update4"}, {Source: "update5"}, {Source: "update6"}},
+					interval:     30,
+				},
+			},
+		},
 	}
 
-	for i, updates := range parsedTestCases {
+	for i, testCase := range testCases {
 
 		expectedGroups := make(map[string]struct{})
-		for _, update := range updates {
-			for _, target := range update.TargetGroups {
+		for _, update := range testCase.updates {
+			for _, target := range update.targetGroups {
 				expectedGroups[target.Source] = struct{}{}
 			}
 		}
@@ -267,7 +223,7 @@ func TestSingleTargetSetWithSingleProviderOnlySendsNewTargetGroups(t *testing.T)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		tp := newMockTargetProvider(updates)
+		tp := newMockTargetProvider(testCase.updates)
 		targetProviders := map[string]TargetProvider{}
 		targetProviders["testProvider"] = tp
 
@@ -276,29 +232,29 @@ func TestSingleTargetSetWithSingleProviderOnlySendsNewTargetGroups(t *testing.T)
 
 		select {
 		case <-time.After(20000 * time.Millisecond):
-			t.Errorf("In test case %v: Test timed out after 20000 millisecond. All targets should be sent within the timeout", i)
+			t.Errorf("In test case %v[%v]: Test timed out after 20000 millisecond. All targets should be sent within the timeout", i, testCase.title)
 
 		case <-finalize:
 
 			if *tp.callCount != 1 {
-				t.Errorf("In test case %v: TargetProvider Run should be called once only, was called %v times", i, *tp.callCount)
+				t.Errorf("In test case %v[%v]: TargetProvider Run should be called once only, was called %v times", i, testCase.title, *tp.callCount)
 			}
 
-			if len(updates) > 0 && updates[0].Interval > 5000 {
+			if len(testCase.updates) > 0 && testCase.updates[0].interval > 5000 {
 				// If the initial set of targets never arrive or arrive after 5 seconds.
 				// The first sync call should receive empty set of targets.
 				if len(initialGroups) != 0 {
-					t.Errorf("In test case %v: Expecting 0 initial target groups, received %v", i, len(initialGroups))
+					t.Errorf("In test case %v[%v]: Expecting 0 initial target groups, received %v", i, testCase.title, len(initialGroups))
 				}
 			}
 
 			if len(syncedGroups) != len(expectedGroups) {
-				t.Errorf("In test case %v: Expecting %v target groups in total, received %v", i, len(expectedGroups), len(syncedGroups))
+				t.Errorf("In test case %v[%v]: Expecting %v target groups in total, received %v", i, testCase.title, len(expectedGroups), len(syncedGroups))
 			}
 
 			for _, tg := range syncedGroups {
 				if _, ok := expectedGroups[tg.Source]; ok == false {
-					t.Errorf("In test case %v: '%s' does not exist in expected target groups: %s", i, tg.Source, expectedGroups)
+					t.Errorf("In test case %v[%v]: '%s' does not exist in expected target groups: %s", i, testCase.title, tg.Source, expectedGroups)
 				} else {
 					delete(expectedGroups, tg.Source) // Remove used targets from the map.
 				}
@@ -309,139 +265,7 @@ func TestSingleTargetSetWithSingleProviderOnlySendsNewTargetGroups(t *testing.T)
 
 func TestSingleTargetSetWithSingleProviderSendsUpdatedTargetGroups(t *testing.T) {
 
-	testCases := `
-# Update same initial group multiple times.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: "10.11.122.11:6001"
-    interval: 3
-
-  - target_groups:
-    - source: initial1
-      targets:
-      - instance: "10.11.122.11:6002"
-    interval: 10
-
-  - target_groups:
-    - source: initial1
-      targets:
-      - instance: "10.11.122.11:6003"
-    interval: 4
-
-# Update second round target.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: "10.11.122.11:6001"
-    interval: 3
-
-  - target_groups:
-    - source: update1
-      targets:
-      - instance: "10.11.122.11:6002"
-    interval: 10
-
-  - target_groups:
-    - source: update1
-      targets:
-      - instance: "10.11.122.11:6003"
-      - instance: "10.11.122.11:6004"
-      - instance: "10.11.122.11:6005"
-    interval: 10
-
-# Next test case.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: "10.11.122.11:6001"
-    - source: initial2
-      targets:
-      - instance: "10.11.122.12:6001"
-    interval: 3
-
-  - target_groups:
-    - source: update1
-      targets:
-      - instance: "10.11.122.13:6001"
-    - source: initial2
-      targets:
-      - instance: "10.11.123.12:6001"
-      - instance: "10.11.123.13:6001"
-    interval: 10
-
-  - target_groups:
-    - source: update2
-      targets:
-      - instance: "10.11.122.14:6001"
-    - source: initial1
-      targets: []
-    interval: 10
-
-  - target_groups:
-    - source: update1
-      targets:
-      - instance: "10.11.122.13:6001"
-      - instance: "10.11.122.15:6001"
-      - instance: "10.11.122.16:6001"
-    interval: 10
-
-# Next test case.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: "10.11.122.11:6001"
-      - instance: "10.11.122.12:6001"
-      - instance: "10.11.122.13:6001"
-    - source: initial2
-      targets:
-      - instance: "10.11.122.14:6001"
-    interval: 3
-
-  - target_groups:
-    - source: initial1
-      targets:
-      - instance: "10.11.122.13:6001"
-    interval: 10
-
-# Next test case.
-- - target_groups:
-    - source: initial1
-      targets:
-      - instance: "10.11.122.11:6001"
-      - instance: "10.11.122.12:6001"
-      - instance: "10.11.122.13:6001"
-    - source: initial2
-      targets:
-      - instance: "10.11.122.14:6001"
-    interval: 1000
-
-  - target_groups:
-    - source: initial1
-      targets:
-      - instance: "10.11.122.12:6001"
-    - source: update1
-      targets:
-      - instance: "10.11.122.15:6001"
-    interval: 3000
-
-  - target_groups:
-    - source: initial1
-      targets: []
-    - source: update1
-      targets:
-      - instance: "10.11.122.15:6001"
-      - instance: "10.11.122.16:6001"
-    interval: 3000
-`
-
-	parsedTestCases := [][]update{}
-	err := yaml.Unmarshal([]byte(testCases), &parsedTestCases)
-	if err != nil {
-		t.Fatalf("error while parsing test cases: %v", err)
-	}
-
-	// Function to determine if this sync call received the latest state of
+	// Function to determine if the sync call received the latest state of
 	// all the target groups that came out of the target provider.
 	endStateAchieved := func(groupsSentToSyc []*config.TargetGroup, endState map[string]config.TargetGroup) bool {
 
@@ -466,11 +290,209 @@ func TestSingleTargetSetWithSingleProviderSendsUpdatedTargetGroups(t *testing.T)
 		return true
 	}
 
-	for i, updates := range parsedTestCases {
+	testCases := []struct {
+		title   string
+		updates []update
+	}{
+		{
+			title: "Update same initial group multiple times",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source:  "initial1",
+							Targets: []model.LabelSet{{"__instance__": "10.11.122.11:6003"}},
+						},
+					},
+					interval: 3,
+				},
+			},
+		},
+		{
+			title: "Update second round target",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source:  "initial1",
+							Targets: []model.LabelSet{{"__instance__": "10.11.122.11:6003"}},
+						},
+					},
+					interval: 3,
+				},
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source:  "update1",
+							Targets: []model.LabelSet{{"__instance__": "10.11.122.12:6003"}},
+						},
+					},
+					interval: 10,
+				},
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source: "update1",
+							Targets: []model.LabelSet{
+								{"__instance__": "10.11.122.12:6003"},
+								{"__instance__": "10.11.122.13:6003"},
+								{"__instance__": "10.11.122.14:6003"},
+							},
+						},
+					},
+					interval: 10,
+				},
+			},
+		},
+		{
+			title: "Next test case",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source:  "initial1",
+							Targets: []model.LabelSet{{"__instance__": "10.11.122.11:6003"}},
+						},
+						{
+							Source:  "initial2",
+							Targets: []model.LabelSet{{"__instance__": "10.11.122.12:6003"}},
+						},
+					},
+					interval: 10,
+				},
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source:  "update1",
+							Targets: []model.LabelSet{{"__instance__": "10.11.122.13:6003"}},
+						},
+						{
+							Source: "initial2",
+							Targets: []model.LabelSet{
+								{"__instance__": "10.11.122.12:6003"},
+								{"__instance__": "10.11.122.14:6003"},
+							},
+						},
+					},
+					interval: 10,
+				},
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source:  "update2",
+							Targets: []model.LabelSet{{"__instance__": "10.11.122.15:6003"}},
+						},
+						{
+							Source:  "initial1",
+							Targets: []model.LabelSet{},
+						},
+					},
+					interval: 10,
+				},
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source: "update1",
+							Targets: []model.LabelSet{
+								{"__instance__": "10.11.122.16:6003"},
+								{"__instance__": "10.11.122.17:6003"},
+								{"__instance__": "10.11.122.18:6003"},
+							},
+						},
+					},
+					interval: 10,
+				},
+			},
+		},
+		{
+			title: "Next test case",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source: "initial1",
+							Targets: []model.LabelSet{
+								{"__instance__": "10.11.122.11:6003"},
+								{"__instance__": "10.11.122.12:6003"},
+								{"__instance__": "10.11.122.13:6003"},
+							},
+						},
+						{
+							Source:  "initial2",
+							Targets: []model.LabelSet{{"__instance__": "10.11.122.14:6003"}},
+						},
+					},
+					interval: 0,
+				},
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source:  "initial1",
+							Targets: []model.LabelSet{{"__instance__": "10.11.122.13:6003"}},
+						},
+					},
+					interval: 10,
+				},
+			},
+		},
+		{
+			title: "Three times sync call",
+			updates: []update{
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source: "initial1",
+							Targets: []model.LabelSet{
+								{"__instance__": "10.11.122.11:6003"},
+								{"__instance__": "10.11.122.12:6003"},
+								{"__instance__": "10.11.122.13:6003"},
+							},
+						},
+						{
+							Source:  "initial2",
+							Targets: []model.LabelSet{{"__instance__": "10.11.122.14:6003"}},
+						},
+					},
+					interval: 1000,
+				},
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source:  "initial1",
+							Targets: []model.LabelSet{{"__instance__": "10.11.122.12:6003"}},
+						},
+						{
+							Source:  "update1",
+							Targets: []model.LabelSet{{"__instance__": "10.11.122.15:6003"}},
+						},
+					},
+					interval: 3000,
+				},
+				{
+					targetGroups: []config.TargetGroup{
+						{
+							Source:  "initial1",
+							Targets: []model.LabelSet{},
+						},
+						{
+							Source: "update1",
+							Targets: []model.LabelSet{
+								{"__instance__": "10.11.122.15:6003"},
+								{"__instance__": "10.11.122.16:6003"},
+							},
+						},
+					},
+					interval: 3000,
+				},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
 
 		expectedGroups := make(map[string]config.TargetGroup)
-		for _, update := range updates {
-			for _, targetGroup := range update.TargetGroups {
+		for _, update := range testCase.updates {
+			for _, targetGroup := range update.targetGroups {
 				expectedGroups[targetGroup.Source] = targetGroup
 			}
 		}
@@ -496,7 +518,7 @@ func TestSingleTargetSetWithSingleProviderSendsUpdatedTargetGroups(t *testing.T)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		tp := newMockTargetProvider(updates)
+		tp := newMockTargetProvider(testCase.updates)
 		targetProviders := map[string]TargetProvider{}
 		targetProviders["testProvider"] = tp
 
@@ -505,7 +527,7 @@ func TestSingleTargetSetWithSingleProviderSendsUpdatedTargetGroups(t *testing.T)
 
 		select {
 		case <-time.After(20000 * time.Millisecond):
-			t.Errorf("In test case %v: Test timed out after 20000 millisecond. All targets should be sent within the timeout", i)
+			t.Errorf("In test case %v[%v]: Test timed out after 20000 millisecond. All targets should be sent within the timeout", i, testCase.title)
 
 		case <-finalize:
 			// System successfully reached to the end state.
@@ -583,18 +605,11 @@ func TestTargetSetRunsSameTargetProviderMultipleTimes(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	updatesData := `
-- target_groups:
-  - source: initial1
-    targets:
-    - instance: 10.11.122.11:6001
-    - instance: 10.11.122.11:6002
-  interval: 5
-`
-	updates := []update{}
-	err := yaml.Unmarshal([]byte(updatesData), &updates)
-	if err != nil {
-		t.Fatalf("error while parsing updates: %v", err)
+	updates := []update{
+		{
+			targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+			interval:     10,
+		},
 	}
 
 	tp := newMockTargetProvider(updates)
@@ -635,44 +650,8 @@ func (s *mockSyncer) Sync(tgs []*config.TargetGroup) {
 }
 
 type update struct {
-	TargetGroups []config.TargetGroup `yaml:"target_groups"`
-	Interval     int
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (u *update) UnmarshalYAML(unmarshal func(interface{}) error) error {
-
-	s := struct {
-		TargetGroups []struct {
-			Source  string
-			Targets []map[string]string
-		} `yaml:"target_groups"`
-		Interval int
-	}{}
-
-	if err := unmarshal(&s); err != nil {
-		return err
-	}
-
-	u.Interval = s.Interval
-
-	u.TargetGroups = make([]config.TargetGroup, len(s.TargetGroups))
-	for groupIndex, targetGroup := range s.TargetGroups {
-
-		u.TargetGroups[groupIndex] = config.TargetGroup{}
-		u.TargetGroups[groupIndex].Source = targetGroup.Source
-
-		u.TargetGroups[groupIndex].Targets = make([]model.LabelSet, len(targetGroup.Targets))
-		for targetIndex, target := range targetGroup.Targets {
-
-			u.TargetGroups[groupIndex].Targets[targetIndex] = make(model.LabelSet)
-			for labelName, labelValue := range target {
-				u.TargetGroups[groupIndex].Targets[targetIndex][model.LabelName(labelName)] = model.LabelValue(labelValue)
-			}
-		}
-	}
-
-	return nil
+	targetGroups []config.TargetGroup
+	interval     time.Duration
 }
 
 type mockTargetProvider struct {
@@ -701,12 +680,12 @@ func (tp mockTargetProvider) Run(ctx context.Context, up chan<- []*config.Target
 func (tp mockTargetProvider) sendUpdates() {
 	for _, update := range tp.updates {
 
-		time.Sleep(time.Duration(update.Interval) * time.Millisecond)
+		time.Sleep(update.interval * time.Millisecond)
 
-		tgs := make([]*config.TargetGroup, len(update.TargetGroups))
-		for groupIndex, _ := range update.TargetGroups {
+		tgs := make([]*config.TargetGroup, len(update.targetGroups))
+		for groupIndex := range update.targetGroups {
 
-			tgs[groupIndex] = &update.TargetGroups[groupIndex]
+			tgs[groupIndex] = &update.targetGroups[groupIndex]
 		}
 
 		tp.up <- tgs

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -29,22 +29,37 @@ import (
 func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 	testCases := []struct {
 		title             string
-		updates           []update
+		updates           map[string][]update
 		expectedSyncCalls [][]string
 	}{
 		{
-			title:   "No updates",
-			updates: []update{},
+			title: "Single TP no updates",
+			updates: map[string][]update{
+				"tp1": {},
+			},
 			expectedSyncCalls: [][]string{
 				{},
 			},
 		},
 		{
-			title: "Empty initials",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{},
-					interval:     5,
+			title: "Multips TPs no updates",
+			updates: map[string][]update{
+				"tp1": {},
+				"tp2": {},
+				"tp3": {},
+			},
+			expectedSyncCalls: [][]string{
+				{},
+			},
+		},
+		{
+			title: "Single TP empty initials",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{},
+						interval:     5,
+					},
 				},
 			},
 			expectedSyncCalls: [][]string{
@@ -52,11 +67,25 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 			},
 		},
 		{
-			title: "Empty initials with a delay",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{},
-					interval:     6000,
+			title: "Multiple TPs empty initials",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{},
+						interval:     5,
+					},
+				},
+				"tp2": {
+					{
+						targetGroups: []config.TargetGroup{},
+						interval:     500,
+					},
+				},
+				"tp3": {
+					{
+						targetGroups: []config.TargetGroup{},
+						interval:     100,
+					},
 				},
 			},
 			expectedSyncCalls: [][]string{
@@ -64,11 +93,33 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 			},
 		},
 		{
-			title: "Initials only",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
-					interval:     0,
+			title: "Multiple TPs empty initials with a delay",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{},
+						interval:     6000,
+					},
+				},
+				"tp2": {
+					{
+						targetGroups: []config.TargetGroup{},
+						interval:     6500,
+					},
+				},
+			},
+			expectedSyncCalls: [][]string{
+				{},
+			},
+		},
+		{
+			title: "Single TP initials only",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+						interval:     0,
+					},
 				},
 			},
 			expectedSyncCalls: [][]string{
@@ -76,11 +127,33 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 			},
 		},
 		{
-			title: "Initials only but after a delay",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
-					interval:     6000,
+			title: "Multiple TPs initials only",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-initial1"}, {Source: "tp1-initial2"}},
+						interval:     0,
+					},
+				},
+				"tp2": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp2-initial1"}},
+						interval:     0,
+					},
+				},
+			},
+			expectedSyncCalls: [][]string{
+				{"tp1-initial1", "tp1-initial2", "tp2-initial1"},
+			},
+		},
+		{
+			title: "Single TP delayed initials only",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+						interval:     6000,
+					},
 				},
 			},
 			expectedSyncCalls: [][]string{
@@ -89,15 +162,38 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 			},
 		},
 		{
-			title: "Initials followed by empty updates",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
-					interval:     0,
+			title: "Multiple TPs with some delayed initials",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-initial1"}, {Source: "tp1-initial2"}},
+						interval:     100,
+					},
 				},
-				{
-					targetGroups: []config.TargetGroup{},
-					interval:     10,
+				"tp2": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp2-initial1"}, {Source: "tp2-initial2"}, {Source: "tp2-initial3"}},
+						interval:     6000,
+					},
+				},
+			},
+			expectedSyncCalls: [][]string{
+				{"tp1-initial1", "tp1-initial2"},
+				{"tp1-initial1", "tp1-initial2", "tp2-initial1", "tp2-initial2", "tp2-initial3"},
+			},
+		},
+		{
+			title: "Single TP initials followed by empty updates",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+						interval:     0,
+					},
+					{
+						targetGroups: []config.TargetGroup{},
+						interval:     10,
+					},
 				},
 			},
 			expectedSyncCalls: [][]string{
@@ -105,15 +201,17 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 			},
 		},
 		{
-			title: "Initials and new groups",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
-					interval:     0,
-				},
-				{
-					targetGroups: []config.TargetGroup{{Source: "update1"}, {Source: "update2"}},
-					interval:     10,
+			title: "Single TP initials and new groups",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+						interval:     0,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "update1"}, {Source: "update2"}},
+						interval:     10,
+					},
 				},
 			},
 			expectedSyncCalls: [][]string{
@@ -122,15 +220,104 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 			},
 		},
 		{
-			title: "Initials and new groups after a delay",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
-					interval:     6000,
+			title: "Multiple TPs initials and new groups",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-initial1"}, {Source: "tp1-initial2"}},
+						interval:     10,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-update1"}, {Source: "tp1-update2"}},
+						interval:     1500,
+					},
 				},
-				{
-					targetGroups: []config.TargetGroup{{Source: "update1"}, {Source: "update2"}},
-					interval:     10,
+				"tp2": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp2-initial1"}, {Source: "tp2-initial2"}},
+						interval:     100,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp2-update1"}, {Source: "tp2-update2"}},
+						interval:     10,
+					},
+				},
+			},
+			expectedSyncCalls: [][]string{
+				{"tp1-initial1", "tp1-initial2", "tp2-initial1", "tp2-initial2"},
+				{"tp1-initial1", "tp1-initial2", "tp2-initial1", "tp2-initial2", "tp1-update1", "tp1-update2", "tp2-update1", "tp2-update2"},
+			},
+		},
+		{
+			title: "One tp initials arrive after other tp updates but still within 5 seconds",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-initial1"}, {Source: "tp1-initial2"}},
+						interval:     10,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-update1"}, {Source: "tp1-update2"}},
+						interval:     1500,
+					},
+				},
+				"tp2": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp2-initial1"}, {Source: "tp2-initial2"}},
+						interval:     2000,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp2-update1"}, {Source: "tp2-update2"}},
+						interval:     1000,
+					},
+				},
+			},
+			expectedSyncCalls: [][]string{
+				{"tp1-initial1", "tp1-initial2", "tp1-update1", "tp1-update2", "tp2-initial1", "tp2-initial2"},
+				{"tp1-initial1", "tp1-initial2", "tp1-update1", "tp1-update2", "tp2-initial1", "tp2-initial2", "tp2-update1", "tp2-update2"},
+			},
+		},
+		{
+			title: "One tp initials arrive after other tp updates and after 5 seconds",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-initial1"}, {Source: "tp1-initial2"}},
+						interval:     10,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-update1"}, {Source: "tp1-update2"}},
+						interval:     1500,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-update3"}},
+						interval:     5000,
+					},
+				},
+				"tp2": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp2-initial1"}, {Source: "tp2-initial2"}},
+						interval:     6000,
+					},
+				},
+			},
+			expectedSyncCalls: [][]string{
+				{"tp1-initial1", "tp1-initial2", "tp1-update1", "tp1-update2"},
+				{"tp1-initial1", "tp1-initial2", "tp1-update1", "tp1-update2", "tp2-initial1", "tp2-initial2", "tp1-update3"},
+			},
+		},
+		{
+			title: "Single TP initials and new groups after a delay",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+						interval:     6000,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "update1"}, {Source: "update2"}},
+						interval:     10,
+					},
 				},
 			},
 			expectedSyncCalls: [][]string{
@@ -139,23 +326,25 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 			},
 		},
 		{
-			title: "Initial and successive updates",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{{Source: "initial1"}},
-					interval:     100,
-				},
-				{
-					targetGroups: []config.TargetGroup{{Source: "update1"}},
-					interval:     100,
-				},
-				{
-					targetGroups: []config.TargetGroup{{Source: "update2"}},
-					interval:     10,
-				},
-				{
-					targetGroups: []config.TargetGroup{{Source: "update3"}},
-					interval:     10,
+			title: "Single TP initial and successive updates",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "initial1"}},
+						interval:     100,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "update1"}},
+						interval:     100,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "update2"}},
+						interval:     10,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "update3"}},
+						interval:     10,
+					},
 				},
 			},
 			expectedSyncCalls: [][]string{
@@ -164,44 +353,75 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 			},
 		},
 		{
-			title: "Large number of updates",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
-					interval:     100,
+			title: "Multiple TPs initials and successive updates",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-initial1"}},
+						interval:     1000,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-update1"}},
+						interval:     1000,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-update2"}},
+						interval:     2000,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp1-update3"}},
+						interval:     2000,
+					},
 				},
-				{
-					targetGroups: []config.TargetGroup{{Source: "update1"}, {Source: "update2"}, {Source: "update3"}, {Source: "update4"}, {Source: "update5"}, {Source: "update6"}},
-					interval:     30,
+				"tp2": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp2-initial1"}},
+						interval:     3000,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp2-update1"}},
+						interval:     1000,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp2-update2"}},
+						interval:     3000,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "tp2-update3"}},
+						interval:     2000,
+					},
 				},
 			},
 			expectedSyncCalls: [][]string{
-				{"initial1", "initial2"},
-				{"initial1", "initial2", "update1", "update2", "update3", "update4", "update5", "update6"},
+				{"tp1-initial1", "tp1-update1", "tp2-initial1"},
+				{"tp1-initial1", "tp1-update1", "tp2-initial1", "tp1-update2", "tp1-update3", "tp2-update1", "tp2-update2"},
+				{"tp1-initial1", "tp1-update1", "tp2-initial1", "tp1-update2", "tp1-update3", "tp2-update1", "tp2-update2", "tp2-update3"},
 			},
 		},
 		{
-			title: "Multiple updates 5 second window",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{{Source: "initial1"}},
-					interval:     10,
-				},
-				{
-					targetGroups: []config.TargetGroup{{Source: "update1"}},
-					interval:     25,
-				},
-				{
-					targetGroups: []config.TargetGroup{{Source: "update2"}, {Source: "update3"}, {Source: "update4"}},
-					interval:     10,
-				},
-				{
-					targetGroups: []config.TargetGroup{{Source: "update5"}},
-					interval:     0,
-				},
-				{
-					targetGroups: []config.TargetGroup{{Source: "update6"}, {Source: "update7"}, {Source: "update8"}},
-					interval:     70,
+			title: "Single TP Multiple updates 5 second window",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "initial1"}},
+						interval:     10,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "update1"}},
+						interval:     25,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "update2"}, {Source: "update3"}, {Source: "update4"}},
+						interval:     10,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "update5"}},
+						interval:     0,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "update6"}, {Source: "update7"}, {Source: "update8"}},
+						interval:     70,
+					},
 				},
 			},
 			expectedSyncCalls: [][]string{
@@ -210,23 +430,25 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 			},
 		},
 		{
-			title: "Empty update in between",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
-					interval:     30,
-				},
-				{
-					targetGroups: []config.TargetGroup{{Source: "update1"}, {Source: "update2"}},
-					interval:     300,
-				},
-				{
-					targetGroups: []config.TargetGroup{},
-					interval:     10,
-				},
-				{
-					targetGroups: []config.TargetGroup{{Source: "update3"}, {Source: "update4"}, {Source: "update5"}, {Source: "update6"}},
-					interval:     6000,
+			title: "Single TP Single provider empty update in between",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{{Source: "initial1"}, {Source: "initial2"}},
+						interval:     30,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "update1"}, {Source: "update2"}},
+						interval:     300,
+					},
+					{
+						targetGroups: []config.TargetGroup{},
+						interval:     10,
+					},
+					{
+						targetGroups: []config.TargetGroup{{Source: "update3"}, {Source: "update4"}, {Source: "update5"}, {Source: "update6"}},
+						interval:     6000,
+					},
 				},
 			},
 			expectedSyncCalls: [][]string{
@@ -263,9 +485,11 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		tp := newMockTargetProvider(testCase.updates)
 		targetProviders := map[string]TargetProvider{}
-		targetProviders["testProvider"] = tp
+		for tpName, tpUpdates := range testCase.updates {
+			tp := newMockTargetProvider(tpUpdates)
+			targetProviders[tpName] = tp
+		}
 
 		go targetSet.Run(ctx)
 		targetSet.UpdateProviders(targetProviders)
@@ -275,9 +499,11 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 			t.Errorf("%d. %q: Test timed out after 20 seconds. All targets should be sent within the timeout", i, testCase.title)
 
 		case <-finalize:
-
-			if *tp.callCount != 1 {
-				t.Errorf("%d. %q: TargetProvider Run should be called once only, was called %v times", i, testCase.title, *tp.callCount)
+			for name, tp := range targetProviders {
+				runCallCount := *tp.(mockTargetProvider).callCount
+				if runCallCount != 1 {
+					t.Errorf("%d. %q: TargetProvider Run should be called once for each target provider. For %q was called %d times", i, testCase.title, name, runCallCount)
+				}
 			}
 
 			if len(syncedGroups) != len(testCase.expectedSyncCalls) {
@@ -301,13 +527,300 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 						delete(expectedGroupsMap, syncedGroup) // Remove used targets from the map.
 					}
 				}
-
 			}
 		}
 	}
 }
 
 func TestTargetSetConsolidatesToTheLatestState(t *testing.T) {
+	testCases := []struct {
+		title   string
+		updates map[string][]update
+	}{
+		{
+			title: "Single TP update same initial group multiple times",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "initial1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.11:6003"}},
+							},
+						},
+						interval: 100,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "initial1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.11:6003"}, {"__instance__": "10.11.122.12:6003"}},
+							},
+						},
+						interval: 250,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "initial1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.12:6003"}},
+							},
+						},
+						interval: 250,
+					},
+				},
+			},
+		},
+		{
+			title: "Multiple TPs update",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "tp1-initial1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.11:6003"}},
+							},
+						},
+						interval: 3,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "tp1-update1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.12:6003"}},
+							},
+						},
+						interval: 10,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source: "tp1-update1",
+								Targets: []model.LabelSet{
+									{"__instance__": "10.11.122.12:6003"},
+									{"__instance__": "10.11.122.13:6003"},
+									{"__instance__": "10.11.122.14:6003"},
+								},
+							},
+						},
+						interval: 10,
+					},
+				},
+				"tp2": {
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "tp2-initial1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.11:6003"}},
+							},
+						},
+						interval: 3,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "tp2-initial1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.12:6003"}},
+							},
+						},
+						interval: 10,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source: "tp2-update1",
+								Targets: []model.LabelSet{
+									{"__instance__": "10.11.122.12:6003"},
+									{"__instance__": "10.11.122.13:6003"},
+									{"__instance__": "10.11.122.14:6003"},
+								},
+							},
+						},
+						interval: 10,
+					},
+				},
+			},
+		},
+		{
+			title: "Multiple TPs update II",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "tp1-initial1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.11:6003"}},
+							},
+							{
+								Source:  "tp1-initial2",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.12:6003"}},
+							},
+						},
+						interval: 100,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "tp1-update1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.13:6003"}},
+							},
+							{
+								Source: "tp1-initial2",
+								Targets: []model.LabelSet{
+									{"__instance__": "10.11.122.12:6003"},
+									{"__instance__": "10.11.122.14:6003"},
+								},
+							},
+						},
+						interval: 100,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "tp1-update2",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.15:6003"}},
+							},
+							{
+								Source:  "tp1-initial1",
+								Targets: []model.LabelSet{},
+							},
+						},
+						interval: 100,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source: "tp1-update1",
+								Targets: []model.LabelSet{
+									{"__instance__": "10.11.122.16:6003"},
+									{"__instance__": "10.11.122.17:6003"},
+									{"__instance__": "10.11.122.18:6003"},
+								},
+							},
+						},
+						interval: 100,
+					},
+				},
+				"tp2": {
+					{
+						targetGroups: []config.TargetGroup{},
+						interval:     100,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "tp2-update1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.13:6003"}},
+							},
+						},
+						interval: 100,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "tp2-update2",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.15:6003"}},
+							},
+							{
+								Source:  "tp2-update1",
+								Targets: []model.LabelSet{},
+							},
+						},
+						interval: 300,
+					},
+				},
+			},
+		},
+		{
+			title: "Three rounds of sync call",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source: "tp1-initial1",
+								Targets: []model.LabelSet{
+									{"__instance__": "10.11.122.11:6003"},
+									{"__instance__": "10.11.122.12:6003"},
+									{"__instance__": "10.11.122.13:6003"},
+								},
+							},
+							{
+								Source:  "tp1-initial2",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.14:6003"}},
+							},
+						},
+						interval: 1000,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "tp1-initial1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.12:6003"}},
+							},
+							{
+								Source:  "tp1-update1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.15:6003"}},
+							},
+						},
+						interval: 3000,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "tp1-initial1",
+								Targets: []model.LabelSet{},
+							},
+							{
+								Source: "tp1-update1",
+								Targets: []model.LabelSet{
+									{"__instance__": "10.11.122.15:6003"},
+									{"__instance__": "10.11.122.16:6003"},
+								},
+							},
+						},
+						interval: 3000,
+					},
+				},
+				"tp2": {
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source: "tp2-initial1",
+								Targets: []model.LabelSet{
+									{"__instance__": "10.11.122.11:6003"},
+								},
+							},
+							{
+								Source:  "tp2-initial2",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.14:6003"}},
+							},
+							{
+								Source:  "tp2-initial3",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.15:6003"}},
+							},
+						},
+						interval: 6000,
+					},
+					{
+						targetGroups: []config.TargetGroup{
+							{
+								Source:  "tp2-initial1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.11:6003"}, {"__instance__": "10.11.122.12:6003"}},
+							},
+							{
+								Source:  "tp2-update1",
+								Targets: []model.LabelSet{{"__instance__": "10.11.122.15:6003"}},
+							},
+						},
+						interval: 3000,
+					},
+				},
+			},
+		},
+	}
+
 	// Function to determine if the sync call received the latest state of
 	// all the target groups that came out of the target provider.
 	endStateAchieved := func(groupsSentToSyc []*config.TargetGroup, endState map[string]config.TargetGroup) bool {
@@ -333,209 +846,13 @@ func TestTargetSetConsolidatesToTheLatestState(t *testing.T) {
 		return true
 	}
 
-	testCases := []struct {
-		title   string
-		updates []update
-	}{
-		{
-			title: "Update same initial group multiple times",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source:  "initial1",
-							Targets: []model.LabelSet{{"__instance__": "10.11.122.11:6003"}},
-						},
-					},
-					interval: 3,
-				},
-			},
-		},
-		{
-			title: "Update second round target",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source:  "initial1",
-							Targets: []model.LabelSet{{"__instance__": "10.11.122.11:6003"}},
-						},
-					},
-					interval: 3,
-				},
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source:  "update1",
-							Targets: []model.LabelSet{{"__instance__": "10.11.122.12:6003"}},
-						},
-					},
-					interval: 10,
-				},
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source: "update1",
-							Targets: []model.LabelSet{
-								{"__instance__": "10.11.122.12:6003"},
-								{"__instance__": "10.11.122.13:6003"},
-								{"__instance__": "10.11.122.14:6003"},
-							},
-						},
-					},
-					interval: 10,
-				},
-			},
-		},
-		{
-			title: "Next test case",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source:  "initial1",
-							Targets: []model.LabelSet{{"__instance__": "10.11.122.11:6003"}},
-						},
-						{
-							Source:  "initial2",
-							Targets: []model.LabelSet{{"__instance__": "10.11.122.12:6003"}},
-						},
-					},
-					interval: 10,
-				},
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source:  "update1",
-							Targets: []model.LabelSet{{"__instance__": "10.11.122.13:6003"}},
-						},
-						{
-							Source: "initial2",
-							Targets: []model.LabelSet{
-								{"__instance__": "10.11.122.12:6003"},
-								{"__instance__": "10.11.122.14:6003"},
-							},
-						},
-					},
-					interval: 10,
-				},
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source:  "update2",
-							Targets: []model.LabelSet{{"__instance__": "10.11.122.15:6003"}},
-						},
-						{
-							Source:  "initial1",
-							Targets: []model.LabelSet{},
-						},
-					},
-					interval: 10,
-				},
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source: "update1",
-							Targets: []model.LabelSet{
-								{"__instance__": "10.11.122.16:6003"},
-								{"__instance__": "10.11.122.17:6003"},
-								{"__instance__": "10.11.122.18:6003"},
-							},
-						},
-					},
-					interval: 10,
-				},
-			},
-		},
-		{
-			title: "Next test case",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source: "initial1",
-							Targets: []model.LabelSet{
-								{"__instance__": "10.11.122.11:6003"},
-								{"__instance__": "10.11.122.12:6003"},
-								{"__instance__": "10.11.122.13:6003"},
-							},
-						},
-						{
-							Source:  "initial2",
-							Targets: []model.LabelSet{{"__instance__": "10.11.122.14:6003"}},
-						},
-					},
-					interval: 0,
-				},
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source:  "initial1",
-							Targets: []model.LabelSet{{"__instance__": "10.11.122.13:6003"}},
-						},
-					},
-					interval: 10,
-				},
-			},
-		},
-		{
-			title: "Three times sync call",
-			updates: []update{
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source: "initial1",
-							Targets: []model.LabelSet{
-								{"__instance__": "10.11.122.11:6003"},
-								{"__instance__": "10.11.122.12:6003"},
-								{"__instance__": "10.11.122.13:6003"},
-							},
-						},
-						{
-							Source:  "initial2",
-							Targets: []model.LabelSet{{"__instance__": "10.11.122.14:6003"}},
-						},
-					},
-					interval: 1000,
-				},
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source:  "initial1",
-							Targets: []model.LabelSet{{"__instance__": "10.11.122.12:6003"}},
-						},
-						{
-							Source:  "update1",
-							Targets: []model.LabelSet{{"__instance__": "10.11.122.15:6003"}},
-						},
-					},
-					interval: 3000,
-				},
-				{
-					targetGroups: []config.TargetGroup{
-						{
-							Source:  "initial1",
-							Targets: []model.LabelSet{},
-						},
-						{
-							Source: "update1",
-							Targets: []model.LabelSet{
-								{"__instance__": "10.11.122.15:6003"},
-								{"__instance__": "10.11.122.16:6003"},
-							},
-						},
-					},
-					interval: 3000,
-				},
-			},
-		},
-	}
-
 	for i, testCase := range testCases {
 		expectedGroups := make(map[string]config.TargetGroup)
-		for _, update := range testCase.updates {
-			for _, targetGroup := range update.targetGroups {
-				expectedGroups[targetGroup.Source] = targetGroup
+		for _, tpUpdates := range testCase.updates {
+			for _, update := range tpUpdates {
+				for _, targetGroup := range update.targetGroups {
+					expectedGroups[targetGroup.Source] = targetGroup
+				}
 			}
 		}
 
@@ -560,9 +877,11 @@ func TestTargetSetConsolidatesToTheLatestState(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		tp := newMockTargetProvider(testCase.updates)
 		targetProviders := map[string]TargetProvider{}
-		targetProviders["testProvider"] = tp
+		for tpName, tpUpdates := range testCase.updates {
+			tp := newMockTargetProvider(tpUpdates)
+			targetProviders[tpName] = tp
+		}
 
 		go targetSet.Run(ctx)
 		targetSet.UpdateProviders(targetProviders)


### PR DESCRIPTION
This pr
* Adds a test covering the case where a target providers sends updated versions of the same target groups and the system should reconcile to the latest version of each of the target groups
* Refactors how input data is represented in the tests. It used to be literal declarations of necessary structs, now it is parsing yaml. Yaml declarations are half as long as the former. And these can be put in a fixture file
* Adds a tiny bit of refactoring on test timeouts https://github.com/prometheus/prometheus/pull/3426/commits/10bad30ed799180ec65e1ea3c290bcf4d425e95f

For the second point, I think it is more developer friendly to read the yaml declarations from a fixture file. I'll work on it, drop a line if there are any opinions.