### PR TITLE
Change docker build to multi-stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,19 @@
+FROM golang:1 AS build
+
+RUN apt-get update && apt-get install -y build-essential
+
+COPY    . /go/src/github.com/prometheus/prometheus/
+WORKDIR /go/src/github.com/prometheus/prometheus/
+
+RUN make build
+
 FROM        quay.io/prometheus/busybox:latest
 LABEL maintainer "The Prometheus Authors <prometheus-developers@googlegroups.com>"
-
-COPY prometheus                             /bin/prometheus
-COPY promtool                               /bin/promtool
-COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
-COPY console_libraries/                     /usr/share/prometheus/console_libraries/
-COPY consoles/                              /usr/share/prometheus/consoles/
+COPY --from=build /go/src/github.com/prometheus/prometheus/prometheus                             /bin/prometheus
+COPY --from=build /go/src/github.com/prometheus/prometheus/promtool                               /bin/promtool
+COPY --from=build /go/src/github.com/prometheus/prometheus/documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
+COPY --from=build /go/src/github.com/prometheus/prometheus/console_libraries/                     /usr/share/prometheus/console_libraries/
+COPY --from=build /go/src/github.com/prometheus/prometheus/consoles/                              /usr/share/prometheus/consoles/
 
 RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
 RUN mkdir -p /prometheus && \

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.10-base
     REPO_PATH: github.com/prometheus/prometheus
   pre:
-    - sudo curl -L -o /usr/bin/docker 'https://download.docker.com/linux/static/stable/x86_64/docker-17.12.1-ce.tgz'
+    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.10.0-circleci'
     - sudo chmod 0755 /usr/bin/docker
     - sudo curl -L 'https://github.com/aktau/github-release/releases/download/v0.6.2/linux-amd64-github-release.tar.bz2' | tar xvjf - --strip-components 3 -C $HOME/bin
   services:

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.10-base
     REPO_PATH: github.com/prometheus/prometheus
   pre:
-    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci'
+    - sudo curl -L -o /usr/bin/docker 'https://download.docker.com/linux/static/stable/x86_64/docker-17.12.1-ce.tgz'
     - sudo chmod 0755 /usr/bin/docker
     - sudo curl -L 'https://github.com/aktau/github-release/releases/download/v0.6.2/linux-amd64-github-release.tar.bz2' | tar xvjf - --strip-components 3 -C $HOME/bin
   services:


### PR DESCRIPTION
Current docker image build depends on binaries built outside of container.
It depends on compile enviroment and result might not be completely preditable.

Using multi-stage build will make the result more predicatle.

https://docs.docker.com/develop/develop-images/multistage-build/

I might be missing why we are not doing it for prometheus already and I couldn't find related posts in issues or PRs. Please let me know if there is a reason.

Drawback is that this change will require Docker 17.05 or higher.