### PR TITLE
*: improve error messages when parsing bad rules

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -163,8 +163,11 @@ func CheckConfig(files ...string) int {
 		fmt.Println()
 
 		for _, rf := range ruleFiles {
-			if n, err := checkRules(rf); err != nil {
-				fmt.Fprintln(os.Stderr, "  FAILED:", err)
+			if n, errs := checkRules(rf); len(errs) > 0 {
+				fmt.Fprintln(os.Stderr, "  FAILED:")
+				for _, err := range errs {
+					fmt.Fprintln(os.Stderr, "    ", err)
+				}
 				failed = true
 			} else {
 				fmt.Printf("  SUCCESS: %d rules found\n", n)

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -15,18 +15,17 @@ package rules
 
 import (
 	"context"
-	"errors"
+	html_template "html/template"
 	"math"
 	"net/url"
 	"sort"
 	"sync"
 	"time"
 
-	html_template "html/template"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
@@ -898,7 +897,7 @@ func (m *Manager) LoadGroups(
 			for _, r := range rg.Rules {
 				expr, err := promql.ParseExpr(r.Expr)
 				if err != nil {
-					return nil, []error{err}
+					return nil, []error{errors.Wrap(err, fn)}
 				}
 
 				if r.Alert != "" {


### PR DESCRIPTION
While debugging rule unit tests, I noticed that error messages weren't explicit when the problem is with the rule files.

Before

```
$ ./promtool test rules unit.yml # with invalid YAML
Unit Testing:  unit.yml
  FAILED:
yaml: line 3: did not find expected key
$ ./promtool test rules unit2.yml # with invalid PromQL expression and templating
Unit Testing:  unit2.yml
  FAILED:
group "test", rule 3, "SomeAlert": could not parse expression: parse error at char 6: unclosed left parenthesis
group "test", rule 3, "SomeAlert": msg=template: __alert_SomeAlert:1: function "xxx" not defined
group "test", rule 3, "SomeAlert": msg=template: __alert_SomeAlert:1: function "yyy" not defined
```

After

```
$ ./promtool test rules unit.yml
Unit Testing:  unit.yml
  FAILED:
test.yml: yaml: line 3: did not find expected key
$ ./promtool test rules unit2.yml # with invalid PromQL expression and templating
Unit Testing:  unit2.yml
  FAILED:
test2.yml: group "test", rule 3, "SomeAlert": could not parse expression: parse error at char 6: unclosed left parenthesis
test2.yml: group "test", rule 3, "SomeAlert": label "foo": template: __alert_SomeAlert:1: function "xxx" not defined
test2.yml: group "test", rule 3, "SomeAlert": annotation "bar": template: __alert_SomeAlert:1: function "yyy" not defined
```

