### PR TITLE
cmd/prometheus: buffer signal chans

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -395,7 +395,7 @@ func main() {
 	var g group.Group
 	{
 		// Termination handler.
-		term := make(chan os.Signal)
+		term := make(chan os.Signal, 1)
 		signal.Notify(term, os.Interrupt, syscall.SIGTERM)
 		cancel := make(chan struct{})
 		g.Add(
@@ -474,7 +474,7 @@ func main() {
 
 		// Make sure that sighup handler is registered with a redirect to the channel before the potentially
 		// long and synchronous tsdb init.
-		hup := make(chan os.Signal)
+		hup := make(chan os.Signal, 1)
 		signal.Notify(hup, syscall.SIGHUP)
 		cancel := make(chan struct{})
 		g.Add(


### PR DESCRIPTION
According to the GoDoc for os.Signal [0]:

> Package signal will not block sending to c: the caller must ensure that
> c has sufficient buffer space to keep up with the expected signal rate.
> For a channel used for notification of just one signal value, a buffer
> of size 1 is sufficient.

[0] https://golang.org/pkg/os/signal/#Notify

Signed-off-by: Lucas Serven <lserven@gmail.com>

cc @brancz @simonpasquier 