### PR TITLE
Always evaluate recording rules first

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -813,7 +813,8 @@ func (m *Manager) LoadGroups(interval time.Duration, filenames ...string) (map[s
 				itv = time.Duration(rg.Interval)
 			}
 
-			rules := make([]Rule, 0, len(rg.Rules))
+			recordingRules := make([]Rule, 0, len(rg.Rules))
+			alertRules := make([]Rule, 0, len(rg.Rules))
 			for _, r := range rg.Rules {
 				expr, err := promql.ParseExpr(r.Expr)
 				if err != nil {
@@ -821,7 +822,7 @@ func (m *Manager) LoadGroups(interval time.Duration, filenames ...string) (map[s
 				}
 
 				if r.Alert != "" {
-					rules = append(rules, NewAlertingRule(
+					alertRules = append(alertRules, NewAlertingRule(
 						r.Alert,
 						expr,
 						time.Duration(r.For),
@@ -832,14 +833,14 @@ func (m *Manager) LoadGroups(interval time.Duration, filenames ...string) (map[s
 					))
 					continue
 				}
-				rules = append(rules, NewRecordingRule(
+				recordingRules = append(recordingRules, NewRecordingRule(
 					r.Record,
 					expr,
 					labels.FromMap(r.Labels),
 				))
 			}
 
-			groups[groupKey(rg.Name, fn)] = NewGroup(rg.Name, fn, itv, rules, shouldRestore, m.opts)
+			groups[groupKey(rg.Name, fn)] = NewGroup(rg.Name, fn, itv, append(recordingRules, alertRules...), shouldRestore, m.opts)
 		}
 	}
 


### PR DESCRIPTION
When loading groups from rules files, change the order of rules to make recording rules evaluate first.
Here is an example rules file:
```
groups:
- name: test
  rules:  
  - alert: http_rate_40
    expr: job:http_rate:5m > 40
    for: 5s
    labels:
      severity: high      
    annotations:
      summary: "rate > 40"
  - alert: http_rate_50    
    expr: job:http_rate:5m > 50
    for: 5s
    labels:
      severity: high
    annotations:
      summary: "rate > 50"        
  - record: job:http_rate:5m
    expr: sum (rate(promhttp_metric_handler_requests_total[5m])) by(instance)
```
Rules evaluates sequentially, so in the first evaluation turn after prometheus starts, these first two alertRules will get a nil when quering from the tsdb because there is no such a metric called job:http_rate:5m in tsdb. In other times, first two alertRules will get an old value of job:http_rate:5m which is evaluated in the last turn. 

Signed-off-by: yeya24 <ben.ye@daocloud.io>