### PR TITLE
fix the zookeper set logger race

### DIFF
--- a/discovery/zookeeper/zookeeper.go
+++ b/discovery/zookeeper/zookeeper.go
@@ -137,8 +137,11 @@ func NewDiscovery(
 		logger = log.NewNopLogger()
 	}
 
-	conn, _, err := zk.Connect(srvs, timeout)
-	conn.SetLogger(treecache.NewZookeeperLogger(logger))
+	conn, _, err := zk.Connect(
+		srvs, timeout,
+		func(c *zk.Conn) {
+			c.SetLogger(treecache.NewZookeeperLogger(logger))
+		})
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
calling `SetLogger()` after calling `zk.Connect()` cases a race 

`Connect()` starts a goroutine `loop()`
https://github.com/prometheus/prometheus/blob/9fe8bcf4be00a7ebd73932df0cf39cc837cbb993/vendor/github.com/samuel/go-zookeeper/zk/conn.go#L217-L222

which calls `connect()` which uses the the logger
https://github.com/prometheus/prometheus/blob/9fe8bcf4be00a7ebd73932df0cf39cc837cbb993/vendor/github.com/samuel/go-zookeeper/zk/conn.go#L328

if we try to set the logger at this time  it is a race in
https://github.com/prometheus/prometheus/blob/9fe8bcf4be00a7ebd73932df0cf39cc837cbb993/vendor/github.com/samuel/go-zookeeper/zk/conn.go#L273-L275

this is fixed by passing the set logger as a functional option.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>