### PR TITLE
github.com/cznic/golex has moved to modernc.org/golex

### DIFF
--- a/pkg/textparse/openmetricsparse.go
+++ b/pkg/textparse/openmetricsparse.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go get github.com/cznic/golex
+//go:generate go get -u modernc.org/golex
 //go:generate golex -o=openmetricslex.l.go openmetricslex.l
 
 package textparse

--- a/pkg/textparse/promparse.go
+++ b/pkg/textparse/promparse.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go get github.com/cznic/golex
+//go:generate go get -u modernc.org/golex
 //go:generate golex -o=promlex.l.go promlex.l
 
 package textparse


### PR DESCRIPTION
`github.com/cznic/golex` has moved to [`modernc.org/golex`](https://godoc.org/modernc.org/golex) ([vcs](https://gitlab.com/cznic/golex)).
Update `go get` paths to `modernc.org/golex`.