### PR TITLE
some minor fixes:

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -364,6 +364,9 @@ func (n *Manager) Send(alerts ...*Alert) {
 	}
 
 	alerts = n.relabelAlerts(alerts)
+	if len(alerts) == 0 {
+		return
+	}
 
 	// Queue capacity should be significantly larger than a single alert
 	// batch could be.
@@ -615,7 +618,7 @@ func postPath(pre string) string {
 	return path.Join("/", pre, alertPushEndpoint)
 }
 
-// alertmanagersFromGroup extracts a list of alertmanagers from a target group
+// alertmanagerFromGroup extracts a list of alertmanagers from a target group
 // and an associated AlertmanagerConfig.
 func alertmanagerFromGroup(tg *targetgroup.Group, cfg *config.AlertmanagerConfig) ([]alertmanager, []alertmanager, error) {
 	var res []alertmanager

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -385,7 +385,7 @@ func TestHandlerQueueing(t *testing.T) {
 	expected = alerts[:maxBatchSize]
 	unblock <- struct{}{}
 
-	for i := 2; i < 4; i++ {
+	for i := 2; i < 5; i++ {
 		select {
 		case <-called:
 			expected = alerts[i*maxBatchSize : (i+1)*maxBatchSize]


### PR DESCRIPTION
1. If alerts is empty after `relabelAlerts`, just return to avoid
subsequent unnecessary operations

2. minor fix in notifier's test case

3. minor fix in comment

Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>