### PR TITLE
Show the warnings during label query

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -501,9 +501,12 @@ func QueryLabels(url *url.URL, name string, p printer) int {
 	// Run query against client.
 	api := v1.NewAPI(c)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	// TODO: Show warnings (second return value) somehow? See https://github.com/prometheus/prometheus/issues/5885
-	val, _, err := api.LabelValues(ctx, name)
+	val, warn, err := api.LabelValues(ctx, name)
 	cancel()
+
+	for _, v := range warn {
+		fmt.Fprintln(os.Stderr, "query warning:", v)
+	}
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "query error:", err)


### PR DESCRIPTION
This patch loops through the warnings while querying the label and spits the
output to stderr.

Fixes #5885

Signed-off-by: Sayan Chowdhury <sayan.chowdhury2012@gmail.com>