### PR TITLE
Allow to control behaviour when there is a failed remote read

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -642,6 +642,7 @@ type RemoteReadConfig struct {
 	URL           *config_util.URL `yaml:"url"`
 	RemoteTimeout model.Duration   `yaml:"remote_timeout,omitempty"`
 	ReadRecent    bool             `yaml:"read_recent,omitempty"`
+	FailOnError   bool             `yaml:"fail_on_error,omitempty"`
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.
 	HTTPClientConfig config_util.HTTPClientConfig `yaml:",inline"`

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1356,6 +1356,11 @@ basic_auth:
 tls_config:
   [ <tls_config> ]
 
+# By default any query errors that occur that aren't from the primary data source (the local tsdb)
+# are returned as a list of warnings and the query continues. If `fail_on_error` is set to `true`
+# for remote reader we will stop query and return error instead query continue.
+[ fail_on_error: <boolean> | default = false ]
+
 # Optional proxy URL.
 [ proxy_url: <string> ]
 ```

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -176,6 +176,7 @@ func (q *errQuerier) Select(*storage.SelectParams, ...*labels.Matcher) (storage.
 func (*errQuerier) LabelValues(name string) ([]string, storage.Warnings, error) { return nil, nil, nil }
 func (*errQuerier) LabelNames() ([]string, storage.Warnings, error)             { return nil, nil, nil }
 func (*errQuerier) Close() error                                                { return nil }
+func (*errQuerier) FailOnError() bool                                           { return true }
 
 // errSeriesSet implements storage.SeriesSet which always returns error.
 type errSeriesSet struct {
@@ -247,6 +248,7 @@ func (*paramCheckerQuerier) LabelValues(name string) ([]string, storage.Warnings
 }
 func (*paramCheckerQuerier) LabelNames() ([]string, storage.Warnings, error) { return nil, nil, nil }
 func (*paramCheckerQuerier) Close() error                                    { return nil }
+func (*paramCheckerQuerier) FailOnError() bool                               { return true }
 
 func TestParamsSetCorrectly(t *testing.T) {
 	opts := EngineOpts{

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -240,7 +240,7 @@ func (q *mergeQuerier) Select(params *SelectParams, matchers ...*labels.Matcher)
 		if err != nil {
 			q.failedQueriers[querier] = struct{}{}
 			// If the error source isn't the primary querier, return the error as a warning and continue.
-			if querier != q.primaryQuerier {
+			if !querier.FailOnError() {
 				warnings = append(warnings, err)
 				continue
 			} else {
@@ -250,6 +250,10 @@ func (q *mergeQuerier) Select(params *SelectParams, matchers ...*labels.Matcher)
 		seriesSets = append(seriesSets, set)
 	}
 	return NewMergeSeriesSet(seriesSets, q), warnings, nil
+}
+
+func (q *mergeQuerier) FailOnError() bool {
+	return true
 }
 
 // LabelValues returns all potential values for a label name.
@@ -265,7 +269,7 @@ func (q *mergeQuerier) LabelValues(name string) ([]string, Warnings, error) {
 		if err != nil {
 			q.failedQueriers[querier] = struct{}{}
 			// If the error source isn't the primary querier, return the error as a warning and continue.
-			if querier != q.primaryQuerier {
+			if !querier.FailOnError() {
 				warnings = append(warnings, err)
 				continue
 			} else {
@@ -333,7 +337,7 @@ func (q *mergeQuerier) LabelNames() ([]string, Warnings, error) {
 
 		if err != nil {
 			// If the error source isn't the primary querier, return the error as a warning and continue.
-			if b != q.primaryQuerier {
+			if !b.FailOnError() {
 				warnings = append(warnings, err)
 				continue
 			} else {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -60,6 +60,8 @@ type Querier interface {
 	// LabelNames returns all the unique label names present in the block in sorted order.
 	LabelNames() ([]string, Warnings, error)
 
+	FailOnError() bool
+
 	// Close releases the resources of the Querier.
 	Close() error
 }

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -30,6 +30,10 @@ func (noopQuerier) Select(*SelectParams, ...*labels.Matcher) (SeriesSet, Warning
 	return NoopSeriesSet(), nil, nil
 }
 
+func (noopQuerier) FailOnError() bool {
+	return false
+}
+
 func (noopQuerier) LabelValues(name string) ([]string, Warnings, error) {
 	return nil, nil, nil
 }

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -56,6 +56,10 @@ type querier struct {
 	client     *Client
 }
 
+func (q *querier) FailOnError() bool {
+	return q.client.failOnError
+}
+
 // Select implements storage.Querier and uses the given matchers to read series
 // sets from the Client.
 func (q *querier) Select(p *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -72,6 +72,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		c, err := NewClient(i, &ClientConfig{
 			URL:              rrConf.URL,
 			Timeout:          rrConf.RemoteTimeout,
+			FailOnError:      rrConf.FailOnError,
 			HTTPClientConfig: rrConf.HTTPClientConfig,
 		})
 		if err != nil {

--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -244,6 +244,10 @@ type querier struct {
 	q tsdb.Querier
 }
 
+func (q querier) FailOnError() bool {
+	return true
+}
+
 func (q querier) Select(_ *storage.SelectParams, oms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
 	ms := make([]tsdbLabels.Matcher, 0, len(oms))
 


### PR DESCRIPTION
Currently if any query errors that occur while we try to read from remote are returned as a list of warnings and the query continues.
Sometimes it can return partition result (data from all other not failed remote readers). Related MR - https://github.com/prometheus/prometheus/pull/4426
After this patch user can define if he wants to stop processing and return error while remote reader error occurs.
New option in `remote_read` config section is `fail_on_error`. By default option is false, so we are not changing current prometheus behaviour.

Also warning that provided is not very helpful:
`{"status":"success","data":{"resultType":"matrix","result":[]},"warnings":["Remote server returned HTTP status 400 Bad Request"]}`

After those change error will be:
`{"status":"success","data":{"resultType":"matrix","result":[]},"warnings":["Remote server http://127.0.0.1:10000/api/v1/read returned HTTP status 400 Bad Request: exceeded sample limit (5)"]}`