### PR TITLE
console_libraries: Update to Bootstrap 4.3.1

### DIFF
--- a/console_libraries/prom.lib
+++ b/console_libraries/prom.lib
@@ -2,7 +2,7 @@
 {{/* Load Prometheus console library JS/CSS. Should go in <head> */}}
 {{ define "prom_console_head" }}
 <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/rickshaw/rickshaw.min.css">
-<link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/bootstrap-4.1.3/css/bootstrap.min.css">
+<link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/bootstrap-4.3.1/css/bootstrap.min.css">
 <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/css/prom_console.css">
 <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/bootstrap4-glyphicons/css/bootstrap-glyphicons.min.css">
 <script src="{{ pathPrefix }}/static/vendor/rickshaw/vendor/d3.v3.js"></script>
@@ -10,7 +10,7 @@
 <script src="{{ pathPrefix }}/static/vendor/rickshaw/rickshaw.min.js"></script>
 <script src="{{ pathPrefix }}/static/vendor/js/jquery-3.3.1.min.js"></script>
 <script src="{{ pathPrefix }}/static/vendor/js/popper.min.js"></script>
-<script src="{{ pathPrefix }}/static/vendor/bootstrap-4.1.3/js/bootstrap.min.js"></script>
+<script src="{{ pathPrefix }}/static/vendor/bootstrap-4.3.1/js/bootstrap.min.js"></script>
 
 <script>
 var PATH_PREFIX = "{{ pathPrefix }}";


### PR DESCRIPTION
PR #5506  update the version for Bootstrap. This change update the
assets for console_libraries on this version of Bootstrap.

cc @brian-brazil 