### PR TITLE
Expose itemtype outside the package

### DIFF
--- a/promql/ast.go
+++ b/promql/ast.go
@@ -99,7 +99,7 @@ type Expressions []Expr
 
 // AggregateExpr represents an aggregation operation on a Vector.
 type AggregateExpr struct {
-	Op       itemType // The used aggregation operation.
+	Op       ItemType // The used aggregation operation.
 	Expr     Expr     // The Vector expression over which is aggregated.
 	Param    Expr     // Parameter used by some aggregators.
 	Grouping []string // The labels by which to group the Vector.
@@ -108,7 +108,7 @@ type AggregateExpr struct {
 
 // BinaryExpr represents a binary expression between two child expressions.
 type BinaryExpr struct {
-	Op       itemType // The operation of the expression.
+	Op       ItemType // The operation of the expression.
 	LHS, RHS Expr     // The operands on the respective sides of the operator.
 
 	// The matching behavior for the operation if both operands are Vectors.
@@ -156,7 +156,7 @@ type StringLiteral struct {
 // UnaryExpr represents a unary operation on another expression.
 // Currently unary operations are only supported for Scalars.
 type UnaryExpr struct {
-	Op   itemType
+	Op   ItemType
 	Expr Expr
 }
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -961,7 +961,7 @@ func (ev *evaluator) VectorUnless(lhs, rhs Vector, matching *VectorMatching) Vec
 }
 
 // VectorBinop evaluates a binary operation between two Vectors, excluding set operators.
-func (ev *evaluator) VectorBinop(op itemType, lhs, rhs Vector, matching *VectorMatching, returnBool bool) Vector {
+func (ev *evaluator) VectorBinop(op ItemType, lhs, rhs Vector, matching *VectorMatching, returnBool bool) Vector {
 	if matching.Card == CardManyToMany {
 		panic("many-to-many only allowed for set operators")
 	}
@@ -1099,7 +1099,7 @@ func signatureFunc(on bool, names ...string) func(labels.Labels) uint64 {
 
 // resultMetric returns the metric for the given sample(s) based on the Vector
 // binary operation and the matching options.
-func resultMetric(lhs, rhs labels.Labels, op itemType, matching *VectorMatching) labels.Labels {
+func resultMetric(lhs, rhs labels.Labels, op ItemType, matching *VectorMatching) labels.Labels {
 	lb := labels.NewBuilder(lhs)
 
 	if shouldDropMetricName(op) {
@@ -1134,7 +1134,7 @@ func resultMetric(lhs, rhs labels.Labels, op itemType, matching *VectorMatching)
 }
 
 // VectorscalarBinop evaluates a binary operation between a Vector and a Scalar.
-func (ev *evaluator) VectorscalarBinop(op itemType, lhs Vector, rhs Scalar, swap, returnBool bool) Vector {
+func (ev *evaluator) VectorscalarBinop(op ItemType, lhs Vector, rhs Scalar, swap, returnBool bool) Vector {
 	vec := make(Vector, 0, len(lhs))
 
 	for _, lhsSample := range lhs {
@@ -1169,7 +1169,7 @@ func dropMetricName(l labels.Labels) labels.Labels {
 }
 
 // scalarBinop evaluates a binary operation between two Scalars.
-func scalarBinop(op itemType, lhs, rhs float64) float64 {
+func scalarBinop(op ItemType, lhs, rhs float64) float64 {
 	switch op {
 	case itemADD:
 		return lhs + rhs
@@ -1200,7 +1200,7 @@ func scalarBinop(op itemType, lhs, rhs float64) float64 {
 }
 
 // vectorElemBinop evaluates a binary operation between two Vector elements.
-func vectorElemBinop(op itemType, lhs, rhs float64) (float64, bool) {
+func vectorElemBinop(op ItemType, lhs, rhs float64) (float64, bool) {
 	switch op {
 	case itemADD:
 		return lhs + rhs, true
@@ -1255,7 +1255,7 @@ type groupedAggregation struct {
 }
 
 // aggregation evaluates an aggregation operation on a Vector.
-func (ev *evaluator) aggregation(op itemType, grouping []string, without bool, param Expr, vec Vector) Vector {
+func (ev *evaluator) aggregation(op ItemType, grouping []string, without bool, param Expr, vec Vector) Vector {
 
 	result := map[uint64]*groupedAggregation{}
 	var k int64
@@ -1461,7 +1461,7 @@ func btos(b bool) float64 {
 
 // shouldDropMetricName returns whether the metric name should be dropped in the
 // result of the op operation.
-func shouldDropMetricName(op itemType) bool {
+func shouldDropMetricName(op ItemType) bool {
 	switch op {
 	case itemADD, itemSUB, itemDIV, itemMUL, itemMOD:
 		return true

--- a/promql/lex.go
+++ b/promql/lex.go
@@ -22,7 +22,7 @@ import (
 
 // item represents a token or text string returned from the scanner.
 type item struct {
-	typ itemType // The type of this item.
+	typ ItemType // The type of this item.
 	pos Pos      // The starting position, in bytes, of this item in the input string.
 	val string   // The value of this item.
 }
@@ -50,25 +50,25 @@ func (i item) String() string {
 
 // isOperator returns true if the item corresponds to a arithmetic or set operator.
 // Returns false otherwise.
-func (i itemType) isOperator() bool { return i > operatorsStart && i < operatorsEnd }
+func (i ItemType) isOperator() bool { return i > operatorsStart && i < operatorsEnd }
 
 // isAggregator returns true if the item belongs to the aggregator functions.
 // Returns false otherwise
-func (i itemType) isAggregator() bool { return i > aggregatorsStart && i < aggregatorsEnd }
+func (i ItemType) isAggregator() bool { return i > aggregatorsStart && i < aggregatorsEnd }
 
 // isAggregator returns true if the item is an aggregator that takes a parameter.
 // Returns false otherwise
-func (i itemType) isAggregatorWithParam() bool {
+func (i ItemType) isAggregatorWithParam() bool {
 	return i == itemTopK || i == itemBottomK || i == itemCountValues || i == itemQuantile
 }
 
 // isKeyword returns true if the item corresponds to a keyword.
 // Returns false otherwise.
-func (i itemType) isKeyword() bool { return i > keywordsStart && i < keywordsEnd }
+func (i ItemType) isKeyword() bool { return i > keywordsStart && i < keywordsEnd }
 
 // isCompairsonOperator returns true if the item corresponds to a comparison operator.
 // Returns false otherwise.
-func (i itemType) isComparisonOperator() bool {
+func (i ItemType) isComparisonOperator() bool {
 	switch i {
 	case itemEQL, itemNEQ, itemLTE, itemLSS, itemGTE, itemGTR:
 		return true
@@ -78,7 +78,7 @@ func (i itemType) isComparisonOperator() bool {
 }
 
 // isSetOperator returns whether the item corresponds to a set operator.
-func (i itemType) isSetOperator() bool {
+func (i ItemType) isSetOperator() bool {
 	switch i {
 	case itemLAND, itemLOR, itemLUnless:
 		return true
@@ -92,7 +92,7 @@ const LowestPrec = 0 // Non-operators.
 // Precedence returns the operator precedence of the binary
 // operator op. If op is not a binary operator, the result
 // is LowestPrec.
-func (i itemType) precedence() int {
+func (i ItemType) precedence() int {
 	switch i {
 	case itemLOR:
 		return 1
@@ -111,7 +111,7 @@ func (i itemType) precedence() int {
 	}
 }
 
-func (i itemType) isRightAssociative() bool {
+func (i ItemType) isRightAssociative() bool {
 	switch i {
 	case itemPOW:
 		return true
@@ -121,10 +121,10 @@ func (i itemType) isRightAssociative() bool {
 
 }
 
-type itemType int
+type ItemType int
 
 const (
-	itemError itemType = iota // Error occurred, value is error message
+	itemError ItemType = iota // Error occurred, value is error message
 	itemEOF
 	itemComment
 	itemIdentifier
@@ -198,7 +198,7 @@ const (
 	keywordsEnd
 )
 
-var key = map[string]itemType{
+var key = map[string]ItemType{
 	// Operators.
 	"and":    itemLAND,
 	"or":     itemLOR,
@@ -235,7 +235,7 @@ var key = map[string]itemType{
 
 // These are the default string representations for common items. It does not
 // imply that those are the only character sequences that can be lexed to such an item.
-var itemTypeStr = map[itemType]string{
+var itemTypeStr = map[ItemType]string{
 	itemLeftParen:    "(",
 	itemRightParen:   ")",
 	itemLeftBrace:    "{",
@@ -274,7 +274,7 @@ func init() {
 	key["nan"] = itemNumber
 }
 
-func (i itemType) String() string {
+func (i ItemType) String() string {
 	if s, ok := itemTypeStr[i]; ok {
 		return s
 	}
@@ -291,7 +291,7 @@ func (i item) desc() string {
 	return fmt.Sprintf("%s %s", i.typ.desc(), i)
 }
 
-func (i itemType) desc() string {
+func (i ItemType) desc() string {
 	switch i {
 	case itemError:
 		return "error"
@@ -366,7 +366,7 @@ func (l *lexer) backup() {
 }
 
 // emit passes an item back to the client.
-func (l *lexer) emit(t itemType) {
+func (l *lexer) emit(t ItemType) {
 	l.items <- item{t, l.start, l.input[l.start:l.pos]}
 	l.start = l.pos
 }

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -314,7 +314,7 @@ func (p *parser) error(err error) {
 }
 
 // expect consumes the next token and guarantees it has the required type.
-func (p *parser) expect(exp itemType, context string) item {
+func (p *parser) expect(exp ItemType, context string) item {
 	token := p.next()
 	if token.typ != exp {
 		p.errorf("unexpected %s in %s, expected %s", token.desc(), context, exp.desc())
@@ -323,7 +323,7 @@ func (p *parser) expect(exp itemType, context string) item {
 }
 
 // expectOneOf consumes the next token and guarantees it has one of the required types.
-func (p *parser) expectOneOf(exp1, exp2 itemType, context string) item {
+func (p *parser) expectOneOf(exp1, exp2 ItemType, context string) item {
 	token := p.next()
 	if token.typ != exp1 && token.typ != exp2 {
 		p.errorf("unexpected %s in %s, expected %s or %s", token.desc(), context, exp1.desc(), exp2.desc())
@@ -509,7 +509,7 @@ func (p *parser) expr() Expr {
 	}
 }
 
-func (p *parser) balance(lhs Expr, op itemType, rhs Expr, vecMatching *VectorMatching, returnBool bool) *BinaryExpr {
+func (p *parser) balance(lhs Expr, op ItemType, rhs Expr, vecMatching *VectorMatching, returnBool bool) *BinaryExpr {
 	if lhsBE, ok := lhs.(*BinaryExpr); ok {
 		precd := lhsBE.Op.precedence() - op.precedence()
 		if (precd < 0) || (precd == 0 && op.isRightAssociative()) {
@@ -810,7 +810,7 @@ func (p *parser) labelSet() labels.Labels {
 //
 //		'{' [ <labelname> <match_op> <match_string>, ... ] '}'
 //
-func (p *parser) labelMatchers(operators ...itemType) []*labels.Matcher {
+func (p *parser) labelMatchers(operators ...ItemType) []*labels.Matcher {
 	const ctx = "label matching"
 
 	matchers := []*labels.Matcher{}


### PR DESCRIPTION
itemtype is not exposed outside of promql package. It will be useful to expose this so that Expr can be used outside this package. Note that all the fields are already exported.