### PR TITLE
Change http to https for security links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Prometheus uses GitHub to manage reviews of pull requests.
   Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments)
   and the _Formatting and style_ section of Peter Bourgon's [Go: Best
   Practices for Production
-  Environments](http://peter.bourgon.org/go-in-production/#formatting-and-style).
+  Environments](https://peter.bourgon.org/go-in-production/#formatting-and-style).
 
 * Be sure to sign off on the [DCO](https://github.com/probot/dco#how-it-works)
 

--- a/NOTICE
+++ b/NOTICE
@@ -2,13 +2,13 @@ The Prometheus systems and service monitoring server
 Copyright 2012-2015 The Prometheus Authors
 
 This product includes software developed at
-SoundCloud Ltd. (http://soundcloud.com/).
+SoundCloud Ltd. (https://soundcloud.com/).
 
 
 The following components are included in this product:
 
 Bootstrap
-http://getbootstrap.com
+https://getbootstrap.com
 Copyright 2011-2014 Twitter, Inc.
 Licensed under the MIT License
 
@@ -52,7 +52,7 @@ Copyright jQuery Foundation and other contributors
 Licensed under the MIT License
 
 Protocol Buffers for Go with Gadgets
-http://github.com/gogo/protobuf/
+https://github.com/gogo/protobuf/
 Copyright (c) 2013, The GoGo Authors.
 See source code for license details.
 
@@ -67,7 +67,7 @@ Copyright 2013 Matt T. Proud
 Licensed under the Apache License, Version 2.0
 
 DNS library in Go
-http://miek.nl/posts/2014/Aug/16/go-dns-package/
+https://miek.nl/2014/august/16/go-dns-package/
 Copyright 2009 The Go Authors, 2011 Miek Gieben
 See https://github.com/miekg/dns/blob/master/LICENSE for license details.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Prometheus will now be reachable at http://localhost:9090/.
 ### Building from source
 
 To build Prometheus from the source code yourself you need to have a working
-Go environment with [version 1.11 or greater installed](http://golang.org/doc/install).
+Go environment with [version 1.11 or greater installed](https://golang.org/doc/install).
 
 You can directly use the `go` tool to download and install the `prometheus`
 and `promtool` binaries into your `GOPATH`:
@@ -87,7 +87,7 @@ The Makefile provides several targets:
 
 ## More information
 
-  * The source code is periodically indexed: [Prometheus Core](http://godoc.org/github.com/prometheus/prometheus).
+  * The source code is periodically indexed: [Prometheus Core](https://godoc.org/github.com/prometheus/prometheus).
   * You will find a Travis CI configuration in `.travis.yml`.
   * See the [Community page](https://prometheus.io/community) for how to reach the Prometheus developers and users on various communication channels.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,7 +35,7 @@ These instructions are currently valid for the Prometheus server, i.e. the [prom
 
 ### Branch management and versioning strategy
 
-We use [Semantic Versioning](http://semver.org/).
+We use [Semantic Versioning](https://semver.org/).
 
 We maintain a separate branch for each minor release, named `release-<major>.<minor>`, e.g. `release-1.1`, `release-2.0`.
 
@@ -97,7 +97,7 @@ Once the binaries have been uploaded, announce the release on `prometheus-users@
 
 The following changes to the above procedures apply:
 
-* In line with [Semantic Versioning](http://semver.org/), append something like `-rc.0` to the version (with the corresponding changes to the tag name, the release name etc.).
+* In line with [Semantic Versioning](https://semver.org/), append something like `-rc.0` to the version (with the corresponding changes to the tag name, the release name etc.).
 * Tick the _This is a pre-release_ box when drafting the release in the Github UI.
 * Still update `CHANGELOG.md`, but when you cut the final release later, merge all the changes from the pre-releases into the one final update.
 


### PR DESCRIPTION
For security, we should change http into https links.