### PR TITLE
Update Graphite remote example for Graphite v1.1.x

### DIFF
--- a/documentation/examples/remote_storage/remote_storage_adapter/README.md
+++ b/documentation/examples/remote_storage/remote_storage_adapter/README.md
@@ -5,8 +5,7 @@ protocol and stores them in Graphite, InfluxDB, or OpenTSDB. It is meant as a
 replacement for the built-in specific remote storage implementations that have
 been removed from Prometheus.
 
-For InfluxDB, this binary is also a read adapter that supports reading back
-data through Prometheus via Prometheus's remote read protocol.
+For Graphite and InfluxDB, this binary is also a read adapter that supports reading back data through Prometheus via Prometheus's remote read protocol.
 
 ## Building
 
@@ -19,7 +18,7 @@ go build
 Graphite example:
 
 ```
-./remote_storage_adapter -graphite-address=localhost:8080
+./remote_storage_adapter -graphite-address=localhost:2003 -graphite-web-address=localhost:8080 -graphite-enable-tags true
 ```
 
 OpenTSDB example:
@@ -49,7 +48,7 @@ To configure Prometheus to send samples to this binary, add the following to you
 remote_write:
   - url: "http://localhost:9201/write"
 
-# Remote read configuration (for InfluxDB only at the moment).
+# Remote read configuration (for Graphite, and InfluxDB).
 remote_read:
   - url: "http://localhost:9201/read"
 ```

--- a/documentation/examples/remote_storage/remote_storage_adapter/graphite/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/graphite/client.go
@@ -15,42 +15,60 @@ package graphite
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"net"
+	"net/http"
+	"net/url"
+	"path"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/prompb"
 )
 
 // Client allows sending batches of Prometheus samples to Graphite.
 type Client struct {
 	logger log.Logger
 
-	address   string
-	transport string
-	timeout   time.Duration
-	prefix    string
+	carbonAddress   string
+	graphiteAddress string
+	transport       string
+	timeout         time.Duration
+	prefix          string
+	enableTags      bool
+}
+
+// TargetResponse allows for easy unmarshalling of graphite responses
+type TargetResponse struct {
+	DataPoints [][2]json.Number  `json:"datapoints"`
+	Tags       map[string]string `json:"tags"`
 }
 
 // NewClient creates a new Client.
-func NewClient(logger log.Logger, address string, transport string, timeout time.Duration, prefix string) *Client {
+func NewClient(logger log.Logger, carbonAddress string, graphiteAddress string, transport string, timeout time.Duration, prefix string, enableTags bool) *Client {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
 	return &Client{
-		logger:    logger,
-		address:   address,
-		transport: transport,
-		timeout:   timeout,
-		prefix:    prefix,
+		logger:          logger,
+		carbonAddress:   carbonAddress,
+		graphiteAddress: graphiteAddress,
+		transport:       transport,
+		timeout:         timeout,
+		prefix:          prefix,
+		enableTags:      enableTags,
 	}
 }
 
-func pathFromMetric(m model.Metric, prefix string) string {
+func pathFromMetric(m model.Metric, prefix string, enableTags bool) string {
 	var buffer bytes.Buffer
 
 	buffer.WriteString(prefix)
@@ -70,18 +88,28 @@ func pathFromMetric(m model.Metric, prefix string) string {
 		if l == model.MetricNameLabel || len(l) == 0 {
 			continue
 		}
+
+		if enableTags {
+			// Write the label using the updated carbon tag format
+			// https://graphite.readthedocs.io/en/latest/tags.html
+			buffer.WriteString(fmt.Sprintf(
+				";%s=%s", string(l), escape(v)))
+			continue
+		}
+
 		// Since we use '.' instead of '=' to separate label and values
 		// it means that we can't have an '.' in the metric name. Fortunately
 		// this is prohibited in prometheus metrics.
 		buffer.WriteString(fmt.Sprintf(
 			".%s.%s", string(l), escape(v)))
 	}
+
 	return buffer.String()
 }
 
 // Write sends a batch of samples to Graphite.
-func (c *Client) Write(samples model.Samples) error {
-	conn, err := net.DialTimeout(c.transport, c.address, c.timeout)
+func (c Client) Write(samples model.Samples) error {
+	conn, err := net.DialTimeout(c.transport, c.carbonAddress, c.timeout)
 	if err != nil {
 		return err
 	}
@@ -89,7 +117,7 @@ func (c *Client) Write(samples model.Samples) error {
 
 	var buf bytes.Buffer
 	for _, s := range samples {
-		k := pathFromMetric(s.Metric, c.prefix)
+		k := pathFromMetric(s.Metric, c.prefix, c.enableTags)
 		t := float64(s.Timestamp.UnixNano()) / 1e9
 		v := float64(s.Value)
 		if math.IsNaN(v) || math.IsInf(v, 0) {
@@ -105,6 +133,158 @@ func (c *Client) Write(samples model.Samples) error {
 	}
 
 	return nil
+}
+
+func (c Client) Read(req *prompb.ReadRequest) (*prompb.ReadResponse, error) {
+	PromSeries := []*prompb.TimeSeries{}
+	for _, q := range req.Queries {
+		formData, err := c.buildForm(q)
+		if err != nil {
+			return nil, err
+		}
+
+		req, err := c.createRequest(formData)
+		if err != nil {
+			return nil, err
+		}
+
+		http.DefaultClient.Do(req)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		series, err := c.parseResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, s := range series {
+			ps, err := buildPromSeries(s)
+			if err != nil {
+				level.Debug(c.logger).Log("msg", "Unable to parse graphite series into valid prometheus series", "reason", err)
+				continue
+			}
+			PromSeries = append(
+				PromSeries,
+				ps,
+			)
+		}
+	}
+
+	queryResponse := prompb.ReadResponse{
+		Results: []*prompb.QueryResult{
+			{Timeseries: make([]*prompb.TimeSeries, 0, len(PromSeries))},
+		},
+	}
+	for _, ts := range PromSeries {
+		queryResponse.Results[0].Timeseries = append(queryResponse.Results[0].Timeseries, ts)
+	}
+	return &queryResponse, nil
+}
+
+func (c Client) createRequest(data url.Values) (*http.Request, error) {
+	u, _ := url.Parse(c.graphiteAddress)
+	u.Path = path.Join(u.Path, "render")
+	u.RawQuery = data.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create request. error: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return req, err
+}
+
+func (c Client) buildForm(q *prompb.Query) (url.Values, error) {
+	tagSet := []string{}
+
+	for _, m := range q.Matchers {
+		var name string
+		if m.Name == model.MetricNameLabel {
+			name = "name"
+		} else {
+			name = m.Name
+		}
+
+		switch m.Type {
+		case prompb.LabelMatcher_EQ:
+			tagSet = append(tagSet, "\""+name+"="+m.Value+"\"")
+		case prompb.LabelMatcher_NEQ:
+			tagSet = append(tagSet, "\""+name+"!="+m.Value+"\"")
+		case prompb.LabelMatcher_RE:
+			tagSet = append(tagSet, "\""+name+"=~^("+m.Value+")$\"")
+		case prompb.LabelMatcher_NRE:
+			tagSet = append(tagSet, "\""+name+"!=~^("+m.Value+")$\"")
+		default:
+			return nil, fmt.Errorf("unknown match type %v", m.Type)
+		}
+	}
+
+	formData := url.Values{
+		"from":   []string{strconv.Itoa(int(q.GetStartTimestampMs()) / 1000)},
+		"until":  []string{strconv.Itoa(int(q.GetEndTimestampMs()) / 1000)},
+		"format": []string{"json"},
+		"target": []string{"seriesByTag(" + strings.Join(tagSet, ",") + ")"},
+	}
+
+	return formData, nil
+}
+
+func (c *Client) parseResponse(res *http.Response) ([]TargetResponse, error) {
+	body, err := ioutil.ReadAll(res.Body)
+	defer res.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("request failed status: %v", res.Status)
+	}
+
+	var data []TargetResponse
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func buildPromSeries(s TargetResponse) (*prompb.TimeSeries, error) {
+	labels := []*prompb.Label{}
+	for k, v := range s.Tags {
+		if k == "name" {
+			k = model.MetricNameLabel
+			// Ensure the metric name is valid in case a regex query returns a
+			// invalid metric
+			if !model.IsValidMetricName(model.LabelValue(v)) {
+				return nil, fmt.Errorf("metric name %v is not a valid prometheus metric", v)
+			}
+		}
+		labels = append(labels, &prompb.Label{Name: k, Value: v})
+	}
+
+	samples := []*prompb.Sample{}
+	for _, pair := range s.DataPoints {
+		// Check to see if if the graphite values are not Null
+		data, err := pair[0].Float64()
+		if err != nil {
+			continue
+		}
+		timestamp, err := pair[1].Float64()
+		if err != nil {
+			continue
+		}
+		samples = append(samples, &prompb.Sample{Value: data, Timestamp: int64(1000 * timestamp)})
+	}
+
+	return &prompb.TimeSeries{
+		Labels:  labels,
+		Samples: samples,
+	}, nil
 }
 
 // Name identifies the client as a Graphite client.

--- a/documentation/examples/remote_storage/remote_storage_adapter/graphite/client_test.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/graphite/client_test.go
@@ -14,9 +14,12 @@
 package graphite
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/prompb"
 )
 
 var (
@@ -45,13 +48,115 @@ func TestEscape(t *testing.T) {
 	}
 }
 
+func TestDecodeTargetJSON(t *testing.T) {
+	exampleResponse := []byte(`[{
+		"datapoints": [
+		[
+			null,
+			null
+		],
+		[
+			3.995926854361851,
+			1510676572
+		]
+		],
+		"tags": {
+			"some": "tag",
+			"name": "some_id_of_a_metric"
+		}
+	}]`)
+	var data []TargetResponse
+	err := json.Unmarshal(exampleResponse, &data)
+	if err != nil {
+		t.Errorf("Expected no error, got %s", err.Error())
+	}
+}
+
 func TestPathFromMetric(t *testing.T) {
 	expected := ("prefix." +
 		"test:metric" +
 		".many_chars.abc!ABC:012-3!45%C3%B667~89%2E%2F\\(\\)\\{\\}\\,%3D%2E\\\"\\\\" +
 		".testlabel.test:value")
-	actual := pathFromMetric(metric, "prefix.")
+	actual := pathFromMetric(metric, "prefix.", false)
 	if expected != actual {
 		t.Errorf("Expected %s, got %s", expected, actual)
+	}
+}
+
+func TestPathFromMetricTagsEnabld(t *testing.T) {
+	expected := ("prefix." +
+		"test:metric" +
+		";many_chars=abc!ABC:012-3!45%C3%B667~89%2E%2F\\(\\)\\{\\}\\,%3D%2E\\\"\\\\" +
+		";testlabel=test:value")
+	actual := pathFromMetric(metric, "prefix.", true)
+	if expected != actual {
+		t.Errorf("Expected %s, got %s", expected, actual)
+	}
+}
+
+func TestBuildPromSeries(t *testing.T) {
+	tests := []struct {
+		name         string
+		targetSeries TargetResponse
+		want         *prompb.TimeSeries
+		wantErr      bool
+	}{
+		{
+			name: "simple metric with null data point",
+			targetSeries: TargetResponse{
+				Tags: map[string]string{
+					"some": "tag",
+					"name": "some_metric",
+				},
+				DataPoints: [][2]json.Number{
+					[2]json.Number{"100", "3.14"},
+					[2]json.Number{"", ""},
+				},
+			},
+			want: &prompb.TimeSeries{
+				Samples: []*prompb.Sample{
+					&prompb.Sample{
+						Value:     100,
+						Timestamp: 3140,
+					},
+				},
+				Labels: []*prompb.Label{
+					&prompb.Label{
+						Value: "tag",
+						Name:  "some",
+					},
+					&prompb.Label{
+						Value: "some_metric",
+						Name:  model.MetricNameLabel,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid metric",
+			targetSeries: TargetResponse{
+				Tags: map[string]string{
+					"name": "random.carbon.metric",
+				},
+				DataPoints: [][2]json.Number{
+					[2]json.Number{"100", "3.14"},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildPromSeries(tt.targetSeries)
+			if err != nil && !tt.wantErr {
+				t.Errorf("Error %v, want no error", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildPromSeries() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This pull request updates the graphite remote write example to take advantage of Graphite's tagging support. It includes an extension to allow for remote-reads.

If tag support is not enabled there is no change in functionality.

If tag support is enabled, series will be written to graphite using the 1.1.x tagging support, and if a graphite web address is specified then remote read functionality will be enabled

https://graphite.readthedocs.io/en/latest/tags.html