### PR TITLE
Correctly stop the timer used in the remote write path.

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -126,7 +126,7 @@ func TestSampleDelivery(t *testing.T) {
 }
 
 func TestSampleDeliveryTimeout(t *testing.T) {
-	// Let's send on less sample than batch size, and wait the timeout duration
+	// Let's send one less sample than batch size, and wait the timeout duration
 	n := config.DefaultQueueConfig.Capacity - 1
 
 	samples := make(model.Samples, 0, n)


### PR DESCRIPTION
Fixes #3809, supersedes #3905 and #3907 

Also, instead of resetting the timer every time we scrape a sample (potentially delaying them indefinitely), only reset when we send a batch.