### PR TITLE
web: remove unused MetricsPath option

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -137,7 +137,6 @@ type Options struct {
 	MaxConnections       int
 	ExternalURL          *url.URL
 	RoutePrefix          string
-	MetricsPath          string
 	UseLocalAssets       bool
 	UserAssetsPath       string
 	ConsoleTemplatesPath string

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -105,7 +105,6 @@ func TestReadyAndHealthy(t *testing.T) {
 		RuleManager:    nil,
 		Notifier:       nil,
 		RoutePrefix:    "/",
-		MetricsPath:    "/metrics/",
 		EnableAdminAPI: true,
 		TSDB:           func() *libtsdb.DB { return db },
 	}
@@ -201,7 +200,6 @@ func TestRoutePrefix(t *testing.T) {
 		RuleManager:    nil,
 		Notifier:       nil,
 		RoutePrefix:    "/prometheus",
-		MetricsPath:    "/prometheus/metrics",
 		EnableAdminAPI: true,
 		TSDB:           func() *libtsdb.DB { return db },
 	}
@@ -290,7 +288,6 @@ func TestDebugHandler(t *testing.T) {
 	} {
 		opts := &Options{
 			RoutePrefix: tc.prefix,
-			MetricsPath: "/metrics",
 		}
 		handler := New(nil, opts)
 		handler.Ready()


### PR DESCRIPTION
@fabxc Cleanup. Metrics path is no longer configurable.