### PR TITLE
added tsdb/head mint maxt metrics

### DIFF
--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -124,6 +124,46 @@ type Options struct {
 	NoLockfile bool
 }
 
+var (
+	startTime   prometheus.GaugeFunc
+	headMaxTime prometheus.GaugeFunc
+	headMinTime prometheus.GaugeFunc
+)
+
+func registerMetrics(db *tsdb.DB, r prometheus.Registerer) {
+
+	startTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_lowest_timestamp_millisecond",
+		Help: "Lowest timestamp value stored in the database.",
+	}, func() float64 {
+		bb := db.Blocks()
+		if len(bb) == 0 {
+			return float64(db.Head().MinTime())
+		}
+		return float64(db.Blocks()[0].Meta().MinTime)
+	})
+	headMaxTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_head_max_time_millisecond",
+		Help: "Maximum timestamp of the head block.",
+	}, func() float64 {
+		return float64(db.Head().MaxTime())
+	})
+	headMinTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_head_min_time_millisecond",
+		Help: "Minimum time bound of the head block.",
+	}, func() float64 {
+		return float64(db.Head().MinTime())
+	})
+
+	if r != nil {
+		r.MustRegister(
+			startTime,
+			headMaxTime,
+			headMinTime,
+		)
+	}
+}
+
 // Open returns a new storage backed by a TSDB database that is configured for Prometheus.
 func Open(path string, l log.Logger, r prometheus.Registerer, opts *Options) (*tsdb.DB, error) {
 	if opts.MinBlockDuration > opts.MaxBlockDuration {
@@ -149,6 +189,8 @@ func Open(path string, l log.Logger, r prometheus.Registerer, opts *Options) (*t
 	if err != nil {
 		return nil, err
 	}
+	registerMetrics(db, r)
+
 	return db, nil
 }
 

--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -133,26 +133,26 @@ var (
 func registerMetrics(db *tsdb.DB, r prometheus.Registerer) {
 
 	startTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_lowest_timestamp_millisecond",
+		Name: "prometheus_tsdb_lowest_timestamp_second",
 		Help: "Lowest timestamp value stored in the database.",
 	}, func() float64 {
 		bb := db.Blocks()
 		if len(bb) == 0 {
-			return float64(db.Head().MinTime())
+			return float64(db.Head().MinTime()) / 1000
 		}
-		return float64(db.Blocks()[0].Meta().MinTime)
-	})
-	headMaxTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_max_time_millisecond",
-		Help: "Maximum timestamp of the head block.",
-	}, func() float64 {
-		return float64(db.Head().MaxTime())
+		return float64(db.Blocks()[0].Meta().MinTime) / 1000
 	})
 	headMinTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_min_time_millisecond",
+		Name: "prometheus_tsdb_head_min_time_second",
 		Help: "Minimum time bound of the head block.",
 	}, func() float64 {
-		return float64(db.Head().MinTime())
+		return float64(db.Head().MinTime()) / 1000
+	})
+	headMaxTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_head_max_time_second",
+		Help: "Maximum timestamp of the head block.",
+	}, func() float64 {
+		return float64(db.Head().MaxTime()) / 1000
 	})
 
 	if r != nil {

--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -133,7 +133,7 @@ var (
 func registerMetrics(db *tsdb.DB, r prometheus.Registerer) {
 
 	startTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_lowest_timestamp_second",
+		Name: "prometheus_tsdb_lowest_timestamp_seconds",
 		Help: "Lowest timestamp value stored in the database.",
 	}, func() float64 {
 		bb := db.Blocks()
@@ -143,13 +143,13 @@ func registerMetrics(db *tsdb.DB, r prometheus.Registerer) {
 		return float64(db.Blocks()[0].Meta().MinTime) / 1000
 	})
 	headMinTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_min_time_second",
+		Name: "prometheus_tsdb_head_min_time_seconds",
 		Help: "Minimum time bound of the head block.",
 	}, func() float64 {
 		return float64(db.Head().MinTime()) / 1000
 	})
 	headMaxTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_max_time_second",
