### PR TITLE
Fix the incrementing of prometheus_target_scrapes_exceeded_sample_limit_total

### DIFF
--- a/retrieval/scrape.go
+++ b/retrieval/scrape.go
@@ -905,10 +905,9 @@ loop:
 		err = p.Err()
 	}
 	if sampleLimitErr != nil {
-		// We only want to increment this once per scrape, so this is Inc'd outside the loop
+		// We only want to increment this once per scrape, so this is Inc'd outside the loop.
 		targetScrapeSampleLimit.Inc()
 	}
-
 	if numOutOfOrder > 0 {
 		level.Warn(sl.l).Log("msg", "Error on ingesting out-of-order samples", "num_dropped", numOutOfOrder)
 	}

--- a/retrieval/scrape.go
+++ b/retrieval/scrape.go
@@ -904,10 +904,11 @@ loop:
 	if err == nil {
 		err = p.Err()
 	}
-	if err == nil && sampleLimitErr != nil {
+	if sampleLimitErr != nil {
+		// We only want to increment this once per scrape, so this is Inc'd outside the loop
 		targetScrapeSampleLimit.Inc()
-		err = sampleLimitErr
 	}
+
 	if numOutOfOrder > 0 {
 		level.Warn(sl.l).Log("msg", "Error on ingesting out-of-order samples", "num_dropped", numOutOfOrder)
 	}


### PR DESCRIPTION
Once a scrape target has reached the samle_limit, any further samples
from that target will continue to result in errSampleLimit.

This means that after the completion of the append loop `err` must still
be errSampleLimit, and so the metric would not have been incremented.

Fixes #3668 (@brian-brazil)