### PR TITLE
sd: Fix stuck Azure service discovery

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -362,6 +362,10 @@ func (d *Discovery) refresh() (tg *targetgroup.Group, err error) {
 					}
 				}
 			}
+
+			// If we get here we haven't sent anything to the channel.
+			// We need to send it something to release it.
+			ch <- target{}
 		}(i, vm)
 	}
 


### PR DESCRIPTION
Our prometheus instances had its Azure SD stuck.

After some analyses with @simonpasquier we think it's because nothing is sent to the channel and we keep waiting for something.

Here the go routine dump of the stuck instance : https://gist.github.com/sylr/8c1e7f78c160fad84b0aea10a16f5ec1