### PR TITLE
[OpenStack SD] Add ProjectID and UserID meta labels

### DIFF
--- a/discovery/openstack/instance.go
+++ b/discovery/openstack/instance.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
-
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/util/strutil"
 )
@@ -35,13 +34,15 @@ import (
 const (
 	openstackLabelPrefix         = model.MetaLabelPrefix + "openstack_"
 	openstackLabelAddressPool    = openstackLabelPrefix + "address_pool"
+	openstackLabelInstanceFlavor = openstackLabelPrefix + "instance_flavor"
 	openstackLabelInstanceID     = openstackLabelPrefix + "instance_id"
 	openstackLabelInstanceName   = openstackLabelPrefix + "instance_name"
 	openstackLabelInstanceStatus = openstackLabelPrefix + "instance_status"
-	openstackLabelInstanceFlavor = openstackLabelPrefix + "instance_flavor"
-	openstackLabelPublicIP       = openstackLabelPrefix + "public_ip"
 	openstackLabelPrivateIP      = openstackLabelPrefix + "private_ip"
+	openstackLabelProjectID      = openstackLabelPrefix + "project_id"
+	openstackLabelPublicIP       = openstackLabelPrefix + "public_ip"
 	openstackLabelTagPrefix      = openstackLabelPrefix + "tag_"
+	openstackLabelUserID         = openstackLabelPrefix + "user_id"
 )
 
 // InstanceDiscovery discovers OpenStack instances.
@@ -134,6 +135,8 @@ func (i *InstanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 				openstackLabelInstanceID:     model.LabelValue(s.ID),
 				openstackLabelInstanceStatus: model.LabelValue(s.Status),
 				openstackLabelInstanceName:   model.LabelValue(s.Name),
+				openstackLabelProjectID:      model.LabelValue(s.TenantID),
+				openstackLabelUserID:         model.LabelValue(s.UserID),
 			}
 
 			id, ok := s.Flavor["id"].(string)

--- a/discovery/openstack/instance_test.go
+++ b/discovery/openstack/instance_test.go
@@ -84,6 +84,8 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 			"__meta_openstack_private_ip":      model.LabelValue("10.0.0.32"),
 			"__meta_openstack_public_ip":       model.LabelValue("10.10.10.2"),
 			"__meta_openstack_address_pool":    model.LabelValue("private"),
+			"__meta_openstack_project_id":      model.LabelValue("fcad67a6189847c4aecfa3c81a05783b"),
+			"__meta_openstack_user_id":         model.LabelValue("9349aff8be7545ac9d2f1d00999a23cd"),
 		},
 		{
 			"__address__":                      model.LabelValue("10.0.0.31:0"),
@@ -93,6 +95,8 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 			"__meta_openstack_instance_name":   model.LabelValue("derp"),
 			"__meta_openstack_private_ip":      model.LabelValue("10.0.0.31"),
 			"__meta_openstack_address_pool":    model.LabelValue("private"),
+			"__meta_openstack_project_id":      model.LabelValue("fcad67a6189847c4aecfa3c81a05783b"),
+			"__meta_openstack_user_id":         model.LabelValue("9349aff8be7545ac9d2f1d00999a23cd"),
 		},
 		{
 			"__address__":                      model.LabelValue("10.0.0.33:0"),
@@ -103,6 +107,8 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 			"__meta_openstack_private_ip":      model.LabelValue("10.0.0.33"),
 			"__meta_openstack_address_pool":    model.LabelValue("private"),
 			"__meta_openstack_tag_env":         model.LabelValue("prod"),
+			"__meta_openstack_project_id":      model.LabelValue("fcad67a6189847c4aecfa3c81a05783b"),
+			"__meta_openstack_user_id":         model.LabelValue("9349aff8be7545ac9d2f1d00999a23cd"),
 		},
 		{
 			"__address__":                      model.LabelValue("10.0.0.34:0"),
@@ -114,6 +120,8 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 			"__meta_openstack_address_pool":    model.LabelValue("private"),
 			"__meta_openstack_tag_env":         model.LabelValue("prod"),
 			"__meta_openstack_public_ip":       model.LabelValue("10.10.10.4"),
+			"__meta_openstack_project_id":      model.LabelValue("fcad67a6189847c4aecfa3c81a05783b"),
+			"__meta_openstack_user_id":         model.LabelValue("9349aff8be7545ac9d2f1d00999a23cd"),
 		},
 	} {
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -503,14 +503,16 @@ interface.
 
 The following meta labels are available on targets during [relabeling](#relabel_config):
 
+* `__meta_openstack_address_pool`: the pool of the private IP.
+* `__meta_openstack_instance_flavor`: the flavor of the OpenStack instance.
 * `__meta_openstack_instance_id`: the OpenStack instance ID.
 * `__meta_openstack_instance_name`: the OpenStack instance name.
 * `__meta_openstack_instance_status`: the status of the OpenStack instance.
-* `__meta_openstack_instance_flavor`: the flavor of the OpenStack instance.
-* `__meta_openstack_public_ip`: the public IP of the OpenStack instance.
 * `__meta_openstack_private_ip`: the private IP of the OpenStack instance.
-* `__meta_openstack_address_pool`: the pool of the private IP.
+* `__meta_openstack_project_id`: the project (tenant) owning this instance.
+* `__meta_openstack_public_ip`: the public IP of the OpenStack instance.
 * `__meta_openstack_tag_<tagkey>`: each tag value of the instance.
+* `__meta_openstack_user_id`: the user account owning the tenant.
 
 See below for the configuration options for OpenStack discovery:
 


### PR DESCRIPTION
Add extra meta labels which will be useful in the case
Prometheus discovery instances from all projects.

Signed-off-by: Kien Nguyen <kiennt2609@gmail.com>