### PR TITLE
discovery: Rename file SD mtime metric

### DIFF
--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -127,7 +127,7 @@ func (t *TimestampCollector) removeDiscoverer(disc *Discovery) {
 func NewTimestampCollector() *TimestampCollector {
 	return &TimestampCollector{
 		Description: prometheus.NewDesc(
-			"prometheus_sd_file_timestamp",
+			"prometheus_sd_file_mtime_seconds",
 			"Timestamp (mtime) of files read by FileSD. Timestamp is set at read time.",
 			[]string{"filename"},
 			nil,


### PR DESCRIPTION
- "timestamp" -> "mtime" to be in line with node exporter and clearer.
- add unit suffix