### PR TITLE
Add Healthcheck to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles
     ln -s /prometheus /etc/prometheus/data
 
 USER       nobody
+HEALTHCHECK CMD wget -q --spider http://localhost:9090/-/healthy || exit 1
 EXPOSE     9090
 VOLUME     [ "/prometheus" ]
 WORKDIR    /etc/prometheus


### PR DESCRIPTION
Adds an internal healthcheck using the `/-/healthy` input to see
if the container is healthy. 

I have tested this with a healthy container and it correctly reports the container as healthy. However, I am not sure how to force Prometheus to report itself as unhealthy and as such, that still needs to be tested.