### PR TITLE
docs: Fix remote_read/remote_timeout default

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1135,7 +1135,7 @@ required_matchers:
   [ <labelname>: <labelvalue> ... ]
 
 # Timeout for requests to the remote read endpoint.
-[ remote_timeout: <duration> | default = 30s ]
+[ remote_timeout: <duration> | default = 1m ]
 
 # Whether reads should be made for queries for time ranges that
 # the local storage should have complete data for.


### PR DESCRIPTION
As we can see here: https://github.com/prometheus/prometheus/blob/master/config/config.go#L130

The default timeout for `read_remote` is 1m and not 30s as specified in the documentation