### PR TITLE
Add "omitempty" to some SD config YAML field tags

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -108,7 +108,7 @@ type SDConfig struct {
 	// See https://www.consul.io/api/catalog.html#list-services
 	// The list of services for which targets are discovered.
 	// Defaults to all services if empty.
-	Services []string `yaml:"services"`
+	Services []string `yaml:"services,omitempty"`
 	// An optional tag used to filter instances inside a service. A single tag is supported
 	// here to match the Consul API.
 	ServiceTag string `yaml:"tag,omitempty"`

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -84,13 +84,13 @@ func (c *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // SDConfig is the configuration for Kubernetes service discovery.
 type SDConfig struct {
-	APIServer          config_util.URL        `yaml:"api_server"`
+	APIServer          config_util.URL        `yaml:"api_server,omitempty"`
 	Role               Role                   `yaml:"role"`
 	BasicAuth          *config_util.BasicAuth `yaml:"basic_auth,omitempty"`
 	BearerToken        config_util.Secret     `yaml:"bearer_token,omitempty"`
 	BearerTokenFile    string                 `yaml:"bearer_token_file,omitempty"`
 	TLSConfig          config_util.TLSConfig  `yaml:"tls_config,omitempty"`
-	NamespaceDiscovery NamespaceDiscovery     `yaml:"namespaces"`
+	NamespaceDiscovery NamespaceDiscovery     `yaml:"namespaces,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.


### PR DESCRIPTION
Especially for Kubernetes SD, this fixes a bug where the rendered
configuration says "api_server: null", which when read back is not
interpreted as an un-set API server (thus the default is not applied).

Signed-off-by: Julius Volz <julius.volz@gmail.com>