### PR TITLE
Expose controller kind and name to labelling rules

### DIFF
--- a/discovery/kubernetes/pod_test.go
+++ b/discovery/kubernetes/pod_test.go
@@ -23,6 +23,10 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+func makeOptionalBool(v bool) *bool {
+	return &v
+}
+
 func makeMultiPortPods() *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -31,6 +35,13 @@ func makeMultiPortPods() *v1.Pod {
 			Labels:      map[string]string{"testlabel": "testvalue"},
 			Annotations: map[string]string{"testannotation": "testannotationvalue"},
 			UID:         types.UID("abc123"),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "testcontrollerkind",
+					Name:       "testcontrollername",
+					Controller: makeOptionalBool(true),
+				},
+			},
 		},
 		Spec: v1.PodSpec{
 			NodeName: "testnode",
@@ -146,6 +157,8 @@ func TestPodDiscoveryBeforeRun(t *testing.T) {
 					"__meta_kubernetes_pod_host_ip":                   "2.3.4.5",
 					"__meta_kubernetes_pod_ready":                     "true",
 					"__meta_kubernetes_pod_uid":                       "abc123",
+					"__meta_kubernetes_pod_controller_kind":           "testcontrollerkind",
+					"__meta_kubernetes_pod_controller_name":           "testcontrollername",
 				},
 				Source: "pod/default/testpod",
 			},

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -694,6 +694,8 @@ Available meta labels:
 * `__meta_kubernetes_pod_node_name`: The name of the node the pod is scheduled onto.
 * `__meta_kubernetes_pod_host_ip`: The current host IP of the pod object.
 * `__meta_kubernetes_pod_uid`: The UID of the pod object.
+* `__meta_kubernetes_pod_controller_kind`: Object kind of the pod controller.
+* `__meta_kubernetes_pod_controller_name`: Name of the pod controller.
 
 #### `endpoints`
 


### PR DESCRIPTION
Relabelling rules can use this information to attach the name of the controller that has created a pod.

In turn, this can be used to slice metrics by workload at query time, ie. "Give me all metrics that have been created by the $name Deployment"

As an illustration when used with the following labelling rules:
```
            - source_labels:
                - __meta_kubernetes_pod_controller_kind
              target_label: kubernetes_pod_controller_kind
            - source_labels:
                - __meta_kubernetes_pod_controller_name
              target_label: kubernetes_pod_controller_name
```
we get:
```
node_disk_bytes_written{device="sr0",instance="192.168.99.106:9100",job="kubernetes-pods",kubernetes_pod_controller_kind="DaemonSet",kubernetes_pod_controller_name="prom-node-exporter",node="minikube"}
```
Of course, with a Deployment we only get access to the ReplicatSet, but that's enough to derive the Deployment name with an extra regex in the labelling rules:
```
kubedns_dnsmasq_errors{job="kubernetes-pods",kubernetes_pod_controller_kind="ReplicaSet",kubernetes_pod_controller_name="kube-dns-1301475494"}

```
