### PR TITLE
Docs: state that all regular expressions are RE2.

### DIFF
--- a/docs/querying/basics.md
+++ b/docs/querying/basics.md
@@ -116,6 +116,9 @@ The following expression selects all metrics that have a name starting with `job
 
     {__name__=~"job:.*"}
 
+All regular expressions in Prometheus use [RE2
+syntax](https://github.com/google/re2/wiki/Syntax).
+
 ### Range Vector Selectors
 
 Range vector literals work like instant vector literals, except that they

--- a/docs/querying/examples.md
+++ b/docs/querying/examples.md
@@ -31,6 +31,9 @@ Note that this does a substring match, not a full string match:
 
     http_requests_total{job=~".*server"}
 
+All regular expressions in Prometheus use [RE2
+syntax](https://github.com/google/re2/wiki/Syntax).
+
 To select all HTTP status codes except 4xx ones, you could run:
 
     http_requests_total{status!~"4.."}


### PR DESCRIPTION
We already mentioned that regular expressions are RE2 for
[relabeling][0], but left open what the regular expression syntax
anywhere else is.

In the querying examples and reference, make it explicit that _all_
regular expressions are RE2.

[0]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config