### PR TITLE
Fix zk connection leak

### DIFF
--- a/util/treecache/treecache.go
+++ b/util/treecache/treecache.go
@@ -266,7 +266,6 @@ func (tc *ZookeeperTreeCache) recursiveNodeUpdate(path string, node *zookeeperTr
 
 	tc.wg.Add(1)
 	go func() {
-		defer tc.wg.Done()
 		numWatchers.Inc()
 		// Pass up zookeeper events, until the node is deleted.
 		select {
@@ -277,6 +276,7 @@ func (tc *ZookeeperTreeCache) recursiveNodeUpdate(path string, node *zookeeperTr
 		case <-node.done:
 		}
 		numWatchers.Dec()
+		tc.wg.Done()
 	}()
 	return nil
 }

--- a/util/treecache/treecache.go
+++ b/util/treecache/treecache.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -68,6 +69,7 @@ type ZookeeperTreeCache struct {
 	prefix string
 	events chan ZookeeperTreeCacheEvent
 	stop   chan struct{}
+	wg     *sync.WaitGroup
 	head   *zookeeperTreeCacheNode
 
 	logger log.Logger
@@ -94,6 +96,7 @@ func NewZookeeperTreeCache(conn *zk.Conn, path string, events chan ZookeeperTree
 		prefix: path,
 		events: events,
 		stop:   make(chan struct{}),
+		wg:     &sync.WaitGroup{},
 
 		logger: logger,
 	}
@@ -102,6 +105,7 @@ func NewZookeeperTreeCache(conn *zk.Conn, path string, events chan ZookeeperTree
 		children: map[string]*zookeeperTreeCacheNode{},
 		stopped:  true,
 	}
+	tc.wg.Add(1)
 	go tc.loop(path)
 	return tc
 }
@@ -109,6 +113,10 @@ func NewZookeeperTreeCache(conn *zk.Conn, path string, events chan ZookeeperTree
 // Stop stops the tree cache.
 func (tc *ZookeeperTreeCache) Stop() {
 	tc.stop <- struct{}{}
+	go func() {
+		tc.wg.Wait()
+		close(tc.events)
+	}()
 }
 
 func (tc *ZookeeperTreeCache) loop(path string) {
@@ -186,6 +194,7 @@ func (tc *ZookeeperTreeCache) loop(path string) {
 			}
 		case <-tc.stop:
 			tc.recursiveStop(tc.head)
+			tc.wg.Done()
 			return
 		}
 	}
@@ -243,6 +252,7 @@ func (tc *ZookeeperTreeCache) recursiveNodeUpdate(path string, node *zookeeperTr
 		}
 	}
 
+	tc.wg.Add(1)
 	go func() {
 		numWatchers.Inc()
 		// Pass up zookeeper events, until the node is deleted.
@@ -254,6 +264,7 @@ func (tc *ZookeeperTreeCache) recursiveNodeUpdate(path string, node *zookeeperTr
 		case <-node.done:
 		}
 		numWatchers.Dec()
+		tc.wg.Done()
 	}()
 	return nil
 }

--- a/util/treecache/treecache.go
+++ b/util/treecache/treecache.go
@@ -104,7 +104,7 @@ func NewZookeeperTreeCache(conn *zk.Conn, path string, events chan ZookeeperTree
 		events:   make(chan zk.Event),
 		children: map[string]*zookeeperTreeCacheNode{},
 		done:     make(chan struct{}, 1),
-		stopped:  true, // set head's stop to be true so that recursiveDelete will not stop the head node
+		stopped:  true, // Set head's stop to be true so that recursiveDelete will not stop the head node.
 	}
 	tc.wg.Add(1)
 	go tc.loop(path)
@@ -115,14 +115,14 @@ func NewZookeeperTreeCache(conn *zk.Conn, path string, events chan ZookeeperTree
 func (tc *ZookeeperTreeCache) Stop() {
 	tc.stop <- struct{}{}
 	go func() {
-		// drain tc.head.events so that go routines can make progress and exit
+		// Drain tc.head.events so that go routines can make progress and exit.
 		for range tc.head.events {
 		}
 	}()
 	go func() {
 		tc.wg.Wait()
-		// close the tc.head.events after all members of the wait group have exited
-		// this makes the go routine above exit
+		// Close the tc.head.events after all members of the wait group have exited.
+		// This makes the go routine above exit.
 		close(tc.head.events)
 		close(tc.events)
 	}()
@@ -204,7 +204,7 @@ func (tc *ZookeeperTreeCache) loop(path string) {
 				failureMode = false
 			}
 		case <-tc.stop:
-			// stop head as well
+			// Stop head as well.
 			tc.head.done <- struct{}{}
 			tc.recursiveStop(tc.head)
 			return


### PR DESCRIPTION
Fixing the same issue mentioned in #5095 and #5093.

This works by creating a wait group for each tree cache. And from within the Stop function, we close the updates channel after all members of the wait group, who are basically the only producers to the updates channel, have exited. With that, this loop https://github.com/prometheus/prometheus/blob/master/discovery/zookeeper/zookeeper.go#L170 can terminate and the connection to zk can be properly shut down.

I tested this by running prometheus against a local zookeeper, and reloading prometheus does not increment the watch count after this patch.