### PR TITLE
Makefile: improve 'make style' reporting

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -49,7 +49,12 @@ all: style staticcheck unused build test
 .PHONY: common-style
 common-style:
 	@echo ">> checking code style"
-	! $(GOFMT) -d $$(find . -path ./vendor -prune -o -name '*.go' -print) | grep '^'
+	@fmtRes=$$($(GOFMT) -d $$(find . -path ./vendor -prune -o -name '*.go' -print)); \
+	if [ -n "$${fmtRes}" ]; then \
+		echo "gofmt checking failed!"; echo "$${fmtRes}"; echo; \
+		echo "Please ensure you are using $$($(GO) version) for formatting code."; \
+		exit 1; \
+	fi
 
 .PHONY: common-check_license
 common-check_license:


### PR DESCRIPTION
Related to https://github.com/prometheus/alertmanager/issues/1504

For a better information, `make style` will display a message explaining that `gofmt` can produce different results with different go versions.