### PR TITLE
Docker images for ARM32v7 and ARM64v8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,11 @@ jobs:
 
     steps:
     - checkout
-    - setup_remote_docker
+    - setup_remote_docker:
+        version: 18.06.0-ce
+    - run: docker run --privileged linuxkit/binfmt:v0.6
     - attach_workspace:
         at: .
-    - run: ln -s .build/linux-amd64/prometheus prometheus
-    - run: ln -s .build/linux-amd64/promtool promtool
     - run: make docker
     - run: make docker DOCKER_REPO=quay.io/prometheus
     - run: docker images
@@ -65,13 +65,17 @@ jobs:
     - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
     - run: make docker-publish
     - run: make docker-publish DOCKER_REPO=quay.io/prometheus
+    - run: make docker-manifest
+    - run: make docker-manifest DOCKER_REPO=quay.io/prometheus
 
   docker_hub_release_tags:
     executor: golang
 
     steps:
     - checkout
-    - setup_remote_docker
+    - setup_remote_docker:
+        version: 18.06.0-ce
+    - run: docker run --privileged linuxkit/binfmt:v0.6
     - run: mkdir -v -p ${HOME}/bin
     - run: curl -L 'https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2' | tar xvjf - --strip-components 3 -C ${HOME}/bin
     - run: echo 'export PATH=${HOME}/bin:${PATH}' >> ${BASH_ENV}
@@ -84,19 +88,23 @@ jobs:
     - store_artifacts:
         path: .tarballs
         destination: releases
-    - run: ln -s .build/linux-amd64/prometheus prometheus
-    - run: ln -s .build/linux-amd64/promtool promtool
     - run: make docker DOCKER_IMAGE_TAG=$CIRCLE_TAG
     - run: make docker DOCKER_IMAGE_TAG=$CIRCLE_TAG DOCKER_REPO=quay.io/prometheus
     - run: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
     - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
+    - run: make docker-publish DOCKER_IMAGE_TAG="$CIRCLE_TAG"
+    - run: make docker-publish DOCKER_IMAGE_TAG="$CIRCLE_TAG" DOCKER_REPO=quay.io/prometheus
+    - run: make docker-manifest DOCKER_IMAGE_TAG="$CIRCLE_TAG"
+    - run: make docker-manifest DOCKER_IMAGE_TAG="$CIRCLE_TAG" DOCKER_REPO=quay.io/prometheus
     - run: |
         if [[ "$CIRCLE_TAG" =~ ^v[0-9]+(\.[0-9]+){2}$ ]]; then
           make docker-tag-latest DOCKER_IMAGE_TAG="$CIRCLE_TAG"
           make docker-tag-latest DOCKER_IMAGE_TAG="$CIRCLE_TAG" DOCKER_REPO=quay.io/prometheus
+          make docker-publish DOCKER_IMAGE_TAG="latest"
+          make docker-publish DOCKER_IMAGE_TAG="latest" DOCKER_REPO=quay.io/prometheus
+          make docker-manifest DOCKER_IMAGE_TAG="latest"
+          make docker-manifest DOCKER_IMAGE_TAG="latest" DOCKER_REPO=quay.io/prometheus
         fi
-    - run: make docker-publish
-    - run: make docker-publish DOCKER_REPO=quay.io/prometheus
 
 workflows:
   version: 2

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@ data/
 .tarballs/
 
 !.build/linux-amd64/
+!.build/linux-armv7/
+!.build/linux-arm64/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM        quay.io/prometheus/busybox:latest
+ARG ARCH="amd64"
+ARG OS="linux"
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-COPY prometheus                             /bin/prometheus
-COPY promtool                               /bin/promtool
+ARG ARCH="amd64"
+ARG OS="linux"
+COPY .build/${OS}-${ARCH}/prometheus        /bin/prometheus
+COPY .build/${OS}-${ARCH}/promtool          /bin/promtool
 COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
 COPY console_libraries/                     /usr/share/prometheus/console_libraries/
 COPY consoles/                              /usr/share/prometheus/consoles/

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Needs to be defined before including Makefile.common to auto-generate targets
+DOCKER_ARCHS ?= amd64 armv7 arm64
+
 include Makefile.common
 
 STATICCHECK_IGNORE = \

--- a/Makefile.common
+++ b/Makefile.common
@@ -80,6 +80,12 @@ BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 DOCKER_REPO             ?= prom
 
+DOCKER_ARCHS            ?= amd64
+
+BUILD_DOCKER_ARCHS = $(addprefix common-docker-,$(DOCKER_ARCHS))
+PUBLISH_DOCKER_ARCHS = $(addprefix common-docker-publish-,$(DOCKER_ARCHS))
+TAG_DOCKER_ARCHS = $(addprefix common-docker-tag-latest-,$(DOCKER_ARCHS))
+
 ifeq ($(GOHOSTARCH),amd64)
         ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux freebsd darwin windows))
                 # Only supported on amd64
@@ -178,17 +184,28 @@ common-tarball: promu
 	@echo ">> building release tarball"
 	$(PROMU) tarball --prefix $(PREFIX) $(BIN_DIR)
 
