### PR TITLE
fix nil pointer dereference in azure discovery

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -335,7 +335,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 				if *networkInterface.Primary {
 					for _, ip := range *networkInterface.IPConfigurations {
-						if ip.PublicIPAddress != nil {
+						if ip.PublicIPAddress != nil && ip.PublicIPAddress.PublicIPAddressPropertiesFormat != nil {
 							labels[azureLabelMachinePublicIP] = model.LabelValue(*ip.PublicIPAddress.IPAddress)
 						}
 						if ip.PrivateIPAddress != nil {


### PR DESCRIPTION
Azure service discovery fails with `panic: runtime error: invalid memory address or nil pointer dereference` on a VM with public IP
This PR adds a simple pointer check.
Refers to #5570
Signed-off-by: Dmitry Shmulevich <dmitry.shmulevich@sysdig.com>