### PR TITLE
 Check for cancellation on every step of a range evaluation

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -791,6 +791,9 @@ func (ev *evaluator) rangeEval(f func([]Value, *EvalNodeHelper) Vector, exprs ..
 	seriess := make(map[uint64]Series, biggestLen) // Output series by series hash.
 	tempNumSamples := ev.currentSamples
 	for ts := ev.startTimestamp; ts <= ev.endTimestamp; ts += ev.interval {
+		if err := contextDone(ev.ctx, "expression evaluation"); err != nil {
+			ev.error(err)
+		}
 		// Reset number of samples in memory after each timestamp.
 		ev.currentSamples = tempNumSamples
 		// Gather input vectors for this timestamp.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -181,12 +181,10 @@ func (q *query) Exec(ctx context.Context) *Result {
 
 // contextDone returns an error if the context was canceled or timed out.
 func contextDone(ctx context.Context, env string) error {
-	select {
-	case <-ctx.Done():
-		return contextErr(ctx.Err(), env)
-	default:
-		return nil
+	if err := ctx.Err(); err != nil {
+		return contextErr(err, env)
 	}
+	return nil
 }
 
 func contextErr(err error, env string) error {


### PR DESCRIPTION
The background to this is I have an end-user sending a query that runs for 17 seconds and cancelling it after 4 seconds.

I know, I should find a way to make them stop, but I couldn't see (a) why this isn't checked already or (b) where this has been discussed.

In case it's a fear of an expensive `select` call I simplified that, although I can't see either change show up in benchmarks.

Justification for the `contextDone()` change from the `Context` docs:

	// If Done is not yet closed, Err returns nil.
	// If Done is closed, Err returns a non-nil error