### PR TITLE
[promtool] Support writing output as json

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/api"
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
@@ -95,7 +96,17 @@ func main() {
 		"The unit test file.",
 	).Required().ExistingFiles()
 
-	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
+	parsedCmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	var p printer
+	switch *queryCmdFmt {
+	case "json":
+		p = &jsonPrinter{}
+	case "promql":
+		p = &promqlPrinter{}
+	}
+
+	switch parsedCmd {
 	case checkConfigCmd.FullCommand():
 		os.Exit(CheckConfig(*configFiles...))
 
@@ -106,13 +117,13 @@ func main() {
 		os.Exit(CheckMetrics())
 
 	case queryInstantCmd.FullCommand():
-		os.Exit(QueryInstant(*queryServer, *queryExpr, *queryCmdFmt))
+		os.Exit(QueryInstant(*queryServer, *queryExpr, p))
 
 	case queryRangeCmd.FullCommand():
-		os.Exit(QueryRange(*queryRangeServer, *queryRangeExpr, *queryRangeBegin, *queryRangeEnd, *queryRangeStep, *queryCmdFmt))
+		os.Exit(QueryRange(*queryRangeServer, *queryRangeExpr, *queryRangeBegin, *queryRangeEnd, *queryRangeStep, p))
 
 	case querySeriesCmd.FullCommand():
-		os.Exit(QuerySeries(*querySeriesServer, *querySeriesMatch, *querySeriesBegin, *querySeriesEnd, *queryCmdFmt))
+		os.Exit(QuerySeries(*querySeriesServer, *querySeriesMatch, *querySeriesBegin, *querySeriesEnd, p))
 
 	case debugPprofCmd.FullCommand():
 		os.Exit(debugPprof(*debugPprofServer))
@@ -124,7 +135,7 @@ func main() {
 		os.Exit(debugAll(*debugAllServer))
 
 	case queryLabelsCmd.FullCommand():
-		os.Exit(QueryLabels(*queryLabelsServer, *queryLabelsName, *queryCmdFmt))
+		os.Exit(QueryLabels(*queryLabelsServer, *queryLabelsName, p))
 
 	case testRulesCmd.FullCommand():
 		os.Exit(RulesUnitTest(*testRulesFiles...))
@@ -318,7 +329,7 @@ func CheckMetrics() int {
 }
 
 // QueryInstant performs an instant query against a Prometheus server.
-func QueryInstant(url, query, format string) int {
+func QueryInstant(url, query string, p printer) int {
 	config := api.Config{
 		Address: url,
 	}
@@ -341,18 +352,13 @@ func QueryInstant(url, query, format string) int {
 		return 1
 	}
 
-	if format == "json" {
-		json.NewEncoder(os.Stdout).Encode(val)
-		return 0
-	}
-
-	fmt.Println(val.String())
+	p.printValue(val)
 
 	return 0
 }
 
 // QueryRange performs a range query against a Prometheus server.
-func QueryRange(url, query, start, end string, step time.Duration, format string) int {
+func QueryRange(url, query, start, end string, step time.Duration, p printer) int {
 	config := api.Config{
 		Address: url,
 	}
@@ -407,17 +413,12 @@ func QueryRange(url, query, start, end string, step time.Duration, format string
 		return 1
 	}
 
-	if format == "json" {
-		json.NewEncoder(os.Stdout).Encode(val)
-		return 0
-	}
-
-	fmt.Println(val.String())
+	p.printValue(val)
 	return 0
 }
 
 // QuerySeries queries for a series against a Prometheus server.
-func QuerySeries(url *url.URL, matchers []string, start, end, format string) int {
+func QuerySeries(url *url.URL, matchers []string, start, end string, p printer) int {
 	config := api.Config{
 		Address: url.String(),
 	}
@@ -466,19 +467,12 @@ func QuerySeries(url *url.URL, matchers []string, start, end, format string) int
 		return 1
 	}
 
-	if format == "json" {
-		json.NewEncoder(os.Stdout).Encode(val)
-		return 0
-	}
-
-	for _, v := range val {
-		fmt.Println(v)
-	}
+	p.printSeries(val)
 	return 0
 }
 
 // QueryLabels queries for label values against a Prometheus server.
-func QueryLabels(url *url.URL, name, format string) int {
+func QueryLabels(url *url.URL, name string, p printer) int {
 	config := api.Config{
 		Address: url.String(),
 	}
@@ -501,14 +495,7 @@ func QueryLabels(url *url.URL, name, format string) int {
 		return 1
 	}
 
-	if format == "json" {
-		json.NewEncoder(os.Stdout).Encode(val)
-		return 0
-	}
-
-	for _, v := range val {
-		fmt.Println(v)
-	}
+	p.printLabelValues(val)
 	return 0
 }
 
@@ -578,4 +565,38 @@ func debugAll(url string) int {
 		return 1
 	}
 	return w.Write()
+}
+
+type printer interface {
+	printValue(v model.Value)
+	printSeries(v []model.LabelSet)
+	printLabelValues(v model.LabelValues)
+}
+
+type promqlPrinter struct{}
+
+func (p *promqlPrinter) printValue(v model.Value) {
+	fmt.Println(v)
+}
+func (p *promqlPrinter) printSeries(val []model.LabelSet) {
+	for _, v := range val {
+		fmt.Println(v)
+	}
+}
+func (j *promqlPrinter) printLabelValues(val model.LabelValues) {
+	for _, v := range val {
+		fmt.Println(v)
+	}
+}
+
+type jsonPrinter struct{}
+
+func (j *jsonPrinter) printValue(v model.Value) {
+	json.NewEncoder(os.Stdout).Encode(v)
+}
+func (j *jsonPrinter) printSeries(v []model.LabelSet) {
+	json.NewEncoder(os.Stdout).Encode(v)
+}
+func (j *jsonPrinter) printLabelValues(v model.LabelValues) {
+	json.NewEncoder(os.Stdout).Encode(v)
 }

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -26,7 +26,8 @@ func TestQueryRange(t *testing.T) {
 	s, getURL := mockServer(200, `{"status": "success", "data": {"resultType": "matrix", "result": []}}`)
 	defer s.Close()
 
-	exitCode := QueryRange(s.URL, "up", "0", "300", 0, "promql")
+	p := &promqlPrinter{}
+	exitCode := QueryRange(s.URL, "up", "0", "300", 0, p)
 	expectedPath := "/api/v1/query_range"
 	if getURL().Path != expectedPath {
 		t.Errorf("unexpected URL path %s (wanted %s)", getURL().Path, expectedPath)
@@ -43,7 +44,7 @@ func TestQueryRange(t *testing.T) {
 		t.Error()
 	}
 
-	exitCode = QueryRange(s.URL, "up", "0", "300", 10*time.Millisecond, "promql")
+	exitCode = QueryRange(s.URL, "up", "0", "300", 10*time.Millisecond, p)
 	if getURL().Path != expectedPath {
 		t.Errorf("unexpected URL path %s (wanted %s)", getURL().Path, expectedPath)
 	}

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -26,7 +26,7 @@ func TestQueryRange(t *testing.T) {
 	s, getURL := mockServer(200, `{"status": "success", "data": {"resultType": "matrix", "result": []}}`)
 	defer s.Close()
 
-	exitCode := QueryRange(s.URL, "up", "0", "300", 0)
+	exitCode := QueryRange(s.URL, "up", "0", "300", 0, "promql")
 	expectedPath := "/api/v1/query_range"
 	if getURL().Path != expectedPath {
 		t.Errorf("unexpected URL path %s (wanted %s)", getURL().Path, expectedPath)
@@ -43,7 +43,7 @@ func TestQueryRange(t *testing.T) {
 		t.Error()
 	}
 
-	exitCode = QueryRange(s.URL, "up", "0", "300", 10*time.Millisecond)
+	exitCode = QueryRange(s.URL, "up", "0", "300", 10*time.Millisecond, "promql")
 	if getURL().Path != expectedPath {
 		t.Errorf("unexpected URL path %s (wanted %s)", getURL().Path, expectedPath)
 	}


### PR DESCRIPTION
Oftentimes I'll want to execute something based on
the output from promtool, and supporting json
makes it easy to pull out values with a supporting
tool such as jq.

Signed-off-by: stuart nelson <stuartnelson3@gmail.com>