### PR TITLE
Build prometheus inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
+FROM golang:1.10-alpine3.7 AS builder
+
+ADD . /go/src/github.com/prometheus/prometheus
+WORKDIR /go/src/github.com/prometheus/prometheus
+
+RUN apk update && apk upgrade && apk add --no-cache git alpine-sdk
+
+RUN make build
+
+# -----------------------------------------------------------------------------
+
 FROM        quay.io/prometheus/busybox:latest
 LABEL maintainer "The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-COPY prometheus                             /bin/prometheus
-COPY promtool                               /bin/promtool
-COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
-COPY console_libraries/                     /usr/share/prometheus/console_libraries/
-COPY consoles/                              /usr/share/prometheus/consoles/
+COPY --from=builder /go/src/github.com/prometheus/prometheus/prometheus                             /bin/prometheus
+COPY --from=builder /go/src/github.com/prometheus/prometheus/promtool                               /bin/promtool
+COPY --from=builder /go/src/github.com/prometheus/prometheus/documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
+COPY --from=builder /go/src/github.com/prometheus/prometheus/console_libraries/                     /usr/share/prometheus/console_libraries/
+COPY --from=builder /go/src/github.com/prometheus/prometheus/consoles/                              /usr/share/prometheus/consoles/
 
 RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
 RUN mkdir -p /prometheus && \


### PR DESCRIPTION
Use a docker golang image to build prometheus and copy the output to make the prometheus docker image.