### PR TITLE
Sorting alerts by group name in /alerts

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -111,8 +111,6 @@ func (a *Alert) needsSending(ts time.Time, resendDelay time.Duration) bool {
 type AlertingRule struct {
 	// The name of the alert.
 	name string
-	//The name of the alerts group
-	gname string
 	// The vector expression from which to generate alerts.
 	vector promql.Expr
 	// The duration for which a labelset needs to persist in the expression
@@ -172,11 +170,6 @@ func NewAlertingRule(
 // Name returns the name of the alerting rule.
 func (r *AlertingRule) Name() string {
 	return r.name
-}
-
-// Gname returns the name of the alerts group.
-func (r *AlertingRule) Gname() string {
-	return r.gname
 }
 
 // SetLastError sets the current error seen by the alerting rule.

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -111,6 +111,8 @@ func (a *Alert) needsSending(ts time.Time, resendDelay time.Duration) bool {
 type AlertingRule struct {
 	// The name of the alert.
 	name string
+	//The name of the alerts group
+	gname string
 	// The vector expression from which to generate alerts.
 	vector promql.Expr
 	// The duration for which a labelset needs to persist in the expression
@@ -170,6 +172,11 @@ func NewAlertingRule(
 // Name returns the name of the alerting rule.
 func (r *AlertingRule) Name() string {
 	return r.name
+}
+
+// Gname returns the name of the alerts group.
+func (r *AlertingRule) Gname() string {
+	return r.gname
 }
 
 // SetLastError sets the current error seen by the alerting rule.

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"math"
 	"net/url"
-	"path/filepath"
 	"sort"
 	"sync"
 	"time"
@@ -268,7 +267,7 @@ func NewGroup(name, file string, interval time.Duration, rules []Rule, shouldRes
 func (g *Group) Name() string { return g.name }
 
 // File returns the group's file.
-func (g *Group) File() string { return filepath.Base(g.file) }
+func (g *Group) File() string { return g.file }
 
 // Rules returns the group's rules.
 func (g *Group) Rules() []Rule { return g.rules }

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"math"
 	"net/url"
+	"path/filepath"
 	"sort"
 	"sync"
 	"time"
@@ -267,7 +268,7 @@ func NewGroup(name, file string, interval time.Duration, rules []Rule, shouldRes
 func (g *Group) Name() string { return g.name }
 
 // File returns the group's file.
-func (g *Group) File() string { return g.file }
+func (g *Group) File() string { return filepath.Base(g.file) }
 
 // Rules returns the group's rules.
 func (g *Group) Rules() []Rule { return g.rules }
@@ -903,9 +904,8 @@ func (m *Manager) RuleGroups() []*Group {
 		rgs = append(rgs, g)
 	}
 
-	// Sort rule groups by file, then by name.
 	sort.Slice(rgs, func(i, j int) bool {
-		if rgs[i].name == rgs[j].name {
+		if rgs[i].file != rgs[j].file {
 			return rgs[i].file < rgs[j].file
 		}
 		return rgs[i].name < rgs[j].name

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -361,7 +361,7 @@ func (g *Group) hash() uint64 {
 	return l.Hash()
 }
 
-// AlertingRules returns the list of the group's alerting rules
+// AlertingRules returns the list of the group's alerting rules.
 func (g *Group) AlertingRules() []*AlertingRule {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
@@ -380,7 +380,7 @@ func (g *Group) AlertingRules() []*AlertingRule {
 	return alerts
 }
 
-// HasAlertingRules returns true if the group contains at least one AlertingRule
+// HasAlertingRules returns true if the group contains at least one AlertingRule.
 func (g *Group) HasAlertingRules() bool {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -901,9 +901,12 @@ func (m *Manager) AlertingRules() []*AlertingRule {
 	defer m.mtx.RUnlock()
 
 	alerts := []*AlertingRule{}
-	for _, rule := range m.Rules() {
-		if alertingRule, ok := rule.(*AlertingRule); ok {
-			alerts = append(alerts, alertingRule)
+	for _, g := range m.groups {
+		for _, rule := range g.rules {
+			if alertingRule, ok := rule.(*AlertingRule); ok {
+				alertingRule.gname = g.name
+				alerts = append(alerts, alertingRule)
+			}
 		}
 	}
 	return alerts

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -901,15 +901,40 @@ func (m *Manager) AlertingRules() []*AlertingRule {
 	defer m.mtx.RUnlock()
 
 	alerts := []*AlertingRule{}
-	for _, g := range m.groups {
-		for _, rule := range g.rules {
-			if alertingRule, ok := rule.(*AlertingRule); ok {
-				alertingRule.gname = g.name
-				alerts = append(alerts, alertingRule)
-			}
+	for _, rule := range m.Rules() {
+		if alertingRule, ok := rule.(*AlertingRule); ok {
+			alerts = append(alerts, alertingRule)
 		}
 	}
 	return alerts
+}
+
+// AlertingRules returns the list of the manager's alerting rules organised by group.
+func (m *Manager) AlertingRulesbyGroup() *AlertingGroups {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	alerts := &AlertingGroups{}
+	for _, g := range m.groups {
+		group := &AlertingGroup{Name: g.name}
+		for _, rule := range g.rules {
+			if alertingRule, ok := rule.(*AlertingRule); ok {
+				group.Rules = append(group.Rules, alertingRule)
+			}
+		}
+		alerts.Groups = append(alerts.Groups, group)
+	}
+	return alerts
+}
+
+type AlertingGroups struct {
+	Groups []*AlertingGroup
+}
+
+type AlertingGroup struct {
+	Name                 string
+	Rules                []*AlertingRule
+	AlertStateToRowClass map[AlertState]string
 }
 
 // Describe implements prometheus.Collector.

--- a/web/ui/templates/alerts.html
+++ b/web/ui/templates/alerts.html
@@ -12,62 +12,70 @@
   </div>
   <table class="table table-bordered table-collapsed">
     <tbody>
-    {{$alertStateToRowClass := .AlertStateToRowClass}}
-    {{range .AlertingRules}}
-      {{$activeAlerts := .ActiveAlerts}}
-      <tr class="alert alert-{{index $alertStateToRowClass .State}} alert_header">
-        <td><i class="icon-chevron-down"></i> <b>{{.Name}} {{.Gname}}</b> ({{len $activeAlerts}} active)</td>
-      </tr>
-      <tr class="alert_details">
-        <td>
-          <div>
-            <pre style="display:block; padding:9.5px; font-size:13px; color:#333; word-break:break-all; background-color:#f5f5f5; border:1px solid #ccc; border-radius:4px;" ><code>{{.HTMLSnippet pathPrefix}}</code></pre>
-          </div>
-          {{if $activeAlerts}}
-          <table class="table table-bordered table-hover table-sm alert_elements_table">
-            <tr class="">
-              <th>Labels</th>
-              <th>State</th>
-              <th>Active Since</th>
-              <th>Value</th>
-            </tr>
-            {{range $activeAlerts}}
-            <tr>
-              <td>
-                {{range $label, $value := .Labels.Map}}
-                  <span class="badge badge-primary">{{$label}}="{{$value}}"</span>
-                {{end}}
-              </td>
-              <td><span class="alert alert-{{ .State | alertStateToClass }} state_indicator text-uppercase">{{.State}}</span></td>
-              <td>{{.ActiveAt.UTC}}</td>
-              <td>{{.Value}}</td>
-            </tr>
-            {{ if .Annotations.Map}}
-            <tr style="display:none" class="alert_annotations">
-              <th colspan="4">Annotations</th>
-            </tr>
-            <tr style="display:none" class="alert_annotations">
-              <td colspan="4">
-                <dl>
-                {{range $label, $value := .Annotations.Map}}
-                  <dt>{{$label}}</dt>
-                  <dd>{{$value}}</dd>
-                {{end}}
-                </dl>
-              </td>
-            </tr>
-            {{end}}
-            {{end}}
-          </table>
-          {{end}}
-        </td>
-      </tr>
-    {{else}}
+      {{range .Groups}}
       <tr>
         <td>
-            No alerting rules defined
-        </td>
+        {{.Name}}
+      </td>
       </tr>
+        {{$alertStateToRowClass := .AlertStateToRowClass}}
+
+        {{range .Rules}}
+          {{$activeAlerts := .ActiveAlerts}}
+          <tr class="alert alert-{{index $alertStateToRowClass .State}} alert_header">
+              <td><i class="icon-chevron-down"></i> <b>{{.Name}}</b> ({{len $activeAlerts}} active)</td>
+          </tr>
+          <tr class="alert_details">
+            <td>
+              <div>
+                <pre style="display:block; padding:9.5px; font-size:13px; color:#333; word-break:break-all; background-color:#f5f5f5; border:1px solid #ccc; border-radius:4px;" ><code>{{.HTMLSnippet pathPrefix}}</code></pre>
+              </div>
+              {{if $activeAlerts}}
+              <table class="table table-bordered table-hover table-sm alert_elements_table">
+                <tr class="">
+                  <th>Labels</th>
+                  <th>State</th>
+                  <th>Active Since</th>
+                  <th>Value</th>
+                </tr>
+                {{range $activeAlerts}}
+                <tr>
+                  <td>
+                    {{range $label, $value := .Labels.Map}}
+                      <span class="badge badge-primary">{{$label}}="{{$value}}"</span>
+                    {{end}}
+                  </td>
+                  <td><span class="alert alert-{{ .State | alertStateToClass }} state_indicator text-uppercase">{{.State}}</span></td>
+                  <td>{{.ActiveAt.UTC}}</td>
+                  <td>{{.Value}}</td>
+                </tr>
+                {{ if .Annotations.Map}}
+                <tr style="display:none" class="alert_annotations">
+                  <th colspan="4">Annotations</th>
+                </tr>
+                <tr style="display:none" class="alert_annotations">
+                  <td colspan="4">
+                    <dl>
+                    {{range $label, $value := .Annotations.Map}}
+                      <dt>{{$label}}</dt>
+                      <dd>{{$value}}</dd>
+                    {{end}}
+                    </dl>
+                  </td>
+                </tr>
+                {{end}}
+                {{end}}
+              </table>
+              {{end}}
+            </td>
+          </tr>
+        {{else}}
+          <tr>
+            <td>
+                No alerting rules defined
+            </td>
+          </tr>
+        {{end}} <!-- end of range groups -->
     {{end}}
     </tbody>
   </table>

--- a/web/ui/templates/alerts.html
+++ b/web/ui/templates/alerts.html
@@ -16,7 +16,7 @@
     {{range .AlertingRules}}
       {{$activeAlerts := .ActiveAlerts}}
       <tr class="alert alert-{{index $alertStateToRowClass .State}} alert_header">
-        <td><i class="icon-chevron-down"></i> <b>{{.Name}}</b> ({{len $activeAlerts}} active)</td>
+        <td><i class="icon-chevron-down"></i> <b>{{.Name}} {{.Gname}}</b> ({{len $activeAlerts}} active)</td>
       </tr>
       <tr class="alert_details">
         <td>

--- a/web/ui/templates/alerts.html
+++ b/web/ui/templates/alerts.html
@@ -12,15 +12,14 @@
   </div>
   <table class="table table-bordered table-collapsed">
     <tbody>
+      {{$alertStateToRowClass := .AlertStateToRowClass}}
       {{range .Groups}}
       <tr>
         <td>
         {{.Name}}
       </td>
       </tr>
-        {{$alertStateToRowClass := .AlertStateToRowClass}}
-
-        {{range .Rules}}
+        {{range .AlertingRules}}
           {{$activeAlerts := .ActiveAlerts}}
           <tr class="alert alert-{{index $alertStateToRowClass .State}} alert_header">
               <td><i class="icon-chevron-down"></i> <b>{{.Name}}</b> ({{len $activeAlerts}} active)</td>
@@ -69,13 +68,13 @@
               {{end}}
             </td>
           </tr>
+        {{end}}
         {{else}}
           <tr>
             <td>
                 No alerting rules defined
             </td>
           </tr>
-        {{end}} <!-- end of range groups -->
     {{end}}
     </tbody>
   </table>

--- a/web/ui/templates/alerts.html
+++ b/web/ui/templates/alerts.html
@@ -15,9 +15,9 @@
       {{$alertStateToRowClass := .AlertStateToRowClass}}
       {{range .Groups}}
       <tr>
-        <td>
-        {{.Name}}
-      </td>
+        <td style="padding: 2px">
+          {{.File}} > {{.Name}}
+        </td>
       </tr>
         {{range .AlertingRules}}
           {{$activeAlerts := .ActiveAlerts}}

--- a/web/web.go
+++ b/web/web.go
@@ -500,10 +500,12 @@ func (h *Handler) Run(ctx context.Context) error {
 
 func (h *Handler) alerts(w http.ResponseWriter, r *http.Request) {
 	alerts := h.ruleManager.AlertingRulesbyGroup()
+	groupSorter := groupNameSorter{Groups:alerts}
+	sort.Sort(groupSorter)
+	alerts = groupSorter.Groups
 	for _, g := range alerts.Groups{
 		alertsSorter := byAlertStateAndNameSorter{alerts: g.Rules}
 		sort.Sort(alertsSorter)
-
 		g.Rules = alertsSorter.alerts
 		g.AlertStateToRowClass = map[rules.AlertState]string{
 				rules.StateInactive: "success",
@@ -947,3 +949,22 @@ func (s byAlertStateAndNameSorter) Less(i, j int) bool {
 func (s byAlertStateAndNameSorter) Swap(i, j int) {
 	s.alerts[i], s.alerts[j] = s.alerts[j], s.alerts[i]
 }
+
+//NEW CODE TO SORT GROUP NAMES
+type groupNameSorter struct {
+	Groups               []*rules.AlertingGroups
+}
+
+func (s groupNameSorter) Len() int {
+	return len(s.Groups)
+}
+
+func (s groupNameSorter) Less(i, j int) bool {
+	return s.Groups[i] < s.Groups[j]
+}
+
+func (s groupNameSorter) Swap(i, j int) {
+	s.Groups[i], s.Groups[j] = s.Groups[j], s.Groups[i]
+}
+
+

--- a/web/web.go
+++ b/web/web.go
@@ -499,19 +499,19 @@ func (h *Handler) Run(ctx context.Context) error {
 }
 
 func (h *Handler) alerts(w http.ResponseWriter, r *http.Request) {
-	alerts := h.ruleManager.AlertingRules()
-	alertsSorter := byAlertStateAndNameSorter{alerts: alerts}
-	sort.Sort(alertsSorter)
+	alerts := h.ruleManager.AlertingRulesbyGroup()
+	for _, g := range alerts.Groups{
+		alertsSorter := byAlertStateAndNameSorter{alerts: g.Rules}
+		sort.Sort(alertsSorter)
 
-	alertStatus := AlertStatus{
-		AlertingRules: alertsSorter.alerts,
-		AlertStateToRowClass: map[rules.AlertState]string{
-			rules.StateInactive: "success",
-			rules.StatePending:  "warning",
-			rules.StateFiring:   "danger",
-		},
-	}
-	h.executeTemplate(w, "alerts.html", alertStatus)
+		g.Rules = alertsSorter.alerts
+		g.AlertStateToRowClass = map[rules.AlertState]string{
+				rules.StateInactive: "success",
+				rules.StatePending:  "warning",
+				rules.StateFiring:   "danger",
+			}
+		}
+	h.executeTemplate(w, "alerts.html", alerts)
 }
 
 func (h *Handler) consoles(w http.ResponseWriter, r *http.Request) {

--- a/web/web.go
+++ b/web/web.go
@@ -507,7 +507,7 @@ func (h *Handler) alerts(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	alertStatus := AlertStatus {
+	alertStatus := AlertStatus{
 		Groups: groups,
 		AlertStateToRowClass: map[rules.AlertState]string{
 			rules.StateInactive: "success",
@@ -930,6 +930,6 @@ func (h *Handler) executeTemplate(w http.ResponseWriter, name string, data inter
 
 // AlertStatus bundles alerting rules and the mapping of alert states to row classes.
 type AlertStatus struct {
-	Groups        []*rules.Group
+	Groups               []*rules.Group
 	AlertStateToRowClass map[rules.AlertState]string
 }


### PR DESCRIPTION
As mentioned in #1371 and #3579, this is a draft pull request for sorting alerts by group name on the alerts page. As it stands I need some help sorting the groups alphabetically, when the page is refreshed the groups shuffle position. 