### PR TITLE
Add ChunksIterator method to Series interface.

### DIFF
--- a/prompb/custom.go
+++ b/prompb/custom.go
@@ -1,0 +1,5 @@
+package prompb
+
+// Make sure Sample implements tsdbutil.Sample interface.
+func (m Sample) T() int64   { return m.Timestamp }
+func (m Sample) V() float64 { return m.Value }

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1115,7 +1115,7 @@ func (ev *evaluator) eval(expr parser.Expr) parser.Value {
 		for i, s := range selVS.Series {
 			points = points[:0]
 			it.Reset(s.Iterator())
-			ss := Series{
+			ss := storage.Series{
 				// For all range vector functions, the only change to the
 				// output labels is dropping the metric name so just do
 				// it once here.
@@ -1196,7 +1196,7 @@ func (ev *evaluator) eval(expr parser.Expr) parser.Value {
 			}
 
 			return Matrix{
-				Series{
+				storage.Series{
 					Metric: createLabelsForAbsentFunction(e.Args[0]),
 					Points: newp,
 				},
@@ -1275,8 +1275,8 @@ func (ev *evaluator) eval(expr parser.Expr) parser.Value {
 		mat := make(Matrix, 0, len(e.Series))
 		it := storage.NewBuffer(durationMilliseconds(ev.lookbackDelta))
 		for i, s := range e.Series {
-			it.Reset(s.Iterator())
-			ss := Series{
+			it.Reset(s.SampleIterator())
+			ss := storage.Series{
 				Metric: e.Series[i].Labels(),
 				Points: getPointSlice(numSteps),
 			}
@@ -1440,7 +1440,7 @@ func (ev *evaluator) matrixSelector(node *parser.MatrixSelector) Matrix {
 			ev.error(err)
 		}
 		it.Reset(s.Iterator())
-		ss := Series{
+		ss := storage.Series{
 			Metric: series[i].Labels(),
 		}
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -783,7 +783,7 @@ load 10s
 			MaxSamples: 3,
 			Result: Result{
 				nil,
-				Matrix{Series{
+				Matrix{storage.Series{
 					Points: []Point{{V: 1, T: 0}, {V: 1, T: 5000}, {V: 2, T: 10000}},
 					Metric: labels.FromStrings("__name__", "metric")},
 				},

--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -136,6 +136,14 @@ type sample struct {
 	v float64
 }
 
+func (s sample) T() int64 {
+	return s.t
+}
+
+func (s sample) V() float64 {
+	return s.v
+}
+
 type sampleRing struct {
 	delta int64
 

--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -15,11 +15,9 @@ package storage
 
 import (
 	"math/rand"
-	"sort"
 	"testing"
 
-	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -107,15 +105,15 @@ func TestBufferedSeriesIterator(t *testing.T) {
 		testutil.Equals(t, ev, v, "value mismatch")
 	}
 
-	it = NewBufferIterator(newListSeriesIterator([]sample{
-		{t: 1, v: 2},
-		{t: 2, v: 3},
-		{t: 3, v: 4},
-		{t: 4, v: 5},
-		{t: 5, v: 6},
-		{t: 99, v: 8},
-		{t: 100, v: 9},
-		{t: 101, v: 10},
+	it = NewBufferIterator(NewSampleIterator(tsdbutil.SampleSlice{
+		sample{t: 1, v: 2},
+		sample{t: 2, v: 3},
+		sample{t: 3, v: 4},
+		sample{t: 4, v: 5},
+		sample{t: 5, v: 6},
+		sample{t: 99, v: 8},
+		sample{t: 100, v: 9},
+		sample{t: 101, v: 10},
 	}), 2)
 
 	testutil.Assert(t, it.Seek(-123), "seek failed")
@@ -147,7 +145,7 @@ func TestBufferedSeriesIterator(t *testing.T) {
 func TestBufferedSeriesIteratorNoBadAt(t *testing.T) {
 	done := false
 
-	m := &mockSeriesIterator{
+	m := &mockSampleIterator{
 		seek: func(int64) bool { return false },
 		at: func() (int64, float64) {
 			testutil.Assert(t, !done, "unexpectedly done")
@@ -177,97 +175,40 @@ func BenchmarkBufferedSeriesIterator(b *testing.B) {
 	testutil.Ok(b, it.Err())
 }
 
-type mockSeriesIterator struct {
+type mockSampleIterator struct {
 	seek func(int64) bool
 	at   func() (int64, float64)
 	next func() bool
 	err  func() error
 }
 
-func (m *mockSeriesIterator) Seek(t int64) bool    { return m.seek(t) }
-func (m *mockSeriesIterator) At() (int64, float64) { return m.at() }
-func (m *mockSeriesIterator) Next() bool           { return m.next() }
-func (m *mockSeriesIterator) Err() error           { return m.err() }
+func (m *mockSampleIterator) Seek(t int64) bool    { return m.seek(t) }
+func (m *mockSampleIterator) At() (int64, float64) { return m.at() }
+func (m *mockSampleIterator) Next() bool           { return m.next() }
+func (m *mockSampleIterator) Err() error           { return m.err() }
 
-type mockSeries struct {
-	labels   func() labels.Labels
-	iterator func() chunkenc.Iterator
-}
-
-func newMockSeries(lset labels.Labels, samples []sample) Series {
-	return &mockSeries{
-		labels: func() labels.Labels {
-			return lset
-		},
-		iterator: func() chunkenc.Iterator {
-			return newListSeriesIterator(samples)
-		},
-	}
-}
-
-func (m *mockSeries) Labels() labels.Labels       { return m.labels() }
-func (m *mockSeries) Iterator() chunkenc.Iterator { return m.iterator() }
-
-type listSeriesIterator struct {
-	list []sample
-	idx  int
-}
-
-func newListSeriesIterator(list []sample) *listSeriesIterator {
-	return &listSeriesIterator{list: list, idx: -1}
-}
-
-func (it *listSeriesIterator) At() (int64, float64) {
-	s := it.list[it.idx]
-	return s.t, s.v
-}
-
-func (it *listSeriesIterator) Next() bool {
-	it.idx++
-	return it.idx < len(it.list)
-}
-
-func (it *listSeriesIterator) Seek(t int64) bool {
-	if it.idx == -1 {
-		it.idx = 0
-	}
-	// Do binary search between current position and end.
-	it.idx = sort.Search(len(it.list)-it.idx, func(i int) bool {
-		s := it.list[i+it.idx]
-		return s.t >= t
-	})
-
-	return it.idx < len(it.list)
-}
-
-func (it *listSeriesIterator) Err() error {
-	return nil
-}
-
-type fakeSeriesIterator struct {
+type fakeSampleIterator struct {
 	nsamples int64
 	step     int64
 	idx      int64
 }
 
-func newFakeSeriesIterator(nsamples, step int64) *fakeSeriesIterator {
-	return &fakeSeriesIterator{nsamples: nsamples, step: step, idx: -1}
+func newFakeSeriesIterator(nsamples, step int64) *fakeSampleIterator {
+	return &fakeSampleIterator{nsamples: nsamples, step: step, idx: -1}
 }
 
-func (it *fakeSeriesIterator) At() (int64, float64) {
+func (it *fakeSampleIterator) At() (int64, float64) {
 	return it.idx * it.step, 123 // value doesn't matter
 }
 
-func (it *fakeSeriesIterator) Next() bool {
+func (it *fakeSampleIterator) Next() bool {
 	it.idx++
 	return it.idx < it.nsamples
 }
 
-func (it *fakeSeriesIterator) Seek(t int64) bool {
+func (it *fakeSampleIterator) Seek(t int64) bool {
 	it.idx = t / it.step
 	return it.idx < it.nsamples
 }
 
-func (it *fakeSeriesIterator) Err() error {
-	return nil
-}
+func (it *fakeSampleIterator) Err() error { return nil }

--- a/storage/generic.go
+++ b/storage/generic.go
@@ -1,0 +1,88 @@
+package storage
+
+import "github.com/prometheus/prometheus/pkg/labels"
+
+// Boilerplate on purpose. Generics some day...
+
+type genericQuerierAdapter struct {
+	baseQuerier
+
+	// Union.
+	q  Querier
+	cq ChunkedQuerier
+}
+
+func (q *genericQuerierAdapter) Select(params *SelectParams, matchers ...*labels.Matcher) (genericSeriesSet, Warnings, error) {
+	if q.q != nil {
+		s, w, err := q.q.Select(params, matchers...)
+		return s.(genericSeriesSet), w, err
+	}
+	s, w, err := q.cq.Select(params, matchers...)
+	return s.(genericSeriesSet), w, err
+}
+func (q *genericQuerierAdapter) SelectSorted(params *SelectParams, matchers ...*labels.Matcher) (genericSeriesSet, Warnings, error) {
+	if q.q != nil {
+		s, w, err := q.q.SelectSorted(params, matchers...)
+		return s.(genericSeriesSet), w, err
+	}
+	s, w, err := q.cq.SelectSorted(params, matchers...)
+	return s.(genericSeriesSet), w, err
+}
+
+func newGenericQuerierFrom(q Querier) genericQuerier {
+	return &genericQuerierAdapter{baseQuerier: q, q: q}
+}
+
+func newGenericQuerierFromChunked(cq ChunkedQuerier) genericQuerier {
+	return &genericQuerierAdapter{baseQuerier: cq, cq: cq}
+}
+
+type genericQuerier interface {
+	baseQuerier
+	Select(*SelectParams, ...*labels.Matcher) (genericSeriesSet, Warnings, error)
+	SelectSorted(*SelectParams, ...*labels.Matcher) (genericSeriesSet, Warnings, error)
+}
+
+type genericSeriesSet interface {
+	Next() bool
+	At() Labeled
+	Err() error
+}
+
+type querierAdapter struct {
+	genericQuerier
+}
+
+func (q *querierAdapter) Select(params *SelectParams, matchers ...*labels.Matcher) (SeriesSet, Warnings, error) {
+	s, w, err := q.Select(params, matchers...)
+	return s.(SeriesSet), w, err
+}
+func (q *querierAdapter) SelectSorted(params *SelectParams, matchers ...*labels.Matcher) (SeriesSet, Warnings, error) {
+	s, w, err := q.SelectSorted(params, matchers...)
+	return s.(SeriesSet), w, err
+}
+
+type chunkedQuerierAdapter struct {
+	genericQuerier
+}
+
+func (q *chunkedQuerierAdapter) Select(params *SelectParams, matchers ...*labels.Matcher) (ChunkedSeriesSet, Warnings, error) {
+	s, w, err := q.Select(params, matchers...)
+	return s.(ChunkedSeriesSet), w, err
+}
+func (q *chunkedQuerierAdapter) SelectSorted(params *SelectParams, matchers ...*labels.Matcher) (ChunkedSeriesSet, Warnings, error) {
+	s, w, err := q.SelectSorted(params, matchers...)
+	return s.(ChunkedSeriesSet), w, err
+}
+
+type genericSeriesMerger interface {
+	NewMergedSeries(...Labeled) Labeled
+}
+
+func newGenericSeriesMergerFrom(q SeriesMerger) genericSeriesMerger {
+
+}
+
+func newGenericSeriesMergerFromChunked(q ChunkedSeriesMerger) genericSeriesMerger {
+
+}

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -32,7 +32,7 @@ func (noopQuerier) SelectSorted(*SelectParams, ...*labels.Matcher) (SeriesSet, W
 	return NoopSeriesSet(), nil, nil
 }
 
-func (noopQuerier) LabelValues(name string) ([]string, Warnings, error) {
+func (noopQuerier) LabelValues(string) ([]string, Warnings, error) {
 	return nil, nil, nil
 }
 
@@ -41,6 +41,33 @@ func (noopQuerier) LabelNames() ([]string, Warnings, error) {
 }
 
 func (noopQuerier) Close() error {
+	return nil
+}
+
+type noopChunkedQuerier struct{}
+
+// NoopChunkedQuerier is a ChunkedQuerier that does nothing.
+func NoopChunkedQuerier() ChunkedQuerier {
+	return noopChunkedQuerier{}
+}
+
+func (noopChunkedQuerier) Select(*SelectParams, ...*labels.Matcher) (ChunkedSeriesSet, Warnings, error) {
+	return NoopChunkedSeriesSet(), nil, nil
+}
+
+func (noopChunkedQuerier) SelectSorted(*SelectParams, ...*labels.Matcher) (ChunkedSeriesSet, Warnings, error) {
+	return NoopChunkedSeriesSet(), nil, nil
+}
+
+func (noopChunkedQuerier) LabelValues(string) ([]string, Warnings, error) {
+	return nil, nil, nil
+}
+
+func (noopChunkedQuerier) LabelNames() ([]string, Warnings, error) {
+	return nil, nil, nil
+}
+
+func (noopChunkedQuerier) Close() error {
 	return nil
 }
 
@@ -56,3 +83,16 @@ func (noopSeriesSet) Next() bool { return false }
 func (noopSeriesSet) At() Series { return nil }
 
 func (noopSeriesSet) Err() error { return nil }
+
+type noopChunkedSeriesSet struct{}
+
+// NoopChunkedSeriesSet is a ChunkedSeriesSet that does nothing.
+func NoopChunkedSeriesSet() ChunkedSeriesSet {
+	return noopChunkedSeriesSet{}
+}
+
+func (noopChunkedSeriesSet) Next() bool { return false }
+
+func (noopChunkedSeriesSet) At() ChunkedSeries { return nil }
+
+func (noopChunkedSeriesSet) Err() error { return nil }

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 )
 
 // decodeReadLimit is the maximum size of a read request body in bytes.
@@ -112,7 +113,7 @@ func ToQueryResult(ss storage.SeriesSet, sampleLimit int) (*prompb.QueryResult, 
 	resp := &prompb.QueryResult{}
 	for ss.Next() {
 		series := ss.At()
-		iter := series.Iterator()
+		iter := series.SampleIterator()
 		samples := []prompb.Sample{}
 
 		for iter.Next() {
@@ -144,6 +145,12 @@ func ToQueryResult(ss storage.SeriesSet, sampleLimit int) (*prompb.QueryResult, 
 	return resp, nil
 }
 
+type Samples []prompb.Sample
+
+func (s Samples) Get(i int) tsdbutil.Sample { return s[i] }
+
+func (s Samples) Len() int { return len(s) }
+
 // FromQueryResult unpacks and sorts a QueryResult proto.
 func FromQueryResult(res *prompb.QueryResult) storage.SeriesSet {
 	series := make([]storage.Series, 0, len(res.Timeseries))
@@ -153,10 +160,7 @@ func FromQueryResult(res *prompb.QueryResult) storage.SeriesSet {
 			return errSeriesSet{err: err}
 		}
 
-		series = append(series, &concreteSeries{
-			labels:  labels,
-			samples: ts.Samples,
-		})
+		series = append(series, storage.NewSeriesFromSamples(labels, Samples(ts.Samples)))
 	}
 	sort.Sort(byLabel(series))
 	return &concreteSeriesSet{
@@ -185,8 +189,83 @@ func NegotiateResponseType(accepted []prompb.ReadRequest_ResponseType) (prompb.R
 }
 
 // StreamChunkedReadResponses iterates over series, builds chunks and streams those to the caller.
-// TODO(bwplotka): Encode only what's needed. Fetch the encoded series from blocks instead of re-encoding everything.
+// It expects Series set with populated chunks.
 func StreamChunkedReadResponses(
+	stream io.Writer,
+	queryIndex int64,
+	ss storage.SeriesSet,
+	sortedExternalLabels []prompb.Label,
+	maxBytesInFrame int,
+) error {
+	var (
+		chks []prompb.Chunk
+		lbls []prompb.Label
+	)
+
+	for ss.Next() {
+		series := ss.At()
+		iter := series.ChunkIterator()
+		lbls = MergeLabels(labelsToLabelsProto(series.Labels(), lbls), sortedExternalLabels)
+
+		frameBytesLeft := maxBytesInFrame
+		for _, lbl := range lbls {
+			frameBytesLeft -= lbl.Size()
+		}
+
+		isNext := iter.Next()
+
+		// Send at most one series per frame; series may be split over multiple frames according to maxBytesInFrame.
+		for isNext {
+			chk := iter.At()
+
+			if chk.Chunk == nil {
+				return errors.Errorf("StreamChunkedReadResponses: found not populated chunk returned by SeriesSet at ref: %v", chk.Ref)
+			}
+
+			// Cut the chunk.
+			chks = append(chks, prompb.Chunk{
+				MinTimeMs: chk.MinTime,
+				MaxTimeMs: chk.MaxTime,
+				Type:      prompb.Chunk_Encoding(chk.Chunk.Encoding()),
+				Data:      chk.Chunk.Bytes(),
+			})
+			frameBytesLeft -= chks[len(chks)-1].Size()
+
+			// We are fine with minor inaccuracy of max bytes per frame. The inaccuracy will be max of full chunk size.
+			isNext = iter.Next()
+			if frameBytesLeft > 0 && isNext {
+				continue
+			}
+
+			b, err := proto.Marshal(&prompb.ChunkedReadResponse{
+				ChunkedSeries: []*prompb.ChunkedSeries{
+					{Labels: lbls, Chunks: chks},
+				},
+				QueryIndex: queryIndex,
+			})
+			if err != nil {
+				return errors.Wrap(err, "marshal ChunkedReadResponse")
+			}
+
+			if _, err := stream.Write(b); err != nil {
+				return errors.Wrap(err, "write to stream")
+			}
+
+			chks = chks[:0]
+		}
+		if err := iter.Err(); err != nil {
+			return err
+		}
+	}
+	if err := ss.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TODO(bwplotka): Delete. For benchmarking purposes only.
+func StreamChunkedReadResponsesOLD(
 	stream io.Writer,
 	queryIndex int64,
 	ss storage.SeriesSet,
@@ -202,7 +281,7 @@ func StreamChunkedReadResponses(
 
 	for ss.Next() {
 		series := ss.At()
-		iter := series.Iterator()
+		iter := series.SampleIterator()
 		lbls = MergeLabels(labelsToLabelsProto(series.Labels(), lbls), sortedExternalLabels)
 
 		lblsSize = 0
@@ -378,58 +457,6 @@ func (c *concreteSeriesSet) At() storage.Series {
 }
 
 func (c *concreteSeriesSet) Err() error {
-	return nil
-}
-
-// concreteSeries implements storage.Series.
-type concreteSeries struct {
-	labels  labels.Labels
-	samples []prompb.Sample
-}
-
-func (c *concreteSeries) Labels() labels.Labels {
-	return labels.New(c.labels...)
-}
-
-func (c *concreteSeries) Iterator() chunkenc.Iterator {
-	return newConcreteSeriersIterator(c)
-}
-
-// concreteSeriesIterator implements storage.SeriesIterator.
-type concreteSeriesIterator struct {
-	cur    int
-	series *concreteSeries
-}
-
-func newConcreteSeriersIterator(series *concreteSeries) chunkenc.Iterator {
-	return &concreteSeriesIterator{
-		cur:    -1,
-		series: series,
-	}
-}
-
-// Seek implements storage.SeriesIterator.
-func (c *concreteSeriesIterator) Seek(t int64) bool {
-	c.cur = sort.Search(len(c.series.samples), func(n int) bool {
-		return c.series.samples[n].Timestamp >= t
-	})
-	return c.cur < len(c.series.samples)
-}
-
-// At implements storage.SeriesIterator.
-func (c *concreteSeriesIterator) At() (t int64, v float64) {
-	s := c.series.samples[c.cur]
-	return s.Timestamp, s.Value
-}
-
-// Next implements storage.SeriesIterator.
-func (c *concreteSeriesIterator) Next() bool {
-	c.cur++
-	return c.cur < len(c.series.samples)
-}
-
-// Err implements storage.SeriesIterator.
-func (c *concreteSeriesIterator) Err() error {
 	return nil
 }
 

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/prompb"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -121,44 +120,6 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestConcreteSeriesSet(t *testing.T) {
-	series1 := &concreteSeries{
-		labels:  labels.FromStrings("foo", "bar"),
-		samples: []prompb.Sample{{Value: 1, Timestamp: 2}},
-	}
-	series2 := &concreteSeries{
-		labels:  labels.FromStrings("foo", "baz"),
-		samples: []prompb.Sample{{Value: 3, Timestamp: 4}},
-	}
-	c := &concreteSeriesSet{
-		series: []storage.Series{series1, series2},
-	}
-	testutil.Assert(t, c.Next(), "Expected Next() to be true.")
-	testutil.Equals(t, series1, c.At(), "Unexpected series returned.")
-	testutil.Assert(t, c.Next(), "Expected Next() to be true.")
-	testutil.Equals(t, series2, c.At(), "Unexpected series returned.")
-	testutil.Assert(t, !c.Next(), "Expected Next() to be false.")
-}
-
-func TestConcreteSeriesClonesLabels(t *testing.T) {
-	lbls := labels.Labels{
-		labels.Label{Name: "a", Value: "b"},
-		labels.Label{Name: "c", Value: "d"},
-	}
-	cs := concreteSeries{
-		labels: labels.New(lbls...),
-	}
-
-	gotLabels := cs.Labels()
-	testutil.Equals(t, lbls, gotLabels)
-
-	gotLabels[0].Value = "foo"
-	gotLabels[1].Value = "bar"
-
-	gotLabels = cs.Labels()
-	testutil.Equals(t, lbls, gotLabels)
 }
 
 func TestFromQueryResultWithDuplicates(t *testing.T) {

--- a/storage/series.go
+++ b/storage/series.go
@@ -1,0 +1,182 @@
+package storage
+
+import (
+	"math"
+	"sort"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
+)
+
+type ConcreteSeries struct {
+	labels           labels.Labels
+	SampleIteratorFn func() chunkenc.Iterator
+	ChunkIteratorFn  func() chunks.Iterator
+}
+
+func NewTestSeries(lset labels.Labels, samples ...[]tsdbutil.Sample) Series {
+	var chks []chunks.Meta
+
+	return &ConcreteSeries{
+		labels: lset,
+		SampleIteratorFn: func() chunkenc.Iterator {
+			var list tsdbutil.SampleSlice
+			for _, l := range samples {
+				list = append(list, l...)
+			}
+			return NewSampleIterator(list)
+		},
+		ChunkIteratorFn: func() chunks.Iterator {
+			// Inefficient chunks encoding implementation, not caring about chunk size.
+			for _, s := range samples {
+				chks = append(chks, tsdbutil.ChunkFromSamples(s))
+			}
+			return NewChunksIterator(chks...)
+		},
+	}
+}
+
+func NewSeriesFromSamples(lset labels.Labels, samples tsdbutil.Samples) Series {
+	return &ConcreteSeries{
+		labels: lset,
+		SampleIteratorFn: func() chunkenc.Iterator {
+			return NewSampleIterator(samples)
+		},
+		ChunkIteratorFn: func() chunks.Iterator {
+			// Inefficient chunks encoding implementation, not caring about chunk size.
+			return NewChunksIterator(tsdbutil.ChunkFromSamplesGeneric(samples))
+		},
+	}
+}
+
+func (s *ConcreteSeries) Labels() labels.Labels             { return s.labels }
+func (s *ConcreteSeries) SampleIterator() chunkenc.Iterator { return s.SampleIteratorFn() }
+func (s *ConcreteSeries) ChunkIterator() chunks.Iterator    { return s.ChunkIteratorFn() }
+
+type SampleSeriesIterator struct {
+	samples tsdbutil.Samples
+	idx     int
+}
+
+func NewSampleIterator(samples tsdbutil.Samples) chunkenc.Iterator {
+	return &SampleSeriesIterator{samples: samples, idx: -1}
+}
+
+func (it *SampleSeriesIterator) At() (int64, float64) {
+	s := it.samples.Get(it.idx)
+	return s.T(), s.V()
+}
+
+func (it *SampleSeriesIterator) Next() bool {
+	it.idx++
+	return it.idx < it.samples.Len()
+}
+
+func (it *SampleSeriesIterator) Seek(t int64) bool {
+	if it.idx == -1 {
+		it.idx = 0
+	}
+	// Do binary search between current position and end.
+	it.idx = sort.Search(it.samples.Len()-it.idx, func(i int) bool {
+		s := it.samples.Get(i + it.idx)
+		return s.T() >= t
+	})
+
+	return it.idx < it.samples.Len()
+}
+
+func (it *SampleSeriesIterator) Err() error { return nil }
+
+//func (it *ChunkSeriesIterator) Seek(t int64) bool {
+//	if it.idx == -1 {
+//		it.idx = 0
+//	}
+//	// Do binary search between current position and end.
+//	it.idx = sort.Search(len(it.samples)-it.idx, func(i int) bool {
+//		s := it.samples[i+it.idx]
+//		return s.t >= t
+//	})
+//
+//	return it.idx < len(it.samples)
+//}
+
+type ChunkReader interface {
+	Chunk(ref uint64) (chunkenc.Chunk, error)
+}
+
+type ChunkSeriesIterator struct {
+	chks []chunks.Meta
+
+	idx int
+}
+
+func NewPopulatedChunksIterator(chks ...chunks.Meta) chunks.Iterator {
+	return &ChunkSeriesIterator{chks: chks, idx: -1}
+}
+
+func (it *ChunkSeriesIterator) At() chunks.Meta {
+	return it.chks[it.idx]
+}
+
+func (it *ChunkSeriesIterator) Next() bool {
+	it.idx++
+	return it.idx < len(it.chks)
+}
+
+func (it *ChunkSeriesIterator) Err() error { return nil }
+
+func NewSeriesFromNotPopulatedChunks(lset labels.Labels, chks ...chunks.Meta) Series {
+	return &ConcreteSeries{
+		labels: lset,
+		SampleIteratorFn: func() chunkenc.Iterator {
+			panic("todo")
+		},
+		ChunkIteratorFn: func() chunks.Iterator {
+			// Inefficient chunks encoding implementation, not caring about chunk size.
+			return NewChunksIterator(tsdbutil.ChunkFromSamplesGeneric(samples))
+		},
+	}
+}
+
+//type ChunkSeriesIterator struct {
+//	chks []chunks.Meta
+//	idx  int
+//}
+//
+//func NewChunksIterator(chks ...chunks.Meta) chunks.Iterator {
+//	return &ChunkSeriesIterator{chks: chks, idx: -1}
+//}
+//
+//func (it *ChunkSeriesIterator) At() chunks.Meta {
+//	return it.chks[it.idx]
+//}
+//
+//func (it *ChunkSeriesIterator) Next() bool {
+//	it.idx++
+//	return it.idx < len(it.chks)
+//}
+//
+//func (it *ChunkSeriesIterator) Err() error { return nil }
+
+func ExpandSamples(iter chunkenc.Iterator) ([]tsdbutil.Sample, error) {
+	var result []tsdbutil.Sample
+	for iter.Next() {
+		t, v := iter.At()
+		// NaNs can't be compared normally, so substitute for another value.
+		if math.IsNaN(v) {
+			v = -42
+		}
+		result = append(result, sample{t, v})
+	}
+	return result, iter.Err()
+}
+
+func ExpandChunks(iter chunks.Iterator) ([]chunks.Meta, error) {
+	var result []chunks.Meta
+	for iter.Next() {
+		result = append(result, iter.At())
+	}
+	return result, iter.Err()
+}

--- a/storage/series_test.go
+++ b/storage/series_test.go
@@ -1,0 +1,3 @@
+package storage
+
+// TODO

--- a/tsdb/chunkenc/chunk_test.go
+++ b/tsdb/chunkenc/chunk_test.go
@@ -111,10 +111,10 @@ func testChunk(t *testing.T, c Chunk) {
 
 func benchmarkIterator(b *testing.B, newChunk func() Chunk) {
 	var (
-		t = int64(1234123324)
-		v = 1243535.123
+		t   = int64(1234123324)
+		v   = 1243535.123
+		exp []pair
 	)
-	var exp []pair
 	for i := 0; i < b.N; i++ {
 		// t += int64(rand.Intn(10000) + 1)
 		t += int64(1000)
@@ -146,7 +146,7 @@ func benchmarkIterator(b *testing.B, newChunk func() Chunk) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	fmt.Println("num", b.N, "created chunks", len(chunks))
+	b.Log("num", b.N, "created chunks", len(chunks))
 
 	res := make([]float64, 0, 1024)
 

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -127,6 +127,7 @@ func (c *XORChunk) iterator(it Iterator) *xorIterator {
 		// We skip that for actual samples.
 		br:       newBReader(c.b.bytes()[2:]),
 		numTotal: binary.BigEndian.Uint16(c.b.bytes()),
+		t:        math.MinInt64,
 	}
 }
 

--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -67,6 +67,20 @@ type Meta struct {
 	MinTime, MaxTime int64
 }
 
+// Iterator iterates over the chunk of a time series.
+type Iterator interface {
+	//// Seek advances the iterator forward to the given timestamp.
+	//// It advances to the chunk with min time at t or first chunk with min time after t.
+	//Seek(t int64) bool
+	// At returns the current meta.
+	// It depends on implementation if the chunk is populated or not.
+	At() Meta
+	// Next advances the iterator by one.
+	Next() bool
+	// Err returns optional error if Next is false.
+	Err() error
+}
+
 // writeHash writes the chunk encoding and raw data into the provided hash.
 func (cm *Meta) writeHash(h hash.Hash, buf []byte) error {
 	buf = append(buf[:0], byte(cm.Chunk.Encoding()))

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -648,7 +648,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 	}
 
 	var (
-		set         storage.ChunkSeriesSet
+		sets        []storage.SeriesSet
 		symbols     index.StringIter
 		closers     = []io.Closer{}
 		overlapping bool
@@ -706,18 +706,14 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		}
 		all = indexr.SortedPostings(all)
 
-		s := newCompactionSeriesSet(indexr, chunkr, tombsr, all)
+		s := newBlockSeriesSet(indexr, chunkr, tombsr, all)
 		syms := indexr.Symbols()
 
 		if i == 0 {
-			set = s
 			symbols = syms
 			continue
 		}
-		set, err = newCompactionMerger(set, s)
-		if err != nil {
-			return err
-		}
+		sets = append(sets, s)
 		symbols = newMergedStringIter(symbols, syms)
 	}
 
@@ -732,6 +728,14 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 
 	delIter := &deletedIterator{}
 	ref := uint64(0)
+
+	var set storage.SeriesSet
+	if overlapping {
+		set = storage.NewMergeSeriesSet(sets, nil)
+	} else {
+		set = storage.NewChainedMergeSeriesSet(sets, nil)
+	}
+
 	for set.Next() {
 		select {
 		case <-c.ctx.Done():
@@ -840,7 +844,9 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 	return nil
 }
 
-type compactionSeriesSet struct {
+var _ storage.SeriesSet = &blockSeriesSet{}
+
+type blockSeriesSet struct {
 	p          index.Postings
 	index      IndexReader
 	chunks     ChunkReader
@@ -852,8 +858,8 @@ type compactionSeriesSet struct {
 	err       error
 }
 
-func newCompactionSeriesSet(i IndexReader, c ChunkReader, t tombstones.Reader, p index.Postings) *compactionSeriesSet {
-	return &compactionSeriesSet{
+func newBlockSeriesSet(i IndexReader, c ChunkReader, t tombstones.Reader, p index.Postings) *blockSeriesSet {
+	return &blockSeriesSet{
 		index:      i,
 		chunks:     c,
 		tombstones: t,
@@ -861,7 +867,7 @@ func newCompactionSeriesSet(i IndexReader, c ChunkReader, t tombstones.Reader, p
 	}
 }
 
-func (c *compactionSeriesSet) Next() bool {
+func (b *blockSeriesSet) Next() bool {
 	if !c.p.Next() {
 		return false
 	}
@@ -893,6 +899,7 @@ func (c *compactionSeriesSet) Next() bool {
 	for i := range c.c {
 		chk := &c.c[i]
 
+		// Populate only later on.
 		chk.Chunk, err = c.chunks.Chunk(chk.Ref)
 		if err != nil {
 			c.err = errors.Wrapf(err, "chunk %d not found", chk.Ref)
@@ -903,102 +910,23 @@ func (c *compactionSeriesSet) Next() bool {
 	return true
 }
 
-func (c *compactionSeriesSet) Err() error {
-	if c.err != nil {
-		return c.err
+func (b *blockSeriesSet) Err() error {
+	if b.err != nil {
+		return b.err
 	}
-	return c.p.Err()
+	return b.p.Err()
 }
 
-func (c *compactionSeriesSet) At() (labels.Labels, []chunks.Meta, tombstones.Intervals) {
-	return c.l, c.c, c.intervals
+func (b *blockSeriesSet) At() storage.Series {
+	return c.l, c.c, c.intervals // TODO
 }
 
-type compactionMerger struct {
-	a, b storage.ChunkSeriesSet
+type verticalSeriesMerger struct{}
 
-	aok, bok  bool
-	l         labels.Labels
-	c         []chunks.Meta
-	intervals tombstones.Intervals
-}
-
-func newCompactionMerger(a, b storage.ChunkSeriesSet) (*compactionMerger, error) {
-	c := &compactionMerger{
-		a: a,
-		b: b,
+func (m *verticalSeriesMerger) NewMergedSeries(labels labels.Labels, s ...Series) Series {
+	return &verticalChainedSeries{
+		series: s,
 	}
-	// Initialize first elements of both sets as Next() needs
-	// one element look-ahead.
-	c.aok = c.a.Next()
-	c.bok = c.b.Next()
-
-	return c, c.Err()
-}
-
-func (c *compactionMerger) compare() int {
-	if !c.aok {
-		return 1
-	}
-	if !c.bok {
-		return -1
-	}
-	a, _, _ := c.a.At()
-	b, _, _ := c.b.At()
-	return labels.Compare(a, b)
-}
-
-func (c *compactionMerger) Next() bool {
-	if !c.aok && !c.bok || c.Err() != nil {
-		return false
-	}
-	// While advancing child iterators the memory used for labels and chunks
-	// may be reused. When picking a series we have to store the result.
-	var lset labels.Labels
-	var chks []chunks.Meta
-
-	d := c.compare()
-	if d > 0 {
-		lset, chks, c.intervals = c.b.At()
-		c.l = append(c.l[:0], lset...)
-		c.c = append(c.c[:0], chks...)
-
-		c.bok = c.b.Next()
-	} else if d < 0 {
-		lset, chks, c.intervals = c.a.At()
-		c.l = append(c.l[:0], lset...)
-		c.c = append(c.c[:0], chks...)
-
-		c.aok = c.a.Next()
-	} else {
-		// Both sets contain the current series. Chain them into a single one.
-		l, ca, ra := c.a.At()
-		_, cb, rb := c.b.At()
-
-		for _, r := range rb {
-			ra = ra.Add(r)
-		}
-
-		c.l = append(c.l[:0], l...)
-		c.c = append(append(c.c[:0], ca...), cb...)
-		c.intervals = ra
-
-		c.aok = c.a.Next()
-		c.bok = c.b.Next()
-	}
-
-	return true
-}
-
-func (c *compactionMerger) Err() error {
-	if c.a.Err() != nil {
-		return c.a.Err()
-	}
-	return c.b.Err()
-}
-
-func (c *compactionMerger) At() (labels.Labels, []chunks.Meta, tombstones.Intervals) {
-	return c.l, c.c, c.intervals
 }
 
 func newMergedStringIter(a index.StringIter, b index.StringIter) index.StringIter {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -80,7 +80,7 @@ func query(t testing.TB, q storage.Querier, matchers ...*labels.Matcher) map[str
 		series := ss.At()
 
 		samples := []tsdbutil.Sample{}
-		it := series.Iterator()
+		it := series.SampleIterator()
 		for it.Next() {
 			t, v := it.At()
 			samples = append(samples, sample{t: t, v: v})

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -804,7 +804,7 @@ func TestDelete_e2e(t *testing.T) {
 				smpls = deletedSamples(smpls, del.drange)
 				// Only append those series for which samples exist as mockSeriesSet
 				// doesn't skip series with no samples.
-				// TODO: But sometimes SeriesSet returns an empty SeriesIterator
+				// TODO: But sometimes SeriesSet returns an empty chunkenc.Iterator
 				if len(smpls) > 0 {
 					matchedSeries = append(matchedSeries, newSeries(
 						m.Map(),

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -191,6 +191,13 @@ func expandSeriesIterator(it chunkenc.Iterator) (r []tsdbutil.Sample, err error)
 	return r, it.Err()
 }
 
+func expandChunkIterator(it ChunkIterator) (chks []chunks.Meta, err error) {
+	for it.Next() {
+		chks = append(chks, it.At())
+	}
+	return chks, it.Err()
+}
+
 type seriesSamples struct {
 	lset   map[string]string
 	chunks [][]sample
@@ -657,62 +664,65 @@ func TestBaseChunkSeries(t *testing.T) {
 	}
 }
 
-type itSeries struct {
-	si chunkenc.Iterator
+type iteratorCase struct {
+	a, b, c, expected []tsdbutil.Sample
+
+	// Only relevant for some iterators that filters by min and max time.
+	mint, maxt int64
+
+	// Seek being zero means do not test seek.
+	seek        int64
+	seekSuccess bool
 }
 
-func (s itSeries) Iterator() chunkenc.Iterator { return s.si }
-func (s itSeries) Labels() labels.Labels       { return labels.Labels{} }
+func (tc iteratorCase) test(t *testing.T, it chunkenc.Iterator) {
+	tv, v := it.At()
+	testutil.Equals(t, int64(math.MinInt64), tv)
+	testutil.Equals(t, float64(0), v)
 
-func TestSeriesIterator(t *testing.T) {
-	itcases := []struct {
-		a, b, c []tsdbutil.Sample
-		exp     []tsdbutil.Sample
+	var r []tsdbutil.Sample
+	if tc.seek != 0 {
+		testutil.Equals(t, tc.seekSuccess, it.Seek(tc.seek))
+		testutil.Equals(t, tc.seekSuccess, it.Seek(tc.seek)) // Next one should be noop.
 
-		mint, maxt int64
-	}{
+		if tc.seekSuccess {
+			// After successful seek iterator is ready. Grab the value.
+			t, v := it.At()
+			r = append(r, sample{t: t, v: v})
+		}
+	}
+	expandedResult, err := expandSeriesIterator(it)
+	testutil.Ok(t, err)
+
+	r = append(r, expandedResult...)
+	testutil.Equals(t, tc.expected, r)
+}
+
+func TestSeriesIterators(t *testing.T) {
+	cases := []iteratorCase{
 		{
-			a: []tsdbutil.Sample{},
-			b: []tsdbutil.Sample{},
-			c: []tsdbutil.Sample{},
-
-			exp: []tsdbutil.Sample{},
-
+			a:    []tsdbutil.Sample{},
+			b:    []tsdbutil.Sample{},
+			c:    []tsdbutil.Sample{},
 			mint: math.MinInt64,
 			maxt: math.MaxInt64,
+
+			expected: nil,
 		},
 		{
 			a: []tsdbutil.Sample{
-				sample{1, 2},
-				sample{2, 3},
-				sample{3, 5},
-				sample{6, 1},
+				sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1},
 			},
 			b: []tsdbutil.Sample{},
 			c: []tsdbutil.Sample{
 				sample{7, 89}, sample{9, 8},
 			},
-
-			exp: []tsdbutil.Sample{
-				sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1}, sample{7, 89}, sample{9, 8},
-			},
 			mint: math.MinInt64,
 			maxt: math.MaxInt64,
-		},
-		{
-			a: []tsdbutil.Sample{},
-			b: []tsdbutil.Sample{
-				sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1},
-			},
-			c: []tsdbutil.Sample{
-				sample{7, 89}, sample{9, 8},
-			},
 
-			exp: []tsdbutil.Sample{
+			expected: []tsdbutil.Sample{
 				sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1}, sample{7, 89}, sample{9, 8},
 			},
-			mint: 2,
-			maxt: 8,
 		},
 		{
 			a: []tsdbutil.Sample{
@@ -724,32 +734,22 @@ func TestSeriesIterator(t *testing.T) {
 			c: []tsdbutil.Sample{
 				sample{10, 22}, sample{203, 3493},
 			},
+			mint: math.MinInt64,
+			maxt: math.MaxInt64,
 
-			exp: []tsdbutil.Sample{
+			expected: []tsdbutil.Sample{
 				sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1}, sample{7, 89}, sample{9, 8}, sample{10, 22}, sample{203, 3493},
 			},
-			mint: 6,
-			maxt: 10,
 		},
-	}
-
-	seekcases := []struct {
-		a, b, c []tsdbutil.Sample
-
-		seek    int64
-		success bool
-		exp     []tsdbutil.Sample
-
-		mint, maxt int64
-	}{
+		// Seek cases.
 		{
-			a: []tsdbutil.Sample{},
-			b: []tsdbutil.Sample{},
-			c: []tsdbutil.Sample{},
+			a:    []tsdbutil.Sample{},
+			b:    []tsdbutil.Sample{},
+			c:    []tsdbutil.Sample{},
+			seek: 1,
 
-			seek:    0,
-			success: false,
-			exp:     nil,
+			seekSuccess: false,
+			expected:    nil,
 		},
 		{
 			a: []tsdbutil.Sample{
@@ -759,12 +759,12 @@ func TestSeriesIterator(t *testing.T) {
 			c: []tsdbutil.Sample{
 				sample{7, 89}, sample{9, 8},
 			},
+			seek: 10,
+			mint: math.MinInt64,
+			maxt: math.MaxInt64,
 
-			seek:    10,
-			success: false,
-			exp:     nil,
-			mint:    math.MinInt64,
-			maxt:    math.MaxInt64,
+			seekSuccess: false,
+			expected:    nil,
 		},
 		{
 			a: []tsdbutil.Sample{},
@@ -774,14 +774,14 @@ func TestSeriesIterator(t *testing.T) {
 			c: []tsdbutil.Sample{
 				sample{7, 89}, sample{9, 8},
 			},
+			seek: 2,
+			mint: math.MinInt64,
+			maxt: math.MaxInt64,
 
-			seek:    2,
-			success: true,
-			exp: []tsdbutil.Sample{
+			seekSuccess: true,
+			expected: []tsdbutil.Sample{
 				sample{3, 5}, sample{6, 1}, sample{7, 89}, sample{9, 8},
 			},
-			mint: 5,
-			maxt: 8,
 		},
 		{
 			a: []tsdbutil.Sample{
@@ -793,14 +793,14 @@ func TestSeriesIterator(t *testing.T) {
 			c: []tsdbutil.Sample{
 				sample{10, 22}, sample{203, 3493},
 			},
+			seek: 10,
+			mint: math.MinInt64,
+			maxt: math.MaxInt64,
 
-			seek:    10,
-			success: true,
-			exp: []tsdbutil.Sample{
+			seekSuccess: true,
+			expected: []tsdbutil.Sample{
 				sample{10, 22}, sample{203, 3493},
 			},
-			mint: 10,
-			maxt: 203,
 		},
 		{
 			a: []tsdbutil.Sample{
@@ -812,133 +812,169 @@ func TestSeriesIterator(t *testing.T) {
 			c: []tsdbutil.Sample{
 				sample{10, 22}, sample{203, 3493},
 			},
+			seek: 203,
+			mint: math.MinInt64,
+			maxt: math.MaxInt64,
 
-			seek:    203,
-			success: true,
-			exp: []tsdbutil.Sample{
+			seekSuccess: true,
+			expected: []tsdbutil.Sample{
 				sample{203, 3493},
 			},
-			mint: 7,
-			maxt: 203,
+		},
+		{
+			a: []tsdbutil.Sample{
+				sample{6, 1},
+			},
+			b: []tsdbutil.Sample{
+				sample{9, 8},
+			},
+			c: []tsdbutil.Sample{
+				sample{10, 22}, sample{203, 3493},
+			},
+			seek: -120,
+			mint: math.MinInt64,
+			maxt: math.MaxInt64,
+
+			seekSuccess: true,
+			expected: []tsdbutil.Sample{
+				sample{6, 1}, sample{9, 8}, sample{10, 22}, sample{203, 3493},
+			},
 		},
 	}
 
-	t.Run("Chunk", func(t *testing.T) {
-		for _, tc := range itcases {
-			chkMetas := []chunks.Meta{
-				tsdbutil.ChunkFromSamples(tc.a),
-				tsdbutil.ChunkFromSamples(tc.b),
-				tsdbutil.ChunkFromSamples(tc.c),
-			}
-			res := newChunkSeriesIterator(chkMetas, nil, tc.mint, tc.maxt)
-
-			smplValid := make([]tsdbutil.Sample, 0)
-			for _, s := range tc.exp {
-				if s.T() >= tc.mint && s.T() <= tc.maxt {
-					smplValid = append(smplValid, tsdbutil.Sample(s))
-				}
-			}
-			exp := newListSeriesIterator(smplValid)
-
-			smplExp, errExp := expandSeriesIterator(exp)
-			smplRes, errRes := expandSeriesIterator(res)
-
-			testutil.Equals(t, errExp, errRes)
-			testutil.Equals(t, smplExp, smplRes)
+	// To make sure we can properly test things, listSeriesIterator has to work properly as well, even if created
+	// for testing purposes.
+	t.Run("TestList", func(t *testing.T) {
+		for i, tc := range cases {
+			t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+				tc.test(t, newListSeriesIterator(append(append(append([]tsdbutil.Sample{}, tc.a...), tc.b...), tc.c...)))
+			})
 		}
+	})
 
-		t.Run("Seek", func(t *testing.T) {
-			extra := []struct {
-				a, b, c []tsdbutil.Sample
+	t.Run("Chunk", func(t *testing.T) {
+		// Only chunk implements time filtering, so add those cases here only.
+		limitedMinMaxtCases := []iteratorCase{
+			{
+				a:    []tsdbutil.Sample{},
+				b:    []tsdbutil.Sample{},
+				c:    []tsdbutil.Sample{},
+				mint: 20,
+				maxt: 21,
 
-				seek    int64
-				success bool
-				exp     []tsdbutil.Sample
-
-				mint, maxt int64
-			}{
-				{
-					a: []tsdbutil.Sample{
-						sample{6, 1},
-					},
-					b: []tsdbutil.Sample{
-						sample{9, 8},
-					},
-					c: []tsdbutil.Sample{
-						sample{10, 22}, sample{203, 3493},
-					},
-
-					seek:    203,
-					success: false,
-					exp:     nil,
-					mint:    2,
-					maxt:    202,
+				expected: nil,
+			},
+			{
+				a: []tsdbutil.Sample{
+					sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1},
 				},
-				{
-					a: []tsdbutil.Sample{
-						sample{6, 1},
-					},
-					b: []tsdbutil.Sample{
-						sample{9, 8},
-					},
-					c: []tsdbutil.Sample{
-						sample{10, 22}, sample{203, 3493},
-					},
-
-					seek:    5,
-					success: true,
-					exp:     []tsdbutil.Sample{sample{10, 22}},
-					mint:    10,
-					maxt:    202,
+				b: []tsdbutil.Sample{},
+				c: []tsdbutil.Sample{
+					sample{7, 89}, sample{9, 8},
 				},
-			}
+				mint: 2,
+				maxt: 8,
 
-			seekcases2 := append(seekcases, extra...)
+				expected: []tsdbutil.Sample{
+					sample{2, 3}, sample{3, 5}, sample{6, 1}, sample{7, 89},
+				},
+			},
+			{
+				a: []tsdbutil.Sample{
+					sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1},
+				},
+				b: []tsdbutil.Sample{
+					sample{7, 89}, sample{9, 8},
+				},
+				c: []tsdbutil.Sample{
+					sample{10, 22}, sample{203, 3493},
+				},
+				mint: 3,
+				maxt: math.MaxInt64,
 
-			for _, tc := range seekcases2 {
+				expected: []tsdbutil.Sample{
+					sample{3, 5}, sample{6, 1}, sample{7, 89}, sample{9, 8}, sample{10, 22}, sample{203, 3493},
+				},
+			},
+			{
+				a: []tsdbutil.Sample{
+					sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1},
+				},
+				b: []tsdbutil.Sample{
+					sample{7, 89}, sample{9, 8},
+				},
+				c: []tsdbutil.Sample{
+					sample{10, 22}, sample{203, 3493},
+				},
+				mint: 6,
+				maxt: 10,
+
+				expected: []tsdbutil.Sample{
+					sample{6, 1}, sample{7, 89}, sample{9, 8}, sample{10, 22},
+				},
+			},
+			// Same with seek.
+			{
+				a: []tsdbutil.Sample{
+					sample{6, 1},
+				},
+				b: []tsdbutil.Sample{
+					sample{9, 8},
+				},
+				c: []tsdbutil.Sample{
+					sample{10, 22}, sample{203, 3493},
+				},
+				seek: 203,
+				mint: 2,
+				maxt: 202,
+
+				seekSuccess: false,
+				expected:    nil,
+			},
+			{
+				a: []tsdbutil.Sample{
+					sample{6, 1},
+				},
+				b: []tsdbutil.Sample{
+					sample{9, 8},
+				},
+				c: []tsdbutil.Sample{
+					sample{10, 22}, sample{203, 3493},
+				},
+				seek: 5,
+				mint: 10,
+				maxt: 202,
+
+				seekSuccess: true,
+				expected:    []tsdbutil.Sample{sample{10, 22}},
+			},
+		}
+		for i, tc := range append(cases, limitedMinMaxtCases...) {
+			t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
 				chkMetas := []chunks.Meta{
 					tsdbutil.ChunkFromSamples(tc.a),
 					tsdbutil.ChunkFromSamples(tc.b),
 					tsdbutil.ChunkFromSamples(tc.c),
 				}
-				res := newChunkSeriesIterator(chkMetas, nil, tc.mint, tc.maxt)
-
-				smplValid := make([]tsdbutil.Sample, 0)
-				for _, s := range tc.exp {
-					if s.T() >= tc.mint && s.T() <= tc.maxt {
-						smplValid = append(smplValid, tsdbutil.Sample(s))
-					}
-				}
-				exp := newListSeriesIterator(smplValid)
-
-				testutil.Equals(t, tc.success, res.Seek(tc.seek))
-
-				if tc.success {
-					// Init the list and then proceed to check.
-					remaining := exp.Next()
-					testutil.Assert(t, remaining == true, "")
-
-					for remaining {
-						sExp, eExp := exp.At()
-						sRes, eRes := res.At()
-						testutil.Equals(t, eExp, eRes)
-						testutil.Equals(t, sExp, sRes)
-
-						remaining = exp.Next()
-						testutil.Equals(t, remaining, res.Next())
-					}
-				}
-			}
-		})
+				tc.test(t, newChunkSeriesIterator(chkMetas, nil, tc.mint, tc.maxt))
+			})
+		}
 	})
 
 	t.Run("Chain", func(t *testing.T) {
+		for i, tc := range cases {
+			t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+				a, b, c := itSeries{si: newListSeriesIterator(tc.a)},
+					itSeries{si: newListSeriesIterator(tc.b)},
+					itSeries{si: newListSeriesIterator(tc.c)}
+				tc.test(t, newChainedSeriesIterator(a, b, c))
+			})
+		}
+	})
+
+	t.Run("Vertical", func(t *testing.T) {
 		// Extra cases for overlapping series.
-		itcasesExtra := []struct {
-			a, b, c    []tsdbutil.Sample
-			exp        []tsdbutil.Sample
-			mint, maxt int64
-		}{
+		overlappingCases := []iteratorCase{
 			{
 				a: []tsdbutil.Sample{
 					sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1},
@@ -949,12 +985,12 @@ func TestSeriesIterator(t *testing.T) {
 				c: []tsdbutil.Sample{
 					sample{2, 33}, sample{4, 44}, sample{10, 3},
 				},
-
-				exp: []tsdbutil.Sample{
-					sample{1, 2}, sample{2, 33}, sample{3, 5}, sample{4, 44}, sample{5, 49}, sample{6, 1}, sample{7, 89}, sample{9, 8}, sample{10, 3},
-				},
 				mint: math.MinInt64,
 				maxt: math.MaxInt64,
+
+				expected: []tsdbutil.Sample{
+					sample{1, 2}, sample{2, 33}, sample{3, 5}, sample{4, 44}, sample{5, 49}, sample{6, 1}, sample{7, 89}, sample{9, 8}, sample{10, 3},
+				},
 			},
 			{
 				a: []tsdbutil.Sample{
@@ -964,83 +1000,305 @@ func TestSeriesIterator(t *testing.T) {
 				c: []tsdbutil.Sample{
 					sample{1, 23}, sample{2, 342}, sample{3, 25}, sample{6, 11},
 				},
-
-				exp: []tsdbutil.Sample{
-					sample{1, 23}, sample{2, 342}, sample{3, 25}, sample{6, 11}, sample{9, 5}, sample{13, 1},
-				},
 				mint: math.MinInt64,
 				maxt: math.MaxInt64,
+
+				expected: []tsdbutil.Sample{
+					sample{1, 23}, sample{2, 342}, sample{3, 25}, sample{6, 11}, sample{9, 5}, sample{13, 1},
+				},
 			},
 		}
-
-		for _, tc := range itcases {
-			a, b, c := itSeries{newListSeriesIterator(tc.a)},
-				itSeries{newListSeriesIterator(tc.b)},
-				itSeries{newListSeriesIterator(tc.c)}
-
-			res := newChainedSeriesIterator(a, b, c)
-			exp := newListSeriesIterator([]tsdbutil.Sample(tc.exp))
-
-			smplExp, errExp := expandSeriesIterator(exp)
-			smplRes, errRes := expandSeriesIterator(res)
-
-			testutil.Equals(t, errExp, errRes)
-			testutil.Equals(t, smplExp, smplRes)
+		for i, tc := range append(cases, overlappingCases...) {
+			t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+				a, b, c :=
+					itSeries{si: newListSeriesIterator(tc.a)},
+					itSeries{si: newListSeriesIterator(tc.b)},
+					itSeries{si: newListSeriesIterator(tc.c)}
+				tc.test(t, newVerticalMergeSeriesIterator(a, b, c))
+			})
 		}
+	})
+}
 
-		for _, tc := range append(itcases, itcasesExtra...) {
-			a, b, c := itSeries{newListSeriesIterator(tc.a)},
-				itSeries{newListSeriesIterator(tc.b)},
-				itSeries{newListSeriesIterator(tc.c)}
+type chunkIteratorCase struct {
+	a, b, c, expected []chunks.Meta
 
-			res := newVerticalMergeSeriesIterator(a, b, c)
-			exp := newListSeriesIterator([]tsdbutil.Sample(tc.exp))
+	// Seek being zero means do not test seek.
+	seek        int64
+	seekSuccess bool
+}
 
-			smplExp, errExp := expandSeriesIterator(exp)
-			smplRes, errRes := expandSeriesIterator(res)
+func (tc chunkIteratorCase) test(t *testing.T, it ChunkIterator) {
+	testutil.Equals(t, chunks.Meta{}, it.At())
+	var r []chunks.Meta
+	if tc.seek != 0 {
+		testutil.Equals(t, tc.seekSuccess, it.Seek(tc.seek))
+		testutil.Equals(t, tc.seekSuccess, it.Seek(tc.seek)) // Next one should be noop.
 
-			testutil.Equals(t, errExp, errRes)
-			testutil.Equals(t, smplExp, smplRes)
+		if tc.seekSuccess {
+			// After successful seek iterator is ready. Grab the value.
+			r = append(r, it.At())
 		}
+	}
+	expandedResult, err := expandChunkIterator(it)
+	testutil.Ok(t, err)
 
-		t.Run("Seek", func(t *testing.T) {
-			for _, tc := range seekcases {
-				ress := []chunkenc.Iterator{
-					newChainedSeriesIterator(
-						itSeries{newListSeriesIterator(tc.a)},
-						itSeries{newListSeriesIterator(tc.b)},
-						itSeries{newListSeriesIterator(tc.c)},
-					),
-					newVerticalMergeSeriesIterator(
-						itSeries{newListSeriesIterator(tc.a)},
-						itSeries{newListSeriesIterator(tc.b)},
-						itSeries{newListSeriesIterator(tc.c)},
-					),
-				}
+	r = append(r, expandedResult...)
+	testutil.Equals(t, tc.expected, r)
+}
 
-				for _, res := range ress {
-					exp := newListSeriesIterator(tc.exp)
+func TestChunkIterators(t *testing.T) {
+	cases := []chunkIteratorCase{
+		{
+			a: []chunks.Meta{},
+			b: []chunks.Meta{},
+			c: []chunks.Meta{},
 
-					testutil.Equals(t, tc.success, res.Seek(tc.seek))
+			expected: nil,
+		},
+		{
+			a: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1},
+				}),
+			},
+			b: []chunks.Meta{},
+			c: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{7, 89}, sample{9, 8},
+				}),
+			},
 
-					if tc.success {
-						// Init the list and then proceed to check.
-						remaining := exp.Next()
-						testutil.Assert(t, remaining == true, "")
+			expected: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1},
+				}),
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{7, 89}, sample{9, 8},
+				}),
+			},
+		},
+		{
+			a: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1},
+				}),
+			},
+			b: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{7, 89}, sample{9, 8},
+				}),
+			},
+			c: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{10, 22}, sample{203, 3493},
+				}),
+			},
 
-						for remaining {
-							sExp, eExp := exp.At()
-							sRes, eRes := res.At()
-							testutil.Equals(t, eExp, eRes)
-							testutil.Equals(t, sExp, sRes)
+			//		t.Run("Seek", func(t *testing.T) {
+			//			for _, tc := range seekcases {
+			//				ress := []chunkenc.Iterator{
+			//					newChainedSeriesIterator(
+			//						itSeries{newListSeriesIterator(tc.a)},
+			//						itSeries{newListSeriesIterator(tc.b)},
+			//						itSeries{newListSeriesIterator(tc.c)},
+			//					),
+			//					newVerticalMergeSeriesIterator(
+			//						itSeries{newListSeriesIterator(tc.a)},
+			//						itSeries{newListSeriesIterator(tc.b)},
+			//						itSeries{newListSeriesIterator(tc.c)},
+			//					),
+			//				}
+			//=======
+			expected: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1},
+				}),
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{7, 89}, sample{9, 8},
+				}),
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{10, 22}, sample{203, 3493},
+				}),
+			},
+		},
+		// Seek cases.
+		{
+			a:    []chunks.Meta{},
+			b:    []chunks.Meta{},
+			c:    []chunks.Meta{},
+			seek: 1,
 
-							remaining = exp.Next()
-							testutil.Equals(t, remaining, res.Next())
-						}
-					}
-				}
-			}
-		})
+			seekSuccess: false,
+			expected:    nil,
+		},
+		{
+			a: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{2, 3},
+				}),
+			},
+			b: []chunks.Meta{},
+			c: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{7, 89}, sample{9, 8},
+				}),
+			},
+			seek: 10,
+
+			seekSuccess: false,
+			expected:    nil,
+		},
+		{
+			a: []chunks.Meta{},
+			b: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{1, 2}, sample{3, 5}, sample{6, 1},
+				}),
+			},
+			c: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{7, 89}, sample{9, 8},
+				}),
+			},
+			seek: 2,
+
+			seekSuccess: true,
+			expected: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{1, 2}, sample{3, 5}, sample{6, 1},
+				}),
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{7, 89}, sample{9, 8},
+				}),
+			},
+		},
+		{
+			a: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{6, 1},
+				}),
+			},
+			b: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{9, 8},
+				}),
+			},
+			c: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{10, 22}, sample{203, 3493},
+				}),
+			},
+			seek: 10,
+
+			seekSuccess: true,
+			expected: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{10, 22}, sample{203, 3493},
+				}),
+			},
+		},
+		{
+			a: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{6, 1},
+				}),
+			},
+			b: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{9, 8},
+				}),
+			},
+			c: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{10, 22}, sample{203, 3493},
+				}),
+			},
+			seek: 203,
+
+			seekSuccess: true,
+			expected: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					sample{10, 22}, sample{203, 3493},
+				}),
+			},
+		},
+	}
+
+	t.Run("Simple", func(t *testing.T) {
+		for i, tc := range cases {
+			t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+				tc.test(t, newChunkIterator(append(append(append([]chunks.Meta{}, tc.a...), tc.b...), tc.c...)))
+			})
+		}
+	})
+
+	t.Run("Chained", func(t *testing.T) {
+		for i, tc := range cases {
+			t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+				tc.test(t, &chainedChunkIterator{chain: []ChunkIterator{
+					newChunkIterator(tc.a),
+					newChunkIterator(tc.b),
+					newChunkIterator(tc.c),
+				}})
+			})
+		}
+	})
+
+	t.Run("Vertical", func(t *testing.T) {
+		overlappingCases := []chunkIteratorCase{
+			{
+				a: []chunks.Meta{
+					tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+						sample{1, 2}, sample{2, 3}, sample{3, 5}, sample{6, 1},
+					}),
+				},
+				b: []chunks.Meta{
+					tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+						sample{5, 49}, sample{7, 89}, sample{9, 8},
+					}),
+				},
+				c: []chunks.Meta{
+					tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+						sample{2, 33}, sample{4, 44}, sample{10, 3},
+					}),
+				},
+
+				expected: []chunks.Meta{
+					tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+						sample{1, 2}, sample{2, 33}, sample{3, 5}, sample{4, 44}, sample{5, 49}, sample{6, 1}, sample{7, 89}, sample{9, 8}, sample{10, 3},
+					}),
+				},
+			},
+			{
+				a: []chunks.Meta{
+					tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+						sample{1, 2}, sample{2, 3}, sample{9, 5}, sample{13, 1},
+					}),
+				},
+				b: []chunks.Meta{},
+				c: []chunks.Meta{
+					tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+						sample{1, 23}, sample{2, 342}, sample{3, 25}, sample{6, 11},
+					}),
+				},
+
+				expected: []chunks.Meta{
+					tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+						sample{1, 23}, sample{2, 342}, sample{3, 25}, sample{6, 11}, sample{9, 5}, sample{13, 1},
+					}),
+				},
+			},
+		}
+		for i, tc := range append(cases, overlappingCases...) {
+			t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+				a, b, c :=
+					itSeries{sc: newChunkIterator(tc.a)},
+					itSeries{sc: newChunkIterator(tc.b)},
+					itSeries{sc: newChunkIterator(tc.c)}
+				tc.test(t, newVerticalMergeChunkIterator(a, b, c))
+			})
+		}
 	})
 }
 
