### PR TITLE
wrap remote triton and marathon reads in an io.LimitReader

### DIFF
--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"net"
@@ -57,6 +58,9 @@ const (
 
 	// Constants for instrumentation.
 	namespace = "prometheus"
+
+	// Maximum bytes to read in remote response
+	maxRemoteReadBytes = 10 * 1024 * 1024
 )
 
 var (
@@ -339,7 +343,7 @@ func fetchApps(client *http.Client, url string) (*AppList, error) {
 		return nil, fmt.Errorf("Non 2xx status '%v' response during marathon service discovery", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, maxRemoteReadBytes))
 	if err != nil {
 		return nil, err
 	}

--- a/discovery/triton/triton.go
+++ b/discovery/triton/triton.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -39,6 +40,7 @@ const (
 	tritonLabelMachineImage = tritonLabel + "machine_image"
 	tritonLabelServerID     = tritonLabel + "server_id"
 	namespace               = "prometheus"
+	maxRemoteReadBytes      = 10 * 1024 * 1024
 )
 
 var (
@@ -198,7 +200,7 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := ioutil.ReadAll(io.LimitReader(resp.Body, maxRemoteReadBytes))
 	if err != nil {
 		return tg, fmt.Errorf("an error occurred when reading the response body. %s", err)
 	}


### PR DESCRIPTION
Previously we allowed unbounded reads from these remote sources, which
can lead to performance and stability issues with prometheus.

Issue: https://github.com/prometheus/prometheus/issues/3228