### PR TITLE
Limit the number of samples remote read can return.

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -168,6 +168,9 @@ func main() {
 	a.Flag("storage.remote.flush-deadline", "How long to wait flushing sample on shutdown or config reload.").
 		Default("1m").PlaceHolder("<duration>").SetValue(&cfg.RemoteFlushDeadline)
 
+	a.Flag("storage.remote.read-sample-limit", "Maximum overall number of samples to return via the remote read interface, in a single query. 0 means no limit.").
+		Default("5e7").IntVar(&cfg.web.RemoteReadLimit)
+
 	a.Flag("rules.alert.for-outage-tolerance", "Max time to tolerate prometheus outage for restoring 'for' state of alert.").
 		Default("1h").SetValue(&cfg.outageTolerance)
 
@@ -176,9 +179,6 @@ func main() {
 
 	a.Flag("rules.alert.resend-delay", "Minimum amount of time to wait before resending an alert to Alertmanager. Must be lower than resolve_timeout in Alertmanager").
 		Default("1m").SetValue(&cfg.resendDelay)
-
-	a.Flag("storage.remote.read-sample-limit", "Maximum number of samples to return via the remote read interface, in a single query.  0 means no limit.").
-		Default("5e7").IntVar(&cfg.web.RemoteReadLimit)
 
 	a.Flag("alertmanager.notification-queue-capacity", "The capacity of the queue for pending Alertmanager notifications.").
 		Default("10000").IntVar(&cfg.notifier.QueueCapacity)

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -177,6 +177,9 @@ func main() {
 	a.Flag("rules.alert.resend-delay", "Minimum amount of time to wait before resending an alert to Alertmanager. Must be lower than resolve_timeout in Alertmanager").
 		Default("1m").SetValue(&cfg.resendDelay)
 
+	a.Flag("storage.remote.read-sample-limit", "Maximum number of samples to return via the remote read interface, in a single query.  0 means no limit.").
+		Default("5e7").IntVar(&cfg.web.RemoteReadLimit)
+
 	a.Flag("alertmanager.notification-queue-capacity", "The capacity of the queue for pending Alertmanager notifications.").
 		Default("10000").IntVar(&cfg.notifier.QueueCapacity)
 

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -32,6 +32,19 @@ import (
 // decodeReadLimit is the maximum size of a read request body in bytes.
 const decodeReadLimit = 32 * 1024 * 1024
 
+type HTTPError struct {
+	msg    string
+	status int
+}
+
+func (e HTTPError) Error() string {
+	return e.msg
+}
+
+func (e HTTPError) Status() int {
+	return e.status
+}
+
 // DecodeReadRequest reads a remote.Request from a http.Request.
 func DecodeReadRequest(r *http.Request) (*prompb.ReadRequest, error) {
 	compressed, err := ioutil.ReadAll(io.LimitReader(r.Body, decodeReadLimit))
@@ -134,7 +147,8 @@ func FromQuery(req *prompb.Query) (int64, int64, []*labels.Matcher, *storage.Sel
 }
 
 // ToQueryResult builds a QueryResult proto.
-func ToQueryResult(ss storage.SeriesSet) (*prompb.QueryResult, error) {
+func ToQueryResult(ss storage.SeriesSet, sampleLimit int) (*prompb.QueryResult, error) {
+	numSamples := 0
 	resp := &prompb.QueryResult{}
 	for ss.Next() {
 		series := ss.At()
@@ -142,6 +156,13 @@ func ToQueryResult(ss storage.SeriesSet) (*prompb.QueryResult, error) {
 		samples := []*prompb.Sample{}
 
 		for iter.Next() {
+			numSamples += 1
+			if sampleLimit > 0 && numSamples > sampleLimit {
+				return nil, HTTPError{
+					msg:    fmt.Sprintf("exceeded sample limit (%d)", sampleLimit),
+					status: http.StatusRequestEntityTooLarge,
+				}
+			}
 			ts, val := iter.At()
 			samples = append(samples, &prompb.Sample{
 				Timestamp: ts,

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -156,11 +156,11 @@ func ToQueryResult(ss storage.SeriesSet, sampleLimit int) (*prompb.QueryResult, 
 		samples := []*prompb.Sample{}
 
 		for iter.Next() {
-			numSamples += 1
+			numSamples++
 			if sampleLimit > 0 && numSamples > sampleLimit {
 				return nil, HTTPError{
 					msg:    fmt.Sprintf("exceeded sample limit (%d)", sampleLimit),
-					status: http.StatusRequestEntityTooLarge,
+					status: http.StatusBadRequest,
 				}
 			}
 			ts, val := iter.At()

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -135,7 +135,7 @@ func TestSeriesSetFilter(t *testing.T) {
 
 	for i, tc := range tests {
 		filtered := newSeriesSetFilter(FromQueryResult(tc.in), tc.toRemove)
-		have, err := ToQueryResult(filtered)
+		have, err := ToQueryResult(filtered, 1e6)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -801,9 +801,9 @@ func (api *API) remoteRead(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			if httpErr, ok := err.(remote.HTTPError); ok {
 				http.Error(w, httpErr.Error(), httpErr.Status())
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
 			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -131,9 +131,10 @@ type API struct {
 	flagsMap              map[string]string
 	ready                 func(http.HandlerFunc) http.HandlerFunc
 
-	db          func() *tsdb.DB
-	enableAdmin bool
-	logger      log.Logger
+	db              func() *tsdb.DB
+	enableAdmin     bool
+	logger          log.Logger
+	remoteReadLimit int
 }
 
 // NewAPI returns an initialized API type.
@@ -149,19 +150,22 @@ func NewAPI(
 	enableAdmin bool,
 	logger log.Logger,
 	rr rulesRetriever,
+	remoteReadLimit int,
 ) *API {
 	return &API{
 		QueryEngine:           qe,
 		Queryable:             q,
 		targetRetriever:       tr,
 		alertmanagerRetriever: ar,
-		now:            time.Now,
-		config:         configFunc,
-		flagsMap:       flagsMap,
-		ready:          readyFunc,
-		db:             db,
-		enableAdmin:    enableAdmin,
-		rulesRetriever: rr,
+
+		now:             time.Now,
+		config:          configFunc,
+		flagsMap:        flagsMap,
+		ready:           readyFunc,
+		db:              db,
+		enableAdmin:     enableAdmin,
+		rulesRetriever:  rr,
+		remoteReadLimit: remoteReadLimit,
 	}
 }
 
@@ -793,9 +797,13 @@ func (api *API) remoteRead(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		resp.Results[i], err = remote.ToQueryResult(set)
+		resp.Results[i], err = remote.ToQueryResult(set, api.remoteReadLimit)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			if httpErr, ok := err.(remote.HTTPError); ok {
+				http.Error(w, httpErr.Error(), httpErr.Status())
+			} else {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
 			return
 		}
 

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -313,7 +313,7 @@ func setupRemote(s storage.Storage) *httptest.Server {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			resp.Results[i], err = remote.ToQueryResult(set)
+			resp.Results[i], err = remote.ToQueryResult(set, 1e6)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -833,6 +833,7 @@ func TestReadEndpoint(t *testing.T) {
 				},
 			}
 		},
+		remoteReadLimit: 1e6,
 	}
 
 	// Encode the request.
@@ -860,6 +861,10 @@ func TestReadEndpoint(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	api.remoteRead(recorder, request)
+
+	if recorder.Code/100 != 2 {
+		t.Fatal(recorder.Code)
+	}
 
 	// Decode the response.
 	compressed, err = ioutil.ReadAll(recorder.Result().Body)

--- a/web/web.go
+++ b/web/web.go
@@ -167,6 +167,7 @@ type Options struct {
 	ConsoleLibrariesPath string
 	EnableLifecycle      bool
 	EnableAdminAPI       bool
+	RemoteReadLimit      int
 }
 
 func instrumentHandler(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
@@ -227,6 +228,7 @@ func New(logger log.Logger, o *Options) *Handler {
 		h.options.EnableAdminAPI,
 		logger,
 		h.ruleManager,
+		h.options.RemoteReadLimit,
 	)
 
 	if o.RoutePrefix != "/" {


### PR DESCRIPTION
Tracking down Prometheus OOMs for a client, initially thought it was PromQL (see #4414), but looks like it is remote read requests.

Quick and dirty limit; probably want this plumbed through as a command line argument?

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>