### PR TITLE
add ignore_error option for remote read

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -653,6 +653,7 @@ type RemoteReadConfig struct {
 	URL           *config_util.URL `yaml:"url"`
 	RemoteTimeout model.Duration   `yaml:"remote_timeout,omitempty"`
 	ReadRecent    bool             `yaml:"read_recent,omitempty"`
+	IgnoreError   bool             `yaml:"ignore_error,omitempty"`
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.
 	HTTPClientConfig config_util.HTTPClientConfig `yaml:",inline"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -93,11 +93,13 @@ var expectedConf = &Config{
 			URL:           mustParseURL("http://remote1/read"),
 			RemoteTimeout: model.Duration(1 * time.Minute),
 			ReadRecent:    true,
+			IgnoreError:   true,
 		},
 		{
 			URL:              mustParseURL("http://remote3/read"),
 			RemoteTimeout:    model.Duration(1 * time.Minute),
 			ReadRecent:       false,
+			IgnoreError:      false,
 			RequiredMatchers: model.LabelSet{"job": "special"},
 		},
 	},

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -23,8 +23,10 @@ remote_write:
 remote_read:
   - url: http://remote1/read
     read_recent: true
+    ignore_error: true
   - url: http://remote3/read
     read_recent: false
+    ignore_error: false
     required_matchers:
       job: special
 

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -37,16 +37,18 @@ const maxErrMsgLen = 256
 
 // Client allows reading and writing from/to a remote HTTP endpoint.
 type Client struct {
-	index   int // Used to differentiate clients in metrics.
-	url     *config_util.URL
-	client  *http.Client
-	timeout time.Duration
+	index       int // Used to differentiate clients in metrics.
+	url         *config_util.URL
+	client      *http.Client
+	timeout     time.Duration
+	ignoreError bool
 }
 
 // ClientConfig configures a Client.
 type ClientConfig struct {
 	URL              *config_util.URL
 	Timeout          model.Duration
+	IgnoreError      bool
 	HTTPClientConfig config_util.HTTPClientConfig
 }
 
@@ -58,10 +60,11 @@ func NewClient(index int, conf *ClientConfig) (*Client, error) {
 	}
 
 	return &Client{
-		index:   index,
-		url:     conf.URL,
-		client:  httpClient,
-		timeout: time.Duration(conf.Timeout),
+		index:       index,
+		url:         conf.URL,
+		client:      httpClient,
+		timeout:     time.Duration(conf.Timeout),
+		ignoreError: conf.IgnoreError,
 	}, nil
 }
 

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
 )
 
@@ -51,7 +52,11 @@ func (q *querier) Select(_ *storage.SelectParams, matchers ...*labels.Matcher) (
 
 	res, err := q.client.Read(q.ctx, query)
 	if err != nil {
-		return nil, err
+		if q.client.ignoreError {
+			res = &prompb.QueryResult{}
+		} else {
+			return nil, err
+		}
 	}
 
 	return FromQueryResult(res), nil

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -63,6 +63,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		c, err := NewClient(i, &ClientConfig{
 			URL:              rwConf.URL,
 			Timeout:          rwConf.RemoteTimeout,
+			IgnoreError:      false,
 			HTTPClientConfig: rwConf.HTTPClientConfig,
 		})
 		if err != nil {
@@ -93,6 +94,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		c, err := NewClient(i, &ClientConfig{
 			URL:              rrConf.URL,
 			Timeout:          rrConf.RemoteTimeout,
+			IgnoreError:      rrConf.IgnoreError,
 			HTTPClientConfig: rrConf.HTTPClientConfig,
 		})
 		if err != nil {


### PR DESCRIPTION
I expect Prometheus to keep working when remote read endpoint is stopped.
Prometheus is important for alerting, and incident response.
Most of remote read endpoint is used for Long term storage, not important for incident response.
So, I propose to add ignore_error option.

I should mention about another point.
`read_recent` could avoid this problem for long term storage, but I want to use this option with `read_recent = true` case.
I create a read adapter for internal use, it is not stable like Prometheus, and not important too.
This is the main use case of `ignore_error` option for me.

Signed-off-by: Mitsuhiro Tanda mitsuhiro.tanda@gmail.com