### PR TITLE
Fix goroutine leak in lexer/parser.

### DIFF
--- a/promql/lex.go
+++ b/promql/lex.go
@@ -434,6 +434,13 @@ func (l *lexer) run() {
 	close(l.items)
 }
 
+// Release resources used by lexer.
+func (l *lexer) close() {
+	for range l.items {
+		// Consume.
+	}
+}
+
 // lineComment is the character that starts a line comment.
 const lineComment = "#"
 

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -337,6 +337,7 @@ func (p *parser) recover(errp *error) {
 			*errp = e.(error)
 		}
 	}
+	p.lex.close()
 }
 
 // expr parses any expression.

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -1581,21 +1581,26 @@ func TestParseSeries(t *testing.T) {
 }
 
 func TestRecoverParserRuntime(t *testing.T) {
-	var p *parser
+	p := newParser("foo bar")
 	var err error
-	defer p.recover(&err)
 
+	defer func() {
+		if err != errUnexpected {
+			t.Fatalf("wrong error message: %q, expected %q", err, errUnexpected)
+		}
+
+		if _, ok := <-p.lex.items; ok {
+			t.Fatalf("lex.items was not closed")
+		}
+	}()
+	defer p.recover(&err)
 	// Cause a runtime panic.
 	var a []int
 	a[123] = 1
-
-	if err != errUnexpected {
-		t.Fatalf("wrong error message: %q, expected %q", err, errUnexpected)
-	}
 }
 
 func TestRecoverParserError(t *testing.T) {
-	var p *parser
+	p := newParser("foo bar")
 	var err error
 
 	e := fmt.Errorf("custom error")


### PR DESCRIPTION
When there was an error in the parser, the
lexer goroutine was left running.

Also make runtime panic test actually test things.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>