### PR TITLE
bugfix: template: nil pointer dereference, e.g. if non-ASCII space

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -265,8 +265,7 @@ func (te Expander) Expand() (result string, resultErr error) {
 		}
 	}()
 
-	tmpl, err := text_template.New(te.name).Funcs(te.funcMap).Parse(te.text)
-	tmpl.Option("missingkey=zero")
+	tmpl, err := text_template.New(te.name).Funcs(te.funcMap).Option("missingkey=zero").Parse(te.text)
 	if err != nil {
 		return "", fmt.Errorf("error parsing template %v: %v", te.name, err)
 	}


### PR DESCRIPTION
If you have a non-ASCII space, e.g. the [non-breaking space](https://en.wikipedia.org/wiki/Non-breaking_space) ` `, in a text template action, Prometheus returns as `label`/`annotation` value:

    <error expanding template: runtime error: invalid memory address or nil pointer dereference>

The correct parsing error should be

    error parsing template test: template: test:1: unexpected unrecognized character in action: U+00A0 in command

as the [Go `text/template` lexer only accepts ASCII spaces ` \t\r\n`](https://github.com/golang/go/blob/master/src/text/template/parse/lex.go#L98).

A failure on Prometheus start resp. `promtool check config` for this would be good, as well.

@brian-brazil 