### PR TITLE
Update remaining deprecated links in docs

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -246,7 +246,7 @@ A `tls_config` allows configuring TLS connections.
 [ key_file: <filename> ]
 
 # ServerName extension to indicate the name of the server.
-# http://tools.ietf.org/html/rfc4366#section-3.1
+# https://tools.ietf.org/html/rfc4366#section-3.1
 [ server_name: <string> ]
 
 # Disable validation of the server certificate.
@@ -938,7 +938,7 @@ Serverset SD configurations allow retrieving scrape targets from [Serversets]
 (https://github.com/twitter/finagle/tree/master/finagle-serversets) which are
 stored in [Zookeeper](https://zookeeper.apache.org/). Serversets are commonly
 used by [Finagle](https://twitter.github.io/finagle/) and
-[Aurora](http://aurora.apache.org/).
+[Aurora](https://aurora.apache.org/).
 
 The following meta labels are available on targets during relabeling:
 

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -18,7 +18,7 @@ and one of the following HTTP response codes:
 
 - `400 Bad Request` when parameters are missing or incorrect.
 - `422 Unprocessable Entity` when an expression can't be executed
-  ([RFC4918](http://tools.ietf.org/html/rfc4918#page-78)).
+  ([RFC4918](https://tools.ietf.org/html/rfc4918#page-78)).
 - `503 Service Unavailable` when queries time out or abort.
 
 Other non-`2xx` codes may be returned for errors occurring before the API

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -97,7 +97,7 @@ delta(cpu_temp_celsius{host="zeus"}[2h])
 ## `deriv()`
 
 `deriv(v range-vector)` calculates the per-second derivative of the time series in a range
-vector `v`, using [simple linear regression](http://en.wikipedia.org/wiki/Simple_linear_regression).
+vector `v`, using [simple linear regression](https://en.wikipedia.org/wiki/Simple_linear_regression).
 
 `deriv` should only be used with gauges.
 
@@ -300,7 +300,7 @@ January etc.
 
 `predict_linear(v range-vector, t scalar)` predicts the value of time series
 `t` seconds from now, based on the range vector `v`, using [simple linear
-regression](http://en.wikipedia.org/wiki/Simple_linear_regression).
+regression](https://en.wikipedia.org/wiki/Simple_linear_regression).
 
 `predict_linear` should only be used with gauges.
 


### PR DESCRIPTION
Most of the links in docs at this moment are correct HTTPS links.
This PR updates the remaining deprecated HTTP links with correct HTTPS links for consistency and security.