### PR TITLE
Introduce min_shards for remote write to set minimum number of shards.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -111,6 +111,7 @@ var (
 		// With a maximum of 1000 shards, assuming an average of 100ms remote write
 		// time and 100 samples per batch, we will be able to push 1M samples/s.
 		MaxShards:         1000,
+		MinShards:         1,
 		MaxSamplesPerSend: 100,
 
 		// By default, buffer 100 batches, which at 100ms per batch is 10s. At
@@ -647,6 +648,9 @@ type QueueConfig struct {
 
 	// Max number of shards, i.e. amount of concurrency.
 	MaxShards int `yaml:"max_shards,omitempty"`
+
+	// Min number of shards, i.e. amount of concurrency.
+	MinShards int `yaml:"min_shards,omitempty"`
 
 	// Maximum number of samples per send.
 	MaxSamplesPerSend int `yaml:"max_samples_per_send,omitempty"`

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1242,6 +1242,8 @@ queue_config:
   [ capacity: <int> | default = 10000 ]
   # Maximum number of shards, i.e. amount of concurrency.
   [ max_shards: <int> | default = 1000 ]
+  # Minimum number of shards, i.e. amount of concurrency.
+  [ min_shards: <int> | default = 1 ]
   # Maximum number of samples per send.
   [ max_samples_per_send: <int> | default = 100]
   # Maximum time a sample will wait in buffer.

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -177,7 +177,7 @@ func NewQueueManager(logger log.Logger, cfg config.QueueConfig, externalLabels m
 		queueName:      client.Name(),
 
 		logLimiter:  rate.NewLimiter(logRateLimit, logBurst),
-		numShards:   1,
+		numShards:   cfg.MinShards,
 		reshardChan: make(chan int),
 		quit:        make(chan struct{}),
 
@@ -326,8 +326,8 @@ func (t *QueueManager) calculateDesiredShards() {
 	numShards := int(math.Ceil(desiredShards))
 	if numShards > t.cfg.MaxShards {
 		numShards = t.cfg.MaxShards
-	} else if numShards < 1 {
-		numShards = 1
+	} else if numShards < t.cfg.MinShards {
+		numShards = t.cfg.MinShards
 	}
 	if numShards == t.numShards {
 		return


### PR DESCRIPTION
After starting Prometheus, number of shards is set to 1 initially and it causes `Remote storage queue full, discarding sample` in heavy-load environment before scaling out shards.
(I have initially implemented `initial_shards` but just after starting Prometheus, it scales down to 1 shard automatically)

This PR introduces `min_shards` parameter that is used as an initial and minimum number of shards.