### PR TITLE
Correctly handle empty labels from alert templates.

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -285,20 +285,26 @@ type Builder struct {
 	add  []Label
 }
 
-// NewBuilder returns a new LabelsBuilder
+// NewBuilder returns a new LabelsBuilder.
 func NewBuilder(base Labels) *Builder {
-	return &Builder{
-		base: base,
-		del:  make([]string, 0, 5),
-		add:  make([]Label, 0, 5),
+	b := &Builder{
+		del: make([]string, 0, 5),
+		add: make([]Label, 0, 5),
 	}
+	b.Reset(base)
+	return b
 }
 
-// Reset clears all current state for the builder
+// Reset clears all current state for the builder.
 func (b *Builder) Reset(base Labels) {
 	b.base = base
 	b.del = b.del[:0]
 	b.add = b.add[:0]
+	for _, l := range b.base {
+		if l.Value == "" {
+			b.del = append(b.del, l.Name)
+		}
+	}
 }
 
 // Del deletes the label of the given name.
@@ -316,6 +322,10 @@ func (b *Builder) Del(ns ...string) *Builder {
 
 // Set the name/value pair as a label.
 func (b *Builder) Set(n, v string) *Builder {
+	if v == "" {
+		// Empty labels are the same as missing labels.
+		return b.Del(n)
+	}
 	for i, a := range b.add {
 		if a.Name == n {
 			b.add[i].Value = v

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -88,11 +88,7 @@ func (rule *RecordingRule) Eval(ctx context.Context, ts time.Time, query QueryFu
 		lb.Set(labels.MetricName, rule.name)
 
 		for _, l := range rule.labels {
-			if l.Value == "" {
-				lb.Del(l.Name)
-			} else {
-				lb.Set(l.Name, l.Value)
-			}
+			lb.Set(l.Name, l.Value)
 		}
 
 		sample.Metric = lb.Labels()

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -449,17 +449,13 @@ func mutateSampleLabels(lset labels.Labels, target *Target, honor bool, rc []*re
 		}
 	} else {
 		for _, l := range target.Labels() {
-			lv := lset.Get(l.Name)
-			if lv != "" {
-				lb.Set(model.ExportedLabelPrefix+l.Name, lv)
-			}
+			// existingValue will be empty if l.Name doesn't exist.
+			existingValue := lset.Get(l.Name)
+			// Because setting a label with an empty value is a no-op,
+			// this will only create the prefixed label if necessary.
+			lb.Set(model.ExportedLabelPrefix+l.Name, existingValue)
+			// It is now safe to set the target label.
 			lb.Set(l.Name, l.Value)
-		}
-	}
-
-	for _, l := range lb.Labels() {
-		if l.Value == "" {
-			lb.Del(l.Name)
 		}
 	}
 
@@ -476,10 +472,7 @@ func mutateReportSampleLabels(lset labels.Labels, target *Target) labels.Labels 
 	lb := labels.NewBuilder(lset)
 
 	for _, l := range target.Labels() {
-		lv := lset.Get(l.Name)
-		if lv != "" {
-			lb.Set(model.ExportedLabelPrefix+l.Name, lv)
-		}
+		lb.Set(model.ExportedLabelPrefix+l.Name, lset.Get(l.Name))
 		lb.Set(l.Name, l.Value)
 	}
 

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -85,7 +85,7 @@ func TestDroppedTargetsList(t *testing.T) {
 			},
 		}
 		sp, _                  = newScrapePool(cfg, app, 0, nil)
-		expectedLabelSetString = "{__address__=\"127.0.0.1:9090\", __metrics_path__=\"\", __scheme__=\"\", job=\"dropMe\"}"
+		expectedLabelSetString = "{__address__=\"127.0.0.1:9090\", job=\"dropMe\"}"
 		expectedLength         = 1
 	)
 	sp.Sync(tgs)


### PR DESCRIPTION
Fixes https://github.com/prometheus/common/issues/36

Move logic handling this into the labels package,
so all the cases are handled in one place and we're
less likely to have this come up again.

@beorn7 