### PR TITLE
web: avoid proxy to connect to the local gRPC server

### DIFF
--- a/web/api/v2/api.go
+++ b/web/api/v2/api.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -73,7 +74,13 @@ func (api *API) HTTPHandler(grpcAddr string) (http.Handler, error) {
 	enc := new(protoutil.JSONPb)
 	mux := runtime.NewServeMux(runtime.WithMarshalerOption(enc.ContentType(), enc))
 
-	opts := []grpc.DialOption{grpc.WithInsecure()}
+	opts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		// Replace the default dialer that connects through proxy when HTTP_PROXY is set.
+		grpc.WithDialer(func(addr string, _ time.Duration) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+		}),
+	}
 
 	err := pb.RegisterAdminHandlerFromEndpoint(ctx, mux, grpcAddr, opts)
 	if err != nil {


### PR DESCRIPTION
Closes #3730

To reproduce the bug on `master`, run:

```
$ HTTP_PROXY=http://localhost:8080/ prometheus 
```

If you try to snapshot the data using the admin V2 API, it will fail with `{"error":"grpc: the connection is unavailable","code":14}`. In addition Prometheus logs show:

```
2018/09/04 16:04:10 grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp [::1]:8080: connect: connection refused"; Reconnecting to {0.0.0.0:9090 <nil>}
```