### PR TITLE
Pool package generalize

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -71,16 +71,16 @@ func (p *Pool) Get(sz int) interface{} {
 }
 
 // Put adds a slice to the right bucket in the pool.
-func (p *Pool) Put(s interface{}) error {
+func (p *Pool) Put(s interface{}) {
 	slice := reflect.ValueOf(s)
-	if slice.Kind() == reflect.Slice {
-		for i, size := range p.sizes {
-			if slice.Cap() > size {
-				continue
-			}
-			p.buckets[i].Put(slice.Slice(0, 0).Interface())
-			return nil
-		}
+
+	if slice.Kind() != reflect.Slice {
+		panic(fmt.Sprintf("%+v is not a slice", slice))
 	}
-	return fmt.Errorf("%+v is not a slice", slice)
+	for i, size := range p.sizes {
+		if slice.Cap() > size {
+			continue
+		}
+		p.buckets[i].Put(slice.Slice(0, 0).Interface())
+	}
 }

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -23,13 +23,13 @@ import (
 type Pool struct {
 	buckets []sync.Pool
 	sizes   []int
-	// initialize is the function used to create an empty slice when none exist yet.
-	initialize func(int) interface{}
+	// make is the function used to create an empty slice when none exist yet.
+	make func(int) interface{}
 }
 
 // New returns a new Pool with size buckets for minSize to maxSize
 // increasing by the given factor.
-func New(minSize, maxSize int, factor float64, newFunc func(int) interface{}) *Pool {
+func New(minSize, maxSize int, factor float64, makeFunc func(int) interface{}) *Pool {
 	if minSize < 1 {
 		panic("invalid minimum pool size")
 	}
@@ -47,9 +47,9 @@ func New(minSize, maxSize int, factor float64, newFunc func(int) interface{}) *P
 	}
 
 	p := &Pool{
-		buckets:    make([]sync.Pool, len(sizes)),
-		sizes:      sizes,
-		initialize: newFunc,
+		buckets: make([]sync.Pool, len(sizes)),
+		sizes:   sizes,
+		make:    makeFunc,
 	}
 
 	return p
@@ -63,11 +63,11 @@ func (p *Pool) Get(sz int) interface{} {
 		}
 		b := p.buckets[i].Get()
 		if b == nil {
-			b = p.initialize(bktSize)
+			b = p.make(bktSize)
 		}
 		return b
 	}
-	return p.initialize(sz)
+	return p.make(sz)
 }
 
 // Put adds a slice to the right bucket in the pool.

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -82,5 +82,6 @@ func (p *Pool) Put(s interface{}) {
 			continue
 		}
 		p.buckets[i].Put(slice.Slice(0, 0).Interface())
+		return
 	}
 }

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -13,17 +13,23 @@
 
 package pool
 
-import "sync"
+import (
+	"fmt"
+	"reflect"
+	"sync"
+)
 
