### PR TITLE
Support force reloading configuration (return response without waiting of restartiong of all scrape loops)

### DIFF
--- a/retrieval/scrape_test.go
+++ b/retrieval/scrape_test.go
@@ -109,6 +109,10 @@ func (l *testLoop) stop() {
 	l.stopFunc()
 }
 
+func (l *testLoop) stopForce() {
+	l.stopFunc()
+}
+
 func TestScrapePoolStop(t *testing.T) {
 	sp := &scrapePool{
 		targets: map[uint64]*Target{},
@@ -144,7 +148,7 @@ func TestScrapePoolStop(t *testing.T) {
 	stopTime := time.Now()
 
 	go func() {
-		sp.stop()
+		sp.stop(false)
 		close(done)
 	}()
 
@@ -239,7 +243,7 @@ func TestScrapePoolReload(t *testing.T) {
 	reloadTime := time.Now()
 
 	go func() {
-		sp.reload(reloadCfg)
+		sp.reload(reloadCfg, false)
 		close(done)
 	}()
 


### PR DESCRIPTION
There is a case, when you have some loops which can be executed for large amount of time. If at this time prometheus receive reload configuration request, response will be send only when all loops are restarted. 
Adding /-/reload/force endpoint will solve this problem. It will return response after validation rules and prometheus config. Restarting scraping loops will be done in background.