### PR TITLE
Fix multiple response.WriteHeader calls error in remote read adapter

### DIFF
--- a/documentation/examples/remote_storage/remote_storage_adapter/main.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/main.go
@@ -296,8 +296,7 @@ func serve(logger log.Logger, addr string, writers []writer, readers []reader) e
 
 		compressed = snappy.Encode(nil, data)
 		if _, err := w.Write(compressed); err != nil {
-			level.Warn(logger).Log("msg", "Resonse write error", "storage", reader.Name(), "err", err)
-			return
+			level.Warn(logger).Log("msg", "Error writing response", "storage", reader.Name(), "err", err)
 		}
 	})
 

--- a/documentation/examples/remote_storage/remote_storage_adapter/main.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/main.go
@@ -296,7 +296,7 @@ func serve(logger log.Logger, addr string, writers []writer, readers []reader) e
 
 		compressed = snappy.Encode(nil, data)
 		if _, err := w.Write(compressed); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			level.Warn(logger).Log("msg", "Resonse write error", "storage", reader.Name(), "err", err)
 			return
 		}
 	})


### PR DESCRIPTION
1. **Error in remote read adapter**
Error in `/documentation/examples/remote_storage/remote_storage_adapter/main.go`. When [w.write](https://github.com/prometheus/prometheus/blob/a2ef8cf2f509b58d140acf9e37f1e906b28582cd/documentation/examples/remote_storage/remote_storage_adapter/main.go#L298) return err, log shows `http: multiple response.WriteHeader calls`. `w.write` and `http.Error(w, err.Error(), http.StatusInternalServerError)` will write header twice，triggers the error.

2. **Bug fix**
Replace the  `http.Error(w, err.Error(), http.StatusInternalServerError)` with log.

