### PR TITLE
Fixes #3909. Match cmux against http1.0 first, then grpc.

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -393,8 +393,8 @@ func (h *Handler) Run(ctx context.Context) error {
 
 	var (
 		m       = cmux.New(listener)
-		grpcl   = m.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
 		httpl   = m.Match(cmux.HTTP1Fast())
+		grpcl   = m.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
 		grpcSrv = grpc.NewServer()
 	)
 	av2 := api_v2.New(


### PR DESCRIPTION
The way cmux works is checking an incoming request against matchers one by one. Additionally, cmux expects http2 request to have an obligatory headers according to the http2 spec.
Hence, if an http2 matcher goes first cmux hangs waiting for more bytes even thoght it's a valid GET / HTTP/1.0 request used by HAProxy by default