### PR TITLE
remove the wrongly adding when errSampleLimit in scrape/scrape.go

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1099,7 +1099,6 @@ loop:
 				// Keep on parsing output if we hit the limit, so we report the correct
 				// total number of samples scraped.
 				sampleLimitErr = err
-				added++
 				continue
 			default:
 				break loop
@@ -1145,7 +1144,6 @@ loop:
 				continue
 			case errSampleLimit:
 				sampleLimitErr = err
-				added++
 				continue
 			default:
 				level.Debug(sl.l).Log("msg", "unexpected error", "series", string(met), "err", err)


### PR DESCRIPTION
https://github.com/prometheus/prometheus/blob/ead0933dd9065602e234ae907eee17a6dd208601/scrape/target.go#L268-L273
When `errSampleLimit` is returned, the `Add` or `AddFast` of `Appender` is not executed. I think the `added++` should be removed.