### PR TITLE
Adding detail of the OS version in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -26,7 +26,9 @@
 
 * System information:
 
-	insert output of `uname -srm` here
+	insert output of `uname -srm` here  
+
+	insert output of `cat /etc/os-release` here
 
 * Prometheus version:
 


### PR DESCRIPTION
Insert the command to check the version of OS in order to
get more detail in Bug Report template.

Co-Authored-By: Dao Cong Tien tiendc@vn.fujitsu.com
Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>