### PR TITLE
Add option to (approximately) limit memory use by queries.

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -92,6 +92,7 @@ func main() {
 		webTimeout          model.Duration
 		queryTimeout        model.Duration
 		queryConcurrency    int
+		querySizeLimit      int64
 		RemoteFlushDeadline model.Duration
 
 		prometheusURL string
@@ -176,6 +177,9 @@ func main() {
 	a.Flag("query.timeout", "Maximum time a query may take before being aborted.").
 		Default("2m").SetValue(&cfg.queryTimeout)
 
+	a.Flag("query.max-size", "Maximum size of a single query can be (in bytes).").
+		Default("-1").Int64Var(&cfg.querySizeLimit)
+
 	a.Flag("query.max-concurrency", "Maximum number of queries executed concurrently.").
 		Default("20").IntVar(&cfg.queryConcurrency)
 
@@ -249,6 +253,7 @@ func main() {
 			prometheus.DefaultRegisterer,
 			cfg.queryConcurrency,
 			time.Duration(cfg.queryTimeout),
+			cfg.querySizeLimit,
 		)
 
 		ruleManager = rules.NewManager(&rules.ManagerOptions{

--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -28,7 +28,7 @@ import (
 func BenchmarkRangeQuery(b *testing.B) {
 	storage := testutil.NewStorage(b)
 	defer storage.Close()
-	engine := NewEngine(nil, nil, 10, 100*time.Second)
+	engine := NewEngine(nil, nil, 10, 100*time.Second, -1)
 
 	metrics := []labels.Labels{}
 	metrics = append(metrics, labels.FromStrings("__name__", "a_one"))

--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -29,7 +29,7 @@ func TestDeriv(t *testing.T) {
 	// so we test it by hand.
 	storage := testutil.NewStorage(t)
 	defer storage.Close()
-	engine := NewEngine(nil, nil, 10, 10*time.Second)
+	engine := NewEngine(nil, nil, 10, 10*time.Second, -1)
 
 	a, err := storage.Appender()
 	testutil.Ok(t, err)

--- a/promql/test.go
+++ b/promql/test.go
@@ -500,7 +500,7 @@ func (t *Test) clear() {
 	}
 	t.storage = testutil.NewStorage(t)
 
-	t.queryEngine = NewEngine(nil, nil, 20, 10*time.Second)
+	t.queryEngine = NewEngine(nil, nil, 20, 10*time.Second, -1)
 	t.context, t.cancelCtx = context.WithCancel(context.Background())
 }
 

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -165,7 +165,7 @@ func TestAlertingRule(t *testing.T) {
 func TestStaleness(t *testing.T) {
 	storage := testutil.NewStorage(t)
 	defer storage.Close()
-	engine := promql.NewEngine(nil, nil, 10, 10*time.Second)
+	engine := promql.NewEngine(nil, nil, 10, 10*time.Second, -1)
 	opts := &ManagerOptions{
 		QueryFunc:  EngineQueryFunc(engine, storage),
 		Appendable: storage,

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -28,7 +28,7 @@ func TestRuleEval(t *testing.T) {
 	storage := testutil.NewStorage(t)
 	defer storage.Close()
 
-	engine := promql.NewEngine(nil, nil, 10, 10*time.Second)
+	engine := promql.NewEngine(nil, nil, 10, 10*time.Second, -1)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
 

--- a/web/federate.go
+++ b/web/federate.go
@@ -89,7 +89,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 
 		// TODO(fabxc): allow fast path for most recent sample either
 		// in the storage itself or caching layer in Prometheus.
-		it := storage.NewBuffer(s.Iterator(), int64(promql.LookbackDelta/1e6))
+		it := storage.NewBuffer(s.Iterator(), int64(promql.LookbackDelta/1e6), -1)
 
 		var t int64
 		var v float64


### PR DESCRIPTION
Implements #4383 

Adds a cmd option to set an approximate query size limit. This limit includes input and output matrices and other assorted objects used during the evaluation of a query.
If a query exceeds this limit at any point during execution it is killed with a (new) oversize error.

Aditionally adds three new metrics:
- prometheus_engine_queries_size_max_bytes: gauge indicating the currently configured query size limit
- prometheus_engine_query_size_bytes_bucket: histogram of query sizes, up to and including the configured limit
- prometheus_engine_queries_oversize_total: counter of the number of queries that returned an error due to exceeding the configured limit

Signed-off-by: Tony Lee <tl@hudson-trading.com>