### PR TITLE
Implement a Reader interface for configs.

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -238,17 +238,18 @@ func New(o *Options, logger log.Logger) *Notifier {
 	return n
 }
 
-// ApplyConfig updates the status state as the new config requires.
-func (n *Notifier) ApplyConfig(conf *config.Config) error {
+// Reload updates the status state as the new config requires.
+func (n *Notifier) Reload(cfg config.ReloadReader) error {
+	config := cfg.Read()
 	n.mtx.Lock()
 	defer n.mtx.Unlock()
 
-	n.opts.ExternalLabels = conf.GlobalConfig.ExternalLabels
-	n.opts.RelabelConfigs = conf.AlertingConfig.AlertRelabelConfigs
+	n.opts.ExternalLabels = config.GlobalConfig.ExternalLabels
+	n.opts.RelabelConfigs = config.AlertingConfig.AlertRelabelConfigs
 
 	amSets := []*alertmanagerSet{}
 
-	for _, cfg := range conf.AlertingConfig.AlertmanagerConfigs {
+	for _, cfg := range config.AlertingConfig.AlertmanagerConfigs {
 		ams, err := newAlertmanagerSet(cfg, n.logger)
 		if err != nil {
 			return err

--- a/relabel/relabel.go
+++ b/relabel/relabel.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/prometheus/common/model"
 
-	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/retrieval/config"
 )
 
 // Process returns a relabeled copy of the given label set. The relabel configurations
@@ -37,7 +37,7 @@ func Process(labels model.LabelSet, cfgs ...*config.RelabelConfig) model.LabelSe
 	return labels
 }
 
-func relabel(labels model.LabelSet, cfg *config.RelabelConfig) model.LabelSet {
+func relabel(labels model.LabelSet, cfg config.RelabelConfig) model.LabelSet {
 	values := make([]string, 0, len(cfg.SourceLabels))
 	for _, ln := range cfg.SourceLabels {
 		values = append(values, string(labels[ln]))

--- a/retrieval/config/config.go
+++ b/retrieval/config/config.go
@@ -1,0 +1,191 @@
+package config
+
+import (
+	"net/url"
+	"regexp"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/util/httputil"
+)
+
+type Reader interface {
+	Read() []struct {
+
+		// The job name to which the job label is set by default.
+		JobName string
+		// Indicator whether the scraped metrics should remain unmodified.
+		HonorLabels bool
+		// A set of query parameters with which the target is scraped.
+		Params url.Values
+		// How frequently to scrape the targets of this scrape config.
+		ScrapeInterval time.Duration
+		// The timeout for scraping targets of this config.
+		ScrapeTimeout time.Duration
+		// The HTTP resource path on which to fetch metrics from targets.
+		MetricsPath string
+		// The URL scheme with which to fetch metrics from targets.
+		Scheme string
+		// More than this many samples post metric-relabelling will cause the scrape to fail.
+		SampleLimit uint
+
+		HTTPClientConfig struct {
+			// The HTTP basic authentication credentials for the targets.
+			BasicAuth *struct {
+				Username string
+				Password string
+			}
+			// The bearer token for the targets.
+			BearerToken string
+			// The bearer token file for the targets.
+			BearerTokenFile string
+			// HTTP proxy server to use to connect to the targets.
+			ProxyURL *url.URL
+			// TLSConfig to use to connect to the targets.
+			TLSConfig struct {
+				// The CA cert to use for the targets.
+				CAFile string
+				// The client cert file for the targets.
+				CertFile string
+				// The client key file for the targets.
+				KeyFile string
+				// Used to verify the hostname for the targets.
+				ServerName string
+				// Disable target certificate validation.
+				InsecureSkipVerify bool
+			}
+		}
+
+		// List of target relabel configurations.
+		RelabelConfigs []struct {
+			// A list of labels from which values are taken and concatenated
+			// with the configured separator in order.
+			SourceLabels []string
+			// Separator is the string between concatenated values from the source labels.
+			Separator string
+			// Regex against which the concatenation is matched.
+			Regex struct {
+				*regexp.Regexp
+				original string
+			}
+			// Modulus to take of the hash of concatenated values from the source labels.
+			Modulus uint64
+			// TargetLabel is the label to which the resulting string is written in a replacement.
+			// Regexp interpolation is allowed for the replace action.
+			TargetLabel string
+			// Replacement is the regex replacement pattern to be used.
+			Replacement string
+			// Action is the action to be performed for the relabeling.
+			Action string
+		}
+		// List of metric relabel configurations.
+		MetricRelabelConfigs []struct {
+			// A list of labels from which values are taken and concatenated
+			// with the configured separator in order.
+			SourceLabels []string
+			// Separator is the string between concatenated values from the source labels.
+			Separator string
+			// Regex against which the concatenation is matched.
+			Regex struct {
+				*regexp.Regexp
+				original string
+			}
+			// Modulus to take of the hash of concatenated values from the source labels.
+			Modulus uint64
+			// TargetLabel is the label to which the resulting string is written in a replacement.
+			// Regexp interpolation is allowed for the replace action.
+			TargetLabel string
+			// Replacement is the regex replacement pattern to be used.
+			Replacement string
+			// Action is the action to be performed for the relabeling.
+			Action string
+		}
+	}
+}
+
+type Config struct {
+	// The job name to which the job label is set by default.
+	JobName string
+	// Indicator whether the scraped metrics should remain unmodified.
+	HonorLabels bool
+	// A set of query parameters with which the target is scraped.
+	Params url.Values
+	// How frequently to scrape the targets of this scrape config.
+	ScrapeInterval time.Duration
+	// The timeout for scraping targets of this config.
+	ScrapeTimeout time.Duration
+	// The HTTP resource path on which to fetch metrics from targets.
+	MetricsPath string
+	// The URL scheme with which to fetch metrics from targets.
+	Scheme string
+	// More than this many samples post metric-relabelling will cause the scrape to fail.
+	SampleLimit uint
+
+	HTTPClientConfig httputil.HTTPClientConfig
+
+	// List of target relabel configurations.
+	RelabelConfigs RelabelConfig
+	// List of metric relabel configurations.
+	MetricRelabelConfigs RelabelConfig
+}
+
+// RelabelConfig is the configuration for relabeling of target label sets.
+type RelabelConfig []struct {
+	// A list of labels from which values are taken and concatenated
+	// with the configured separator in order.
+	SourceLabels []string
+	// Separator is the string between concatenated values from the source labels.
+	Separator string
+	// Regex against which the concatenation is matched.
+	Regex struct {
+		*regexp.Regexp
+		original string
+	}
+	// Modulus to take of the hash of concatenated values from the source labels.
+	Modulus uint64
+	// TargetLabel is the label to which the resulting string is written in a replacement.
+	// Regexp interpolation is allowed for the replace action.
+	TargetLabel string
+	// Replacement is the regex replacement pattern to be used.
+	Replacement string
+	// Action is the action to be performed for the relabeling.
+	Action string
+}
+
+const (
+	// RelabelReplace performs a regex replacement.
+	RelabelReplace = "replace"
+	// RelabelKeep drops targets for which the input does not match the regex.
+	RelabelKeep = "keep"
+	// RelabelDrop drops targets for which the input does match the regex.
+	RelabelDrop = "drop"
+	// RelabelHashMod sets a label to the modulus of a hash of labels.
+	RelabelHashMod = "hashmod"
+	// RelabelLabelMap copies labels to other labelnames based on a regex.
+	RelabelLabelMap = "labelmap"
+	// RelabelLabelDrop drops any label matching the regex.
+	RelabelLabelDrop = "labeldrop"
+	// RelabelLabelKeep drops any label not matching the regex.
+	RelabelLabelKeep = "labelkeep"
+)
+
+// // RelabelAction is the action to be performed on relabeling.
+// type RelabelAction string
+
+// Regexp encapsulates a regexp.Regexp and makes it YAML marshallable.
+// type Regexp struct {
+// 	*regexp.Regexp
+// 	original string
+// }
+
+// TargetGroup is a set of targets with a common label set(production , test, staging etc.).
+type TargetGroup struct {
+	// Targets is a list of targets identified by a label set. Each target is
+	// uniquely identifiable in the group by its address label.
+	Targets []model.LabelSet
+	// Labels is a set of labels that is common across all targets in the group.
+	Labels model.LabelSet
+
+	// Source is an identifier that describes a group of targets.
+	Source string
+}

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -54,8 +54,6 @@ type ScrapeManager struct {
 
 // Run starts background processing to handle target updates and reload the scraping loops.
 func (m *ScrapeManager) Run(tsets <-chan map[string][]*config.TargetGroup) error {
-	level.Info(m.logger).Log("msg", "Starting scrape manager...")
-
 	for {
 		select {
 		case f := <-m.actionCh:

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -305,7 +305,7 @@ func TestUpdate(t *testing.T) {
 	})
 	ruleManager.Run()
 
-	err := ruleManager.Update(0, nil)
+	err := ruleManager.Reload(nil)
 	testutil.Ok(t, err)
 	for _, g := range ruleManager.groups {
 		g.seriesInPreviousEval = []map[string]labels.Labels{
@@ -313,7 +313,7 @@ func TestUpdate(t *testing.T) {
 		}
 	}
 
-	err = ruleManager.Update(0, nil)
+	err = ruleManager.Reload(nil)
 	testutil.Ok(t, err)
 	for _, g := range ruleManager.groups {
 		for _, actual := range g.seriesInPreviousEval {

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -49,13 +49,13 @@ func NewStorage(l log.Logger, stCallback startTimeCallback) *Storage {
 	return &Storage{logger: l, localStartTimeCallback: stCallback}
 }
 
-// ApplyConfig updates the state as the new config requires.
-func (s *Storage) ApplyConfig(conf *config.Config) error {
+// Reload updates the state as the new config requires.
+func (s *Storage) Reload(cfg config.ReloadReader) error {
+	conf := cfg.Read()
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
 	// Update write queues
-
 	newQueues := []*QueueManager{}
 	// TODO: we should only stop & recreate queues which have changes,
 	// as this can be quite disruptive.

--- a/web/federate.go
+++ b/web/federate.go
@@ -124,7 +124,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 
 	sort.Sort(byName(vec))
 
-	externalLabels := h.config.GlobalConfig.ExternalLabels.Clone()
+	externalLabels := h.config.Read().GlobalConfig.ExternalLabels.Clone()
 	if _, ok := externalLabels[model.InstanceLabel]; !ok {
 		externalLabels[model.InstanceLabel] = ""
 	}

--- a/web/web.go
+++ b/web/web.go
@@ -99,16 +99,6 @@ type Handler struct {
 	ready uint32 // ready is uint32 rather than boolean to be able to use atomic functions.
 }
 
-// Reload updates the config field of the Handler struct
-// func (h *Handler) Reload(conf config.ReloadReader) error {
-// 	h.mtx.Lock()
-// 	defer h.mtx.Unlock()
-
-// 	h.config = conf
-
-// 	return nil
-// }
-
 // PrometheusVersion contains build information about Prometheus.
 type PrometheusVersion struct {
 	Version   string `json:"version"`

--- a/web/web.go
+++ b/web/web.go
@@ -42,9 +42,9 @@ import (
 	"github.com/cockroachdb/cmux"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/mwitkow/go-conntrack"
+	conntrack "github.com/mwitkow/go-conntrack"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
@@ -85,7 +85,7 @@ type Handler struct {
 	quitCh       chan struct{}
 	reloadCh     chan chan error
 	options      *Options
-	config       *config.Config
+	config       config.ReloadReader
 	configString string
 	versionInfo  *PrometheusVersion
 	birth        time.Time
@@ -99,15 +99,15 @@ type Handler struct {
 	ready uint32 // ready is uint32 rather than boolean to be able to use atomic functions.
 }
 
-// ApplyConfig updates the config field of the Handler struct
-func (h *Handler) ApplyConfig(conf *config.Config) error {
-	h.mtx.Lock()
-	defer h.mtx.Unlock()
+// Reload updates the config field of the Handler struct
+// func (h *Handler) Reload(conf config.ReloadReader) error {
+// 	h.mtx.Lock()
+// 	defer h.mtx.Unlock()
 
-	h.config = conf
+// 	h.config = conf
 
-	return nil
-}
+// 	return nil
+// }
 
 // PrometheusVersion contains build information about Prometheus.
 type PrometheusVersion struct {
@@ -146,7 +146,7 @@ type Options struct {
 }
 
 // New initializes a new web Handler.
-func New(logger log.Logger, o *Options) *Handler {
+func New(logger log.Logger, o *Options, cfg config.ReloadReader) *Handler {
 	router := route.New()
 	cwd, err := os.Getwd()
 
@@ -179,13 +179,15 @@ func New(logger log.Logger, o *Options) *Handler {
 		now: model.Now,
 
 		ready: 0,
+
+		config: cfg,
 	}
 
 	h.apiV1 = api_v1.NewAPI(h.queryEngine, h.storage, h.scrapeManager, h.notifier,
 		func() config.Config {
 			h.mtx.RLock()
 			defer h.mtx.RUnlock()
-			return *h.config
+			return h.config.Read()
 		},
 		h.testReady,
 		h.options.TSDB,
@@ -578,7 +580,7 @@ func (h *Handler) serveConfig(w http.ResponseWriter, r *http.Request) {
 	h.mtx.RLock()
 	defer h.mtx.RUnlock()
 
-	h.executeTemplate(w, "config.html", h.config.String())
+	h.executeTemplate(w, "config.html", h.config.Read().String())
 }
 
 func (h *Handler) rules(w http.ResponseWriter, r *http.Request) {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -107,7 +107,7 @@ func TestReadyAndHealthy(t *testing.T) {
 
 	opts.Flags = map[string]string{}
 
-	webHandler := New(nil, opts)
+	webHandler := New(nil, opts, nil)
 	go webHandler.Run(context.Background())
 
 	// Give some time for the web goroutine to run since we need the server
@@ -198,7 +198,7 @@ func TestRoutePrefix(t *testing.T) {
 
 	opts.Flags = map[string]string{}
 
-	webHandler := New(nil, opts)
+	webHandler := New(nil, opts, nil)
 	go func() {
 		err := webHandler.Run(context.Background())
 		if err != nil {
@@ -282,7 +282,7 @@ func TestDebugHandler(t *testing.T) {
 			RoutePrefix: tc.prefix,
 			MetricsPath: "/metrics",
 		}
-		handler := New(nil, opts)
+		handler := New(nil, opts, nil)
 		handler.Ready()
 
 		w := httptest.NewRecorder()


### PR DESCRIPTION
1. Eliminate ApplyConfig method for components that only need to read most updated configs. now can use the `config.Read() ` interface method.
2. Remove the need of the  reloadReady channel blocker workaround.
3. Renamed `ApplyConfig` to `Reload` and the `Reload` method has a more distinct function of reloading a component where previously it was used for reloading only the config for some component. 
4. Fixes a bug when while reloading the configuration  the discovery manager send new targets and the scrape manager still reads the config before the reload.(configuration mismatch between components.)

TODO:
- [ ] fix the tests
- [ ] test the reload for each component!
- [ ] config reload tests!

Another PR:
when at least one component/manager don't like the new config  on a `Reload`, roll back previous configuration so that prometheus continues to work.

PTAL: @fabxc , @brancz , @simonpasquier 
