### PR TITLE
Sorting alerts by group name in /alerts

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -109,8 +109,6 @@ func (a *Alert) needsSending(ts time.Time, resendDelay time.Duration) bool {
 type AlertingRule struct {
 	// The name of the alert.
 	name string
-	//The name of the alerts group
-	gname string
 	// The vector expression from which to generate alerts.
 	vector promql.Expr
 	// The duration for which a labelset needs to persist in the expression
@@ -158,11 +156,6 @@ func NewAlertingRule(name string, vec promql.Expr, hold time.Duration, lbls, ann
 // Name returns the name of the alerting rule.
 func (r *AlertingRule) Name() string {
 	return r.name
-}
-
-// Gname returns the name of the alerts group.
-func (r *AlertingRule) Gname() string {
-	return r.gname
 }
 
 // SetLastError sets the current error seen by the alerting rule.

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -109,6 +109,8 @@ func (a *Alert) needsSending(ts time.Time, resendDelay time.Duration) bool {
 type AlertingRule struct {
 	// The name of the alert.
 	name string
+	//The name of the alerts group
+	gname string
 	// The vector expression from which to generate alerts.
 	vector promql.Expr
 	// The duration for which a labelset needs to persist in the expression
@@ -156,6 +158,11 @@ func NewAlertingRule(name string, vec promql.Expr, hold time.Duration, lbls, ann
 // Name returns the name of the alerting rule.
 func (r *AlertingRule) Name() string {
 	return r.name
+}
+
+// Gname returns the name of the alerts group.
+func (r *AlertingRule) Gname() string {
+	return r.gname
 }
 
 // SetLastError sets the current error seen by the alerting rule.

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -899,9 +899,12 @@ func (m *Manager) AlertingRules() []*AlertingRule {
 	defer m.mtx.RUnlock()
 
 	alerts := []*AlertingRule{}
-	for _, rule := range m.Rules() {
-		if alertingRule, ok := rule.(*AlertingRule); ok {
-			alerts = append(alerts, alertingRule)
+	for _, g := range m.groups {
+		for _, rule := range g.rules {
+			if alertingRule, ok := rule.(*AlertingRule); ok {
+				alertingRule.gname = g.name
+				alerts = append(alerts, alertingRule)
+			}
 		}
 	}
 	return alerts

--- a/web/ui/templates/alerts.html
+++ b/web/ui/templates/alerts.html
@@ -12,62 +12,70 @@
   </div>
   <table class="table table-bordered table-collapsed">
     <tbody>
-    {{$alertStateToRowClass := .AlertStateToRowClass}}
-    {{range .AlertingRules}}
-      {{$activeAlerts := .ActiveAlerts}}
-      <tr class="alert alert-{{index $alertStateToRowClass .State}} alert_header">
-        <td><i class="icon-chevron-down"></i> <b>{{.Name}} {{.Gname}}</b> ({{len $activeAlerts}} active)</td>
-      </tr>
-      <tr class="alert_details">
-        <td>
-          <div>
-            <pre style="display:block; padding:9.5px; font-size:13px; color:#333; word-break:break-all; background-color:#f5f5f5; border:1px solid #ccc; border-radius:4px;" ><code>{{.HTMLSnippet pathPrefix}}</code></pre>
-          </div>
-          {{if $activeAlerts}}
-          <table class="table table-bordered table-hover table-sm alert_elements_table">
-            <tr class="">
-              <th>Labels</th>
-              <th>State</th>
-              <th>Active Since</th>
-              <th>Value</th>
-            </tr>
-            {{range $activeAlerts}}
-            <tr>
-              <td>
-                {{range $label, $value := .Labels.Map}}
-                  <span class="badge badge-primary">{{$label}}="{{$value}}"</span>
-                {{end}}
-              </td>
-              <td><span class="alert alert-{{ .State | alertStateToClass }} state_indicator text-uppercase">{{.State}}</span></td>
-              <td>{{.ActiveAt.UTC}}</td>
-              <td>{{.Value}}</td>
-            </tr>
-            {{ if .Annotations.Map}}
-            <tr style="display:none" class="alert_annotations">
-              <th colspan="4">Annotations</th>
-            </tr>
-            <tr style="display:none" class="alert_annotations">
-              <td colspan="4">
-                <dl>
-                {{range $label, $value := .Annotations.Map}}
-                  <dt>{{$label}}</dt>
-                  <dd>{{$value}}</dd>
-                {{end}}
-                </dl>
-              </td>
-            </tr>
-            {{end}}
-            {{end}}
-          </table>
-          {{end}}
-        </td>
-      </tr>
-    {{else}}
+      {{range .Groups}}
       <tr>
         <td>
-            No alerting rules defined
-        </td>
+        {{.Name}}
+      </td>
       </tr>
+        {{$alertStateToRowClass := .AlertStateToRowClass}}
+
+        {{range .Rules}}
+          {{$activeAlerts := .ActiveAlerts}}
+          <tr class="alert alert-{{index $alertStateToRowClass .State}} alert_header">
+              <td><i class="icon-chevron-down"></i> <b>{{.Name}}</b> ({{len $activeAlerts}} active)</td>
+          </tr>
+          <tr class="alert_details">
+            <td>
+              <div>
+                <pre style="display:block; padding:9.5px; font-size:13px; color:#333; word-break:break-all; background-color:#f5f5f5; border:1px solid #ccc; border-radius:4px;" ><code>{{.HTMLSnippet pathPrefix}}</code></pre>
+              </div>
+              {{if $activeAlerts}}
+              <table class="table table-bordered table-hover table-sm alert_elements_table">
+                <tr class="">
+                  <th>Labels</th>
+                  <th>State</th>
+                  <th>Active Since</th>
+                  <th>Value</th>
+                </tr>
+                {{range $activeAlerts}}
+                <tr>
+                  <td>
+                    {{range $label, $value := .Labels.Map}}
+                      <span class="badge badge-primary">{{$label}}="{{$value}}"</span>
+                    {{end}}
+                  </td>
+                  <td><span class="alert alert-{{ .State | alertStateToClass }} state_indicator text-uppercase">{{.State}}</span></td>
+                  <td>{{.ActiveAt.UTC}}</td>
+                  <td>{{.Value}}</td>
+                </tr>
+                {{ if .Annotations.Map}}
+                <tr style="display:none" class="alert_annotations">
+                  <th colspan="4">Annotations</th>
+                </tr>
+                <tr style="display:none" class="alert_annotations">
+                  <td colspan="4">
+                    <dl>
+                    {{range $label, $value := .Annotations.Map}}
+                      <dt>{{$label}}</dt>
+                      <dd>{{$value}}</dd>
+                    {{end}}
+                    </dl>
+                  </td>
+                </tr>
+                {{end}}
+                {{end}}
+              </table>
+              {{end}}
+            </td>
+          </tr>
+        {{else}}
+          <tr>
+            <td>
+                No alerting rules defined
+            </td>
+          </tr>
+        {{end}} <!-- end of range groups -->
     {{end}}
     </tbody>
   </table>

--- a/web/ui/templates/alerts.html
+++ b/web/ui/templates/alerts.html
@@ -16,7 +16,7 @@
     {{range .AlertingRules}}
       {{$activeAlerts := .ActiveAlerts}}
       <tr class="alert alert-{{index $alertStateToRowClass .State}} alert_header">
-        <td><i class="icon-chevron-down"></i> <b>{{.Name}}</b> ({{len $activeAlerts}} active)</td>
+        <td><i class="icon-chevron-down"></i> <b>{{.Name}} {{.Gname}}</b> ({{len $activeAlerts}} active)</td>
       </tr>
       <tr class="alert_details">
         <td>

--- a/web/web.go
+++ b/web/web.go
@@ -498,10 +498,12 @@ func (h *Handler) Run(ctx context.Context) error {
 
 func (h *Handler) alerts(w http.ResponseWriter, r *http.Request) {
 	alerts := h.ruleManager.AlertingRulesbyGroup()
+	groupSorter := groupNameSorter{Groups:alerts}
+	sort.Sort(groupSorter)
+	alerts = groupSorter.Groups
 	for _, g := range alerts.Groups{
 		alertsSorter := byAlertStateAndNameSorter{alerts: g.Rules}
 		sort.Sort(alertsSorter)
-
 		g.Rules = alertsSorter.alerts
 		g.AlertStateToRowClass = map[rules.AlertState]string{
 				rules.StateInactive: "success",
@@ -931,3 +933,22 @@ func (s byAlertStateAndNameSorter) Less(i, j int) bool {
 func (s byAlertStateAndNameSorter) Swap(i, j int) {
 	s.alerts[i], s.alerts[j] = s.alerts[j], s.alerts[i]
 }
+
+//NEW CODE TO SORT GROUP NAMES
+type groupNameSorter struct {
+	Groups               []*rules.AlertingGroups
+}
+
+func (s groupNameSorter) Len() int {
+	return len(s.Groups)
+}
+
+func (s groupNameSorter) Less(i, j int) bool {
+	return s.Groups[i] < s.Groups[j]
+}
+
+func (s groupNameSorter) Swap(i, j int) {
+	s.Groups[i], s.Groups[j] = s.Groups[j], s.Groups[i]
+}
+
+

--- a/web/web.go
+++ b/web/web.go
@@ -497,19 +497,19 @@ func (h *Handler) Run(ctx context.Context) error {
 }
 
 func (h *Handler) alerts(w http.ResponseWriter, r *http.Request) {
-	alerts := h.ruleManager.AlertingRules()
-	alertsSorter := byAlertStateAndNameSorter{alerts: alerts}
-	sort.Sort(alertsSorter)
+	alerts := h.ruleManager.AlertingRulesbyGroup()
+	for _, g := range alerts.Groups{
+		alertsSorter := byAlertStateAndNameSorter{alerts: g.Rules}
+		sort.Sort(alertsSorter)
 
-	alertStatus := AlertStatus{
-		AlertingRules: alertsSorter.alerts,
-		AlertStateToRowClass: map[rules.AlertState]string{
-			rules.StateInactive: "success",
-			rules.StatePending:  "warning",
-			rules.StateFiring:   "danger",
-		},
-	}
-	h.executeTemplate(w, "alerts.html", alertStatus)
+		g.Rules = alertsSorter.alerts
+		g.AlertStateToRowClass = map[rules.AlertState]string{
+				rules.StateInactive: "success",
+				rules.StatePending:  "warning",
+				rules.StateFiring:   "danger",
+			}
+		}
+	h.executeTemplate(w, "alerts.html", alerts)
 }
 
 func (h *Handler) consoles(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
As mentioned in #1371 and #3579, this is a draft pull request for sorting alerts by group name on the alerts page. As it stands I need some help sorting the groups alphabetically, when the page is refreshed the groups shuffle position. 