### PR TITLE
read bearer token on every request + some http and scrape tests

### DIFF
--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -56,8 +56,6 @@ type ScrapeManager struct {
 
 // Run starts background processing to handle target updates and reload the scraping loops.
 func (m *ScrapeManager) Run(tsets <-chan map[string][]*targetgroup.Group) error {
-	level.Info(m.logger).Log("msg", "Starting scrape manager...")
-
 	for {
 		select {
 		case ts := <-tsets:

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -17,9 +17,11 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
@@ -229,4 +231,45 @@ func TestPopulateLabels(t *testing.T) {
 			t.Errorf("case %d: expected resOrig\n\t%+v\n got\n\t%+v", i, c.resOrig, orig)
 		}
 	}
+}
+
+// TestScrapeManagerReloadNoChange tests that no scrape reload happens when there is no config change.
+func TestManagerReloadNoChange(t *testing.T) {
+	tsetName := "test"
+
+	reloadCfg := &config.Config{
+		ScrapeConfigs: []*config.ScrapeConfig{
+			&config.ScrapeConfig{
+				ScrapeInterval: model.Duration(3 * time.Second),
+				ScrapeTimeout:  model.Duration(2 * time.Second),
+			},
+		},
+	}
+
+	scrapeManager := NewScrapeManager(nil, nil)
+	scrapeManager.scrapeConfigs[tsetName] = reloadCfg.ScrapeConfigs[0]
+	// As reload never happens, new loop should never be called.
+	newLoop := func(_ *Target, s scraper) loop {
+		t.Fatal("reload happened")
+		return nil
+	}
+	sp := &scrapePool{
+		appendable: &nopAppendable{},
+		targets:    map[uint64]*Target{},
+		loops: map[uint64]loop{
+			1: &scrapeLoop{},
+		},
+		newLoop: newLoop,
+		logger:  nil,
+		config:  reloadCfg.ScrapeConfigs[0],
+	}
+	scrapeManager.scrapePools = map[string]*scrapePool{
+		tsetName: sp,
+	}
+
+	targets := map[string][]*targetgroup.Group{
+		tsetName: []*targetgroup.Group{},
+	}
+
+	scrapeManager.reload(targets)
 }

--- a/retrieval/scrape_test.go
+++ b/retrieval/scrape_test.go
@@ -699,7 +699,7 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 	}
 	value := metric.GetCounter().GetValue()
 	if (value - beforeMetricValue) != 1 {
-		t.Fatal("Unexpected change of sample limit metric: %f", (value - beforeMetricValue))
+		t.Fatalf("Unexpected change of sample limit metric: %f", (value - beforeMetricValue))
 	}
 
 	// And verify that we got the samples that fit under the limit.

--- a/util/httputil/client_test.go
+++ b/util/httputil/client_test.go
@@ -289,13 +289,13 @@ func TestBearerAuthRoundTripper(t *testing.T) {
 		}
 	}, nil, nil)
 
-	//Normal flow
+	// Normal flow.
 	bearerAuthRoundTripper := NewBearerAuthRoundTripper(BearerToken, fakeRoundTripper)
 	request, _ := http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("User-Agent", "Douglas Adams mind")
 	bearerAuthRoundTripper.RoundTrip(request)
 
-	//Should honor already Authorization header set
+	// Should honor already Authorization header set.
 	bearerAuthRoundTripperShouldNotModifyExistingAuthorization := NewBearerAuthRoundTripper(newBearerToken, fakeRoundTripper)
 	request, _ = http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("Authorization", ExpectedBearer)
@@ -315,13 +315,13 @@ func TestBearerAuthFileRoundTripper(t *testing.T) {
 		}
 	}, nil, nil)
 
-	//Normal flow
+	// Normal flow.
 	bearerAuthRoundTripper := NewBearerAuthFileRoundTripper(BearerTokenFile, fakeRoundTripper)
 	request, _ := http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("User-Agent", "Douglas Adams mind")
 	bearerAuthRoundTripper.RoundTrip(request)
 
-	//Should honor already Authorization header set
+	// Should honor already Authorization header set.
 	bearerAuthRoundTripperShouldNotModifyExistingAuthorization := NewBearerAuthFileRoundTripper(MissingBearerTokenFile, fakeRoundTripper)
 	request, _ = http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("Authorization", ExpectedBearer)
@@ -347,14 +347,14 @@ func TestBasicAuthRoundTripper(t *testing.T) {
 		}
 	}, nil, nil)
 
-	//Normal flow
+	// Normal flow.
 	basicAuthRoundTripper := NewBasicAuthRoundTripper(ExpectedUsername,
 		ExpectedPassword, fakeRoundTripper)
 	request, _ := http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("User-Agent", "Douglas Adams mind")
 	basicAuthRoundTripper.RoundTrip(request)
 
