### PR TITLE
Include Pod UID in the discovery metadata.

### DIFF
--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -126,6 +127,7 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testpod",
 			Namespace: "default",
+			UID:       types.UID("deadbeef"),
 		},
 		Spec: v1.PodSpec{
 			NodeName: "testnode",
@@ -210,6 +212,7 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 						"__meta_kubernetes_pod_container_port_name":     "mainport",
 						"__meta_kubernetes_pod_container_port_number":   "9000",
 						"__meta_kubernetes_pod_container_port_protocol": "TCP",
+						"__meta_kubernetes_pod_uid":                     "deadbeef",
 					},
 					{
 						"__address__":                                   "1.2.3.4:9001",
@@ -222,6 +225,7 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 						"__meta_kubernetes_pod_container_port_name":     "sideport",
 						"__meta_kubernetes_pod_container_port_number":   "9001",
 						"__meta_kubernetes_pod_container_port_protocol": "TCP",
+						"__meta_kubernetes_pod_uid":                     "deadbeef",
 					},
 				},
 				Labels: model.LabelSet{

--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -140,6 +140,7 @@ const (
 	podAnnotationPrefix           = metaLabelPrefix + "pod_annotation_"
 	podNodeNameLabel              = metaLabelPrefix + "pod_node_name"
 	podHostIPLabel                = metaLabelPrefix + "pod_host_ip"
+	podUID                        = metaLabelPrefix + "pod_uid"
 )
 
 func podLabels(pod *apiv1.Pod) model.LabelSet {
@@ -149,6 +150,7 @@ func podLabels(pod *apiv1.Pod) model.LabelSet {
 		podReadyLabel:    podReady(pod),
 		podNodeNameLabel: lv(pod.Spec.NodeName),
 		podHostIPLabel:   lv(pod.Status.HostIP),
+		podUID:           lv(string(pod.ObjectMeta.UID)),
 	}
 
 	for k, v := range pod.Labels {

--- a/discovery/kubernetes/pod_test.go
+++ b/discovery/kubernetes/pod_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -43,6 +44,7 @@ func makeMultiPortPod() *v1.Pod {
 			Namespace:   "default",
 			Labels:      map[string]string{"testlabel": "testvalue"},
 			Annotations: map[string]string{"testannotation": "testannotationvalue"},
+			UID:         types.UID("abc123"),
 		},
 		Spec: v1.PodSpec{
 			NodeName: "testnode",
@@ -85,6 +87,7 @@ func makePod() *v1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testpod",
 			Namespace: "default",
+			UID:       types.UID("abc123"),
 		},
 		Spec: v1.PodSpec{
 			NodeName: "testnode",
@@ -151,6 +154,7 @@ func TestPodDiscoveryInitial(t *testing.T) {
 					"__meta_kubernetes_pod_ip":                        "1.2.3.4",
 					"__meta_kubernetes_pod_host_ip":                   "2.3.4.5",
 					"__meta_kubernetes_pod_ready":                     "true",
+					"__meta_kubernetes_pod_uid":                       "abc123",
 				},
 				Source: "pod/default/testpod",
 			},
@@ -182,6 +186,7 @@ func TestPodDiscoveryAdd(t *testing.T) {
 					"__meta_kubernetes_pod_ip":        "1.2.3.4",
 					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
 					"__meta_kubernetes_pod_ready":     "true",
+					"__meta_kubernetes_pod_uid":       "abc123",
 				},
 				Source: "pod/default/testpod",
 			},
@@ -214,6 +219,7 @@ func TestPodDiscoveryDelete(t *testing.T) {
 					"__meta_kubernetes_pod_ip":        "1.2.3.4",
 					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
 					"__meta_kubernetes_pod_ready":     "true",
+					"__meta_kubernetes_pod_uid":       "abc123",
 				},
 				Source: "pod/default/testpod",
 			},
@@ -251,6 +257,7 @@ func TestPodDiscoveryDeleteUnknownCacheState(t *testing.T) {
 					"__meta_kubernetes_pod_ip":        "1.2.3.4",
 					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
 					"__meta_kubernetes_pod_ready":     "true",
+					"__meta_kubernetes_pod_uid":       "abc123",
 				},
 				Source: "pod/default/testpod",
 			},
@@ -312,6 +319,7 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 					"__meta_kubernetes_pod_ip":        "1.2.3.4",
 					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
 					"__meta_kubernetes_pod_ready":     "unknown",
+					"__meta_kubernetes_pod_uid":       "",
 				},
 				Source: "pod/default/testpod",
 			},
@@ -334,6 +342,7 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 					"__meta_kubernetes_pod_ip":        "1.2.3.4",
 					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
 					"__meta_kubernetes_pod_ready":     "true",
+					"__meta_kubernetes_pod_uid":       "abc123",
 				},
 				Source: "pod/default/testpod",
 			},

--- a/discovery/kubernetes/pod_test.go
+++ b/discovery/kubernetes/pod_test.go
@@ -276,6 +276,7 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testpod",
 			Namespace: "default",
+			UID:       "xyz321",
 		},
 		Spec: v1.PodSpec{
 			NodeName: "testnode",
@@ -319,7 +320,7 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 					"__meta_kubernetes_pod_ip":        "1.2.3.4",
 					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
 					"__meta_kubernetes_pod_ready":     "unknown",
-					"__meta_kubernetes_pod_uid":       "",
+					"__meta_kubernetes_pod_uid":       "xyz321",
 				},
 				Source: "pod/default/testpod",
 			},

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -643,6 +643,7 @@ Available meta labels:
 * `__meta_kubernetes_pod_ready`: Set to `true` or `false` for the pod's ready state.
 * `__meta_kubernetes_pod_node_name`: The name of the node the pod is scheduled onto.
 * `__meta_kubernetes_pod_host_ip`: The current host IP of the pod object.
+* `__meta_kubernetes_pod_uid`: The UID of the pod object.
 
 #### `endpoints`
 


### PR DESCRIPTION
I'm using Promtheus' discovery library in a log tailing agent, and the logs are arranged in the filesystem by Pod UID.  So I'd like to include Pod UID in the discovery metadata if thats alright.  Any objections?