### PR TITLE
Documented /healthy, /ready and lifecycle API

### DIFF
--- a/docs/management_api.md
+++ b/docs/management_api.md
@@ -1,0 +1,50 @@
+---
+title: Management API
+sort_rank: 7
+---
+
+# Management API
+
+Prometheus provides a set of management API to ease automation and integrations.
+
+
+### Health check
+
+```
+GET /-/healthy
+```
+
+This endpoint always returns 200 and should be used to check Prometheus health.
+
+
+### Readiness check
+
+```
+GET /-/ready
+```
+
+This endpoint returns 200 when Prometheus is ready to serve traffic (i.e. respond to queries).
+
+
+### Reload
+
+```
+PUT  /-/reload
+POST /-/reload
+```
+
+This endpoint triggers a reload of the Prometheus configuration and rule files. It's disabled by default and can be enabled via the `--web.enable-lifecycle` flag.
+
+An alternative way trigger a configuration reload is by sending a `SIGHUP` to the Prometheus process.
+
+
+### Quit
+
+```
+PUT  /-/quit
+POST /-/quit
+```
+
+This endpoint triggers a graceful shutdown of Prometheus. It's disabled by default and can be enabled via the `--web.enable-lifecycle` flag.
+
+An alternative way trigger a graceful shutdown is by sending a `SIGTERM` to the Prometheus process.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,6 +1,6 @@
 ---
 title: Migration
-sort_rank: 7
+sort_rank: 8
 ---
 
 # Prometheus 2.0 migration guide

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,6 +1,6 @@
 ---
 title: API Stability
-sort_rank: 8
+sort_rank: 9
 ---
 
 # API Stability Guarantees


### PR DESCRIPTION
Prometheus is currently lacking the documentation about some API endpoints, including the following one for which I've attempted a brief doc in this PR:
- `/-/healthy`
- `/-/ready`
- `/-/reload`
- `/-/quit`

Considerations:
- I've created a new page in the doc since, since this content doesn't look fitting well in the already existing ones
- I've named the section "Management API", but I'm open to a better naming
- I've added the new page between "Federation" and "Migration", but I'm open to suggestions

Questions:
- Should we document `/debug` endpoints as well?

Fixes https://github.com/prometheus/docs/issues/1310.

@brian-brazil (since you're the maintainer of the `prometheus/docs` project)