### PR TITLE
Adding private_dns_name to the list of ec2 labels which can be used i…

### DIFF
--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -45,6 +45,7 @@ const (
 	ec2LabelOwnerID         = ec2Label + "owner_id"
 	ec2LabelPublicDNS       = ec2Label + "public_dns_name"
 	ec2LabelPublicIP        = ec2Label + "public_ip"
+	ec2LabelPrivateDNS      = ec2Label + "private_dns_name"
 	ec2LabelPrivateIP       = ec2Label + "private_ip"
 	ec2LabelPrimarySubnetID = ec2Label + "primary_subnet_id"
 	ec2LabelSubnetID        = ec2Label + "subnet_id"
@@ -245,6 +246,7 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 					ec2LabelInstanceID: model.LabelValue(*inst.InstanceId),
 				}
 				labels[ec2LabelPrivateIP] = model.LabelValue(*inst.PrivateIpAddress)
+				labels[ec2LabelPrivateDNS] = model.LabelValue(*inst.PrivateDnsName)
 				addr := net.JoinHostPort(*inst.PrivateIpAddress, fmt.Sprintf("%d", d.port))
 				labels[model.AddressLabel] = model.LabelValue(addr)
 

--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -246,7 +246,9 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 					ec2LabelInstanceID: model.LabelValue(*inst.InstanceId),
 				}
 				labels[ec2LabelPrivateIP] = model.LabelValue(*inst.PrivateIpAddress)
-				labels[ec2LabelPrivateDNS] = model.LabelValue(*inst.PrivateDnsName)
+				if inst.PrivateDnsName != nil {
+					labels[ec2LabelPrivateDNS] = model.LabelValue(*inst.PrivateDnsName)
+				}
 				addr := net.JoinHostPort(*inst.PrivateIpAddress, fmt.Sprintf("%d", d.port))
 				labels[model.AddressLabel] = model.LabelValue(addr)
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -406,6 +406,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_ec2_instance_type`: the type of the EC2 instance
 * `__meta_ec2_owner_id`: the ID of the AWS account that owns the EC2 instance
 * `__meta_ec2_primary_subnet_id`: the subnet ID of the primary network interface, if available
+* `__meta_ec2_private_dns_name`: the private DNS name of the instance, if available
 * `__meta_ec2_private_ip`: the private IP address of the instance, if present
 * `__meta_ec2_public_dns_name`: the public DNS name of the instance, if available
 * `__meta_ec2_public_ip`: the public IP address of the instance, if available


### PR DESCRIPTION
…n node naming for dynamic environments