### PR TITLE
promtool - add option to check rule from slice

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -285,6 +285,20 @@ func checkRules(filename string) (int, []error) {
 	return numRules, nil
 }
 
+func CheckRule(rule []byte) (int, []error) {
+	rgs, errs := rulefmt.Parse(rule)
+	if errs != nil {
+		return 0, errs
+	}
+
+	numRules := 0
+	for _, rg := range rgs.Groups {
+		numRules += len(rg.Rules)
+	}
+
+	return numRules, nil
+}
+
 // UpdateRules updates the rule files.
 func UpdateRules(files ...string) int {
 	failed := false


### PR DESCRIPTION
I've added an option to check rules directly from a byte slice instead of a file
this helps me creating a service that can verify rules at runtime through using promtool as a lib
