### PR TITLE
Don't reset FiredAt for inactive alerts

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -649,7 +649,7 @@ func computeExternalURL(u, listenAddr string) (*url.URL, error) {
 	return eu, nil
 }
 
-// sendAlerts implements a the rules.NotifyFunc for a Notifier.
+// sendAlerts implements the rules.NotifyFunc for a Notifier.
 // It filters any non-firing alerts from the input.
 func sendAlerts(n *notifier.Notifier, externalURL string) rules.NotifyFunc {
 	return func(ctx context.Context, expr string, alerts ...*rules.Alert) error {

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -266,7 +266,6 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 			if a.State != StateInactive {
 				a.State = StateInactive
 				a.ResolvedAt = ts
-				a.FiredAt = time.Time{}
 			}
 			continue
 		}


### PR DESCRIPTION
This seems too obvious to be true. Reviews more than welcomed...

Fixes #3543.