### PR TITLE
cleanup gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,17 +6,6 @@
 /*.rules
 *.exe
 
-# Editor files #
-################
-*~
-.*.swp
-.*.swo
-*.iml
-.idea
-tags
-.history
-.vscode
-
 /prometheus
 /promtool
 benchmark.txt


### PR DESCRIPTION
just found a neat trick that any custom gitignore requirements can be set in `.git/info/exclude` this way everyone can have a custom local gitignore without any need to keep this in the official `.gitignore`

Let me know if I should remove anything else than the editors ignores.