### PR TITLE
Expose the WAL watcher WriteTo interface

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -155,7 +155,7 @@ type StorageClient interface {
 }
 
 // QueueManager manages a queue of samples to be sent to the Storage
-// indicated by the provided StorageClient. Implements writeTo interface
+// indicated by the provided StorageClient. Implements WriteTo interface
 // used by WAL Watcher.
 type QueueManager struct {
 	logger log.Logger


### PR DESCRIPTION
In order for other applications to easily use the WALWatcher it would be nice for this interface to be exposed. Is there any reason this interface is not exposed right now?

cc: @cstyan / @tomwilkie / @gouthamve 