### PR TITLE
Add GODEBUG to the runtime page

### DIFF
--- a/web/ui/templates/status.html
+++ b/web/ui/templates/status.html
@@ -46,6 +46,10 @@
           <td>{{.GOGC}}</td>
         </tr>
         <tr>
+          <th>GODEBUG</th>
+          <td>{{.GODEBUG}}</td>
+        </tr>
+        <tr>
           <th>Storage Retention</th>
           <td>{{.StorageRetention}}</td>
         </tr>

--- a/web/web.go
+++ b/web/web.go
@@ -587,6 +587,7 @@ func (h *Handler) status(w http.ResponseWriter, r *http.Request) {
 		GoroutineCount      int
 		GOMAXPROCS          int
 		GOGC                string
+		GODEBUG             string
 		CorruptionCount     int64
 		ChunkCount          int64
 		TimeSeriesCount     int64
@@ -601,6 +602,7 @@ func (h *Handler) status(w http.ResponseWriter, r *http.Request) {
 		GoroutineCount: runtime.NumGoroutine(),
 		GOMAXPROCS:     runtime.GOMAXPROCS(0),
 		GOGC:           os.Getenv("GOGC"),
+		GODEBUG:        os.Getenv("GODEBUG"),
 	}
 
 	if h.options.TSDBCfg.RetentionDuration != 0 {


### PR DESCRIPTION
This is useful, e.g. with go 1.12 to see if TLS1.3 has been enabled.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>