### PR TITLE
Dockerfile: Remove VOLUME instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,5 @@ RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles
 
 USER       nobody
 EXPOSE     9090
-VOLUME     [ "/prometheus" ]
 WORKDIR    /etc/prometheus
 ENTRYPOINT [ "/bin/prometheus" ]


### PR DESCRIPTION
This instruction is usually useless e.g. when using Docker's novolume-plugin and in cloud environments.

In cloud environments volumes must be mounted and there's no point in keeping Prometheus data temporary volume dir only during life-time of a container. In local environments writable layers storage is good enough for testing.

Another downside of using VOLUME instruction is it hard to undone it in child images and one would need to re-write the Dockerfile.

If there are no BC breaks after this change I think it'll make life easier for many people.

Related discussions: https://github.com/kubernetes/kube-state-metrics/pull/471 https://github.com/openshift/prometheus/pull/20