### PR TITLE
Make match_target argument optional in targetMetadata

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -594,7 +594,7 @@ func (api *API) targetMetadata(r *http.Request) apiFuncResult {
 	matchers := []*labels.Matcher{}
 	if s := r.FormValue("match_target"); s != "" {
 		var err error
-		matchers, err = promql.ParseMetricSelector(r.FormValue("match_target"))
+		matchers, err = promql.ParseMetricSelector(s)
 		if err != nil {
 			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 		}

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -591,9 +591,13 @@ func (api *API) targetMetadata(r *http.Request) apiFuncResult {
 		}
 	}
 
-	matchers, err := promql.ParseMetricSelector(r.FormValue("match_target"))
-	if err != nil {
-		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
+	matchers := []*labels.Matcher{}
+	if s := r.FormValue("match_target"); s != "" {
+		var err error
+		matchers, err = promql.ParseMetricSelector(r.FormValue("match_target"))
+		if err != nil {
+			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
+		}
 	}
 
 	metric := r.FormValue("metric")


### PR DESCRIPTION
I would like people on my team to have an easy way to view metrics' help strings. As far as I can tell the only place they are exposed in Prometheus is at the `/api/v1/targets/metadata` endpoint. I'd like to scrape that endpoint to produce a page with metrics and their help strings. Unfortunately, it's currently hard to scrape that endpoint programmatically knowing only the relevant metrics' name, you need to provide a label matcher as well.

This PR makes it easier to scrape the `/api/v1/targets/metadata` endpoint.

As the `targetMetadata` function is not covered by any unit tests, I have not added any.