### PR TITLE
Pass Authorization header to RR backend

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -30,6 +30,7 @@ import (
 
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/web/api/auth"
 )
 
 const maxErrMsgLen = 256
@@ -139,6 +140,11 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query) (*prompb.QueryRe
 	httpReq.Header.Add("Content-Encoding", "snappy")
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
 	httpReq.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
+
+	token, ok := auth.GetBearerToken(ctx)
+	if ok {
+		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", string(token)))
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()

--- a/web/api/auth/auth.go
+++ b/web/api/auth/auth.go
@@ -1,0 +1,41 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+type ctxKey string
+
+var (
+	ctxKeyBearerToken = ctxKey("bearer-token")
+)
+
+func WithBearerToken(ctx context.Context, r *http.Request) context.Context {
+	authorization := r.Header.Get("Authorization")
+	if strings.HasPrefix(strings.ToLower(authorization), "bearer ") {
+		return context.WithValue(ctx, ctxKeyBearerToken, authorization[7:])
+	} else {
+		return ctx
+	}
+
+}
+
+func GetBearerToken(ctx context.Context) (string, bool) {
+	token, ok := ctx.Value(ctxKeyBearerToken).(string)
+	return token, ok
+}

--- a/web/api/auth/auth_test.go
+++ b/web/api/auth/auth_test.go
@@ -1,0 +1,70 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"net/http"
+	"testing"
+)
+
+var authtoken = "an-auth-token"
+
+var testcases = []struct {
+	headers map[string]string
+	ok      bool
+}{
+	{
+		headers: map[string]string{
+			"Authorization": "Bearer " + authtoken,
+		},
+		ok: true,
+	},
+	{
+		headers: map[string]string{
+			"Authorization": "Bearer" + authtoken,
+		},
+		ok: false,
+	},
+	{
+		headers: map[string]string{
+			"Authorization": authtoken,
+		},
+		ok: false,
+	},
+	{
+		headers: map[string]string{
+			"X-Other-header": "some-value",
+		},
+		ok: false,
+	},
+}
+
+func TestBearerToken(t *testing.T) {
+
+	for i, test := range testcases {
+		r, _ := http.NewRequest("get", "http://someurl", nil)
+		for k, v := range test.headers {
+			r.Header.Set(k, v)
+		}
+		ctx := WithBearerToken(r.Context(), r)
+		token, ok := GetBearerToken(ctx)
+		if test.ok != ok {
+			t.Fatalf("Test %d: GetBearerToken unexpectedly returned ok %t\n", i, ok)
+		}
+		if test.ok && token != authtoken {
+			t.Fatalf("Test %d: GetBearerToken returned unexpected token %s\n", i, token)
+		}
+
+	}
+}

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -44,6 +44,7 @@ import (
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/util/httputil"
 	"github.com/prometheus/prometheus/util/stats"
+	"github.com/prometheus/prometheus/web/api/auth"
 	tsdbLabels "github.com/prometheus/tsdb/labels"
 )
 
@@ -240,7 +241,7 @@ func (api *API) query(r *http.Request) (interface{}, *apiError, func()) {
 		return nil, &apiError{errorBadData, err}, nil
 	}
 
-	res := qry.Exec(ctx)
+	res := qry.Exec(auth.WithBearerToken(ctx, r))
 	if res.Err != nil {
 		switch res.Err.(type) {
 		case promql.ErrQueryCanceled:
@@ -314,7 +315,7 @@ func (api *API) queryRange(r *http.Request) (interface{}, *apiError, func()) {
 		return nil, &apiError{errorBadData, err}, nil
 	}
 
-	res := qry.Exec(ctx)
+	res := qry.Exec(auth.WithBearerToken(ctx, r))
 	if res.Err != nil {
 		switch res.Err.(type) {
 		case promql.ErrQueryCanceled:


### PR DESCRIPTION
Using a PR as the way to discuss this, given that it's pretty simple and I needed it anyway. 

An alternate approach could be to have a configurable whitelist of headers that are passed-on to the backend, but I'm not convinced we need to do that unless we have a need for it.