### PR TITLE
discovery/marathon: include url in fetchApps error

### DIFF
--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -344,7 +344,11 @@ func fetchApps(client *http.Client, url string) (*AppList, error) {
 		return nil, err
 	}
 
-	return parseAppJSON(body)
+	apps, err := parseAppJSON(body)
+	if err != nil {
+		return nil, fmt.Errorf("%v in %s", err, url)
+	}
+	return apps, nil
 }
 
 func parseAppJSON(body []byte) (*AppList, error) {


### PR DESCRIPTION
This was previously part of a larger PR, but that was closed.

See: https://github.com/prometheus/prometheus/issues/4048#issuecomment-389899997

This change could include auth information in the URL. That's been fixed in upstream go, but not until Go 1.11. See: https://github.com/golang/go/issues/24572