### PR TITLE
remote storage improve performance 

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -149,7 +149,7 @@ type QueueManager struct {
 	queueName      string
 	logLimiter     *rate.Limiter
 
-	shardsMtx   sync.Mutex
+	shardsMtx   sync.RWMutex
 	shards      *shards
 	numShards   int
 	reshardChan chan int
@@ -218,9 +218,9 @@ func (t *QueueManager) Append(s *model.Sample) error {
 		return nil
 	}
 
-	t.shardsMtx.Lock()
+	t.shardsMtx.RLock()
 	enqueued := t.shards.enqueue(&snew)
-	t.shardsMtx.Unlock()
+	t.shardsMtx.RUnlock()
 
 	if enqueued {
 		queueLength.WithLabelValues(t.queueName).Inc()


### PR DESCRIPTION
metrics  sync to remote storage affect local storage scrape due to the shardsMutex write lock，I  think read
lock for metrics enqueue is a good choose 。 our online services targets’ scrope get right  after upgrading to read lock。