### PR TITLE
Fixed race condition in map iteration and map write in Discovery (#3735)

### DIFF
--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -96,9 +96,11 @@ func (t *TimestampCollector) Collect(ch chan<- prometheus.Metric) {
 	uniqueFiles := make(map[string]float64)
 	t.lock.RLock()
 	for fileSD := range t.discoverers {
+		fileSD.lock.Lock()
 		for filename, timestamp := range fileSD.timestamps {
 			uniqueFiles[filename] = timestamp
 		}
+		fileSD.lock.Unlock()
 	}
 	t.lock.RUnlock()
 	for filename, timestamp := range uniqueFiles {

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -96,11 +96,11 @@ func (t *TimestampCollector) Collect(ch chan<- prometheus.Metric) {
 	uniqueFiles := make(map[string]float64)
 	t.lock.RLock()
 	for fileSD := range t.discoverers {
-		fileSD.lock.Lock()
+		fileSD.lock.RLock()
 		for filename, timestamp := range fileSD.timestamps {
 			uniqueFiles[filename] = timestamp
 		}
-		fileSD.lock.Unlock()
+		fileSD.lock.RUnlock()
 	}
 	t.lock.RUnlock()
 	for filename, timestamp := range uniqueFiles {


### PR DESCRIPTION
Added lock for this loop 
[https://github.com/prometheus/prometheus/blob/master/discovery/file/file.go#L99-L101](https://github.com/prometheus/prometheus/blob/master/discovery/file/file.go#L99-L101) 
using `fileSD.lock`

(Issue [#3735](https://github.com/prometheus/prometheus/issues/3735))