### PR TITLE
Populate series in the PromQL engine in two phases.

### DIFF
--- a/promql/ast.go
+++ b/promql/ast.go
@@ -112,6 +112,7 @@ type MatrixSelector struct {
 	LabelMatchers []*labels.Matcher
 
 	// The series are populated at query preparation time.
+	set    storage.SeriesSet
 	series []storage.Series
 }
 
@@ -145,6 +146,7 @@ type VectorSelector struct {
 	LabelMatchers []*labels.Matcher
 
 	// The series are populated at query preparation time.
+	set    storage.SeriesSet
 	series []storage.Series
 }
 


### PR DESCRIPTION
This allows other storage implementations (for instance, where Select might take more time to execute) to process multiple selects in the background and speed up queries.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>