### PR TITLE
add prefix "common-" to make target names

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -41,13 +41,18 @@ DOCKER_REPO             ?= prom
 .PHONY: all
 all: style staticcheck unused build test
 
-.PHONY: style
-style:
+# This rule is used to forward a target like "build" to "common-build".  This
+# allows a new "build" target to be defined in a Makefile which includes this
+# one and override "common-build" without override warnings.
+%: common-% ;
+
+.PHONY: common-style
+common-style:
 	@echo ">> checking code style"
 	! $(GOFMT) -d $$(find . -path ./vendor -prune -o -name '*.go' -print) | grep '^'
 
-.PHONY: check_license
-check_license:
+.PHONY: common-check_license
+common-check_license:
 	@echo ">> checking license header"
 	@licRes=$$(for file in $$(find . -type f -iname '*.go' ! -path './vendor/*') ; do \
                awk 'NR<=3' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
@@ -57,56 +62,56 @@ check_license:
                exit 1; \
        fi
 
-.PHONY: test-short
-test-short:
+.PHONY: common-test-short
+common-test-short:
 	@echo ">> running short tests"
 	$(GO) test -short $(pkgs)
 
-.PHONY: test
-test:
+.PHONY: common-test
+common-test:
 	@echo ">> running all tests"
 	$(GO) test -race $(pkgs)
 
-.PHONY: format
-format:
+.PHONY: common-format
+common-format:
 	@echo ">> formatting code"
 	$(GO) fmt $(pkgs)
 
-.PHONY: vet
-vet:
+.PHONY: common-vet
+common-vet:
 	@echo ">> vetting code"
 	$(GO) vet $(pkgs)
 
-.PHONY: staticcheck
-staticcheck: $(STATICCHECK)
+.PHONY: common-staticcheck
+common-staticcheck: $(STATICCHECK)
 	@echo ">> running staticcheck"
 	$(STATICCHECK) -ignore "$(STATICCHECK_IGNORE)" $(pkgs)
 
-.PHONY: unused
-unused: $(GOVENDOR)
+.PHONY: common-unused
+common-unused: $(GOVENDOR)
 	@echo ">> running check for unused packages"
 	@$(GOVENDOR) list +unused | grep . && exit 1 || echo 'No unused packages'
 
-.PHONY: build
-build: promu
+.PHONY: common-build
+common-build: promu
 	@echo ">> building binaries"
 	$(PROMU) build --prefix $(PREFIX)
 
-.PHONY: tarball
-tarball: promu
+.PHONY: common-tarball
+common-tarball: promu
 	@echo ">> building release tarball"
 	$(PROMU) tarball --prefix $(PREFIX) $(BIN_DIR)
 
-.PHONY: docker
-docker:
+.PHONY: common-docker
+common-docker:
 	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
 
-.PHONY: docker-publish
-docker-publish:
+.PHONY: common-docker-publish
+common-docker-publish:
 	docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)"
 
-.PHONY: docker-tag-latest
-docker-tag-latest:
+.PHONY: common-docker-tag-latest
+common-docker-tag-latest:
 	docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):latest"
 
 .PHONY: promu


### PR DESCRIPTION
The node_exporter build is printing warnings due to overriding target names:
```
Makefile:74: warning: overriding recipe for target 'test'
Makefile.common:61: warning: ignoring old recipe for target 'test'
Makefile:105: warning: overriding recipe for target 'docker'
Makefile.common:89: warning: ignoring old recipe for target 'docker'
```

This change allows rules to be overridden without getting warnings about conflicting target names.  The make targets can still be called using their normal names such as "make build", however the actual target name in Makefile.common is "common-build".  And "common-build" will be skipped if there is a "build" target in Makefile. 

Signed-off-by: Paul Gier <pgier@redhat.com>