### PR TITLE
Cleanup .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 *#
 .#*
-*-stamp
 /*.yaml
 /*.yml
-/*.rules
 *.exe
 
 /prometheus
@@ -12,11 +10,7 @@ benchmark.txt
 /data
 /cmd/prometheus/data
 /cmd/prometheus/debug
-/.build
-/.release
-/.tarballs
 
-!/circle.yml
 !/.travis.yml
 !/.promu.yml
 /documentation/examples/remote_storage/remote_storage_adapter/remote_storage_adapter


### PR DESCRIPTION
`*-stamp`, `/.build`, `/.release`, `/.tarballs` are remnants from our
old build system.

`*.rules` are Prom1.x rules files.

CircleCI config is now in its own directory.

Signed-off-by: beorn7 <beorn@soundcloud.com>