### PR TITLE
Added HTTP security headers to web.go

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -71,7 +71,7 @@ import (
 
 var localhostRepresentations = []string{"127.0.0.1", "localhost"}
 
-// SecureHeaders adds secure headers to the responses
+// secureHeadersMiddleware adds common HTTP security headers to responses.
 func secureHeadersMiddleware(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("X-XSS-Protection", "1; mode=block")

--- a/web/web.go
+++ b/web/web.go
@@ -71,6 +71,17 @@ import (
 
 var localhostRepresentations = []string{"127.0.0.1", "localhost"}
 
+// SecureHeaders adds secure headers to the responses
+func secureHeadersMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("X-XSS-Protection", "1; mode=block")
+		w.Header().Add("X-Content-Type-Options", "nosniff")
+		w.Header().Add("X-Frame-Options", "SAMEORIGIN")
+		w.Header().Add("Content-Security-Policy", "frame-ancestors 'self'")
+		h.ServeHTTP(w, r)
+	})
+}
+
 var (
 	requestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -478,8 +489,10 @@ func (h *Handler) Run(ctx context.Context) error {
 
 	errlog := stdlog.New(log.NewStdlibAdapter(level.Error(h.logger)), "", 0)
 
+	withSecureHeaders := nethttp.Middleware(opentracing.GlobalTracer(), secureHeadersMiddleware(mux), operationName)
+
 	httpSrv := &http.Server{
-		Handler:     nethttp.Middleware(opentracing.GlobalTracer(), mux, operationName),
+		Handler:     withSecureHeaders,
 		ErrorLog:    errlog,
 		ReadTimeout: h.options.ReadTimeout,
 	}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -83,6 +83,58 @@ func TestGlobalURL(t *testing.T) {
 	}
 }
 
+func TestEndpointHeaders(t *testing.T) {
+	t.Parallel()
+	dbDir, err := ioutil.TempDir("", "tsdb-ready")
+
+	testutil.Ok(t, err)
+
+	defer os.RemoveAll(dbDir)
+
+	db, err := libtsdb.Open(dbDir, nil, nil, nil)
+
+	testutil.Ok(t, err)
+
+	opts := &Options{
+		ListenAddress:  ":9095",
+		ReadTimeout:    30 * time.Second,
+		MaxConnections: 512,
+		Context:        nil,
+		Storage:        &tsdb.ReadyStorage{},
+		QueryEngine:    nil,
+		RuleManager:    nil,
+		Notifier:       nil,
+		RoutePrefix:    "/",
+		EnableAdminAPI: true,
+		TSDB:           func() *libtsdb.DB { return db },
+	}
+
+	opts.Flags = map[string]string{}
+
+	webHandler := New(nil, opts)
+	go func() {
+		err := webHandler.Run(context.Background())
+		if err != nil {
+			panic(fmt.Sprintf("Can't start webhandler error %s", err))
+		}
+	}()
+
+	time.Sleep(5 * time.Second)
+
+	webHandler.Ready()
+
+	resp, err := http.Get("http://localhost:9095/version")
+
+	testutil.Ok(t, err)
+	testutil.Equals(t, http.StatusOK, resp.StatusCode)
+
+	testutil.Equals(t, "1; mode=block", resp.Header.Get("X-XSS-Protection"))
+	testutil.Equals(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+	testutil.Equals(t, "SAMEORIGIN", resp.Header.Get("X-Frame-Options"))
+	testutil.Equals(t, "frame-ancestors 'self'", resp.Header.Get("Content-Security-Policy"))
+
+}
+
 func TestReadyAndHealthy(t *testing.T) {
 	t.Parallel()
 	dbDir, err := ioutil.TempDir("", "tsdb-ready")


### PR DESCRIPTION
Added standard HTTP security headers for both the root/redirect requests and all template-based UI pages.

This configuration for the headers is very unrestrictive, while still meeting most compliance frameworks and industry best practices. They should not interfere with any functionality in Prometheus (and did not in my testing).