### PR TITLE
Prevent reshard concurrent with calling stop

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -322,9 +322,9 @@ func (t *QueueManager) Stop() {
 	defer level.Info(t.logger).Log("msg", "Remote storage stopped.")
 
 	close(t.quit)
+	t.wg.Wait()
 	t.shards.stop()
 	t.watcher.Stop()
-	t.wg.Wait()
 
 	// On shutdown, release the strings in the labels from the intern pool.
 	t.seriesMtx.Lock()

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -323,6 +323,9 @@ func (t *QueueManager) Stop() {
 
 	close(t.quit)
 	t.wg.Wait()
+	// Wait for all QueueManager routines to end before stopping shards and WAL watcher. This
+	// is to ensure we don't end up executing a reshard and shards.stop() at the same time, which
+	// causes a closed channel panic.
 	t.shards.stop()
 	t.watcher.Stop()
 


### PR DESCRIPTION
We should wait util the reshard loop and reshard calculations are complete before calling stop, otherwise the reshard stop, start can happen concurrently.

In practice this happens when doing a Prometheus reload at the same time as a reshard loop is happening

fixes: https://github.com/prometheus/prometheus/issues/5451