### PR TITLE
Re-use timer in remote storage queue

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -430,6 +430,8 @@ func (s *shards) runShard(i int) {
 	// anyways.
 	pendingSamples := model.Samples{}
 
+	timer := time.NewTimer(s.qm.cfg.BatchSendDeadline)
+
 	for {
 		select {
 		case sample, ok := <-queue:
@@ -449,7 +451,11 @@ func (s *shards) runShard(i int) {
 				s.sendSamples(pendingSamples[:s.qm.cfg.MaxSamplesPerSend])
 				pendingSamples = pendingSamples[s.qm.cfg.MaxSamplesPerSend:]
 			}
-		case <-time.After(s.qm.cfg.BatchSendDeadline):
+			if !timer.Stop() {
+				<-timer.C
+			}
+			timer.Reset(s.qm.cfg.BatchSendDeadline)
+		case <-timer.C:
 			if len(pendingSamples) > 0 {
 				s.sendSamples(pendingSamples)
 				pendingSamples = pendingSamples[:0]


### PR DESCRIPTION
Current code is allocating a new `Timer` object and `chan Time` on every sample enqueued for remote storage. The [docs](https://golang.org/pkg/time/#After) for `time.After()` note that:

> The underlying `Timer` is not recovered by the garbage collector until the timer fires. If efficiency is a concern, use `NewTimer` instead and call `Timer.Stop` if the timer is no longer needed.

To illustrate the impact:
```
.../prometheus/storage/remote$ go test -run=TestSampleDelivery -memprofile=mem.out
PASS
ok  	github.com/prometheus/prometheus/storage/remote	1.416s
.../prometheus/storage/remote$ go tool pprof -inuse_space -top mem.out
File: remote.test
Type: inuse_space
Time: Jan 24, 2018 at 12:40pm (UTC)
Showing nodes accounting for 19070.72kB, 100% of 19070.72kB total
      flat  flat%   sum%        cum   cum%
15361.12kB 80.55% 80.55% 16482.56kB 86.43%  time.NewTimer /usr/local/go/src/time/sleep.go
 1121.44kB  5.88% 86.43%  1121.44kB  5.88%  time.startTimer /usr/local/go/src/runtime/time.go
 1024.56kB  5.37% 91.80%  1024.56kB  5.37%  reflect.mapassign /usr/local/go/src/runtime/hashmap.go
[...]
```

Same test with this change:
```
$ go tool pprof -inuse_space -top mem.out
File: remote.test
Type: inuse_space
Time: Jan 24, 2018 at 12:45pm (UTC)
Showing nodes accounting for 3602.65kB, 100% of 3602.65kB total
      flat  flat%   sum%        cum   cum%
 1554.07kB 43.14% 43.14%  1554.07kB 43.14%  github.com/prometheus/prometheus/vendor/github.com/beorn7/perks/quantile.NewTargeted /home/vagrant/src/github.com/prometheus/prometheus/vendor/github.com/beorn7/perks/quantile/stream.go
 1024.38kB 28.43% 71.57%  1024.38kB 28.43%  reflect.mapassign /usr/local/go/src/runtime/hashmap.go
```

