### PR TITLE
Change StalenessDelta to be per-statement

### DIFF
--- a/promql/ast.go
+++ b/promql/ast.go
@@ -72,6 +72,10 @@ type EvalStmt struct {
 	Start, End model.Time
 	// Time between two evaluated instants for the range [Start:End].
 	Interval time.Duration
+
+	// StalenessDelta determines the time since the last sample after which a time
+	// series is considered stale.
+	stalenessDelta time.Duration
 }
 
 // RecordStmt represents an added recording rule.


### PR DESCRIPTION
With the current package-global StalenessDelta you have to pick a single
StalenessDelta for all queries that will be ever done in your process.
This is difficult, when the queries you are processing vary wildly in
duration (1h vs 30d). In the case of a 1h query, a 5m StalenessDelta is
okay (maybe too long) but for a 30d range that might be too low (as the
step interval may be significnatly longer).

This change allows the user of the engine to define a function to
determine a StalenessDelta based on the query that you are processing.
This maintains compatibility by providing a default function to return a
5m duration (the old hard-code).