### PR TITLE
Remote Write: Queue Manager specific metrics shouldn't exist if the queue no longer exists

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -189,7 +189,7 @@ type QueueManager struct {
 	sentBatchDuration          prometheus.Observer
 	succeededSamplesTotal      prometheus.Counter
 	retriedSamplesTotal        prometheus.Counter
-	queueMetrics               []prometheus.Collector
+	shardCapacity              prometheus.Gauge
 }
 
 // NewQueueManager builds a new QueueManager.
@@ -220,31 +220,10 @@ func NewQueueManager(logger log.Logger, walDir string, samplesIn *ewmaRate, cfg 
 		samplesDropped:     newEWMARate(ewmaWeight, shardUpdateDuration),
 		samplesOut:         newEWMARate(ewmaWeight, shardUpdateDuration),
 		samplesOutDuration: newEWMARate(ewmaWeight, shardUpdateDuration),
-
-		highestSentTimestampMetric: &maxGauge{
-			Gauge: queueHighestSentTimestamp.WithLabelValues(name),
-		},
-		pendingSamplesMetric:  queuePendingSamples.WithLabelValues(name),
-		enqueueRetriesMetric:  enqueueRetriesTotal.WithLabelValues(name),
-		droppedSamplesTotal:   droppedSamplesTotal.WithLabelValues(name),
-		numShardsMetric:       numShards.WithLabelValues(name),
-		failedSamplesTotal:    failedSamplesTotal.WithLabelValues(name),
-		sentBatchDuration:     sentBatchDuration.WithLabelValues(name),
-		succeededSamplesTotal: succeededSamplesTotal.WithLabelValues(name),
-		retriedSamplesTotal:   retriedSamplesTotal.WithLabelValues(name),
-	}
-	// We can't add sentBatchDuration because Observer doesn't implement Collector interface.
-	t.queueMetrics = []prometheus.Collector{
-		t.highestSentTimestampMetric.Gauge, t.pendingSamplesMetric, t.enqueueRetriesMetric,
-		t.droppedSamplesTotal, t.numShardsMetric, t.failedSamplesTotal, t.succeededSamplesTotal, t.retriedSamplesTotal,
 	}
 
 	t.watcher = NewWALWatcher(logger, name, t, walDir)
 	t.shards = t.newShards()
-
-	// Initialise some metrics.
-	shardCapacity.WithLabelValues(name).Set(float64(t.cfg.Capacity))
-	t.pendingSamplesMetric.Set(0)
 
 	return t
 }
@@ -313,6 +292,27 @@ outer:
 // Start the queue manager sending samples to the remote storage.
 // Does not block.
 func (t *QueueManager) Start() {
+	// Setup the QueueManagers metrics. We do this here rather than in the
+	// constructor because of the ordering of creating Queue Managers's, stopping them,
+	// and then starting new ones in storage/remote/storage.go ApplyConfig.
+	name := t.client.Name()
+	t.highestSentTimestampMetric = &maxGauge{
+		Gauge: queueHighestSentTimestamp.WithLabelValues(name),
+	}
+	t.pendingSamplesMetric = queuePendingSamples.WithLabelValues(name)
+	t.enqueueRetriesMetric = enqueueRetriesTotal.WithLabelValues(name)
+	t.droppedSamplesTotal = droppedSamplesTotal.WithLabelValues(name)
+	t.numShardsMetric = numShards.WithLabelValues(name)
+	t.failedSamplesTotal = failedSamplesTotal.WithLabelValues(name)
+	t.sentBatchDuration = sentBatchDuration.WithLabelValues(name)
+	t.succeededSamplesTotal = succeededSamplesTotal.WithLabelValues(name)
+	t.retriedSamplesTotal = retriedSamplesTotal.WithLabelValues(name)
+	t.shardCapacity = shardCapacity.WithLabelValues(name)
+
+	// Initialise some metrics.
+	t.shardCapacity.Set(float64(t.cfg.Capacity))
+	t.pendingSamplesMetric.Set(0)
+
 	t.shards.start(t.numShards)
 	t.watcher.Start()
 
@@ -338,10 +338,18 @@ func (t *QueueManager) Stop() {
 	for _, labels := range t.seriesLabels {
 		release(labels)
 	}
-	// Un-register metrics so we don't have alerts for queues that are gone.
-	for _, m := range t.queueMetrics {
-		prometheus.Unregister(m)
-	}
+	// Delete metrics so we don't have alerts for queues that are gone.
+	name := t.client.Name()
+	queueHighestSentTimestamp.DeleteLabelValues(name)
+	queuePendingSamples.DeleteLabelValues(name)
+	enqueueRetriesTotal.DeleteLabelValues(name)
+	droppedSamplesTotal.DeleteLabelValues(name)
+	numShards.DeleteLabelValues(name)
+	failedSamplesTotal.DeleteLabelValues(name)
+	sentBatchDuration.DeleteLabelValues(name)
+	succeededSamplesTotal.DeleteLabelValues(name)
+	retriedSamplesTotal.DeleteLabelValues(name)
+	shardCapacity.DeleteLabelValues(name)
 }
 
 // StoreSeries keeps track of which series we know about for lookups when sending samples to remote.

--- a/storage/remote/wal_watcher.go
+++ b/storage/remote/wal_watcher.go
@@ -132,10 +132,7 @@ func NewWALWatcher(logger log.Logger, name string, writer writeTo, walDir string
 	}
 }
 
-// Start the WALWatcher.
-func (w *WALWatcher) Start() {
-	level.Info(w.logger).Log("msg", "starting WAL watcher", "queue", w.name)
-
+func (w *WALWatcher) setMetrics() {
 	// Setup the WAL Watchers metrics. We do this here rather than in the
 	// constructor because of the ordering of creating Queue Managers's,
 	// stopping them, and then starting new ones in storage/remote/storage.go ApplyConfig.
@@ -143,6 +140,12 @@ func (w *WALWatcher) Start() {
 	w.recordDecodeFailsMetric = watcherRecordDecodeFails.WithLabelValues(w.name)
 	w.samplesSentPreTailing = watcherSamplesSentPreTailing.WithLabelValues(w.name)
 	w.currentSegmentMetric = watcherCurrentSegment.WithLabelValues(w.name)
+}
+
+// Start the WALWatcher.
+func (w *WALWatcher) Start() {
+	w.setMetrics()
+	level.Info(w.logger).Log("msg", "starting WAL watcher", "queue", w.name)
 
 	go w.loop()
 }


### PR DESCRIPTION
Unregister remote write queue manager specific metrics when stopping the queue manager.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

fixes #5395
@tomwilkie 