### PR TITLE
rulemanager: block `Update`s after `Stop`ing

### DIFF
--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -314,3 +314,20 @@ func TestUpdate(t *testing.T) {
 		}
 	}
 }
+
+func TestStop(t *testing.T) {
+	files := []string{"fixtures/rules.yaml"}
+	ruleManager := NewManager(&ManagerOptions{
+		Context: context.Background(),
+		Logger:  log.NewNopLogger(),
+	})
+	ruleManager.Run()
+
+	err := ruleManager.Update(10*time.Second, files)
+	testutil.Ok(t, err)
+
+	ruleManager.Stop()
+
+	err = ruleManager.Update(10*time.Second, files)
+	testutil.Ok(t, err)
+}


### PR DESCRIPTION
Simply block any further calls to the Rule Manager's `Update` method after `Stop` has been called.

This is a simple but also very naive approach @krasi-georgiev, @bboreham, and @brian-brazil but may work.  I would love to have used the `block` channel instead but I don't think it can block early enough in the `Update` routine to be effective.  Feels on something like this or is there something more sophisticated we'd like?