### PR TITLE
Allow '.' and '-' in metric names.

### DIFF
--- a/pkg/textparse/lex.l
+++ b/pkg/textparse/lex.l
@@ -43,7 +43,8 @@ func (l *lexer) Lex() token {
 
 D     [0-9]
 L     [a-zA-Z_]
-M     [a-zA-Z_:]
+M     [a-zA-Z_:.-]
+N     [a-zA-Z_:.-]
 C     [^\n]
 
 %x sComment sMeta1 sMeta2 sLabels sLValue sValue sTimestamp
@@ -63,10 +64,10 @@ C     [^\n]
 #                                     return l.consumeComment()
 <sComment>HELP[\t ]+                  l.state = sMeta1; return tHelp
 <sComment>TYPE[\t ]+                  l.state = sMeta1; return tType
-<sMeta1>{M}({M}|{D})*                 l.state = sMeta2; return tMName
+<sMeta1>{M}({N}|{D})*                 l.state = sMeta2; return tMName
 <sMeta2>{C}*                          l.state = sInit; return tText
 
-{M}({M}|{D})*                         l.state = sValue; return tMName
+{M}({N}|{D})*                         l.state = sValue; return tMName
 <sValue>\{                            l.state = sLabels; return tBraceOpen
 <sLabels>{L}({L}|{D})*                return tLName
 <sLabels>\}                           l.state = sValue; return tBraceClose

--- a/promql/lex.go
+++ b/promql/lex.go
@@ -845,7 +845,7 @@ func lexKeywordOrIdentifier(l *lexer) stateFn {
 Loop:
 	for {
 		switch r := l.next(); {
-		case isAlphaNumeric(r) || r == ':':
+		case isAlphaNumeric(r) || r == ':' || r == '.' || r == '-':
 			// absorb.
 		default:
 			l.backup()

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -42,16 +42,20 @@ var scenarios = map[string]struct {
 		code:   200,
 		body:   ``,
 	},
+	"metric name with minus": {
+		params: "match[]=valid-metric-name",
+		code:   200,
+		body:   ``,
+	},
+	"metric name with dot": {
+		params: "match[]=valid.metric.name",
+		code:   200,
+		body:   ``,
+	},
 	"invalid params from the beginning": {
 		params: "match[]=-not-a-valid-metric-name",
 		code:   400,
 		body: `parse error at char 1: vector selector must contain label matchers or metric name
-`,
-	},
-	"invalid params somewhere in the middle": {
-		params: "match[]=not-a-valid-metric-name",
-		code:   400,
-		body: `parse error at char 4: could not parse remaining input "-a-valid-metric"...
 `,
 	},
 	"test_metric1": {


### PR DESCRIPTION
There are several standards which uses metric names that are not allowed
in Prometheus. For example:

* The 3GPP standard for mobile telephony uses '.' in metric names
  (See TS 32.404, chapter 3.3, bullet “e”)

* YANG data models should use '-' as a separator for all names, including
  metric names.
  (See rfc6087-bis: https://tools.ietf.org/id/draft-ietf-netmod-rfc6087bis-13.html#rfc.section.4.3.1)

This patch makes it possible to use Prometheus out of the box with these
standards, without having to do any name conversion.