### PR TITLE
Fix spelling mistakes found by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ https://prometheus.io/docs/prometheus/2.0/migration/
 * [CHANGE] Removed `count_scalar`, `drop_common_labels` functions and `keep_common` modifier from PromQL.
 * [CHANGE] Rewritten exposition format parser with much higher performance. The Protobuf exposition format is no longer supported.
 * [CHANGE] Example console templates updated for new storage and metrics names. Examples other than node exporter and Prometheus removed.
-* [CHANGE] Admin and lifecycle APIs now disabled by default, can be reenabled via flags
+* [CHANGE] Admin and lifecycle APIs now disabled by default, can be re-enabled via flags
 * [CHANGE] Flags switched to using Kingpin, all flags are now --flagname rather than -flagname.
 * [FEATURE/CHANGE] Remote read can be configured to not read data which is available locally. This is enabled by default.
 * [FEATURE] Rules can be grouped now. Rules within a rule group are executed sequentially.
@@ -922,9 +922,9 @@ All changes:
 * [BUGFIX] Fixed special value handling in division and modulo of the query
   language.
 * [BUGFIX] Fix embed-static.sh.
-* [CLEANUP] Added intial HTTP API tests.
+* [CLEANUP] Added initial HTTP API tests.
 * [CLEANUP] Misc. other code cleanups.
-* [MAINTENANCE] Updated vendored dependcies to their newest versions.
+* [MAINTENANCE] Updated vendored dependencies to their newest versions.
 
 ## 0.12.0 / 2015-03-04
 * [CHANGE] Use client_golang v0.3.1. THIS CHANGES FINGERPRINTING AND INVALIDATES

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -600,8 +600,8 @@ func postPath(pre string) string {
 	return path.Join("/", pre, alertPushEndpoint)
 }
 
-// alertmanagersFromGroup extracts a list of alertmanagers from a target group and an associcated
-// AlertmanagerConfig.
+// alertmanagersFromGroup extracts a list of alertmanagers from a target group
+// and an associated AlertmanagerConfig.
 func alertmanagerFromGroup(tg *targetgroup.Group, cfg *config.AlertmanagerConfig) ([]alertmanager, []alertmanager, error) {
 	var res []alertmanager
 	var droppedAlertManagers []alertmanager

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -1430,7 +1430,7 @@ func TestNaNExpression(t *testing.T) {
 	expr, err := ParseExpr("NaN")
 	if err != nil {
 		t.Errorf("error on input 'NaN'")
-		t.Fatalf("coud not parse: %s", err)
+		t.Fatalf("could not parse: %s", err)
 	}
 
 	nl, ok := expr.(*NumberLiteral)

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1161,7 +1161,7 @@ func TestTargetScrapeScrapeCancel(t *testing.T) {
 		}
 	}
 	// If this is closed in a defer above the function the test server
-	// does not terminate and the test doens't complete.
+	// doesn't terminate and the test doesn't complete.
 	close(block)
 }
 

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -48,7 +48,7 @@ var scenarios = map[string]struct {
 		body: `parse error at char 1: vector selector must contain label matchers or metric name
 `,
 	},
-	"invalid params somehwere in the middle": {
+	"invalid params somewhere in the middle": {
 		params: "match[]=not-a-valid-metric-name",
 		code:   400,
 		body: `parse error at char 4: could not parse remaining input "-a-valid-metric"...


### PR DESCRIPTION
`codespell` can be found here: https://github.com/lucasdemarchi/codespell

Signed-off-by: Karsten Weiss <knweiss@gmail.com>