### PR TITLE
Use `CONSUL_HTTP_ADDR` adress when available in environment for consul discovery

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -330,7 +330,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 ```yaml
 # The information to access the Consul API. It is to be defined
 # as the Consul documentation requires.
-[ server: <host> | default = "localhost:8500" ]
+[ server: <host> | default = env(CONSUL_HTTP_ADDR) | "localhost:8500" ]
 [ token: <secret> ]
 [ datacenter: <string> ]
 [ scheme: <string> | default = "http" ]

--- a/documentation/examples/custom-sd/adapter-usage/main.go
+++ b/documentation/examples/custom-sd/adapter-usage/main.go
@@ -38,7 +38,7 @@ import (
 var (
 	a             = kingpin.New("sd adapter usage", "Tool to generate file_sd target files for unimplemented SD mechanisms.")
 	outputFile    = a.Flag("output.file", "Output file for file_sd compatible file.").Default("custom_sd.json").String()
-	listenAddress = a.Flag("listen.address", "The address the Consul HTTP API is listening on for requests.").Default("localhost:8500").String()
+	listenAddress = a.Flag("listen.address", "The address the Consul HTTP API is listening on for requests.").Default("env(CONSUL_HTTP_ADDR) | localhost:8500").String()
 	logger        log.Logger
 
 	// addressLabel is the name for the label containing a target's address.


### PR DESCRIPTION
By default consul tools use `CONSUL_HTTP_ADDR` to guess the schemes/server ip/port.

Use the same naming convention, so exporting http://consul.machine.acme.org:8500
will be used for consul discovery instead of localhost:8500.

This also detect the scheme and apply similar rules as Consul if scheme is not
setup.