### PR TITLE
Correctly handle {__name__="a"}

### DIFF
--- a/promql/printer.go
+++ b/promql/printer.go
@@ -179,8 +179,8 @@ func (node *UnaryExpr) String() string {
 func (node *VectorSelector) String() string {
 	labelStrings := make([]string, 0, len(node.LabelMatchers)-1)
 	for _, matcher := range node.LabelMatchers {
-		// Only include the __name__ label if its no equality matching.
-		if matcher.Name == labels.MetricName && matcher.Type == labels.MatchEqual {
+		// Only include the __name__ label if its equality matching and matches the name.
+		if matcher.Name == labels.MetricName && matcher.Type == labels.MatchEqual && matcher.Value == node.Name {
 			continue
 		}
 		labelStrings = append(labelStrings, matcher.String())

--- a/promql/printer_test.go
+++ b/promql/printer_test.go
@@ -81,6 +81,9 @@ func TestExprString(t *testing.T) {
 		{
 			in: `a[5m] offset 1m`,
 		},
+		{
+			in: `{__name__="a"}`,
+		},
 	}
 
 	for _, test := range inputs {


### PR DESCRIPTION
This can cause problems in alerts.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>