### PR TITLE
promtool command to obfuscate symbols of index file

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -774,6 +774,8 @@ func writePostings(indexw *index.Writer, values map[string]map[string]struct{}, 
 	var (
 		maxNumValues      int
 		numLabelValues    int
+		mappedName        string
+		ok                bool
 		names             = make([]string, 0, len(values)+1)
 		apkName, apkValue = index.AllPostingsKey()
 	)
@@ -792,14 +794,14 @@ func writePostings(indexw *index.Writer, values map[string]map[string]struct{}, 
 		if mappedName, ok := symbolMap[n]; ok {
 			n = mappedName
 		} else {
-			return fmt.Errorf("Mapped symbol not found for name: %s", n)
+			return fmt.Errorf("mapped symbol not found for name: %s", n)
 		}
 
 		for val := range v {
 			if mappedVal, ok := symbolMap[val]; ok {
 				labelValuesBuf = append(labelValuesBuf, mappedVal)
 			} else {
-				return fmt.Errorf("Mapped symbol not found for value: %s", val)
+				return fmt.Errorf("mapped symbol not found for value: %s", val)
 			}
 		}
 		if err := indexw.WriteLabelIndex([]string{n}, labelValuesBuf); err != nil {
@@ -817,10 +819,9 @@ func writePostings(indexw *index.Writer, values map[string]map[string]struct{}, 
 		}
 		sort.Strings(labelValuesBuf)
 
-		if mappedName, ok := symbolMap[n]; ok {
-			n = mappedName
-		} else {
-			return fmt.Errorf("Mapped symbol not found for name: %s", n)
+		mappedName, ok = symbolMap[n]
+		if !ok {
+			return fmt.Errorf("mapped symbol not found for name: %s", n)
 		}
 
 		for _, v := range labelValuesBuf {
@@ -830,11 +831,11 @@ func writePostings(indexw *index.Writer, values map[string]map[string]struct{}, 
 			}
 
 			if mappedVal, ok := symbolMap[v]; ok {
-				if err := indexw.WritePostings(n, mappedVal, posts); err != nil {
+				if err := indexw.WritePostings(mappedName, mappedVal, posts); err != nil {
 					return err
 				}
 			} else {
-				return fmt.Errorf("Mapped symbol not found for value: %s", v)
+				return fmt.Errorf("mapped symbol not found for value: %s", v)
 			}
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -272,16 +272,16 @@ github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 # github.com/prometheus/tsdb v0.9.1
+github.com/prometheus/tsdb/chunks
+github.com/prometheus/tsdb/index
+github.com/prometheus/tsdb/labels
 github.com/prometheus/tsdb
 github.com/prometheus/tsdb/fileutil
-github.com/prometheus/tsdb/labels
 github.com/prometheus/tsdb/wal
 github.com/prometheus/tsdb/chunkenc
-github.com/prometheus/tsdb/chunks
-github.com/prometheus/tsdb/encoding
 github.com/prometheus/tsdb/errors
+github.com/prometheus/tsdb/encoding
 github.com/prometheus/tsdb/goversion
-github.com/prometheus/tsdb/index
 # github.com/samuel/go-zookeeper v0.0.0-20161028232340-1d7be4effb13
 github.com/samuel/go-zookeeper/zk
 # github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371


### PR DESCRIPTION
While working on postings compression with @naivewong we needed real-world index file to run tests on it. This command will help obfuscate the index file to hide any sensitive data.

This might also help in sharing index files for debugging without worrying about sensitive data.