### PR TITLE
test to ensure no change of the global config after unmarshling.

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
@@ -24,7 +25,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	sd_config "github.com/prometheus/prometheus/discovery/config"
+	"github.com/prometheus/prometheus/notifier"
+	"github.com/prometheus/prometheus/scrape"
+	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/util/testutil"
+	"github.com/prometheus/prometheus/web"
+	k8s_runtime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var promPath string
@@ -172,4 +182,55 @@ func TestFailedStartupExitCode(t *testing.T) {
 	} else {
 		t.Errorf("unable to retrieve the exit status for prometheus: %v", err)
 	}
+}
+
+// TestApplyConfig ensures that no component is modifing the global config.
+// The config includes many pointers so modifing it has global side effects.
+func TestApplyConfig(t *testing.T) {
+	// Disable k8s logs.
+	k8s_runtime.ErrorHandlers = []func(error){}
+
+	var (
+		cfgOrig          *config.Config
+		ctx, cancel      = context.WithCancel(context.Background())
+		logger           = log.NewNopLogger()
+		notifyManager    = notifier.NewManager(&notifier.Options{}, logger)
+		discoveryManager = discovery.NewManager(ctx, logger)
+		scrapeManager    = scrape.NewManager(logger, nil)
+		webHandler       = web.New(logger, &web.Options{RoutePrefix: "/"})
+		remoteStorage    = remote.NewStorage(logger, nil, time.Duration(1*time.Millisecond))
+	)
+	defer cancel() // Just in case to avoid goroutine leaks.
+
+	// Load the config in all components.
+	reloaders := []func(cfg *config.Config) error{
+		// Save the config so we can compare it with a new untouched copy.
+		// Since this is a pointer any modification will be reflected in the saved copy.
+		func(cfg *config.Config) error {
+			cfgOrig = cfg
+			return nil
+		},
+		remoteStorage.ApplyConfig,
+		webHandler.ApplyConfig,
+		notifyManager.ApplyConfig,
+		scrapeManager.ApplyConfig,
+		scrapeManager.ApplyConfig,
+		func(cfg *config.Config) error {
+			c := make(map[string]sd_config.ServiceDiscoveryConfig)
+			for _, v := range cfg.ScrapeConfigs {
+				c[v.JobName] = v.ServiceDiscoveryConfig
+			}
+			return discoveryManager.ApplyConfig(c)
+		},
+	}
+	testutil.Ok(t, reloadConfig("../../config/testdata/conf.good.yml", logger, reloaders...))
+
+	// Need to reload the file again so we have a completely new untouched copy.
+	reloaders = []func(cfg *config.Config) error{
+		func(cfg *config.Config) error {
+			testutil.Equals(t, cfgOrig, cfg)
+			return nil
+		},
+	}
+	testutil.Ok(t, reloadConfig("../../config/testdata/conf.good.yml", logger, reloaders...))
 }

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -184,8 +184,8 @@ func TestFailedStartupExitCode(t *testing.T) {
 	}
 }
 
