### PR TITLE
Correctly handle empty data set in the console view

### DIFF
--- a/web/ui/bindata.go
+++ b/web/ui/bindata.go
@@ -465,7 +465,7 @@ func webUiStaticJsGraphJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "web/ui/static/js/graph.js", size: 29862, mode: os.FileMode(420), modTime: time.Unix(1511639377, 0)}
+	info := bindataFileInfo{name: "web/ui/static/js/graph.js", size: 29928, mode: os.FileMode(420), modTime: time.Unix(1512035831, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/web/ui/static/js/graph.js
+++ b/web/ui/static/js/graph.js
@@ -451,7 +451,7 @@ Prometheus.Graph.prototype.submitQuery = function() {
         if (xhr.responseJSON.data !== undefined) {
           if (xhr.responseJSON.data.resultType === "scalar") {
             totalTimeSeries = 1;
-          } else {
+          } else if(xhr.responseJSON.data.result !== null) {
             totalTimeSeries = xhr.responseJSON.data.result.length;
           }
         }
@@ -720,7 +720,7 @@ Prometheus.Graph.prototype.handleConsoleResponse = function(data, textStatus) {
 
   switch(data.resultType) {
   case "vector":
-    if (data.result.length === 0) {
+    if (data.result === null || data.result.length === 0) {
       tBody.append("<tr><td colspan='2'><i>no data</i></td></tr>");
       return;
     }


### PR DESCRIPTION
When there is an empty result set, the Prometheus server replies with

`{"status":"success","data":{"resultType":"vector","result":null}}`

That "null" reply was not handled correctly by the graphing library.
This commit handles that case and shows "no data" in the UI console view
instead of throwing an error in the browser javascript console.

Fixes #3515

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>