### PR TITLE
filtering alerts by state and display count of alerts in each state

### DIFF
--- a/web/ui/static/js/alerts.js
+++ b/web/ui/static/js/alerts.js
@@ -37,8 +37,8 @@ function init() {
       $("#inactiveAlerts").parent().removeClass("active");
       displayAlerts("alert-success", false);
   }
-  if(localStorage.hideActiveAlerts === "true") {
-      $("#activeAlerts").parent().removeClass("active");
+  if(localStorage.hidePendingAlerts === "true") {
+      $("#pendingAlerts").parent().removeClass("active");
       displayAlerts("alert-warning", false);
   }
   if(localStorage.hideFiringAlerts === "true") {
@@ -52,8 +52,8 @@ function init() {
         if (target === "inactiveAlerts") {
             localStorage.setItem("hideInactiveAlerts", shouldHide);
             displayAlerts("alert-success", !shouldHide);
-        } else if (target === "activeAlerts") {
-            localStorage.setItem("hideActiveAlerts", shouldHide);
+        } else if (target === "pendingAlerts") {
+            localStorage.setItem("hidePendingAlerts", shouldHide);
             displayAlerts("alert-warning", !shouldHide);
         } else if (target === "firingAlerts") {
             localStorage.setItem("hideFiringAlerts", shouldHide);

--- a/web/ui/static/js/alerts.js
+++ b/web/ui/static/js/alerts.js
@@ -26,6 +26,47 @@ function init() {
         targetEl.removeClass('is-checked');
     }
   });
+
+  function displayAlerts(alertState, shouldDisplay) {
+      $("#alertsTable > tbody > tr").each(function(_, container) {
+          if($(container).hasClass(alertState)) {
+              if(shouldDisplay) {
+                  $(container).show();
+              } else {
+                  $(container).hide();
+              }
+          }
+      });
+  }
+
+  if(localStorage.hideInactiveAlerts === "true") {
+      $("#inactiveAlerts").parent().removeClass("active");
+      displayAlerts("alert-success", false);
+  }
+  if(localStorage.hideActiveAlerts === "true") {
+      $("#activeAlerts").parent().removeClass("active");
+      displayAlerts("alert-warning", false);
+  }
+  if(localStorage.hideFiringAlerts === "true") {
+      $("#firingAlerts").parent().removeClass("active");
+      displayAlerts("alert-danger", false);
+  }
+
+  $("#alertFilters :input").change(function() {
+        const target = $(this).attr("id");
+        var isActive = $(this).parent().hasClass("active");
+        if (target === "inactiveAlerts") {
+            localStorage.setItem("hideInactiveAlerts", isActive);
+            displayAlerts("alert-success", !isActive);
+        } else if (target === "activeAlerts") {
+            localStorage.setItem("hideActiveAlerts", isActive);
+            displayAlerts("alert-warning", !isActive);
+        } else if (target === "firingAlerts") {
+            localStorage.setItem("hideFiringAlerts", isActive);
+            displayAlerts("alert-danger", !isActive);
+        }
+  });
+
 }
 
 $(init);

--- a/web/ui/static/js/alerts.js
+++ b/web/ui/static/js/alerts.js
@@ -28,14 +28,8 @@ function init() {
   });
 
   function displayAlerts(alertState, shouldDisplay) {
-      $("#alertsTable > tbody > tr").each(function(_, container) {
-          if($(container).hasClass(alertState)) {
-              if(shouldDisplay) {
-                  $(container).show();
-              } else {
-                  $(container).hide();
-              }
-          }
+      $("#alertsTable > tbody > tr." + alertState).each(function(_, container) {
+          $(container).toggle(shouldDisplay);
       });
   }
 

--- a/web/ui/static/js/alerts.js
+++ b/web/ui/static/js/alerts.js
@@ -48,16 +48,16 @@ function init() {
 
   $("#alertFilters :input").change(function() {
         const target = $(this).attr("id");
-        var isActive = $(this).parent().hasClass("active");
+        var shouldHide = $(this).parent().hasClass("active");
         if (target === "inactiveAlerts") {
-            localStorage.setItem("hideInactiveAlerts", isActive);
-            displayAlerts("alert-success", !isActive);
+            localStorage.setItem("hideInactiveAlerts", shouldHide);
+            displayAlerts("alert-success", !shouldHide);
         } else if (target === "activeAlerts") {
-            localStorage.setItem("hideActiveAlerts", isActive);
-            displayAlerts("alert-warning", !isActive);
+            localStorage.setItem("hideActiveAlerts", shouldHide);
+            displayAlerts("alert-warning", !shouldHide);
         } else if (target === "firingAlerts") {
-            localStorage.setItem("hideFiringAlerts", isActive);
-            displayAlerts("alert-danger", !isActive);
+            localStorage.setItem("hideFiringAlerts", shouldHide);
+            displayAlerts("alert-danger", !shouldHide);
         }
   });
 

--- a/web/ui/static/js/targets.js
+++ b/web/ui/static/js/targets.js
@@ -22,10 +22,10 @@ function showUnhealthy(_, container) {
 
 function init() {
   if ($("#unhealthy-targets").length) {
-    if (!localStorage.selectedTab || localStorage.selectedTab == "all-targets") {
+    if (!localStorage.selectedTargetsTab || localStorage.selectedTargetsTab == "all-targets") {
       $("#all-targets").parent().addClass("active");
       $(".table-container").each(showAll);
-    } else if (localStorage.selectedTab == "unhealthy-targets") {
+    } else if (localStorage.selectedTargetsTab == "unhealthy-targets") {
       $("#unhealthy-targets").parent().addClass("active");
       $(".table-container").each(showUnhealthy);
     }
@@ -33,7 +33,6 @@ function init() {
     $(".table-container").each(showAll);
   }
 
-  $("button.targets").click(function() {
     const tableTitle = $(this).closest("h2").find("a").attr("id");
 
     if ($(this).hasClass("collapsed-table")) {
@@ -57,10 +56,10 @@ function init() {
 
     if (target === "all-targets") {
       $(".table-container").each(showAll);
-      localStorage.setItem("selectedTab", "all-targets");
+      localStorage.setItem("selectedTargetsTab", "all-targets");
     } else if (target === "unhealthy-targets") {
       $(".table-container").each(showUnhealthy);
-      localStorage.setItem("selectedTab", "unhealthy-targets");
+      localStorage.setItem("selectedTargetsTab", "unhealthy-targets");
     }
   });
 }

--- a/web/ui/static/js/targets.js
+++ b/web/ui/static/js/targets.js
@@ -33,6 +33,7 @@ function init() {
     $(".table-container").each(showAll);
   }
 
+  $("button.targets").click(function() {
     const tableTitle = $(this).closest("h2").find("a").attr("id");
 
     if ($(this).hasClass("collapsed-table")) {

--- a/web/ui/templates/alerts.html
+++ b/web/ui/templates/alerts.html
@@ -11,7 +11,7 @@
             <input type="checkbox" name="alertFilters" id="inactiveAlerts" autocomplete="off"> Inactive ({{ .Counts.Inactive }})
         </label>
         <label class="btn btn-primary active">
-            <input type="checkbox" name="alertFilters" id="activeAlerts" autocomplete="off"> Active ({{ .Counts.Active }})
+            <input type="checkbox" name="alertFilters" id="pendingAlerts" autocomplete="off"> Pending ({{ .Counts.Pending }})
         </label>
         <label class="btn btn-primary active">
             <input type="checkbox" name="alertFilters" id="firingAlerts" autocomplete="off"> Firing ({{ .Counts.Firing }})

--- a/web/ui/templates/alerts.html
+++ b/web/ui/templates/alerts.html
@@ -6,11 +6,23 @@
 {{define "content"}}
 <div class="container-fluid">
   <h1>Alerts</h1>
+    <div id="alertFilters" class="btn-group btn-group-toggle" data-toggle="buttons">
+        <label class="btn btn-primary active">
+            <input type="checkbox" name="alertFilters" id="inactiveAlerts" autocomplete="off"> Inactive ({{ .Counts.Inactive }})
+        </label>
+        <label class="btn btn-primary active">
+            <input type="checkbox" name="alertFilters" id="activeAlerts" autocomplete="off"> Active ({{ .Counts.Active }})
+        </label>
+        <label class="btn btn-primary active">
+            <input type="checkbox" name="alertFilters" id="firingAlerts" autocomplete="off"> Firing ({{ .Counts.Firing }})
+        </label>
+        </br>
+    </div>
   <div class="show-annotations">
      <i class="glyphicon glyphicon-unchecked"></i>
        <button type="button" class="show-annotations" title="show annotations">Show annotations</button>
   </div>
-  <table class="table table-bordered table-collapsed">
+  <table id="alertsTable" class="table table-bordered table-collapsed">
     <tbody>
       {{$alertStateToRowClass := .AlertStateToRowClass}}
       {{range .Groups}}

--- a/web/web.go
+++ b/web/web.go
@@ -548,8 +548,27 @@ func (h *Handler) alerts(w http.ResponseWriter, r *http.Request) {
 			rules.StatePending:  "warning",
 			rules.StateFiring:   "danger",
 		},
+		Counts: alertCounts(groups),
 	}
 	h.executeTemplate(w, "alerts.html", alertStatus)
+}
+
+func alertCounts(groups []*rules.Group) AlertByStateCount {
+	result := AlertByStateCount{}
+
+	for _, group := range groups {
+		for _, alert := range group.AlertingRules() {
+			switch alert.State() {
+			case rules.StateInactive:
+				result.Inactive++
+			case rules.StatePending:
+				result.Active++
+			case rules.StateFiring:
+				result.Firing++
+			}
+		}
+	}
+	return result
 }
 
 func (h *Handler) consoles(w http.ResponseWriter, r *http.Request) {
@@ -966,4 +985,11 @@ func (h *Handler) executeTemplate(w http.ResponseWriter, name string, data inter
 type AlertStatus struct {
 	Groups               []*rules.Group
 	AlertStateToRowClass map[rules.AlertState]string
+	Counts               AlertByStateCount
+}
+
+type AlertByStateCount struct {
+	Inactive int32
+	Active   int32
+	Firing   int32
 }

--- a/web/web.go
+++ b/web/web.go
@@ -562,7 +562,7 @@ func alertCounts(groups []*rules.Group) AlertByStateCount {
 			case rules.StateInactive:
 				result.Inactive++
 			case rules.StatePending:
-				result.Active++
+				result.Pending++
 			case rules.StateFiring:
 				result.Firing++
 			}
@@ -990,6 +990,6 @@ type AlertStatus struct {
 
 type AlertByStateCount struct {
 	Inactive int32
-	Active   int32
+	Pending  int32
 	Firing   int32
 }


### PR DESCRIPTION
This is improvement I made on https://github.com/prometheus/prometheus/issues/5655
In my first PR in this area (https://github.com/prometheus/prometheus/pull/5664) someone noted, that simply displaying active alerts on top would make order basically random so it would be hard to track single group. In this PR I took different approach - Added possibility to filter alerts and also number of alerts in each state is displayed, as on below screenshot
![2019-07-12-123518_572x380_scrot](https://user-images.githubusercontent.com/1153719/61122241-8637bb00-a4a1-11e9-831b-9f357dd91dfc.png)

I hope this will make more people happy than shuffling alerts.
