### PR TITLE
fix reset of timer in remote storage queue

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -454,13 +454,13 @@ func (s *shards) runShard(i int) {
 			if !timer.Stop() {
 				<-timer.C
 			}
-			timer.Reset(s.qm.cfg.BatchSendDeadline)
 		case <-timer.C:
 			if len(pendingSamples) > 0 {
 				s.sendSamples(pendingSamples)
 				pendingSamples = pendingSamples[:0]
 			}
 		}
+		timer.Reset(s.qm.cfg.BatchSendDeadline)
 	}
 }
 


### PR DESCRIPTION
This PR fixes a bug introduced in #3731 and reported in #3809.

The timer has to be resetted in both cases, as otherwise the for loop does not continue if the queue is flushed due to a timeout. The proposed solution is race-free, as in both cases the timer has already expired before it is resetted.

@tomwilkie