### PR TITLE
building individual binaries with make build

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -201,7 +201,7 @@ endif
 .PHONY: common-build
 common-build: promu
 	@echo ">> building binaries"
-	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX) $(BUILD_NAMES)
+	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX) $(PROMU_BINARIES)
 
 .PHONY: common-tarball
 common-tarball: promu

--- a/Makefile.common
+++ b/Makefile.common
@@ -201,7 +201,7 @@ endif
 .PHONY: common-build
 common-build: promu
 	@echo ">> building binaries"
-	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX)
+	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX) $(BUILD_NAMES)
 
 .PHONY: common-tarball
 common-tarball: promu


### PR DESCRIPTION
allows: `make build PROMU_BINARIES="prometheus,promtool"`

@simonpasquier I am working on a pr to use circle ci artifacts for peombench test then we probably won't need this, but we need this for https://github.com/prometheus/prombench/pull/271 now, otherwise will need another `make promu` step but I think this is still an useful feature to have.

cc @SuperQ 