### PR TITLE
Alert API Values as Strings

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -450,7 +450,10 @@ $ curl http://localhost:9090/api/v1/rules
                                     "severity": "page"
                                 },
                                 "state": "firing",
-                                "value": 1
+                                "value": [
+                                  1552085678.2,
+                                  "1"
+                                ]
                             }
                         ],
                         "annotations": {
@@ -507,7 +510,10 @@ $ curl http://localhost:9090/api/v1/alerts
                     "alertname": "my-alert"
                 },
                 "state": "firing",
-                "value": 1
+                "value": [
+                  1552085678.2,
+                  "1"
+                ]
             }
         ]
     },

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -85,11 +85,12 @@ type Alert struct {
 	Value float64
 	// The interval during which the condition of this alert held true.
 	// ResolvedAt will be 0 to indicate a still active alert.
-	ActiveAt   time.Time
-	FiredAt    time.Time
-	ResolvedAt time.Time
-	LastSentAt time.Time
-	ValidUntil time.Time
+	ActiveAt    time.Time
+	FiredAt     time.Time
+	ResolvedAt  time.Time
+	LastSentAt  time.Time
+	ValidUntil  time.Time
+	EvaluatedAt time.Time
 }
 
 func (a *Alert) needsSending(ts time.Time, resendDelay time.Duration) bool {
@@ -348,6 +349,7 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 		if alert, ok := r.active[h]; ok && alert.State != StateInactive {
 			alert.Value = smpl.V
 			alert.Annotations = annotations
+			alert.EvaluatedAt = ts
 			continue
 		}
 
@@ -355,6 +357,7 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 			Labels:      lbs,
 			Annotations: annotations,
 			ActiveAt:    ts,
+			EvaluatedAt: ts,
 			State:       StatePending,
 			Value:       smpl.V,
 		}

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -85,12 +85,11 @@ type Alert struct {
 	Value float64
 	// The interval during which the condition of this alert held true.
 	// ResolvedAt will be 0 to indicate a still active alert.
-	ActiveAt    time.Time
-	FiredAt     time.Time
-	ResolvedAt  time.Time
-	LastSentAt  time.Time
-	ValidUntil  time.Time
-	EvaluatedAt time.Time
+	ActiveAt   time.Time
+	FiredAt    time.Time
+	ResolvedAt time.Time
+	LastSentAt time.Time
+	ValidUntil time.Time
 }
 
 func (a *Alert) needsSending(ts time.Time, resendDelay time.Duration) bool {
@@ -349,7 +348,6 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 		if alert, ok := r.active[h]; ok && alert.State != StateInactive {
 			alert.Value = smpl.V
 			alert.Annotations = annotations
-			alert.EvaluatedAt = ts
 			continue
 		}
 
@@ -357,7 +355,6 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 			Labels:      lbs,
 			Annotations: annotations,
 			ActiveAt:    ts,
-			EvaluatedAt: ts,
 			State:       StatePending,
 			Value:       smpl.V,
 		}

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -698,7 +698,7 @@ func (api *API) alerts(r *http.Request) apiFuncResult {
 	for _, alertingRule := range alertingRules {
 		alerts = append(
 			alerts,
-			rulesAlertsToAPIAlerts(alertingRule.ActiveAlerts())...,
+			rulesAlertsToAPIAlerts(alertingRule.ActiveAlerts(), alertingRule.GetEvaluationTimestamp())...,
 		)
 	}
 
@@ -707,7 +707,7 @@ func (api *API) alerts(r *http.Request) apiFuncResult {
 	return apiFuncResult{res, nil, nil, nil}
 }
 
-func rulesAlertsToAPIAlerts(rulesAlerts []*rules.Alert) []*Alert {
+func rulesAlertsToAPIAlerts(rulesAlerts []*rules.Alert, alertTimestamp time.Time) []*Alert {
 	apiAlerts := make([]*Alert, len(rulesAlerts))
 	for i, ruleAlert := range rulesAlerts {
 		apiAlerts[i] = &Alert{
@@ -715,7 +715,7 @@ func rulesAlertsToAPIAlerts(rulesAlerts []*rules.Alert) []*Alert {
 			Annotations: ruleAlert.Annotations,
 			State:       ruleAlert.State.String(),
 			ActiveAt:    &ruleAlert.ActiveAt,
-			Scalar:      promql.Scalar{T: timestamp.FromTime(ruleAlert.EvaluatedAt), V: ruleAlert.Value},
+			Scalar:      promql.Scalar{T: timestamp.FromTime(alertTimestamp), V: ruleAlert.Value},
 		}
 	}
 
@@ -790,7 +790,7 @@ func (api *API) rules(r *http.Request) apiFuncResult {
 					Duration:    rule.Duration().Seconds(),
 					Labels:      rule.Labels(),
 					Annotations: rule.Annotations(),
-					Alerts:      rulesAlertsToAPIAlerts(rule.ActiveAlerts()),
+					Alerts:      rulesAlertsToAPIAlerts(rule.ActiveAlerts(), rule.GetEvaluationTimestamp()),
 					Health:      rule.Health(),
 					LastError:   lastError,
 					Type:        "alerting",

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -15,6 +15,7 @@ package v1
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -682,13 +683,20 @@ type AlertDiscovery struct {
 	Alerts []*Alert `json:"alerts"`
 }
 
+// AlertValue
+type AlertValue float64
+
+func (p AlertValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strconv.FormatFloat(float64(p), 'f', -1, 64))
+}
+
 // Alert has info for an alert.
 type Alert struct {
 	Labels      labels.Labels `json:"labels"`
 	Annotations labels.Labels `json:"annotations"`
 	State       string        `json:"state"`
 	ActiveAt    *time.Time    `json:"activeAt,omitempty"`
-	Value       float64       `json:"value"`
+	Value       AlertValue    `json:"value"`
 }
 
 func (api *API) alerts(r *http.Request) apiFuncResult {
@@ -715,7 +723,7 @@ func rulesAlertsToAPIAlerts(rulesAlerts []*rules.Alert) []*Alert {
 			Annotations: ruleAlert.Annotations,
 			State:       ruleAlert.State.String(),
 			ActiveAt:    &ruleAlert.ActiveAt,
-			Value:       ruleAlert.Value,
+			Value:       AlertValue(ruleAlert.Value),
 		}
 	}
 

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -15,7 +15,6 @@ package v1
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -683,20 +682,13 @@ type AlertDiscovery struct {
 	Alerts []*Alert `json:"alerts"`
 }
 
-// AlertValue
-type AlertValue float64
-
-func (p AlertValue) MarshalJSON() ([]byte, error) {
-	return json.Marshal(strconv.FormatFloat(float64(p), 'f', -1, 64))
-}
-
 // Alert has info for an alert.
 type Alert struct {
 	Labels      labels.Labels `json:"labels"`
 	Annotations labels.Labels `json:"annotations"`
 	State       string        `json:"state"`
 	ActiveAt    *time.Time    `json:"activeAt,omitempty"`
-	Value       AlertValue    `json:"value"`
+	Scalar      promql.Scalar `json:"value"`
 }
 
 func (api *API) alerts(r *http.Request) apiFuncResult {
@@ -723,7 +715,7 @@ func rulesAlertsToAPIAlerts(rulesAlerts []*rules.Alert) []*Alert {
 			Annotations: ruleAlert.Annotations,
 			State:       ruleAlert.State.String(),
 			ActiveAt:    &ruleAlert.ActiveAt,
-			Value:       AlertValue(ruleAlert.Value),
+			Scalar:      promql.Scalar{T: timestamp.FromTime(ruleAlert.EvaluatedAt), V: ruleAlert.Value},
 		}
 	}
 


### PR DESCRIPTION
This patch changes the `api/v1/alert` endpoint to return string alert values mimicking the `api/v1/query` return values. The change ensures `null`, and `+-Inf` values can be properly parsed.

We are using the [`client_golang`](https://github.com/prometheus/client_golang) library in our applications to interact with the `api/v1/alert` endpoint. We've recently hit an issue where the library failed to parse the return values from a `+Inf` alert value. We traced the problem back to the alert api not using string return values. We noticed `NaN` values are also affected. 

**Problem**
Create an alert with a `+Inf` return value; for example ```count(up)/0 != 0```. When curling the api endpoint you can see the returned value is as follows:

```
$ curl -s http://$(hostname)/prometheus/api/v1/rules |jq '.data.groups[] |select(.name == "breaking")'
{
  "name": "breaking",
  "file": "rules.yml",
  "rules": [
    {
      "name": "InfRule",
      "query": "count(up) / 0 != 0",
      "duration": 30,
      "labels": {
        "severy": "p2"
      },
      "annotations": {
        "decription": " This rule should break ",
        "summary": " Breaking +INF rule "
      },
      "alerts": [
        {
          "labels": {
            "alertname": "InfRule",
            "severy": "p2"
          },
          "annotations": {
            "decription": " This rule should break ",
            "summary": " Breaking +INF rule "
          },
          "state": "firing",
          "activeAt": "2019-02-26T12:43:21.527666941-05:00",
          "value": 1.7976931348623157e+308
        }
      ],
      "health": "ok",
      "type": "alerting"
    }
  ],
  "interval": 60
}
```

Running the same query against the `query` api results in:

```
$ curl -s  -g 'http://$(hostname)/prometheus/api/v1/query?query=count(up)/0'|jq .
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {},
        "value": [
          1551461908.309,
          "+Inf"
        ]
      }
    ]
  }
}
```

The resulting error when parsing using the `client_golang` library is:
```
bad_response: invalid character '+' looking for beginning of value
```

**Solution**
This patch converts the return values for the `alert` api to strings. Running the same query now results with:


```
{                                                           
  "name": "breaking",    
  "file": "rules.yml",
  "rules": [
    {                
      "name": "InfRule",
      "query": "count(up) / 0 != 0",
      "duration": 30,
      "labels": {       
        "severity": "p2"                          
      },             
      "annotations": {
        "decription": " This rule should break {{ $labels.value }}",
        "summary": " Breaking +INF rule "
      },              
      "alerts": [                                                  
        {                               
          "labels": {
            "alertname": "InfRule",
            "severity": "p2"
          },         
          "annotations": {         
            "decription": " This rule should break ",
            "summary": " Breaking +INF rule "
          },              
          "state": "firing",                         
          "activeAt": "2019-03-04T09:39:21.527666941-05:00",
          "value": "+Inf"
        }                   
      ],                                                    
      "health": "ok",   
      "type": "alerting"
    },  
    {                
      "name": "NanRule",
      "query": "(count(up) - count(up)) / 0 != 0",
      "duration": 30,
      "labels": {
        "severity": "p2"
      },
      "annotations": {                                             
        "decription": " This rule should break {{ $labels.value}}",
        "summary": " Breaking Nan rule "
      },                           
      "alerts": [           
        {            
          "labels": {              
            "alertname": "NanRule",                  
            "severity": "p2"                 
          },              
          "annotations": {                           
            "decription": " This rule should break ",       
            "summary": " Breaking Nan rule "
          },                
          "state": "firing",                                
          "activeAt": "2019-03-04T09:39:21.527666941-05:00",
          "value": "NaN"
        }
      ],             
      "health": "ok",   
      "type": "alerting"                          
    }                
  ],             
  "interval": 60        
}               
```
**Prometheus Version:** 2.6.0