### PR TITLE
Add tests for tsdb CLI commands

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/labels"
-	"github.com/prometheus/prometheus/util/testutil"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
+	"github.com/prometheus/prometheus/util/testutil"
 )
 
 // In Prometheus 2.1.0 we had a bug where the meta.json version was falsely bumped

--- a/tsdb/cmd/tsdb/main.go
+++ b/tsdb/cmd/tsdb/main.go
@@ -32,11 +32,18 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
+	"gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/labels"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+const (
+	printBlocksTableHeader = "BLOCK ULID\tMIN TIME\tMAX TIME\tNUM SAMPLES\tNUM CHUNKS\tNUM SERIES"
+	defaultAnalyzeLimit    = "20"
+	timeDelta              = 30000
 )
 
 func main() {
@@ -62,7 +69,7 @@ func execute() (err error) {
 		analyzeCmd           = cli.Command("analyze", "analyze churn, label pair cardinality.")
 		analyzePath          = analyzeCmd.Arg("db path", "database path (default is "+defaultDBPath+")").Default(defaultDBPath).String()
 		analyzeBlockID       = analyzeCmd.Arg("block id", "block to analyze (default is the last block)").String()
-		analyzeLimit         = analyzeCmd.Flag("limit", "how many items to show in each list").Default("20").Int()
+		analyzeLimit         = analyzeCmd.Flag("limit", "how many items to show in each list").Default(defaultAnalyzeLimit).Int()
 		dumpCmd              = cli.Command("dump", "dump samples from a TSDB")
 		dumpPath             = dumpCmd.Arg("db path", "database path (default is "+defaultDBPath+")").Default(defaultDBPath).String()
 		dumpMinTime          = dumpCmd.Flag("min-time", "minimum timestamp to dump").Default(strconv.FormatInt(math.MinInt64, 10)).Int64()
@@ -95,7 +102,7 @@ func execute() (err error) {
 		if err != nil {
 			return err
 		}
-		printBlocks(blocks, listCmdHumanReadable)
+		printBlocks(os.Stdout, blocks, listCmdHumanReadable)
 	case analyzeCmd.FullCommand():
 		db, err := tsdb.OpenDBReadOnly(*analyzePath, nil)
 		if err != nil {
@@ -110,21 +117,12 @@ func execute() (err error) {
 		if err != nil {
 			return err
 		}
-		var block tsdb.BlockReader
-		if *analyzeBlockID != "" {
-			for _, b := range blocks {
-				if b.Meta().ULID.String() == *analyzeBlockID {
-					block = b
-					break
-				}
-			}
-		} else if len(blocks) > 0 {
-			block = blocks[len(blocks)-1]
+		block, err := extractBlock(blocks, analyzeBlockID)
+		if err != nil {
+			return err
 		}
-		if block == nil {
-			return fmt.Errorf("block not found")
-		}
-		return analyzeBlock(block, *analyzeLimit)
+
+		return analyzeBlock(os.Stdout, block, *analyzeLimit)
 	case dumpCmd.FullCommand():
 		db, err := tsdb.OpenDBReadOnly(*dumpPath, nil)
 		if err != nil {
@@ -138,6 +136,25 @@ func execute() (err error) {
 		return dumpSamples(db, *dumpMinTime, *dumpMaxTime)
 	}
 	return nil
+}
+
+// extractBlock takes a slice of BlockReader and returns a specific block by ID.
+func extractBlock(blocks []tsdb.BlockReader, analyzeBlockID *string) (tsdb.BlockReader, error) {
+	var block tsdb.BlockReader
+	if *analyzeBlockID != "" {
+		for _, b := range blocks {
+			if b.Meta().ULID.String() == *analyzeBlockID {
+				block = b
+				break
+			}
+		}
+	} else if len(blocks) > 0 {
+		block = blocks[len(blocks)-1]
+	}
+	if block == nil {
+		return nil, fmt.Errorf("block not found")
+	}
+	return block, nil
 }
 
 type writeBenchmark struct {
@@ -206,9 +223,7 @@ func (b *writeBenchmark) run() error {
 	var total uint64
 
 	dur, err := measureTime("ingestScrapes", func() error {
-		if err := b.startProfiling(); err != nil {
-			return err
-		}
+		b.startProfiling()
 		total, err = b.ingestScrapes(labels, 3000)
 		if err != nil {
 			return err
@@ -236,8 +251,6 @@ func (b *writeBenchmark) run() error {
 	}
 	return nil
 }
-
-const timeDelta = 30000
 
 func (b *writeBenchmark) ingestScrapes(lbls []labels.Labels, scrapeCount int) (uint64, error) {
 	var mu sync.Mutex
@@ -436,11 +449,11 @@ func readPrometheusLabels(r io.Reader, n int) ([]labels.Labels, error) {
 	return mets, nil
 }
 
-func printBlocks(blocks []tsdb.BlockReader, humanReadable *bool) {
-	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+func printBlocks(w io.Writer, blocks []tsdb.BlockReader, humanReadable *bool) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	defer tw.Flush()
 
-	fmt.Fprintln(tw, "BLOCK ULID\tMIN TIME\tMAX TIME\tNUM SAMPLES\tNUM CHUNKS\tNUM SERIES")
+	fmt.Fprintln(tw, printBlocksTableHeader)
 	for _, b := range blocks {
 		meta := b.Meta()
 
@@ -463,12 +476,12 @@ func getFormatedTime(timestamp int64, humanReadable *bool) string {
 	return strconv.FormatInt(timestamp, 10)
 }
 
-func analyzeBlock(b tsdb.BlockReader, limit int) error {
+func analyzeBlock(w io.Writer, b tsdb.BlockReader, limit int) error {
 	meta := b.Meta()
-	fmt.Printf("Block ID: %s\n", meta.ULID)
+	fmt.Fprintf(w, "Block ID: %s\n", meta.ULID)
 	// Presume 1ms resolution that Prometheus uses.
-	fmt.Printf("Duration: %s\n", (time.Duration(meta.MaxTime-meta.MinTime) * 1e6).String())
-	fmt.Printf("Series: %d\n", meta.Stats.NumSeries)
+	fmt.Fprintf(w, "Duration: %s\n", (time.Duration(meta.MaxTime-meta.MinTime) * 1e6).String())
+	fmt.Fprintf(w, "Series: %d\n", meta.Stats.NumSeries)
 	ir, err := b.Index()
 	if err != nil {
 		return err
@@ -479,7 +492,7 @@ func analyzeBlock(b tsdb.BlockReader, limit int) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Label names: %d\n", len(allLabelNames))
+	fmt.Fprintf(w, "Label names: %d\n", len(allLabelNames))
 
 	type postingInfo struct {
 		key    string
@@ -491,7 +504,7 @@ func analyzeBlock(b tsdb.BlockReader, limit int) error {
 		sort.Slice(postingInfos, func(i, j int) bool { return postingInfos[i].metric > postingInfos[j].metric })
 
 		for i, pc := range postingInfos {
-			fmt.Printf("%d %s\n", pc.metric, pc.key)
+			fmt.Fprintf(w, "%d %s\n", pc.metric, pc.key)
 			if i >= limit {
 				break
 			}
@@ -525,15 +538,15 @@ func analyzeBlock(b tsdb.BlockReader, limit int) error {
 	if p.Err() != nil {
 		return p.Err()
 	}
-	fmt.Printf("Postings (unique label pairs): %d\n", len(labelpairsUncovered))
-	fmt.Printf("Postings entries (total label pairs): %d\n", entries)
+	fmt.Fprintf(w, "Postings (unique label pairs): %d\n", len(labelpairsUncovered))
+	fmt.Fprintf(w, "Postings entries (total label pairs): %d\n", entries)
 
 	postingInfos = postingInfos[:0]
 	for k, m := range labelpairsUncovered {
 		postingInfos = append(postingInfos, postingInfo{k, uint64(float64(m) / float64(meta.MaxTime-meta.MinTime))})
 	}
 
-	fmt.Printf("\nLabel pairs most involved in churning:\n")
+	fmt.Fprintf(w, "\nLabel pairs most involved in churning:\n")
 	printInfo(postingInfos)
 
 	postingInfos = postingInfos[:0]
@@ -541,7 +554,7 @@ func analyzeBlock(b tsdb.BlockReader, limit int) error {
 		postingInfos = append(postingInfos, postingInfo{k, uint64(float64(m) / float64(meta.MaxTime-meta.MinTime))})
 	}
 
-	fmt.Printf("\nLabel names most involved in churning:\n")
+	fmt.Fprintf(w, "\nLabel names most involved in churning:\n")
 	printInfo(postingInfos)
 
 	postingInfos = postingInfos[:0]
@@ -549,7 +562,7 @@ func analyzeBlock(b tsdb.BlockReader, limit int) error {
 		postingInfos = append(postingInfos, postingInfo{k, m})
 	}
 
-	fmt.Printf("\nMost common label pairs:\n")
+	fmt.Fprintf(w, "\nMost common label pairs:\n")
 	printInfo(postingInfos)
 
 	postingInfos = postingInfos[:0]
@@ -561,7 +574,7 @@ func analyzeBlock(b tsdb.BlockReader, limit int) error {
 		var cumulativeLength uint64
 
 		for i := 0; i < values.Len(); i++ {
-			value, err := values.At(i)
+			value, _ := values.At(i)
 			if err != nil {
 				return err
 			}
@@ -573,7 +586,7 @@ func analyzeBlock(b tsdb.BlockReader, limit int) error {
 		postingInfos = append(postingInfos, postingInfo{n, cumulativeLength})
 	}
 
-	fmt.Printf("\nLabel names with highest cumulative label value length:\n")
+	fmt.Fprintf(w, "\nLabel names with highest cumulative label value length:\n")
 	printInfo(postingInfos)
 
 	postingInfos = postingInfos[:0]
@@ -584,7 +597,7 @@ func analyzeBlock(b tsdb.BlockReader, limit int) error {
 		}
 		postingInfos = append(postingInfos, postingInfo{n, uint64(lv.Len())})
 	}
-	fmt.Printf("\nHighest cardinality labels:\n")
+	fmt.Fprintf(w, "\nHighest cardinality labels:\n")
 	printInfo(postingInfos)
 
 	postingInfos = postingInfos[:0]
@@ -612,7 +625,7 @@ func analyzeBlock(b tsdb.BlockReader, limit int) error {
 			postingInfos = append(postingInfos, postingInfo{n, uint64(count)})
 		}
 	}
-	fmt.Printf("\nHighest cardinality metric names:\n")
+	fmt.Fprintf(w, "\nHighest cardinality metric names:\n")
 	printInfo(postingInfos)
 	return nil
 }

--- a/tsdb/cmd/tsdb/main_test.go
+++ b/tsdb/cmd/tsdb/main_test.go
@@ -1,0 +1,227 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"text/tabwriter"
+	"time"
+
+	"github.com/prometheus/prometheus/tsdb"
+)
+
+func createRoDb(t *testing.T) (*tsdb.DBReadOnly, func()) {
+	tmpdir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		os.RemoveAll(tmpdir)
+		t.Error(err)
+	}
+
+	safeDBOptions := *tsdb.DefaultOptions
+	safeDBOptions.RetentionDuration = 0
+
+	tsdb.CreateBlock(nil, tmpdir, tsdb.GenSeries(1, 1, 0, 1))
+
+	dbRO, err := tsdb.OpenDBReadOnly(tmpdir, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	return dbRO, func() {
+		os.RemoveAll(tmpdir)
+	}
+}
+
+func TestPrintBlocks(t *testing.T) {
+	db, closeFn := createRoDb(t)
+	defer closeFn()
+
+	var b bytes.Buffer
+	hr := false
+	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+	defer tw.Flush()
+
+	// Set table header.
+	_, err := fmt.Fprintln(&b, printBlocksTableHeader)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Test table header.
+	actual := b.String()
+	expected := fmt.Sprintln(printBlocksTableHeader)
+	if expected != actual {
+		t.Errorf("expected (%#v) != actual (%#v)", expected, actual)
+	}
+
+	// Set table contents.
+	blocks, err := db.Blocks()
+	if err != nil {
+		t.Error(err)
+	}
+	meta := blocks[0].Meta()
+
+	_, err = fmt.Fprintf(&b,
+		"%v\t%v\t%v\t%v\t%v\t%v\n",
+		meta.ULID,
+		getFormatedTime(meta.MinTime, &hr),
+		getFormatedTime(meta.MaxTime, &hr),
+		meta.Stats.NumSamples,
+		meta.Stats.NumChunks,
+		meta.Stats.NumSeries,
+	)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Test table contents.
+	blocks, err = db.Blocks()
+	if err != nil {
+		t.Error(err)
+	}
+
+	var actualStdout bytes.Buffer
+	printBlocks(&actualStdout, blocks, &hr)
+
+	actual = actualStdout.String()
+	actual = strings.Replace(actual, " ", "", -1)
+	actual = strings.Replace(actual, "\t", "", -1)
+	actual = strings.Replace(actual, "\n", "", -1)
+
+	expected = b.String()
+	expected = strings.Replace(expected, " ", "", -1)
+	expected = strings.Replace(expected, "\t", "", -1)
+	expected = strings.Replace(expected, "\n", "", -1)
+
+	if expected != actual {
+		t.Errorf("expected (%#v) != actual (%#v)", b.String(), actualStdout.String())
+	}
+}
+
+func TestExtractBlock(t *testing.T) {
+	db, closeFn := createRoDb(t)
+	defer closeFn()
+
+	blocks, err := db.Blocks()
+	if err != nil {
+		t.Error(err)
+	}
+
+	var analyzeBlockID string
+
+	// Pass: analyze last block (default).
+	block, err := extractBlock(blocks, &analyzeBlockID)
+	if err != nil {
+		t.Error(err)
+	}
+	if block == nil {
+		t.Error("block shouldn't be nil")
+	}
+
+	// Pass: analyze specific block.
+	analyzeBlockID = block.Meta().ULID.String()
+	block, err = extractBlock(blocks, &analyzeBlockID)
+	if err != nil {
+		t.Error(err)
+	}
+	if block == nil {
+		t.Error("block shouldn't be nil")
+	}
+
+	// Fail: analyze non-existing block
+	analyzeBlockID = "foo"
+	block, err = extractBlock(blocks, &analyzeBlockID)
+	if err == nil {
+		t.Errorf("Analyzing block ID %q should throw error", analyzeBlockID)
+	}
+	if block != nil {
+		t.Error("block should be nil")
+	}
+}
+
+func TestAnalyzeBlocks(t *testing.T) {
+	db, closeFn := createRoDb(t)
+	defer closeFn()
+
+	blocks, err := db.Blocks()
+	if err != nil {
+		t.Error(err)
+	}
+
+	var analyzeBlockID string
+	block, err := extractBlock(blocks, &analyzeBlockID)
+	if err != nil {
+		t.Error(err)
+	}
+	if block == nil {
+		t.Errorf("block shouldn't be nil")
+	}
+
+	dal, err := strconv.Atoi(defaultAnalyzeLimit)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var (
+		expected bytes.Buffer
+		actual   bytes.Buffer
+	)
+
+	// Actual output.
+	err = analyzeBlock(&actual, block, dal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	act := actual.String()
+	act = strings.Replace(act, " ", "", -1)
+	act = strings.Replace(act, "\t", "", -1)
+	act = strings.Replace(act, "\n", "", -1)
+
+	// Expected output.
+	meta := block.Meta()
+	fmt.Fprintf(&expected, "Block ID: %s\n", meta.ULID)
+	fmt.Fprintf(&expected, "Duration: %s\n", (time.Duration(meta.MaxTime-meta.MinTime) * 1e6).String())
+	fmt.Fprintf(&expected, "Series: %d\n", 1)
+	fmt.Fprintf(&expected, "Label names: %d\n", 1)
+	fmt.Fprintf(&expected, "Postings (unique label pairs): %d\n", 1)
+	fmt.Fprintf(&expected, "Postings entries (total label pairs): %d\n", 1)
+	fmt.Fprintf(&expected, "\nLabel pairs most involved in churning:\n")
+	fmt.Fprintf(&expected, "1 %s=0", tsdb.MockDefaultLabelName)
+	fmt.Fprintf(&expected, "\nLabel names most involved in churning:\n")
+	fmt.Fprintf(&expected, "1 %s", tsdb.MockDefaultLabelName)
+	fmt.Fprintf(&expected, "\nMost common label pairs:\n")
+	fmt.Fprintf(&expected, "1 %s=0", tsdb.MockDefaultLabelName)
+	fmt.Fprintf(&expected, "\nLabel names with highest cumulative label value length:\n")
+	fmt.Fprintf(&expected, "1 %s", tsdb.MockDefaultLabelName)
+	fmt.Fprintf(&expected, "\nHighest cardinality labels:\n")
+	fmt.Fprintf(&expected, "1 %s", tsdb.MockDefaultLabelName)
+	fmt.Fprintf(&expected, "\nHighest cardinality metric names:\n")
+
+	exp := expected.String()
+	exp = strings.Replace(exp, " ", "", -1)
+	exp = strings.Replace(exp, "\t", "", -1)
+	exp = strings.Replace(exp, "\n", "", -1)
+
+	if exp != act {
+		t.Errorf("expected (%#v) != actual (%#v)", expected.String(), actual.String())
+	}
+}

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -288,7 +288,7 @@ func TestLeveledCompactor_plan(t *testing.T) {
 		},
 		`Regression test: we were wrongly assuming that new block is fresh from WAL when its ULID is newest.
 		We need to actually look on max time instead.
-		
+
 		With previous, wrong approach "8" block was ignored, so we were wrongly compacting 5 and 7 and introducing
 		block overlaps`: {
 			metas: []dirMeta{
@@ -651,7 +651,7 @@ func TestCompaction_populateBlock(t *testing.T) {
 			expErr:         errors.New("found chunk with minTime: 10 maxTime: 30 outside of compacted minTime: 0 maxTime: 20"),
 		},
 		{
-			// Introduced by https://github.com/prometheus/prometheus/tsdb/issues/347.
+			// Introduced by https://github.com/prometheus/tsdb/issues/347.
 			title: "Populate from single block containing extra chunk",
 			inputSeriesSamples: [][]seriesSamples{
 				{
@@ -691,7 +691,7 @@ func TestCompaction_populateBlock(t *testing.T) {
 			},
 		},
 		{
-			// Introduced by https://github.com/prometheus/prometheus/tsdb/pull/539.
+			// Introduced by https://github.com/prometheus/tsdb/pull/539.
 			title: "Populate from three blocks that the last two are overlapping.",
 			inputSeriesSamples: [][]seriesSamples{
 				{
@@ -837,7 +837,7 @@ func BenchmarkCompaction(b *testing.B) {
 			blockDirs := make([]string, 0, len(c.ranges))
 			var blocks []*Block
 			for _, r := range c.ranges {
-				block, err := OpenBlock(nil, createBlock(b, dir, genSeries(nSeries, 10, r[0], r[1])), nil)
+				block, err := OpenBlock(nil, CreateBlock(b, dir, GenSeries(nSeries, 10, r[0], r[1])), nil)
 				testutil.Ok(b, err)
 				blocks = append(blocks, block)
 				defer func() {
@@ -923,9 +923,9 @@ func TestCancelCompactions(t *testing.T) {
 	}()
 
 	// Create some blocks to fall within the compaction range.
-	createBlock(t, tmpdir, genSeries(10, 10000, 0, 1000))
-	createBlock(t, tmpdir, genSeries(10, 10000, 1000, 2000))
-	createBlock(t, tmpdir, genSeries(1, 1, 2000, 2001)) // The most recent block is ignored so can be e small one.
+	CreateBlock(t, tmpdir, GenSeries(10, 10000, 0, 1000))
+	CreateBlock(t, tmpdir, GenSeries(10, 10000, 1000, 2000))
+	CreateBlock(t, tmpdir, GenSeries(1, 1, 2000, 2001)) // The most recent block is ignored so can be e small one.
 
 	// Copy the db so we have an exact copy to compare compaction times.
 	tmpdirCopy := tmpdir + "Copy"
@@ -1009,7 +1009,7 @@ func TestDeleteCompactionBlockAfterFailedReload(t *testing.T) {
 				{MinTime: 150, MaxTime: 200},
 			}
 			for _, m := range blocks {
-				createBlock(t, db.Dir(), genSeries(1, 1, m.MinTime, m.MaxTime))
+				CreateBlock(t, db.Dir(), GenSeries(1, 1, m.MinTime, m.MaxTime))
 			}
 			testutil.Ok(t, db.reload())
 			testutil.Equals(t, len(blocks), len(db.Blocks()), "unexpected block count after a reload")
@@ -1032,7 +1032,7 @@ func TestDeleteCompactionBlockAfterFailedReload(t *testing.T) {
 			expBlocks := bootStrap(db)
 
 			// Create a block that will trigger the reload to fail.
-			blockPath := createBlock(t, db.Dir(), genSeries(1, 1, 200, 300))
+			blockPath := CreateBlock(t, db.Dir(), GenSeries(1, 1, 200, 300))
 			lastBlockIndex := path.Join(blockPath, indexFilename)
 			actBlocks, err := blockDirs(db.Dir())
 			testutil.Ok(t, err)

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -95,7 +95,7 @@ func TestDB_reloadOrder(t *testing.T) {
 		{MinTime: 100, MaxTime: 110},
 	}
 	for _, m := range metas {
-		createBlock(t, db.Dir(), genSeries(1, 1, m.MinTime, m.MaxTime))
+		CreateBlock(t, db.Dir(), GenSeries(1, 1, m.MinTime, m.MaxTime))
 	}
 
 	testutil.Ok(t, db.reload())
@@ -229,7 +229,7 @@ func TestAppendEmptyLabelsIgnored(t *testing.T) {
 	testutil.Ok(t, err)
 
 	// Construct labels manually so there is an empty label.
-	ref2, err := app1.Add(labels.Labels{labels.Label{Name: "a", Value: "b"}, labels.Label{Name: "c", Value: ""}}, 124, 0)
+	ref2, err := app1.Add(labels.Labels{labels.Label{"a", "b"}, labels.Label{"c", ""}}, 124, 0)
 	testutil.Ok(t, err)
 
 	// Should be the same series.
@@ -281,7 +281,7 @@ Outer:
 		smpls := make([]float64, numSamples)
 		for i := int64(0); i < numSamples; i++ {
 			smpls[i] = rand.Float64()
-			app.Add(labels.Labels{{Name: "a", Value: "b"}}, i, smpls[i])
+			app.Add(labels.Labels{{"a", "b"}}, i, smpls[i])
 		}
 
 		testutil.Ok(t, app.Commit())
@@ -405,9 +405,9 @@ func TestSkippingInvalidValuesInSameTxn(t *testing.T) {
 
 	// Append AmendedValue.
 	app := db.Appender()
-	_, err := app.Add(labels.Labels{{Name: "a", Value: "b"}}, 0, 1)
+	_, err := app.Add(labels.Labels{{"a", "b"}}, 0, 1)
 	testutil.Ok(t, err)
-	_, err = app.Add(labels.Labels{{Name: "a", Value: "b"}}, 0, 2)
+	_, err = app.Add(labels.Labels{{"a", "b"}}, 0, 2)
 	testutil.Ok(t, err)
 	testutil.Ok(t, app.Commit())
 
@@ -418,14 +418,14 @@ func TestSkippingInvalidValuesInSameTxn(t *testing.T) {
 	ssMap := query(t, q, labels.NewEqualMatcher("a", "b"))
 
 	testutil.Equals(t, map[string][]tsdbutil.Sample{
-		labels.New(labels.Label{Name: "a", Value: "b"}).String(): {sample{0, 1}},
+		labels.New(labels.Label{"a", "b"}).String(): {sample{0, 1}},
 	}, ssMap)
 
 	// Append Out of Order Value.
 	app = db.Appender()
-	_, err = app.Add(labels.Labels{{Name: "a", Value: "b"}}, 10, 3)
+	_, err = app.Add(labels.Labels{{"a", "b"}}, 10, 3)
 	testutil.Ok(t, err)
-	_, err = app.Add(labels.Labels{{Name: "a", Value: "b"}}, 7, 5)
+	_, err = app.Add(labels.Labels{{"a", "b"}}, 7, 5)
 	testutil.Ok(t, err)
 	testutil.Ok(t, app.Commit())
 
@@ -435,7 +435,7 @@ func TestSkippingInvalidValuesInSameTxn(t *testing.T) {
 	ssMap = query(t, q, labels.NewEqualMatcher("a", "b"))
 
 	testutil.Equals(t, map[string][]tsdbutil.Sample{
-		labels.New(labels.Label{Name: "a", Value: "b"}).String(): {sample{0, 1}, sample{10, 3}},
+		labels.New(labels.Label{"a", "b"}).String(): {sample{0, 1}, sample{10, 3}},
 	}, ssMap)
 }
 
@@ -556,7 +556,7 @@ func TestDB_SnapshotWithDelete(t *testing.T) {
 	smpls := make([]float64, numSamples)
 	for i := int64(0); i < numSamples; i++ {
 		smpls[i] = rand.Float64()
-		app.Add(labels.Labels{{Name: "a", Value: "b"}}, i, smpls[i])
+		app.Add(labels.Labels{{"a", "b"}}, i, smpls[i])
 	}
 
 	testutil.Ok(t, app.Commit())
@@ -645,44 +645,44 @@ func TestDB_e2e(t *testing.T) {
 	// Create 8 series with 1000 data-points of different ranges and run queries.
 	lbls := [][]labels.Label{
 		{
-			{Name: "a", Value: "b"},
-			{Name: "instance", Value: "localhost:9090"},
-			{Name: "job", Value: "prometheus"},
+			{"a", "b"},
+			{"instance", "localhost:9090"},
+			{"job", "prometheus"},
 		},
 		{
-			{Name: "a", Value: "b"},
-			{Name: "instance", Value: "127.0.0.1:9090"},
-			{Name: "job", Value: "prometheus"},
+			{"a", "b"},
+			{"instance", "127.0.0.1:9090"},
+			{"job", "prometheus"},
 		},
 		{
-			{Name: "a", Value: "b"},
-			{Name: "instance", Value: "127.0.0.1:9090"},
-			{Name: "job", Value: "prom-k8s"},
+			{"a", "b"},
+			{"instance", "127.0.0.1:9090"},
+			{"job", "prom-k8s"},
 		},
 		{
-			{Name: "a", Value: "b"},
-			{Name: "instance", Value: "localhost:9090"},
-			{Name: "job", Value: "prom-k8s"},
+			{"a", "b"},
+			{"instance", "localhost:9090"},
+			{"job", "prom-k8s"},
 		},
 		{
-			{Name: "a", Value: "c"},
-			{Name: "instance", Value: "localhost:9090"},
-			{Name: "job", Value: "prometheus"},
+			{"a", "c"},
+			{"instance", "localhost:9090"},
+			{"job", "prometheus"},
 		},
 		{
-			{Name: "a", Value: "c"},
-			{Name: "instance", Value: "127.0.0.1:9090"},
-			{Name: "job", Value: "prometheus"},
+			{"a", "c"},
+			{"instance", "127.0.0.1:9090"},
+			{"job", "prometheus"},
 		},
 		{
-			{Name: "a", Value: "c"},
-			{Name: "instance", Value: "127.0.0.1:9090"},
-			{Name: "job", Value: "prom-k8s"},
+			{"a", "c"},
+			{"instance", "127.0.0.1:9090"},
+			{"job", "prom-k8s"},
 		},
 		{
-			{Name: "a", Value: "c"},
-			{Name: "instance", Value: "localhost:9090"},
-			{Name: "job", Value: "prom-k8s"},
+			{"a", "c"},
+			{"instance", "localhost:9090"},
+			{"job", "prom-k8s"},
 		},
 	}
 
@@ -883,7 +883,7 @@ func TestTombstoneClean(t *testing.T) {
 	smpls := make([]float64, numSamples)
 	for i := int64(0); i < numSamples; i++ {
 		smpls[i] = rand.Float64()
-		app.Add(labels.Labels{{Name: "a", Value: "b"}}, i, smpls[i])
+		app.Add(labels.Labels{{"a", "b"}}, i, smpls[i])
 	}
 
 	testutil.Ok(t, app.Commit())
@@ -986,7 +986,7 @@ func TestTombstoneCleanFail(t *testing.T) {
 	// totalBlocks should be >=2 so we have enough blocks to trigger compaction failure.
 	totalBlocks := 2
 	for i := 0; i < totalBlocks; i++ {
-		blockDir := createBlock(t, db.Dir(), genSeries(1, 1, 0, 1))
+		blockDir := CreateBlock(t, db.Dir(), GenSeries(1, 1, 0, 1))
 		block, err := OpenBlock(nil, blockDir, nil)
 		testutil.Ok(t, err)
 		// Add some some fake tombstones to trigger the compaction.
@@ -1030,7 +1030,7 @@ func (c *mockCompactorFailing) Write(dest string, b BlockReader, mint, maxt int6
 		return ulid.ULID{}, fmt.Errorf("the compactor already did the maximum allowed blocks so it is time to fail")
 	}
 
-	block, err := OpenBlock(nil, createBlock(c.t, dest, genSeries(1, 1, 0, 1)), nil)
+	block, err := OpenBlock(nil, CreateBlock(c.t, dest, GenSeries(1, 1, 0, 1)), nil)
 	testutil.Ok(c.t, err)
 	testutil.Ok(c.t, block.Close()) // Close block as we won't be using anywhere.
 	c.blocks = append(c.blocks, block)
@@ -1070,7 +1070,7 @@ func TestTimeRetention(t *testing.T) {
 	}
 
 	for _, m := range blocks {
-		createBlock(t, db.Dir(), genSeries(10, 10, m.MinTime, m.MaxTime))
+		CreateBlock(t, db.Dir(), GenSeries(10, 10, m.MinTime, m.MaxTime))
 	}
 
 	testutil.Ok(t, db.reload())                       // Reload the db to register the new blocks.
@@ -1106,7 +1106,7 @@ func TestSizeRetention(t *testing.T) {
 	}
 
 	for _, m := range blocks {
-		createBlock(t, db.Dir(), genSeries(100, 10, m.MinTime, m.MaxTime))
+		CreateBlock(t, db.Dir(), GenSeries(100, 10, m.MinTime, m.MaxTime))
 	}
 
 	// Test that registered size matches the actual disk size.
@@ -1339,7 +1339,7 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 	}, OverlappingBlocks(nc1))
 }
 
-// Regression test for https://github.com/prometheus/prometheus/tsdb/issues/347
+// Regression test for https://github.com/prometheus/tsdb/issues/347
 func TestChunkAtBlockBoundary(t *testing.T) {
 	db, delete := openTestDB(t, nil)
 	defer func() {
@@ -1498,7 +1498,7 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 			testutil.Ok(t, os.RemoveAll(dir))
 		}()
 
-		createBlock(t, dir, genSeries(1, 1, 1000, 2000))
+		CreateBlock(t, dir, GenSeries(1, 1, 1000, 2000))
 
 		db, err := Open(dir, nil, nil, nil)
 		testutil.Ok(t, err)
@@ -1514,7 +1514,7 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 			testutil.Ok(t, os.RemoveAll(dir))
 		}()
 
-		createBlock(t, dir, genSeries(1, 1, 1000, 6000))
+		CreateBlock(t, dir, GenSeries(1, 1, 1000, 6000))
 
 		testutil.Ok(t, os.MkdirAll(path.Join(dir, "wal"), 0777))
 		w, err := wal.New(nil, nil, path.Join(dir, "wal"), false)
@@ -1635,7 +1635,7 @@ func TestNoEmptyBlocks(t *testing.T) {
 			{MinTime: currentTime + 100, MaxTime: currentTime + 100 + db.opts.BlockRanges[0]},
 		}
 		for _, m := range blocks {
-			createBlock(t, db.Dir(), genSeries(2, 2, m.MinTime, m.MaxTime))
+			CreateBlock(t, db.Dir(), GenSeries(2, 2, m.MinTime, m.MaxTime))
 		}
 
 		oldBlocks := db.Blocks()
@@ -1666,26 +1666,26 @@ func TestDB_LabelNames(t *testing.T) {
 	}{
 		{
 			sampleLabels1: [][2]string{
-				{"name1", "1"},
-				{"name3", "3"},
-				{"name2", "2"},
+				[2]string{"name1", "1"},
+				[2]string{"name3", "3"},
+				[2]string{"name2", "2"},
 			},
 			sampleLabels2: [][2]string{
-				{"name4", "4"},
-				{"name1", "1"},
+				[2]string{"name4", "4"},
+				[2]string{"name1", "1"},
 			},
 			exp1: []string{"name1", "name2", "name3"},
 			exp2: []string{"name1", "name2", "name3", "name4"},
 		},
 		{
 			sampleLabels1: [][2]string{
-				{"name2", "2"},
-				{"name1", "1"},
-				{"name2", "2"},
+				[2]string{"name2", "2"},
+				[2]string{"name1", "1"},
+				[2]string{"name2", "2"},
 			},
 			sampleLabels2: [][2]string{
-				{"name6", "6"},
-				{"name0", "0"},
+				[2]string{"name6", "6"},
+				[2]string{"name0", "0"},
 			},
 			exp1: []string{"name1", "name2"},
 			exp2: []string{"name0", "name1", "name2", "name6"},
@@ -1802,13 +1802,13 @@ func TestVerticalCompaction(t *testing.T) {
 		//        |----------------|
 		{
 			blockSeries: [][]Series{
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{0, 0}, sample{1, 0}, sample{2, 0}, sample{4, 0},
 						sample{5, 0}, sample{7, 0}, sample{8, 0}, sample{9, 0},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{3, 99}, sample{5, 99}, sample{6, 99}, sample{7, 99},
 						sample{8, 99}, sample{9, 99}, sample{10, 99}, sample{11, 99},
@@ -1830,14 +1830,14 @@ func TestVerticalCompaction(t *testing.T) {
 		//        |----------------|
 		{
 			blockSeries: [][]Series{
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{0, 0}, sample{1, 0}, sample{2, 0}, sample{4, 0},
 						sample{5, 0}, sample{7, 0}, sample{8, 0}, sample{9, 0},
 						sample{11, 0}, sample{13, 0}, sample{17, 0},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{3, 99}, sample{5, 99}, sample{6, 99}, sample{7, 99},
 						sample{8, 99}, sample{9, 99}, sample{10, 99},
@@ -1859,20 +1859,20 @@ func TestVerticalCompaction(t *testing.T) {
 		//                           |--------------------|
 		{
 			blockSeries: [][]Series{
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{0, 0}, sample{1, 0}, sample{2, 0}, sample{4, 0},
 						sample{5, 0}, sample{7, 0}, sample{8, 0}, sample{9, 0},
 						sample{11, 0}, sample{13, 0}, sample{17, 0},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{3, 99}, sample{5, 99}, sample{6, 99}, sample{7, 99},
 						sample{8, 99}, sample{9, 99},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{14, 59}, sample{15, 59}, sample{17, 59}, sample{20, 59},
 						sample{21, 59}, sample{22, 59},
@@ -1895,19 +1895,19 @@ func TestVerticalCompaction(t *testing.T) {
 		//               |----------------|
 		{
 			blockSeries: [][]Series{
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{0, 0}, sample{1, 0}, sample{2, 0}, sample{4, 0},
 						sample{5, 0}, sample{8, 0}, sample{9, 0},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{14, 59}, sample{15, 59}, sample{17, 59}, sample{20, 59},
 						sample{21, 59}, sample{22, 59},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{5, 99}, sample{6, 99}, sample{7, 99}, sample{8, 99},
 						sample{9, 99}, sample{10, 99}, sample{13, 99}, sample{15, 99},
@@ -1931,7 +1931,7 @@ func TestVerticalCompaction(t *testing.T) {
 		//      |-------------------------|
 		{
 			blockSeries: [][]Series{
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{0, 0}, sample{1, 0}, sample{2, 0}, sample{4, 0},
 						sample{5, 0}, sample{8, 0}, sample{9, 0}, sample{10, 0},
@@ -1939,13 +1939,13 @@ func TestVerticalCompaction(t *testing.T) {
 						sample{20, 0}, sample{22, 0},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{7, 59}, sample{8, 59}, sample{9, 59}, sample{10, 59},
 						sample{11, 59},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{3, 99}, sample{5, 99}, sample{6, 99}, sample{8, 99},
 						sample{9, 99}, sample{10, 99}, sample{13, 99}, sample{15, 99},
@@ -1969,7 +1969,7 @@ func TestVerticalCompaction(t *testing.T) {
 		//      |-------------------------|
 		{
 			blockSeries: [][]Series{
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{0, 0}, sample{1, 0}, sample{2, 0}, sample{4, 0},
 						sample{5, 0}, sample{8, 0}, sample{9, 0}, sample{10, 0},
@@ -1989,7 +1989,7 @@ func TestVerticalCompaction(t *testing.T) {
 						sample{20, 0}, sample{22, 0},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"__name__": "a"}, []tsdbutil.Sample{
 						sample{7, 59}, sample{8, 59}, sample{9, 59}, sample{10, 59},
 						sample{11, 59},
@@ -2007,7 +2007,7 @@ func TestVerticalCompaction(t *testing.T) {
 						sample{11, 59},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{3, 99}, sample{5, 99}, sample{6, 99}, sample{8, 99},
 						sample{9, 99}, sample{10, 99}, sample{13, 99}, sample{15, 99},
@@ -2066,26 +2066,26 @@ func TestVerticalCompaction(t *testing.T) {
 		//                                                  |----------------|
 		{
 			blockSeries: [][]Series{
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{0, 0}, sample{1, 0}, sample{2, 0}, sample{4, 0},
 						sample{5, 0}, sample{7, 0}, sample{8, 0}, sample{9, 0},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{3, 99}, sample{5, 99}, sample{6, 99}, sample{7, 99},
 						sample{8, 99}, sample{9, 99}, sample{10, 99}, sample{11, 99},
 						sample{12, 99}, sample{13, 99}, sample{14, 99},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{20, 0}, sample{21, 0}, sample{22, 0}, sample{24, 0},
 						sample{25, 0}, sample{27, 0}, sample{28, 0}, sample{29, 0},
 					}),
 				},
-				{
+				[]Series{
 					newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{
 						sample{23, 99}, sample{25, 99}, sample{26, 99}, sample{27, 99},
 						sample{28, 99}, sample{29, 99}, sample{30, 99}, sample{31, 99},
@@ -2117,7 +2117,7 @@ func TestVerticalCompaction(t *testing.T) {
 			}()
 
 			for _, series := range c.blockSeries {
-				createBlock(t, tmpdir, series)
+				CreateBlock(t, tmpdir, series)
 			}
 			opts := *DefaultOptions
 			opts.AllowOverlappingBlocks = true
@@ -2177,7 +2177,7 @@ func TestBlockRanges(t *testing.T) {
 	// Test that the compactor doesn't create overlapping blocks
 	// when a non standard block already exists.
 	firstBlockMaxT := int64(3)
-	createBlock(t, dir, genSeries(1, 1, 0, firstBlockMaxT))
+	CreateBlock(t, dir, GenSeries(1, 1, 0, firstBlockMaxT))
 	db, err := Open(dir, logger, nil, DefaultOptions)
 	if err != nil {
 		t.Fatalf("Opening test storage failed: %s", err)
@@ -2186,7 +2186,7 @@ func TestBlockRanges(t *testing.T) {
 		os.RemoveAll(dir)
 	}()
 	app := db.Appender()
-	lbl := labels.Labels{{Name: "a", Value: "b"}}
+	lbl := labels.Labels{{"a", "b"}}
 	_, err = app.Add(lbl, firstBlockMaxT-1, rand.Float64())
 	if err == nil {
 		t.Fatalf("appending a sample with a timestamp covered by a previous block shouldn't be possible")
@@ -2227,7 +2227,7 @@ func TestBlockRanges(t *testing.T) {
 	testutil.Ok(t, db.Close())
 
 	thirdBlockMaxt := secondBlockMaxt + 2
-	createBlock(t, dir, genSeries(1, 1, secondBlockMaxt+1, thirdBlockMaxt))
+	CreateBlock(t, dir, GenSeries(1, 1, secondBlockMaxt+1, thirdBlockMaxt))
 
 	db, err = Open(dir, logger, nil, DefaultOptions)
 	if err != nil {
@@ -2285,7 +2285,7 @@ func TestDBReadOnly(t *testing.T) {
 		}
 
 		for _, m := range dbBlocks {
-			createBlock(t, dbDir, genSeries(1, 1, m.MinTime, m.MaxTime))
+			CreateBlock(t, dbDir, GenSeries(1, 1, m.MinTime, m.MaxTime))
 		}
 		expSeriesCount++
 	}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func BenchmarkCreateSeries(b *testing.B) {
-	series := genSeries(b.N, 10, 0, 0)
+	series := GenSeries(b.N, 10, 0, 0)
 
 	h, err := NewHead(nil, nil, nil, 10000)
 	testutil.Ok(b, err)
@@ -368,7 +368,7 @@ func TestHeadDeleteSimple(t *testing.T) {
 		return ss
 	}
 	smplsAll := buildSmpls([]int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
-	lblDefault := labels.Label{Name: "a", Value: "b"}
+	lblDefault := labels.Label{"a", "b"}
 
 	cases := []struct {
 		dranges  Intervals
@@ -536,7 +536,7 @@ func TestDeleteUntilCurMax(t *testing.T) {
 	smpls := make([]float64, numSamples)
 	for i := int64(0); i < numSamples; i++ {
 		smpls[i] = rand.Float64()
-		_, err := app.Add(labels.Labels{{Name: "a", Value: "b"}}, i, smpls[i])
+		_, err := app.Add(labels.Labels{{"a", "b"}}, i, smpls[i])
 		testutil.Ok(t, err)
 	}
 	testutil.Ok(t, app.Commit())
@@ -551,7 +551,7 @@ func TestDeleteUntilCurMax(t *testing.T) {
 
 	// Add again and test for presence.
 	app = hb.Appender()
-	_, err = app.Add(labels.Labels{{Name: "a", Value: "b"}}, 11, 1)
+	_, err = app.Add(labels.Labels{{"a", "b"}}, 11, 1)
 	testutil.Ok(t, err)
 	testutil.Ok(t, app.Commit())
 	q, err = NewBlockQuerier(hb, 0, 100000)
@@ -582,7 +582,7 @@ func TestDeletedSamplesAndSeriesStillInWALAfterCheckpoint(t *testing.T) {
 	defer hb.Close()
 	for i := 0; i < numSamples; i++ {
 		app := hb.Appender()
-		_, err := app.Add(labels.Labels{{Name: "a", Value: "b"}}, int64(i), 0)
+		_, err := app.Add(labels.Labels{{"a", "b"}}, int64(i), 0)
 		testutil.Ok(t, err)
 		testutil.Ok(t, app.Commit())
 	}
@@ -623,44 +623,44 @@ func TestDelete_e2e(t *testing.T) {
 	// Create 8 series with 1000 data-points of different ranges, delete and run queries.
 	lbls := [][]labels.Label{
 		{
-			{Name: "a", Value: "b"},
-			{Name: "instance", Value: "localhost:9090"},
-			{Name: "job", Value: "prometheus"},
+			{"a", "b"},
+			{"instance", "localhost:9090"},
+			{"job", "prometheus"},
 		},
 		{
-			{Name: "a", Value: "b"},
-			{Name: "instance", Value: "127.0.0.1:9090"},
-			{Name: "job", Value: "prometheus"},
+			{"a", "b"},
+			{"instance", "127.0.0.1:9090"},
+			{"job", "prometheus"},
 		},
 		{
-			{Name: "a", Value: "b"},
-			{Name: "instance", Value: "127.0.0.1:9090"},
-			{Name: "job", Value: "prom-k8s"},
+			{"a", "b"},
+			{"instance", "127.0.0.1:9090"},
+			{"job", "prom-k8s"},
 		},
 		{
-			{Name: "a", Value: "b"},
-			{Name: "instance", Value: "localhost:9090"},
-			{Name: "job", Value: "prom-k8s"},
+			{"a", "b"},
+			{"instance", "localhost:9090"},
+			{"job", "prom-k8s"},
 		},
 		{
-			{Name: "a", Value: "c"},
-			{Name: "instance", Value: "localhost:9090"},
-			{Name: "job", Value: "prometheus"},
+			{"a", "c"},
+			{"instance", "localhost:9090"},
+			{"job", "prometheus"},
 		},
 		{
-			{Name: "a", Value: "c"},
-			{Name: "instance", Value: "127.0.0.1:9090"},
-			{Name: "job", Value: "prometheus"},
+			{"a", "c"},
+			{"instance", "127.0.0.1:9090"},
+			{"job", "prometheus"},
 		},
 		{
-			{Name: "a", Value: "c"},
-			{Name: "instance", Value: "127.0.0.1:9090"},
-			{Name: "job", Value: "prom-k8s"},
+			{"a", "c"},
+			{"instance", "127.0.0.1:9090"},
+			{"job", "prom-k8s"},
 		},
 		{
-			{Name: "a", Value: "c"},
-			{Name: "instance", Value: "localhost:9090"},
-			{Name: "job", Value: "prom-k8s"},
+			{"a", "c"},
+			{"instance", "localhost:9090"},
+			{"job", "prom-k8s"},
 		},
 	}
 	seriesMap := map[string][]tsdbutil.Sample{}
@@ -1185,7 +1185,7 @@ func TestNewWalSegmentOnTruncate(t *testing.T) {
 	defer h.Close()
 	add := func(ts int64) {
 		app := h.Appender()
-		_, err := app.Add(labels.Labels{{Name: "a", Value: "b"}}, ts, 0)
+		_, err := app.Add(labels.Labels{{"a", "b"}}, ts, 0)
 		testutil.Ok(t, err)
 		testutil.Ok(t, app.Commit())
 	}

--- a/tsdb/mocks.go
+++ b/tsdb/mocks.go
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019 The Prometheus Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tsdb
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+
+	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+// This file holds types and functions that are used for testing
+// purposes.
+
+const (
+	// MockDefaultLabelName is the default label name used in tests.
+	MockDefaultLabelName = "labelName"
+	// MockDefaultLabelValue is the default label value used in tests.
+	MockDefaultLabelValue = "labelValue"
+)
+
+type mockSeries struct {
+	labels   func() labels.Labels
+	iterator func() SeriesIterator
+}
+
+// CreateBlock creates a block with given set of series and returns its dir.
+// Intended for testing purposes.
+func CreateBlock(tb testing.TB, dir string, series []Series) string {
+	head := createHead(tb, series)
+	compactor, err := NewLeveledCompactor(context.Background(), nil, log.NewNopLogger(), []int64{1000000}, nil)
+	testutil.Ok(tb, err)
+
+	testutil.Ok(tb, os.MkdirAll(dir, 0777))
+
+	// Add +1 millisecond to block maxt because block intervals are half-open: [b.MinTime, b.MaxTime).
+	// Because of this block intervals are always +1 than the total samples it includes.
+	ulid, err := compactor.Write(dir, head, head.MinTime(), head.MaxTime()+1, nil)
+	testutil.Ok(tb, err)
+	return filepath.Join(dir, ulid.String())
+}
+
+func createHead(tb testing.TB, series []Series) *Head {
+	head, err := NewHead(nil, nil, nil, 2*60*60*1000)
+	testutil.Ok(tb, err)
+	defer head.Close()
+
+	app := head.Appender()
+	for _, s := range series {
+		ref := uint64(0)
+		it := s.Iterator()
+		for it.Next() {
+			t, v := it.At()
+			if ref != 0 {
+				err := app.AddFast(ref, t, v)
+				if err == nil {
+					continue
+				}
+			}
+			ref, err = app.Add(s.Labels(), t, v)
+			testutil.Ok(tb, err)
+		}
+		testutil.Ok(tb, it.Err())
+	}
+	err = app.Commit()
+	testutil.Ok(tb, err)
+	return head
+}
+
+// GenSeries generates series with a given number of labels and values.
+// Intended for testing purposes.
+func GenSeries(totalSeries, labelCount int, mint, maxt int64) []Series {
+	if totalSeries == 0 || labelCount == 0 {
+		return nil
+	}
+
+	series := make([]Series, totalSeries)
+
+	for i := 0; i < totalSeries; i++ {
+		lbls := make(map[string]string, labelCount)
+		lbls[MockDefaultLabelName] = strconv.Itoa(i)
+		for j := 1; len(lbls) < labelCount; j++ {
+			lbls[MockDefaultLabelName+strconv.Itoa(j)] = MockDefaultLabelValue + strconv.Itoa(j)
+		}
+		samples := make([]tsdbutil.Sample, 0, maxt-mint+1)
+		for t := mint; t < maxt; t++ {
+			samples = append(samples, sample{t: t, v: rand.Float64()})
+		}
+		series[i] = newSeries(lbls, samples)
+	}
+	return series
+}
+
+func newSeries(l map[string]string, s []tsdbutil.Sample) Series {
+	return &mockSeries{
+		labels:   func() labels.Labels { return labels.FromMap(l) },
+		iterator: func() SeriesIterator { return newListSeriesIterator(s) },
+	}
+}
+func (m *mockSeries) Labels() labels.Labels    { return m.labels() }
+func (m *mockSeries) Iterator() SeriesIterator { return m.iterator() }
+
+type listSeriesIterator struct {
+	list []tsdbutil.Sample
+	idx  int
+}
+
+func newListSeriesIterator(list []tsdbutil.Sample) *listSeriesIterator {
+	return &listSeriesIterator{list: list, idx: -1}
+}
+
+func (it *listSeriesIterator) At() (int64, float64) {
+	s := it.list[it.idx]
+	return s.T(), s.V()
+}
+
+func (it *listSeriesIterator) Next() bool {
+	it.idx++
+	return it.idx < len(it.list)
+}
+
+func (it *listSeriesIterator) Seek(t int64) bool {
+	if it.idx == -1 {
+		it.idx = 0
+	}
+	// Do binary search between current position and end.
+	it.idx = sort.Search(len(it.list)-it.idx, func(i int) bool {
+		s := it.list[i+it.idx]
+		return s.T() >= t
+	})
+
+	return it.idx < len(it.list)
+}
+
+func (it *listSeriesIterator) Err() error {
+	return nil
+}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -461,9 +461,9 @@ func TestBlockQuerierDelete(t *testing.T) {
 			},
 		},
 		tombstones: &memTombstones{intvlGroups: map[uint64]Intervals{
-			1: {{1, 3}},
-			2: {{1, 3}, {6, 10}},
-			3: {{6, 10}},
+			1: Intervals{{1, 3}},
+			2: Intervals{{1, 3}, {6, 10}},
+			3: Intervals{{6, 10}},
 		}},
 		queries: []query{
 			{
@@ -578,7 +578,7 @@ func TestBaseChunkSeries(t *testing.T) {
 		{
 			series: []refdSeries{
 				{
-					lset: labels.New([]labels.Label{{Name: "a", Value: "a"}}...),
+					lset: labels.New([]labels.Label{{"a", "a"}}...),
 					chunks: []chunks.Meta{
 						{Ref: 29}, {Ref: 45}, {Ref: 245}, {Ref: 123}, {Ref: 4232}, {Ref: 5344},
 						{Ref: 121},
@@ -586,19 +586,19 @@ func TestBaseChunkSeries(t *testing.T) {
 					ref: 12,
 				},
 				{
-					lset: labels.New([]labels.Label{{Name: "a", Value: "a"}, {Name: "b", Value: "b"}}...),
+					lset: labels.New([]labels.Label{{"a", "a"}, {"b", "b"}}...),
 					chunks: []chunks.Meta{
 						{Ref: 82}, {Ref: 23}, {Ref: 234}, {Ref: 65}, {Ref: 26},
 					},
 					ref: 10,
 				},
 				{
-					lset:   labels.New([]labels.Label{{Name: "b", Value: "c"}}...),
+					lset:   labels.New([]labels.Label{{"b", "c"}}...),
 					chunks: []chunks.Meta{{Ref: 8282}},
 					ref:    1,
 				},
 				{
-					lset: labels.New([]labels.Label{{Name: "b", Value: "b"}}...),
+					lset: labels.New([]labels.Label{{"b", "b"}}...),
 					chunks: []chunks.Meta{
 						{Ref: 829}, {Ref: 239}, {Ref: 2349}, {Ref: 659}, {Ref: 269},
 					},
@@ -611,14 +611,14 @@ func TestBaseChunkSeries(t *testing.T) {
 		{
 			series: []refdSeries{
 				{
-					lset: labels.New([]labels.Label{{Name: "a", Value: "a"}, {Name: "b", Value: "b"}}...),
+					lset: labels.New([]labels.Label{{"a", "a"}, {"b", "b"}}...),
 					chunks: []chunks.Meta{
 						{Ref: 82}, {Ref: 23}, {Ref: 234}, {Ref: 65}, {Ref: 26},
 					},
 					ref: 10,
 				},
 				{
-					lset:   labels.New([]labels.Label{{Name: "b", Value: "c"}}...),
+					lset:   labels.New([]labels.Label{{"b", "c"}}...),
 					chunks: []chunks.Meta{{Ref: 8282}},
 					ref:    3,
 				},
@@ -1044,7 +1044,7 @@ func TestSeriesIterator(t *testing.T) {
 	})
 }
 
-// Regression for: https://github.com/prometheus/prometheus/tsdb/pull/97
+// Regression for: https://github.com/prometheus/tsdb/pull/97
 func TestChunkSeriesIterator_DoubleSeek(t *testing.T) {
 	chkMetas := []chunks.Meta{
 		tsdbutil.ChunkFromSamples([]tsdbutil.Sample{}),
@@ -1094,7 +1094,7 @@ func TestChunkSeriesIterator_NextWithMinTime(t *testing.T) {
 }
 
 func TestPopulatedCSReturnsValidChunkSlice(t *testing.T) {
-	lbls := []labels.Labels{labels.New(labels.Label{Name: "a", Value: "b"})}
+	lbls := []labels.Labels{labels.New(labels.Label{"a", "b"})}
 	chunkMetas := [][]chunks.Meta{
 		{
 			{MinTime: 1, MaxTime: 2, Ref: 1},
@@ -1428,56 +1428,6 @@ func (m mockIndex) LabelNames() ([]string, error) {
 	return labelNames, nil
 }
 
-type mockSeries struct {
-	labels   func() labels.Labels
-	iterator func() SeriesIterator
-}
-
-func newSeries(l map[string]string, s []tsdbutil.Sample) Series {
-	return &mockSeries{
-		labels:   func() labels.Labels { return labels.FromMap(l) },
-		iterator: func() SeriesIterator { return newListSeriesIterator(s) },
-	}
-}
-func (m *mockSeries) Labels() labels.Labels    { return m.labels() }
-func (m *mockSeries) Iterator() SeriesIterator { return m.iterator() }
-
-type listSeriesIterator struct {
-	list []tsdbutil.Sample
-	idx  int
-}
-
-func newListSeriesIterator(list []tsdbutil.Sample) *listSeriesIterator {
-	return &listSeriesIterator{list: list, idx: -1}
-}
-
-func (it *listSeriesIterator) At() (int64, float64) {
-	s := it.list[it.idx]
-	return s.T(), s.V()
-}
-
-func (it *listSeriesIterator) Next() bool {
-	it.idx++
-	return it.idx < len(it.list)
-}
-
-func (it *listSeriesIterator) Seek(t int64) bool {
-	if it.idx == -1 {
-		it.idx = 0
-	}
-	// Do binary search between current position and end.
-	it.idx = sort.Search(len(it.list)-it.idx, func(i int) bool {
-		s := it.list[i+it.idx]
-		return s.T() >= t
-	})
-
-	return it.idx < len(it.list)
-}
-
-func (it *listSeriesIterator) Err() error {
-	return nil
-}
-
 func BenchmarkQueryIterator(b *testing.B) {
 	cases := []struct {
 		numBlocks                   int
@@ -1516,14 +1466,14 @@ func BenchmarkQueryIterator(b *testing.B) {
 					mint := i*int64(c.numSamplesPerSeriesPerBlock) - offset
 					maxt := mint + int64(c.numSamplesPerSeriesPerBlock) - 1
 					if len(prefilledLabels) == 0 {
-						generatedSeries = genSeries(c.numSeries, 10, mint, maxt)
+						generatedSeries = GenSeries(c.numSeries, 10, mint, maxt)
 						for _, s := range generatedSeries {
 							prefilledLabels = append(prefilledLabels, s.Labels().Map())
 						}
 					} else {
 						generatedSeries = populateSeries(prefilledLabels, mint, maxt)
 					}
-					block, err := OpenBlock(nil, createBlock(b, dir, generatedSeries), nil)
+					block, err := OpenBlock(nil, CreateBlock(b, dir, generatedSeries), nil)
 					testutil.Ok(b, err)
 					blocks = append(blocks, block)
 					defer block.Close()
@@ -1590,14 +1540,14 @@ func BenchmarkQuerySeek(b *testing.B) {
 					mint := i*int64(c.numSamplesPerSeriesPerBlock) - offset
 					maxt := mint + int64(c.numSamplesPerSeriesPerBlock) - 1
 					if len(prefilledLabels) == 0 {
-						generatedSeries = genSeries(c.numSeries, 10, mint, maxt)
+						generatedSeries = GenSeries(c.numSeries, 10, mint, maxt)
 						for _, s := range generatedSeries {
 							prefilledLabels = append(prefilledLabels, s.Labels().Map())
 						}
 					} else {
 						generatedSeries = populateSeries(prefilledLabels, mint, maxt)
 					}
-					block, err := OpenBlock(nil, createBlock(b, dir, generatedSeries), nil)
+					block, err := OpenBlock(nil, CreateBlock(b, dir, generatedSeries), nil)
 					testutil.Ok(b, err)
 					blocks = append(blocks, block)
 					defer block.Close()
@@ -1735,14 +1685,14 @@ func BenchmarkSetMatcher(b *testing.B) {
 			mint := i * int64(c.numSamplesPerSeriesPerBlock)
 			maxt := mint + int64(c.numSamplesPerSeriesPerBlock) - 1
 			if len(prefilledLabels) == 0 {
-				generatedSeries = genSeries(c.numSeries, 10, mint, maxt)
+				generatedSeries = GenSeries(c.numSeries, 10, mint, maxt)
 				for _, s := range generatedSeries {
 					prefilledLabels = append(prefilledLabels, s.Labels().Map())
 				}
 			} else {
 				generatedSeries = populateSeries(prefilledLabels, mint, maxt)
 			}
-			block, err := OpenBlock(nil, createBlock(b, dir, generatedSeries), nil)
+			block, err := OpenBlock(nil, CreateBlock(b, dir, generatedSeries), nil)
 			testutil.Ok(b, err)
 			blocks = append(blocks, block)
 			defer block.Close()
@@ -2090,8 +2040,8 @@ func TestClose(t *testing.T) {
 		testutil.Ok(t, os.RemoveAll(dir))
 	}()
 
-	createBlock(t, dir, genSeries(1, 1, 0, 10))
-	createBlock(t, dir, genSeries(1, 1, 10, 20))
+	CreateBlock(t, dir, GenSeries(1, 1, 0, 10))
+	CreateBlock(t, dir, GenSeries(1, 1, 10, 20))
 
 	db, err := Open(dir, nil, nil, DefaultOptions)
 	if err != nil {
@@ -2109,27 +2059,27 @@ func TestClose(t *testing.T) {
 
 func BenchmarkQueries(b *testing.B) {
 	cases := map[string]labels.Selector{
-		"Eq Matcher: Expansion - 1": {
+		"Eq Matcher: Expansion - 1": labels.Selector{
 			labels.NewEqualMatcher("la", "va"),
 		},
-		"Eq Matcher: Expansion - 2": {
+		"Eq Matcher: Expansion - 2": labels.Selector{
 			labels.NewEqualMatcher("la", "va"),
 			labels.NewEqualMatcher("lb", "vb"),
 		},
 
-		"Eq Matcher: Expansion - 3": {
+		"Eq Matcher: Expansion - 3": labels.Selector{
 			labels.NewEqualMatcher("la", "va"),
 			labels.NewEqualMatcher("lb", "vb"),
 			labels.NewEqualMatcher("lc", "vc"),
 		},
-		"Regex Matcher: Expansion - 1": {
+		"Regex Matcher: Expansion - 1": labels.Selector{
 			labels.NewMustRegexpMatcher("la", ".*va"),
 		},
-		"Regex Matcher: Expansion - 2": {
+		"Regex Matcher: Expansion - 2": labels.Selector{
 			labels.NewMustRegexpMatcher("la", ".*va"),
 			labels.NewMustRegexpMatcher("lb", ".*vb"),
 		},
-		"Regex Matcher: Expansion - 3": {
+		"Regex Matcher: Expansion - 3": labels.Selector{
 			labels.NewMustRegexpMatcher("la", ".*va"),
 			labels.NewMustRegexpMatcher("lb", ".*vb"),
 			labels.NewMustRegexpMatcher("lc", ".*vc"),
@@ -2155,7 +2105,7 @@ func BenchmarkQueries(b *testing.B) {
 					testutil.Ok(b, os.RemoveAll(dir))
 				}()
 
-				series := genSeries(nSeries, 5, 1, int64(nSamples))
+				series := GenSeries(nSeries, 5, 1, int64(nSamples))
 
 				// Add some common labels to make the matchers select these series.
 				{
@@ -2181,7 +2131,7 @@ func BenchmarkQueries(b *testing.B) {
 
 				qs := []Querier{}
 				for x := 0; x <= 10; x++ {
-					block, err := OpenBlock(nil, createBlock(b, dir, series), nil)
+					block, err := OpenBlock(nil, CreateBlock(b, dir, series), nil)
 					testutil.Ok(b, err)
 					q, err := NewBlockQuerier(block, 1, int64(nSamples))
 					testutil.Ok(b, err)


### PR DESCRIPTION
Signed-off-by: obitech <ajknipping@mailbox.org>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Copies over work from https://github.com/prometheus/tsdb/pull/673

Resolves #5864

---

This PR introduces tests for the TSDB CLI tool, verifying the output is correct.

A requirement for this is to refactor out certain utility functions such as createBlock (-> `CreateBlock`) and genSeries (-> `GenSeries`) into a new file, mocks.go, so they can be imported by package main. Certain other types and functions that are required by those test functions are moved out of the respective test files, where they were defined previously, into `mocks.go`.

In order to work around annoying `\t` expansion in `os.Stdout`, all white space is stripped from expected and actual in `main_test.go`

## Test ls
`printBlocks()` now takes an `io.Writer` which can be tested with a `bytes.Buffer`.

##Test analyze
`analyzeBlock()` now takes an `io.Writer` which can be tested with a `bytes.Buffer`.
The functionality of retrieving a block by ID, out of a `[]BlockReader` has been factored out into the function `extractBlock()`, in order to increase testability.