### PR TITLE
fix deadlock in scrape manager

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -110,6 +110,7 @@ func (m *Manager) reload() {
 			scrapeConfig, ok := m.scrapeConfigs[setName]
 			if !ok {
 				level.Error(m.logger).Log("msg", "error reloading target set", "err", "invalid config id:"+setName)
+				m.mtxScrape.Unlock()
 				return
 			}
 			sp = newScrapePool(scrapeConfig, m.append, log.With(m.logger, "scrape_pool", setName))


### PR DESCRIPTION
Scrape manager will fall in deadlock when we reload configs frequently.

Situation:
We don't use prometheus discovery to re-config our targets. As instead, we implemented an external discoverer to generate static scrape config. So it will reload prometheus when some configs are changed. 
When it reloads prometheus in a high frequency (~ 20/min), prometheus gets stuck occasionally.

The logic of the deadlock is:
```go
func (m *Manager) reload() {
	m.mtxScrape.Lock()
	var wg sync.WaitGroup
	// m.targetSets is from discovery. It's from old config.
	for setName, groups := range m.targetSets {
		var sp *scrapePool
		// m.scrapePools and m.scrapeConfigs are from new config.
		// New config has deleted some static scrape job. So it causes error.
		existing, ok := m.scrapePools[setName]
		if !ok {
			scrapeConfig, ok := m.scrapeConfigs[setName]
			if !ok {
				level.Error(m.logger).Log("msg", "error reloading target set", "err", "invalid config id:"+setName)
				return
			}
			sp = newScrapePool(scrapeConfig, m.append, log.With(m.logger, "scrape_pool", setName))
			m.scrapePools[setName] = sp
		} else {
			sp = existing
		}

		wg.Add(1)
		go func(sp *scrapePool, groups []*targetgroup.Group) {
			sp.Sync(groups)
			wg.Done()
		}(sp, groups)

	}
	m.mtxScrape.Unlock()
	wg.Wait()
}
```


