### PR TITLE
Remove max_retries from queue_config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -116,8 +116,7 @@ var (
 		Capacity:          10,
 		BatchSendDeadline: model.Duration(5 * time.Second),
 
-		// Max number of times to retry a batch on recoverable errors.
-		MaxRetries: 3,
+		// Backoff times for retrying a batch of samples on recoverable errors.
 		MinBackoff: model.Duration(30 * time.Millisecond),
 		MaxBackoff: model.Duration(100 * time.Millisecond),
 	}
@@ -593,9 +592,6 @@ type QueueConfig struct {
 
 	// Maximum time sample will wait in buffer.
 	BatchSendDeadline model.Duration `yaml:"batch_send_deadline,omitempty"`
-
-	// Max number of times to retry a batch on recoverable errors.
-	MaxRetries int `yaml:"max_retries,omitempty"`
 
 	// On recoverable errors, backoff exponentially.
 	MinBackoff model.Duration `yaml:"min_backoff,omitempty"`

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1298,8 +1298,6 @@ queue_config:
   [ max_samples_per_send: <int> | default = 100]
   # Maximum time a sample will wait in buffer.
   [ batch_send_deadline: <duration> | default = 5s ]
-  # Maximum number of times to retry a batch on recoverable errors.
-  [ max_retries: <int> | default = 3 ]
   # Initial retry delay. Gets doubled for every retry.
   [ min_backoff: <duration> | default = 30ms ]
   # Maximum retry delay.


### PR DESCRIPTION
Re #5636, remote write no longer uses the max retries config option. We retry endlessly for recoverable errors.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

cc @tomwilkie @brian-brazil 