### PR TITLE
Fix default of read_recent to be false.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -197,7 +197,6 @@ var (
 	// DefaultRemoteReadConfig is the default remote read configuration.
 	DefaultRemoteReadConfig = RemoteReadConfig{
 		RemoteTimeout: model.Duration(1 * time.Minute),
-		ReadRecent:    true,
 	}
 )
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1136,6 +1136,10 @@ required_matchers:
 # Timeout for requests to the remote read endpoint.
 [ remote_timeout: <duration> | default = 30s ]
 
+# Whether reads should be made for queries for time ranges that
+# the local storage should have complete data for.
+[ read_recent: <boolean> | default = false ]
+
 # Sets the `Authorization` header on every remote read request with the
 # configured username and password.
 basic_auth:


### PR DESCRIPTION
This is what is documented in the migration guide, and the default settings
should make sense for a true long term storage.

Document the setting.