### PR TITLE
Added flags for size based retention

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -163,6 +163,9 @@ func main() {
 	a.Flag("storage.tsdb.retention", "How long to retain samples in storage.").
 		Default("15d").SetValue(&cfg.tsdb.Retention)
 
+	a.Flag("storage.tsdb.maxbytes", "Maximum number of bytes that can be stored for blocks.").
+		Default("0").Int64Var(&cfg.tsdb.MaxBytes)
+
 	a.Flag("storage.tsdb.no-lockfile", "Do not create lockfile in data directory.").
 		Default("false").BoolVar(&cfg.tsdb.NoLockfile)
 

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -160,10 +160,13 @@ func main() {
 		"Maximum duration compacted blocks may span. For use in testing. (Defaults to 10% of the retention period).").
 		Hidden().PlaceHolder("<duration>").SetValue(&cfg.tsdb.MaxBlockDuration)
 
-	a.Flag("storage.tsdb.retention", "How long to retain samples in storage.").
+	a.Flag("storage.tsdb.retention", "How long to retain samples in storage. (This flag has been deprecated. Use storage.tsdb.retention.time as a replacement.)").
 		Default("15d").SetValue(&cfg.tsdb.Retention)
 
-	a.Flag("storage.tsdb.maxbytes", "Maximum number of bytes that can be stored for blocks.").
+	a.Flag("storage.tsdb.retention.time", "How long to retain samples in storage.").
+		Default("15d").SetValue(&cfg.tsdb.Retention)
+
+	a.Flag("storage.tsdb.retention.size", "Maximum number of bytes that can be stored for blocks.").
 		Default("0").Int64Var(&cfg.tsdb.MaxBytes)
 
 	a.Flag("storage.tsdb.no-lockfile", "Do not create lockfile in data directory.").

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -52,7 +52,8 @@ For further details on file format, see [TSDB format](https://github.com/prometh
 Prometheus has several flags that allow configuring the local storage. The most important ones are:
 
 * `--storage.tsdb.path`: This determines where Prometheus writes its database. Defaults to `data/`.
-* `--storage.tsdb.retention`: This determines when to remove old data. Defaults to `15d`.
+* `--storage.tsdb.retention.time`: This determines when to remove old data. Defaults to `15d`.
+* `--storage.tsdb.retention.size`: This determines the maximum number of bytes that storage blocks can use (note that this does not include the WAL size, which can be substantial). The oldest data will be removed first. Defaults to `0` or disabled.
 
 On average, Prometheus uses only around 1-2 bytes per sample. Thus, to plan the capacity of a Prometheus server, you can use the rough formula:
 
@@ -63,6 +64,8 @@ needed_disk_space = retention_time_seconds * ingested_samples_per_second * bytes
 To tune the rate of ingested samples per second, you can either reduce the number of time series you scrape (fewer targets or fewer series per target), or you can increase the scrape interval. However, reducing the number of series is likely more effective, due to compression of samples within a series.
 
 If your local storage becomes corrupted for whatever reason, your best bet is to shut down Prometheus and remove the entire storage directory. However, you can also try removing individual block directories to resolve the problem. This means losing a time window of around two hours worth of data per block directory. Again, Prometheus's local storage is not meant as durable long-term storage.
+
+If both time and size retention policies are specified, whichever policy triggers first will be used at that instant.
 
 ## Remote storage integrations
 

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 	github.com/prometheus/common v0.0.0-20180518154759-7600349dcfe1
 	github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9 // indirect
-	github.com/prometheus/tsdb v0.2.0
+	github.com/prometheus/tsdb v0.1.1-0.20181120193419-f9476466d022
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a // indirect
 	github.com/rlmcpherson/s3gof3r v0.5.0 // indirect
 	github.com/rubyist/circuitbreaker v2.2.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/prometheus/common v0.0.0-20180518154759-7600349dcfe1 h1:osmNoEW2SCW3L
 github.com/prometheus/common v0.0.0-20180518154759-7600349dcfe1/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9 h1:IrO4Eb9oGw+GxzOhO4b2QC5EWO85Omh/4iTSPZktMm8=
 github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
-github.com/prometheus/tsdb v0.2.0 h1:27z98vFd/gPew17nmKEbLn37exGCwc2F5EyrgScg6bk=
-github.com/prometheus/tsdb v0.2.0/go.mod h1:lFf/o1J2a31WmWQbxYXfY1azJK5Xp5D8hwKMnVMBTGU=
+github.com/prometheus/tsdb v0.1.1-0.20181120193419-f9476466d022 h1:EIEFPDBN3/+3GuBw/V3RcFV7/efdVNhqxuaMne2RrGU=
+github.com/prometheus/tsdb v0.1.1-0.20181120193419-f9476466d022/go.mod h1:lFf/o1J2a31WmWQbxYXfY1azJK5Xp5D8hwKMnVMBTGU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rlmcpherson/s3gof3r v0.5.0 h1:1izOJpTiohSibfOHuNyEA/yQnAirh05enzEdmhez43k=

--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -120,6 +120,9 @@ type Options struct {
 	// Duration for how long to retain data.
 	Retention model.Duration
 
+	// Maximum number of bytes to be retained.
+	MaxBytes int64
+
 	// Disable creation and consideration of lockfile.
 	NoLockfile bool
 }
@@ -143,6 +146,7 @@ func Open(path string, l log.Logger, r prometheus.Registerer, opts *Options) (*t
 	db, err := tsdb.Open(path, l, r, &tsdb.Options{
 		WALFlushInterval:  10 * time.Second,
 		RetentionDuration: uint64(time.Duration(opts.Retention).Seconds() * 1000),
+		MaxBytes:          opts.MaxBytes,
 		BlockRanges:       rngs,
 		NoLockfile:        opts.NoLockfile,
 	})

--- a/vendor/github.com/prometheus/tsdb/block.go
+++ b/vendor/github.com/prometheus/tsdb/block.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb/chunkenc"
@@ -141,6 +143,12 @@ type Appendable interface {
 	Appender() Appender
 }
 
+// SizeReader returns the size of the object in bytes.
+type SizeReader interface {
+	//Size returns the size in bytes.
+	Size() int64
+}
+
 // BlockMeta provides meta information about a block.
 type BlockMeta struct {
 	// Unique identifier for the block and its contents. Changes on compaction.
@@ -167,6 +175,7 @@ type BlockStats struct {
 	NumSeries     uint64 `json:"numSeries,omitempty"`
 	NumChunks     uint64 `json:"numChunks,omitempty"`
 	NumTombstones uint64 `json:"numTombstones,omitempty"`
+	NumBytes      int64  `json:"numBytes,omitempty"`
 }
 
 // BlockDesc describes a block by ULID and time range.
@@ -258,7 +267,10 @@ type Block struct {
 
 // OpenBlock opens the block in the directory. It can be passed a chunk pool, which is used
 // to instantiate chunk structs.
-func OpenBlock(dir string, pool chunkenc.Pool) (*Block, error) {
+func OpenBlock(logger log.Logger, dir string, pool chunkenc.Pool) (*Block, error) {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
 	meta, err := readMetaFile(dir)
 	if err != nil {
 		return nil, err
@@ -273,9 +285,18 @@ func OpenBlock(dir string, pool chunkenc.Pool) (*Block, error) {
 		return nil, err
 	}
 
-	tr, err := readTombstones(dir)
+	tr, tsr, err := readTombstones(dir)
 	if err != nil {
 		return nil, err
+	}
+
+	// TODO refactor to set this at block creation time as
+	// that would be the logical place for a block size to be calculated.
+	bs := blockSize(cr, ir, tsr)
+	meta.Stats.NumBytes = bs
+	err = writeMetaFile(dir, meta)
+	if err != nil {
+		level.Warn(logger).Log("msg", "couldn't write the meta file for the block size", "block", dir, "err", err)
 	}
 
 	// Calculating symbol table size.
@@ -297,6 +318,17 @@ func OpenBlock(dir string, pool chunkenc.Pool) (*Block, error) {
 		symbolTableSize: symTblSize,
 	}
 	return pb, nil
+}
+
+func blockSize(rr ...SizeReader) int64 {
+	var total int64
+	for _, r := range rr {
+		if r != nil {
+			t := r.Size()
+			total += t
+		}
+	}
+	return total
 }
 
 // Close closes the on-disk block. It blocks as long as there are readers reading from the block.
@@ -325,6 +357,9 @@ func (pb *Block) Dir() string { return pb.dir }
 
 // Meta returns meta information about the block.
 func (pb *Block) Meta() BlockMeta { return pb.meta }
+
+// Size returns the number of bytes that the block takes up.
+func (pb *Block) Size() int64 { return pb.meta.Stats.NumBytes }
 
 // ErrClosing is returned when a block is in the process of being closed.
 var ErrClosing = errors.New("block is closing")

--- a/vendor/github.com/prometheus/tsdb/chunks/chunks.go
+++ b/vendor/github.com/prometheus/tsdb/chunks/chunks.go
@@ -345,6 +345,15 @@ func (s *Reader) Close() error {
 	return closeAll(s.cs...)
 }
 
+// Size returns the size of the chunks.
+func (s *Reader) Size() int64 {
+	var size int64
+	for _, f := range s.bs {
+		size += int64(f.Len())
+	}
+	return size
+}
+
 func (s *Reader) Chunk(ref uint64) (chunkenc.Chunk, error) {
 	var (
 		seq = int(ref >> 32)

--- a/vendor/github.com/prometheus/tsdb/compact.go
+++ b/vendor/github.com/prometheus/tsdb/compact.go
@@ -347,7 +347,7 @@ func (c *LeveledCompactor) Compact(dest string, dirs []string, open []*Block) (u
 
 		if b == nil {
 			var err error
-			b, err = OpenBlock(d, c.chunkPool)
+			b, err = OpenBlock(c.logger, d, c.chunkPool)
 			if err != nil {
 				return uid, err
 			}

--- a/vendor/github.com/prometheus/tsdb/index/index.go
+++ b/vendor/github.com/prometheus/tsdb/index/index.go
@@ -934,6 +934,11 @@ func (r *Reader) SortedPostings(p Postings) Postings {
 	return p
 }
 
+// Size returns the size of an index file.
+func (r *Reader) Size() int64 {
+	return int64(r.b.Len())
+}
+
 // LabelNames returns all the unique label names present in the index.
 func (r *Reader) LabelNames() ([]string, error) {
 	labelNamesMap := make(map[string]struct{}, len(r.labels))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/prometheus/common/route
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 # github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9
 github.com/prometheus/procfs
-# github.com/prometheus/tsdb v0.2.0
+# github.com/prometheus/tsdb v0.1.1-0.20181120193419-f9476466d022
 github.com/prometheus/tsdb
 github.com/prometheus/tsdb/labels
 github.com/prometheus/tsdb/chunkenc

--- a/web/web.go
+++ b/web/web.go
@@ -69,6 +69,25 @@ import (
 
 var localhostRepresentations = []string{"127.0.0.1", "localhost"}
 
+// withStackTrace logs the stack trace in case the request panics. The function
+// will re-raise the error which will then be handled by the net/http package.
+// It is needed because the go-kit log package doesn't manage properly the
+// panics from net/http (see https://github.com/go-kit/kit/issues/233).
+func withStackTracer(h http.Handler, l log.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				const size = 64 << 10
+				buf := make([]byte, size)
+				buf = buf[:runtime.Stack(buf, false)]
+				level.Error(l).Log("msg", "panic while serving request", "client", r.RemoteAddr, "url", r.URL, "err", err, "stack", buf)
+				panic(err)
+			}
+		}()
+		h.ServeHTTP(w, r)
+	})
+}
+
 var (
 	requestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -459,7 +478,7 @@ func (h *Handler) Run(ctx context.Context) error {
 	errlog := stdlog.New(log.NewStdlibAdapter(level.Error(h.logger)), "", 0)
 
 	httpSrv := &http.Server{
-		Handler:     nethttp.Middleware(opentracing.GlobalTracer(), mux, operationName),
+		Handler:     withStackTracer(nethttp.Middleware(opentracing.GlobalTracer(), mux, operationName), h.logger),
 		ErrorLog:    errlog,
 		ReadTimeout: h.options.ReadTimeout,
 	}


### PR DESCRIPTION
Added a new flags for setting maximum number of bytes that can be stored locally and necessary fields in tsdb for storing it. This PR is in conjunction with a PR with prometheus/tsdb. The idea is to allow a user to set a maximum number of bytes that the local storage can take up, in conjunction with the retention period, and whenever that limit is exceeded the oldest block will be deleted to regain space.

closes https://github.com/prometheus/prometheus/issues/968

Signed-off-by: Mark Knapp <mknapp@hudson-trading.com>