### PR TITLE
Change snapshot file permissions from 777 -> 750

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -880,7 +880,7 @@ func (api *API) snapshot(r *http.Request) (interface{}, *apiError, func()) {
 			rand.Int())
 		dir = filepath.Join(snapdir, name)
 	)
-	if err := os.MkdirAll(dir, 0777); err != nil {
+	if err := os.MkdirAll(dir, 0750); err != nil {
 		return nil, &apiError{errorInternal, fmt.Errorf("create snapshot directory: %s", err)}, nil
 	}
 	if err := db.Snapshot(dir, !skipHead); err != nil {

--- a/web/api/v2/api.go
+++ b/web/api/v2/api.go
@@ -179,7 +179,7 @@ func (s *Admin) TSDBSnapshot(_ old_ctx.Context, req *pb.TSDBSnapshotRequest) (*p
 			rand.Int())
 		dir = filepath.Join(snapdir, name)
 	)
-	if err := os.MkdirAll(dir, 0777); err != nil {
+	if err := os.MkdirAll(dir, 0750); err != nil {
 		return nil, status.Errorf(codes.Internal, "created snapshot directory: %s", err)
 	}
 	if err := db.Snapshot(dir, !req.SkipHead); err != nil {


### PR DESCRIPTION
This should be more secure and was pointed out by the `gosec` static
analysis tool.

Signed-off-by: Julius Volz <julius.volz@gmail.com>