### PR TITLE
ui: Expand expression_select to 220px

### DIFF
--- a/web/ui/static/css/graph.css
+++ b/web/ui/static/css/graph.css
@@ -194,7 +194,7 @@ input[name="end_input"], input[name="range_input"] {
 }
 
 .expression_select {
-  width: 210px !important;
+  width: 220px !important;
   margin-left: 7px;
 }
 


### PR DESCRIPTION

- insert metric at cursor -  is not fully visible in 2.8


Prometheus 2.7 (chrome/firefox)
![crome3](https://user-images.githubusercontent.com/291750/54059749-8164b100-41fa-11e9-8d15-091261cf0697.png)
![ff3](https://user-images.githubusercontent.com/291750/54059750-8164b100-41fa-11e9-8c97-ca21cf086925.png)


Prometheus 2.8-rc0
![chrom1](https://user-images.githubusercontent.com/291750/54059766-92152700-41fa-11e9-8c87-e1d782388841.png)
![ff1](https://user-images.githubusercontent.com/291750/54059767-92152700-41fa-11e9-91e9-b7b01e1d0f9c.png)


With this patch
![ff2](https://user-images.githubusercontent.com/291750/54059775-9ccfbc00-41fa-11e9-9f30-81f5704dc668.png)
![crome2](https://user-images.githubusercontent.com/291750/54059777-9d685280-41fa-11e9-9e26-631809c12674.png)



Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>