### PR TITLE
notifier: Moved config package dependency from notifier package.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,9 +23,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/prometheus/pkg/relabel"
-
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/azure"
+	sd_config "github.com/prometheus/prometheus/discovery/config"
 	"github.com/prometheus/prometheus/discovery/consul"
 	"github.com/prometheus/prometheus/discovery/dns"
 	"github.com/prometheus/prometheus/discovery/ec2"
@@ -36,10 +37,8 @@ import (
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/discovery/triton"
 	"github.com/prometheus/prometheus/discovery/zookeeper"
-
-	config_util "github.com/prometheus/common/config"
-	"github.com/prometheus/common/model"
-	sd_config "github.com/prometheus/prometheus/discovery/config"
+	"github.com/prometheus/prometheus/notifier"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/util/testutil"
 	"gopkg.in/yaml.v2"
 )
@@ -571,8 +570,6 @@ var expectedConf = &Config{
 	AlertingConfig: AlertingConfig{
 		AlertmanagerConfigs: []*AlertmanagerConfig{
 			{
-				Scheme:  "https",
-				Timeout: model.Duration(10 * time.Second),
 				ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
 					StaticConfigs: []*targetgroup.Group{
 						{
@@ -584,6 +581,10 @@ var expectedConf = &Config{
 							Source: "0",
 						},
 					},
+				},
+				NotifierConfig: notifier.Config{
+					Scheme:  "https",
+					Timeout: model.Duration(10 * time.Second),
 				},
 			},
 		},


### PR DESCRIPTION
Follow up from https://github.com/prometheus/prometheus/pull/4955 to make notifier independent of config package.

~TODO in next PR: Move notifier to `pkg/notifier`, @bbrazil what do you think?~

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>