-.PHONY: common-docker
-common-docker:
-	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+.PHONY: common-docker $(BUILD_DOCKER_ARCHS)
+common-docker: $(BUILD_DOCKER_ARCHS)
+$(BUILD_DOCKER_ARCHS): common-docker-%:
+	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)" \
+		--build-arg ARCH="$*" \
+		--build-arg OS="linux" \
+		.
 
-.PHONY: common-docker-publish
-common-docker-publish:
-	docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)"
+.PHONY: common-docker-publish $(PUBLISH_DOCKER_ARCHS)
+common-docker-publish: $(PUBLISH_DOCKER_ARCHS)
+$(PUBLISH_DOCKER_ARCHS): common-docker-publish-%:
+	docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)"
 
-.PHONY: common-docker-tag-latest
-common-docker-tag-latest:
-	docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):latest"
+.PHONY: common-docker-tag-latest $(TAG_DOCKER_ARCHS)
+common-docker-tag-latest: $(TAG_DOCKER_ARCHS)
+$(TAG_DOCKER_ARCHS): common-docker-tag-latest-%:
+	docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:latest"
+
+.PHONY: common-docker-manifest
+common-docker-manifest:
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" $(foreach ARCH,$(DOCKER_ARCHS),$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$(ARCH):$(DOCKER_IMAGE_TAG))
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
 
 .PHONY: promu
 promu: $(PROMU)


### PR DESCRIPTION
Build and push docker images for linux arm32v7 and arm64v8.

Fixes https://github.com/prometheus/promu/issues/89

**Building**
The ARM images are building using `binfmt_misc`, which is the same mechanism also used by Docker for Mac to support building ARM images, some details are here https://www.ecliptik.com/Cross-Building-and-Running-Multi-Arch-Docker-Images/

While the circle docker executor doesn't natively support building ARM images, the machine executor has almost all the necessary dependencies pre-installed and allows privileged execution, which is required to setup `binfmt_misc`

The setup itself is done via`docker run --privileged linuxkit/binfmt:v0.6`, which is the same script also used inside Docker for Mac. (Source https://github.com/linuxkit/linuxkit/tree/master/pkg/binfmt)

As the default machine image is fairly old and `binfmt_misc` requires a Kernel 4.8+, use a more recent machine image https://circleci.com/docs/2.0/configuration-reference/#machine

**Publishing**

The two ARM images would be published to `prom/prometheus-arm32v7-linux` and `prom/prometheus-arm64v8-linux`, so those 2 docker hub / quay.io repositories would need to be created.

To simplify image consumption a multi-arch manifest is created using https://docs.docker.com/edge/engine/reference/commandline/manifest/, which allows `docker pull prometheus/prometheus` to pull the respective amd64, arm32v7 and arm64v8 image automatically.

Requires https://github.com/prometheus/busybox/pull/19 to have an arm32v7 and arm64v8 base image.

**Test**

Build images locally and pushed them to my registry using:
```
promu crossbuild -v -p "linux/amd64 linux/armv7 linux/arm64"
make docker DOCKER_REPO=johanneswuerbach
make docker-publish DOCKER_REPO=johanneswuerbach
```

Using them on macOS via Docker for Mac:
```
$ docker pull johanneswuerbach/prometheus:docker-arm && docker run --rm -it johanneswuerbach/prometheus:docker-arm --version
docker-arm: Pulling from johanneswuerbach/prometheus
Digest: sha256:c8212d84d2d79f32d9b824d9235d3b4ab178e21c3a762a643c8abe12145a2d22
Status: Image is up to date for johanneswuerbach/prometheus:docker-arm
prometheus, version 2.6.0 (branch: master, revision: 2e725a195a17155dfd1e172a1e1205fc7d6986ec)
  build user:       root@682d9280fbbf
  build date:       20181221-21:56:26
  go version:       go1.11.4
```

Using them on a Raspberry Pi 3:
```
$ docker pull johanneswuerbach/prometheus:docker-arm && docker run --rm -it johanneswuerbach/prometheus:docker-arm --version
docker-arm: Pulling from johanneswuerbach/prometheus
Digest: sha256:c8212d84d2d79f32d9b824d9235d3b4ab178e21c3a762a643c8abe12145a2d22
Status: Image is up to date for johanneswuerbach/prometheus:docker-arm
prometheus, version 2.6.0 (branch: master, revision: 2e725a195a17155dfd1e172a1e1205fc7d6986ec)
  build user:       root@682d9280fbbf
  build date:       20181221-22:07:33
  go version:       go1.11.4
```

while the current `latest` fails as expected:

```
$ docker pull prom/prometheus && docker run --rm -it prom/prometheus --version
Using default tag: latest
latest: Pulling from prom/prometheus
Digest: sha256:1ffbf5d3c6476384905e8f57c98ac0611f328af68bedb909ec3f350d7e18b134
Status: Image is up to date for prom/prometheus:latest
standard_init_linux.go:190: exec user process caused "exec format error"
```

Feedback more then welcome :-)
