### PR TITLE
[docs] Update the 'consistency-modes' consul.io/api link to point to its new location

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -340,7 +340,7 @@ services:
 # The string by which Consul tags are joined into the tag label.
 [ tag_separator: <string> | default = , ]
 
-# Allow stale Consul results (see https://www.consul.io/api/index.html#consistency-modes). Will reduce load on Consul.
+# Allow stale Consul results (see https://www.consul.io/api/features/consistency.html). Will reduce load on Consul.
 [ allow_stale: <bool> ]
 
 # The time after which the provided names are refreshed.


### PR DESCRIPTION
i.e. https://www.consul.io/api/features/consistency.html

Ref: https://github.com/hashicorp/consul/commit/626392eb62994e05ebf675dcee5a6fbea5bd174a / https://github.com/hashicorp/consul/pull/5732