### PR TITLE
Fix error strings, slice declaration and expression 'c <= 'ÿ'' is always 'true'

### DIFF
--- a/pkg/textparse/promlex.l.go
+++ b/pkg/textparse/promlex.l.go
@@ -263,7 +263,7 @@ yystart21:
 		goto yyrule9
 	case c == '\t' || c == ' ':
 		goto yystate23
-	case c >= '\x01' && c <= '\b' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
+	case c >= '\x01' && c <= '\b' || c >= '\v' && c <= '\x1f' || c >= '!':
 		goto yystate22
 	}
 
@@ -272,7 +272,7 @@ yystate22:
 	switch {
 	default:
 		goto yyrule9
-	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= 'ÿ':
+	case c >= '\x01' && c <= '\t' || c >= '\v':
 		goto yystate22
 	}
 
@@ -283,7 +283,7 @@ yystate23:
 		goto yyrule3
 	case c == '\t' || c == ' ':
 		goto yystate23
-	case c >= '\x01' && c <= '\b' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
+	case c >= '\x01' && c <= '\b' || c >= '\v' && c <= '\x1f' || c >= '!':
 		goto yystate22
 	}
 
@@ -349,7 +349,7 @@ yystate30:
 		goto yystate31
 	case c == '\\':
 		goto yystate32
-	case c >= '\x01' && c <= '!' || c >= '#' && c <= '[' || c >= ']' && c <= 'ÿ':
+	case c >= '\x01' && c <= '!' || c >= '#' && c <= '[' || c >= ']':
 		goto yystate30
 	}
 
@@ -362,7 +362,7 @@ yystate32:
 	switch {
 	default:
 		goto yyabort
-	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= 'ÿ':
+	case c >= '\x01' && c <= '\t' || c >= '\v':
 		goto yystate30
 	}
 
@@ -377,7 +377,7 @@ yystart33:
 		goto yystate3
 	case c == '{':
 		goto yystate35
-	case c >= '\x01' && c <= '\b' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'z' || c >= '|' && c <= 'ÿ':
+	case c >= '\x01' && c <= '\b' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'z' || c >= '|':
 		goto yystate34
 	}
 
@@ -386,7 +386,7 @@ yystate34:
 	switch {
 	default:
 		goto yyrule17
-	case c >= '\x01' && c <= '\b' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'z' || c >= '|' && c <= 'ÿ':
+	case c >= '\x01' && c <= '\b' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'z' || c >= '|':
 		goto yystate34
 	}
 

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -302,13 +302,13 @@ func (c *concreteSeriesIterator) Err() error {
 func validateLabelsAndMetricName(ls labels.Labels) error {
 	for _, l := range ls {
 		if l.Name == labels.MetricName && !model.IsValidMetricName(model.LabelValue(l.Value)) {
-			return fmt.Errorf("Invalid metric name: %v", l.Value)
+			return fmt.Errorf("invalid metric name: %v", l.Value)
 		}
 		if !model.LabelName(l.Name).IsValid() {
-			return fmt.Errorf("Invalid label name: %v", l.Name)
+			return fmt.Errorf("invalid label name: %v", l.Name)
 		}
 		if !model.LabelValue(l.Value).IsValid() {
-			return fmt.Errorf("Invalid label value: %v", l.Value)
+			return fmt.Errorf("invalid label value: %v", l.Value)
 		}
 	}
 	return nil

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -153,7 +153,7 @@ func ToQueryResult(ss storage.SeriesSet, sampleLimit int) (*prompb.QueryResult, 
 	for ss.Next() {
 		series := ss.At()
 		iter := series.Iterator()
-		samples := []prompb.Sample{}
+		var samples []prompb.Sample
 
 		for iter.Next() {
 			numSamples++

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -112,6 +112,7 @@ func TestExternalLabelsQuerierAddExternalLabels(t *testing.T) {
 }
 
 func TestSeriesSetFilter(t *testing.T) {
+	var samples []prompb.Sample
 	tests := []struct {
 		in       *prompb.QueryResult
 		toRemove model.LabelSet
@@ -122,12 +123,12 @@ func TestSeriesSetFilter(t *testing.T) {
 			toRemove: model.LabelSet{"foo": "bar"},
 			in: &prompb.QueryResult{
 				Timeseries: []*prompb.TimeSeries{
-					{Labels: labelsToLabelsProto(labels.FromStrings("foo", "bar", "a", "b")), Samples: []prompb.Sample{}},
+					{Labels: labelsToLabelsProto(labels.FromStrings("foo", "bar", "a", "b")), Samples: samples},
 				},
 			},
 			expected: &prompb.QueryResult{
 				Timeseries: []*prompb.TimeSeries{
-					{Labels: labelsToLabelsProto(labels.FromStrings("a", "b")), Samples: []prompb.Sample{}},
+					{Labels: labelsToLabelsProto(labels.FromStrings("a", "b")), Samples: samples},
 				},
 			},
 		},

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -62,7 +62,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 
 	// Update write queues
 
-	newQueues := []*QueueManager{}
+	var newQueues []*QueueManager
 	// TODO: we should only stop & recreate queues which have changes,
 	// as this can be quite disruptive.
 	for i, rwConf := range conf.RemoteWriteConfigs {


### PR DESCRIPTION
1. Error string should not be capitalized or end with punctuation, fix in `storage/remote/codec.go`.
2. Slice declaration with empty literal initializer instead of nil, change the declaration to avoid an unnecessary allocation
3.Expression 'c <= 'ÿ'' is always 'true', delete them in `pkg/textparse/promlex.l.go`.