### PR TITLE
discovery package - allow registering Discoverers

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -47,7 +47,18 @@ import (
 	promlogflag "github.com/prometheus/common/promlog/flag"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/azure"
 	sd_config "github.com/prometheus/prometheus/discovery/config"
+	"github.com/prometheus/prometheus/discovery/consul"
+	"github.com/prometheus/prometheus/discovery/dns"
+	"github.com/prometheus/prometheus/discovery/ec2"
+	"github.com/prometheus/prometheus/discovery/file"
+	"github.com/prometheus/prometheus/discovery/gce"
+	"github.com/prometheus/prometheus/discovery/kubernetes"
+	"github.com/prometheus/prometheus/discovery/marathon"
+	"github.com/prometheus/prometheus/discovery/openstack"
+	"github.com/prometheus/prometheus/discovery/triton"
+	"github.com/prometheus/prometheus/discovery/zookeeper"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/retrieval"
@@ -292,23 +303,16 @@ func main() {
 		notifier.ApplyConfig,
 		scrapeManager.ApplyConfig,
 		func(cfg *config.Config) error {
-			c := make(map[string]sd_config.ServiceDiscoveryConfig)
-			for _, v := range cfg.ScrapeConfigs {
-				c[v.JobName] = v.ServiceDiscoveryConfig
-			}
-			return discoveryManagerScrape.ApplyConfig(c)
+			discoveryManagerScrape.Register(scrapeDiscoverersFromConfig(cfg, logger))
+			return discoveryManagerScrape.ApplyConfig()
 		},
 		func(cfg *config.Config) error {
-			c := make(map[string]sd_config.ServiceDiscoveryConfig)
-			for _, v := range cfg.AlertingConfig.AlertmanagerConfigs {
-				// AlertmanagerConfigs doesn't hold an unique identifier so we use the config hash as the identifier.
-				b, err := json.Marshal(v)
-				if err != nil {
-					return err
-				}
-				c[fmt.Sprintf("%x", md5.Sum(b))] = v.ServiceDiscoveryConfig
+			if n, e := notifyDiscoverersFromConfig(cfg, logger); e != nil {
+				return e
+			} else {
+				discoveryManagerNotify.Register(n)
+				return discoveryManagerNotify.ApplyConfig()
 			}
-			return discoveryManagerNotify.ApplyConfig(c)
 		},
 		func(cfg *config.Config) error {
 			// Get all rule files matching the configuration oaths.
@@ -677,4 +681,112 @@ func sendAlerts(n *notifier.Notifier, externalURL string) rules.NotifyFunc {
 		}
 		return nil
 	}
+}
+
+func scrapeDiscoverersFromConfig(cfg *config.Config, l log.Logger) map[discovery.Key]discovery.Discoverer {
+	c := make(map[string]sd_config.ServiceDiscoveryConfig)
+	for _, v := range cfg.ScrapeConfigs {
+		c[v.JobName] = v.ServiceDiscoveryConfig
+	}
+	return providersFromConfig(c, l)
+}
+
+func notifyDiscoverersFromConfig(cfg *config.Config, l log.Logger) (map[discovery.Key]discovery.Discoverer, error) {
+	c := make(map[string]sd_config.ServiceDiscoveryConfig)
+	for _, v := range cfg.AlertingConfig.AlertmanagerConfigs {
+		// AlertmanagerConfigs doesn't hold an unique identifier so we use the config hash as the identifier.
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		c[fmt.Sprintf("%x", md5.Sum(b))] = v.ServiceDiscoveryConfig
+	}
+	return providersFromConfig(c, l), nil
+}
+
+func providersFromConfig(sdConfig map[string]sd_config.ServiceDiscoveryConfig, logger log.Logger) map[discovery.Key]discovery.Discoverer {
+
+	providers := make(map[discovery.Key]discovery.Discoverer)
+
+	for k, cfg := range sdConfig {
+		app := func(mech string, i int, tp discovery.Discoverer) {
+			providers[discovery.Key{
+				GroupName:      k,
+				DiscovererName: fmt.Sprintf("%s/%d", mech, i),
+			}] = tp
+		}
+
+		for i, c := range cfg.DNSSDConfigs {
+			app("dns", i, dns.NewDiscovery(*c, log.With(logger, "discovery", "dns")))
+		}
+		for i, c := range cfg.FileSDConfigs {
+			app("file", i, file.NewDiscovery(c, log.With(logger, "discovery", "file")))
+		}
+		for i, c := range cfg.ConsulSDConfigs {
+			k, err := consul.NewDiscovery(c, log.With(logger, "discovery", "consul"))
+			if err != nil {
+				level.Error(logger).Log("msg", "Cannot create Consul discovery", "err", err)
+				continue
+			}
+			app("consul", i, k)
+		}
+		for i, c := range cfg.MarathonSDConfigs {
+			t, err := marathon.NewDiscovery(*c, log.With(logger, "discovery", "marathon"))
+			if err != nil {
+				level.Error(logger).Log("msg", "Cannot create Marathon discovery", "err", err)
+				continue
+			}
+			app("marathon", i, t)
+		}
+		for i, c := range cfg.KubernetesSDConfigs {
+			k, err := kubernetes.New(log.With(logger, "discovery", "k8s"), c)
+			if err != nil {
+				level.Error(logger).Log("msg", "Cannot create Kubernetes discovery", "err", err)
+				continue
+			}
+			app("kubernetes", i, k)
+		}
+		for i, c := range cfg.ServersetSDConfigs {
+			app("serverset", i, zookeeper.NewServersetDiscovery(c, log.With(logger, "discovery", "zookeeper")))
+		}
+		for i, c := range cfg.NerveSDConfigs {
+			app("nerve", i, zookeeper.NewNerveDiscovery(c, log.With(logger, "discovery", "nerve")))
+		}
+		for i, c := range cfg.EC2SDConfigs {
+			app("ec2", i, ec2.NewDiscovery(c, log.With(logger, "discovery", "ec2")))
+		}
+		for i, c := range cfg.OpenstackSDConfigs {
+			openstackd, err := openstack.NewDiscovery(c, log.With(logger, "discovery", "openstack"))
+			if err != nil {
+				level.Error(logger).Log("msg", "Cannot initialize OpenStack discovery", "err", err)
+				continue
+			}
+			app("openstack", i, openstackd)
+		}
+
+		for i, c := range cfg.GCESDConfigs {
+			gced, err := gce.NewDiscovery(*c, log.With(logger, "discovery", "gce"))
+			if err != nil {
+				level.Error(logger).Log("msg", "Cannot initialize GCE discovery", "err", err)
+				continue
+			}
+			app("gce", i, gced)
+		}
+		for i, c := range cfg.AzureSDConfigs {
+			app("azure", i, azure.NewDiscovery(c, log.With(logger, "discovery", "azure")))
+		}
+		for i, c := range cfg.TritonSDConfigs {
+			t, err := triton.New(log.With(logger, "discovery", "trition"), c)
+			if err != nil {
+				level.Error(logger).Log("msg", "Cannot create Triton discovery", "err", err)
+				continue
+			}
+			app("triton", i, t)
+		}
+		if len(cfg.StaticConfigs) > 0 {
+			app("static", 0, discovery.NewStaticProvider(cfg.StaticConfigs))
+		}
+	}
+
+	return providers
 }


### PR DESCRIPTION
A step closer to making the discovery package very decoupled and the
posibility to use without any modifications.
for example for https://github.com/prometheus/prometheus/pull/3720

Register discoverers at initialiazation so i is easy to plugin your own
discoverer just by implementing the interface.

It is completely decoupled form the config package

TODO
- [ ] fix the tests
- [ ] update the docs to show how to register custom Discoverers