### PR TITLE
Fix remote read labelset corruption

### DIFF
--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -201,7 +201,7 @@ type concreteSeries struct {
 }
 
 func (c *concreteSeries) Labels() labels.Labels {
-	return c.labels
+	return labels.New(c.labels...)
 }
 
 func (c *concreteSeries) Iterator() storage.SeriesIterator {

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -16,6 +16,8 @@ package remote
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
@@ -123,4 +125,23 @@ func TestConcreteSeriesSet(t *testing.T) {
 	if c.Next() {
 		t.Fatalf("Expected Next() to be false.")
 	}
+}
+
+func TestConcreteSeriesClonesLabels(t *testing.T) {
+	lbls := labels.Labels{
+		labels.Label{Name: "a", Value: "b"},
+		labels.Label{Name: "c", Value: "d"},
+	}
+	cs := concreteSeries{
+		labels: labels.New(lbls...),
+	}
+
+	gotLabels := cs.Labels()
+	require.Equal(t, lbls, gotLabels)
+
+	gotLabels[0].Value = "foo"
+	gotLabels[1].Value = "bar"
+
+	gotLabels = cs.Labels()
+	require.Equal(t, lbls, gotLabels)
 }


### PR DESCRIPTION
The labelsets returned from remote read are mutated in higher levels
(like seriesFilter.Labels()) and since the concreteSeriesSet didn't
return a copy, the external mutation affected the labelset in the
concreteSeries itself. This resulted in bizarre bugs where local and
remote series would show with identical label sets in the UI, but not be
deduplicated, since internally, a series might come to look like:

```
{__name__="node_load5", instance="192.168.1.202:12090", job="node_exporter", node="odroid", node="odroid"}
```

(note the repetition of the last label)

This is what the problem looked like when reading from a 1.x server in 2.0 that was collecting the same series:

![](https://i.imgur.com/xgxFagx.png)