### PR TITLE
Handle nil pointer in EC2 discovery

### DIFF
--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -263,6 +263,9 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 					var subnets []string
 					subnetsMap := make(map[string]struct{})
 					for _, eni := range inst.NetworkInterfaces {
+						if eni.SubnetId == nil {
+							continue
+						}
 						if _, ok := subnetsMap[*eni.SubnetId]; !ok {
 							subnetsMap[*eni.SubnetId] = struct{}{}
 							subnets = append(subnets, *eni.SubnetId)


### PR DESCRIPTION
This handles a nil pointer that was being accessed in EC2 discovery https://github.com/prometheus/prometheus/blob/master/discovery/ec2/ec2.go#L265-L270

Fixes: #4441

