### PR TITLE
Insert .idea/ in file .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ benchmark.txt
 !/.promu.yml
 /documentation/examples/remote_storage/remote_storage_adapter/remote_storage_adapter
 /documentation/examples/remote_storage/example_write_adapter/example_writer_adapter
+.idea/


### PR DESCRIPTION
Ignore folder `.idea/` when open project Prometheus with
IntelliJ IDEA.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>