### PR TITLE
Use `USER 99`instead of 'USER nobody' in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles
 RUN mkdir -p /prometheus && \
     chown -R nobody:nogroup etc/prometheus /prometheus
 
-USER       nobody
+# use 'USER 99' instead of 'USER nobody' because Kubernetes can't verify non numeric users.
+USER       99
 EXPOSE     9090
 VOLUME     [ "/prometheus" ]
 WORKDIR    /prometheus


### PR DESCRIPTION
User "nobody" has `id=99`, for Kubernetes, in order to run container as low privileged user, necessary to specify numeric `USER` in docker image, because Kubernetes can't verify non numeric users.