### PR TITLE
added dockerfile path and build context

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -86,7 +86,8 @@ endif
 PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
-DOCKERFILE_PATH         ?= ./
+DOCKERFILE_PATH         ?= ./Dockerfile
+DOCKERBUILD_CONTEXT     ?= ./
 DOCKER_REPO             ?= prom
 
 DOCKER_ARCHS            ?= amd64
@@ -211,9 +212,10 @@ common-tarball: promu
 common-docker: $(BUILD_DOCKER_ARCHS)
 $(BUILD_DOCKER_ARCHS): common-docker-%:
 	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)" \
+		-f $(DOCKERFILE_PATH) \
 		--build-arg ARCH="$*" \
 		--build-arg OS="linux" \
-		$(DOCKERFILE_PATH)
+		$(DOCKERBUILD_CONTEXT)
 
 .PHONY: common-docker-publish $(PUBLISH_DOCKER_ARCHS)
 common-docker-publish: $(PUBLISH_DOCKER_ARCHS)


### PR DESCRIPTION
`DOCKERFILE_PATH` was added to `Makefile.common` in #5635

This PR changes that to be passed to the `-f` flag and adds a new variable `DOCKERBUILD_CONTEXT` which specifies the build context for the docker build.

more info:
https://docs.docker.com/engine/reference/commandline/build/#build-with-path

cc  @simonpasquier  @SuperQ 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>