### PR TITLE
Work around golangci-lint issues

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -248,7 +248,9 @@ proto:
 ifdef GOLANGCI_LINT
 $(GOLANGCI_LINT):
 	mkdir -p $(FIRST_GOPATH)/bin
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(FIRST_GOPATH)/bin $(GOLANGCI_LINT_VERSION)
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh \
+		| sed -e '/install -d/d' \
+		| sh -s -- -b $(FIRST_GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 endif
 
 ifdef GOVENDOR


### PR DESCRIPTION
The version on goreleaser is broken and different from the one in
Github: golangci/golangci-lint#575 – use the direct Github URL as a
workaround.

Additionally, the installer script attempts to `install -d /go/bin` on
CircleCI, which doesn't work due to permissions. Patch that line out –
we don't need it because we make sure the directory exists anyway.