### PR TITLE
IMPORTANT: Revert "add logic to check if an azure VM is deallocated or not (#4908)"

### DIFF
--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -26,10 +26,6 @@ func TestMapFromVMWithEmptyTags(t *testing.T) {
 	vmType := "type"
 	location := "westeurope"
 	networkProfile := compute.NetworkProfile{}
-	provisioningStatusCode := "ProvisioningState/succeeded"
-	provisionDisplayStatus := "Provisioning succeeded"
-	powerStatusCode := "PowerState/running"
-	powerDisplayStatus := "VM running"
 	properties := &compute.VirtualMachineProperties{
 		StorageProfile: &compute.StorageProfile{
 			OsDisk: &compute.OSDisk{
@@ -37,20 +33,6 @@ func TestMapFromVMWithEmptyTags(t *testing.T) {
 			},
 		},
 		NetworkProfile: &networkProfile,
-		InstanceView: &compute.VirtualMachineInstanceView{
-			Statuses: &[]compute.InstanceViewStatus{
-				{
-					Code:          &provisioningStatusCode,
-					Level:         "Info",
-					DisplayStatus: &provisionDisplayStatus,
-				},
-				{
-					Code:          &powerStatusCode,
-					Level:         "Info",
-					DisplayStatus: &powerDisplayStatus,
-				},
-			},
-		},
 	}
 
 	testVM := compute.VirtualMachine{
@@ -70,7 +52,6 @@ func TestMapFromVMWithEmptyTags(t *testing.T) {
 		OsType:         "Linux",
 		Tags:           map[string]*string{},
 		NetworkProfile: networkProfile,
-		PowerStateCode: "PowerState/running",
 	}
 
 	actualVM := mapFromVM(testVM)
@@ -88,10 +69,6 @@ func TestMapFromVMWithTags(t *testing.T) {
 	tags := map[string]*string{
 		"prometheus": new(string),
 	}
-	provisioningStatusCode := "ProvisioningState/succeeded"
-	provisionDisplayStatus := "Provisioning succeeded"
-	powerStatusCode := "PowerState/running"
-	powerDisplayStatus := "VM running"
 	networkProfile := compute.NetworkProfile{}
 	properties := &compute.VirtualMachineProperties{
 		StorageProfile: &compute.StorageProfile{
@@ -100,20 +77,6 @@ func TestMapFromVMWithTags(t *testing.T) {
 			},
 		},
 		NetworkProfile: &networkProfile,
-		InstanceView: &compute.VirtualMachineInstanceView{
-			Statuses: &[]compute.InstanceViewStatus{
-				{
-					Code:          &provisioningStatusCode,
-					Level:         "Info",
-					DisplayStatus: &provisionDisplayStatus,
-				},
-				{
-					Code:          &powerStatusCode,
-					Level:         "Info",
-					DisplayStatus: &powerDisplayStatus,
-				},
-			},
-		},
 	}
 
 	testVM := compute.VirtualMachine{
@@ -133,7 +96,6 @@ func TestMapFromVMWithTags(t *testing.T) {
 		OsType:         "Linux",
 		Tags:           tags,
 		NetworkProfile: networkProfile,
-		PowerStateCode: "PowerState/running",
 	}
 
 	actualVM := mapFromVM(testVM)
@@ -149,10 +111,6 @@ func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 	vmType := "type"
 	location := "westeurope"
 	networkProfile := compute.NetworkProfile{}
-	provisioningStatusCode := "ProvisioningState/succeeded"
-	provisionDisplayStatus := "Provisioning succeeded"
-	powerStatusCode := "PowerState/running"
-	powerDisplayStatus := "VM running"
 	properties := &compute.VirtualMachineScaleSetVMProperties{
 		StorageProfile: &compute.StorageProfile{
 			OsDisk: &compute.OSDisk{
@@ -160,20 +118,6 @@ func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 			},
 		},
 		NetworkProfile: &networkProfile,
-		InstanceView: &compute.VirtualMachineInstanceView{
-			Statuses: &[]compute.InstanceViewStatus{
-				{
-					Code:          &provisioningStatusCode,
-					Level:         "Info",
-					DisplayStatus: &provisionDisplayStatus,
-				},
-				{
-					Code:          &powerStatusCode,
-					Level:         "Info",
-					DisplayStatus: &powerDisplayStatus,
-				},
-			},
-		},
 	}
 
 	testVM := compute.VirtualMachineScaleSetVM{
@@ -195,7 +139,6 @@ func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 		Tags:           map[string]*string{},
 		NetworkProfile: networkProfile,
 		ScaleSet:       scaleSet,
-		PowerStateCode: "PowerState/running",
 	}
 
 	actualVM := mapFromVMScaleSetVM(testVM, scaleSet)
@@ -214,10 +157,6 @@ func TestMapFromVMScaleSetVMWithTags(t *testing.T) {
 		"prometheus": new(string),
 	}
 	networkProfile := compute.NetworkProfile{}
-	provisioningStatusCode := "ProvisioningState/succeeded"
-	provisionDisplayStatus := "Provisioning succeeded"
-	powerStatusCode := "PowerState/running"
-	powerDisplayStatus := "VM running"
 	properties := &compute.VirtualMachineScaleSetVMProperties{
 		StorageProfile: &compute.StorageProfile{
 			OsDisk: &compute.OSDisk{
@@ -225,20 +164,6 @@ func TestMapFromVMScaleSetVMWithTags(t *testing.T) {
 			},
 		},
 		NetworkProfile: &networkProfile,
-		InstanceView: &compute.VirtualMachineInstanceView{
-			Statuses: &[]compute.InstanceViewStatus{
-				{
-					Code:          &provisioningStatusCode,
-					Level:         "Info",
-					DisplayStatus: &provisionDisplayStatus,
-				},
-				{
-					Code:          &powerStatusCode,
-					Level:         "Info",
-					DisplayStatus: &powerDisplayStatus,
-				},
-			},
-		},
 	}
 
 	testVM := compute.VirtualMachineScaleSetVM{
@@ -260,61 +185,11 @@ func TestMapFromVMScaleSetVMWithTags(t *testing.T) {
 		Tags:           tags,
 		NetworkProfile: networkProfile,
 		ScaleSet:       scaleSet,
-		PowerStateCode: "PowerState/running",
 	}
 
 	actualVM := mapFromVMScaleSetVM(testVM, scaleSet)
 
 	if !reflect.DeepEqual(expectedVM, actualVM) {
 		t.Errorf("Expected %v got %v", expectedVM, actualVM)
-	}
-}
-
-func TestGetPowerStatusFromVM(t *testing.T) {
-	provisioningStatusCode := "ProvisioningState/succeeded"
-	provisionDisplayStatus := "Provisioning succeeded"
-	powerStatusCode := "PowerState/running"
-	powerDisplayStatus := "VM running"
-	properties := &compute.VirtualMachineScaleSetVMProperties{
-		StorageProfile: &compute.StorageProfile{
-			OsDisk: &compute.OSDisk{
-				OsType: "Linux",
-			},
-		},
-		InstanceView: &compute.VirtualMachineInstanceView{
-			Statuses: &[]compute.InstanceViewStatus{
-				{
-					Code:          &provisioningStatusCode,
-					Level:         "Info",
-					DisplayStatus: &provisionDisplayStatus,
-				},
-				{
-					Code:          &powerStatusCode,
-					Level:         "Info",
-					DisplayStatus: &powerDisplayStatus,
-				},
-			},
-		},
-	}
-
-	testVM := compute.VirtualMachineScaleSetVM{
-		Properties: properties,
-	}
-
-	actual := getPowerStateFromVMInstanceView(testVM.Properties.InstanceView)
-
-	expected := "PowerState/running"
-
-	if actual != expected {
-		t.Errorf("expected powerStatus %s, but got %s instead", expected, actual)
-	}
-
-	// Noq we test a virtualMachine with an empty InstanceView struct.
-	testVM.Properties.InstanceView = &compute.VirtualMachineInstanceView{}
-
-	actual = getPowerStateFromVMInstanceView(testVM.Properties.InstanceView)
-
-	if actual != "" {
-		t.Errorf("expected powerStatus %s, but got %s instead", expected, actual)
 	}
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -263,11 +263,10 @@ The following meta labels are available on targets during relabeling:
 * `__meta_azure_machine_location`: the location the machine runs in
 * `__meta_azure_machine_name`: the machine name
 * `__meta_azure_machine_os_type`: the machine operating system
-* `__meta_azure_machine_power_state`: the current power state of the machine
 * `__meta_azure_machine_private_ip`: the machine's private IP
 * `__meta_azure_machine_resource_group`: the machine's resource group
-* `__meta_azure_machine_scale_set`: the name of the scale set which the vm is part of (this value is only set if you are using a [scale set](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/))
 * `__meta_azure_machine_tag_<tagname>`: each tag value of the machine
+* `__meta_azure_machine_scale_set`: the name of the scale set which the vm is part of (this value is only set if you are using a [scale set](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/))
 
 See below for the configuration options for Azure discovery:
 


### PR DESCRIPTION
This is required because InstanceView struct is only exposed and never populated. This is an issue the azure-go-sdk vendor of prometheus.

The solution to get around this problem would be to update azure-go-sdk dependencies and then attempt to retrieve the VM powerstate via InstanceView.

@simonpasquier @brian-brazil FYI. My apologies for this oversight and I have created this PR to make the required amends.

The v2.6.0 release notes will have to be amended as well to reflect this reversion.