### PR TITLE
[FIX] EC2 DS: Check for existence of OwnerID

### DIFF
--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -241,9 +241,13 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 					continue
 				}
 				labels := model.LabelSet{
-					ec2LabelOwnerID:    model.LabelValue(*r.OwnerId),
 					ec2LabelInstanceID: model.LabelValue(*inst.InstanceId),
 				}
+
+				if r.OwnerId != nil {
+					labels[ec2LabelOwnerID] = model.LabelValue(*r.OwnerId)
+				}
+
 				labels[ec2LabelPrivateIP] = model.LabelValue(*inst.PrivateIpAddress)
 				addr := net.JoinHostPort(*inst.PrivateIpAddress, fmt.Sprintf("%d", d.port))
 				labels[model.AddressLabel] = model.LabelValue(addr)


### PR DESCRIPTION
Commit 1c89984 introduced the ability to expose the owner of the instance.
However, this breaks Prometheus if there is no OwnerID in the reservation (Eg. if you are using a private EC2-API introduced by #4333)

This is the reopened PR for #4638 (https://github.com/prometheus/prometheus/pull/4638#issuecomment-425393366)

Signed-off-by: Jannick Fahlbusch <git@jf-projects.de>

Closes https://github.com/prometheus/prometheus/pull/4672