### PR TITLE
Compute WAL size and use it during retention size checks

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"encoding/binary"
 
+	"github.com/prometheus/prometheus/tsdb/fileutil"
+
 	"errors"
 	"io/ioutil"
 	"math/rand"
@@ -175,7 +177,8 @@ func TestBlockSize(t *testing.T) {
 			testutil.Ok(t, blockInit.Close())
 		}()
 		expSizeInit = blockInit.Size()
-		actSizeInit := testutil.DirSize(t, blockInit.Dir())
+		actSizeInit, err := fileutil.DirSize(blockInit.Dir())
+		testutil.Ok(t, err)
 		testutil.Equals(t, expSizeInit, actSizeInit)
 	}
 
@@ -184,7 +187,7 @@ func TestBlockSize(t *testing.T) {
 		testutil.Ok(t, blockInit.Delete(1, 10, labels.NewMustRegexpMatcher("", ".*")))
 		expAfterDelete := blockInit.Size()
 		testutil.Assert(t, expAfterDelete > expSizeInit, "after a delete the block size should be bigger as the tombstone file should grow %v > %v", expAfterDelete, expSizeInit)
-		actAfterDelete := testutil.DirSize(t, blockDirInit)
+		actAfterDelete, err := fileutil.DirSize(blockDirInit)
 		testutil.Ok(t, err)
 		testutil.Equals(t, expAfterDelete, actAfterDelete, "after a delete reported block size doesn't match actual disk size")
 
@@ -198,7 +201,8 @@ func TestBlockSize(t *testing.T) {
 			testutil.Ok(t, blockAfterCompact.Close())
 		}()
 		expAfterCompact := blockAfterCompact.Size()
-		actAfterCompact := testutil.DirSize(t, blockAfterCompact.Dir())
+		actAfterCompact, err := fileutil.DirSize(blockAfterCompact.Dir())
+		testutil.Ok(t, err)
 		testutil.Assert(t, actAfterDelete > actAfterCompact, "after a delete and compaction the block size should be smaller %v,%v", actAfterDelete, actAfterCompact)
 		testutil.Equals(t, expAfterCompact, actAfterCompact, "after a delete and compaction reported block size doesn't match actual disk size")
 	}

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -933,7 +933,11 @@ func (db *DB) beyondSizeRetention(blocks []*Block) (deleteable map[ulid.ULID]*Bl
 	}
 
 	deleteable = make(map[ulid.ULID]*Block)
