### PR TITLE
discovery - handle Discoverers that send only target Group updates.

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -69,8 +69,8 @@ func NewManager(logger log.Logger) *Manager {
 	}
 }
 
-// Manager maintains a set of discovery providers and sends each update to a channel used by other packages.
-// Targets sent to the channel are grouped by the target set name.
+// Manager maintains a set of discovery providers and sends each update to a map channel.
+// Targets are grouped by the target set name.
 type Manager struct {
 	logger         log.Logger
 	actionCh       chan func(context.Context)
@@ -182,7 +182,7 @@ func (m *Manager) allGroups() map[string][]*targetgroup.Group {
 		for pkey, tsets := range m.targets {
 			for _, tg := range tsets {
 				// Even if the target group 'tg' is empty we still need to send it to the 'Scrape manager'
-				// to singal that is needs to stop all scrape loops for this target set.
+				// to signal that it needs to stop all scrape loops for this target set.
 				tSetsAll[pkey.setName] = append(tSetsAll[pkey.setName], tg)
 			}
 		}

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -155,11 +155,6 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
 	done := make(chan struct{})
 
 	m.actionCh <- func(ctx context.Context) {
-		if tgs == nil {
-			close(done)
-			return
-		}
-
 		for _, tg := range tgs {
 			if tg != nil { // Some Discoverers send nil target group so need to check for it to avoid panics.
 				if _, ok := m.targets[poolKey]; !ok {

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -75,7 +75,7 @@ type Manager struct {
 	actionCh       chan func(context.Context)
 	discoverCancel []context.CancelFunc
 	// Some Discoverers(eg. k8s) send only the updates for a given target group
-	// so we use map[tg.Source]*targetgroup.Group to  know which group to update.
+	// so we use map[tg.Source]*targetgroup.Group to know which group to update.
 	targets map[poolKey]map[string]*targetgroup.Group
 	// The sync channels sends the updates in map[targetSetName] where targetSetName is the job value from the scrape config.
 	syncCh chan map[string][]*targetgroup.Group

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -154,14 +154,17 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
 	done := make(chan struct{})
 
 	m.actionCh <- func(ctx context.Context) {
-		if tgs != nil {
-			for _, tg := range tgs {
-				if tg != nil { // Some Discoverers send nil targetgroup so need to check for it to avoid panics.
-					if _, ok := m.targets[poolKey]; !ok {
-						m.targets[poolKey] = make(map[string]*targetgroup.Group)
-					}
-					m.targets[poolKey][tg.Source] = tg
+		if tgs == nil {
+			close(done)
+			return
+		}
+
+		for _, tg := range tgs {
+			if tg != nil { // Some Discoverers send nil targetgroup so need to check for it to avoid panics.
+				if _, ok := m.targets[poolKey]; !ok {
+					m.targets[poolKey] = make(map[string]*targetgroup.Group)
 				}
+				m.targets[poolKey][tg.Source] = tg
 			}
 		}
 		close(done)

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -179,8 +179,16 @@ func (m *Manager) allGroups() map[string][]*targetgroup.Group {
 	m.actionCh <- func(ctx context.Context) {
 		tSetsAll := map[string][]*targetgroup.Group{}
 		for pkey, tsets := range m.targets {
+			del := true
 			for _, tg := range tsets {
-				tSetsAll[pkey.setName] = append(tSetsAll[pkey.setName], tg)
+				if len(tg.Targets) != 0 {
+					tSetsAll[pkey.setName] = append(tSetsAll[pkey.setName], tg)
+					del = false
+				}
+			}
+			// Delete the empty map for this target set to avoid memory leaks.
+			if del {
+				delete(m.targets, pkey)
 			}
 		}
 		tSets <- tSetsAll

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -74,7 +74,8 @@ type Manager struct {
 	logger         log.Logger
 	actionCh       chan func(context.Context)
 	discoverCancel []context.CancelFunc
-	// We use map[string]*targetgroup.Group to handle Discoverers that send only updates instead of all targets on every update.
+	// Some Discoverers(eg. k8s) send only the updates for a given target group
+	// so we use map[tg.Source]*targetgroup.Group to  know which group to update.
 	targets map[poolKey]map[string]*targetgroup.Group
 	// The sync channels sends the updates in map[targetSetName] where targetSetName is the job value from the scrape config.
 	syncCh chan map[string][]*targetgroup.Group

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -103,11 +104,11 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "initial1",
+								Source:  "tp1_group1",
 								Targets: []model.LabelSet{{"__instance__": "1"}},
 							},
 							{
-								Source:  "initial2",
+								Source:  "tp1_group2",
 								Targets: []model.LabelSet{{"__instance__": "2"}},
 							}},
 					},
@@ -116,11 +117,11 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 			expectedTargets: [][]*targetgroup.Group{
 				{
 					{
-						Source:  "initial1",
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "1"}},
 					},
 					{
-						Source:  "initial2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "2"}},
 					},
 				},
@@ -133,11 +134,11 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "tp1-initial1",
+								Source:  "tp1_group1",
 								Targets: []model.LabelSet{{"__instance__": "1"}},
 							},
 							{
-								Source:  "tp1-initial2",
+								Source:  "tp1_group2",
 								Targets: []model.LabelSet{{"__instance__": "2"}},
 							},
 						},
@@ -147,7 +148,7 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "tp2-initial1",
+								Source:  "tp2_group1",
 								Targets: []model.LabelSet{{"__instance__": "3"}},
 							},
 						},
@@ -158,24 +159,24 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 			expectedTargets: [][]*targetgroup.Group{
 				{
 					{
-						Source:  "tp1-initial1",
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "1"}},
 					},
 					{
-						Source:  "tp1-initial2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "2"}},
 					},
 				}, {
 					{
-						Source:  "tp1-initial1",
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "1"}},
 					},
 					{
-						Source:  "tp1-initial2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "2"}},
 					},
 					{
-						Source:  "tp2-initial1",
+						Source:  "tp2_group1",
 						Targets: []model.LabelSet{{"__instance__": "3"}},
 					},
 				},
@@ -188,48 +189,11 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "initial1",
+								Source:  "tp1_group1",
 								Targets: []model.LabelSet{{"__instance__": "1"}},
 							},
 							{
-								Source:  "initial2",
-								Targets: []model.LabelSet{{"__instance__": "2"}},
-							},
-						},
-						interval: 0,
-					},
-					{
-						targetGroups: []targetgroup.Group{},
-						interval:     10,
-					},
-				},
-			},
-			expectedTargets: [][]*targetgroup.Group{
-				{
-					{
-						Source:  "initial1",
-						Targets: []model.LabelSet{{"__instance__": "1"}},
-					},
-					{
-						Source:  "initial2",
-						Targets: []model.LabelSet{{"__instance__": "2"}},
-					},
-				},
-				{},
-			},
-		},
-		{
-			title: "Single TP initials and new groups",
-			updates: map[string][]update{
-				"tp1": {
-					{
-						targetGroups: []targetgroup.Group{
-							{
-								Source:  "initial1",
-								Targets: []model.LabelSet{{"__instance__": "1"}},
-							},
-							{
-								Source:  "initial2",
+								Source:  "tp1_group2",
 								Targets: []model.LabelSet{{"__instance__": "2"}},
 							},
 						},
@@ -238,12 +202,12 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "update1",
-								Targets: []model.LabelSet{{"__instance__": "3"}},
+								Source:  "tp1_group1",
+								Targets: []model.LabelSet{},
 							},
 							{
-								Source:  "update2",
-								Targets: []model.LabelSet{{"__instance__": "4"}},
+								Source:  "tp1_group2",
+								Targets: []model.LabelSet{},
 							},
 						},
 						interval: 10,
@@ -253,22 +217,85 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 			expectedTargets: [][]*targetgroup.Group{
 				{
 					{
-						Source:  "initial1",
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "1"}},
 					},
 					{
-						Source:  "initial2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "2"}},
 					},
 				},
 				{
 					{
-						Source:  "update1",
+						Source:  "tp1_group1",
+						Targets: []model.LabelSet{},
+					},
+					{
+						Source:  "tp1_group2",
+						Targets: []model.LabelSet{},
+					},
+				},
+			},
+		},
+		{
+			title: "Single TP initials and new groups",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []targetgroup.Group{
+							{
+								Source:  "tp1_group1",
+								Targets: []model.LabelSet{{"__instance__": "1"}},
+							},
+							{
+								Source:  "tp1_group2",
+								Targets: []model.LabelSet{{"__instance__": "2"}},
+							},
+						},
+						interval: 0,
+					},
+					{
+						targetGroups: []targetgroup.Group{
+							{
+								Source:  "tp1_group1",
+								Targets: []model.LabelSet{{"__instance__": "3"}},
+							},
+							{
+								Source:  "tp1_group2",
+								Targets: []model.LabelSet{{"__instance__": "4"}},
+							},
+							{
+								Source:  "tp1_group3",
+								Targets: []model.LabelSet{{"__instance__": "1"}},
+							},
+						},
+						interval: 10,
+					},
+				},
+			},
+			expectedTargets: [][]*targetgroup.Group{
+				{
+					{
+						Source:  "tp1_group1",
+						Targets: []model.LabelSet{{"__instance__": "1"}},
+					},
+					{
+						Source:  "tp1_group2",
+						Targets: []model.LabelSet{{"__instance__": "2"}},
+					},
+				},
+				{
+					{
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "3"}},
 					},
 					{
-						Source:  "update2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "4"}},
+					},
+					{
+						Source:  "tp1_group3",
+						Targets: []model.LabelSet{{"__instance__": "1"}},
 					},
 				},
 			},
