### PR TITLE
tests: Remove the prepended watch reactor from the fake k8s client

### DIFF
--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -69,14 +69,13 @@ func makeEndpoints() *v1.Endpoints {
 }
 
 func TestEndpointsDiscoveryBeforeRun(t *testing.T) {
-	n, c, w := makeDiscovery(RoleEndpoint, NamespaceDiscovery{})
+	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
 		discovery: n,
 		beforeRun: func() {
 			obj := makeEndpoints()
 			c.CoreV1().Endpoints(obj.Namespace).Create(obj)
-			w.Endpoints().Add(obj)
 		},
 		expectedMaxItems: 1,
 		expectedRes: map[string]*targetgroup.Group{
@@ -148,7 +147,7 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 			PodIP:  "1.2.3.4",
 		},
 	}
-	n, c, w := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, obj)
+	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, obj)
 
 	k8sDiscoveryTest{
 		discovery: n,
@@ -181,7 +180,6 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 				},
 			}
 			c.CoreV1().Endpoints(obj.Namespace).Create(obj)
-			w.Endpoints().Add(obj)
 		},
 		expectedMaxItems: 1,
 		expectedRes: map[string]*targetgroup.Group{
@@ -232,14 +230,13 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryDelete(t *testing.T) {
-	n, c, w := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
+	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
 			obj := makeEndpoints()
 			c.CoreV1().Endpoints(obj.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})
-			w.Endpoints().Delete(obj)
 		},
 		expectedMaxItems: 2,
 		expectedRes: map[string]*targetgroup.Group{
@@ -251,7 +248,7 @@ func TestEndpointsDiscoveryDelete(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryUpdate(t *testing.T) {
-	n, c, w := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
+	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
 		discovery: n,
@@ -293,7 +290,6 @@ func TestEndpointsDiscoveryUpdate(t *testing.T) {
 				},
 			}
 			c.CoreV1().Endpoints(obj.Namespace).Update(obj)
-			w.Endpoints().Modify(obj)
 		},
 		expectedMaxItems: 2,
 		expectedRes: map[string]*targetgroup.Group{
@@ -323,7 +319,7 @@ func TestEndpointsDiscoveryUpdate(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryEmptySubsets(t *testing.T) {
-	n, c, w := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
+	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
 		discovery: n,
@@ -336,7 +332,6 @@ func TestEndpointsDiscoveryEmptySubsets(t *testing.T) {
 				Subsets: []v1.EndpointSubset{},
 			}
 			c.CoreV1().Endpoints(obj.Namespace).Update(obj)
-			w.Endpoints().Modify(obj)
 		},
 		expectedMaxItems: 2,
 		expectedRes: map[string]*targetgroup.Group{
@@ -352,7 +347,7 @@ func TestEndpointsDiscoveryEmptySubsets(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryWithService(t *testing.T) {
-	n, c, w := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
+	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
 		discovery: n,
@@ -367,7 +362,6 @@ func TestEndpointsDiscoveryWithService(t *testing.T) {
 				},
 			}
 			c.CoreV1().Services(obj.Namespace).Create(obj)
-			w.Services().Add(obj)
 		},
 		expectedMaxItems: 1,
 		expectedRes: map[string]*targetgroup.Group{
@@ -405,7 +399,7 @@ func TestEndpointsDiscoveryWithService(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryWithServiceUpdate(t *testing.T) {
-	n, c, w := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
+	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
 		discovery: n,
@@ -420,7 +414,6 @@ func TestEndpointsDiscoveryWithServiceUpdate(t *testing.T) {
 				},
 			}
 			c.CoreV1().Services(obj.Namespace).Create(obj)
-			w.Services().Add(obj)
 		},
 		afterStart: func() {
 			obj := &v1.Service{
@@ -434,7 +427,6 @@ func TestEndpointsDiscoveryWithServiceUpdate(t *testing.T) {
 				},
 			}
 			c.CoreV1().Services(obj.Namespace).Update(obj)
-			w.Services().Modify(obj)
 		},
 		expectedMaxItems: 2,
 		expectedRes: map[string]*targetgroup.Group{
@@ -540,7 +532,7 @@ func TestEndpointsDiscoveryNamespaces(t *testing.T) {
 			},
 		},
 	}
-	n, _, _ := makeDiscovery(RoleEndpoint, NamespaceDiscovery{Names: []string{"ns1", "ns2"}}, objs...)
+	n, _ := makeDiscovery(RoleEndpoint, NamespaceDiscovery{Names: []string{"ns1", "ns2"}}, objs...)
 
 	k8sDiscoveryTest{
 		discovery:        n,

--- a/discovery/kubernetes/ingress_test.go
+++ b/discovery/kubernetes/ingress_test.go
@@ -129,14 +129,13 @@ func expectedTargetGroups(ns string, tls TLSMode) map[string]*targetgroup.Group 
 }
 
 func TestIngressDiscoveryAdd(t *testing.T) {
-	n, c, w := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"default"}})
+	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"default"}})
 
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
 			obj := makeIngress(TLSNo)
 			c.ExtensionsV1beta1().Ingresses("default").Create(obj)
