### PR TITLE
Support for context cancellation in Querier (tsdb)

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -270,7 +270,7 @@ type DBReadOnly struct {
 }
 
 // Queryable implements a layer for context cancelations over the Querier.
-// Cancelation of any query would lead to rollback and close
+// Cancellation of any read request would lead to closing of the db
 type Queryable interface {
 	Querier(ctx context.Context, mint, maxt int64) (Querier, error)
 }

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -14,6 +14,7 @@
 package tsdb
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -2329,8 +2330,8 @@ func TestDBReadOnly(t *testing.T) {
 		for i, expBlock := range expBlocks {
 			testutil.Equals(t, expBlock.Meta(), blocks[i].Meta(), "block meta mismatch")
 		}
-
-		q, err := dbReadOnly.Querier(math.MinInt64, math.MaxInt64)
+		ctx := context.Background()
+		q, err := dbReadOnly.Querier(ctx, math.MinInt64, math.MaxInt64)
 		testutil.Ok(t, err)
 		readOnlySeries := query(t, q, matchAll)
 		readOnlyDBHash := testutil.DirHash(t, dbDir)
@@ -2356,6 +2357,7 @@ func TestDBReadOnlyClosing(t *testing.T) {
 	testutil.Equals(t, db.Close(), ErrClosed)
 	_, err = db.Blocks()
 	testutil.Equals(t, err, ErrClosed)
-	_, err = db.Querier(0, 1)
+	ctx := context.Background()
+	_, err = db.Querier(ctx, 0, 1)
 	testutil.Equals(t, err, ErrClosed)
 }


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
Refers to #5878 

This PR adds context cancellation for `Querier` **(tsdb)** in the transaction lifecycle.