### PR TITLE
Regulate the package name.

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -48,10 +48,10 @@ import (
 	promlogflag "github.com/prometheus/common/promlog/flag"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
-	sd_config "github.com/prometheus/prometheus/discovery/config"
+	sdconfig "github.com/prometheus/prometheus/discovery/config"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/pkg/relabel"
-	prom_runtime "github.com/prometheus/prometheus/pkg/runtime"
+	promruntime "github.com/prometheus/prometheus/pkg/runtime"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
@@ -328,9 +328,9 @@ func main() {
 
 	level.Info(logger).Log("msg", "Starting Prometheus", "version", version.Info())
 	level.Info(logger).Log("build_context", version.BuildContext())
-	level.Info(logger).Log("host_details", prom_runtime.Uname())
-	level.Info(logger).Log("fd_limits", prom_runtime.FdLimits())
-	level.Info(logger).Log("vm_limits", prom_runtime.VmLimits())
+	level.Info(logger).Log("host_details", promruntime.Uname())
+	level.Info(logger).Log("fd_limits", promruntime.FdLimits())
+	level.Info(logger).Log("vm_limits", promruntime.VmLimits())
 
 	var (
 		localStorage  = &tsdb.ReadyStorage{}
@@ -423,7 +423,7 @@ func main() {
 		// they need to read the most updated config when receiving the new targets list.
 		scrapeManager.ApplyConfig,
 		func(cfg *config.Config) error {
-			c := make(map[string]sd_config.ServiceDiscoveryConfig)
+			c := make(map[string]sdconfig.ServiceDiscoveryConfig)
 			for _, v := range cfg.ScrapeConfigs {
 				c[v.JobName] = v.ServiceDiscoveryConfig
 			}
@@ -431,7 +431,7 @@ func main() {
 		},
 		notifierManager.ApplyConfig,
 		func(cfg *config.Config) error {
-			c := make(map[string]sd_config.ServiceDiscoveryConfig)
+			c := make(map[string]sdconfig.ServiceDiscoveryConfig)
 			for _, v := range cfg.AlertingConfig.AlertmanagerConfigs {
 				// AlertmanagerConfigs doesn't hold an unique identifier so we use the config hash as the identifier.
 				b, err := json.Marshal(v)
@@ -666,7 +666,7 @@ func main() {
 				if err != nil {
 					return errors.Wrapf(err, "opening storage failed")
 				}
-				level.Info(logger).Log("fs_type", prom_runtime.Statfs(cfg.localStoragePath))
+				level.Info(logger).Log("fs_type", promruntime.Statfs(cfg.localStoragePath))
 				level.Info(logger).Log("msg", "TSDB started")
 				level.Debug(logger).Log("msg", "TSDB options",
 					"MinBlockDuration", cfg.tsdb.MinBlockDuration,

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -247,7 +247,7 @@ func checkConfig(filename string) ([]string, error) {
 	return ruleFiles, nil
 }
 
-func checkTLSConfig(tlsConfig config_util.TLSConfig) error {
+func checkTLSConfig(tlsConfig commonconfig.TLSConfig) error {
 	if err := checkFileExists(tlsConfig.CertFile); err != nil {
 		return errors.Wrapf(err, "error checking client cert file %q", tlsConfig.CertFile)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -23,11 +23,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	yaml "gopkg.in/yaml.v2"
 
-	sd_config "github.com/prometheus/prometheus/discovery/config"
+	sdconfig "github.com/prometheus/prometheus/discovery/config"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
 )
@@ -156,19 +156,19 @@ func resolveFilepaths(baseDir string, cfg *Config) {
 		cfg.RuleFiles[i] = join(rf)
 	}
 
-	tlsPaths := func(cfg *config_util.TLSConfig) {
+	tlsPaths := func(cfg *commonconfig.TLSConfig) {
 		cfg.CAFile = join(cfg.CAFile)
 		cfg.CertFile = join(cfg.CertFile)
 		cfg.KeyFile = join(cfg.KeyFile)
 	}
-	clientPaths := func(scfg *config_util.HTTPClientConfig) {
+	clientPaths := func(scfg *commonconfig.HTTPClientConfig) {
 		if scfg.BasicAuth != nil {
 			scfg.BasicAuth.PasswordFile = join(scfg.BasicAuth.PasswordFile)
 		}
 		scfg.BearerTokenFile = join(scfg.BearerTokenFile)
 		tlsPaths(&scfg.TLSConfig)
 	}
-	sdPaths := func(cfg *sd_config.ServiceDiscoveryConfig) {
+	sdPaths := func(cfg *sdconfig.ServiceDiscoveryConfig) {
 		for _, kcfg := range cfg.KubernetesSDConfigs {
 			clientPaths(&kcfg.HTTPClientConfig)
 		}
@@ -364,8 +364,8 @@ type ScrapeConfig struct {
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.
 
-	ServiceDiscoveryConfig sd_config.ServiceDiscoveryConfig `yaml:",inline"`
-	HTTPClientConfig       config_util.HTTPClientConfig     `yaml:",inline"`
+	ServiceDiscoveryConfig sdconfig.ServiceDiscoveryConfig `yaml:",inline"`
+	HTTPClientConfig       commonconfig.HTTPClientConfig   `yaml:",inline"`
 
 	// List of target relabel configurations.
 	RelabelConfigs []*relabel.Config `yaml:"relabel_configs,omitempty"`
@@ -493,8 +493,8 @@ type AlertmanagerConfig struct {
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.
 
-	ServiceDiscoveryConfig sd_config.ServiceDiscoveryConfig `yaml:",inline"`
-	HTTPClientConfig       config_util.HTTPClientConfig     `yaml:",inline"`
+	ServiceDiscoveryConfig sdconfig.ServiceDiscoveryConfig `yaml:",inline"`
+	HTTPClientConfig       commonconfig.HTTPClientConfig   `yaml:",inline"`
 
 	// The URL scheme to use when talking to Alertmanagers.
 	Scheme string `yaml:"scheme,omitempty"`
@@ -569,8 +569,8 @@ func CheckTargetAddress(address model.LabelValue) error {
 
 // ClientCert contains client cert credentials.
 type ClientCert struct {
-	Cert string             `yaml:"cert"`
-	Key  config_util.Secret `yaml:"key"`
+	Cert string              `yaml:"cert"`
+	Key  commonconfig.Secret `yaml:"key"`
 }
 
 // FileSDConfig is the configuration for file based discovery.
@@ -581,14 +581,14 @@ type FileSDConfig struct {
 
 // RemoteWriteConfig is the configuration for writing to remote storage.
 type RemoteWriteConfig struct {
-	URL                 *config_util.URL  `yaml:"url"`
+	URL                 *commonconfig.URL `yaml:"url"`
 	RemoteTimeout       model.Duration    `yaml:"remote_timeout,omitempty"`
 	WriteRelabelConfigs []*relabel.Config `yaml:"write_relabel_configs,omitempty"`
 
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.
-	HTTPClientConfig config_util.HTTPClientConfig `yaml:",inline"`
-	QueueConfig      QueueConfig                  `yaml:"queue_config,omitempty"`
+	HTTPClientConfig commonconfig.HTTPClientConfig `yaml:",inline"`
+	QueueConfig      QueueConfig                   `yaml:"queue_config,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -639,12 +639,12 @@ type QueueConfig struct {
 
 // RemoteReadConfig is the configuration for reading from remote storage.
 type RemoteReadConfig struct {
-	URL           *config_util.URL `yaml:"url"`
-	RemoteTimeout model.Duration   `yaml:"remote_timeout,omitempty"`
-	ReadRecent    bool             `yaml:"read_recent,omitempty"`
+	URL           *commonconfig.URL `yaml:"url"`
+	RemoteTimeout model.Duration    `yaml:"remote_timeout,omitempty"`
+	ReadRecent    bool              `yaml:"read_recent,omitempty"`
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.
-	HTTPClientConfig config_util.HTTPClientConfig `yaml:",inline"`
+	HTTPClientConfig commonconfig.HTTPClientConfig `yaml:",inline"`
 
 	// RequiredMatchers is an optional list of equality matchers which have to
 	// be present in a selector to query the remote read endpoint.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,12 +23,12 @@ import (
 	"testing"
 	"time"
 
-	config_util "github.com/prometheus/common/config"
+	configutil "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/prometheus/discovery/azure"
-	sd_config "github.com/prometheus/prometheus/discovery/config"
+	sdconfig "github.com/prometheus/prometheus/discovery/config"
 	"github.com/prometheus/prometheus/discovery/consul"
 	"github.com/prometheus/prometheus/discovery/dns"
 	"github.com/prometheus/prometheus/discovery/ec2"
@@ -44,12 +44,12 @@ import (
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
-func mustParseURL(u string) *config_util.URL {
+func mustParseURL(u string) *configutil.URL {
 	parsed, err := url.Parse(u)
 	if err != nil {
 		panic(err)
 	}
-	return &config_util.URL{URL: parsed}
+	return &configutil.URL{URL: parsed}
 }
 
 var expectedConf = &Config{
@@ -88,8 +88,8 @@ var expectedConf = &Config{
 			URL:           mustParseURL("http://remote2/push"),
 			RemoteTimeout: model.Duration(30 * time.Second),
 			QueueConfig:   DefaultQueueConfig,
-			HTTPClientConfig: config_util.HTTPClientConfig{
-				TLSConfig: config_util.TLSConfig{
+			HTTPClientConfig: configutil.HTTPClientConfig{
+				TLSConfig: configutil.TLSConfig{
 					CertFile: filepath.FromSlash("testdata/valid_cert_file"),
 					KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 				},
@@ -108,8 +108,8 @@ var expectedConf = &Config{
 			RemoteTimeout:    model.Duration(1 * time.Minute),
 			ReadRecent:       false,
 			RequiredMatchers: model.LabelSet{"job": "special"},
-			HTTPClientConfig: config_util.HTTPClientConfig{
-				TLSConfig: config_util.TLSConfig{
+			HTTPClientConfig: configutil.HTTPClientConfig{
+				TLSConfig: configutil.TLSConfig{
 					CertFile: filepath.FromSlash("testdata/valid_cert_file"),
 					KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 				},
@@ -129,11 +129,11 @@ var expectedConf = &Config{
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
 
-			HTTPClientConfig: config_util.HTTPClientConfig{
+			HTTPClientConfig: configutil.HTTPClientConfig{
 				BearerTokenFile: filepath.FromSlash("testdata/valid_token_file"),
 			},
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				StaticConfigs: []*targetgroup.Group{
 					{
 						Targets: []model.LabelSet{
@@ -199,8 +199,8 @@ var expectedConf = &Config{
 			ScrapeTimeout:   model.Duration(5 * time.Second),
 			SampleLimit:     1000,
 
-			HTTPClientConfig: config_util.HTTPClientConfig{
-				BasicAuth: &config_util.BasicAuth{
+			HTTPClientConfig: configutil.HTTPClientConfig{
+				BasicAuth: &configutil.BasicAuth{
 					Username: "admin_name",
 					Password: "multiline\nmysecret\ntest",
 				},
@@ -208,7 +208,7 @@ var expectedConf = &Config{
 			MetricsPath: "/my_path",
 			Scheme:      "https",
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				DNSSDConfigs: []*dns.SDConfig{
 					{
 						Names: []string{
@@ -291,7 +291,7 @@ var expectedConf = &Config{
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				ConsulSDConfigs: []*consul.SDConfig{
 					{
 						Server:          "localhost:1234",
@@ -303,7 +303,7 @@ var expectedConf = &Config{
 						Scheme:          "https",
 						RefreshInterval: consul.DefaultSDConfig.RefreshInterval,
 						AllowStale:      true,
-						TLSConfig: config_util.TLSConfig{
+						TLSConfig: configutil.TLSConfig{
 							CertFile:           filepath.FromSlash("testdata/valid_cert_file"),
 							KeyFile:            filepath.FromSlash("testdata/valid_key_file"),
 							CAFile:             filepath.FromSlash("testdata/valid_ca_file"),
@@ -334,8 +334,8 @@ var expectedConf = &Config{
 			MetricsPath: "/metrics",
 			Scheme:      "http",
 
-			HTTPClientConfig: config_util.HTTPClientConfig{
-				TLSConfig: config_util.TLSConfig{
+			HTTPClientConfig: configutil.HTTPClientConfig{
+				TLSConfig: configutil.TLSConfig{
 					CertFile: filepath.FromSlash("testdata/valid_cert_file"),
 					KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 				},
@@ -353,17 +353,17 @@ var expectedConf = &Config{
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				KubernetesSDConfigs: []*kubernetes.SDConfig{
 					{
 						APIServer: kubernetesSDHostURL(),
 						Role:      kubernetes.RoleEndpoint,
-						HTTPClientConfig: config_util.HTTPClientConfig{
-							BasicAuth: &config_util.BasicAuth{
+						HTTPClientConfig: configutil.HTTPClientConfig{
+							BasicAuth: &configutil.BasicAuth{
 								Username: "myusername",
 								Password: "mysecret",
 							},
-							TLSConfig: config_util.TLSConfig{
+							TLSConfig: configutil.TLSConfig{
 								CertFile: filepath.FromSlash("testdata/valid_cert_file"),
 								KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 							},
@@ -382,14 +382,14 @@ var expectedConf = &Config{
 
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
-			HTTPClientConfig: config_util.HTTPClientConfig{
-				BasicAuth: &config_util.BasicAuth{
+			HTTPClientConfig: configutil.HTTPClientConfig{
+				BasicAuth: &configutil.BasicAuth{
 					Username:     "myusername",
 					PasswordFile: filepath.FromSlash("testdata/valid_password_file"),
 				},
 			},
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				KubernetesSDConfigs: []*kubernetes.SDConfig{
 					{
 						APIServer: kubernetesSDHostURL(),
@@ -413,16 +413,16 @@ var expectedConf = &Config{
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				MarathonSDConfigs: []*marathon.SDConfig{
 					{
 						Servers: []string{
 							"https://marathon.example.com:443",
 						},
 						RefreshInterval: model.Duration(30 * time.Second),
-						AuthToken:       config_util.Secret("mysecret"),
-						HTTPClientConfig: config_util.HTTPClientConfig{
-							TLSConfig: config_util.TLSConfig{
+						AuthToken:       configutil.Secret("mysecret"),
+						HTTPClientConfig: configutil.HTTPClientConfig{
+							TLSConfig: configutil.TLSConfig{
 								CertFile: filepath.FromSlash("testdata/valid_cert_file"),
 								KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 							},
@@ -441,7 +441,7 @@ var expectedConf = &Config{
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				EC2SDConfigs: []*ec2.SDConfig{
 					{
 						Region:          "us-east-1",
@@ -474,7 +474,7 @@ var expectedConf = &Config{
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				AzureSDConfigs: []*azure.SDConfig{
 					{
 						Environment:          "AzurePublicCloud",
@@ -499,7 +499,7 @@ var expectedConf = &Config{
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				NerveSDConfigs: []*zookeeper.NerveSDConfig{
 					{
 						Servers: []string{"localhost"},
@@ -519,7 +519,7 @@ var expectedConf = &Config{
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				StaticConfigs: []*targetgroup.Group{
 					{
 						Targets: []model.LabelSet{
@@ -540,7 +540,7 @@ var expectedConf = &Config{
 			MetricsPath: "/federate",
 			Scheme:      DefaultScrapeConfig.Scheme,
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				StaticConfigs: []*targetgroup.Group{
 					{
 						Targets: []model.LabelSet{
@@ -561,7 +561,7 @@ var expectedConf = &Config{
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				StaticConfigs: []*targetgroup.Group{
 					{
 						Targets: []model.LabelSet{
@@ -582,7 +582,7 @@ var expectedConf = &Config{
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				TritonSDConfigs: []*triton.SDConfig{
 					{
 
@@ -592,7 +592,7 @@ var expectedConf = &Config{
 						Port:            9163,
 						RefreshInterval: model.Duration(60 * time.Second),
 						Version:         1,
-						TLSConfig: config_util.TLSConfig{
+						TLSConfig: configutil.TLSConfig{
 							CertFile: "testdata/valid_cert_file",
 							KeyFile:  "testdata/valid_key_file",
 						},
@@ -610,14 +610,14 @@ var expectedConf = &Config{
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
 
-			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+			ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 				OpenstackSDConfigs: []*openstack.SDConfig{
 					{
 						Role:            "instance",
 						Region:          "RegionOne",
 						Port:            80,
 						RefreshInterval: model.Duration(60 * time.Second),
-						TLSConfig: config_util.TLSConfig{
+						TLSConfig: configutil.TLSConfig{
 							CAFile:   "testdata/valid_ca_file",
 							CertFile: "testdata/valid_cert_file",
 							KeyFile:  "testdata/valid_key_file",
@@ -633,7 +633,7 @@ var expectedConf = &Config{
 				Scheme:     "https",
 				Timeout:    model.Duration(10 * time.Second),
 				APIVersion: AlertmanagerAPIVersionV1,
-				ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+				ServiceDiscoveryConfig: sdconfig.ServiceDiscoveryConfig{
 					StaticConfigs: []*targetgroup.Group{
 						{
 							Targets: []model.LabelSet{
@@ -923,7 +923,7 @@ func TestEmptyGlobalBlock(t *testing.T) {
 	testutil.Equals(t, exp, *c)
 }
 
-func kubernetesSDHostURL() config_util.URL {
+func kubernetesSDHostURL() configutil.URL {
 	tURL, _ := url.Parse("https://localhost:1234")
-	return config_util.URL{URL: tURL}
+	return configutil.URL{URL: tURL}
 }

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/discovery/refresh"
@@ -66,14 +66,14 @@ var DefaultSDConfig = SDConfig{
 
 // SDConfig is the configuration for Azure based service discovery.
 type SDConfig struct {
-	Environment          string             `yaml:"environment,omitempty"`
-	Port                 int                `yaml:"port"`
-	SubscriptionID       string             `yaml:"subscription_id"`
-	TenantID             string             `yaml:"tenant_id,omitempty"`
-	ClientID             string             `yaml:"client_id,omitempty"`
-	ClientSecret         config_util.Secret `yaml:"client_secret,omitempty"`
-	RefreshInterval      model.Duration     `yaml:"refresh_interval,omitempty"`
-	AuthenticationMethod string             `yaml:"authentication_method,omitempty"`
+	Environment          string              `yaml:"environment,omitempty"`
+	Port                 int                 `yaml:"port"`
+	SubscriptionID       string              `yaml:"subscription_id"`
+	TenantID             string              `yaml:"tenant_id,omitempty"`
+	ClientID             string              `yaml:"client_id,omitempty"`
+	ClientSecret         commonconfig.Secret `yaml:"client_secret,omitempty"`
+	RefreshInterval      model.Duration      `yaml:"refresh_interval,omitempty"`
+	AuthenticationMethod string              `yaml:"authentication_method,omitempty"`
 }
 
 func validateAuthParam(param, name string) error {

--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -28,7 +28,7 @@ import (
 	conntrack "github.com/mwitkow/go-conntrack"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -95,13 +95,13 @@ var (
 
 // SDConfig is the configuration for Consul service discovery.
 type SDConfig struct {
-	Server       string             `yaml:"server,omitempty"`
-	Token        config_util.Secret `yaml:"token,omitempty"`
-	Datacenter   string             `yaml:"datacenter,omitempty"`
-	TagSeparator string             `yaml:"tag_separator,omitempty"`
-	Scheme       string             `yaml:"scheme,omitempty"`
-	Username     string             `yaml:"username,omitempty"`
-	Password     config_util.Secret `yaml:"password,omitempty"`
+	Server       string              `yaml:"server,omitempty"`
+	Token        commonconfig.Secret `yaml:"token,omitempty"`
+	Datacenter   string              `yaml:"datacenter,omitempty"`
+	TagSeparator string              `yaml:"tag_separator,omitempty"`
+	Scheme       string              `yaml:"scheme,omitempty"`
+	Username     string              `yaml:"username,omitempty"`
+	Password     commonconfig.Secret `yaml:"password,omitempty"`
 
 	// See https://www.consul.io/docs/internals/consensus.html#consistency-modes,
 	// stale reads are a lot cheaper and are a necessity if you have >5k targets.
@@ -121,7 +121,7 @@ type SDConfig struct {
 	// Desired node metadata.
 	NodeMeta map[string]string `yaml:"node_meta,omitempty"`
 
-	TLSConfig config_util.TLSConfig `yaml:"tls_config,omitempty"`
+	TLSConfig commonconfig.TLSConfig `yaml:"tls_config,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -168,7 +168,7 @@ func NewDiscovery(conf *SDConfig, logger log.Logger) (*Discovery, error) {
 		logger = log.NewNopLogger()
 	}
 
-	tls, err := config_util.NewTLSConfig(&conf.TLSConfig)
+	tls, err := commonconfig.NewTLSConfig(&conf.TLSConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -28,7 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/discovery/refresh"
@@ -69,15 +69,15 @@ type Filter struct {
 
 // SDConfig is the configuration for EC2 based service discovery.
 type SDConfig struct {
-	Endpoint        string             `yaml:"endpoint"`
-	Region          string             `yaml:"region"`
-	AccessKey       string             `yaml:"access_key,omitempty"`
-	SecretKey       config_util.Secret `yaml:"secret_key,omitempty"`
-	Profile         string             `yaml:"profile,omitempty"`
-	RoleARN         string             `yaml:"role_arn,omitempty"`
-	RefreshInterval model.Duration     `yaml:"refresh_interval,omitempty"`
-	Port            int                `yaml:"port"`
-	Filters         []*Filter          `yaml:"filters"`
+	Endpoint        string              `yaml:"endpoint"`
+	Region          string              `yaml:"region"`
+	AccessKey       string              `yaml:"access_key,omitempty"`
+	SecretKey       commonconfig.Secret `yaml:"secret_key,omitempty"`
+	Profile         string              `yaml:"profile,omitempty"`
+	RoleARN         string              `yaml:"role_arn,omitempty"`
+	RefreshInterval model.Duration      `yaml:"refresh_interval,omitempty"`
+	Port            int                 `yaml:"port"`
+	Filters         []*Filter           `yaml:"filters"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	apiv1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -87,10 +87,10 @@ func (c *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // SDConfig is the configuration for Kubernetes service discovery.
 type SDConfig struct {
-	APIServer          config_util.URL              `yaml:"api_server,omitempty"`
-	Role               Role                         `yaml:"role"`
-	HTTPClientConfig   config_util.HTTPClientConfig `yaml:",inline"`
-	NamespaceDiscovery NamespaceDiscovery           `yaml:"namespaces,omitempty"`
+	APIServer          commonconfig.URL              `yaml:"api_server,omitempty"`
+	Role               Role                          `yaml:"role"`
+	HTTPClientConfig   commonconfig.HTTPClientConfig `yaml:",inline"`
+	NamespaceDiscovery NamespaceDiscovery            `yaml:"namespaces,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -108,7 +108,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err != nil {
 		return err
 	}
-	if c.APIServer.URL == nil && !reflect.DeepEqual(c.HTTPClientConfig, config_util.HTTPClientConfig{}) {
+	if c.APIServer.URL == nil && !reflect.DeepEqual(c.HTTPClientConfig, commonconfig.HTTPClientConfig{}) {
 		return errors.Errorf("to use custom HTTP client configuration please provide the 'api_server' URL explicitly")
 	}
 	return nil
@@ -191,7 +191,7 @@ func New(l log.Logger, conf *SDConfig) (*Discovery, error) {
 		}
 		level.Info(l).Log("msg", "Using pod service account via in-cluster config")
 	} else {
-		rt, err := config_util.NewRoundTripperFromConfig(conf.HTTPClientConfig, "kubernetes_sd", false)
+		rt, err := commonconfig.NewRoundTripperFromConfig(conf.HTTPClientConfig, "kubernetes_sd", false)
 		if err != nil {
 			return nil, err
 		}

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 
-	sd_config "github.com/prometheus/prometheus/discovery/config"
+	sdconfig "github.com/prometheus/prometheus/discovery/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 
 	"github.com/prometheus/prometheus/discovery/azure"
@@ -181,7 +181,7 @@ func (m *Manager) SyncCh() <-chan map[string][]*targetgroup.Group {
 }
 
 // ApplyConfig removes all running discovery providers and starts new ones using the provided config.
-func (m *Manager) ApplyConfig(cfg map[string]sd_config.ServiceDiscoveryConfig) error {
+func (m *Manager) ApplyConfig(cfg map[string]sdconfig.ServiceDiscoveryConfig) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -317,7 +317,7 @@ func (m *Manager) allGroups() map[string][]*targetgroup.Group {
 	return tSets
 }
 
-func (m *Manager) registerProviders(cfg sd_config.ServiceDiscoveryConfig, setName string) {
+func (m *Manager) registerProviders(cfg sdconfig.ServiceDiscoveryConfig, setName string) {
 	var added bool
 	add := func(cfg interface{}, newDiscoverer func() (Discoverer, error)) {
 		t := reflect.TypeOf(cfg).String()

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
-	sd_config "github.com/prometheus/prometheus/discovery/config"
+	sdconfig "github.com/prometheus/prometheus/discovery/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"gopkg.in/yaml.v2"
 )
@@ -765,7 +765,7 @@ scrape_configs:
 	discoveryManager.updatert = 100 * time.Millisecond
 	go discoveryManager.Run()
 
-	c := make(map[string]sd_config.ServiceDiscoveryConfig)
+	c := make(map[string]sdconfig.ServiceDiscoveryConfig)
 	for _, v := range cfg.ScrapeConfigs {
 		c[v.JobName] = v.ServiceDiscoveryConfig
 	}
@@ -784,7 +784,7 @@ scrape_configs:
 	if err := yaml.UnmarshalStrict([]byte(sTwo), cfg); err != nil {
 		t.Fatalf("Unable to load YAML config sTwo: %s", err)
 	}
-	c = make(map[string]sd_config.ServiceDiscoveryConfig)
+	c = make(map[string]sdconfig.ServiceDiscoveryConfig)
 	for _, v := range cfg.ScrapeConfigs {
 		c[v.JobName] = v.ServiceDiscoveryConfig
 	}
@@ -816,7 +816,7 @@ scrape_configs:
 	discoveryManager.updatert = 100 * time.Millisecond
 	go discoveryManager.Run()
 
-	c := make(map[string]sd_config.ServiceDiscoveryConfig)
+	c := make(map[string]sdconfig.ServiceDiscoveryConfig)
 	for _, v := range cfg.ScrapeConfigs {
 		c[v.JobName] = v.ServiceDiscoveryConfig
 	}
@@ -833,7 +833,7 @@ scrape_configs:
 	if err := yaml.UnmarshalStrict([]byte(sTwo), cfg); err != nil {
 		t.Fatalf("Unable to load YAML config sTwo: %s", err)
 	}
-	c = make(map[string]sd_config.ServiceDiscoveryConfig)
+	c = make(map[string]sdconfig.ServiceDiscoveryConfig)
 	for _, v := range cfg.ScrapeConfigs {
 		c[v.JobName] = v.ServiceDiscoveryConfig
 	}
@@ -895,7 +895,7 @@ scrape_configs:
 	discoveryManager.updatert = 100 * time.Millisecond
 	go discoveryManager.Run()
 
-	c := make(map[string]sd_config.ServiceDiscoveryConfig)
+	c := make(map[string]sdconfig.ServiceDiscoveryConfig)
 	for _, v := range cfg.ScrapeConfigs {
 		c[v.JobName] = v.ServiceDiscoveryConfig
 	}
@@ -934,7 +934,7 @@ scrape_configs:
 	discoveryManager.updatert = 100 * time.Millisecond
 	go discoveryManager.Run()
 
-	c := make(map[string]sd_config.ServiceDiscoveryConfig)
+	c := make(map[string]sdconfig.ServiceDiscoveryConfig)
 	for _, v := range processedConfig.ScrapeConfigs {
 		c[v.JobName] = v.ServiceDiscoveryConfig
 	}

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/discovery/refresh"
@@ -65,11 +65,11 @@ var DefaultSDConfig = SDConfig{
 
 // SDConfig is the configuration for services running on Marathon.
 type SDConfig struct {
-	Servers          []string                     `yaml:"servers,omitempty"`
-	RefreshInterval  model.Duration               `yaml:"refresh_interval,omitempty"`
-	AuthToken        config_util.Secret           `yaml:"auth_token,omitempty"`
-	AuthTokenFile    string                       `yaml:"auth_token_file,omitempty"`
-	HTTPClientConfig config_util.HTTPClientConfig `yaml:",inline"`
+	Servers          []string                      `yaml:"servers,omitempty"`
+	RefreshInterval  model.Duration                `yaml:"refresh_interval,omitempty"`
+	AuthToken        commonconfig.Secret           `yaml:"auth_token,omitempty"`
+	AuthTokenFile    string                        `yaml:"auth_token_file,omitempty"`
+	HTTPClientConfig commonconfig.HTTPClientConfig `yaml:",inline"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -108,7 +108,7 @@ type Discovery struct {
 
 // NewDiscovery returns a new Marathon Discovery.
 func NewDiscovery(conf SDConfig, logger log.Logger) (*Discovery, error) {
-	rt, err := config_util.NewRoundTripperFromConfig(conf.HTTPClientConfig, "marathon_sd", false)
+	rt, err := commonconfig.NewRoundTripperFromConfig(conf.HTTPClientConfig, "marathon_sd", false)
 	if err != nil {
 		return nil, err
 	}
@@ -137,12 +137,12 @@ func NewDiscovery(conf SDConfig, logger log.Logger) (*Discovery, error) {
 }
 
 type authTokenRoundTripper struct {
-	authToken config_util.Secret
+	authToken commonconfig.Secret
 	rt        http.RoundTripper
 }
 
 // newAuthTokenRoundTripper adds the provided auth token to a request.
-func newAuthTokenRoundTripper(token config_util.Secret, rt http.RoundTripper) (http.RoundTripper, error) {
+func newAuthTokenRoundTripper(token commonconfig.Secret, rt http.RoundTripper) (http.RoundTripper, error) {
 	return &authTokenRoundTripper{token, rt}, nil
 }
 

--- a/discovery/openstack/openstack.go
+++ b/discovery/openstack/openstack.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack"
 	conntrack "github.com/mwitkow/go-conntrack"
 	"github.com/pkg/errors"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/discovery/refresh"
@@ -38,23 +38,23 @@ var DefaultSDConfig = SDConfig{
 
 // SDConfig is the configuration for OpenStack based service discovery.
 type SDConfig struct {
-	IdentityEndpoint            string                `yaml:"identity_endpoint"`
-	Username                    string                `yaml:"username"`
-	UserID                      string                `yaml:"userid"`
-	Password                    config_util.Secret    `yaml:"password"`
-	ProjectName                 string                `yaml:"project_name"`
-	ProjectID                   string                `yaml:"project_id"`
-	DomainName                  string                `yaml:"domain_name"`
-	DomainID                    string                `yaml:"domain_id"`
-	ApplicationCredentialName   string                `yaml:"application_credential_name"`
-	ApplicationCredentialID     string                `yaml:"application_credential_id"`
-	ApplicationCredentialSecret config_util.Secret    `yaml:"application_credential_secret"`
-	Role                        Role                  `yaml:"role"`
-	Region                      string                `yaml:"region"`
-	RefreshInterval             model.Duration        `yaml:"refresh_interval,omitempty"`
-	Port                        int                   `yaml:"port"`
-	AllTenants                  bool                  `yaml:"all_tenants,omitempty"`
-	TLSConfig                   config_util.TLSConfig `yaml:"tls_config,omitempty"`
+	IdentityEndpoint            string                 `yaml:"identity_endpoint"`
+	Username                    string                 `yaml:"username"`
+	UserID                      string                 `yaml:"userid"`
+	Password                    commonconfig.Secret    `yaml:"password"`
+	ProjectName                 string                 `yaml:"project_name"`
+	ProjectID                   string                 `yaml:"project_id"`
+	DomainName                  string                 `yaml:"domain_name"`
+	DomainID                    string                 `yaml:"domain_id"`
+	ApplicationCredentialName   string                 `yaml:"application_credential_name"`
+	ApplicationCredentialID     string                 `yaml:"application_credential_id"`
+	ApplicationCredentialSecret commonconfig.Secret    `yaml:"application_credential_secret"`
+	Role                        Role                   `yaml:"role"`
+	Region                      string                 `yaml:"region"`
+	RefreshInterval             model.Duration         `yaml:"refresh_interval,omitempty"`
+	Port                        int                    `yaml:"port"`
+	AllTenants                  bool                   `yaml:"all_tenants,omitempty"`
+	TLSConfig                   commonconfig.TLSConfig `yaml:"tls_config,omitempty"`
 }
 
 // Role is the role of the target in OpenStack.
@@ -146,7 +146,7 @@ func newRefresher(conf *SDConfig, l log.Logger) (refresher, error) {
 	if err != nil {
 		return nil, err
 	}
-	tls, err := config_util.NewTLSConfig(&conf.TLSConfig)
+	tls, err := commonconfig.NewTLSConfig(&conf.TLSConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/discovery/triton/triton.go
+++ b/discovery/triton/triton.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-kit/kit/log"
 	conntrack "github.com/mwitkow/go-conntrack"
 	"github.com/pkg/errors"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/discovery/refresh"
@@ -53,14 +53,14 @@ var DefaultSDConfig = SDConfig{
 
 // SDConfig is the configuration for Triton based service discovery.
 type SDConfig struct {
-	Account         string                `yaml:"account"`
-	DNSSuffix       string                `yaml:"dns_suffix"`
-	Endpoint        string                `yaml:"endpoint"`
-	Groups          []string              `yaml:"groups,omitempty"`
-	Port            int                   `yaml:"port"`
-	RefreshInterval model.Duration        `yaml:"refresh_interval,omitempty"`
-	TLSConfig       config_util.TLSConfig `yaml:"tls_config,omitempty"`
-	Version         int                   `yaml:"version"`
+	Account         string                 `yaml:"account"`
+	DNSSuffix       string                 `yaml:"dns_suffix"`
+	Endpoint        string                 `yaml:"endpoint"`
+	Groups          []string               `yaml:"groups,omitempty"`
+	Port            int                    `yaml:"port"`
+	RefreshInterval model.Duration         `yaml:"refresh_interval,omitempty"`
+	TLSConfig       commonconfig.TLSConfig `yaml:"tls_config,omitempty"`
+	Version         int                    `yaml:"version"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -109,7 +109,7 @@ type Discovery struct {
 
 // New returns a new Discovery which periodically refreshes its targets.
 func New(logger log.Logger, conf *SDConfig) (*Discovery, error) {
-	tls, err := config_util.NewTLSConfig(&conf.TLSConfig)
+	tls, err := commonconfig.NewTLSConfig(&conf.TLSConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -35,7 +35,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 
@@ -635,7 +635,7 @@ type alertmanagerSet struct {
 }
 
 func newAlertmanagerSet(cfg *config.AlertmanagerConfig, logger log.Logger) (*alertmanagerSet, error) {
-	client, err := config_util.NewClientFromConfig(cfg.HTTPClientConfig, "alertmanager", false)
+	client, err := commonconfig.NewClientFromConfig(cfg.HTTPClientConfig, "alertmanager", false)
 	if err != nil {
 		return nil, err
 	}

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -30,7 +30,7 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -156,8 +156,8 @@ func TestHandlerSendAll(t *testing.T) {
 
 	h := NewManager(&Options{}, nil)
 
-	authClient, _ := config_util.NewClientFromConfig(config_util.HTTPClientConfig{
-		BasicAuth: &config_util.BasicAuth{
+	authClient, _ := commonconfig.NewClientFromConfig(commonconfig.HTTPClientConfig{
+		BasicAuth: &commonconfig.BasicAuth{
 			Username: "prometheus",
 			Password: "testing_password",
 		},

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	html_template "html/template"
+	htmltemplate "html/template"
 
 	yaml "gopkg.in/yaml.v2"
 
@@ -503,7 +503,7 @@ func (r *AlertingRule) String() string {
 // HTMLSnippet returns an HTML snippet representing this alerting rule. The
 // resulting snippet is expected to be presented in a <pre> element, so that
 // line breaks and other returned whitespace is respected.
-func (r *AlertingRule) HTMLSnippet(pathPrefix string) html_template.HTML {
+func (r *AlertingRule) HTMLSnippet(pathPrefix string) htmltemplate.HTML {
 	alertMetric := model.Metric{
 		model.MetricNameLabel: alertMetricName,
 		alertNameLabel:        model.LabelValue(r.name),
@@ -511,17 +511,17 @@ func (r *AlertingRule) HTMLSnippet(pathPrefix string) html_template.HTML {
 
 	labelsMap := make(map[string]string, len(r.labels))
 	for _, l := range r.labels {
-		labelsMap[l.Name] = html_template.HTMLEscapeString(l.Value)
+		labelsMap[l.Name] = htmltemplate.HTMLEscapeString(l.Value)
 	}
 
 	annotationsMap := make(map[string]string, len(r.annotations))
 	for _, l := range r.annotations {
-		annotationsMap[l.Name] = html_template.HTMLEscapeString(l.Value)
+		annotationsMap[l.Name] = htmltemplate.HTMLEscapeString(l.Value)
 	}
 
 	ar := rulefmt.Rule{
 		Alert:       fmt.Sprintf("<a href=%q>%s</a>", pathPrefix+strutil.TableLinkForExpression(alertMetric.String()), r.name),
-		Expr:        fmt.Sprintf("<a href=%q>%s</a>", pathPrefix+strutil.TableLinkForExpression(r.vector.String()), html_template.HTMLEscapeString(r.vector.String())),
+		Expr:        fmt.Sprintf("<a href=%q>%s</a>", pathPrefix+strutil.TableLinkForExpression(r.vector.String()), htmltemplate.HTMLEscapeString(r.vector.String())),
 		For:         model.Duration(r.holdDuration),
 		Labels:      labelsMap,
 		Annotations: annotationsMap,
@@ -529,9 +529,9 @@ func (r *AlertingRule) HTMLSnippet(pathPrefix string) html_template.HTML {
 
 	byt, err := yaml.Marshal(ar)
 	if err != nil {
-		return html_template.HTML(fmt.Sprintf("error marshaling alerting rule: %q", html_template.HTMLEscapeString(err.Error())))
+		return htmltemplate.HTML(fmt.Sprintf("error marshaling alerting rule: %q", htmltemplate.HTMLEscapeString(err.Error())))
 	}
-	return html_template.HTML(byt)
+	return htmltemplate.HTML(byt)
 }
 
 // HoldDuration returns the holdDuration of the alerting rule.

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	html_template "html/template"
+	htmltemplate "html/template"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -213,7 +213,7 @@ type Rule interface {
 	GetEvaluationTimestamp() time.Time
 	// HTMLSnippet returns a human-readable string representation of the rule,
 	// decorated with HTML elements for use the web frontend.
-	HTMLSnippet(pathPrefix string) html_template.HTML
+	HTMLSnippet(pathPrefix string) htmltemplate.HTML
 }
 
 // Group is a set of rules that have a logical relation.

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -31,7 +31,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 
@@ -188,7 +188,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app Appendable, jitterSeed uint64, 
 		logger = log.NewNopLogger()
 	}
 
-	client, err := config_util.NewClientFromConfig(cfg.HTTPClientConfig, cfg.JobName, false)
+	client, err := commonconfig.NewClientFromConfig(cfg.HTTPClientConfig, cfg.JobName, false)
 	if err != nil {
 		targetScrapePoolsFailed.Inc()
 		return nil, errors.Wrap(err, "error creating HTTP client")
@@ -286,7 +286,7 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 	sp.mtx.Lock()
 	defer sp.mtx.Unlock()
 
-	client, err := config_util.NewClientFromConfig(cfg.HTTPClientConfig, cfg.JobName, false)
+	client, err := commonconfig.NewClientFromConfig(cfg.HTTPClientConfig, cfg.JobName, false)
 	if err != nil {
 		targetScrapePoolReloadsFailed.Inc()
 		return errors.Wrap(err, "error creating HTTP client")

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/prometheus/common/model"
 
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
@@ -148,10 +148,10 @@ func TestNewHTTPBearerToken(t *testing.T) {
 	)
 	defer server.Close()
 
-	cfg := config_util.HTTPClientConfig{
+	cfg := commonconfig.HTTPClientConfig{
 		BearerToken: "1234",
 	}
-	c, err := config_util.NewClientFromConfig(cfg, "test", false)
+	c, err := commonconfig.NewClientFromConfig(cfg, "test", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,10 +175,10 @@ func TestNewHTTPBearerTokenFile(t *testing.T) {
 	)
 	defer server.Close()
 
-	cfg := config_util.HTTPClientConfig{
+	cfg := commonconfig.HTTPClientConfig{
 		BearerTokenFile: "testdata/bearertoken.txt",
 	}
-	c, err := config_util.NewClientFromConfig(cfg, "test", false)
+	c, err := commonconfig.NewClientFromConfig(cfg, "test", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,13 +201,13 @@ func TestNewHTTPBasicAuth(t *testing.T) {
 	)
 	defer server.Close()
 
-	cfg := config_util.HTTPClientConfig{
-		BasicAuth: &config_util.BasicAuth{
+	cfg := commonconfig.HTTPClientConfig{
+		BasicAuth: &commonconfig.BasicAuth{
 			Username: "user",
 			Password: "password123",
 		},
 	}
-	c, err := config_util.NewClientFromConfig(cfg, "test", false)
+	c, err := commonconfig.NewClientFromConfig(cfg, "test", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,12 +230,12 @@ func TestNewHTTPCACert(t *testing.T) {
 	server.StartTLS()
 	defer server.Close()
 
-	cfg := config_util.HTTPClientConfig{
-		TLSConfig: config_util.TLSConfig{
+	cfg := commonconfig.HTTPClientConfig{
+		TLSConfig: commonconfig.TLSConfig{
 			CAFile: caCertPath,
 		},
 	}
-	c, err := config_util.NewClientFromConfig(cfg, "test", false)
+	c, err := commonconfig.NewClientFromConfig(cfg, "test", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,14 +262,14 @@ func TestNewHTTPClientCert(t *testing.T) {
 	server.StartTLS()
 	defer server.Close()
 
-	cfg := config_util.HTTPClientConfig{
-		TLSConfig: config_util.TLSConfig{
+	cfg := commonconfig.HTTPClientConfig{
+		TLSConfig: commonconfig.TLSConfig{
 			CAFile:   caCertPath,
 			CertFile: "testdata/client.cer",
 			KeyFile:  "testdata/client.key",
 		},
 	}
-	c, err := config_util.NewClientFromConfig(cfg, "test", false)
+	c, err := commonconfig.NewClientFromConfig(cfg, "test", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -292,13 +292,13 @@ func TestNewHTTPWithServerName(t *testing.T) {
 	server.StartTLS()
 	defer server.Close()
 
-	cfg := config_util.HTTPClientConfig{
-		TLSConfig: config_util.TLSConfig{
+	cfg := commonconfig.HTTPClientConfig{
+		TLSConfig: commonconfig.TLSConfig{
 			CAFile:     caCertPath,
 			ServerName: "prometheus.rocks",
 		},
 	}
-	c, err := config_util.NewClientFromConfig(cfg, "test", false)
+	c, err := commonconfig.NewClientFromConfig(cfg, "test", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,13 +321,13 @@ func TestNewHTTPWithBadServerName(t *testing.T) {
 	server.StartTLS()
 	defer server.Close()
 
-	cfg := config_util.HTTPClientConfig{
-		TLSConfig: config_util.TLSConfig{
+	cfg := commonconfig.HTTPClientConfig{
+		TLSConfig: commonconfig.TLSConfig{
 			CAFile:     caCertPath,
 			ServerName: "badname",
 		},
 	}
-	c, err := config_util.NewClientFromConfig(cfg, "test", false)
+	c, err := commonconfig.NewClientFromConfig(cfg, "test", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,14 +359,14 @@ func newTLSConfig(certName string, t *testing.T) *tls.Config {
 }
 
 func TestNewClientWithBadTLSConfig(t *testing.T) {
-	cfg := config_util.HTTPClientConfig{
-		TLSConfig: config_util.TLSConfig{
+	cfg := commonconfig.HTTPClientConfig{
+		TLSConfig: commonconfig.TLSConfig{
 			CAFile:   "testdata/nonexistent_ca.cer",
 			CertFile: "testdata/nonexistent_client.cer",
 			KeyFile:  "testdata/nonexistent_client.key",
 		},
 	}
-	_, err := config_util.NewClientFromConfig(cfg, "test", false)
+	_, err := commonconfig.NewClientFromConfig(cfg, "test", false)
 	if err == nil {
 		t.Fatalf("Expected error, got nil.")
 	}

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 
@@ -40,21 +40,21 @@ var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 // Client allows reading and writing from/to a remote HTTP endpoint.
 type Client struct {
 	index   int // Used to differentiate clients in metrics.
-	url     *config_util.URL
+	url     *commonconfig.URL
 	client  *http.Client
 	timeout time.Duration
 }
 
 // ClientConfig configures a Client.
 type ClientConfig struct {
-	URL              *config_util.URL
+	URL              *commonconfig.URL
 	Timeout          model.Duration
-	HTTPClientConfig config_util.HTTPClientConfig
+	HTTPClientConfig commonconfig.HTTPClientConfig
 }
 
 // NewClient creates a new Client.
 func NewClient(index int, conf *ClientConfig) (*Client, error) {
-	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage", false)
+	httpClient, err := commonconfig.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage", false)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/util/testutil"
@@ -67,7 +67,7 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 		}
 
 		c, err := NewClient(0, &ClientConfig{
-			URL:     &config_util.URL{URL: serverURL},
+			URL:     &commonconfig.URL{URL: serverURL},
 			Timeout: model.Duration(time.Second),
 		})
 		if err != nil {

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 
-	client_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -277,7 +277,7 @@ func TestReleaseNoninternedString(t *testing.T) {
 		m.SeriesReset(1)
 	}
 
-	metric := client_testutil.ToFloat64(noReferenceReleases)
+	metric := promtestutil.ToFloat64(noReferenceReleases)
 	testutil.Assert(t, metric == 0, "expected there to be no calls to release for strings that were not already interned: %d", int(metric))
 }
 

--- a/template/template.go
+++ b/template/template.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	html_template "html/template"
-	text_template "text/template"
+	htmltemplate "html/template"
+	texttemplate "text/template"
 
 	"github.com/pkg/errors"
 
@@ -103,7 +103,7 @@ type Expander struct {
 	text    string
 	name    string
 	data    interface{}
-	funcMap text_template.FuncMap
+	funcMap texttemplate.FuncMap
 }
 
 // NewTemplateExpander returns a template expander ready to use.
@@ -120,7 +120,7 @@ func NewTemplateExpander(
 		text: text,
 		name: name,
 		data: data,
-		funcMap: text_template.FuncMap{
+		funcMap: texttemplate.FuncMap{
 			"query": func(q string) (queryResult, error) {
 				return query(ctx, q, timestamp.Time(), queryFunc)
 			},
@@ -150,8 +150,8 @@ func NewTemplateExpander(
 				re := regexp.MustCompile(pattern)
 				return re.ReplaceAllString(text, repl)
 			},
-			"safeHtml": func(text string) html_template.HTML {
-				return html_template.HTML(text)
+			"safeHtml": func(text string) htmltemplate.HTML {
+				return htmltemplate.HTML(text)
 			},
 			"match":     regexp.MatchString,
 			"title":     strings.Title,
@@ -278,7 +278,7 @@ func AlertTemplateData(labels map[string]string, externalLabels map[string]strin
 
 // Funcs adds the functions in fm to the Expander's function map.
 // Existing functions will be overwritten in case of conflict.
-func (te Expander) Funcs(fm text_template.FuncMap) {
+func (te Expander) Funcs(fm texttemplate.FuncMap) {
 	for k, v := range fm {
 		te.funcMap[k] = v
 	}
@@ -303,7 +303,7 @@ func (te Expander) Expand() (result string, resultErr error) {
 
 	templateTextExpansionTotal.Inc()
 
-	tmpl, err := text_template.New(te.name).Funcs(te.funcMap).Option("missingkey=zero").Parse(te.text)
+	tmpl, err := texttemplate.New(te.name).Funcs(te.funcMap).Option("missingkey=zero").Parse(te.text)
 	if err != nil {
 		return "", errors.Wrapf(err, "error parsing template %v", te.name)
 	}
@@ -327,13 +327,13 @@ func (te Expander) ExpandHTML(templateFiles []string) (result string, resultErr 
 		}
 	}()
 
-	tmpl := html_template.New(te.name).Funcs(html_template.FuncMap(te.funcMap))
+	tmpl := htmltemplate.New(te.name).Funcs(htmltemplate.FuncMap(te.funcMap))
 	tmpl.Option("missingkey=zero")
-	tmpl.Funcs(html_template.FuncMap{
-		"tmpl": func(name string, data interface{}) (html_template.HTML, error) {
+	tmpl.Funcs(htmltemplate.FuncMap{
+		"tmpl": func(name string, data interface{}) (htmltemplate.HTML, error) {
 			var buffer bytes.Buffer
 			err := tmpl.ExecuteTemplate(&buffer, name, data)
-			return html_template.HTML(buffer.String()), err
+			return htmltemplate.HTML(buffer.String()), err
 		},
 	})
 	tmpl, err := tmpl.Parse(te.text)
@@ -356,7 +356,7 @@ func (te Expander) ExpandHTML(templateFiles []string) (result string, resultErr 
 
 // ParseTest parses the templates and returns the error if any.
 func (te Expander) ParseTest() error {
-	_, err := text_template.New(te.name).Funcs(te.funcMap).Option("missingkey=zero").Parse(te.text)
+	_, err := texttemplate.New(te.name).Funcs(te.funcMap).Option("missingkey=zero").Parse(te.text)
 	if err != nil {
 		return err
 	}

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/labels"
@@ -243,7 +243,7 @@ func writeMetaFile(logger log.Logger, dir string, meta *BlockMeta) (int64, error
 		return 0, err
 	}
 
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 	n, err := f.Write(jsonMeta)
 	if err != nil {
 		merr.Add(err)
@@ -297,7 +297,7 @@ func OpenBlock(logger log.Logger, dir string, pool chunkenc.Pool) (pb *Block, er
 	var closers []io.Closer
 	defer func() {
 		if err != nil {
-			var merr tsdb_errors.MultiError
+			var merr tsdberrors.MultiError
 			merr.Add(err)
 			merr.Add(closeAll(closers))
 			err = merr.Err()
@@ -350,7 +350,7 @@ func (pb *Block) Close() error {
 
 	pb.pendingReaders.Wait()
 
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 
 	merr.Add(pb.chunkr.Close())
 	merr.Add(pb.indexr.Close())

--- a/tsdb/checkpoint.go
+++ b/tsdb/checkpoint.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/wal"
 )
@@ -68,7 +68,7 @@ func LastCheckpoint(dir string) (string, int, error) {
 
 // DeleteCheckpoints deletes all checkpoints in a directory below a given index.
 func DeleteCheckpoints(dir string, maxIndex int) error {
-	var errs tsdb_errors.MultiError
+	var errs tsdberrors.MultiError
 
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {

--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 )
 
@@ -411,7 +411,7 @@ func NewDirReader(dir string, pool chunkenc.Pool) (*Reader, error) {
 	var (
 		bs   []ByteSlice
 		cs   []io.Closer
-		merr tsdb_errors.MultiError
+		merr tsdberrors.MultiError
 	)
 	for _, fn := range files {
 		f, err := fileutil.OpenMmapFile(fn)
@@ -503,7 +503,7 @@ func sequenceFiles(dir string) ([]string, error) {
 }
 
 func closeAll(cs []io.Closer) error {
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 
 	for _, c := range cs {
 		merr.Add(c.Close())

--- a/tsdb/cmd/tsdb/main.go
+++ b/tsdb/cmd/tsdb/main.go
@@ -34,7 +34,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunks"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/labels"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
@@ -70,7 +70,7 @@ func execute() (err error) {
 	)
 
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 
 	switch kingpin.MustParse(cli.Parse(os.Args[1:])) {
 	case benchWriteCmd.FullCommand():
@@ -624,7 +624,7 @@ func dumpSamples(db *tsdb.DBReadOnly, mint, maxt int64) (err error) {
 		return err
 	}
 	defer func() {
-		var merr tsdb_errors.MultiError
+		var merr tsdberrors.MultiError
 		merr.Add(err)
 		merr.Add(q.Close())
 		err = merr.Err()

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -31,7 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/labels"
@@ -450,7 +450,7 @@ func (c *LeveledCompactor) Compact(dest string, dirs []string, open []*Block) (u
 		return uid, nil
 	}
 
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 	merr.Add(err)
 	if err != context.Canceled {
 		for _, b := range bs {
@@ -528,7 +528,7 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockRe
 	tmp := dir + ".tmp"
 	var closers []io.Closer
 	defer func(t time.Time) {
-		var merr tsdb_errors.MultiError
+		var merr tsdberrors.MultiError
 		merr.Add(err)
 		merr.Add(closeAll(closers))
 		err = merr.Err()
@@ -588,7 +588,7 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockRe
 	// though these are covered under defer. This is because in Windows,
 	// you cannot delete these unless they are closed and the defer is to
 	// make sure they are closed if the function exits due to an error above.
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 	for _, w := range closers {
 		merr.Add(w.Close())
 	}
@@ -654,7 +654,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		overlapping bool
 	)
 	defer func() {
-		var merr tsdb_errors.MultiError
+		var merr tsdberrors.MultiError
 		merr.Add(err)
 		merr.Add(closeAll(closers))
 		err = merr.Err()

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -35,7 +35,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	_ "github.com/prometheus/prometheus/tsdb/goversion"
 	"github.com/prometheus/prometheus/tsdb/labels"
@@ -420,7 +420,7 @@ func (db *DBReadOnly) Close() error {
 	}
 	close(db.closed)
 
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 
 	for _, b := range db.closers {
 		merr.Add(b.Close())
@@ -1074,7 +1074,7 @@ func (db *DB) Close() error {
 		g.Go(pb.Close)
 	}
 
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 
 	merr.Add(g.Wait())
 
@@ -1315,7 +1315,7 @@ func nextSequenceFile(dir string) (string, int, error) {
 }
 
 func closeAll(cs []io.Closer) error {
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 
 	for _, c := range cs {
 		merr.Add(c.Close())

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/labels"
@@ -1082,7 +1082,7 @@ func TestTimeRetention(t *testing.T) {
 	expBlocks := blocks[1:]
 	actBlocks := db.Blocks()
 
-	testutil.Equals(t, 1, int(prom_testutil.ToFloat64(db.metrics.timeRetentionCount)), "metric retention count mismatch")
+	testutil.Equals(t, 1, int(promtestutil.ToFloat64(db.metrics.timeRetentionCount)), "metric retention count mismatch")
 	testutil.Equals(t, len(expBlocks), len(actBlocks))
 	testutil.Equals(t, expBlocks[0].MaxTime, actBlocks[0].meta.MaxTime)
 	testutil.Equals(t, expBlocks[len(expBlocks)-1].MaxTime, actBlocks[len(actBlocks)-1].meta.MaxTime)
@@ -1110,9 +1110,9 @@ func TestSizeRetention(t *testing.T) {
 	}
 
 	// Test that registered size matches the actual disk size.
-	testutil.Ok(t, db.reload())                                       // Reload the db to register the new db size.
-	testutil.Equals(t, len(blocks), len(db.Blocks()))                 // Ensure all blocks are registered.
-	expSize := int64(prom_testutil.ToFloat64(db.metrics.blocksBytes)) // Use the the actual internal metrics.
+	testutil.Ok(t, db.reload())                                      // Reload the db to register the new db size.
+	testutil.Equals(t, len(blocks), len(db.Blocks()))                // Ensure all blocks are registered.
+	expSize := int64(promtestutil.ToFloat64(db.metrics.blocksBytes)) // Use the the actual internal metrics.
 	actSize := testutil.DirSize(t, db.Dir())
 	testutil.Equals(t, expSize, actSize, "registered size doesn't match actual disk size")
 
@@ -1125,8 +1125,8 @@ func TestSizeRetention(t *testing.T) {
 
 	expBlocks := blocks[1:]
 	actBlocks := db.Blocks()
-	expSize = int64(prom_testutil.ToFloat64(db.metrics.blocksBytes))
-	actRetentCount := int(prom_testutil.ToFloat64(db.metrics.sizeRetentionCount))
+	expSize = int64(promtestutil.ToFloat64(db.metrics.blocksBytes))
+	actRetentCount := int(promtestutil.ToFloat64(db.metrics.sizeRetentionCount))
 	actSize = testutil.DirSize(t, db.Dir())
 
 	testutil.Equals(t, 1, actRetentCount, "metric retention count mismatch")
@@ -1154,7 +1154,7 @@ func TestSizeRetentionMetric(t *testing.T) {
 			MaxBytes:    c.maxBytes,
 		})
 
-		actMaxBytes := int64(prom_testutil.ToFloat64(db.metrics.maxBytes))
+		actMaxBytes := int64(promtestutil.ToFloat64(db.metrics.maxBytes))
 		testutil.Equals(t, actMaxBytes, c.expMaxBytes, "metric retention limit bytes mismatch")
 
 		testutil.Ok(t, db.Close())
@@ -1543,7 +1543,7 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		testutil.Equals(t, int64(6000), db.head.MinTime())
 		testutil.Equals(t, int64(15000), db.head.MaxTime())
 		// Check that old series has been GCed.
-		testutil.Equals(t, 1.0, prom_testutil.ToFloat64(db.head.metrics.series))
+		testutil.Equals(t, 1.0, promtestutil.ToFloat64(db.head.metrics.series))
 	})
 }
 
@@ -1567,7 +1567,7 @@ func TestNoEmptyBlocks(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Equals(t, len(db.Blocks()), len(actBlocks))
 		testutil.Equals(t, 0, len(actBlocks))
-		testutil.Equals(t, 0, int(prom_testutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.ran)), "no compaction should be triggered here")
+		testutil.Equals(t, 0, int(promtestutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.ran)), "no compaction should be triggered here")
 	})
 
 	t.Run("Test no blocks after deleting all samples from head.", func(t *testing.T) {
@@ -1581,7 +1581,7 @@ func TestNoEmptyBlocks(t *testing.T) {
 		testutil.Ok(t, app.Commit())
 		testutil.Ok(t, db.Delete(math.MinInt64, math.MaxInt64, defaultMatcher))
 		testutil.Ok(t, db.compact())
-		testutil.Equals(t, 1, int(prom_testutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.ran)), "compaction should have been triggered here")
+		testutil.Equals(t, 1, int(promtestutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.ran)), "compaction should have been triggered here")
 
 		actBlocks, err := blockDirs(db.Dir())
 		testutil.Ok(t, err)
@@ -1603,7 +1603,7 @@ func TestNoEmptyBlocks(t *testing.T) {
 		testutil.Ok(t, app.Commit())
 
 		testutil.Ok(t, db.compact())
-		testutil.Equals(t, 2, int(prom_testutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.ran)), "compaction should have been triggered here")
+		testutil.Equals(t, 2, int(promtestutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.ran)), "compaction should have been triggered here")
 		actBlocks, err = blockDirs(db.Dir())
 		testutil.Ok(t, err)
 		testutil.Equals(t, len(db.Blocks()), len(actBlocks))
@@ -1624,7 +1624,7 @@ func TestNoEmptyBlocks(t *testing.T) {
 		testutil.Ok(t, app.Commit())
 		testutil.Ok(t, db.head.Delete(math.MinInt64, math.MaxInt64, defaultMatcher))
 		testutil.Ok(t, db.compact())
-		testutil.Equals(t, 3, int(prom_testutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.ran)), "compaction should have been triggered here")
+		testutil.Equals(t, 3, int(promtestutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.ran)), "compaction should have been triggered here")
 		testutil.Equals(t, oldBlocks, db.Blocks())
 	})
 
@@ -1643,7 +1643,7 @@ func TestNoEmptyBlocks(t *testing.T) {
 		testutil.Equals(t, len(blocks)+len(oldBlocks), len(db.Blocks())) // Ensure all blocks are registered.
 		testutil.Ok(t, db.Delete(math.MinInt64, math.MaxInt64, defaultMatcher))
 		testutil.Ok(t, db.compact())
-		testutil.Equals(t, 5, int(prom_testutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.ran)), "compaction should have been triggered here once for each block that have tombstones")
+		testutil.Equals(t, 5, int(promtestutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.ran)), "compaction should have been triggered here once for each block that have tombstones")
 
 		actBlocks, err := blockDirs(db.Dir())
 		testutil.Ok(t, err)
@@ -2137,12 +2137,12 @@ func TestVerticalCompaction(t *testing.T) {
 
 			// Vertical compaction.
 			lc := db.compactor.(*LeveledCompactor)
-			testutil.Equals(t, 0, int(prom_testutil.ToFloat64(lc.metrics.overlappingBlocks)), "overlapping blocks count should be still 0 here")
+			testutil.Equals(t, 0, int(promtestutil.ToFloat64(lc.metrics.overlappingBlocks)), "overlapping blocks count should be still 0 here")
 			err = db.compact()
 			testutil.Ok(t, err)
 			testutil.Equals(t, c.expBlockNum, len(db.Blocks()), "Wrong number of blocks [after compact]")
 
-			testutil.Equals(t, c.expOverlappingBlocks, int(prom_testutil.ToFloat64(lc.metrics.overlappingBlocks)), "overlapping blocks count mismatch")
+			testutil.Equals(t, c.expOverlappingBlocks, int(promtestutil.ToFloat64(lc.metrics.overlappingBlocks)), "overlapping blocks count mismatch")
 
 			// Query test after merging the overlapping blocks.
 			querier, err = db.Querier(0, 100)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
@@ -1133,7 +1133,7 @@ func TestWalRepair_DecodingError(t *testing.T) {
 
 					h, err := NewHead(nil, nil, w, 1)
 					testutil.Ok(t, err)
-					testutil.Equals(t, 0.0, prom_testutil.ToFloat64(h.metrics.walCorruptionsTotal))
+					testutil.Equals(t, 0.0, promtestutil.ToFloat64(h.metrics.walCorruptionsTotal))
 					initErr := h.Init(math.MinInt64)
 
 					err = errors.Cause(initErr) // So that we can pick up errors even if wrapped.
@@ -1149,7 +1149,7 @@ func TestWalRepair_DecodingError(t *testing.T) {
 					defer func() {
 						testutil.Ok(t, db.Close())
 					}()
-					testutil.Equals(t, 1.0, prom_testutil.ToFloat64(db.head.metrics.walCorruptionsTotal))
+					testutil.Equals(t, 1.0, promtestutil.ToFloat64(db.head.metrics.walCorruptionsTotal))
 				}
 
 				// Read the wal content after the repair.

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/encoding"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/labels"
 )
@@ -652,7 +652,7 @@ func NewFileReader(path string) (*Reader, error) {
 	}
 	r, err := newReader(realByteSlice(f.Bytes()), f)
 	if err != nil {
-		var merr tsdb_errors.MultiError
+		var merr tsdberrors.MultiError
 		merr.Add(err)
 		merr.Add(f.Close())
 		return nil, merr

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/labels"
 )
@@ -136,7 +136,7 @@ func (q *querier) sel(qs []Querier, ms []labels.Matcher) (SeriesSet, error) {
 }
 
 func (q *querier) Close() error {
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 
 	for _, bq := range q.blocks {
 		merr.Add(bq.Close())
@@ -259,7 +259,7 @@ func (q *blockQuerier) Close() error {
 		return errors.New("block querier already closed")
 	}
 
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 	merr.Add(q.index.Close())
 	merr.Add(q.chunks.Close())
 	merr.Add(q.tombstones.Close())

--- a/tsdb/repair.go
+++ b/tsdb/repair.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 )
 
@@ -85,7 +85,7 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 			return wrapErr(err, d)
 		}
 
-		var merr tsdb_errors.MultiError
+		var merr tsdberrors.MultiError
 
 		// Set the 5th byte to 2 to indicate the correct file format version.
 		if _, err := repl.WriteAt([]byte{2}, 4); err != nil {

--- a/tsdb/tombstones.go
+++ b/tsdb/tombstones.go
@@ -26,7 +26,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/tsdb/encoding"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 )
 
@@ -113,7 +113,7 @@ func writeTombstoneFile(logger log.Logger, dir string, tr TombstoneReader) (int6
 	}
 	size += n
 
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 	if merr.Add(f.Sync()); merr.Err() != nil {
 		merr.Add(f.Close())
 		return 0, merr.Err()

--- a/tsdb/wal/reader_test.go
+++ b/tsdb/wal/reader_test.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -278,7 +278,7 @@ func (m *multiReadCloser) Read(p []byte) (n int, err error) {
 	return m.reader.Read(p)
 }
 func (m *multiReadCloser) Close() error {
-	var merr tsdb_errors.MultiError
+	var merr tsdberrors.MultiError
 	for _, closer := range m.closers {
 		merr.Add(closer.Close())
 	}

--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	client_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -361,7 +361,7 @@ func TestSegmentMetric(t *testing.T) {
 	w, err := NewSize(nil, nil, dir, segmentSize, false)
 	testutil.Ok(t, err)
 
-	initialSegment := client_testutil.ToFloat64(w.currentSegment)
+	initialSegment := promtestutil.ToFloat64(w.currentSegment)
 
 	// Write 3 records, each of which is half the segment size, meaning we should rotate to the next segment.
 	for i := 0; i < 3; i++ {
@@ -372,7 +372,7 @@ func TestSegmentMetric(t *testing.T) {
 		err = w.Log(buf)
 		testutil.Ok(t, err)
 	}
-	testutil.Assert(t, client_testutil.ToFloat64(w.currentSegment) == initialSegment+1, "segment metric did not increment after segment rotation")
+	testutil.Assert(t, promtestutil.ToFloat64(w.currentSegment) == initialSegment+1, "segment metric did not increment after segment rotation")
 	testutil.Ok(t, w.Close())
 }
 

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -34,11 +34,11 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
-	config_util "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/route"
-	tsdbLabels "github.com/prometheus/prometheus/tsdb/labels"
+	tsdblabels "github.com/prometheus/prometheus/tsdb/labels"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/gate"
@@ -301,7 +301,7 @@ func TestEndpoints(t *testing.T) {
 		err = remote.ApplyConfig(&config.Config{
 			RemoteReadConfigs: []*config.RemoteReadConfig{
 				{
-					URL:           &config_util.URL{URL: u},
+					URL:           &commonconfig.URL{URL: u},
 					RemoteTimeout: model.Duration(1 * time.Second),
 					ReadRecent:    true,
 				},
@@ -1024,7 +1024,7 @@ type fakeDB struct {
 }
 
 func (f *fakeDB) CleanTombstones() error                                  { return f.err }
-func (f *fakeDB) Delete(mint, maxt int64, ms ...tsdbLabels.Matcher) error { return f.err }
+func (f *fakeDB) Delete(mint, maxt int64, ms ...tsdblabels.Matcher) error { return f.err }
 func (f *fakeDB) Dir() string {
 	dir, _ := ioutil.TempDir("", "fakeDB")
 	f.closer = func() {


### PR DESCRIPTION
Regulate the package name.

There are two types of non-standard package names (https://blog.golang.org/package-names):

1. myPackage
2. my_package

There is also the case where the aliases for the same package are different.

Modified principle：

1. myPackage  -> mypackage
2. my_package -> mypackage

There are exceptions:

`github.com/prometheus/common/config` use `commonconfig` instead of `configutil`, because `configutil` is more confusing.

See diff results for more detailed modifications
