### PR TITLE
un-generalize the pool package

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -14,8 +14,6 @@
 package pool
 
 import (
-	"fmt"
-	"reflect"
 	"sync"
 )
 
@@ -23,13 +21,11 @@ import (
 type Pool struct {
 	buckets []sync.Pool
 	sizes   []int
-	// make is the function used to create an empty slice when none exist yet.
-	make func(int) interface{}
 }
 
 // New returns a new Pool with size buckets for minSize to maxSize
 // increasing by the given factor.
-func New(minSize, maxSize int, factor float64, makeFunc func(int) interface{}) *Pool {
+func New(minSize, maxSize int, factor float64) *Pool {
 	if minSize < 1 {
 		panic("invalid minimum pool size")
 	}
@@ -49,39 +45,34 @@ func New(minSize, maxSize int, factor float64, makeFunc func(int) interface{}) *
 	p := &Pool{
 		buckets: make([]sync.Pool, len(sizes)),
 		sizes:   sizes,
-		make:    makeFunc,
 	}
 
 	return p
 }
 
 // Get returns a new byte slices that fits the given size.
-func (p *Pool) Get(sz int) interface{} {
+func (p *Pool) Get(sz int) []byte {
 	for i, bktSize := range p.sizes {
 		if sz > bktSize {
 			continue
 		}
 		b := p.buckets[i].Get()
 		if b == nil {
-			b = p.make(bktSize)
+			return make([]byte, 0, bktSize)
 		}
-		return b
+		return *(b.(*[]byte))
 	}
-	return p.make(sz)
+	return make([]byte, 0, sz)
 }
 
 // Put adds a slice to the right bucket in the pool.
-func (p *Pool) Put(s interface{}) {
-	slice := reflect.ValueOf(s)
-
-	if slice.Kind() != reflect.Slice {
-		panic(fmt.Sprintf("%+v is not a slice", slice))
-	}
+func (p *Pool) Put(s []byte) {
+	s = s[:0]
 	for i, size := range p.sizes {
-		if slice.Cap() > size {
+		if cap(s) > size {
 			continue
 		}
-		p.buckets[i].Put(slice.Slice(0, 0).Interface())
+		p.buckets[i].Put(&s)
 		return
 	}
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -148,7 +148,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app Appendable, logger log.Logger) 
 		level.Error(logger).Log("msg", "Error creating HTTP client", "err", err)
 	}
 
-	buffers := pool.New(163, 100e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) })
+	buffers := pool.New(163, 100e6, 3)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sp := &scrapePool{
@@ -611,7 +611,7 @@ func newScrapeLoop(ctx context.Context,
 		l = log.NewNopLogger()
 	}
 	if buffers == nil {
-		buffers = pool.New(1e3, 1e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) })
+		buffers = pool.New(1e3, 1e6, 3)
 	}
 	sl := &scrapeLoop{
 		scraper:             sc,
@@ -669,7 +669,7 @@ mainLoop:
 			)
 		}
 
-		b := sl.buffers.Get(sl.lastScrapeSize).([]byte)
+		b := sl.buffers.Get(sl.lastScrapeSize)
 		buf := bytes.NewBuffer(b)
 
 		scrapeErr := sl.scraper.scrape(scrapeCtx, buf)


### PR DESCRIPTION
PR #3835 generalized the pool package by allowing users to pass a make function that returned an interface. Presumably, this is so that the pool can be used for any type of slice.

The only usage of the pool at the moment is for byte slices, but allowing it to be generic introduces a bunch of type safety issues.

This respecializes the pool to be for byte slices only, which buys higher type safety, makes the usage more obvious, and removes the reflect package.

Lastly, we now put `*[]byte` into the internal sync.Pool's as opposed to `[]byte`, see: https://staticcheck.io/docs/staticcheck#SA6002.

(I'm find with closing & deleting this if the desire to use `pool` for other than byte slices exists).