### PR TITLE
discovery/file: Fix the bug mentioned in #5901

### DIFF
--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -367,6 +367,10 @@ func (d *Discovery) readFile(filename string) ([]*targetgroup.Group, error) {
 		return nil, err
 	}
 
+	if len(content) == 0 {
+		return nil, errors.New("empty file")
+	}
+
 	info, err := fd.Stat()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
fix the bug mentioned in #5901 

## Root Cause

read an empty file, no error, return an empty `[]*targetgroup.Group`

https://github.com/prometheus/prometheus/blob/ec94df49d45baa8e680d81e732294eb04fff00de/discovery/file/file.go#L368

## Why this error doesn't happen very often

Because of the following code:

https://github.com/prometheus/prometheus/blob/ec94df49d45baa8e680d81e732294eb04fff00de/discovery/file/file_test.go#L70

If out channel action occurs earlier , there is no error. But if out channel later, there is an error.

https://github.com/prometheus/prometheus/blob/ec94df49d45baa8e680d81e732294eb04fff00de/discovery/file/file_test.go#L113




