### PR TITLE
EC2 Platform meta label

### DIFF
--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -43,6 +43,7 @@ const (
 	ec2LabelInstanceState   = ec2Label + "instance_state"
 	ec2LabelInstanceType    = ec2Label + "instance_type"
 	ec2LabelOwnerID         = ec2Label + "owner_id"
+	ec2LabelPlatform        = ec2Label + "platform"
 	ec2LabelPublicDNS       = ec2Label + "public_dns_name"
 	ec2LabelPublicIP        = ec2Label + "public_ip"
 	ec2LabelPrivateIP       = ec2Label + "private_ip"
@@ -247,6 +248,10 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 				labels[ec2LabelPrivateIP] = model.LabelValue(*inst.PrivateIpAddress)
 				addr := net.JoinHostPort(*inst.PrivateIpAddress, fmt.Sprintf("%d", d.port))
 				labels[model.AddressLabel] = model.LabelValue(addr)
+
+				if inst.Platform != nil {
+					labels[ec2LabelPlatform] = model.LabelValue(*inst.Platform)
+				}
 
 				if inst.PublicIpAddress != nil {
 					labels[ec2LabelPublicIP] = model.LabelValue(*inst.PublicIpAddress)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -406,6 +406,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_ec2_instance_type`: the type of the EC2 instance
 * `__meta_ec2_owner_id`: the ID of the AWS account that owns the EC2 instance
 * `__meta_ec2_primary_subnet_id`: the subnet ID of the primary network interface, if available
+* `__meta_ec2_platform`: the Operating System platform, set to 'windows' on Windows servers, absent otherwise
 * `__meta_ec2_private_ip`: the private IP address of the instance, if present
 * `__meta_ec2_public_dns_name`: the public DNS name of the instance, if available
 * `__meta_ec2_public_ip`: the public IP address of the instance, if available

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -405,8 +405,8 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_ec2_instance_state`: the state of the EC2 instance
 * `__meta_ec2_instance_type`: the type of the EC2 instance
 * `__meta_ec2_owner_id`: the ID of the AWS account that owns the EC2 instance
-* `__meta_ec2_primary_subnet_id`: the subnet ID of the primary network interface, if available
 * `__meta_ec2_platform`: the Operating System platform, set to 'windows' on Windows servers, absent otherwise
+* `__meta_ec2_primary_subnet_id`: the subnet ID of the primary network interface, if available
 * `__meta_ec2_private_ip`: the private IP address of the instance, if present
 * `__meta_ec2_public_dns_name`: the public DNS name of the instance, if available
 * `__meta_ec2_public_ip`: the public IP address of the instance, if available


### PR DESCRIPTION
Set __meta_ec2_platform label with the instance platform string. Set to 'windows' on Windows servers and absent otherwise. This is the only way to distinguish Linux from Windows EC2 instances.

Signed-off-by: Silvio Gissi <silvio@gissilabs.com>