-// BytesPool is a bucketed pool for variably sized byte slices.
-type BytesPool struct {
+// Pool is a bucketed pool for variably sized byte slices.
+type Pool struct {
 	buckets []sync.Pool
 	sizes   []int
+	// initialize is the function used to create an empty slice when none exist yet.
+	initialize func(int) interface{}
 }
 
-// NewBytesPool returns a new BytesPool with size buckets for minSize to maxSize
+// New returns a new Pool with size buckets for minSize to maxSize
 // increasing by the given factor.
-func NewBytesPool(minSize, maxSize int, factor float64) *BytesPool {
+func New(minSize, maxSize int, factor float64, newFunc func(int) interface{}) *Pool {
 	if minSize < 1 {
 		panic("invalid minimum pool size")
 	}
@@ -40,36 +46,41 @@ func NewBytesPool(minSize, maxSize int, factor float64) *BytesPool {
 		sizes = append(sizes, s)
 	}
 
-	p := &BytesPool{
-		buckets: make([]sync.Pool, len(sizes)),
-		sizes:   sizes,
+	p := &Pool{
+		buckets:    make([]sync.Pool, len(sizes)),
+		sizes:      sizes,
+		initialize: newFunc,
 	}
 
 	return p
 }
 
 // Get returns a new byte slices that fits the given size.
-func (p *BytesPool) Get(sz int) []byte {
+func (p *Pool) Get(sz int) interface{} {
 	for i, bktSize := range p.sizes {
 		if sz > bktSize {
 			continue
 		}
-		b, ok := p.buckets[i].Get().([]byte)
-		if !ok {
-			b = make([]byte, 0, bktSize)
+		b := p.buckets[i].Get()
+		if b == nil {
+			b = p.initialize(bktSize)
 		}
 		return b
 	}
-	return make([]byte, 0, sz)
+	return p.initialize(sz)
 }
 
-// Put returns a byte slice to the right bucket in the pool.
-func (p *BytesPool) Put(b []byte) {
-	for i, bktSize := range p.sizes {
-		if cap(b) > bktSize {
-			continue
+// Put adds a slice to the right bucket in the pool.
+func (p *Pool) Put(s interface{}) error {
+	slice := reflect.ValueOf(s)
+	if slice.Kind() == reflect.Slice {
+		for i, size := range p.sizes {
+			if slice.Cap() > size {
+				continue
+			}
+			p.buckets[i].Put(slice.Slice(0, 0).Interface())
+			return nil
 		}
-		p.buckets[i].Put(b[:0])
-		return
 	}
+	return fmt.Errorf("%+v is not a slice", slice)
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -148,7 +148,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app Appendable, logger log.Logger) 
 		level.Error(logger).Log("msg", "Error creating HTTP client", "err", err)
 	}
 
-	buffers := pool.NewBytesPool(163, 100e6, 3)
+	buffers := pool.New(163, 100e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sp := &scrapePool{
@@ -481,7 +481,7 @@ type scrapeLoop struct {
 	l              log.Logger
 	cache          *scrapeCache
 	lastScrapeSize int
-	buffers        *pool.BytesPool
+	buffers        *pool.Pool
 
 	appender            func() storage.Appender
 	sampleMutator       labelsMutator
@@ -596,7 +596,7 @@ func (c *scrapeCache) forEachStale(f func(labels.Labels) bool) {
 func newScrapeLoop(ctx context.Context,
 	sc scraper,
 	l log.Logger,
-	buffers *pool.BytesPool,
+	buffers *pool.Pool,
 	sampleMutator labelsMutator,
 	reportSampleMutator labelsMutator,
 	appender func() storage.Appender,
@@ -605,7 +605,7 @@ func newScrapeLoop(ctx context.Context,
 		l = log.NewNopLogger()
 	}
 	if buffers == nil {
-		buffers = pool.NewBytesPool(1e3, 1e6, 3)
+		buffers = pool.New(1e3, 1e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) })
 	}
 	sl := &scrapeLoop{
 		scraper:             sc,
@@ -662,7 +662,11 @@ mainLoop:
 				time.Since(last).Seconds(),
 			)
 		}
-		b := sl.buffers.Get(sl.lastScrapeSize)
+		b, ok := sl.buffers.Get(sl.lastScrapeSize).([]byte)
+		if !ok {
+			b = make([]byte, 0, sl.lastScrapeSize)
+			level.Error(sl.l).Log("msg", "buffer pool type assertion error")
+		}
 		buf := bytes.NewBuffer(b)
 
 		scrapeErr := sl.scraper.scrape(scrapeCtx, buf)
@@ -695,7 +699,9 @@ mainLoop:
 			}
 		}
 
-		sl.buffers.Put(b)
+		if err := sl.buffers.Put(b); err != nil {
+			level.Error(sl.l).Log("msg", "buffer pool error", "err", err)
+		}
 
 		if scrapeErr == nil {
 			scrapeErr = appErr

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -699,9 +699,7 @@ mainLoop:
 			}
 		}
 
-		if err := sl.buffers.Put(b); err != nil {
-			level.Error(sl.l).Log("msg", "buffer pool error", "err", err)
-		}
+		sl.buffers.Put(b)
 
 		if scrapeErr == nil {
 			scrapeErr = appErr

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -662,11 +662,8 @@ mainLoop:
 				time.Since(last).Seconds(),
 			)
 		}
-		b, ok := sl.buffers.Get(sl.lastScrapeSize).([]byte)
-		if !ok {
-			b = make([]byte, 0, sl.lastScrapeSize)
-			level.Error(sl.l).Log("msg", "buffer pool type assertion error")
-		}
+
+		b := sl.buffers.Get(sl.lastScrapeSize).([]byte)
 		buf := bytes.NewBuffer(b)
 
 		scrapeErr := sl.scraper.scrape(scrapeCtx, buf)


### PR DESCRIPTION
makes the pool package general to be used for any type by specifying its own constructor when initialising  the pool
this is in order to use the pool in promql to optimise the memory pool reuse.

@fabxc as we discussed it when talking about the promql optimisation. The text PR would be to refactor promql use the Pool.