### PR TITLE
Fix some typos in comment

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -240,7 +240,7 @@ func Compare(a, b Labels) int {
 	return len(a) - len(b)
 }
 
-// Builder allows modifiying Labels.
+// Builder allows modifying Labels.
 type Builder struct {
 	base Labels
 	del  []string

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -903,7 +903,7 @@ var testExpr = []struct {
 	}, {
 		input: `foo{a>="b"}`,
 		fail:  true,
-		// TODO(fabxc): willingly lexing wrong tokens allows for more precrise error
+		// TODO(fabxc): willingly lexing wrong tokens allows for more precise error
 		// messages from the parser - consider if this is an option.
 		errMsg: "unexpected character inside braces: '>'",
 	}, {


### PR DESCRIPTION
1. "modifiying" to "modifying" in line 243.
2. "precrise" to "precise" in line 906.