### PR TITLE
Remote write sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 /prometheus
 /promtool
+/remotewrite
 benchmark.txt
 /data
 /cmd/prometheus/data

--- a/.promu.yml
+++ b/.promu.yml
@@ -10,6 +10,8 @@ build:
           path: ./cmd/prometheus
         - name: promtool
           path: ./cmd/promtool
+        - name: remotewrite
+          path: ./cmd/remotewrite
     flags: -mod=vendor -a -tags netgo
     ldflags: |
         -X github.com/prometheus/common/version.Version={{.Version}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG ARCH="amd64"
 ARG OS="linux"
 COPY .build/${OS}-${ARCH}/prometheus        /bin/prometheus
 COPY .build/${OS}-${ARCH}/promtool          /bin/promtool
+COPY .build/${OS}-${ARCH}/remotewrite       /bin/remotewrite
 COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
 COPY console_libraries/                     /usr/share/prometheus/console_libraries/
 COPY consoles/                              /usr/share/prometheus/consoles/

--- a/cmd/remotewrite/main.go
+++ b/cmd/remotewrite/main.go
@@ -1,0 +1,202 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/oklog/run"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promlog"
+	promlogflag "github.com/prometheus/common/promlog/flag"
+	"github.com/prometheus/common/version"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/prometheus/prometheus/web"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+func main() {
+	cfg := struct {
+		configFile string
+
+		localStoragePath    string
+		web                 web.Options
+		RemoteFlushDeadline model.Duration
+
+		promlogConfig promlog.Config
+	}{
+		promlogConfig: promlog.Config{},
+	}
+	a := kingpin.New(filepath.Base(os.Args[0]), "The Prometheus monitoring server")
+
+	a.Version(version.Print("remotewrite"))
+
+	a.HelpFlag.Short('h')
+
+	a.Flag("config.file", "Prometheus configuration file path.").
+		Default("prometheus.yml").StringVar(&cfg.configFile)
+
+	a.Flag("web.listen-address", "Address to listen on for UI, API, and telemetry.").
+		Default("0.0.0.0:9090").StringVar(&cfg.web.ListenAddress)
+
+	a.Flag("storage.tsdb.path", "Base path for metrics storage.").
+		Default("data/").StringVar(&cfg.localStoragePath)
+
+	a.Flag("storage.remote.flush-deadline", "How long to wait flushing sample on shutdown or config reload.").
+		Default("1m").PlaceHolder("<duration>").SetValue(&cfg.RemoteFlushDeadline)
+
+	promlogflag.AddFlags(a, &cfg.promlogConfig)
+
+	_, err := a.Parse(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error parsing commandline arguments"))
+		a.Usage(os.Args[1:])
+		os.Exit(2)
+	}
+
+	logger := promlog.New(&cfg.promlogConfig)
+
+	remoteWriteStorage := remote.NewWriteStorage(logger, cfg.localStoragePath, time.Duration(cfg.RemoteFlushDeadline), true)
+
+	// sync.Once is used to make sure we can close the channel at different execution stages(SIGTERM or when the config is loaded).
+	type closeOnce struct {
+		C     chan struct{}
+		once  sync.Once
+		Close func()
+	}
+	// Wait until the server is ready to handle reloading.
+	reloadReady := &closeOnce{
+		C: make(chan struct{}),
+	}
+	reloadReady.Close = func() {
+		reloadReady.once.Do(func() {
+			close(reloadReady.C)
+		})
+	}
+
+	var g run.Group
+	{
+		// Termination handler.
+		term := make(chan os.Signal, 1)
+		signal.Notify(term, os.Interrupt, syscall.SIGTERM)
+		cancel := make(chan struct{})
+		g.Add(
+			func() error {
+				// Don't forget to release the reloadReady channel so that waiting blocks can exit normally.
+				select {
+				case <-term:
+					level.Warn(logger).Log("msg", "Received SIGTERM, exiting gracefully...")
+					reloadReady.Close()
+				case <-cancel:
+					reloadReady.Close()
+					break
+				}
+				return nil
+			},
+			func(err error) {
+				close(cancel)
+			},
+		)
+	}
+	{
+		// Reload handler.
+		hup := make(chan os.Signal, 1)
+		signal.Notify(hup, syscall.SIGHUP)
+		cancel := make(chan struct{})
+		g.Add(
+			func() error {
+				<-reloadReady.C
+
+				for {
+					select {
+					case <-hup:
+						if err := reloadConfig(cfg.configFile, logger, remoteWriteStorage.ApplyConfig); err != nil {
+							level.Error(logger).Log("msg", "Error reloading config", "err", err)
+						}
+					case <-cancel:
+						return nil
+					}
+				}
+
+			},
+			func(err error) {
+				// Wait for any in-progress reloads to complete to avoid
+				// reloading things after they have been shutdown.
+				cancel <- struct{}{}
+			},
+		)
+	}
+	{
+		// Initial configuration loading.
+		cancel := make(chan struct{})
+		g.Add(
+			func() error {
+				if err := reloadConfig(cfg.configFile, logger, remoteWriteStorage.ApplyConfig); err != nil {
+					return errors.Wrapf(err, "error loading config from %q", cfg.configFile)
+				}
+
+				reloadReady.Close()
+
+				<-cancel
+				return nil
+			},
+			func(err error) {
+				close(cancel)
+				if err := remoteWriteStorage.Close(); err != nil {
+					level.Error(logger).Log("msg", "Error remote write storage", "err", err)
+				}
+			},
+		)
+	}
+	if err := g.Run(); err != nil {
+		level.Error(logger).Log("err", err)
+		os.Exit(1)
+	}
+	level.Info(logger).Log("msg", "See you next time!")
+}
+
+func reloadConfig(filename string, logger log.Logger, rls ...func(*config.Config) error) (err error) {
+	level.Info(logger).Log("msg", "Loading configuration file", "filename", filename)
+
+	conf, err := config.LoadFile(filename)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't load configuration (--config.file=%q)", filename)
+	}
+
+	failed := false
+	for _, rl := range rls {
+		if err := rl(conf); err != nil {
+			level.Error(logger).Log("msg", "Failed to apply configuration", "err", err)
+			failed = true
+		}
+	}
+	if failed {
+		return errors.Errorf("one or more errors occurred while applying the new configuration (--config.file=%q)", filename)
+	}
+
+	promql.SetDefaultEvaluationInterval(time.Duration(conf.GlobalConfig.EvaluationInterval))
+	level.Info(logger).Log("msg", "Completed loading of configuration file", "filename", filename)
+	return nil
+}

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -52,7 +52,7 @@ func NewStorage(l log.Logger, reg prometheus.Registerer, stCallback startTimeCal
 	s := &Storage{
 		logger:                 logging.Dedupe(l, 1*time.Minute),
 		localStartTimeCallback: stCallback,
-		rws:                    NewWriteStorage(l, walDir, flushDeadline),
+		rws:                    NewWriteStorage(l, walDir, flushDeadline, false),
 	}
 	return s
 }

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -14,8 +14,16 @@
 package remote
 
 import (
+	"crypto/md5"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 )
@@ -37,17 +45,123 @@ var (
 	}
 )
 
