### PR TITLE
Fixs typo: "possibliy" to "possibly"

### DIFF
--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -156,7 +156,7 @@ Loop:
 		case <-time.After(timeout):
 			// Because we use queue, an object that is created then
 			// deleted or updated may be processed only once.
-			// So possibliy we may skip events, timed out here.
+			// So possibly we may skip events, timed out here.
 			t.Logf("timed out, got %d (max: %d) items, some events are skipped", len(allTgs), max)
 			break Loop
 		}


### PR DESCRIPTION
Fixs typo in [kubernetes_test.go](https://github.com/prometheus/prometheus/compare/master...JoeWrightss:patch-1#diff-97a9b815cfaca1b24df6057c54ee7241) at line 159.