@@ -280,11 +307,11 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "tp1-initial1",
+								Source:  "tp1_group1",
 								Targets: []model.LabelSet{{"__instance__": "1"}},
 							},
 							{
-								Source:  "tp1-initial2",
+								Source:  "tp1_group2",
 								Targets: []model.LabelSet{{"__instance__": "2"}},
 							},
 						},
@@ -293,11 +320,11 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "tp1-update1",
+								Source:  "tp1_group3",
 								Targets: []model.LabelSet{{"__instance__": "3"}},
 							},
 							{
-								Source:  "tp1-update2",
+								Source:  "tp1_group4",
 								Targets: []model.LabelSet{{"__instance__": "4"}},
 							},
 						},
@@ -308,11 +335,11 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "tp2-initial1",
+								Source:  "tp2_group1",
 								Targets: []model.LabelSet{{"__instance__": "5"}},
 							},
 							{
-								Source:  "tp2-initial2",
+								Source:  "tp2_group2",
 								Targets: []model.LabelSet{{"__instance__": "6"}},
 							},
 						},
@@ -321,11 +348,11 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "tp2-update1",
+								Source:  "tp2_group3",
 								Targets: []model.LabelSet{{"__instance__": "7"}},
 							},
 							{
-								Source:  "tp2-update2",
+								Source:  "tp2_group4",
 								Targets: []model.LabelSet{{"__instance__": "8"}},
 							},
 						},
