### PR TITLE
web: restore old path prefix behavior

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -770,13 +770,7 @@ func tmplFuncs(consolesPath string, opts *Options) template_text.FuncMap {
 			return time.Since(t) / time.Millisecond * time.Millisecond
 		},
 		"consolesPath": func() string { return consolesPath },
-		"pathPrefix": func() string {
-			if opts.RoutePrefix == "/" {
-				return ""
-			} else {
-				return opts.RoutePrefix
-			}
-		},
+		"pathPrefix":   func() string { return opts.ExternalURL.Path },
 		"buildVersion": func() string { return opts.Version.Revision },
 		"stripLabels": func(lset map[string]string, labels ...string) map[string]string {
 			for _, ln := range labels {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -319,42 +319,6 @@ func TestRoutePrefix(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Equals(t, http.StatusOK, resp.StatusCode)
 }
-
-func TestPathPrefix(t *testing.T) {
-
-	tests := []struct {
-		routePrefix string
-		pathPrefix  string
-	}{
-		{
-			routePrefix: "/",
-			// If we have pathPrefix as "/", URL in UI gets "//"" as prefix,
-			// hence doesn't remain relative path anymore.
-			pathPrefix: "",
-		},
-		{
-			routePrefix: "/prometheus",
-			pathPrefix:  "/prometheus",
-		},
-		{
-			routePrefix: "/p1/p2/p3/p4",
-			pathPrefix:  "/p1/p2/p3/p4",
-		},
-	}
-
-	for _, test := range tests {
-		opts := &Options{
-			RoutePrefix: test.routePrefix,
-		}
-
-		pathPrefix := tmplFuncs("", opts)["pathPrefix"].(func() string)
-		pp := pathPrefix()
-
-		testutil.Equals(t, test.pathPrefix, pp)
-	}
-
-}
-
 func TestDebugHandler(t *testing.T) {
 	for _, tc := range []struct {
 		prefix, url string


### PR DESCRIPTION
Signed-off-by: Fabian Reinartz <freinartz@google.com>

@brian-brazil 

@beorn7 I believe your issue in #4004 was not a bug in that sense. `--web.route-prefix` sets a prefix for the internal HTTP router, while `--web.external-url` allows defining a prefix path that is exposed to the outside world. 
The intention being that different kinds of reverse prefix may or may not strip path prefixes away. Thus we need support to configure both things independently.