### PR TITLE
Do not override GOOS and GOARCH

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -121,12 +121,12 @@ common-docker-tag-latest:
 
 .PHONY: promu
 promu:
-	GOOS= GOARCH= $(GO) get -u github.com/prometheus/promu
+	$(GO) get -u github.com/prometheus/promu
 
 .PHONY: $(STATICCHECK)
 $(STATICCHECK):
-	GOOS= GOARCH= $(GO) get -u honnef.co/go/tools/cmd/staticcheck
+	$(GO) get -u honnef.co/go/tools/cmd/staticcheck
 
 .PHONY: $(GOVENDOR)
 $(GOVENDOR):
-	GOOS= GOARCH= $(GO) get -u github.com/kardianos/govendor
+	$(GO) get -u github.com/kardianos/govendor


### PR DESCRIPTION
The two variables should be in control by the user, not the Makefile.

I wanted to compile Prometheus on a Mac for Linux but was unable to do this, as the Makefile overrides my variables.

Signed-off-by: Jannick Fahlbusch <git@jf-projects.de>