### PR TITLE
change Groupname -> groupname

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -50,7 +50,7 @@ func (g *RuleGroups) Validate() (errs []error) {
 
 	for _, g := range g.Groups {
 		if g.Name == "" {
-			errs = append(errs, errors.Errorf("Groupname should not be empty"))
+			errs = append(errs, errors.Errorf("groupname should not be empty"))
 		}
 
 		if _, ok := set[g.Name]; ok {


### PR DESCRIPTION
change the capitalization of the initials of groupname to make it uniform.
Signed-off-by: yeya24 <ben.ye@daocloud.io>