### PR TITLE
web/ui: display the job label in /targets

### DIFF
--- a/web/ui/templates/targets.html
+++ b/web/ui/templates/targets.html
@@ -55,8 +55,7 @@
             </td>
             <td class="labels">
               <span class="cursor-pointer" data-toggle="tooltip" title="" data-html=true data-original-title="<b>Before relabeling:</b>{{range $k, $v := .DiscoveredLabels.Map}}<br>{{$ev := $v | html}}{{$k}}=&quot;{{$ev}}&quot;{{end}}">
-                {{$labels := stripLabels .Labels.Map "job"}}
-                {{range $label, $value := $labels}}
+                {{range $label, $value := .Labels.Map}}
                   <span class="badge badge-primary">{{$label}}="{{$value}}"</span>
                 {{else}}
                   <span class="badge badge-default">none</span>

--- a/web/web.go
+++ b/web/web.go
@@ -766,12 +766,6 @@ func tmplFuncs(consolesPath string, opts *Options) template_text.FuncMap {
 		"pathPrefix":   func() string { return opts.ExternalURL.Path },
 		"pageTitle":    func() string { return opts.PageTitle },
 		"buildVersion": func() string { return opts.Version.Revision },
-		"stripLabels": func(lset map[string]string, labels ...string) map[string]string {
-			for _, ln := range labels {
-				delete(lset, ln)
-			}
-			return lset
-		},
 		"globalURL": func(u *url.URL) *url.URL {
 			host, port, err := net.SplitHostPort(u.Host)
 			if err != nil {


### PR DESCRIPTION
It was already done in #4806 but removed accidently by #5192 (Bootstrap upgrade).

Closes #5404 