### PR TITLE
pkg/runtime: use panic instead of log.Fatal for system call errors

### DIFF
--- a/pkg/runtime/limits_default.go
+++ b/pkg/runtime/limits_default.go
@@ -17,7 +17,6 @@ package runtime
 
 import (
 	"fmt"
-	"log"
 	"syscall"
 )
 
@@ -37,7 +36,7 @@ func getLimits(resource int, unit string) string {
 	rlimit := syscall.Rlimit{}
 	err := syscall.Getrlimit(resource, &rlimit)
 	if err != nil {
-		log.Fatal("Error!")
+		panic("syscall.Getrlimit failed: " + err.Error())
 	}
 	return fmt.Sprintf("(soft=%s, hard=%s)", limitToString(uint64(rlimit.Cur), unit), limitToString(uint64(rlimit.Max), unit))
 }

--- a/pkg/runtime/uname_linux.go
+++ b/pkg/runtime/uname_linux.go
@@ -14,7 +14,6 @@
 package runtime
 
 import (
-	"log"
 	"syscall"
 )
 
@@ -23,7 +22,7 @@ func Uname() string {
 	buf := syscall.Utsname{}
 	err := syscall.Uname(&buf)
 	if err != nil {
-		log.Fatal("Error!")
+		panic("syscall.Uname failed: " + err.Error())
 	}
 
 	str := "(" + charsToString(buf.Sysname[:])


### PR DESCRIPTION
A panic will dump a stack trace, and the failure message is now more informative. This way there's a much easier way to diagnose any potential issues here, rather than `log.Fatal` with a generic error.