### PR TITLE
promql: Make printer formatting less vintage

### DIFF
--- a/promql/printer.go
+++ b/promql/printer.go
@@ -134,19 +134,21 @@ func (es Expressions) String() (s string) {
 }
 
 func (node *AggregateExpr) String() string {
-	aggrString := fmt.Sprintf("%s(", node.Op)
+	aggrString := node.Op.String()
+
+	if node.Without {
+		aggrString += fmt.Sprintf(" without(%s) ", strings.Join(node.Grouping, ", "))
+	} else {
+		if len(node.Grouping) > 0 {
+			aggrString += fmt.Sprintf(" by(%s) ", strings.Join(node.Grouping, ", "))
+		}
+	}
+
+	aggrString += "("
 	if node.Op.isAggregatorWithParam() {
 		aggrString += fmt.Sprintf("%s, ", node.Param)
 	}
 	aggrString += fmt.Sprintf("%s)", node.Expr)
-
-	if node.Without {
-		aggrString = fmt.Sprintf("%s WITHOUT (%s)", aggrString, strings.Join(node.Grouping, ", "))
-	} else {
-		if len(node.Grouping) > 0 {
-			aggrString = fmt.Sprintf("%s BY (%s)", aggrString, strings.Join(node.Grouping, ", "))
-		}
-	}
 
 	return aggrString
 }
@@ -154,23 +156,23 @@ func (node *AggregateExpr) String() string {
 func (node *BinaryExpr) String() string {
 	returnBool := ""
 	if node.ReturnBool {
-		returnBool = " BOOL"
+		returnBool = " bool"
 	}
 
 	matching := ""
 	vm := node.VectorMatching
 	if vm != nil && (len(vm.MatchingLabels) > 0 || vm.On) {
 		if vm.On {
-			matching = fmt.Sprintf(" ON(%s)", strings.Join(vm.MatchingLabels, ", "))
+			matching = fmt.Sprintf(" on(%s)", strings.Join(vm.MatchingLabels, ", "))
 		} else {
-			matching = fmt.Sprintf(" IGNORING(%s)", strings.Join(vm.MatchingLabels, ", "))
+			matching = fmt.Sprintf(" ignoring(%s)", strings.Join(vm.MatchingLabels, ", "))
 		}
 		if vm.Card == CardManyToOne || vm.Card == CardOneToMany {
-			matching += " GROUP_"
+			matching += " group_"
 			if vm.Card == CardManyToOne {
-				matching += "LEFT"
+				matching += "left"
 			} else {
-				matching += "RIGHT"
+				matching += "right"
 			}
 			matching += fmt.Sprintf("(%s)", strings.Join(vm.Include, ", "))
 		}
@@ -189,7 +191,7 @@ func (node *MatrixSelector) String() string {
 	}
 	offset := ""
 	if node.Offset != time.Duration(0) {
-		offset = fmt.Sprintf(" OFFSET %s", model.Duration(node.Offset))
+		offset = fmt.Sprintf(" offset %s", model.Duration(node.Offset))
 	}
 	return fmt.Sprintf("%s[%s]%s", vecSelector.String(), model.Duration(node.Range), offset)
 }
@@ -221,7 +223,7 @@ func (node *VectorSelector) String() string {
 	}
 	offset := ""
 	if node.Offset != time.Duration(0) {
-		offset = fmt.Sprintf(" OFFSET %s", model.Duration(node.Offset))
+		offset = fmt.Sprintf(" offset %s", model.Duration(node.Offset))
 	}
 
 	if len(labelStrings) == 0 {

--- a/promql/printer_test.go
+++ b/promql/printer_test.go
@@ -57,17 +57,17 @@ func TestExprString(t *testing.T) {
 		in, out string
 	}{
 		{
-			in:  `sum(task:errors:rate10s{job="s"}) BY ()`,
+			in:  `sum by() (task:errors:rate10s{job="s"})`,
 			out: `sum(task:errors:rate10s{job="s"})`,
 		},
 		{
-			in: `sum(task:errors:rate10s{job="s"}) BY (code)`,
+			in: `sum by(code) (task:errors:rate10s{job="s"})`,
 		},
 		{
-			in: `sum(task:errors:rate10s{job="s"}) WITHOUT ()`,
+			in: `sum without() (task:errors:rate10s{job="s"})`,
 		},
 		{
-			in: `sum(task:errors:rate10s{job="s"}) WITHOUT (instance)`,
+			in: `sum without(instance) (task:errors:rate10s{job="s"})`,
 		},
 		{
 			in: `topk(5, task:errors:rate10s{job="s"})`,
@@ -76,42 +76,42 @@ func TestExprString(t *testing.T) {
 			in: `count_values("value", task:errors:rate10s{job="s"})`,
 		},
 		{
-			in: `a - ON() c`,
+			in: `a - on() c`,
 		},
 		{
-			in: `a - ON(b) c`,
+			in: `a - on(b) c`,
 		},
 		{
-			in: `a - ON(b) GROUP_LEFT(x) c`,
+			in: `a - on(b) group_left(x) c`,
 		},
 		{
-			in: `a - ON(b) GROUP_LEFT(x, y) c`,
+			in: `a - on(b) group_left(x, y) c`,
 		},
 		{
-			in:  `a - ON(b) GROUP_LEFT c`,
-			out: `a - ON(b) GROUP_LEFT() c`,
+			in:  `a - on(b) group_left c`,
+			out: `a - on(b) group_left() c`,
 		},
 		{
-			in: `a - ON(b) GROUP_LEFT() (c)`,
+			in: `a - on(b) group_left() (c)`,
 		},
 		{
-			in: `a - IGNORING(b) c`,
+			in: `a - ignoring(b) c`,
 		},
 		{
-			in:  `a - IGNORING() c`,
+			in:  `a - ignoring() c`,
 			out: `a - c`,
 		},
 		{
-			in: `up > BOOL 0`,
+			in: `up > bool 0`,
 		},
 		{
-			in: `a OFFSET 1m`,
+			in: `a offset 1m`,
 		},
 		{
-			in: `a{c="d"}[5m] OFFSET 1m`,
+			in: `a{c="d"}[5m] offset 1m`,
 		},
 		{
-			in: `a[5m] OFFSET 1m`,
+			in: `a[5m] offset 1m`,
 		},
 	}
 


### PR DESCRIPTION
- lower-case modifiers
- reverse order of aggregation modifiers and aggregated expression
- remove spacing before modifier parentheses