### PR TITLE
Various WAL remote write updates.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/getsentry/raven-go v0.1.0 // indirect
 	github.com/go-ini/ini v1.21.1 // indirect
 	github.com/go-kit/kit v0.8.0
+	github.com/go-logfmt/logfmt v0.4.0
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-sql-driver/mysql v1.4.0 // indirect
 	github.com/gogo/protobuf v1.2.0

--- a/pkg/logging/dedupe.go
+++ b/pkg/logging/dedupe.go
@@ -1,0 +1,126 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package logging
+
+import (
+	"bytes"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-logfmt/logfmt"
+)
+
+const (
+	garbageCollectEvery = 10 * time.Second
+	expireEntriesAfter  = 1 * time.Minute
+)
+
+type logfmtEncoder struct {
+	*logfmt.Encoder
+	buf bytes.Buffer
+}
+
+var logfmtEncoderPool = sync.Pool{
+	New: func() interface{} {
+		var enc logfmtEncoder
+		enc.Encoder = logfmt.NewEncoder(&enc.buf)
+		return &enc
+	},
+}
+
+// Deduper implement log.Logger, dedupes log lines.
+type Deduper struct {
+	next   log.Logger
+	repeat time.Duration
+	quit   chan struct{}
+	mtx    sync.RWMutex
+	seen   map[string]time.Time
+}
+
+// Dedupe log lines to next, only repeating every repeat duration.
+func Dedupe(next log.Logger, repeat time.Duration) *Deduper {
+	d := &Deduper{
+		next:   next,
+		repeat: repeat,
+		quit:   make(chan struct{}),
+		seen:   map[string]time.Time{},
+	}
+	go d.run()
+	return d
+}
+
+// Stop the Deduper.
+func (d *Deduper) Stop() {
+	close(d.quit)
+}
+
+func (d *Deduper) run() {
+	ticker := time.NewTicker(garbageCollectEvery)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			d.mtx.Lock()
+			now := time.Now()
+			for line, seen := range d.seen {
+				if now.Sub(seen) > expireEntriesAfter {
+					delete(d.seen, line)
+				}
+			}
+			d.mtx.Unlock()
+		case <-d.quit:
+			return
+		}
+	}
+}
+
+// Log implements log.Logger.
+func (d *Deduper) Log(keyvals ...interface{}) error {
+	line, err := encode(keyvals...)
+	if err != nil {
+		return err
+	}
+
+	d.mtx.RLock()
+	last, ok := d.seen[line]
+	d.mtx.RUnlock()
+
+	if ok && time.Since(last) < d.repeat {
+		return nil
+	}
+
+	d.mtx.Lock()
+	d.seen[line] = time.Now()
+	d.mtx.Unlock()
+
+	return d.next.Log(keyvals...)
+}
+
+func encode(keyvals ...interface{}) (string, error) {
+	enc := logfmtEncoderPool.Get().(*logfmtEncoder)
+	enc.buf.Reset()
+	defer logfmtEncoderPool.Put(enc)
+
+	if err := enc.EncodeKeyvals(keyvals...); err != nil {
+		return "", err
+	}
+
+	// Add newline to the end of the buffer
+	if err := enc.EndRecord(); err != nil {
+		return "", err
+	}
+
+	return enc.buf.String(), nil
+}

--- a/pkg/logging/dedupe_test.go
+++ b/pkg/logging/dedupe_test.go
@@ -1,0 +1,46 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package logging
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type counter int
+
+func (c *counter) Log(keyvals ...interface{}) error {
+	(*c)++
+	return nil
+}
+
+func TestDedupe(t *testing.T) {
+	var c counter
+	d := Dedupe(&c, 100*time.Millisecond)
+	defer d.Stop()
+
+	// Log 10 times quickly, ensure they are deduped.
+	for i := 0; i < 10; i++ {
+		err := d.Log("msg", "hello")
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, int(c))
+
+	// Wait, then log again, make sure it is logged.
+	time.Sleep(200 * time.Millisecond)
+	err := d.Log("msg", "hello")
+	require.NoError(t, err)
+	require.Equal(t, 2, int(c))
+}

