### PR TITLE
Remove /heap endpoint

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -38,7 +38,6 @@ import (
 
 	"google.golang.org/grpc"
 
-	pprof_runtime "runtime/pprof"
 	template_text "text/template"
 
 	"github.com/cockroachdb/cmux"
@@ -254,8 +253,6 @@ func New(logger log.Logger, o *Options) *Handler {
 	router.Get("/targets", readyf(h.targets))
 	router.Get("/version", readyf(h.version))
 	router.Get("/service-discovery", readyf(h.serviceDiscovery))
-
-	router.Get("/heap", h.dumpHeap)
 
 	router.Get("/metrics", promhttp.Handler().ServeHTTP)
 
@@ -875,18 +872,6 @@ func (h *Handler) executeTemplate(w http.ResponseWriter, name string, data inter
 		return
 	}
 	io.WriteString(w, result)
-}
-
-func (h *Handler) dumpHeap(w http.ResponseWriter, r *http.Request) {
-	target := fmt.Sprintf("/tmp/%d.heap", time.Now().Unix())
-	f, err := os.Create(target)
-	if err != nil {
-		level.Error(h.logger).Log("msg", "Could not dump heap", "err", err)
-	}
-	fmt.Fprintf(w, "Writing to %s...", target)
-	defer f.Close()
-	pprof_runtime.WriteHeapProfile(f)
-	fmt.Fprintf(w, "Done")
 }
 
 // AlertStatus bundles alerting rules and the mapping of alert states to row classes.


### PR DESCRIPTION
It was added 5 years ago by Matt and I'm not sure anyone ever used
it after public release (since we have /debug/pprof/heap as well).

It also lacked error checking and allows people to write to disk over HTTP.

Signed-off-by: Julius Volz <julius.volz@gmail.com>