### PR TITLE
KairosDB Client in the remote storage example

### DIFF
--- a/documentation/examples/remote_storage/remote_storage_adapter/README.md
+++ b/documentation/examples/remote_storage/remote_storage_adapter/README.md
@@ -1,7 +1,7 @@
 # Remote storage adapter
 
 This is a write adapter that receives samples via Prometheus's remote write
-protocol and stores them in Graphite, InfluxDB, or OpenTSDB. It is meant as a
+protocol and stores them in Graphite, InfluxDB, KairosDB or OpenTSDB. It is meant as a
 replacement for the built-in specific remote storage implementations that have
 been removed from Prometheus.
 
@@ -20,6 +20,12 @@ Graphite example:
 
 ```
 ./remote_storage_adapter -graphite-address=localhost:8080
+```
+
+KairosDB example:
+
+```
+./remote_storage_adapter -kairosdb-url=http://localhost:8080
 ```
 
 OpenTSDB example:

--- a/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client.go
@@ -57,11 +57,11 @@ func NewClient(logger log.Logger, url string, timeout time.Duration) *Client {
 //https://kairosdb.github.io/docs/build/html/restapi/AddDataPoints.html
 //everything with caps for easier debugging of the jsons
 type StoreSamplesRequest struct {
-	Name      TagValue              `json:"name"`
-	Timestamp int64               `json:"timestamp"`
-	Value     float64             `json:"value"`
-	Type     string             `json:"type"`
-	Tags      map[string]TagValue       	      `json:"tags"`
+	Name      TagValue             `json:"name"`
+	Timestamp int64                `json:"timestamp"`
+	Value     float64               `json:"value"`
+	Type      string               `json:"type"`
+	Tags      map[string]TagValue  `json:"tags"`
 }
 
 // tagsFromMetric translates Prometheus metric into KairosDB tags.
@@ -98,11 +98,11 @@ func (c *Client) Write(samples model.Samples) error {
 		}
 		// All types will be double even if they are int, maybe could be fixed
 		reqs = append(reqs, StoreSamplesRequest{
-			Name:    metric,
+			Name:      metric,
 			Timestamp: int64(s.Timestamp),
 			Value:     v,
 			Tags:      tags_parse,
-			Type: "double",
+			Type:      "double",
 		})
 	}
 	u, err := url.Parse(c.url)

