### PR TITLE
fix query with offset incorrect end time issue

### DIFF
--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -59,7 +59,12 @@ type querier struct {
 // Select implements storage.Querier and uses the given matchers to read series
 // sets from the Client.
 func (q *querier) Select(p *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
-	query, err := ToQuery(q.mint, q.maxt, matchers, p)
+	// use end time from select parameters which apply offset for the specific selector
+	qmaxt := q.maxt
+	if p != nil {
+		qmaxt = p.End
+	}
+	query, err := ToQuery(q.mint, qmaxt, matchers, p)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Now query with offset, promql engine will shift query start time to be `offset` ago, however, it doesn't shift query end time accordingly. It will cause query too long time range. Although later evaluation will drop the out of boundary metrics, it still brings too much pressure to tsdb.

For example: `metric offset 1w`, without the fix, it will query 1w+5m time range for vector and 1w+ time range for matrix.

Signed-off-by: xiancli <xiancli@ebay.com>