### PR TITLE
Only check last directory when discovering checkpoint number

### DIFF
--- a/storage/remote/wal_watcher.go
+++ b/storage/remote/wal_watcher.go
@@ -526,7 +526,7 @@ func (w *WALWatcher) readCheckpoint(checkpointDir string) error {
 
 func checkpointNum(dir string) (int, error) {
 	// Checkpoint dir names are in the format checkpoint.000001
-	chunks := strings.Split(dir, ".")
+	chunks := strings.Split(path.Base(dir), ".")
 	if len(chunks) != 2 {
 		return 0, errors.Errorf("invalid checkpoint dir string: %s", dir)
 	}

--- a/storage/remote/wal_watcher.go
+++ b/storage/remote/wal_watcher.go
@@ -526,6 +526,7 @@ func (w *WALWatcher) readCheckpoint(checkpointDir string) error {
 
 func checkpointNum(dir string) (int, error) {
 	// Checkpoint dir names are in the format checkpoint.000001
+	// dir may contain a hidden directory, so only check the base directory
 	chunks := strings.Split(path.Base(dir), ".")
 	if len(chunks) != 2 {
 		return 0, errors.Errorf("invalid checkpoint dir string: %s", dir)


### PR DESCRIPTION
We keep our Prometheus TSDB data under a hidden directory which breaks `remote_writes` since the function that finds the checkpoint number simply splits on `.`. 

This PR ensures that we only look at the base directory when discovery the checkpoint number. 