### PR TITLE
feat(azure_sd): Allow filtering VMs and scale sets by tags

### DIFF
--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -193,3 +193,155 @@ func TestMapFromVMScaleSetVMWithTags(t *testing.T) {
 		t.Errorf("Expected %v got %v", expectedVM, actualVM)
 	}
 }
+
+func TestIncludesTags(t *testing.T) {
+	empty := ""
+	a := "a"
+	a2 := "a"
+	b := "b"
+	c := "c"
+
+	// nil tags on vm
+	if !IncludesTags(
+		map[string]*string{},
+		nil,
+	) {
+		t.Error()
+	}
+
+	if IncludesTags(
+		map[string]*string{
+			"a": &a,
+		},
+		nil,
+	) {
+		t.Error()
+	}
+
+	// Empty tags
+	if !IncludesTags(
+		map[string]*string{},
+		&map[string]*string{},
+	) {
+		t.Error()
+	}
+
+	if !IncludesTags(
+		map[string]*string{},
+		&map[string]*string{
+			"empty": &empty,
+		},
+	) {
+		t.Error()
+	}
+
+	if !IncludesTags(
+		map[string]*string{},
+		&map[string]*string{
+			"a": &a,
+		},
+	) {
+		t.Error()
+	}
+
+	if !IncludesTags(
+		map[string]*string{
+			"a": &a,
+		},
+		&map[string]*string{
+			"a": &a,
+		},
+	) {
+		t.Error()
+	}
+
+	if !IncludesTags(
+		map[string]*string{
+			"a": &a,
+		},
+		&map[string]*string{
+			"a": &a2,
+		},
+	) {
+		t.Error()
+	}
+
+	if !IncludesTags(
+		map[string]*string{
+			"empty": &empty,
+		},
+		&map[string]*string{
+			"empty": &empty,
+		},
+	) {
+		t.Error()
+	}
+
+	if IncludesTags(
+		map[string]*string{
+			"empty": &empty,
+			"a":     &a,
+		},
+		&map[string]*string{
+			"empty": &empty,
+		},
+	) {
+		t.Error()
+	}
+
+	if IncludesTags(
+		map[string]*string{
+			"empty": &empty,
+			"a":     &a,
+		},
+		&map[string]*string{
+			"a": &a,
+		},
+	) {
+		t.Error()
+	}
+
+	if IncludesTags(
+		map[string]*string{
+			"a": &a,
+		},
+		&map[string]*string{
+			"a": &b,
+		},
+	) {
+		t.Error()
+	}
+
+	if IncludesTags(
+		map[string]*string{
+			"a": &a,
+		},
+		&map[string]*string{},
+	) {
+		t.Error()
+	}
+
+	if IncludesTags(
+		map[string]*string{
+			"empty": &empty,
+		},
+		&map[string]*string{},
+	) {
+		t.Error()
+	}
+
+	if IncludesTags(
+		map[string]*string{
+			"a": &a,
+			"b": &b,
+			"c": &c,
+		},
+		&map[string]*string{
+			"a": &a,
+			"b": &b,
+			"c": &a,
+		},
+	) {
+		t.Error()
+	}
+}


### PR DESCRIPTION
Currently with Azure service discovery there is no way to filter the VMs and scale sets that are scraped - the only option is to always scrape all servers.

This change extends `azure_sd_config` with a `tags` field. If tags are specified, only VMs and scale sets who's tags are a superset of the configured tags are scraped. This allows to scrape services only where they are running (e.g. to scrape the webserver stats only from VMs which are webservers).

I'm new to this codebase and to Go, so treat my code with suspicion :rofl: 