### PR TITLE
Add documentation for new marathon-sd functionality

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -874,8 +874,12 @@ tls_config:
 
 By default every app listed in Marathon will be scraped by Prometheus. If not all
 of your services provide Prometheus metrics, you can use a Marathon label and
-Prometheus relabeling to control which instances will actually be scraped. Also
-by default all apps will show up as a single job in Prometheus (the one specified
+Prometheus relabeling to control which instances will actually be scraped.
+See [the Prometheus marathon-sd configuration file](/documentation/examples/prometheus-marathon.yml)
+for a practical example on how to set up your Marathon app and your Prometheus
+configuration.
+
+By default, all apps will show up as a single job in Prometheus (the one specified
 in the configuration file), which can also be changed using relabeling.
 
 ### `<nerve_sd_config>`

--- a/documentation/examples/prometheus-marathon.yml
+++ b/documentation/examples/prometheus-marathon.yml
@@ -1,0 +1,60 @@
+# A example scrape configuration for running Prometheus on a Marathon
+# (or DC/OS) cluster.
+
+scrape_configs:
+  
+  # Make Prometheus scrape itself for metrics.
+  - job_name: 'prometheus'
+    static_configs:
+    - targets: ['localhost:9090']
+
+  # Discover Marathon services to scrape.
+  - job_name: 'marathon'
+
+    # Scrape Marathon itself to discover new services every minute.
+    marathon_sd_configs:
+      - servers:
+        - http://marathon.mesos:8080
+        refresh_interval: 60s
+
+    relabel_configs:
+
+      # Only scrape targets that have a port label called 'metrics' specified on a port
+      # in their app definitions. Example using a port mapping (container or bridge networking):
+      #
+      #  "portMappings": [
+      #    {
+      #      "containerPort": 9091,
+      #      "name": "prometheus",
+      #      "labels": {
+      #        "metrics": "/metrics"
+      #      }
+      #    }
+      #  ]
+      #
+      # Or, in case your service uses host networking, using a port definition:
+      #
+      #  "portDefinitions" : [
+      #    {
+      #      "port" : 9091,
+      #      "name" : "prometheus",
+      #      "labels": {
+      #        "metrics": "/metrics"
+      #      }
+      #    }
+      #  ]
+
+      # Match a slash-prefixed string either in a portMapping or a portDefinition label.
+      - source_labels: [__meta_marathon_port_mapping_label_metrics,__meta_marathon_port_definition_label_metrics]
+        regex: (\/.+;|;\/.+)
+        action: keep
+
+      # If a portMapping 'metrics' label is set, use the label value as the URI to scrape.
+      - source_labels: [__meta_marathon_port_mapping_label_metrics]
+        regex: (\/.+)
+        target_label: __metrics_path__
+      
+      # If a portDefinition 'metrics' label is set, use the label value as the URI to scrape.
+      - source_labels: [__meta_marathon_port_definition_label_metrics]
+        regex: (\/.+)
+        target_label: __metrics_path__


### PR DESCRIPTION
Hi all

Since #4499 (bound to drop in 2.5.0(?)), the functionality has expanded somewhat, and the documentation leaves it pretty much up to the user to scour the (very few) resources on the internet on how to configure port labels and making it all work together. This can be quite daunting as a first-timer, so this example configuration might help.

This might not be in the correct format, but I tried following the convention of the existing Kubernetes example. It's dense on comments, but I figured it was a better place than putting it in `configuration.md` itself.

Please let me know how this can be improved, or if there's anything missing.