### PR TITLE
notifier: use testutil for testing

### DIFF
--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"testing"
 	"time"
 
@@ -64,9 +63,7 @@ func TestPostPath(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		if res := postPath(c.in); res != c.out {
-			t.Errorf("Expected post path %q for %q but got %q", c.out, c.in, res)
-		}
+		testutil.Equals(t, c.out, postPath(c.in))
 	}
 }
 
@@ -83,34 +80,23 @@ func TestHandlerNextBatch(t *testing.T) {
 
 	b := h.nextBatch()
 
-	if len(b) != maxBatchSize {
-		t.Fatalf("Expected first batch of length %d, but got %d", maxBatchSize, len(b))
-	}
-	if !alertsEqual(expected[0:maxBatchSize], b) {
-		t.Fatalf("First batch did not match")
-	}
+	testutil.Equals(t, maxBatchSize, len(b))
+
+	testutil.Assert(t, alertsEqual(expected[0:maxBatchSize], b), "First batch did not match")
 
 	b = h.nextBatch()
 
-	if len(b) != maxBatchSize {
-		t.Fatalf("Expected second batch of length %d, but got %d", maxBatchSize, len(b))
-	}
-	if !alertsEqual(expected[maxBatchSize:2*maxBatchSize], b) {
-		t.Fatalf("Second batch did not match")
-	}
+	testutil.Equals(t, maxBatchSize, len(b))
+
+	testutil.Assert(t, alertsEqual(expected[maxBatchSize:2*maxBatchSize], b), "Second batch did not match")
 
 	b = h.nextBatch()
 
-	if len(b) != 1 {
-		t.Fatalf("Expected third batch of length %d, but got %d", 1, len(b))
-	}
-	if !alertsEqual(expected[2*maxBatchSize:], b) {
-		t.Fatalf("Third batch did not match")
-	}
+	testutil.Equals(t, 1, len(b))
 
-	if len(h.queue) != 0 {
-		t.Fatalf("Expected queue to be empty but got %d alerts", len(h.queue))
-	}
+	testutil.Assert(t, alertsEqual(expected[2*maxBatchSize:], b), "Third batch did not match")
+
+	testutil.Assert(t, len(h.queue) == 0, "Expected queue to be empty but got %d alerts", len(h.queue))
 }
 
 func alertsEqual(a, b []*Alert) bool {
@@ -137,29 +123,28 @@ func TestHandlerSendAll(t *testing.T) {
 		defer r.Body.Close()
 
 		var alerts []*Alert
-		if err := json.NewDecoder(r.Body).Decode(&alerts); err != nil {
-			t.Fatalf("Unexpected error on input decoding: %s", err)
-		}
+		testutil.Ok(t, json.NewDecoder(r.Body).Decode(&alerts))
 
-		if !alertsEqual(alerts, expected) {
-			t.Errorf("%#v %#v", *alerts[0], *expected[0])
-			t.Fatalf("Unexpected alerts received %v exp %v", alerts, expected)
-		}
+		testutil.Assert(t, alertsEqual(alerts, expected), "Unexpected alerts received %v exp %v", alerts, expected)
 	}
 	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		user, pass, _ := r.BasicAuth()
-		if user != "prometheus" || pass != "testing_password" {
-			t.Fatalf("Incorrect auth details for an alertmanager")
-		}
+		testutil.Assert(
+			t,
+			user == "prometheus" || pass == "testing_password",
+			"Incorrect auth details for an alertmanager",
+		)
 
 		f(w, r)
 		w.WriteHeader(status1)
 	}))
 	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		user, pass, _ := r.BasicAuth()
-		if user != "" || pass != "" {
-			t.Fatalf("Incorrectly received auth details for an alertmanager")
-		}
+		testutil.Assert(
+			t,
+			user == "" || pass == "",
+			"Incorrectly received auth details for an alertmanager",
+		)
 
 		f(w, r)
 		w.WriteHeader(status2)
