### PR TITLE
docs/querying: improve wording

### DIFF
--- a/docs/querying/examples.md
+++ b/docs/querying/examples.md
@@ -40,11 +40,11 @@ To select all HTTP status codes except 4xx ones, you could run:
 
 ## Subquery
 
-This query returns 5-minute rate of `http_requests_total` metric for the past 30 minutes, at a resolution of 1 minute.
+Return the 5-minute rate of the `http_requests_total` metric for the past 30 minutes, with a resolution of 1 minute.
 
     rate(http_requests_total[5m])[30m:1m]
 
-This is an example of nested subquery. The subquery for the `deriv` function uses default resolution. Note that using subqueries unnecessarily is unwise.
+This is an example of a nested subquery. The subquery for the `deriv` function uses the default resolution. Note that using subqueries unnecessarily is unwise.
 
     max_over_time(deriv(rate(distance_covered_total[5s])[30s:5s])[10m:])
 


### PR DESCRIPTION
This commit improves the wording of the subquery examples and makes
them more consistent with other examples.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>