### PR TITLE
discovery/azure:optimize iteration logic for VMScalesets, VMScalesetVMs, and VMs

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -420,22 +420,15 @@ func (client *azureClient) getVMs(ctx context.Context) ([]virtualMachine, error)
 	var vms []virtualMachine
 	result, err := client.vm.ListAll(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("could not list virtual machines: %s", err)
+		return nil, fmt.Errorf("could not list virtual machines: %s", err.Error())
 	}
-
-	for _, vm := range result.Values() {
-		vms = append(vms, mapFromVM(vm))
-	}
-
-	// If we still have results, keep going until we have no more.
 	for result.NotDone() {
-		err = result.NextWithContext(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("could not list virtual machines: %s", err)
-		}
-
 		for _, vm := range result.Values() {
 			vms = append(vms, mapFromVM(vm))
+		}
+		err = result.NextWithContext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("could not list virtual machines: %s", err.Error())
 		}
 	}
 
@@ -446,16 +439,14 @@ func (client *azureClient) getScaleSets(ctx context.Context) ([]compute.VirtualM
 	var scaleSets []compute.VirtualMachineScaleSet
 	result, err := client.vmss.ListAll(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("could not list virtual machine scale sets: %s", err)
+		return nil, fmt.Errorf("could not list virtual machine scale sets: %s", err.Error())
 	}
-	scaleSets = append(scaleSets, result.Values()...)
-
 	for result.NotDone() {
+		scaleSets = append(scaleSets, result.Values()...)
 		err = result.NextWithContext(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("could not list virtual machine scale sets: %s", err)
+			return nil, fmt.Errorf("could not list virtual machine scale sets: %s", err.Error())
 		}
-		scaleSets = append(scaleSets, result.Values()...)
 	}
 
 	return scaleSets, nil
@@ -472,21 +463,15 @@ func (client *azureClient) getScaleSetVMs(ctx context.Context, scaleSet compute.
 
 	result, err := client.vmssvm.List(ctx, r.ResourceGroup, *(scaleSet.Name), "", "", "")
 	if err != nil {
-		return nil, fmt.Errorf("could not list virtual machine scale set vms: %s", err)
+		return nil, fmt.Errorf("could not list virtual machine scale set vms: %s", err.Error())
 	}
-
-	for _, vm := range result.Values() {
-		vms = append(vms, mapFromVMScaleSetVM(vm, *scaleSet.Name))
-	}
-
 	for result.NotDone() {
-		err = result.NextWithContext(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("could not list virtual machine scale set vms: %s", err)
-		}
-
 		for _, vm := range result.Values() {
 			vms = append(vms, mapFromVMScaleSetVM(vm, *scaleSet.Name))
+		}
+		err = result.NextWithContext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("could not list virtual machine scale set vms: %s", err.Error())
 		}
 	}
 


### PR DESCRIPTION
This PR optimizes the iteration logic into something saner. There is unnecessary duplication.