### PR TITLE
Make ErrStorage a concrete type not an interface

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -74,7 +74,7 @@ type (
 	ErrTooManySamples string
 	// ErrStorage is returned if an error was encountered in the storage layer
 	// during query handling.
-	ErrStorage error
+	ErrStorage struct{ error }
 )
 
 func (e ErrQueryTimeout) Error() string {
@@ -85,6 +85,9 @@ func (e ErrQueryCanceled) Error() string {
 }
 func (e ErrTooManySamples) Error() string {
 	return fmt.Sprintf("query processing would load too many samples into memory in %s", string(e))
+}
+func (e ErrStorage) Error() string {
+	return e.error.Error()
 }
 
 // A Query is derived from an a raw query string and can be run against an engine

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -193,7 +193,7 @@ func TestQueryError(t *testing.T) {
 		Timeout:       10 * time.Second,
 	}
 	engine := NewEngine(opts)
-	errStorage := ErrStorage(fmt.Errorf("storage error"))
+	errStorage := ErrStorage{fmt.Errorf("storage error")}
 	queryable := storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 		return &errQuerier{err: errStorage}, nil
 	})


### PR DESCRIPTION
Fixes #4629 

Since it is [used in a type assertion](https://github.com/prometheus/prometheus/blob/3e87c04/web/api/v1/api.go#L265-L271), having `ErrStorage` as an alias to the error interface is the same as saying `error`, i.e. it succeeds for all types of error.  Change to a struct which is a concrete type and the type assertion will only succeed if the type is identical.

https://golang.org/ref/spec#Type_assertions

This change will break downstream projects that are using the type, but I argue they can't be using it to any great benefit as it stands.