### PR TITLE
Adding support for multiple azure environments

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -441,6 +441,7 @@ var expectedConf = &Config{
 			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
 				AzureSDConfigs: []*azure.SDConfig{
 					{
+						Environment:     "AzurePublicCloud",
 						SubscriptionID:  "11AAAA11-A11A-111A-A111-1111A1111A11",
 						TenantID:        "BBBB222B-B2B2-2B22-B222-2BB2222BB2B2",
 						ClientID:        "333333CC-3C33-3333-CCC3-33C3CCCCC33C",

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -195,7 +195,8 @@ scrape_configs:
 
 - job_name: service-azure
   azure_sd_configs:
-    - subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
+    - environment: AzurePublicCloud
+      subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
       tenant_id: BBBB222B-B2B2-2B22-B222-2BB2222BB2B2
       client_id: 333333CC-3C33-3333-CCC3-33C3CCCCC33C
       client_secret: mysecret

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -272,6 +272,8 @@ See below for the configuration options for Azure discovery:
 
 ```yaml
 # The information to access the Azure API.
+# The Azure environment.
+[ environment: <string> | default = AzurePublicCloud ]
 # The subscription ID.
 subscription_id: <string>
 # The tenant ID.


### PR DESCRIPTION
Currently, the azure discovery assumes the environment as AzurePublicCloud. Other supported Azure Environments won't with the current code.

This PR changes that.  Minor code improvements have been made as well.