### PR TITLE
Revert #4586

### DIFF
--- a/discovery/dns/dns.go
+++ b/discovery/dns/dns.go
@@ -181,6 +181,9 @@ func (d *Discovery) refresh(ctx context.Context, name string, ch chan<- []*targe
 		target := model.LabelValue("")
 		switch addr := record.(type) {
 		case *dns.SRV:
+			// Remove the final dot from rooted DNS names to make them look more usual.
+			addr.Target = strings.TrimRight(addr.Target, ".")
+
 			target = hostPort(addr.Target, int(addr.Port))
 		case *dns.A:
 			target = hostPort(addr.A.String(), d.port)


### PR DESCRIPTION
From #4586, @grobie:

> This is a breaking change and will change/invalidate relabel rules based on __address__ labels afaics. While I see the motivation for this change, it has serious side effects for users of the DNS discovery.

While is indeed breaking some people, it is also technically a bug. Not sure if we should keep it or revert it.