### PR TITLE
Remove bits about substring matching from the docs

### DIFF
--- a/docs/querying/basics.md
+++ b/docs/querying/basics.md
@@ -88,8 +88,8 @@ against regular expressions. The following label matching operators exist:
 
 * `=`: Select labels that are exactly equal to the provided string.
 * `!=`: Select labels that are not equal to the provided string.
-* `=~`: Select labels that regex-match the provided string (or substring).
-* `!~`: Select labels that do not regex-match the provided string (or substring).
+* `=~`: Select labels that regex-match the provided string.
+* `!~`: Select labels that do not regex-match the provided string.
 
 For example, this selects all `http_requests_total` time series for `staging`,
 `testing`, and `development` environments and HTTP methods other than `GET`.

--- a/docs/querying/examples.md
+++ b/docs/querying/examples.md
@@ -26,8 +26,7 @@ Note that an expression resulting in a range vector cannot be graphed directly,
 but viewed in the tabular ("Console") view of the expression browser.
 
 Using regular expressions, you could select time series only for jobs whose
-name match a certain pattern, in this case, all jobs that end with `server`.
-Note that this does a substring match, not a full string match:
+name match a certain pattern, in this case, all jobs that end with `server`:
 
     http_requests_total{job=~".*server"}
 


### PR DESCRIPTION
Substring matching for labels doesn't work anymore.
These parts are misleading, and contradict with the rest of the
documentation.