### PR TITLE
Set consul server default to localhost:8500

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -82,12 +82,13 @@ var (
 	DefaultSDConfig = SDConfig{
 		TagSeparator: ",",
 		Scheme:       "http",
+		Server:       "localhost:8500",
 	}
 )
 
 // SDConfig is the configuration for Consul service discovery.
 type SDConfig struct {
-	Server       string             `yaml:"server"`
+	Server       string             `yaml:"server,omitempty"`
 	Token        config_util.Secret `yaml:"token,omitempty"`
 	Datacenter   string             `yaml:"datacenter,omitempty"`
 	TagSeparator string             `yaml:"tag_separator,omitempty"`

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -305,10 +305,10 @@ The following meta labels are available on targets during [relabeling](#relabel_
 ```yaml
 # The information to access the Consul API. It is to be defined
 # as the Consul documentation requires.
-server: <host> | default = "localhost:8500"
+[ server: <host> | default = "localhost:8500" ]
 [ token: <secret> ]
 [ datacenter: <string> ]
-[ scheme: <string> | default = "http"]
+[ scheme: <string> | default = "http" ]
 [ username: <string> ]
 [ password: <secret> ]
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -305,7 +305,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 ```yaml
 # The information to access the Consul API. It is to be defined
 # as the Consul documentation requires.
-server: <host>
+server: <host> | default = "localhost:8500"
 [ token: <secret> ]
 [ datacenter: <string> ]
 [ scheme: <string> | default = "http"]


### PR DESCRIPTION
Set the consul server default to `localhost:8500` as that is the default port consul listens on.

see: https://github.com/prometheus/prometheus/issues/3702
@brian-brazil 