### PR TITLE
Close idle scrape connections after reload and shutdown

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -151,6 +151,7 @@ func TestScrapePoolStop(t *testing.T) {
 		activeTargets: map[uint64]*Target{},
 		loops:         map[uint64]loop{},
 		cancel:        func() {},
+		client:        &http.Client{Transport: &http.Transport{}},
 	}
 	var mtx sync.Mutex
 	stopped := map[uint64]bool{}
@@ -244,6 +245,7 @@ func TestScrapePoolReload(t *testing.T) {
 		loops:         map[uint64]loop{},
 		newLoop:       newLoop,
 		logger:        nil,
+		client:        &http.Client{Transport: &http.Transport{}},
 	}
 
 	// Reloading a scrape pool with a new scrape configuration must stop all scrape


### PR DESCRIPTION
When doing a reload and when shutting down tcp connections were left open until they timed out from the `IdleConnTimeout` field in Transport. Which means that they persist for 5 minutes when they will never be used again. In the case of a reload, we were seeing a doubling of tcp connections for a few minutes as a new client was setup on reload and both the new and the old client had established connections.

Signed-off-by: Mark Knapp <mknapp@hudson-trading.com>