### PR TITLE
Add tests to ensure we can marshal and unmarshal our min/max times

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -439,8 +439,11 @@ func (api *API) labelValues(r *http.Request) apiFuncResult {
 }
 
 var (
-	minTime = time.Unix(math.MinInt64/1000+62135596801, 0)
-	maxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999)
+	minTime = time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
+	maxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
+
+	minTimeFormatted = minTime.Format(time.RFC3339Nano)
+	maxTimeFormatted = maxTime.Format(time.RFC3339Nano)
 )
 
 func (api *API) series(r *http.Request) apiFuncResult {
@@ -1161,6 +1164,17 @@ func parseTime(s string) (time.Time, error) {
 	}
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 		return t, nil
+	}
+
+	// Stdlib's time parser can only handle 4 digit years. As a workaround until
+	// that is fixed we want to at least support our own boundary times.
+	// Context: https://github.com/prometheus/client_golang/issues/614
+	// Upstream issue: https://github.com/golang/go/issues/20555
+	switch s {
+	case minTimeFormatted:
+		return minTime, nil
+	case maxTimeFormatted:
+		return maxTime, nil
 	}
 	return time.Time{}, errors.Errorf("cannot parse %q to a valid timestamp", s)
 }

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1331,6 +1331,14 @@ func TestParseTime(t *testing.T) {
 			input:  "1543578564.705",
 			result: time.Unix(1543578564, 705*1e6),
 		},
+		{
+			input:  minTime.Format(time.RFC3339Nano),
+			result: minTime,
+		},
+		{
+			input:  maxTime.Format(time.RFC3339Nano),
+			result: maxTime,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Related to https://github.com/prometheus/client_golang/issues/614

This simply showcases the exact issue. If this test passes then the issue will be resolved (either moving the min/max time so we can parse them, or implementing parsing for the times we currently have).

cc @brian-brazil  @krasi-georgiev 