-			w.Ingresses().Add(obj)
 		},
 		expectedMaxItems: 1,
 		expectedRes:      expectedTargetGroups("default", TLSNo),
@@ -144,14 +143,13 @@ func TestIngressDiscoveryAdd(t *testing.T) {
 }
 
 func TestIngressDiscoveryAddTLS(t *testing.T) {
-	n, c, w := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"default"}})
+	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"default"}})
 
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
 			obj := makeIngress(TLSYes)
 			c.ExtensionsV1beta1().Ingresses("default").Create(obj)
-			w.Ingresses().Add(obj)
 		},
 		expectedMaxItems: 1,
 		expectedRes:      expectedTargetGroups("default", TLSYes),
@@ -159,14 +157,13 @@ func TestIngressDiscoveryAddTLS(t *testing.T) {
 }
 
 func TestIngressDiscoveryAddMixed(t *testing.T) {
-	n, c, w := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"default"}})
+	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"default"}})
 
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
 			obj := makeIngress(TLSMixed)
 			c.ExtensionsV1beta1().Ingresses("default").Create(obj)
-			w.Ingresses().Add(obj)
 		},
 		expectedMaxItems: 1,
 		expectedRes:      expectedTargetGroups("default", TLSMixed),
@@ -174,7 +171,7 @@ func TestIngressDiscoveryAddMixed(t *testing.T) {
 }
 
 func TestIngressDiscoveryNamespaces(t *testing.T) {
-	n, c, w := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"ns1", "ns2"}})
+	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"ns1", "ns2"}})
 
 	expected := expectedTargetGroups("ns1", TLSNo)
 	for k, v := range expectedTargetGroups("ns2", TLSNo) {
@@ -187,7 +184,6 @@ func TestIngressDiscoveryNamespaces(t *testing.T) {
 				obj := makeIngress(TLSNo)
 				obj.Namespace = ns
 				c.ExtensionsV1beta1().Ingresses(obj.Namespace).Create(obj)
-				w.Ingresses().Add(obj)
 			}
 		},
 		expectedMaxItems: 2,

