### PR TITLE
Add Continuous Fuzzing via Fuzzit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,10 @@ executors:
     docker:
     - image: circleci/golang:1.12
 
+  fuzzit:
+    docker:
+      - image: fuzzitdev/golang:1.12.7-buster
+
 jobs:
   test:
     executor: golang
@@ -32,6 +36,20 @@ jobs:
         file: prometheus
     - prometheus/store_artifact:
         file: promtool
+  fuzzit_regression:
+    executor: fuzzit
+    working_directory: /go/src/github.com/prometheus/prometheus
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: ./fuzzit.sh local-regression
+  fuzzit_fuzzing:
+    executor: fuzzit
+    working_directory: /go/src/github.com/prometheus/prometheus
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: ./fuzzit.sh fuzzing
 
   makefile_sync:
     executor: golang
@@ -44,6 +62,10 @@ workflows:
   prometheus:
     jobs:
     - test:
+        filters:
+          tags:
+            only: /.*/
+    - fuzzit_regression:
         filters:
           tags:
             only: /.*/
@@ -80,4 +102,6 @@ workflows:
                 - master
     jobs:
     - makefile_sync:
+        context: org-context
+    - fuzzit_fuzzing:
         context: org-context

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
-
+dist: bionic
+services:
+  - docker
 # Whenever the Go version is updated here, .circleci/config.yml and .promu.yml
 # should also be updated.
 go:
@@ -17,3 +19,9 @@ before_install:
 script:
 - make check_license style unused test lint check_assets
 - git diff --exit-code
+- ./fuzzit.sh
+
+env:
+  global:
+    # This is FUZZIT_API_KEY environment variable
+    secure: DhQmBKuIbrkwoTDSCW5zVDrtq5YBWdJooyfPxJB5Ms1hYoiiJg+8d9BMcdEtT+n+KxXGd1vAjSwIdPILqIUBM1aw3f8W9926kSuuK2N+ObcuvtDYYgx76VdVqRoEbgE8chrbVV3QxH8YfdzcUwGSZmzpHUdL/7JZbSugKr6oZN8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: go
-dist: bionic
-services:
-  - docker
+
 # Whenever the Go version is updated here, .circleci/config.yml and .promu.yml
 # should also be updated.
 go:
@@ -19,9 +17,3 @@ before_install:
 script:
 - make check_license style unused test lint check_assets
 - git diff --exit-code
-- ./fuzzit.sh
-
-env:
-  global:
-    # This is FUZZIT_API_KEY environment variable
-    secure: DhQmBKuIbrkwoTDSCW5zVDrtq5YBWdJooyfPxJB5Ms1hYoiiJg+8d9BMcdEtT+n+KxXGd1vAjSwIdPILqIUBM1aw3f8W9926kSuuK2N+ObcuvtDYYgx76VdVqRoEbgE8chrbVV3QxH8YfdzcUwGSZmzpHUdL/7JZbSugKr6oZN8=

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/prom/prometheus.svg?maxAge=604800)][hub]
 [![Go Report Card](https://goreportcard.com/badge/github.com/prometheus/prometheus)](https://goreportcard.com/report/github.com/prometheus/prometheus)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/486/badge)](https://bestpractices.coreinfrastructure.org/projects/486)
+[![fuzzit](https://app.fuzzit.dev/badge?org_id=prometheus&branch=master)](https://fuzzit.dev)
 
 Visit [prometheus.io](https://prometheus.io) for the full documentation,
 examples and guides.

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -xe
+
+# Go-fuzz doesn't support modules yet, so ensure we do everything in the old style GOPATH way
+export GO111MODULE="off"
+
+# Install go-fuzz
+go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+
+# Target names on fuzzit.dev
+TARGETS=("promql-parse-metric" "promql-parse-open-metric" "promql-parse-metric-selector" "promql-parse-expr")
+
+# Prometheus fuzz functions
+FUZZ_FUNCTIONS=("FuzzParseMetric" "FuzzParseOpenMetric" "FuzzParseMetricSelector" "FuzzParseExpr")
+
+# Compiling prometheus fuzz targets in fuzz.go with go-fuzz (https://github.com/dvyukov/go-fuzz) and libFuzzer support
+for ((i=0;i<${#TARGETS[@]};++i));
+do
+    go-fuzz-build -libfuzzer -func ${FUZZ_FUNCTIONS[i]} -o ${TARGETS[i]}.a ./promql
+    clang -fsanitize=fuzzer ${TARGETS[i]}.a -o ${TARGETS[i]}
+done
+
+# Install fuzzit CLI
+wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64
+chmod a+x fuzzit
+
+# Upload fuzz target for long fuzz testing on fuzzit.dev server or run locally for regression on PRs
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+	TYPE=fuzzing
+else
+	TYPE=local-regression
+fi
+for TARGET in "${TARGETS[@]}"
+do
+    ./fuzzit create job --type $TYPE prometheus/${TARGET} ${TARGET}
+done

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -17,20 +17,14 @@ FUZZ_FUNCTIONS=("FuzzParseMetric" "FuzzParseOpenMetric" "FuzzParseMetricSelector
 for ((i=0;i<${#TARGETS[@]};++i));
 do
     go-fuzz-build -libfuzzer -func ${FUZZ_FUNCTIONS[i]} -o ${TARGETS[i]}.a ./promql
-    clang -fsanitize=fuzzer ${TARGETS[i]}.a -o ${TARGETS[i]}
+    clang-9 -fsanitize=fuzzer ${TARGETS[i]}.a -o ${TARGETS[i]}
 done
 
 # Install fuzzit CLI
 wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64
 chmod a+x fuzzit
 
-# Upload fuzz target for long fuzz testing on fuzzit.dev server or run locally for regression on PRs
-if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-	TYPE=fuzzing
-else
-	TYPE=local-regression
-fi
 for TARGET in "${TARGETS[@]}"
 do
-    ./fuzzit create job --type $TYPE prometheus/${TARGET} ${TARGET}
+    ./fuzzit create job --type $1 prometheus/${TARGET} ${TARGET}
 done


### PR DESCRIPTION
This PR adds a continuous fuzzing integration to prometheus's travis pipeline via [Fuzzit](https://fuzzit.dev) service.

This means the following:

- Every time new code is pushed to master new fuzzers are built and push to fuzzit where they run continuously generate new test-cases and alerts if new crashes are found
- Every pull-request the fuzzers runs through a quick regression tests with the generated test-cases from the previous step. If something new/old bugs are introduced you will see this immediately in the Travis check.


To take ownership of the organisation, please login to https://app.fuzzit.dev and let me know your account.

Please review and feel free to comment/ask questions.