### PR TITLE
Add ability to filter triton_sd targets by pre-defined groups

### DIFF
--- a/discovery/triton/triton_test.go
+++ b/discovery/triton/triton_test.go
@@ -55,6 +55,16 @@ var (
 			CertFile:           "shouldnotexist.cert",
 		},
 	}
+	groupsconf = SDConfig{
+		Account:         "testAccount",
+		DNSSuffix:       "triton.example.com",
+		Endpoint:        "127.0.0.1",
+		Groups:          []string{"foo", "bar"},
+		Port:            443,
+		Version:         1,
+		RefreshInterval: 1,
+		TLSConfig:       config.TLSConfig{InsecureSkipVerify: true},
+	}
 )
 
 func TestTritonSDNew(t *testing.T) {
@@ -74,6 +84,20 @@ func TestTritonSDNewBadConfig(t *testing.T) {
 	td, err := New(nil, &badconf)
 	testutil.NotOk(t, err, "")
 	testutil.Assert(t, td == nil, "")
+}
+
+func TestTritonSDNewGroupsConfig(t *testing.T) {
+	td, err := New(nil, &groupsconf)
+	testutil.Ok(t, err)
+	testutil.Assert(t, td != nil, "")
+	testutil.Assert(t, td.client != nil, "")
+	testutil.Assert(t, td.interval != 0, "")
+	testutil.Assert(t, td.sdConfig != nil, "")
+	testutil.Equals(t, groupsconf.Account, td.sdConfig.Account)
+	testutil.Equals(t, groupsconf.DNSSuffix, td.sdConfig.DNSSuffix)
+	testutil.Equals(t, groupsconf.Endpoint, td.sdConfig.Endpoint)
+	testutil.Equals(t, groupsconf.Groups, td.sdConfig.Groups)
+	testutil.Equals(t, groupsconf.Port, td.sdConfig.Port)
 }
 
 func TestTritonSDRun(t *testing.T) {
@@ -112,6 +136,7 @@ func TestTritonSDRefreshMultipleTargets(t *testing.T) {
 	var (
 		dstr = `{"containers":[
 		 	{
+                                "groups":["foo","bar","baz"],
 				"server_uuid":"44454c4c-5000-104d-8037-b7c04f5a5131",
 				"vm_alias":"server01",
 				"vm_brand":"lx",

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -929,10 +929,12 @@ discovery endpoints.
 
 The following meta labels are available on targets during relabeling:
 
-* `__meta_triton_machine_id`: the UUID of the target container
+* `__meta_triton_groups`: the list of groups belonging to the target joined by a comma separator
 * `__meta_triton_machine_alias`: the alias of the target container
+* `__meta_triton_machine_brand`: the brand of the target container
+* `__meta_triton_machine_id`: the UUID of the target container
 * `__meta_triton_machine_image`: the target containers image type
-* `__meta_triton_machine_server_id`: the server UUID for the target container
+* `__meta_triton_server_id`: the server UUID for the target container
 
 ```yaml
 # The information to access the Triton discovery API.
@@ -946,6 +948,11 @@ dns_suffix: <string>
 # The Triton discovery endpoint (e.g. 'cmon.us-east-3b.triton.zone'). This is
 # often the same value as dns_suffix.
 endpoint: <string>
+
+# A list of groups for which targets are retrieved. If omitted, all containers
+# available to the requesting account are scraped.
+groups: 
+  [ - <string> ... ]
 
 # The port to use for discovery and metric scraping.
 [ port: <int> | default = 9163 ]


### PR DESCRIPTION
Signed-off-by: Richard Kiene <richard.kiene@joyent.com>

As Triton and Manta installs have become substantially larger and customer reliance upon Prometheus has become more important, it has become painfully obvious that filtering is a necessary feature of Triton Service Discovery. This pull request leverages the newly added group filtering support that we've added to [Triton CMON](https://github.com/joyent/triton-cmon).

//cc: @fabxc @brian-brazil 