### PR TITLE
tsdb: return err instead of panic for corrupted chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [BUGFIX] Fix tsdb panic when querying corrupted chunks. #5991
+
 ## 2.12.0 / 2019-08-17
 
 * [FEATURE] Track currently active PromQL queries in a log file. #5794


### PR DESCRIPTION
Update https://github.com/prometheus/prometheus/issues/4128

Related to https://github.com/thanos-io/thanos/issues/1467

