### PR TITLE
Ctx name

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -892,7 +892,7 @@ mainLoop:
 
 		var (
 			start             = time.Now()
-			scrapeCtx, cancel = context.WithTimeout(sl.parentCtx, timeout)
+			scrapeCtx, cancel = context.WithTimeout(sl.ctx, timeout)
 		)
 
 		// Only record after the first scrape.

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -601,8 +601,8 @@ type scrapeLoop struct {
 	sampleMutator       labelsMutator
 	reportSampleMutator labelsMutator
 
+	parentCtx context.Context
 	ctx       context.Context
-	scrapeCtx context.Context
 	cancel    func()
 	stopped   chan struct{}
 }
@@ -857,10 +857,10 @@ func newScrapeLoop(ctx context.Context,
 		stopped:             make(chan struct{}),
 		jitterSeed:          jitterSeed,
 		l:                   l,
-		ctx:                 ctx,
+		parentCtx:           ctx,
 		honorTimestamps:     honorTimestamps,
 	}
-	sl.scrapeCtx, sl.cancel = context.WithCancel(ctx)
+	sl.ctx, sl.cancel = context.WithCancel(ctx)
 
 	return sl
 }
@@ -869,7 +869,7 @@ func (sl *scrapeLoop) run(interval, timeout time.Duration, errc chan<- error) {
 	select {
 	case <-time.After(sl.scraper.offset(interval, sl.jitterSeed)):
 		// Continue after a scraping offset.
-	case <-sl.scrapeCtx.Done():
+	case <-sl.ctx.Done():
 		close(sl.stopped)
 		return
 	}
@@ -882,17 +882,17 @@ func (sl *scrapeLoop) run(interval, timeout time.Duration, errc chan<- error) {
 mainLoop:
 	for {
 		select {
-		case <-sl.ctx.Done():
+		case <-sl.parentCtx.Done():
 			close(sl.stopped)
 			return
-		case <-sl.scrapeCtx.Done():
+		case <-sl.ctx.Done():
 			break mainLoop
 		default:
 		}
 
 		var (
 			start             = time.Now()
-			scrapeCtx, cancel = context.WithTimeout(sl.ctx, timeout)
+			scrapeCtx, cancel = context.WithTimeout(sl.parentCtx, timeout)
 		)
 
 		// Only record after the first scrape.
@@ -947,10 +947,10 @@ mainLoop:
 		last = start
 
 		select {
-		case <-sl.ctx.Done():
+		case <-sl.parentCtx.Done():
 			close(sl.stopped)
 			return
-		case <-sl.scrapeCtx.Done():
+		case <-sl.ctx.Done():
 			break mainLoop
 		case <-ticker.C:
 		}
@@ -977,7 +977,7 @@ func (sl *scrapeLoop) endOfRunStaleness(last time.Time, ticker *time.Ticker, int
 	// Wait for when the next scrape would have been, record its timestamp.
 	var staleTime time.Time
 	select {
-	case <-sl.ctx.Done():
+	case <-sl.parentCtx.Done():
 		return
 	case <-ticker.C:
 		staleTime = time.Now()
@@ -986,14 +986,14 @@ func (sl *scrapeLoop) endOfRunStaleness(last time.Time, ticker *time.Ticker, int
 	// Wait for when the next scrape would have been, if the target was recreated
 	// samples should have been ingested by now.
 	select {
-	case <-sl.ctx.Done():
+	case <-sl.parentCtx.Done():
 		return
 	case <-ticker.C:
 	}
 
 	// Wait for an extra 10% of the interval, just to be safe.
 	select {
-	case <-sl.ctx.Done():
+	case <-sl.parentCtx.Done():
 		return
 	case <-time.After(interval / 10):
 	}


### PR DESCRIPTION
The two contexts here are confusing:

https://github.com/prometheus/prometheus/blob/b5c833ca2194db5581b8979048b3450cc869b88a/scrape/scrape.go#L604-L606

In general, `ctx` and `cancel` are pair(`scrapeCtx` and `cancel` are pair here), but not here. It will produce misleading(bug).

https://github.com/prometheus/prometheus/blob/b5c833ca2194db5581b8979048b3450cc869b88a/scrape/scrape.go#L895

A sibling context is generated from the parent context of the current context. 

https://github.com/prometheus/prometheus/blob/b5c833ca2194db5581b8979048b3450cc869b88a/scrape/scrape.go#L324

`stop` can't cancel the sibling context above.