### PR TITLE
removed docreference to meta label that doesnt exist

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -738,7 +738,6 @@ Available meta labels:
 * `__meta_kubernetes_service_labelpresent_<labelname>`: `true` for each label of the service object.
 * `__meta_kubernetes_service_name`: The name of the service object.
 * `__meta_kubernetes_service_port_name`: Name of the service port for the target.
-* `__meta_kubernetes_service_port_number`: Number of the service port for the target.
 * `__meta_kubernetes_service_port_protocol`: Protocol of the service port for the target.
 
 #### `pod`


### PR DESCRIPTION
In the configuration documentation page its stated the kubernetes_sd (service role) provides 

__meta_kubernetes_service_port_number: Number of the service port for the target.

This is not the case. Only name and protocol are provided by the kubernetes_sd.