### PR TITLE
Makefile.common: use gotestsum if present

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,8 @@ jobs:
         key: v1-npm-deps-{{ checksum "web/ui/react-app/yarn.lock" }}
         paths:
         - web/ui/react-app/node_modules
+    - store_test_results:
+        path: test-results
   test_windows:
     executor: win/default
     working_directory: /go/src/github.com/prometheus/prometheus

--- a/Makefile.common
+++ b/Makefile.common
@@ -69,6 +69,15 @@ else
 	GO_BUILD_PLATFORM ?= $(GOHOSTOS)-$(GOHOSTARCH)
 endif
 
+GOTEST := $(GO) test
+GOTEST_DIR :=
+ifneq ($(CIRCLE_JOB),)
+ifneq ($(shell which gotestsum),)
+	GOTEST_DIR := test-results
+	GOTEST := gotestsum --junitfile $(GOTEST_DIR)/unit-tests.xml --
+endif
+endif
+
 PROMU_VERSION ?= 0.5.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
@@ -142,14 +151,17 @@ else
 endif
 
 .PHONY: common-test-short
-common-test-short:
+common-test-short: $(GOTEST_DIR)
 	@echo ">> running short tests"
-	GO111MODULE=$(GO111MODULE) $(GO) test -short $(GOOPTS) $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GOTEST) -short $(GOOPTS) $(pkgs)
 
 .PHONY: common-test
-common-test:
+common-test: $(GOTEST_DIR)
 	@echo ">> running all tests"
-	GO111MODULE=$(GO111MODULE) $(GO) test $(test-flags) $(GOOPTS) $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GOTEST) $(test-flags) $(GOOPTS) $(pkgs)
+
+$(GOTEST_DIR):
+	@mkdir -p $@
 
 .PHONY: common-format
 common-format:


### PR DESCRIPTION
Using gotestsum with CircleCI, we can gain more insights on failing tests. See https://circleci.com/docs/2.0/collect-test-data/ and https://circleci.com/blog/level-up-go-test-with-gotestsum/ for more details.

~~This can't be used currently for the Prometheus repository itself because of resource limitations in CircleCI but it is beneficial for the other repositories.~~