### PR TITLE
update the discover tests

### DIFF
--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -29,8 +29,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// TestDiscoveryManagerSyncCalls checks that the target updates are received in the expected order.
-func TestDiscoveryManagerSyncCalls(t *testing.T) {
+// TestTargetUpdatesOrder checks that the target updates are received in the expected order.
+func TestTargetUpdatesOrder(t *testing.T) {
 
 	// The order by which the updates are send is detirmened by the interval passed to the mock discovery adapter
 	// Final targets array is ordered alphabetically by the name of the discoverer.
@@ -656,15 +656,14 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		discoveryManager := NewManager(nil)
-		go discoveryManager.Run(ctx)
 
 		var totalUpdatesCount int
-		for tpName, update := range testCase.updates {
-			provider := newMockDiscoveryProvider(update)
-			discoveryManager.startProvider(ctx, poolKey{setName: strconv.Itoa(testIndex), provider: tpName}, provider)
 
-			if len(update) > 0 {
-				totalUpdatesCount = totalUpdatesCount + len(update)
+		provUpdates := make(chan []*targetgroup.Group)
+		for _, up := range testCase.updates {
+			go newMockDiscoveryProvider(up).Run(ctx, provUpdates)
+			if len(up) > 0 {
+				totalUpdatesCount = totalUpdatesCount + len(up)
 			}
 		}
 
@@ -674,9 +673,10 @@ func TestDiscoveryManagerSyncCalls(t *testing.T) {
 			case <-time.After(10 * time.Second):
 				t.Errorf("%v. %q: no update arrived within the timeout limit", x, testCase.title)
 				break Loop
-			case tsetMap := <-discoveryManager.SyncCh():
-				for _, received := range tsetMap {
-					// Need to sort by the Groups source as the Discovery manager doesn't guarantee the order.
+			case tgs := <-provUpdates:
+				discoveryManager.updateGroup(poolKey{setName: strconv.Itoa(testIndex), provider: testCase.title}, tgs)
+				for _, received := range discoveryManager.allGroups() {
+					// Need to sort by the Groups source as the received order is not guaranteed.
 					sort.Sort(byGroupSource(received))
 					if !reflect.DeepEqual(received, testCase.expectedTargets[x]) {
 						var receivedFormated string


### PR DESCRIPTION
the discovery test is now only testing update and get groups.
It doesn't do an e2e test but just a unit test of setting and receiving
target groups