### PR TITLE
Expose EC2 instance owner as a discovery label.

### DIFF
--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -42,6 +42,7 @@ const (
 	ec2LabelInstanceID      = ec2Label + "instance_id"
 	ec2LabelInstanceState   = ec2Label + "instance_state"
 	ec2LabelInstanceType    = ec2Label + "instance_type"
+	ec2LabelOwnerID         = ec2Label + "owner_id"
 	ec2LabelPublicDNS       = ec2Label + "public_dns_name"
 	ec2LabelPublicIP        = ec2Label + "public_ip"
 	ec2LabelPrivateIP       = ec2Label + "private_ip"
@@ -240,6 +241,7 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 					continue
 				}
 				labels := model.LabelSet{
+					ec2LabelOwnerID:    model.LabelValue(*r.OwnerId),
 					ec2LabelInstanceID: model.LabelValue(*inst.InstanceId),
 				}
 				labels[ec2LabelPrivateIP] = model.LabelValue(*inst.PrivateIpAddress)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -402,6 +402,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_ec2_instance_id`: the EC2 instance ID
 * `__meta_ec2_instance_state`: the state of the EC2 instance
 * `__meta_ec2_instance_type`: the type of the EC2 instance
+* `__meta_ec2_owner_id`: the ID of the AWS account that owns the EC2 instance
 * `__meta_ec2_primary_subnet_id`: the subnet ID of the primary network interface, if available
 * `__meta_ec2_private_ip`: the private IP address of the instance, if present
 * `__meta_ec2_public_dns_name`: the public DNS name of the instance, if available


### PR DESCRIPTION
This account ID/owner ID is necessary for uniquely identifying a VM instance.
This exposes the OwnerID field of the DescribeInstances response as `__meta_ec2_owner_id`. Other valid names could be `__meta_aws_account_id` and `__meta_ec2_account_id`.

Signed-off-by: Javier Kohen <jkohen@google.com>