### PR TITLE
Adding alert rule filtering function

### DIFF
--- a/discovery/kubernetes/service_test.go
+++ b/discovery/kubernetes/service_test.go
@@ -86,8 +86,8 @@ func TestServiceDiscoveryAdd(t *testing.T) {
 				Targets: []model.LabelSet{
 					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
-						"__address__":                             "testservice.default.svc:30900",
-						"__meta_kubernetes_service_port_name":     "testport",
+						"__address__":                         "testservice.default.svc:30900",
+						"__meta_kubernetes_service_port_name": "testport",
 					},
 				},
 				Labels: model.LabelSet{
@@ -135,13 +135,13 @@ func TestServiceDiscoveryUpdate(t *testing.T) {
 				Targets: []model.LabelSet{
 					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
-						"__address__":                             "testservice.default.svc:30900",
-						"__meta_kubernetes_service_port_name":     "testport0",
+						"__address__":                         "testservice.default.svc:30900",
+						"__meta_kubernetes_service_port_name": "testport0",
 					},
 					{
 						"__meta_kubernetes_service_port_protocol": "UDP",
-						"__address__":                             "testservice.default.svc:30901",
-						"__meta_kubernetes_service_port_name":     "testport1",
+						"__address__":                         "testservice.default.svc:30901",
+						"__meta_kubernetes_service_port_name": "testport1",
 					},
 				},
 				Labels: model.LabelSet{
@@ -175,8 +175,8 @@ func TestServiceDiscoveryNamespaces(t *testing.T) {
 				Targets: []model.LabelSet{
 					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
-						"__address__":                             "testservice.ns1.svc:30900",
-						"__meta_kubernetes_service_port_name":     "testport",
+						"__address__":                         "testservice.ns1.svc:30900",
+						"__meta_kubernetes_service_port_name": "testport",
 					},
 				},
 				Labels: model.LabelSet{
@@ -189,8 +189,8 @@ func TestServiceDiscoveryNamespaces(t *testing.T) {
 				Targets: []model.LabelSet{
 					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
-						"__address__":                             "testservice.ns2.svc:30900",
-						"__meta_kubernetes_service_port_name":     "testport",
+						"__address__":                         "testservice.ns2.svc:30900",
+						"__meta_kubernetes_service_port_name": "testport",
 					},
 				},
 				Labels: model.LabelSet{

--- a/pkg/rulefmt/testdata/test.yaml
+++ b/pkg/rulefmt/testdata/test.yaml
@@ -62,3 +62,24 @@ groups:
       severity: critical
     annotations:
       description: "stuff's happening with {{ $.labels.service }}"
+    filters:
+      match:
+      - label:
+          instance: prometheus
+        v: 50
+        op: lt
+      - label:
+          instance: prometheuss
+          job: prom
+        v: 1
+        op: gt
+      match_re:
+      - label_re:
+          instance: prometheusre.*
+        v: 50
+        op: '>='
+      - label_re:
+          instance: prometheuss.*
+        v_range:
+          min: 1
+          max: 100

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -26,7 +26,7 @@ import (
 func TestAlertingRuleHTMLSnippet(t *testing.T) {
 	expr, err := promql.ParseExpr(`foo{html="<b>BOLD<b>"}`)
 	testutil.Ok(t, err)
-	rule := NewAlertingRule("testrule", expr, 0, labels.FromStrings("html", "<b>BOLD</b>"), labels.FromStrings("html", "<b>BOLD</b>"), false, nil)
+	rule := NewAlertingRule("testrule", expr, 0, labels.FromStrings("html", "<b>BOLD</b>"), labels.FromStrings("html", "<b>BOLD</b>"), false, nil, nil)
 
 	const want = `alert: <a href="/test/prefix/graph?g0.expr=ALERTS%7Balertname%3D%22testrule%22%7D&g0.tab=1">testrule</a>
 expr: <a href="/test/prefix/graph?g0.expr=foo%7Bhtml%3D%22%3Cb%3EBOLD%3Cb%3E%22%7D&g0.tab=1">foo{html=&#34;&lt;b&gt;BOLD&lt;b&gt;&#34;}</a>
@@ -34,6 +34,9 @@ labels:
   html: '&lt;b&gt;BOLD&lt;/b&gt;'
 annotations:
   html: '&lt;b&gt;BOLD&lt;/b&gt;'
+filters:
+  match: []
+  match_re: []
 `
 
 	got := rule.HTMLSnippet("/test/prefix")
@@ -62,7 +65,7 @@ func TestAlertingRuleLabelsUpdate(t *testing.T) {
 		// If an alert is going back and forth between two label values it will never fire.
 		// Instead, you should write two alerts with constant labels.
 		labels.FromStrings("severity", "{{ if lt $value 80.0 }}critical{{ else }}warning{{ end }}"),
-		nil, true, nil,
+		nil, true, nil, nil,
 	)
 
 	results := []promql.Vector{

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -51,7 +51,7 @@ func TestAlertingRule(t *testing.T) {
 		expr,
 		time.Minute,
 		labels.FromStrings("severity", "{{\"c\"}}ritical"),
-		nil, true, nil,
+		nil, true, nil, nil,
 	)
 	result := promql.Vector{
 		{
@@ -192,7 +192,7 @@ func TestForStateAddSamples(t *testing.T) {
 		expr,
 		time.Minute,
 		labels.FromStrings("severity", "{{\"c\"}}ritical"),
-		nil, true, nil,
+		nil, true, nil, nil,
 	)
 	result := promql.Vector{
 		{
@@ -366,7 +366,7 @@ func TestForStateRestore(t *testing.T) {
 		expr,
 		alertForDuration,
 		labels.FromStrings("severity", "critical"),
-		nil, true, nil,
+		nil, true, nil, nil,
 	)
 
 	group := NewGroup("default", "", time.Second, []Rule{rule}, true, opts)
@@ -426,7 +426,7 @@ func TestForStateRestore(t *testing.T) {
 			expr,
 			alertForDuration,
 			labels.FromStrings("severity", "critical"),
-			nil, false, nil,
+			nil, false, nil, nil,
 		)
 		newGroup := NewGroup("default", "", time.Second, []Rule{newRule}, true, opts)
 
@@ -574,7 +574,7 @@ func readSeriesSet(ss storage.SeriesSet) (map[string][]promql.Point, error) {
 func TestCopyState(t *testing.T) {
 	oldGroup := &Group{
 		rules: []Rule{
-			NewAlertingRule("alert", nil, 0, nil, nil, true, nil),
+			NewAlertingRule("alert", nil, 0, nil, nil, true, nil, nil),
 			NewRecordingRule("rule1", nil, nil),
 			NewRecordingRule("rule2", nil, nil),
 			NewRecordingRule("rule3", nil, nil),
@@ -595,7 +595,7 @@ func TestCopyState(t *testing.T) {
 			NewRecordingRule("rule3", nil, nil),
 			NewRecordingRule("rule3", nil, nil),
 			NewRecordingRule("rule3", nil, nil),
-			NewAlertingRule("alert", nil, 0, nil, nil, true, nil),
+			NewAlertingRule("alert", nil, 0, nil, nil, true, nil, nil),
 			NewRecordingRule("rule1", nil, nil),
 			NewRecordingRule("rule4", nil, nil),
 		},
@@ -672,7 +672,7 @@ func TestNotify(t *testing.T) {
 
 	expr, err := promql.ParseExpr("a > 1")
 	testutil.Ok(t, err)
-	rule := NewAlertingRule("aTooHigh", expr, 0, labels.Labels{}, labels.Labels{}, true, log.NewNopLogger())
+	rule := NewAlertingRule("aTooHigh", expr, 0, labels.Labels{}, labels.Labels{}, true, log.NewNopLogger(), nil)
 	group := NewGroup("alert", "", time.Second, []Rule{rule}, true, opts)
 
 	app, _ := storage.Appender()

--- a/rules/match/match.go
+++ b/rules/match/match.go
@@ -1,0 +1,201 @@
+// Copyright 2015 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package match
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/prometheus/common/model"
+	"regexp"
+	"strconv"
+)
+
+// Matcher defines a matching rule for the value of a given label.
+type Matcher struct {
+	Name    string `json:"name"`
+	Value   string `json:"value"`
+	IsRegex bool   `json:"isRegex"`
+	Regex   *regexp.Regexp
+}
+
+func (m *Matcher) String() string {
+	if m.IsRegex {
+		return fmt.Sprintf("%s=~%q", m.Name, m.Value)
+	}
+	return fmt.Sprintf("%s=%q", m.Name, m.Value)
+}
+
+// Validate returns true iff all fields of the matcher have valid values.
+func (m *Matcher) Validate() error {
+	if !model.LabelName(m.Name).IsValid() {
+		return fmt.Errorf("invalid name %q", m.Name)
+	}
+	if m.IsRegex {
+		if _, err := regexp.Compile(m.Value); err != nil {
+			return fmt.Errorf("invalid regular expression %q", m.Value)
+		}
+	} else if !model.LabelValue(m.Value).IsValid() || len(m.Value) == 0 {
+		return fmt.Errorf("invalid value %q", m.Value)
+	}
+	return nil
+}
+
+func (m *Matcher) Match(lset map[string]string) bool {
+	v := lset[m.Name]
+	if m.IsRegex {
+		return m.Regex.MatchString(v)
+	}
+	return v == m.Value
+}
+
+// NewMatcher returns a new matcher that compares against equality of
+// the given value.
+func NewMatcher(name, value string) *Matcher {
+	return &Matcher{
+		Name:    name,
+		Value:   value,
+		IsRegex: false,
+	}
+}
+
+// NewRegexMatcher returns a new matcher that compares values against
+// a regular expression. The matcher is already initialized.
+//
+// TODO(fabxc): refactor usage.
+func NewRegexMatcher(name string, re *regexp.Regexp) *Matcher {
+	return &Matcher{
+		Name:    name,
+		Value:   re.String(),
+		IsRegex: true,
+		Regex:   re,
+	}
+}
+
+// Matchers provides the Match and Fingerprint methods for a slice of Matchers.
+// Matchers must always be sorted.
+type Matchers struct {
+	Matches            []*Matcher
+	Value              float64
+	MinValue           float64
+	MaxValue           float64
+	RelationalOperator string
+	IsRangeValue       bool
+}
+
+func NewMatchers(matches []*Matcher, value float64, op string, minValue, maxValue float64) *Matchers {
+	isRangeValue := false
+	if op == "" {
+		isRangeValue = true
+	}
+	return &Matchers{
+		Matches:            matches,
+		Value:              value,
+		MinValue:           minValue,
+		MaxValue:           maxValue,
+		RelationalOperator: op,
+		IsRangeValue:       isRangeValue,
+	}
+}
+
+// Validate matchers
+func (ms *Matchers) Validate() error {
+	if len(ms.Matches) > 0 {
+		for _, m := range ms.Matches {
+			if err := m.Validate(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Match checks whether all matchers are fulfilled against the given label set.
+func (ms Matchers) Match(lset map[string]string, v float64) bool {
+	for _, m := range ms.Matches {
+		if !m.Match(lset) {
+			return false
+		}
+	}
+	return ms.MatchValue(v)
+}
+
+func (ms Matchers) MatchValue(v float64) bool {
+	if ms.IsRangeValue {
+		if v >= ms.MinValue && v <= ms.MaxValue {
+			return true
+		}
+		return false
+	}
+	// v[gt,ge] > maxValue true, v[lt,le] < minValue true
+	switch ms.RelationalOperator {
+	case "=", "eq":
+		return ms.Value == v
+	case "!=", "ne":
+		return ms.Value != v
+	case ">", "gt":
+		return ms.Value > v
+	case ">=", "ge":
+		return ms.Value >= v
+	case "<", "lt":
+		return ms.Value < v
+	case "<=", "le":
+		return ms.Value <= v
+	}
+	return false
+}
+
+func (ms Matchers) String() string {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, m := range ms.Matches {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(m.String())
+	}
+	buf.WriteByte(',')
+	if ms.IsRangeValue {
+		buf.WriteString(fmt.Sprintf("new_value_range: [%s, %s]", strconv.FormatFloat(ms.MinValue, 'f', -1, 64),
+			strconv.FormatFloat(ms.MaxValue, 'f', -1, 64)))
+	} else {
+		buf.WriteString(fmt.Sprintf("new_value: %s, op: %s", strconv.FormatFloat(ms.Value, 'f', -1, 64), ms.RelationalOperator))
+	}
+	buf.WriteByte('}')
+	return buf.String()
+}
+
+type MatchersConds []*Matchers
+
+// Validate MatchersConds
+func (conds MatchersConds) Validate() error {
+	for _, mrs := range conds {
+		if err := mrs.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (conds MatchersConds) String() string {
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	for i, mrs := range conds {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(mrs.String())
+	}
+	buf.WriteByte(']')
+	return buf.String()
+}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -123,6 +123,7 @@ func (m rulesRetrieverMock) AlertingRules() []*rules.AlertingRule {
 		labels.Labels{},
 		true,
 		log.NewNopLogger(),
+		nil,
 	)
 	rule2 := rules.NewAlertingRule(
 		"test_metric4",
@@ -132,6 +133,7 @@ func (m rulesRetrieverMock) AlertingRules() []*rules.AlertingRule {
 		labels.Labels{},
 		true,
 		log.NewNopLogger(),
+		nil,
 	)
 	var r []*rules.AlertingRule
 	r = append(r, rule1)
@@ -220,11 +222,11 @@ func TestEndpoints(t *testing.T) {
 			QueryEngine:           suite.QueryEngine(),
 			targetRetriever:       testTargetRetriever{},
 			alertmanagerRetriever: testAlertmanagerRetriever{},
-			now:            func() time.Time { return now },
-			config:         func() config.Config { return samplePrometheusCfg },
-			flagsMap:       sampleFlagMap,
-			ready:          func(f http.HandlerFunc) http.HandlerFunc { return f },
-			rulesRetriever: algr,
+			now:                   func() time.Time { return now },
+			config:                func() config.Config { return samplePrometheusCfg },
+			flagsMap:              sampleFlagMap,
+			ready:                 func(f http.HandlerFunc) http.HandlerFunc { return f },
+			rulesRetriever:        algr,
 		}
 
 		testEndpoints(t, api, true)
@@ -273,11 +275,11 @@ func TestEndpoints(t *testing.T) {
 			QueryEngine:           suite.QueryEngine(),
 			targetRetriever:       testTargetRetriever{},
 			alertmanagerRetriever: testAlertmanagerRetriever{},
-			now:            func() time.Time { return now },
-			config:         func() config.Config { return samplePrometheusCfg },
-			flagsMap:       sampleFlagMap,
-			ready:          func(f http.HandlerFunc) http.HandlerFunc { return f },
-			rulesRetriever: algr,
+			now:                   func() time.Time { return now },
+			config:                func() config.Config { return samplePrometheusCfg },
+			flagsMap:              sampleFlagMap,
+			ready:                 func(f http.HandlerFunc) http.HandlerFunc { return f },
+			rulesRetriever:        algr,
 		}
 
 		testEndpoints(t, api, false)

--- a/web/ui/assets_vfsdata.go
+++ b/web/ui/assets_vfsdata.go
@@ -549,7 +549,7 @@ func (fs vfsgen۰FS) Open(path string) (http.File, error) {
 		}
 		return &vfsgen۰CompressedFile{
 			vfsgen۰CompressedFileInfo: f,
-			gr: gr,
+			gr:                        gr,
 		}, nil
 	case *vfsgen۰DirInfo:
 		return &vfsgen۰Dir{


### PR DESCRIPTION
The current alert rule is global, and is not very friendly for some special cases. For example, if the CPU idle of the A machine is less than 10, the CPU idle of the B machine is less than 20, and the others are less than 30, we need to write the alert rule three times.

I added the filter function, the tag returned for the global expr matches the filter tag (the match draws on the Alertmanager match idea and some code) and the value returned by expr is compared with the filter to provide a new value, once again filtered. In this way, we can write filter matching (support regular) rules for special cases.

Currently, the filter function has been added, performance testing has not been performed, and test cases have not been perfected.

new alert rule yaml eg:

```
groups:
- name: alertOs
  rules:
  - alert: LowerCPUIdle
    expr: clamp_max(avg by (instance) (sum by (instance,cpu)((clamp_max(rate(node_cpu_seconds_total{mode="idle", job="linux"}[2m]),1)))),1)*100 < 30
    for: 1m
    labels:
      severity: High
    annotations:
      summary: Low CPU Idle On {{ $labels.instance }}
      description: "{{ $labels.instance }} of cpu idle usage has been less than the threshold (current value: {{ $value }}s)"
    filters:
      match:
      - label:
          instance: prometheus
        v: 20
        op: lt
      - label:
          instance: 192.168.1.2
        v_range:
          min: 1
          max: 10

      match_re:
      - label_re:
          instance: op-bigdata.*
        v: 10
        op: lt
      - label_re:
          instance: op-bigdata2.*
          job: a
        v: 15
        op: '<='
```

