### PR TITLE
Add metrics for max/min/desired shards to queue manager.

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -226,6 +226,27 @@
             },
           },
           {
+            alert: 'PrometheusRemoteWriteDesiredShards',
+            expr: |||
+              # Without max_over_time, failed scrapes could create false negatives, see
+              # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+              (
+                max_over_time(prometheus_remote_storage_shards_desired{%(prometheusSelector)s}[5m])
+              > on(job, instance) group_right
+                max_over_time(prometheus_remote_storage_shards_max{%(prometheusSelector)s}[5m])
+              )
+              == 1
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Prometheus remote write desired shards calculation wants to run more than configured max shards.',
+              description: 'Prometheus %(prometheusName)s remote write is {{ printf "%%.1f" $value }}s behind for queue {{$labels.queue}}.' % $._config,
+            },
+          },
+          {
             alert: 'PrometheusRuleFailures',
             expr: |||
               increase(prometheus_rule_evaluation_failures_total{%(prometheusSelector)s}[5m]) > 0

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -235,7 +235,6 @@
               > on(job, instance) group_right
                 max_over_time(prometheus_remote_storage_shards_max{%(prometheusSelector)s}[5m])
               )
-              == 1
             ||| % $._config,
             'for': '15m',
             labels: {
@@ -243,7 +242,7 @@
             },
             annotations: {
               summary: 'Prometheus remote write desired shards calculation wants to run more than configured max shards.',
-              description: 'Prometheus %(prometheusName)s remote write is {{ printf "%%.1f" $value }}s behind for queue {{$labels.queue}}.' % $._config,
+              description: 'Prometheus %(prometheusName)s remote write desired shards calculation wants to run {{ printf $value }} shards, which is more than the max of {{ printf `prometheus_remote_storage_shards_max{instance="%%s",%(prometheusSelector)s}` $labels.instance | query | first | value }}.' % $._config,
             },
           },
           {


### PR DESCRIPTION
Add metrics for max shards, min shards, and desired shards to queue manager. This will help remote write users determine whether they to raise the max shards in their config.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

@csmarchbanks 
cc @tomwilkie @gouthamve 