### PR TITLE
cmd: fix TestFailedStartupExitCode

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -163,6 +163,10 @@ func TestComputeExternalURL(t *testing.T) {
 
 // Let's provide an invalid configuration file and verify the exit status indicates the error.
 func TestFailedStartupExitCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	fakeInputFile := "fake-input-file"
 	expectedExitStatus := 1
 


### PR DESCRIPTION
Fixes #5063.
I think there are two ways to fix this problem. Another one is run `go build` in short test too. I personally prefer this one.