### PR TITLE
Update ISSUE_TEMPLATE.md - add FAQ link to the wiki

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,8 @@
 <!--
 
     Please do *NOT* ask usage questions in Github issues.
+    
+    Read the https://github.com/prometheus/prometheus/wiki/FAQ for most common pitfalls.
 
     If your issue is not a feature request or bug report use:
     https://groups.google.com/forum/#!forum/prometheus-users. If


### PR DESCRIPTION
these FAQ will be updated frequently and don't quite fit in the official FAQ page on the website.
I am thinking to keep these to a bare minimum - 20-30 at max and delete questions that haven't been asked in the last 2-3 months.

I would like to try and see if it will help reduce the issues and if it becomes useless will just remove the link.