### PR TITLE
Improve wording of remote write documentation.

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -64,7 +64,7 @@ If your local storage becomes corrupted for whatever reason, your best bet is to
 
 ## Remote storage integrations
 
-As outlined above, Prometheus's local storage is limited in its scalability and durability. Instead of trying to solve long-term storage in Prometheus itself, Prometheus has a set of interfaces that allow integrating with remote long-term storage systems.
+Prometheus's local storage is limited by single nodes in its scalability and durability. Instead of trying to solve clustered storage in Prometheus itself, Prometheus has a set of interfaces that allow integrating with remote storage systems.
 
 ### Overview
 
@@ -75,7 +75,7 @@ Prometheus integrates with remote storage systems in two ways:
 
 ![Remote read and write architecture](images/remote_integrations.png)
 
-The read and write protocols both use a snappy-compressed protocol buffer encoding over HTTP. The protocols are not considered as stable APIs yet and may change to use gRPC over HTTP/2 in the future, when all hops between Prometheus and the long-term storage can safely be assumed to support HTTP/2.
+The read and write protocols both use a snappy-compressed protocol buffer encoding over HTTP. The protocols are not considered as stable APIs yet and may change to use gRPC over HTTP/2 in the future, when all hops between Prometheus and the remote storage can safely be assumed to support HTTP/2.
 
 For details on configuring remote storage integrations in Prometheus, see the [remote write](configuration/configuration.md#remote_write) and [remote read](configuration/configuration.md#remote_read) sections of the Prometheus configuration documentation.
 


### PR DESCRIPTION
Reduce the use of the term `long-term`, when what we're really talking
about is remote clustered storage for increased capacity and durability.