### PR TITLE
*: enable golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - checkout
     - run: make promu
-    - run: make check_license style unused staticcheck build check_assets
+    - run: make check_license style unused lint build check_assets
     - run:
        command: |
          curl -s -L https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip > /tmp/protoc.zip

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ benchmark.txt
 
 !/.travis.yml
 !/.promu.yml
+!/.golangci.yml
 /documentation/examples/remote_storage/remote_storage_adapter/remote_storage_adapter
 /documentation/examples/remote_storage/example_write_adapter/example_writer_adapter

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+run:
+  modules-download-mode: vendor
+
+# Run only staticcheck for now. Additional linters will be enabled one-by-one.
+linters:
+  enable:
+  - staticcheck
+  disable-all: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_install:
 - travis_retry make deps
 
 script:
-- make check_license style unused test staticcheck check_assets
+- make check_license style unused test lint check_assets
 - git diff --exit-code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ go build ./cmd/prometheus/
 make test         # Make sure all the tests pass before you commit and push :)
 ```
 
-We use `golangci-lint`[https://github.com/golangci/golangci-lint] for linting the code. If it reports an issue and you think that it deserves an exception, you can add a special comment `//nolint:linter1[,linter2,...]` before the offending line. Use this sparingly though, fixing the code to comply with the linter's recommendation is in general the preferred course of action.
+We use `golangci-lint`[https://github.com/golangci/golangci-lint] for linting the code. If it reports an issue and you think that the warning needs to be disregarded or is a false-positive, you can add a special comment `//nolint:linter1[,linter2,...]` before the offending line. Use this sparingly though, fixing the code to comply with the linter's recommendation is in general the preferred course of action.
 
 All our issues are regularly tagged so that you can also filter down the issues involving the components you want to work on. For our labeling policy refer [the wiki page](https://github.com/prometheus/prometheus/wiki/Label-Names-and-Descriptions).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ go build ./cmd/prometheus/
 make test         # Make sure all the tests pass before you commit and push :)
 ```
 
+We use `golangci-lint`[https://github.com/golangci/golangci-lint] for linting the code. If it reports an issue and you think that it deserves an exception, you can add a special comment `//nolint:linter1[,linter2,...]` before the offending line. Use this sparingly though, fixing the code to comply with the linter's recommendation is in general the preferred course of action.
+
 All our issues are regularly tagged so that you can also filter down the issues involving the components you want to work on. For our labeling policy refer [the wiki page](https://github.com/prometheus/prometheus/wiki/Label-Names-and-Descriptions).
 
 ## Pull Request Checklist

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,6 @@
 
 include Makefile.common
 
-STATICCHECK_IGNORE = \
-  github.com/prometheus/prometheus/pkg/textparse/promlex.l.go:SA4006 \
-  github.com/prometheus/prometheus/pkg/textparse/openmetricslex.l.go:SA4006
-
 DOCKER_IMAGE_NAME       ?= prometheus
 
 .PHONY: assets

--- a/Makefile.common
+++ b/Makefile.common
@@ -166,6 +166,10 @@ else
 endif
 endif
 
+# For backward-compatibility.
+.PHONY: common-staticcheck
+common-staticcheck: lint
+
 .PHONY: common-unused
 common-unused: $(GOVENDOR)
 ifdef GOVENDOR

--- a/Makefile.common
+++ b/Makefile.common
@@ -72,14 +72,13 @@ endif
 PROMU_VERSION ?= 0.3.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
-STATICCHECK :=
+GOLANGCI_LINT :=
+GOLANGCI_LINT_VERSION ?= v1.16.0
 # staticcheck only supports linux, freebsd, darwin and windows platforms on i386/amd64
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux freebsd darwin))
 	ifeq ($(GOHOSTARCH),$(filter $(GOHOSTARCH),amd64 i386))
-		STATICCHECK := $(FIRST_GOPATH)/bin/staticcheck
-		STATICCHECK_VERSION ?= 2019.1
-		STATICCHECK_URL := https://github.com/dominikh/go-tools/releases/download/$(STATICCHECK_VERSION)/staticcheck_$(GOHOSTOS)_$(GOHOSTARCH)
+		GOLANGCI_LINT := $(FIRST_GOPATH)/bin/golangci-lint
 	endif
 endif
 
@@ -101,7 +100,7 @@ endif
 %: common-% ;
 
 .PHONY: common-all
-common-all: precheck style check_license staticcheck unused build test
+common-all: precheck style check_license lint unused build test
 
 .PHONY: common-style
 common-style:
@@ -153,18 +152,17 @@ common-vet:
 	@echo ">> vetting code"
 	GO111MODULE=$(GO111MODULE) $(GO) vet $(GOOPTS) $(pkgs)
 
-.PHONY: common-staticcheck
-common-staticcheck: $(STATICCHECK)
-ifdef STATICCHECK
-	@echo ">> running staticcheck"
-	chmod +x $(STATICCHECK)
+.PHONY: common-lint
+common-lint: $(GOLANGCI_LINT)
+ifdef GOLANGCI_LINT
+	@echo ">> running golangci-lint"
 ifdef GO111MODULE
 # 'go list' needs to be executed before staticcheck to prepopulate the modules cache.
 # Otherwise staticcheck might fail randomly for some reason not yet explained.
 	GO111MODULE=$(GO111MODULE) $(GO) list -e -compiled -test=true -export=false -deps=true -find=false -tags= -- ./... > /dev/null
-	GO111MODULE=$(GO111MODULE) $(STATICCHECK) -ignore "$(STATICCHECK_IGNORE)" $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GOLANGCI_LINT) run $(pkgs)
 else
