### PR TITLE
discovery/dns: add trim_final_dot option for SRV records

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -218,6 +218,7 @@ var expectedConf = &Config{
 						},
 						RefreshInterval: model.Duration(15 * time.Second),
 						Type:            "SRV",
+						TrimFinalDot:    false,
 					},
 					{
 						Names: []string{
@@ -225,6 +226,7 @@ var expectedConf = &Config{
 						},
 						RefreshInterval: model.Duration(30 * time.Second),
 						Type:            "SRV",
+						TrimFinalDot:    true,
 					},
 				},
 			},

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -95,9 +95,11 @@ scrape_configs:
     names:
     - first.dns.address.domain.com
     - second.dns.address.domain.com
+    trim_final_dot: false
   - names:
     - first.dns.address.domain.com
     # refresh_interval defaults to 30s.
+    # trim_final_dot defaults to true.
 
   relabel_configs:
   - source_labels: [job]

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -405,6 +405,9 @@ names:
 
 # The time after which the provided names are refreshed.
 [ refresh_interval: <duration> | default = 30s ]
+
+# Trim the final dot from SRV records.
+[ trim_final_dot: <boolean> | default = true ]
 ```
 
 Where `<domain_name>` is a valid DNS domain name.


### PR DESCRIPTION
Closes #3196

Following @juliusv's [suggestion](https://github.com/prometheus/prometheus/issues/3196#issuecomment-432663344), I've implemented an additional configuration option (`trim_final_dot`) that controls the removal of the leading dot. The default value is `true` to preserve the existing behavior.

cc @bboreham @grobie 