### PR TITLE
Add replay to re-build alert state

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -365,6 +365,8 @@ func main() {
 				}
 				files = append(files, fs...)
 			}
+			// Add replay to re-build alert state
+			ruleManager.Replay(time.Duration(cfg.GlobalConfig.EvaluationInterval), files)
 			return ruleManager.Update(time.Duration(cfg.GlobalConfig.EvaluationInterval), files)
 		},
 	}

--- a/rules/fixtures/alerts.yaml
+++ b/rules/fixtures/alerts.yaml
@@ -1,0 +1,9 @@
+groups:
+  - name: test
+    rules:
+    - alert: http_requests_alerts
+      expr: http_requests > 100
+      for: 3m
+    - alert: db_requests_alerts
+      expr: db_requests > 100
+      for: 5m


### PR DESCRIPTION
If Prometheus crash or restarted, the on-the-fly alert state will be lost, we need to replay the rules within the holding duration to re-build alert state.

Signed-off-by: xiancli <xiancli@ebay.com>