### PR TITLE
Update vendoring of prometheus/tsdb

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -555,7 +555,10 @@ func main() {
 				db, err := tsdb.Open(
 					cfg.localStoragePath,
 					log.With(logger, "component", "tsdb"),
-					prometheus.DefaultRegisterer,
+					prometheus.WrapRegistererWithPrefix(
+						"prometheus_",
+						prometheus.DefaultRegisterer,
+					),
 					&cfg.tsdb,
 				)
 				if err != nil {

--- a/vendor/github.com/prometheus/tsdb/block.go
+++ b/vendor/github.com/prometheus/tsdb/block.go
@@ -15,6 +15,7 @@
 package tsdb
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -248,6 +249,10 @@ type Block struct {
 	dir  string
 	meta BlockMeta
 
+	// Symbol Table Size in bytes.
+	// We maintain this variable to avoid recalculation everytime.
+	symbolTableSize uint64
+
 	chunkr     ChunkReader
 	indexr     IndexReader
 	tombstones TombstoneReader
@@ -275,12 +280,23 @@ func OpenBlock(dir string, pool chunkenc.Pool) (*Block, error) {
 		return nil, err
 	}
 
+	// Calculating symbol table size.
+	tmp := make([]byte, 8)
+	symTblSize := uint64(0)
+	for _, v := range ir.SymbolTable() {
+		// Size of varint length of the symbol.
+		symTblSize += uint64(binary.PutUvarint(tmp, uint64(len(v))))
+		// Size of the symbol.
+		symTblSize += uint64(len(v))
+	}
+
 	pb := &Block{
-		dir:        dir,
-		meta:       *meta,
-		chunkr:     cr,
-		indexr:     ir,
-		tombstones: tr,
+		dir:             dir,
+		meta:            *meta,
+		chunkr:          cr,
+		indexr:          ir,
+		tombstones:      tr,
+		symbolTableSize: symTblSize,
 	}
 	return pb, nil
 }
@@ -348,6 +364,11 @@ func (pb *Block) Tombstones() (TombstoneReader, error) {
 		return nil, err
 	}
 	return blockTombstoneReader{TombstoneReader: pb.tombstones, b: pb}, nil
+}
+
+// GetSymbolTableSize returns the Symbol Table Size in the index of this block.
+func (pb *Block) GetSymbolTableSize() uint64 {
+	return pb.symbolTableSize
 }
 
 func (pb *Block) setCompactionFailed() error {

--- a/vendor/github.com/prometheus/tsdb/compact.go
+++ b/vendor/github.com/prometheus/tsdb/compact.go
@@ -84,30 +84,30 @@ func newCompactorMetrics(r prometheus.Registerer) *compactorMetrics {
 	m := &compactorMetrics{}
 
 	m.ran = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_compactions_total",
+		Name: "tsdb_compactions_total",
 		Help: "Total number of compactions that were executed for the partition.",
 	})
 	m.failed = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_compactions_failed_total",
+		Name: "tsdb_compactions_failed_total",
 		Help: "Total number of compactions that failed for the partition.",
 	})
 	m.duration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "prometheus_tsdb_compaction_duration_seconds",
+		Name:    "tsdb_compaction_duration_seconds",
 		Help:    "Duration of compaction runs",
 		Buckets: prometheus.ExponentialBuckets(1, 2, 10),
 	})
 	m.chunkSize = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "prometheus_tsdb_compaction_chunk_size",
+		Name:    "tsdb_compaction_chunk_size_bytes",
 		Help:    "Final size of chunks on their first compaction",
 		Buckets: prometheus.ExponentialBuckets(32, 1.5, 12),
 	})
 	m.chunkSamples = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "prometheus_tsdb_compaction_chunk_samples",
+		Name:    "tsdb_compaction_chunk_samples",
 		Help:    "Final number of samples on their first compaction",
 		Buckets: prometheus.ExponentialBuckets(4, 1.5, 12),
 	})
 	m.chunkRange = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "prometheus_tsdb_compaction_chunk_range",
+		Name:    "tsdb_compaction_chunk_range_seconds",
 		Help:    "Final time range of chunks on their first compaction",
 		Buckets: prometheus.ExponentialBuckets(100, 4, 10),
 	})

