### PR TITLE
scrape: Add global jitter for HA server

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -15,6 +15,8 @@ package scrape
 
 import (
 	"fmt"
+	"hash/fnv"
+	"os"
 	"reflect"
 	"sync"
 	"time"
@@ -22,6 +24,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/storage"
@@ -54,6 +57,7 @@ type Manager struct {
 	append    Appendable
 	graceShut chan struct{}
 
+	jitterSeed    uint64     // Global jitterSeed seed is using to spread scrape workload across HA setup.
 	mtxScrape     sync.Mutex // Guards the fields below.
 	scrapeConfigs map[string]*config.ScrapeConfig
 	scrapePools   map[string]*scrapePool
@@ -111,7 +115,7 @@ func (m *Manager) reload() {
 				level.Error(m.logger).Log("msg", "error reloading target set", "err", "invalid config id:"+setName)
 				continue
 			}
-			sp, err := newScrapePool(scrapeConfig, m.append, log.With(m.logger, "scrape_pool", setName))
+			sp, err := newScrapePool(scrapeConfig, m.append, m.jitterSeed, log.With(m.logger, "scrape_pool", setName))
 			if err != nil {
 				level.Error(m.logger).Log("msg", "error creating new scrape pool", "err", err, "scrape_pool", setName)
 				continue
@@ -129,6 +133,20 @@ func (m *Manager) reload() {
 	}
 	m.mtxScrape.Unlock()
 	wg.Wait()
+}
+
+// setJitterSeed calculates global jitterSeed per server relying on extra label set.
+func (m *Manager) setJitterSeed(labels model.LabelSet) error {
+	h := fnv.New64a()
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+	if _, err := h.Write([]byte(hostname + labels.String())); err != nil {
+		return err
+	}
+	m.jitterSeed = h.Sum64()
+	return nil
 }
 
 // Stop cancels all running scrape pools and blocks until all have exited.
@@ -158,6 +176,10 @@ func (m *Manager) ApplyConfig(cfg *config.Config) error {
 		c[scfg.JobName] = scfg
 	}
 	m.scrapeConfigs = c
+
+	if err := m.setJitterSeed(cfg.GlobalConfig.ExternalLabels); err != nil {
+		return err
+	}
 
 	// Cleanup and reload pool if the configuration has changed.
 	var failed bool

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -19,14 +19,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/prometheus/pkg/relabel"
-
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/util/testutil"
-
 	yaml "gopkg.in/yaml.v2"
 )
 

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -125,12 +125,14 @@ func (t *Target) hash() uint64 {
 }
 
 // offset returns the time until the next scrape cycle for the target.
-func (t *Target) offset(interval time.Duration) time.Duration {
+// It includes the global server jitterSeed for scrapes of HA setup to be spread across the time interval.
+func (t *Target) offset(interval time.Duration, jitterSeed uint64) time.Duration {
 	now := time.Now().UnixNano()
 
+	// base is a pinned to a absolute time, no matter how often offset is called.
 	var (
 		base   = int64(interval) - now%int64(interval)
-		offset = t.hash() % uint64(interval)
+		offset = (t.hash()^uint64(jitterSeed)) % uint64(interval)
 		next   = base + int64(offset)
 	)
 

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -125,14 +125,14 @@ func (t *Target) hash() uint64 {
 }
 
 // offset returns the time until the next scrape cycle for the target.
-// It includes the global server jitterSeed for scrapes of HA setup to be spread across the time interval.
+// It includes the global server jitterSeed for scrapes from multiple Prometheus to try to be at different times.
 func (t *Target) offset(interval time.Duration, jitterSeed uint64) time.Duration {
 	now := time.Now().UnixNano()
 
-	// base is a pinned to a absolute time, no matter how often offset is called.
+	// Base is a pinned to absolute time, no matter how often offset is called.
 	var (
 		base   = int64(interval) - now%int64(interval)
-		offset = (t.hash()^uint64(jitterSeed)) % uint64(interval)
+		offset = (t.hash() ^ jitterSeed) % uint64(interval)
 		next   = base + int64(offset)
 	)
 

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -47,6 +47,7 @@ func TestTargetLabels(t *testing.T) {
 
 func TestTargetOffset(t *testing.T) {
 	interval := 10 * time.Second
+	jitter := uint64(0)
 
 	offsets := make([]time.Duration, 10000)
 
@@ -55,7 +56,7 @@ func TestTargetOffset(t *testing.T) {
 		target := newTestTarget("example.com:80", 0, labels.FromStrings(
 			"label", fmt.Sprintf("%d", i),
 		))
-		offsets[i] = target.offset(interval)
+		offsets[i] = target.offset(interval, jitter)
 	}
 
 	// Put the offsets into buckets and validate that they are all


### PR DESCRIPTION
Covers issue in https://github.com/prometheus/prometheus/pull/4926#issuecomment-449039848
where the HA setup become a problem for targets unable to be scraped simultaneously.
The new jitter per server relies on a hostname and external labels which necessarily to be uniq.

As before, scrape offset will be calculated with regard the absolute time, so even
restart/reload doesn't change scrape time per scrape target + prometheus instance.

Jitter interval was chosen within the boundaries 0-59 seconds, which should be enough
to bring entropy for the scrapes across HA setup.