### PR TITLE
[ServiceDiscovery] Unregister source when the target is empty

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -232,11 +232,6 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
 				m.targets[poolKey] = make(map[string]*targetgroup.Group)
 			}
 			m.targets[poolKey][tg.Source] = tg
-
-			// Clear the key in the case where the targets is empty.
-			if tg.Targets == nil || len(tg.Targets) <= 0 {
-				delete(m.targets[poolKey], tg.Source)
-			}
 		}
 	}
 }

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -232,6 +232,11 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
 				m.targets[poolKey] = make(map[string]*targetgroup.Group)
 			}
 			m.targets[poolKey][tg.Source] = tg
+
+			// Clear the key in the case where the targets is empty.
+			if tg.Targets == nil || len(tg.Targets) <= 0 {
+				delete(m.targets[poolKey], tg.Source)
+			}
 		}
 	}
 }

--- a/documentation/examples/custom-sd/adapter-usage/main.go
+++ b/documentation/examples/custom-sd/adapter-usage/main.go
@@ -200,7 +200,7 @@ func (d *discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 			tgs = append(tgs, tg)
 			newSourceList[tg.Source] = true
 		}
-		// when targetGroup disappear, send an update with empty targetList
+		// When targetGroup disappear, send an update with empty targetList.
 		for key := range d.oldSourceList {
 			if !newSourceList[key] {
 				tgs = append(tgs, &targetgroup.Group{

--- a/documentation/examples/custom-sd/adapter-usage/main.go
+++ b/documentation/examples/custom-sd/adapter-usage/main.go
@@ -94,6 +94,7 @@ type discovery struct {
 	clientDatacenter string
 	tagSeparator     string
 	logger           log.Logger
+	oldSourceList    map[string]bool
 }
 
 func (d *discovery) parseServiceNodes(resp *http.Response, name string) (*targetgroup.Group, error) {
@@ -180,6 +181,8 @@ func (d *discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 		// list of targets simply because there may have been a timeout. If the service is actually
 		// gone as far as consul is concerned, that will be picked up during the next iteration of
 		// the outer loop.
+
+		newSourceList := make(map[string]bool)
 		for name := range srvs {
 			if name == "consul" {
 				continue
@@ -195,7 +198,17 @@ func (d *discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 				break
 			}
 			tgs = append(tgs, tg)
+			newSourceList[tg.Source] = true
 		}
+		// when targetGroup disappear, send an update with empty targetList
+		for key := range d.oldSourceList {
+			if !newSourceList[key] {
+				tgs = append(tgs, &targetgroup.Group{
+					Source: key,
+				})
+			}
+		}
+		d.oldSourceList = newSourceList
 		if err == nil {
 			// We're returning all Consul services as a single targetgroup.
 			ch <- tgs
@@ -216,6 +229,7 @@ func newDiscovery(conf sdConfig) (*discovery, error) {
 		refreshInterval: conf.RefreshInterval,
 		tagSeparator:    conf.TagSeparator,
 		logger:          logger,
+		oldSourceList:   make(map[string]bool),
 	}
 	return cd, nil
 }

--- a/documentation/examples/custom-sd/adapter/adapter.go
+++ b/documentation/examples/custom-sd/adapter/adapter.go
@@ -18,14 +18,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
-	"github.com/prometheus/prometheus/discovery"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 type customSD struct {

--- a/documentation/examples/custom-sd/adapter/adapter.go
+++ b/documentation/examples/custom-sd/adapter/adapter.go
@@ -60,6 +60,12 @@ func (a *Adapter) generateTargetGroups(allTargetGroups map[string][]*targetgroup
 	tempGroups := make(map[string]*customSD)
 	for k, sdTargetGroups := range allTargetGroups {
 		for i, group := range sdTargetGroups {
+
+			// There is no target, so no need to keep it
+			if len(group.Targets) <= 0 {
+				continue
+			}
+
 			newTargets := make([]string, 0)
 			newLabels := make(map[string]string)
 

--- a/documentation/examples/custom-sd/adapter/adapter.go
+++ b/documentation/examples/custom-sd/adapter/adapter.go
@@ -59,7 +59,7 @@ func generateTargetGroups(allTargetGroups map[string][]*targetgroup.Group) map[s
 	for k, sdTargetGroups := range allTargetGroups {
 		for i, group := range sdTargetGroups {
 
-			// There is no target, so no need to keep it
+			// There is no target, so no need to keep it.
 			if len(group.Targets) <= 0 {
 				continue
 			}

--- a/documentation/examples/custom-sd/adapter/adapter_test.go
+++ b/documentation/examples/custom-sd/adapter/adapter_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 // TestGenerateTargetGroups checks that the target is correctly generated.
-// It covers the case when the target is empty
+// It covers the case when the target is empty.
 func TestGenerateTargetGroups(t *testing.T) {
 	testCases := []struct {
 		title            string

--- a/documentation/examples/custom-sd/adapter/adapter_test.go
+++ b/documentation/examples/custom-sd/adapter/adapter_test.go
@@ -1,0 +1,151 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"reflect"
+	"testing"
+)
+
+// TestGenerateTargetGroups checks that the target is correctly generated.
+// It covers the case when the target is empty
+func TestGenerateTargetGroups(t *testing.T) {
+	testCases := []struct {
+		title            string
+		targetGroup      map[string][]*targetgroup.Group
+		expectedCustomSD map[string]*customSD
+	}{
+		{
+			title: "Empty targetGroup",
+			targetGroup: map[string][]*targetgroup.Group{
+				"customSD": {
+					{
+						Source: "Consul",
+					},
+					{
+						Source: "Kubernetes",
+					},
+				},
+			},
+			expectedCustomSD: map[string]*customSD{},
+		},
+		{
+			title: "targetGroup filled",
+			targetGroup: map[string][]*targetgroup.Group{
+				"customSD": {
+					{
+						Source: "Azure",
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: "host1",
+							},
+							{
+								model.AddressLabel: "host2",
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("__meta_test_label"): model.LabelValue("label_test_1"),
+						},
+					},
+					{
+						Source: "Openshift",
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: "host3",
+							},
+							{
+								model.AddressLabel: "host4",
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("__meta_test_label"): model.LabelValue("label_test_2"),
+						},
+					},
+				},
+			},
+			expectedCustomSD: map[string]*customSD{
+				"customSD:Azure:0": {
+					Targets: []string{
+						"host1",
+						"host2",
+					},
+					Labels: map[string]string{
+						"__meta_test_label": "label_test_1",
+					},
+				},
+				"customSD:Openshift:1": {
+					Targets: []string{
+						"host3",
+						"host4",
+					},
+					Labels: map[string]string{
+						"__meta_test_label": "label_test_2",
+					},
+				},
+			},
+		},
+		{
+			title: "Mixed between empty targetGroup and targetGroup filled",
+			targetGroup: map[string][]*targetgroup.Group{
+				"customSD": {
+					{
+						Source: "GCE",
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: "host1",
+							},
+							{
+								model.AddressLabel: "host2",
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("__meta_test_label"): model.LabelValue("label_test_1"),
+						},
+					},
+					{
+						Source: "Kubernetes",
+						Labels: model.LabelSet{
+							model.LabelName("__meta_test_label"): model.LabelValue("label_test_2"),
+						},
+					},
+				},
+			},
+			expectedCustomSD: map[string]*customSD{
+				"customSD:GCE:0": {
+					Targets: []string{
+						"host1",
+						"host2",
+					},
+					Labels: map[string]string{
+						"__meta_test_label": "label_test_1",
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		result := generateTargetGroups(testCase.targetGroup)
+
+		if !reflect.DeepEqual(result, testCase.expectedCustomSD) {
+			t.Errorf("%v :\nresult produced %v\nmismatch the expected customSD: %v",
+				testCase.title,
+				result,
+				testCase.expectedCustomSD)
+		}
+
+	}
+}

--- a/documentation/examples/custom-sd/adapter/adapter_test.go
+++ b/documentation/examples/custom-sd/adapter/adapter_test.go
@@ -14,10 +14,11 @@
 package adapter
 
 import (
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"reflect"
 	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 // TestGenerateTargetGroups checks that the target is correctly generated.
@@ -141,7 +142,7 @@ func TestGenerateTargetGroups(t *testing.T) {
 		result := generateTargetGroups(testCase.targetGroup)
 
 		if !reflect.DeepEqual(result, testCase.expectedCustomSD) {
-			t.Errorf("%v :\nresult produced %v\nmismatch the expected customSD: %v",
+			t.Errorf("%q failed\ngot: %#v\nexpected: %v",
 				testCase.title,
 				result,
 				testCase.expectedCustomSD)


### PR DESCRIPTION
close #4573 

We could do a similar things in the Adapter (in the method generateTargetGroups for example),  but it's cleaner to unregister the target in the Manager level. In this way it wil reduce he size of the map `targets`
