### PR TITLE
Fix prometheus_rule_group_last_evaluation_timestamp_seconds

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -385,7 +385,7 @@ func (g *Group) GetEvaluationTimestamp() time.Time {
 
 // setEvaluationTimestamp updates evaluationTimestamp to the timestamp of when the rule group was last evaluated.
 func (g *Group) setEvaluationTimestamp(ts time.Time) {
-	g.metrics.groupLastEvalTime.WithLabelValues(groupKey(g.file, g.name)).Set(float64(ts.Second()))
+	g.metrics.groupLastEvalTime.WithLabelValues(groupKey(g.file, g.name)).Set(float64(ts.UnixNano()) / 1e9)
 
 	g.mtx.Lock()
 	defer g.mtx.Unlock()


### PR DESCRIPTION
It should be a unix timestamp, not the seconds in the minute.

This replicates and supersedes #5184 . The different is that this is based on the release-2.7 branch to avoid cherrypicking of bugfixes (as per our release guidelines).