### PR TITLE
Improve rule group metrics

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -241,6 +241,7 @@ func main() {
 		NotifyFunc:  sendAlerts(notifier, cfg.web.ExternalURL.String()),
 		Context:     ctx,
 		ExternalURL: cfg.web.ExternalURL,
+		Registerer:  prometheus.DefaultRegisterer,
 		Logger:      log.With(logger, "component", "rule manager"),
 	})
 

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -67,18 +67,18 @@ var (
 	)
 	iterationDuration = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace:  namespace,
-		Name:       "evaluator_duration_seconds",
+		Name:       "rule_group_duration_seconds",
 		Help:       "The duration of rule group evaluations.",
 		Objectives: map[float64]float64{0.01: 0.001, 0.05: 0.005, 0.5: 0.05, 0.90: 0.01, 0.99: 0.001},
 	})
 	iterationsMissed = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
-		Name:      "evaluator_iterations_missed_total",
+		Name:      "rule_group_iterations_missed_total",
 		Help:      "The total number of rule group evaluations missed due to slow rule group evaluation.",
 	})
 	iterationsScheduled = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
-		Name:      "evaluator_iterations_total",
+		Name:      "rule_group_iterations_total",
 		Help:      "The total number of scheduled rule group evaluations, whether executed or missed.",
 	})
 )

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -284,6 +284,8 @@ func (g *Group) offset() time.Duration {
 // Rules are matched based on their name. If there are duplicates, the
 // first is matched with the first, second with the second etc.
 func (g *Group) copyState(from *Group) {
+	g.evaluationTime = from.evaluationTime
+
 	ruleMap := make(map[string][]int, len(from.rules))
 
 	for fi, fromRule := range from.rules {

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -266,6 +266,7 @@ func TestCopyState(t *testing.T) {
 			map[string]labels.Labels{"r3a": nil},
 			map[string]labels.Labels{"r3b": nil},
 		},
+		evaluationTime: time.Second,
 	}
 	oldGroup.rules[0].(*AlertingRule).active[42] = nil
 	newGroup := &Group{
@@ -291,6 +292,7 @@ func TestCopyState(t *testing.T) {
 	}
 	testutil.Equals(t, want, newGroup.seriesInPreviousEval)
 	testutil.Equals(t, oldGroup.rules[0], newGroup.rules[3])
+	testutil.Equals(t, oldGroup.evaluationTime, newGroup.evaluationTime)
 }
 
 func TestUpdate(t *testing.T) {


### PR DESCRIPTION
This adds per-rule group duration and interval, so you can see where your time is being spent. From there you can go to the UI to find the particular rules which are problems.

This also changes the names of existing metrics and removes labels, to make them easier to understand.

Example output: https://gist.github.com/brian-brazil/81f4e71cbc9c5bd384b8e11c5ee0922f

@brancz 