### PR TITLE
added meta_marathon_host label

### DIFF
--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -51,6 +51,7 @@ const (
 	taskLabel model.LabelName = metaLabelPrefix + "task"
 	// hostLabel contains the mesos task host address of the app instance
 	hostLabel model.LabelName = metaLabelPrefix + "host"
+
 	// portMappingLabelPrefix is the prefix for the application portMappings labels.
 	portMappingLabelPrefix = metaLabelPrefix + "port_mapping_label_"
 	// portDefinitionLabelPrefix is the prefix for the application portDefinitions labels.

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -49,7 +49,8 @@ const (
 	portIndexLabel model.LabelName = metaLabelPrefix + "port_index"
 	// taskLabel contains the mesos task name of the app instance.
 	taskLabel model.LabelName = metaLabelPrefix + "task"
-
+	// hostLabel contains the mesos task host address of the app instance
+	hostLabel model.LabelName = metaLabelPrefix + "host"
 	// portMappingLabelPrefix is the prefix for the application portMappings labels.
 	portMappingLabelPrefix = metaLabelPrefix + "port_mapping_label_"
 	// portDefinitionLabelPrefix is the prefix for the application portDefinitions labels.
@@ -468,6 +469,7 @@ func targetsForApp(app *App) []model.LabelSet {
 				model.AddressLabel: model.LabelValue(targetAddress),
 				taskLabel:          model.LabelValue(t.ID),
 				portIndexLabel:     model.LabelValue(strconv.Itoa(i)),
+				hostLabel:          model.LabelValue(t.Host),
 			}
 
 			// Gather all port labels and set them on the current target, skip if the port has no Marathon labels.

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -49,7 +49,7 @@ const (
 	portIndexLabel model.LabelName = metaLabelPrefix + "port_index"
 	// taskLabel contains the mesos task name of the app instance.
 	taskLabel model.LabelName = metaLabelPrefix + "task"
-	// hostLabel contains the mesos task host address of the app instance
+	// hostLabel contains the mesos task host address of the app instance.
 	hostLabel model.LabelName = metaLabelPrefix + "host"
 
 	// portMappingLabelPrefix is the prefix for the application portMappings labels.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -832,6 +832,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_marathon_app`: the name of the app (with slashes replaced by dashes)
 * `__meta_marathon_image`: the name of the Docker image used (if available)
 * `__meta_marathon_task`: the ID of the Mesos task
+* `__meta_marathon_host`: the Host Address of the Mesos task
 * `__meta_marathon_app_label_<labelname>`: any Marathon labels attached to the app
 * `__meta_marathon_port_definition_label_<labelname>`: the port definition labels
 * `__meta_marathon_port_mapping_label_<labelname>`: the port mapping labels


### PR DESCRIPTION
This pull request should address the criticism received in a prior pull request that hard coded logic in the marathon_sd configuration.  

It addresses the following issue:
https://github.com/prometheus/prometheus/issues/5067