-// TestApplyConfig ensures that no component is modifing the global config.
-// The config includes many pointers so modifing it has global side effects.
+// TestApplyConfig ensures that no component is modifying the global config.
+// The config includes many pointers so modifying it has global side effects.
 func TestApplyConfig(t *testing.T) {
 	// Disable k8s logs.
 	k8s_runtime.ErrorHandlers = []func(error){}
@@ -213,7 +213,6 @@ func TestApplyConfig(t *testing.T) {
 		remoteStorage.ApplyConfig,
 		webHandler.ApplyConfig,
 		notifyManager.ApplyConfig,
-		scrapeManager.ApplyConfig,
 		scrapeManager.ApplyConfig,
 		func(cfg *config.Config) error {
 			c := make(map[string]sd_config.ServiceDiscoveryConfig)

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -222,7 +222,7 @@ func TestApplyConfig(t *testing.T) {
 			return discoveryManager.ApplyConfig(c)
 		},
 	}
-	testutil.Ok(t, reloadConfig("../../config/testdata/conf.good.yml", logger, reloaders...))
+	testutil.Ok(t, reloadConfig("../../config/testdata/conf.good.multi.static.yml", logger, reloaders...))
 
 	// Need to reload the file again so we have a completely new untouched copy.
 	reloaders = []func(cfg *config.Config) error{
@@ -231,5 +231,5 @@ func TestApplyConfig(t *testing.T) {
 			return nil
 		},
 	}
-	testutil.Ok(t, reloadConfig("../../config/testdata/conf.good.yml", logger, reloaders...))
+	testutil.Ok(t, reloadConfig("../../config/testdata/conf.good.multi.static.yml", logger, reloaders...))
 }

--- a/config/testdata/conf.good.multi.static.yml
+++ b/config/testdata/conf.good.multi.static.yml
@@ -1,0 +1,245 @@
+# my global config
+global:
+  scrape_interval:     15s
+  evaluation_interval: 30s
+  # scrape_timeout is set to the global default (10s).
+
+  external_labels:
+    monitor: codelab
+    foo:     bar
+
+rule_files:
+- "first.rules"
+- "my/*.rules"
+
+remote_write:
+  - url: http://remote1/push
+    write_relabel_configs:
+    - source_labels: [__name__]
+      regex:         expensive.*
+      action:        drop
+  - url: http://remote2/push
+
+remote_read:
+  - url: http://remote1/read
+    read_recent: true
+  - url: http://remote3/read
+    read_recent: false
+    required_matchers:
+      job: special
+
+scrape_configs:
+- job_name: prometheus
+
+  honor_labels: true
+  # scrape_interval is defined by the configured global (15s).
+  # scrape_timeout is defined by the global default (10s).
+
+  # metrics_path defaults to '/metrics'
+  # scheme defaults to 'http'.
+
+  file_sd_configs:
+    - files:
+      - foo/*.slow.json
+      - foo/*.slow.yml
+      - single/file.yml
+      refresh_interval: 10m
+    - files:
+      - bar/*.yaml
+
+  static_configs:
+  - targets: ['localhost:9090', 'localhost:9191']
+  - targets: ["foo:9090"]
+  - targets: ["bar:9090"]
+  - targets: ["baz:9090"]
+    labels:
+      my:   label
+      your: label
+
+  relabel_configs:
+  - source_labels: [job, __meta_dns_name]
+    regex:         (.*)some-[regex]
+    target_label:  job
+    replacement:   foo-${1}
+    # action defaults to 'replace'
+  - source_labels: [abc]
+    target_label:  cde
+  - replacement:   static
+    target_label:  abc
+  - regex:
+    replacement:   static
+    target_label:  abc
+
+  bearer_token_file: valid_token_file
+
+
+- job_name: service-x
+
+  basic_auth:
+    username: admin_name
+    password: "multiline\nmysecret\ntest"
+
+  scrape_interval: 50s
+  scrape_timeout:  5s
+
+  sample_limit: 1000
+
+  metrics_path: /my_path
+  scheme: https
+
+  dns_sd_configs:
+  - refresh_interval: 15s
+    names:
+    - first.dns.address.domain.com
+    - second.dns.address.domain.com
+  - names:
+    - first.dns.address.domain.com
+    # refresh_interval defaults to 30s.
+
+  relabel_configs:
+  - source_labels: [job]
+    regex:         (.*)some-[regex]
+    action:        drop
+  - source_labels: [__address__]
+    modulus:       8
+    target_label:  __tmp_hash
+    action:        hashmod
+  - source_labels: [__tmp_hash]
+    regex:         1
+    action:        keep
+  - action:        labelmap
+    regex:         1
+  - action:        labeldrop
+    regex:         d
+  - action:        labelkeep
+    regex:         k
+
+  metric_relabel_configs:
+  - source_labels: [__name__]
+    regex:         expensive_metric.*
+    action:        drop
+
+- job_name: service-y
+
+  consul_sd_configs:
+  - server: 'localhost:1234'
+    token: mysecret
+    services: ['nginx', 'cache', 'mysql']
+    tag: "canary"
+    node_meta:
+      rack: "123"
+    allow_stale: true
+    scheme: https
+    tls_config:
+      ca_file: valid_ca_file
+      cert_file: valid_cert_file
+      key_file:  valid_key_file
+      insecure_skip_verify: false
+
+  relabel_configs:
+  - source_labels: [__meta_sd_consul_tags]
+    separator:     ','
+    regex:         label:([^=]+)=([^,]+)
+    target_label:  ${1}
+    replacement:   ${2}
+
+- job_name: service-z
+
+  tls_config:
+    cert_file: valid_cert_file
+    key_file: valid_key_file
+
+  bearer_token: mysecret
+
+- job_name: service-kubernetes
+
+  kubernetes_sd_configs:
+  - role: endpoints
+    api_server: 'https://localhost:1234'
+
+    basic_auth:
+      username: 'myusername'
+      password: 'mysecret'
+
+- job_name: service-kubernetes-namespaces
+
+  kubernetes_sd_configs:
+  - role: endpoints
+    api_server: 'https://localhost:1234'
+    namespaces:
+      names:
+        - default
+
+- job_name: service-marathon
+  marathon_sd_configs:
+  - servers:
+    - 'https://marathon.example.com:443'
+
+    auth_token: "mysecret"
+    tls_config:
+      cert_file: valid_cert_file
+      key_file: valid_key_file
+
+- job_name: service-ec2
+  ec2_sd_configs:
+    - region: us-east-1
+      access_key: access
+      secret_key: mysecret
+      profile: profile
+      filters:
+        - name: tag:environment
+          values:
+            - prod
+
+        - name: tag:service
+          values:
+            - web
+            - db
+
+- job_name: service-azure
+  azure_sd_configs:
+    - subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
+      tenant_id: BBBB222B-B2B2-2B22-B222-2BB2222BB2B2
+      client_id: 333333CC-3C33-3333-CCC3-33C3CCCCC33C
+      client_secret: mysecret
+      port: 9100
+
+- job_name: service-nerve
+  nerve_sd_configs:
+    - servers:
+      - localhost
+      paths:
+      - /monitoring
+
+- job_name: 0123service-xxx
+  metrics_path: /metrics
+  static_configs:
+    - targets:
+      - localhost:9090
+
+- job_name: 測試
+  metrics_path: /metrics
+  static_configs:
+    - targets:
+      - localhost:9090
+
+- job_name: service-triton
+  triton_sd_configs:
+  - account: 'testAccount'
+    dns_suffix: 'triton.example.com'
+    endpoint: 'triton.example.com'
+    port: 9163
+    refresh_interval: 1m
+    version: 1
+    tls_config:
+      cert_file: testdata/valid_cert_file
+      key_file: testdata/valid_key_file
+
+alerting:
+  alertmanagers:
+  - scheme: https
+    static_configs:
+    - targets:
+      - "1.2.3.4:9093"
+      - "1.2.3.5:9093"
+      - "1.2.3.6:9093"

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -774,45 +774,6 @@ scrape_configs:
 	verifyPresence(discoveryManager.targets, poolKey{setName: "prometheus", provider: "static/0"}, "{__address__=\"bar:9090\"}", false)
 }
 
-func TestApplyConfigDoesNotModifyStaticProviderTargets(t *testing.T) {
-	cfgText := `
-scrape_configs:
- - job_name: 'prometheus'
-   static_configs:
-   - targets: ["foo:9090"]
-   - targets: ["bar:9090"]
-   - targets: ["baz:9090"]
-`
-	originalConfig := &config.Config{}
-	if err := yaml.UnmarshalStrict([]byte(cfgText), originalConfig); err != nil {
-		t.Fatalf("Unable to load YAML config cfgYaml: %s", err)
-	}
-	origScrpCfg := originalConfig.ScrapeConfigs[0]
-
-	processedConfig := &config.Config{}
-	if err := yaml.UnmarshalStrict([]byte(cfgText), processedConfig); err != nil {
-		t.Fatalf("Unable to load YAML config cfgYaml: %s", err)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	discoveryManager := NewManager(ctx, nil)
-	go discoveryManager.Run()
-
-	c := make(map[string]sd_config.ServiceDiscoveryConfig)
-	for _, v := range processedConfig.ScrapeConfigs {
-		c[v.JobName] = v.ServiceDiscoveryConfig
-	}
-	discoveryManager.ApplyConfig(c)
-	<-discoveryManager.SyncCh()
-
-	for _, sdcfg := range c {
-		if !reflect.DeepEqual(origScrpCfg.ServiceDiscoveryConfig.StaticConfigs, sdcfg.StaticConfigs) {
-			t.Fatalf("discovery manager modified static config \n  expected: %v\n  got: %v\n",
-				origScrpCfg.ServiceDiscoveryConfig.StaticConfigs, sdcfg.StaticConfigs)
-		}
-	}
-}
-
 type update struct {
 	targetGroups []targetgroup.Group
 	interval     time.Duration


### PR DESCRIPTION
Came up with this idea for a more global check.
This is a better more global test to catch bugs like #4214 


In general the config handling needs some serious refactoring as this global state and pointers have caused few other issues and races and I think this will bite us again.


Signed-off-by: Krasi Georgiev kgeorgie@redhat.com