### PR TITLE
Set display: inline-block for .label class

### DIFF
--- a/web/ui/static/css/prometheus.css
+++ b/web/ui/static/css/prometheus.css
@@ -23,4 +23,5 @@ body {
 
 .label {
   white-space: normal;
+  display: inline-block;
 }


### PR DESCRIPTION
Overrides bootstrap style, fixes #3972

This goes for option 1 mentioned in that issue but to be honest, it doesn't make that much of a difference in height.