--- a/vendor/github.com/prometheus/tsdb/head.go
+++ b/vendor/github.com/prometheus/tsdb/head.go
@@ -82,8 +82,8 @@ type headMetrics struct {
 	seriesRemoved       prometheus.Counter
 	seriesNotFound      prometheus.Counter
 	chunks              prometheus.Gauge
-	chunksCreated       prometheus.Gauge
-	chunksRemoved       prometheus.Gauge
+	chunksCreated       prometheus.Counter
+	chunksRemoved       prometheus.Counter
 	gcDuration          prometheus.Summary
 	minTime             prometheus.GaugeFunc
 	maxTime             prometheus.GaugeFunc
@@ -95,59 +95,59 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 	m := &headMetrics{}
 
 	m.activeAppenders = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_active_appenders",
+		Name: "tsdb_head_active_appenders",
 		Help: "Number of currently active appender transactions",
 	})
 	m.series = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_series",
+		Name: "tsdb_head_series",
 		Help: "Total number of series in the head block.",
 	})
-	m.seriesCreated = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_series_created_total",
+	m.seriesCreated = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "tsdb_head_series_created_total",
 		Help: "Total number of series created in the head",
 	})
-	m.seriesRemoved = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_series_removed_total",
+	m.seriesRemoved = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "tsdb_head_series_removed_total",
 		Help: "Total number of series removed in the head",
 	})
 	m.seriesNotFound = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_head_series_not_found",
+		Name: "tsdb_head_series_not_found_total",
 		Help: "Total number of requests for series that were not found.",
 	})
 	m.chunks = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_chunks",
+		Name: "tsdb_head_chunks",
 		Help: "Total number of chunks in the head block.",
 	})
-	m.chunksCreated = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_chunks_created_total",
+	m.chunksCreated = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "tsdb_head_chunks_created_total",
 		Help: "Total number of chunks created in the head",
 	})
-	m.chunksRemoved = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_chunks_removed_total",
+	m.chunksRemoved = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "tsdb_head_chunks_removed_total",
 		Help: "Total number of chunks removed in the head",
 	})
 	m.gcDuration = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "prometheus_tsdb_head_gc_duration_seconds",
+		Name: "tsdb_head_gc_duration_seconds",
 		Help: "Runtime of garbage collection in the head block.",
 	})
 	m.maxTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_max_time",
+		Name: "tsdb_head_max_time",
 		Help: "Maximum timestamp of the head block.",
 	}, func() float64 {
 		return float64(h.MaxTime())
 	})
 	m.minTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_min_time",
+		Name: "tsdb_head_min_time",
 		Help: "Minimum time bound of the head block.",
 	}, func() float64 {
 		return float64(h.MinTime())
 	})
 	m.walTruncateDuration = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "prometheus_tsdb_wal_truncate_duration_seconds",
+		Name: "tsdb_wal_truncate_duration_seconds",
 		Help: "Duration of WAL truncation.",
 	})
 	m.samplesAppended = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_head_samples_appended_total",
+		Name: "tsdb_head_samples_appended_total",
 		Help: "Total number of appended samples.",
 	})
 

--- a/vendor/github.com/prometheus/tsdb/wal.go
+++ b/vendor/github.com/prometheus/tsdb/wal.go
@@ -64,11 +64,11 @@ func newWalMetrics(wal *SegmentWAL, r prometheus.Registerer) *walMetrics {
 	m := &walMetrics{}
 
 	m.fsyncDuration = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "prometheus_tsdb_wal_fsync_duration_seconds",
+		Name: "tsdb_wal_fsync_duration_seconds",
 		Help: "Duration of WAL fsync.",
 	})
 	m.corruptions = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_wal_corruptions_total",
+		Name: "tsdb_wal_corruptions_total",
 		Help: "Total number of WAL corruptions.",
 	})
 

--- a/vendor/github.com/prometheus/tsdb/wal/wal.go
+++ b/vendor/github.com/prometheus/tsdb/wal/wal.go
@@ -190,15 +190,15 @@ func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSi
 		stopc:       make(chan chan struct{}),
 	}
 	w.fsyncDuration = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "prometheus_tsdb_wal_fsync_duration_seconds",
+		Name: "tsdb_wal_fsync_duration_seconds",
 		Help: "Duration of WAL fsync.",
 	})
 	w.pageFlushes = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_wal_page_flushes_total",
+		Name: "tsdb_wal_page_flushes_total",
 		Help: "Total number of page flushes.",
 	})
 	w.pageCompletions = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_wal_completed_pages_total",
