### PR TITLE
expose kubernetes node metrics on discovered kubernetes pods

### DIFF
--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -317,7 +317,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 				cache.NewSharedInformer(plw, &apiv1.Pod{}, resyncPeriod),
 			)
 			d.discoverers = append(d.discoverers, pod)
-			go pod.informer.Run(ctx.Done())
+			go pod.podInf.Run(ctx.Done())
 		}
 	case RoleService:
 		for _, namespace := range namespaces {

--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -228,7 +228,7 @@ func (i *Ingress) hasSynced() bool {
 }
 
 func (p *Pod) hasSynced() bool {
-	return p.podInf.HasSynced()
+	return p.podInf.HasSynced() && p.nodeInf.HasSynced()
 }
 
 func (s *Service) hasSynced() bool {

--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -228,7 +228,7 @@ func (i *Ingress) hasSynced() bool {
 }
 
 func (p *Pod) hasSynced() bool {
-	return p.informer.HasSynced()
+	return p.podInf.HasSynced()
 }
 
 func (s *Service) hasSynced() bool {

--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -228,7 +228,7 @@ func (i *Ingress) hasSynced() bool {
 }
 
 func (p *Pod) hasSynced() bool {
-	return p.podInf.HasSynced() && p.nodeInf.HasSynced()
+	return p.podInf.HasSynced() && (p.nodeInf == nil || p.nodeInf.HasSynced())
 }
 
 func (s *Service) hasSynced() bool {

--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -34,10 +34,10 @@ import (
 
 // Pod discovers new pod targets.
 type Pod struct {
-	informer cache.SharedInformer
-	store    cache.Store
-	logger   log.Logger
-	queue    *workqueue.Type
+	podInf cache.SharedInformer
+	store  cache.Store
+	logger log.Logger
+	queue  *workqueue.Type
 }
 
 // NewPod creates a new pod discovery.
@@ -46,12 +46,12 @@ func NewPod(l log.Logger, pods cache.SharedInformer) *Pod {
 		l = log.NewNopLogger()
 	}
 	p := &Pod{
-		informer: pods,
-		store:    pods.GetStore(),
-		logger:   l,
-		queue:    workqueue.NewNamed("pod"),
+		podInf: pods,
+		store:  pods.GetStore(),
+		logger: l,
+		queue:  workqueue.NewNamed("pod"),
 	}
-	p.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	p.podInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o interface{}) {
 			eventCount.WithLabelValues("pod", "add").Inc()
 			p.enqueue(o)
@@ -81,8 +81,8 @@ func (p *Pod) enqueue(obj interface{}) {
 func (p *Pod) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	defer p.queue.ShutDown()
 
-	if !cache.WaitForCacheSync(ctx.Done(), p.informer.HasSynced) {
-		level.Error(p.logger).Log("msg", "pod informer unable to sync cache")
+	if !cache.WaitForCacheSync(ctx.Done(), p.podInf.HasSynced) {
+		level.Error(p.logger).Log("msg", "pod role pod informer unable to sync cache")
 		return
 	}
 

--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -88,7 +88,7 @@ func (p *Pod) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 		return
 	}
 
-	if !cache.WaitForCacheSync(ctx.Done(), p.nodeInf.HasSynced) {
+	if p.nodeInf != nil && !cache.WaitForCacheSync(ctx.Done(), p.nodeInf.HasSynced) {
 		level.Error(p.logger).Log("msg", "pod role node informer unable to sync cache")
 		return
 	}
@@ -171,6 +171,10 @@ func GetControllerOf(controllee metav1.Object) *metav1.OwnerReference {
 }
 
 func (p *Pod) resolveNode(name string) *apiv1.Node {
+	if p.nodeInf == nil {
+		return nil
+	}
+
 	n := &apiv1.Node{}
 	n.Name = name
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -820,6 +820,10 @@ tls_config:
 namespaces:
   names:
     [ - <string> ]
+
+# With `role: pod`, pods will be annotated with all labels from the node where
+# the pod runs.
+[ pod_node_labels: <true|false> ]
 ```
 
 Where `<role>` must be `endpoints`, `service`, `pod`, `node`, or

--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -248,6 +248,8 @@ scrape_configs:
   kubernetes_sd_configs:
   - role: pod
 
+  pod_node_labels: true
+
   relabel_configs:
   # Example relabel to scrape only pods that have
   # "example.io/should_be_scraped = true" annotation.
@@ -279,3 +281,6 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_name]
     action: replace
     target_label: kubernetes_pod_name
+  - source_labels: [__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region]
+    action: replace
+    target_label: region


### PR DESCRIPTION
We use kubernetes discovery with `role: pod` as our primary way to discover kubernetes services. Unfortunately, pod labels / annotations do not include properties of the node like instance type or region.

This change adds node labels to pods, so that discovered pods include information about the node that runs them.