-// Appender implements scrape.Appendable.
-func (s *Storage) Appender() (storage.Appender, error) {
+// WriteStorage represents all the remote write storage.
+type WriteStorage struct {
+	logger log.Logger
+	mtx    sync.Mutex
+
+	configHash    [16]byte
+	walDir        string
+	queues        []*QueueManager
+	samplesIn     *ewmaRate
+	flushDeadline time.Duration
+}
+
+// NewWriteStorage creates and runs a WriteStorage.
+func NewWriteStorage(logger log.Logger, walDir string, flushDeadline time.Duration) *WriteStorage {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+	rws := &WriteStorage{
+		logger:        logger,
+		flushDeadline: flushDeadline,
+		samplesIn:     newEWMARate(ewmaWeight, shardUpdateDuration),
+		walDir:        walDir,
+	}
+	go rws.run()
+	return rws
+}
+
+func (rws *WriteStorage) run() {
+	ticker := time.NewTicker(shardUpdateDuration)
+	defer ticker.Stop()
+	for range ticker.C {
+		rws.samplesIn.tick()
+	}
+}
+
+// ApplyConfig updates the state as the new config requires.
+func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
+	rws.mtx.Lock()
+	defer rws.mtx.Unlock()
+
+	// Remote write queues only need to change if the remote write config or
+	// external labels change. Hash these together and only reload if the hash
+	// changes.
+	cfgBytes, err := json.Marshal(conf.RemoteWriteConfigs)
+	if err != nil {
+		return err
+	}
+	externalLabelBytes, err := json.Marshal(conf.GlobalConfig.ExternalLabels)
+	if err != nil {
+		return err
+	}
+
+	hash := md5.Sum(append(cfgBytes, externalLabelBytes...))
+	if hash == rws.configHash {
+		level.Debug(rws.logger).Log("msg", "remote write config has not changed, no need to restart QueueManagers")
+		return nil
+	}
+
+	rws.configHash = hash
+
+	// Update write queues
+	newQueues := []*QueueManager{}
+	// TODO: we should only stop & recreate queues which have changes,
+	// as this can be quite disruptive.
+	for i, rwConf := range conf.RemoteWriteConfigs {
+		c, err := NewClient(i, &ClientConfig{
+			URL:              rwConf.URL,
+			Timeout:          rwConf.RemoteTimeout,
+			HTTPClientConfig: rwConf.HTTPClientConfig,
+		})
+		if err != nil {
+			return err
+		}
+		newQueues = append(newQueues, NewQueueManager(
+			rws.logger,
+			rws.walDir,
+			rws.samplesIn,
+			rwConf.QueueConfig,
+			conf.GlobalConfig.ExternalLabels,
+			rwConf.WriteRelabelConfigs,
+			c,
+			rws.flushDeadline,
+		))
+	}
+
+	for _, q := range rws.queues {
+		q.Stop()
+	}
+
+	rws.queues = newQueues
+	for _, q := range rws.queues {
+		q.Start()
+	}
+	return nil
+}
+
+// Appender implements storage.Storage.
+func (rws *WriteStorage) Appender() (storage.Appender, error) {
 	return &timestampTracker{
-		storage: s,
+		remoteWriteStorage: rws,
 	}, nil
 }
 
