### PR TITLE
Makefile.common: add check_license by default.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -93,7 +93,7 @@ endif
 %: common-% ;
 
 .PHONY: common-all
-common-all: precheck style check_license staticcheck unused test
+common-all: precheck style check_license staticcheck unused test build
 
 .PHONY: common-style
 common-style:

--- a/Makefile.common
+++ b/Makefile.common
@@ -93,7 +93,7 @@ endif
 %: common-% ;
 
 .PHONY: common-all
-common-all: precheck style check_license staticcheck unused test build
+common-all: precheck style check_license staticcheck unused build test
 
 .PHONY: common-style
 common-style:

--- a/Makefile.common
+++ b/Makefile.common
@@ -87,13 +87,13 @@ ifeq ($(GOHOSTARCH),amd64)
         endif
 endif
 
-.PHONY: all
-all: precheck style staticcheck unused build test
-
 # This rule is used to forward a target like "build" to "common-build".  This
 # allows a new "build" target to be defined in a Makefile which includes this
 # one and override "common-build" without override warnings.
 %: common-% ;
+
+.PHONY: common-all
+common-all: precheck style check_license staticcheck unused test
 
 .PHONY: common-style
 common-style:


### PR DESCRIPTION
for repos that fail on the check_license check can override it in the main Makefile.

Not sure about removing the build target. Do you know why it was added to run by default?

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>