### PR TITLE
[WIP] Use circle-ci builds to make docker images for PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,20 +16,46 @@ jobs:
     - run: make check_license style unused staticcheck build
     - run: rm -v prometheus
 
-  build:
+  promu:
     machine: true
     working_directory: /home/circleci/.go_workspace/src/github.com/prometheus/prometheus
 
     steps:
     - checkout
     - run: make promu
+    - persist_to_workspace:
+        root:  /home/circleci/.go_workspace/
+        paths:
+        - bin
+        - src/github.com/prometheus/prometheus
+
+  crossbuild-linux-amd64:
+    machine: true
+    working_directory: /home/circleci/.go_workspace/src/github.com/prometheus/prometheus
+
+    steps:
+    - attach_workspace:
+        at: /home/circleci/.go_workspace/
+    - run: promu crossbuild -v -p linux/amd64
+    - persist_to_workspace:
+        root: /home/circleci/.go_workspace/
+        paths:
+        - src/github.com/prometheus/prometheus
+
+  crossbuild:
+    machine: true
+    working_directory: /home/circleci/.go_workspace/src/github.com/prometheus/prometheus
+
+    steps:
+    - attach_workspace:
+        at: /home/circleci/.go_workspace/
     - run: promu crossbuild -v
     - persist_to_workspace:
-        root: .
+        root: /home/circleci/.go_workspace/
         paths:
-        - .build
+        - src/github.com/prometheus/prometheus
 
-  docker_hub_master:
+  docker_hub_pr:
     docker:
     - image: circleci/golang:1.10
     working_directory: /go/src/github.com/prometheus/prometheus
@@ -38,11 +64,28 @@ jobs:
     - checkout
     - setup_remote_docker
     - attach_workspace:
-        at: .
+        at: /home/circleci/.go_workspace/
     - run: ln -s .build/linux-amd64/prometheus prometheus
     - run: ln -s .build/linux-amd64/promtool promtool
-    - run: make docker
-    - run: make docker DOCKER_REPO=quay.io/prometheus
+    - run: make docker DOCKER_IMAGE_TAG=pr-${CIRCLE_PR_NUMBER} DOCKER_REPO=quay.io/prometheus
+    - run: docker images
+    - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
+    - run: make docker-publish DOCKER_REPO=quay.io/prometheus
+
+  docker_hub_master_and_releases:
+    docker:
+    - image: circleci/golang:1.10
+    working_directory: /go/src/github.com/prometheus/prometheus
+
+    steps:
+    - checkout
+    - setup_remote_docker
+    - attach_workspace:
+        at: /home/circleci/.go_workspace/
+    - run: ln -s .build/linux-amd64/prometheus prometheus
+    - run: ln -s .build/linux-amd64/promtool promtool
+    - run: make docker DOCKER_IMAGE_TAG=${CIRCLE_BRANCH}
+    - run: make docker DOCKER_IMAGE_TAG=${CIRCLE_BRANCH} DOCKER_REPO=quay.io/prometheus
     - run: docker images
     - run: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
     - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
@@ -61,7 +104,7 @@ jobs:
     - run: curl -L 'https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2' | tar xvjf - --strip-components 3 -C ${HOME}/bin
     - run: echo 'export PATH=${HOME}/bin:${PATH}' >> ${BASH_ENV}
     - attach_workspace:
-        at: .
+        at: /home/circleci/.go_workspace/
     - run: make promu
     - run: promu crossbuild tarballs
     - run: promu checksum .tarballs
@@ -85,27 +128,68 @@ jobs:
 
 workflows:
   version: 2
-  prometheus:
+  prometheus-pr:
     jobs:
     - test:
         filters:
-          tags:
-            only: /.*/
-    - build:
+          branches:
+            ignore: /^(master|release-.*)$/
+    - promu:
         filters:
-          tags:
-            only: /.*/
-    - docker_hub_master:
+          branches:
+            ignore: /^(master|release-.*)$/
+    - crossbuild-linux-amd64:
         requires:
-        - test
+        - promu
+        filters:
+          branches:
+            ignore: /^(master|release-.*)$/
+    - docker_hub_pr:
+        requires:
+        - promu
         - build
         filters:
           branches:
-            only: master
+            ignore: /^(master|release-.*)$/
+    - crossbuild:
+        requires:
+        - promu
+        - build
+        filters:
+          branches:
+            ignore: /^(master|release-.*)$/
+  prometheus-master-and-releases:
+    jobs:
+    - test:
+        filters:
+          branches:
+            only: /^(master|release-.*)$/
+    - promu:
+        requires:
+        - test
+        filters:
+          branches:
+            only: /^(master|release-.*)$/
+    - crossbuild:
+        requires:
+        - test
+        - promu
+        filters:
+          branches:
+            only: /^(master|release-.*)$/
+    - docker_hub_master_and_releases:
+        requires:
+        - test
+        - promu
+        - crossbuild
+        filters:
+          branches:
+            only: /^(master|release-.*)$/
     - docker_hub_release_tags:
         requires:
         - test
-        - build
+        - promu
+        - crossbuild
         filters:
           tags:
             only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/


### PR DESCRIPTION
New/Changed jobs:

- promu: factorizes promu building for following build and crossbuild steps
- crossbuild: replaces current build job which does a promu crossbuild
- crossbuild-linux-amd64: calls promu crossbuild to only build linux/amd64

New/Changed workflow:

- prometheus-pr: builds pull requests

  + test
  + promu
  + crossbuild-linux-amd64
  + docker_push_pr
  + crossbuild

crossbuild step lasts 1 hour so we first use build to only make the binary needed
for the docker image and we build that docker image. This allows to have a docker
image ready to test in a few minutes. Then we crossbuild.

Docker tags are named `pr-<github-pr-#>` and pushed to quay.io/prometheus repository.

- prometheus-master-and-releases: replaces prometheus workflow

  + test
  + promu
  + crossbuild
  + docker_hub_master_and_releases
  + docker_hub_release_tags

This does exactly what old prometheus workflow used to except it also builds a
master like image for each release-.* branches.