### PR TITLE
api: Added v1/status/flags endpoint.

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -278,7 +278,14 @@ func main() {
 	}
 
 	cfg.web.Flags = map[string]string{}
+
+	// Exclude kingpin default flags to expose only Prometheus ones.
+	boilerplateFlags := kingpin.New("", "").Version("")
 	for _, f := range a.Model().Flags {
+		if boilerplateFlags.GetFlag(f.Name) != nil {
+			continue
+		}
+
 		cfg.web.Flags[f.Name] = f.Value.String()
 	}
 

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -382,6 +382,79 @@ $ curl http://localhost:9090/api/v1/alertmanagers
 }
 ```
 
+## Status
+
+Following status endpoints expose current Prometheus configuration.
+
+### Config
+
+The following endpoint returns currently loaded configuration file:
+
+```
+GET /api/v1/status/config
+```
+
+Currently, config is returned as dumped YAML file.
+
+```json
+$ curl http://localhost:9090/api/v1/status/config
+{
+  "status": "success",
+  "data": {
+    "yaml": "<content of the loaded config file in YAML>",
+  }
+}
+```
+
+### Flags
+
+The following endpoint returns flag values that Prometheus was configured with:
+
+```
+GET /api/v1/status/flags
+```
+
+All values are in a form of "string".
+
+```json
+$ curl http://localhost:9090/api/v1/status/flags
+{
+  "status": "success",
+  "data": {
+    "alertmanager.notification-queue-capacity": "10000",
+    "alertmanager.timeout": "10s",
+    "completion-bash": "false",
+    "completion-script-bash": "false",
+    "completion-script-zsh": "false",
+    "config.file": "/etc/prometheus/prometheus.yaml",
+    "help": "false",
+    "help-long": "false",
+    "help-man": "false",
+    "log.level": "info",
+    "query.lookback-delta": "5m",
+    "query.max-concurrency": "20",
+    "query.timeout": "2m",
+    "storage.tsdb.max-block-duration": "36h",
+    "storage.tsdb.min-block-duration": "2h",
+    "storage.tsdb.no-lockfile": "false",
+    "storage.tsdb.path": "data/",
+    "storage.tsdb.retention": "15d",
+    "version": "false",
+    "web.console.libraries": "console_libraries",
+    "web.console.templates": "consoles",
+    "web.enable-admin-api": "false",
+    "web.enable-lifecycle": "false",
+    "web.external-url": "",
+    "web.listen-address": "0.0.0.0:9090",
+    "web.max-connections": "512",
+    "web.read-timeout": "5m",
+    "web.route-prefix": "/",
+    "web.user-assets": ""
+  }
+}
+```
+
+*New in v2.2*
 
 ## TSDB Admin APIs
 These are APIs that expose database functionalities for the advanced user. These APIs are not enabled unless the `--web.enable-admin-api` is set.

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -394,7 +394,8 @@ The following endpoint returns currently loaded configuration file:
 GET /api/v1/status/config
 ```
 
-Currently, config is returned as dumped YAML file.
+The config is returned as dumped YAML file. Due to limitation of the YAML
+library, YAML comments are not included.
 
 ```json
 $ curl http://localhost:9090/api/v1/status/config
@@ -423,33 +424,10 @@ $ curl http://localhost:9090/api/v1/status/flags
   "data": {
     "alertmanager.notification-queue-capacity": "10000",
     "alertmanager.timeout": "10s",
-    "completion-bash": "false",
-    "completion-script-bash": "false",
-    "completion-script-zsh": "false",
-    "config.file": "/etc/prometheus/prometheus.yaml",
-    "help": "false",
-    "help-long": "false",
-    "help-man": "false",
     "log.level": "info",
     "query.lookback-delta": "5m",
     "query.max-concurrency": "20",
-    "query.timeout": "2m",
-    "storage.tsdb.max-block-duration": "36h",
-    "storage.tsdb.min-block-duration": "2h",
-    "storage.tsdb.no-lockfile": "false",
-    "storage.tsdb.path": "data/",
-    "storage.tsdb.retention": "15d",
-    "version": "false",
-    "web.console.libraries": "console_libraries",
-    "web.console.templates": "consoles",
-    "web.enable-admin-api": "false",
-    "web.enable-lifecycle": "false",
-    "web.external-url": "",
-    "web.listen-address": "0.0.0.0:9090",
-    "web.max-connections": "512",
-    "web.read-timeout": "5m",
-    "web.route-prefix": "/",
-    "web.user-assets": ""
+    ...
   }
 }
 ```

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -63,6 +63,11 @@ var samplePrometheusCfg = config.Config{
 	RemoteReadConfigs:  []*config.RemoteReadConfig{},
 }
 
+var sampleFlagMap = map[string]string{
+	"flag1": "value1",
+	"flag2": "value2",
+}
+
 func TestEndpoints(t *testing.T) {
 	suite, err := promql.NewTest(t, `
 		load 1m
@@ -108,9 +113,10 @@ func TestEndpoints(t *testing.T) {
 		QueryEngine:           suite.QueryEngine(),
 		targetRetriever:       tr,
 		alertmanagerRetriever: ar,
-		now:    func() time.Time { return now },
-		config: func() config.Config { return samplePrometheusCfg },
-		ready:  func(f http.HandlerFunc) http.HandlerFunc { return f },
+		now:      func() time.Time { return now },
+		config:   func() config.Config { return samplePrometheusCfg },
+		flagsMap: sampleFlagMap,
+		ready:    func(f http.HandlerFunc) http.HandlerFunc { return f },
 	}
 
 	start := time.Unix(0, 0)
@@ -448,6 +454,10 @@ func TestEndpoints(t *testing.T) {
 			response: &prometheusConfig{
 				YAML: samplePrometheusCfg.String(),
 			},
+		},
+		{
+			endpoint: api.serveFlags,
+			response: sampleFlagMap,
 		},
 	}
 

--- a/web/web.go
+++ b/web/web.go
@@ -187,6 +187,7 @@ func New(logger log.Logger, o *Options) *Handler {
 			defer h.mtx.RUnlock()
 			return *h.config
 		},
+		o.Flags,
 		h.testReady,
 		h.options.TSDB,
 		h.options.EnableAdminAPI,


### PR DESCRIPTION
Endpoint URL: `/api/v1/status/flags`
Example Output:
```json
{
  "status": "success",
  "data": {
    "alertmanager.notification-queue-capacity": "10000",
    "alertmanager.timeout": "10s",
    "completion-bash": "false",
    "completion-script-bash": "false",
    "completion-script-zsh": "false",
    "config.file": "my_cool_prometheus.yaml",
    "help": "false",
    "help-long": "false",
    "help-man": "false",
    "log.level": "info",
    "query.lookback-delta": "5m",
    "query.max-concurrency": "20",
    "query.timeout": "2m",
    "storage.tsdb.max-block-duration": "36h",
    "storage.tsdb.min-block-duration": "2h",
    "storage.tsdb.no-lockfile": "false",
    "storage.tsdb.path": "data/",
    "storage.tsdb.retention": "15d",
    "version": "false",
    "web.console.libraries": "console_libraries",
    "web.console.templates": "consoles",
    "web.enable-admin-api": "false",
    "web.enable-lifecycle": "false",
    "web.external-url": "",
    "web.listen-address": "0.0.0.0:9090",
    "web.max-connections": "512",
    "web.read-timeout": "5m",
    "web.route-prefix": "/",
    "web.user-assets": ""
  }
}
```

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>