### PR TITLE
[WIP] Add series and samples touched by a qry.

### DIFF
--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -63,12 +63,14 @@ type queryTimings struct {
 
 // QueryStats currently only holding query timings.
 type QueryStats struct {
-	Timings queryTimings `json:"timings,omitempty"`
+	Timings    queryTimings `json:"timings,omitempty"`
+	NumSeries  int64        `json:"numSeries,omitempty"`
+	NumSamples int64        `json:"numSamples,omitempty"`
 }
 
 // NewQueryStats makes a QueryStats struct with all QueryTimings found in the
 // given TimerGroup.
-func NewQueryStats(tg *TimerGroup) *QueryStats {
+func NewQueryStats(numSeries, numSamples int64, tg *TimerGroup) *QueryStats {
 	var qt queryTimings
 
 	for s, timer := range tg.timers {
@@ -90,6 +92,10 @@ func NewQueryStats(tg *TimerGroup) *QueryStats {
 		}
 	}
 
-	qs := QueryStats{Timings: qt}
+	qs := QueryStats{
+		Timings:    qt,
+		NumSeries:  numSeries,
+		NumSamples: numSamples,
+	}
 	return &qs
 }

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -46,7 +46,7 @@ func TestQueryStatsWithTimers(t *testing.T) {
 	timer.Stop()
 
 	var qs *QueryStats
-	qs = NewQueryStats(tg)
+	qs = NewQueryStats(0, 0, tg)
 	actual, err := json.Marshal(qs)
 	if err != nil {
 		t.Fatalf("Unexpected error during serialization: %v", err)

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -225,7 +225,8 @@ func (api *API) query(r *http.Request) (interface{}, *apiError) {
 	// Optional stats field in response if parameter "stats" is not empty.
 	var qs *stats.QueryStats
 	if r.FormValue("stats") != "" {
-		qs = stats.NewQueryStats(qry.Stats())
+		sts := qry.Stats()
+		qs = stats.NewQueryStats(sts.NumSeries, sts.NumSamples, sts.Timers)
 	}
 
 	return &queryData{
@@ -297,7 +298,8 @@ func (api *API) queryRange(r *http.Request) (interface{}, *apiError) {
 	// Optional stats field in response if parameter "stats" is not empty.
 	var qs *stats.QueryStats
 	if r.FormValue("stats") != "" {
-		qs = stats.NewQueryStats(qry.Stats())
+		sts := qry.Stats()
+		qs = stats.NewQueryStats(sts.NumSeries, sts.NumSamples, sts.Timers)
 	}
 
 	return &queryData{


### PR DESCRIPTION
* Restructured the engine a little bit to make sure that we have most of
the query execution handled by the query object itself instead of
handing it off to the engine.

* Added an atomic counter for every sample touched.

Tests are yet to be added, but a quick look appreciated, specially around atomically increasing a counter for every sample accessed.

/cc @grobie @brian-brazil @fabxc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/3499)
<!-- Reviewable:end -->