-	blocksSize := int64(0)
+
+	walSize, _ := db.Head().wal.Size()
+	// Initializing size counter with WAL size,
+	// as that is part of the retention strategy.
+	blocksSize := walSize
 	for i, block := range blocks {
 		blocksSize += block.Size()
 		if blocksSize > db.opts.MaxBytes {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1115,7 +1115,6 @@ func TestSizeRetention(t *testing.T) {
 
 	headBlocks := []*BlockMeta{
 		{MinTime: 700, MaxTime: 800},
-		{MinTime: 800, MaxTime: 900},
 	}
 
 	// Add some data to the WAL.
@@ -1123,18 +1122,10 @@ func TestSizeRetention(t *testing.T) {
 	for _, m := range headBlocks {
 		series := genSeries(100, 10, m.MinTime, m.MaxTime)
 		for _, s := range series {
-			var err error
-			ref := uint64(0)
 			it := s.Iterator()
 			for it.Next() {
 				tim, v := it.At()
-				if ref != 0 {
-					err := headApp.AddFast(ref, tim, v)
-					if err == nil {
-						continue
-					}
-				}
-				ref, err = headApp.Add(s.Labels(), tim, v)
+				_, err := headApp.Add(s.Labels(), tim, v)
 				testutil.Ok(t, err)
 			}
 			testutil.Ok(t, it.Err())

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1117,6 +1117,10 @@ func TestSizeRetention(t *testing.T) {
 	testutil.Ok(t, db.reload())                                       // Reload the db to register the new db size.
 	testutil.Equals(t, len(blocks), len(db.Blocks()))                 // Ensure all blocks are registered.
 	expSize := int64(prom_testutil.ToFloat64(db.metrics.blocksBytes)) // Use the the actual internal metrics.
+	walSize, err := db.Head().wal.Size()
+	testutil.Ok(t, err)
+	// Expected size should take into account block size + WAL size
+	expSize += walSize
 	actSize, err := fileutil.DirSize(db.Dir())
 	testutil.Ok(t, err)
 	testutil.Equals(t, expSize, actSize, "registered size doesn't match actual disk size")
@@ -1131,6 +1135,10 @@ func TestSizeRetention(t *testing.T) {
 	expBlocks := blocks[1:]
 	actBlocks := db.Blocks()
 	expSize = int64(prom_testutil.ToFloat64(db.metrics.blocksBytes))
+	walSize, err = db.Head().wal.Size()
+	testutil.Ok(t, err)
+	// Expected size should take into account block size + WAL size
+	expSize += walSize
 	actRetentCount := int(prom_testutil.ToFloat64(db.metrics.sizeRetentionCount))
 	actSize, err = fileutil.DirSize(db.Dir())
 	testutil.Ok(t, err)

--- a/tsdb/fileutil/dir.go
+++ b/tsdb/fileutil/dir.go
@@ -1,0 +1,33 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func DirSize(dir string) (int64, error) {
+	var size int64
+	err := filepath.Walk(dir, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size, err
+}

--- a/tsdb/wal/wal.go
+++ b/tsdb/wal/wal.go
@@ -876,3 +876,9 @@ func (r *segmentBufReader) Read(b []byte) (n int, err error) {
 	r.buf.Reset(r.segs[r.cur])
 	return n, nil
 }
+
+// Computing size of the WAL.
+// We do this by adding the sizes of all the files under the WAL dir.
+func (w *WAL) Size() (int64, error) {
+	return fileutil.DirSize(w.Dir())
+}

--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/prometheus/prometheus/tsdb/fileutil"
+
 	client_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/util/testutil"
 )
@@ -408,8 +410,10 @@ func TestCompression(t *testing.T) {
 		testutil.Ok(t, os.RemoveAll(dirUnCompressed))
 	}()
 
-	uncompressedSize := testutil.DirSize(t, dirUnCompressed)
-	compressedSize := testutil.DirSize(t, dirCompressed)
+	uncompressedSize, err := fileutil.DirSize(dirUnCompressed)
+	testutil.Ok(t, err)
+	compressedSize, err := fileutil.DirSize(dirCompressed)
+	testutil.Ok(t, err)
 
 	testutil.Assert(t, float64(uncompressedSize)*0.75 > float64(compressedSize), "Compressing zeroes should save at least 25%% space - uncompressedSize: %d, compressedSize: %d", uncompressedSize, compressedSize)
 }

--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -537,7 +537,7 @@ func TestWAL_Size(t *testing.T) {
 	walSizeAfterChkpt, err := wall.Size()
 	testutil.Ok(t, err)
 	// Test to see if the WAL size has now increased as expected
-	testutil.Equals(t, walSizeAfterChkpt, walSizeBeforeChkpt+chkptedSegmentsSize)
+	testutil.Equals(t, walSizeAfterChkpt, walSizeBeforeChkpt+chkptedSegmentsSize, "WAL size after checkpoint does not match expected")
 
 	// Truncate everything before the latest segment
 	err = wall.Truncate(lastSegment)
@@ -546,10 +546,10 @@ func TestWAL_Size(t *testing.T) {
 	f, l, err := wall.Segments()
 	testutil.Ok(t, err)
 	// Test to see if the truncate has gone through fine.
-	testutil.Equals(t, f, l)
+	testutil.Equals(t, f, l, "Number of segments after WAL truncate has not changed as expected")
 
 	walSizeAfterTruncate, err := wall.Size()
 	testutil.Ok(t, err)
 	// Test to see if the WAL size has now decreased as expected.
-	testutil.Equals(t, walSizeAfterTruncate, walSizeAfterChkpt-chkptedSegmentsSize)
+	testutil.Equals(t, walSizeAfterTruncate, walSizeAfterChkpt-chkptedSegmentsSize, "WAL size after truncate does not match expected")
 }

--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -17,6 +17,8 @@ package wal
 import (
 	"bytes"
 	"fmt"
+	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/record"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -478,4 +480,76 @@ func BenchmarkWAL_Log(b *testing.B) {
 			b.StopTimer()
 		})
 	}
+}
+
+func TestWAL_Size(t *testing.T) {
+	dir, err := ioutil.TempDir("", "wal_size")
+	testutil.Ok(t, err)
+	defer func() {
+		testutil.Ok(t, os.RemoveAll(dir))
+	}()
+
+	var enc record.Encoder
+
+	var (
+		logger           = testutil.NewLogger(t)
+		requiredSegments = 4
+		segmentSize      = pageSize * 2
+	)
+
+	wall, err := NewSize(logger, nil, dir, segmentSize, false)
+	testutil.Ok(t, err)
+
+	// Fill with random records until we reach the required number of segments.
+	for idx := 0; ; idx++ {
+		_, lastSegment, err := wall.Segments()
+		testutil.Ok(t, err)
+		if lastSegment+1 >= requiredSegments {
+			break
+		}
+		if idx == 0 {
+			series := enc.Series([]record.RefSeries{
+				{Ref: 1, Labels: labels.FromStrings("foo", "bar")},
+			}, nil)
+			testutil.Ok(t, wall.Log(series))
+		}
+		samples := enc.Samples([]record.RefSample{
+			{Ref: 0, T: int64(idx + 10), V: float64(idx)},
+		}, nil)
+		testutil.Ok(t, wall.Log(samples))
+	}
+
+	// Check if WAL size is as expected before checkpointing.
+	walSizeBeforeChkpt, err := wall.Size()
+	testutil.Ok(t, err)
+
+	firstSegment, lastSegment, err := wall.Segments()
+	testutil.Ok(t, err)
+
+	// Checkpoint everything, except the most recent segment.
+	_, err = Checkpoint(wall, firstSegment, lastSegment-1, func(x uint64) bool {
+		return false
+	}, 0)
+	testutil.Ok(t, err)
+
+	chkptedSegmentsSize := int64((lastSegment - firstSegment) * segmentSize)
+
+	walSizeAfterChkpt, err := wall.Size()
+	testutil.Ok(t, err)
+	// Test to see if the WAL size has now increased as expected
+	testutil.Equals(t, walSizeAfterChkpt, walSizeBeforeChkpt+chkptedSegmentsSize)
+
+	// Truncate everything before the latest segment
+	err = wall.Truncate(lastSegment)
+	testutil.Ok(t, err)
+
+	f, l, err := wall.Segments()
+	testutil.Ok(t, err)
+	// Test to see if the truncate has gone through fine.
+	testutil.Equals(t, f, l)
+
+	walSizeAfterTruncate, err := wall.Size()
+	testutil.Ok(t, err)
+	// Test to see if the WAL size has now decreased as expected.
+	testutil.Equals(t, walSizeAfterTruncate, walSizeAfterChkpt-chkptedSegmentsSize)
 }

--- a/util/testutil/directory.go
+++ b/util/testutil/directory.go
@@ -133,20 +133,6 @@ func NewTemporaryDirectory(name string, t T) (handler TemporaryDirectory) {
 	return
 }
 
-// DirSize returns the size in bytes of all files in a directory.
-func DirSize(t *testing.T, path string) int64 {
-	var size int64
-	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
-		Ok(t, err)
-		if !info.IsDir() {
-			size += info.Size()
-		}
-		return nil
-	})
-	Ok(t, err)
-	return size
-}
-
 // DirHash returns a hash of all files attribites and their content within a directory.
 func DirHash(t *testing.T, path string) []byte {
 	hash := sha256.New()


### PR DESCRIPTION
Signed-off-by: Dipack P Panjabi <dpanjabi@hudson-trading.com>

Closes: https://github.com/prometheus/prometheus/issues/5771

Compute the size of the WAL and use it while calculating if exceeding the max retention size limit.

(Port of https://github.com/prometheus/tsdb/pull/651)