@@ -336,82 +363,106 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 			expectedTargets: [][]*targetgroup.Group{
 				{
 					{
-						Source:  "tp1-initial1",
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "1"}},
 					},
 					{
-						Source:  "tp1-initial2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "2"}},
 					},
 				},
 				{
 					{
-						Source:  "tp1-initial1",
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "1"}},
 					},
 					{
-						Source:  "tp1-initial2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "2"}},
 					},
 					{
-						Source:  "tp2-initial1",
+						Source:  "tp2_group1",
 						Targets: []model.LabelSet{{"__instance__": "5"}},
 					},
 					{
-						Source:  "tp2-initial2",
+						Source:  "tp2_group2",
 						Targets: []model.LabelSet{{"__instance__": "6"}},
 					},
 				},
 				{
 					{
-						Source:  "tp1-initial1",
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "1"}},
 					},
 					{
-						Source:  "tp1-initial2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "2"}},
 					},
 					{
-						Source:  "tp2-update1",
+						Source:  "tp2_group1",
+						Targets: []model.LabelSet{{"__instance__": "5"}},
+					},
+					{
+						Source:  "tp2_group2",
+						Targets: []model.LabelSet{{"__instance__": "6"}},
+					},
+					{
+						Source:  "tp2_group3",
 						Targets: []model.LabelSet{{"__instance__": "7"}},
 					},
 					{
-						Source:  "tp2-update2",
+						Source:  "tp2_group4",
 						Targets: []model.LabelSet{{"__instance__": "8"}},
 					},
 				},
 				{
 					{
-						Source:  "tp1-update1",
+						Source:  "tp1_group1",
+						Targets: []model.LabelSet{{"__instance__": "1"}},
+					},
+					{
+						Source:  "tp1_group2",
+						Targets: []model.LabelSet{{"__instance__": "2"}},
+					},
+					{
+						Source:  "tp1_group3",
 						Targets: []model.LabelSet{{"__instance__": "3"}},
 					},
 					{
-						Source:  "tp1-update2",
+						Source:  "tp1_group4",
 						Targets: []model.LabelSet{{"__instance__": "4"}},
 					},
 					{
-						Source:  "tp2-update1",
+						Source:  "tp2_group1",
+						Targets: []model.LabelSet{{"__instance__": "5"}},
+					},
+					{
+						Source:  "tp2_group2",
+						Targets: []model.LabelSet{{"__instance__": "6"}},
+					},
+					{
+						Source:  "tp2_group3",
 						Targets: []model.LabelSet{{"__instance__": "7"}},
 					},
 					{
-						Source:  "tp2-update2",
+						Source:  "tp2_group4",
 						Targets: []model.LabelSet{{"__instance__": "8"}},
 					},
 				},
 			},
 		},
 		{
-			title: "One tp initials arrive after other tp updates.",
+			title: "One TP initials arrive after other TP updates.",
 			updates: map[string][]update{
 				"tp1": {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "tp1-initial1",
+								Source:  "tp1_group1",
 								Targets: []model.LabelSet{{"__instance__": "1"}},
 							},
 							{
-								Source:  "tp1-initial2",
+								Source:  "tp1_group2",
 								Targets: []model.LabelSet{{"__instance__": "2"}},
 							},
 						},
@@ -420,11 +471,11 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "tp1-update1",
+								Source:  "tp1_group1",
 								Targets: []model.LabelSet{{"__instance__": "3"}},
 							},
 							{
-								Source:  "tp1-update2",
+								Source:  "tp1_group2",
 								Targets: []model.LabelSet{{"__instance__": "4"}},
 							},
 						},
