### PR TITLE
Add an OpenTracing span for each rule

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -325,16 +325,16 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 		}
 
 		func(i int, rule Rule) {
+			sp, ctx := opentracing.StartSpanFromContext(ctx, "rule")
+			sp.SetTag("name", rule.Name())
 			defer func(t time.Time) {
+				sp.Finish()
 				evalDuration.Observe(time.Since(t).Seconds())
 				rule.SetEvaluationTime(time.Since(t))
 			}(time.Now())
 
 			evalTotal.Inc()
 
-			sp, ctx := opentracing.StartSpanFromContext(ctx, "rule")
-			sp.SetTag("name", rule.Name())
-			defer sp.Finish()
 			vector, err := rule.Eval(ctx, ts, g.opts.QueryFunc, g.opts.ExternalURL)
 			if err != nil {
 				// Canceled queries are intentional termination of queries. This normally

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -331,6 +332,9 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 
 			evalTotal.Inc()
 
+			sp, ctx := opentracing.StartSpanFromContext(ctx, "rule")
+			sp.SetTag("name", rule.Name())
+			defer sp.Finish()
 			vector, err := rule.Eval(ctx, ts, g.opts.QueryFunc, g.opts.ExternalURL)
 			if err != nil {
 				// Canceled queries are intentional termination of queries. This normally


### PR DESCRIPTION
So that tags and child spans can be traced back to the rule that they refer to.