### PR TITLE
[tsdb] Improve mergeSeriesSet

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -112,27 +112,21 @@ func (q *querier) LabelValuesFor(string, labels.Label) ([]string, error) {
 }
 
 func (q *querier) Select(ms ...labels.Matcher) (SeriesSet, error) {
-	return q.sel(q.blocks, ms)
-}
-
-func (q *querier) sel(qs []Querier, ms []labels.Matcher) (SeriesSet, error) {
-	if len(qs) == 0 {
+	if len(q.blocks) == 0 {
 		return EmptySeriesSet(), nil
 	}
-	if len(qs) == 1 {
-		return qs[0].Select(ms...)
+	ss := make([]SeriesSet, len(q.blocks))
+	var s SeriesSet
+	var err error
+	for i, b := range q.blocks {
+		s, err = b.Select(ms...)
+		if err != nil {
+			return nil, err
+		}
+		ss[i] = s
 	}
-	l := len(qs) / 2
 
-	a, err := q.sel(qs[:l], ms)
-	if err != nil {
-		return nil, err
-	}
-	b, err := q.sel(qs[l:], ms)
-	if err != nil {
-		return nil, err
-	}
-	return newMergedSeriesSet(a, b), nil
+	return NewMergedSeriesSet(ss), nil
 }
 
 func (q *querier) Close() error {
@@ -530,29 +524,30 @@ func EmptySeriesSet() SeriesSet {
 	return emptySeriesSet
 }
 
-// mergedSeriesSet takes two series sets as a single series set. The input series sets
-// must be sorted and sequential in time, i.e. if they have the same label set,
-// the datapoints of a must be before the datapoints of b.
+// mergedSeriesSet returns a series sets slice as a single series set. The input series sets
+// must be sorted and sequential in time.
 type mergedSeriesSet struct {
-	a, b SeriesSet
-
-	cur          Series
-	adone, bdone bool
+	all  []SeriesSet
+	buf  []SeriesSet // A buffer for keeping the order of SeriesSet slice during forwarding the SeriesSet.
+	ids  []int       // The indices of chosen SeriesSet for the current run.
+	done bool
+	err  error
+	cur  Series
 }
 
-// NewMergedSeriesSet takes two series sets as a single series set. The input series sets
-// must be sorted and sequential in time, i.e. if they have the same label set,
-// the datapoints of a must be before the datapoints of b.
-func NewMergedSeriesSet(a, b SeriesSet) SeriesSet {
-	return newMergedSeriesSet(a, b)
-}
-
-func newMergedSeriesSet(a, b SeriesSet) *mergedSeriesSet {
-	s := &mergedSeriesSet{a: a, b: b}
-	// Initialize first elements of both sets as Next() needs
+func NewMergedSeriesSet(all []SeriesSet) SeriesSet {
+	if len(all) == 1 {
+		return all[0]
+	} else if len(all) == 2 {
+		return newBinaryMergedSeriesSet(all[0], all[1])
+	}
+	s := &mergedSeriesSet{all: all}
+	// Initialize first elements of all sets as Next() needs
 	// one element look-ahead.
-	s.adone = !s.a.Next()
-	s.bdone = !s.b.Next()
+	s.nextAll()
+	if len(s.all) == 0 {
+		s.done = true
+	}
 
 	return s
 }
@@ -562,13 +557,130 @@ func (s *mergedSeriesSet) At() Series {
 }
 
 func (s *mergedSeriesSet) Err() error {
+	return s.err
+}
+
+// This function is to call Next() for all SeriesSet.
+// Because the order of the SeriesSet slice will affect the results,
+// we need to use an buffer slice to hold the order.
+func (s *mergedSeriesSet) nextAll() {
+	s.buf = s.buf[:0]
+	for _, ss := range s.all {
+		if ss.Next() {
+			s.buf = append(s.buf, ss)
+		} else if ss.Err() != nil {
+			s.done = true
+			s.err = ss.Err()
+			break
+		}
+	}
+	s.all, s.buf = s.buf, s.all
+}
+
+// This function is to call Next() for the SeriesSet with the indices of s.ids.
+// Because the order of the SeriesSet slice will affect the results,
+// we need to use an buffer slice to hold the order.
+func (s *mergedSeriesSet) nextWithID() {
+	if len(s.ids) == 0 {
+		return
+	}
+
+	s.buf = s.buf[:0]
+	i1 := 0
+	i2 := 0
+	for i1 < len(s.all) {
+		if i1 == s.ids[i2] {
+			if !s.all[s.ids[i2]].Next() {
+				if s.all[s.ids[i2]].Err() != nil {
+					s.done = true
+					s.err = s.all[s.ids[i2]].Err()
+					break
+				}
+				i2++
+				i1++
+				continue
+			}
+			i2++
+		}
+		s.buf = append(s.buf, s.all[i1])
+		i1++
+	}
+	s.all, s.buf = s.buf, s.all
+}
+
+func (s *mergedSeriesSet) Next() bool {
+	if s.done {
+		return false
+	}
+
+	s.nextWithID()
+	if s.done {
+		return false
+	}
+	s.ids = s.ids[:0]
+	if len(s.all) == 0 {
+		s.done = true
+		return false
+	}
+
+	// Here we are looking for a set of series sets with the lowest labels,
+	// and we will cache their indexes in s.ids.
+	s.ids = append(s.ids, 0)
+	for i := 1; i < len(s.all); i++ {
+		cmp := labels.Compare(s.all[s.ids[0]].At().Labels(), s.all[i].At().Labels())
+		if cmp > 0 {
+			s.ids = s.ids[:1]
+			s.ids[0] = i
+		} else if cmp == 0 {
+			s.ids = append(s.ids, i)
+		}
+	}
+
+	if len(s.ids) > 1 {
+		series := make([]Series, len(s.ids))
+		for i, idx := range s.ids {
+			series[i] = s.all[idx].At()
+		}
+		s.cur = &chainedSeries{series: series}
+	} else {
+		s.cur = s.all[s.ids[0]].At()
+	}
+	return true
+}
+
+type binaryMergedSeriesSet struct {
+	a, b SeriesSet
+
+	cur          Series
+	adone, bdone bool
+}
+
+func NewBinaryMergedSeriesSet(a, b SeriesSet) SeriesSet {
+	return newBinaryMergedSeriesSet(a, b)
+}
+
+func newBinaryMergedSeriesSet(a, b SeriesSet) *binaryMergedSeriesSet {
+	s := &binaryMergedSeriesSet{a: a, b: b}
+	// Initialize first elements of both sets as Next() needs
+	// one element look-ahead.
+	s.adone = !s.a.Next()
+	s.bdone = !s.b.Next()
+
+	return s
+}
+
+func (s *binaryMergedSeriesSet) At() Series {
+	return s.cur
+}
+
+func (s *binaryMergedSeriesSet) Err() error {
 	if s.a.Err() != nil {
 		return s.a.Err()
 	}
 	return s.b.Err()
 }
 
-func (s *mergedSeriesSet) compare() int {
+func (s *binaryMergedSeriesSet) compare() int {
 	if s.adone {
 		return 1
 	}
@@ -578,7 +690,7 @@ func (s *mergedSeriesSet) compare() int {
 	return labels.Compare(s.a.At().Labels(), s.b.At().Labels())
 }
 
-func (s *mergedSeriesSet) Next() bool {
+func (s *binaryMergedSeriesSet) Next() bool {
 	if s.adone && s.bdone || s.Err() != nil {
 		return false
 	}

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -560,7 +560,7 @@ func (s *mergedSeriesSet) Err() error {
 	return s.err
 }
 
-// This function is to call Next() for all SeriesSet.
+// nextAll is to call Next() for all SeriesSet.
 // Because the order of the SeriesSet slice will affect the results,
 // we need to use an buffer slice to hold the order.
 func (s *mergedSeriesSet) nextAll() {
@@ -577,7 +577,7 @@ func (s *mergedSeriesSet) nextAll() {
 	s.all, s.buf = s.buf, s.all
 }
 
-// This function is to call Next() for the SeriesSet with the indices of s.ids.
+// nextWithID is to call Next() for the SeriesSet with the indices of s.ids.
 // Because the order of the SeriesSet slice will affect the results,
 // we need to use an buffer slice to hold the order.
 func (s *mergedSeriesSet) nextWithID() {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -156,7 +156,7 @@ func TestMergedSeriesSet(t *testing.T) {
 
 Outer:
 	for _, c := range cases {
-		res := newMergedSeriesSet(c.a, c.b)
+		res := NewMergedSeriesSet([]SeriesSet{c.a, c.b})
 
 		for {
 			eok, rok := c.exp.Next(), res.Next()
@@ -1170,17 +1170,8 @@ func (m *mockChunkSeriesSet) Err() error {
 // Test the cost of merging series sets for different number of merged sets and their size.
 // The subset are all equivalent so this does not capture merging of partial or non-overlapping sets well.
 func BenchmarkMergedSeriesSet(b *testing.B) {
-	var sel func(sets []SeriesSet) SeriesSet
-
-	sel = func(sets []SeriesSet) SeriesSet {
-		if len(sets) == 0 {
-			return EmptySeriesSet()
-		}
-		if len(sets) == 1 {
-			return sets[0]
-		}
-		l := len(sets) / 2
-		return newMergedSeriesSet(sel(sets[:l]), sel(sets[l:]))
+	var sel = func(sets []SeriesSet) SeriesSet {
+		return NewMergedSeriesSet(sets)
 	}
 
 	for _, k := range []int{


### PR DESCRIPTION
Using the idea similar to [tsdb/pr616](https://github.com/prometheus/tsdb/pull/616) to improve both time and alloc.
Currently I use the original `mergeSeriesSet` if the len of the passed-in seriesset slice = **2**, because I think the original one is the most efficient way for merging only **2** seriesset.
Benchmark results of `BenchmarkMergedSeriesSet`.
```
benchmark                                             old ns/op     new ns/op     delta
BenchmarkMergedSeriesSet/series=100,blocks=1-8        4746          4807          +1.29%
BenchmarkMergedSeriesSet/series=100,blocks=2-8        43989         44127         +0.31%
BenchmarkMergedSeriesSet/series=100,blocks=4-8        130592        89924         -31.14%
BenchmarkMergedSeriesSet/series=100,blocks=8-8        291087        165807        -43.04%
BenchmarkMergedSeriesSet/series=100,blocks=16-8       653520        331504        -49.27%
BenchmarkMergedSeriesSet/series=100,blocks=32-8       1344424       660384        -50.88%
BenchmarkMergedSeriesSet/series=1000,blocks=1-8       8172          8902          +8.93%
BenchmarkMergedSeriesSet/series=1000,blocks=2-8       441894        443515        +0.37%
BenchmarkMergedSeriesSet/series=1000,blocks=4-8       1311465       939890        -28.33%
BenchmarkMergedSeriesSet/series=1000,blocks=8-8       3088490       1883928       -39.00%
BenchmarkMergedSeriesSet/series=1000,blocks=16-8      6871918       3531934       -48.60%
BenchmarkMergedSeriesSet/series=1000,blocks=32-8      12685259      6169894       -51.36%
BenchmarkMergedSeriesSet/series=10000,blocks=1-8      36889         36654         -0.64%
BenchmarkMergedSeriesSet/series=10000,blocks=2-8      3186629       3136228       -1.58%
BenchmarkMergedSeriesSet/series=10000,blocks=4-8      8641566       6963987       -19.41%
BenchmarkMergedSeriesSet/series=10000,blocks=8-8      18862093      13080495      -30.65%
BenchmarkMergedSeriesSet/series=10000,blocks=16-8     41348147      24343738      -41.12%
BenchmarkMergedSeriesSet/series=10000,blocks=32-8     86234288      48789802      -43.42%
BenchmarkMergedSeriesSet/series=20000,blocks=1-8      69872         68857         -1.45%
BenchmarkMergedSeriesSet/series=20000,blocks=2-8      7255853       7572243       +4.36%
BenchmarkMergedSeriesSet/series=20000,blocks=4-8      17507968      15065738      -13.95%
BenchmarkMergedSeriesSet/series=20000,blocks=8-8      37290957      26177634      -29.80%
BenchmarkMergedSeriesSet/series=20000,blocks=16-8     78885648      48284644      -38.79%
BenchmarkMergedSeriesSet/series=20000,blocks=32-8     173633339     98093248      -43.51%

benchmark                                             old allocs     new allocs     delta
BenchmarkMergedSeriesSet/series=100,blocks=1-8        11             11             +0.00%
BenchmarkMergedSeriesSet/series=100,blocks=2-8        217            217            +0.00%
BenchmarkMergedSeriesSet/series=100,blocks=4-8        628            232            -63.06%
BenchmarkMergedSeriesSet/series=100,blocks=8-8        1449           251            -82.68%
BenchmarkMergedSeriesSet/series=100,blocks=16-8       3090           286            -90.74%
BenchmarkMergedSeriesSet/series=100,blocks=32-8       6371           353            -94.46%
BenchmarkMergedSeriesSet/series=1000,blocks=1-8       11             11             +0.00%
BenchmarkMergedSeriesSet/series=1000,blocks=2-8       2017           2017           +0.00%
BenchmarkMergedSeriesSet/series=1000,blocks=4-8       6028           2032           -66.29%
BenchmarkMergedSeriesSet/series=1000,blocks=8-8       14049          2051           -85.40%
BenchmarkMergedSeriesSet/series=1000,blocks=16-8      30090          2086           -93.07%
BenchmarkMergedSeriesSet/series=1000,blocks=32-8      62171          2153           -96.54%
BenchmarkMergedSeriesSet/series=10000,blocks=1-8      11             11             +0.00%
BenchmarkMergedSeriesSet/series=10000,blocks=2-8      20017          20017          +0.00%
BenchmarkMergedSeriesSet/series=10000,blocks=4-8      60028          20032          -66.63%
BenchmarkMergedSeriesSet/series=10000,blocks=8-8      140049         20051          -85.68%
BenchmarkMergedSeriesSet/series=10000,blocks=16-8     300090         20086          -93.31%
BenchmarkMergedSeriesSet/series=10000,blocks=32-8     620171         20153          -96.75%
BenchmarkMergedSeriesSet/series=20000,blocks=1-8      11             11             +0.00%
BenchmarkMergedSeriesSet/series=20000,blocks=2-8      40017          40017          +0.00%
BenchmarkMergedSeriesSet/series=20000,blocks=4-8      120028         40032          -66.65%
BenchmarkMergedSeriesSet/series=20000,blocks=8-8      280049         40051          -85.70%
BenchmarkMergedSeriesSet/series=20000,blocks=16-8     600090         40086          -93.32%
BenchmarkMergedSeriesSet/series=20000,blocks=32-8     1240171        40153          -96.76%

benchmark                                             old bytes     new bytes     delta
BenchmarkMergedSeriesSet/series=100,blocks=1-8        552           552           +0.00%
BenchmarkMergedSeriesSet/series=100,blocks=2-8        7184          7184          +0.00%
BenchmarkMergedSeriesSet/series=100,blocks=4-8        20448         10920         -46.60%
BenchmarkMergedSeriesSet/series=100,blocks=8-8        46976         18184         -61.29%
BenchmarkMergedSeriesSet/series=100,blocks=16-8       100032        32712         -67.30%
BenchmarkMergedSeriesSet/series=100,blocks=32-8       206144        61768         -70.04%
BenchmarkMergedSeriesSet/series=1000,blocks=1-8       552           552           +0.00%
BenchmarkMergedSeriesSet/series=1000,blocks=2-8       64784         64784         +0.00%
BenchmarkMergedSeriesSet/series=1000,blocks=4-8       193248        97320         -49.64%
BenchmarkMergedSeriesSet/series=1000,blocks=8-8       450176        162184        -63.97%
BenchmarkMergedSeriesSet/series=1000,blocks=16-8      964033        291912        -69.72%
BenchmarkMergedSeriesSet/series=1000,blocks=32-8      1991745       551368        -72.32%
BenchmarkMergedSeriesSet/series=10000,blocks=1-8      552           552           +0.00%
BenchmarkMergedSeriesSet/series=10000,blocks=2-8      640784        640784        +0.00%
BenchmarkMergedSeriesSet/series=10000,blocks=4-8      1921249       961320        -49.96%
BenchmarkMergedSeriesSet/series=10000,blocks=8-8      4482178       1602185       -64.25%
BenchmarkMergedSeriesSet/series=10000,blocks=16-8     9604032       2883913       -69.97%
BenchmarkMergedSeriesSet/series=10000,blocks=32-8     19847753      5447371       -72.55%
BenchmarkMergedSeriesSet/series=20000,blocks=1-8      552           552           +0.00%
BenchmarkMergedSeriesSet/series=20000,blocks=2-8      1280784       1280784       +0.00%
BenchmarkMergedSeriesSet/series=20000,blocks=4-8      3841249       1921320       -49.98%
BenchmarkMergedSeriesSet/series=20000,blocks=8-8      8962178       3202184       -64.27%
BenchmarkMergedSeriesSet/series=20000,blocks=16-8     19204032      5763912       -69.99%
BenchmarkMergedSeriesSet/series=20000,blocks=32-8     39687748      10887368      -72.57%
```