### PR TITLE
Clarifying honor_labels documentation

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -127,8 +127,11 @@ job_name: <job_name>
 # If honor_labels is set to "false", label conflicts are resolved by renaming
 # conflicting labels in the scraped data to "exported_<original-label>" (for
 # example "exported_instance", "exported_job") and then attaching server-side
-# labels. This is useful for use cases such as federation, where all labels
-# specified in the target should be preserved.
+# labels.
+#
+# Setting honor_labels to "true" is useful for use cases such as federation and
+# scraping the Pushgateway, where all labels specified in the target should be
+# preserved.
 #
 # Note that any globally configured "external_labels" are unaffected by this
 # setting. In communication with external systems, they are always applied only


### PR DESCRIPTION
Previously, the wording could be misunderstood as setting honor_labels
to "false" for federation.

This also adds scraping the Pushgateway as a typical use case for
honor_labels=true.

Signed-off-by: beorn7 <beorn@grafana.com>