### PR TITLE
Implement `Required` option for remote_read

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -614,6 +614,9 @@ type RemoteReadConfig struct {
 	// RequiredMatchers is an optional list of equality matchers which have to
 	// be present in a selector to query the remote read endpoint.
 	RequiredMatchers model.LabelSet `yaml:"required_matchers,omitempty"`
+
+	// Required makes reads from this remote-read endpoint required for querying
+	Required bool `yaml:"required,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -106,6 +106,9 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		if !rrConf.ReadRecent {
 			q = PreferLocalStorageFilter(q, s.localStartTimeCallback)
 		}
+		if !rrConf.Required {
+			q = storage.WarningQueryable(q)
+		}
 		queryables = append(queryables, q)
 	}
 	s.queryables = queryables


### PR DESCRIPTION
This allows the user to define whether the data from a remote-read is required or not. The default maintains the same current behavior (where all errors from a remote-read are marked as warnings).

In addition to the additional flexibility IMO this is a cleaner implementation (as the mergequerier now doesn't have to deal with primary vs secondary queriers.

Fixes #5662

Signed-off-by: Thomas Jackson <jacksontj.89@gmail.com>