### PR TITLE
Included default flags into Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ WORKDIR    /prometheus
 ENTRYPOINT [ "/bin/prometheus", \
              "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "--web.console.templates=/usr/share/prometheus/consoles"]
+             "--web.console.templates=/usr/share/prometheus/consoles" ]
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ USER       nobody
 EXPOSE     9090
 VOLUME     [ "/prometheus" ]
 WORKDIR    /prometheus
-ENTRYPOINT [ "/bin/prometheus" ]
-CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+ENTRYPOINT [ "/bin/prometheus", \
              "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "--web.console.templates=/usr/share/prometheus/consoles" ]
+             "--web.console.templates=/usr/share/prometheus/consoles"]
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ VOLUME     [ "/prometheus" ]
 WORKDIR    /prometheus
 ENTRYPOINT [ "/bin/prometheus", \
              "--storage.tsdb.path=/prometheus", \
-             "--web.console.libraries=/usr/share/prometheus/console_libraries", \
-             "--web.console.templates=/usr/share/prometheus/consoles" ]
-CMD        [ "--config.file=/etc/prometheus/prometheus.yml" ]
+             "--web.console.libraries=/etc/prometheus/console_libraries", \
+             "--web.console.templates=/etc/prometheus/consoles", \
+             "--config.file=/etc/prometheus/prometheus.yml" ]


### PR DESCRIPTION
Fixes #4776  
Changes:
1. Moved common default flags into ENTRYPOINT to avoid re-entering all flags when custom flags is needed
2. Left `--config.file` flag in CMD since it's a flag that's likely to be changed and referred to by the user at a custom location.