### PR TITLE
Improve the healthy handler

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/storage/tsdb"
+	"github.com/prometheus/prometheus/util/health"
 	"github.com/prometheus/prometheus/util/strutil"
 	"github.com/prometheus/prometheus/web"
 )
@@ -267,6 +268,9 @@ func main() {
 	cfg.web.ScrapeManager = scrapeManager
 	cfg.web.RuleManager = ruleManager
 	cfg.web.Notifier = notifier
+	cfg.web.HealthReporters = []health.Reporter{
+		health.NewDiskSpaceReporter(cfg.localStoragePath),
+	}
 
 	cfg.web.Version = &web.PrometheusVersion{
 		Version:   version.Version,

--- a/util/health/disk.go
+++ b/util/health/disk.go
@@ -1,0 +1,29 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+type dsReporter struct {
+	path string
+}
+
+// NewDiskSpaceReporter returns a health reporter on the disk space.
+func NewDiskSpaceReporter(p string) Reporter {
+	return &dsReporter{
+		path: p,
+	}
+}
+
+func (d *dsReporter) String() string {
+	return "Disk space"
+}

--- a/util/health/disk_default.go
+++ b/util/health/disk_default.go
@@ -1,0 +1,35 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !netbsd
+// +build !openbsd
+// +build !windows
+
+package health
+
+import (
+	"errors"
+	"syscall"
+)
+
+func (d *dsReporter) Report() error {
+	fs := syscall.Statfs_t{}
+	err := syscall.Statfs(d.path, &fs)
+	if err != nil {
+		return err
+	}
+	if fs.Bavail == 0 {
+		return errors.New("No more space left")
+	}
+	return nil
+}

--- a/util/health/disk_netbsd.go
+++ b/util/health/disk_netbsd.go
@@ -1,0 +1,18 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+func (d *dsReporter) Report() error {
+	return nil
+}

--- a/util/health/disk_openbsd.go
+++ b/util/health/disk_openbsd.go
@@ -1,0 +1,31 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"errors"
+	"syscall"
+)
+
+func (d *dsReporter) Report() error {
+	fs := syscall.Statfs_t{}
+	err := syscall.Statfs(d.path, &fs)
+	if err != nil {
+		return err
+	}
+	if fs.F_bavail == 0 {
+		return errors.New("No more space left")
+	}
+	return nil
+}

--- a/util/health/disk_windows.go
+++ b/util/health/disk_windows.go
@@ -1,0 +1,18 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+func (d *dsReporter) Report() error {
+	return nil
+}

--- a/util/health/interface.go
+++ b/util/health/interface.go
@@ -1,0 +1,20 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+// Reporter reports the health status of a component
+type Reporter interface {
+	Report() error
+	String() string
+}


### PR DESCRIPTION
Prometheus will report itself as healthy if it can write to the local
metrics storage directory.

It is a naive and simplistic implementation but should at least address the issue described in #3807. There's also a discussion on #3650 about other things to check.

closes https://github.com/prometheus/prometheus/issues/3807