### PR TITLE
Populate __meta_gce_instance_id discovery label

### DIFF
--- a/discovery/gce/gce.go
+++ b/discovery/gce/gce.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -210,7 +211,7 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 			labels := model.LabelSet{
 				gceLabelProject:        model.LabelValue(d.project),
 				gceLabelZone:           model.LabelValue(inst.Zone),
-				gceLabelInstanceID:     model.LabelValue(inst.Id),
+				gceLabelInstanceID:     model.LabelValue(strconv.FormatUint(inst.Id, 10)),
 				gceLabelInstanceName:   model.LabelValue(inst.Name),
 				gceLabelInstanceStatus: model.LabelValue(inst.Status),
 				gceLabelMachineType:    model.LabelValue(inst.MachineType),

--- a/discovery/gce/gce.go
+++ b/discovery/gce/gce.go
@@ -40,6 +40,7 @@ const (
 	gceLabelSubnetwork     = gceLabel + "subnetwork"
 	gceLabelPublicIP       = gceLabel + "public_ip"
 	gceLabelPrivateIP      = gceLabel + "private_ip"
+	gceLabelInstanceID     = gceLabel + "instance_id"
 	gceLabelInstanceName   = gceLabel + "instance_name"
 	gceLabelInstanceStatus = gceLabel + "instance_status"
 	gceLabelTags           = gceLabel + "tags"
@@ -209,6 +210,7 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 			labels := model.LabelSet{
 				gceLabelProject:        model.LabelValue(d.project),
 				gceLabelZone:           model.LabelValue(inst.Zone),
+				gceLabelInstanceID:     model.LabelValue(inst.Id),
 				gceLabelInstanceName:   model.LabelValue(inst.Name),
 				gceLabelInstanceStatus: model.LabelValue(inst.Status),
 				gceLabelMachineType:    model.LabelValue(inst.MachineType),

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -589,6 +589,7 @@ address with relabeling.
 
 The following meta labels are available on targets during [relabeling](#relabel_config):
 
+* `__meta_gce_instance_id`: the numeric id of the instance
 * `__meta_gce_instance_name`: the name of the instance
 * `__meta_gce_label_<name>`: each GCE label of the instance
 * `__meta_gce_machine_type`: full or partial URL of the machine type of the instance


### PR DESCRIPTION
Populated from instance.ID. I will follow up with a change to the documentation.