### PR TITLE
Fix unexported method on exported interface.

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -100,7 +100,7 @@ type AlertingRule struct {
 	// Non-identifying key/value pairs.
 	annotations labels.Labels
 	// Time in seconds taken to evaluate rule.
-	evaluationTimeSeconds float64
+	evaluationTime time.Duration
 
 	// Protects the below.
 	mtx sync.Mutex
@@ -151,18 +151,18 @@ func (r *AlertingRule) sample(alert *Alert, ts time.Time) promql.Sample {
 	return s
 }
 
-// setEvaluationTimeSeconds updates evaluationSeconds to the time in seconds it took to evaluate the rule on its last evaluation.
-func (r *AlertingRule) setEvaluationTimeSeconds(seconds float64) {
+// SetEvaluationTime updates evaluationTime to the duration it took to evaluate the rule on its last evaluation.
+func (r *AlertingRule) SetEvaluationTime(dur time.Duration) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
-	r.evaluationTimeSeconds = seconds
+	r.evaluationTime = dur
 }
 
-// GetEvaluationTimeSeconds returns the time in seconds it took to evaluate the alerting rule.
-func (r *AlertingRule) GetEvaluationTimeSeconds() float64 {
+// GetEvaluationTime returns the time in seconds it took to evaluate the alerting rule.
+func (r *AlertingRule) GetEvaluationTime() time.Duration {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
-	return r.evaluationTimeSeconds
+	return r.evaluationTime
 }
 
 // resolvedRetention is the duration for which a resolved alert instance

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -116,8 +116,8 @@ type Rule interface {
 	// String returns a human-readable string representation of the rule.
 	String() string
 
-	setEvaluationTimeSeconds(float64)
-	GetEvaluationTimeSeconds() float64
+	SetEvaluationTime(time.Duration)
+	GetEvaluationTime() time.Duration
 	// HTMLSnippet returns a human-readable string representation of the rule,
 	// decorated with HTML elements for use the web frontend.
 	HTMLSnippet(pathPrefix string) html_template.HTML
@@ -125,14 +125,14 @@ type Rule interface {
 
 // Group is a set of rules that have a logical relation.
 type Group struct {
-	name                  string
-	file                  string
-	interval              time.Duration
-	rules                 []Rule
-	seriesInPreviousEval  []map[string]labels.Labels // One per Rule.
-	opts                  *ManagerOptions
-	evaluationTimeSeconds float64
-	mtx                   sync.Mutex
+	name                 string
+	file                 string
+	interval             time.Duration
+	rules                []Rule
+	seriesInPreviousEval []map[string]labels.Labels // One per Rule.
+	opts                 *ManagerOptions
+	evaluationTime       time.Duration
+	mtx                  sync.Mutex
 
 	done       chan struct{}
 	terminated chan struct{}
@@ -181,7 +181,7 @@ func (g *Group) run() {
 		g.Eval(start)
 
 		iterationDuration.Observe(time.Since(start).Seconds())
-		g.setEvaluationTimeSeconds(time.Since(start).Seconds())
+		g.SetEvaluationTime(time.Since(start))
 	}
 	lastTriggered := time.Now()
 	iter()
@@ -224,17 +224,18 @@ func (g *Group) hash() uint64 {
 	return l.Hash()
 }
 
-// GetEvaluationTimeSeconds returns the time in seconds it took to evaluate the rule group.
-func (g *Group) GetEvaluationTimeSeconds() float64 {
+// GetEvaluationTime returns the time in seconds it took to evaluate the rule group.
+func (g *Group) GetEvaluationTime() time.Duration {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
-	return g.evaluationTimeSeconds
+	return g.evaluationTime
 }
 
-func (g *Group) setEvaluationTimeSeconds(seconds float64) {
+// SetEvaluationTime sets the time in seconds the last evaluation took.
+func (g *Group) SetEvaluationTime(dur time.Duration) {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
-	g.evaluationTimeSeconds = seconds
+	g.evaluationTime = dur
 }
 
 // offset returns until the next consistently slotted evaluation interval.
@@ -313,7 +314,7 @@ func (g *Group) Eval(ts time.Time) {
 		func(i int, rule Rule) {
 			defer func(t time.Time) {
 				evalDuration.WithLabelValues(rtyp).Observe(time.Since(t).Seconds())
-				rule.setEvaluationTimeSeconds(time.Since(t).Seconds())
+				rule.SetEvaluationTime(time.Since(t))
 			}(time.Now())
 
 			evalTotal.WithLabelValues(rtyp).Inc()

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -31,11 +31,11 @@ import (
 
 // A RecordingRule records its vector expression into new timeseries.
 type RecordingRule struct {
-	name                  string
-	vector                promql.Expr
-	labels                labels.Labels
-	mtx                   sync.Mutex
-	evaluationTimeSeconds float64
+	name           string
+	vector         promql.Expr
+	labels         labels.Labels
+	mtx            sync.Mutex
+	evaluationTime time.Duration
 }
 
 // NewRecordingRule returns a new recording rule.
@@ -116,18 +116,18 @@ func (rule *RecordingRule) String() string {
 	return string(byt)
 }
 
-// setEvaluationTimeSeconds updates evaluationTimeSeconds to the time in seconds it took to evaluate the rule on its last evaluation.
-func (rule *RecordingRule) setEvaluationTimeSeconds(seconds float64) {
+// SetEvaluationTime updates evaluationTimeSeconds to the time in seconds it took to evaluate the rule on its last evaluation.
+func (rule *RecordingRule) SetEvaluationTime(dur time.Duration) {
 	rule.mtx.Lock()
 	defer rule.mtx.Unlock()
-	rule.evaluationTimeSeconds = seconds
+	rule.evaluationTime = dur
 }
 
-// GetEvaluationTimeSeconds returns the time in seconds it took to evaluate the recording rule.
-func (rule *RecordingRule) GetEvaluationTimeSeconds() float64 {
+// GetEvaluationTime returns the time in seconds it took to evaluate the recording rule.
+func (rule *RecordingRule) GetEvaluationTime() time.Duration {
 	rule.mtx.Lock()
 	defer rule.mtx.Unlock()
-	return rule.evaluationTimeSeconds
+	return rule.evaluationTime
 }
 
 // HTMLSnippet returns an HTML snippet representing this rule.

--- a/web/ui/bindata.go
+++ b/web/ui/bindata.go
@@ -125,7 +125,7 @@ func webUiTemplates_baseHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/_base.html", size: 2863, mode: os.FileMode(420), modTime: time.Unix(1507565507, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/_base.html", size: 2863, mode: os.FileMode(420), modTime: time.Unix(1510812562, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -145,7 +145,7 @@ func webUiTemplatesAlertsHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/alerts.html", size: 1836, mode: os.FileMode(420), modTime: time.Unix(1507742757, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/alerts.html", size: 1836, mode: os.FileMode(420), modTime: time.Unix(1510812562, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -165,7 +165,7 @@ func webUiTemplatesConfigHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/config.html", size: 175, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/config.html", size: 175, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -185,7 +185,7 @@ func webUiTemplatesFlagsHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/flags.html", size: 433, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/flags.html", size: 433, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -205,12 +205,12 @@ func webUiTemplatesGraphHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/graph.html", size: 2061, mode: os.FileMode(420), modTime: time.Unix(1507565507, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/graph.html", size: 2061, mode: os.FileMode(420), modTime: time.Unix(1511327106, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
-var _webUiTemplatesRulesHtml = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x94\x92\x41\x6f\xd4\x30\x10\x85\xef\xf9\x15\x23\xdf\x37\x96\x7a\x44\x4e\xb8\x80\xca\x01\x10\xa2\x15\x57\xe4\xc4\x93\xda\xc2\x6b\x47\xf6\x38\x74\xb1\xfc\xdf\x91\xb3\x94\x8d\xaa\x0d\x2b\x72\x88\x34\x7e\xe3\xe4\x9b\x37\x2f\x67\x85\x93\x71\x08\x4c\xa3\x54\xac\x94\x46\x58\xe3\x7e\x00\x9d\x66\xec\x18\xe1\x33\xf1\x31\x46\x06\x01\x6d\xc7\x22\x9d\x2c\x46\x8d\x48\x0c\x74\xc0\xa9\x63\x39\xc3\x2c\x49\x7f\x09\x38\x99\x67\x28\x85\x47\x92\x64\xc6\x7a\x87\x87\x64\x31\xb6\x63\x8c\x6f\x97\x2e\x67\x18\x92\xb1\xea\x1b\x86\x68\xbc\x83\x52\x58\xdf\xe4\x8c\x4e\x95\xd2\x34\x17\x88\xd1\x3b\x42\x47\x95\x03\x40\x28\xb3\xc0\x68\x65\x8c\xdd\x2a\x48\xe3\x30\x1c\x26\x9b\x8c\x62\x7d\x03\x00\x20\x48\x0e\x16\x5f\x7a\xce\xc5\xfa\x3e\x0c\x3e\x28\x0c\xf8\xd2\x08\x90\x73\x90\xee\x09\xa1\xfd\x9a\x2c\xde\x07\x9f\xe6\xb8\xfe\xe4\xfc\x08\xaa\xe3\xf7\x7f\xeb\x7a\x12\xb6\x65\x3d\x50\xbd\xd0\x77\x7d\xce\xed\x67\x79\xc4\x52\x04\xd7\x77\xbd\xe0\xa4\xf6\xfa\x74\x3a\x4a\x67\x7e\xe1\xbb\x14\x24\xd5\xa9\xdb\x7b\xa4\xf7\x8b\xb4\x69\x2d\x1f\xcd\x11\x1f\x70\xf4\x4e\xc5\x9d\x8f\x09\xbe\x85\x10\xfc\x15\xa4\xa0\xc1\xab\xd3\x2d\x68\x58\xb7\xd6\xb1\xc9\x3b\x3a\xfc\x44\xf3\xa4\xe9\xcd\xe0\xad\x62\x7d\x75\xe2\x2a\xff\xfe\x95\x0b\x3d\x54\xfc\x7f\x03\xbf\x32\x7d\xeb\xf7\x0e\xea\x9f\x45\xd6\xe4\x7c\x1f\xd1\x5a\x56\xdd\xfe\xf0\xf8\xe9\xe3\x83\x33\xf3\x8c\xb4\x09\x5b\xb5\xec\x9a\xf5\xff\x6b\xfb\xad\x01\xce\x11\xdd\xe8\x5b\xcf\xb7\xb2\xe0\x6b\xf2\xaa\x24\xb8\x32\xcb\x25\xdf\xbf\x03\x00\x00\xff\xff\x5c\x86\x3c\x40\x64\x03\x00\x00")
+var _webUiTemplatesRulesHtml = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x94\x92\x41\x6f\xd4\x30\x10\x85\xef\xf9\x15\x23\xdf\x37\x96\x7a\x44\x4e\xb8\x80\xca\x01\x10\xa2\x15\x57\xe4\xc4\x93\xda\xc2\x6b\x47\xf6\x38\x74\xb1\xfc\xdf\x91\xb3\x94\x8d\xaa\x0d\x2b\x72\x88\x34\x9e\x71\xf2\xbd\x37\x2f\x67\x85\x93\x71\x08\x4c\xa3\x54\xac\x94\x46\x58\xe3\x7e\x00\x9d\x66\xec\x18\xe1\x33\xf1\x31\x46\x06\x01\x6d\xc7\x22\x9d\x2c\x46\x8d\x48\x0c\x74\xc0\xa9\x63\x39\xc3\x2c\x49\x7f\x09\x38\x99\x67\x28\x85\x47\x92\x64\xc6\x7a\x87\x87\x64\x31\xb6\x63\x8c\x6f\x97\x2e\x67\x18\x92\xb1\xea\x1b\x86\x68\xbc\x83\x52\x58\xdf\xe4\x8c\x4e\x95\xd2\x34\x17\x88\xd1\x3b\x42\x47\x95\x03\x40\x28\xb3\xc0\x68\x65\x8c\xdd\xda\x90\xc6\x61\x38\x4c\x36\x19\xc5\xfa\x06\x00\x40\x90\x1c\x2c\xbe\xcc\x9c\x8b\xf5\x7d\x18\x7c\x50\x18\xf0\x65\x10\x20\xe7\x20\xdd\x13\x42\xfb\x35\x59\xbc\x0f\x3e\xcd\x71\xfd\xc9\xf9\x11\x54\xe5\xf7\x7f\xeb\x7a\x12\xb6\x65\x3d\x50\xbd\xd0\x77\x7d\xce\xed\x67\x79\xc4\x52\x04\xd7\x77\xbd\xe0\xa4\xf6\xe6\x74\x3a\x4a\x67\x7e\xe1\xbb\x14\x24\x55\xd5\xed\x3d\xd2\xfb\x45\xda\xb4\x96\x8f\xe6\x88\xed\x03\x8e\xde\xa9\xb8\xf3\x35\xc1\xb7\x14\x82\xbf\xa2\x14\x34\x78\x75\xba\x45\x0d\xeb\xda\x3a\x36\x79\x47\x87\x9f\x68\x9e\x34\xbd\x19\xbc\x55\xac\xaf\x56\x5c\x15\xb0\x7f\xe5\x82\x0f\x95\xff\xdf\xc0\xaf\x5c\xdf\x1a\xbe\x83\xfa\x67\x93\x35\x3a\xdf\x47\xb4\x96\x55\xbb\x3f\x3c\x7e\xfa\xf8\xe0\xcc\x3c\x23\x6d\xd2\x56\x2d\xbb\xe6\xfd\x7f\xfb\x7e\x4b\xc1\x39\xa4\x9b\xfe\xd6\xf4\x6d\x5b\xf0\x35\x7b\xb5\x25\xb8\x32\xcb\x25\xe1\xbf\x03\x00\x00\xff\xff\x9e\xc2\xdb\x6e\x66\x03\x00\x00")
 
 func webUiTemplatesRulesHtmlBytes() ([]byte, error) {
 	return bindataRead(
@@ -225,7 +225,7 @@ func webUiTemplatesRulesHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/rules.html", size: 868, mode: os.FileMode(420), modTime: time.Unix(1511363701, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/rules.html", size: 870, mode: os.FileMode(420), modTime: time.Unix(1511444602, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -245,7 +245,7 @@ func webUiTemplatesStatusHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/status.html", size: 1756, mode: os.FileMode(420), modTime: time.Unix(1506332318, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/status.html", size: 1756, mode: os.FileMode(420), modTime: time.Unix(1510812562, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -265,7 +265,7 @@ func webUiTemplatesTargetsHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/templates/targets.html", size: 3258, mode: os.FileMode(420), modTime: time.Unix(1510849471, 0)}
+	info := bindataFileInfo{name: "web/ui/templates/targets.html", size: 3258, mode: os.FileMode(420), modTime: time.Unix(1511326533, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -285,7 +285,7 @@ func webUiStaticCssAlertsCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/css/alerts.css", size: 74, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/css/alerts.css", size: 74, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -305,7 +305,7 @@ func webUiStaticCssGraphCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/css/graph.css", size: 2709, mode: os.FileMode(420), modTime: time.Unix(1509641939, 0)}
+	info := bindataFileInfo{name: "web/ui/static/css/graph.css", size: 2709, mode: os.FileMode(420), modTime: time.Unix(1511327106, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -325,7 +325,7 @@ func webUiStaticCssProm_consoleCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/css/prom_console.css", size: 2883, mode: os.FileMode(420), modTime: time.Unix(1491488441, 0)}
+	info := bindataFileInfo{name: "web/ui/static/css/prom_console.css", size: 2883, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -345,7 +345,7 @@ func webUiStaticCssPrometheusCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/css/prometheus.css", size: 322, mode: os.FileMode(420), modTime: time.Unix(1507565507, 0)}
+	info := bindataFileInfo{name: "web/ui/static/css/prometheus.css", size: 322, mode: os.FileMode(420), modTime: time.Unix(1510812562, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -365,7 +365,7 @@ func webUiStaticCssRulesCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/css/rules.css", size: 190, mode: os.FileMode(420), modTime: time.Unix(1511359976, 0)}
+	info := bindataFileInfo{name: "web/ui/static/css/rules.css", size: 190, mode: os.FileMode(420), modTime: time.Unix(1511439761, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -385,7 +385,7 @@ func webUiStaticCssTargetsCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/css/targets.css", size: 182, mode: os.FileMode(420), modTime: time.Unix(1507565507, 0)}
+	info := bindataFileInfo{name: "web/ui/static/css/targets.css", size: 182, mode: os.FileMode(420), modTime: time.Unix(1511326533, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -405,7 +405,7 @@ func webUiStaticImgAjaxLoaderGif() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/img/ajax-loader.gif", size: 847, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/img/ajax-loader.gif", size: 847, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -425,7 +425,7 @@ func webUiStaticImgFaviconIco() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/img/favicon.ico", size: 15086, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/img/favicon.ico", size: 15086, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -445,7 +445,7 @@ func webUiStaticJsAlertsJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/js/alerts.js", size: 445, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/js/alerts.js", size: 445, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -465,7 +465,7 @@ func webUiStaticJsGraphJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/js/graph.js", size: 29862, mode: os.FileMode(420), modTime: time.Unix(1509641934, 0)}
+	info := bindataFileInfo{name: "web/ui/static/js/graph.js", size: 29862, mode: os.FileMode(420), modTime: time.Unix(1511327106, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -485,7 +485,7 @@ func webUiStaticJsGraph_templateHandlebar() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/js/graph_template.handlebar", size: 6343, mode: os.FileMode(420), modTime: time.Unix(1507565507, 0)}
+	info := bindataFileInfo{name: "web/ui/static/js/graph_template.handlebar", size: 6343, mode: os.FileMode(420), modTime: time.Unix(1510812562, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -505,7 +505,7 @@ func webUiStaticJsProm_consoleJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/js/prom_console.js", size: 22477, mode: os.FileMode(420), modTime: time.Unix(1506332318, 0)}
+	info := bindataFileInfo{name: "web/ui/static/js/prom_console.js", size: 22477, mode: os.FileMode(420), modTime: time.Unix(1510812562, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -525,7 +525,7 @@ func webUiStaticJsTargetsJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/js/targets.js", size: 983, mode: os.FileMode(420), modTime: time.Unix(1507565507, 0)}
+	info := bindataFileInfo{name: "web/ui/static/js/targets.js", size: 983, mode: os.FileMode(420), modTime: time.Unix(1511326533, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -545,7 +545,7 @@ func webUiStaticVendorBootstrap331CssBootstrapThemeMinCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/css/bootstrap-theme.min.css", size: 19835, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/css/bootstrap-theme.min.css", size: 19835, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -565,7 +565,7 @@ func webUiStaticVendorBootstrap331CssBootstrapMinCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/css/bootstrap.min.css", size: 113498, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/css/bootstrap.min.css", size: 113498, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -585,7 +585,7 @@ func webUiStaticVendorBootstrap331FontsGlyphiconsHalflingsRegularEot() (*asset, 
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.eot", size: 20335, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.eot", size: 20335, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -605,7 +605,7 @@ func webUiStaticVendorBootstrap331FontsGlyphiconsHalflingsRegularSvg() (*asset, 
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.svg", size: 62926, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.svg", size: 62926, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -625,7 +625,7 @@ func webUiStaticVendorBootstrap331FontsGlyphiconsHalflingsRegularTtf() (*asset, 
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.ttf", size: 41280, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.ttf", size: 41280, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -645,7 +645,7 @@ func webUiStaticVendorBootstrap331FontsGlyphiconsHalflingsRegularWoff() (*asset,
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.woff", size: 23320, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/fonts/glyphicons-halflings-regular.woff", size: 23320, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -665,7 +665,7 @@ func webUiStaticVendorBootstrap331JsBootstrapMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/js/bootstrap.min.js", size: 35601, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/js/bootstrap.min.js", size: 35601, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -685,7 +685,7 @@ func webUiStaticVendorBootstrap331JsNpmJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/js/npm.js", size: 484, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap-3.3.1/js/npm.js", size: 484, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -705,7 +705,7 @@ func webUiStaticVendorBootstrap3TypeaheadBootstrap3TypeaheadMinJs() (*asset, err
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap3-typeahead/bootstrap3-typeahead.min.js", size: 7856, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/bootstrap3-typeahead/bootstrap3-typeahead.min.js", size: 7856, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -725,7 +725,7 @@ func webUiStaticVendorEonasdanBootstrapDatetimepickerBootstrapDatetimepickerMinC
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/eonasdan-bootstrap-datetimepicker/bootstrap-datetimepicker.min.css", size: 7771, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/eonasdan-bootstrap-datetimepicker/bootstrap-datetimepicker.min.css", size: 7771, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -745,7 +745,7 @@ func webUiStaticVendorEonasdanBootstrapDatetimepickerBootstrapDatetimepickerMinJ
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/eonasdan-bootstrap-datetimepicker/bootstrap-datetimepicker.min.js", size: 48881, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/eonasdan-bootstrap-datetimepicker/bootstrap-datetimepicker.min.js", size: 48881, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -765,7 +765,7 @@ func webUiStaticVendorFuzzyFuzzyJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/fuzzy/fuzzy.js", size: 5669, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/fuzzy/fuzzy.js", size: 5669, mode: os.FileMode(420), modTime: time.Unix(1510812562, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -785,7 +785,7 @@ func webUiStaticVendorJsJqueryHotkeysJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/js/jquery.hotkeys.js", size: 4490, mode: os.FileMode(420), modTime: time.Unix(1507565507, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/js/jquery.hotkeys.js", size: 4490, mode: os.FileMode(420), modTime: time.Unix(1510812562, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -805,7 +805,7 @@ func webUiStaticVendorJsJqueryMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/js/jquery.min.js", size: 86671, mode: os.FileMode(420), modTime: time.Unix(1507565507, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/js/jquery.min.js", size: 86671, mode: os.FileMode(420), modTime: time.Unix(1510812562, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -825,7 +825,7 @@ func webUiStaticVendorJsJquerySelectionJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/js/jquery.selection.js", size: 12881, mode: os.FileMode(420), modTime: time.Unix(1507565507, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/js/jquery.selection.js", size: 12881, mode: os.FileMode(420), modTime: time.Unix(1510812562, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -845,7 +845,7 @@ func webUiStaticVendorMomentMomentTimezoneWithDataMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/moment/moment-timezone-with-data.min.js", size: 184190, mode: os.FileMode(420), modTime: time.Unix(1507565507, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/moment/moment-timezone-with-data.min.js", size: 184190, mode: os.FileMode(420), modTime: time.Unix(1510812562, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -865,7 +865,7 @@ func webUiStaticVendorMomentMomentMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/moment/moment.min.js", size: 61281, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/moment/moment.min.js", size: 61281, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -885,7 +885,7 @@ func webUiStaticVendorMustacheMustacheMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/mustache/mustache.min.js", size: 9528, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/mustache/mustache.min.js", size: 9528, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -905,7 +905,7 @@ func webUiStaticVendorRickshawRickshawMinCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/rickshaw.min.css", size: 6102, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/rickshaw.min.css", size: 6102, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -925,7 +925,7 @@ func webUiStaticVendorRickshawRickshawMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/rickshaw.min.js", size: 76322, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/rickshaw.min.js", size: 76322, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -945,7 +945,7 @@ func webUiStaticVendorRickshawVendorD3LayoutMinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/vendor/d3.layout.min.js", size: 17514, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/vendor/d3.layout.min.js", size: 17514, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -965,7 +965,7 @@ func webUiStaticVendorRickshawVendorD3V3Js() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/vendor/d3.v3.js", size: 144718, mode: os.FileMode(420), modTime: time.Unix(1491481787, 0)}
+	info := bindataFileInfo{name: "web/ui/static/vendor/rickshaw/vendor/d3.v3.js", size: 144718, mode: os.FileMode(420), modTime: time.Unix(1498039472, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/web/ui/templates/rules.html
+++ b/web/ui/templates/rules.html
@@ -9,7 +9,7 @@
         <thead>
           <tr>
             <td><h2>{{.Name}}</h2></td>
-            <td><h2>{{humanizeDuration .GetEvaluationTimeSeconds}}</h2></td>
+            <td><h2>{{humanizeDuration .GetEvaluationTime.Seconds}}</h2></td>
           </tr>
         </thead>
         <tbody>
@@ -20,7 +20,7 @@
           {{range .Rules}}
           <tr>
             <td class="rule_cell">{{.HTMLSnippet pathPrefix}}</td>
-            <td>{{humanizeDuration .GetEvaluationTimeSeconds}}</td>
+            <td>{{humanizeDuration .GetEvaluationTime.Seconds}}</td>
           </tr>
           {{end}}
         </tbody>


### PR DESCRIPTION
`setEvaluationTimeSeconds` was unexported on a public interface. And model.Duration is better here for the timings. Thanks @fabxc for both suggestions. 

Sorry for not catching them in my previous review, @Conorbro. Do you mind taking a look at the changes?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/3509)
<!-- Reviewable:end -->
