### PR TITLE
promql: fill_absent function support

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -109,6 +109,11 @@ Special cases are:
 * `Exp(+Inf) = +Inf`
 * `Exp(NaN) = NaN`
 
+## `fill_absent()`
+
+`fill_absent(v instant-vector, val=0 scalar)` fills all absent values in `v`
+to have all value of `val`.
+
 ## `floor()`
 
 `floor(v instant-vector)` rounds the sample values of all elements in `v` down

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -313,14 +313,14 @@ load 5m
 	test_fill_absent{src="fill-a"}	50
 	test_fill_absent{src="fill-b"}	100
 
-eval instant at 0m absent(test_fill_absent)
+eval instant at 0m fill_absent(test_fill_absent)
 	{src="fill-a"}	50
 	{src="fill-b"}	100
 
-eval instant at 50m absent(absen_nonexistent1{job="testjob", instance="testinstance", method=~".x"})
+eval instant at 50m fill_absent(absen_nonexistent1{job="testjob", instance="testinstance", method=~".x"})
 	{instance="testinstance", job="testjob"} 0
 
-eval instant at 0m absent(absen_nonexistent2{job="testjob", instance="testinstance", method=~".x"}, 50)
+eval instant at 0m fill_absent(absen_nonexistent2{job="testjob", instance="testinstance", method=~".x"}, 50)
 	{instance="testinstance", job="testjob"} 50
 
 # Tests for sort/sort_desc.

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -310,19 +310,18 @@ eval instant at 0m clamp_max(clamp_min(test_clamp, -20), 70)
 
 # Tests for fill_absent()
 load 5m
-	test_fill_absent{src="clamp-a"}	-50
-	test_fill_absent{src="clamp-b"}	NaN
-	test_fill_absent{src="clamp-c"}	100
+	test_fill_absent{src="fill-a"}	50
+	test_fill_absent{src="fill-b"}	100
 
-eval instant at 0m fill_absent(test_fill_absent)
-	{src="clamp-a"}	-50
-	{src="clamp-b"}	0
-	{src="clamp-c"}	100
+eval instant at 0m absent(test_fill_absent)
+	{src="fill-a"}	50
+	{src="fill-b"}	100
 
-eval instant at 0m fill_absent(test_fill_absent, 50)
-	{src="clamp-a"}	-50
-	{src="clamp-b"}	50
-	{src="clamp-c"}	100
+eval instant at 50m absent(absen_nonexistent1{job="testjob", instance="testinstance", method=~".x"})
+	{instance="testinstance", job="testjob"} 0
+
+eval instant at 0m absent(absen_nonexistent2{job="testjob", instance="testinstance", method=~".x"}, 50)
+	{instance="testinstance", job="testjob"} 50
 
 # Tests for sort/sort_desc.
 clear

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -317,11 +317,11 @@ eval instant at 0m fill_absent(test_fill_absent)
 	{src="fill-a"}	50
 	{src="fill-b"}	100
 
-eval instant at 50m fill_absent(nonexistent_metric{job="testjob", instance="testinstance", method=~".x"})
-	{instance="testinstance", job="testjob"} 0
+eval instant at 50m fill_absent(nonexistent_metric)
+	{} 0
 
-eval instant at 0m fill_absent(nonexistent_metric{job="testjob", instance="testinstance", method=~".x"}, 50)
-	{instance="testinstance", job="testjob"} 50
+eval instant at 0m fill_absent(nonexistent_metric, 50)
+	{} 50
 
 # Tests for sort/sort_desc.
 clear

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -308,6 +308,21 @@ eval instant at 0m clamp_max(clamp_min(test_clamp, -20), 70)
 	{src="clamp-b"}	0
 	{src="clamp-c"}	70
 
+# Tests for fill_absent()
+load 5m
+	test_fill_absent{src="clamp-a"}	-50
+	test_fill_absent{src="clamp-b"}	NaN
+	test_fill_absent{src="clamp-c"}	100
+
+eval instant at 0m fill_absent(test_fill_absent)
+	{src="clamp-a"}	-50
+	{src="clamp-b"}	0
+	{src="clamp-c"}	100
+
+eval instant at 0m fill_absent(test_fill_absent, 50)
+	{src="clamp-a"}	-50
+	{src="clamp-b"}	50
+	{src="clamp-c"}	100
 
 # Tests for sort/sort_desc.
 clear

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -317,10 +317,10 @@ eval instant at 0m fill_absent(test_fill_absent)
 	{src="fill-a"}	50
 	{src="fill-b"}	100
 
-eval instant at 50m fill_absent(absen_nonexistent1{job="testjob", instance="testinstance", method=~".x"})
+eval instant at 50m fill_absent(nonexistent_metric{job="testjob", instance="testinstance", method=~".x"})
 	{instance="testinstance", job="testjob"} 0
 
-eval instant at 0m fill_absent(absen_nonexistent2{job="testjob", instance="testinstance", method=~".x"}, 50)
+eval instant at 0m fill_absent(nonexistent_metric{job="testjob", instance="testinstance", method=~".x"}, 50)
 	{instance="testinstance", job="testjob"} 50
 
 # Tests for sort/sort_desc.


### PR DESCRIPTION
## Feature request ##
Ability to fill absent(empty) values with desired value, e.g. querying with
```
fill_absent(up)
```
will fill absent values with zeroes(by default).

Or explicitly with custom value:
```
fill_absent(up, 100)
```

This similar to what `clamp_max`, `clamp_min` and `absent` do.

Also, labels for empty values should be retained.
