### PR TITLE
Check for duplicate label names in remote read

### DIFF
--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -280,8 +280,7 @@ func (c *concreteSeriesIterator) Err() error {
 // validateLabelsAndMetricName validates the label names/values and metric names returned from remote read,
 // also making sure that there are no labels with duplicate names
 func validateLabelsAndMetricName(ls labels.Labels) error {
-	var prevLabelName string
-	for _, l := range ls {
+	for i, l := range ls {
 		if l.Name == labels.MetricName && !model.IsValidMetricName(model.LabelValue(l.Value)) {
 			return errors.Errorf("invalid metric name: %v", l.Value)
 		}
@@ -291,10 +290,9 @@ func validateLabelsAndMetricName(ls labels.Labels) error {
 		if !model.LabelValue(l.Value).IsValid() {
 			return errors.Errorf("invalid label value: %v", l.Value)
 		}
-		if l.Name == prevLabelName {
+		if i > 0 && l.Name == ls[i-1].Name {
 			return errors.Errorf("duplicate label with name: %v", l.Name)
 		}
-		prevLabelName = l.Name
 	}
 	return nil
 }

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -280,7 +280,7 @@ func (c *concreteSeriesIterator) Err() error {
 // validateLabelsAndMetricName validates the label names/values and metric names returned from remote read,
 // also making sure that there are no labels with duplicate names
 func validateLabelsAndMetricName(ls labels.Labels) error {
-	existingLabelNames := make(map[string]bool, len(ls))
+	var prevLabelName string
 	for _, l := range ls {
 		if l.Name == labels.MetricName && !model.IsValidMetricName(model.LabelValue(l.Value)) {
 			return errors.Errorf("invalid metric name: %v", l.Value)
@@ -291,10 +291,10 @@ func validateLabelsAndMetricName(ls labels.Labels) error {
 		if !model.LabelValue(l.Value).IsValid() {
 			return errors.Errorf("invalid label value: %v", l.Value)
 		}
-		if _, there := existingLabelNames[l.Name]; there {
+		if l.Name == prevLabelName {
 			return errors.Errorf("duplicate label with name: %v", l.Name)
 		}
-		existingLabelNames[l.Name] = true
+		prevLabelName = l.Name
 	}
 	return nil
 }

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -84,7 +84,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			),
 			expectedErr: "invalid label value: " + string([]byte{0xff}),
 			shouldPass:  false,
-			description: "label value is 0xff",
+			description: "label value is an invalid UTF-8 value",
 		},
 		{
 			input: labels.FromStrings(

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -112,6 +112,15 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			shouldPass:  true,
 			description: "duplicate label values",
 		},
+		{
+			input: labels.FromStrings(
+				"", "name",
+				"label2", "name",
+			),
+			expectedErr: "Invalid label name: ",
+			shouldPass:  false,
+			description: "don't report as duplicate label name",
+		},
 	}
 
 	for _, test := range tests {

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -30,6 +30,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 		input       labels.Labels
 		expectedErr string
 		shouldPass  bool
+		description string
 	}{
 		{
 			input: labels.FromStrings(
@@ -38,6 +39,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			),
 			expectedErr: "",
 			shouldPass:  true,
+			description: "regular labels",
 		},
 		{
 			input: labels.FromStrings(
@@ -46,6 +48,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			),
 			expectedErr: "",
 			shouldPass:  true,
+			description: "label name with _",
 		},
 		{
 			input: labels.FromStrings(
@@ -54,6 +57,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			),
 			expectedErr: "Invalid label name: @labelName",
 			shouldPass:  false,
+			description: "label name with @",
 		},
 		{
 			input: labels.FromStrings(
@@ -62,6 +66,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			),
 			expectedErr: "Invalid label name: 123labelName",
 			shouldPass:  false,
+			description: "label name starts with numbers",
 		},
 		{
 			input: labels.FromStrings(
@@ -70,6 +75,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			),
 			expectedErr: "Invalid label name: ",
 			shouldPass:  false,
+			description: "label name is empty string",
 		},
 		{
 			input: labels.FromStrings(
@@ -78,6 +84,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			),
 			expectedErr: "Invalid label value: " + string([]byte{0xff}),
 			shouldPass:  false,
+			description: "label value is 0xff",
 		},
 		{
 			input: labels.FromStrings(
@@ -85,6 +92,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			),
 			expectedErr: "Invalid metric name: @invalid_name",
 			shouldPass:  false,
+			description: "metric name starts with @",
 		},
 		{
 			input: labels.FromStrings(
@@ -93,6 +101,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			),
 			expectedErr: "Duplicate label with name: __name__",
 			shouldPass:  false,
+			description: "duplicate label names",
 		},
 		{
 			input: labels.FromStrings(
@@ -101,18 +110,21 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			),
 			expectedErr: "",
 			shouldPass:  true,
+			description: "duplicate label values",
 		},
 	}
 
 	for _, test := range tests {
-		err := validateLabelsAndMetricName(test.input)
-		if test.shouldPass != (err == nil) {
-			if test.shouldPass {
-				t.Fatalf("Test should pass, got unexpected error: %v", err)
-			} else {
-				t.Fatalf("Test should fail, unexpected error, got: %v, expected: %v", err, test.expectedErr)
+		t.Run(test.description, func(t *testing.T) {
+			err := validateLabelsAndMetricName(test.input)
+			if test.shouldPass != (err == nil) {
+				if test.shouldPass {
+					t.Fatalf("Test should pass, got unexpected error: %v", err)
+				} else {
+					t.Fatalf("Test should fail, unexpected error, got: %v, expected: %v", err, test.expectedErr)
+				}
 			}
-		}
+		})
 	}
 }
 

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -55,7 +55,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"__name__", "name",
 				"@labelName", "labelValue",
 			),
-			expectedErr: "Invalid label name: @labelName",
+			expectedErr: "invalid label name: @labelName",
 			shouldPass:  false,
 			description: "label name with @",
 		},
@@ -64,7 +64,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"__name__", "name",
 				"123labelName", "labelValue",
 			),
-			expectedErr: "Invalid label name: 123labelName",
+			expectedErr: "invalid label name: 123labelName",
 			shouldPass:  false,
 			description: "label name starts with numbers",
 		},
@@ -73,7 +73,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"__name__", "name",
 				"", "labelValue",
 			),
-			expectedErr: "Invalid label name: ",
+			expectedErr: "invalid label name: ",
 			shouldPass:  false,
 			description: "label name is empty string",
 		},
