### PR TITLE
Omit honor_timestamps directive when false

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -347,7 +347,7 @@ type ScrapeConfig struct {
 	// Indicator whether the scraped metrics should remain unmodified.
 	HonorLabels bool `yaml:"honor_labels,omitempty"`
 	// Indicator whether the scraped timestamps should be respected.
-	HonorTimestamps bool `yaml:"honor_timestamps"`
+	HonorTimestamps bool `yaml:"honor_timestamps,omitempty"`
 	// A set of query parameters with which the target is scraped.
 	Params url.Values `yaml:"params,omitempty"`
 	// How frequently to scrape the targets of this scrape config.


### PR DESCRIPTION
This PR makes the `honor_timestamps` directive consistent with others in having the `omitempty` flag. This means `honor_timestamps: false`, which is the default, will be omitted from config files.