### PR TITLE
bug fixed: wait for interval-now%interval to make sure target will be collected at a fixed point within an interval

### DIFF
--- a/scrape/target.go
+++ b/scrape/target.go
@@ -129,7 +129,7 @@ func (t *Target) offset(interval time.Duration) time.Duration {
 	now := time.Now().UnixNano()
 
 	var (
-		base   = now % int64(interval)
+		base   = int64(interval) - now%int64(interval)
 		offset = t.hash() % uint64(interval)
 		next   = base + int64(offset)
 	)


### PR DESCRIPTION
Issue:
each target will not be collect at a fixed position in each interval and this position will be determined randomly according to the prometheus start time.
Senario: 
Suppose interval = 1m, now= 11:00:21, offset = 10s, this target will be collect at 11:00:52(wait 21+10s), but I doubt if it makes sense. But this target should be at collect at 11:01:10.
