### PR TITLE
Reload scrape on config change rebased

### DIFF
--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -139,8 +139,7 @@ func (m *ScrapeManager) reload(t map[string][]*targetgroup.Group) error {
 			sp := newScrapePool(scrapeConfig, m.append, log.With(m.logger, "scrape_pool", tsetName))
 			m.scrapePools[tsetName] = sp
 			sp.Sync(tgroup)
-
-		} else if !(reflect.DeepEqual(existing.config, scrapeConfig)) {
+		} else if !reflect.DeepEqual(existing.config, scrapeConfig) {
 			existing.reload(scrapeConfig)
 		} else {
 			existing.Sync(tgroup)

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -15,6 +15,7 @@ package retrieval
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -55,8 +56,6 @@ type ScrapeManager struct {
 
 // Run starts background processing to handle target updates and reload the scraping loops.
 func (m *ScrapeManager) Run(tsets <-chan map[string][]*targetgroup.Group) error {
-	level.Info(m.logger).Log("msg", "Starting scrape manager...")
-
 	for {
 		select {
 		case f := <-m.actionCh:
@@ -141,6 +140,8 @@ func (m *ScrapeManager) reload(t map[string][]*targetgroup.Group) error {
 			m.scrapePools[tsetName] = sp
 			sp.Sync(tgroup)
 
+		} else if !(reflect.DeepEqual(existing.config, scrapeConfig)) {
+			existing.reload(scrapeConfig)
 		} else {
 			existing.Sync(tgroup)
 		}

--- a/util/httputil/client_test.go
+++ b/util/httputil/client_test.go
@@ -218,17 +218,6 @@ func TestNewClientFromInvalidConfig(t *testing.T) {
 					InsecureSkipVerify: true},
 			},
 			errorMsg: fmt.Sprintf("unable to use specified CA cert %s:", MissingCA),
-		}, {
-			clientConfig: config_util.HTTPClientConfig{
-				BearerTokenFile: MissingBearerTokenFile,
-				TLSConfig: config_util.TLSConfig{
-					CAFile:             TLSCAChainPath,
-					CertFile:           BarneyCertificatePath,
-					KeyFile:            BarneyKeyNoPassPath,
-					ServerName:         "",
-					InsecureSkipVerify: false},
-			},
-			errorMsg: fmt.Sprintf("unable to read bearer token file %s:", MissingBearerTokenFile),
 		},
 	}
 
@@ -243,6 +232,47 @@ func TestNewClientFromInvalidConfig(t *testing.T) {
 		if !strings.Contains(err.Error(), invalidConfig.errorMsg) {
 			t.Errorf("Expected error %s does not contain %s", err.Error(), invalidConfig.errorMsg)
 		}
+	}
+}
+
+func TestMissingBearerAuthFile(t *testing.T) {
+	cfg := config_util.HTTPClientConfig{
+		BearerTokenFile: MissingBearerTokenFile,
+		TLSConfig: config_util.TLSConfig{
+			CAFile:             TLSCAChainPath,
+			CertFile:           BarneyCertificatePath,
+			KeyFile:            BarneyKeyNoPassPath,
+			ServerName:         "",
+			InsecureSkipVerify: false},
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		bearer := r.Header.Get("Authorization")
+		if bearer != ExpectedBearer {
+			fmt.Fprintf(w, "The expected Bearer Authorization (%s) differs from the obtained Bearer Authorization (%s)",
+				ExpectedBearer, bearer)
+		} else {
+			fmt.Fprint(w, ExpectedMessage)
+		}
+	}
+
+	testServer, err := newTestServer(handler)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer testServer.Close()
+
+	client, err := NewClientFromConfig(cfg, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Get(testServer.URL)
+	if err == nil {
+		t.Fatal("No error is returned here")
+	}
+
+	if !strings.Contains(err.Error(), "unable to read bearer token file missing/bearer.token: open missing/bearer.token: no such file or directory") {
+		t.Fatal("wrong error message being returned")
 	}
 }
 
@@ -267,6 +297,32 @@ func TestBearerAuthRoundTripper(t *testing.T) {
 
 	//Should honor already Authorization header set
 	bearerAuthRoundTripperShouldNotModifyExistingAuthorization := NewBearerAuthRoundTripper(newBearerToken, fakeRoundTripper)
+	request, _ = http.NewRequest("GET", "/hitchhiker", nil)
+	request.Header.Set("Authorization", ExpectedBearer)
+	bearerAuthRoundTripperShouldNotModifyExistingAuthorization.RoundTrip(request)
+}
+
+func TestBearerAuthFileRoundTripper(t *testing.T) {
+	const (
+		newBearerToken = "goodbyeandthankyouforthefish"
+	)
+
+	fakeRoundTripper := testutil.NewRoundTripCheckRequest(func(req *http.Request) {
+		bearer := req.Header.Get("Authorization")
+		if bearer != ExpectedBearer {
+			t.Errorf("The expected Bearer Authorization (%s) differs from the obtained Bearer Authorization (%s)",
+				ExpectedBearer, bearer)
+		}
+	}, nil, nil)
+
+	//Normal flow
+	bearerAuthRoundTripper := NewBearerAuthFileRoundTripper(BearerTokenFile, fakeRoundTripper)
+	request, _ := http.NewRequest("GET", "/hitchhiker", nil)
+	request.Header.Set("User-Agent", "Douglas Adams mind")
+	bearerAuthRoundTripper.RoundTrip(request)
+
+	//Should honor already Authorization header set
+	bearerAuthRoundTripperShouldNotModifyExistingAuthorization := NewBearerAuthFileRoundTripper(MissingBearerTokenFile, fakeRoundTripper)
 	request, _ = http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("Authorization", ExpectedBearer)
 	bearerAuthRoundTripperShouldNotModifyExistingAuthorization.RoundTrip(request)


### PR DESCRIPTION
the scrape pool needs to be restarted for any change in the config file (scrape interval , bearer token etc.) not just changes in the targets

closes #2756, #2830