### PR TITLE
unused target didn't trigger an error for unused packages

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -75,7 +75,7 @@ staticcheck: $(STATICCHECK)
 
 unused: $(GOVENDOR)
 	@echo ">> running check for unused packages"
-	@$(GOVENDOR) list +unused
+	@$(GOVENDOR) list +unused | grep . && exit 1 || echo 'No unused packages'
 
 build: promu
 	@echo ">> building binaries"


### PR DESCRIPTION
Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>