@@ -1053,8 +1311,9 @@ func TestChunkSeriesIterator_DoubleSeek(t *testing.T) {
 	}
 
 	res := newChunkSeriesIterator(chkMetas, nil, 2, 8)
-	testutil.Assert(t, res.Seek(1) == true, "")
-	testutil.Assert(t, res.Seek(2) == true, "")
+	testutil.Assert(t, res.Seek(1), "")
+	testutil.Assert(t, res.Seek(2), "")
+	testutil.Assert(t, res.Seek(2), "")
 	ts, v := res.At()
 	testutil.Equals(t, int64(2), ts)
 	testutil.Equals(t, float64(2), v)
@@ -1071,15 +1330,28 @@ func TestChunkSeriesIterator_SeekInCurrentChunk(t *testing.T) {
 
 	it := newChunkSeriesIterator(metas, nil, 1, 7)
 
-	testutil.Assert(t, it.Next() == true, "")
+	testutil.Assert(t, it.Next(), "")
 	ts, v := it.At()
 	testutil.Equals(t, int64(1), ts)
 	testutil.Equals(t, float64(2), v)
 
-	testutil.Assert(t, it.Seek(4) == true, "")
+	testutil.Assert(t, it.Seek(4), "")
 	ts, v = it.At()
 	testutil.Equals(t, int64(5), ts)
 	testutil.Equals(t, float64(6), v)
+}
+
+// Calling Seek() with a time between [mint, maxt] after the iterator had
+// already passed the end would incorrectly return true.
+func TestChunkSeriesIterator_SeekWithMinTime(t *testing.T) {
+	metas := []chunks.Meta{
+		tsdbutil.ChunkFromSamples([]tsdbutil.Sample{sample{1, 6}, sample{5, 6}, sample{7, 8}}),
+	}
+
+	it := newChunkSeriesIterator(metas, nil, 2, 5)
+	testutil.Assert(t, it.Seek(6) == false, "")
+	// A second, within bounds Seek() used to succeed. Make sure it also returns false.
+	testutil.Assert(t, it.Seek(3) == false, "")
 }
 
 // Regression when calling Next() with a time bounded to fit within two samples.
