### PR TITLE
EC2 DS: Allow to set a custom endpoint

### DIFF
--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -77,6 +77,7 @@ type Filter struct {
 
 // SDConfig is the configuration for EC2 based service discovery.
 type SDConfig struct {
+	Endpoint        string             `yaml:"endpoint"`
 	Region          string             `yaml:"region"`
 	AccessKey       string             `yaml:"access_key,omitempty"`
 	SecretKey       config_util.Secret `yaml:"secret_key,omitempty"`
@@ -143,6 +144,7 @@ func NewDiscovery(conf *SDConfig, logger log.Logger) *Discovery {
 	}
 	return &Discovery{
 		aws: &aws.Config{
+			Endpoint:    &conf.Endpoint,
 			Region:      &conf.Region,
 			Credentials: creds,
 		},

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -415,6 +415,9 @@ See below for the configuration options for EC2 discovery:
 # The AWS Region.
 region: <string>
 
+# Custom endpoint to be used.
+[ endpoint: <string> ]
+
 # The AWS API keys. If blank, the environment variables `AWS_ACCESS_KEY_ID`
 # and `AWS_SECRET_ACCESS_KEY` are used.
 [ access_key: <string> ]


### PR DESCRIPTION
Allowing to set a custom endpoint makes it easy to monitor targets on non AWS providers with EC2 compliant APIs.

Signed-off-by: Jannick Fahlbusch <git@jf-projects.de>