### PR TITLE
fix some unnecessary conversions

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1393,9 +1393,9 @@ func scalarBinop(op ItemType, lhs, rhs float64) float64 {
 	case itemDIV:
 		return lhs / rhs
 	case itemPOW:
-		return math.Pow(float64(lhs), float64(rhs))
+		return math.Pow(lhs, rhs)
 	case itemMOD:
-		return math.Mod(float64(lhs), float64(rhs))
+		return math.Mod(lhs, rhs)
 	case itemEQL:
 		return btos(lhs == rhs)
 	case itemNEQ:
@@ -1424,9 +1424,9 @@ func vectorElemBinop(op ItemType, lhs, rhs float64) (float64, bool) {
 	case itemDIV:
 		return lhs / rhs, true
 	case itemPOW:
-		return math.Pow(float64(lhs), float64(rhs)), true
+		return math.Pow(lhs, rhs), true
 	case itemMOD:
-		return math.Mod(float64(lhs), float64(rhs)), true
+		return math.Mod(lhs, rhs), true
 	case itemEQL:
 		return lhs, lhs == rhs
 	case itemNEQ:
@@ -1502,7 +1502,7 @@ func (ev *evaluator) aggregation(op ItemType, grouping []string, without bool, p
 			lb.Del(labels.MetricName)
 		}
 		if op == itemCountValues {
-			lb.Set(valueLabel, strconv.FormatFloat(float64(s.V), 'f', -1, 64))
+			lb.Set(valueLabel, strconv.FormatFloat(s.V, 'f', -1, 64))
 		}
 
 		var (
@@ -1570,12 +1570,12 @@ func (ev *evaluator) aggregation(op ItemType, grouping []string, without bool, p
 			group.groupCount++
 
 		case itemMax:
-			if group.value < s.V || math.IsNaN(float64(group.value)) {
+			if group.value < s.V || math.IsNaN(group.value) {
 				group.value = s.V
 			}
 
 		case itemMin:
-			if group.value > s.V || math.IsNaN(float64(group.value)) {
+			if group.value > s.V || math.IsNaN(group.value) {
 				group.value = s.V
 			}
 
@@ -1588,7 +1588,7 @@ func (ev *evaluator) aggregation(op ItemType, grouping []string, without bool, p
 			group.groupCount++
 
 		case itemTopK:
-			if int64(len(group.heap)) < k || group.heap[0].V < s.V || math.IsNaN(float64(group.heap[0].V)) {
+			if int64(len(group.heap)) < k || group.heap[0].V < s.V || math.IsNaN(group.heap[0].V) {
 				if int64(len(group.heap)) == k {
 					heap.Pop(&group.heap)
 				}
@@ -1599,7 +1599,7 @@ func (ev *evaluator) aggregation(op ItemType, grouping []string, without bool, p
 			}
 
 		case itemBottomK:
-			if int64(len(group.reverseHeap)) < k || group.reverseHeap[0].V > s.V || math.IsNaN(float64(group.reverseHeap[0].V)) {
+			if int64(len(group.reverseHeap)) < k || group.reverseHeap[0].V > s.V || math.IsNaN(group.reverseHeap[0].V) {
 				if int64(len(group.reverseHeap)) == k {
 					heap.Pop(&group.reverseHeap)
 				}
@@ -1627,12 +1627,12 @@ func (ev *evaluator) aggregation(op ItemType, grouping []string, without bool, p
 			aggr.value = float64(aggr.groupCount)
 
 		case itemStdvar:
-			avg := float64(aggr.value) / float64(aggr.groupCount)
-			aggr.value = float64(aggr.valuesSquaredSum)/float64(aggr.groupCount) - avg*avg
+			avg := aggr.value / float64(aggr.groupCount)
+			aggr.value = aggr.valuesSquaredSum/float64(aggr.groupCount) - avg*avg
 
 		case itemStddev:
-			avg := float64(aggr.value) / float64(aggr.groupCount)
-			aggr.value = math.Sqrt(float64(aggr.valuesSquaredSum)/float64(aggr.groupCount) - avg*avg)
+			avg := aggr.value / float64(aggr.groupCount)
+			aggr.value = math.Sqrt(aggr.valuesSquaredSum/float64(aggr.groupCount) - avg*avg)
 
 		case itemTopK:
 			// The heap keeps the lowest value on top, so reverse it.

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -299,7 +299,7 @@ func funcClampMax(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 	for _, el := range vec {
 		enh.out = append(enh.out, Sample{
 			Metric: enh.dropMetricName(el.Metric),
-			Point:  Point{V: math.Min(max, float64(el.V))},
+			Point:  Point{V: math.Min(max, el.V)},
 		})
 	}
 	return enh.out
@@ -312,7 +312,7 @@ func funcClampMin(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 	for _, el := range vec {
 		enh.out = append(enh.out, Sample{
 			Metric: enh.dropMetricName(el.Metric),
-			Point:  Point{V: math.Max(min, float64(el.V))},
+			Point:  Point{V: math.Max(min, el.V)},
 		})
 	}
 	return enh.out
@@ -331,7 +331,7 @@ func funcRound(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 	toNearestInverse := 1.0 / toNearest
 
 	for _, el := range vec {
-		v := math.Floor(float64(el.V)*toNearestInverse+0.5) / toNearestInverse
+		v := math.Floor(el.V*toNearestInverse+0.5) / toNearestInverse
 		enh.out = append(enh.out, Sample{
 			Metric: enh.dropMetricName(el.Metric),
 			Point:  Point{V: v},
@@ -392,7 +392,7 @@ func funcMaxOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector
 	return aggrOverTime(vals, enh, func(values []Point) float64 {
 		max := math.Inf(-1)
 		for _, v := range values {
-			max = math.Max(max, float64(v.V))
+			max = math.Max(max, v.V)
 		}
 		return max
 	})
@@ -403,7 +403,7 @@ func funcMinOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector
 	return aggrOverTime(vals, enh, func(values []Point) float64 {
 		min := math.Inf(1)
 		for _, v := range values {
-			min = math.Min(min, float64(v.V))
+			min = math.Min(min, v.V)
 		}
 		return min
 	})
@@ -451,7 +451,7 @@ func funcStddevOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vec
 			count++
 		}
 		avg := sum / count
-		return math.Sqrt(float64(squaredSum/count - avg*avg))
+		return math.Sqrt(squaredSum/count - avg*avg)
 	})
 }
 
@@ -698,7 +698,7 @@ func funcChanges(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 		prev := samples.Points[0].V
 		for _, sample := range samples.Points[1:] {
 			current := sample.V
-			if current != prev && !(math.IsNaN(float64(current)) && math.IsNaN(float64(prev))) {
+			if current != prev && !(math.IsNaN(current) && math.IsNaN(prev)) {
 				changes++
 			}
 			prev = current
@@ -727,7 +727,7 @@ func funcLabelReplace(vals []Value, args Expressions, enh *EvalNodeHelper) Vecto
 		if err != nil {
 			panic(fmt.Errorf("invalid regular expression in label_replace(): %s", regexStr))
 		}
-		if !model.LabelNameRE.MatchString(string(dst)) {
+		if !model.LabelNameRE.MatchString(dst) {
 			panic(fmt.Errorf("invalid destination label name in label_replace(): %s", dst))
 		}
 		enh.dmn = make(map[uint64]labels.Labels, len(enh.out))
@@ -1217,7 +1217,7 @@ func (s vectorByValueHeap) Len() int {
 }
 
 func (s vectorByValueHeap) Less(i, j int) bool {
-	if math.IsNaN(float64(s[i].V)) {
+	if math.IsNaN(s[i].V) {
 		return true
 	}
 	return s[i].V < s[j].V
@@ -1246,7 +1246,7 @@ func (s vectorByReverseValueHeap) Len() int {
 }
 
 func (s vectorByReverseValueHeap) Less(i, j int) bool {
-	if math.IsNaN(float64(s[i].V)) {
+	if math.IsNaN(s[i].V) {
 		return true
 	}
 	return s[i].V > s[j].V

--- a/promql/quantile.go
+++ b/promql/quantile.go
@@ -104,7 +104,7 @@ func bucketQuantile(q float64, buckets buckets) float64 {
 		count -= buckets[b-1].count
 		rank -= buckets[b-1].count
 	}
-	return bucketStart + (bucketEnd-bucketStart)*float64(rank/count)
+	return bucketStart + (bucketEnd-bucketStart)*(rank/count)
 }
 
 // The assumption that bucket counts increase monotonically with increasing
@@ -179,5 +179,5 @@ func quantile(q float64, values vectorByValueHeap) float64 {
 	upperIndex := math.Min(n-1, lowerIndex+1)
 
 	weight := rank - math.Floor(rank)
-	return float64(values[int(lowerIndex)].V)*(1-weight) + float64(values[int(upperIndex)].V)*weight
+	return values[int(lowerIndex)].V*(1-weight) + values[int(upperIndex)].V*weight
 }


### PR DESCRIPTION
Hi @brian-brazil , @fabxc,

I fixed some trivial issues that `unconvert`reports. The remaining ones are `protobuf` files, see:
```
$ gometalinter --vendor --disable-all --enable=unconvert --deadline 6m ./...
prompb/remote.pb.go:400:25:warning: unnecessary conversion (unconvert)
prompb/rpc.pb.go:467:22:warning: unnecessary conversion (unconvert)
prompb/types.pb.go:194:49:warning: unnecessary conversion (unconvert)
prompb/types.pb.go:194:74:warning: unnecessary conversion (unconvert)
prompb/types.pb.go:435:24:warning: unnecessary conversion (unconvert)
prompb/types.pb.go:474:14:warning: unnecessary conversion (unconvert)
prompb/types.pb.go:476:21:warning: unnecessary conversion (unconvert)
```