### PR TITLE
discovery/openstack: discover all interfaces

### DIFF
--- a/discovery/openstack/instance.go
+++ b/discovery/openstack/instance.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	openstackLabelPrefix         = model.MetaLabelPrefix + "openstack_"
+	openstackLabelAddressPool    = openstackLabelPrefix + "address_pool"
 	openstackLabelInstanceID     = openstackLabelPrefix + "instance_id"
 	openstackLabelInstanceName   = openstackLabelPrefix + "instance_name"
 	openstackLabelInstanceStatus = openstackLabelPrefix + "instance_status"
@@ -184,7 +185,7 @@ func (i *InstanceDiscovery) refresh() (*targetgroup.Group, error) {
 				name := strutil.SanitizeLabelName(k)
 				labels[openstackLabelTagPrefix+model.LabelName(name)] = model.LabelValue(v)
 			}
-			for _, address := range s.Addresses {
+			for pool, address := range s.Addresses {
 				md, ok := address.([]interface{})
 				if !ok {
 					level.Warn(i.logger).Log("msg", "Invalid type for address, expected array")
@@ -212,6 +213,7 @@ func (i *InstanceDiscovery) refresh() (*targetgroup.Group, error) {
 					for k, v := range labels {
 						lbls[k] = v
 					}
+					lbls[openstackLabelAddressPool] = model.LabelValue(pool)
 					lbls[openstackLabelPrivateIP] = model.LabelValue(addr)
 					if val, ok := floatingIPList[floatingIPKey{id: s.ID, fixed: addr}]; ok {
 						lbls[openstackLabelPublicIP] = model.LabelValue(val)

--- a/discovery/openstack/instance_test.go
+++ b/discovery/openstack/instance_test.go
@@ -14,6 +14,7 @@
 package openstack
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -56,28 +57,58 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 	mock := &OpenstackSDInstanceTestSuite{}
 	mock.SetupTest(t)
 
-	instance, _ := mock.openstackAuthSuccess()
+	instance, err := mock.openstackAuthSuccess()
+	testutil.Ok(t, err)
+
 	tg, err := instance.refresh()
 
 	testutil.Ok(t, err)
 	testutil.Assert(t, tg != nil, "")
 	testutil.Assert(t, tg.Targets != nil, "")
-	testutil.Assert(t, len(tg.Targets) == 3, "")
+	testutil.Equals(t, 4, len(tg.Targets))
 
-	testutil.Equals(t, tg.Targets[0]["__address__"], model.LabelValue("10.0.0.32:0"))
-	testutil.Equals(t, tg.Targets[0]["__meta_openstack_instance_flavor"], model.LabelValue("1"))
-	testutil.Equals(t, tg.Targets[0]["__meta_openstack_instance_id"], model.LabelValue("ef079b0c-e610-4dfb-b1aa-b49f07ac48e5"))
-	testutil.Equals(t, tg.Targets[0]["__meta_openstack_instance_name"], model.LabelValue("herp"))
-	testutil.Equals(t, tg.Targets[0]["__meta_openstack_instance_status"], model.LabelValue("ACTIVE"))
-	testutil.Equals(t, tg.Targets[0]["__meta_openstack_private_ip"], model.LabelValue("10.0.0.32"))
-	testutil.Equals(t, tg.Targets[0]["__meta_openstack_public_ip"], model.LabelValue("10.10.10.2"))
-
-	testutil.Equals(t, tg.Targets[1]["__address__"], model.LabelValue("10.0.0.31:0"))
-	testutil.Equals(t, tg.Targets[1]["__meta_openstack_instance_flavor"], model.LabelValue("1"))
-	testutil.Equals(t, tg.Targets[1]["__meta_openstack_instance_id"], model.LabelValue("9e5476bd-a4ec-4653-93d6-72c93aa682ba"))
-	testutil.Equals(t, tg.Targets[1]["__meta_openstack_instance_name"], model.LabelValue("derp"))
-	testutil.Equals(t, tg.Targets[1]["__meta_openstack_instance_status"], model.LabelValue("ACTIVE"))
-	testutil.Equals(t, tg.Targets[1]["__meta_openstack_private_ip"], model.LabelValue("10.0.0.31"))
+	for i, lbls := range []model.LabelSet{
+		model.LabelSet{
+			"__address__":                      model.LabelValue("10.0.0.32:0"),
+			"__meta_openstack_instance_flavor": model.LabelValue("1"),
+			"__meta_openstack_instance_id":     model.LabelValue("ef079b0c-e610-4dfb-b1aa-b49f07ac48e5"),
+			"__meta_openstack_instance_status": model.LabelValue("ACTIVE"),
+			"__meta_openstack_instance_name":   model.LabelValue("herp"),
+			"__meta_openstack_private_ip":      model.LabelValue("10.0.0.32"),
+			"__meta_openstack_public_ip":       model.LabelValue("10.10.10.2"),
+		},
+		model.LabelSet{
+			"__address__":                      model.LabelValue("10.0.0.31:0"),
+			"__meta_openstack_instance_flavor": model.LabelValue("1"),
+			"__meta_openstack_instance_id":     model.LabelValue("9e5476bd-a4ec-4653-93d6-72c93aa682ba"),
+			"__meta_openstack_instance_status": model.LabelValue("ACTIVE"),
+			"__meta_openstack_instance_name":   model.LabelValue("derp"),
+			"__meta_openstack_private_ip":      model.LabelValue("10.0.0.31"),
+		},
+		model.LabelSet{
+			"__address__":                      model.LabelValue("10.0.0.33:0"),
+			"__meta_openstack_instance_flavor": model.LabelValue("4"),
+			"__meta_openstack_instance_id":     model.LabelValue("9e5476bd-a4ec-4653-93d6-72c93aa682bb"),
+			"__meta_openstack_instance_status": model.LabelValue("ACTIVE"),
+			"__meta_openstack_instance_name":   model.LabelValue("merp"),
+			"__meta_openstack_private_ip":      model.LabelValue("10.0.0.33"),
+			"__meta_openstack_tag_env":         model.LabelValue("prod"),
+		},
+		model.LabelSet{
+			"__address__":                      model.LabelValue("10.0.0.34:0"),
+			"__meta_openstack_instance_flavor": model.LabelValue("4"),
+			"__meta_openstack_instance_id":     model.LabelValue("9e5476bd-a4ec-4653-93d6-72c93aa682bb"),
+			"__meta_openstack_instance_status": model.LabelValue("ACTIVE"),
+			"__meta_openstack_instance_name":   model.LabelValue("merp"),
+			"__meta_openstack_private_ip":      model.LabelValue("10.0.0.34"),
+			"__meta_openstack_tag_env":         model.LabelValue("prod"),
+			"__meta_openstack_public_ip":       model.LabelValue("10.10.10.4"),
+		},
+	} {
+		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
+			testutil.Equals(t, lbls, tg.Targets[i])
+		})
+	}
 
 	mock.TearDownSuite()
 }

--- a/discovery/openstack/instance_test.go
+++ b/discovery/openstack/instance_test.go
@@ -76,6 +76,7 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 			"__meta_openstack_instance_name":   model.LabelValue("herp"),
 			"__meta_openstack_private_ip":      model.LabelValue("10.0.0.32"),
 			"__meta_openstack_public_ip":       model.LabelValue("10.10.10.2"),
+			"__meta_openstack_address_pool":    model.LabelValue("private"),
 		},
 		model.LabelSet{
 			"__address__":                      model.LabelValue("10.0.0.31:0"),
@@ -84,6 +85,7 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 			"__meta_openstack_instance_status": model.LabelValue("ACTIVE"),
 			"__meta_openstack_instance_name":   model.LabelValue("derp"),
 			"__meta_openstack_private_ip":      model.LabelValue("10.0.0.31"),
+			"__meta_openstack_address_pool":    model.LabelValue("private"),
 		},
 		model.LabelSet{
 			"__address__":                      model.LabelValue("10.0.0.33:0"),
@@ -92,6 +94,7 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 			"__meta_openstack_instance_status": model.LabelValue("ACTIVE"),
 			"__meta_openstack_instance_name":   model.LabelValue("merp"),
 			"__meta_openstack_private_ip":      model.LabelValue("10.0.0.33"),
+			"__meta_openstack_address_pool":    model.LabelValue("private"),
 			"__meta_openstack_tag_env":         model.LabelValue("prod"),
 		},
 		model.LabelSet{
@@ -101,6 +104,7 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 			"__meta_openstack_instance_status": model.LabelValue("ACTIVE"),
 			"__meta_openstack_instance_name":   model.LabelValue("merp"),
 			"__meta_openstack_private_ip":      model.LabelValue("10.0.0.34"),
+			"__meta_openstack_address_pool":    model.LabelValue("private"),
 			"__meta_openstack_tag_env":         model.LabelValue("prod"),
 			"__meta_openstack_public_ip":       model.LabelValue("10.10.10.4"),
 		},

--- a/discovery/openstack/mock_test.go
+++ b/discovery/openstack/mock_test.go
@@ -327,6 +327,11 @@ const serverListBody = `
 						"version": 4,
 						"addr": "10.0.0.32",
 						"OS-EXT-IPS:type": "fixed"
+					},
+					{
+						"version": 4,
+						"addr": "10.10.10.2",
+						"OS-EXT-IPS:type": "floating"
 					}
 				]
 			},
@@ -463,10 +468,19 @@ const serverListBody = `
 		"addresses": {
 			"private": [
 				{
-					"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:9e:89:be",
 					"version": 4,
-					"addr": "10.0.0.31",
+					"addr": "10.0.0.33",
 					"OS-EXT-IPS:type": "fixed"
+				},
+				{
+					"version": 4,
+					"addr": "10.0.0.34",
+					"OS-EXT-IPS:type": "fixed"
+				},
+				{
+					"version": 4,
+					"addr": "10.10.10.4",
+					"OS-EXT-IPS:type": "floating"
 				}
 			]
 		},
@@ -488,7 +502,7 @@ const serverListBody = `
 		"OS-SRV-USG:launched_at": "2014-09-25T13:04:49.000000",
 		"OS-EXT-SRV-ATTR:hypervisor_hostname": "devstack",
 		"flavor": {
-			"id": "1",
+			"id": "4",
 			"links": [
 				{
 					"href": "http://104.130.131.164:8774/fcad67a6189847c4aecfa3c81a05783b/flavors/1",
@@ -515,7 +529,9 @@ const serverListBody = `
 		"progress": 0,
 		"OS-EXT-STS:power_state": 1,
 		"config_drive": "",
-		"metadata": {}
+		"metadata": {
+			"env": "prod"
+		}
 	}
 	]
 }
