### PR TITLE
Cache labels.Labels to Identify Series in Remote Write

### DIFF
--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -526,8 +526,8 @@ func labelsToLabelsProto(labels labels.Labels) []prompb.Label {
 	result := make([]prompb.Label, 0, len(labels))
 	for _, l := range labels {
 		result = append(result, prompb.Label{
-			Name:  interner.intern(l.Name),
-			Value: interner.intern(l.Value),
+			Name:  l.Name,
+			Value: l.Value,
 		})
 	}
 	return result

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -133,12 +133,12 @@ func TestSeriesSetFilter(t *testing.T) {
 			toRemove: labels.Labels{{Name: "foo", Value: "bar"}},
 			in: &prompb.QueryResult{
 				Timeseries: []*prompb.TimeSeries{
-					{Labels: labelsToLabelsProto(labels.FromStrings("foo", "bar", "a", "b")), Samples: []prompb.Sample{}},
+					{Labels: labelsToLabelsProto(labels.FromStrings("foo", "bar", "a", "b"), nil), Samples: []prompb.Sample{}},
 				},
 			},
 			expected: &prompb.QueryResult{
 				Timeseries: []*prompb.TimeSeries{
-					{Labels: labelsToLabelsProto(labels.FromStrings("a", "b")), Samples: []prompb.Sample{}},
+					{Labels: labelsToLabelsProto(labels.FromStrings("a", "b"), nil), Samples: []prompb.Sample{}},
 				},
 			},
 		},


### PR DESCRIPTION
This is an experiment to have the remote write component use `labels.Labels` instead of `[]prompb.Label` when passing samples around/identifying series. A `label.Label` uses less space so steady state memory usage should be less, with the tradeoff of transforming `label.Labels` to `[]prompb.Label` for each remote request.

Results after removing some extra sources of allocations look very good. This is for a server with three remote-write targets, and ~8k samples per second ingestion.

### Benchmarks
```
benchmark                     old ns/op     new ns/op     delta
BenchmarkSampleDelivery-8     998914        1007751       +0.88%

benchmark                     old allocs     new allocs     delta
BenchmarkSampleDelivery-8     7117           6117           -14.05%

benchmark                     old bytes     new bytes     delta
BenchmarkSampleDelivery-8     688391        640400        -6.97%
```

### Heap profiles
Heap profiles show a 50% reduction in memory used by StoreSeries as expected.

#### v2.11.1:
![v2 11 1](https://user-images.githubusercontent.com/3280472/62817409-4fca7b80-baf3-11e9-9a7b-41374b458568.png)

#### rw-use-labels branch
![rw-use-labels](https://user-images.githubusercontent.com/3280472/62817410-50631200-baf3-11e9-97b4-a83e4697a0a8.png)

### Other metrics
CPU usage is very similar between the servers. However, there is a reduction in allocations:
![ReducedAllocations](https://user-images.githubusercontent.com/3280472/62817450-3413a500-baf4-11e9-8e1e-48495836d7b7.png)

