### PR TITLE
Fix Docker Hub markdown link

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ the respective repository.
 
 All Prometheus services are available as Docker images on
 [Quay.io](https://quay.io/repository/prometheus/prometheus) or
-[Docker Hub[(https://hub.docker.com/u/prom/).
+[Docker Hub](https://hub.docker.com/u/prom/).
 
 Running Prometheus on Docker is as simple as `docker run -p 9090:9090
 prom/prometheus`. This starts Prometheus with a sample


### PR DESCRIPTION
The syntax is `[Text](link)`, but it was `[Text[(link)`.