### PR TITLE
docs: added undocumented step api parameter format

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -132,7 +132,7 @@ URL query parameters:
 - `query=<string>`: Prometheus expression query string.
 - `start=<rfc3339 | unix_timestamp>`: Start timestamp.
 - `end=<rfc3339 | unix_timestamp>`: End timestamp.
-- `step=<duration>`: Query resolution step width.
+- `step=<duration | float>`: Query resolution step width in `duration` format or float number of seconds.
 - `timeout=<duration>`: Evaluation timeout. Optional. Defaults to and
    is capped by the value of the `-query.timeout` flag.
 


### PR DESCRIPTION
@juliusv 
So it does't look I'm only complaining :)

Documented second allowed format for the `step` parameter in the HTTP API for `query_range` allowing to specify the `step` using number of seconds in as float.
