### PR TITLE
Fix context for the showWarning function

### DIFF
--- a/web/ui/static/js/graph/index.js
+++ b/web/ui/static/js/graph/index.js
@@ -246,7 +246,7 @@ Prometheus.Graph.prototype.checkTimeDrift = function() {
             var diff = Math.abs(browserTime - serverTime);
 
             if (diff >= 30) {
-              this.showWarning(
+              self.showWarning(
                   "<div class=\"alert alert-warning\"><strong>Warning!</strong> Detected " +
                   diff.toFixed(2) +
                   " seconds time difference between your browser and the server. Prometheus relies on accurate time and time drift might cause unexpected query results.</div>"


### PR DESCRIPTION
If the difference between the current time on a client and time on a server is quite big, Prometheus tries to show a related warning in UI on the Graph tab. But in the code, an incorrect context is used to invoke this method. As a result, an error is showed in the web developer console and the whole page stop working at all.

This commit fixes #5832

CC @juliusv

Signed-off-by: Vyacheslav Kulakov <vkulakov@swiftserve.com>