@@ -82,7 +82,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"__name__", "name",
 				"labelName", string([]byte{0xff}),
 			),
-			expectedErr: "Invalid label value: " + string([]byte{0xff}),
+			expectedErr: "invalid label value: " + string([]byte{0xff}),
 			shouldPass:  false,
 			description: "label value is 0xff",
 		},
@@ -90,7 +90,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			input: labels.FromStrings(
 				"__name__", "@invalid_name",
 			),
-			expectedErr: "Invalid metric name: @invalid_name",
+			expectedErr: "invalid metric name: @invalid_name",
 			shouldPass:  false,
 			description: "metric name starts with @",
 		},
@@ -99,7 +99,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"__name__", "name1",
 				"__name__", "name2",
 			),
-			expectedErr: "Duplicate label with name: __name__",
+			expectedErr: "duplicate label with name: __name__",
 			shouldPass:  false,
 			description: "duplicate label names",
 		},
@@ -117,7 +117,7 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"", "name",
 				"label2", "name",
 			),
-			expectedErr: "Invalid label name: ",
+			expectedErr: "invalid label name: ",
 			shouldPass:  false,
 			description: "don't report as duplicate label name",
 		},
@@ -126,11 +126,15 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			err := validateLabelsAndMetricName(test.input)
-			if test.shouldPass != (err == nil) {
+			if err == nil {
+				if !test.shouldPass {
+					t.Fatalf("Test should fail, but passed instead.")
+				}
+			} else {
 				if test.shouldPass {
 					t.Fatalf("Test should pass, got unexpected error: %v", err)
-				} else {
-					t.Fatalf("Test should fail, unexpected error, got: %v, expected: %v", err, test.expectedErr)
+				} else if err.Error() != test.expectedErr {
+					t.Fatalf("Test should fail with: %s got unexpected error instead: %v", test.expectedErr, err)
 				}
 			}
 		})


### PR DESCRIPTION
In #5731 a bug was discovered where there would sometimes be a timeseries from local storage and a timeseries from a remoteRead that were duplicates of eachother. This happened in cases where a timeseries coming from a remoteRead had duplicate label names. This caused `mergeSeriesSet` to not merge the remoteRead timeseries with the local storage timeseries.

This PR fixes this issue by adding a function to check for and remove duplicate label names coming from a remoteRead. There are also tests that ensure this is really happening.

CC @brian-brazil 