### PR TITLE
Avoid infinite loop on duplicate NaN values.

### DIFF
--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -450,10 +450,10 @@ func (c *mergeIterator) Next() bool {
 		return false
 	}
 
-	currt, currv := c.At()
+	currt, _ := c.At()
 	for len(c.h) > 0 {
-		nextt, nextv := c.h[0].At()
-		if nextt != currt || nextv != currv {
+		nextt, _ := c.h[0].At()
+		if nextt != currt {
 			break
 		}
 


### PR DESCRIPTION
Fixes #4254

NaNs don't equal themselves, so a duplicate NaN would
always hit the break statement and never get popped.

We should not be returning multiple data point for the same
timestamp, so don't compare values at all.