### PR TITLE
notifier: Remove redundant format conversions.

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -567,7 +567,7 @@ func alertsToOpenAPIAlerts(alerts []*Alert) models.PostableAlerts {
 func labelsToOpenAPILabelSet(modelLabelSet labels.Labels) models.LabelSet {
 	apiLabelSet := models.LabelSet{}
 	for _, label := range modelLabelSet {
-		apiLabelSet[label.Name] = string(label.Value)
+		apiLabelSet[label.Name] = label.Value
 	}
 
 	return apiLabelSet


### PR DESCRIPTION
https://github.com/prometheus/prometheus/blob/b5c833ca2194db5581b8979048b3450cc869b88a/notifier/notifier.go#L570

String is redundant