### PR TITLE
Don't import testing in code which is imported from non-test code. (#…

### DIFF
--- a/util/testutil/testing.go
+++ b/util/testutil/testing.go
@@ -24,11 +24,18 @@ package testutil
 
 import (
 	"reflect"
-	"testing"
 )
 
+// This package is imported by non-test code and therefore cannot import the
+// testing package, which has side effects such as adding flags. Hence we use an
+// interface to testing.{T,B}.
+type TB interface {
+	Helper()
+	Fatalf(string, ...interface{})
+}
+
 // Assert fails the test if the condition is false.
-func Assert(tb testing.TB, condition bool, format string, a ...interface{}) {
+func Assert(tb TB, condition bool, format string, a ...interface{}) {
 	tb.Helper()
 	if !condition {
 		tb.Fatalf("\033[31m"+format+"\033[39m\n", a...)
@@ -36,7 +43,7 @@ func Assert(tb testing.TB, condition bool, format string, a ...interface{}) {
 }
 
 // Ok fails the test if an err is not nil.
-func Ok(tb testing.TB, err error) {
+func Ok(tb TB, err error) {
 	tb.Helper()
 	if err != nil {
 		tb.Fatalf("\033[31munexpected error: %v\033[39m\n", err)
@@ -44,7 +51,7 @@ func Ok(tb testing.TB, err error) {
 }
 
 // NotOk fails the test if an err is nil.
-func NotOk(tb testing.TB, err error, format string, a ...interface{}) {
+func NotOk(tb TB, err error, format string, a ...interface{}) {
 	tb.Helper()
 	if err == nil {
 		if len(a) != 0 {
@@ -55,7 +62,7 @@ func NotOk(tb testing.TB, err error, format string, a ...interface{}) {
 }
 
 // Equals fails the test if exp is not equal to act.
-func Equals(tb testing.TB, exp, act interface{}) {
+func Equals(tb TB, exp, act interface{}) {
 	tb.Helper()
 	if !reflect.DeepEqual(exp, act) {
 		tb.Fatalf("\033[31m\nexp: %#v\n\ngot: %#v\033[39m\n", exp, act)


### PR DESCRIPTION
…4400)

It polutes the flags.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>