### PR TITLE
fix of endless loop while doing Consul service discovery.

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -312,8 +312,9 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 			case <-ctx.Done():
 				ticker.Stop()
 				return
-			case <-ticker.C:
+			default:
 				d.watchServices(ctx, ch, &lastIndex, services)
+				<-ticker.C
 			}
 		}
 
@@ -426,8 +427,9 @@ func (d *Discovery) watchService(ctx context.Context, ch chan<- []*targetgroup.G
 			case <-ctx.Done():
 				ticker.Stop()
 				return
-			case <-ticker.C:
+			default:
 				srv.watch(ctx, ch, catalog, &lastIndex)
+				<-ticker.C
 			}
 		}
 	}()


### PR DESCRIPTION
There is and endless loop while doing Consul service discovery, reloading Prometheus configs does not stop this loop. This makes a goroutine leak every time prometheus configs are reloaded.

To reproduce bug:
1. start Prometheus with log.level=debug pointing to one of Consul services. Wait until line  `Watching service` appears. 
2. change Prometheus config pointing to another service.
3. reload config sending SIGHUP. 
4. Previous `Watching service` message continues to appear along with a new one.

cc: @brian-brazil