### PR TITLE
Add support for POSTing to /series endpoint

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -74,6 +74,7 @@ The following endpoint evaluates an instant query at a single point in time:
 
 ```
 GET /api/v1/query
+POST /api/v1/query
 ```
 
 URL query parameters:
@@ -84,6 +85,10 @@ URL query parameters:
    is capped by the value of the `-query.timeout` flag.
 
 The current server time is used if the `time` parameter is omitted.
+
+You can URL-encode these parameters directly in the request body by using the `POST` method and
+`Content-Type: application/x-www-form-urlencoded` header. This is useful when specifying a large
+or dynamic number of series selectors that may breach server-side URL character limits.
 
 The `data` section of the query result has the following format:
 
@@ -135,6 +140,7 @@ The following endpoint evaluates an expression query over a range of time:
 
 ```
 GET /api/v1/query_range
+POST /api/v1/query_range
 ```
 
 URL query parameters:
@@ -145,6 +151,10 @@ URL query parameters:
 - `step=<duration | float>`: Query resolution step width in `duration` format or float number of seconds.
 - `timeout=<duration>`: Evaluation timeout. Optional. Defaults to and
    is capped by the value of the `-query.timeout` flag.
+
+You can URL-encode these parameters directly in the request body by using the `POST` method and
+`Content-Type: application/x-www-form-urlencoded` header. This is useful when specifying a large
+or dynamic number of series selectors that may breach server-side URL character limits.
 
 The `data` section of the query result has the following format:
 

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -201,7 +201,7 @@ $ curl 'http://localhost:9090/api/v1/query_range?query=up&start=2015-07-01T20:10
 
 ### Finding series by label matchers
 
-The following endpoints return the list of time series that match a certain label set.
+The following endpoint returns the list of time series that match a certain label set.
 
 ```
 GET /api/v1/series

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -201,10 +201,11 @@ $ curl 'http://localhost:9090/api/v1/query_range?query=up&start=2015-07-01T20:10
 
 ### Finding series by label matchers
 
-The following endpoint returns the list of time series that match a certain label set.
+The following endpoints return the list of time series that match a certain label set.
 
 ```
 GET /api/v1/series
+POST /api/v1/series
 ```
 
 URL query parameters:
@@ -214,6 +215,10 @@ URL query parameters:
 - `start=<rfc3339 | unix_timestamp>`: Start timestamp.
 - `end=<rfc3339 | unix_timestamp>`: End timestamp.
 
+You can URL-encode these parameters directly in the request body by using the `POST` method and
+`Content-Type: application/x-www-form-urlencoded` header. This is useful when specifying a large
+or dynamic number of series selectors that may breach server-side URL character limits.
+
 The `data` section of the query result consists of a list of objects that
 contain the label name/value pairs which identify each series.
 
@@ -221,7 +226,7 @@ The following example returns all series that match either of the selectors
 `up` or `process_start_time_seconds{job="prometheus"}`:
 
 ```json
-$ curl -g 'http://localhost:9090/api/v1/series?match[]=up&match[]=process_start_time_seconds{job="prometheus"}'
+$ curl -g 'http://localhost:9090/api/v1/series?' --data-urlencode='match[]=up' --data-urlencode='match[]=process_start_time_seconds{job="prometheus"}'
 {
    "status" : "success",
    "data" : [

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -231,6 +231,7 @@ func (api *API) Register(r *route.Router) {
 	r.Get("/label/:name/values", wrap(api.labelValues))
 
 	r.Get("/series", wrap(api.series))
+	r.Post("/series", wrap(api.series))
 	r.Del("/series", wrap(api.dropSeries))
 
 	r.Get("/targets", wrap(api.targets))

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -835,7 +835,7 @@ func testEndpoints(t *testing.T, api *API, testLabelAPI bool) {
 
 	methods := func(f apiFunc) []string {
 		fp := reflect.ValueOf(f).Pointer()
-		if fp == reflect.ValueOf(api.query).Pointer() || fp == reflect.ValueOf(api.queryRange).Pointer() {
+		if fp == reflect.ValueOf(api.query).Pointer() || fp == reflect.ValueOf(api.queryRange).Pointer() || fp == reflect.ValueOf(api.series).Pointer() {
 			return []string{http.MethodGet, http.MethodPost}
 		}
 		return []string{http.MethodGet}


### PR DESCRIPTION
Closes #5417

The [ParseForm()](https://github.com/prometheus/prometheus/blob/master/web/api/v1/api.go#L446) method in [net/http](https://golang.org/pkg/net/http/#Request.ParseForm) supports url-encoded parameters in the request body if the method is `POST`, with a built-in 10 MB limit.

This change should mitigate issues where a user runs into query string length limits when providing a large number of selectors using the `GET` method inline in the URL query string.