### PR TITLE
Fix missing 'msg' in remote storage adapter main.go .Log info message

### DIFF
--- a/documentation/examples/remote_storage/remote_storage_adapter/main.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/main.go
@@ -197,7 +197,7 @@ func buildClients(logger log.Logger, cfg *config) ([]writer, []reader) {
 		writers = append(writers, c)
 		readers = append(readers, c)
 	}
-	level.Info(logger).Log("Starting up...")
+	level.Info(logger).Log("msg", "Starting up...")
 	return writers, readers
 }
 


### PR DESCRIPTION
Signed-off-by: Peter Gallerani <peter.gallerani@gmail.com>

@juliusv, lets see if this gets passed DCO