### PR TITLE
Add target_label comparison to keep/drop relabel actions.

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -951,8 +951,10 @@ anchored on both ends. To un-anchor the regex, use `.*<regex>.*`.
   `target_label` to `replacement`, with match group references
   (`${1}`, `${2}`, ...) in `replacement` substituted by their value. If `regex`
   does not match, no replacement takes place.
-* `keep`: Drop targets for which `regex` does not match the concatenated `source_labels`.
-* `drop`: Drop targets for which `regex` matches the concatenated `source_labels`.
+* `keep`: Drop targets for which the concatenated `source_labels` does not match `regex` 
+   , nor the value of `target\_label` if specified.
+* `drop`: Drop targets for which the concatenated `source_labels` match `regex`, or the value of `target\_label`
+   if specified.
 * `hashmod`: Set `target_label` to the `modulus` of a hash of the concatenated `source_labels`.
 * `labelmap`: Match `regex` against all label names. Then copy the values of the matching labels
    to label names given by `replacement` with match group references

--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -130,6 +130,9 @@ scrape_configs:
 
 # Scrape config for service endpoints.
 #
+# This will scrape all pods for which the `prometheus.io/port` annotation is
+# set to the name of a specific port to scrape.
+#
 # The relabeling allows the actual service scrape endpoint to be configured
 # via the following annotations:
 #
@@ -148,6 +151,12 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
     action: keep
     regex: true
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: ""
+    action: drop
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_port]
+    target_label: __meta_kubernetes_endpoint_port_name
+    action: keep
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
     action: replace
     target_label: __scheme__
@@ -156,11 +165,6 @@ scrape_configs:
     action: replace
     target_label: __metrics_path__
     regex: (.+)
-  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-    action: replace
-    target_label: __address__
-    regex: ([^:]+)(?::\d+)?;(\d+)
-    replacement: $1:$2
   - action: labelmap
     regex: __meta_kubernetes_service_label_(.+)
   - source_labels: [__meta_kubernetes_namespace]
@@ -169,6 +173,41 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_service_name]
     action: replace
     target_label: kubernetes_name
+    #
+# Scrape config for service endpoints witb no port specification.
+# 
+# This scrape is the same as aboave, but will scrape all ports on any
+# pod with scraping enabled, but no speceific port specified.
+
+- job_name: 'kubernetes-service-endpoints-all-ports'
+
+  kubernetes_sd_configs:
+  - role: endpoints
+
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+    action: keep
+    regex: true
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: "(.+)"
+    action: drop
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    action: replace
+    target_label: __scheme__
+    regex: (https?)
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    action: replace
+    target_label: __metrics_path__
+    regex: (.+)
+  - action: labelmap
+    regex: __meta_kubernetes_service_label_(.+)
+  - source_labels: [__meta_kubernetes_namespace]
+    action: replace
+    target_label: kubernetes_namespace
+  - source_labels: [__meta_kubernetes_service_name]
+    action: replace
+    target_label: kubernetes_name
+
 
 # Example scrape config for probing services via the Blackbox Exporter.
 #

--- a/pkg/relabel/relabel.go
+++ b/pkg/relabel/relabel.go
@@ -45,17 +45,23 @@ func relabel(lset labels.Labels, cfg *config.RelabelConfig) labels.Labels {
 	}
 	val := strings.Join(values, cfg.Separator)
 
+	targetVal := ""
+	if lset.Has(cfg.TargetLabel) {
+		targetVal = lset.Get(cfg.TargetLabel)
+	}
+
 	lb := labels.NewBuilder(lset)
 
 	switch cfg.Action {
 	case config.RelabelDrop:
-		if cfg.Regex.MatchString(val) {
+		if (cfg.TargetLabel != "" && val == targetVal) || cfg.Regex.MatchString(val) {
 			return nil
 		}
 	case config.RelabelKeep:
-		if !cfg.Regex.MatchString(val) {
-			return nil
+		if (cfg.TargetLabel != "" && val == targetVal) || cfg.Regex.MatchString(val) {
+			return lb.Labels()
 		}
+		return nil
 	case config.RelabelReplace:
 		indexes := cfg.Regex.FindStringSubmatchIndex(val)
 		// If there is no match no replacement must take place.

--- a/pkg/relabel/relabel_test.go
+++ b/pkg/relabel/relabel_test.go
@@ -195,6 +195,87 @@ func TestRelabel(t *testing.T) {
 			}),
 		},
 		{
+			input: labels.FromMap(map[string]string{
+				"a": "foo",
+				"b": "bar",
+			}),
+			relabel: []*config.RelabelConfig{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					TargetLabel:  "b",
+					Regex:        config.MustNewRegexp(""),
+					Action:       config.RelabelKeep,
+				},
+			},
+			output: nil,
+		},
+		{
+			input: labels.FromMap(map[string]string{
+				"a": "foo",
+				"b": "foo",
+			}),
+			relabel: []*config.RelabelConfig{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					TargetLabel:  "b",
+					Regex:        config.MustNewRegexp(""),
+					Action:       config.RelabelKeep,
+				},
+			},
+			output: labels.FromMap(map[string]string{
+				"a": "foo",
+				"b": "foo",
+			}),
+		},
+		{
+			input: labels.FromMap(map[string]string{
+				"a": "foo",
+				"b": "foo",
+			}),
+			relabel: []*config.RelabelConfig{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					TargetLabel:  "b",
+					Regex:        config.MustNewRegexp(""),
+					Action:       config.RelabelDrop,
+				},
+			},
+			output: nil,
+		},
+		{
+			input: labels.FromMap(map[string]string{
+				"a": "foo",
+				"b": "bar",
+			}),
+			relabel: []*config.RelabelConfig{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					TargetLabel:  "b",
+					Regex:        config.MustNewRegexp(""),
+					Action:       config.RelabelDrop,
+				},
+			},
+			output: labels.FromMap(map[string]string{
+				"a": "foo",
+				"b": "bar",
+			}),
+		},
+		{
+			input: labels.FromMap(map[string]string{
+				"a": "foo",
+				"b": "foo",
+			}),
+			relabel: []*config.RelabelConfig{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					TargetLabel:  "b",
+					Regex:        config.MustNewRegexp("x.+"),
+					Action:       config.RelabelDrop,
+				},
+			},
+			output: nil,
+		},
+		{
 			// No replacement must be applied if there is no match.
 			input: labels.FromMap(map[string]string{
 				"a": "boo",


### PR DESCRIPTION
This allows for comparison of the concatenated source_labels against
the value of the label specified by target_label in the keep/drop
actions.