### PR TITLE
Meta labels sd 3693

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -301,6 +301,10 @@ func (sp *scrapePool) sync(targets []*Target) {
 			sp.loops[hash] = l
 
 			go l.run(interval, timeout, nil)
+		} else {
+			// Need to keep the most updated labels information
+			// for displaying it in the Service Discovery web page.
+			sp.targets[hash].SetDiscoveredLabels(t.DiscoveredLabels())
 		}
 	}
 

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -115,6 +115,11 @@ func (t *Target) DiscoveredLabels() labels.Labels {
 	return lset
 }
 
+// SetDiscoveredLabels sets new DiscoveredLabels
+func (t *Target) SetDiscoveredLabels(l labels.Labels) {
+	t.discoveredLabels = l
+}
+
 // URL returns a copy of the target's URL.
 func (t *Target) URL() *url.URL {
 	params := url.Values{}


### PR DESCRIPTION
fixes #3693
added an additional function to update the `DiscoveredLabels` even when the new labels don't affect the target hash.
The `hash` is calculated  form the target labels after the relabelling takes place so if the new labels don't affect the hash than `DiscoveredLabels` were never updated.

*The  `DiscoveredLabels` are used in the Service discovery page.
