### PR TITLE
Discovery/Kubernetes: If target is Node, attach labels of it.

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -671,6 +671,7 @@ Available meta labels:
   * `__meta_kubernetes_endpoint_port_protocol`: Protocol of the endpoint port.
 * If the endpoints belong to a service, all labels of the `role: service` discovery are attached.
 * For all targets backed by a pod, all labels of the `role: pod` discovery are attached.
+* For all targets backed by a node, all labels of the `role: node` discovery are attached.
 
 #### `ingress`
 


### PR DESCRIPTION
## What this PR does

For all targets backed by a node, all labels of the `role: node`
discovery are attached.

## Why we need it

We are currently using [prometheus-operator](https://github.com/coreos/prometheus-operator) to scrape metrics from kubelet. `prometheus-operator` maintains a endpoint object (`kubelet` by default), e.g:

```
apiVersion: v1
kind: Endpoints
metadata:
  labels:
    k8s-app: kubelet
  name: kubelet
  namespace: kube-system
subsets:
- addresses:
  - ip: 192.168.128.116
    targetRef:
      kind: Node
      name: nodea
      uid: 1c75a366-1e85-11e7-bacc-f23c9184ec92
  - ip: 192.168.130.217
    targetRef:
      kind: Node
      name: nodeb
      uid: 5165df10-888b-11e7-83d7-f23c9184ec92
  ports:
  - name: http-metrics
    port: 10255
    protocol: TCP
  - name: cadvisor
    port: 4194
    protocol: TCP
  - name: https-metrics
    port: 10250
    protocol: TC
```

In current prometheus, if kubernetes discovery role is `endpoint`, it does not attach labels of `role: node`. Metrics scraped from `kubelet` on each node does not contain node labels. In many cases, we need to do [vector matching](https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching) with others metrics (e.g. `kube_node_labels` from `kube-state-metrics`). But without node name label, it's hard to do.

IMHO, it will be convenient, if targets backed by a node, all labels of the `role: node`
discovery are attached, like `Pod` target.