### PR TITLE
code optimize for config/config.go

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,14 +37,14 @@ var (
 )
 
 // Load parses the YAML input s into a Config.
-func Load(s string) (*Config, error) {
+func Load(s []byte) (*Config, error) {
 	cfg := &Config{}
 	// If the entire config body is empty the UnmarshalYAML method is
 	// never called. We thus have to set the DefaultConfig at the entry
 	// point as well.
 	*cfg = DefaultConfig
 
-	err := yaml.UnmarshalStrict([]byte(s), cfg)
+	err := yaml.UnmarshalStrict(s, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func LoadFile(filename string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg, err := Load(string(content))
+	cfg, err := Load(content)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing YAML file %s", filename)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -909,14 +909,14 @@ func TestBadStaticConfigsYML(t *testing.T) {
 }
 
 func TestEmptyConfig(t *testing.T) {
-	c, err := Load("")
+	c, err := Load([]byte(""))
 	testutil.Ok(t, err)
 	exp := DefaultConfig
 	testutil.Equals(t, exp, *c)
 }
 
 func TestEmptyGlobalBlock(t *testing.T) {
-	c, err := Load("global:\n")
+	c, err := Load([]byte("global:\n"))
 	testutil.Ok(t, err)
 	exp := DefaultConfig
 	exp.original = "global:\n"


### PR DESCRIPTION
## before
In config/config.go, the data tranfered between func#LoadFile and func#Load is type converted unnecessary, ie:
```go
line 61:    cfg, err := Load(string(content))   // []byte -> string
line 47:    err := yaml.UnmarshalStrict([]byte(s), cfg)     //string -> []byte
```
Can we optimize these code as this PR?


## after
refer the commit in this PR