### PR TITLE
Reduce CircleCI duplication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,6 @@ jobs:
     - image: circleci/golang:1.10
     working_directory: /go/src/github.com/prometheus/prometheus
 
-    environment:
-      DOCKER_IMAGE_NAME: prom/prometheus
-      QUAY_IMAGE_NAME: quay.io/prometheus/prometheus
-
     steps:
     - checkout
     - setup_remote_docker
@@ -43,22 +39,18 @@ jobs:
         at: .
     - run: ln -s .build/linux-amd64/prometheus prometheus
     - run: ln -s .build/linux-amd64/promtool promtool
-    - run: make docker DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME
-    - run: make docker DOCKER_IMAGE_NAME=$QUAY_IMAGE_NAME
+    - run: make docker
+    - run: make docker DOCKER_REPO=quay.io/prometheus
     - run: docker images
     - run: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
     - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
-    - run: docker push $DOCKER_IMAGE_NAME
-    - run: docker push $QUAY_IMAGE_NAME
+    - run: make docker-publish
+    - run: make docker-publish DOCKER_REPO=quay.io/prometheus
 
   docker_hub_release_tags:
     docker:
     - image: circleci/golang:1.10
     working_directory: /go/src/github.com/prometheus/prometheus
-
-    environment:
-      DOCKER_IMAGE_NAME: prom/prometheus
-      QUAY_IMAGE_NAME: quay.io/prometheus/prometheus
 
     steps:
     - checkout
@@ -77,17 +69,17 @@ jobs:
         destination: releases
     - run: ln -s .build/linux-amd64/prometheus prometheus
     - run: ln -s .build/linux-amd64/promtool promtool
-    - run: make docker DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME DOCKER_IMAGE_TAG=$CIRCLE_TAG
-    - run: make docker DOCKER_IMAGE_NAME=$QUAY_IMAGE_NAME DOCKER_IMAGE_TAG=$CIRCLE_TAG
+    - run: make docker DOCKER_IMAGE_TAG=$CIRCLE_TAG
+    - run: make docker DOCKER_IMAGE_TAG=$CIRCLE_TAG DOCKER_REPO=quay.io/prometheus
     - run: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
     - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
     - run: |
         if [[ "$CIRCLE_TAG" =~ ^v[0-9]+(\.[0-9]+){2}$ ]]; then
-          docker tag "$DOCKER_IMAGE_NAME:$CIRCLE_TAG" "$DOCKER_IMAGE_NAME:latest"
-          docker tag "$QUAY_IMAGE_NAME:$CIRCLE_TAG" "$QUAY_IMAGE_NAME:latest"
+          make docker-tag-latest DOCKER_IMAGE_TAG="$CIRCLE_TAG"
+          make docker-tag-latest DOCKER_IMAGE_TAG="$CIRCLE_TAG" DOCKER_REPO=quay.io/prometheus
         fi
-    - run: docker push $DOCKER_IMAGE_NAME
-    - run: docker push $QUAY_IMAGE_NAME
+    - run: make docker-publish
+    - run: make docker-publish DOCKER_REPO=quay.io/prometheus
 
 workflows:
   version: 2

--- a/Makefile.common
+++ b/Makefile.common
@@ -36,6 +36,7 @@ pkgs          = ./...
 PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
+DOCKER_REPO             ?= prom
 
 .PHONY: all
 all: style staticcheck unused build test
@@ -98,7 +99,15 @@ tarball: promu
 
 .PHONY: docker
 docker:
-	docker build -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+
+.PHONY: docker-publish
+docker:
+	docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)"
+
+.PHONY: docker-tag-latest
+docker:
+	docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):latest"
 
 .PHONY: promu
 promu:


### PR DESCRIPTION
Reduce the duplication of per-project specifics in the CircleCI config.
* Add docker repo variable, default to docker hub.
* Add make targets for docker push and tag latest.

Signed-off-by: Ben Kochie <superq@gmail.com>