### PR TITLE
handle web_test webhandler errors.

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -35,6 +35,9 @@ func TestMain(m *testing.M) {
 	if testing.Short() {
 		os.Exit(m.Run())
 	}
+	// On linux with a global proxy the tests will fail as the go client(http,grpc) tries to connect through the proxy.
+	os.Setenv("no_proxy", "localhost,127.0.0.1,0.0.0.0,:")
+
 	var err error
 	promPath, err = os.Getwd()
 	if err != nil {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -15,7 +15,6 @@ package web
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -111,7 +110,7 @@ func TestReadyAndHealthy(t *testing.T) {
 	go func() {
 		err := webHandler.Run(context.Background())
 		if err != nil {
-			panic(fmt.Sprintf("Can't start web handler:%s", err))
+			t.Fatalf("Can't start web handler:%s", err)
 		}
 	}()
 
@@ -207,7 +206,7 @@ func TestRoutePrefix(t *testing.T) {
 	go func() {
 		err := webHandler.Run(context.Background())
 		if err != nil {
-			panic(fmt.Sprintf("Can't start web handler:%s", err))
+			t.Fatalf("Can't start web handler:%s", err)
 		}
 	}()
 

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -108,7 +108,12 @@ func TestReadyAndHealthy(t *testing.T) {
 	opts.Flags = map[string]string{}
 
 	webHandler := New(nil, opts)
-	go webHandler.Run(context.Background())
+	go func() {
+		err := webHandler.Run(context.Background())
+		if err != nil {
+			panic(fmt.Sprintf("Can't start web handler:%s", err))
+		}
+	}()
 
 	// Give some time for the web goroutine to run since we need the server
 	// to be up before starting tests.
@@ -202,7 +207,7 @@ func TestRoutePrefix(t *testing.T) {
 	go func() {
 		err := webHandler.Run(context.Background())
 		if err != nil {
-			panic(fmt.Sprintf("Can't start webhandler error %s", err))
+			panic(fmt.Sprintf("Can't start web handler:%s", err))
 		}
 	}()
 

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -29,6 +29,11 @@ import (
 	libtsdb "github.com/prometheus/tsdb"
 )
 
+func TestMain(m *testing.M) {
+	// On linux with a global proxy the tests will fail as the go client(http,grpc) tries to connect through the proxy.
+	os.Setenv("no_proxy", "localhost,127.0.0.1,0.0.0.0,:")
+	os.Exit(m.Run())
+}
 func TestGlobalURL(t *testing.T) {
 	opts := &Options{
 		ListenAddress: ":9090",


### PR DESCRIPTION
will handle errors like: `panic: Can't start webhandler error listen tcp :9090: bind: address already in use`