### PR TITLE
scrape,api: provide per-target metric metadata

### DIFF
--- a/pkg/textparse/parse.go
+++ b/pkg/textparse/parse.go
@@ -237,6 +237,7 @@ const (
 type MetricType string
 
 const (
+	MetricTypeUnknown   = ""
 	MetricTypeCounter   = "counter"
 	MetricTypeGauge     = "gauge"
 	MetricTypeHistogram = "histogram"

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -33,7 +33,6 @@ type Appendable interface {
 
 // NewManager is the Manager constructor
 func NewManager(logger log.Logger, app Appendable) *Manager {
-
 	return &Manager{
 		append:        app,
 		logger:        logger,

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -161,6 +161,10 @@ func newScrapePool(cfg *config.ScrapeConfig, app Appendable, logger log.Logger) 
 		logger:     logger,
 	}
 	sp.newLoop = func(t *Target, s scraper, limit int, honor bool, mrc []*config.RelabelConfig) loop {
+		// Update the targets retrieval function for metadata to a new scrape cache.
+		cache := newScrapeCache()
+		t.setMetadataFunc(cache.getMetadata)
+
 		return newScrapeLoop(
 			ctx,
 			s,
@@ -175,6 +179,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app Appendable, logger log.Logger) 
 				}
 				return appender(app, limit)
 			},
+			cache,
 		)
 	}
 
@@ -523,43 +528,61 @@ type scrapeCache struct {
 
 	// Parsed string to an entry with information about the actual label set
 	// and its storage reference.
-	entries map[string]*cacheEntry
+	series map[string]*cacheEntry
 
 	// Cache of dropped metric strings and their iteration. The iteration must
 	// be a pointer so we can update it without setting a new entry with an unsafe
 	// string in addDropped().
-	dropped map[string]*uint64
+	droppedSeries map[string]*uint64
 
 	// seriesCur and seriesPrev store the labels of series that were seen
 	// in the current and previous scrape.
 	// We hold two maps and swap them out to save allocations.
 	seriesCur  map[uint64]labels.Labels
 	seriesPrev map[uint64]labels.Labels
+
+	metaMtx  sync.Mutex
+	metadata map[string]*metaEntry
+}
+
+// metaEntry holds meta information about a metric.
+type metaEntry struct {
+	lastIter uint64
+	typ      textparse.MetricType
+	help     string
 }
 
 func newScrapeCache() *scrapeCache {
 	return &scrapeCache{
-		entries:    map[string]*cacheEntry{},
-		dropped:    map[string]*uint64{},
-		seriesCur:  map[uint64]labels.Labels{},
-		seriesPrev: map[uint64]labels.Labels{},
+		series:        map[string]*cacheEntry{},
+		droppedSeries: map[string]*uint64{},
+		seriesCur:     map[uint64]labels.Labels{},
+		seriesPrev:    map[uint64]labels.Labels{},
+		metadata:      map[string]*metaEntry{},
 	}
 }
 
 func (c *scrapeCache) iterDone() {
-	// refCache and lsetCache may grow over time through series churn
+	// All caches may grow over time through series churn
 	// or multiple string representations of the same metric. Clean up entries
 	// that haven't appeared in the last scrape.
-	for s, e := range c.entries {
+	for s, e := range c.series {
 		if c.iter-e.lastIter > 2 {
-			delete(c.entries, s)
+			delete(c.series, s)
 		}
 	}
-	for s, iter := range c.dropped {
+	for s, iter := range c.droppedSeries {
 		if c.iter-*iter > 2 {
-			delete(c.dropped, s)
+			delete(c.droppedSeries, s)
 		}
 	}
+	c.metaMtx.Lock()
+	for m, e := range c.metadata {
+		if c.iter-e.lastIter > 10 {
+			delete(c.metadata, m)
+		}
+	}
+	c.metaMtx.Unlock()
 
 	// Swap current and previous series.
 	c.seriesPrev, c.seriesCur = c.seriesCur, c.seriesPrev
@@ -573,7 +596,7 @@ func (c *scrapeCache) iterDone() {
 }
 
 func (c *scrapeCache) get(met string) (*cacheEntry, bool) {
-	e, ok := c.entries[met]
+	e, ok := c.series[met]
 	if !ok {
 		return nil, false
 	}
@@ -585,16 +608,16 @@ func (c *scrapeCache) addRef(met string, ref uint64, lset labels.Labels, hash ui
 	if ref == 0 {
 		return
 	}
-	c.entries[met] = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
+	c.series[met] = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
 }
 
 func (c *scrapeCache) addDropped(met string) {
 	iter := c.iter
-	c.dropped[met] = &iter
+	c.droppedSeries[met] = &iter
 }
 
 func (c *scrapeCache) getDropped(met string) bool {
-	iterp, ok := c.dropped[met]
+	iterp, ok := c.droppedSeries[met]
 	if ok {
 		*iterp = c.iter
 	}
@@ -615,6 +638,47 @@ func (c *scrapeCache) forEachStale(f func(labels.Labels) bool) {
 	}
 }
 
+func (c *scrapeCache) setType(metric []byte, t textparse.MetricType) {
+	c.metaMtx.Lock()
+
+	e, ok := c.metadata[yoloString(metric)]
+	if !ok {
+		e = &metaEntry{typ: textparse.MetricTypeUnknown}
+		c.metadata[string(metric)] = e
+	}
+	e.typ = t
+	e.lastIter = c.iter
+
+	c.metaMtx.Unlock()
+}
+
+func (c *scrapeCache) setHelp(metric, help []byte) {
+	c.metaMtx.Lock()
+
+	e, ok := c.metadata[yoloString(metric)]
+	if !ok {
+		e = &metaEntry{typ: textparse.MetricTypeUnknown}
+		c.metadata[string(metric)] = e
+	}
+	if e.help != yoloString(help) {
+		e.help = string(help)
+	}
+	e.lastIter = c.iter
+
+	c.metaMtx.Unlock()
+}
+
+func (c *scrapeCache) getMetadata(metric string) (textparse.MetricType, string, bool) {
+	c.metaMtx.Lock()
+	defer c.metaMtx.Unlock()
+
+	m, ok := c.metadata[metric]
+	if !ok {
+		return textparse.MetricTypeUnknown, "", false
+	}
+	return m.typ, m.help, true
+}
+
 func newScrapeLoop(ctx context.Context,
 	sc scraper,
 	l log.Logger,
@@ -622,6 +686,7 @@ func newScrapeLoop(ctx context.Context,
 	sampleMutator labelsMutator,
 	reportSampleMutator labelsMutator,
 	appender func() storage.Appender,
+	cache *scrapeCache,
 ) *scrapeLoop {
 	if l == nil {
 		l = log.NewNopLogger()
@@ -629,10 +694,13 @@ func newScrapeLoop(ctx context.Context,
 	if buffers == nil {
 		buffers = pool.New(1e3, 1e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) })
 	}
+	if cache == nil {
+		cache = newScrapeCache()
+	}
 	sl := &scrapeLoop{
 		scraper:             sc,
 		buffers:             buffers,
-		cache:               newScrapeCache(),
+		cache:               cache,
 		appender:            appender,
 		sampleMutator:       sampleMutator,
 		reportSampleMutator: reportSampleMutator,
@@ -838,8 +906,16 @@ loop:
 			}
 			break
 		}
-		if et != textparse.EntrySeries {
+		switch et {
+		case textparse.EntryType:
+			sl.cache.setType(p.Type())
 			continue
+		case textparse.EntryHelp:
+			sl.cache.setHelp(p.Help())
+			continue
+		case textparse.EntryComment:
+			continue
+		default:
 		}
 		total++
 

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql"
@@ -63,6 +64,7 @@ const (
 	errorBadData     errorType = "bad_data"
 	errorInternal    errorType = "internal"
 	errorUnavailable errorType = "unavailable"
+	errorNotFound    errorType = "not_found"
 )
 
 var corsHeaders = map[string]string{
@@ -182,6 +184,7 @@ func (api *API) Register(r *route.Router) {
 	r.Del("/series", wrap(api.dropSeries))
 
 	r.Get("/targets", wrap(api.targets))
+	r.Get("/targets/metadata", wrap(api.targetMetadata))
 	r.Get("/alertmanagers", wrap(api.alertmanagers))
 
 	r.Get("/status/config", wrap(api.serveConfig))
@@ -457,7 +460,6 @@ func (api *API) targets(r *http.Request) (interface{}, *apiError) {
 	res := &TargetDiscovery{ActiveTargets: make([]*Target, len(tActive)), DroppedTargets: make([]*DroppedTarget, len(tDropped))}
 
 	for i, t := range tActive {
-
 		lastErrStr := ""
 		lastErr := t.LastError()
 		if lastErr != nil {
@@ -480,6 +482,63 @@ func (api *API) targets(r *http.Request) (interface{}, *apiError) {
 		}
 	}
 	return res, nil
+}
+
+func (api *API) targetMetadata(r *http.Request) (interface{}, *apiError) {
+	limit := -1
+	if s := r.FormValue("limit"); s != "" {
+		var err error
+		if limit, err = strconv.Atoi(s); err != nil {
+			return nil, &apiError{errorBadData, fmt.Errorf("limit must be a  number")}
+		}
+	}
+
+	matchers, err := promql.ParseMetricSelector(r.FormValue("match"))
+	if err != nil {
+		return nil, &apiError{errorBadData, err}
+	}
+
+	var metric string
+	for i, m := range matchers {
+		if m.Name == labels.MetricName && m.Type == labels.MatchEqual {
+			metric = m.Value
+			matchers = append(matchers[:i], matchers[i+1:]...)
+			break
+		}
+	}
+	if metric == "" {
+		return nil, &apiError{errorBadData, errors.New("matcher must specify metric name")}
+	}
+
+	var res []metricMetadata
+Outer:
+	for _, t := range api.targetRetriever.TargetsActive() {
+		if limit >= 0 && len(res) >= limit {
+			break
+		}
+		for _, m := range matchers {
+			if !m.Matches(t.Labels().Get(m.Name)) {
+				continue Outer
+			}
+		}
+		if typ, help, ok := t.Metadata(metric); ok {
+			res = append(res, metricMetadata{
+				Target: t.Labels(),
+				Type:   typ,
+				Help:   help,
+			})
+		}
+	}
+	if len(res) == 0 {
+		return nil, &apiError{errorNotFound, errors.New("specified metadata not found")}
+	}
+	return res, nil
+}
+
+type metricMetadata struct {
+	Target labels.Labels        `json:"target"`
+	Type   textparse.MetricType `json:"type"`
+	Help   string               `json:"help"`
 }
 
 // AlertmanagerDiscovery has all the active Alertmanagers.
@@ -779,6 +838,8 @@ func respondError(w http.ResponseWriter, apiErr *apiError, data interface{}) {
 		code = http.StatusServiceUnavailable
 	case errorInternal:
 		code = http.StatusInternalServerError
+	case errorNotFound:
+		code = http.StatusNotFound
 	default:
 		code = http.StatusInternalServerError
 	}


### PR DESCRIPTION
This adds a per-target cache of scraped metadata. The metadata is only
available for the lifecycle of the attached target. An API endpoint allows
to select metadata by metric name and a label selection of targets.

Per my (so far short-running test) I somewhat surprisingly cannot detect any difference in memory or CPU utilization.

I'll throw in an API-level test once we have agreement on it. It's kinda tedious due to some tech debt.

API example:

```bash
curl -G http://localhost:9091/api/v1/targets/metadata \
    --data-urlencode 'match=go_goroutines{job="prometheus"}' \
    --data-urlencode 'limit=3' | jq
{
  "status": "success",
  "data": [
    {
      "target": {
        "instance": "127.0.0.1:9090",
        "job": "prometheus"
      },
      "type": "gauge",
      "help": "Number of goroutines that currently exist."
    },
    {
      "target": {
        "instance": "127.0.0.1:9091",
        "job": "prometheus"
      },
      "type": "gauge",
      "help": "Number of goroutines that currently exist."
    },
    {
      "target": {
        "instance": "localhost:9090",
        "job": "prometheus"
      },
      "type": "gauge",
      "help": "Number of goroutines that currently exist."
    }
  ]
}
```

@brian-brazil @jkohen