### PR TITLE
Using shebang in shell script

### DIFF
--- a/vendor/google.golang.org/grpc/internal/binarylog/regenerate.sh
+++ b/vendor/google.golang.org/grpc/internal/binarylog/regenerate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Adding `#!/usr/bin/env bash` in order to indicate that scripts use
bash shell for interpreting

Signed-off-by: Nguyen Hai Truong <nguyenhaitruonghp@gmail.com>