### PR TITLE
Add context parameter and return error for ruleRetriever interface

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -780,7 +780,7 @@ func groupKey(name, file string) string {
 }
 
 // RuleGroups returns the list of manager's rule groups.
-func (m *Manager) RuleGroups() []*Group {
+func (m *Manager) RuleGroups(ctx context.Context) []*Group {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -810,7 +810,7 @@ func (m *Manager) Rules() []Rule {
 }
 
 // AlertingRules returns the list of the manager's alerting rules.
-func (m *Manager) AlertingRules() []*AlertingRule {
+func (m *Manager) AlertingRules(ctx context.Context) []*AlertingRule {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -832,7 +832,7 @@ func (m *Manager) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements prometheus.Collector.
 func (m *Manager) Collect(ch chan<- prometheus.Metric) {
-	for _, g := range m.RuleGroups() {
+	for _, g := range m.RuleGroups(context.Background()) {
 		lastEvaluationTime := g.GetEvaluationTimestamp()
 		lastEvaluationTimestamp := math.Inf(-1)
 		if !lastEvaluationTime.IsZero() {
@@ -848,7 +848,7 @@ func (m *Manager) Collect(ch chan<- prometheus.Metric) {
 			g.GetEvaluationDuration().Seconds(),
 			key)
 	}
-	for _, g := range m.RuleGroups() {
+	for _, g := range m.RuleGroups(context.Background()) {
 		ch <- prometheus.MustNewConstMetric(groupInterval,
 			prometheus.GaugeValue,
 			g.interval.Seconds(),

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -110,8 +110,8 @@ type alertmanagerRetriever interface {
 }
 
 type rulesRetriever interface {
-	RuleGroups() []*rules.Group
-	AlertingRules() []*rules.AlertingRule
+	RuleGroups(context.Context) []*rules.Group
+	AlertingRules(context.Context) []*rules.AlertingRule
 }
 
 type response struct {
@@ -695,7 +695,7 @@ type Alert struct {
 }
 
 func (api *API) alerts(r *http.Request) apiFuncResult {
-	alertingRules := api.rulesRetriever.AlertingRules()
+	alertingRules := api.rulesRetriever.AlertingRules(context.Background())
 	alerts := []*Alert{}
 
 	for _, alertingRule := range alertingRules {
@@ -767,7 +767,7 @@ type recordingRule struct {
 }
 
 func (api *API) rules(r *http.Request) apiFuncResult {
-	ruleGroups := api.rulesRetriever.RuleGroups()
+	ruleGroups := api.rulesRetriever.RuleGroups(r.Context())
 	res := &RuleDiscovery{RuleGroups: make([]*RuleGroup, len(ruleGroups))}
 	for i, grp := range ruleGroups {
 		apiRuleGroup := &RuleGroup{

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -125,7 +125,7 @@ type rulesRetrieverMock struct {
 	testing *testing.T
 }
 
-func (m rulesRetrieverMock) AlertingRules() []*rules.AlertingRule {
+func (m rulesRetrieverMock) AlertingRules(ctx context.Context) []*rules.AlertingRule {
 	expr1, err := promql.ParseExpr(`absent(test_metric3) != 1`)
 	if err != nil {
 		m.testing.Fatalf("unable to parse alert expression: %s", err)
@@ -159,9 +159,9 @@ func (m rulesRetrieverMock) AlertingRules() []*rules.AlertingRule {
 	return r
 }
 
-func (m rulesRetrieverMock) RuleGroups() []*rules.Group {
+func (m rulesRetrieverMock) RuleGroups(ctx context.Context) []*rules.Group {
 	var ar rulesRetrieverMock
-	arules := ar.AlertingRules()
+	arules := ar.AlertingRules(context.Background())
 	storage := testutil.NewStorage(m.testing)
 	defer storage.Close()
 
@@ -232,16 +232,16 @@ func TestEndpoints(t *testing.T) {
 
 	var algr rulesRetrieverMock
 	algr.testing = t
-	algr.AlertingRules()
-	algr.RuleGroups()
+	algr.AlertingRules(context.Background())
+	algr.RuleGroups(context.Background())
 
 	t.Run("local", func(t *testing.T) {
 		var algr rulesRetrieverMock
 		algr.testing = t
 
-		algr.AlertingRules()
+		algr.AlertingRules(context.Background())
 
-		algr.RuleGroups()
+		algr.RuleGroups(context.Background())
 
 		api := &API{
 			Queryable:             suite.Storage(),
@@ -299,9 +299,9 @@ func TestEndpoints(t *testing.T) {
 		var algr rulesRetrieverMock
 		algr.testing = t
 
-		algr.AlertingRules()
+		algr.AlertingRules(context.Background())
 
-		algr.RuleGroups()
+		algr.RuleGroups(context.Background())
 
 		api := &API{
 			Queryable:             remote,

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -125,7 +125,7 @@ type rulesRetrieverMock struct {
 	testing *testing.T
 }
 
-func (m rulesRetrieverMock) AlertingRules(ctx context.Context) []*rules.AlertingRule {
+func (m rulesRetrieverMock) AlertingRules(ctx context.Context) ([]*rules.AlertingRule, error) {
 	expr1, err := promql.ParseExpr(`absent(test_metric3) != 1`)
 	if err != nil {
 		m.testing.Fatalf("unable to parse alert expression: %s", err)
@@ -156,12 +156,12 @@ func (m rulesRetrieverMock) AlertingRules(ctx context.Context) []*rules.Alerting
 	var r []*rules.AlertingRule
 	r = append(r, rule1)
 	r = append(r, rule2)
-	return r
+	return r, err
 }
 
-func (m rulesRetrieverMock) RuleGroups(ctx context.Context) []*rules.Group {
+func (m rulesRetrieverMock) RuleGroups(ctx context.Context) ([]*rules.Group, error) {
 	var ar rulesRetrieverMock
-	arules := ar.AlertingRules(context.Background())
+	arules, _ := ar.AlertingRules(context.Background())
 	storage := testutil.NewStorage(m.testing)
 	defer storage.Close()
 
@@ -195,7 +195,7 @@ func (m rulesRetrieverMock) RuleGroups(ctx context.Context) []*rules.Group {
 	r = append(r, recordingRule)
 
 	group := rules.NewGroup("grp", "/path/to/file", time.Second, r, false, opts)
-	return []*rules.Group{group}
+	return []*rules.Group{group}, nil
 }
 
 var samplePrometheusCfg = config.Config{

--- a/web/web.go
+++ b/web/web.go
@@ -511,7 +511,12 @@ func (h *Handler) Run(ctx context.Context) error {
 }
 
 func (h *Handler) alerts(w http.ResponseWriter, r *http.Request) {
-	alerts := h.ruleManager.AlertingRules(context.Background())
+	alerts, err := h.ruleManager.AlertingRules(context.Background())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	alertsSorter := byAlertStateAndNameSorter{alerts: alerts}
 	sort.Sort(alertsSorter)
 

--- a/web/web.go
+++ b/web/web.go
@@ -511,7 +511,7 @@ func (h *Handler) Run(ctx context.Context) error {
 }
 
 func (h *Handler) alerts(w http.ResponseWriter, r *http.Request) {
-	alerts := h.ruleManager.AlertingRules()
+	alerts := h.ruleManager.AlertingRules(context.Background())
 	alertsSorter := byAlertStateAndNameSorter{alerts: alerts}
 	sort.Sort(alertsSorter)
 


### PR DESCRIPTION
This work does not directly relate to prometheus. It allows the prometheus API to be reused in the [cortex project](https://github.com/cortexproject/cortex) for the rule evaluation component. If this is acceptable that would be great, and make matching the prometheus API much easier. Let me know if there is anything I can do to help make this possible.