### PR TITLE
Fix docker hub link in installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ the respective repository.
 
 All Prometheus services are available as Docker images on
 [Quay.io](https://quay.io/repository/prometheus/prometheus) or
-[Docker Hub](https://hub.docker.com/u/prom/).
+[Docker Hub](https://hub.docker.com/r/prom/prometheus/).
 
 Running Prometheus on Docker is as simple as `docker run -p 9090:9090
 prom/prometheus`. This starts Prometheus with a sample


### PR DESCRIPTION
This PR fixes the docker hub link in the installation guide.
Signed-off-by: c2c-engg-20170100 <c2c-20170100@click2cloud.net>