### PR TITLE
Consistent Content-Type for js and css

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f
-	github.com/prometheus/common v0.3.0
+	github.com/prometheus/common v0.4.0
 	github.com/prometheus/tsdb v0.7.1
 	github.com/rlmcpherson/s3gof3r v0.5.0 // indirect
 	github.com/rubyist/circuitbreaker v2.2.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f h1:BVwpUVJ
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
-github.com/prometheus/common v0.3.0 h1:taZ4h8Tkxv2kNyoSctBvfXEHmBmxrwmIidZTIaHons4=
-github.com/prometheus/common v0.3.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.4.0 h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=
+github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1 h1:/K3IL0Z1quvmJ7X0A1AwNEK7CRkVK3YwfOU/QAL4WGg=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=

--- a/vendor/github.com/prometheus/common/server/static_file_server.go
+++ b/vendor/github.com/prometheus/common/server/static_file_server.go
@@ -1,0 +1,41 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+	"path/filepath"
+)
+
+var mimeTypes = map[string]string{
+	".js":  "application/javascript",
+	".css": "text/css",
+	".png": "image/png",
+	".jpg": "image/jpeg",
+	".gif": "image/gif",
+}
+
+func StaticFileServer(root http.FileSystem) http.Handler {
+	return http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			fileExt := filepath.Ext(r.URL.Path)
+
+			if t, ok := mimeTypes[fileExt]; ok {
+				w.Header().Set("Content-Type", t)
+			}
+
+			http.FileServer(root).ServeHTTP(w, r)
+		},
+	)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -227,7 +227,7 @@ github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/testutil
 # github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f
 github.com/prometheus/client_model/go
-# github.com/prometheus/common v0.3.0
+# github.com/prometheus/common v0.4.0
 github.com/prometheus/common/model
 github.com/prometheus/common/promlog
 github.com/prometheus/common/promlog/flag
@@ -235,6 +235,7 @@ github.com/prometheus/common/version
 github.com/prometheus/common/config
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/route
+github.com/prometheus/common/server
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 # github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1
 github.com/prometheus/procfs

--- a/web/web.go
+++ b/web/web.go
@@ -48,6 +48,7 @@ import (
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
+	"github.com/prometheus/common/server"
 	"github.com/prometheus/tsdb"
 	"github.com/soheilhy/cmux"
 	"golang.org/x/net/netutil"
@@ -296,7 +297,7 @@ func New(logger log.Logger, o *Options) *Handler {
 
 	router.Get("/static/*filepath", func(w http.ResponseWriter, r *http.Request) {
 		r.URL.Path = path.Join("/static", route.Param(r.Context(), "filepath"))
-		fs := http.FileServer(ui.Assets)
+		fs := server.StaticFileServer(ui.Assets)
 		fs.ServeHTTP(w, r)
 	})
 


### PR DESCRIPTION
Alternative of https://github.com/prometheus/prometheus/pull/5525

Currently, When `/etc/mime.types` has a unusual mime type, web of prometheus uses the type and you may get unexpected result.
With this change, web returns consistent Content-Type header for static js and css files

To reproduce:
1. Add a type at the end of `/etc/mime` like `text/x-js js`
2. Run prometheus
3. Request js file like `http://localhost:9090/static/vendor/js/jquery.min.js`
4. You will see Content-Type of the response is `text/x-js` instead of `application/javascript`

Relates to https://github.com/prometheus/prometheus/issues/4246

Signed-off-by: mrasu <m.rasu.hitsuji@gmail.com>