--- a/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client.go
@@ -80,7 +80,7 @@ func (c *Client) Write(samples model.Samples) error {
 
 		v := float64(s.Value)
 		if math.IsNaN(v) || math.IsInf(v, 0) {
-			level.Debug(c.logger).Log("msg", "cannot send value to OpenTSDB, skipping sample", "value", v, "sample", s)
+			level.Debug(c.logger).Log("msg", "cannot send value to KairosDB, skipping sample", "value", v, "sample", s)
 			continue
 		}
 		metric := TagValue(s.Metric[model.MetricNameLabel])
@@ -139,11 +139,11 @@ func (c *Client) Write(samples model.Samples) error {
         if err := json.Unmarshal(buf, &r); err != nil {
                 return err
         }
-        return fmt.Errorf("failed to write %d samples to OpenTSDB, %d succeeded", r["failed"], r["success"])
+        return fmt.Errorf("failed to write %d samples to KairosDB, %d succeeded", r["failed"], r["success"])
 
 }
 
-// Name identifies the client as an OpenTSDB client.
+// Name identifies the client as an KairosDB client.
 func (c Client) Name() string {
 	return "kairosdb"
 }

--- a/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client.go
@@ -1,0 +1,149 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kairosdb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"net/http"
+	"net/url"
+	"time"
+	//"reflect"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/common/model"
+	"golang.org/x/net/context/ctxhttp"
+)
+
+const (
+	putEndpoint     = "/api/v1/datapoints"
+	contentTypeJSON = "application/json"
+)
+// Client allows sending batches of Prometheus samples to KairosDB.
+type Client struct {
+	logger log.Logger
+
+	url     string
+	timeout time.Duration
+}
+
+// NewClient creates a new Client.
+func NewClient(logger log.Logger, url string, timeout time.Duration) *Client {
+	return &Client{
+		logger:  logger,
+		url:     url,
+		timeout: timeout,
+	}
+}
+
+// StoreSamplesRequest is used for building a JSON request for storing samples
+// via the KairosDB.
+//https://kairosdb.github.io/docs/build/html/restapi/AddDataPoints.html
+//everything with caps for easier debugging of the jsons
+type StoreSamplesRequest struct {
+	Name      TagValue              `json:"name"`
+	Timestamp int64               `json:"timestamp"`
+	Value     float64             `json:"value"`
+	Type     string             `json:"type"`
+	Tags      map[string]TagValue       	      `json:"tags"`
+}
+
+// tagsFromMetric translates Prometheus metric into KairosDB tags.
+func tagsFromMetric(m model.Metric) map[string]TagValue {
+        tags := make(map[string]TagValue, len(m)-1)
+        for l, v := range m {
+                tags[string(l)] = TagValue(v)
+        }
+        return tags
+}
+
+// Write sends a batch of samples to KairosDB via its HTTP API.
+func (c *Client) Write(samples model.Samples) error {
+	reqs := make([]StoreSamplesRequest, 0, len(samples))
+	for _, s := range samples {
+
+		v := float64(s.Value)
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			level.Debug(c.logger).Log("msg", "cannot send value to OpenTSDB, skipping sample", "value", v, "sample", s)
+			continue
+		}
+		metric := TagValue(s.Metric[model.MetricNameLabel])
+		tags_parse := tagsFromMetric(s.Metric)
+		exit := 0
+		for key,value := range tags_parse {
+			if len(value) == 0 {
+				exit = 1
+				level.Debug(c.logger).Log("msg", "cannot send value to KairosDB, empty tag, skipping sample", "tag", key, "value", v, "sample", s)
+				break
+			}
+		}
+		if exit == 1 {
+			continue
+		}
+		// All types will be double even if they are int, maybe could be fixed
+		reqs = append(reqs, StoreSamplesRequest{
+			Name:    metric,
+			Timestamp: int64(s.Timestamp),
+			Value:     v,
+			Tags:      tags_parse,
+			Type: "double",
+		})
+	}
+	u, err := url.Parse(c.url)
+	if err != nil {
+		return err
+	}
+	u.Path = putEndpoint
+	
+	buf, err := json.Marshal(reqs)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	resp, err := ctxhttp.Post(ctx, http.DefaultClient, u.String(), contentTypeJSON, bytes.NewBuffer(buf))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// API returns status code 204 for successful writes.
+	//https://kairosdb.github.io/docs/build/html/restapi/AddDataPoints.html
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	// API returns status code 400 on error, encoding error details in the
+	// response content in JSON.
+	buf, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+        var r map[string]int
+        if err := json.Unmarshal(buf, &r); err != nil {
+                return err
+        }
+        return fmt.Errorf("failed to write %d samples to OpenTSDB, %d succeeded", r["failed"], r["success"])
+
+}
+
+// Name identifies the client as an OpenTSDB client.
+func (c Client) Name() string {
+	return "kairosdb"
+}

