### PR TITLE
scrape configs as files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -136,6 +136,7 @@ type Config struct {
 	AlertingConfig AlertingConfig  `yaml:"alerting,omitempty"`
 	RuleFiles      []string        `yaml:"rule_files,omitempty"`
 	ScrapeConfigs  []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
+	ScrapeFiles    []string        `yaml:"scrape_files,omitempty"`
 
 	RemoteWriteConfigs []*RemoteWriteConfig `yaml:"remote_write,omitempty"`
 	RemoteReadConfigs  []*RemoteReadConfig  `yaml:"remote_read,omitempty"`
@@ -156,6 +157,10 @@ func resolveFilepaths(baseDir string, cfg *Config) {
 
 	for i, rf := range cfg.RuleFiles {
 		cfg.RuleFiles[i] = join(rf)
+	}
+
+	for i, rf := range cfg.ScrapeFiles {
+		cfg.ScrapeFiles[i] = join(rf)
 	}
 
 	clientPaths := func(scfg *config_util.HTTPClientConfig) {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -75,6 +75,10 @@ rule_files:
 scrape_configs:
   [ - <scrape_config> ... ]
 
+# A list of scrape configuration files.
+scrape_files:
+  [ - <filepath_glob> ... ]
+
 # Alerting specifies settings related to the Alertmanager.
 alerting:
   alert_relabel_configs:


### PR DESCRIPTION
Additional logic to handle scrape configs as files, as in rule file blobs.
Builds as is, requires testing.

   -- for consideration only, please hold on merge.