### PR TITLE
Re-use label builder in promql aggregation

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -292,6 +292,13 @@ func NewBuilder(base Labels) *Builder {
 	}
 }
 
+// Reset clears all current state for the builder
+func (b *Builder) Reset(base Labels) {
+	b.base = base
+	b.del = b.del[:0]
+	b.add = b.add[:0]
+}
+
 // Del deletes the label of the given name.
 func (b *Builder) Del(ns ...string) *Builder {
 	for _, n := range ns {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1718,11 +1718,13 @@ func (ev *evaluator) aggregation(op ItemType, grouping []string, without bool, p
 		}
 	}
 
+	lb := labels.NewBuilder(nil)
+
 	for _, s := range vec {
 		metric := s.Metric
 
 		if op == ItemCountValues {
-			lb := labels.NewBuilder(metric)
+			lb.Reset(metric)
 			lb.Set(valueLabel, strconv.FormatFloat(s.V, 'f', -1, 64))
 			metric = lb.Labels()
 		}
@@ -1742,7 +1744,7 @@ func (ev *evaluator) aggregation(op ItemType, grouping []string, without bool, p
 			var m labels.Labels
 
 			if without {
-				lb := labels.NewBuilder(metric)
+				lb.Reset(metric)
 				lb.Del(grouping...)
 				lb.Del(labels.MetricName)
 				m = lb.Labels()


### PR DESCRIPTION
For my benchmarks on aggregation this reduces allocations by ~5% (~10%
time improvement):

```
benchmark                                                    old ns/op     new ns/op     delta
BenchmarkEvaluations/benchdata/aggregators.test/promxy-4     727692        649626        -10.73%

benchmark                                                    old allocs     new allocs     delta
BenchmarkEvaluations/benchdata/aggregators.test/promxy-4     2566           2434           -5.14%

benchmark                                                    old bytes     new bytes     delta
BenchmarkEvaluations/benchdata/aggregators.test/promxy-4     162760        148854        -8.54%
```