### PR TITLE
circleci: switch to 2.1 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 ---
-version: 2
+version: 2.1
 
 jobs:
   test:


### PR DESCRIPTION
See https://github.com/CircleCI-Public/config-preview-sdk/blob/master/docs/whats-new.md#whats-in-in-21-configuration for what is new with the 2.1 configuration. One of them is the ability to define reusable executors which would reduce duplication: the container image to use can be defined in one place and referenced across jobs.

It is mandatory to switch the version to `2.1` before using any feature from 2.1.

cc @SuperQ 