### PR TITLE
send updates only when there was a change in the targets.

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -16,7 +16,6 @@ package discovery
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -239,7 +238,7 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) (update
 			// "kube-scheduler" even though these don't actually include any targets.
 			// Even if we find a way to filter these in the k8s client
 			// this check is safer for other misbehaving providers.
-			if !reflect.DeepEqual(m.targets[poolKey][tg.Source], tg) {
+			if _, exist := m.targets[poolKey][tg.Source]; !exist || !m.targets[poolKey][tg.Source].Equal(tg) {
 				m.targets[poolKey][tg.Source] = tg
 				updated = true
 			}

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	sd_config "github.com/prometheus/prometheus/discovery/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/testutil"
 	"gopkg.in/yaml.v2"
 )
 
@@ -866,6 +867,24 @@ scrape_configs:
 				origScrpCfg.ServiceDiscoveryConfig.StaticConfigs, sdcfg.StaticConfigs)
 		}
 	}
+}
+
+func TestUpdateGroupNoChanges(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	discoveryManager := NewManager(ctx, nil)
+
+	tg := []*targetgroup.Group{
+		{
+			Source: "tp1_group1",
+			Targets: []model.LabelSet{
+				{"__instance__": "1"},
+			},
+		},
+	}
+	pk := poolKey{setName: "test", provider: "test"}
+	testutil.Assert(t, discoveryManager.updateGroup(pk, tg) == true, "Expected to return true when adding a new target group.")
+	testutil.Assert(t, discoveryManager.updateGroup(pk, tg) != true, "Expected to return false when we add the same target group without any changes.")
 }
 
 type update struct {

--- a/discovery/targetgroup/targetgroup.go
+++ b/discovery/targetgroup/targetgroup.go
@@ -94,7 +94,7 @@ func (tg *Group) UnmarshalJSON(b []byte) error {
 
 // Equal returns true if all fields have exactly the same values and lenghts.
 // To keep a good performance the `Targets []model.LabelSet` is not sorted
-// so if these arrive in a different order the comparing won't work.
+// so if Targets of the compared objects are in different order they are not equal.
 func (tg *Group) Equal(newTg *Group) bool {
 	if tg.Source != newTg.Source {
 		return false

--- a/discovery/targetgroup/targetgroup.go
+++ b/discovery/targetgroup/targetgroup.go
@@ -91,3 +91,26 @@ func (tg *Group) UnmarshalJSON(b []byte) error {
 	tg.Labels = g.Labels
 	return nil
 }
+
+// Equal returns true if all fields have exactly the same values and lenghts.
+// To keep a good performance the `Targets []model.LabelSet` is not sorted
+// so if these arrive in a different order the comparing won't work.
+func (tg *Group) Equal(newTg *Group) bool {
+	if tg.Source != newTg.Source {
+		return false
+	}
+	if !tg.Labels.Equal(newTg.Labels) {
+		return false
+	}
+
+	if len(tg.Targets) != len(newTg.Targets) {
+		return false
+	}
+
+	for i, t := range tg.Targets {
+		if !t.Equal(newTg.Targets[i]) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
this will limit the unnecessary CPU cicles when providers keep sending
updates that didn't actually change anything.

closes: https://github.com/prometheus/prometheus/issues/4518


see https://github.com/kubernetes/client-go/issues/454 for more details.
Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>