### PR TITLE
Make TestUpdate() do some work

### DIFF
--- a/rules/fixtures/rules.yaml
+++ b/rules/fixtures/rules.yaml
@@ -1,0 +1,5 @@
+groups:
+  - name: test
+    rules:
+    - record: job:http_requests:rate5m
+      expr: sum by (job)(rate(http_requests_total[5m]))

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -287,6 +287,7 @@ func TestCopyState(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	files := []string{"fixtures/rules.yaml"}
 	expected := map[string]labels.Labels{
 		"test": labels.FromStrings("name", "value"),
 	}
@@ -296,15 +297,16 @@ func TestUpdate(t *testing.T) {
 	})
 	ruleManager.Run()
 
-	err := ruleManager.Update(0, nil)
+	err := ruleManager.Update(10*time.Second, files)
 	testutil.Ok(t, err)
+	testutil.Assert(t, len(ruleManager.groups) > 0, "expected non-empty rule groups")
 	for _, g := range ruleManager.groups {
 		g.seriesInPreviousEval = []map[string]labels.Labels{
 			expected,
 		}
 	}
 
-	err = ruleManager.Update(0, nil)
+	err = ruleManager.Update(10*time.Second, files)
 	testutil.Ok(t, err)
 	for _, g := range ruleManager.groups {
 		for _, actual := range g.seriesInPreviousEval {


### PR DESCRIPTION
Previously it would set no preconditions and check no postconditions, as the `groups` member was empty.
