### PR TITLE
simplified SD updates throttling

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -82,10 +82,6 @@ type Manager struct {
 	targets map[poolKey]map[string]*targetgroup.Group
 	// The sync channels sends the updates in map[targetSetName] where targetSetName is the job value from the scrape config.
 	syncCh chan map[string][]*targetgroup.Group
-	// True if updates were received in the last 5 seconds.
-	recentlyUpdated bool
-	// Protects recentlyUpdated.
-	recentlyUpdatedMtx sync.Mutex
 }
 
 // Run starts the background processing
@@ -132,43 +128,48 @@ func (m *Manager) startProvider(ctx context.Context, poolKey poolKey, worker Dis
 
 	go worker.Run(ctx, updates)
 	go m.runProvider(ctx, poolKey, updates)
-	go m.runUpdater(ctx)
 }
 
 func (m *Manager) runProvider(ctx context.Context, poolKey poolKey, updates chan []*targetgroup.Group) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	updateReceived := make(chan struct{}, 1)
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case tgs, ok := <-updates:
-			// Handle the case that a target provider exits and closes the channel
-			// before the context is done.
+			// Handle the case that a target provider(E.g. StaticProvider) exits and
+			// closes the channel before the context is done.
+			// This will prevent sending the updates to the receiver so we send them before exiting.
 			if !ok {
+				select {
+				case m.syncCh <- m.allGroups():
+				default:
+					level.Debug(m.logger).Log("msg", "discovery receiver's channel was full")
+				}
 				return
 			}
 			m.updateGroup(poolKey, tgs)
-			m.recentlyUpdatedMtx.Lock()
-			m.recentlyUpdated = true
-			m.recentlyUpdatedMtx.Unlock()
-		}
-	}
-}
 
-func (m *Manager) runUpdater(ctx context.Context) {
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			m.recentlyUpdatedMtx.Lock()
-			if m.recentlyUpdated {
-				m.syncCh <- m.allGroups()
-				m.recentlyUpdated = false
+			// Signal that there was an update.
+			select {
+			case updateReceived <- struct{}{}:
+			default:
 			}
-			m.recentlyUpdatedMtx.Unlock()
+		case <-ticker.C: // Some discoverers send updates too often so we send these to the receiver once every 5 seconds.
+			select {
+			case <-ctx.Done():
+				return
+			case <-updateReceived: // Send only when there is a new update.
+				select {
+				case m.syncCh <- m.allGroups():
+				default:
+					level.Debug(m.logger).Log("msg", "discovery receiver's channel was full")
+				}
+			}
 		}
 	}
 }

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -161,14 +161,13 @@ func (m *Manager) runProvider(ctx context.Context, poolKey poolKey, updates chan
 			}
 		case <-ticker.C: // Some discoverers send updates too often so we send these to the receiver once every 5 seconds.
 			select {
-			case <-ctx.Done():
-				return
 			case <-updateReceived: // Send only when there is a new update.
 				select {
 				case m.syncCh <- m.allGroups():
 				default:
 					level.Debug(m.logger).Log("msg", "discovery receiver's channel was full")
 				}
+			default:
 			}
 		}
 	}


### PR DESCRIPTION
as part of troubleshooting the SD updates bug I figured that when the receiver can't take any new updates(channel is full) the current throttling will block any targets updates

this is blocked 

https://github.com/prometheus/prometheus/blob/c66347768889f140253ecc7a0f4358bc051aaa01/discovery/manager.go#L150-L152
because we keep the lock here when the receiving channel is full.
https://github.com/prometheus/prometheus/blob/c66347768889f140253ecc7a0f4358bc051aaa01/discovery/manager.go#L166-L171

it also closes: #4470

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>