@@ -435,11 +486,11 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "tp2-initial1",
+								Source:  "tp2_group1",
 								Targets: []model.LabelSet{{"__instance__": "5"}},
 							},
 							{
-								Source:  "tp2-initial2",
+								Source:  "tp2_group2",
 								Targets: []model.LabelSet{{"__instance__": "6"}},
 							},
 						},
@@ -448,11 +499,11 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "tp2-update1",
+								Source:  "tp2_group1",
 								Targets: []model.LabelSet{{"__instance__": "7"}},
 							},
 							{
-								Source:  "tp2-update2",
+								Source:  "tp2_group2",
 								Targets: []model.LabelSet{{"__instance__": "8"}},
 							},
 						},
@@ -463,57 +514,57 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 			expectedTargets: [][]*targetgroup.Group{
 				{
 					{
-						Source:  "tp1-initial1",
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "1"}},
 					},
 					{
-						Source:  "tp1-initial2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "2"}},
 					},
 				},
 				{
 					{
-						Source:  "tp1-update1",
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "3"}},
 					},
 					{
-						Source:  "tp1-update2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "4"}},
 					},
 				},
 				{
 					{
-						Source:  "tp1-update1",
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "3"}},
 					},
 					{
-						Source:  "tp1-update2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "4"}},
 					},
 					{
-						Source:  "tp2-initial1",
+						Source:  "tp2_group1",
 						Targets: []model.LabelSet{{"__instance__": "5"}},
 					},
 					{
-						Source:  "tp2-initial2",
+						Source:  "tp2_group2",
 						Targets: []model.LabelSet{{"__instance__": "6"}},
 					},
 				},
 				{
 					{
-						Source:  "tp1-update1",
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "3"}},
 					},
 					{
-						Source:  "tp1-update2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "4"}},
 					},
 					{
-						Source:  "tp2-update1",
+						Source:  "tp2_group1",
 						Targets: []model.LabelSet{{"__instance__": "7"}},
 					},
 					{
-						Source:  "tp2-update2",
+						Source:  "tp2_group2",
 						Targets: []model.LabelSet{{"__instance__": "8"}},
 					},
 				},
