### PR TITLE
use rangehead for queries and pre allocate chunk slices.

### DIFF
--- a/vendor/github.com/prometheus/tsdb/db.go
+++ b/vendor/github.com/prometheus/tsdb/db.go
@@ -793,7 +793,11 @@ func (db *DB) Querier(mint, maxt int64) (Querier, error) {
 		}
 	}
 	if maxt >= db.head.MinTime() {
-		blocks = append(blocks, db.head)
+		blocks = append(blocks, &rangeHead{
+			head: db.head,
+			mint: mint,
+			maxt: maxt,
+		})
 	}
 
 	sq := &querier{

--- a/vendor/github.com/prometheus/tsdb/querier.go
+++ b/vendor/github.com/prometheus/tsdb/querier.go
@@ -504,6 +504,14 @@ func (s *baseChunkSeries) Next() bool {
 		err      error
 	)
 
+	// Optimistically pre allocate the slices.
+	if lsetLen := len(s.lset); lsetLen > 0 {
+		lset = make(labels.Labels, lsetLen)
+	}
+	if chksLen := len(s.chks); chksLen > 0 {
+		chkMetas = make([]chunks.Meta, chksLen)
+	}
+
 	for s.p.Next() {
 		ref := s.p.At()
 		if err := s.index.Series(ref, &lset, &chkMetas); err != nil {


### PR DESCRIPTION
benching some tsdb optimisations from https://github.com/prometheus/tsdb/pull/351
Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>