### PR TITLE
fix flaky file discovery tests

### DIFF
--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -85,7 +85,6 @@ func testFileSD(t *testing.T, prefix, ext string, expect bool) {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	time.Sleep(500 * time.Millisecond)
 	_, err = io.Copy(newf, f)
 	if err != nil {
 		t.Fatal(err)
@@ -138,7 +137,6 @@ retry:
 	// not try to make sense of it all...
 	drained := make(chan struct{})
 	go func() {
-	Loop:
 		for {
 			select {
 			case tgs := <-ch:
@@ -148,10 +146,10 @@ retry:
 					t.Errorf("Unexpected empty target groups received: %s", tgs)
 				}
 			case <-time.After(500 * time.Millisecond):
-				break Loop
+				close(drained)
+				return
 			}
 		}
-		close(drained)
 	}()
 
 	newf, err = os.Create(testDir + "/_test.new")

--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -15,7 +15,6 @@ package file
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -30,10 +29,10 @@ import (
 const testDir = "fixtures"
 
 func TestFileSD(t *testing.T) {
-	defer os.Remove(testDir + "/_test_valid.yml")
-	defer os.Remove(testDir + "/_test_valid.json")
-	defer os.Remove(testDir + "/_test_invalid_nil.json")
-	defer os.Remove(testDir + "/_test_invalid_nil.yml")
+	defer os.Remove(filepath.Join(testDir, "_test_valid.yml"))
+	defer os.Remove(filepath.Join(testDir, "_test_valid.json"))
+	defer os.Remove(filepath.Join(testDir, "_test_invalid_nil.json"))
+	defer os.Remove(filepath.Join(testDir, "_test_invalid_nil.yml"))
 	testFileSD(t, "valid", ".yml", true)
 	testFileSD(t, "valid", ".json", true)
 	testFileSD(t, "invalid_nil", ".json", false)
@@ -44,7 +43,7 @@ func testFileSD(t *testing.T, prefix, ext string, expect bool) {
 	// As interval refreshing is more of a fallback, we only want to test
 	// whether file watches work as expected.
 	var conf config.FileSDConfig
-	conf.Files = []string{testDir + "/_*" + ext}
+	conf.Files = []string{filepath.Join(testDir, "_*"+ext)}
 	conf.RefreshInterval = model.Duration(1 * time.Hour)
 
 	var (
@@ -74,13 +73,13 @@ func testFileSD(t *testing.T, prefix, ext string, expect bool) {
 		}
 	}()
 
-	newf, err := os.Create(testDir + "/_test_" + prefix + ext)
+	newf, err := os.Create(filepath.Join(testDir, "_test_"+prefix+ext))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer newf.Close()
 
-	f, err := os.Open(testDir + "/" + prefix + ext)
+	f, err := os.Open(filepath.Join(testDir, prefix+ext))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,12 +118,12 @@ retry:
 			if _, ok := tg.Labels["foo"]; !ok {
 				t.Fatalf("Label not parsed")
 			}
-			if tg.String() != filepath.FromSlash(fmt.Sprintf(testDir+"/_test_%s%s:0", prefix, ext)) {
+			if tg.String() != filepath.Join(testDir, "_test_"+prefix+ext+":0") {
 				t.Fatalf("Unexpected target group %s", tg)
 			}
 
 			tg = tgs[1]
-			if tg.String() != filepath.FromSlash(fmt.Sprintf(testDir+"/_test_%s%s:1", prefix, ext)) {
+			if tg.String() != filepath.Join(testDir, "_test_"+prefix+ext+":1") {
 				t.Fatalf("Unexpected target groups %s", tg)
 			}
 			break retry
@@ -152,7 +151,7 @@ retry:
 		}
 	}()
 
-	newf, err = os.Create(testDir + "/_test.new")
+	newf, err = os.Create(filepath.Join(testDir, "_test.new"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +162,7 @@ retry:
 	}
 	newf.Close()
 
-	os.Rename(newf.Name(), testDir+"/_test_"+prefix+ext)
+	os.Rename(newf.Name(), filepath.Join(testDir, "_test_"+prefix+ext))
 
 	cancel()
 	<-drained

--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -94,11 +94,12 @@ func testFileSD(t *testing.T, prefix, ext string, expect bool) {
 	close(filesReady)
 	newf.Close()
 
+	timeout := time.After(15 * time.Second)
 	// The files contain two target groups.
 retry:
 	for {
 		select {
-		case <-time.After(15 * time.Second):
+		case <-timeout:
 			if expect {
 				t.Fatalf("Expected new target group but got none")
 			} else {


### PR DESCRIPTION
Fixes: https://github.com/prometheus/prometheus/issues/3419
fsnotify send invalid updates causing the fd service to send empty `group[]` struct before the test files are written to disk

Now using an extra sync channel to ignore the fd updates until the test files are written to disk.