### PR TITLE
Efficient iteration and search in HashForLabels and HashWithoutLabels

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -131,21 +131,23 @@ func (ls Labels) Hash() uint64 {
 }
 
 // HashForLabels returns a hash value for the labels matching the provided names.
-func (ls Labels) HashForLabels(names ...string) uint64 {
-	b := make([]byte, 0, 1024)
+func (ls Labels) HashForLabels(b []byte, names ...string) (uint64, []byte) {
+	b = b[:0]
+	i, j, n1, n2 := 0, 0, len(names), len(ls)
+	for i < n1 {
+		j = sort.Search(n2, func(idx int) bool {
+			return ls[idx].Name >= names[i]
+		})
 
-	for _, v := range ls {
-		for _, n := range names {
-			if v.Name == n {
-				b = append(b, v.Name...)
-				b = append(b, sep)
-				b = append(b, v.Value...)
-				b = append(b, sep)
-				break
-			}
+		if j < n2 && ls[j].Name == names[i] {
+			b = append(b, ls[j].Name...)
+			b = append(b, sep)
+			b = append(b, ls[j].Value...)
+			b = append(b, sep)
 		}
+		i++
 	}
-	return xxhash.Sum64(b)
+	return xxhash.Sum64(b), b
 }
 
 // HashWithoutLabels returns a hash value for all labels except those matching

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -133,13 +133,13 @@ func (ls Labels) Hash() uint64 {
 // HashForLabels returns a hash value for the labels matching the provided names.
 func (ls Labels) HashForLabels(b []byte, names ...string) (uint64, []byte) {
 	b = b[:0]
-	i, j, n1, n2 := 0, 0, len(names), len(ls)
-	for i < n1 {
-		j = sort.Search(n2, func(idx int) bool {
+	i, j, lsLen := 0, 0, len(ls)
+	for i < len(names) {
+		j = sort.Search(lsLen, func(idx int) bool {
 			return ls[idx].Name >= names[i]
 		})
 
-		if j < n2 && ls[j].Name == names[i] {
+		if j < lsLen && ls[j].Name == names[i] {
 			b = append(b, ls[j].Name...)
 			b = append(b, sep)
 			b = append(b, ls[j].Value...)

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -131,6 +131,7 @@ func (ls Labels) Hash() uint64 {
 }
 
 // HashForLabels returns a hash value for the labels matching the provided names.
+// The provided names have to be unique.
 func (ls Labels) HashForLabels(b []byte, names ...string) (uint64, []byte) {
 	b = b[:0]
 	i, j, lsLen := 0, 0, len(ls)
@@ -152,25 +153,30 @@ func (ls Labels) HashForLabels(b []byte, names ...string) (uint64, []byte) {
 
 // HashWithoutLabels returns a hash value for all labels except those matching
 // the provided names.
-func (ls Labels) HashWithoutLabels(names ...string) uint64 {
-	b := make([]byte, 0, 1024)
-
+func (ls Labels) HashWithoutLabels(b []byte, names ...string) (uint64, []byte) {
+	b = b[:0]
+	i, j, namesLen := 0, 0, len(names)
 Outer:
-	for _, v := range ls {
-		if v.Name == MetricName {
+	for i < len(ls) {
+		if ls[i].Name == MetricName {
+			i++
 			continue
 		}
-		for _, n := range names {
-			if v.Name == n {
+		j = 0
+		for j < namesLen {
+			if ls[i].Name == names[j] {
+				i++
 				continue Outer
 			}
+			j++
 		}
-		b = append(b, v.Name...)
+		b = append(b, ls[i].Name...)
 		b = append(b, sep)
-		b = append(b, v.Value...)
+		b = append(b, ls[i].Value...)
 		b = append(b, sep)
+		i++
 	}
-	return xxhash.Sum64(b)
+	return xxhash.Sum64(b), b
 }
 
 // Copy returns a copy of the labels.

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -157,24 +157,18 @@ func (ls Labels) HashForLabels(b []byte, names ...string) (uint64, []byte) {
 // 'names' have to be sorted in ascending order.
 func (ls Labels) HashWithoutLabels(b []byte, names ...string) (uint64, []byte) {
 	b = b[:0]
-	i, j := 0, 0
-	for i < len(ls) {
-		if ls[i].Name == MetricName {
-			i++
+	j := 0
+	for i := range ls {
+		for j < len(names) && names[j] < ls[i].Name {
+			j++
+		}
+		if ls[i].Name == MetricName || (j < len(names) && ls[i].Name == names[j]) {
 			continue
 		}
-		if j == len(names) || ls[i].Name < names[j] {
-			b = append(b, ls[i].Name...)
-			b = append(b, sep)
-			b = append(b, ls[i].Value...)
-			b = append(b, sep)
-			i++
-		} else if names[j] < ls[i].Name {
-			j++
-		} else {
-			i++
-			j++
-		}
+		b = append(b, ls[i].Name...)
+		b = append(b, sep)
+		b = append(b, ls[i].Value...)
+		b = append(b, sep)
 	}
 	return xxhash.Sum64(b), b
 }

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1526,6 +1526,7 @@ func signatureFunc(on bool, names ...string) func(labels.Labels) uint64 {
 	// TODO(fabxc): ensure names are sorted and then use that and sortedness
 	// of labels by names to speed up the operations below.
 	// Alternatively, inline the hashing and don't build new label sets.
+	sort.Strings(names)
 	if on {
 		return func(lset labels.Labels) uint64 {
 			h, _ := lset.HashForLabels(make([]byte, 0, 1024), names...)
@@ -1728,6 +1729,7 @@ func (ev *evaluator) aggregation(op ItemType, grouping []string, without bool, p
 		}
 	}
 
+	sort.Strings(grouping)
 	lb := labels.NewBuilder(nil)
 	buf := make([]byte, 0, 1024)
 	for _, s := range vec {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1532,7 +1532,10 @@ func signatureFunc(on bool, names ...string) func(labels.Labels) uint64 {
 			return h
 		}
 	}
-	return func(lset labels.Labels) uint64 { return lset.HashWithoutLabels(names...) }
+	return func(lset labels.Labels) uint64 {
+		h, _ := lset.HashWithoutLabels(make([]byte, 0, 1024), names...)
+		return h
+	}
 }
 
 // resultMetric returns the metric for the given sample(s) based on the Vector
@@ -1740,7 +1743,7 @@ func (ev *evaluator) aggregation(op ItemType, grouping []string, without bool, p
 			groupingKey uint64
 		)
 		if without {
-			groupingKey = metric.HashWithoutLabels(grouping...)
+			groupingKey, buf = metric.HashWithoutLabels(buf, grouping...)
 		} else {
 			groupingKey, buf = metric.HashForLabels(buf, grouping...)
 		}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1523,9 +1523,6 @@ func (ev *evaluator) VectorBinop(op ItemType, lhs, rhs Vector, matching *VectorM
 // signatureFunc returns a function that calculates the signature for a metric
 // ignoring the provided labels. If on, then the given labels are only used instead.
 func signatureFunc(on bool, names ...string) func(labels.Labels) uint64 {
-	// TODO(fabxc): ensure names are sorted and then use that and sortedness
-	// of labels by names to speed up the operations below.
-	// Alternatively, inline the hashing and don't build new label sets.
 	sort.Strings(names)
 	if on {
 		return func(lset labels.Labels) uint64 {


### PR DESCRIPTION
This brought down the time taken by `HashForLabels` from `23+s` for a single query to `<2s`.

In this PR:
* Don't have a range over the slice to avoid copying of slice. Instead, use traditional loop iteration.
* Use binary search instead of linear search (for this I swapped the loops).
* Reuse byte buffer.