### PR TITLE
Reordering fields of String datetype

### DIFF
--- a/promql/value.go
+++ b/promql/value.go
@@ -47,8 +47,8 @@ const (
 
 // String represents a string value.
 type String struct {
-	V string
 	T int64
+	V string
 }
 
 func (s String) String() string {


### PR DESCRIPTION
Other types has timestamp as first field, but only String type has value as first field.

Signed-off-by: gangseok.lee <gangseok.lee@samsung.com>