### PR TITLE
Add Azure tenant and subscription ID labels

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -26,19 +26,19 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
-
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/util/strutil"
 )
 
 const (
 	azureLabel                     = model.MetaLabelPrefix + "azure_"
+	azureLabelSubscriptionID       = azureLabel + "subscription_id"
+	azureLabelTenantID             = azureLabel + "tenant_id"
 	azureLabelMachineID            = azureLabel + "machine_id"
 	azureLabelMachineResourceGroup = azureLabel + "machine_resource_group"
 	azureLabelMachineName          = azureLabel + "machine_name"
@@ -313,6 +313,8 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 			}
 
 			labels := model.LabelSet{
+				azureLabelSubscriptionID:       model.LabelValue(d.cfg.SubscriptionID),
+				azureLabelTenantID:             model.LabelValue(d.cfg.TenantID),
 				azureLabelMachineID:            model.LabelValue(vm.ID),
 				azureLabelMachineName:          model.LabelValue(vm.Name),
 				azureLabelMachineOSType:        model.LabelValue(vm.OsType),

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -259,6 +259,8 @@ Azure SD configurations allow retrieving scrape targets from Azure VMs.
 
 The following meta labels are available on targets during relabeling:
 
+* `__meta_azure_subscription_id`: the subscription ID
+* `__meta_azure_tenant_id`: the tenant ID
 * `__meta_azure_machine_id`: the machine ID
 * `__meta_azure_machine_location`: the location the machine runs in
 * `__meta_azure_machine_name`: the machine name


### PR DESCRIPTION
This copies subscription and tenant ID e discovered labels of all Azure targets.
We do the same for project ID's in the GCE discovery. So this should be a consistent change.

@simonpasquier, since this is a minor change it would be great to still get this into 2.6.