+// Close closes the RemoteWriteStorage.
+func (rws *WriteStorage) Close() error {
+	rws.mtx.Lock()
+	defer rws.mtx.Unlock()
+	for _, q := range rws.queues {
+		q.Stop()
+	}
+	return nil
+}
+
 type timestampTracker struct {
-	storage          *Storage
-	samples          int64
-	highestTimestamp int64
+	remoteWriteStorage *WriteStorage
+	samples            int64
+	highestTimestamp   int64
 }
 
 // Add implements storage.Appender.
@@ -67,7 +181,7 @@ func (t *timestampTracker) AddFast(l labels.Labels, _ uint64, ts int64, v float6
 
 // Commit implements storage.Appender.
 func (t *timestampTracker) Commit() error {
-	t.storage.samplesIn.incr(t.samples)
+	t.remoteWriteStorage.samplesIn.incr(t.samples)
 
 	samplesIn.Add(float64(t.samples))
 	highestTimestamp.Set(float64(t.highestTimestamp / 1000))

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -1,0 +1,95 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestWriteStorageLifecycle(t *testing.T) {
+	dir, err := ioutil.TempDir("", "TestWriteStorageLifecycle")
+	testutil.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	s := NewWriteStorage(nil, dir, defaultFlushDeadline)
+	conf := &config.Config{
+		GlobalConfig: config.DefaultGlobalConfig,
+		RemoteWriteConfigs: []*config.RemoteWriteConfig{
+			&config.DefaultRemoteWriteConfig,
+		},
+	}
+	s.ApplyConfig(conf)
+	testutil.Equals(t, 1, len(s.queues))
+
+	err = s.Close()
+	testutil.Ok(t, err)
+}
+
+func TestUpdateExternalLabels(t *testing.T) {
+	dir, err := ioutil.TempDir("", "TestUpdateExternalLabels")
+	testutil.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	s := NewWriteStorage(nil, dir, defaultFlushDeadline)
+
+	externalLabels := labels.FromStrings("external", "true")
+	conf := &config.Config{
+		GlobalConfig: config.GlobalConfig{},
+		RemoteWriteConfigs: []*config.RemoteWriteConfig{
+			&config.DefaultRemoteWriteConfig,
+		},
+	}
+	s.ApplyConfig(conf)
+	testutil.Equals(t, 1, len(s.queues))
+	testutil.Equals(t, labels.Labels(nil), s.queues[0].externalLabels)
+
+	conf.GlobalConfig.ExternalLabels = externalLabels
+	s.ApplyConfig(conf)
+	testutil.Equals(t, 1, len(s.queues))
+	testutil.Equals(t, externalLabels, s.queues[0].externalLabels)
+
+	err = s.Close()
+	testutil.Ok(t, err)
+}
+
+func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
+	dir, err := ioutil.TempDir("", "TestWriteStorageApplyConfigsIdempotent")
+	testutil.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	s := NewWriteStorage(nil, dir, defaultFlushDeadline)
+
+	conf := &config.Config{
+		GlobalConfig: config.GlobalConfig{},
+		RemoteWriteConfigs: []*config.RemoteWriteConfig{
+			&config.DefaultRemoteWriteConfig,
+		},
+	}
+	s.ApplyConfig(conf)
+	testutil.Equals(t, 1, len(s.queues))
+	queue := s.queues[0]
+
+	s.ApplyConfig(conf)
+	testutil.Equals(t, 1, len(s.queues))
+	testutil.Assert(t, queue == s.queues[0], "Queue pointer should have remained the same")
+
+	err = s.Close()
+	testutil.Ok(t, err)
+}

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -28,7 +28,7 @@ func TestWriteStorageLifecycle(t *testing.T) {
 	testutil.Ok(t, err)
 	defer os.RemoveAll(dir)
 
-	s := NewWriteStorage(nil, dir, defaultFlushDeadline)
+	s := NewWriteStorage(nil, dir, defaultFlushDeadline, false)
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
@@ -47,7 +47,7 @@ func TestUpdateExternalLabels(t *testing.T) {
 	testutil.Ok(t, err)
 	defer os.RemoveAll(dir)
 
-	s := NewWriteStorage(nil, dir, defaultFlushDeadline)
+	s := NewWriteStorage(nil, dir, defaultFlushDeadline, false)
 
 	externalLabels := labels.FromStrings("external", "true")
 	conf := &config.Config{
@@ -74,7 +74,7 @@ func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
 	testutil.Ok(t, err)
 	defer os.RemoveAll(dir)
 
-	s := NewWriteStorage(nil, dir, defaultFlushDeadline)
+	s := NewWriteStorage(nil, dir, defaultFlushDeadline, false)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -233,8 +233,8 @@ github.com/prometheus/common/promlog
 github.com/prometheus/common/promlog/flag
 github.com/prometheus/common/version
 github.com/prometheus/common/config
-github.com/prometheus/common/expfmt
 github.com/prometheus/common/route
+github.com/prometheus/common/expfmt
 github.com/prometheus/common/server
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 # github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1


### PR DESCRIPTION
This PR adds a binary that implements the remote write protocol that can be run as a sidecar to the Prometheus process.

The configuration will be identical to the current remote write configuration, the biggest difference being that the sample rate for calculating sharding will come from a second WALWatcher running instead of from samples being scraped.

Closes #5539 

@gouthamve I would love a review from you to make sure this would work for your customers as well.

Current state: Everything is working, I have been running it in a cluster without issue for a couple of days now without issue.