### PR TITLE
Pass through content-type for non-compressed output.

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -480,7 +480,10 @@ func (s *targetScraper) scrape(ctx context.Context, w io.Writer) (string, error)
 
 	if resp.Header.Get("Content-Encoding") != "gzip" {
 		_, err = io.Copy(w, resp.Body)
-		return "", err
+		if err != nil {
+			return "", err
+		}
+		return resp.Header.Get("Content-Type"), nil
 	}
 
 	if s.gzipr == nil {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1212,9 +1212,11 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 	}
 	var buf bytes.Buffer
 
-	if _, err := ts.scrape(context.Background(), &buf); err != nil {
+	contentType, err := ts.scrape(context.Background(), &buf)
+	if err != nil {
 		t.Fatalf("Unexpected scrape error: %s", err)
 	}
+	require.Equal(t, "text/plain; version=0.0.4", contentType)
 	require.Equal(t, "metric_a 1\nmetric_b 2\n", buf.String())
 }
 


### PR DESCRIPTION
Fixes #4911

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>