### PR TITLE
rules: Minor naming/comment cleanups

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -102,7 +102,7 @@ type AlertingRule struct {
 	// Non-identifying key/value pairs.
 	annotations labels.Labels
 	// Time in seconds taken to evaluate rule.
-	evaluationTime time.Duration
+	evaluationDuration time.Duration
 
 	// Protects the below.
 	mtx sync.Mutex
@@ -153,18 +153,18 @@ func (r *AlertingRule) sample(alert *Alert, ts time.Time) promql.Sample {
 	return s
 }
 
-// SetEvaluationTime updates evaluationTime to the duration it took to evaluate the rule on its last evaluation.
-func (r *AlertingRule) SetEvaluationTime(dur time.Duration) {
+// SetEvaluationDuration updates evaluationDuration to the duration it took to evaluate the rule on its last evaluation.
+func (r *AlertingRule) SetEvaluationDuration(dur time.Duration) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
-	r.evaluationTime = dur
+	r.evaluationDuration = dur
 }
 
-// GetEvaluationTime returns the time in seconds it took to evaluate the alerting rule.
-func (r *AlertingRule) GetEvaluationTime() time.Duration {
+// GetEvaluationDuration returns the time in seconds it took to evaluate the alerting rule.
+func (r *AlertingRule) GetEvaluationDuration() time.Duration {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
-	return r.evaluationTime
+	return r.evaluationDuration
 }
 
 // resolvedRetention is the duration for which a resolved alert instance

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -106,7 +106,7 @@ type QueryFunc func(ctx context.Context, q string, t time.Time) (promql.Vector, 
 
 // EngineQueryFunc returns a new query function that executes instant queries against
 // the given engine.
-// It converts scaler into vector results.
+// It converts scalar into vector results.
 func EngineQueryFunc(engine *promql.Engine, q storage.Queryable) QueryFunc {
 	return func(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
 		q, err := engine.NewInstantQuery(q, qs, t)
@@ -140,8 +140,8 @@ type Rule interface {
 	// String returns a human-readable string representation of the rule.
 	String() string
 
-	SetEvaluationTime(time.Duration)
-	GetEvaluationTime() time.Duration
+	SetEvaluationDuration(time.Duration)
+	GetEvaluationDuration() time.Duration
 	// HTMLSnippet returns a human-readable string representation of the rule,
 	// decorated with HTML elements for use the web frontend.
 	HTMLSnippet(pathPrefix string) html_template.HTML
@@ -155,7 +155,7 @@ type Group struct {
 	rules                []Rule
 	seriesInPreviousEval []map[string]labels.Labels // One per Rule.
 	opts                 *ManagerOptions
-	evaluationTime       time.Duration
+	evaluationDuration   time.Duration
 	mtx                  sync.Mutex
 
 	done       chan struct{}
@@ -207,7 +207,7 @@ func (g *Group) run(ctx context.Context) {
 		timeSinceStart := time.Since(start)
 
 		iterationDuration.Observe(timeSinceStart.Seconds())
-		g.SetEvaluationTime(timeSinceStart)
+		g.SetEvaluationDuration(timeSinceStart)
 	}
 
 	// The assumption here is that since the ticker was started after having
@@ -251,18 +251,18 @@ func (g *Group) hash() uint64 {
 	return l.Hash()
 }
 
-// GetEvaluationTime returns the time in seconds it took to evaluate the rule group.
-func (g *Group) GetEvaluationTime() time.Duration {
+// GetEvaluationDuration returns the time in seconds it took to evaluate the rule group.
+func (g *Group) GetEvaluationDuration() time.Duration {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
-	return g.evaluationTime
+	return g.evaluationDuration
 }
 
-// SetEvaluationTime sets the time in seconds the last evaluation took.
-func (g *Group) SetEvaluationTime(dur time.Duration) {
+// SetEvaluationDuration sets the time in seconds the last evaluation took.
+func (g *Group) SetEvaluationDuration(dur time.Duration) {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
-	g.evaluationTime = dur
+	g.evaluationDuration = dur
 }
 
 // evalTimestamp returns the immediately preceding consistently slotted evaluation time.
@@ -282,7 +282,7 @@ func (g *Group) evalTimestamp() time.Time {
 // Rules are matched based on their name. If there are duplicates, the
 // first is matched with the first, second with the second etc.
 func (g *Group) copyState(from *Group) {
-	g.evaluationTime = from.evaluationTime
+	g.evaluationDuration = from.evaluationDuration
 
 	ruleMap := make(map[string][]int, len(from.rules))
 
@@ -330,7 +330,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 			defer func(t time.Time) {
 				sp.Finish()
 				evalDuration.Observe(time.Since(t).Seconds())
-				rule.SetEvaluationTime(time.Since(t))
+				rule.SetEvaluationDuration(time.Since(t))
 			}(time.Now())
 
 			evalTotal.Inc()
@@ -476,7 +476,6 @@ func (m *Manager) Update(interval time.Duration, files []string) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	// To be replaced with a configurable per-group interval.
 	groups, errs := m.loadGroups(interval, files...)
 	if errs != nil {
 		for _, e := range errs {
@@ -633,7 +632,7 @@ func (m *Manager) Collect(ch chan<- prometheus.Metric) {
 	for _, g := range m.RuleGroups() {
 		ch <- prometheus.MustNewConstMetric(lastDuration,
 			prometheus.GaugeValue,
-			g.GetEvaluationTime().Seconds(),
+			g.GetEvaluationDuration().Seconds(),
 			groupKey(g.file, g.name))
 	}
 	for _, g := range m.RuleGroups() {

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -257,7 +257,7 @@ func TestCopyState(t *testing.T) {
 			map[string]labels.Labels{"r3a": nil},
 			map[string]labels.Labels{"r3b": nil},
 		},
-		evaluationTime: time.Second,
+		evaluationDuration: time.Second,
 	}
 	oldGroup.rules[0].(*AlertingRule).active[42] = nil
 	newGroup := &Group{
@@ -283,7 +283,7 @@ func TestCopyState(t *testing.T) {
 	}
 	testutil.Equals(t, want, newGroup.seriesInPreviousEval)
 	testutil.Equals(t, oldGroup.rules[0], newGroup.rules[3])
-	testutil.Equals(t, oldGroup.evaluationTime, newGroup.evaluationTime)
+	testutil.Equals(t, oldGroup.evaluationDuration, newGroup.evaluationDuration)
 }
 
 func TestUpdate(t *testing.T) {

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -31,11 +31,11 @@ import (
 
 // A RecordingRule records its vector expression into new timeseries.
 type RecordingRule struct {
-	name           string
-	vector         promql.Expr
-	labels         labels.Labels
-	mtx            sync.Mutex
-	evaluationTime time.Duration
+	name               string
+	vector             promql.Expr
+	labels             labels.Labels
+	mtx                sync.Mutex
+	evaluationDuration time.Duration
 }
 
 // NewRecordingRule returns a new recording rule.
@@ -95,18 +95,18 @@ func (rule *RecordingRule) String() string {
 	return string(byt)
 }
 
-// SetEvaluationTime updates evaluationTimeSeconds to the time in seconds it took to evaluate the rule on its last evaluation.
-func (rule *RecordingRule) SetEvaluationTime(dur time.Duration) {
+// SetEvaluationDuration updates evaluationDuration to the time in seconds it took to evaluate the rule on its last evaluation.
+func (rule *RecordingRule) SetEvaluationDuration(dur time.Duration) {
 	rule.mtx.Lock()
 	defer rule.mtx.Unlock()
-	rule.evaluationTime = dur
+	rule.evaluationDuration = dur
 }
 
-// GetEvaluationTime returns the time in seconds it took to evaluate the recording rule.
-func (rule *RecordingRule) GetEvaluationTime() time.Duration {
+// GetEvaluationDuration returns the time in seconds it took to evaluate the recording rule.
+func (rule *RecordingRule) GetEvaluationDuration() time.Duration {
 	rule.mtx.Lock()
 	defer rule.mtx.Unlock()
-	return rule.evaluationTime
+	return rule.evaluationDuration
 }
 
 // HTMLSnippet returns an HTML snippet representing this rule.


### PR DESCRIPTION
Mainly the `evaluationTime` name confused me while reading the code because it sounds like a timestamp.