### PR TITLE
Remove obsolete TODO in API code

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -320,7 +320,6 @@ func (api *API) labelValues(r *http.Request) (interface{}, *apiError) {
 	}
 	defer q.Close()
 
-	// TODO(fabxc): add back request context.
 	vals, err := q.LabelValues(name)
 	if err != nil {
 		return nil, &apiError{errorExec, err}


### PR DESCRIPTION
In https://github.com/prometheus/prometheus/pull/3230/files, contexts were
added to the Querier() method instead, and Cortex is fine with that.