### PR TITLE
documentation: __meta* variables are not exposed to <metric_relabel_configs>

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -963,8 +963,12 @@ once the labels are removed.
 ### `<metric_relabel_configs>`
 
 Metric relabeling is applied to samples as the last step before ingestion. It
-has the same configuration format and actions as target relabeling. Metric
-relabeling does not apply to automatically generated timeseries such as `up`.
+has the same configuration format and actions as target relabeling. However,
+the service discovery labels, starting with `__meta`, are not exposed to the
+`<metric_relabel_configs>` rules.
+
+Metric relabeling does not apply to automatically generated timeseries such as
+up`.
 
 One use for this is to blacklist time series that are too expensive to ingest.
 


### PR DESCRIPTION
I've been bitten by that, trying to make it work. __meta_* variables are
exposed to <relabel_configs> but not to the metric relabelling rules.

Document the current status.