### PR TITLE
Prevent invalid label names with labelmap

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -569,6 +569,9 @@ func (c *RelabelConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if c.Action == RelabelReplace && !relabelTarget.MatchString(c.TargetLabel) {
 		return fmt.Errorf("%q is invalid 'target_label' for %s action", c.TargetLabel, c.Action)
 	}
+	if c.Action == RelabelLabelMap && !relabelTarget.MatchString(c.Replacement) {
+		return fmt.Errorf("%q is invalid 'replacement' for %s action", c.Replacement, c.Action)
+	}
 	if c.Action == RelabelHashMod && !model.LabelName(c.TargetLabel).IsValid() {
 		return fmt.Errorf("%q is invalid 'target_label' for %s action", c.TargetLabel, c.Action)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -636,6 +636,9 @@ var expectedErrors = []struct {
 		filename: "labeldrop5.bad.yml",
 		errMsg:   "labeldrop action requires only 'regex', and no other fields",
 	}, {
+		filename: "labelmap.bad.yml",
+		errMsg:   "\"l-$1\" is invalid 'replacement' for labelmap action",
+	}, {
 		filename: "rules.bad.yml",
 		errMsg:   "invalid rule file path",
 	}, {

--- a/config/testdata/labelmap.bad.yml
+++ b/config/testdata/labelmap.bad.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: prometheus
+    relabel_configs:
+      - action: labelmap
+        replacement: l-$1


### PR DESCRIPTION
This change ensures that the relabeling configurations using labelmap
can't generate invalid label names. ~~It also checks that the label names
generated by labelmap actions are valid.~~

Fixes #3850.