### PR TITLE
API documentation: mention step unit

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -132,7 +132,7 @@ URL query parameters:
 - `query=<string>`: Prometheus expression query string.
 - `start=<rfc3339 | unix_timestamp>`: Start timestamp.
 - `end=<rfc3339 | unix_timestamp>`: End timestamp.
-- `step=<duration>`: Query resolution step width.
+- `step=<duration>`: Query resolution step width in seconds.
 - `timeout=<duration>`: Evaluation timeout. Optional. Defaults to and
    is capped by the value of the `-query.timeout` flag.
 


### PR DESCRIPTION
Mention in http api docs that step parameter is in seconds.

@brian-brazil I imagine this is trivial enough to not have to create an issue first, right?

Signed-off-by: Joel Takvorian <jtakvori@redhat.com>