@@ -521,34 +572,43 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 		},
 
 		{
-			title: "Single TP Single provider empty update in between",
+			title: "Single TP empty update in between",
 			updates: map[string][]update{
 				"tp1": {
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "initial1",
+								Source:  "tp1_group1",
 								Targets: []model.LabelSet{{"__instance__": "1"}},
 							},
 							{
-								Source:  "initial2",
+								Source:  "tp1_group2",
 								Targets: []model.LabelSet{{"__instance__": "2"}},
 							},
 						},
 						interval: 30,
 					},
 					{
-						targetGroups: []targetgroup.Group{},
-						interval:     10,
+						targetGroups: []targetgroup.Group{
+							{
+								Source:  "tp1_group1",
+								Targets: []model.LabelSet{},
+							},
+							{
+								Source:  "tp1_group2",
+								Targets: []model.LabelSet{},
+							},
+						},
+						interval: 10,
 					},
 					{
 						targetGroups: []targetgroup.Group{
 							{
-								Source:  "update1",
+								Source:  "tp1_group1",
 								Targets: []model.LabelSet{{"__instance__": "3"}},
 							},
 							{
-								Source:  "update2",
+								Source:  "tp1_group2",
 								Targets: []model.LabelSet{{"__instance__": "4"}},
 							},
 						},
@@ -559,22 +619,31 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 			expectedTargets: [][]*targetgroup.Group{
 				{
 					{
-						Source:  "initial1",
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "1"}},
 					},
 					{
-						Source:  "initial2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "2"}},
 					},
 				},
-				{},
 				{
 					{
-						Source:  "update1",
+						Source:  "tp1_group1",
+						Targets: []model.LabelSet{},
+					},
+					{
+						Source:  "tp1_group2",
+						Targets: []model.LabelSet{},
+					},
+				},
+				{
+					{
+						Source:  "tp1_group1",
 						Targets: []model.LabelSet{{"__instance__": "3"}},
 					},
 					{
-						Source:  "update2",
+						Source:  "tp1_group2",
 						Targets: []model.LabelSet{{"__instance__": "4"}},
 					},
 				},
@@ -606,6 +675,8 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 				break Loop
 			case tsetMap := <-discoveryManager.SyncCh():
 				for _, received := range tsetMap {
+					// Need to sort by the Groups source as the Discovery manager doesn't guarantee the order.
+					sort.Sort(byGroupSource(received))
 					if !reflect.DeepEqual(received, testCase.expectedTargets[x]) {
 						var receivedFormated string
 						for _, receivedTargets := range received {
@@ -628,7 +699,7 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 }
 
 func TestTargetSetRecreatesTargetGroupsEveryRun(t *testing.T) {
-	verifyPresence := func(tSets map[poolKey][]*targetgroup.Group, poolKey poolKey, label string, present bool) {
+	verifyPresence := func(tSets map[poolKey]map[string]*targetgroup.Group, poolKey poolKey, label string, present bool) {
 		if _, ok := tSets[poolKey]; !ok {
 			t.Fatalf("'%s' should be present in Pool keys: %v", poolKey, tSets)
 			return
@@ -729,3 +800,10 @@ func (tp mockdiscoveryProvider) sendUpdates() {
 		tp.up <- tgs
 	}
 }
+
+// byGroupSource implements sort.Interface so we can sort by the Source field.
+type byGroupSource []*targetgroup.Group
+
+func (a byGroupSource) Len() int           { return len(a) }
+func (a byGroupSource) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byGroupSource) Less(i, j int) bool { return a[i].Source < a[j].Source }

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -649,57 +649,6 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 				},
 			},
 		},
-		{
-			title: "Single TP update with an empty group to check for memory leaks",
-			updates: map[string][]update{
-				"tp1": {
-					{
-						targetGroups: []targetgroup.Group{
-							{
-								Source:  "tp1_group1",
-								Targets: []model.LabelSet{{"__instance__": "1"}},
-							},
-							{
-								Source:  "tp1_group2",
-								Targets: []model.LabelSet{{"__instance__": "2"}},
-							},
-						},
-						interval: 30,
-					},
-					{
-						targetGroups: []targetgroup.Group{
-							{
-								Source:  "tp1_group1",
-								Targets: []model.LabelSet{{"__instance__": "3"}},
-							},
-							{
-								Source:  "tp1_group2",
-								Targets: nil,
-							},
-						},
-						interval: 10,
-					},
-				},
-			},
-			expectedTargets: [][]*targetgroup.Group{
-				{
-					{
-						Source:  "tp1_group1",
-						Targets: []model.LabelSet{{"__instance__": "1"}},
-					},
-					{
-						Source:  "tp1_group2",
-						Targets: []model.LabelSet{{"__instance__": "2"}},
-					},
-				},
-				{
-					{
-						Source:  "tp1_group1",
-						Targets: []model.LabelSet{{"__instance__": "3"}},
-					},
-				},
-			},
-		},
 	}
 
 	for testIndex, testCase := range testCases {

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -649,6 +649,57 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 				},
 			},
 		},
