### PR TITLE
Use github.com/oklog/run not archived oklog/oklog

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -36,7 +36,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	conntrack "github.com/mwitkow/go-conntrack"
-	"github.com/oklog/oklog/pkg/group"
+	"github.com/oklog/run"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -470,7 +470,7 @@ func main() {
 		})
 	}
 
-	var g group.Group
+	var g run.Group
 	{
 		// Termination handler.
 		term := make(chan os.Signal, 1)

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
 	github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
-	github.com/oklog/oklog v0.0.0-20170918173356-f857583a70c3
+	github.com/oklog/run v1.0.0
 	github.com/olekukonko/tablewriter v0.0.1 // indirect
 	github.com/opentracing-contrib/go-stdlib v0.0.0-20170113013457-1de4cc2120e7
 	github.com/opentracing/basictracer-go v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808 h1:pmpDGKLw4n82
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/oklog/oklog v0.0.0-20170918173356-f857583a70c3 h1:K/4JIfLQRyyHKJGd6ZfHply0GYxMuiqLCGuA8904lJk=
-github.com/oklog/oklog v0.0.0-20170918173356-f857583a70c3/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
+github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
+github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=

--- a/vendor/github.com/oklog/run/.gitignore
+++ b/vendor/github.com/oklog/run/.gitignore
@@ -1,0 +1,14 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/

--- a/vendor/github.com/oklog/run/.travis.yml
+++ b/vendor/github.com/oklog/run/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+sudo: false
+go:
+  - 1.x
+  - tip
+install:
+  - go get -v github.com/golang/lint/golint
+  - go build ./...
+script:
+  - go vet ./...
+  - $HOME/gopath/bin/golint .
+  - go test -v -race ./...

--- a/vendor/github.com/oklog/run/LICENSE
+++ b/vendor/github.com/oklog/run/LICENSE
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/oklog/run/README.md
+++ b/vendor/github.com/oklog/run/README.md
@@ -1,0 +1,73 @@
+# run
+
+[![GoDoc](https://godoc.org/github.com/oklog/run?status.svg)](https://godoc.org/github.com/oklog/run) 
+[![Build Status](https://travis-ci.org/oklog/run.svg?branch=master)](https://travis-ci.org/oklog/run) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/oklog/run)](https://goreportcard.com/report/github.com/oklog/run)
+[![Apache 2 licensed](https://img.shields.io/badge/license-Apache2-blue.svg)](https://raw.githubusercontent.com/oklog/run/master/LICENSE)
+
+run.Group is a universal mechanism to manage goroutine lifecycles.
+
+Create a zero-value run.Group, and then add actors to it. Actors are defined as
+a pair of functions: an **execute** function, which should run synchronously;
+and an **interrupt** function, which, when invoked, should cause the execute
+function to return. Finally, invoke Run, which blocks until the first actor
+returns. This general-purpose API allows callers to model pretty much any
+runnable task, and achieve well-defined lifecycle semantics for the group.
+
+run.Group was written to manage component lifecycles in func main for 
+[OK Log](https://github.com/oklog/oklog). 
+But it's useful in any circumstance where you need to orchestrate multiple
+goroutines as a unit whole.
+[Click here](https://www.youtube.com/watch?v=LHe1Cb_Ud_M&t=15m45s) to see a
+video of a talk where run.Group is described.
+
+## Examples
+
+### context.Context
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+g.Add(func() error {
+	return myProcess(ctx, ...)
+}, func(error) {
+	cancel()
+})
+```
+
+### net.Listener
+
+```go
+ln, _ := net.Listen("tcp", ":8080")
+g.Add(func() error {
+	return http.Serve(ln, nil)
+}, func(error) {
+	ln.Close()
+})
+```
+
+### io.ReadCloser
+
+```go
+var conn io.ReadCloser = ...
+g.Add(func() error {
+	s := bufio.NewScanner(conn)
+	for s.Scan() {
+		println(s.Text())
+	}
+	return s.Err()
+}, func(error) {
+	conn.Close()
+})
+```
+
+## Comparisons
+
+Package run is somewhat similar to package 
+[errgroup](https://godoc.org/golang.org/x/sync/errgroup), 
+except it doesn't require actor goroutines to understand context semantics.
+
+It's somewhat similar to package
+[tomb.v1](https://godoc.org/gopkg.in/tomb.v1) or 
+[tomb.v2](https://godoc.org/gopkg.in/tomb.v2),
+except it has a much smaller API surface, delegating e.g. staged shutdown of 
+goroutines to the caller.

--- a/vendor/github.com/oklog/run/group.go
+++ b/vendor/github.com/oklog/run/group.go
@@ -1,9 +1,9 @@
-// Package group implements an actor-runner with deterministic teardown. It is
+// Package run implements an actor-runner with deterministic teardown. It is
 // somewhat similar to package errgroup, except it does not require actor
-// goroutines to understand context semantics. This makes it suitable for use
-// in more circumstances; for example, goroutines which are handling
-// connections from net.Listeners, or scanning input from a closable io.Reader.
-package group
+// goroutines to understand context semantics. This makes it suitable for use in
+// more circumstances; for example, goroutines which are handling connections
+// from net.Listeners, or scanning input from a closable io.Reader.
+package run
 
 // Group collects actors (functions) and runs them concurrently.
 // When one actor (function) returns, all actors are interrupted.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -206,8 +206,8 @@ github.com/modern-go/concurrent
 github.com/modern-go/reflect2
 # github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
 github.com/mwitkow/go-conntrack
-# github.com/oklog/oklog v0.0.0-20170918173356-f857583a70c3
-github.com/oklog/oklog/pkg/group
+# github.com/oklog/run v1.0.0
+github.com/oklog/run
 # github.com/oklog/ulid v1.3.1
 github.com/oklog/ulid
 # github.com/opentracing-contrib/go-stdlib v0.0.0-20170113013457-1de4cc2120e7


### PR DESCRIPTION
https://github.com/oklog/oklog was archived and the run group package was extracted as https://github.com/oklog/run. We should use this instead for possible future updates.