### PR TITLE
web/api: Expose rule health and last error

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -406,6 +406,7 @@ $ curl http://localhost:9090/api/v1/rules
                             "summary": "High request latency"
                         },
                         "duration": 600,
+                        "health": "ok",
                         "labels": {
                             "severity": "page"
                         },
@@ -414,6 +415,7 @@ $ curl http://localhost:9090/api/v1/rules
                         "type": "alerting"
                     },
                     {
+                        "health": "ok",
                         "name": "job:http_inprogress_requests:sum",
                         "query": "sum(http_inprogress_requests) by (job)",
                         "type": "recording"

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -681,6 +681,7 @@ func testEndpoints(t *testing.T, api *API, testLabelAPI bool) {
 								Labels:      labels.Labels{},
 								Annotations: labels.Labels{},
 								Alerts:      []*Alert{},
+								Health:      "unknown",
 								Type:        "alerting",
 							},
 							alertingRule{
@@ -690,12 +691,14 @@ func testEndpoints(t *testing.T, api *API, testLabelAPI bool) {
 								Labels:      labels.Labels{},
 								Annotations: labels.Labels{},
 								Alerts:      []*Alert{},
+								Health:      "unknown",
 								Type:        "alerting",
 							},
 							recordingRule{
 								Name:   "recording-rule-1",
 								Query:  "vector(1)",
 								Labels: labels.Labels{},
+								Health: "unknown",
 								Type:   "recording",
 							},
 						},


### PR DESCRIPTION
Expose rule health and last evaluation error on `/api/v1/rules`.

//CC @noqcks

Follow up to https://github.com/prometheus/prometheus/pull/4457#pullrequestreview-143589537.