### PR TITLE
zookeeper: fix panic

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -304,12 +304,12 @@ func (m *Manager) registerProviders(cfg sd_config.ServiceDiscoveryConfig, setNam
 	}
 	for _, c := range cfg.ServersetSDConfigs {
 		add(c, func() (Discoverer, error) {
-			return zookeeper.NewServersetDiscovery(c, log.With(m.logger, "discovery", "zookeeper")), nil
+			return zookeeper.NewServersetDiscovery(c, log.With(m.logger, "discovery", "zookeeper"))
 		})
 	}
 	for _, c := range cfg.NerveSDConfigs {
 		add(c, func() (Discoverer, error) {
-			return zookeeper.NewNerveDiscovery(c, log.With(m.logger, "discovery", "nerve")), nil
+			return zookeeper.NewNerveDiscovery(c, log.With(m.logger, "discovery", "nerve"))
 		})
 	}
 	for _, c := range cfg.EC2SDConfigs {

--- a/discovery/zookeeper/zookeeper.go
+++ b/discovery/zookeeper/zookeeper.go
@@ -115,12 +115,12 @@ type Discovery struct {
 }
 
 // NewNerveDiscovery returns a new Discovery for the given Nerve config.
-func NewNerveDiscovery(conf *NerveSDConfig, logger log.Logger) *Discovery {
+func NewNerveDiscovery(conf *NerveSDConfig, logger log.Logger) (*Discovery, error) {
 	return NewDiscovery(conf.Servers, time.Duration(conf.Timeout), conf.Paths, logger, parseNerveMember)
 }
 
 // NewServersetDiscovery returns a new Discovery for the given serverset config.
-func NewServersetDiscovery(conf *ServersetSDConfig, logger log.Logger) *Discovery {
+func NewServersetDiscovery(conf *ServersetSDConfig, logger log.Logger) (*Discovery, error) {
 	return NewDiscovery(conf.Servers, time.Duration(conf.Timeout), conf.Paths, logger, parseServersetMember)
 }
 
@@ -132,7 +132,7 @@ func NewDiscovery(
 	paths []string,
 	logger log.Logger,
 	pf func(data []byte, path string) (model.LabelSet, error),
-) *Discovery {
+) (*Discovery, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -143,7 +143,7 @@ func NewDiscovery(
 			c.SetLogger(treecache.NewZookeeperLogger(logger))
 		})
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	updates := make(chan treecache.ZookeeperTreeCacheEvent)
 	sd := &Discovery{
@@ -156,7 +156,7 @@ func NewDiscovery(
 	for _, path := range paths {
 		sd.treeCaches = append(sd.treeCaches, treecache.NewZookeeperTreeCache(conn, path, updates, logger))
 	}
-	return sd
+	return sd, nil
 }
 
 // Run implements the Discoverer interface.

--- a/discovery/zookeeper/zookeeper_test.go
+++ b/discovery/zookeeper/zookeeper_test.go
@@ -1,0 +1,32 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zookeeper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+)
+
+func TestNewDiscoveryError(t *testing.T) {
+	_, err := NewDiscovery(
+		[]string{"unreachable.test"},
+		time.Second, []string{"/"},
+		nil,
+		func(data []byte, path string) (model.LabelSet, error) { return nil, nil })
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}


### PR DESCRIPTION
The zookeeper SD constructor returned `nil` with no error when it couldn't couldn't connect to the server(s). Eventually it triggered a `panic` in the `Run()` method. The issue was already present in previous releases of Prometheus.

Closes #4668 