+		Name: "tsdb_wal_completed_pages_total",
 		Help: "Total number of completed pages.",
 	})
 	if reg != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -847,46 +847,46 @@
 			"revisionTime": "2016-04-11T19:08:41Z"
 		},
 		{
-			"checksumSHA1": "vRK6HrNOeJheYudfpCIUyh42T3o=",
+			"checksumSHA1": "Q6uLx6Qrg0gC+5K/LSumPt7UlgA=",
 			"path": "github.com/prometheus/tsdb",
-			"revision": "06f01d45ad2ca2853c9dc1a0d5db6c75c8af6a5a",
-			"revisionTime": "2018-08-07T11:25:08Z"
+			"revision": "1b651ea7d4d855de181a6cc052acc5779bce7c77",
+			"revisionTime": "2018-09-17T13:16:04Z"
 		},
 		{
 			"checksumSHA1": "QI0UME2olSr4kH6Z8UkpffM59Mc=",
 			"path": "github.com/prometheus/tsdb/chunkenc",
-			"revision": "06f01d45ad2ca2853c9dc1a0d5db6c75c8af6a5a",
-			"revisionTime": "2018-08-07T11:25:08Z"
+			"revision": "1b651ea7d4d855de181a6cc052acc5779bce7c77",
+			"revisionTime": "2018-09-17T13:16:04Z"
 		},
 		{
 			"checksumSHA1": "+5bPifRe479zdFeTYhZ+CZRLMgw=",
 			"path": "github.com/prometheus/tsdb/chunks",
-			"revision": "06f01d45ad2ca2853c9dc1a0d5db6c75c8af6a5a",
-			"revisionTime": "2018-08-07T11:25:08Z"
+			"revision": "1b651ea7d4d855de181a6cc052acc5779bce7c77",
+			"revisionTime": "2018-09-17T13:16:04Z"
 		},
 		{
 			"checksumSHA1": "bL3t5K2Q8e1GuM6gy5PAJ05go14=",
 			"path": "github.com/prometheus/tsdb/fileutil",
-			"revision": "06f01d45ad2ca2853c9dc1a0d5db6c75c8af6a5a",
-			"revisionTime": "2018-08-07T11:25:08Z"
+			"revision": "1b651ea7d4d855de181a6cc052acc5779bce7c77",
+			"revisionTime": "2018-09-17T13:16:04Z"
 		},
 		{
 			"checksumSHA1": "AZGFK4UtJe8/j8pHqGTNQ8wu27g=",
 			"path": "github.com/prometheus/tsdb/index",
-			"revision": "06f01d45ad2ca2853c9dc1a0d5db6c75c8af6a5a",
-			"revisionTime": "2018-08-07T11:25:08Z"
+			"revision": "1b651ea7d4d855de181a6cc052acc5779bce7c77",
+			"revisionTime": "2018-09-17T13:16:04Z"
 		},
 		{
 			"checksumSHA1": "Va8HWvOFTwFeewZFadMAOzNGDps=",
 			"path": "github.com/prometheus/tsdb/labels",
-			"revision": "06f01d45ad2ca2853c9dc1a0d5db6c75c8af6a5a",
-			"revisionTime": "2018-08-07T11:25:08Z"
+			"revision": "1b651ea7d4d855de181a6cc052acc5779bce7c77",
+			"revisionTime": "2018-09-17T13:16:04Z"
 		},
 		{
-			"checksumSHA1": "6GXK7RnUngyM9OT/M2uzv8T3DOY=",
+			"checksumSHA1": "DQEDO4+dAI/FMxMJYbhroNmRlTQ=",
 			"path": "github.com/prometheus/tsdb/wal",
-			"revision": "06f01d45ad2ca2853c9dc1a0d5db6c75c8af6a5a",
-			"revisionTime": "2018-08-07T11:25:08Z"
+			"revision": "1b651ea7d4d855de181a6cc052acc5779bce7c77",
+			"revisionTime": "2018-09-17T13:16:04Z"
 		},
 		{
 			"checksumSHA1": "5SYLEhADhdBVZAGPVHWggQl7H8k=",


### PR DESCRIPTION
The new version has no prometheus_ metrics prefix hardcoded anymore,
so this commit adds it using the new WrapRegistererWithPrefix
function.

Signed-off-by: beorn7 <beorn@soundcloud.com>

@gouthamve @brancz @grobie as promised. The metrics look the same as before.