### PR TITLE
Fix bug from 4025

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -666,7 +666,13 @@ func tmplFuncs(consolesPath string, opts *Options) template_text.FuncMap {
 			return time.Since(t) / time.Millisecond * time.Millisecond
 		},
 		"consolesPath": func() string { return consolesPath },
-		"pathPrefix":   func() string { return opts.RoutePrefix },
+		"pathPrefix":   func() string { 
+			if opts.RoutePrefix == "/" {
+				return ""
+			} else {
+				return opts.RoutePrefix
+			}
+		},
 		"buildVersion": func() string { return opts.Version.Revision },
 		"stripLabels": func(lset map[string]string, labels ...string) map[string]string {
 			for _, ln := range labels {

--- a/web/web.go
+++ b/web/web.go
@@ -666,7 +666,7 @@ func tmplFuncs(consolesPath string, opts *Options) template_text.FuncMap {
 			return time.Since(t) / time.Millisecond * time.Millisecond
 		},
 		"consolesPath": func() string { return consolesPath },
-		"pathPrefix":   func() string { 
+		"pathPrefix": func() string {
 			if opts.RoutePrefix == "/" {
 				return ""
 			} else {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -274,6 +274,41 @@ func TestRoutePrefix(t *testing.T) {
 	testutil.Equals(t, http.StatusOK, resp.StatusCode)
 }
 
+func TestPathPrefix(t *testing.T) {
+
+	tests := []struct {
+		routePrefix string
+		pathPrefix  string
+	}{
+		{
+			routePrefix: "/",
+			// If we have pathPrefix as "/", URL in UI gets "//"" as prefix,
+			// hence doesn't remain relative path anymore.
+			pathPrefix: "",
+		},
+		{
+			routePrefix: "/prometheus",
+			pathPrefix:  "/prometheus",
+		},
+		{
+			routePrefix: "/p1/p2/p3/p4",
+			pathPrefix:  "/p1/p2/p3/p4",
+		},
+	}
+
+	for _, test := range tests {
+		opts := &Options{
+			RoutePrefix: test.routePrefix,
+		}
+
+		pathPrefix := tmplFuncs("", opts)["pathPrefix"].(func() string)
+		pp := pathPrefix()
+
+		testutil.Equals(t, test.pathPrefix, pp)
+	}
+
+}
+
 func TestDebugHandler(t *testing.T) {
 	for _, tc := range []struct {
 		prefix, url string


### PR DESCRIPTION
My previous PR [#4025](https://github.com/prometheus/prometheus/pull/4025) fixed for a route-prefix but broke for a normal run (without `--web.route-prefix`).

This PR fixes that, I have also added a test for the same.

/cc @beorn7 