### PR TITLE
travis: remove testing with go 1.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ version: 2
 
 jobs:
   test:
+    # Whenever the Go version is updated here, .travis.yml should also be
+    # updated.
     docker:
     - image: circleci/golang:1.10
     working_directory: /go/src/github.com/prometheus/prometheus

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: false
 
 language: go
 
+# Whenever the Go version is updated here, .circleci/config.yml should also be
+# updated.
 go:
 - 1.10.x
-- 1.x
 
 go_import_path: github.com/prometheus/prometheus
 


### PR DESCRIPTION
https://github.com/travis-ci/gimme/issues/152 is the upstream issue (`gimme` was returning a beta version for `1.x`) but in any case, it makes sense to run TravisCI with the same go version as what is used by CircleCI to build the artifacts (eg the latest `1.10.x`).

Closes #4332.