--- a/pkg/logging/ratelimit.go
+++ b/pkg/logging/ratelimit.go
@@ -1,0 +1,38 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package logging
+
+import (
+	"github.com/go-kit/kit/log"
+	"golang.org/x/time/rate"
+)
+
+type ratelimiter struct {
+	limiter *rate.Limiter
+	next    log.Logger
+}
+
+// RateLimit write to a loger.
+func RateLimit(next log.Logger, limit rate.Limit) log.Logger {
+	return &ratelimiter{
+		limiter: rate.NewLimiter(limit, int(limit)),
+		next:    next,
+	}
+}
+
+func (r *ratelimiter) Log(keyvals ...interface{}) error {
+	if r.limiter.Allow() {
+		return r.next.Log(keyvals...)
+	}
+	return nil
+}

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -126,7 +126,7 @@ var (
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "queue_highest_sent_timestamp",
-			Help:      "Timestamp from a WAL sample, the highest timestamp successfully sent by this queue.",
+			Help:      "Timestamp from a WAL sample, the highest timestamp successfully sent by this queue, in seconds since epoch.",
 		},
 		[]string{queue},
 	)
@@ -524,7 +524,7 @@ func (t *QueueManager) setHighestSentTimestamp(highest int64) {
 	defer t.timestampLock.Unlock()
 	if highest > t.highestSentTimestamp {
 		t.highestSentTimestamp = highest
-		t.highestSentTimestampMetric.Set(float64(t.highestSentTimestamp))
+		t.highestSentTimestampMetric.Set(float64(t.highestSentTimestamp) / 1000.)
 	}
 }
 

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -60,7 +60,7 @@ func NewStorage(l log.Logger, reg prometheus.Registerer, stCallback startTimeCal
 	}
 	shardUpdateDuration := 10 * time.Second
 	s := &Storage{
-		logger:                 logging.RateLimit(logging.Dedupe(l, 1*time.Minute), 1),
+		logger:                 logging.Dedupe(l, 1*time.Minute),
 		localStartTimeCallback: stCallback,
 		flushDeadline:          flushDeadline,
 		walDir:                 walDir,

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/logging"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/storage"
 )
@@ -59,7 +60,7 @@ func NewStorage(l log.Logger, reg prometheus.Registerer, stCallback startTimeCal
 	}
 	shardUpdateDuration := 10 * time.Second
 	s := &Storage{
-		logger:                 l,
+		logger:                 logging.RateLimit(logging.Dedupe(l, 1*time.Minute), 1),
 		localStartTimeCallback: stCallback,
 		flushDeadline:          flushDeadline,
 		walDir:                 walDir,

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -71,7 +71,7 @@ func NewStorage(l log.Logger, reg prometheus.Registerer, stCallback startTimeCal
 		}),
 		highestTimestampMetric: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "prometheus_remote_storage_highest_timestamp_in",
-			Help: "Highest timestamp that has come into the remote storage via the Appender interface.",
+			Help: "Highest timestamp that has come into the remote storage via the Appender interface, in seconds since epoch.",
 		}),
 	}
 	reg.MustRegister(s.samplesInMetric)

--- a/storage/remote/wal_watcher.go
+++ b/storage/remote/wal_watcher.go
@@ -233,53 +233,38 @@ func (w *WALWatcher) runWatcher() {
 	}
 
 	w.currentSegment = first
