### PR TITLE
notifier: return nil is better.

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -594,7 +594,7 @@ func (n *Manager) sendOne(ctx context.Context, c *http.Client, url string, b []b
 		return errors.Errorf("bad response status %s", resp.Status)
 	}
 
-	return err
+	return nil
 }
 
 // Stop shuts down the notification handler.


### PR DESCRIPTION
https://github.com/prometheus/prometheus/blob/b5c833ca2194db5581b8979048b3450cc869b88a/notifier/notifier.go#L597

Return err is misleading and unnecessary：

https://github.com/prometheus/prometheus/blob/b5c833ca2194db5581b8979048b3450cc869b88a/notifier/notifier.go#L584-L586

an error check  has existed.