### PR TITLE
move runtime debug funcs in own package

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
+	prom_runtime "github.com/prometheus/prometheus/pkg/runtime"
 	"gopkg.in/alecthomas/kingpin.v2"
 	k8s_runtime "k8s.io/apimachinery/pkg/util/runtime"
 
@@ -229,9 +230,9 @@ func main() {
 
 	level.Info(logger).Log("msg", "Starting Prometheus", "version", version.Info())
 	level.Info(logger).Log("build_context", version.BuildContext())
-	level.Info(logger).Log("host_details", Uname())
-	level.Info(logger).Log("fd_limits", FdLimits())
-	level.Info(logger).Log("vm_limits", VmLimits())
+	level.Info(logger).Log("host_details", prom_runtime.Uname())
+	level.Info(logger).Log("fd_limits", prom_runtime.FdLimits())
+	level.Info(logger).Log("vm_limits", prom_runtime.VmLimits())
 
 	var (
 		localStorage  = &tsdb.ReadyStorage{}

--- a/pkg/runtime/limits_default.go
+++ b/pkg/runtime/limits_default.go
@@ -13,7 +13,7 @@
 
 // +build !windows
 
-package main
+package runtime
 
 import (
 	"fmt"

--- a/pkg/runtime/limits_windows.go
+++ b/pkg/runtime/limits_windows.go
@@ -11,18 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build 386 amd64 arm64 mips64 mips64le mips mipsle
-// +build linux
+// +build windows
 
-package main
+package runtime
 
-func charsToString(ca []int8) string {
-	s := make([]byte, 0, len(ca))
-	for _, c := range ca {
-		if byte(c) == 0 {
-			break
-		}
-		s = append(s, byte(c))
-	}
-	return string(s)
+// FdLimits not supported on Windows
+func FdLimits() string {
+	return "N/A"
+}
+
+// VmLimits not supported on Windows
+func VmLimits() string {
+	return "N/A"
 }

--- a/pkg/runtime/uname_default.go
+++ b/pkg/runtime/uname_default.go
@@ -11,26 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+// +build !linux
 
-import (
-	"log"
-	"syscall"
-)
+package runtime
 
-// Uname returns the uname of the host machine.
+import "runtime"
+
+// Uname for any platform other than linux.
 func Uname() string {
-	buf := syscall.Utsname{}
-	err := syscall.Uname(&buf)
-	if err != nil {
-		log.Fatal("Error!")
-	}
-
-	str := "(" + charsToString(buf.Sysname[:])
-	str += " " + charsToString(buf.Release[:])
-	str += " " + charsToString(buf.Version[:])
-	str += " " + charsToString(buf.Machine[:])
-	str += " " + charsToString(buf.Nodename[:])
-	str += " " + charsToString(buf.Domainname[:]) + ")"
-	return str
+	return "(" + runtime.GOOS + ")"
 }

--- a/pkg/runtime/uname_linux.go
+++ b/pkg/runtime/uname_linux.go
@@ -11,16 +11,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build windows
+package runtime
 
-package main
+import (
+	"log"
+	"syscall"
+)
 
-// FdLimits not supported on Windows
-func FdLimits() string {
-	return "N/A"
-}
+// Uname returns the uname of the host machine.
+func Uname() string {
+	buf := syscall.Utsname{}
+	err := syscall.Uname(&buf)
+	if err != nil {
+		log.Fatal("Error!")
+	}
 
-// VmLimits not supported on Windows
-func VmLimits() string {
-	return "N/A"
+	str := "(" + charsToString(buf.Sysname[:])
+	str += " " + charsToString(buf.Release[:])
+	str += " " + charsToString(buf.Version[:])
+	str += " " + charsToString(buf.Machine[:])
+	str += " " + charsToString(buf.Nodename[:])
+	str += " " + charsToString(buf.Domainname[:]) + ")"
+	return str
 }

--- a/pkg/runtime/uname_linux_int8.go
+++ b/pkg/runtime/uname_linux_int8.go
@@ -11,13 +11,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !linux
+// +build 386 amd64 arm64 mips64 mips64le mips mipsle
+// +build linux
 
-package main
+package runtime
 
-import "runtime"
-
-// Uname for any platform other than linux.
-func Uname() string {
-	return "(" + runtime.GOOS + ")"
+func charsToString(ca []int8) string {
+	s := make([]byte, 0, len(ca))
+	for _, c := range ca {
+		if byte(c) == 0 {
+			break
+		}
+		s = append(s, byte(c))
+	}
+	return string(s)
 }

--- a/pkg/runtime/uname_linux_uint8.go
+++ b/pkg/runtime/uname_linux_uint8.go
@@ -14,7 +14,7 @@
 // +build arm ppc64 ppc64le s390x
 // +build linux
 
-package main
+package runtime
 
 func charsToString(ca []uint8) string {
 	s := make([]byte, 0, len(ca))

--- a/pkg/runtime/vmlimits_default.go
+++ b/pkg/runtime/vmlimits_default.go
@@ -14,7 +14,7 @@
 // +build !windows
 // +build !openbsd
 
-package main
+package runtime
 
 import (
 	"syscall"

--- a/pkg/runtime/vmlimits_openbsd.go
+++ b/pkg/runtime/vmlimits_openbsd.go
@@ -13,7 +13,7 @@
 
 // +build openbsd
 
-package main
+package runtime
 
 import (
 	"syscall"


### PR DESCRIPTION
fixes: https://github.com/prometheus/prometheus/issues/4493

To make local debuging with `go run` easyer moved all files into a
dedicate package `runtime`.
This allows running prometheus just by using `go run main.go` instead of
passing mani files like `go run main.go limits_default.go ...`

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>