--- a/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client_test.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/client_test.go
@@ -1,0 +1,75 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kairosdb
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/common/model"
+)
+
+var (
+	metric = model.Metric{
+		model.MetricNameLabel: "test:metric",
+		"testlabel":           "test:value",
+		"many_chars":          "abc!ABC:012-3!45ö67~89./",
+	}
+)
+
+func TestTagsFromMetric(t *testing.T) {
+	expected := map[string]TagValue{
+		"testlabel":  TagValue("test:value"),
+		"many_chars": TagValue("abc!ABC:012-3!45ö67~89./"),
+	}
+	actual := tagsFromMetric(metric)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Expected %#v, got %#v", expected, actual)
+	}
+}
+
+func TestMarshalStoreSamplesRequest(t *testing.T) {
+	request := StoreSamplesRequest{
+		Metric:    TagValue("test:metric"),
+		Timestamp: 4711,
+		Value:     3.1415,
+		Tags:      tagsFromMetric(metric),
+	}
+	expectedJSON := []byte(`{"metric":"test_.metric","timestamp":4711,"value":3.1415,"tags":{"many_chars":"abc_21ABC_.012-3_2145_C3_B667_7E89./","testlabel":"test_.value"}}`)
+
+	resultingJSON, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("Marshal(request) resulted in err: %s", err)
+	}
+	if !bytes.Equal(resultingJSON, expectedJSON) {
+		t.Errorf(
+			"Marshal(request) => %q, want %q",
+			resultingJSON, expectedJSON,
+		)
+	}
+
+	var unmarshaledRequest StoreSamplesRequest
+	err = json.Unmarshal(expectedJSON, &unmarshaledRequest)
+	if err != nil {
+		t.Fatalf("Unmarshal(expectedJSON, &unmarshaledRequest) resulted in err: %s", err)
+	}
+	if !reflect.DeepEqual(unmarshaledRequest, request) {
+		t.Errorf(
+			"Unmarshal(expectedJSON, &unmarshaledRequest) => %#v, want %#v",
+			unmarshaledRequest, request,
+		)
+	}
+}

--- a/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/tagvalue.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/tagvalue.go
@@ -1,0 +1,157 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opentsdb
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/prometheus/common/model"
+)
+//This probably has to be simplified for KairosDB
+// TagValue is a model.LabelValue that implements json.Marshaler and
+// json.Unmarshaler. These implementations avoid characters illegal in
+// OpenTSDB. See the MarshalJSON for details. TagValue is used for the values of
+// OpenTSDB tags as well as for OpenTSDB metric names.
+type TagValue model.LabelValue
+
+// MarshalJSON marshals this TagValue into JSON that only contains runes allowed
+// in OpenTSDB. It implements json.Marshaler. The runes allowed in OpenTSDB are
+// all single-byte. This function encodes the arbitrary byte sequence found in
+// this TagValue in the following way:
+//
+// - The string that underlies TagValue is scanned byte by byte.
+//
+// - If a byte represents a legal OpenTSDB rune with the exception of '_', that
+// byte is directly copied to the resulting JSON byte slice.
+//
+// - If '_' is encountered, it is kept as '_'.
+//
+// - If ':' is encountered, it is replaced by '_.'.
+//
+// - All other bytes are replaced by '_' followed by two bytes containing the
+// uppercase ASCII representation of their hexadecimal value.
+//
+// This encoding allows to save arbitrary Go strings in OpenTSDB. That's
+// required because Prometheus label values can contain anything, and even
+// Prometheus metric names may (and often do) contain ':' (which is disallowed
+// in OpenTSDB strings). The encoding uses '_' as an escape character and
+// renders a ':' more or less recognizable as '_.'
+//
+// Examples:
+//
+// "foo-bar-42" -> "foo-bar-42"
+//
+// "foo_bar_42" -> "foo__bar__42"
+//
+// "http://example.org:8080" -> "http_.//example.org_.8080"
+//
+// "Björn's email: bjoern@soundcloud.com" ->
+// "Bj_C3_B6rn_27s_20email_._20bjoern_40soundcloud.com"
+//
+// "日" -> "_E6_97_A5"
+func (tv TagValue) MarshalJSON() ([]byte, error) {
+	length := len(tv)
+	// Need at least two more bytes than in tv.
+	result := bytes.NewBuffer(make([]byte, 0, length+2))
+	result.WriteByte('"')
+	for i := 0; i < length; i++ {
+		b := tv[i]
+		switch {
+		case (b >= '-' && b <= '9') || // '-', '.', '/', 0-9
+			(b >= 'A' && b <= 'Z') ||
+			(b >= 'a' && b <= 'z'):
+			result.WriteByte(b)
+		case b == '_':
+			result.WriteString("_")
+		case b == ':':
+			result.WriteString("_.")
+		default:
+			result.WriteString(fmt.Sprintf("_%X", b))
+		}
+	}
+	result.WriteByte('"')
+	return result.Bytes(), nil
+}
+
+// UnmarshalJSON unmarshals JSON strings coming from OpenTSDB into Go strings
+// by applying the inverse of what is described for the MarshalJSON method.
+func (tv *TagValue) UnmarshalJSON(json []byte) error {
+	escapeLevel := 0 // How many bytes after '_'.
+	var parsedByte byte
+
+	// Might need fewer bytes, but let's avoid realloc.
+	result := bytes.NewBuffer(make([]byte, 0, len(json)-2))
+
+	for i, b := range json {
+		if i == 0 {
+			if b != '"' {
+				return fmt.Errorf("expected '\"', got %q", b)
+			}
+			continue
+		}
+		if i == len(json)-1 {
+			if b != '"' {
+				return fmt.Errorf("expected '\"', got %q", b)
+			}
+			break
+		}
+		switch escapeLevel {
+		case 0:
+			if b == '_' {
+				escapeLevel = 1
+				continue
+			}
+			result.WriteByte(b)
+		case 1:
+			switch {
+			case b == '_':
+				result.WriteByte('_')
+				escapeLevel = 0
+			case b == '.':
+				result.WriteByte(':')
+				escapeLevel = 0
+			case b >= '0' && b <= '9':
+				parsedByte = (b - 48) << 4
+				escapeLevel = 2
+			case b >= 'A' && b <= 'F': // A-F
+				parsedByte = (b - 55) << 4
+				escapeLevel = 2
+			default:
+				return fmt.Errorf(
+					"illegal escape sequence at byte %d (%c)",
+					i, b,
+				)
+			}
+		case 2:
+			switch {
+			case b >= '0' && b <= '9':
+				parsedByte += b - 48
+			case b >= 'A' && b <= 'F': // A-F
+				parsedByte += b - 55
+			default:
+				return fmt.Errorf(
+					"illegal escape sequence at byte %d (%c)",
+					i, b,
+				)
+			}
+			result.WriteByte(parsedByte)
+			escapeLevel = 0
+		default:
+			panic("unexpected escape level")
+		}
+	}
+	*tv = TagValue(result.String())
+	return nil
+}

