### PR TITLE
Fix promql benchmarks

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -32,7 +32,7 @@ func BenchmarkRangeQuery(b *testing.B) {
 		Logger:        nil,
 		Reg:           nil,
 		MaxConcurrent: 10,
-		MaxSamples:    10,
+		MaxSamples:    50000000,
 		Timeout:       100 * time.Second,
 	}
 	engine := NewEngine(opts)


### PR DESCRIPTION
Previously every benchmark was failing since they query more than 10 samples. MaxSamples now matches the default value used when starting Prometheus.

Signed-off-by: Chris Marchbanks <csmarchbanks@gmail.com>