### PR TITLE
prometheus-mixin: remove PrometheusTSDBWALCorruptions

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -125,20 +125,6 @@
             },
           },
           {
-            alert: 'PrometheusTSDBWALCorruptions',
-            expr: |||
-              increase(tsdb_wal_corruptions_total{%(prometheusSelector)s}[3h]) > 0
-            ||| % $._config,
-            'for': '4h',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              summary: 'Prometheus is detecting WAL corruptions.',
-              description: 'Prometheus %(prometheusName)s has detected {{$value | humanize}} corruptions of the write-ahead log (WAL) over the last 3h.' % $._config,
-            },
-          },
-          {
             alert: 'PrometheusNotIngestingSamples',
             expr: |||
               rate(prometheus_tsdb_head_samples_appended_total{%(prometheusSelector)s}[5m]) <= 0


### PR DESCRIPTION
This is for discussion as I'm not sure what's the proper way to handle. Maybe we need to reconsider the metric itself?

The counter is only increased when tsdb.Open() is called which
Prometheus does only once in its lifetime (when it initializes). If the
corruption can't be recovered, tsdb.Open() returns an error and
Prometheus exits. Hence the metric is either 0 (no corruption) or 1
(corruption detected and repaired).

The metric name is 'prometheus_tsdb_wal_corruptions_total', not
'tsdb_wal_corruptions_total'.