--- a/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/tagvalue_test.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/kairosdb/tagvalue_test.go
@@ -1,0 +1,64 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kairosdb
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+var stringtests = []struct {
+	tv   TagValue
+	json []byte
+}{
+	{TagValue("foo-bar-42"), []byte(`"foo-bar-42"`)},
+	{TagValue("foo_bar_42"), []byte(`"foo__bar__42"`)},
+	{TagValue("http://example.org:8080"), []byte(`"http_.//example.org_.8080"`)},
+	{TagValue("Björn's email: bjoern@soundcloud.com"), []byte(`"Bj_C3_B6rn_27s_20email_._20bjoern_40soundcloud.com"`)},
+	{TagValue("日"), []byte(`"_E6_97_A5"`)},
+}
+
+func TestTagValueMarshaling(t *testing.T) {
+	for i, tt := range stringtests {
+		json, err := json.Marshal(tt.tv)
+		if err != nil {
+			t.Errorf("%d. Marshal(%q) returned err: %s", i, tt.tv, err)
+		} else {
+			if !bytes.Equal(json, tt.json) {
+				t.Errorf(
+					"%d. Marshal(%q) => %q, want %q",
+					i, tt.tv, json, tt.json,
+				)
+			}
+		}
+	}
+}
+
+func TestTagValueUnMarshaling(t *testing.T) {
+	for i, tt := range stringtests {
+		var tv TagValue
+		err := json.Unmarshal(tt.json, &tv)
+		if err != nil {
+			t.Errorf("%d. Unmarshal(%q, &str) returned err: %s", i, tt.json, err)
+		} else {
+			if tv != tt.tv {
+				t.Errorf(
+					"%d. Unmarshal(%q, &str) => str==%q, want %q",
+					i, tt.json, tv, tt.tv,
+				)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hey,
Here is a quick and dirty rewrte of the OpenTSDB remote storage example to KairosDB.
I use the same TagValue, although I do not rewrite the _ to __ (since this is not needed by KairosDB)
