### PR TITLE
Improve Kubernetes Discovery Performance

### DIFF
--- a/discovery/kubernetes/endpoints.go
+++ b/discovery/kubernetes/endpoints.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 )
 
 // Endpoints discovers new endpoint targets.
@@ -38,6 +39,8 @@ type Endpoints struct {
 	podStore       cache.Store
 	endpointsStore cache.Store
 	serviceStore   cache.Store
+
+	queue *workqueue.Type
 }
 
 // NewEndpoints returns a new endpoints discovery.
@@ -45,7 +48,7 @@ func NewEndpoints(l log.Logger, svc, eps, pod cache.SharedInformer) *Endpoints {
 	if l == nil {
 		l = log.NewNopLogger()
 	}
-	ep := &Endpoints{
+	e := &Endpoints{
 		logger:         l,
 		endpointsInf:   eps,
 		endpointsStore: eps.GetStore(),
@@ -53,25 +56,48 @@ func NewEndpoints(l log.Logger, svc, eps, pod cache.SharedInformer) *Endpoints {
 		serviceStore:   svc.GetStore(),
 		podInf:         pod,
 		podStore:       pod.GetStore(),
+		queue:          workqueue.NewNamed("endpoints"),
 	}
 
-	return ep
+	e.endpointsInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(o interface{}) {
+			eventCount.WithLabelValues("endpoints", "add").Inc()
+			e.enqueue(o)
+		},
+		UpdateFunc: func(_, o interface{}) {
+			eventCount.WithLabelValues("endpoints", "update").Inc()
+			e.enqueue(o)
+		},
+		DeleteFunc: func(o interface{}) {
+			eventCount.WithLabelValues("endpoints", "delete").Inc()
+			e.enqueue(o)
+		},
+	})
+
+	return e
+}
+
+func (e *Endpoints) enqueue(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	e.queue.Add(key)
 }
 
 // Run implements the Discoverer interface.
 func (e *Endpoints) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
-	// Send full initial set of endpoint targets.
-	var initial []*targetgroup.Group
-
-	for _, o := range e.endpointsStore.List() {
-		tg := e.buildEndpoints(o.(*apiv1.Endpoints))
-		initial = append(initial, tg)
+	cacheSyncs := []cache.InformerSynced{
+		e.endpointsInf.HasSynced,
+		e.serviceInf.HasSynced,
+		e.podInf.HasSynced,
 	}
-	select {
-	case <-ctx.Done():
+	if !cache.WaitForCacheSync(ctx.Done(), cacheSyncs...) {
+		level.Error(e.logger).Log("msg", "endpoints informer unable to sync cache")
 		return
-	case ch <- initial:
 	}
+
 	// Send target groups for pod updates.
 	send := func(tg *targetgroup.Group) {
 		if tg == nil {
@@ -84,73 +110,44 @@ func (e *Endpoints) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 		}
 	}
 
-	e.endpointsInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(o interface{}) {
-			eventCount.WithLabelValues("endpoints", "add").Inc()
+	workFunc := func() bool {
+		keyObj, quit := e.queue.Get()
+		if quit {
+			return true
+		}
+		defer e.queue.Done(keyObj)
+		key := keyObj.(string)
 
-			eps, err := convertToEndpoints(o)
-			if err != nil {
-				level.Error(e.logger).Log("msg", "converting to Endpoints object failed", "err", err)
-				return
-			}
-			send(e.buildEndpoints(eps))
-		},
-		UpdateFunc: func(_, o interface{}) {
-			eventCount.WithLabelValues("endpoints", "update").Inc()
-
-			eps, err := convertToEndpoints(o)
-			if err != nil {
-				level.Error(e.logger).Log("msg", "converting to Endpoints object failed", "err", err)
-				return
-			}
-			send(e.buildEndpoints(eps))
-		},
-		DeleteFunc: func(o interface{}) {
-			eventCount.WithLabelValues("endpoints", "delete").Inc()
-
-			eps, err := convertToEndpoints(o)
-			if err != nil {
-				level.Error(e.logger).Log("msg", "converting to Endpoints object failed", "err", err)
-				return
-			}
-			send(&targetgroup.Group{Source: endpointsSource(eps)})
-		},
-	})
-
-	serviceUpdate := func(o interface{}) {
-		svc, err := convertToService(o)
+		namespace, name, err := cache.SplitMetaNamespaceKey(key)
 		if err != nil {
-			level.Error(e.logger).Log("msg", "converting to Service object failed", "err", err)
+			level.Error(e.logger).Log("msg", "spliting key failed", "key", key)
+			return false
+		}
+
+		o, exists, err := e.endpointsStore.GetByKey(key)
+		if err != nil {
+			level.Error(e.logger).Log("msg", "getting object from store failed", "key", key)
+			return false
+		}
+		if !exists {
+			send(&targetgroup.Group{Source: endpointsSourceFromNamespaceAndName(namespace, name)})
+			return false
+		}
+		eps, err := convertToEndpoints(o)
+		if err != nil {
+			level.Error(e.logger).Log("msg", "converting to Endpoints object failed", "err", err)
+			return false
+		}
+		send(e.buildEndpoints(eps))
+		return false
+	}
+
+	for {
+		quit := workFunc()
+		if quit {
 			return
 		}
-
-		ep := &apiv1.Endpoints{}
-		ep.Namespace = svc.Namespace
-		ep.Name = svc.Name
-		obj, exists, err := e.endpointsStore.Get(ep)
-		if exists && err != nil {
-			send(e.buildEndpoints(obj.(*apiv1.Endpoints)))
-		}
-		if err != nil {
-			level.Error(e.logger).Log("msg", "retrieving endpoints failed", "err", err)
-		}
 	}
-	e.serviceInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		// TODO(fabxc): potentially remove add and delete event handlers. Those should
-		// be triggered via the endpoint handlers already.
-		AddFunc: func(o interface{}) {
-			eventCount.WithLabelValues("service", "add").Inc()
-			serviceUpdate(o)
-		},
-		UpdateFunc: func(_, o interface{}) {
-			eventCount.WithLabelValues("service", "update").Inc()
-			serviceUpdate(o)
-		},
-		DeleteFunc: func(o interface{}) {
-			eventCount.WithLabelValues("service", "delete").Inc()
-			serviceUpdate(o)
-		},
-	})
 
 	// Block until the target provider is explicitly canceled.
 	<-ctx.Done()
