### PR TITLE
Fix prometheus-mixin dashboards to use grafanaDashboards

### DIFF
--- a/documentation/prometheus-mixin/dashboards.jsonnet
+++ b/documentation/prometheus-mixin/dashboards.jsonnet
@@ -1,4 +1,4 @@
-local dashboards = (import 'mixin.libsonnet').dashboards;
+local dashboards = (import 'mixin.libsonnet').grafanaDashboards;
 
 {
   [name]: dashboards[name]

--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -1,7 +1,7 @@
 local g = import 'grafana-builder/grafana.libsonnet';
 
 {
-  dashboards+: {
+  grafanaDashboards+:: {
     'prometheus.json':
       g.dashboard('Prometheus')
       .addMultiTemplate('job', 'prometheus_build_info', 'job')


### PR DESCRIPTION
Updating to the latest version of this prometheus-mixin, I found that it doesn't show up in my Grafana.

Instead of using `grafanaDashboards+::` the mixin currently uses `dashboards+::` which is wrong.
The confusion is probably coming from the original [Monitoring Mixin Design Doc](https://docs.google.com/document/d/1A9xvzwqnFVSOZ5fD3blKODXfsat5fg6ZhnKu9LK3lB4/edit#) which first talks about `dashboards+::` and then further down actually uses `grafanaDashboards+::` (search for Proposed Schema).

Here are a few examples using `grafanaDashboards+::`:
[kubernetes-mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/dashboards/use.libsonnet#L4)
[etcd-mixin](https://github.com/etcd-io/etcd/blob/master/Documentation/etcd-mixin/mixin.libsonnet#L198)