### PR TITLE
Add AlertManagers' url to "Service Discovery" page.

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -411,6 +411,30 @@ func (n *Manager) setMore() {
 	}
 }
 
+// AllAlertManagers returns a slices of active Alertmanager URLs and dropped.
+func (n *Manager) AllAlertManagers() ([]*url.URL, []*url.URL) {
+	n.mtx.RLock()
+	amSets := n.alertmanagers
+	n.mtx.RUnlock()
+
+	var res []*url.URL
+	var dRes []*url.URL
+
+	for _, ams := range amSets {
+		ams.mtx.RLock()
+		for _, am := range ams.ams {
+			res = append(res, am.url())
+		}
+
+		for _, dam := range ams.droppedAms {
+			dRes = append(dRes, dam.url())
+		}
+		ams.mtx.RUnlock()
+	}
+
+	return res, dRes
+}
+
 // Alertmanagers returns a slice of Alertmanager URLs.
 func (n *Manager) Alertmanagers() []*url.URL {
 	n.mtx.RLock()

--- a/web/ui/templates/service-discovery.html
+++ b/web/ui/templates/service-discovery.html
@@ -98,13 +98,21 @@
           <thead>
             <tr>
               <th>Discovered URL</th>
+              <th>Status</th>
             </tr>
           </thead>
           <tbody>
-            {{range $manager := .AlertingManagers}}
+            {{range $manager := .Managers}}
               <tr>
                 <td>
-                  {{$manager.String}}
+                  {{$manager.Url.String}}
+                </td>
+                <td>
+                  {{if $manager.IsActive }}
+                    Active
+                  {{else}}
+                    Dropped
+                  {{end}}
                 </td>
               </tr>
             {{end}}

--- a/web/ui/templates/service-discovery.html
+++ b/web/ui/templates/service-discovery.html
@@ -16,12 +16,13 @@
 {{define "content"}}
   <div class="container-fluid">
 
+    {{with .ScrapeConfigData}}
     <h1>Service Discovery</h1>
     <div>
       <ul>
         {{range $i, $job := .Index}}
           <li>
-            <a href="#job-{{$job}}">{{$job}}</a> ({{ index $.Active $i }}/{{ index $.Total $i }} active targets)
+            <a href="#job-{{$job}}">{{$job}}</a> ({{ index $.ScrapeConfigData.Active $i }}/{{ index $.ScrapeConfigData.Total $i }} active targets)
           </li>
         {{end}}
       </ul>
@@ -35,7 +36,7 @@
         {{$job}}
         <button type="button" class="targets collapsed-table btn btn-primary">show more</button>
       </h2>
-      {{with index $.Dropped $i}}
+      {{with index $.ScrapeConfigData.Dropped $i}}
       {{if gt . 100 }}
       <div class="collapsed-element" style="display:none">
         {{ . }} targets have been dropped, showing only the first 100 dropped targets as examples.
@@ -86,7 +87,31 @@
         </tbody>
       </table>
     </div>
-    {{ end }}
+    {{end}}
+    {{end}}
+
+    {{with .AlertConfigData}}
+      <h1>Alert Manager</h1>
+
+      <div class="table-container">
+        <table class="table table-sm table-bordered table-striped table-hover">
+          <thead>
+            <tr>
+              <th>Discovered URL</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range $manager := .AlertingManagers}}
+              <tr>
+                <td>
+                  {{$manager.String}}
+                </td>
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </div>
+    {{end}}
   </div>
 
 {{end}}

--- a/web/web.go
+++ b/web/web.go
@@ -723,10 +723,29 @@ func (h *Handler) serviceDiscovery(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	urls, dUrls := h.notifier.AllAlertManagers()
+	type manager struct {
+		Url      *url.URL
+		IsActive bool
+	}
 	alertConfigData := struct {
-		AlertingManagers []*url.URL
+		Managers []manager
 	}{
-		AlertingManagers: h.notifier.Alertmanagers(),
+		Managers: make([]manager, len(urls)+len(dUrls)),
+	}
+
+	for i, u := range urls {
+		alertConfigData.Managers[i] = manager{
+			Url:      u,
+			IsActive: true,
+		}
+	}
+
+	for i, u := range dUrls {
+		alertConfigData.Managers[len(urls)+i] = manager{
+			Url:      u,
+			IsActive: false,
+		}
 	}
 
 	configData := map[string]interface{}{

--- a/web/web.go
+++ b/web/web.go
@@ -723,7 +723,17 @@ func (h *Handler) serviceDiscovery(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	h.executeTemplate(w, "service-discovery.html", scrapeConfigData)
+	alertConfigData := struct {
+		AlertingManagers []*url.URL
+	}{
+		AlertingManagers: h.notifier.Alertmanagers(),
+	}
+
+	configData := map[string]interface{}{
+		"ScrapeConfigData": scrapeConfigData,
+		"AlertConfigData":  alertConfigData,
+	}
+	h.executeTemplate(w, "service-discovery.html", configData)
 }
 
 func (h *Handler) targets(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
For https://github.com/prometheus/prometheus/issues/3843, add AlertManagers' url to "Service Discovery" page.

I add only url found by service discovery because `alertmanager` expose only `url()`
If there is other information useful, I will add.

This iscurrent page.
![image](https://user-images.githubusercontent.com/1549784/57969200-6909d300-79af-11e9-9838-b15fe46485ae.png)

Signed-off-by: mrasu <m.rasu.hitsuji@gmail.com>