### PR TITLE
Updated alert templating docs

### DIFF
--- a/docs/configuration/template_examples.md
+++ b/docs/configuration/template_examples.md
@@ -5,11 +5,11 @@ sort_rank: 4
 
 # Template examples
 
-Prometheus supports templating in the summary and description fields of
-alerts, as well as in served console pages. Templates have the ability to run
-queries against the local database, iterate over data, use conditionals, format
-data, etc. The Prometheus templating language is based on the
-[Go templating](http://golang.org/pkg/text/template/) system.
+Prometheus supports templating in annotation fields of alerts, as well
+as in served console pages. Templates have the ability to run queries
+against the local database, iterate over data, use conditionals, format
+data, etc. The Prometheus templating language is based on the [Go
+templating](http://golang.org/pkg/text/template/) system.
 
 ## Simple alert field templates
 

--- a/docs/configuration/template_examples.md
+++ b/docs/configuration/template_examples.md
@@ -5,10 +5,10 @@ sort_rank: 4
 
 # Template examples
 
-Prometheus supports templating in annotation fields of alerts, as well
-as in served console pages. Templates have the ability to run queries
-against the local database, iterate over data, use conditionals, format
-data, etc. The Prometheus templating language is based on the [Go
+Prometheus supports templating in the annotations and labels of alerts,
+as well as in served console pages. Templates have the ability to run
+queries against the local database, iterate over data, use conditionals,
+format data, etc. The Prometheus templating language is based on the [Go
 templating](http://golang.org/pkg/text/template/) system.
 
 ## Simple alert field templates
@@ -19,7 +19,6 @@ expr: up == 0
 for: 5m
 labels:
   - severity: page
-  
 annotations:
   - summary: "Instance {{$labels.instance}} down"
   - description: "{{$labels.instance}} of job {{$labels.job}} has been down for more than 5 minutes."

--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -5,11 +5,11 @@ sort_rank: 5
 
 # Template reference
 
-Prometheus supports templating in the summary and description fields of
-alerts, as well as in served console pages. Templates have the ability to run
-queries against the local database, iterate over data, use conditionals, format
-data, etc. The Prometheus templating language is based on the
-[Go templating](http://golang.org/pkg/text/template/) system.
+Prometheus supports templating in annotation fields of alerts, as well
+as in served console pages. Templates have the ability to run queries
+against the local database, iterate over data, use conditionals, format
+data, etc. The Prometheus templating language is based on the [Go
+templating](http://golang.org/pkg/text/template/) system.
 
 ## Data Structures
 

--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -5,10 +5,10 @@ sort_rank: 5
 
 # Template reference
 
-Prometheus supports templating in annotation fields of alerts, as well
-as in served console pages. Templates have the ability to run queries
-against the local database, iterate over data, use conditionals, format
-data, etc. The Prometheus templating language is based on the [Go
+Prometheus supports templating in the annotations and labels of alerts,
+as well as in served console pages. Templates have the ability to run
+queries against the local database, iterate over data, use conditionals,
+format data, etc. The Prometheus templating language is based on the [Go
 templating](http://golang.org/pkg/text/template/) system.
 
 ## Data Structures


### PR DESCRIPTION
The docs suggest that alert templating only works in the summary and
description annotation fields. Some testing and a review of the code
suggests this is no longer true and that you can template any
annotation field.