### PR TITLE
Only set CORS headers if they aren't set already

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -101,7 +101,9 @@ type response struct {
 // Enables cross-site script calls.
 func setCORS(w http.ResponseWriter) {
 	for h, v := range corsHeaders {
-		w.Header().Set(h, v)
+		if _, ok := w.Header()[h]; !ok {
+			w.Header().Set(h, v)
+		}
 	}
 }
 


### PR DESCRIPTION
This allow for middleware to set these to more specific values if desired