### PR TITLE
corrected regex string check for anyorigin(*)

### DIFF
--- a/util/httputil/cors.go
+++ b/util/httputil/cors.go
@@ -36,7 +36,7 @@ func SetCORS(w http.ResponseWriter, o *regexp.Regexp, r *http.Request) {
 		w.Header().Set(k, v)
 	}
 
-	if o.String() == ".*" {
+	if o.String() == "^(?:.*)$" {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		return
 	}


### PR DESCRIPTION
forgot to change this with #5011

currently it will return with whatever `Origin` header the request has because the default regex is `.*` and will match any Origin anyway.

but default behavior of returning `*` for `Access-Control-Allow-Origin` is changed. 

this PR fixes that.


Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>