### PR TITLE
Add taggedAddress to the labels in Consul Service Discovery

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -55,6 +55,8 @@ const (
 	servicePortLabel = model.MetaLabelPrefix + "consul_service_port"
 	// datacenterLabel is the name of the label containing the datacenter ID.
 	datacenterLabel = model.MetaLabelPrefix + "consul_dc"
+	// taggedAddressesLabel is the prefix for the labels mapping to a target's tagged addresses.
+	taggedAddressesLabel = model.MetaLabelPrefix + "consul_tagged_address_"
 	// serviceIDLabel is the name of the label containing the service ID.
 	serviceIDLabel = model.MetaLabelPrefix + "consul_service_id"
 
@@ -487,7 +489,7 @@ func (srv *consulService) watch(ctx context.Context, ch chan<- []*targetgroup.Gr
 		var tags = srv.tagSeparator + strings.Join(node.ServiceTags, srv.tagSeparator) + srv.tagSeparator
 
 		// If the service address is not empty it should be used instead of the node address
-		// since the service may be registered remotely through a different node
+		// since the service may be registered remotely through a different node.
 		var addr string
 		if node.ServiceAddress != "" {
 			addr = net.JoinHostPort(node.ServiceAddress, fmt.Sprintf("%d", node.ServicePort))
@@ -505,16 +507,22 @@ func (srv *consulService) watch(ctx context.Context, ch chan<- []*targetgroup.Gr
 			serviceIDLabel:      model.LabelValue(node.ServiceID),
 		}
 
-		// Add all key/value pairs from the node's metadata as their own labels
+		// Add all key/value pairs from the node's metadata as their own labels.
 		for k, v := range node.NodeMeta {
 			name := strutil.SanitizeLabelName(k)
 			labels[metaDataLabel+model.LabelName(name)] = model.LabelValue(v)
 		}
 
-		// Add all key/value pairs from the service's metadata as their own labels
+		// Add all key/value pairs from the service's metadata as their own labels.
 		for k, v := range node.ServiceMeta {
 			name := strutil.SanitizeLabelName(k)
 			labels[serviceMetaDataLabel+model.LabelName(name)] = model.LabelValue(v)
+		}
+
+		// Add all key/value pairs from the service's tagged addresses as their own labels.
+		for k, v := range node.TaggedAddresses {
+			name := strutil.SanitizeLabelName(k)
+			labels[taggedAddressesLabel+model.LabelName(name)] = model.LabelValue(v)
 		}
 
 		tgroup.Targets = append(tgroup.Targets, labels)

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -87,6 +87,7 @@ const (
 "Node": "node1",
 "Address": "1.1.1.1",
 "Datacenter": "test-dc",
+"TaggedAddresses": {"lan":"192.168.10.10","wan":"10.0.10.10"},
 "NodeMeta": {"rack_name": "2304"},
 "ServiceID": "test",
 "ServiceName": "test",

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -300,6 +300,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 
 * `__meta_consul_address`: the address of the target
 * `__meta_consul_dc`: the datacenter name for the target
+* `__meta_consul_tagged_address_<key>`: each node tagged address key value of the target
 * `__meta_consul_metadata_<key>`: each node metadata key value of the target
 * `__meta_consul_node`: the node name defined for the target
 * `__meta_consul_service_address`: the service address of the target


### PR DESCRIPTION
Useful when multiple (tagged) addresses for a node are exposed on the catalog API: https://www.consul.io/api/catalog.html#taggedaddresses - and one of those required for relabeling.

Similar to what happened in https://github.com/prometheus/prometheus/pull/4280

cc/ @fabxc @brian-brazil as SD maintainers 