### PR TITLE
Fixes issue #5529

### DIFF
--- a/pkg/rulefmt/rulefmt_test.go
+++ b/pkg/rulefmt/rulefmt_test.go
@@ -30,6 +30,19 @@ func TestParseFileSuccess(t *testing.T) {
 	}
 }
 
+func TestParseFileSameRulesInGroupFailure(t *testing.T) {
+	errorCount := 0
+	if _, errs := ParseFile("testdata/test)samerules.yaml"); len(errs) > 0 {
+		for _, err := range errs {
+			if (err.Error() != `group "my-group-name", rule 2, "HighErrors": Alertrule HighErrors is repeated more than one time in my-group-name group` &&
+			err.Error() != `group "my-another-name", rule 2, "HighErrors": Alertrule HighErrors is repeated more than one time in my-another-name group`) {
+				errorCount++
+			}
+		}
+	} 
+	testutil.Assert(t, errorCount > 0, "Same rules should not be allowed")
+}
+
 func TestParseFileFailure(t *testing.T) {
 	table := []struct {
 		filename string

--- a/pkg/rulefmt/testdata/test_samerules.yaml
+++ b/pkg/rulefmt/testdata/test_samerules.yaml
@@ -23,7 +23,7 @@ groups:
       abc: edf
       uvw: xyz
 
-  - alert: HighErrors2
+  - alert: HighErrors
     expr: | 
       sum without(instance) (rate(errors_total[5m]))
       / 
@@ -37,7 +37,7 @@ groups:
 - name: my-another-name
   interval: 30s   # defaults to global interval
   rules:
-  - alert: HighErrors3
+  - alert: HighErrors
     expr: | 
       sum without(instance) (rate(errors_total[5m]))
       / 
@@ -52,7 +52,7 @@ groups:
       / 
       sum without(instance) (rate(requests_total[5m]))
 
-  - alert: HighErrors4
+  - alert: HighErrors
     expr: | 
       sum without(instance) (rate(errors_total[5m]))
       / 

--- a/rules/fixtures/samerules.yaml
+++ b/rules/fixtures/samerules.yaml
@@ -1,0 +1,15 @@
+---
+groups:
+  - name: "test"
+    interval: "1s"
+    rules:
+      - record: test_metric
+        expr: "0"
+        labels:
+            label: "value"
+      - record: "test_metric"
+        expr: "1"
+      - record: "result"
+        expr: "max(test_metric) by (label)"
+        labels:
+            label: "value"


### PR DESCRIPTION
This is supposed to fix [Issue 5529] (https://github.com/prometheus/prometheus/issues/5529) by checking that rules are not repeated in the same group,

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->