### PR TITLE
alerting: Set StartedAt to the time the alerti is active, not firing

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -672,7 +672,7 @@ func sendAlerts(n *notifier.Manager, externalURL string) rules.NotifyFunc {
 				continue
 			}
 			a := &notifier.Alert{
-				StartsAt:     alert.FiredAt,
+				StartsAt:     alert.ActiveAt,
 				Labels:       alert.Labels,
 				Annotations:  alert.Annotations,
 				GeneratorURL: externalURL + strutil.TableLinkForExpression(expr),


### PR DESCRIPTION
It makes more sense to send to the Alertmanager the time the alert has
really started, not the time it fires.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>