### PR TITLE
web api: handle alert with Infinity/NaN values

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -465,7 +465,7 @@ $ curl http://localhost:9090/api/v1/rules
                                     "severity": "page"
                                 },
                                 "state": "firing",
-                                "value": 1
+                                "value": "1e+00"
                             }
                         ],
                         "annotations": {
@@ -522,7 +522,7 @@ $ curl http://localhost:9090/api/v1/alerts
                     "alertname": "my-alert"
                 },
                 "state": "firing",
-                "value": 1
+                "value": "1e+00"
             }
         ]
     },

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -694,7 +694,7 @@ type Alert struct {
 	Annotations labels.Labels `json:"annotations"`
 	State       string        `json:"state"`
 	ActiveAt    *time.Time    `json:"activeAt,omitempty"`
-	Value       float64       `json:"value"`
+	Value       string        `json:"value"`
 }
 
 func (api *API) alerts(r *http.Request) apiFuncResult {
@@ -721,7 +721,7 @@ func rulesAlertsToAPIAlerts(rulesAlerts []*rules.Alert) []*Alert {
 			Annotations: ruleAlert.Annotations,
 			State:       ruleAlert.State.String(),
 			ActiveAt:    &ruleAlert.ActiveAt,
-			Value:       ruleAlert.Value,
+			Value:       strconv.FormatFloat(ruleAlert.Value, 'e', -1, 64),
 		}
 	}
 


### PR DESCRIPTION
The problem:
- `json-iterator/go` library encodes `math.Inf` and `math.NaN` as is (which is invalid json spec), where standard `encoding/json` raises an error: https://github.com/json-iterator/go/issues/365

The solution I see is to return 0 instead of Infinity/NaN values.

There is a pull request (https://github.com/prometheus/prometheus/pull/5303), but it is not correct and seems to be abandoned