### PR TITLE
remote_storage_adapter - reuse connection to graphite

### DIFF
--- a/documentation/examples/remote_storage/remote_storage_adapter/main.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/main.go
@@ -54,6 +54,7 @@ type config struct {
 	remoteTimeout           time.Duration
 	listenAddr              string
 	telemetryPath           string
+	logLevel                string
 }
 
 var (
@@ -99,7 +100,7 @@ func main() {
 	http.Handle(cfg.telemetryPath, prometheus.Handler())
 
 	logLevel := promlog.AllowedLevel{}
-	logLevel.Set("debug")
+	logLevel.Set(cfg.logLevel)
 
 	logger := promlog.New(logLevel)
 
@@ -141,6 +142,7 @@ func parseFlags() *config {
 	)
 	flag.StringVar(&cfg.listenAddr, "web.listen-address", ":9201", "Address to listen on for web endpoints.")
 	flag.StringVar(&cfg.telemetryPath, "web.telemetry-path", "/metrics", "Address to listen on for web endpoints.")
+	flag.StringVar(&cfg.logLevel, "log.level", "debug", "Logging level, one of debug, info, warn, error.")
 
 	flag.Parse()
 


### PR DESCRIPTION
Hello,

Currently, the graphite remote_storage_adapter creates a new connection each time it sends data to graphite. This can be an issue for logstash, that is not able to cope with so many connections and crashes.

This patch tries to reuse the connection, if exists already. Otherwise, it creates it. Since the send can be initiated by a remote call to the adapter (that can be in parallel with the current one), the connection object is protected with a lock.

Another small addition is a flag to allow configuring logging verbosity, as I've seen lots of metrics being logged that they are not sent when they have a NaN value.

If you want to integrate PR #3533 first, it's no problem - I can redo the changes here - just let me know.

Thanks!