### PR TITLE
Makefile.common: add deps target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,12 @@ go:
 
 go_import_path: github.com/prometheus/prometheus
 
+# This ensures that the local cache is filled before running the CI.
+# travis_retry retries the command 3 times if it fails as we've experienced
+# random issues on Travis.
+before_install:
+- travis_retry make deps
+
 script:
-- GO111MODULE=on travis_retry go mod download
 - make check_license style unused test staticcheck check_assets
 - git diff --exit-code

--- a/Makefile.common
+++ b/Makefile.common
@@ -116,6 +116,15 @@ common-check_license:
                exit 1; \
        fi
 
+.PHONY: common-deps
+common-deps:
+	@echo ">> getting dependencies"
+ifdef GO111MODULE
+	GO111MODULE=$(GO111MODULE) $(GO) mod download
+else
+	$(GO) get $(GOOPTS) -t ./...
+endif
+
 .PHONY: common-test-short
 common-test-short:
 	@echo ">> running short tests"
@@ -220,7 +229,6 @@ precheck::
 
 define PRECHECK_COMMAND_template =
 precheck:: $(1)_precheck
-
 
 PRECHECK_COMMAND_$(1) ?= $(1) $$(strip $$(PRECHECK_OPTIONS_$(1)))
 .PHONY: $(1)_precheck


### PR DESCRIPTION
Follow up of #5335 

Due to Travis CI having intermittent issues, we warm up the modules cache before running the tests. This will also be useful for prometheus/common and prometheus/tsdb that already have a similar target in their Makefile.