### PR TITLE
Added all_tenants <boolean> config to discover instances from all openstack projects

### DIFF
--- a/discovery/openstack/instance.go
+++ b/discovery/openstack/instance.go
@@ -46,6 +46,7 @@ const (
 // InstanceDiscovery discovers OpenStack instances.
 type InstanceDiscovery struct {
 	authOpts *gophercloud.AuthOptions
+        listOpts *servers.ListOpts
 	region   string
 	interval time.Duration
 	logger   log.Logger
@@ -53,13 +54,13 @@ type InstanceDiscovery struct {
 }
 
 // NewInstanceDiscovery returns a new instance discovery.
-func NewInstanceDiscovery(opts *gophercloud.AuthOptions,
-	interval time.Duration, port int, region string, l log.Logger) *InstanceDiscovery {
+func NewInstanceDiscovery(opts *gophercloud.AuthOptions, 
+	listOpts *servers.ListOpts, interval time.Duration, port int, region string, l log.Logger) *InstanceDiscovery {
 	if l == nil {
 		l = log.NewNopLogger()
 	}
-	return &InstanceDiscovery{authOpts: opts,
-		region: region, interval: interval, port: port, logger: l}
+	return &InstanceDiscovery{authOpts: opts, 
+		listOpts: listOpts, region: region, interval: interval, port: port, logger: l}
 }
 
 // Run implements the Discoverer interface.
@@ -143,7 +144,7 @@ func (i *InstanceDiscovery) refresh() (*targetgroup.Group, error) {
 
 	// OpenStack API reference
 	// https://developer.openstack.org/api-ref/compute/#list-servers
-	opts := servers.ListOpts{}
+	opts :=  i.listOpts
 	pager := servers.List(client, opts)
 	tg := &targetgroup.Group{
 		Source: fmt.Sprintf("OS_" + i.region),

--- a/discovery/openstack/instance_test.go
+++ b/discovery/openstack/instance_test.go
@@ -55,6 +55,7 @@ func (s *OpenstackSDInstanceTestSuite) openstackAuthSuccess() (Discovery, error)
 		DomainName:       "12345",
 		Region:           "RegionOne",
 		Role:             "instance",
+		AllTenants:       "true",
 	}
 	return NewDiscovery(&conf, nil)
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -526,6 +526,11 @@ region: <string>
 [ project_name: <string> ]
 [ project_id: <string> ]
 
+# If you need to discover all instances from openstack (project wide) change
+# all_tenants to true. Otherwise it will only discover instances from the
+# specified project_name or project_id even if you provide admin credentials.
+[ all_tenants: <boolean> ]
+
 # Refresh interval to re-read the instance list.
 [ refresh_interval: <duration> | default = 60s ]
 


### PR DESCRIPTION
Openstack SD by default only queries for instances from specified project. The only way to discover instances from different openstack projects is adding several openstack_sd_configs for each project on prometheus.yml.

This pull requests adds the query filter 'AllTenants' to Openstack SD (compute servers v2 - gophercloud) and made it available on the configuration file (yaml) using the variable all_tenants: <boolean>.

Example:

```yaml
  - job_name: 'openstack_all_instances'

    openstack_sd_configs:
      - role: instance
        region: RegionOne
        identity_endpoint: http://<my_identity_server>/identity/v3
        username: my_username
        password: my_super_secret_password
        domain_name: Default
        project_name: my_project
        all_tenants: true
```