### PR TITLE
Fix some spelling issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ This release has a fix for a Stored DOM XSS vulnerability that can be triggered 
 
 ## 2.7.0 / 2019-01-28
 
-We're rolling back the Dockerfile changes introduced in 2.6.0. If you made changes to your docker deployment in 2.6.0, you will need to roll them back. This release also adds experimental support for disk size based retention. To accomodate that we are deprecating the flag `storage.tsdb.retention` in favour of `storage.tsdb.retention.time`. We print a warning if the flag is in use, but it will function without breaking until Prometheus 3.0.
+We're rolling back the Dockerfile changes introduced in 2.6.0. If you made changes to your docker deployment in 2.6.0, you will need to roll them back. This release also adds experimental support for disk size based retention. To accommodate that we are deprecating the flag `storage.tsdb.retention` in favour of `storage.tsdb.retention.time`. We print a warning if the flag is in use, but it will function without breaking until Prometheus 3.0.
 
 * [CHANGE] Rollback Dockerfile to version at 2.5.0. Rollback of the breaking change introduced in 2.6.0. #5122
 * [FEATURE] Add subqueries to PromQL. #4831

--- a/Makefile.common
+++ b/Makefile.common
@@ -73,7 +73,7 @@ PROMU_VERSION ?= 0.3.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 STATICCHECK :=
-# staticcheck only supports linux, freebsd, darwin and windows plaforms on i386/amd64
+# staticcheck only supports linux, freebsd, darwin and windows platforms on i386/amd64
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux freebsd darwin))
 	ifeq ($(GOHOSTARCH),$(filter $(GOHOSTARCH),amd64 i386))

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -152,7 +152,7 @@ func TestConfiguredServiceWithTags(t *testing.T) {
 		}
 		ret := consulDiscovery.shouldWatch(tc.serviceName, tc.serviceTags)
 		if ret != tc.shouldWatch {
-			t.Errorf("Expected should watch? %t, got %t. Watched serivce and tags: %s %+v, input was %s %+v", tc.shouldWatch, ret, tc.conf.Services, tc.conf.ServiceTags, tc.serviceName, tc.serviceTags)
+			t.Errorf("Expected should watch? %t, got %t. Watched service and tags: %s %+v, input was %s %+v", tc.shouldWatch, ret, tc.conf.Services, tc.conf.ServiceTags, tc.serviceName, tc.serviceTags)
 		}
 
 	}

--- a/pkg/logging/ratelimit.go
+++ b/pkg/logging/ratelimit.go
@@ -22,7 +22,7 @@ type ratelimiter struct {
 	next    log.Logger
 }
 
-// RateLimit write to a loger.
+// RateLimit write to a logger.
 func RateLimit(next log.Logger, limit rate.Limit) log.Logger {
 	return &ratelimiter{
 		limiter: rate.NewLimiter(limit, int(limit)),

--- a/promql/test_test.go
+++ b/promql/test_test.go
@@ -32,7 +32,7 @@ func TestLazyLoader_WithSamplesTill(t *testing.T) {
 
 	cases := []struct {
 		loadString string
-		// These testCases are run in sequence. So the testCase being run is dependant on the previous testCase.
+		// These testCases are run in sequence. So the testCase being run is dependent on the previous testCase.
 		testCases []testCase
 	}{
 		{


### PR DESCRIPTION
Hi @brian-brazil,

I fixed here some trivial spelling issues reported by codespell.

See,
```
$ codespell -S './vendor/*,./.git*,./web/ui/static/vendor*' --ignore-words-list="uint,dur,ue,iff,te,wan"
```