### PR TITLE
web/ui: Fix padding in navbar container

### DIFF
--- a/web/ui/static/css/prometheus.css
+++ b/web/ui/static/css/prometheus.css
@@ -24,3 +24,8 @@ body {
 .label {
   white-space: normal;
 }
+
+/* The navbar adds horizontal padding already */
+.navbar .container-fluid {
+    padding: 0;
+}


### PR DESCRIPTION
Running `v2.8.0-rc.0` on my cluster I noticed the slightly off Prometheus heading in the navbar. That's just too annoying to leave it like that.
The navbar and the container inside of that both add a horiztonal padding of ~15px. This PR removes the inner padding of the container in this specific case.

Before:
![prometheus_off](https://user-images.githubusercontent.com/872251/54450293-5de8bb80-4750-11e9-99bb-008f81673140.png)

Afterwards:
![prometheus_on](https://user-images.githubusercontent.com/872251/54450360-7eb11100-4750-11e9-9b6c-156ceeefa76a.png)
