### PR TITLE
ui: Remove time picker borders

### DIFF
--- a/web/ui/static/css/graph.css
+++ b/web/ui/static/css/graph.css
@@ -163,6 +163,10 @@ input[name="end_input"], input[name="range_input"] {
   border-color: #ccc;
 }
 
+.prometheus_input_group .timepicker-picker .btn {
+  border-color: transparent;
+}
+
 .prometheus_input_group .input {
   width: 100px;
   


### PR DESCRIPTION
2.7:
![xxtn](https://user-images.githubusercontent.com/291750/54058441-1e711b00-41f6-11e9-8113-f4661b463b89.png)



2.8-rc0:
![xxtn22](https://user-images.githubusercontent.com/291750/54058455-25982900-41f6-11e9-9175-c1fa8b6b76fe.png)


With this patch:
![btn](https://user-images.githubusercontent.com/291750/54058465-2c26a080-41f6-11e9-87cc-62187b48deb2.png)



Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>