@@ -213,19 +198,13 @@ func TestHandlerSendAll(t *testing.T) {
 
 	status1 = http.StatusOK
 	status2 = http.StatusOK
-	if !h.sendAll(h.queue...) {
-		t.Fatalf("all sends failed unexpectedly")
-	}
+	testutil.Assert(t, h.sendAll(h.queue...), "all sends failed unexpectedly")
 
 	status1 = http.StatusNotFound
-	if !h.sendAll(h.queue...) {
-		t.Fatalf("all sends failed unexpectedly")
-	}
+	testutil.Assert(t, h.sendAll(h.queue...), "all sends failed unexpectedly")
 
 	status2 = http.StatusInternalServerError
-	if h.sendAll(h.queue...) {
-		t.Fatalf("all sends succeeded unexpectedly")
-	}
+	testutil.Assert(t, !h.sendAll(h.queue...), "all sends succeeded unexpectedly")
 }
 
 func TestCustomDo(t *testing.T) {
@@ -237,15 +216,13 @@ func TestCustomDo(t *testing.T) {
 		Do: func(ctx old_ctx.Context, client *http.Client, req *http.Request) (*http.Response, error) {
 			received = true
 			body, err := ioutil.ReadAll(req.Body)
-			if err != nil {
-				t.Fatalf("Unable to read request body: %v", err)
-			}
-			if string(body) != testBody {
-				t.Fatalf("Unexpected body; want %v, got %v", testBody, string(body))
-			}
-			if req.URL.String() != testURL {
-				t.Fatalf("Unexpected URL; want %v, got %v", testURL, req.URL.String())
-			}
+
+			testutil.Ok(t, err)
+
+			testutil.Equals(t, testBody, string(body))
+
+			testutil.Equals(t, testURL, req.URL.String())
+
 			return &http.Response{
 				Body: ioutil.NopCloser(nil),
 			}, nil
@@ -254,9 +231,7 @@ func TestCustomDo(t *testing.T) {
 
 	h.sendOne(context.Background(), nil, testURL, []byte(testBody))
 
-	if !received {
-		t.Fatal("Expected to receive an alert, but didn't")
-	}
+	testutil.Assert(t, received, "Expected to receive an alert, but didn't")
 }
 
 func TestExternalLabels(t *testing.T) {
@@ -290,9 +265,7 @@ func TestExternalLabels(t *testing.T) {
 		{Labels: labels.FromStrings("alertname", "externalrelabelthis", "a", "c")},
 	}
 
-	if !alertsEqual(expected, h.queue) {
-		t.Errorf("Expected alerts %v, got %v", expected, h.queue)
-	}
+	testutil.Assert(t, alertsEqual(expected, h.queue), "Expected alerts %v, got %v", expected, h.queue)
 }
 
 func TestHandlerRelabel(t *testing.T) {
@@ -328,9 +301,7 @@ func TestHandlerRelabel(t *testing.T) {
 		{Labels: labels.FromStrings("alertname", "renamed")},
 	}
 
-	if !alertsEqual(expected, h.queue) {
-		t.Errorf("Expected alerts %v, got %v", expected, h.queue)
-	}
+	testutil.Assert(t, alertsEqual(expected, h.queue), "Expected alerts %v, got %v", expected, h.queue)
 }
 
 func TestHandlerQueueing(t *testing.T) {
@@ -347,13 +318,9 @@ func TestHandlerQueueing(t *testing.T) {
 		defer r.Body.Close()
 
 		var alerts []*Alert
-		if err := json.NewDecoder(r.Body).Decode(&alerts); err != nil {
-			t.Fatalf("Unexpected error on input decoding: %s", err)
-		}
+		testutil.Ok(t, json.NewDecoder(r.Body).Decode(&alerts))
 
-		if !alertsEqual(expected, alerts) {
-			t.Errorf("Expected alerts %v, got %v", expected, alerts)
-		}
+		testutil.Assert(t, alertsEqual(expected, alerts), "Expected alerts %v, got %v", expected, alerts)
 	}))
 
 	h := NewManager(&Options{
@@ -443,13 +410,11 @@ func (a alertmanagerMock) url() *url.URL {
 func TestLabelSetNotReused(t *testing.T) {
 	tg := makeInputTargetGroup()
 	_, _, err := alertmanagerFromGroup(tg, &config.AlertmanagerConfig{})
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	if !reflect.DeepEqual(tg, makeInputTargetGroup()) {
-		t.Fatal("Target modified during alertmanager extraction")
-	}
+	testutil.Ok(t, err)
+
+	// Target modified during alertmanager extraction
+	testutil.Equals(t, tg, makeInputTargetGroup())
 }
 
 func TestReload(t *testing.T) {


### PR DESCRIPTION
- Use `util/testutil` in `notifier` testsuit. Related #3242 