### PR TITLE
Validate SD configuration

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -86,6 +86,9 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err != nil {
 		return err
 	}
+	if c.SubscriptionID == "" {
+		return fmt.Errorf("Azure SD configuration requires a subscription_id")
+	}
 
 	return yaml_util.CheckOverflow(c.XXX, "azure_sd_config")
 }

--- a/discovery/openstack/openstack.go
+++ b/discovery/openstack/openstack.go
@@ -103,6 +103,9 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if c.Role == "" {
 		return fmt.Errorf("role missing (one of: instance, hypervisor)")
 	}
+	if c.Region == "" {
+		return fmt.Errorf("Openstack SD configuration requires a region")
+	}
 	return yaml_util.CheckOverflow(c.XXX, "openstack_sd_config")
 }
 


### PR DESCRIPTION
This PR adds validation to SD configuration so it matches required fields described in SD documentation.
I avoided validating all the fields, because some clients extract that information from environment variables or have own defaults. This should avoid breaking users in case of errors, if they configured SD based on documentation they should have those fields already filled. 

fixes https://github.com/prometheus/prometheus/pull/3911