### PR TITLE
Refactor discovery

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -292,23 +292,23 @@ func (ts *TargetSet) listenUpdates(ctx context.Context, wg *sync.WaitGroup, upda
 			if !ok {
 				return
 			}
+			if len(tgs) == 0 {
+				continue
+			}
+
 			for _, tg := range tgs {
-				ts.update(name, tg)
+				ts.setTargetGroup(name, tg)
+			}
+
+			select {
+			case ts.syncCh <- struct{}{}:
+			default:
 			}
 		}
 	}
 }
 
-// update handles a target group update from a target provider identified by the name.
-func (ts *TargetSet) update(name string, tgroup *config.TargetGroup) {
-	ts.setTargetGroup(name, tgroup)
-
-	select {
-	case ts.syncCh <- struct{}{}:
-	default:
-	}
-}
-
+// setTargetGroup handles a target group update from a target provider identified by the name.
 func (ts *TargetSet) setTargetGroup(name string, tg *config.TargetGroup) {
 	ts.mtx.Lock()
 	defer ts.mtx.Unlock()

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -496,7 +496,7 @@ func TestTargetSetThrottlesTheSyncCalls(t *testing.T) {
 
 		select {
 		case <-time.After(20 * time.Second):
-			t.Errorf("%d. %q: Test timed out after 20 seconds. All targets should be sent within the timeout", i, testCase.title)
+			t.Fatalf("%d. %q: Test timed out after 20 seconds. All targets should be sent within the timeout", i, testCase.title)
 
 		case <-finalize:
 			for name, tp := range targetProviders {
@@ -888,7 +888,7 @@ func TestTargetSetConsolidatesToTheLatestState(t *testing.T) {
 
 		select {
 		case <-time.After(20 * time.Second):
-			t.Errorf("%d. %q: Test timed out after 20 seconds. All targets should be sent within the timeout", i, testCase.title)
+			t.Fatalf("%d. %q: Test timed out after 20 seconds. All targets should be sent within the timeout", i, testCase.title)
 
 		case <-finalize:
 			// System successfully reached to the end state.


### PR DESCRIPTION
This pr does some small refactoring on discovery package:
* The only logical change is https://github.com/prometheus/prometheus/pull/3477/commits/13c23c6740acad393785838fd0acc866ca00a566. Code used to try to send a signal to the sync channel for each target group in an update. Sync channel is a buffered channel with size 1. So multiple signals doesn't have any effect. I changed the logic to send a signal per update.

* Mechanical change https://github.com/prometheus/prometheus/pull/3477/commits/5e0de7894a8c1429fbf558ac37ff840d72d404a7. Logic of binding to the updates of a TargetProvider is extracted to its own function.

* https://github.com/prometheus/prometheus/pull/3477/commits/871c5bcc207e251af74883bd4f69e7f72ab393f6 Tests fail immediately on timeouts.

Lastly, now that there is decent test coverage on this package, I am confident about the logical change.