### PR TITLE
discovery/dns: add force_tcp option

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -387,6 +387,9 @@ names:
 
 # The time after which the provided names are refreshed.
 [ refresh_interval: <duration> | default = 30s ]
+
+# Forces the use of TCP for DNS SRV lookups.
+[ force_tcp: <boolean> | default = false ]
 ```
 
 Where `<domain_name>` is a valid DNS domain name.


### PR DESCRIPTION
Adds a configurable option to dns_sd_config which forces the use of DNS lookups over TCP.

I have been experiencing issues with DNS SD via CoreDNS and an issue relating to the truncation bit. Basically when there are a certain number of records returned via SRV lookup the additional section is truncated but the TC bit is not set on the response and Prometheus doesn't attempt to retry via TCP.

The following errors show in the logs:

```
level=warn ts=2018-08-15T22:38:18.755247522Z caller=dns.go:301 component="discovery manager scrape" discovery=dns msg="DNS resolution failed" server=redacted name=redacted. err="dns: overflow unpacking uint16"

level=warn ts=2018-08-15T22:38:18.86874238Z caller=dns.go:301 component="discovery manager scrape" discovery=dns msg="DNS resolution failed" server=redacted name=redacted. err="dns: overflow unpacking uint16"

level=error ts=2018-08-15T22:38:18.868800607Z caller=dns.go:162 component="discovery manager scrape" discovery=dns msg="Error refreshing DNS targets" err="could not resolve \"redacted\": all servers responded with errors to at least one search domain"
```

There is a PR open to the DNS library for CoreDNS at https://github.com/miekg/dns/pull/708
which I believe will fix the underlying issue if/when it is merged.

This change would be useful in order to workaround the issue on the Prometheus side.