### PR TITLE
Add OS type meta label to Azure SD

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -40,6 +40,7 @@ const (
 	azureLabelMachineID            = azureLabel + "machine_id"
 	azureLabelMachineResourceGroup = azureLabel + "machine_resource_group"
 	azureLabelMachineName          = azureLabel + "machine_name"
+	azureLabelMachineOSType        = azureLabel + "machine_os_type"
 	azureLabelMachineLocation      = azureLabel + "machine_location"
 	azureLabelMachinePrivateIP     = azureLabel + "machine_private_ip"
 	azureLabelMachineTag           = azureLabel + "machine_tag_"
@@ -247,6 +248,7 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 			labels := model.LabelSet{
 				azureLabelMachineID:            model.LabelValue(*vm.ID),
 				azureLabelMachineName:          model.LabelValue(*vm.Name),
+				azureLabelMachineOSType:        model.LabelValue(vm.Properties.StorageProfile.OsDisk.OsType),
 				azureLabelMachineLocation:      model.LabelValue(*vm.Location),
 				azureLabelMachineResourceGroup: model.LabelValue(r.ResourceGroup),
 			}

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -260,6 +260,7 @@ The following meta labels are available on targets during relabeling:
 * `__meta_azure_machine_id`: the machine ID
 * `__meta_azure_machine_location`: the location the machine runs in
 * `__meta_azure_machine_name`: the machine name
+* `__meta_azure_machine_os_type`: the machine operating system
 * `__meta_azure_machine_private_ip`: the machine's private IP
 * `__meta_azure_machine_resource_group`: the machine's resource group
 * `__meta_azure_machine_tag_<tagname>`: each tag value of the machine


### PR DESCRIPTION
There is currently no way to differentiate Windows instances from Linux ones in Azure SD. This is needed when you have a mix of node_exporters / wmi_exporters for OS-level metrics and you want to have them in separate scrape jobs.

This change allows you to do just that. Example:

```
  - job_name: 'node'
    azure_sd_configs:
      - <azure_sd_config>
    relabel_configs:
      - source_labels: [__meta_azure_machine_os_type]
        regex: Linux
        action: keep
```

The way the vendor'd AzureSDK provides to get the OsType is a bit awkward - as far as I can tell, this information can only be gotten from the startup disk. Newer versions of the SDK appear to improve this a
bit (by having OS information in the InstanceView), but the current way still works in them.

As per MAINTAINERS.md, can either @brian-brazil or @fabxc review this please?