### PR TITLE
labelkeep action should ignore __name__ label

### DIFF
--- a/pkg/relabel/relabel.go
+++ b/pkg/relabel/relabel.go
@@ -243,6 +243,10 @@ func relabel(lset labels.Labels, cfg *Config) labels.Labels {
 		}
 	case LabelKeep:
 		for _, l := range lset {
+			// Should ignore metrics name
+			if l.Name == labels.MetricName {
+				continue
+			}
 			if !cfg.Regex.MatchString(l.Name) {
 				lb.Del(l.Name)
 			}


### PR DESCRIPTION
  the labelkeep action is used to keep just some labels, and the '__name__' is also one of
the labels, while few people will add the '__name__' label when use labelkeep, which may waste
much time to debug