### PR TITLE
Add symlink commands back in circle-ci config so that Dockerfile will work locally.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,8 @@ jobs:
     - run: docker run --privileged linuxkit/binfmt:v0.6
     - attach_workspace:
         at: .
+    - run: ln -s .build/linux-amd64/prometheus prometheus	
+    - run: ln -s .build/linux-amd64/promtool promtool
     - run: make docker
     - run: make docker DOCKER_REPO=quay.io/prometheus
     - run: docker images
@@ -89,6 +91,8 @@ jobs:
     - store_artifacts:
         path: .tarballs
         destination: releases
+    - run: ln -s .build/linux-amd64/prometheus prometheus	
+    - run: ln -s .build/linux-amd64/promtool promtool
     - run: make docker DOCKER_IMAGE_TAG=$CIRCLE_TAG
     - run: make docker DOCKER_IMAGE_TAG=$CIRCLE_TAG DOCKER_REPO=quay.io/prometheus
     - run: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com
 
 ARG ARCH="amd64"
 ARG OS="linux"
-COPY .build/${OS}-${ARCH}/prometheus        /bin/prometheus
-COPY .build/${OS}-${ARCH}/promtool          /bin/promtool
+COPY prometheus        /bin/prometheus
+COPY promtool          /bin/promtool
 COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
 COPY console_libraries/                     /usr/share/prometheus/console_libraries/
 COPY consoles/                              /usr/share/prometheus/consoles/


### PR DESCRIPTION
Changes in #5031 broke the locker `make docker` locally, 
```Step 6/19 : ARG OS="linux"
 ---> Using cache
 ---> 762f78671055
Step 7/19 : COPY .build/${OS}-${ARCH}/prometheus        /bin/prometheus
COPY failed: stat /var/lib/docker/tmp/docker-builder535576532/.build/linux-amd64/prometheus: no such file or directory
make: *** [Makefile.common:212: common-docker-amd64] Error 1```

cc @SuperQ @johanneswuerbach 

Signed-off-by: Callum Styan <callumstyan@gmail.com>