### PR TITLE
Add duplicate-labelset check for range/instant vectors

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -719,6 +719,9 @@ func (ev *evaluator) rangeEval(f func([]Value, *EvalNodeHelper) Vector, exprs ..
 		// Make the function call.
 		enh.ts = ts
 		result := f(args, enh)
+		if result.ContainsSameLabelset() {
+			ev.errorf("vector cannot contain metrics with the same labelset")
+		}
 		enh.out = result[:0] // Reuse result vector.
 		// If this could be an instant query, shortcut so as not to change sort order.
 		if ev.endTimestamp == ev.startTimestamp {
@@ -726,9 +729,6 @@ func (ev *evaluator) rangeEval(f func([]Value, *EvalNodeHelper) Vector, exprs ..
 			for i, s := range result {
 				s.Point.T = ts
 				mat[i] = Series{Metric: s.Metric, Points: []Point{s.Point}}
-			}
-			if mat.ContainsSameLabelset() {
-				ev.errorf("vector cannot contain metrics with the same labelset")
 			}
 			return mat
 		}
@@ -757,9 +757,6 @@ func (ev *evaluator) rangeEval(f func([]Value, *EvalNodeHelper) Vector, exprs ..
 	mat := make(Matrix, 0, len(seriess))
 	for _, ss := range seriess {
 		mat = append(mat, ss)
-	}
-	if mat.ContainsSameLabelset() {
-		ev.errorf("vector cannot contain metrics with the same labelset")
 	}
 	return mat
 }

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -905,7 +905,7 @@ func (ev *evaluator) eval(expr Expr) Value {
 				}
 			}
 			if mat.ContainsSameLabelset() {
-				panic(fmt.Errorf("vector cannot contain metrics with the same labelset"))
+				ev.errorf("vector cannot contain metrics with the same labelset")
 			}
 		}
 		return mat

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -874,6 +874,9 @@ func (ev *evaluator) eval(expr Expr) Value {
 				enh.ts = ts
 				// Make the function call.
 				outVec := e.Func.Call(inArgs, e.Args, enh)
+				if outVec.ContainsSameLabelset() {
+					panic(fmt.Errorf("vector cannot contain metrics with the same labelset"))
+				}
 				enh.out = outVec[:0]
 				if len(outVec) > 0 {
 					ss.Points = append(ss.Points, Point{V: outVec[0].Point.V, T: ts})

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -719,6 +719,9 @@ func (ev *evaluator) rangeEval(f func([]Value, *EvalNodeHelper) Vector, exprs ..
 		// Make the function call.
 		enh.ts = ts
 		result := f(args, enh)
+		if result.ContainsSameLabelset() {
+			panic(fmt.Errorf("vector cannot contain metrics with the same labelset"))
+		}
 		enh.out = result[:0] // Reuse result vector.
 		// If this could be an instant query, shortcut so as not to change sort order.
 		if ev.endTimestamp == ev.startTimestamp {
@@ -896,6 +899,9 @@ func (ev *evaluator) eval(expr Expr) Value {
 				for j := range mat[i].Points {
 					mat[i].Points[j].V = -mat[i].Points[j].V
 				}
+			}
+			if mat.ContainsSameLabelset() {
+				panic(fmt.Errorf("vector cannot contain metrics with the same labelset"))
 			}
 		}
 		return mat

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -734,7 +734,6 @@ func funcLabelReplace(vals []Value, args Expressions, enh *EvalNodeHelper) Vecto
 		enh.dmn = make(map[uint64]labels.Labels, len(enh.out))
 	}
 
-	outSet := make(map[uint64]struct{}, len(vector))
 	for _, el := range vector {
 		h := el.Metric.Hash()
 		var outMetric labels.Labels
@@ -759,17 +758,10 @@ func funcLabelReplace(vals []Value, args Expressions, enh *EvalNodeHelper) Vecto
 			}
 		}
 
-		outHash := outMetric.Hash()
-		if _, ok := outSet[outHash]; ok {
-			panic(fmt.Errorf("duplicated label set in output of label_replace(): %s", el.Metric))
-		} else {
-			enh.out = append(enh.out,
-				Sample{
-					Metric: outMetric,
-					Point:  Point{V: el.Point.V},
-				})
-			outSet[outHash] = struct{}{}
-		}
+		enh.out = append(enh.out, Sample{
+			Metric: outMetric,
+			Point:  Point{V: el.Point.V},
+		})
 	}
 	return enh.out
 }
@@ -808,7 +800,6 @@ func funcLabelJoin(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 		panic(fmt.Errorf("invalid destination label name in label_join(): %s", dst))
 	}
 