-	w.currentSegmentMetric.Set(float64(w.currentSegment))
-	segment, err := wal.OpenReadSegment(wal.SegmentName(w.walDir, w.currentSegment))
-	// TODO: callum, is this error really fatal?
-	if err != nil {
-		level.Error(w.logger).Log("err", err)
-		return
-	}
-	reader := wal.NewLiveReader(segment)
 	tail := false
 
 	for {
-		// If we've replayed the existing WAL, start tailing.
 		if w.currentSegment == last {
 			tail = true
 		}
-		if tail {
-			level.Info(w.logger).Log("msg", "watching segment", "segment", w.currentSegment)
-		} else {
-			level.Info(w.logger).Log("msg", "replaying segment", "segment", w.currentSegment)
-		}
+
+		w.currentSegmentMetric.Set(float64(w.currentSegment))
+		level.Info(w.logger).Log("msg", "process segment", "segment", w.currentSegment, "tail", tail)
 
 		// On start, after reading the existing WAL for series records, we have a pointer to what is the latest segment.
 		// On subsequent calls to this function, currentSegment will have been incremented and we should open that segment.
-		err := w.watch(nw, reader, tail)
-		segment.Close()
-		if err != nil {
+		if err := w.watch(nw, w.currentSegment, tail); err != nil {
 			level.Error(w.logger).Log("msg", "runWatcher is ending", "err", err)
 			return
 		}
 
 		w.currentSegment++
-		w.currentSegmentMetric.Set(float64(w.currentSegment))
-
-		segment, err = wal.OpenReadSegment(wal.SegmentName(w.walDir, w.currentSegment))
-		// TODO: callum, is this error really fatal?
-		if err != nil {
-			level.Error(w.logger).Log("err", err)
-			return
-		}
-		reader = wal.NewLiveReader(segment)
 	}
 }
 
 // Use tail true to indicate thatreader is currently on a segment that is
 // actively being written to. If false, assume it's a full segment and we're
 // replaying it on start to cache the series records.
