### PR TITLE
init discovery manager props under locking

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -191,6 +191,9 @@ func (m *Manager) ApplyConfig(cfg map[string]sd_config.ServiceDiscoveryConfig) e
 		}
 	}
 	m.cancelDiscoverers()
+	m.targets = make(map[poolKey]map[string]*targetgroup.Group)
+	m.providers = nil
+	m.discoverCancel = nil
 	for name, scfg := range cfg {
 		m.registerProviders(scfg, name)
 		discoveredTargets.WithLabelValues(m.name, name).Set(0)
@@ -280,9 +283,6 @@ func (m *Manager) cancelDiscoverers() {
 	for _, c := range m.discoverCancel {
 		c()
 	}
-	m.targets = make(map[poolKey]map[string]*targetgroup.Group)
-	m.providers = nil
-	m.discoverCancel = nil
 }
 
 func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
Fixes #5929  along with suggestions from [comment](https://github.com/prometheus/prometheus/issues/5929#issuecomment-523919012)