-	$(STATICCHECK) -ignore "$(STATICCHECK_IGNORE)" $(pkgs)
+	$(GOLANGCI_LINT) run $(pkgs)
 endif
 endif
 
@@ -224,10 +222,10 @@ proto:
 	@echo ">> generating code from proto files"
 	@./scripts/genproto.sh
 
-ifdef STATICCHECK
-$(STATICCHECK):
+ifdef GOLANGCI_LINT
+$(GOLANGCI_LINT):
 	mkdir -p $(FIRST_GOPATH)/bin
-	curl -s -L $(STATICCHECK_URL) > $(STATICCHECK)
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(FIRST_GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 endif
 
 ifdef GOVENDOR

--- a/Makefile.common
+++ b/Makefile.common
@@ -74,9 +74,9 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 
 GOLANGCI_LINT :=
 GOLANGCI_LINT_VERSION ?= v1.16.0
-# staticcheck only supports linux, freebsd, darwin and windows platforms on i386/amd64
+# golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
-ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux freebsd darwin))
+ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))
 	ifeq ($(GOHOSTARCH),$(filter $(GOHOSTARCH),amd64 i386))
 		GOLANGCI_LINT := $(FIRST_GOPATH)/bin/golangci-lint
 	endif


### PR DESCRIPTION
[golangci-lint](https://github.com/golangci/golangci-lint) runs many Go linters at the same time. In addition to [staticcheck](https://staticcheck.io/) that we already use in mostly all the repositories, it can also run [errcheck](https://github.com/kisielk/errcheck) (currently used by AlertManager), [govet](https://golang.org/cmd/vet/) and [more](https://github.com/golangci/golangci-lint#enabled-by-default-linters). The main advantage of using golangci-lint over each individual linter is that it's one-step installation and we can easily turn on/tune linters on a per-repository basis. It seems to have sane defaults and is also quite good at detecting and skipping generated code. I've checked with a few other repositories (tsbd, alertmanager, client_golang, common) and the update would be trivial.

There's also a GitHub app but again it requires broad access to the repositories (https://github.com/golangci/golangci/issues/32) which I'm not comfortable with.