### PR TITLE
rules: HTML-escape rule YAML marshal errors

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -433,7 +433,7 @@ func (r *AlertingRule) HTMLSnippet(pathPrefix string) html_template.HTML {
 
 	byt, err := yaml.Marshal(ar)
 	if err != nil {
-		return html_template.HTML(fmt.Sprintf("error marshalling alerting rule: %q", err.Error()))
+		return html_template.HTML(fmt.Sprintf("error marshalling alerting rule: %q", html_template.HTMLEscapeString(err.Error())))
 	}
 	return html_template.HTML(byt)
 }

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -135,7 +135,7 @@ func (rule *RecordingRule) HTMLSnippet(pathPrefix string) template.HTML {
 
 	byt, err := yaml.Marshal(r)
 	if err != nil {
-		return template.HTML(fmt.Sprintf("error marshalling recording rule: %q", err.Error()))
+		return template.HTML(fmt.Sprintf("error marshalling recording rule: %q", template.HTMLEscapeString(err.Error())))
 	}
 
 	return template.HTML(byt)


### PR DESCRIPTION
This was pointed out by `gosec`.

Signed-off-by: Julius Volz <julius.volz@gmail.com>