### PR TITLE
tsdb/wal: pull out wal metrics separately as tsdb.DB

### DIFF
--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -361,7 +361,7 @@ func TestSegmentMetric(t *testing.T) {
 	w, err := NewSize(nil, nil, dir, segmentSize, false)
 	testutil.Ok(t, err)
 
-	initialSegment := client_testutil.ToFloat64(w.currentSegment)
+	initialSegment := client_testutil.ToFloat64(w.metrics.currentSegment)
 
 	// Write 3 records, each of which is half the segment size, meaning we should rotate to the next segment.
 	for i := 0; i < 3; i++ {
@@ -372,7 +372,7 @@ func TestSegmentMetric(t *testing.T) {
 		err = w.Log(buf)
 		testutil.Ok(t, err)
 	}
-	testutil.Assert(t, client_testutil.ToFloat64(w.currentSegment) == initialSegment+1, "segment metric did not increment after segment rotation")
+	testutil.Assert(t, client_testutil.ToFloat64(w.metrics.currentSegment) == initialSegment+1, "segment metric did not increment after segment rotation")
 	testutil.Ok(t, w.Close())
 }
 


### PR DESCRIPTION
Extract wal's metrics for better encapsulation, like tsdb.DB

https://github.com/prometheus/prometheus/blob/5ecef3542d67f7af5fa519eb73261b07d167416a/tsdb/db.go#L121