### PR TITLE
limit size of POST requests against remote read endpoint

### DIFF
--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -15,6 +15,7 @@ package remote
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"sort"
@@ -28,9 +29,12 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
+// decodeReadLimit is the maximum size of a read request body in bytes.
+const decodeReadLimit = 32 * 1024 * 1024
+
 // DecodeReadRequest reads a remote.Request from a http.Request.
 func DecodeReadRequest(r *http.Request) (*prompb.ReadRequest, error) {
-	compressed, err := ioutil.ReadAll(r.Body)
+	compressed, err := ioutil.ReadAll(io.LimitReader(r.Body, decodeReadLimit))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit fixes a denial-of-service issue of the remote
read endpoint. It limits the size of the POST request body
to 32 MB such that clients cannot write arbitrary amounts
of data to the server memory.

Fixes #4238

Signed-off-by: Andreas Auernhammer <aead@mail.de>