-func (w *WALWatcher) watch(wl *wal.WAL, reader *wal.LiveReader, tail bool) error {
+func (w *WALWatcher) watch(wl *wal.WAL, segmentNum int, tail bool) error {
+	segment, err := wal.OpenReadSegment(wal.SegmentName(w.walDir, segmentNum))
+	if err != nil {
+		return err
+	}
+	defer segment.Close()
+
+	reader := wal.NewLiveReader(segment)
 
 	readTicker := time.NewTicker(readPeriod)
 	defer readTicker.Stop()
@@ -289,6 +274,7 @@ func (w *WALWatcher) watch(wl *wal.WAL, reader *wal.LiveReader, tail bool) error
 
 	segmentTicker := time.NewTicker(segmentCheckPeriod)
 	defer segmentTicker.Stop()
+
 	// If we're replaying the segment we need to know the size of the file to know
 	// when to return from watch and move on to the next segment.
 	size := int64(math.MaxInt64)

--- a/storage/remote/wal_watcher.go
+++ b/storage/remote/wal_watcher.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"os"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -182,7 +183,7 @@ func NewWALWatcher(logger log.Logger, name string, writer writeTo, walDir string
 
 func (w *WALWatcher) Start() {
 	level.Info(w.logger).Log("msg", "starting WAL watcher", "queue", w.name)
-	go w.runWatcher()
+	go w.loop()
 }
 
 func (w *WALWatcher) Stop() {
@@ -190,68 +191,92 @@ func (w *WALWatcher) Stop() {
 	close(w.quit)
 }
 
-func (w *WALWatcher) runWatcher() {
-	// The WAL dir may not exist when Prometheus first starts up.
+func (w *WALWatcher) loop() {
+	// We may encourter failures processing the WAL; we should wait and retry.
+
 	for {
-		if _, err := os.Stat(w.walDir); os.IsNotExist(err) {
-			time.Sleep(time.Second)
-		} else {
-			break
+		if err := w.run(); err != nil {
+			level.Error(w.logger).Log("msg", "error tailing WAL", "err", err)
+		}
+
+		select {
+		case <-w.quit:
+			return
+		case <-time.After(5 * time.Second):
 		}
 	}
+}
 
+func (w *WALWatcher) run() error {
 	nw, err := wal.New(nil, nil, w.walDir)
 	if err != nil {
-		level.Error(w.logger).Log("err", err)
-		return
-	}
-
-	first, last, err := nw.Segments()
-	if err != nil {
-		level.Error(w.logger).Log("err", err)
-		return
-	}
-
-	if last == -1 {
-		level.Error(w.logger).Log("err", err)
-		return
+		return errors.Wrap(err, "wal.New")
 	}
 
 	// Backfill from the checkpoint first if it exists.
-	dir, _, err := tsdb.LastCheckpoint(w.walDir)
+	var nextIndex int
+	w.lastCheckpoint, nextIndex, err = tsdb.LastCheckpoint(w.walDir)
 	if err != nil && err != tsdb.ErrNotFound {
-		level.Error(w.logger).Log("msg", "error looking for existing checkpoint, some samples may be dropped", "err", errors.Wrap(err, "find last checkpoint"))
+		return err
 	}
 
-	level.Debug(w.logger).Log("msg", "reading checkpoint", "dir", dir)
+	level.Debug(w.logger).Log("msg", "reading checkpoint", "dir", w.lastCheckpoint, "startFrom", nextIndex)
 	if err == nil {
-		w.lastCheckpoint = dir
-		err = w.readCheckpoint(dir)
-		if err != nil {
-			level.Error(w.logger).Log("msg", "error reading existing checkpoint, some samples may be dropped", "err", err)
+		if err = w.readCheckpoint(w.lastCheckpoint); err != nil {
+			return err
 		}
 	}
 
-	w.currentSegment = first
-	tail := false
+	w.currentSegment, err = w.findSegmentForIndex(nextIndex)
+	if err != nil {
+		return err
+	}
+
+	level.Debug(w.logger).Log("msg", "starting from", "currentSegment", w.currentSegment)
 
 	for {
-		if w.currentSegment == last {
-			tail = true
-		}
-
 		w.currentSegmentMetric.Set(float64(w.currentSegment))
-		level.Info(w.logger).Log("msg", "process segment", "segment", w.currentSegment, "tail", tail)
+		level.Info(w.logger).Log("msg", "process segment", "segment", w.currentSegment)
 
 		// On start, after reading the existing WAL for series records, we have a pointer to what is the latest segment.
 		// On subsequent calls to this function, currentSegment will have been incremented and we should open that segment.
-		if err := w.watch(nw, w.currentSegment, tail); err != nil {
+		if err := w.watch(nw, w.currentSegment, true); err != nil {
 			level.Error(w.logger).Log("msg", "runWatcher is ending", "err", err)
-			return
+			return err
 		}
 
 		w.currentSegment++
 	}
+}
+
+func (w *WALWatcher) findSegmentForIndex(index int) (int, error) {
+	files, err := fileutil.ReadDir(w.walDir)
+	if err != nil {
+		return -1, err
+	}
+
+	var refs []int
+	var last int
+	for _, fn := range files {
+		k, err := strconv.Atoi(fn)
+		if err != nil {
+			continue
+		}
+		if len(refs) > 0 && k > last+1 {
+			return -1, errors.New("segments are not sequential")
+		}
+		refs = append(refs, k)
+		last = k
+	}
+	sort.Sort(sort.IntSlice(refs))
+
+	for _, r := range refs {
+		if r >= index {
+			return r, nil
+		}
+	}
+
+	return -1, errors.New("failed to find segment for index")
 }
 
 // Use tail true to indicate thatreader is currently on a segment that is
@@ -444,11 +469,15 @@ func (w *WALWatcher) readCheckpoint(checkpointDir string) error {
 
 	// w.readSeriesRecords(wal.NewLiveReader(sr), i, size)
 	r := wal.NewLiveReader(sr)
-	w.readSegment(r)
+	if err := w.readSegment(r); err != nil {
+		return errors.Wrap(err, "readSegment")
+	}
+
 	if r.TotalRead() != size {
 		level.Warn(w.logger).Log("msg", "may not have read all data from checkpoint")
 	}
 	level.Debug(w.logger).Log("msg", "read series references from checkpoint", "checkpoint", checkpointDir)
+
 	return nil
 }
 

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -55,7 +55,7 @@ func (t *timestampTracker) Commit() error {
 	defer t.storage.highestTimestampMtx.Unlock()
 	if t.highestTimestamp > t.storage.highestTimestamp {
 		t.storage.highestTimestamp = t.highestTimestamp
-		t.storage.highestTimestampMetric.Set(float64(t.highestTimestamp))
+		t.storage.highestTimestampMetric.Set(float64(t.highestTimestamp) / 1000.)
 	}
 	return nil
 }


### PR DESCRIPTION
- Export timestamps in seconds.
- Refactor WAL watcher to remove some duplication
- Factor out logging ratelimit & dedupe middleware.