### PR TITLE
Fix markdown in recording rules documentation.

### DIFF
--- a/docs/configuration/recording_rules.md
+++ b/docs/configuration/recording_rules.md
@@ -78,6 +78,7 @@ rules:
 ### `<rule>`
 
 The syntax for recording rules is:
+
 ```
 # The name of the time series to output to. Must be a valid metric name.
 record: <string>
@@ -93,6 +94,7 @@ labels:
 ```
 
 The syntax for alerting rules is:
+
 ```
 # The name of the alert. Must be a valid metric name.
 alert: <string>


### PR DESCRIPTION
This PR resolves an issue where the generated page for the [recording rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) was incorrect due to how the source markdown was formatted.