### PR TITLE
[bugfix] custom SD: when ip out of order, reflect.deepEqual can not correctly identify whether there is a change

### DIFF
--- a/documentation/examples/custom-sd/adapter/adapter.go
+++ b/documentation/examples/custom-sd/adapter/adapter.go
@@ -152,11 +152,8 @@ func deepEqualGroupTarget(a, b []string) bool {
 		}
 
 	}
-
 	return true
 }
-
-
 
 // Writes JSON formatted targets to output file.
 func (a *Adapter) writeOutput() error {

--- a/documentation/examples/custom-sd/adapter/adapter.go
+++ b/documentation/examples/custom-sd/adapter/adapter.go
@@ -18,16 +18,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/discovery"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 type customSD struct {
@@ -76,7 +76,7 @@ func generateTargetGroups(allTargetGroups map[string][]*targetgroup.Group) map[s
 					newTargets = append(newTargets, string(target))
 				}
 			}
-			sort.Strings(newTargets[:])
+			sort.Strings(newTargets)
 			for name, value := range group.Labels {
 				newLabels[string(name)] = string(value)
 			}

--- a/documentation/examples/custom-sd/adapter/adapter.go
+++ b/documentation/examples/custom-sd/adapter/adapter.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/common/model"

--- a/documentation/examples/custom-sd/adapter/adapter_test.go
+++ b/documentation/examples/custom-sd/adapter/adapter_test.go
@@ -194,7 +194,7 @@ func TestGenerateTargetGroups(t *testing.T) {
 						"192.168.1.33",
 					},
 					Labels: map[string]string{
-						"__meta_test_label": "label_test_1",
+						"__meta_test_label": "label_test_2",
 					},
 				},
 				"cart:alibaba:1112e97a13b159fa": {
@@ -203,7 +203,7 @@ func TestGenerateTargetGroups(t *testing.T) {
 						"192.168.1.55",
 					},
 					Labels: map[string]string{
-						"__meta_test_label": "label_test_1",
+						"__meta_test_label": "label_test_2",
 					},
 				},
 			},

--- a/documentation/examples/custom-sd/adapter/adapter_test.go
+++ b/documentation/examples/custom-sd/adapter/adapter_test.go
@@ -194,7 +194,7 @@ func TestGenerateTargetGroups(t *testing.T) {
 						"192.168.1.33",
 					},
 					Labels: map[string]string{
-						"__meta_test_label": "label_test_2",
+						"__meta_test_label": "label_test_1",
 					},
 				},
 				"cart:alibaba:1112e97a13b159fa": {
@@ -203,7 +203,7 @@ func TestGenerateTargetGroups(t *testing.T) {
 						"192.168.1.55",
 					},
 					Labels: map[string]string{
-						"__meta_test_label": "label_test_2",
+						"__meta_test_label": "label_test_1",
 					},
 				},
 			},

--- a/documentation/examples/custom-sd/adapter/adapter_test.go
+++ b/documentation/examples/custom-sd/adapter/adapter_test.go
@@ -154,22 +154,6 @@ func TestGenerateTargetGroups(t *testing.T) {
 		{
 			title: "Disordered Ips in Alibaba's application management system",
 			targetGroup: map[string][]*targetgroup.Group{
-				"buy": {
-					{
-						Source: "alibaba",
-						Targets: []model.LabelSet{
-							{
-								model.AddressLabel: "192.168.1.22",
-							},
-							{
-								model.AddressLabel: "192.168.1.33",
-							},
-						},
-						Labels: model.LabelSet{
-							model.LabelName("__meta_test_label"): model.LabelValue("label_test_1"),
-						},
-					},
-				},
 				"cart": {
 					{
 						Source: "alibaba",
@@ -179,6 +163,22 @@ func TestGenerateTargetGroups(t *testing.T) {
 							},
 							{
 								model.AddressLabel: "192.168.1.44",
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("__meta_test_label"): model.LabelValue("label_test_1"),
+						},
+					},
+				},
+				"buy": {
+					{
+						Source: "alibaba",
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: "192.168.1.22",
+							},
+							{
+								model.AddressLabel: "192.168.1.33",
 							},
 						},
 						Labels: model.LabelSet{

--- a/documentation/examples/custom-sd/adapter/adapter_test.go
+++ b/documentation/examples/custom-sd/adapter/adapter_test.go
@@ -14,7 +14,6 @@
 package adapter
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -151,12 +150,69 @@ func TestGenerateTargetGroups(t *testing.T) {
 				},
 			},
 		},
+		{
+			title: "Disordered Ips in Alibaba's application management system",
+			targetGroup: map[string][]*targetgroup.Group{
+				"buy": {
+					{
+						Source: "alibaba",
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: "192.168.1.22",
+							},
+							{
+								model.AddressLabel: "192.168.1.33",
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("__meta_test_label"): model.LabelValue("label_test_1"),
+						},
+					},
+				},
+				"cart": {
+					{
+						Source: "alibaba",
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: "192.168.1.44",
+							},
+							{
+								model.AddressLabel: "192.168.1.55",
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("__meta_test_label"): model.LabelValue("label_test_1"),
+						},
+					},
+				},
+			},
+			expectedCustomSD: map[string]*customSD{
+				"buy:alibaba:21c0d97a1e27e6fe": {
+					Targets: []string{
+						"192.168.1.22",
+						"192.168.1.33",
+					},
+					Labels: map[string]string{
+						"__meta_test_label": "label_test_1",
+					},
+				},
+				"cart:alibaba:1112e97a13b159fa": {
+					Targets: []string{
+						"192.168.1.55",
+						"192.168.1.44",
+					},
+					Labels: map[string]string{
+						"__meta_test_label": "label_test_1",
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
 		result := generateTargetGroups(testCase.targetGroup)
 
-		if !reflect.DeepEqual(result, testCase.expectedCustomSD) {
+		if !deepEqualDisorder(result, testCase.expectedCustomSD) {
 			t.Errorf("%q failed\ngot: %#v\nexpected: %v",
 				testCase.title,
 				result,

--- a/documentation/examples/custom-sd/adapter/adapter_test.go
+++ b/documentation/examples/custom-sd/adapter/adapter_test.go
@@ -14,6 +14,7 @@
 package adapter
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -174,10 +175,10 @@ func TestGenerateTargetGroups(t *testing.T) {
 						Source: "alibaba",
 						Targets: []model.LabelSet{
 							{
-								model.AddressLabel: "192.168.1.44",
+								model.AddressLabel: "192.168.1.55",
 							},
 							{
-								model.AddressLabel: "192.168.1.55",
+								model.AddressLabel: "192.168.1.44",
 							},
 						},
 						Labels: model.LabelSet{
@@ -198,8 +199,8 @@ func TestGenerateTargetGroups(t *testing.T) {
 				},
 				"cart:alibaba:1112e97a13b159fa": {
 					Targets: []string{
-						"192.168.1.55",
 						"192.168.1.44",
+						"192.168.1.55",
 					},
 					Labels: map[string]string{
 						"__meta_test_label": "label_test_1",
@@ -212,7 +213,7 @@ func TestGenerateTargetGroups(t *testing.T) {
 	for _, testCase := range testCases {
 		result := generateTargetGroups(testCase.targetGroup)
 
-		if !deepEqualDisorder(result, testCase.expectedCustomSD) {
+		if !reflect.DeepEqual(result, testCase.expectedCustomSD) {
 			t.Errorf("%q failed\ngot: %#v\nexpected: %v",
 				testCase.title,
 				result,


### PR DESCRIPTION
[bugfix] custom SD: when ip out of order, reflect.deepEqual can not correctly identify whether there is a change