### PR TITLE
Fix typo in comment

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -93,7 +93,7 @@ func (a *Alert) Resolved() bool {
 	return a.ResolvedAt(time.Now())
 }
 
-// ResolvedAt returns true off the activity interval ended before
+// ResolvedAt returns true iff the activity interval ended before
 // the given timestamp.
 func (a *Alert) ResolvedAt(ts time.Time) bool {
 	if a.EndsAt.IsZero() {


### PR DESCRIPTION
I think it is a typo in comment of Alert.ResolvedAt .