### PR TITLE
Field Objectives in prometheus.SummaryOpts was deprecated

### DIFF
--- a/discovery/kubernetes/client_metrics.go
+++ b/discovery/kubernetes/client_metrics.go
@@ -44,7 +44,6 @@ var (
 			Namespace:  metricsNamespace,
 			Name:       "http_request_duration_seconds",
 			Help:       "Summary of latencies for HTTP requests to the Kubernetes API by endpoint.",
-			Objectives: map[float64]float64{},
 		},
 		[]string{"endpoint"},
 	)
@@ -62,7 +61,6 @@ var (
 			Namespace:  cacheMetricsNamespace,
 			Name:       "list_duration_seconds",
 			Help:       "Duration of a Kubernetes API call in seconds.",
-			Objectives: map[float64]float64{},
 		},
 	)
 	clientGoCacheItemsInListCountMetric = prometheus.NewSummary(
@@ -70,7 +68,6 @@ var (
 			Namespace:  cacheMetricsNamespace,
 			Name:       "list_items",
 			Help:       "Count of items in a list from the Kubernetes API.",
-			Objectives: map[float64]float64{},
 		},
 	)
 	clientGoCacheWatchesCountMetric = prometheus.NewCounter(
@@ -92,7 +89,6 @@ var (
 			Namespace:  cacheMetricsNamespace,
 			Name:       "watch_duration_seconds",
 			Help:       "Duration of watches on the Kubernetes API.",
-			Objectives: map[float64]float64{},
 		},
 	)
 	clientGoCacheItemsInWatchesCountMetric = prometheus.NewSummary(
@@ -100,7 +96,6 @@ var (
 			Namespace:  cacheMetricsNamespace,
 			Name:       "watch_events",
 			Help:       "Number of items in watches on the Kubernetes API.",
-			Objectives: map[float64]float64{},
 		},
 	)
 	clientGoCacheLastResourceVersionMetric = prometheus.NewGauge(
@@ -133,7 +128,6 @@ var (
 			Namespace:  workqueueMetricsNamespace,
 			Name:       "latency_seconds",
 			Help:       "How long an item stays in the work queue.",
-			Objectives: map[float64]float64{},
 		},
 		[]string{"queue_name"},
 	)
@@ -158,7 +152,6 @@ var (
 			Namespace:  workqueueMetricsNamespace,
 			Name:       "work_duration_seconds",
 			Help:       "How long processing an item from the work queue takes.",
-			Objectives: map[float64]float64{},
 		},
 		[]string{"queue_name"},
 	)

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -99,7 +99,6 @@ func NewGroupMetrics(reg prometheus.Registerer) *Metrics {
 			Namespace:  namespace,
 			Name:       "rule_group_duration_seconds",
 			Help:       "The duration of rule group evaluations.",
-			Objectives: map[float64]float64{0.01: 0.001, 0.05: 0.005, 0.5: 0.05, 0.90: 0.01, 0.99: 0.001},
 		}),
 		iterationsMissed: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -51,7 +51,6 @@ var (
 		prometheus.SummaryOpts{
 			Name:       "prometheus_target_interval_length_seconds",
 			Help:       "Actual intervals between scrapes.",
-			Objectives: map[float64]float64{0.01: 0.001, 0.05: 0.005, 0.5: 0.05, 0.90: 0.01, 0.99: 0.001},
 		},
 		[]string{"interval"},
 	)
@@ -59,7 +58,6 @@ var (
 		prometheus.SummaryOpts{
 			Name:       "prometheus_target_reload_length_seconds",
 			Help:       "Actual interval to reload the scrape pool with a given configuration.",
-			Objectives: map[float64]float64{0.01: 0.001, 0.05: 0.005, 0.5: 0.05, 0.90: 0.01, 0.99: 0.001},
 		},
 		[]string{"interval"},
 	)
@@ -91,7 +89,6 @@ var (
 		prometheus.SummaryOpts{
 			Name:       "prometheus_target_sync_length_seconds",
 			Help:       "Actual interval to sync the scrape pool.",
-			Objectives: map[float64]float64{0.01: 0.001, 0.05: 0.005, 0.5: 0.05, 0.90: 0.01, 0.99: 0.001},
 		},
 		[]string{"scrape_job"},
 	)


### PR DESCRIPTION
Field `Objectives` in `prometheus.SummaryOpts` was deprecated. 

Signed-off-by: aixeshunter <aixeshunter@gmail.com>