### PR TITLE
fix redundant err!=nil check in web.go

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -253,10 +253,7 @@ func New(logger log.Logger, o *Options) *Handler {
 		o.Flags,
 		h.testReady,
 		func() api_v1.TSDBAdmin {
-			if db := h.options.TSDB(); db != nil {
-				return db
-			}
-			return nil
+			return h.options.TSDB()
 		},
 		h.options.EnableAdminAPI,
 		logger,


### PR DESCRIPTION
The err != nil check to retrieve the tsdb instance is unnecessary and can be reduced to one statement.