### PR TITLE
promql: Modify the order of return values.

### DIFF
--- a/promql/query_logger_test.go
+++ b/promql/query_logger_test.go
@@ -113,7 +113,7 @@ func TestMMapFile(t *testing.T) {
 	filename := file.Name()
 	defer os.Remove(filename)
 
-	err, fileAsBytes := getMMapedFile(filename, 2, nil)
+	fileAsBytes, err := getMMapedFile(filename, 2, nil)
 
 	if err != nil {
 		t.Fatalf("Couldn't create test mmaped file")


### PR DESCRIPTION
Modify the order of return values and return value.

https://github.com/prometheus/prometheus/blob/04cb37fea8a05b1c2287d128e63c06b80c12865d/promql/query_logger.go#L78

1. Error is usually the last of several return values
2.  It's more common that slice returns nil in error case.
3. format import orders(goimports).