### PR TITLE
Added public IP label to Azure SD targets.

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -264,6 +264,8 @@ The following meta labels are available on targets during relabeling:
 * `__meta_azure_machine_name`: the machine name
 * `__meta_azure_machine_os_type`: the machine operating system
 * `__meta_azure_machine_private_ip`: the machine's private IP
+* `__meta_azure_machine_public_ip`: the machine's public IP, if available
+* `__meta_azure_machine_public_dns_name`: the machine's public DNS Name, if available
 * `__meta_azure_machine_resource_group`: the machine's resource group
 * `__meta_azure_machine_tag_<tagname>`: each tag value of the machine
 


### PR DESCRIPTION
@brian-brazil 

Hi,
I added Public IP information to Azure SD labels.
I needed this to do some load tests on Public Azure VMs.
Resolves #3970