### PR TITLE
add debounce support in prometheus

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -95,7 +95,7 @@ type Rule struct {
 	Record      string            `yaml:"record,omitempty"`
 	Alert       string            `yaml:"alert,omitempty"`
 	Expr        string            `yaml:"expr"`
-	For         model.Duration    `yaml:"for,omitempty"`
+	For         string            `yaml:"for,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 }
@@ -118,7 +118,7 @@ func (r *Rule) Validate() (errs []error) {
 		if len(r.Annotations) > 0 {
 			errs = append(errs, errors.Errorf("invalid field 'annotations' in recording rule"))
 		}
-		if r.For != 0 {
+		if len(r.For) > 0 {
 			errs = append(errs, errors.Errorf("invalid field 'for' in recording rule"))
 		}
 		if !model.IsValidMetricName(model.LabelValue(r.Record)) {

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -26,7 +26,7 @@ import (
 func TestAlertingRuleHTMLSnippet(t *testing.T) {
 	expr, err := promql.ParseExpr(`foo{html="<b>BOLD<b>"}`)
 	testutil.Ok(t, err)
-	rule := NewAlertingRule("testrule", expr, 0, labels.FromStrings("html", "<b>BOLD</b>"), labels.FromStrings("html", "<b>BOLD</b>"), false, nil)
+	rule := NewAlertingRule("testrule", expr, 0, 0, 0, labels.FromStrings("html", "<b>BOLD</b>"), labels.FromStrings("html", "<b>BOLD</b>"), false, nil)
 
 	const want = `alert: <a href="/test/prefix/graph?g0.expr=ALERTS%7Balertname%3D%22testrule%22%7D&g0.tab=1">testrule</a>
 expr: <a href="/test/prefix/graph?g0.expr=foo%7Bhtml%3D%22%3Cb%3EBOLD%3Cb%3E%22%7D&g0.tab=1">foo{html=&#34;&lt;b&gt;BOLD&lt;b&gt;&#34;}</a>
@@ -57,7 +57,7 @@ func TestAlertingRuleLabelsUpdate(t *testing.T) {
 	rule := NewAlertingRule(
 		"HTTPRequestRateLow",
 		expr,
-		time.Minute,
+		time.Minute, 0, 0,
 		// Basing alerting rule labels off of a value that can change is a very bad idea.
 		// If an alert is going back and forth between two label values it will never fire.
 		// Instead, you should write two alerts with constant labels.

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -138,7 +138,7 @@ func (m rulesRetrieverMock) AlertingRules() []*rules.AlertingRule {
 	rule1 := rules.NewAlertingRule(
 		"test_metric3",
 		expr1,
-		time.Second,
+		time.Second, 0, 0,
 		labels.Labels{},
 		labels.Labels{},
 		true,
@@ -147,7 +147,7 @@ func (m rulesRetrieverMock) AlertingRules() []*rules.AlertingRule {
 	rule2 := rules.NewAlertingRule(
 		"test_metric4",
 		expr2,
-		time.Second,
+		time.Second, 0, 0,
 		labels.Labels{},
 		labels.Labels{},
 		true,


### PR DESCRIPTION
You can specify either hold duration or debounce in alerting rule for field. Here `for: 3/4` represents that alerting if 3 matches in last 4 round evaluations.
```
- alert: test1
  expr: up > 0
  for: 3/4
- alert: test2
  expr: up > 0
  for: 3m
```

Signed-off-by: xiancli <xiancli@ebay.com>