### PR TITLE
Update queue config documentation

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1287,8 +1287,8 @@ tls_config:
 
 # Configures the queue used to write to remote storage.
 queue_config:
-  # Number of samples to buffer per shard before we start dropping them.
-  [ capacity: <int> | default = 10000 ]
+  # Number of samples to buffer per shard before we block reading of more samples from the WAL.
+  [ capacity: <int> | default = 10 ]
   # Maximum number of shards, i.e. amount of concurrency.
   [ max_shards: <int> | default = 1000 ]
   # Minimum number of shards, i.e. amount of concurrency.


### PR DESCRIPTION
Update queue config documentation to reflect default value change for capacity. It's now a queue length (shard capacity) of 10 by default (see #4588).

Signed-off-by: Callum Styan <callumstyan@gmail.com>