### PR TITLE
Add sequential rule evaluation in a group for remote storage backend

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -474,6 +474,9 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 			} else {
 				g.seriesInPreviousEval[i] = seriesReturned
 			}
+
+			// commit sync to wait remote storage call completed
+			storage.CommitAsyncStatus(rule.Name())
 		}(i, rule)
 	}
 }

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -63,9 +63,14 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 	// Update write queues
 
 	newQueues := []*QueueManager{}
+	storage.RemoteStorageCount = 0
 	// TODO: we should only stop & recreate queues which have changes,
 	// as this can be quite disruptive.
 	for i, rwConf := range conf.RemoteWriteConfigs {
+		if storage.MaximumTimeout < rwConf.RemoteTimeout {
+			storage.MaximumTimeout = rwConf.RemoteTimeout
+		}
+		storage.RemoteStorageCount++
 		c, err := NewClient(i, &ClientConfig{
 			URL:              rwConf.URL,
 			Timeout:          rwConf.RemoteTimeout,

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -26,6 +26,8 @@ func (s *Storage) Appender() (storage.Appender, error) {
 
 // Add implements storage.Appender.
 func (s *Storage) Add(l labels.Labels, t int64, v float64) (uint64, error) {
+	storage.IncAsyncStatus(l.Get(labels.MetricName))
+
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	for _, q := range s.queues {

--- a/storage/remote_async.go
+++ b/storage/remote_async.go
@@ -1,0 +1,99 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/common/model"
+)
+
+// Maximum timeout of the remote storage call
+var (
+	MaximumTimeout     model.Duration
+	RemoteStorageCount int
+)
+
+type AsyncStatus struct {
+	mtx       sync.RWMutex
+	waitGroup map[string]*sync.WaitGroup
+}
+
+var asyncStatus = &AsyncStatus{
+	waitGroup: map[string]*sync.WaitGroup{},
+}
+
+// IncAsyncStatus increase the wait group
+func IncAsyncStatus(ruleName string) {
+	if len(ruleName) >= 0 {
+		asyncStatus.mtx.Lock()
+		defer asyncStatus.mtx.Unlock()
+		wg, ok := asyncStatus.waitGroup[ruleName]
+		if !ok {
+			wg = &sync.WaitGroup{}
+		}
+		wg.Add(RemoteStorageCount)
+		asyncStatus.waitGroup[ruleName] = wg
+	}
+}
+
+// DescAsyncStatus decrease the wait group
+func DescAsyncStatus(ruleName string) {
+	if len(ruleName) >= 0 {
+		asyncStatus.mtx.Lock()
+		defer asyncStatus.mtx.Unlock()
+		if wg, ok := asyncStatus.waitGroup[ruleName]; ok {
+			wg.Done()
+		}
+	}
+}
+
+// CommitAsyncStatus wait async remote write completed
+func CommitAsyncStatus(ruleName string) {
+	if len(ruleName) >= 0 {
+		wg := GetAsyncStatusWaitGroup(ruleName)
+		if wg != nil {
+			if mt, err := time.ParseDuration(MaximumTimeout.String()); err == nil {
+				defer delete(asyncStatus.waitGroup, ruleName)
+				WaitWithTimeout(wg, mt)
+			}
+		}
+	}
+}
+
+// GetAsyncStatusWaitGroup get async status wait group from cache for specific rule
+func GetAsyncStatusWaitGroup(ruleName string) *sync.WaitGroup {
+	asyncStatus.mtx.RLock()
+	defer asyncStatus.mtx.RUnlock()
+	if wg, ok := asyncStatus.waitGroup[ruleName]; ok {
+		return wg
+	}
+	return nil
+}
+
+// WaitWithTimeout add timeout for wait group
+func WaitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return false
+	case <-time.After(timeout):
+		return true
+	}
+}


### PR DESCRIPTION
Sometimes remote write service is synchronized. However, remote storage queue manager in prometheus doesn't wait remote write response and run next rule in the group immediately which means that we cannot ensure sequential rule evaluation in a group if it is remote storage backend although the remote write service is sychronized. This PR will make sure rule evaluation for one group wait the remote write response before evaluating next rule in the group.

Signed-off-by: Garrett Li