### PR TITLE
web: deduplicate handler label for HTTP metrics

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -171,6 +171,14 @@ type Options struct {
 	RemoteReadConcurrencyLimit int
 }
 
+type instrumentHandlerFunc func(handlerName string, handler http.HandlerFunc) http.HandlerFunc
+
+func instrumentHandlerWithPrefix(prefix string) instrumentHandlerFunc {
+	return func(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
+		return instrumentHandler(prefix+handlerName, handler)
+	}
+}
+
 func instrumentHandler(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
 	return promhttp.InstrumentHandlerDuration(
 		requestDuration.MustCurryWith(prometheus.Labels{"handler": handlerName}),
@@ -434,7 +442,7 @@ func (h *Handler) Run(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.Handle("/", h.router)
 
-	av1 := route.New().WithInstrumentation(instrumentHandler)
+	av1 := route.New().WithInstrumentation(instrumentHandlerWithPrefix("/api/v1"))
 	h.apiV1.Register(av1)
 	apiPath := "/api"
 	if h.options.RoutePrefix != "/" {

--- a/web/web.go
+++ b/web/web.go
@@ -171,9 +171,7 @@ type Options struct {
 	RemoteReadConcurrencyLimit int
 }
 
-type instrumentHandlerFunc func(handlerName string, handler http.HandlerFunc) http.HandlerFunc
-
-func instrumentHandlerWithPrefix(prefix string) instrumentHandlerFunc {
+func instrumentHandlerWithPrefix(prefix string) func(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
 	return func(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
 		return instrumentHandler(prefix+handlerName, handler)
 	}


### PR DESCRIPTION
Some HTTP handlers for the UI and the API v1 have identical names (eg `alerts`, `rules`, ...) but the `handler` label for HTTP metrics didn't distinguish between them.

Before:

![image](https://user-images.githubusercontent.com/2587585/47089836-f15da500-d221-11e8-8fb1-5588bd6ada2b.png)

After:

![image](https://user-images.githubusercontent.com/2587585/47089372-038b1380-d221-11e8-9ab3-c74c065ca293.png)
