### PR TITLE
[WIP] Added CORS Origin flag

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -50,6 +51,7 @@ import (
 	"github.com/prometheus/prometheus/discovery"
 	sd_config "github.com/prometheus/prometheus/discovery/config"
 	"github.com/prometheus/prometheus/notifier"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
@@ -99,7 +101,8 @@ func main() {
 		queryMaxSamples     int
 		RemoteFlushDeadline model.Duration
 
-		prometheusURL string
+		prometheusURL   string
+		corsRegexString string
 
 		promlogConfig promlog.Config
 	}{
@@ -205,8 +208,8 @@ func main() {
 	a.Flag("query.max-samples", "Maximum number of samples a single query can load into memory. Note that queries will fail if they would load more samples than this into memory, so this also limits the number of samples a query can return.").
 		Default("50000000").IntVar(&cfg.queryMaxSamples)
 
-	a.Flag("web.cors.origin", "CORS origin to use").
-		PlaceHolder("<URL>").StringsVar(&cfg.web.CORSOrigins)
+	a.Flag("web.cors.origin", "Regex for CORS origin").
+		Default(".*").StringVar(&cfg.corsRegexString)
 
 	promlogflag.AddFlags(a, &cfg.promlogConfig)
 
@@ -220,6 +223,12 @@ func main() {
 	cfg.web.ExternalURL, err = computeExternalURL(cfg.prometheusURL, cfg.web.ListenAddress)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "parse external URL %q", cfg.prometheusURL))
+		os.Exit(2)
+	}
+
+	cfg.web.CORSOrigin, err = compileCORSRegexString(cfg.corsRegexString)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "could not compile regex string %q", cfg.corsRegexString))
 		os.Exit(2)
 	}
 
@@ -664,6 +673,15 @@ func reloadConfig(filename string, logger log.Logger, rls ...func(*config.Config
 func startsOrEndsWithQuote(s string) bool {
 	return strings.HasPrefix(s, "\"") || strings.HasPrefix(s, "'") ||
 		strings.HasSuffix(s, "\"") || strings.HasSuffix(s, "'")
+}
+
+// compileCORSRegexString compiles corsRegexString and adds anchors
+func compileCORSRegexString(s string) (*regexp.Regexp, error) {
+	r, err := relabel.NewRegexp(s)
+	if err != nil {
+		return nil, err
+	}
+	return r.Regexp, nil
 }
 
 // computeExternalURL computes a sanitized external URL from a raw input. It infers unset

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -226,9 +226,9 @@ func main() {
 		os.Exit(2)
 	}
 
-	cfg.web.CORSOrigin, err = compileRegexString(cfg.corsRegexString)
+	cfg.web.CORSOrigin, err = compileCORSRegexString(cfg.corsRegexString)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "could not compile regex string %q", cfg.corsRegexString))
+		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "could not compile CORS regex string %q", cfg.corsRegexString))
 		os.Exit(2)
 	}
 
@@ -675,8 +675,8 @@ func startsOrEndsWithQuote(s string) bool {
 		strings.HasSuffix(s, "\"") || strings.HasSuffix(s, "'")
 }
 