--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -16,7 +16,6 @@ package kubernetes
 import (
 	"context"
 	"encoding/json"
-	"sync"
 	"testing"
 	"time"
 
@@ -24,72 +23,21 @@ import (
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/util/testutil"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 )
 
-type watcherFactory struct {
-	sync.RWMutex
-	watchers map[schema.GroupVersionResource]*watch.FakeWatcher
-}
-
-func (wf *watcherFactory) watchFor(gvr schema.GroupVersionResource) *watch.FakeWatcher {
-	wf.Lock()
-	defer wf.Unlock()
-
-	var fakewatch *watch.FakeWatcher
-	fakewatch, ok := wf.watchers[gvr]
-	if !ok {
-		fakewatch = watch.NewFakeWithChanSize(128, true)
-		wf.watchers[gvr] = fakewatch
-	}
-	return fakewatch
-}
-
-func (wf *watcherFactory) Nodes() *watch.FakeWatcher {
-	return wf.watchFor(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"})
-}
-
-func (wf *watcherFactory) Ingresses() *watch.FakeWatcher {
-	return wf.watchFor(schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "ingresses"})
-}
-
-func (wf *watcherFactory) Endpoints() *watch.FakeWatcher {
-	return wf.watchFor(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpoints"})
-}
-
-func (wf *watcherFactory) Services() *watch.FakeWatcher {
-	return wf.watchFor(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"})
-}
-
-func (wf *watcherFactory) Pods() *watch.FakeWatcher {
-	return wf.watchFor(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"})
-}
-
 // makeDiscovery creates a kubernetes.Discovery instance for testing.
-func makeDiscovery(role Role, nsDiscovery NamespaceDiscovery, objects ...runtime.Object) (*Discovery, kubernetes.Interface, *watcherFactory) {
+func makeDiscovery(role Role, nsDiscovery NamespaceDiscovery, objects ...runtime.Object) (*Discovery, kubernetes.Interface) {
 	clientset := fake.NewSimpleClientset(objects...)
-	// Current client-go we are using does not support push event on
-	// Add/Update/Create, so we need to emit event manually.
-	// See https://github.com/kubernetes/kubernetes/issues/54075.
-	// TODO update client-go thChanSizeand related packages to kubernetes-1.10.0+
-	wf := &watcherFactory{
-		watchers: make(map[schema.GroupVersionResource]*watch.FakeWatcher),
-	}
-	clientset.PrependWatchReactor("*", func(action k8stesting.Action) (handled bool, ret watch.Interface, err error) {
-		gvr := action.GetResource()
-		return true, wf.watchFor(gvr), nil
-	})
+
 	return &Discovery{
 		client:             clientset,
 		logger:             log.NewNopLogger(),
 		role:               role,
 		namespaceDiscovery: &nsDiscovery,
-	}, clientset, wf
+	}, clientset
 }
 
 type k8sDiscoveryTest struct {

--- a/discovery/kubernetes/node_test.go
+++ b/discovery/kubernetes/node_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -51,7 +51,7 @@ func makeEnumeratedNode(i int) *v1.Node {
 }
 
 func TestNodeDiscoveryBeforeStart(t *testing.T) {
-	n, c, w := makeDiscovery(RoleNode, NamespaceDiscovery{})
+	n, c := makeDiscovery(RoleNode, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
 		discovery: n,
@@ -63,7 +63,6 @@ func TestNodeDiscoveryBeforeStart(t *testing.T) {
 				map[string]string{"testannotation": "testannotationvalue"},
 			)
 			c.CoreV1().Nodes().Create(obj)
-			w.Nodes().Add(obj)
 		},
 		expectedMaxItems: 1,
 		expectedRes: map[string]*targetgroup.Group{
@@ -87,14 +86,13 @@ func TestNodeDiscoveryBeforeStart(t *testing.T) {
 }
 
 func TestNodeDiscoveryAdd(t *testing.T) {
-	n, c, w := makeDiscovery(RoleNode, NamespaceDiscovery{})
+	n, c := makeDiscovery(RoleNode, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
 			obj := makeEnumeratedNode(1)
 			c.CoreV1().Nodes().Create(obj)
-			w.Nodes().Add(obj)
 		},
 		expectedMaxItems: 1,
 		expectedRes: map[string]*targetgroup.Group{
@@ -117,13 +115,12 @@ func TestNodeDiscoveryAdd(t *testing.T) {
 
 func TestNodeDiscoveryDelete(t *testing.T) {
 	obj := makeEnumeratedNode(0)
-	n, c, w := makeDiscovery(RoleNode, NamespaceDiscovery{}, obj)
+	n, c := makeDiscovery(RoleNode, NamespaceDiscovery{}, obj)
 
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
 			c.CoreV1().Nodes().Delete(obj.Name, &metav1.DeleteOptions{})
-			w.Nodes().Delete(obj)
 		},
 		expectedMaxItems: 2,
 		expectedRes: map[string]*targetgroup.Group{
@@ -135,14 +132,13 @@ func TestNodeDiscoveryDelete(t *testing.T) {
 }
 
 func TestNodeDiscoveryUpdate(t *testing.T) {
-	n, c, w := makeDiscovery(RoleNode, NamespaceDiscovery{})
+	n, c := makeDiscovery(RoleNode, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
 			obj1 := makeEnumeratedNode(0)
 			c.CoreV1().Nodes().Create(obj1)
-			w.Nodes().Add(obj1)
 			obj2 := makeNode(
 				"test0",
 				"1.2.3.4",
@@ -150,7 +146,6 @@ func TestNodeDiscoveryUpdate(t *testing.T) {
 				map[string]string{},
 			)
 			c.CoreV1().Nodes().Update(obj2)
-			w.Nodes().Modify(obj2)
 		},
 		expectedMaxItems: 2,
 		expectedRes: map[string]*targetgroup.Group{

--- a/discovery/kubernetes/service_test.go
+++ b/discovery/kubernetes/service_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -95,17 +95,15 @@ func makeExternalService() *v1.Service {
 }
 
 func TestServiceDiscoveryAdd(t *testing.T) {
-	n, c, w := makeDiscovery(RoleService, NamespaceDiscovery{})
+	n, c := makeDiscovery(RoleService, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
 			obj := makeService()
 			c.CoreV1().Services(obj.Namespace).Create(obj)
-			w.Services().Add(obj)
 			obj = makeExternalService()
 			c.CoreV1().Services(obj.Namespace).Create(obj)
-			w.Services().Add(obj)
 		},
 		expectedMaxItems: 2,
 		expectedRes: map[string]*targetgroup.Group{
@@ -144,14 +142,13 @@ func TestServiceDiscoveryAdd(t *testing.T) {
 }
 
 func TestServiceDiscoveryDelete(t *testing.T) {
-	n, c, w := makeDiscovery(RoleService, NamespaceDiscovery{}, makeService())
+	n, c := makeDiscovery(RoleService, NamespaceDiscovery{}, makeService())
 
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
 			obj := makeService()
 			c.CoreV1().Services(obj.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})
-			w.Services().Delete(obj)
 		},
 		expectedMaxItems: 2,
 		expectedRes: map[string]*targetgroup.Group{
@@ -163,14 +160,13 @@ func TestServiceDiscoveryDelete(t *testing.T) {
 }
 
 func TestServiceDiscoveryUpdate(t *testing.T) {
-	n, c, w := makeDiscovery(RoleService, NamespaceDiscovery{}, makeService())
+	n, c := makeDiscovery(RoleService, NamespaceDiscovery{}, makeService())
 
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
 			obj := makeMultiPortService()
 			c.CoreV1().Services(obj.Namespace).Update(obj)
-			w.Services().Modify(obj)
 		},
 		expectedMaxItems: 2,
 		expectedRes: map[string]*targetgroup.Group{
@@ -202,7 +198,7 @@ func TestServiceDiscoveryUpdate(t *testing.T) {
 }
 
 func TestServiceDiscoveryNamespaces(t *testing.T) {
-	n, c, w := makeDiscovery(RoleService, NamespaceDiscovery{Names: []string{"ns1", "ns2"}})
+	n, c := makeDiscovery(RoleService, NamespaceDiscovery{Names: []string{"ns1", "ns2"}})
 
 	k8sDiscoveryTest{
 		discovery: n,
@@ -211,7 +207,6 @@ func TestServiceDiscoveryNamespaces(t *testing.T) {
 				obj := makeService()
 				obj.Namespace = ns
 				c.CoreV1().Services(obj.Namespace).Create(obj)
-				w.Services().Add(obj)
 			}
 		},
 		expectedMaxItems: 2,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -419,16 +419,16 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/apis/meta/v1beta1
 k8s.io/apimachinery/pkg/apis/meta/internalversion
-k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/runtime/serializer/json
 k8s.io/apimachinery/pkg/runtime/serializer/protobuf
 k8s.io/apimachinery/pkg/runtime/serializer/recognizer
 k8s.io/apimachinery/pkg/runtime/serializer/versioning
+k8s.io/apimachinery/pkg/util/strategicpatch
+k8s.io/apimachinery/pkg/util/framer
+k8s.io/apimachinery/pkg/util/yaml
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/third_party/forked/golang/json
-k8s.io/apimachinery/pkg/util/framer
-k8s.io/apimachinery/pkg/util/yaml
 # k8s.io/client-go v2.0.0-alpha.0.0.20181121191925-a47917edff34+incompatible
 k8s.io/client-go/kubernetes
 k8s.io/client-go/rest
@@ -479,7 +479,6 @@ k8s.io/client-go/tools/pager
 k8s.io/client-go/util/buffer
 k8s.io/client-go/util/retry
 k8s.io/client-go/kubernetes/fake
-k8s.io/client-go/testing
 k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/tools/reference
 k8s.io/client-go/util/integer
@@ -520,6 +519,7 @@ k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/storage/v1/fake
 k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake
+k8s.io/client-go/testing
 # k8s.io/klog v0.1.0 => github.com/simonpasquier/klog-gokit v0.1.0
 k8s.io/klog
 # k8s.io/kube-openapi v0.0.0-20180629012420-d83b052f768a


### PR DESCRIPTION
This PR improves the test suite by removing the unnecessary watch reactor. The latest client-go supports the adding of events automatically CRUD events, so the reactor should not be required anymore. 

This change should be safe (hopefully) as only tests cases are modified. Hurray to new client-go libs ;)