### PR TITLE
Add queue name to logger for remote writes

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -164,6 +164,8 @@ type QueueManager struct {
 func NewQueueManager(logger log.Logger, cfg config.QueueConfig, externalLabels model.LabelSet, relabelConfigs []*config.RelabelConfig, client StorageClient, flushDeadline time.Duration) *QueueManager {
 	if logger == nil {
 		logger = log.NewNopLogger()
+	} else {
+		logger = log.With(logger, "queue", client.Name())
 	}
 	t := &QueueManager{
 		logger:         logger,


### PR DESCRIPTION
More than one remote_write destination can be configured, in which case it's essential to know which one each log message refers to.