-// compileRegexString compiles given string and adds anchors
-func compileRegexString(s string) (*regexp.Regexp, error) {
+// compileCORSRegexString compiles given string and adds anchors
+func compileCORSRegexString(s string) (*regexp.Regexp, error) {
 	r, err := relabel.NewRegexp(s)
 	if err != nil {
 		return nil, err

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -206,7 +206,7 @@ func main() {
 		Default("50000000").IntVar(&cfg.queryMaxSamples)
 
 	a.Flag("web.cors.origin", "CORS origin to use").
-		Default("*").StringVar(&cfg.web.CORSOrigin)
+		PlaceHolder("<URL>").StringsVar(&cfg.web.CORSOrigins)
 
 	promlogflag.AddFlags(a, &cfg.promlogConfig)
 

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -205,6 +205,9 @@ func main() {
 	a.Flag("query.max-samples", "Maximum number of samples a single query can load into memory. Note that queries will fail if they would load more samples than this into memory, so this also limits the number of samples a query can return.").
 		Default("50000000").IntVar(&cfg.queryMaxSamples)
 
+	a.Flag("web.cors.origin", "CORS origin to use").
+		Default("*").StringVar(&cfg.web.CORSOrigin)
+
 	promlogflag.AddFlags(a, &cfg.promlogConfig)
 
 	_, err := a.Parse(os.Args[1:])

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -208,7 +208,7 @@ func main() {
 	a.Flag("query.max-samples", "Maximum number of samples a single query can load into memory. Note that queries will fail if they would load more samples than this into memory, so this also limits the number of samples a query can return.").
 		Default("50000000").IntVar(&cfg.queryMaxSamples)
 
-	a.Flag("web.cors.origin", `Regex for CORS origin. It is anchored in both ends by prometheus. Eg. 'https?://(domain1|domain2)\.com'`).
+	a.Flag("web.cors.origin", `Regex for CORS origin. It is fully anchored. Eg. 'https?://(domain1|domain2)\.com'`).
 		Default(".*").StringVar(&cfg.corsRegexString)
 
 	promlogflag.AddFlags(a, &cfg.promlogConfig)

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -208,7 +208,7 @@ func main() {
 	a.Flag("query.max-samples", "Maximum number of samples a single query can load into memory. Note that queries will fail if they would load more samples than this into memory, so this also limits the number of samples a query can return.").
 		Default("50000000").IntVar(&cfg.queryMaxSamples)
 
-	a.Flag("web.cors.origin", "Regex for CORS origin").
+	a.Flag("web.cors.origin", `Regex for CORS origin. It is anchored in both ends by prometheus. Eg. 'https?://(domain1|domain2)\.com'`).
 		Default(".*").StringVar(&cfg.corsRegexString)
 
 	promlogflag.AddFlags(a, &cfg.promlogConfig)
@@ -226,7 +226,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	cfg.web.CORSOrigin, err = compileCORSRegexString(cfg.corsRegexString)
+	cfg.web.CORSOrigin, err = compileRegexString(cfg.corsRegexString)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "could not compile regex string %q", cfg.corsRegexString))
 		os.Exit(2)
@@ -675,8 +675,8 @@ func startsOrEndsWithQuote(s string) bool {
 		strings.HasSuffix(s, "\"") || strings.HasSuffix(s, "'")
 }
 
-// compileCORSRegexString compiles corsRegexString and adds anchors
-func compileCORSRegexString(s string) (*regexp.Regexp, error) {
+// compileRegexString compiles given string and adds anchors
+func compileRegexString(s string) (*regexp.Regexp, error) {
 	r, err := relabel.NewRegexp(s)
 	if err != nil {
 		return nil, err

--- a/util/httputil/cors.go
+++ b/util/httputil/cors.go
@@ -15,6 +15,7 @@ package httputil
 
 import (
 	"net/http"
+	"regexp"
 )
 
 var corsHeaders = map[string]string{
@@ -25,7 +26,7 @@ var corsHeaders = map[string]string{
 }
 
 // Enables cross-site script calls.
-func SetCORS(w http.ResponseWriter, o []string, r *http.Request) {
+func SetCORS(w http.ResponseWriter, o *regexp.Regexp, r *http.Request) {
 	origin := r.Header.Get("Origin")
 	if origin == "" {
 		return
@@ -35,15 +36,12 @@ func SetCORS(w http.ResponseWriter, o []string, r *http.Request) {
 		w.Header().Set(k, v)
 	}
 
-	if len(o) == 0 {
+	if o.String() == ".*" {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		return
 	}
 
-	for _, allowedOrigin := range o {
-		if origin == allowedOrigin {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-			break
-		}
+	if o.MatchString(origin) {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
 	}
 }

--- a/util/httputil/cors.go
+++ b/util/httputil/cors.go
@@ -1,0 +1,49 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httputil
+
+import (
+	"net/http"
+)
+
+var corsHeaders = map[string]string{
+	"Access-Control-Allow-Headers":  "Accept, Authorization, Content-Type, Origin",
+	"Access-Control-Allow-Methods":  "GET, POST, OPTIONS",
+	"Access-Control-Expose-Headers": "Date",
+	"Vary":                          "Origin",
+}
+
+// Enables cross-site script calls.
+func SetCORS(w http.ResponseWriter, o []string, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return
+	}
+
+	for k, v := range corsHeaders {
+		w.Header().Set(k, v)
+	}
+
+	if len(o) == 0 {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		return
+	}
+
+	for _, allowedOrigin := range o {
+		if origin == allowedOrigin {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			break
+		}
+	}
+}

--- a/util/httputil/cors_test.go
+++ b/util/httputil/cors_test.go
@@ -1,0 +1,68 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httputil
+
+import (
+	"net/http"
+	"testing"
+)
+
+func getCORSHandlerFunc() http.Handler {
+	hf := func(w http.ResponseWriter, r *http.Request) {
+		SetCORS(w, []string{"https://foo.com"}, r)
+		w.WriteHeader(http.StatusOK)
+	}
+	return http.HandlerFunc(hf)
+}
+
+func TestCORSHandler(t *testing.T) {
+	tearDown := setup()
+	defer tearDown()
+	client := &http.Client{}
+
+	ch := getCORSHandlerFunc()
+	mux.Handle("/any_path", ch)
+
+	dummyOrigin := "https://foo.com"
+
+	// OPTIONS WITH LEGIT ORIGIN
+	req, err := http.NewRequest("OPTIONS", server.URL+"/any_path", nil)
+	req.Header.Set("Origin", dummyOrigin)
+	resp, err := client.Do(req)
+
+	if err != nil {
+		t.Error("client get failed with unexpected error")
+	}
+
+	AccessControlAllowOrigin := resp.Header.Get("Access-Control-Allow-Origin")
+
+	if AccessControlAllowOrigin != dummyOrigin {
+		t.Fatalf("%q does not match %q", dummyOrigin, AccessControlAllowOrigin)
+	}
+
+	// OPTIONS WITH BAD ORIGIN
+	req, err = http.NewRequest("OPTIONS", server.URL+"/any_path", nil)
+	req.Header.Set("Origin", "https://not-foo.com")
+	resp, err = client.Do(req)
+
+	if err != nil {
+		t.Error("client get failed with unexpected error")
+	}
+
+	AccessControlAllowOrigin = resp.Header.Get("Access-Control-Allow-Origin")
+
+	if AccessControlAllowOrigin != "" {
+		t.Fatalf("Access-Control-Allow-Origin should not exist but it was set to: %q", AccessControlAllowOrigin)
+	}
+}

--- a/util/httputil/cors_test.go
+++ b/util/httputil/cors_test.go
@@ -38,6 +38,11 @@ func TestCORSHandler(t *testing.T) {
 
 	// OPTIONS WITH LEGIT ORIGIN
 	req, err := http.NewRequest("OPTIONS", server.URL+"/any_path", nil)
+
+	if err != nil {
+		t.Error("could not create request")
+	}
+
 	req.Header.Set("Origin", dummyOrigin)
 	resp, err := client.Do(req)
 
@@ -53,6 +58,11 @@ func TestCORSHandler(t *testing.T) {
 
 	// OPTIONS WITH BAD ORIGIN
 	req, err = http.NewRequest("OPTIONS", server.URL+"/any_path", nil)
+
+	if err != nil {
+		t.Error("could not create request")
+	}
+
 	req.Header.Set("Origin", "https://not-foo.com")
 	resp, err = client.Do(req)
 

--- a/util/httputil/cors_test.go
+++ b/util/httputil/cors_test.go
@@ -15,12 +15,14 @@ package httputil
 
 import (
 	"net/http"
+	"regexp"
 	"testing"
 )
 
 func getCORSHandlerFunc() http.Handler {
 	hf := func(w http.ResponseWriter, r *http.Request) {
-		SetCORS(w, []string{"https://foo.com"}, r)
+		reg := regexp.MustCompile(`^https://foo\.com$`)
+		SetCORS(w, reg, r)
 		w.WriteHeader(http.StatusOK)
 	}
 	return http.HandlerFunc(hf)

--- a/util/httputil/cors_test.go
+++ b/util/httputil/cors_test.go
@@ -36,7 +36,7 @@ func TestCORSHandler(t *testing.T) {
 
 	dummyOrigin := "https://foo.com"
 
-	// OPTIONS WITH LEGIT ORIGIN
+	// OPTIONS with legit origin
 	req, err := http.NewRequest("OPTIONS", server.URL+"/any_path", nil)
 
 	if err != nil {
@@ -56,7 +56,7 @@ func TestCORSHandler(t *testing.T) {
 		t.Fatalf("%q does not match %q", dummyOrigin, AccessControlAllowOrigin)
 	}
 
-	// OPTIONS WITH BAD ORIGIN
+	// OPTIONS with bad origin
 	req, err = http.NewRequest("OPTIONS", server.URL+"/any_path", nil)
 
 	if err != nil {

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"time"
@@ -151,7 +152,7 @@ type API struct {
 	logger                log.Logger
 	remoteReadSampleLimit int
 	remoteReadGate        *gate.Gate
-	CORSOrigins           []string
+	CORSOrigin            *regexp.Regexp
 }
 
 func init() {
@@ -174,7 +175,7 @@ func NewAPI(
 	rr rulesRetriever,
 	remoteReadSampleLimit int,
 	remoteReadConcurrencyLimit int,
-	CORSOrigins []string,
+	CORSOrigin *regexp.Regexp,
 ) *API {
 	return &API{
 		QueryEngine:           qe,
@@ -192,7 +193,7 @@ func NewAPI(
 		remoteReadSampleLimit: remoteReadSampleLimit,
 		remoteReadGate:        gate.New(remoteReadConcurrencyLimit),
 		logger:                logger,
-		CORSOrigins:           CORSOrigins,
+		CORSOrigin:            CORSOrigin,
 	}
 }
 
@@ -200,7 +201,7 @@ func NewAPI(
 func (api *API) Register(r *route.Router) {
 	wrap := func(f apiFunc) http.HandlerFunc {
 		hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			httputil.SetCORS(w, api.CORSOrigins, r)
+			httputil.SetCORS(w, api.CORSOrigin, r)
 			result := f(r)
 			if result.err != nil {
 				api.respondError(w, result.err, result.data)

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1416,13 +1416,6 @@ func TestOptionsMethod(t *testing.T) {
 	if resp.StatusCode != http.StatusNoContent {
 		t.Fatalf("Expected status %d, got %d", http.StatusNoContent, resp.StatusCode)
 	}
-
-    // this will fail
-	for h, v := range corsHeaders {
-		if resp.Header.Get(h) != v {
-			t.Fatalf("Expected %q for header %q, got %q", v, h, resp.Header.Get(h))
-		}
-	}
 }
 
 func TestRespond(t *testing.T) {

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1417,6 +1417,7 @@ func TestOptionsMethod(t *testing.T) {
 		t.Fatalf("Expected status %d, got %d", http.StatusNoContent, resp.StatusCode)
 	}
 
+    // this will fail
 	for h, v := range corsHeaders {
 		if resp.Header.Get(h) != v {
 			t.Fatalf("Expected %q for header %q, got %q", v, h, resp.Header.Get(h))

--- a/web/web.go
+++ b/web/web.go
@@ -344,35 +344,6 @@ func New(logger log.Logger, o *Options) *Handler {
 	return h
 }
 
-// Enables cross-site script calls.
-func setCORS(w http.ResponseWriter, o []string, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if origin == "" {
-		return
-	}
-
-	headers := map[string]string{
-		"Access-Control-Allow-Headers":  "Accept, Authorization, Content-Type, Origin",
-		"Access-Control-Allow-Methods":  "GET, POST, OPTIONS, DELETE",
-		"Access-Control-Expose-Headers": "Date",
-	}
-
-	for k, v := range headers {
-		w.Header().Set(k, v)
-	}
-
-	if len(o) == 0 {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-	}
-
-	for _, allowedOrigin := range o {
-		if origin == allowedOrigin {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-			break
-		}
-	}
-}
-
 func serveDebug(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	subpath := route.Param(ctx, "subpath")
@@ -493,7 +464,7 @@ func (h *Handler) Run(ctx context.Context) error {
 
 	mux.Handle(apiPath+"/", http.StripPrefix(apiPath,
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			setCORS(w, h.options.CORSOrigins, r)
+			httputil.SetCORS(w, h.options.CORSOrigins, r)
 			hhFunc(w, r)
 		}),
 	))

--- a/web/web.go
+++ b/web/web.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -175,7 +176,7 @@ type Options struct {
 	Flags         map[string]string
 
 	ListenAddress              string
-	CORSOrigins                []string
+	CORSOrigin                 *regexp.Regexp
 	ReadTimeout                time.Duration
 	MaxConnections             int
 	ExternalURL                *url.URL
@@ -262,7 +263,7 @@ func New(logger log.Logger, o *Options) *Handler {
 		h.ruleManager,
 		h.options.RemoteReadSampleLimit,
 		h.options.RemoteReadConcurrencyLimit,
-		h.options.CORSOrigins,
+		h.options.CORSOrigin,
 	)
 
 	if o.RoutePrefix != "/" {
@@ -464,7 +465,7 @@ func (h *Handler) Run(ctx context.Context) error {
 
 	mux.Handle(apiPath+"/", http.StripPrefix(apiPath,
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			httputil.SetCORS(w, h.options.CORSOrigins, r)
+			httputil.SetCORS(w, h.options.CORSOrigin, r)
 			hhFunc(w, r)
 		}),
 	))

--- a/web/web.go
+++ b/web/web.go
@@ -138,6 +138,7 @@ type Handler struct {
 	externalLabels model.LabelSet
 	mtx            sync.RWMutex
 	now            func() model.Time
+	headers        map[string]string
 
 	ready uint32 // ready is uint32 rather than boolean to be able to use atomic functions.
 }
@@ -175,6 +176,7 @@ type Options struct {
 	Flags         map[string]string
 
 	ListenAddress              string
+	CORSOrigin                 string
 	ReadTimeout                time.Duration
 	MaxConnections             int
 	ExternalURL                *url.URL
@@ -242,6 +244,13 @@ func New(logger log.Logger, o *Options) *Handler {
 		ready: 0,
 	}
 
+	h.headers = map[string]string{
+		"Access-Control-Allow-Headers":  "Accept, Authorization, Content-Type, Origin",
+		"Access-Control-Allow-Methods":  "GET, OPTIONS",
+		"Access-Control-Allow-Origin":   o.CORSOrigin,
+		"Access-Control-Expose-Headers": "Date",
+	}
+
 	h.apiV1 = api_v1.NewAPI(h.queryEngine, h.storage, h.scrapeManager, h.notifier,
 		func() config.Config {
 			h.mtx.RLock()
@@ -261,6 +270,7 @@ func New(logger log.Logger, o *Options) *Handler {
 		h.ruleManager,
 		h.options.RemoteReadSampleLimit,
 		h.options.RemoteReadConcurrencyLimit,
+		h.headers,
 	)
 
 	if o.RoutePrefix != "/" {
@@ -342,17 +352,10 @@ func New(logger log.Logger, o *Options) *Handler {
 	return h
 }
 
-var corsHeaders = map[string]string{
-	"Access-Control-Allow-Headers":  "Accept, Authorization, Content-Type, Origin",
-	"Access-Control-Allow-Methods":  "GET, OPTIONS",
-	"Access-Control-Allow-Origin":   "*",
-	"Access-Control-Expose-Headers": "Date",
-}
-
 // Enables cross-site script calls.
-func setCORS(w http.ResponseWriter) {
-	for h, v := range corsHeaders {
-		w.Header().Set(h, v)
+func setCORS(w http.ResponseWriter, h map[string]string) {
+	for k, v := range h {
+		w.Header().Set(k, v)
 	}
 }
 
@@ -476,7 +479,7 @@ func (h *Handler) Run(ctx context.Context) error {
 
 	mux.Handle(apiPath+"/", http.StripPrefix(apiPath,
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			setCORS(w)
+			setCORS(w, h.headers)
 			hhFunc(w, r)
 		}),
 	))


### PR DESCRIPTION
ref #5010 
I don't know if this is the best way to implement this flag but it seems to work, and I didn't change the test as the implementation is not confirmed.

In this PR:
- added `--web.cors.origin` flag
- removed `corsHeaders` variable
- added `headers` field to `/web/api/v1/api.go:API` and `/web/web.go:Handler`
- headers are initilized in `/web/web.go:New` instead

@brian-brazil `/web/api/v1/api.go` and `/web/web.go` have a function `setCORS` will it be a good idea to change it to `setHeaders`? 
this signature of the function is also changed in this PR.

https://github.com/prometheus/prometheus/blob/68f0787c37d530394328171a1e9e86d336f2cfb3/web/api/v1/api.go#L133-L137

https://github.com/prometheus/prometheus/blob/68f0787c37d530394328171a1e9e86d336f2cfb3/web/web.go#L353-L357



Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>