### PR TITLE
config: fix Kubernetes config with empty API server

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -632,6 +632,11 @@ func TestLoadConfigRuleFilesAbsolutePath(t *testing.T) {
 	testutil.Equals(t, ruleFilesExpectedConf, c)
 }
 
+func TestKubernetesEmptyAPIServer(t *testing.T) {
+	_, err := LoadFile("testdata/kubernetes_empty_apiserver.good.yml")
+	testutil.Ok(t, err)
+}
+
 var expectedErrors = []struct {
 	filename string
 	errMsg   string

--- a/config/testdata/kubernetes_empty_apiserver.good.yml
+++ b/config/testdata/kubernetes_empty_apiserver.good.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+- job_name: prometheus
+  kubernetes_sd_configs:
+  - role: endpoints

--- a/config/testdata/kubernetes_http_config_without_api_server.bad.yml
+++ b/config/testdata/kubernetes_http_config_without_api_server.bad.yml
@@ -1,6 +1,5 @@
 scrape_configs:
   - job_name: prometheus
-
     kubernetes_sd_configs:
     - role: pod
       bearer_token: 1234

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -107,7 +107,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err != nil {
 		return err
 	}
-	if c.APIServer.URL == nil && !reflect.DeepEqual(c.HTTPClientConfig, &config_util.HTTPClientConfig{}) {
+	if c.APIServer.URL == nil && !reflect.DeepEqual(c.HTTPClientConfig, config_util.HTTPClientConfig{}) {
 		return fmt.Errorf("to use custom HTTP client configuration please provide the 'api_server' URL explicitly")
 	}
 	return nil


### PR DESCRIPTION
Follow-up of #5211 