### PR TITLE
Cleanup licence check script

### DIFF
--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -1,10 +1,29 @@
 #!/bin/sh
+#
+# Copyright 2018 The Prometheus Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-licRes=$(
-for file in $(find . -type f -iname '*.go' ! -path './vendor/*'); do
-	head -n3 "${file}" | grep -Eq "(Copyright|generated|GENERATED)" || echo -e "  ${file}"
-done;)
+check_license() {
+  local file=""
+  for file in $(find . -type f -iname '*.go' ! -path './vendor/*'); do
+    head -n3 "${file}" | grep -Eq "(Copyright|generated|GENERATED)" || echo "  ${file}"
+  done
+}
+
+licRes=$(check_license)
+
 if [ -n "${licRes}" ]; then
-	echo -e "license header checking failed:\n${licRes}"
-	exit 255
+  echo "license header checking failed:"
+  echo "${licRes}"
+  exit 255
 fi

--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -25,5 +25,5 @@ licRes=$(check_license)
 if [ -n "${licRes}" ]; then
   echo "license header checking failed:"
   echo "${licRes}"
-  exit 255
+  exit 1
 fi


### PR DESCRIPTION
* `echo -e` is not supported by POSIX shell.
* Add a license to the check script.
* Split out license check loop into function for clarity.
* Exit 1.