### PR TITLE
Dedupe samples in the mergeIterator.

### DIFF
--- a/storage/fanout_test.go
+++ b/storage/fanout_test.go
@@ -136,6 +136,14 @@ func TestMergeIterator(t *testing.T) {
 			},
 			expected: []sample{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}},
 		},
+		{
+			input: []SeriesIterator{
+				newListSeriesIterator([]sample{{0, 0}, {1, 1}}),
+				newListSeriesIterator([]sample{{0, 0}, {2, 2}}),
+				newListSeriesIterator([]sample{{2, 2}, {3, 3}}),
+			},
+			expected: []sample{{0, 0}, {1, 1}, {2, 2}, {3, 3}},
+		},
 	} {
 		merged := newMergeIterator(tc.input)
 		actual := drainSamples(merged)


### PR DESCRIPTION
Partial fix for #4184 - this will dedupe samples from local and remote.  But its not clear why they are coming back from remote, as ReadRecent defaults to false.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>