### PR TITLE
discovery/ec2: Maintain order of subnet_id label

### DIFF
--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -37,18 +37,19 @@ import (
 )
 
 const (
-	ec2Label              = model.MetaLabelPrefix + "ec2_"
-	ec2LabelAZ            = ec2Label + "availability_zone"
-	ec2LabelInstanceID    = ec2Label + "instance_id"
-	ec2LabelInstanceState = ec2Label + "instance_state"
-	ec2LabelInstanceType  = ec2Label + "instance_type"
-	ec2LabelPublicDNS     = ec2Label + "public_dns_name"
-	ec2LabelPublicIP      = ec2Label + "public_ip"
-	ec2LabelPrivateIP     = ec2Label + "private_ip"
-	ec2LabelSubnetID      = ec2Label + "subnet_id"
-	ec2LabelTag           = ec2Label + "tag_"
-	ec2LabelVPCID         = ec2Label + "vpc_id"
-	subnetSeparator       = ","
+	ec2Label                = model.MetaLabelPrefix + "ec2_"
+	ec2LabelAZ              = ec2Label + "availability_zone"
+	ec2LabelInstanceID      = ec2Label + "instance_id"
+	ec2LabelInstanceState   = ec2Label + "instance_state"
+	ec2LabelInstanceType    = ec2Label + "instance_type"
+	ec2LabelPublicDNS       = ec2Label + "public_dns_name"
+	ec2LabelPublicIP        = ec2Label + "public_ip"
+	ec2LabelPrivateIP       = ec2Label + "private_ip"
+	ec2LabelPrimarySubnetID = ec2Label + "primary_subnet_id"
+	ec2LabelSubnetID        = ec2Label + "subnet_id"
+	ec2LabelTag             = ec2Label + "tag_"
+	ec2LabelVPCID           = ec2Label + "vpc_id"
+	subnetSeparator         = ","
 )
 
 var (
@@ -256,6 +257,7 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 
 				if inst.VpcId != nil {
 					labels[ec2LabelVPCID] = model.LabelValue(*inst.VpcId)
+					labels[ec2LabelPrimarySubnetID] = model.LabelValue(*inst.SubnetId)
 
 					// Deduplicate VPC Subnet IDs maintaining the order of the network interfaces returned by EC2.
 					var subnets []string

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -401,6 +401,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_ec2_instance_id`: the EC2 instance ID
 * `__meta_ec2_instance_state`: the state of the EC2 instance
 * `__meta_ec2_instance_type`: the type of the EC2 instance
+* `__meta_ec2_primary_subnet_id`: the subnet ID of the primary network interface, if available
 * `__meta_ec2_private_ip`: the private IP address of the instance, if present
 * `__meta_ec2_public_dns_name`: the public DNS name of the instance, if available
 * `__meta_ec2_public_ip`: the public IP address of the instance, if available


### PR DESCRIPTION
The current method for deduplicating Subnet IDs on EC2 VPC instances makes the resulting order nondeterministic because it ranges over keys from a map. This is OK for filtering, but causes issues if the meta label from discovery is relabeled on the resulting metrics.

This PR changes the way the IDs are deduplicated to maintain the order of the network interfaces as returned by the EC2 API, which should be constant. It also sets the Instance's main Subnet as the first subnet on the list, to aid with relabeling if the user is only interested in the main Subnet.