### PR TITLE
minor doc improvement in migration.md sample

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -181,6 +181,9 @@ metadata:
 spec:
   securityContext:
     runAsUser: 0
+  containers:
+    - name: prometheus
+      image: quay.io/prometheus/prometheus
 ...
 ```
 


### PR DESCRIPTION
This PR improves the documentation for running prometheus as a non-root user. Hoping to make it more beginner-friendly. Also the example seems to be inspired by [this](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). So thought it would make sense to follow suit.