### PR TITLE
add a metric for the last time we appended metrics to local storage

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -248,7 +248,7 @@ func main() {
 	level.Info(logger).Log("vm_limits", prom_runtime.VmLimits())
 
 	var (
-		localStorage  = &tsdb.ReadyStorage{}
+		localStorage  = tsdb.NewReadyStorage(prometheus.DefaultRegisterer)
 		remoteStorage = remote.NewStorage(log.With(logger, "component", "remote"), localStorage.StartTime, time.Duration(cfg.RemoteFlushDeadline))
 		fanoutStorage = storage.NewFanout(logger, localStorage, remoteStorage)
 	)


### PR DESCRIPTION
@krasi-georgiev as discussed on https://github.com/prometheus/tsdb/pull/401

I don't know how we could solve https://github.com/prometheus/tsdb/issues/395 because we kind of have to get that metric from within TSDB itself. We have no information about Head/WAL truncation and what the oldest metric timestamp is from Prometheus itself.

Signed-off-by: Callum Styan <callumstyan@gmail.com>