### PR TITLE
Reference non-goals in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Prometheus uses GitHub to manage reviews of pull requests.
 * If you plan to do something more involved, first discuss your ideas
   on our [mailing list](https://groups.google.com/forum/?fromgroups#!forum/prometheus-developers).
   This will avoid unnecessary work and surely give you and us a good deal
-  of inspiration.
+  of inspiration. Also please see our [non-goals issue](https://github.com/prometheus/docs/issues/149) on areas that the Prometheus community doesn't plan to work on.
 
 * Relevant coding style guidelines are the [Go Code Review
   Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments)


### PR DESCRIPTION
https://github.com/prometheus/docs/issues/149

In CNCF, I've come across members in our community who have questions on what Prometheus plans to work on and what they don't plan to work on. We should also reference the non-goals issue in the contributing guidelines so contributors have easy access to this. In the future, we may want to put something on the website.

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>