### PR TITLE
Fix binop output labels when using on()/ignoring()

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1544,27 +1544,18 @@ func resultMetric(lhs, rhs labels.Labels, op ItemType, matching *VectorMatching,
 		return ret
 	}
 
-	lb := labels.NewBuilder(lhs)
+	var lb *labels.Builder
+	if matching.Card == CardOneToMany {
+		// Choose the rhs metric because lhs and rhs have been swapped.
+		lb = labels.NewBuilder(rhs)
+	} else {
+		lb = labels.NewBuilder(lhs)
+	}
 
 	if shouldDropMetricName(op) {
 		lb.Del(labels.MetricName)
 	}
 
-	if matching.Card == CardOneToOne {
-		if matching.On {
-		Outer:
-			for _, l := range lhs {
-				for _, n := range matching.MatchingLabels {
-					if l.Name == n {
-						continue Outer
-					}
-				}
-				lb.Del(l.Name)
-			}
-		} else {
-			lb.Del(matching.MatchingLabels...)
-		}
-	}
 	for _, ln := range matching.Include {
 		// Included labels from the `group_x` modifier are taken from the "one"-side.
 		if v := rhs.Get(ln); v != "" {

--- a/promql/testdata/operators.test
+++ b/promql/testdata/operators.test
@@ -176,10 +176,10 @@ eval instant at 50m http_requests{group="canary"} unless on(job, instance) http_
 	http_requests{group="canary", instance="1", job="app-server"} 800
 
 eval instant at 50m http_requests{group="canary"} / on(instance,job) http_requests{group="production"}
-	{instance="0", job="api-server"} 3
-	{instance="0", job="app-server"} 1.4
-	{instance="1", job="api-server"} 2
-	{instance="1", job="app-server"} 1.3333333333333333
+	{group="canary", instance="0", job="api-server"} 3
+	{group="canary", instance="0", job="app-server"} 1.4
+	{group="canary", instance="1", job="api-server"} 2
+	{group="canary", instance="1", job="app-server"} 1.3333333333333333
 
 eval instant at 50m http_requests{group="canary"} unless ignoring(group, instance) http_requests{instance="0"}
 
@@ -188,10 +188,10 @@ eval instant at 50m http_requests{group="canary"} unless ignoring(group) http_re
 	http_requests{group="canary", instance="1", job="app-server"} 800
 
 eval instant at 50m http_requests{group="canary"} / ignoring(group) http_requests{group="production"}
-	{instance="0", job="api-server"} 3
-	{instance="0", job="app-server"} 1.4
-	{instance="1", job="api-server"} 2
-	{instance="1", job="app-server"} 1.3333333333333333
+	{group="canary", instance="0", job="api-server"} 3
+	{group="canary", instance="0", job="app-server"} 1.4
+	{group="canary", instance="1", job="api-server"} 2
+	{group="canary", instance="1", job="app-server"} 1.3333333333333333
 
 # https://github.com/prometheus/prometheus/issues/1489
 eval instant at 50m http_requests AND ON (dummy) vector(1)
@@ -398,7 +398,7 @@ load 5m
 
 # On with no labels, for metrics with no common labels.
 eval instant at 5m random + on() metricA
-  {} 5
+  {foo="bar"} 5
 
 # Ignoring with no labels is the same as no ignoring.
 eval instant at 5m metricA + ignoring() metricB

--- a/promql/testdata/operators.test
+++ b/promql/testdata/operators.test
@@ -176,10 +176,10 @@ eval instant at 50m http_requests{group="canary"} unless on(job, instance) http_
 	http_requests{group="canary", instance="1", job="app-server"} 800
 
 eval instant at 50m http_requests{group="canary"} / on(instance,job) http_requests{group="production"}
-	{group="canary", instance="0", job="api-server"} 3
-	{group="canary", instance="0", job="app-server"} 1.4
-	{group="canary", instance="1", job="api-server"} 2
-	{group="canary", instance="1", job="app-server"} 1.3333333333333333
+	{instance="0", job="api-server"} 3
+	{instance="0", job="app-server"} 1.4
+	{instance="1", job="api-server"} 2
+	{instance="1", job="app-server"} 1.3333333333333333
 
 eval instant at 50m http_requests{group="canary"} unless ignoring(group, instance) http_requests{instance="0"}
 
@@ -188,10 +188,10 @@ eval instant at 50m http_requests{group="canary"} unless ignoring(group) http_re
 	http_requests{group="canary", instance="1", job="app-server"} 800
 
 eval instant at 50m http_requests{group="canary"} / ignoring(group) http_requests{group="production"}
-	{group="canary", instance="0", job="api-server"} 3
-	{group="canary", instance="0", job="app-server"} 1.4
-	{group="canary", instance="1", job="api-server"} 2
-	{group="canary", instance="1", job="app-server"} 1.3333333333333333
+	{instance="0", job="api-server"} 3
+	{instance="0", job="app-server"} 1.4
+	{instance="1", job="api-server"} 2
+	{instance="1", job="app-server"} 1.3333333333333333
 
 # https://github.com/prometheus/prometheus/issues/1489
 eval instant at 50m http_requests AND ON (dummy) vector(1)
@@ -398,7 +398,7 @@ load 5m
 
 # On with no labels, for metrics with no common labels.
 eval instant at 5m random + on() metricA
-  {foo="bar"} 5
+  {} 5
 
 # Ignoring with no labels is the same as no ignoring.
 eval instant at 5m metricA + ignoring() metricB


### PR DESCRIPTION
The entire label set from the LHS should be returned, not just the
supplied matching labels.

Fixes https://github.com/prometheus/prometheus/issues/5326

Signed-off-by: Julius Volz <julius.volz@gmail.com>