### PR TITLE
Fix 'addrConn.resetTransport' error (#3004)

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -411,7 +411,7 @@ func (h *Handler) Run(ctx context.Context) error {
 	)
 	av2.RegisterGRPC(grpcSrv)
 
-	hh, err := av2.HTTPHandler(grpcl.Addr().String())
+	hh, err := av2.HTTPHandler(h.options.ListenAddress)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
net.Listener converts 0.0.0.0 to :: which fails for hosts where IPv6 is
disabled. This change uses the original listen address parameter instead
of grpcl.Addr().String().

The proposed fix is similar to https://github.com/coreos/etcd/commit/63350f5ac10a8035e9284c8385e75d2e27d669c3.