### PR TITLE
Remove duplicated words in comments

### DIFF
--- a/discovery/README.md
+++ b/discovery/README.md
@@ -59,7 +59,7 @@ label with the host:port of the target (preferably an IP address to avoid DNS
 lookups). No other labelnames should be exposed.
 
 It is very common for initial pull requests for new SDs to include hardcoded
-assumptions that make sense for the the author's setup. SD should be generic,
+assumptions that make sense for the author's setup. SD should be generic,
 any customisation should be handled via relabelling. There should be basically
 no business logic, filtering, or transformations of the data from the SD beyond
 that which is needed to fit it into the metadata data model. 

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -935,7 +935,7 @@ func (p *parser) expectType(node Node, want ValueType, context string) {
 // check the types of the children of each node and raise an error
 // if they do not form a valid node.
 //
-// Some of these checks are redundant as the the parsing stage does not allow
+// Some of these checks are redundant as the parsing stage does not allow
 // them, but the costs are small and might reveal errors when making changes.
 func (p *parser) checkType(node Node) (typ ValueType) {
 	// For expressions the type is determined by their Type function.

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -74,7 +74,7 @@ func TestTargetOffset(t *testing.T) {
 
 	t.Log(buckets)
 
-	// Calculate whether the the number of targets per bucket
+	// Calculate whether the number of targets per bucket
 	// does not differ more than a given tolerance.
 	avg := len(offsets) / len(buckets)
 	tolerance := 0.15


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects
while reading.

Co-Authored-By: Kim Bao Long longkb@vn.fujitsu.com
Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>