### PR TITLE
Use fixed length millisecond timestamp format for logs

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -85,6 +85,10 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	// Define fixed length millisecond timestamp format.
+	log.DefaultTimestamp = log.TimestampFormat(time.Now, "2006-01-02T15:04:05.000Z07:00")
+	log.DefaultTimestampUTC = log.TimestampFormat(func() time.Time { return time.Now().UTC() }, "2006-01-02T15:04:05.000Z07:00")
 }
 
 func main() {


### PR DESCRIPTION
Makes things smoother to read:

```
level=info ts=2019-02-16T11:05:15.197Z caller=main.go:306 msg="Starting Prometheus" version="(version=2.7.1, branch=log-timestamp, revision=252be41e6c31f64f670103b8a63639388c505291)"
level=info ts=2019-02-16T11:05:15.197Z caller=main.go:307 build_context="(go=go1.11.5, user=sylvain@khety.home, date=20190216-11:00:36)"
level=info ts=2019-02-16T11:05:15.197Z caller=main.go:308 host_details=(darwin)
level=info ts=2019-02-16T11:05:15.197Z caller=main.go:309 fd_limits="(soft=4864, hard=unlimited)"
level=info ts=2019-02-16T11:05:15.197Z caller=main.go:310 vm_limits="(soft=unlimited, hard=unlimited)"
level=info ts=2019-02-16T11:05:15.198Z caller=main.go:624 msg="Starting TSDB ..."
level=info ts=2019-02-16T11:05:15.198Z caller=web.go:416 component=web msg="Start listening for connections" address=0.0.0.0:9090
level=info ts=2019-02-16T11:05:15.200Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1548986400000 maxt=1549044000000 ulid=01D3TPJVTSF8NB7TFDQJMFEMDW
level=info ts=2019-02-16T11:05:15.201Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549044000000 maxt=1549108800000 ulid=01D3TPJVXTQGW8DQHX8JESK2F4
level=info ts=2019-02-16T11:05:15.201Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549108800000 maxt=1549173600000 ulid=01D3TPJW19VFZKB314Q8RFQ4EW
level=info ts=2019-02-16T11:05:15.201Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549173600000 maxt=1549238400000 ulid=01D3TPJW4EG3HCH2V1ZP0Z1385
level=info ts=2019-02-16T11:05:15.202Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549238400000 maxt=1549303200000 ulid=01D3TPJW7HR2B6JYBWNVP6X4NY
level=info ts=2019-02-16T11:05:15.202Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549303200000 maxt=1549368000000 ulid=01D3TPJWASRQENB0VV23FR7TDM
level=info ts=2019-02-16T11:05:15.202Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549368000000 maxt=1549432800000 ulid=01D3TPJWDP5NAQ1DH8VVPMX0R1
level=info ts=2019-02-16T11:05:15.202Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549432800000 maxt=1549497600000 ulid=01D3TPJWGG4414R6H8DAKRQH3Z
level=info ts=2019-02-16T11:05:15.203Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549497600000 maxt=1549562400000 ulid=01D3TPJWK62N00FYRX3FKHYS6Z
level=info ts=2019-02-16T11:05:15.203Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549562400000 maxt=1549627200000 ulid=01D3TPJWPY31KXPP6J0M0EDM14
level=info ts=2019-02-16T11:05:15.203Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549627200000 maxt=1549692000000 ulid=01D3TPJWTAK4VX5BAW8ZDR55HB
level=info ts=2019-02-16T11:05:15.203Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549692000000 maxt=1549756800000 ulid=01D3TPJWXDY4MXATPTNGKW7009
level=info ts=2019-02-16T11:05:15.203Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549756800000 maxt=1549821600000 ulid=01D3TPJX0FFZXA949R8YP3CQSE
level=info ts=2019-02-16T11:05:15.203Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549821600000 maxt=1549886400000 ulid=01D3TPJX3CVCY6WTCK5ZDFECTG
level=info ts=2019-02-16T11:05:15.204Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549886400000 maxt=1549951200000 ulid=01D3TPJX6D0S2W8DWP6M3SK61X
level=info ts=2019-02-16T11:05:15.204Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1549951200000 maxt=1550016000000 ulid=01D3TPJX9SDDYSTG1G2WP5Y7BJ
level=info ts=2019-02-16T11:05:15.204Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1550016000000 maxt=1550080800000 ulid=01D3TPJXCNT03YSC9NAPJSKFRW
level=info ts=2019-02-16T11:05:15.204Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1550080800000 maxt=1550145600000 ulid=01D3TPJXFSBZ9H90G0WRYQ7VKZ
level=info ts=2019-02-16T11:05:15.204Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1550145600000 maxt=1550210400000 ulid=01D3TPJXJFKQCMHRDZ88H2CHZF
level=info ts=2019-02-16T11:05:15.204Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1550210400000 maxt=1550275200000 ulid=01D3TPJXNPGWCCZ2AQZ4BEQHNX
level=info ts=2019-02-16T11:05:15.204Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1550296800000 maxt=1550304000000 ulid=01D3TWA5XHMJ2A3KFC0V7BSAX4
level=info ts=2019-02-16T11:05:15.205Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1550275200000 maxt=1550296800000 ulid=01D3TWA63GV1RJA7TRZQ121G2X
level=info ts=2019-02-16T11:05:15.205Z caller=repair.go:48 component=tsdb msg="found healthy block" mint=1550304000000 maxt=1550311200000 ulid=01D3TZD1ZKF1TAVN1F3EMJ8D4Z
level=warn ts=2019-02-16T11:05:15.594Z caller=head.go:440 component=tsdb msg="unknown series references" count=2139
level=info ts=2019-02-16T11:05:15.596Z caller=main.go:639 msg="TSDB started"
level=info ts=2019-02-16T11:05:15.596Z caller=main.go:699 msg="Loading configuration file" filename=documentation/examples/prometheus.yml
level=info ts=2019-02-16T11:05:15.597Z caller=main.go:726 msg="Completed loading of configuration file" filename=documentation/examples/prometheus.yml
level=info ts=2019-02-16T11:05:15.597Z caller=main.go:593 msg="Server is ready to receive web requests."
level=warn ts=2019-02-16T11:05:17.379Z caller=main.go:468 msg="Received SIGTERM, exiting gracefully..."
level=info ts=2019-02-16T11:05:17.380Z caller=main.go:493 msg="Stopping scrape discovery manager..."
level=info ts=2019-02-16T11:05:17.380Z caller=main.go:507 msg="Stopping notify discovery manager..."
level=info ts=2019-02-16T11:05:17.380Z caller=main.go:529 msg="Stopping scrape manager..."
level=info ts=2019-02-16T11:05:17.380Z caller=manager.go:736 component="rule manager" msg="Stopping rule manager..."
level=info ts=2019-02-16T11:05:17.380Z caller=manager.go:742 component="rule manager" msg="Rule manager stopped"
level=info ts=2019-02-16T11:05:17.380Z caller=main.go:489 msg="Scrape discovery manager stopped"
level=info ts=2019-02-16T11:05:17.380Z caller=main.go:503 msg="Notify discovery manager stopped"
level=info ts=2019-02-16T11:05:17.380Z caller=main.go:523 msg="Scrape manager stopped"
level=info ts=2019-02-16T11:05:17.396Z caller=notifier.go:521 component=notifier msg="Stopping notification manager..."
level=info ts=2019-02-16T11:05:17.397Z caller=main.go:683 msg="Notifier manager stopped"
level=info ts=2019-02-16T11:05:17.397Z caller=main.go:695 msg="See you next time!"
```

Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>