-	//Should honor already Authorization header set
+	// Should honor already Authorization header set.
 	basicAuthRoundTripperShouldNotModifyExistingAuthorization := NewBasicAuthRoundTripper(newUsername,
 		newPassword, fakeRoundTripper)
 	request, _ = http.NewRequest("GET", "/hitchhiker", nil)

--- a/util/httputil/client_test.go
+++ b/util/httputil/client_test.go
@@ -218,17 +218,6 @@ func TestNewClientFromInvalidConfig(t *testing.T) {
 					InsecureSkipVerify: true},
 			},
 			errorMsg: fmt.Sprintf("unable to use specified CA cert %s:", MissingCA),
-		}, {
-			clientConfig: config_util.HTTPClientConfig{
-				BearerTokenFile: MissingBearerTokenFile,
-				TLSConfig: config_util.TLSConfig{
-					CAFile:             TLSCAChainPath,
-					CertFile:           BarneyCertificatePath,
-					KeyFile:            BarneyKeyNoPassPath,
-					ServerName:         "",
-					InsecureSkipVerify: false},
-			},
-			errorMsg: fmt.Sprintf("unable to read bearer token file %s:", MissingBearerTokenFile),
 		},
 	}
 
@@ -243,6 +232,47 @@ func TestNewClientFromInvalidConfig(t *testing.T) {
 		if !strings.Contains(err.Error(), invalidConfig.errorMsg) {
 			t.Errorf("Expected error %s does not contain %s", err.Error(), invalidConfig.errorMsg)
 		}
+	}
+}
+
+func TestMissingBearerAuthFile(t *testing.T) {
+	cfg := config_util.HTTPClientConfig{
+		BearerTokenFile: MissingBearerTokenFile,
+		TLSConfig: config_util.TLSConfig{
+			CAFile:             TLSCAChainPath,
+			CertFile:           BarneyCertificatePath,
+			KeyFile:            BarneyKeyNoPassPath,
+			ServerName:         "",
+			InsecureSkipVerify: false},
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		bearer := r.Header.Get("Authorization")
+		if bearer != ExpectedBearer {
+			fmt.Fprintf(w, "The expected Bearer Authorization (%s) differs from the obtained Bearer Authorization (%s)",
+				ExpectedBearer, bearer)
+		} else {
+			fmt.Fprint(w, ExpectedMessage)
+		}
+	}
+
+	testServer, err := newTestServer(handler)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer testServer.Close()
+
+	client, err := NewClientFromConfig(cfg, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Get(testServer.URL)
+	if err == nil {
+		t.Fatal("No error is returned here")
+	}
+
+	if !strings.Contains(err.Error(), "unable to read bearer token file missing/bearer.token: open missing/bearer.token: no such file or directory") {
+		t.Fatal("wrong error message being returned")
 	}
 }
 
@@ -267,6 +297,32 @@ func TestBearerAuthRoundTripper(t *testing.T) {
 
 	//Should honor already Authorization header set
 	bearerAuthRoundTripperShouldNotModifyExistingAuthorization := NewBearerAuthRoundTripper(newBearerToken, fakeRoundTripper)
+	request, _ = http.NewRequest("GET", "/hitchhiker", nil)
+	request.Header.Set("Authorization", ExpectedBearer)
+	bearerAuthRoundTripperShouldNotModifyExistingAuthorization.RoundTrip(request)
+}
+
+func TestBearerAuthFileRoundTripper(t *testing.T) {
+	const (
+		newBearerToken = "goodbyeandthankyouforthefish"
+	)
+
+	fakeRoundTripper := testutil.NewRoundTripCheckRequest(func(req *http.Request) {
+		bearer := req.Header.Get("Authorization")
+		if bearer != ExpectedBearer {
+			t.Errorf("The expected Bearer Authorization (%s) differs from the obtained Bearer Authorization (%s)",
+				ExpectedBearer, bearer)
+		}
+	}, nil, nil)
+
+	//Normal flow
+	bearerAuthRoundTripper := NewBearerAuthFileRoundTripper(BearerTokenFile, fakeRoundTripper)
+	request, _ := http.NewRequest("GET", "/hitchhiker", nil)
+	request.Header.Set("User-Agent", "Douglas Adams mind")
+	bearerAuthRoundTripper.RoundTrip(request)
+
+	//Should honor already Authorization header set
+	bearerAuthRoundTripperShouldNotModifyExistingAuthorization := NewBearerAuthFileRoundTripper(MissingBearerTokenFile, fakeRoundTripper)
 	request, _ = http.NewRequest("GET", "/hitchhiker", nil)
 	request.Header.Set("Authorization", ExpectedBearer)
 	bearerAuthRoundTripperShouldNotModifyExistingAuthorization.RoundTrip(request)


### PR DESCRIPTION
read bearer token on every request
removed unuseful  scrape manager startup log
new tests -TestScrapeManagerReloadNoChange( scrape pool is not reloaded
when the config hasn't changed), TestMissingBearerAuthFile ,
TestBearerAuthFileRoundTripper