### PR TITLE
fix race for instr handler

### DIFF
--- a/vendor/github.com/prometheus/common/route/route.go
+++ b/vendor/github.com/prometheus/common/route/route.go
@@ -54,9 +54,12 @@ func (r *Router) handle(handlerName string, h http.HandlerFunc) httprouter.Handl
 			ctx = context.WithValue(ctx, param(p.Key), p.Value)
 		}
 		if r.instrh != nil {
-			h = r.instrh(handlerName, h)
+			hh := r.instrh(handlerName, h)
+			hh(w, req.WithContext(ctx))
+
+		} else {
+			h(w, req.WithContext(ctx))
 		}
-		h(w, req.WithContext(ctx))
 	}
 }
 


### PR DESCRIPTION
running master with race enabled and refreshing /targets page really fast shows this race.

Don't merge , will open against common.


```
==================
WARNING: DATA RACE
Read at 0x00c42000e2a8 by goroutine 57:
  github.com/prometheus/prometheus/vendor/github.com/prometheus/common/route.(*Router).handle.func1()
      /home/krasi/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/common/route/route.go:57 +0x366
  github.com/prometheus/prometheus/vendor/github.com/julienschmidt/httprouter.(*Router).ServeHTTP()
      /home/krasi/src/github.com/prometheus/prometheus/vendor/github.com/julienschmidt/httprouter/router.go:299 +0xbad
  github.com/prometheus/prometheus/vendor/github.com/prometheus/common/route.(*Router).ServeHTTP()
      /home/krasi/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/common/route/route.go:97 +0x67
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/go/src/net/http/server.go:2337 +0x9f
  github.com/prometheus/prometheus/vendor/github.com/opentracing-contrib/go-stdlib/nethttp.Middleware.func2()
      /home/krasi/src/github.com/prometheus/prometheus/vendor/github.com/opentracing-contrib/go-stdlib/nethttp/server.go:74 +0x4fb
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1947 +0x51
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2694 +0xb9
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1830 +0x7dc

Previous write at 0x00c42000e2a8 by goroutine 256:
  github.com/prometheus/prometheus/vendor/github.com/prometheus/common/route.(*Router).handle.func1()
      /home/krasi/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/common/route/route.go:57 +0x3b2
  github.com/prometheus/prometheus/vendor/github.com/julienschmidt/httprouter.(*Router).ServeHTTP()
      /home/krasi/src/github.com/prometheus/prometheus/vendor/github.com/julienschmidt/httprouter/router.go:299 +0xbad
  github.com/prometheus/prometheus/vendor/github.com/prometheus/common/route.(*Router).ServeHTTP()
      /home/krasi/src/github.com/prometheus/prometheus/vendor/github.com/prometheus/common/route/route.go:97 +0x67
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/go/src/net/http/server.go:2337 +0x9f
  github.com/prometheus/prometheus/vendor/github.com/opentracing-contrib/go-stdlib/nethttp.Middleware.func2()
      /home/krasi/src/github.com/prometheus/prometheus/vendor/github.com/opentracing-contrib/go-stdlib/nethttp/server.go:74 +0x4fb
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1947 +0x51
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2694 +0xb9
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1830 +0x7dc

Goroutine 57 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:2795 +0x364
  github.com/prometheus/prometheus/web.(*Handler).Run.func5()
      /home/krasi/src/github.com/prometheus/prometheus/web/web.go:488 +0x53

Goroutine 256 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:2795 +0x364
  github.com/prometheus/prometheus/web.(*Handler).Run.func5()
      /home/krasi/src/github.com/prometheus/prometheus/web/web.go:488 +0x53
==================
```