### PR TITLE
Reset the timer after reading from its channel

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -453,13 +453,13 @@ func (s *shards) runShard(i int) {
 			if !timer.Stop() {
 				<-timer.C
 			}
-			timer.Reset(s.qm.cfg.BatchSendDeadline)
 		case <-timer.C:
 			if len(pendingSamples) > 0 {
 				s.sendSamples(pendingSamples)
 				pendingSamples = pendingSamples[:0]
 			}
 		}
+		timer.Reset(s.qm.cfg.BatchSendDeadline)
 	}
 }
 


### PR DESCRIPTION
Before this change, if the <-timer.C case is entered, the timer isn't reset, but the channel is drained, so if timer.Stop() returns false and L454 tries to read from timer.C, it gets stuck.