### PR TITLE
[FIX] Azure DS: Return error when request failed

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -551,13 +551,12 @@ func (client *azureClient) getNetworkInterfaceByID(networkInterfaceID string) (*
 
 	resp, err := client.nic.GetSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
 		return nil, autorest.NewErrorWithError(err, "network.InterfacesClient", "Get", resp, "Failure sending request")
 	}
 
 	result, err = client.nic.GetResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "network.InterfacesClient", "Get", resp, "Failure responding to request")
+		return nil, autorest.NewErrorWithError(err, "network.InterfacesClient", "Get", resp, "Failure responding to request")
 	}
 
 	return &result, nil


### PR DESCRIPTION
This fixes the issue that the error is swallowed when the request failed.

Signed-off-by: Jannick Fahlbusch <git@jf-projects.de>