### PR TITLE
WIP: Change docker build to multi-stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,19 @@
+FROM golang:1 AS build
+
+RUN apt-get update && apt-get install -y build-essential
+
+COPY    . /go/src/github.com/prometheus/prometheus/
+WORKDIR /go/src/github.com/prometheus/prometheus/
+
+RUN make build
+
 FROM        quay.io/prometheus/busybox:latest
 LABEL maintainer "The Prometheus Authors <prometheus-developers@googlegroups.com>"
-
-COPY prometheus                             /bin/prometheus
-COPY promtool                               /bin/promtool
-COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
-COPY console_libraries/                     /usr/share/prometheus/console_libraries/
-COPY consoles/                              /usr/share/prometheus/consoles/
+COPY --from=build /go/src/github.com/prometheus/prometheus/prometheus                             /bin/prometheus
+COPY --from=build /go/src/github.com/prometheus/prometheus/promtool                               /bin/promtool
+COPY --from=build /go/src/github.com/prometheus/prometheus/documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
+COPY --from=build /go/src/github.com/prometheus/prometheus/console_libraries/                     /usr/share/prometheus/console_libraries/
+COPY --from=build /go/src/github.com/prometheus/prometheus/consoles/                              /usr/share/prometheus/consoles/
 
 RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
 RUN mkdir -p /prometheus && \


### PR DESCRIPTION
Current docker image build depends on binaries built outside of container.
It depends on compile enviroment and result might not be completely preditable.

Using multi-stage build will make the result more predicatle.

https://docs.docker.com/develop/develop-images/multistage-build/

This change will require Docker 17.05 or higher and refactoring circleci setup to 2.0.
