### PR TITLE
discovery: Throttle updating discovery per provider

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -298,8 +298,14 @@ func (n *Notifier) nextBatch() []*Alert {
 
 // Run dispatches notifications continuously.
 func (n *Notifier) Run(tsets <-chan map[string][]*targetgroup.Group) {
-
 	for {
+		// Throttle syncing to once per five seconds.
+		select {
+		case <-n.ctx.Done():
+			return
+		case <-time.After(5 * time.Second):
+		}
+
 		select {
 		case <-n.ctx.Done():
 			return

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -396,7 +396,7 @@ func TestHandlerQueueing(t *testing.T) {
 		case <-called:
 			expected = alerts[i*maxBatchSize : (i+1)*maxBatchSize]
 			unblock <- struct{}{}
-		case <-time.After(5 * time.Second):
+		case <-time.After(60 * time.Second):
 			t.Fatalf("Alerts were not pushed")
 		}
 	}
@@ -422,7 +422,7 @@ func TestHandlerQueueing(t *testing.T) {
 		case <-called:
 			expected = alerts[i*maxBatchSize : (i+1)*maxBatchSize]
 			unblock <- struct{}{}
-		case <-time.After(5 * time.Second):
+		case <-time.After(60 * time.Second):
 			t.Fatalf("Alerts were not pushed")
 		}
 	}

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -59,6 +60,13 @@ func (m *ScrapeManager) Run(tsets <-chan map[string][]*targetgroup.Group) error 
 	level.Info(m.logger).Log("msg", "Starting scrape manager...")
 
 	for {
+		// Throttle syncing to once per five seconds.
+		select {
+		case <-m.graceShut:
+			return nil
+		case <-time.After(5 * time.Second):
+		}
+
 		select {
 		case ts := <-tsets:
 			m.reload(ts)


### PR DESCRIPTION
This PR is still in progress as context handling needs to be added. The initial round of profiling suggested that syncs are happening very often so targets and their labels are built/allocated often. This PR throttles updates to targets to once every 5 seconds. This is the same behavior that we had in `v2.0.0`, for `v2.1.0` this throttle was removed in a series of refactorings.

This is what the memory allocations look like with the patch applied

query: `rate(go_memstats_alloc_bytes_total{job="prometheus"}[1m])`

![screenshot from 2018-01-25 22-35-53](https://user-images.githubusercontent.com/4546722/35413601-445e8fda-0220-11e8-972a-8ca531960881.png)

As you can see this is still higher than `v2.0.0`, so I profiled again and the new result is very different.

![alloc](https://user-images.githubusercontent.com/4546722/35414137-f004d262-0221-11e8-918e-0c98f0d5944b.png)

It instead shows that the majority of allocations are coming from reads from disk, this is a separate problem though.

I believe this closes #3715.