### PR TITLE
api/v1: added /status/runtimeinfo

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -60,6 +60,7 @@ import (
 	"github.com/prometheus/prometheus/storage/tsdb"
 	"github.com/prometheus/prometheus/util/strutil"
 	"github.com/prometheus/prometheus/web"
+	"github.com/prometheus/prometheus/web/web_types"
 )
 
 var (
@@ -377,7 +378,7 @@ func main() {
 	cfg.web.Notifier = notifierManager
 	cfg.web.TSDBCfg = cfg.tsdb
 
-	cfg.web.Version = &web.PrometheusVersion{
+	cfg.web.Version = &web_types.PrometheusVersion{
 		Version:   version.Version,
 		Revision:  version.Revision,
 		Branch:    version.Branch,

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -683,6 +683,52 @@ $ curl http://localhost:9090/api/v1/status/flags
 
 *New in v2.2*
 
+###  Runtime Information
+
+The following endpoint returns runtime information of the Prometheus server.
+
+*Note that the exact values returned may change over time*
+
+```
+GET api/v1/status/runtimeinfo
+```
+
+```json
+$ curl http://localhost:9090/api/v1/status/runtimeinfo
+{
+  "status": "success",
+  "data": {
+    "alertmanagers": [
+      {
+        "scheme": "http",
+        "host": "localhost:9093",
+        "path": "/api/v1/alerts"
+      }
+    ],
+    "startTime": "2019-02-03T16:39:29.446031696+05:30",
+    "chunks": 356,
+    "corruptionCount": 0,
+    "goGC": "",
+    "goMaxProcs": 4,
+    "goroutines": 29,
+    "lastConfigTime": "2019-02-03T16:39:31+05:30",
+    "reloadConfigSuccess": true,
+    "timeSeries": 356,
+    "version": {
+      "branch": "master",
+      "buildDate": "20190203-11:08:16",
+      "buildUser": "user@this",
+      "goVersion": "go1.11.4",
+      "revision": "3f93820f8c47e88faa77b7aad6672c4e6e29f4dc",
+      "version": "2.7.0"
+    },
+    "cwd": "/home/vn-ki/Projects/git/prometheus/"
+  }
+}
+```
+
+*New in 2.8*
+
 ## TSDB Admin APIs
 These are APIs that expose database functionalities for the advanced user. These APIs are not enabled unless the `--web.enable-admin-api` is set.
 

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage/tsdb"
 	"github.com/prometheus/prometheus/util/testutil"
+	"github.com/prometheus/prometheus/web/web_types"
 	libtsdb "github.com/prometheus/tsdb"
 )
 
@@ -116,7 +117,7 @@ func TestReadyAndHealthy(t *testing.T) {
 			Host:   "localhost:9090",
 			Path:   "/",
 		},
-		Version: &PrometheusVersion{},
+		Version: &web_types.PrometheusVersion{},
 	}
 
 	opts.Flags = map[string]string{}

--- a/web/web_types/types.go
+++ b/web/web_types/types.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web_types
+
+import (
+	"time"
+)
+
+// RuntimeInfo contains runtime info about Prometheus.
+type RuntimeInfo struct {
+	Birth               time.Time          `json:"startTime"`
+	CWD                 string             `json:"cwd"`
+	Version             *PrometheusVersion `json:"version"`
+	Alertmanagers       []Alertmanager     `json:"alertmanagers"`
+	GoroutineCount      int                `json:"goroutines"`
+	GOMAXPROCS          int                `json:"goMaxProcs"`
+	GOGC                string             `json:"goGC"`
+	GODEBUG             string             `json:"goDebug"`
+	CorruptionCount     int64              `json:"corruptionCount"`
+	ChunkCount          int64              `json:"chunks"`
+	TimeSeriesCount     int64              `json:"timeSeries"`
+	LastConfigTime      time.Time          `json:"lastConfigTime"`
+	ReloadConfigSuccess bool               `json:"reloadConfigSuccess"`
+	StorageRetention    string             `json:"storageRetention"`
+}
+
+// PrometheusVersion contains build information about Prometheus.
+type PrometheusVersion struct {
+	Version   string `json:"version"`
+	Revision  string `json:"revision"`
+	Branch    string `json:"branch"`
+	BuildUser string `json:"buildUser"`
+	BuildDate string `json:"buildDate"`
+	GoVersion string `json:"goVersion"`
+}
+
+type Alertmanager struct {
+	Scheme string `json:"scheme"`
+	Host   string `json:"host"`
+	Path   string `json:"path"`
+}


### PR DESCRIPTION
This does not yet build. I want some pointers before I can go ahead.

Right now, because I have the types in `web.go`, I am running into a cyclic import.

Is there a file where I can place `RuntimeInfo` struct and `PrometheusVersion` struct?

If not, how do I tackle this problem? Is my approach fundamentally wrong?

Ping: @brancz @mxinden 

Closes #2467 

Signed-off-by: Vishnunarayan K I <appukuttancr@gmail.com>