### PR TITLE
fix buf redeclared in scrapeloop

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -782,11 +782,8 @@ func (sl *scrapeLoop) run(interval, timeout time.Duration, errc chan<- error) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	buf := bytes.NewBuffer(make([]byte, 0, 16000))
-
 mainLoop:
 	for {
-		buf.Reset()
 		select {
 		case <-sl.ctx.Done():
 			close(sl.stopped)
@@ -809,7 +806,7 @@ mainLoop:
 		}
 
 		b := sl.buffers.Get(sl.lastScrapeSize).([]byte)
-		buf = bytes.NewBuffer(b)
+		buf := bytes.NewBuffer(b)
 
 		contentType, scrapeErr := sl.scraper.scrape(scrapeCtx, buf)
 		cancel()

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -809,7 +809,7 @@ mainLoop:
 		}
 
 		b := sl.buffers.Get(sl.lastScrapeSize).([]byte)
-		buf := bytes.NewBuffer(b)
+		buf = bytes.NewBuffer(b)
 
 		contentType, scrapeErr := sl.scraper.scrape(scrapeCtx, buf)
 		cancel()


### PR DESCRIPTION
buf Has been declared in line 785, I think it is unnecessary to declare a new variable again here.

Signed-off-by: arugakiWei <arugaki.wei@daocloud.io>