### PR TITLE
Fixes #4090. Marathon service discovery for 5XX http response

### DIFF
--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -336,6 +336,10 @@ func fetchApps(client *http.Client, url string) (*AppList, error) {
 		return nil, err
 	}
 
+	if (resp.StatusCode < 200) || (resp.StatusCode >= 300) {
+		return nil, fmt.Errorf("Non 2xx status '%v' response during marathon service discovery", resp.StatusCode)
+	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Test execution without fix:

```bash
$ go test -v
=== RUN   TestMarathonSDHandleError
--- PASS: TestMarathonSDHandleError (0.00s)
=== RUN   TestMarathonSDEmptyList
--- PASS: TestMarathonSDEmptyList (0.00s)
=== RUN   TestMarathonSDSendGroup
--- PASS: TestMarathonSDSendGroup (0.00s)
=== RUN   TestMarathonSDRemoveApp
--- PASS: TestMarathonSDRemoveApp (0.00s)
=== RUN   TestMarathonSDRunAndStop
--- PASS: TestMarathonSDRunAndStop (0.01s)
=== RUN   TestMarathonSDSendGroupWithMutiplePort
--- PASS: TestMarathonSDSendGroupWithMutiplePort (0.00s)
=== RUN   TestMarathonZeroTaskPorts
--- PASS: TestMarathonZeroTaskPorts (0.00s)
=== RUN   Test500ErrorHttpResponseWithValidJSONBody
--- FAIL: Test500ErrorHttpResponseWithValidJSONBody (0.00s)
    marathon_test.go:356: Expected error for 5xx HTTP response from marathon server
=== RUN   TestMarathonSDSendGroupWithoutPortMappings
--- PASS: TestMarathonSDSendGroupWithoutPortMappings (0.00s)
=== RUN   TestMarathonSDSendGroupWithoutPortDefinitions
--- PASS: TestMarathonSDSendGroupWithoutPortDefinitions (0.00s)
=== RUN   TestMarathonSDSendGroupWithContainerPortMappings
--- PASS: TestMarathonSDSendGroupWithContainerPortMappings (0.00s)
FAIL
exit status 1
FAIL    github.com/prometheus/prometheus/discovery/marathon    0.026s
```

Test execution with fix:

```bash
$ go test -v
=== RUN   TestMarathonSDHandleError
--- PASS: TestMarathonSDHandleError (0.00s)
=== RUN   TestMarathonSDEmptyList
--- PASS: TestMarathonSDEmptyList (0.00s)
=== RUN   TestMarathonSDSendGroup
--- PASS: TestMarathonSDSendGroup (0.00s)
=== RUN   TestMarathonSDRemoveApp
--- PASS: TestMarathonSDRemoveApp (0.00s)
=== RUN   TestMarathonSDRunAndStop
--- PASS: TestMarathonSDRunAndStop (0.01s)
=== RUN   TestMarathonSDSendGroupWithMutiplePort
--- PASS: TestMarathonSDSendGroupWithMutiplePort (0.00s)
=== RUN   TestMarathonZeroTaskPorts
--- PASS: TestMarathonZeroTaskPorts (0.00s)
=== RUN   Test500ErrorHttpResponseWithValidJSONBody
--- PASS: Test500ErrorHttpResponseWithValidJSONBody (0.00s)
=== RUN   TestMarathonSDSendGroupWithoutPortMappings
--- PASS: TestMarathonSDSendGroupWithoutPortMappings (0.00s)
=== RUN   TestMarathonSDSendGroupWithoutPortDefinitions
--- PASS: TestMarathonSDSendGroupWithoutPortDefinitions (0.00s)
=== RUN   TestMarathonSDSendGroupWithContainerPortMappings
--- PASS: TestMarathonSDSendGroupWithContainerPortMappings (0.00s)
PASS
ok      github.com/prometheus/prometheus/discovery/marathon    0.024s
```