### PR TITLE
Make a rule's evaluation timestamp available to alert templates

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -156,7 +156,7 @@ func testTemplateParsing(rl *Rule) (errs []error) {
 	}
 
 	// Trying to parse templates.
-	tmplData := template.AlertTemplateData(map[string]string{}, map[string]string{}, 0)
+	tmplData := template.AlertTemplateData(map[string]string{}, map[string]string{}, 0, time.Now())
 	defs := []string{
 		"{{$labels := .Labels}}",
 		"{{$externalLabels := .ExternalLabels}}",

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -318,7 +318,7 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 			l[lbl.Name] = lbl.Value
 		}
 
-		tmplData := template.AlertTemplateData(l, r.externalLabels, smpl.V)
+		tmplData := template.AlertTemplateData(l, r.externalLabels, smpl.V, r.evaluationTimestamp)
 		// Inject some convenience variables that are easier to remember for users
 		// who are not used to Go's templating system.
 		defs := []string{

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -507,14 +507,15 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 		func(i int, rule Rule) {
 			sp, ctx := opentracing.StartSpanFromContext(ctx, "rule")
 			sp.SetTag("name", rule.Name())
+			now := time.Now()
+			rule.SetEvaluationTimestamp(now)
 			defer func(t time.Time) {
 				sp.Finish()
 
 				since := time.Since(t)
 				g.metrics.evalDuration.Observe(since.Seconds())
 				rule.SetEvaluationDuration(since)
-				rule.SetEvaluationTimestamp(t)
-			}(time.Now())
+			}(now)
 
 			g.metrics.evalTotal.Inc()
 

--- a/template/template.go
+++ b/template/template.go
@@ -264,15 +264,17 @@ func NewTemplateExpander(
 }
 
 // AlertTemplateData returns the interface to be used in expanding the template.
-func AlertTemplateData(labels map[string]string, externalLabels map[string]string, value float64) interface{} {
+func AlertTemplateData(labels map[string]string, externalLabels map[string]string, value float64, ts time.Time) interface{} {
 	return struct {
-		Labels         map[string]string
-		ExternalLabels map[string]string
-		Value          float64
+		Labels              map[string]string
+		ExternalLabels      map[string]string
+		Value               float64
+		EvaluationTimestamp time.Time
 	}{
-		Labels:         labels,
-		ExternalLabels: externalLabels,
-		Value:          value,
+		Labels:              labels,
+		ExternalLabels:      externalLabels,
+		Value:               value,
+		EvaluationTimestamp: ts,
 	}
 }
 


### PR DESCRIPTION
We have a fairly complex monitoring/alerting pipeline, that includes several monitoring systems all routing into a homegrown alert router and out to various endpoints. I am measuring latency of all components by sending synthetic alerts throught the system, recording ingress and egress timestamps of all subsystems in the alert itself. For prometheus, I can record an ingress timestamp because the metric it is fetching is a magical one that is always a timestamp-like value. But a sensible definition of "latency inside prometheus" should take into account the fact that metric ingress and evaluation of a rule happen at different times, so I would really like to record the evaluation time as well.

This seemed simple enough to do: prometheus already is recording this information, I just had to change it to record it a bit earlier, and then add it to the template data. I hope this approach is acceptable.