+		{
+			title: "Single TP update with an empty group to check for memory leaks",
+			updates: map[string][]update{
+				"tp1": {
+					{
+						targetGroups: []targetgroup.Group{
+							{
+								Source:  "tp1_group1",
+								Targets: []model.LabelSet{{"__instance__": "1"}},
+							},
+							{
+								Source:  "tp1_group2",
+								Targets: []model.LabelSet{{"__instance__": "2"}},
+							},
+						},
+						interval: 30,
+					},
+					{
+						targetGroups: []targetgroup.Group{
+							{
+								Source:  "tp1_group1",
+								Targets: []model.LabelSet{{"__instance__": "3"}},
+							},
+							{
+								Source:  "tp1_group2",
+								Targets: nil,
+							},
+						},
+						interval: 10,
+					},
+				},
+			},
+			expectedTargets: [][]*targetgroup.Group{
+				{
+					{
+						Source:  "tp1_group1",
+						Targets: []model.LabelSet{{"__instance__": "1"}},
+					},
+					{
+						Source:  "tp1_group2",
+						Targets: []model.LabelSet{{"__instance__": "2"}},
+					},
+				},
+				{
+					{
+						Source:  "tp1_group1",
+						Targets: []model.LabelSet{{"__instance__": "3"}},
+					},
+				},
+			},
+		},
 	}
 
 	for testIndex, testCase := range testCases {

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -146,20 +146,15 @@ func (m *ScrapeManager) reload(t map[string][]*targetgroup.Group) error {
 		} else {
 			existing.Sync(tgroup)
 		}
+	}
 
-		// Cleanup - check the config and cancel the scrape loops if it don't exist in the scrape config.
-		jobs := make(map[string]struct{})
-
-		for k := range m.scrapeConfigs {
-			jobs[k] = struct{}{}
-		}
-
-		for name, sp := range m.scrapePools {
-			if _, ok := jobs[name]; !ok {
-				sp.stop()
-				delete(m.scrapePools, name)
-			}
+	// Cleanup - check the config and cancel the scrape loops if it don't exist in the scrape config.
+	for name, sp := range m.scrapePools {
+		if _, ok := m.scrapeConfigs[name]; !ok {
+			sp.stop()
+			delete(m.scrapePools, name)
 		}
 	}
+
 	return nil
 }

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -83,9 +83,11 @@ func (m *ScrapeManager) Stop() {
 func (m *ScrapeManager) ApplyConfig(cfg *config.Config) error {
 	done := make(chan struct{})
 	m.actionCh <- func() {
+		c := make(map[string]*config.ScrapeConfig)
 		for _, scfg := range cfg.ScrapeConfigs {
-			m.scrapeConfigs[scfg.JobName] = scfg
+			c[scfg.JobName] = scfg
 		}
+		m.scrapeConfigs = c
 		close(done)
 	}
 	<-done


### PR DESCRIPTION
The new Service Discovery implementation  assumed that SD providers will send all target groups on every update which is not the case for all SD providers. 
k8s for example sends only the updates and removed targets are send as an update to a target group  with zero targets in the struct.

So now we are using a string map for the targetGroups and just match the targetgroup updates by the `target Source` identifier.

fixes #3653 , #3651




Signed-off-by: Krasi Georgiev <krasi.root@gmail.com>
  
  