### PR TITLE
Fix misspell in manager_test.go

### DIFF
--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -51,7 +51,7 @@ func TestTargetUpdatesOrder(t *testing.T) {
 			expectedTargets: nil,
 		},
 		{
-			title: "Multips TPs no updates",
+			title: "Multiple TPs no updates",
 			updates: map[string][]update{
 				"tp1": {},
 				"tp2": {},


### PR DESCRIPTION
"Multips" to "Multiple" in line 54.