### PR TITLE
Put myself down for 2.9 release.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ Release cadence of first pre-releases being cut is 6 weeks.
 | v2.6           | 2018-12-05                                 | Simon Pasquier (GitHub: @simonpasquier)     |
 | v2.7           | 2019-01-16                                 | Goutham Veeramachaneni (GitHub: @gouthamve) |
 | v2.8           | 2019-02-27                                 | Ganesh Vernekar (GitHub: @codesome)         |
-| v2.9           | 2019-04-10                                 | **searching for volunteer**                 |
+| v2.9           | 2019-04-10                                 | Brian Brazil (GitHub: @brian-brazil)        |
 | v2.10          | 2019-05-22                                 | **searching for volunteer**                 |
 
 If you are interested in volunteering please create a pull request against the [prometheus/prometheus](https://github.com/prometheus/prometheus) repository and propose yourself for the release series of your choice.
@@ -91,7 +91,7 @@ If the release has happened in the latest release branch, merge the changes into
 
 To update the docs, a PR needs to be created to `prometheus/docs`. See [this PR](https://github.com/prometheus/docs/pull/952/files) for inspiration.
 
-Once the binaries have been uploaded, announce the release on `prometheus-users@googlegroups.com`. Start the subject with `[ANN]`. Check out previous announcement mails for inspiration.
+Once the binaries have been uploaded, announce the release on `prometheus-users@googlegroups.com` and `prometheus-announce@googlegroups.com`. Start the subject with `[ANN]`. Check out previous announcement mails for inspiration.
 
 ### Pre-releases
 


### PR DESCRIPTION
Update docs on where to email release announcements.


Google Groups does not allow one group to be a member of another, so for now document our existing practice of emailing both -users and -ann.