### PR TITLE
web: group targets by job then instance

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -55,7 +55,6 @@ import (
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/notifier"
-	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
@@ -702,7 +701,8 @@ func (h *Handler) targets(w http.ResponseWriter, r *http.Request) {
 	tps := h.scrapeManager.TargetsActive()
 	for _, targets := range tps {
 		sort.Slice(targets, func(i, j int) bool {
-			return targets[i].Labels().Get(labels.InstanceName) < targets[j].Labels().Get(labels.InstanceName)
+			return targets[i].Labels().Get(model.JobLabel) < targets[j].Labels().Get(model.JobLabel) ||
+				targets[i].Labels().Get(model.InstanceLabel) < targets[j].Labels().Get(model.InstanceLabel)
 		})
 	}
 


### PR DESCRIPTION
Closes #4853

After #4526 the targets page no longer groups the targets by job label but by scrape configuration name. This change ensures that targets inside a scrape configuration are sorted by job then instance.