### PR TITLE
Added rule name to rule error for easier debugging

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -26,13 +26,14 @@ import (
 
 // Error represents semantical errors on parsing rule groups.
 type Error struct {
-	Group string
-	Rule  int
-	Err   error
+	Group    string
+	Rule     int
+	RuleName string
+	Err      error
 }
 
 func (err *Error) Error() string {
-	return errors.Wrapf(err.Err, "group %q, rule %d", err.Group, err.Rule).Error()
+	return errors.Wrapf(err.Err, "group %q, rule %d, %q", err.Group, err.Rule, err.RuleName).Error()
 }
 
 // RuleGroups is a set of rule groups that are typically exposed in a file.
@@ -67,10 +68,17 @@ func (g *RuleGroups) Validate() (errs []error) {
 
 		for i, r := range g.Rules {
 			for _, err := range r.Validate() {
+				var ruleName string
+				if r.Alert != "" {
+					ruleName = r.Alert
+				} else {
+					ruleName = r.Record
+				}
 				errs = append(errs, &Error{
-					Group: g.Name,
-					Rule:  i,
-					Err:   err,
+					Group:    g.Name,
+					Rule:     i,
+					RuleName: ruleName,
+					Err:      err,
 				})
 			}
 		}


### PR DESCRIPTION
Added rule name to errors generated while validating rule groups as I believe this will alleviate trying to parse the troublesome rule by eye with only the index.

Before: 

`err="group \"alert.rule\", rule 1: could not parse expression: parse error at char 34: binary expression must contain only scalar and instant vector types"`

Now:

`err="group \"alert.rule\", rule 1, \"InstanceDown\": could not parse expression: parse error at char 34: binary expression must contain only scalar and instant vector types"`