### PR TITLE
promql: allow `.` in metric names

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -270,6 +270,11 @@ func (ng *Engine) newQuery(q storage.Queryable, expr Expr, start, end time.Time,
 	return qry
 }
 
+// NewQuery returns a Query. Most users should use NewRangeQuery or NewInstantQuery.
+func (ng *Engine) NewQuery(q storage.Queryable, expr Expr, start, end time.Time, interval time.Duration) Query {
+	return ng.newQuery(q, expr, start, end, interval)
+}
+
 // testStmt is an internal helper statement that allows execution
 // of an arbitrary function during handling. It is used to test the Engine.
 type testStmt func(context.Context) error


### PR DESCRIPTION
Tests pending.

This would allow people implement PromQL on datasources that also support metrics with `.` in their name. We are the only system I know of that doesn't allow `.` and given how many systems want to integrate with PromQL, I think it only makes sense to give them a way to do so.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/prometheus/4020)
<!-- Reviewable:end -->
