### PR TITLE
Enable to run Prometheus from repo's root even when using dev tag

### DIFF
--- a/web/ui/constants.go
+++ b/web/ui/constants.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2019 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,12 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package ui provides the assets via a virtual filesystem.
+// +build dev
+// +build !generate
+
 package ui
 
-import (
-	// The blank import is to make Go modules happy.
-	_ "github.com/shurcooL/vfsgen"
-)
-
-//go:generate go run -mod=vendor "-tags=dev generate" assets_generate.go
+var uiRootDirectory = "./web/ui"

--- a/web/ui/constants_generate.go
+++ b/web/ui/constants_generate.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2019 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,12 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package ui provides the assets via a virtual filesystem.
+// +build dev
+// +build generate
+
 package ui
 
-import (
-	// The blank import is to make Go modules happy.
-	_ "github.com/shurcooL/vfsgen"
-)
-
-//go:generate go run -mod=vendor "-tags=dev generate" assets_generate.go
+var uiRootDirectory = "."

--- a/web/ui/ui.go
+++ b/web/ui/ui.go
@@ -25,7 +25,7 @@ import (
 )
 
 var static http.FileSystem = filter.Keep(
-	http.Dir("./static"),
+	http.Dir(uiRootDirectory+"/static"),
 	func(path string, fi os.FileInfo) bool {
 		return fi.IsDir() ||
 			(!strings.HasSuffix(path, "map.js") &&
@@ -36,7 +36,7 @@ var static http.FileSystem = filter.Keep(
 )
 
 var templates http.FileSystem = filter.Keep(
-	http.Dir("./templates"),
+	http.Dir(uiRootDirectory+"/templates"),
 	func(path string, fi os.FileInfo) bool {
 		return fi.IsDir() || strings.HasSuffix(path, ".html")
 	},


### PR DESCRIPTION
Currently, we need to run Prometheus at `web/ui` directory when using `-tags dev` flag
like `cd web/ui; ../../prometheus --config.file="../../prometheus.yml"`.

And after run it, `data` directory inside `web/ui` is not ignored from git.

With this change, it becomes possible to run Prometheus from repo's root.

Signed-off-by: mrasu <m.rasu.hitsuji@gmail.com>