-	outSet := make(map[uint64]struct{}, len(vector))
 	srcVals := make([]string, len(srcLabels))
 	for _, el := range vector {
 		h := el.Metric.Hash()
@@ -833,17 +824,11 @@ func funcLabelJoin(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 			outMetric = lb.Labels()
 			enh.dmn[h] = outMetric
 		}
-		outHash := outMetric.Hash()
 
-		if _, exists := outSet[outHash]; exists {
-			panic(fmt.Errorf("duplicated label set in output of label_join(): %s", el.Metric))
-		} else {
-			enh.out = append(enh.out, Sample{
-				Metric: outMetric,
-				Point:  Point{V: el.Point.V},
-			})
-			outSet[outHash] = struct{}{}
-		}
+		enh.out = append(enh.out, Sample{
+			Metric: outMetric,
+			Point:  Point{V: el.Point.V},
+		})
 	}
 	return enh.out
 }

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -514,3 +514,11 @@ eval instant at 0m days_in_month(vector(1454284800))
 eval instant at 0m days_in_month(vector(1485907200))
   {} 28
 
+clear
+
+# Test duplicate labelset in promql output.
+load 5m
+  testmetric1{src="a",dst="b"} 0
+  testmetric2{src="a",dst="b"} 1
+
+eval_fail instant at 0m changes({__name__=~'testmetric1|testmetric2'}[5m])

--- a/promql/testdata/legacy.test
+++ b/promql/testdata/legacy.test
@@ -357,3 +357,12 @@ load 1h
 eval instant at 0h testmetric
 	testmetric{aa="bb"} 1
 	testmetric{a="abb"} 2
+
+clear
+
+# Test duplicate labelset in promql output.
+load 5m
+  testmetric1{src="a",dst="b"} 0
+  testmetric2{src="a",dst="b"} 1
+
+eval_fail instant at 0m ceil({__name__=~'testmetric1|testmetric2'})

--- a/promql/testdata/operators.test
+++ b/promql/testdata/operators.test
@@ -367,3 +367,12 @@ eval instant at 5m metricA + ignoring() metricB
 
 eval instant at 5m metricA + metricB
   {baz="meh"} 7
+
+clear
+
+# Test duplicate labelset in promql output.
+load 5m
+  testmetric1{src="a",dst="b"} 0
+  testmetric2{src="a",dst="b"} 1
+
+eval_fail instant at 0m -{__name__=~'testmetric1|testmetric2'}

--- a/promql/value.go
+++ b/promql/value.go
@@ -140,6 +140,20 @@ func (vec Vector) String() string {
 	return strings.Join(entries, "\n")
 }
 
+// ContainsSameLabelset checks if a vector has samples with the same labelset
+// Such a behaviour is semantically undefined
+// https://github.com/prometheus/prometheus/issues/4562
+func (vec Vector) ContainsSameLabelset() bool {
+	l := make(map[uint64]struct{}, len(vec))
+	for _, s := range vec {
+		hash := s.Metric.Hash()
+		if _, ok := l[hash]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // Matrix is a slice of Seriess that implements sort.Interface and
 // has a String method.
 type Matrix []Series
@@ -158,6 +172,20 @@ func (m Matrix) String() string {
 func (m Matrix) Len() int           { return len(m) }
 func (m Matrix) Less(i, j int) bool { return labels.Compare(m[i].Metric, m[j].Metric) < 0 }
 func (m Matrix) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+
+// ContainsSameLabelset checks if a matrix has samples with the same labelset
+// Such a behaviour is semantically undefined
+// https://github.com/prometheus/prometheus/issues/4562
+func (m Matrix) ContainsSameLabelset() bool {
+	l := make(map[uint64]struct{}, len(m))
+	for _, ss := range m {
+		hash := ss.Metric.Hash()
+		if _, ok := l[hash]; ok {
+			return true
+		}
+	}
+	return false
+}
 
 // Result holds the resulting value of an execution or an error
 // if any occurred.

--- a/promql/value.go
+++ b/promql/value.go
@@ -149,6 +149,8 @@ func (vec Vector) ContainsSameLabelset() bool {
 		hash := s.Metric.Hash()
 		if _, ok := l[hash]; ok {
 			return true
+		} else {
+			l[hash] = struct{}{}
 		}
 	}
 	return false
@@ -182,6 +184,8 @@ func (m Matrix) ContainsSameLabelset() bool {
 		hash := ss.Metric.Hash()
 		if _, ok := l[hash]; ok {
 			return true
+		} else {
+			l[hash] = struct{}{}
 		}
 	}
 	return false


### PR DESCRIPTION
Closes #4562 

This PR adds a duplicate-label set check for range-vector & instant-vectors.
Signed-off-by: Harsh Agarwal <cs15btech11019@iith.ac.in>

cc @brian-brazil 