### PR TITLE
import aliases 'yaml' that can be omitted

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/template"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Error represents semantical errors on parsing rule groups.


### PR DESCRIPTION
The import `gopkg.in/yaml.v2` that package also named `yaml`(package yaml), the aliases `yaml` is redundant.