@@ -543,10 +559,17 @@ const listOutput = `
             "pool": "nova"
         },
         {
-            "fixed_ip": "166.78.185.201",
+            "fixed_ip": "10.0.0.32",
             "id": "2",
             "instance_id": "ef079b0c-e610-4dfb-b1aa-b49f07ac48e5",
             "ip": "10.10.10.2",
+            "pool": "nova"
+        },
+        {
+            "fixed_ip": "10.0.0.34",
+            "id": "3",
+            "instance_id": "9e5476bd-a4ec-4653-93d6-72c93aa682bb",
+            "ip": "10.10.10.4",
             "pool": "nova"
         }
     ]

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -489,6 +489,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_openstack_instance_flavor`: the flavor of the OpenStack instance.
 * `__meta_openstack_public_ip`: the public IP of the OpenStack instance.
 * `__meta_openstack_private_ip`: the private IP of the OpenStack instance.
+* `__meta_openstack_address_pool`: the pool of the private IP.
 * `__meta_openstack_tag_<tagkey>`: each tag value of the instance.
 
 See below for the configuration options for OpenStack discovery:

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -477,8 +477,9 @@ The following meta labels are available on targets during [relabeling](#relabel_
 
 #### `instance`
 
-The `instance` role discovers one target per Nova instance. The target
-address defaults to the first private IP address of the instance.
+The `instance` role discovers one target per network interface of Nova
+instance. The target address defaults to the private IP address of the network
+interface.
 
 The following meta labels are available on targets during [relabeling](#relabel_config):
 


### PR DESCRIPTION
Closes #4339 

This PR discovers one target per network interface of Nova instance instead of picking one arbitrary IP address. I've tested with a local install and it works fine. If a private IP address is associated to a floating address, `__meta_openstack_public_ip` will be set. The only trick is to skip any floating IP address that may be listed in the `Addresses` map.

cc @alfarme that filed the corresponding issue.