### PR TITLE
*: implement query params

### DIFF
--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -16,6 +16,7 @@ package promql
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
@@ -85,7 +86,7 @@ func TestDeriv(t *testing.T) {
 	// so we test it by hand.
 	storage := testutil.NewStorage(t)
 	defer storage.Close()
-	engine := NewEngine(storage, nil)
+	engine := NewEngine(nil, nil, 10, 10*time.Second)
 
 	a, err := storage.Appender()
 	if err != nil {
@@ -100,7 +101,7 @@ func TestDeriv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	query, err := engine.NewInstantQuery("deriv(foo[30m])", timestamp.Time(1493712846939))
+	query, err := engine.NewInstantQuery(storage, "deriv(foo[30m])", timestamp.Time(1493712846939))
 	if err != nil {
 		t.Fatalf("Error parsing query: %s", err)
 	}

--- a/promql/test.go
+++ b/promql/test.go
@@ -83,6 +83,11 @@ func (t *Test) QueryEngine() *Engine {
 	return t.queryEngine
 }
 
+// Queryable allows querying the test data.
+func (t *Test) Queryable() storage.Queryable {
+	return t.storage
+}
+
 // Context returns the test's context.
 func (t *Test) Context() context.Context {
 	return t.context
@@ -460,7 +465,7 @@ func (t *Test) exec(tc testCommand) error {
 		}
 
 	case *evalCmd:
-		q := t.queryEngine.newQuery(cmd.expr, cmd.start, cmd.end, cmd.interval)
+		q := t.queryEngine.newQuery(t.storage, cmd.expr, cmd.start, cmd.end, cmd.interval)
 		res := q.Exec(t.context)
 		if res.Err != nil {
 			if cmd.fail {
@@ -495,7 +500,7 @@ func (t *Test) clear() {
 	}
 	t.storage = testutil.NewStorage(t)
 
-	t.queryEngine = NewEngine(t.storage, nil)
+	t.queryEngine = NewEngine(nil, nil, 20, 10*time.Second)
 	t.context, t.cancelCtx = context.WithCancel(context.Background())
 }
 

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -106,9 +106,9 @@ type QueryFunc func(ctx context.Context, q string, t time.Time) (promql.Vector, 
 // EngineQueryFunc returns a new query function that executes instant queries against
 // the given engine.
 // It converts scaler into vector results.
-func EngineQueryFunc(engine *promql.Engine) QueryFunc {
+func EngineQueryFunc(engine *promql.Engine, q storage.Queryable) QueryFunc {
 	return func(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
-		q, err := engine.NewInstantQuery(qs, t)
+		q, err := engine.NewInstantQuery(q, qs, t)
 		if err != nil {
 			return nil, err
 		}

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -144,7 +144,7 @@ func TestAlertingRule(t *testing.T) {
 
 		evalTime := baseTime.Add(test.time)
 
-		res, err := rule.Eval(suite.Context(), evalTime, EngineQueryFunc(suite.QueryEngine()), nil)
+		res, err := rule.Eval(suite.Context(), evalTime, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil)
 		testutil.Ok(t, err)
 
 		for i := range test.result {
@@ -174,9 +174,9 @@ func annotateWithTime(lines []string, ts time.Time) []string {
 func TestStaleness(t *testing.T) {
 	storage := testutil.NewStorage(t)
 	defer storage.Close()
-	engine := promql.NewEngine(storage, nil)
+	engine := promql.NewEngine(nil, nil, 10, 10*time.Second)
 	opts := &ManagerOptions{
-		QueryFunc:  EngineQueryFunc(engine),
+		QueryFunc:  EngineQueryFunc(engine, storage),
 		Appendable: storage,
 		Context:    context.Background(),
 		Logger:     log.NewNopLogger(),
@@ -210,7 +210,7 @@ func TestStaleness(t *testing.T) {
 	matcher, err := labels.NewMatcher(labels.MatchEqual, model.MetricNameLabel, "a_plus_one")
 	testutil.Ok(t, err)
 
-	set, err := querier.Select(matcher)
+	set, err := querier.Select(nil, matcher)
 	testutil.Ok(t, err)
 
 	samples, err := readSeriesSet(set)

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -28,7 +28,7 @@ func TestRuleEval(t *testing.T) {
 	storage := testutil.NewStorage(t)
 	defer storage.Close()
 
-	engine := promql.NewEngine(storage, nil)
+	engine := promql.NewEngine(nil, nil, 10, 10*time.Second)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
 
@@ -62,7 +62,7 @@ func TestRuleEval(t *testing.T) {
 
 	for _, test := range suite {
 		rule := NewRecordingRule(test.name, test.expr, test.labels)
-		result, err := rule.Eval(ctx, now, EngineQueryFunc(engine), nil)
+		result, err := rule.Eval(ctx, now, EngineQueryFunc(engine, storage), nil)
 		testutil.Ok(t, err)
 		testutil.Equals(t, result, test.result)
 	}

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -216,10 +216,10 @@ func NewMergeQuerier(queriers []Querier) Querier {
 }
 
 // Select returns a set of series that matches the given label matchers.
-func (q *mergeQuerier) Select(matchers ...*labels.Matcher) (SeriesSet, error) {
+func (q *mergeQuerier) Select(params *SelectParams, matchers ...*labels.Matcher) (SeriesSet, error) {
 	seriesSets := make([]SeriesSet, 0, len(q.queriers))
 	for _, querier := range q.queriers {
-		set, err := querier.Select(matchers...)
+		set, err := querier.Select(params, matchers...)
 		if err != nil {
 			return nil, err
 		}

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -52,13 +52,19 @@ type Queryable interface {
 // Querier provides reading access to time series data.
 type Querier interface {
 	// Select returns a set of series that matches the given label matchers.
-	Select(...*labels.Matcher) (SeriesSet, error)
+	Select(*SelectParams, ...*labels.Matcher) (SeriesSet, error)
 
 	// LabelValues returns all potential values for a label name.
 	LabelValues(name string) ([]string, error)
 
 	// Close releases the resources of the Querier.
 	Close() error
+}
+
+// SelectParams specifies parameters passed to data selections.
+type SelectParams struct {
+	Step int64  // Query step size in milliseconds.
+	Func string // String representation of surrounding function or aggregation.
 }
 
 // QueryableFunc is an adapter to allow the use of ordinary functions as

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -22,7 +22,7 @@ func NoopQuerier() Querier {
 	return noopQuerier{}
 }
 
-func (noopQuerier) Select(...*labels.Matcher) (SeriesSet, error) {
+func (noopQuerier) Select(*SelectParams, ...*labels.Matcher) (SeriesSet, error) {
 	return NoopSeriesSet(), nil
 }
 

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -43,7 +43,7 @@ type querier struct {
 
 // Select implements storage.Querier and uses the given matchers to read series
 // sets from the Client.
-func (q *querier) Select(matchers ...*labels.Matcher) (storage.SeriesSet, error) {
+func (q *querier) Select(_ *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, error) {
 	query, err := ToQuery(q.mint, q.maxt, matchers)
 	if err != nil {
 		return nil, err
@@ -91,9 +91,9 @@ type externalLabelsQuerier struct {
 // Select adds equality matchers for all external labels to the list of matchers
 // before calling the wrapped storage.Queryable. The added external labels are
 // removed from the returned series sets.
-func (q externalLabelsQuerier) Select(matchers ...*labels.Matcher) (storage.SeriesSet, error) {
+func (q externalLabelsQuerier) Select(p *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, error) {
 	m, added := q.addExternalLabels(matchers)
-	s, err := q.Querier.Select(m...)
+	s, err := q.Querier.Select(p, m...)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ type requiredMatchersQuerier struct {
 
 // Select returns a NoopSeriesSet if the given matchers don't match the label
 // set of the requiredMatchersQuerier. Otherwise it'll call the wrapped querier.
-func (q requiredMatchersQuerier) Select(matchers ...*labels.Matcher) (storage.SeriesSet, error) {
+func (q requiredMatchersQuerier) Select(p *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, error) {
 	ms := q.requiredMatchers
 	for _, m := range matchers {
 		for i, r := range ms {
@@ -160,7 +160,7 @@ func (q requiredMatchersQuerier) Select(matchers ...*labels.Matcher) (storage.Se
 	if len(ms) > 0 {
 		return storage.NoopSeriesSet(), nil
 	}
-	return q.Querier.Select(matchers...)
+	return q.Querier.Select(p, matchers...)
 }
 
 // addExternalLabels adds matchers for each external label. External labels

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -42,7 +42,7 @@ func TestExternalLabelsQuerierSelect(t *testing.T) {
 		externalLabels: model.LabelSet{"region": "europe"},
 	}
 	want := newSeriesSetFilter(mockSeriesSet{}, q.externalLabels)
-	have, err := q.Select(matchers...)
+	have, err := q.Select(nil, matchers...)
 	if err != nil {
 		t.Error(err)
 	}
@@ -157,7 +157,7 @@ type mockSeriesSet struct {
 	storage.SeriesSet
 }
 
-func (mockQuerier) Select(...*labels.Matcher) (storage.SeriesSet, error) {
+func (mockQuerier) Select(*storage.SelectParams, ...*labels.Matcher) (storage.SeriesSet, error) {
 	return mockSeriesSet{}, nil
 }
 
@@ -313,7 +313,7 @@ func TestRequiredLabelsQuerierSelect(t *testing.T) {
 			requiredMatchers: test.requiredMatchers,
 		}
 
-		have, err := q.Select(test.matchers...)
+		have, err := q.Select(nil, test.matchers...)
 		if err != nil {
 			t.Error(err)
 		}

--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -188,7 +188,7 @@ type querier struct {
 	q tsdb.Querier
 }
 
-func (q querier) Select(oms ...*labels.Matcher) (storage.SeriesSet, error) {
+func (q querier) Select(_ *storage.SelectParams, oms ...*labels.Matcher) (storage.SeriesSet, error) {
 	ms := make([]tsdbLabels.Matcher, 0, len(oms))
 
 	for _, om := range oms {

--- a/web/federate.go
+++ b/web/federate.go
@@ -74,7 +74,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 
 	var sets []storage.SeriesSet
 	for _, mset := range matcherSets {
-		s, err := q.Select(mset...)
+		s, err := q.Select(nil, mset...)
 		if err != nil {
 			federationErrors.Inc()
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/web/web.go
+++ b/web/web.go
@@ -536,7 +536,7 @@ func (h *Handler) consoles(w http.ResponseWriter, r *http.Request) {
 		"__console_"+name,
 		data,
 		h.now(),
-		template.QueryFunc(rules.EngineQueryFunc(h.queryEngine)),
+		template.QueryFunc(rules.EngineQueryFunc(h.queryEngine, h.storage)),
 		h.options.ExternalURL,
 	)
 	filenames, err := filepath.Glob(h.options.ConsoleLibrariesPath + "/*.lib")
@@ -766,7 +766,7 @@ func (h *Handler) executeTemplate(w http.ResponseWriter, name string, data inter
 		name,
 		data,
 		h.now(),
-		template.QueryFunc(rules.EngineQueryFunc(h.queryEngine)),
+		template.QueryFunc(rules.EngineQueryFunc(h.queryEngine, h.storage)),
 		h.options.ExternalURL,
 	)
 	tmpl.Funcs(tmplFuncs(h.consolesPath(), h.options))


### PR DESCRIPTION
This adds a parameter to the storage selection interface which allows
query engine(s) to pass information about the operations surrounding a
data selection.
This can for example be used by remote storage backends to infer the
correct downsampling aggregates that need to be provided.

@brian-brazil  @Bplotka 