@@ -1510,56 +1782,6 @@ func (m mockIndex) LabelNames() ([]string, error) {
 	}
 	sort.Strings(l)
 	return l, nil
-}
-
-type mockSeries struct {
-	labels   func() labels.Labels
-	iterator func() chunkenc.Iterator
-}
-
-func newSeries(l map[string]string, s []tsdbutil.Sample) storage.Series {
-	return &mockSeries{
-		labels:   func() labels.Labels { return labels.FromMap(l) },
-		iterator: func() chunkenc.Iterator { return newListSeriesIterator(s) },
-	}
-}
-func (m *mockSeries) Labels() labels.Labels       { return m.labels() }
-func (m *mockSeries) Iterator() chunkenc.Iterator { return m.iterator() }
-
-type listSeriesIterator struct {
-	list []tsdbutil.Sample
-	idx  int
-}
-
-func newListSeriesIterator(list []tsdbutil.Sample) *listSeriesIterator {
-	return &listSeriesIterator{list: list, idx: -1}
-}
-
-func (it *listSeriesIterator) At() (int64, float64) {
-	s := it.list[it.idx]
-	return s.T(), s.V()
-}
-
-func (it *listSeriesIterator) Next() bool {
-	it.idx++
-	return it.idx < len(it.list)
-}
-
-func (it *listSeriesIterator) Seek(t int64) bool {
-	if it.idx == -1 {
-		it.idx = 0
-	}
-	// Do binary search between current position and end.
-	it.idx = sort.Search(len(it.list)-it.idx, func(i int) bool {
-		s := it.list[i+it.idx]
-		return s.T() >= t
-	})
-
-	return it.idx < len(it.list)
-}
-
-func (it *listSeriesIterator) Err() error {
-	return nil
 }
 
 func BenchmarkQueryIterator(b *testing.B) {

--- a/tsdb/tsdbutil/chunks.go
+++ b/tsdb/tsdbutil/chunks.go
@@ -18,23 +18,37 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
+type Samples interface {
+	Get(i int) Sample
+	Len() int
+}
+
 type Sample interface {
 	T() int64
 	V() float64
 }
 
+type SampleSlice []Sample
+
+func (s SampleSlice) Get(i int) Sample { return s[i] }
+func (s SampleSlice) Len() int         { return len(s) }
+
 func ChunkFromSamples(s []Sample) chunks.Meta {
+	return ChunkFromSamplesGeneric(SampleSlice(s))
+}
+
+func ChunkFromSamplesGeneric(s Samples) chunks.Meta {
 	mint, maxt := int64(0), int64(0)
 
-	if len(s) > 0 {
-		mint, maxt = s[0].T(), s[len(s)-1].T()
+	if s.Len() > 0 {
+		mint, maxt = s.Get(0).T(), s.Get(s.Len()-1).T()
 	}
 
 	c := chunkenc.NewXORChunk()
 	ca, _ := c.Appender()
 
-	for _, s := range s {
-		ca.Append(s.T(), s.V())
+	for i := 0; i < s.Len(); i++ {
+		ca.Append(s.Get(i).T(), s.Get(i).V())
 	}
 	return chunks.Meta{
 		MinTime: mint,

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -560,7 +560,7 @@ func (api *API) series(r *http.Request) apiFuncResult {
 		sets = append(sets, s)
 	}
 
-	set := storage.NewMergeSeriesSet(sets, nil)
+	set := storage.NewChainedMergeSeriesSet(sets, nil)
 	metrics := []labels.Labels{}
 	for set.Next() {
 		metrics = append(metrics, set.At().Labels())

--- a/web/federate.go
+++ b/web/federate.go
@@ -101,14 +101,14 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 		sets = append(sets, s)
 	}
 
-	set := storage.NewMergeSeriesSet(sets, nil)
+	set := storage.NewChainedMergeSeriesSet(sets, nil)
 	it := storage.NewBuffer(int64(h.lookbackDelta / 1e6))
 	for set.Next() {
 		s := set.At()
 
 		// TODO(fabxc): allow fast path for most recent sample either
 		// in the storage itself or caching layer in Prometheus.
-		it.Reset(s.Iterator())
+		it.Reset(s.SampleIterator())
 
 		var t int64
 		var v float64


### PR DESCRIPTION
Continuation from: https://github.com/prometheus/tsdb/pull/665

## Changes:

* Adjusts Iterator Interface of Series e.g Seek
* Reuse single interface instead of 3 same ones spread across 3 packages.
* Refactored tests
* Added ChunkIterator to iterate over chunks if requested by the client. 

Fixes: https://github.com/prometheus/prometheus/issues/5871