### PR TITLE
Clarify label_replace()

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -258,6 +258,15 @@ timeseries is returned with the label `dst_label` replaced by the expansion of
 second etc. If the regular expression doesn't match then the timeseries is
 returned unchanged.
 
+If `src_label` and `dst_label` are the same, the label's value will be altered based on the regex. 
+If they are different, a new `dst_label` will be added.
+
+This example will add a new label "container_name" having the same values as "container" as (.+) selects everything:
+
+```
+label_replace(kube_pod_container_resource_requests_cpu_cores, "container_name", "$1", "container", "(.+)" )
+```
+
 This example will return a vector with each time series having a `foo`
 label with the value `a` added to it:
 

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -261,7 +261,7 @@ returned unchanged.
 If `src_label` and `dst_label` are the same, the label's value will be altered based on the regex. 
 If they are different, a new `dst_label` will be added.
 
-This example will add a new label "container_name" having the same values as "container" as (.+) selects everything:
+This example will add a new label "container_name" having the same values as "container" (if "container is not empty):
 
 ```
 label_replace(kube_pod_container_resource_requests_cpu_cores, "container_name", "$1", "container", "(.+)" )


### PR DESCRIPTION
It's a really useful function but I find the current docs too high level and "scientific" for people not so averse with monitoring to understand. The two sentences added might be implied from the already existing doc, but the conclusion is not straightforward.

It's best to simplify docs and terms in order for adoption to grow.