### PR TITLE
Fix Dockerfile label syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM        quay.io/prometheus/busybox:latest
-LABEL maintainer "The Prometheus Authors <prometheus-developers@googlegroups.com>"
+LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 COPY prometheus                             /bin/prometheus
 COPY promtool                               /bin/promtool


### PR DESCRIPTION
Minor syntax file in the Dockerfile. I believe this should not have any impact.