### PR TITLE
Support discover instances from all projects

### DIFF
--- a/discovery/openstack/instance_test.go
+++ b/discovery/openstack/instance_test.go
@@ -48,6 +48,7 @@ func (s *OpenstackSDInstanceTestSuite) openstackAuthSuccess() (Discovery, error)
 		DomainName:       "12345",
 		Region:           "RegionOne",
 		Role:             "instance",
+		AllTenants:       true,
 	}
 	return NewDiscovery(&conf, nil)
 }

--- a/discovery/openstack/openstack.go
+++ b/discovery/openstack/openstack.go
@@ -27,7 +27,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
-
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
@@ -63,6 +62,7 @@ type SDConfig struct {
 	Region           string                `yaml:"region"`
 	RefreshInterval  model.Duration        `yaml:"refresh_interval,omitempty"`
 	Port             int                   `yaml:"port"`
+	AllTenants       bool                  `yaml:"all_tenants,omitempty"`
 	TLSConfig        config_util.TLSConfig `yaml:"tls_config,omitempty"`
 }
 
@@ -168,7 +168,7 @@ func NewDiscovery(conf *SDConfig, l log.Logger) (Discovery, error) {
 		return hypervisor, nil
 	case OpenStackRoleInstance:
 		instance := NewInstanceDiscovery(client, &opts,
-			time.Duration(conf.RefreshInterval), conf.Port, conf.Region, l)
+			time.Duration(conf.RefreshInterval), conf.Port, conf.Region, conf.AllTenants, l)
 		return instance, nil
 	default:
 		return nil, errors.New("unknown OpenStack discovery role")

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -531,6 +531,10 @@ region: <string>
 [ project_name: <string> ]
 [ project_id: <string> ]
 
+# Whether the service discovery should list all instances for all projects.
+# It is only relevant for the 'instance' role and usually requires admin permissions.
+[ all_tenants: <boolean> | default: false ]
+
 # Refresh interval to re-read the instance list.
 [ refresh_interval: <duration> | default = 60s ]
 


### PR DESCRIPTION
By default, OpenStack SD only queries for instances from specified project. To discover instances from other projects, users have to add more openstack_sd_configs for each project.

This patch adds `all_tenants` <bool> options to openstack_sd_configs. For example:

```YAML
- job_name: 'openstack_all_instances'
  openstack_sd_configs:
    - role: instance
      region: RegionOne
      identity_endpoint: http://<identity_server>/identity/v3
      username: <username>
      password: <super_secret_password>
      domain_name: Default
      all_tenants: true
```

This pull request is the follow-up work of #4449 .

Co-authored-by: Kien Nguyen <kiennt2609@gmail.com>
Signed-off-by: dmatosl <danielmatos.lima@gmail.com>