### PR TITLE
discovery/marathon: pass context to the client

### DIFF
--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -228,7 +228,7 @@ func (d *Discovery) updateServices(ctx context.Context, ch chan<- []*targetgroup
 		}
 	}()
 
-	targetMap, err := d.fetchTargetGroups()
+	targetMap, err := d.fetchTargetGroups(ctx)
 	if err != nil {
 		return err
 	}
@@ -261,9 +261,9 @@ func (d *Discovery) updateServices(ctx context.Context, ch chan<- []*targetgroup
 	return nil
 }
 
-func (d *Discovery) fetchTargetGroups() (map[string]*targetgroup.Group, error) {
+func (d *Discovery) fetchTargetGroups(ctx context.Context) (map[string]*targetgroup.Group, error) {
 	url := RandomAppsURL(d.servers)
-	apps, err := d.appsClient(d.client, url)
+	apps, err := d.appsClient(ctx, d.client, url)
 	if err != nil {
 		return nil, err
 	}
@@ -341,14 +341,15 @@ type AppList struct {
 }
 
 // AppListClient defines a function that can be used to get an application list from marathon.
-type AppListClient func(client *http.Client, url string) (*AppList, error)
+type AppListClient func(ctx context.Context, client *http.Client, url string) (*AppList, error)
 
 // fetchApps requests a list of applications from a marathon server.
-func fetchApps(client *http.Client, url string) (*AppList, error) {
+func fetchApps(ctx context.Context, client *http.Client, url string) (*AppList, error) {
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
+	request = request.WithContext(ctx)
 
 	resp, err := client.Do(request)
 	if err != nil {

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -45,7 +45,7 @@ func TestMarathonSDHandleError(t *testing.T) {
 	var (
 		errTesting = errors.New("testing failure")
 		ch         = make(chan []*targetgroup.Group, 1)
-		client     = func(client *http.Client, url string) (*AppList, error) { return nil, errTesting }
+		client     = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) { return nil, errTesting }
 	)
 	if err := testUpdateServices(client, ch); err != errTesting {
 		t.Fatalf("Expected error: %s", err)
@@ -60,7 +60,7 @@ func TestMarathonSDHandleError(t *testing.T) {
 func TestMarathonSDEmptyList(t *testing.T) {
 	var (
 		ch     = make(chan []*targetgroup.Group, 1)
-		client = func(client *http.Client, url string) (*AppList, error) { return &AppList{}, nil }
+		client = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) { return &AppList{}, nil }
 	)
 	if err := testUpdateServices(client, ch); err != nil {
 		t.Fatalf("Got error: %s", err)
@@ -103,7 +103,7 @@ func marathonTestAppList(labels map[string]string, runningTasks int) *AppList {
 func TestMarathonSDSendGroup(t *testing.T) {
 	var (
 		ch     = make(chan []*targetgroup.Group, 1)
-		client = func(client *http.Client, url string) (*AppList, error) {
+		client = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) {
 			return marathonTestAppList(marathonValidLabel, 1), nil
 		}
 	)
@@ -139,7 +139,7 @@ func TestMarathonSDRemoveApp(t *testing.T) {
 		t.Fatalf("%s", err)
 	}
 
-	md.appsClient = func(client *http.Client, url string) (*AppList, error) {
+	md.appsClient = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) {
 		return marathonTestAppList(marathonValidLabel, 1), nil
 	}
 	if err := md.updateServices(context.Background(), ch); err != nil {
@@ -147,7 +147,7 @@ func TestMarathonSDRemoveApp(t *testing.T) {
 	}
 	up1 := (<-ch)[0]
 
-	md.appsClient = func(client *http.Client, url string) (*AppList, error) {
+	md.appsClient = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) {
 		return marathonTestAppList(marathonValidLabel, 0), nil
 	}
 	if err := md.updateServices(context.Background(), ch); err != nil {
@@ -174,7 +174,7 @@ func TestMarathonSDRunAndStop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
-	md.appsClient = func(client *http.Client, url string) (*AppList, error) {
+	md.appsClient = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) {
 		return marathonTestAppList(marathonValidLabel, 1), nil
 	}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -228,7 +228,7 @@ func marathonTestAppListWithMultiplePorts(labels map[string]string, runningTasks
 func TestMarathonSDSendGroupWithMultiplePort(t *testing.T) {
 	var (
 		ch     = make(chan []*targetgroup.Group, 1)
-		client = func(client *http.Client, url string) (*AppList, error) {
+		client = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) {
 			return marathonTestAppListWithMultiplePorts(marathonValidLabel, 1), nil
 		}
 	)
@@ -289,7 +289,7 @@ func marathonTestZeroTaskPortAppList(labels map[string]string, runningTasks int)
 func TestMarathonZeroTaskPorts(t *testing.T) {
 	var (
 		ch     = make(chan []*targetgroup.Group, 1)
-		client = func(client *http.Client, url string) (*AppList, error) {
+		client = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) {
 			return marathonTestZeroTaskPortAppList(marathonValidLabel, 1), nil
 		}
 	)
@@ -371,7 +371,7 @@ func marathonTestAppListWithPortDefinitions(labels map[string]string, runningTas
 func TestMarathonSDSendGroupWithPortDefinitions(t *testing.T) {
 	var (
 		ch     = make(chan []*targetgroup.Group, 1)
-		client = func(client *http.Client, url string) (*AppList, error) {
+		client = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) {
 			return marathonTestAppListWithPortDefinitions(marathonValidLabel, 1), nil
 		}
 	)
@@ -445,7 +445,7 @@ func marathonTestAppListWithPortDefinitionsRequirePorts(labels map[string]string
 func TestMarathonSDSendGroupWithPortDefinitionsRequirePorts(t *testing.T) {
 	var (
 		ch     = make(chan []*targetgroup.Group, 1)
-		client = func(client *http.Client, url string) (*AppList, error) {
+		client = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) {
 			return marathonTestAppListWithPortDefinitionsRequirePorts(marathonValidLabel, 1), nil
 		}
 	)
@@ -514,7 +514,7 @@ func marathonTestAppListWithPorts(labels map[string]string, runningTasks int) *A
 func TestMarathonSDSendGroupWithPorts(t *testing.T) {
 	var (
 		ch     = make(chan []*targetgroup.Group, 1)
-		client = func(client *http.Client, url string) (*AppList, error) {
+		client = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) {
 			return marathonTestAppListWithPorts(marathonValidLabel, 1), nil
 		}
 	)
@@ -592,7 +592,7 @@ func marathonTestAppListWithContainerPortMappings(labels map[string]string, runn
 func TestMarathonSDSendGroupWithContainerPortMappings(t *testing.T) {
 	var (
 		ch     = make(chan []*targetgroup.Group, 1)
-		client = func(client *http.Client, url string) (*AppList, error) {
+		client = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) {
 			return marathonTestAppListWithContainerPortMappings(marathonValidLabel, 1), nil
 		}
 	)
@@ -670,7 +670,7 @@ func marathonTestAppListWithDockerContainerPortMappings(labels map[string]string
 func TestMarathonSDSendGroupWithDockerContainerPortMappings(t *testing.T) {
 	var (
 		ch     = make(chan []*targetgroup.Group, 1)
-		client = func(client *http.Client, url string) (*AppList, error) {
+		client = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) {
 			return marathonTestAppListWithDockerContainerPortMappings(marathonValidLabel, 1), nil
 		}
 	)
@@ -752,7 +752,7 @@ func marathonTestAppListWithContainerNetworkAndPortMappings(labels map[string]st
 func TestMarathonSDSendGroupWithContainerNetworkAndPortMapping(t *testing.T) {
 	var (
 		ch     = make(chan []*targetgroup.Group, 1)
-		client = func(client *http.Client, url string) (*AppList, error) {
+		client = func(_ context.Context, _ *http.Client, _ string) (*AppList, error) {
 			return marathonTestAppListWithContainerNetworkAndPortMappings(marathonValidLabel, 1), nil
 		}
 	)


### PR DESCRIPTION
The change should be safe but it would be good if someone with a Marathon environment could give it a try. 
cc @tommarute @ti-mo  @rjanovski @adrien-f.