### PR TITLE
Stop removing the final dot from rooted DNS names

### DIFF
--- a/discovery/dns/dns.go
+++ b/discovery/dns/dns.go
@@ -181,9 +181,6 @@ func (d *Discovery) refresh(ctx context.Context, name string, ch chan<- []*targe
 		target := model.LabelValue("")
 		switch addr := record.(type) {
 		case *dns.SRV:
-			// Remove the final dot from rooted DNS names to make them look more usual.
-			addr.Target = strings.TrimRight(addr.Target, ".")
-
 			target = hostPort(addr.Target, int(addr.Port))
 		case *dns.A:
 			target = hostPort(addr.A.String(), d.port)


### PR DESCRIPTION
Removing a final dot changes the meaning of the name and can cause extra DNS lookups as the resolver traverses its search path.

Fixes #3196 