### PR TITLE
Change http to https for security links

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -24,7 +24,7 @@ This will also reload any configured rule files.
 
 To specify which configuration file to load, use the `--config.file` flag.
 
-The file is written in [YAML format](http://en.wikipedia.org/wiki/YAML),
+The file is written in [YAML format](https://en.wikipedia.org/wiki/YAML),
 defined by the scheme described below.
 Brackets indicate that a parameter is optional. For non-list parameters the
 value is set to the specified default.
@@ -678,7 +678,7 @@ service account and place the credential file in one of the expected locations.
 ### `<kubernetes_sd_config>`
 
 Kubernetes SD configurations allow retrieving scrape targets from
-[Kubernetes'](http://kubernetes.io/) REST API and always staying synchronized with
+[Kubernetes'](https://kubernetes.io/) REST API and always staying synchronized with
 the cluster state.
 
 One of the following `role` types can be configured to discover targets:
@@ -938,7 +938,7 @@ Serverset SD configurations allow retrieving scrape targets from [Serversets]
 (https://github.com/twitter/finagle/tree/master/finagle-serversets) which are
 stored in [Zookeeper](https://zookeeper.apache.org/). Serversets are commonly
 used by [Finagle](https://twitter.github.io/finagle/) and
-[Aurora](http://aurora.apache.org/).
+[Aurora](https://aurora.apache.org/).
 
 The following meta labels are available on targets during relabeling:
 

--- a/docs/configuration/template_examples.md
+++ b/docs/configuration/template_examples.md
@@ -9,7 +9,7 @@ Prometheus supports templating in the annotations and labels of alerts,
 as well as in served console pages. Templates have the ability to run
 queries against the local database, iterate over data, use conditionals,
 format data, etc. The Prometheus templating language is based on the [Go
-templating](http://golang.org/pkg/text/template/) system.
+templating](https://golang.org/pkg/text/template/) system.
 
 ## Simple alert field templates
 

--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -9,7 +9,7 @@ Prometheus supports templating in the annotations and labels of alerts,
 as well as in served console pages. Templates have the ability to run
 queries against the local database, iterate over data, use conditionals,
 format data, etc. The Prometheus templating language is based on the [Go
-templating](http://golang.org/pkg/text/template/) system.
+templating](https://golang.org/pkg/text/template/) system.
 
 ## Data Structures
 
@@ -31,7 +31,7 @@ The metric name of the sample is encoded in a special `__name__` label in the `L
 ## Functions
 
 In addition to the [default
-functions](http://golang.org/pkg/text/template/#hdr-Functions) provided by Go
+functions](https://golang.org/pkg/text/template/#hdr-Functions) provided by Go
 templating, Prometheus provides functions for easier processing of query
 results in templates.
 
@@ -53,7 +53,7 @@ If functions are used in a pipeline, the pipeline value is passed as the last ar
 
 | Name          | Arguments     | Returns |  Notes    |
 | ------------- | --------------| --------| --------- |
-| humanize      | number        | string  | Converts a number to a more readable format, using [metric prefixes](http://en.wikipedia.org/wiki/Metric_prefix).
+| humanize      | number        | string  | Converts a number to a more readable format, using [metric prefixes](https://en.wikipedia.org/wiki/Metric_prefix).
 | humanize1024  | number        | string  | Like `humanize`, but uses 1024 as the base rather than 1000. |
 | humanizeDuration | number     | string  | Converts a duration in seconds to a more readable format. |
 | humanizeTimestamp | number    | string  | Converts a Unix timestamp in seconds to a more readable format. |
@@ -66,11 +66,11 @@ versions.
 
 | Name          | Arguments     | Returns |    Notes    |
 | ------------- | ------------- | ------- | ----------- |
-| title         | string        | string  | [strings.Title](http://golang.org/pkg/strings/#Title), capitalises first character of each word.|
-| toUpper       | string        | string  | [strings.ToUpper](http://golang.org/pkg/strings/#ToUpper), converts all characters to upper case.|
-| toLower       | string        | string  | [strings.ToLower](http://golang.org/pkg/strings/#ToLower), converts all characters to lower case.|
-| match         | pattern, text | boolean | [regexp.MatchString](http://golang.org/pkg/regexp/#MatchString) Tests for a unanchored regexp match. |
-| reReplaceAll  | pattern, replacement, text | string | [Regexp.ReplaceAllString](http://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
+| title         | string        | string  | [strings.Title](https://golang.org/pkg/strings/#Title), capitalises first character of each word.|
+| toUpper       | string        | string  | [strings.ToUpper](https://golang.org/pkg/strings/#ToUpper), converts all characters to upper case.|
+| toLower       | string        | string  | [strings.ToLower](https://golang.org/pkg/strings/#ToLower), converts all characters to lower case.|
+| match         | pattern, text | boolean | [regexp.MatchString](https://golang.org/pkg/regexp/#MatchString) Tests for a unanchored regexp match. |
+| reReplaceAll  | pattern, replacement, text | string | [Regexp.ReplaceAllString](https://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
 | graphLink  | expr | string | Returns path to graph view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
 | tableLink  | expr | string | Returns path to tabular ("Console") view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
 
@@ -98,7 +98,7 @@ Consoles are exposed on `/consoles/`, and sourced from the directory pointed to
 by the `-web.console.templates` flag.
 
 Console templates are rendered with
-[html/template](http://golang.org/pkg/html/template/), which provides
+[html/template](https://golang.org/pkg/html/template/), which provides
 auto-escaping. To bypass the auto-escaping use the `safe*` functions.,
 
 URL parameters are available as a map in `.Params`. To access multiple URL

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -18,7 +18,7 @@ and one of the following HTTP response codes:
 
 - `400 Bad Request` when parameters are missing or incorrect.
 - `422 Unprocessable Entity` when an expression can't be executed
-  ([RFC4918](http://tools.ietf.org/html/rfc4918#page-78)).
+  ([RFC4918](https://tools.ietf.org/html/rfc4918#page-78)).
 - `503 Service Unavailable` when queries time out or abort.
 
 Other non-`2xx` codes may be returned for errors occurring before the API

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -97,7 +97,7 @@ delta(cpu_temp_celsius{host="zeus"}[2h])
 ## `deriv()`
 
 `deriv(v range-vector)` calculates the per-second derivative of the time series in a range
-vector `v`, using [simple linear regression](http://en.wikipedia.org/wiki/Simple_linear_regression).
+vector `v`, using [simple linear regression](https://en.wikipedia.org/wiki/Simple_linear_regression).
 
 `deriv` should only be used with gauges.
 
@@ -300,7 +300,7 @@ January etc.
 
 `predict_linear(v range-vector, t scalar)` predicts the value of time series
 `t` seconds from now, based on the range vector `v`, using [simple linear
-regression](http://en.wikipedia.org/wiki/Simple_linear_regression).
+regression](https://en.wikipedia.org/wiki/Simple_linear_regression).
 
 `predict_linear` should only be used with gauges.
 

--- a/documentation/examples/kubernetes-rabbitmq/README.md
+++ b/documentation/examples/kubernetes-rabbitmq/README.md
@@ -12,7 +12,7 @@ With this pod running you will have the exporter scraping data, but Prometheus h
 yet found the exporter and is not scraping data from it.
 
 For more details on how to use Kubernetes service discovery take a look at the 
-[documentation](http://prometheus.io/docs/operating/configuration/#kubernetes-sd-configurations-kubernetes_sd_config)
+[documentation](https://prometheus.io/docs/operating/configuration/#kubernetes-sd-configurations-kubernetes_sd_config)
 and at the [available examples](./../).
 
 After you got Kubernetes service discovery up and running you just need to advertise that RabbitMQ


### PR DESCRIPTION
For security, we should change http into https links.