### PR TITLE
fix k8s config example

### DIFF
--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -20,27 +20,26 @@ scrape_configs:
 
   kubernetes_sd_configs:
   - role: endpoints
+    # This TLS & bearer token file config is used to connect to the actual scrape
+    # endpoints for cluster components. This is separate to discovery auth
+    # configuration because discovery & scraping are two separate concerns in
+    # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+    # the cluster. Otherwise, more config options have to be provided within the
+    # <kubernetes_sd_config>.
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      # If your node certificates are self-signed or use a different CA to the
+      # master CA, then disable certificate verification below. Note that
+      # certificate verification is an integral part of a secure infrastructure
+      # so this should only be disabled in a controlled environment. You can
+      # disable certificate verification by uncommenting the line below.
+      #
+      # insecure_skip_verify: true
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
   # Default to scraping over https. If required, just disable this or change to
   # `http`.
   scheme: https
-
-  # This TLS & bearer token file config is used to connect to the actual scrape
-  # endpoints for cluster components. This is separate to discovery auth
-  # configuration because discovery & scraping are two separate concerns in
-  # Prometheus. The discovery auth config is automatic if Prometheus runs inside
-  # the cluster. Otherwise, more config options have to be provided within the
-  # <kubernetes_sd_config>.
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    # If your node certificates are self-signed or use a different CA to the
-    # master CA, then disable certificate verification below. Note that
-    # certificate verification is an integral part of a secure infrastructure
-    # so this should only be disabled in a controlled environment. You can
-    # disable certificate verification by uncommenting the line below.
-    #
-    # insecure_skip_verify: true
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
   # Keep only the default/kubernetes service endpoints for the https port. This
   # will add targets for each API server which Kubernetes adds an endpoint to
@@ -62,18 +61,17 @@ scrape_configs:
   # `http`.
   scheme: https
 
-  # This TLS & bearer token file config is used to connect to the actual scrape
-  # endpoints for cluster components. This is separate to discovery auth
-  # configuration because discovery & scraping are two separate concerns in
-  # Prometheus. The discovery auth config is automatic if Prometheus runs inside
-  # the cluster. Otherwise, more config options have to be provided within the
-  # <kubernetes_sd_config>.
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
   kubernetes_sd_configs:
   - role: node
+    # This TLS & bearer token file config is used to connect to the actual scrape
+    # endpoints for cluster components. This is separate to discovery auth
+    # configuration because discovery & scraping are two separate concerns in
+    # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+    # the cluster. Otherwise, more config options have to be provided within the
+    # <kubernetes_sd_config>.
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
   relabel_configs:
   - action: labelmap
@@ -105,18 +103,17 @@ scrape_configs:
   # `http`.
   scheme: https
 
-  # This TLS & bearer token file config is used to connect to the actual scrape
-  # endpoints for cluster components. This is separate to discovery auth
-  # configuration because discovery & scraping are two separate concerns in
-  # Prometheus. The discovery auth config is automatic if Prometheus runs inside
-  # the cluster. Otherwise, more config options have to be provided within the
-  # <kubernetes_sd_config>.
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
   kubernetes_sd_configs:
   - role: node
+    # This TLS & bearer token file config is used to connect to the actual scrape
+    # endpoints for cluster components. This is separate to discovery auth
+    # configuration because discovery & scraping are two separate concerns in
+    # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+    # the cluster. Otherwise, more config options have to be provided within the
+    # <kubernetes_sd_config>.
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
   relabel_configs:
   - action: labelmap


### PR DESCRIPTION
tls_config is an element of kubernetes_sd_configs:
https://github.com/prometheus/prometheus/blob/cfbd72b4f1b5257ab7e0074bfab0631168747556/discovery/kubernetes/kubernetes.go#L91