### PR TITLE
Fix incorrect examples in docs

### DIFF
--- a/documentation/examples/remote_storage/remote_storage_adapter/README.md
+++ b/documentation/examples/remote_storage/remote_storage_adapter/README.md
@@ -19,19 +19,19 @@ go build
 Graphite example:
 
 ```
-./remote_storage_adapter -graphite-address=localhost:8080
+./remote_storage_adapter --graphite-address=localhost:8080
 ```
 
 OpenTSDB example:
 
 ```
-./remote_storage_adapter -opentsdb-url=http://localhost:8081/
+./remote_storage_adapter --opentsdb-url=http://localhost:8081/
 ```
 
 InfluxDB example:
 
 ```
-./remote_storage_adapter -influxdb-url=http://localhost:8086/ -influxdb.database=prometheus -influxdb.retention-policy=autogen
+./remote_storage_adapter --influxdb-url=http://localhost:8086/ --influxdb.database=prometheus --influxdb.retention-policy=autogen
 ```
 
 To show all flags:


### PR DESCRIPTION
These examples don't run with a single `-`.