### PR TITLE
api/v1: Expose rules and alerts

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -363,6 +363,103 @@ $ curl http://localhost:9090/api/v1/targets
 }
 ```
 
+
+## Rules
+
+The `/rules` API endpoint returns a list of alerting and recording rules that
+are currently loaded. In addition it returns the currently active alerts fired
+by the Prometheus instance of each alerting rule.
+
+As the `/rules` endpoint is fairly new, it does not have the same stability
+guarantees as the overarching API v1.
+
+```
+GET /api/v1/rules
+```
+
+```json
+$ curl http://localhost:9090/api/v1/rules
+
+{
+    "data": {
+        "groups": [
+            {
+                "rules": [
+                    {
+                        "alerts": [
+                            {
+                                "activeAt": "2018-07-04T20:27:12.60602144+02:00",
+                                "annotations": {
+                                    "summary": "High request latency"
+                                },
+                                "labels": {
+                                    "alertname": "HighRequestLatency",
+                                    "severity": "page"
+                                },
+                                "state": "firing",
+                                "value": 1
+                            }
+                        ],
+                        "annotations": {
+                            "summary": "High request latency"
+                        },
+                        "duration": 600,
+                        "labels": {
+                            "severity": "page"
+                        },
+                        "name": "HighRequestLatency",
+                        "query": "job:request_latency_seconds:mean5m{job=\"myjob\"} > 0.5",
+                        "type": "alerting"
+                    },
+                    {
+                        "name": "job:http_inprogress_requests:sum",
+                        "query": "sum(http_inprogress_requests) by (job)",
+                        "type": "recording"
+                    }
+                ],
+                "file": "/rules.yaml",
+                "interval": 60,
+                "name": "example"
+            }
+        ]
+    },
+    "status": "success"
+}
+```
+
+
+## Alerts
+
+The `/alerts` endpoint returns a list of all active alerts.
+
+As the `/alerts` endpoint is fairly new, it does not have the same stability
+guarantees as the overarching API v1.
+
+```
+GET /api/v1/alerts
+```
+
+```json
+$ curl http://localhost:9090/api/v1/alerts
+
+{
+    "data": {
+        "alerts": [
+            {
+                "activeAt": "2018-07-04T20:27:12.60602144+02:00",
+                "annotations": {},
+                "labels": {
+                    "alertname": "my-alert"
+                },
+                "state": "firing",
+                "value": 1
+            }
+        ]
+    },
+    "status": "success"
+}
+```
+
 ## Querying target metadata
 
 The following endpoint returns metadata about metrics currently scraped by targets.

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -126,44 +126,29 @@ func NewAlertingRule(name string, vec promql.Expr, hold time.Duration, lbls, ann
 	}
 }
 
-// Name returns the name of the alert.
+// Name returns the name of the alerting rule.
 func (r *AlertingRule) Name() string {
 	return r.name
 }
 
-// Query returns the query expression of the alert.
+// Query returns the query expression of the alerting rule.
 func (r *AlertingRule) Query() promql.Expr {
 	return r.vector
 }
 
-// Duration returns the hold duration of the alert.
+// Duration returns the hold duration of the alerting rule.
 func (r *AlertingRule) Duration() time.Duration {
 	return r.holdDuration
 }
 
-// Labels returns the labels of the alert.
+// Labels returns the labels of the alerting rule.
 func (r *AlertingRule) Labels() labels.Labels {
 	return r.labels
 }
 
-// Annotations returns the annotations of the alert.
+// Annotations returns the annotations of the alerting rule.
 func (r *AlertingRule) Annotations() labels.Labels {
 	return r.annotations
-}
-
-// Alertinfo return an array of alerts
-func (r *AlertingRule) Alertinfo() []*Alert {
-	activealerts := &r.active
-	alertsarr := make([]*Alert, 0)
-	if len(*activealerts) > 0 {
-		for _, a := range *activealerts {
-			if a.ResolvedAt.IsZero() {
-				alertsarr = append(alertsarr, a)
-			}
-		}
-		return alertsarr
-	}
-	return nil
 }
 
 func (r *AlertingRule) equal(o *AlertingRule) bool {

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -131,6 +131,41 @@ func (r *AlertingRule) Name() string {
 	return r.name
 }
 
+// Query returns the query expression of the alert.
+func (r *AlertingRule) Query() promql.Expr {
+	return r.vector
+}
+
+// Duration returns the hold duration of the alert.
+func (r *AlertingRule) Duration() time.Duration {
+	return r.holdDuration
+}
+
+// Labels returns the labels of the alert.
+func (r *AlertingRule) Labels() labels.Labels {
+	return r.labels
+}
+
+// Annotations returns the annotations of the alert.
+func (r *AlertingRule) Annotations() labels.Labels {
+	return r.annotations
+}
+
+// Alertinfo return an array of alerts
+func (r *AlertingRule) Alertinfo() []*Alert {
+	activealerts := &r.active
+	alertsarr := make([]*Alert, 0)
+	if len(*activealerts) > 0 {
+		for _, a := range *activealerts {
+			if a.ResolvedAt.IsZero() {
+				alertsarr = append(alertsarr, a)
+			}
+		}
+		return alertsarr
+	}
+	return nil
+}
+
 func (r *AlertingRule) equal(o *AlertingRule) bool {
 	return r.name == o.name && labels.Equal(r.labels, o.labels)
 }

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -188,6 +188,9 @@ func (g *Group) File() string { return g.file }
 // Rules returns the group's rules.
 func (g *Group) Rules() []Rule { return g.rules }
 
+// Interval returns the group's interval.
+func (g *Group) Interval() time.Duration { return g.interval }
+
 func (g *Group) run(ctx context.Context) {
 	defer close(g.terminated)
 

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -52,6 +52,16 @@ func (rule *RecordingRule) Name() string {
 	return rule.name
 }
 
+// Query returns the rule query expression.
+func (rule *RecordingRule) Query() promql.Expr {
+	return rule.vector
+}
+
+// Labels returns the rule labels.
+func (rule *RecordingRule) Labels() labels.Labels {
+	return rule.labels
+}
+
 // Eval evaluates the rule and then overrides the metric names and labels accordingly.
 func (rule *RecordingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, _ *url.URL) (promql.Vector, error) {
 	vector, err := query(ctx, rule.vector.String(), ts)

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -41,6 +41,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
@@ -95,6 +96,19 @@ type alertmanagerRetriever interface {
 	DroppedAlertmanagers() []*url.URL
 }
 
+type alertRetreiver interface {
+	AlertingRules() []*rules.AlertingRule
+}
+
+type rulesRetreiver interface {
+	RuleGroups() []*rules.Group
+}
+
+type alertsrulesRetreiver interface {
+	alertRetreiver
+	rulesRetreiver
+}
+
 type response struct {
 	Status    status      `json:"status"`
 	Data      interface{} `json:"data,omitempty"`
@@ -119,11 +133,11 @@ type API struct {
 
 	targetRetriever       targetRetriever
 	alertmanagerRetriever alertmanagerRetriever
-
-	now      func() time.Time
-	config   func() config.Config
-	flagsMap map[string]string
-	ready    func(http.HandlerFunc) http.HandlerFunc
+	alertsrulesRetreiver  alertsrulesRetreiver
+	now                   func() time.Time
+	config                func() config.Config
+	flagsMap              map[string]string
+	ready                 func(http.HandlerFunc) http.HandlerFunc
 
 	db          func() *tsdb.DB
 	enableAdmin bool
@@ -142,18 +156,20 @@ func NewAPI(
 	db func() *tsdb.DB,
 	enableAdmin bool,
 	logger log.Logger,
+	al alertsrulesRetreiver,
 ) *API {
 	return &API{
 		QueryEngine:           qe,
 		Queryable:             q,
 		targetRetriever:       tr,
 		alertmanagerRetriever: ar,
-		now:         time.Now,
-		config:      configFunc,
-		flagsMap:    flagsMap,
-		ready:       readyFunc,
-		db:          db,
-		enableAdmin: enableAdmin,
+		now:                  time.Now,
+		config:               configFunc,
+		flagsMap:             flagsMap,
+		ready:                readyFunc,
+		db:                   db,
+		enableAdmin:          enableAdmin,
+		alertsrulesRetreiver: al,
 	}
 }
 
@@ -198,6 +214,9 @@ func (api *API) Register(r *route.Router) {
 	r.Get("/status/config", wrap(api.serveConfig))
 	r.Get("/status/flags", wrap(api.serveFlags))
 	r.Post("/read", api.ready(http.HandlerFunc(api.remoteRead)))
+
+	r.Get("/alerts", wrap(api.alerts))
+	r.Get("/rules", wrap(api.rules))
 
 	// Admin APIs
 	r.Post("/admin/tsdb/delete_series", wrap(api.deleteSeries))
@@ -576,6 +595,94 @@ func (api *API) alertmanagers(r *http.Request) (interface{}, *apiError, func()) 
 		ams.DroppedAlertmanagers[i] = &AlertmanagerTarget{URL: url.String()}
 	}
 	return ams, nil, nil
+}
+
+// AlertDiscovery has info for all alerts
+type AlertDiscovery struct {
+	Alertgrps []*Alertgrp `json:"alertgrp"`
+}
+
+// Alert has info for a alert
+type Alert struct {
+	Labels      labels.Labels `json:"labels"`
+	Status      string        `json:"status"`
+	Activesince *time.Time    `json:"activesince,omitempty"`
+}
+
+// Alertgrp has info for alerts part of a group
+type Alertgrp struct {
+	Name        string        `json:"name"`
+	Query       string        `json:"query"`
+	Duration    string        `json:"duration"`
+	Annotations labels.Labels `json:"annotations,omitempty"`
+	Alerts      []*Alert      `json:"alerts"`
+}
+
+func (api *API) alerts(r *http.Request) (interface{}, *apiError) {
+	alertingrules := api.alertsrulesRetreiver.AlertingRules()
+	var alertgrps []*Alertgrp
+	res := &AlertDiscovery{Alertgrps: alertgrps}
+	for _, activerule := range alertingrules {
+		t := &Alertgrp{
+			Name:        activerule.Name(),
+			Query:       fmt.Sprintf("%v", activerule.Query()),
+			Duration:    activerule.Duration().String(),
+			Annotations: activerule.Annotations(),
+		}
+		alerts := activerule.Alertinfo()
+		var activealerts []*Alert
+		for _, alert := range alerts {
+			q := &Alert{
+				Labels:      alert.Labels,
+				Status:      alert.State.String(),
+				Activesince: &alert.ActiveAt,
+			}
+
+			activealerts = append(activealerts, q)
+		}
+		t.Alerts = activealerts
+		res.Alertgrps = append(res.Alertgrps, t)
+	}
+
+	return res, nil
+}
+
+// GroupDiscovery has info for all rules
+type GroupDiscovery struct {
+	Rulegrps []*Rulegrp `json:"groups"`
+}
+
+// Rulegrp has info for rules which are part of a group
+type Rulegrp struct {
+	Name  string      `json:"name"`
+	File  string      `json:"file"`
+	Rules []*Ruleinfo `json:"rules"`
+}
+
+// Ruleinfo has rule in human readable format using \n as line separators
+type Ruleinfo struct {
+	Rule string `json:"rule"`
+}
+
+func (api *API) rules(r *http.Request) (interface{}, *apiError) {
+	grps := api.alertsrulesRetreiver.RuleGroups()
+	res := &GroupDiscovery{Rulegrps: make([]*Rulegrp, len(grps))}
+	for i, grp := range grps {
+		t := &Rulegrp{
+			Name: grp.Name(),
+			File: grp.File(),
+		}
+		var rulearr []*Ruleinfo
+		for _, rule := range grp.Rules() {
+			q := &Ruleinfo{
+				Rule: rule.String(),
+			}
+			rulearr = append(rulearr, q)
+		}
+		t.Rules = rulearr
+		res.Rulegrps[i] = t
+	}
+	return res, nil
 }
 
 type prometheusConfig struct {

--- a/web/web.go
+++ b/web/web.go
@@ -228,6 +228,7 @@ func New(logger log.Logger, o *Options) *Handler {
 		h.options.TSDB,
 		h.options.EnableAdminAPI,
 		logger,
+		h.ruleManager,
 	)
 
 	if o.RoutePrefix != "/" {


### PR DESCRIPTION
This PR builds on top of @mg03 work and is a follow up to https://github.com/prometheus/prometheus/pull/4012:
- Addressing outstanding comments on https://github.com/prometheus/prometheus/pull/4012
- Adjusting to Prometheus coding style
- Differentiating between alerting and recording rules
- ...

The first commit contains @mg03 original changes rebased to current `master`. The second commit contains all follow up changes by me.

Let me know what you think.

//CC @brancz @kyoto