### PR TITLE
cmd/promtool: add $externalLabels for alert unit tests

### DIFF
--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -144,6 +144,7 @@ type testGroup struct {
 	InputSeries     []series         `yaml:"input_series"`
 	AlertRuleTests  []alertTestCase  `yaml:"alert_rule_test,omitempty"`
 	PromqlExprTests []promqlTestCase `yaml:"promql_expr_test,omitempty"`
+	ExternalLabels  labels.Labels    `yaml:"external_labels,omitempty"`
 }
 
 // test performs the unit tests.
@@ -164,8 +165,7 @@ func (tg *testGroup) test(mint, maxt time.Time, evalInterval time.Duration, grou
 		Logger:     log.NewNopLogger(),
 	}
 	m := rules.NewManager(opts)
-	// TODO(beorn7): Provide a way to pass in external labels.
-	groupsMap, ers := m.LoadGroups(tg.Interval, nil, ruleFiles...)
+	groupsMap, ers := m.LoadGroups(tg.Interval, tg.ExternalLabels, ruleFiles...)
 	if ers != nil {
 		return ers
 	}

--- a/docs/configuration/unit_testing_rules.md
+++ b/docs/configuration/unit_testing_rules.md
@@ -53,6 +53,10 @@ alert_rule_test:
 # Unit tests PromQL expressions.
 promql_expr_test:
   [ - <promql_test_case> ]
+
+# External labels accessible to the alert template.
+external_labels:
+  [ <labelname>: <string> ... ]
 ```
 
 ### `<series>`


### PR DESCRIPTION
Reported [here](https://groups.google.com/d/msg/prometheus-users/HUpugdInqyo/4gzE851ECAAJ).