### PR TITLE
Allow PromQL to register custom funcs

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -623,7 +623,7 @@ type EvalNodeHelper struct {
 	out Vector
 
 	// Caches.
-	// dropMetricName and label_*.
+	// DropMetricName and label_*.
 	dmn map[uint64]labels.Labels
 	// signatureFunc.
 	sigf map[uint64]uint64
@@ -638,8 +638,8 @@ type EvalNodeHelper struct {
 	resultMetric map[uint64]labels.Labels
 }
 
-// dropMetricName is a cached version of dropMetricName.
-func (enh *EvalNodeHelper) dropMetricName(l labels.Labels) labels.Labels {
+// DropMetricName is a cached version of DropMetricName.
+func (enh *EvalNodeHelper) DropMetricName(l labels.Labels) labels.Labels {
 	if enh.dmn == nil {
 		enh.dmn = make(map[uint64]labels.Labels, len(enh.out))
 	}
@@ -1389,7 +1389,7 @@ func (ev *evaluator) VectorscalarBinop(op ItemType, lhs Vector, rhs Scalar, swap
 		if keep {
 			lhsSample.V = value
 			if shouldDropMetricName(op) || returnBool {
-				lhsSample.Metric = enh.dropMetricName(lhsSample.Metric)
+				lhsSample.Metric = enh.DropMetricName(lhsSample.Metric)
 			}
 			enh.out = append(enh.out, lhsSample)
 		}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -50,6 +50,16 @@ type Function struct {
 	Call func(vals []Value, args Expressions, enh *EvalNodeHelper) Vector
 }
 
+// RegisterFunction allows to register custom functions into PromQL
+func RegisterFunction(fnName string, fn *Function) error {
+	if _, ok := functions[fnName]; ok {
+		return fmt.Errorf("unable to register function %s as it already exists", fnName)
+	}
+
+	functions[fnName] = fn
+	return nil
+}
+
 // === time() float64 ===
 func funcTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 	return Vector{Sample{Point: Point{
@@ -298,7 +308,7 @@ func funcClampMax(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 	max := vals[1].(Vector)[0].Point.V
 	for _, el := range vec {
 		enh.out = append(enh.out, Sample{
-			Metric: enh.dropMetricName(el.Metric),
+			Metric: enh.DropMetricName(el.Metric),
 			Point:  Point{V: math.Min(max, el.V)},
 		})
 	}
@@ -311,7 +321,7 @@ func funcClampMin(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 	min := vals[1].(Vector)[0].Point.V
 	for _, el := range vec {
 		enh.out = append(enh.out, Sample{
-			Metric: enh.dropMetricName(el.Metric),
+			Metric: enh.DropMetricName(el.Metric),
 			Point:  Point{V: math.Max(min, el.V)},
 		})
 	}
@@ -333,7 +343,7 @@ func funcRound(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 	for _, el := range vec {
 		v := math.Floor(el.V*toNearestInverse+0.5) / toNearestInverse
 		enh.out = append(enh.out, Sample{
-			Metric: enh.dropMetricName(el.Metric),
+			Metric: enh.DropMetricName(el.Metric),
 			Point:  Point{V: v},
 		})
 	}
@@ -498,7 +508,7 @@ func funcAbsent(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 func simpleFunc(vals []Value, enh *EvalNodeHelper, f func(float64) float64) Vector {
 	for _, el := range vals[0].(Vector) {
 		enh.out = append(enh.out, Sample{
-			Metric: enh.dropMetricName(el.Metric),
+			Metric: enh.DropMetricName(el.Metric),
 			Point:  Point{V: f(el.V)},
 		})
 	}
@@ -550,7 +560,7 @@ func funcTimestamp(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 	vec := vals[0].(Vector)
 	for _, el := range vec {
 		enh.out = append(enh.out, Sample{
-			Metric: enh.dropMetricName(el.Metric),
+			Metric: enh.DropMetricName(el.Metric),
 			Point:  Point{V: float64(el.T) / 1000},
 		})
 	}
@@ -850,7 +860,7 @@ func dateWrapper(vals []Value, enh *EvalNodeHelper, f func(time.Time) float64) V
 	for _, el := range vals[0].(Vector) {
 		t := time.Unix(int64(el.V), 0).UTC()
 		enh.out = append(enh.out, Sample{
-			Metric: enh.dropMetricName(el.Metric),
+			Metric: enh.DropMetricName(el.Metric),
 			Point:  Point{V: f(t)},
 		})
 	}


### PR DESCRIPTION
This PR attempts to achieve what is stated in https://github.com/prometheus/prometheus/issues/4522

As seen in the test case, this would allow us to register a custom function on PromQL and achieve use-cases that are not generic enough to be committed back into Prometheus. 

Kindly take a look and provide feedback.