### PR TITLE
Enable to run Prometheus from repo's root when using local templates too

### DIFF
--- a/web/ui/ui.go
+++ b/web/ui/ui.go
@@ -25,7 +25,7 @@ import (
 )
 
 var static http.FileSystem = filter.Keep(
-	http.Dir("./static"),
+	http.Dir("./web/ui/static"),
 	func(path string, fi os.FileInfo) bool {
 		return fi.IsDir() ||
 			(!strings.HasSuffix(path, "map.js") &&
@@ -36,7 +36,7 @@ var static http.FileSystem = filter.Keep(
 )
 
 var templates http.FileSystem = filter.Keep(
-	http.Dir("./templates"),
+	http.Dir("./web/ui/templates"),
 	func(path string, fi os.FileInfo) bool {
 		return fi.IsDir() || strings.HasSuffix(path, ".html")
 	},


### PR DESCRIPTION
Currently, we need to run Prometheus at `ui` directory while changing template files locally like `cd web/ui; ../../prometheus --config.file="../../prometheus.yml"`.
And after run it, `data` directory inside `ui` is not ignored from git.

With this change, it becomes possible to run Prometheus from repo's root.

Signed-off-by: mrasu <m.rasu.hitsuji@gmail.com>