### PR TITLE
promparse: sort all labels when parsing

### DIFF
--- a/pkg/textparse/promparse.go
+++ b/pkg/textparse/promparse.go
@@ -227,9 +227,8 @@ func (p *PromParser) Metric(l *labels.Labels) string {
 		*l = append(*l, labels.Label{Name: s[a:b], Value: s[c:d]})
 	}
 
-	// Sort labels. We can skip the first entry since the metric name is
-	// already at the right place.
-	sort.Sort((*l)[1:])
+	// Sort labels to maintain the sorted labels invariant.
+	sort.Sort(*l)
 
 	return s
 }

--- a/pkg/textparse/promparse_test.go
+++ b/pkg/textparse/promparse_test.go
@@ -37,6 +37,7 @@ go_gc_duration_seconds{quantile="0.8", a="b"} 8.3835e-05
 go_gc_duration_seconds{ quantile="0.9", a="b"} 8.3835e-05
 # Hrandom comment starting with prefix of HELP
 #
+wind_speed{A="2",c="3"} 12345
 # comment with escaped \n newline
 # comment with escaped \ escape character
 # HELP nohelp1
@@ -97,6 +98,10 @@ testmetric{label="\"bar\""} 1`
 			comment: "# Hrandom comment starting with prefix of HELP",
 		}, {
 			comment: "#",
+		}, {
+			m:    `wind_speed{A="2",c="3"}`,
+			v:    12345,
+			lset: labels.FromStrings("__name__", "wind_speed", "A", "2", "c", "3"),
 		}, {
 			comment: "# comment with escaped \\n newline",
 		}, {

--- a/pkg/textparse/promparse_test.go
+++ b/pkg/textparse/promparse_test.go
@@ -101,7 +101,7 @@ testmetric{label="\"bar\""} 1`
 		}, {
 			m:    `wind_speed{A="2",c="3"}`,
 			v:    12345,
-			lset: labels.FromStrings("__name__", "wind_speed", "A", "2", "c", "3"),
+			lset: labels.FromStrings("A", "2", "__name__", "wind_speed", "c", "3"),
 		}, {
 			comment: "# comment with escaped \\n newline",
 		}, {


### PR DESCRIPTION
Some label names might start with an uppercase letter in which case it
needs to come before `__name__`. Without this, it means that we are not
maintaining the same invariant that all label names should be sorted in
such cases.

Amend the tests to check this problem automatically. Without the change
the tests do not pass.