@@ -175,6 +172,10 @@ func convertToEndpoints(o interface{}) (*apiv1.Endpoints, error) {
 
 func endpointsSource(ep *apiv1.Endpoints) string {
 	return "endpoints/" + ep.ObjectMeta.Namespace + "/" + ep.ObjectMeta.Name
+}
+
+func endpointsSourceFromNamespaceAndName(namespace, name string) string {
+	return "endpoints/" + namespace + "/" + name
 }
 
 const (

--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -24,12 +24,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func endpointsStoreKeyFunc(obj interface{}) (string, error) {
-	return obj.(*v1.Endpoints).ObjectMeta.Name, nil
-}
-
 func newFakeEndpointsInformer() *fakeInformer {
-	return newFakeInformer(endpointsStoreKeyFunc)
+	return newFakeInformer(cache.DeletionHandlingMetaNamespaceKeyFunc)
 }
 
 func makeTestEndpointsDiscovery() (*Endpoints, *fakeInformer, *fakeInformer, *fakeInformer) {
@@ -81,44 +77,6 @@ func makeEndpoints() *v1.Endpoints {
 			},
 		},
 	}
-}
-
-func TestEndpointsDiscoveryInitial(t *testing.T) {
-	n, _, eps, _ := makeTestEndpointsDiscovery()
-	eps.GetStore().Add(makeEndpoints())
-
-	k8sDiscoveryTest{
-		discovery: n,
-		expectedInitial: []*targetgroup.Group{
-			{
-				Targets: []model.LabelSet{
-					{
-						"__address__":                              "1.2.3.4:9000",
-						"__meta_kubernetes_endpoint_port_name":     "testport",
-						"__meta_kubernetes_endpoint_port_protocol": "TCP",
-						"__meta_kubernetes_endpoint_ready":         "true",
-					},
-					{
-						"__address__":                              "2.3.4.5:9001",
-						"__meta_kubernetes_endpoint_port_name":     "testport",
-						"__meta_kubernetes_endpoint_port_protocol": "TCP",
-						"__meta_kubernetes_endpoint_ready":         "true",
-					},
-					{
-						"__address__":                              "2.3.4.5:9001",
-						"__meta_kubernetes_endpoint_port_name":     "testport",
-						"__meta_kubernetes_endpoint_port_protocol": "TCP",
-						"__meta_kubernetes_endpoint_ready":         "false",
-					},
-				},
-				Labels: model.LabelSet{
-					"__meta_kubernetes_namespace":      "default",
-					"__meta_kubernetes_endpoints_name": "testendpoints",
-				},
-				Source: "endpoints/default/testendpoints",
-			},
-		},
-	}.Run(t)
 }
 
 func TestEndpointsDiscoveryAdd(t *testing.T) {
@@ -260,8 +218,17 @@ func TestEndpointsDiscoveryDeleteUnknownCacheState(t *testing.T) {
 	eps.GetStore().Add(makeEndpoints())
 
 	k8sDiscoveryTest{
-		discovery:  n,
-		afterStart: func() { go func() { eps.Delete(cache.DeletedFinalStateUnknown{Obj: makeEndpoints()}) }() },
+		discovery: n,
+		afterStart: func() {
+			go func() {
+				obj := makeEndpoints()
+				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				if err != nil {
+					t.Errorf("failed to get key for %v: %v", obj, err)
+				}
+				eps.Delete(cache.DeletedFinalStateUnknown{Key: key, Obj: obj})
+			}()
+		},
 		expectedRes: []*targetgroup.Group{
 			{
 				Source: "endpoints/default/testendpoints",

--- a/discovery/kubernetes/kubernetes_shared.go
+++ b/discovery/kubernetes/kubernetes_shared.go
@@ -16,7 +16,6 @@ package kubernetes
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -145,20 +144,18 @@ func (c *kubernetesSharedCache) Count() int {
 	return len(c.shared)
 }
 
+// Start runs all informers. This is called after all discovery instances are
+// configured, no need to lock.
 func (c *kubernetesSharedCache) Start(stopCh <-chan struct{}) {
 	for _, shared := range c.shared {
 		for key, informer := range shared.informers {
 			go informer.Run(stopCh)
-			for !informer.HasSynced() {
-				time.Sleep(100 * time.Millisecond)
-			}
-			level.Info(c.logger).Log("msg", "Kubernetes informer synced", "key", key)
+			level.Info(c.logger).Log("msg", "Kubernetes informer started", "key", key)
 		}
 	}
 }
 
 func NewKubernetesSharedCache(l log.Logger) KubernetesSharedCache {
-
 	return &kubernetesSharedCache{
 		logger: l,
 		shared: make(map[string]*kubernetesShared),

--- a/discovery/kubernetes/kubernetes_shared.go
+++ b/discovery/kubernetes/kubernetes_shared.go
@@ -1,0 +1,166 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	apiv1 "k8s.io/client-go/pkg/api/v1"
+	extensionsv1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type KubernetesShared interface {
+	GetSharedInformer(resource string, namespace string) (informer cache.SharedInformer, err error)
+	MustGetSharedInformer(resource string, namespace string) cache.SharedInformer
+}
+
+type kubernetesShared struct {
+	sync.Mutex
+	client    kubernetes.Interface
+	count     int32
+	informers map[string]cache.SharedInformer
+}
+
+func newKubernetesShared(client kubernetes.Interface) *kubernetesShared {
+	return &kubernetesShared{client: client, count: 1, informers: map[string]cache.SharedInformer{}}
+}
+
+func (ks *kubernetesShared) MustGetSharedInformer(resource string, namespace string) cache.SharedInformer {
+	informer, err := ks.GetSharedInformer(resource, namespace)
+	if err != nil {
+		panic(err)
+	}
+	return informer
+}
+
+func (ks *kubernetesShared) createAndRunSharedInformer(resource string, namespace string) (informer cache.SharedInformer, err error) {
+	rclient := ks.client.CoreV1().RESTClient()
+	reclient := ks.client.ExtensionsV1beta1().RESTClient()
+	var lw *cache.ListWatch
+	var obj runtime.Object
+	switch resource {
+	case "endpoints":
+		lw = cache.NewListWatchFromClient(rclient, resource, namespace, nil)
+		obj = &apiv1.Endpoints{}
+	case "services":
+		lw = cache.NewListWatchFromClient(rclient, resource, namespace, nil)
+		obj = &apiv1.Service{}
+	case "pods":
+		lw = cache.NewListWatchFromClient(rclient, resource, namespace, nil)
+		obj = &apiv1.Pod{}
+	case "nodes":
+		lw = cache.NewListWatchFromClient(rclient, resource, namespace, nil)
+		obj = &apiv1.Node{}
+	case "ingresses":
+		lw = cache.NewListWatchFromClient(reclient, resource, namespace, nil)
+		obj = &extensionsv1beta1.Ingress{}
+	default:
+		err = fmt.Errorf("unknown Kubernetes discovery kind: %s", resource)
+		return
+	}
+	informer = cache.NewSharedInformer(lw, obj, resyncPeriod)
+	return
+}
+
+func (ks *kubernetesShared) GetSharedInformer(resource string, namespace string) (informer cache.SharedInformer, err error) {
+	ks.Lock()
+	defer ks.Unlock()
+	key := fmt.Sprintf("%s/%s", resource, namespace)
+	informer, ok := ks.informers[key]
+	if !ok {
+		informer, err = ks.createAndRunSharedInformer(resource, namespace)
+		if err != nil {
+			return nil, err
+		}
+		ks.informers[key] = informer
+	}
+	return informer, nil
+}
+
+type KubernetesSharedCache interface {
+	GetOrCreate(key string, create func() (*kubernetesShared, error)) (KubernetesShared, error)
+	Count() int
+	Release(key string)
+	Start(stopCh <-chan struct{})
+}
+
+type kubernetesSharedCache struct {
+	logger log.Logger
+	sync.Mutex
+	shared map[string]*kubernetesShared
+}
+
+func (c *kubernetesSharedCache) GetOrCreate(key string, create func() (*kubernetesShared, error)) (KubernetesShared, error) {
+	c.Lock()
+	defer c.Unlock()
+	shared, ok := c.shared[key]
+	if ok {
+		shared.count++
+	} else {
+		var err error
+		if create == nil {
+			return nil, fmt.Errorf("create func should not be nil")
+		}
+		shared, err = create()
+		if err != nil {
+			return nil, err
+		}
+		c.shared[key] = shared
+	}
+	return shared, nil
+}
+
+func (c *kubernetesSharedCache) Release(key string) {
+	c.Lock()
+	defer c.Unlock()
+	if shared, ok := c.shared[key]; ok {
+		shared.count--
+		if shared.count <= 0 {
+			delete(c.shared, key)
+		}
+	}
+}
+
+func (c *kubernetesSharedCache) Count() int {
+	c.Lock()
+	defer c.Unlock()
+	return len(c.shared)
+}
+
+func (c *kubernetesSharedCache) Start(stopCh <-chan struct{}) {
+	for _, shared := range c.shared {
+		for key, informer := range shared.informers {
+			go informer.Run(stopCh)
+			for !informer.HasSynced() {
+				time.Sleep(100 * time.Millisecond)
+			}
+			level.Info(c.logger).Log("msg", "Kubernetes informer synced", "key", key)
+		}
+	}
+}
+
+func NewKubernetesSharedCache(l log.Logger) KubernetesSharedCache {
+
+	return &kubernetesSharedCache{
+		logger: l,
+		shared: make(map[string]*kubernetesShared),
+	}
+}

--- a/discovery/kubernetes/kubernetes_shared_test.go
+++ b/discovery/kubernetes/kubernetes_shared_test.go
@@ -1,0 +1,107 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+)
+
+func TestKubernetesSharedCache(t *testing.T) {
+	{
+		// test GetOrCreate
+		cache := NewKubernetesSharedCache(log.NewNopLogger())
+		tmpShared := &kubernetesShared{}
+		testcases := []struct {
+			name                     string
+			key                      string
+			create                   func() (*kubernetesShared, error)
+			expectedKubernetesShared KubernetesShared
+			expectedErr              bool
+		}{
+			{
+				name: "create successfully",
+				key:  "test",
+				create: func() (*kubernetesShared, error) {
+					return tmpShared, nil
+				},
+				expectedKubernetesShared: tmpShared,
+				expectedErr:              false,
+			},
+			{
+				name: "create failed",
+				key:  "test2",
+				create: func() (*kubernetesShared, error) {
+					return nil, fmt.Errorf("create error")
+				},
+				expectedKubernetesShared: nil,
+				expectedErr:              true,
+			},
+		}
+		for _, v := range testcases {
+			shared, err := cache.GetOrCreate(v.key, v.create)
+			if v.expectedErr && err == nil {
+				t.Errorf("test %s: err should be non-nil", v.name)
+			}
+			if v.expectedKubernetesShared != shared {
+				t.Errorf("test %s: shared should be %+v, got %+v", v.name, v.expectedKubernetesShared, shared)
+			}
+		}
+	}
+
+	{
+		// test GetOrCreate with same key
+		cache := NewKubernetesSharedCache(log.NewNopLogger())
+		tmpShared := &kubernetesShared{}
+		count := 0
+		for i := 0; i < 10; i++ {
+			cache.GetOrCreate("test", func() (*kubernetesShared, error) {
+				count++
+				return tmpShared, nil
+			})
+		}
+		if count != 1 {
+			t.Errorf("create function for same key should only be called once, called %d times", count)
+		}
+
+		shared, err := cache.GetOrCreate("test", nil)
+		if err != nil {
+			t.Errorf("err should be nil, got: %v", err)
+		}
+		if shared != tmpShared {
+			t.Errorf("shared should be %v, got %v", tmpShared, shared)
+		}
+	}
+
+	{
+		// test GetOrCreate then release
+		cache := NewKubernetesSharedCache(log.NewNopLogger())
+		tmpShared := &kubernetesShared{}
+		if cache.Count() != 0 {
+			t.Errorf("count should be 0 at beginning")
+		}
+		cache.GetOrCreate("test", func() (*kubernetesShared, error) {
+			return tmpShared, nil
+		})
+		if cache.Count() != 1 {
+			t.Errorf("count should be 1, got: %d", cache.Count())
+		}
+		cache.Release("test")
+		if cache.Count() != 0 {
+			t.Errorf("count should be 0, got: %d", cache.Count())
+		}
+	}
+}

--- a/discovery/kubernetes/node_test.go
+++ b/discovery/kubernetes/node_test.go
@@ -79,6 +79,7 @@ func (i *fakeInformer) Add(obj interface{}) {
 	i.blockDeltas.Lock()
 	defer i.blockDeltas.Unlock()
 
+	i.store.Add(obj)
 	for _, h := range i.handlers {
 		h.OnAdd(obj)
 	}
@@ -88,6 +89,7 @@ func (i *fakeInformer) Delete(obj interface{}) {
 	i.blockDeltas.Lock()
 	defer i.blockDeltas.Unlock()
 
+	i.store.Delete(obj)
 	for _, h := range i.handlers {
 		h.OnDelete(obj)
 	}
@@ -97,6 +99,7 @@ func (i *fakeInformer) Update(obj interface{}) {
 	i.blockDeltas.Lock()
 	defer i.blockDeltas.Unlock()
 
+	i.store.Update(obj)
 	for _, h := range i.handlers {
 		h.OnUpdate(nil, obj)
 	}
@@ -115,16 +118,11 @@ type k8sDiscoveryTest struct {
 
 func (d k8sDiscoveryTest) Run(t *testing.T) {
 	ch := make(chan []*targetgroup.Group)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*10)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
 		d.discovery.Run(ctx, ch)
 	}()
-
-	initialRes := <-ch
-	if d.expectedInitial != nil {
-		requireTargetGroups(t, d.expectedInitial, initialRes)
-	}
 
 	if d.afterStart != nil && d.expectedRes != nil {
 		d.afterStart()
@@ -147,12 +145,8 @@ func requireTargetGroups(t *testing.T, expected, res []*targetgroup.Group) {
 	require.JSONEq(t, string(b1), string(b2))
 }
 
-func nodeStoreKeyFunc(obj interface{}) (string, error) {
-	return obj.(*v1.Node).ObjectMeta.Name, nil
-}
-
 func newFakeNodeInformer() *fakeInformer {
-	return newFakeInformer(nodeStoreKeyFunc)
+	return newFakeInformer(cache.DeletionHandlingMetaNamespaceKeyFunc)
 }
 
 func makeTestNodeDiscovery() (*Node, *fakeInformer) {
@@ -187,37 +181,6 @@ func makeEnumeratedNode(i int) *v1.Node {
 	return makeNode(fmt.Sprintf("test%d", i), "1.2.3.4", map[string]string{}, map[string]string{})
 }
 
-func TestNodeDiscoveryInitial(t *testing.T) {
-	n, i := makeTestNodeDiscovery()
-	i.GetStore().Add(makeNode(
-		"test",
-		"1.2.3.4",
-		map[string]string{"testlabel": "testvalue"},
-		map[string]string{"testannotation": "testannotationvalue"},
-	))
-
-	k8sDiscoveryTest{
-		discovery: n,
-		expectedInitial: []*targetgroup.Group{
-			{
-				Targets: []model.LabelSet{
-					{
-						"__address__": "1.2.3.4:10250",
-						"instance":    "test",
-						"__meta_kubernetes_node_address_InternalIP": "1.2.3.4",
-					},
-				},
-				Labels: model.LabelSet{
-					"__meta_kubernetes_node_name":                      "test",
-					"__meta_kubernetes_node_label_testlabel":           "testvalue",
-					"__meta_kubernetes_node_annotation_testannotation": "testannotationvalue",
-				},
-				Source: "node/test",
-			},
-		},
-	}.Run(t)
-}
-
 func TestNodeDiscoveryAdd(t *testing.T) {
 	n, i := makeTestNodeDiscovery()
 
@@ -249,21 +212,6 @@ func TestNodeDiscoveryDelete(t *testing.T) {
 	k8sDiscoveryTest{
 		discovery:  n,
 		afterStart: func() { go func() { i.Delete(makeEnumeratedNode(0)) }() },
-		expectedInitial: []*targetgroup.Group{
-			{
-				Targets: []model.LabelSet{
-					{
-						"__address__": "1.2.3.4:10250",
-						"instance":    "test0",
-						"__meta_kubernetes_node_address_InternalIP": "1.2.3.4",
-					},
-				},
-				Labels: model.LabelSet{
-					"__meta_kubernetes_node_name": "test0",
-				},
-				Source: "node/test0",
-			},
-		},
 		expectedRes: []*targetgroup.Group{
 			{
 				Source: "node/test0",
@@ -277,22 +225,16 @@ func TestNodeDiscoveryDeleteUnknownCacheState(t *testing.T) {
 	i.GetStore().Add(makeEnumeratedNode(0))
 
 	k8sDiscoveryTest{
-		discovery:  n,
-		afterStart: func() { go func() { i.Delete(cache.DeletedFinalStateUnknown{Obj: makeEnumeratedNode(0)}) }() },
-		expectedInitial: []*targetgroup.Group{
-			{
-				Targets: []model.LabelSet{
-					{
-						"__address__": "1.2.3.4:10250",
-						"instance":    "test0",
-						"__meta_kubernetes_node_address_InternalIP": "1.2.3.4",
-					},
-				},
-				Labels: model.LabelSet{
-					"__meta_kubernetes_node_name": "test0",
-				},
-				Source: "node/test0",
-			},
+		discovery: n,
+		afterStart: func() {
+			go func() {
+				obj := makeEnumeratedNode(0)
+				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				if err != nil {
+					t.Errorf("failed to get key for %v: %v", obj, err)
+				}
+				i.Delete(cache.DeletedFinalStateUnknown{Key: key, Obj: obj})
+			}()
 		},
 		expectedRes: []*targetgroup.Group{
 			{
@@ -304,12 +246,12 @@ func TestNodeDiscoveryDeleteUnknownCacheState(t *testing.T) {
 
 func TestNodeDiscoveryUpdate(t *testing.T) {
 	n, i := makeTestNodeDiscovery()
-	i.GetStore().Add(makeEnumeratedNode(0))
 
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
 			go func() {
+				i.GetStore().Add(makeEnumeratedNode(0))
 				i.Update(
 					makeNode(
 						"test0",
@@ -319,21 +261,6 @@ func TestNodeDiscoveryUpdate(t *testing.T) {
 					),
 				)
 			}()
-		},
-		expectedInitial: []*targetgroup.Group{
-			{
-				Targets: []model.LabelSet{
-					{
-						"__address__": "1.2.3.4:10250",
-						"instance":    "test0",
-						"__meta_kubernetes_node_address_InternalIP": "1.2.3.4",
-					},
-				},
-				Labels: model.LabelSet{
-					"__meta_kubernetes_node_name": "test0",
-				},
-				Source: "node/test0",
-			},
 		},
 		expectedRes: []*targetgroup.Group{
 			{

--- a/discovery/kubernetes/service.go
+++ b/discovery/kubernetes/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/common/model"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/util/strutil"
@@ -34,6 +35,7 @@ type Service struct {
 	logger   log.Logger
 	informer cache.SharedInformer
 	store    cache.Store
+	queue    *workqueue.Type
 }
 
 // NewService returns a new service discovery.
@@ -41,21 +43,38 @@ func NewService(l log.Logger, inf cache.SharedInformer) *Service {
 	if l == nil {
 		l = log.NewNopLogger()
 	}
-	return &Service{logger: l, informer: inf, store: inf.GetStore()}
+	s := &Service{logger: l, informer: inf, store: inf.GetStore(), queue: workqueue.NewNamed("ingress")}
+	s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(o interface{}) {
+			eventCount.WithLabelValues("service", "add").Inc()
+			s.enqueue(o)
+		},
+		DeleteFunc: func(o interface{}) {
+			eventCount.WithLabelValues("service", "delete").Inc()
+			s.enqueue(o)
+		},
+		UpdateFunc: func(_, o interface{}) {
+			eventCount.WithLabelValues("service", "update").Inc()
+			s.enqueue(o)
+		},
+	})
+	return s
+}
+
+func (e *Service) enqueue(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	e.queue.Add(key)
 }
 
 // Run implements the Discoverer interface.
 func (s *Service) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
-	// Send full initial set of pod targets.
-	var initial []*targetgroup.Group
-	for _, o := range s.store.List() {
-		tg := s.buildService(o.(*apiv1.Service))
-		initial = append(initial, tg)
-	}
-	select {
-	case <-ctx.Done():
+	if !cache.WaitForCacheSync(ctx.Done(), s.informer.HasSynced) {
+		level.Error(s.logger).Log("msg", "service informer unable to sync cache")
 		return
-	case ch <- initial:
 	}
 
 	// Send target groups for service updates.
@@ -65,38 +84,43 @@ func (s *Service) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 		case ch <- []*targetgroup.Group{tg}:
 		}
 	}
-	s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(o interface{}) {
-			eventCount.WithLabelValues("service", "add").Inc()
 
-			svc, err := convertToService(o)
-			if err != nil {
-				level.Error(s.logger).Log("msg", "converting to Service object failed", "err", err)
-				return
-			}
-			send(s.buildService(svc))
-		},
-		DeleteFunc: func(o interface{}) {
-			eventCount.WithLabelValues("service", "delete").Inc()
+	workFunc := func() bool {
+		keyObj, quit := s.queue.Get()
+		if quit {
+			return true
+		}
+		defer s.queue.Done(keyObj)
+		key := keyObj.(string)
 
-			svc, err := convertToService(o)
-			if err != nil {
-				level.Error(s.logger).Log("msg", "converting to Service object failed", "err", err)
-				return
-			}
-			send(&targetgroup.Group{Source: serviceSource(svc)})
-		},
-		UpdateFunc: func(_, o interface{}) {
-			eventCount.WithLabelValues("service", "update").Inc()
+		namespace, name, err := cache.SplitMetaNamespaceKey(key)
+		if err != nil {
+			return false
+		}
 
-			svc, err := convertToService(o)
-			if err != nil {
-				level.Error(s.logger).Log("msg", "converting to Service object failed", "err", err)
-				return
-			}
-			send(s.buildService(svc))
-		},
-	})
+		o, exists, err := s.store.GetByKey(key)
+		if err != nil {
+			return false
+		}
+		if !exists {
+			send(&targetgroup.Group{Source: serviceSourceFromNamespaceAndName(namespace, name)})
+			return false
+		}
+		eps, err := convertToService(o)
+		if err != nil {
+			level.Error(s.logger).Log("msg", "converting to Service object failed", "err", err)
+			return false
+		}
+		send(s.buildService(eps))
+		return false
+	}
+
+	for {
+		quit := workFunc()
+		if quit {
+			return
+		}
+	}
 
 	// Block until the target provider is explicitly canceled.
 	<-ctx.Done()
@@ -120,6 +144,10 @@ func convertToService(o interface{}) (*apiv1.Service, error) {
 
 func serviceSource(s *apiv1.Service) string {
 	return "svc/" + s.Namespace + "/" + s.Name
+}
+
+func serviceSourceFromNamespaceAndName(namespace, name string) string {
+	return "svc/" + namespace + "/" + name
 }
 
 const (

--- a/vendor/k8s.io/client-go/LICENSE
+++ b/vendor/k8s.io/client-go/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2014 The Kubernetes Authors.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/k8s.io/client-go/util/workqueue/default_rate_limiters.go
+++ b/vendor/k8s.io/client-go/util/workqueue/default_rate_limiters.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"github.com/juju/ratelimit"
+)
+
+type RateLimiter interface {
+	// When gets an item and gets to decide how long that item should wait
+	When(item interface{}) time.Duration
+	// Forget indicates that an item is finished being retried.  Doesn't matter whether its for perm failing
+	// or for success, we'll stop tracking it
+	Forget(item interface{})
+	// NumRequeues returns back how many failures the item has had
+	NumRequeues(item interface{}) int
+}
+
+// DefaultControllerRateLimiter is a no-arg constructor for a default rate limiter for a workqueue.  It has
+// both overall and per-item rate limitting.  The overall is a token bucket and the per-item is exponential
+func DefaultControllerRateLimiter() RateLimiter {
+	return NewMaxOfRateLimiter(
+		NewItemExponentialFailureRateLimiter(5*time.Millisecond, 1000*time.Second),
+		// 10 qps, 100 bucket size.  This is only for retry speed and its only the overall factor (not per item)
+		&BucketRateLimiter{Bucket: ratelimit.NewBucketWithRate(float64(10), int64(100))},
+	)
+}
+
+// BucketRateLimiter adapts a standard bucket to the workqueue ratelimiter API
+type BucketRateLimiter struct {
+	*ratelimit.Bucket
+}
+
+var _ RateLimiter = &BucketRateLimiter{}
+
+func (r *BucketRateLimiter) When(item interface{}) time.Duration {
+	return r.Bucket.Take(1)
+}
+
+func (r *BucketRateLimiter) NumRequeues(item interface{}) int {
+	return 0
+}
+
+func (r *BucketRateLimiter) Forget(item interface{}) {
+}
+
+// ItemExponentialFailureRateLimiter does a simple baseDelay*10^<num-failures> limit
+// dealing with max failures and expiration are up to the caller
+type ItemExponentialFailureRateLimiter struct {
+	failuresLock sync.Mutex
+	failures     map[interface{}]int
+
+	baseDelay time.Duration
+	maxDelay  time.Duration
+}
+
+var _ RateLimiter = &ItemExponentialFailureRateLimiter{}
+
+func NewItemExponentialFailureRateLimiter(baseDelay time.Duration, maxDelay time.Duration) RateLimiter {
+	return &ItemExponentialFailureRateLimiter{
+		failures:  map[interface{}]int{},
+		baseDelay: baseDelay,
+		maxDelay:  maxDelay,
+	}
+}
+
+func DefaultItemBasedRateLimiter() RateLimiter {
+	return NewItemExponentialFailureRateLimiter(time.Millisecond, 1000*time.Second)
+}
+
+func (r *ItemExponentialFailureRateLimiter) When(item interface{}) time.Duration {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	exp := r.failures[item]
+	r.failures[item] = r.failures[item] + 1
+
+	// The backoff is capped such that 'calculated' value never overflows.
+	backoff := float64(r.baseDelay.Nanoseconds()) * math.Pow(2, float64(exp))
+	if backoff > math.MaxInt64 {
+		return r.maxDelay
+	}
+
+	calculated := time.Duration(backoff)
+	if calculated > r.maxDelay {
+		return r.maxDelay
+	}
+
+	return calculated
+}
+
+func (r *ItemExponentialFailureRateLimiter) NumRequeues(item interface{}) int {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	return r.failures[item]
+}
+
+func (r *ItemExponentialFailureRateLimiter) Forget(item interface{}) {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	delete(r.failures, item)
+}
+
+// ItemFastSlowRateLimiter does a quick retry for a certain number of attempts, then a slow retry after that
+type ItemFastSlowRateLimiter struct {
+	failuresLock sync.Mutex
+	failures     map[interface{}]int
+
+	maxFastAttempts int
+	fastDelay       time.Duration
+	slowDelay       time.Duration
+}
+
+var _ RateLimiter = &ItemFastSlowRateLimiter{}
+
+func NewItemFastSlowRateLimiter(fastDelay, slowDelay time.Duration, maxFastAttempts int) RateLimiter {
+	return &ItemFastSlowRateLimiter{
+		failures:        map[interface{}]int{},
+		fastDelay:       fastDelay,
+		slowDelay:       slowDelay,
+		maxFastAttempts: maxFastAttempts,
+	}
+}
+
+func (r *ItemFastSlowRateLimiter) When(item interface{}) time.Duration {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	r.failures[item] = r.failures[item] + 1
+
+	if r.failures[item] <= r.maxFastAttempts {
+		return r.fastDelay
+	}
+
+	return r.slowDelay
+}
+
+func (r *ItemFastSlowRateLimiter) NumRequeues(item interface{}) int {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	return r.failures[item]
+}
+
+func (r *ItemFastSlowRateLimiter) Forget(item interface{}) {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	delete(r.failures, item)
+}
+
+// MaxOfRateLimiter calls every RateLimiter and returns the worst case response
+// When used with a token bucket limiter, the burst could be apparently exceeded in cases where particular items
+// were separately delayed a longer time.
+type MaxOfRateLimiter struct {
+	limiters []RateLimiter
+}
+
+func (r *MaxOfRateLimiter) When(item interface{}) time.Duration {
+	ret := time.Duration(0)
+	for _, limiter := range r.limiters {
+		curr := limiter.When(item)
+		if curr > ret {
+			ret = curr
+		}
+	}
+
+	return ret
+}
+
+func NewMaxOfRateLimiter(limiters ...RateLimiter) RateLimiter {
+	return &MaxOfRateLimiter{limiters: limiters}
+}
+
+func (r *MaxOfRateLimiter) NumRequeues(item interface{}) int {
+	ret := 0
+	for _, limiter := range r.limiters {
+		curr := limiter.NumRequeues(item)
+		if curr > ret {
+			ret = curr
+		}
+	}
+
+	return ret
+}
+
+func (r *MaxOfRateLimiter) Forget(item interface{}) {
+	for _, limiter := range r.limiters {
+		limiter.Forget(item)
+	}
+}

--- a/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/vendor/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"sort"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/util/clock"
+)
+
+// DelayingInterface is an Interface that can Add an item at a later time. This makes it easier to
+// requeue items after failures without ending up in a hot-loop.
+type DelayingInterface interface {
+	Interface
+	// AddAfter adds an item to the workqueue after the indicated duration has passed
+	AddAfter(item interface{}, duration time.Duration)
+}
+
+// NewDelayingQueue constructs a new workqueue with delayed queuing ability
+func NewDelayingQueue() DelayingInterface {
+	return newDelayingQueue(clock.RealClock{}, "")
+}
+
+func NewNamedDelayingQueue(name string) DelayingInterface {
+	return newDelayingQueue(clock.RealClock{}, name)
+}
+
+func newDelayingQueue(clock clock.Clock, name string) DelayingInterface {
+	ret := &delayingType{
+		Interface:          NewNamed(name),
+		clock:              clock,
+		heartbeat:          clock.Tick(maxWait),
+		stopCh:             make(chan struct{}),
+		waitingTimeByEntry: map[t]time.Time{},
+		waitingForAddCh:    make(chan waitFor, 1000),
+		metrics:            newRetryMetrics(name),
+	}
+
+	go ret.waitingLoop()
+
+	return ret
+}
+
+// delayingType wraps an Interface and provides delayed re-enquing
+type delayingType struct {
+	Interface
+
+	// clock tracks time for delayed firing
+	clock clock.Clock
+
+	// stopCh lets us signal a shutdown to the waiting loop
+	stopCh chan struct{}
+
+	// heartbeat ensures we wait no more than maxWait before firing
+	//
+	// TODO: replace with Ticker (and add to clock) so this can be cleaned up.
+	// clock.Tick will leak.
+	heartbeat <-chan time.Time
+
+	// waitingForAdd is an ordered slice of items to be added to the contained work queue
+	waitingForAdd []waitFor
+	// waitingTimeByEntry holds wait time by entry, so we can lookup pre-existing indexes
+	waitingTimeByEntry map[t]time.Time
+	// waitingForAddCh is a buffered channel that feeds waitingForAdd
+	waitingForAddCh chan waitFor
+
+	// metrics counts the number of retries
+	metrics retryMetrics
+}
+
+// waitFor holds the data to add and the time it should be added
+type waitFor struct {
+	data    t
+	readyAt time.Time
+}
+
+// ShutDown gives a way to shut off this queue
+func (q *delayingType) ShutDown() {
+	q.Interface.ShutDown()
+	close(q.stopCh)
+}
+
+// AddAfter adds the given item to the work queue after the given delay
+func (q *delayingType) AddAfter(item interface{}, duration time.Duration) {
+	// don't add if we're already shutting down
+	if q.ShuttingDown() {
+		return
+	}
+
+	q.metrics.retry()
+
+	// immediately add things with no delay
+	if duration <= 0 {
+		q.Add(item)
+		return
+	}
+
+	select {
+	case <-q.stopCh:
+		// unblock if ShutDown() is called
+	case q.waitingForAddCh <- waitFor{data: item, readyAt: q.clock.Now().Add(duration)}:
+	}
+}
+
+// maxWait keeps a max bound on the wait time. It's just insurance against weird things happening.
+// Checking the queue every 10 seconds isn't expensive and we know that we'll never end up with an
+// expired item sitting for more than 10 seconds.
+const maxWait = 10 * time.Second
+
+// waitingLoop runs until the workqueue is shutdown and keeps a check on the list of items to be added.
+func (q *delayingType) waitingLoop() {
+	defer utilruntime.HandleCrash()
+
+	// Make a placeholder channel to use when there are no items in our list
+	never := make(<-chan time.Time)
+
+	for {
+		if q.Interface.ShuttingDown() {
+			// discard waiting entries
+			q.waitingForAdd = nil
+			q.waitingTimeByEntry = nil
+			return
+		}
+
+		now := q.clock.Now()
+
+		// Add ready entries
+		readyEntries := 0
+		for _, entry := range q.waitingForAdd {
+			if entry.readyAt.After(now) {
+				break
+			}
+			q.Add(entry.data)
+			delete(q.waitingTimeByEntry, entry.data)
+			readyEntries++
+		}
+		q.waitingForAdd = q.waitingForAdd[readyEntries:]
+
+		// Set up a wait for the first item's readyAt (if one exists)
+		nextReadyAt := never
+		if len(q.waitingForAdd) > 0 {
+			nextReadyAt = q.clock.After(q.waitingForAdd[0].readyAt.Sub(now))
+		}
+
+		select {
+		case <-q.stopCh:
+			return
+
+		case <-q.heartbeat:
+			// continue the loop, which will add ready items
+
+		case <-nextReadyAt:
+			// continue the loop, which will add ready items
+
+		case waitEntry := <-q.waitingForAddCh:
+			if waitEntry.readyAt.After(q.clock.Now()) {
+				q.waitingForAdd = insert(q.waitingForAdd, q.waitingTimeByEntry, waitEntry)
+			} else {
+				q.Add(waitEntry.data)
+			}
+
+			drained := false
+			for !drained {
+				select {
+				case waitEntry := <-q.waitingForAddCh:
+					if waitEntry.readyAt.After(q.clock.Now()) {
+						q.waitingForAdd = insert(q.waitingForAdd, q.waitingTimeByEntry, waitEntry)
+					} else {
+						q.Add(waitEntry.data)
+					}
+				default:
+					drained = true
+				}
+			}
+		}
+	}
+}
+
+// inserts the given entry into the sorted entries list
+// same semantics as append()... the given slice may be modified,
+// and the returned value should be used
+//
+// TODO: This should probably be converted to use container/heap to improve
+// running time for a large number of items.
+func insert(entries []waitFor, knownEntries map[t]time.Time, entry waitFor) []waitFor {
+	// if the entry is already in our retry list and the existing time is before the new one, just skip it
+	existingTime, exists := knownEntries[entry.data]
+	if exists && existingTime.Before(entry.readyAt) {
+		return entries
+	}
+
+	// if the entry exists and is scheduled for later, go ahead and remove the entry
+	if exists {
+		if existingIndex := findEntryIndex(entries, existingTime, entry.data); existingIndex >= 0 && existingIndex < len(entries) {
+			entries = append(entries[:existingIndex], entries[existingIndex+1:]...)
+		}
+	}
+
+	insertionIndex := sort.Search(len(entries), func(i int) bool {
+		return entry.readyAt.Before(entries[i].readyAt)
+	})
+
+	// grow by 1
+	entries = append(entries, waitFor{})
+	// shift items from the insertion point to the end
+	copy(entries[insertionIndex+1:], entries[insertionIndex:])
+	// insert the record
+	entries[insertionIndex] = entry
+
+	knownEntries[entry.data] = entry.readyAt
+
+	return entries
+}
+
+// findEntryIndex returns the index for an existing entry
+func findEntryIndex(entries []waitFor, existingTime time.Time, data t) int {
+	index := sort.Search(len(entries), func(i int) bool {
+		return entries[i].readyAt.After(existingTime) || existingTime == entries[i].readyAt
+	})
+
+	// we know this is the earliest possible index, but there could be multiple with the same time
+	// iterate from here to find the dupe
+	for ; index < len(entries); index++ {
+		if entries[index].data == data {
+			break
+		}
+	}
+
+	return index
+}

--- a/vendor/k8s.io/client-go/util/workqueue/doc.go
+++ b/vendor/k8s.io/client-go/util/workqueue/doc.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package workqueue provides a simple queue that supports the following
+// features:
+//  * Fair: items processed in the order in which they are added.
+//  * Stingy: a single item will not be processed multiple times concurrently,
+//      and if an item is added multiple times before it can be processed, it
+//      will only be processed once.
+//  * Multiple consumers and producers. In particular, it is allowed for an
+//      item to be reenqueued while it is being processed.
+//  * Shutdown notifications.
+package workqueue

--- a/vendor/k8s.io/client-go/util/workqueue/metrics.go
+++ b/vendor/k8s.io/client-go/util/workqueue/metrics.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"sync"
+	"time"
+)
+
+// This file provides abstractions for setting the provider (e.g., prometheus)
+// of metrics.
+
+type queueMetrics interface {
+	add(item t)
+	get(item t)
+	done(item t)
+}
+
+// GaugeMetric represents a single numerical value that can arbitrarily go up
+// and down.
+type GaugeMetric interface {
+	Inc()
+	Dec()
+}
+
+// CounterMetric represents a single numerical value that only ever
+// goes up.
+type CounterMetric interface {
+	Inc()
+}
+
+// SummaryMetric captures individual observations.
+type SummaryMetric interface {
+	Observe(float64)
+}
+
+type noopMetric struct{}
+
+func (noopMetric) Inc()            {}
+func (noopMetric) Dec()            {}
+func (noopMetric) Observe(float64) {}
+
+type defaultQueueMetrics struct {
+	// current depth of a workqueue
+	depth GaugeMetric
+	// total number of adds handled by a workqueue
+	adds CounterMetric
+	// how long an item stays in a workqueue
+	latency SummaryMetric
+	// how long processing an item from a workqueue takes
+	workDuration         SummaryMetric
+	addTimes             map[t]time.Time
+	processingStartTimes map[t]time.Time
+}
+
+func (m *defaultQueueMetrics) add(item t) {
+	if m == nil {
+		return
+	}
+
+	m.adds.Inc()
+	m.depth.Inc()
+	if _, exists := m.addTimes[item]; !exists {
+		m.addTimes[item] = time.Now()
+	}
+}
+
+func (m *defaultQueueMetrics) get(item t) {
+	if m == nil {
+		return
+	}
+
+	m.depth.Dec()
+	m.processingStartTimes[item] = time.Now()
+	if startTime, exists := m.addTimes[item]; exists {
+		m.latency.Observe(sinceInMicroseconds(startTime))
+		delete(m.addTimes, item)
+	}
+}
+
+func (m *defaultQueueMetrics) done(item t) {
+	if m == nil {
+		return
+	}
+
+	if startTime, exists := m.processingStartTimes[item]; exists {
+		m.workDuration.Observe(sinceInMicroseconds(startTime))
+		delete(m.processingStartTimes, item)
+	}
+}
+
+// Gets the time since the specified start in microseconds.
+func sinceInMicroseconds(start time.Time) float64 {
+	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
+}
+
+type retryMetrics interface {
+	retry()
+}
+
+type defaultRetryMetrics struct {
+	retries CounterMetric
+}
+
+func (m *defaultRetryMetrics) retry() {
+	if m == nil {
+		return
+	}
+
+	m.retries.Inc()
+}
+
+// MetricsProvider generates various metrics used by the queue.
+type MetricsProvider interface {
+	NewDepthMetric(name string) GaugeMetric
+	NewAddsMetric(name string) CounterMetric
+	NewLatencyMetric(name string) SummaryMetric
+	NewWorkDurationMetric(name string) SummaryMetric
+	NewRetriesMetric(name string) CounterMetric
+}
+
+type noopMetricsProvider struct{}
+
+func (_ noopMetricsProvider) NewDepthMetric(name string) GaugeMetric {
+	return noopMetric{}
+}
+
+func (_ noopMetricsProvider) NewAddsMetric(name string) CounterMetric {
+	return noopMetric{}
+}
+
+func (_ noopMetricsProvider) NewLatencyMetric(name string) SummaryMetric {
+	return noopMetric{}
+}
+
+func (_ noopMetricsProvider) NewWorkDurationMetric(name string) SummaryMetric {
+	return noopMetric{}
+}
+
+func (_ noopMetricsProvider) NewRetriesMetric(name string) CounterMetric {
+	return noopMetric{}
+}
+
+var metricsFactory = struct {
+	metricsProvider MetricsProvider
+	setProviders    sync.Once
+}{
+	metricsProvider: noopMetricsProvider{},
+}
+
+func newQueueMetrics(name string) queueMetrics {
+	var ret *defaultQueueMetrics
+	if len(name) == 0 {
+		return ret
+	}
+	return &defaultQueueMetrics{
+		depth:                metricsFactory.metricsProvider.NewDepthMetric(name),
+		adds:                 metricsFactory.metricsProvider.NewAddsMetric(name),
+		latency:              metricsFactory.metricsProvider.NewLatencyMetric(name),
+		workDuration:         metricsFactory.metricsProvider.NewWorkDurationMetric(name),
+		addTimes:             map[t]time.Time{},
+		processingStartTimes: map[t]time.Time{},
+	}
+}
+
+func newRetryMetrics(name string) retryMetrics {
+	var ret *defaultRetryMetrics
+	if len(name) == 0 {
+		return ret
+	}
+	return &defaultRetryMetrics{
+		retries: metricsFactory.metricsProvider.NewRetriesMetric(name),
+	}
+}
+
+// SetProvider sets the metrics provider of the metricsFactory.
+func SetProvider(metricsProvider MetricsProvider) {
+	metricsFactory.setProviders.Do(func() {
+		metricsFactory.metricsProvider = metricsProvider
+	})
+}

--- a/vendor/k8s.io/client-go/util/workqueue/parallelizer.go
+++ b/vendor/k8s.io/client-go/util/workqueue/parallelizer.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"sync"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+type DoWorkPieceFunc func(piece int)
+
+// Parallelize is a very simple framework that allow for parallelizing
+// N independent pieces of work.
+func Parallelize(workers, pieces int, doWorkPiece DoWorkPieceFunc) {
+	toProcess := make(chan int, pieces)
+	for i := 0; i < pieces; i++ {
+		toProcess <- i
+	}
+	close(toProcess)
+
+	if pieces < workers {
+		workers = pieces
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer utilruntime.HandleCrash()
+			defer wg.Done()
+			for piece := range toProcess {
+				doWorkPiece(piece)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/vendor/k8s.io/client-go/util/workqueue/queue.go
+++ b/vendor/k8s.io/client-go/util/workqueue/queue.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"sync"
+)
+
+type Interface interface {
+	Add(item interface{})
+	Len() int
+	Get() (item interface{}, shutdown bool)
+	Done(item interface{})
+	ShutDown()
+	ShuttingDown() bool
+}
+
+// New constructs a new workqueue (see the package comment).
+func New() *Type {
+	return NewNamed("")
+}
+
+func NewNamed(name string) *Type {
+	return &Type{
+		dirty:      set{},
+		processing: set{},
+		cond:       sync.NewCond(&sync.Mutex{}),
+		metrics:    newQueueMetrics(name),
+	}
+}
+
+// Type is a work queue (see the package comment).
+type Type struct {
+	// queue defines the order in which we will work on items. Every
+	// element of queue should be in the dirty set and not in the
+	// processing set.
+	queue []t
+
+	// dirty defines all of the items that need to be processed.
+	dirty set
+
+	// Things that are currently being processed are in the processing set.
+	// These things may be simultaneously in the dirty set. When we finish
+	// processing something and remove it from this set, we'll check if
+	// it's in the dirty set, and if so, add it to the queue.
+	processing set
+
+	cond *sync.Cond
+
+	shuttingDown bool
+
+	metrics queueMetrics
+}
+
+type empty struct{}
+type t interface{}
+type set map[t]empty
+
+func (s set) has(item t) bool {
+	_, exists := s[item]
+	return exists
+}
+
+func (s set) insert(item t) {
+	s[item] = empty{}
+}
+
+func (s set) delete(item t) {
+	delete(s, item)
+}
+
+// Add marks item as needing processing.
+func (q *Type) Add(item interface{}) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	if q.shuttingDown {
+		return
+	}
+	if q.dirty.has(item) {
+		return
+	}
+
+	q.metrics.add(item)
+
+	q.dirty.insert(item)
+	if q.processing.has(item) {
+		return
+	}
+
+	q.queue = append(q.queue, item)
+	q.cond.Signal()
+}
+
+// Len returns the current queue length, for informational purposes only. You
+// shouldn't e.g. gate a call to Add() or Get() on Len() being a particular
+// value, that can't be synchronized properly.
+func (q *Type) Len() int {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	return len(q.queue)
+}
+
+// Get blocks until it can return an item to be processed. If shutdown = true,
+// the caller should end their goroutine. You must call Done with item when you
+// have finished processing it.
+func (q *Type) Get() (item interface{}, shutdown bool) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	for len(q.queue) == 0 && !q.shuttingDown {
+		q.cond.Wait()
+	}
+	if len(q.queue) == 0 {
+		// We must be shutting down.
+		return nil, true
+	}
+
+	item, q.queue = q.queue[0], q.queue[1:]
+
+	q.metrics.get(item)
+
+	q.processing.insert(item)
+	q.dirty.delete(item)
+
+	return item, false
+}
+
+// Done marks item as done processing, and if it has been marked as dirty again
+// while it was being processed, it will be re-added to the queue for
+// re-processing.
+func (q *Type) Done(item interface{}) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+
+	q.metrics.done(item)
+
+	q.processing.delete(item)
+	if q.dirty.has(item) {
+		q.queue = append(q.queue, item)
+		q.cond.Signal()
+	}
+}
+
+// ShutDown will cause q to ignore all new items added to it. As soon as the
+// worker goroutines have drained the existing items in the queue, they will be
+// instructed to exit.
+func (q *Type) ShutDown() {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	q.shuttingDown = true
+	q.cond.Broadcast()
+}
+
+func (q *Type) ShuttingDown() bool {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+
+	return q.shuttingDown
+}

--- a/vendor/k8s.io/client-go/util/workqueue/rate_limitting_queue.go
+++ b/vendor/k8s.io/client-go/util/workqueue/rate_limitting_queue.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+// RateLimitingInterface is an interface that rate limits items being added to the queue.
+type RateLimitingInterface interface {
+	DelayingInterface
+
+	// AddRateLimited adds an item to the workqueue after the rate limiter says its ok
+	AddRateLimited(item interface{})
+
+	// Forget indicates that an item is finished being retried.  Doesn't matter whether its for perm failing
+	// or for success, we'll stop the rate limiter from tracking it.  This only clears the `rateLimiter`, you
+	// still have to call `Done` on the queue.
+	Forget(item interface{})
+
+	// NumRequeues returns back how many times the item was requeued
+	NumRequeues(item interface{}) int
+}
+
+// NewRateLimitingQueue constructs a new workqueue with rateLimited queuing ability
+// Remember to call Forget!  If you don't, you may end up tracking failures forever.
+func NewRateLimitingQueue(rateLimiter RateLimiter) RateLimitingInterface {
+	return &rateLimitingType{
+		DelayingInterface: NewDelayingQueue(),
+		rateLimiter:       rateLimiter,
+	}
+}
+
+func NewNamedRateLimitingQueue(rateLimiter RateLimiter, name string) RateLimitingInterface {
+	return &rateLimitingType{
+		DelayingInterface: NewNamedDelayingQueue(name),
+		rateLimiter:       rateLimiter,
+	}
+}
+
+// rateLimitingType wraps an Interface and provides rateLimited re-enquing
+type rateLimitingType struct {
+	DelayingInterface
+
+	rateLimiter RateLimiter
+}
+
+// AddRateLimited AddAfter's the item based on the time when the rate limiter says its ok
+func (q *rateLimitingType) AddRateLimited(item interface{}) {
+	q.DelayingInterface.AddAfter(item, q.rateLimiter.When(item))
+}
+
+func (q *rateLimitingType) NumRequeues(item interface{}) int {
+	return q.rateLimiter.NumRequeues(item)
+}
+
+func (q *rateLimitingType) Forget(item interface{}) {
+	q.rateLimiter.Forget(item)
+}

--- a/vendor/k8s.io/client-go/util/workqueue/timed_queue.go
+++ b/vendor/k8s.io/client-go/util/workqueue/timed_queue.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import "time"
+
+type TimedWorkQueue struct {
+	*Type
+}
+
+type TimedWorkQueueItem struct {
+	StartTime time.Time
+	Object    interface{}
+}
+
+func NewTimedWorkQueue() *TimedWorkQueue {
+	return &TimedWorkQueue{New()}
+}
+
+// Add adds the obj along with the current timestamp to the queue.
+func (q TimedWorkQueue) Add(timedItem *TimedWorkQueueItem) {
+	q.Type.Add(timedItem)
+}
+
+// Get gets the obj along with its timestamp from the queue.
+func (q TimedWorkQueue) Get() (timedItem *TimedWorkQueueItem, shutdown bool) {
+	origin, shutdown := q.Type.Get()
+	if origin == nil {
+		return nil, shutdown
+	}
+	timedItem, _ = origin.(*TimedWorkQueueItem)
+	return timedItem, shutdown
+}
+
+func (q TimedWorkQueue) Done(timedItem *TimedWorkQueueItem) error {
+	q.Type.Done(timedItem)
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2024,6 +2024,12 @@
 			"path": "k8s.io/client-go/util/integer",
 			"revision": "3627aeb7d4f6ade38f995d2c923e459146493c7e",
 			"revisionTime": "2017-03-31T20:34:26Z"
+		},
+		{
+			"checksumSHA1": "cy88zyzH3VJWVaIb41DDBlv+mmU=",
+			"path": "k8s.io/client-go/util/workqueue",
+			"revision": "3627aeb7d4f6ade38f995d2c923e459146493c7e",
+			"revisionTime": "2017-03-31T20:34:26Z"
 		}
 	],
 	"rootPath": "github.com/prometheus/prometheus"


### PR DESCRIPTION
Hi, we are running a multi-tenant Kubernetes cluster. Users of kubernetes cluster create Kuberntes service discovery jobs to discovery targets in their namespaces. If there are two many jobs, latency to discover new or updated target is huge. I did some improvements  to mitigate this issue:

- Share kubernete1s informers in kubernetes discovery to improve performance.
  - In previous Kubernetes discovery, each job creates its own client and informers, if there are many jobs, prometheus will keep a lot of connections to Kubernetes apiserver. After sharing kubernetes client and informers to same apiserver, network traffic between prometheus and kube-apiserver goes down tremendously, and also number of go routines. 
- Refactor kubernetes controller
  - Do initial listing and syncing to scrape manager, then register event handlers may lost events happening in listing and syncing (if it lasted a long time). We should register event handlers at the very begining, before processing just wait until informers synced (sync in informer will list all objects and call `OnUpdate` event handler).
  - Use a queue then we don't block event callbacks and an object will be processed only once if added multiple times before it being processed.

What do you think?