### PR TITLE
Use first label pointer as Labels ID instead of the hash

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -601,9 +601,9 @@ type EvalNodeHelper struct {
 
 	// Caches.
 	// dropMetricName and label_*.
-	dmn map[uint64]labels.Labels
+	dmn map[*labels.Label]labels.Labels
 	// signatureFunc.
-	sigf map[uint64]uint64
+	sigf map[*labels.Label]uint64
 	// funcHistogramQuantile.
 	signatureToMetricWithBuckets map[uint64]*metricWithBuckets
 	// label_replace.
@@ -615,35 +615,43 @@ type EvalNodeHelper struct {
 	resultMetric map[uint64]labels.Labels
 }
 
+// firstLabel returns the address of the first label, as a unique identifier of a Labels instance.
+func firstLabel(l labels.Labels) *labels.Label {
+	if len(l) == 0 {
+		return nil
+	}
+	return &l[0]
+}
+
 // dropMetricName is a cached version of dropMetricName.
 func (enh *EvalNodeHelper) dropMetricName(l labels.Labels) labels.Labels {
 	if enh.dmn == nil {
-		enh.dmn = make(map[uint64]labels.Labels, len(enh.out))
+		enh.dmn = make(map[*labels.Label]labels.Labels, len(enh.out))
 	}
-	h := l.Hash()
-	ret, ok := enh.dmn[h]
+	k := firstLabel(l)
+	ret, ok := enh.dmn[k]
 	if ok {
 		return ret
 	}
 	ret = dropMetricName(l)
-	enh.dmn[h] = ret
+	enh.dmn[k] = ret
 	return ret
 }
 
 // signatureFunc is a cached version of signatureFunc.
 func (enh *EvalNodeHelper) signatureFunc(on bool, names ...string) func(labels.Labels) uint64 {
 	if enh.sigf == nil {
-		enh.sigf = make(map[uint64]uint64, len(enh.out))
+		enh.sigf = make(map[*labels.Label]uint64, len(enh.out))
 	}
 	f := signatureFunc(on, names...)
 	return func(l labels.Labels) uint64 {
-		h := l.Hash()
-		ret, ok := enh.sigf[h]
+		k := firstLabel(l)
+		ret, ok := enh.sigf[k]
 		if ok {
 			return ret
 		}
 		ret = f(l)
-		enh.sigf[h] = ret
+		enh.sigf[k] = ret
 		return ret
 	}
 }


### PR DESCRIPTION
Use first label pointer as Labels ID instead of computing the hash. This provides a boost of ~10% to vector binary ops with one series on each side -- compare the `a_one_and_b_one,steps=1000` benchmark -- and ~25% to vector binary ops with 100 series on each side -- compare the `a_hundred_and_b_hundred,steps=1000` benchmark: [before](https://github.com/prometheus/prometheus/files/2101515/before.txt) and [after](https://github.com/prometheus/prometheus/files/2101517/after.txt). The gain to functions that deal with labels is slightly lower, because of the string/regexp operations overhead.

Within the context of an `EvalNodeHelper`, the `labels.Labels` instance associated with an eval vector never changes, meaning that a pointer to the instance could be used as a unique identifier instead of computing a hash value (which is relatively costly). Slices however, seem to actually be references to the underlying array, so the address of a slice (which is what `labels.Labels` is) actually seems to change as it gets passed around. The workaround is to use the address of the first label in the slice, or `nil` iff the slice is empty.

Note that this performance optimization doesn't affect the correctness of the eval code: it is only used for caching, so even if somehow the `labels.Labels` instance identifying a vector changes during evaluation, what happens is that no cached value will be found and the signature and/or label drop will have to be recomputed. The only case in which correctness might be affected is if two `labels.Labels` values get swapped (or one is deallocated and the other gets allocated in the same memory location).