+		Name: "prometheus_tsdb_head_max_time_seconds",
 		Help: "Maximum timestamp of the head block.",
 	}, func() float64 {
 		return float64(db.Head().MaxTime()) / 1000

--- a/storage/tsdb/tsdb_export_test.go
+++ b/storage/tsdb/tsdb_export_test.go
@@ -1,0 +1,21 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+// Export the internal variables only for tests.
+var (
+	StartTime   = &startTime
+	HeadMaxTime = &headMaxTime
+	HeadMinTime = &headMinTime
+)

--- a/storage/tsdb/tsdb_test.go
+++ b/storage/tsdb/tsdb_test.go
@@ -1,0 +1,64 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb_test
+
+import (
+	"math"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/storage/tsdb"
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestMetrics(t *testing.T) {
+	db := testutil.NewStorage(t)
+	defer db.Close()
+
+	metrics := &dto.Metric{}
+	startTime := *tsdb.StartTime
+	headMinTime := *tsdb.HeadMinTime
+	headMaxTime := *tsdb.HeadMaxTime
+
+	// Check initial values.
+	testutil.Ok(t, startTime.Write(metrics))
+	testutil.Equals(t, float64(math.MaxInt64), metrics.Gauge.GetValue())
+
+	testutil.Ok(t, headMinTime.Write(metrics))
+	testutil.Equals(t, float64(math.MaxInt64), metrics.Gauge.GetValue())
+
+	testutil.Ok(t, headMaxTime.Write(metrics))
+	testutil.Equals(t, float64(math.MinInt64), metrics.Gauge.GetValue())
+
+	app, err := db.Appender()
+	testutil.Ok(t, err)
+
+	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 1, 1)
+	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 2, 1)
+	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 3, 1)
+	testutil.Ok(t, app.Commit())
+
+	// Check after adding some samples.
+	testutil.Ok(t, startTime.Write(metrics))
+	testutil.Equals(t, float64(1), metrics.Gauge.GetValue())
+
+	testutil.Ok(t, headMinTime.Write(metrics))
+	testutil.Equals(t, float64(1), metrics.Gauge.GetValue())
+
+	testutil.Ok(t, headMaxTime.Write(metrics))
+	testutil.Equals(t, float64(3), metrics.Gauge.GetValue())
+
+}

--- a/storage/tsdb/tsdb_test.go
+++ b/storage/tsdb/tsdb_test.go
@@ -14,7 +14,6 @@
 package tsdb_test
 
 import (
-	"math"
 	"testing"
 
 	dto "github.com/prometheus/client_model/go"
@@ -35,13 +34,13 @@ func TestMetrics(t *testing.T) {
 
 	// Check initial values.
 	testutil.Ok(t, startTime.Write(metrics))
-	testutil.Equals(t, float64(math.MaxInt64), metrics.Gauge.GetValue())
+	testutil.Equals(t, float64(model.Latest)/1000, metrics.Gauge.GetValue())
 
 	testutil.Ok(t, headMinTime.Write(metrics))
-	testutil.Equals(t, float64(math.MaxInt64), metrics.Gauge.GetValue())
+	testutil.Equals(t, float64(model.Latest)/1000, metrics.Gauge.GetValue())
 
 	testutil.Ok(t, headMaxTime.Write(metrics))
-	testutil.Equals(t, float64(math.MinInt64), metrics.Gauge.GetValue())
+	testutil.Equals(t, float64(model.Earliest)/1000, metrics.Gauge.GetValue())
 
 	app, err := db.Appender()
 	testutil.Ok(t, err)
@@ -53,12 +52,12 @@ func TestMetrics(t *testing.T) {
 
 	// Check after adding some samples.
 	testutil.Ok(t, startTime.Write(metrics))
-	testutil.Equals(t, float64(1), metrics.Gauge.GetValue())
+	testutil.Equals(t, 0.001, metrics.Gauge.GetValue())
 
 	testutil.Ok(t, headMinTime.Write(metrics))
-	testutil.Equals(t, float64(1), metrics.Gauge.GetValue())
+	testutil.Equals(t, 0.001, metrics.Gauge.GetValue())
 
 	testutil.Ok(t, headMaxTime.Write(metrics))
-	testutil.Equals(t, float64(3), metrics.Gauge.GetValue())
+	testutil.Equals(t, 0.003, metrics.Gauge.GetValue())
 
 }


### PR DESCRIPTION
added the head metrics with the correct suffix.

fixes #4882 
fixes https://github.com/prometheus/tsdb/issues/395

The original issue in https://github.com/prometheus/prometheus/issues/4882 requests these to be in seconds, but in my optionion we shouldn't loose the precision and convert this at query time.

cc @SuperQ 	, @simonpasquier 

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>