### PR TITLE
comments with TargetProvider should read Discoverer instead

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -95,7 +95,7 @@ func init() {
 }
 
 // Discovery periodically performs Azure-SD requests. It implements
-// the TargetProvider interface.
+// the Discoverer interface.
 type Discovery struct {
 	cfg      *SDConfig
 	interval time.Duration
@@ -116,7 +116,7 @@ func NewDiscovery(cfg *SDConfig, logger log.Logger) *Discovery {
 	}
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	ticker := time.NewTicker(d.interval)
 	defer ticker.Stop()

--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -202,7 +202,7 @@ func (d *Discovery) shouldWatch(name string) bool {
 	return false
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	// Watched services and their cancelation functions.
 	services := map[string]func(){}

--- a/discovery/dns/dns.go
+++ b/discovery/dns/dns.go
@@ -102,7 +102,7 @@ func init() {
 }
 
 // Discovery periodically performs DNS-SD requests. It implements
-// the TargetProvider interface.
+// the Discoverer interface.
 type Discovery struct {
 	names []string
 
@@ -136,7 +136,7 @@ func NewDiscovery(conf SDConfig, logger log.Logger) *Discovery {
 	}
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	ticker := time.NewTicker(d.interval)
 	defer ticker.Stop()

--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -117,7 +117,7 @@ func init() {
 }
 
 // Discovery periodically performs EC2-SD requests. It implements
-// the TargetProvider interface.
+// the Discoverer interface.
 type Discovery struct {
 	aws      *aws.Config
 	interval time.Duration
@@ -149,7 +149,7 @@ func NewDiscovery(conf *SDConfig, logger log.Logger) *Discovery {
 	}
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	ticker := time.NewTicker(d.interval)
 	defer ticker.Stop()

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -221,7 +221,7 @@ func (d *Discovery) watchFiles() {
 	}
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {

--- a/discovery/gce/gce.go
+++ b/discovery/gce/gce.go
@@ -114,7 +114,7 @@ func init() {
 }
 
 // Discovery periodically performs GCE-SD requests. It implements
-// the TargetProvider interface.
+// the Discoverer interface.
 type Discovery struct {
 	project      string
 	zone         string
@@ -155,7 +155,7 @@ func NewDiscovery(conf SDConfig, logger log.Logger) (*Discovery, error) {
 	return gd, nil
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	// Get an initial set right away.
 	tg, err := d.refresh()

--- a/discovery/kubernetes/endpoints.go
+++ b/discovery/kubernetes/endpoints.go
@@ -58,7 +58,7 @@ func NewEndpoints(l log.Logger, svc, eps, pod cache.SharedInformer) *Endpoints {
 	return ep
 }
 
-// Run implements the retrieval.TargetProvider interface.
+// Run implements the Discoverer interface.
 func (e *Endpoints) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	// Send full initial set of endpoint targets.
 	var initial []*targetgroup.Group

--- a/discovery/kubernetes/ingress.go
+++ b/discovery/kubernetes/ingress.go
@@ -38,7 +38,7 @@ func NewIngress(l log.Logger, inf cache.SharedInformer) *Ingress {
 	return &Ingress{logger: l, informer: inf, store: inf.GetStore()}
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (s *Ingress) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	// Send full initial set of pod targets.
 	var initial []*targetgroup.Group

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -152,7 +152,7 @@ func init() {
 	}
 }
 
-// Discovery implements the TargetProvider interface for discovering
+// Discovery implements the Discoverer interface for discovering
 // targets from Kubernetes.
 type Discovery struct {
 	client             kubernetes.Interface
@@ -244,7 +244,7 @@ func New(l log.Logger, conf *SDConfig) (*Discovery, error) {
 
 const resyncPeriod = 10 * time.Minute
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	rclient := d.client.Core().RESTClient()
 	reclient := d.client.Extensions().RESTClient()

--- a/discovery/kubernetes/node.go
+++ b/discovery/kubernetes/node.go
@@ -44,7 +44,7 @@ func NewNode(l log.Logger, inf cache.SharedInformer) *Node {
 	return &Node{logger: l, informer: inf, store: inf.GetStore()}
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (n *Node) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	// Send full initial set of pod targets.
 	var initial []*targetgroup.Group

--- a/discovery/kubernetes/node_test.go
+++ b/discovery/kubernetes/node_test.go
@@ -103,12 +103,12 @@ func (i *fakeInformer) Update(obj interface{}) {
 	}
 }
 
-type targetProvider interface {
+type discoverer interface {
 	Run(ctx context.Context, up chan<- []*targetgroup.Group)
 }
 
 type k8sDiscoveryTest struct {
-	discovery       targetProvider
+	discovery       discoverer
 	afterStart      func()
 	expectedInitial []*targetgroup.Group
 	expectedRes     []*targetgroup.Group

--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -50,7 +50,7 @@ func NewPod(l log.Logger, pods cache.SharedInformer) *Pod {
 	}
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (p *Pod) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	// Send full initial set of pod targets.
 	var initial []*targetgroup.Group

--- a/discovery/kubernetes/service.go
+++ b/discovery/kubernetes/service.go
@@ -44,7 +44,7 @@ func NewService(l log.Logger, inf cache.SharedInformer) *Service {
 	return &Service{logger: l, informer: inf, store: inf.GetStore()}
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (s *Service) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	// Send full initial set of pod targets.
 	var initial []*targetgroup.Group

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -175,7 +175,7 @@ func NewDiscovery(conf SDConfig, logger log.Logger) (*Discovery, error) {
 	}, nil
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	for {
 		select {

--- a/discovery/openstack/hypervisor.go
+++ b/discovery/openstack/hypervisor.go
@@ -53,7 +53,7 @@ func NewHypervisorDiscovery(opts *gophercloud.AuthOptions,
 		region: region, interval: interval, port: port, logger: l}
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (h *HypervisorDiscovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	// Get an initial set right away.
 	tg, err := h.refresh()

--- a/discovery/openstack/instance.go
+++ b/discovery/openstack/instance.go
@@ -62,7 +62,7 @@ func NewInstanceDiscovery(opts *gophercloud.AuthOptions,
 		region: region, interval: interval, port: port, logger: l}
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (i *InstanceDiscovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	// Get an initial set right away.
 	tg, err := i.refresh()

--- a/discovery/openstack/openstack.go
+++ b/discovery/openstack/openstack.go
@@ -112,7 +112,7 @@ func init() {
 }
 
 // Discovery periodically performs OpenStack-SD requests. It implements
-// the TargetProvider interface.
+// the Discoverer interface.
 type Discovery interface {
 	Run(ctx context.Context, ch chan<- []*targetgroup.Group)
 	refresh() (tg *targetgroup.Group, err error)

--- a/discovery/triton/triton.go
+++ b/discovery/triton/triton.go
@@ -115,7 +115,7 @@ type DiscoveryResponse struct {
 }
 
 // Discovery periodically performs Triton-SD requests. It implements
-// the TargetProvider interface.
+// the Discoverer interface.
 type Discovery struct {
 	client   *http.Client
 	interval time.Duration
@@ -151,7 +151,7 @@ func New(logger log.Logger, conf *SDConfig) (*Discovery, error) {
 	}, nil
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	defer close(ch)
 

--- a/discovery/zookeeper/zookeeper.go
+++ b/discovery/zookeeper/zookeeper.go
@@ -113,7 +113,7 @@ func (c *NerveSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-// Discovery implements the TargetProvider interface for discovering
+// Discovery implements the Discoverer interface for discovering
 // targets from Zookeeper.
 type Discovery struct {
 	conn *zk.Conn
@@ -169,7 +169,7 @@ func NewDiscovery(
 	return sd
 }
 
-// Run implements the TargetProvider interface.
+// Run implements the Discoverer interface.
 func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	defer func() {
 		for _, tc := range d.treeCaches {

--- a/retrieval/helpers_test.go
+++ b/retrieval/helpers_test.go
@@ -14,7 +14,6 @@
 package retrieval
 
 import (
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 )
@@ -69,26 +68,3 @@ func (a *collectResultAppender) Add(m labels.Labels, t int64, v float64) (uint64
 
 func (a *collectResultAppender) Commit() error   { return nil }
 func (a *collectResultAppender) Rollback() error { return nil }
-
-// fakeTargetProvider implements a TargetProvider and allows manual injection
-// of TargetGroups through the update channel.
-type fakeTargetProvider struct {
-	sources []string
-	update  chan *targetgroup.Group
-}
-
-func (tp *fakeTargetProvider) Run(ch chan<- targetgroup.Group, done <-chan struct{}) {
-	defer close(ch)
-	for {
-		select {
-		case tg := <-tp.update:
-			ch <- *tg
-		case <-done:
-			return
-		}
-	}
-}
-
-func (tp *fakeTargetProvider) Sources() []string {
-	return tp.sources
-}


### PR DESCRIPTION
Just updating comments to read `Discoverer` rather than `TargetProvider`, but this cause a moment of confusion while working on #3658 