### PR TITLE
Merge 2.3 fixes to master

### DIFF
--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -250,28 +250,31 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	switch d.role {
 	case RoleEndpoint:
 		for _, namespace := range namespaces {
+			e := d.client.CoreV1().Endpoints(namespace)
 			elw := &cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					return d.client.CoreV1().Endpoints(namespace).List(options)
+					return e.List(options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return d.client.CoreV1().Endpoints(namespace).Watch(options)
+					return e.Watch(options)
 				},
 			}
+			s := d.client.CoreV1().Services(namespace)
 			slw := &cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					return d.client.CoreV1().Services(namespace).List(options)
+					return s.List(options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return d.client.CoreV1().Services(namespace).Watch(options)
+					return s.Watch(options)
 				},
 			}
+			p := d.client.CoreV1().Pods(namespace)
 			plw := &cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					return d.client.CoreV1().Pods(namespace).List(options)
+					return p.List(options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return d.client.CoreV1().Pods(namespace).Watch(options)
+					return p.Watch(options)
 				},
 			}
 			eps := NewEndpoints(
@@ -287,12 +290,13 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 		}
 	case RolePod:
 		for _, namespace := range namespaces {
+			p := d.client.CoreV1().Pods(namespace)
 			plw := &cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					return d.client.CoreV1().Pods(namespace).List(options)
+					return p.List(options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return d.client.CoreV1().Pods(namespace).Watch(options)
+					return p.Watch(options)
 				},
 			}
 			pod := NewPod(
@@ -304,12 +308,13 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 		}
 	case RoleService:
 		for _, namespace := range namespaces {
+			s := d.client.CoreV1().Services(namespace)
 			slw := &cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					return d.client.CoreV1().Services(namespace).List(options)
+					return s.List(options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return d.client.CoreV1().Services(namespace).Watch(options)
+					return s.Watch(options)
 				},
 			}
 			svc := NewService(
@@ -321,12 +326,13 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 		}
 	case RoleIngress:
 		for _, namespace := range namespaces {
+			i := d.client.ExtensionsV1beta1().Ingresses(namespace)
 			ilw := &cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					return d.client.ExtensionsV1beta1().Ingresses(namespace).List(options)
+					return i.List(options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return d.client.ExtensionsV1beta1().Ingresses(namespace).Watch(options)
+					return i.Watch(options)
 				},
 			}
 			ingress := NewIngress(

--- a/web/web.go
+++ b/web/web.go
@@ -757,13 +757,7 @@ func tmplFuncs(consolesPath string, opts *Options) template_text.FuncMap {
 			return time.Since(t) / time.Millisecond * time.Millisecond
 		},
 		"consolesPath": func() string { return consolesPath },
-		"pathPrefix": func() string {
-			if opts.RoutePrefix == "/" {
-				return ""
-			} else {
-				return opts.RoutePrefix
-			}
-		},
+		"pathPrefix":   func() string { return opts.ExternalURL.Path },
 		"buildVersion": func() string { return opts.Version.Revision },
 		"stripLabels": func(lset map[string]string, labels ...string) map[string]string {
 			for _, ln := range labels {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -271,42 +271,6 @@ func TestRoutePrefix(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Equals(t, http.StatusOK, resp.StatusCode)
 }
-
-func TestPathPrefix(t *testing.T) {
-
-	tests := []struct {
-		routePrefix string
-		pathPrefix  string
-	}{
-		{
-			routePrefix: "/",
-			// If we have pathPrefix as "/", URL in UI gets "//"" as prefix,
-			// hence doesn't remain relative path anymore.
-			pathPrefix: "",
-		},
-		{
-			routePrefix: "/prometheus",
-			pathPrefix:  "/prometheus",
-		},
-		{
-			routePrefix: "/p1/p2/p3/p4",
-			pathPrefix:  "/p1/p2/p3/p4",
-		},
-	}
-
-	for _, test := range tests {
-		opts := &Options{
-			RoutePrefix: test.routePrefix,
-		}
-
-		pathPrefix := tmplFuncs("", opts)["pathPrefix"].(func() string)
-		pp := pathPrefix()
-
-		testutil.Equals(t, test.pathPrefix, pp)
-	}
-
-}
-
 func TestDebugHandler(t *testing.T) {
 	for _, tc := range []struct {
 		prefix, url string


### PR DESCRIPTION
cc @brian-brazil @krasi-georgiev 

The fix removing the security headers already exists in master as #4258 (#4259 on the release-2.3 branch) but reading the [Wiki](https://github.com/prometheus/prometheus/wiki/HOWTO-cut-a-new-release#branch-management-and-versioning-strategy), I understand that there's nothing special to do about it.