### PR TITLE
merge relabel into pkg/relabel

### DIFF
--- a/relabel/relabel.go
+++ b/relabel/relabel.go
@@ -28,7 +28,7 @@ import (
 // If a label set is dropped, nil is returned.
 // May return the input labelSet modified.
 // TODO(https://github.com/prometheus/prometheus/issues/3647): Get rid of this package in favor of pkg/relabel
-//  once usage of `model.LabelSet` is removed.
+// once usage of `model.LabelSet` is removed.
 func Process(labels model.LabelSet, cfgs ...*pkgrelabel.Config) model.LabelSet {
 	for _, cfg := range cfgs {
 		labels = relabel(labels, cfg)


### PR DESCRIPTION
Signed-off-by: sipian <cs15btech11019@iith.ac.in>
#3647 
relabel.go is removed by interconverting between model.LabelSet and labels.Labels before sending to Process function in pkg/relabel 
