### PR TITLE
improve remote storage enqueue performance

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -149,7 +149,7 @@ type QueueManager struct {
 	queueName      string
 	logLimiter     *rate.Limiter
 
-	shardsMtx   sync.Mutex
+	shardsMtx   sync.RWMutex
 	shards      *shards
 	numShards   int
 	reshardChan chan int
@@ -218,9 +218,9 @@ func (t *QueueManager) Append(s *model.Sample) error {
 		return nil
 	}
 
-	t.shardsMtx.Lock()
+	t.shardsMtx.RLock()
 	enqueued := t.shards.enqueue(&snew)
-	t.shardsMtx.Unlock()
+	t.shardsMtx.RUnlock()
 
 	if enqueued {
 		queueLength.WithLabelValues(t.queueName).Inc()


### PR DESCRIPTION
Signed-off-by: fyc <fyc22788@ly.com>
The writes of the remote store slows down the local storing performance, because the remote uses the write lock for enqueue. Read lock is better in this case as the metrics enqueue is not blocked. My app has benefited from the performance after using the read lock.
