### PR TITLE
web: remove security headers

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -71,17 +71,6 @@ import (
 
 var localhostRepresentations = []string{"127.0.0.1", "localhost"}
 
-// secureHeadersMiddleware adds common HTTP security headers to responses.
-func secureHeadersMiddleware(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("X-XSS-Protection", "1; mode=block")
-		w.Header().Add("X-Content-Type-Options", "nosniff")
-		w.Header().Add("X-Frame-Options", "SAMEORIGIN")
-		w.Header().Add("Content-Security-Policy", "frame-ancestors 'self'")
-		h.ServeHTTP(w, r)
-	})
-}
-
 var (
 	requestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -489,10 +478,8 @@ func (h *Handler) Run(ctx context.Context) error {
 
 	errlog := stdlog.New(log.NewStdlibAdapter(level.Error(h.logger)), "", 0)
 
-	withSecureHeaders := nethttp.Middleware(opentracing.GlobalTracer(), secureHeadersMiddleware(mux), operationName)
-
 	httpSrv := &http.Server{
-		Handler:     withSecureHeaders,
+		Handler:     nethttp.Middleware(opentracing.GlobalTracer(), mux, operationName),
 		ErrorLog:    errlog,
 		ReadTimeout: h.options.ReadTimeout,
 	}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -83,54 +83,6 @@ func TestGlobalURL(t *testing.T) {
 	}
 }
 
-func TestEndpointHeaders(t *testing.T) {
-	t.Parallel()
-	dbDir, err := ioutil.TempDir("", "tsdb-ready")
-
-	testutil.Ok(t, err)
-
-	defer os.RemoveAll(dbDir)
-
-	db, err := libtsdb.Open(dbDir, nil, nil, nil)
-
-	testutil.Ok(t, err)
-
-	opts := &Options{
-		ListenAddress:  ":9095",
-		ReadTimeout:    30 * time.Second,
-		MaxConnections: 512,
-		Context:        nil,
-		Storage:        &tsdb.ReadyStorage{},
-		QueryEngine:    nil,
-		RuleManager:    nil,
-		Notifier:       nil,
-		RoutePrefix:    "/",
-		EnableAdminAPI: true,
-		TSDB:           func() *libtsdb.DB { return db },
-	}
-
-	opts.Flags = map[string]string{}
-
-	webHandler := New(nil, opts)
-	go func() {
-		err := webHandler.Run(context.Background())
-		if err != nil {
-			panic(fmt.Sprintf("Can't start webhandler error %s", err))
-		}
-	}()
-
-	time.Sleep(5 * time.Second)
-
-	resp, err := http.Get("http://localhost:9095/version")
-
-	testutil.Ok(t, err)
-	testutil.Equals(t, "1; mode=block", resp.Header.Get("X-XSS-Protection"))
-	testutil.Equals(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
-	testutil.Equals(t, "SAMEORIGIN", resp.Header.Get("X-Frame-Options"))
-	testutil.Equals(t, "frame-ancestors 'self'", resp.Header.Get("Content-Security-Policy"))
-
-}
-
 func TestReadyAndHealthy(t *testing.T) {
 	t.Parallel()
 	dbDir, err := ioutil.TempDir("", "tsdb-ready")


### PR DESCRIPTION
This reverts changes from #3583 due to issues it causes in #4246

From the original PR:

> This configuration for the headers is very unrestrictive, while still meeting most compliance frameworks and industry best practices. They should not interfere with any functionality in Prometheus (and did not in my testing).

This does not seem to hold true. Maybe we just need to set yet another set of headers when serving our JS files? I don't know and the original PR didn't go into any detail what those headers actually do and how they help.  
Given they were not addressing an imminent problem and are breaking things in the current state, reverting them seems to be the best solution for now.

@eavalenzuela if you can shed some lights on this or have a solution to fix this quickly, that'd be great.

