### PR TITLE
Move WAL watcher code to tsdb/wal package.

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -224,7 +224,7 @@ type QueueManager struct {
 }
 
 // NewQueueManager builds a new QueueManager.
-func NewQueueManager(logger log.Logger, walDir string, samplesIn *ewmaRate, cfg config.QueueConfig, externalLabels labels.Labels, relabelConfigs []*relabel.Config, client StorageClient, flushDeadline time.Duration) *QueueManager {
+func NewQueueManager(reg prometheus.Registerer, logger log.Logger, walDir string, samplesIn *ewmaRate, cfg config.QueueConfig, externalLabels labels.Labels, relabelConfigs []*relabel.Config, client StorageClient, flushDeadline time.Duration) *QueueManager {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -253,7 +253,7 @@ func NewQueueManager(logger log.Logger, walDir string, samplesIn *ewmaRate, cfg 
 		samplesOutDuration: newEWMARate(ewmaWeight, shardUpdateDuration),
 	}
 
-	t.watcher = wal.NewWatcher(prometheus.DefaultRegisterer, wal.NewWatcherMetrics(prometheus.DefaultRegisterer), logger, name, t, walDir)
+	t.watcher = wal.NewWatcher(reg, wal.NewWatcherMetrics(reg), logger, name, t, walDir)
 	t.shards = t.newShards()
 
 	return t

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -32,8 +32,9 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/prompb"
-	"github.com/prometheus/prometheus/tsdb"
 	tsdbLabels "github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/wal"
 )
 
 // String constants for instrumentation.
@@ -191,7 +192,7 @@ type QueueManager struct {
 	externalLabels labels.Labels
 	relabelConfigs []*relabel.Config
 	client         StorageClient
-	watcher        *WALWatcher
+	watcher        *wal.Watcher
 
 	seriesLabels         map[uint64]labels.Labels
 	seriesSegmentIndexes map[uint64]int
@@ -252,7 +253,7 @@ func NewQueueManager(logger log.Logger, walDir string, samplesIn *ewmaRate, cfg 
 		samplesOutDuration: newEWMARate(ewmaWeight, shardUpdateDuration),
 	}
 
-	t.watcher = NewWALWatcher(logger, name, t, walDir)
+	t.watcher = wal.NewWatcher(prometheus.DefaultRegisterer, wal.NewWatcherMetrics(prometheus.DefaultRegisterer), logger, name, t, walDir)
 	t.shards = t.newShards()
 
 	return t
@@ -260,7 +261,7 @@ func NewQueueManager(logger log.Logger, walDir string, samplesIn *ewmaRate, cfg 
 
 // Append queues a sample to be sent to the remote storage. Blocks until all samples are
 // enqueued on their shards or a shutdown signal is received.
-func (t *QueueManager) Append(samples []tsdb.RefSample) bool {
+func (t *QueueManager) Append(samples []record.RefSample) bool {
 outer:
 	for _, s := range samples {
 		lbls, ok := t.seriesLabels[s.Ref]
@@ -376,7 +377,7 @@ func (t *QueueManager) Stop() {
 }
 
 // StoreSeries keeps track of which series we know about for lookups when sending samples to remote.
-func (t *QueueManager) StoreSeries(series []tsdb.RefSeries, index int) {
+func (t *QueueManager) StoreSeries(series []record.RefSeries, index int) {
 	for _, s := range series {
 		ls := processExternalLabels(s.Labels, t.externalLabels)
 		lbls := relabel.Process(ls, t.relabelConfigs...)

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -141,6 +141,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			return err
 		}
 		newQueues = append(newQueues, NewQueueManager(
+			prometheus.DefaultRegisterer,
 			rws.logger,
 			rws.walDir,
 			rws.samplesIn,

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
 )
 
 // IndexWriter serializes the index for a block of series data.
@@ -135,8 +136,8 @@ type BlockReader interface {
 	// Chunks returns a ChunkReader over the block's data.
 	Chunks() (ChunkReader, error)
 
-	// Tombstones returns a TombstoneReader over the block's deleted data.
-	Tombstones() (TombstoneReader, error)
+	// Tombstones returns a tombstones.Reader over the block's deleted data.
+	Tombstones() (tombstones.Reader, error)
 
 	// Meta provides meta information about the block reader.
 	Meta() BlockMeta
@@ -279,7 +280,7 @@ type Block struct {
 
 	chunkr     ChunkReader
 	indexr     IndexReader
-	tombstones TombstoneReader
+	tombstones tombstones.Reader
 
 	logger log.Logger
 
@@ -321,7 +322,7 @@ func OpenBlock(logger log.Logger, dir string, pool chunkenc.Pool) (pb *Block, er
 	}
 	closers = append(closers, ir)
 
-	tr, sizeTomb, err := readTombstones(dir)
+	tr, sizeTomb, err := tombstones.ReadTombstones(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -412,11 +413,11 @@ func (pb *Block) Chunks() (ChunkReader, error) {
 }
 
 // Tombstones returns a new TombstoneReader against the block data.
-func (pb *Block) Tombstones() (TombstoneReader, error) {
+func (pb *Block) Tombstones() (tombstones.Reader, error) {
 	if err := pb.startRead(); err != nil {
 		return nil, err
 	}
-	return blockTombstoneReader{TombstoneReader: pb.tombstones, b: pb}, nil
+	return blockTombstoneReader{Reader: pb.tombstones, b: pb}, nil
 }
 
 // GetSymbolTableSize returns the Symbol Table Size in the index of this block.
@@ -483,7 +484,7 @@ func (r blockIndexReader) Close() error {
 }
 
 type blockTombstoneReader struct {
-	TombstoneReader
+	tombstones.Reader
 	b *Block
 }
 
@@ -519,7 +520,7 @@ func (pb *Block) Delete(mint, maxt int64, ms ...labels.Matcher) error {
 	ir := pb.indexr
 
 	// Choose only valid postings which have chunks in the time-range.
-	stones := newMemTombstones()
+	stones := tombstones.NewMemTombstones()
 
 	var lset labels.Labels
 	var chks []chunks.Meta
@@ -535,7 +536,7 @@ Outer:
 			if chk.OverlapsClosedInterval(mint, maxt) {
 				// Delete only until the current values and not beyond.
 				tmin, tmax := clampInterval(mint, maxt, chks[0].MinTime, chks[len(chks)-1].MaxTime)
-				stones.addInterval(p.At(), Interval{tmin, tmax})
+				stones.AddInterval(p.At(), tombstones.Interval{tmin, tmax})
 				continue Outer
 			}
 		}
@@ -545,9 +546,9 @@ Outer:
 		return p.Err()
 	}
 
-	err = pb.tombstones.Iter(func(id uint64, ivs Intervals) error {
+	err = pb.tombstones.Iter(func(id uint64, ivs tombstones.Intervals) error {
 		for _, iv := range ivs {
-			stones.addInterval(id, iv)
+			stones.AddInterval(id, iv)
 		}
 		return nil
 	})
@@ -557,7 +558,7 @@ Outer:
 	pb.tombstones = stones
 	pb.meta.Stats.NumTombstones = pb.tombstones.Total()
 
-	n, err := writeTombstoneFile(pb.logger, pb.dir, pb.tombstones)
+	n, err := tombstones.WriteFile(pb.logger, pb.dir, pb.tombstones)
 	if err != nil {
 		return err
 	}
@@ -575,7 +576,7 @@ Outer:
 func (pb *Block) CleanTombstones(dest string, c Compactor) (*ulid.ULID, error) {
 	numStones := 0
 
-	if err := pb.tombstones.Iter(func(id uint64, ivs Intervals) error {
+	if err := pb.tombstones.Iter(func(id uint64, ivs tombstones.Intervals) error {
 		numStones += len(ivs)
 		return nil
 	}); err != nil {
@@ -610,7 +611,7 @@ func (pb *Block) Snapshot(dir string) error {
 	for _, fname := range []string{
 		metaFilename,
 		indexFilename,
-		tombstoneFilename,
+		tombstones.Filename,
 	} {
 		if err := os.Link(filepath.Join(pb.dir, fname), filepath.Join(blockDir, fname)); err != nil {
 			return errors.Wrapf(err, "create snapshot %s", fname)

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -536,7 +536,7 @@ Outer:
 			if chk.OverlapsClosedInterval(mint, maxt) {
 				// Delete only until the current values and not beyond.
 				tmin, tmax := clampInterval(mint, maxt, chks[0].MinTime, chks[len(chks)-1].MaxTime)
-				stones.AddInterval(p.At(), tombstones.Interval{tmin, tmax})
+				stones.AddInterval(p.At(), tombstones.Interval{Mint: tmin, Maxt: tmax})
 				continue Outer
 			}
 		}
@@ -611,7 +611,7 @@ func (pb *Block) Snapshot(dir string) error {
 	for _, fname := range []string{
 		metaFilename,
 		indexFilename,
-		tombstones.Filename,
+		tombstones.TombstonesFilename,
 	} {
 		if err := os.Link(filepath.Join(pb.dir, fname), filepath.Join(blockDir, fname)); err != nil {
 			return errors.Wrapf(err, "create snapshot %s", fname)

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
 )
 
 // ExponentialBlockRanges returns the time ranges based on the stepSize.
@@ -607,7 +608,7 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockRe
 	}
 
 	// Create an empty tombstones file.
-	if _, err := writeTombstoneFile(c.logger, tmp, newMemTombstones()); err != nil {
+	if _, err := tombstones.WriteFile(c.logger, tmp, tombstones.NewMemTombstones()); err != nil {
 		return errors.Wrap(err, "write new tombstones file")
 	}
 
@@ -768,7 +769,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 			//
 			// TODO think how to avoid the typecasting to verify when it is head block.
 			if _, isHeadChunk := chk.Chunk.(*safeChunk); isHeadChunk && chk.MaxTime >= meta.MaxTime {
-				dranges = append(dranges, Interval{Mint: meta.MaxTime, Maxt: math.MaxInt64})
+				dranges = append(dranges, tombstones.Interval{Mint: meta.MaxTime, Maxt: math.MaxInt64})
 
 			} else
 			// Sanity check for disk blocks.
@@ -876,15 +877,15 @@ type compactionSeriesSet struct {
 	p          index.Postings
 	index      IndexReader
 	chunks     ChunkReader
-	tombstones TombstoneReader
+	tombstones tombstones.Reader
 
 	l         labels.Labels
 	c         []chunks.Meta
-	intervals Intervals
+	intervals tombstones.Intervals
 	err       error
 }
 
-func newCompactionSeriesSet(i IndexReader, c ChunkReader, t TombstoneReader, p index.Postings) *compactionSeriesSet {
+func newCompactionSeriesSet(i IndexReader, c ChunkReader, t tombstones.Reader, p index.Postings) *compactionSeriesSet {
 	return &compactionSeriesSet{
 		index:      i,
 		chunks:     c,
@@ -914,7 +915,7 @@ func (c *compactionSeriesSet) Next() bool {
 	if len(c.intervals) > 0 {
 		chks := make([]chunks.Meta, 0, len(c.c))
 		for _, chk := range c.c {
-			if !(Interval{chk.MinTime, chk.MaxTime}.isSubrange(c.intervals)) {
+			if !(tombstones.Interval{chk.MinTime, chk.MaxTime}.IsSubrange(c.intervals)) {
 				chks = append(chks, chk)
 			}
 		}
@@ -942,7 +943,7 @@ func (c *compactionSeriesSet) Err() error {
 	return c.p.Err()
 }
 
-func (c *compactionSeriesSet) At() (labels.Labels, []chunks.Meta, Intervals) {
+func (c *compactionSeriesSet) At() (labels.Labels, []chunks.Meta, tombstones.Intervals) {
 	return c.l, c.c, c.intervals
 }
 
@@ -952,7 +953,7 @@ type compactionMerger struct {
 	aok, bok  bool
 	l         labels.Labels
 	c         []chunks.Meta
-	intervals Intervals
+	intervals tombstones.Intervals
 }
 
 func newCompactionMerger(a, b ChunkSeriesSet) (*compactionMerger, error) {
@@ -1008,7 +1009,7 @@ func (c *compactionMerger) Next() bool {
 		_, cb, rb := c.b.At()
 
 		for _, r := range rb {
-			ra = ra.add(r)
+			ra = ra.Add(r)
 		}
 
 		c.l = append(c.l[:0], l...)
@@ -1029,6 +1030,6 @@ func (c *compactionMerger) Err() error {
 	return c.b.Err()
 }
 
-func (c *compactionMerger) At() (labels.Labels, []chunks.Meta, Intervals) {
+func (c *compactionMerger) At() (labels.Labels, []chunks.Meta, tombstones.Intervals) {
 	return c.l, c.c, c.intervals
 }

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -915,7 +915,7 @@ func (c *compactionSeriesSet) Next() bool {
 	if len(c.intervals) > 0 {
 		chks := make([]chunks.Meta, 0, len(c.c))
 		for _, chk := range c.c {
-			if !(tombstones.Interval{chk.MinTime, chk.MaxTime}.IsSubrange(c.intervals)) {
+			if !(tombstones.Interval{Mint: chk.MinTime, Maxt: chk.MaxTime}.IsSubrange(c.intervals)) {
 				chks = append(chks, chk)
 			}
 		}

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -456,10 +456,10 @@ func metaRange(name string, mint, maxt int64, stats *BlockStats) dirMeta {
 
 type erringBReader struct{}
 
-func (erringBReader) Index() (IndexReader, error)          { return nil, errors.New("index") }
-func (erringBReader) Chunks() (ChunkReader, error)         { return nil, errors.New("chunks") }
-func (erringBReader) Tombstones() (TombstoneReader, error) { return nil, errors.New("tombstones") }
-func (erringBReader) Meta() BlockMeta                      { return BlockMeta{} }
+func (erringBReader) Index() (IndexReader, error)            { return nil, errors.New("index") }
+func (erringBReader) Chunks() (ChunkReader, error)           { return nil, errors.New("chunks") }
+func (erringBReader) Tombstones() (tombstones.Reader, error) { return nil, errors.New("tombstones") }
+func (erringBReader) Meta() BlockMeta                        { return BlockMeta{} }
 
 type nopChunkWriter struct{}
 

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/tsdb/wal"
 	"github.com/prometheus/prometheus/util/testutil"
@@ -243,27 +245,27 @@ func TestDeleteSimple(t *testing.T) {
 	numSamples := int64(10)
 
 	cases := []struct {
-		intervals Intervals
+		Intervals tombstones.Intervals
 		remaint   []int64
 	}{
 		{
-			intervals: Intervals{{0, 3}},
+			Intervals: tombstones.Intervals{{0, 3}},
 			remaint:   []int64{4, 5, 6, 7, 8, 9},
 		},
 		{
-			intervals: Intervals{{1, 3}},
+			Intervals: tombstones.Intervals{{1, 3}},
 			remaint:   []int64{0, 4, 5, 6, 7, 8, 9},
 		},
 		{
-			intervals: Intervals{{1, 3}, {4, 7}},
+			Intervals: tombstones.Intervals{{1, 3}, {4, 7}},
 			remaint:   []int64{0, 8, 9},
 		},
 		{
-			intervals: Intervals{{1, 3}, {4, 700}},
+			Intervals: tombstones.Intervals{{1, 3}, {4, 700}},
 			remaint:   []int64{0},
 		},
 		{ // This case is to ensure that labels and symbols are deleted.
-			intervals: Intervals{{0, 9}},
+			Intervals: tombstones.Intervals{{0, 9}},
 			remaint:   []int64{},
 		},
 	}
@@ -288,7 +290,7 @@ Outer:
 
 		// TODO(gouthamve): Reset the tombstones somehow.
 		// Delete the ranges.
-		for _, r := range c.intervals {
+		for _, r := range c.Intervals {
 			testutil.Ok(t, db.Delete(r.Mint, r.Maxt, labels.NewEqualMatcher("a", "b")))
 		}
 
@@ -561,11 +563,11 @@ func TestDB_SnapshotWithDelete(t *testing.T) {
 
 	testutil.Ok(t, app.Commit())
 	cases := []struct {
-		intervals Intervals
+		intervals tombstones.Intervals
 		remaint   []int64
 	}{
 		{
-			intervals: Intervals{{1, 3}, {4, 7}},
+			intervals: tombstones.Intervals{{1, 3}, {4, 7}},
 			remaint:   []int64{0, 8, 9},
 		},
 	}
@@ -888,11 +890,11 @@ func TestTombstoneClean(t *testing.T) {
 
 	testutil.Ok(t, app.Commit())
 	cases := []struct {
-		intervals Intervals
+		intervals tombstones.Intervals
 		remaint   []int64
 	}{
 		{
-			intervals: Intervals{{1, 3}, {4, 7}},
+			intervals: tombstones.Intervals{{1, 3}, {4, 7}},
 			remaint:   []int64{0, 8, 9},
 		},
 	}
@@ -964,7 +966,7 @@ func TestTombstoneClean(t *testing.T) {
 		}
 
 		for _, b := range db.Blocks() {
-			testutil.Equals(t, newMemTombstones(), b.tombstones)
+			testutil.Equals(t, tombstones.NewMemTombstones(), b.tombstones)
 		}
 	}
 }
@@ -990,8 +992,8 @@ func TestTombstoneCleanFail(t *testing.T) {
 		block, err := OpenBlock(nil, blockDir, nil)
 		testutil.Ok(t, err)
 		// Add some some fake tombstones to trigger the compaction.
-		tomb := newMemTombstones()
-		tomb.addInterval(0, Interval{0, 1})
+		tomb := tombstones.NewMemTombstones()
+		tomb.AddInterval(0, tombstones.Interval{0, 1})
 		block.tombstones = tomb
 
 		db.blocks = append(db.blocks, block)
@@ -1470,13 +1472,13 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		w, err := wal.New(nil, nil, path.Join(dir, "wal"), false)
 		testutil.Ok(t, err)
 
-		var enc RecordEncoder
+		var enc record.Encoder
 		err = w.Log(
-			enc.Series([]RefSeries{
+			enc.Series([]record.RefSeries{
 				{Ref: 123, Labels: labels.FromStrings("a", "1")},
 				{Ref: 124, Labels: labels.FromStrings("a", "2")},
 			}, nil),
-			enc.Samples([]RefSample{
+			enc.Samples([]record.RefSample{
 				{Ref: 123, T: 5000, V: 1},
 				{Ref: 124, T: 15000, V: 1},
 			}, nil),
@@ -1520,13 +1522,13 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		w, err := wal.New(nil, nil, path.Join(dir, "wal"), false)
 		testutil.Ok(t, err)
 
-		var enc RecordEncoder
+		var enc record.Encoder
 		err = w.Log(
-			enc.Series([]RefSeries{
+			enc.Series([]record.RefSeries{
 				{Ref: 123, Labels: labels.FromStrings("a", "1")},
 				{Ref: 124, Labels: labels.FromStrings("a", "2")},
 			}, nil),
-			enc.Samples([]RefSample{
+			enc.Samples([]record.RefSample{
 				{Ref: 123, T: 5000, V: 1},
 				{Ref: 124, T: 15000, V: 1},
 			}, nil),

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -249,23 +249,23 @@ func TestDeleteSimple(t *testing.T) {
 		remaint   []int64
 	}{
 		{
-			Intervals: tombstones.Intervals{{0, 3}},
+			Intervals: tombstones.Intervals{{Mint: 0, Maxt: 3}},
 			remaint:   []int64{4, 5, 6, 7, 8, 9},
 		},
 		{
-			Intervals: tombstones.Intervals{{1, 3}},
+			Intervals: tombstones.Intervals{{Mint: 1, Maxt: 3}},
 			remaint:   []int64{0, 4, 5, 6, 7, 8, 9},
 		},
 		{
-			Intervals: tombstones.Intervals{{1, 3}, {4, 7}},
+			Intervals: tombstones.Intervals{{Mint: 1, Maxt: 3}, {Mint: 4, Maxt: 7}},
 			remaint:   []int64{0, 8, 9},
 		},
 		{
-			Intervals: tombstones.Intervals{{1, 3}, {4, 700}},
+			Intervals: tombstones.Intervals{{Mint: 1, Maxt: 3}, {Mint: 4, Maxt: 700}},
 			remaint:   []int64{0},
 		},
 		{ // This case is to ensure that labels and symbols are deleted.
-			Intervals: tombstones.Intervals{{0, 9}},
+			Intervals: tombstones.Intervals{{Mint: 0, Maxt: 9}},
 			remaint:   []int64{},
 		},
 	}
@@ -567,7 +567,7 @@ func TestDB_SnapshotWithDelete(t *testing.T) {
 		remaint   []int64
 	}{
 		{
-			intervals: tombstones.Intervals{{1, 3}, {4, 7}},
+			intervals: tombstones.Intervals{{Mint: 1, Maxt: 3}, {Mint: 4, Maxt: 7}},
 			remaint:   []int64{0, 8, 9},
 		},
 	}
@@ -894,7 +894,7 @@ func TestTombstoneClean(t *testing.T) {
 		remaint   []int64
 	}{
 		{
-			intervals: tombstones.Intervals{{1, 3}, {4, 7}},
+			intervals: tombstones.Intervals{{Mint: 1, Maxt: 3}, {Mint: 4, Maxt: 7}},
 			remaint:   []int64{0, 8, 9},
 		},
 	}
@@ -993,7 +993,7 @@ func TestTombstoneCleanFail(t *testing.T) {
 		testutil.Ok(t, err)
 		// Add some some fake tombstones to trigger the compaction.
 		tomb := tombstones.NewMemTombstones()
-		tomb.AddInterval(0, tombstones.Interval{0, 1})
+		tomb.AddInterval(0, tombstones.Interval{Mint: 0, Maxt: 1})
 		block.tombstones = tomb
 
 		db.blocks = append(db.blocks, block)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -998,7 +998,7 @@ func (h *Head) Delete(mint, maxt int64, ms ...labels.Matcher) error {
 		// Delete only until the current values and not beyond.
 		t0, t1 = clampInterval(mint, maxt, t0, t1)
 		if h.wal != nil {
-			stones = append(stones, tombstones.Stone{p.At(), tombstones.Intervals{{t0, t1}}})
+			stones = append(stones, tombstones.Stone{Ref: p.At(), Intervals: tombstones.Intervals{{Mint: t0, Maxt: t1}}})
 		}
 		if err := h.chunkRewrite(p.At(), tombstones.Intervals{{Mint: t0, Maxt: t1}}); err != nil {
 			return errors.Wrap(err, "delete samples")

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -33,6 +33,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/tsdb/wal"
 )
 
@@ -54,7 +56,7 @@ var (
 
 	// emptyTombstoneReader is a no-op Tombstone Reader.
 	// This is used by head to satisfy the Tombstones() function call.
-	emptyTombstoneReader = newMemTombstones()
+	emptyTombstoneReader = tombstones.NewMemTombstones()
 )
 
 // Head handles reads and writes of time series data within a time window.
@@ -64,6 +66,7 @@ type Head struct {
 	wal        *wal.WAL
 	logger     log.Logger
 	appendPool sync.Pool
+	seriesPool sync.Pool
 	bytesPool  sync.Pool
 	numSeries  uint64
 
@@ -256,7 +259,7 @@ func NewHead(r prometheus.Registerer, l log.Logger, wal *wal.WAL, chunkRange int
 // Samples before the mint timestamp are discarded.
 func (h *Head) processWALSamples(
 	minValidTime int64,
-	input <-chan []RefSample, output chan<- []RefSample,
+	input <-chan []record.RefSample, output chan<- []record.RefSample,
 ) (unknownRefs uint64) {
 	defer close(output)
 
@@ -331,8 +334,8 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64) (err error) {
 		wg           sync.WaitGroup
 		multiRefLock sync.Mutex
 		n            = runtime.GOMAXPROCS(0)
-		inputs       = make([]chan []RefSample, n)
-		outputs      = make([]chan []RefSample, n)
+		inputs       = make([]chan []record.RefSample, n)
+		outputs      = make([]chan []record.RefSample, n)
 	)
 	wg.Add(n)
 
@@ -349,10 +352,10 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64) (err error) {
 	}()
 
 	for i := 0; i < n; i++ {
-		outputs[i] = make(chan []RefSample, 300)
-		inputs[i] = make(chan []RefSample, 300)
+		outputs[i] = make(chan []record.RefSample, 300)
+		inputs[i] = make(chan []record.RefSample, 300)
 
-		go func(input <-chan []RefSample, output chan<- []RefSample) {
+		go func(input <-chan []record.RefSample, output chan<- []record.RefSample) {
 			unknown := h.processWALSamples(h.minValidTime, input, output)
 			atomic.AddUint64(&unknownRefs, unknown)
 			wg.Done()
@@ -360,11 +363,11 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64) (err error) {
 	}
 
 	var (
-		dec       RecordDecoder
-		series    []RefSeries
-		samples   []RefSample
-		tstones   []Stone
-		allStones = newMemTombstones()
+		dec       record.Decoder
+		series    []record.RefSeries
+		samples   []record.RefSample
+		tstones   []tombstones.Stone
+		allStones = tombstones.NewMemTombstones()
 	)
 	defer func() {
 		if err := allStones.Close(); err != nil {
@@ -376,7 +379,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64) (err error) {
 		rec := r.Record()
 
 		switch dec.Type(rec) {
-		case RecordSeries:
+		case record.Series:
 			series, err = dec.Series(rec, series)
 			if err != nil {
 				return &wal.CorruptionErr{
@@ -399,7 +402,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64) (err error) {
 					h.lastSeriesID = s.Ref
 				}
 			}
-		case RecordSamples:
+		case record.Samples:
 			samples, err = dec.Samples(rec, samples)
 			s := samples
 			if err != nil {
@@ -418,9 +421,9 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64) (err error) {
 				if len(samples) < m {
 					m = len(samples)
 				}
-				shards := make([][]RefSample, n)
+				shards := make([][]record.RefSample, n)
 				for i := 0; i < n; i++ {
-					var buf []RefSample
+					var buf []record.RefSample
 					select {
 					case buf = <-outputs[i]:
 					default:
@@ -440,7 +443,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64) (err error) {
 				samples = samples[m:]
 			}
 			samples = s // Keep whole slice for reuse.
-		case RecordTombstones:
+		case record.Tombstones:
 			tstones, err = dec.Tombstones(rec, tstones)
 			if err != nil {
 				return &wal.CorruptionErr{
@@ -450,15 +453,15 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64) (err error) {
 				}
 			}
 			for _, s := range tstones {
-				for _, itv := range s.intervals {
+				for _, itv := range s.Intervals {
 					if itv.Maxt < h.minValidTime {
 						continue
 					}
-					if m := h.series.getByID(s.ref); m == nil {
+					if m := h.series.getByID(s.Ref); m == nil {
 						unknownRefs++
 						continue
 					}
-					allStones.addInterval(s.ref, itv)
+					allStones.AddInterval(s.Ref, itv)
 				}
 			}
 		default:
@@ -482,7 +485,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64) (err error) {
 		return errors.Wrap(r.Err(), "read records")
 	}
 
-	if err := allStones.Iter(func(ref uint64, dranges Intervals) error {
+	if err := allStones.Iter(func(ref uint64, dranges tombstones.Intervals) error {
 		return h.chunkRewrite(ref, dranges)
 	}); err != nil {
 		return errors.Wrap(r.Err(), "deleting samples from tombstones")
@@ -508,8 +511,10 @@ func (h *Head) Init(minValidTime int64) error {
 
 	level.Info(h.logger).Log("msg", "replaying WAL, this may take awhile")
 	// Backfill the checkpoint first if it exists.
-	dir, startFrom, err := LastCheckpoint(h.wal.Dir())
-	if err != nil && err != ErrNotFound {
+	dir, startFrom, err := wal.LastCheckpoint(h.wal.Dir())
+	// We need to compare err to record.ErrNotFound as that's what
+	// wal.LastCheckpoint would return, not tsdb.ErrNotFound.
+	if err != nil && err != record.ErrNotFound {
 		return errors.Wrap(err, "find last checkpoint")
 	}
 	multiRef := map[uint64]uint64{}
@@ -629,7 +634,7 @@ func (h *Head) Truncate(mint int64) (err error) {
 		return ok
 	}
 	h.metrics.checkpointCreationTotal.Inc()
-	if _, err = Checkpoint(h.wal, first, last, keep, mint); err != nil {
+	if _, err = wal.Checkpoint(h.wal, first, last, keep, mint); err != nil {
 		h.metrics.checkpointCreationFail.Inc()
 		return errors.Wrap(err, "create checkpoint")
 	}
@@ -651,7 +656,7 @@ func (h *Head) Truncate(mint int64) (err error) {
 	h.deletedMtx.Unlock()
 
 	h.metrics.checkpointDeleteTotal.Inc()
-	if err := DeleteCheckpoints(h.wal.Dir(), last); err != nil {
+	if err := wal.DeleteCheckpoints(h.wal.Dir(), last); err != nil {
 		// Leftover old checkpoints do not cause problems down the line beyond
 		// occupying disk space.
 		// They will just be ignored since a higher checkpoint exists.
@@ -693,7 +698,7 @@ func (h *rangeHead) Chunks() (ChunkReader, error) {
 	return h.head.chunksRange(h.mint, h.maxt), nil
 }
 
-func (h *rangeHead) Tombstones() (TombstoneReader, error) {
+func (h *rangeHead) Tombstones() (tombstones.Reader, error) {
 	return emptyTombstoneReader, nil
 }
 
@@ -779,6 +784,7 @@ func (h *Head) appender() *headAppender {
 		mint:         math.MaxInt64,
 		maxt:         math.MinInt64,
 		samples:      h.getAppendBuffer(),
+		sampleSeries: h.getSeriesBuffer(),
 	}
 }
 
@@ -789,17 +795,30 @@ func max(a, b int64) int64 {
 	return b
 }
 
-func (h *Head) getAppendBuffer() []RefSample {
+func (h *Head) getAppendBuffer() []record.RefSample {
 	b := h.appendPool.Get()
 	if b == nil {
-		return make([]RefSample, 0, 512)
+		return make([]record.RefSample, 0, 512)
 	}
-	return b.([]RefSample)
+	return b.([]record.RefSample)
 }
 
-func (h *Head) putAppendBuffer(b []RefSample) {
+func (h *Head) putAppendBuffer(b []record.RefSample) {
 	//lint:ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 	h.appendPool.Put(b[:0])
+}
+
+func (h *Head) getSeriesBuffer() []*memSeries {
+	b := h.seriesPool.Get()
+	if b == nil {
+		return make([]*memSeries, 0, 512)
+	}
+	return b.([]*memSeries)
+}
+
+func (h *Head) putSeriesBuffer(b []*memSeries) {
+	//lint:ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
+	h.seriesPool.Put(b[:0])
 }
 
 func (h *Head) getBytesBuffer() []byte {
@@ -820,8 +839,9 @@ type headAppender struct {
 	minValidTime int64 // No samples below this timestamp are allowed.
 	mint, maxt   int64
 
-	series  []RefSeries
-	samples []RefSample
+	series       []record.RefSeries
+	samples      []record.RefSample
+	sampleSeries []*memSeries
 }
 
 func (a *headAppender) Add(lset labels.Labels, t int64, v float64) (uint64, error) {
@@ -834,7 +854,7 @@ func (a *headAppender) Add(lset labels.Labels, t int64, v float64) (uint64, erro
 
 	s, created := a.head.getOrCreate(lset.Hash(), lset)
 	if created {
-		a.series = append(a.series, RefSeries{
+		a.series = append(a.series, record.RefSeries{
 			Ref:    s.ref,
 			Labels: lset,
 		})
@@ -866,12 +886,12 @@ func (a *headAppender) AddFast(ref uint64, t int64, v float64) error {
 		a.maxt = t
 	}
 
-	a.samples = append(a.samples, RefSample{
-		Ref:    ref,
-		T:      t,
-		V:      v,
-		series: s,
+	a.samples = append(a.samples, record.RefSample{
+		Ref: ref,
+		T:   t,
+		V:   v,
 	})
+	a.sampleSeries = append(a.sampleSeries, s)
 	return nil
 }
 
@@ -884,7 +904,7 @@ func (a *headAppender) log() error {
 	defer func() { a.head.putBytesBuffer(buf) }()
 
 	var rec []byte
-	var enc RecordEncoder
+	var enc record.Encoder
 
 	if len(a.series) > 0 {
 		rec = enc.Series(a.series, buf)
@@ -908,18 +928,21 @@ func (a *headAppender) log() error {
 func (a *headAppender) Commit() error {
 	defer a.head.metrics.activeAppenders.Dec()
 	defer a.head.putAppendBuffer(a.samples)
+	defer a.head.putSeriesBuffer(a.sampleSeries)
 
 	if err := a.log(); err != nil {
 		return errors.Wrap(err, "write to WAL")
 	}
 
 	total := len(a.samples)
+	var series *memSeries
 
-	for _, s := range a.samples {
-		s.series.Lock()
-		ok, chunkCreated := s.series.append(s.T, s.V)
-		s.series.pendingCommit = false
-		s.series.Unlock()
+	for i, s := range a.samples {
+		series = a.sampleSeries[i]
+		series.Lock()
+		ok, chunkCreated := series.append(s.T, s.V)
+		series.pendingCommit = false
+		series.Unlock()
 
 		if !ok {
 			total--
@@ -938,10 +961,12 @@ func (a *headAppender) Commit() error {
 
 func (a *headAppender) Rollback() error {
 	a.head.metrics.activeAppenders.Dec()
-	for _, s := range a.samples {
-		s.series.Lock()
-		s.series.pendingCommit = false
-		s.series.Unlock()
+	var series *memSeries
+	for i := range a.samples {
+		series = a.sampleSeries[i]
+		series.Lock()
+		series.pendingCommit = false
+		series.Unlock()
 	}
 	a.head.putAppendBuffer(a.samples)
 
@@ -964,7 +989,7 @@ func (h *Head) Delete(mint, maxt int64, ms ...labels.Matcher) error {
 		return errors.Wrap(err, "select series")
 	}
 
-	var stones []Stone
+	var stones []tombstones.Stone
 	dirty := false
 	for p.Next() {
 		series := h.series.getByID(p.At())
@@ -976,9 +1001,9 @@ func (h *Head) Delete(mint, maxt int64, ms ...labels.Matcher) error {
 		// Delete only until the current values and not beyond.
 		t0, t1 = clampInterval(mint, maxt, t0, t1)
 		if h.wal != nil {
-			stones = append(stones, Stone{p.At(), Intervals{{t0, t1}}})
+			stones = append(stones, tombstones.Stone{p.At(), tombstones.Intervals{{t0, t1}}})
 		}
-		if err := h.chunkRewrite(p.At(), Intervals{{t0, t1}}); err != nil {
+		if err := h.chunkRewrite(p.At(), tombstones.Intervals{{t0, t1}}); err != nil {
 			return errors.Wrap(err, "delete samples")
 		}
 		dirty = true
@@ -986,7 +1011,7 @@ func (h *Head) Delete(mint, maxt int64, ms ...labels.Matcher) error {
 	if p.Err() != nil {
 		return p.Err()
 	}
-	var enc RecordEncoder
+	var enc record.Encoder
 	if h.wal != nil {
 		// Although we don't store the stones in the head
 		// we need to write them to the WAL to mark these as deleted
@@ -1005,7 +1030,7 @@ func (h *Head) Delete(mint, maxt int64, ms ...labels.Matcher) error {
 // chunkRewrite re-writes the chunks which overlaps with deleted ranges
 // and removes the samples in the deleted ranges.
 // Chunks is deleted if no samples are left at the end.
-func (h *Head) chunkRewrite(ref uint64, dranges Intervals) (err error) {
+func (h *Head) chunkRewrite(ref uint64, dranges tombstones.Intervals) (err error) {
 	if len(dranges) == 0 {
 		return nil
 	}
@@ -1097,7 +1122,7 @@ func (h *Head) gc() {
 }
 
 // Tombstones returns a new reader over the head's tombstones
-func (h *Head) Tombstones() (TombstoneReader, error) {
+func (h *Head) Tombstones() (tombstones.Reader, error) {
 	return emptyTombstoneReader, nil
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -377,23 +377,23 @@ func TestHeadDeleteSimple(t *testing.T) {
 		smplsExp []sample
 	}{
 		{
-			dranges:  tombstones.Intervals{{0, 3}},
+			dranges:  tombstones.Intervals{{Mint: 0, Maxt: 3}},
 			smplsExp: buildSmpls([]int64{4, 5, 6, 7, 8, 9}),
 		},
 		{
-			dranges:  tombstones.Intervals{{1, 3}},
+			dranges:  tombstones.Intervals{{Mint: 1, Maxt: 3}},
 			smplsExp: buildSmpls([]int64{0, 4, 5, 6, 7, 8, 9}),
 		},
 		{
-			dranges:  tombstones.Intervals{{1, 3}, {4, 7}},
+			dranges:  tombstones.Intervals{{Mint: 1, Maxt: 3}, {Mint: 4, Maxt: 7}},
 			smplsExp: buildSmpls([]int64{0, 8, 9}),
 		},
 		{
-			dranges:  tombstones.Intervals{{1, 3}, {4, 700}},
+			dranges:  tombstones.Intervals{{Mint: 1, Maxt: 3}, {Mint: 4, Maxt: 700}},
 			smplsExp: buildSmpls([]int64{0}),
 		},
 		{ // This case is to ensure that labels and symbols are deleted.
-			dranges:  tombstones.Intervals{{0, 9}},
+			dranges:  tombstones.Intervals{{Mint: 0, Maxt: 9}},
 			smplsExp: buildSmpls([]int64{}),
 		},
 	}
@@ -698,14 +698,14 @@ func TestDelete_e2e(t *testing.T) {
 	}{
 		{
 			ms:     []labels.Matcher{labels.NewEqualMatcher("a", "b")},
-			drange: tombstones.Intervals{{300, 500}, {600, 670}},
+			drange: tombstones.Intervals{{Mint: 300, Maxt: 500}, {Mint: 600, Maxt: 670}},
 		},
 		{
 			ms: []labels.Matcher{
 				labels.NewEqualMatcher("a", "b"),
 				labels.NewEqualMatcher("job", "prom-k8s"),
 			},
-			drange: tombstones.Intervals{{300, 500}, {100, 670}},
+			drange: tombstones.Intervals{{Mint: 300, Maxt: 500}, {Mint: 100, Maxt: 670}},
 		},
 		{
 			ms: []labels.Matcher{
@@ -713,7 +713,7 @@ func TestDelete_e2e(t *testing.T) {
 				labels.NewEqualMatcher("instance", "localhost:9090"),
 				labels.NewEqualMatcher("job", "prometheus"),
 			},
-			drange: tombstones.Intervals{{300, 400}, {100, 6700}},
+			drange: tombstones.Intervals{{Mint: 300, Maxt: 400}, {Mint: 100, Maxt: 6700}},
 		},
 		// TODO: Add Regexp Matchers.
 	}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/tsdb/wal"
 	"github.com/prometheus/prometheus/util/testutil"
@@ -51,14 +53,14 @@ func BenchmarkCreateSeries(b *testing.B) {
 }
 
 func populateTestWAL(t testing.TB, w *wal.WAL, recs []interface{}) {
-	var enc RecordEncoder
+	var enc record.Encoder
 	for _, r := range recs {
 		switch v := r.(type) {
-		case []RefSeries:
+		case []record.RefSeries:
 			testutil.Ok(t, w.Log(enc.Series(v, nil)))
-		case []RefSample:
+		case []record.RefSample:
 			testutil.Ok(t, w.Log(enc.Samples(v, nil)))
-		case []Stone:
+		case []tombstones.Stone:
 			testutil.Ok(t, w.Log(enc.Tombstones(v, nil)))
 		}
 	}
@@ -69,22 +71,22 @@ func readTestWAL(t testing.TB, dir string) (recs []interface{}) {
 	testutil.Ok(t, err)
 	defer sr.Close()
 
-	var dec RecordDecoder
+	var dec record.Decoder
 	r := wal.NewReader(sr)
 
 	for r.Next() {
 		rec := r.Record()
 
 		switch dec.Type(rec) {
-		case RecordSeries:
+		case record.Series:
 			series, err := dec.Series(rec, nil)
 			testutil.Ok(t, err)
 			recs = append(recs, series)
-		case RecordSamples:
+		case record.Samples:
 			samples, err := dec.Samples(rec, nil)
 			testutil.Ok(t, err)
 			recs = append(recs, samples)
-		case RecordTombstones:
+		case record.Tombstones:
 			tstones, err := dec.Tombstones(rec, nil)
 			testutil.Ok(t, err)
 			recs = append(recs, tstones)
@@ -100,28 +102,28 @@ func TestHead_ReadWAL(t *testing.T) {
 	for _, compress := range []bool{false, true} {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
 			entries := []interface{}{
-				[]RefSeries{
+				[]record.RefSeries{
 					{Ref: 10, Labels: labels.FromStrings("a", "1")},
 					{Ref: 11, Labels: labels.FromStrings("a", "2")},
 					{Ref: 100, Labels: labels.FromStrings("a", "3")},
 				},
-				[]RefSample{
+				[]record.RefSample{
 					{Ref: 0, T: 99, V: 1},
 					{Ref: 10, T: 100, V: 2},
 					{Ref: 100, T: 100, V: 3},
 				},
-				[]RefSeries{
+				[]record.RefSeries{
 					{Ref: 50, Labels: labels.FromStrings("a", "4")},
 					// This series has two refs pointing to it.
 					{Ref: 101, Labels: labels.FromStrings("a", "3")},
 				},
-				[]RefSample{
+				[]record.RefSample{
 					{Ref: 10, T: 101, V: 5},
 					{Ref: 50, T: 101, V: 6},
 					{Ref: 101, T: 101, V: 7},
 				},
-				[]Stone{
-					{ref: 0, intervals: []Interval{{Mint: 99, Maxt: 101}}},
+				[]tombstones.Stone{
+					{Ref: 0, Intervals: []tombstones.Interval{{Mint: 99, Maxt: 101}}},
 				},
 			}
 			dir, err := ioutil.TempDir("", "test_read_wal")
@@ -326,14 +328,14 @@ func TestHeadDeleteSeriesWithoutSamples(t *testing.T) {
 	for _, compress := range []bool{false, true} {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
 			entries := []interface{}{
-				[]RefSeries{
+				[]record.RefSeries{
 					{Ref: 10, Labels: labels.FromStrings("a", "1")},
 				},
-				[]RefSample{},
-				[]RefSeries{
+				[]record.RefSample{},
+				[]record.RefSeries{
 					{Ref: 50, Labels: labels.FromStrings("a", "2")},
 				},
-				[]RefSample{
+				[]record.RefSample{
 					{Ref: 50, T: 80, V: 1},
 					{Ref: 50, T: 90, V: 1},
 				},
@@ -371,27 +373,27 @@ func TestHeadDeleteSimple(t *testing.T) {
 	lblDefault := labels.Label{Name: "a", Value: "b"}
 
 	cases := []struct {
-		dranges  Intervals
+		dranges  tombstones.Intervals
 		smplsExp []sample
 	}{
 		{
-			dranges:  Intervals{{0, 3}},
+			dranges:  tombstones.Intervals{{0, 3}},
 			smplsExp: buildSmpls([]int64{4, 5, 6, 7, 8, 9}),
 		},
 		{
-			dranges:  Intervals{{1, 3}},
+			dranges:  tombstones.Intervals{{1, 3}},
 			smplsExp: buildSmpls([]int64{0, 4, 5, 6, 7, 8, 9}),
 		},
 		{
-			dranges:  Intervals{{1, 3}, {4, 7}},
+			dranges:  tombstones.Intervals{{1, 3}, {4, 7}},
 			smplsExp: buildSmpls([]int64{0, 8, 9}),
 		},
 		{
-			dranges:  Intervals{{1, 3}, {4, 700}},
+			dranges:  tombstones.Intervals{{1, 3}, {4, 700}},
 			smplsExp: buildSmpls([]int64{0}),
 		},
 		{ // This case is to ensure that labels and symbols are deleted.
-			dranges:  Intervals{{0, 9}},
+			dranges:  tombstones.Intervals{{0, 9}},
 			smplsExp: buildSmpls([]int64{}),
 		},
 	}
@@ -591,7 +593,7 @@ func TestDeletedSamplesAndSeriesStillInWALAfterCheckpoint(t *testing.T) {
 	testutil.Ok(t, hb.Close())
 
 	// Confirm there's been a checkpoint.
-	cdir, _, err := LastCheckpoint(dir)
+	cdir, _, err := wal.LastCheckpoint(dir)
 	testutil.Ok(t, err)
 	// Read in checkpoint and WAL.
 	recs := readTestWAL(t, cdir)
@@ -600,11 +602,11 @@ func TestDeletedSamplesAndSeriesStillInWALAfterCheckpoint(t *testing.T) {
 	var series, samples, stones int
 	for _, rec := range recs {
 		switch rec.(type) {
-		case []RefSeries:
+		case []record.RefSeries:
 			series++
-		case []RefSample:
+		case []record.RefSample:
 			samples++
-		case []Stone:
+		case []tombstones.Stone:
 			stones++
 		default:
 			t.Fatalf("unknown record type")
@@ -692,18 +694,18 @@ func TestDelete_e2e(t *testing.T) {
 	// Delete a time-range from each-selector.
 	dels := []struct {
 		ms     []labels.Matcher
-		drange Intervals
+		drange tombstones.Intervals
 	}{
 		{
 			ms:     []labels.Matcher{labels.NewEqualMatcher("a", "b")},
-			drange: Intervals{{300, 500}, {600, 670}},
+			drange: tombstones.Intervals{{300, 500}, {600, 670}},
 		},
 		{
 			ms: []labels.Matcher{
 				labels.NewEqualMatcher("a", "b"),
 				labels.NewEqualMatcher("job", "prom-k8s"),
 			},
-			drange: Intervals{{300, 500}, {100, 670}},
+			drange: tombstones.Intervals{{300, 500}, {100, 670}},
 		},
 		{
 			ms: []labels.Matcher{
@@ -711,7 +713,7 @@ func TestDelete_e2e(t *testing.T) {
 				labels.NewEqualMatcher("instance", "localhost:9090"),
 				labels.NewEqualMatcher("job", "prometheus"),
 			},
-			drange: Intervals{{300, 400}, {100, 6700}},
+			drange: tombstones.Intervals{{300, 400}, {100, 6700}},
 		},
 		// TODO: Add Regexp Matchers.
 	}
@@ -794,12 +796,12 @@ func boundedSamples(full []tsdbutil.Sample, mint, maxt int64) []tsdbutil.Sample 
 	return full
 }
 
-func deletedSamples(full []tsdbutil.Sample, dranges Intervals) []tsdbutil.Sample {
+func deletedSamples(full []tsdbutil.Sample, dranges tombstones.Intervals) []tsdbutil.Sample {
 	ds := make([]tsdbutil.Sample, 0, len(full))
 Outer:
 	for _, s := range full {
 		for _, r := range dranges {
-			if r.inBounds(s.T()) {
+			if r.InBounds(s.T()) {
 				continue Outer
 			}
 		}
@@ -1055,9 +1057,9 @@ func TestHead_LogRollback(t *testing.T) {
 
 			testutil.Equals(t, 1, len(recs))
 
-			series, ok := recs[0].([]RefSeries)
+			series, ok := recs[0].([]record.RefSeries)
 			testutil.Assert(t, ok, "expected series record but got %+v", recs[0])
-			testutil.Equals(t, []RefSeries{{Ref: 1, Labels: labels.FromStrings("a", "b")}}, series)
+			testutil.Equals(t, []record.RefSeries{{Ref: 1, Labels: labels.FromStrings("a", "b")}}, series)
 		})
 	}
 }
@@ -1065,7 +1067,7 @@ func TestHead_LogRollback(t *testing.T) {
 // TestWalRepair_DecodingError ensures that a repair is run for an error
 // when decoding a record.
 func TestWalRepair_DecodingError(t *testing.T) {
-	var enc RecordEncoder
+	var enc record.Encoder
 	for name, test := range map[string]struct {
 		corrFunc  func(rec []byte) []byte // Func that applies the corruption to a record.
 		rec       []byte
@@ -1077,10 +1079,10 @@ func TestWalRepair_DecodingError(t *testing.T) {
 				// Do not modify the base record because it is Logged multiple times.
 				res := make([]byte, len(rec))
 				copy(res, rec)
-				res[0] = byte(RecordInvalid)
+				res[0] = byte(record.Invalid)
 				return res
 			},
-			enc.Series([]RefSeries{{Ref: 1, Labels: labels.FromStrings("a", "b")}}, []byte{}),
+			enc.Series([]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("a", "b")}}, []byte{}),
 			9,
 			5,
 		},
@@ -1088,7 +1090,7 @@ func TestWalRepair_DecodingError(t *testing.T) {
 			func(rec []byte) []byte {
 				return rec[:3]
 			},
-			enc.Series([]RefSeries{{Ref: 1, Labels: labels.FromStrings("a", "b")}}, []byte{}),
+			enc.Series([]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("a", "b")}}, []byte{}),
 			9,
 			5,
 		},
@@ -1096,7 +1098,7 @@ func TestWalRepair_DecodingError(t *testing.T) {
 			func(rec []byte) []byte {
 				return rec[:3]
 			},
-			enc.Samples([]RefSample{{Ref: 0, T: 99, V: 1}}, []byte{}),
+			enc.Samples([]record.RefSample{{Ref: 0, T: 99, V: 1}}, []byte{}),
 			9,
 			5,
 		},
@@ -1104,7 +1106,7 @@ func TestWalRepair_DecodingError(t *testing.T) {
 			func(rec []byte) []byte {
 				return rec[:3]
 			},
-			enc.Tombstones([]Stone{{ref: 1, intervals: Intervals{}}}, []byte{}),
+			enc.Tombstones([]tombstones.Stone{{Ref: 1, Intervals: tombstones.Intervals{}}}, []byte{}),
 			9,
 			5,
 		},

--- a/tsdb/mocks_test.go
+++ b/tsdb/mocks_test.go
@@ -75,7 +75,7 @@ type mockBReader struct {
 
 func (r *mockBReader) Index() (IndexReader, error)  { return r.ir, nil }
 func (r *mockBReader) Chunks() (ChunkReader, error) { return r.cr, nil }
-func (r *mockBReader) Tombstones() (tombstones.TombstoneReader, error) {
+func (r *mockBReader) Tombstones() (tombstones.Reader, error) {
 	return tombstones.NewMemTombstones(), nil
 }
 func (r *mockBReader) Meta() BlockMeta { return BlockMeta{MinTime: r.mint, MaxTime: r.maxt} }

--- a/tsdb/mocks_test.go
+++ b/tsdb/mocks_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
 )
 
 type mockIndexWriter struct {
@@ -72,7 +73,9 @@ type mockBReader struct {
 	maxt int64
 }
 
-func (r *mockBReader) Index() (IndexReader, error)          { return r.ir, nil }
-func (r *mockBReader) Chunks() (ChunkReader, error)         { return r.cr, nil }
-func (r *mockBReader) Tombstones() (TombstoneReader, error) { return newMemTombstones(), nil }
-func (r *mockBReader) Meta() BlockMeta                      { return BlockMeta{MinTime: r.mint, MaxTime: r.maxt} }
+func (r *mockBReader) Index() (IndexReader, error)  { return r.ir, nil }
+func (r *mockBReader) Chunks() (ChunkReader, error) { return r.cr, nil }
+func (r *mockBReader) Tombstones() (tombstones.TombstoneReader, error) {
+	return tombstones.NewMemTombstones(), nil
+}
+func (r *mockBReader) Meta() BlockMeta { return BlockMeta{MinTime: r.mint, MaxTime: r.maxt} }

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -25,6 +25,7 @@ import (
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
 )
 
 // Querier provides querying access over time series data of a fixed
@@ -204,7 +205,7 @@ func NewBlockQuerier(b BlockReader, mint, maxt int64) (Querier, error) {
 type blockQuerier struct {
 	index      IndexReader
 	chunks     ChunkReader
-	tombstones TombstoneReader
+	tombstones tombstones.Reader
 
 	closed bool
 
@@ -671,7 +672,7 @@ func (s *mergedVerticalSeriesSet) Next() bool {
 // actual series itself.
 type ChunkSeriesSet interface {
 	Next() bool
-	At() (labels.Labels, []chunks.Meta, Intervals)
+	At() (labels.Labels, []chunks.Meta, tombstones.Intervals)
 	Err() error
 }
 
@@ -680,19 +681,19 @@ type ChunkSeriesSet interface {
 type baseChunkSeries struct {
 	p          index.Postings
 	index      IndexReader
-	tombstones TombstoneReader
+	tombstones tombstones.Reader
 
 	lset      labels.Labels
 	chks      []chunks.Meta
-	intervals Intervals
+	intervals tombstones.Intervals
 	err       error
 }
 
 // LookupChunkSeries retrieves all series for the given matchers and returns a ChunkSeriesSet
 // over them. It drops chunks based on tombstones in the given reader.
-func LookupChunkSeries(ir IndexReader, tr TombstoneReader, ms ...labels.Matcher) (ChunkSeriesSet, error) {
+func LookupChunkSeries(ir IndexReader, tr tombstones.Reader, ms ...labels.Matcher) (ChunkSeriesSet, error) {
 	if tr == nil {
-		tr = newMemTombstones()
+		tr = tombstones.NewMemTombstones()
 	}
 	p, err := PostingsForMatchers(ir, ms...)
 	if err != nil {
@@ -705,7 +706,7 @@ func LookupChunkSeries(ir IndexReader, tr TombstoneReader, ms ...labels.Matcher)
 	}, nil
 }
 
-func (s *baseChunkSeries) At() (labels.Labels, []chunks.Meta, Intervals) {
+func (s *baseChunkSeries) At() (labels.Labels, []chunks.Meta, tombstones.Intervals) {
 	return s.lset, s.chks, s.intervals
 }
 
@@ -741,7 +742,7 @@ func (s *baseChunkSeries) Next() bool {
 			// Only those chunks that are not entirely deleted.
 			chks := make([]chunks.Meta, 0, len(s.chks))
 			for _, chk := range s.chks {
-				if !(Interval{chk.MinTime, chk.MaxTime}.isSubrange(s.intervals)) {
+				if !(tombstones.Interval{chk.MinTime, chk.MaxTime}.IsSubrange(s.intervals)) {
 					chks = append(chks, chk)
 				}
 			}
@@ -768,10 +769,10 @@ type populatedChunkSeries struct {
 	err       error
 	chks      []chunks.Meta
 	lset      labels.Labels
-	intervals Intervals
+	intervals tombstones.Intervals
 }
 
-func (s *populatedChunkSeries) At() (labels.Labels, []chunks.Meta, Intervals) {
+func (s *populatedChunkSeries) At() (labels.Labels, []chunks.Meta, tombstones.Intervals) {
 	return s.lset, s.chks, s.intervals
 }
 
@@ -866,7 +867,7 @@ type chunkSeries struct {
 
 	mint, maxt int64
 
-	intervals Intervals
+	intervals tombstones.Intervals
 }
 
 func (s *chunkSeries) Labels() labels.Labels {
@@ -1067,10 +1068,10 @@ type chunkSeriesIterator struct {
 
 	maxt, mint int64
 
-	intervals Intervals
+	intervals tombstones.Intervals
 }
 
-func newChunkSeriesIterator(cs []chunks.Meta, dranges Intervals, mint, maxt int64) *chunkSeriesIterator {
+func newChunkSeriesIterator(cs []chunks.Meta, dranges tombstones.Intervals, mint, maxt int64) *chunkSeriesIterator {
 	csi := &chunkSeriesIterator{
 		chunks: cs,
 		i:      0,
@@ -1169,7 +1170,7 @@ func (it *chunkSeriesIterator) Err() error {
 type deletedIterator struct {
 	it chunkenc.Iterator
 
-	intervals Intervals
+	intervals tombstones.Intervals
 }
 
 func (it *deletedIterator) At() (int64, float64) {
@@ -1182,7 +1183,7 @@ Outer:
 		ts, _ := it.it.At()
 
 		for _, tr := range it.intervals {
-			if tr.inBounds(ts) {
+			if tr.InBounds(ts) {
 				continue Outer
 			}
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -742,7 +742,7 @@ func (s *baseChunkSeries) Next() bool {
 			// Only those chunks that are not entirely deleted.
 			chks := make([]chunks.Meta, 0, len(s.chks))
 			for _, chk := range s.chks {
-				if !(tombstones.Interval{chk.MinTime, chk.MaxTime}.IsSubrange(s.intervals)) {
+				if !(tombstones.Interval{Mint: chk.MinTime, Maxt: chk.MaxTime}.IsSubrange(s.intervals)) {
 					chks = append(chks, chk)
 				}
 			}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -462,9 +462,9 @@ func TestBlockQuerierDelete(t *testing.T) {
 			},
 		},
 		tombstones: tombstones.NewTestMemTombstones([]tombstones.Intervals{
-			tombstones.Intervals{{1, 3}},
-			tombstones.Intervals{{1, 3}, {6, 10}},
-			tombstones.Intervals{{6, 10}},
+			tombstones.Intervals{{Mint: 1, Maxt: 3}},
+			tombstones.Intervals{{Mint: 1, Maxt: 3}, {Mint: 6, Maxt: 10}},
+			tombstones.Intervals{{Mint: 6, Maxt: 10}},
 		}),
 		queries: []query{
 			{
@@ -1258,16 +1258,16 @@ func TestDeletedIterator(t *testing.T) {
 	cases := []struct {
 		r tombstones.Intervals
 	}{
-		{r: tombstones.Intervals{{1, 20}}},
-		{r: tombstones.Intervals{{1, 10}, {12, 20}, {21, 23}, {25, 30}}},
-		{r: tombstones.Intervals{{1, 10}, {12, 20}, {20, 30}}},
-		{r: tombstones.Intervals{{1, 10}, {12, 23}, {25, 30}}},
-		{r: tombstones.Intervals{{1, 23}, {12, 20}, {25, 30}}},
-		{r: tombstones.Intervals{{1, 23}, {12, 20}, {25, 3000}}},
-		{r: tombstones.Intervals{{0, 2000}}},
-		{r: tombstones.Intervals{{500, 2000}}},
-		{r: tombstones.Intervals{{0, 200}}},
-		{r: tombstones.Intervals{{1000, 20000}}},
+		{r: tombstones.Intervals{{Mint: 1, Maxt: 20}}},
+		{r: tombstones.Intervals{{Mint: 1, Maxt: 10}, {Mint: 12, Maxt: 20}, {Mint: 21, Maxt: 23}, {Mint: 25, Maxt: 30}}},
+		{r: tombstones.Intervals{{Mint: 1, Maxt: 10}, {Mint: 12, Maxt: 20}, {Mint: 20, Maxt: 30}}},
+		{r: tombstones.Intervals{{Mint: 1, Maxt: 10}, {Mint: 12, Maxt: 23}, {Mint: 25, Maxt: 30}}},
+		{r: tombstones.Intervals{{Mint: 1, Maxt: 23}, {Mint: 12, Maxt: 20}, {Mint: 25, Maxt: 30}}},
+		{r: tombstones.Intervals{{Mint: 1, Maxt: 23}, {Mint: 12, Maxt: 20}, {Mint: 25, Maxt: 3000}}},
+		{r: tombstones.Intervals{{Mint: 0, Maxt: 2000}}},
+		{r: tombstones.Intervals{{Mint: 500, Maxt: 2000}}},
+		{r: tombstones.Intervals{{Mint: 0, Maxt: 200}}},
+		{r: tombstones.Intervals{{Mint: 1000, Maxt: 20000}}},
 	}
 
 	for _, c := range cases {

--- a/tsdb/record/record_test.go
+++ b/tsdb/record/record_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tsdb
+package record
 
 import (
 	"testing"

--- a/tsdb/record/record_test.go
+++ b/tsdb/record/record_test.go
@@ -20,12 +20,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
 func TestRecord_EncodeDecode(t *testing.T) {
-	var enc RecordEncoder
-	var dec RecordDecoder
+	var enc Encoder
+	var dec Decoder
 
 	series := []RefSeries{
 		{
@@ -54,31 +55,31 @@ func TestRecord_EncodeDecode(t *testing.T) {
 
 	// Intervals get split up into single entries. So we don't get back exactly
 	// what we put in.
-	tstones := []Stone{
-		{ref: 123, intervals: Intervals{
+	tstones := []tombstones.Stone{
+		{Ref: 123, Intervals: tombstones.Intervals{
 			{Mint: -1000, Maxt: 1231231},
 			{Mint: 5000, Maxt: 0},
 		}},
-		{ref: 13, intervals: Intervals{
+		{Ref: 13, Intervals: tombstones.Intervals{
 			{Mint: -1000, Maxt: -11},
 			{Mint: 5000, Maxt: 1000},
 		}},
 	}
 	decTstones, err := dec.Tombstones(enc.Tombstones(tstones, nil), nil)
 	testutil.Ok(t, err)
-	testutil.Equals(t, []Stone{
-		{ref: 123, intervals: Intervals{{Mint: -1000, Maxt: 1231231}}},
-		{ref: 123, intervals: Intervals{{Mint: 5000, Maxt: 0}}},
-		{ref: 13, intervals: Intervals{{Mint: -1000, Maxt: -11}}},
-		{ref: 13, intervals: Intervals{{Mint: 5000, Maxt: 1000}}},
+	testutil.Equals(t, []tombstones.Stone{
+		{Ref: 123, Intervals: tombstones.Intervals{{Mint: -1000, Maxt: 1231231}}},
+		{Ref: 123, Intervals: tombstones.Intervals{{Mint: 5000, Maxt: 0}}},
+		{Ref: 13, Intervals: tombstones.Intervals{{Mint: -1000, Maxt: -11}}},
+		{Ref: 13, Intervals: tombstones.Intervals{{Mint: 5000, Maxt: 1000}}},
 	}, decTstones)
 }
 
 // TestRecord_Corruputed ensures that corrupted records return the correct error.
 // Bugfix check for pull/521 and pull/523.
 func TestRecord_Corruputed(t *testing.T) {
-	var enc RecordEncoder
-	var dec RecordDecoder
+	var enc Encoder
+	var dec Decoder
 
 	t.Run("Test corrupted series record", func(t *testing.T) {
 		series := []RefSeries{
@@ -104,8 +105,8 @@ func TestRecord_Corruputed(t *testing.T) {
 	})
 
 	t.Run("Test corrupted tombstone record", func(t *testing.T) {
-		tstones := []Stone{
-			{ref: 123, intervals: Intervals{
+		tstones := []tombstones.Stone{
+			{Ref: 123, Intervals: tombstones.Intervals{
 				{Mint: -1000, Maxt: 1231231},
 				{Mint: 5000, Maxt: 0},
 			}},

--- a/tsdb/tombstones/tombstones.go
+++ b/tsdb/tombstones/tombstones.go
@@ -11,11 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tsdb
+package tombstones
 
 import (
 	"encoding/binary"
 	"fmt"
+	"hash"
+	"hash/crc32"
 	"io"
 	"io/ioutil"
 	"os"
@@ -30,7 +32,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 )
 
-const tombstoneFilename = "tombstones"
+const Filename = "tombstones"
 
 const (
 	// MagicTombstone is 4 bytes at the head of a tombstone file.
@@ -39,8 +41,23 @@ const (
 	tombstoneFormatV1 = 1
 )
 
-// TombstoneReader gives access to tombstone intervals by series reference.
-type TombstoneReader interface {
+// The table gets initialized with sync.Once but may still cause a race
+// with any other use of the crc32 package anywhere. Thus we initialize it
+// before.
+var castagnoliTable *crc32.Table
+
+func init() {
+	castagnoliTable = crc32.MakeTable(crc32.Castagnoli)
+}
+
+// newCRC32 initializes a CRC32 hash with a preconfigured polynomial, so the
+// polynomial may be easily changed in one location at a later time, if necessary.
+func newCRC32() hash.Hash32 {
+	return crc32.New(castagnoliTable)
+}
+
+// Reader gives access to tombstone intervals by series reference.
+type Reader interface {
 	// Get returns deletion intervals for the series with the given reference.
 	Get(ref uint64) (Intervals, error)
 
@@ -54,8 +71,8 @@ type TombstoneReader interface {
 	Close() error
 }
 
-func writeTombstoneFile(logger log.Logger, dir string, tr TombstoneReader) (int64, error) {
-	path := filepath.Join(dir, tombstoneFilename)
+func WriteFile(logger log.Logger, dir string, tr Reader) (int64, error) {
+	path := filepath.Join(dir, Filename)
 	tmp := path + ".tmp"
 	hash := newCRC32()
 	var size int
@@ -129,14 +146,14 @@ func writeTombstoneFile(logger log.Logger, dir string, tr TombstoneReader) (int6
 // Stone holds the information on the posting and time-range
 // that is deleted.
 type Stone struct {
-	ref       uint64
-	intervals Intervals
+	Ref       uint64
+	Intervals Intervals
 }
 
-func readTombstones(dir string) (TombstoneReader, int64, error) {
-	b, err := ioutil.ReadFile(filepath.Join(dir, tombstoneFilename))
+func ReadTombstones(dir string) (Reader, int64, error) {
+	b, err := ioutil.ReadFile(filepath.Join(dir, Filename))
 	if os.IsNotExist(err) {
-		return newMemTombstones(), 0, nil
+		return NewMemTombstones(), 0, nil
 	} else if err != nil {
 		return nil, 0, err
 	}
@@ -166,7 +183,7 @@ func readTombstones(dir string) (TombstoneReader, int64, error) {
 		return nil, 0, errors.New("checksum did not match")
 	}
 
-	stonesMap := newMemTombstones()
+	stonesMap := NewMemTombstones()
 
 	for d.Len() > 0 {
 		k := d.Uvarint64()
@@ -176,7 +193,7 @@ func readTombstones(dir string) (TombstoneReader, int64, error) {
 			return nil, 0, d.Err()
 		}
 
-		stonesMap.addInterval(k, Interval{mint, maxt})
+		stonesMap.AddInterval(k, Interval{mint, maxt})
 	}
 
 	return stonesMap, int64(len(b)), nil
@@ -187,9 +204,9 @@ type memTombstones struct {
 	mtx         sync.RWMutex
 }
 
-// newMemTombstones creates new in memory TombstoneReader
+// NewMemTombstones creates new in memory TombstoneReader
 // that allows adding new intervals.
-func newMemTombstones() *memTombstones {
+func NewMemTombstones() *memTombstones {
 	return &memTombstones{intvlGroups: make(map[uint64]Intervals)}
 }
 
@@ -221,12 +238,12 @@ func (t *memTombstones) Total() uint64 {
 	return total
 }
 
-// addInterval to an existing memTombstones
-func (t *memTombstones) addInterval(ref uint64, itvs ...Interval) {
+// AddInterval to an existing memTombstones.
+func (t *memTombstones) AddInterval(ref uint64, itvs ...Interval) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	for _, itv := range itvs {
-		t.intvlGroups[ref] = t.intvlGroups[ref].add(itv)
+		t.intvlGroups[ref] = t.intvlGroups[ref].Add(itv)
 	}
 }
 
@@ -239,13 +256,13 @@ type Interval struct {
 	Mint, Maxt int64
 }
 
-func (tr Interval) inBounds(t int64) bool {
+func (tr Interval) InBounds(t int64) bool {
 	return t >= tr.Mint && t <= tr.Maxt
 }
 
-func (tr Interval) isSubrange(dranges Intervals) bool {
+func (tr Interval) IsSubrange(dranges Intervals) bool {
 	for _, r := range dranges {
-		if r.inBounds(tr.Mint) && r.inBounds(tr.Maxt) {
+		if r.InBounds(tr.Mint) && r.InBounds(tr.Maxt) {
 			return true
 		}
 	}
@@ -256,12 +273,12 @@ func (tr Interval) isSubrange(dranges Intervals) bool {
 // Intervals represents	a set of increasing and non-overlapping time-intervals.
 type Intervals []Interval
 
-// add the new time-range to the existing ones.
+// Add the new time-range to the existing ones.
 // The existing ones must be sorted.
-func (itvs Intervals) add(n Interval) Intervals {
+func (itvs Intervals) Add(n Interval) Intervals {
 	for i, r := range itvs {
 		// TODO(gouthamve): Make this codepath easier to digest.
-		if r.inBounds(n.Mint-1) || r.inBounds(n.Mint) {
+		if r.InBounds(n.Mint-1) || r.InBounds(n.Mint) {
 			if n.Maxt > r.Maxt {
 				itvs[i].Maxt = n.Maxt
 			}
@@ -282,7 +299,7 @@ func (itvs Intervals) add(n Interval) Intervals {
 			return itvs
 		}
 
-		if r.inBounds(n.Maxt+1) || r.inBounds(n.Maxt) {
+		if r.InBounds(n.Maxt+1) || r.InBounds(n.Maxt) {
 			if n.Mint < r.Maxt {
 				itvs[i].Mint = n.Mint
 			}

--- a/tsdb/tombstones/tombstones_test.go
+++ b/tsdb/tombstones/tombstones_test.go
@@ -47,7 +47,7 @@ func TestWriteAndReadbackTombStones(t *testing.T) {
 		stones.AddInterval(ref, dranges...)
 	}
 
-	_, err := WriteTombstoneFile(log.NewNopLogger(), tmpdir, stones)
+	_, err := WriteFile(log.NewNopLogger(), tmpdir, stones)
 	testutil.Ok(t, err)
 
 	restr, _, err := ReadTombstones(tmpdir)

--- a/tsdb/wal.go
+++ b/tsdb/wal.go
@@ -34,6 +34,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/tsdb/wal"
 )
 
@@ -89,9 +91,9 @@ func newWalMetrics(wal *SegmentWAL, r prometheus.Registerer) *walMetrics {
 // DEPRECATED: use wal pkg combined with the record codex instead.
 type WAL interface {
 	Reader() WALReader
-	LogSeries([]RefSeries) error
-	LogSamples([]RefSample) error
-	LogDeletes([]Stone) error
+	LogSeries([]record.RefSeries) error
+	LogSamples([]record.RefSample) error
+	LogDeletes([]tombstones.Stone) error
 	Truncate(mint int64, keep func(uint64) bool) error
 	Close() error
 }
@@ -99,25 +101,10 @@ type WAL interface {
 // WALReader reads entries from a WAL.
 type WALReader interface {
 	Read(
-		seriesf func([]RefSeries),
-		samplesf func([]RefSample),
-		deletesf func([]Stone),
+		seriesf func([]record.RefSeries),
+		samplesf func([]record.RefSample),
+		deletesf func([]tombstones.Stone),
 	) error
-}
-
-// RefSeries is the series labels with the series ID.
-type RefSeries struct {
-	Ref    uint64
-	Labels labels.Labels
-}
-
-// RefSample is a timestamp/value pair associated with a reference to a series.
-type RefSample struct {
-	Ref uint64
-	T   int64
-	V   float64
-
-	series *memSeries
 }
 
 // segmentFile wraps a file object of a segment and tracks the highest timestamp
@@ -240,9 +227,9 @@ type repairingWALReader struct {
 }
 
 func (r *repairingWALReader) Read(
-	seriesf func([]RefSeries),
-	samplesf func([]RefSample),
-	deletesf func([]Stone),
+	seriesf func([]record.RefSeries),
+	samplesf func([]record.RefSample),
+	deletesf func([]tombstones.Stone),
 ) error {
 	err := r.r.Read(seriesf, samplesf, deletesf)
 	if err == nil {
@@ -348,8 +335,8 @@ func (w *SegmentWAL) Truncate(mint int64, keep func(uint64) bool) error {
 	var (
 		csf          = newSegmentFile(f)
 		crc32        = newCRC32()
-		decSeries    = []RefSeries{}
-		activeSeries = []RefSeries{}
+		decSeries    = []record.RefSeries{}
+		activeSeries = []record.RefSeries{}
 	)
 
 	for r.next() {
@@ -433,7 +420,7 @@ func (w *SegmentWAL) Truncate(mint int64, keep func(uint64) bool) error {
 
 // LogSeries writes a batch of new series labels to the log.
 // The series have to be ordered.
-func (w *SegmentWAL) LogSeries(series []RefSeries) error {
+func (w *SegmentWAL) LogSeries(series []record.RefSeries) error {
 	buf := w.getBuffer()
 
 	flag := w.encodeSeries(buf, series)
@@ -460,7 +447,7 @@ func (w *SegmentWAL) LogSeries(series []RefSeries) error {
 }
 
 // LogSamples writes a batch of new samples to the log.
-func (w *SegmentWAL) LogSamples(samples []RefSample) error {
+func (w *SegmentWAL) LogSamples(samples []record.RefSample) error {
 	buf := w.getBuffer()
 
 	flag := w.encodeSamples(buf, samples)
@@ -486,7 +473,7 @@ func (w *SegmentWAL) LogSamples(samples []RefSample) error {
 }
 
 // LogDeletes write a batch of new deletes to the log.
-func (w *SegmentWAL) LogDeletes(stones []Stone) error {
+func (w *SegmentWAL) LogDeletes(stones []tombstones.Stone) error {
 	buf := w.getBuffer()
 
 	flag := w.encodeDeletes(buf, stones)
@@ -504,7 +491,7 @@ func (w *SegmentWAL) LogDeletes(stones []Stone) error {
 	tf := w.head()
 
 	for _, s := range stones {
-		for _, iv := range s.intervals {
+		for _, iv := range s.Intervals {
 			if tf.maxTime < iv.Maxt {
 				tf.maxTime = iv.Maxt
 			}
@@ -797,7 +784,7 @@ const (
 	walDeletesSimple = 1
 )
 
-func (w *SegmentWAL) encodeSeries(buf *encoding.Encbuf, series []RefSeries) uint8 {
+func (w *SegmentWAL) encodeSeries(buf *encoding.Encbuf, series []record.RefSeries) uint8 {
 	for _, s := range series {
 		buf.PutBE64(s.Ref)
 		buf.PutUvarint(len(s.Labels))
@@ -810,7 +797,7 @@ func (w *SegmentWAL) encodeSeries(buf *encoding.Encbuf, series []RefSeries) uint
 	return walSeriesSimple
 }
 
-func (w *SegmentWAL) encodeSamples(buf *encoding.Encbuf, samples []RefSample) uint8 {
+func (w *SegmentWAL) encodeSamples(buf *encoding.Encbuf, samples []record.RefSample) uint8 {
 	if len(samples) == 0 {
 		return walSamplesSimple
 	}
@@ -831,10 +818,10 @@ func (w *SegmentWAL) encodeSamples(buf *encoding.Encbuf, samples []RefSample) ui
 	return walSamplesSimple
 }
 
-func (w *SegmentWAL) encodeDeletes(buf *encoding.Encbuf, stones []Stone) uint8 {
+func (w *SegmentWAL) encodeDeletes(buf *encoding.Encbuf, stones []tombstones.Stone) uint8 {
 	for _, s := range stones {
-		for _, iv := range s.intervals {
-			buf.PutBE64(s.ref)
+		for _, iv := range s.Intervals {
+			buf.PutBE64(s.Ref)
 			buf.PutVarint64(iv.Mint)
 			buf.PutVarint64(iv.Maxt)
 		}
@@ -877,9 +864,9 @@ func (r *walReader) Err() error {
 }
 
 func (r *walReader) Read(
-	seriesf func([]RefSeries),
-	samplesf func([]RefSample),
-	deletesf func([]Stone),
+	seriesf func([]record.RefSeries),
+	samplesf func([]record.RefSample),
+	deletesf func([]tombstones.Stone),
 ) error {
 	// Concurrency for replaying the WAL is very limited. We at least split out decoding and
 	// processing into separate threads.
@@ -898,19 +885,19 @@ func (r *walReader) Read(
 
 		for x := range datac {
 			switch v := x.(type) {
-			case []RefSeries:
+			case []record.RefSeries:
 				if seriesf != nil {
 					seriesf(v)
 				}
 				//lint:ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 				seriesPool.Put(v[:0])
-			case []RefSample:
+			case []record.RefSample:
 				if samplesf != nil {
 					samplesf(v)
 				}
 				//lint:ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 				samplePool.Put(v[:0])
-			case []Stone:
+			case []tombstones.Stone:
 				if deletesf != nil {
 					deletesf(v)
 				}
@@ -931,11 +918,11 @@ func (r *walReader) Read(
 		// Those should generally be catched by entry decoding before.
 		switch et {
 		case WALEntrySeries:
-			var series []RefSeries
+			var series []record.RefSeries
 			if v := seriesPool.Get(); v == nil {
-				series = make([]RefSeries, 0, 512)
+				series = make([]record.RefSeries, 0, 512)
 			} else {
-				series = v.([]RefSeries)
+				series = v.([]record.RefSeries)
 			}
 
 			err = r.decodeSeries(flag, b, &series)
@@ -952,11 +939,11 @@ func (r *walReader) Read(
 				}
 			}
 		case WALEntrySamples:
-			var samples []RefSample
+			var samples []record.RefSample
 			if v := samplePool.Get(); v == nil {
-				samples = make([]RefSample, 0, 512)
+				samples = make([]record.RefSample, 0, 512)
 			} else {
-				samples = v.([]RefSample)
+				samples = v.([]record.RefSample)
 			}
 
 			err = r.decodeSamples(flag, b, &samples)
@@ -974,11 +961,11 @@ func (r *walReader) Read(
 				}
 			}
 		case WALEntryDeletes:
-			var deletes []Stone
+			var deletes []tombstones.Stone
 			if v := deletePool.Get(); v == nil {
-				deletes = make([]Stone, 0, 512)
+				deletes = make([]tombstones.Stone, 0, 512)
 			} else {
-				deletes = v.([]Stone)
+				deletes = v.([]tombstones.Stone)
 			}
 
 			err = r.decodeDeletes(flag, b, &deletes)
@@ -991,7 +978,7 @@ func (r *walReader) Read(
 			// Update the times for the WAL segment file.
 			cf := r.current()
 			for _, s := range deletes {
-				for _, iv := range s.intervals {
+				for _, iv := range s.Intervals {
 					if cf.maxTime < iv.Maxt {
 						cf.maxTime = iv.Maxt
 					}
@@ -1128,7 +1115,7 @@ func (r *walReader) entry(cr io.Reader) (WALEntryType, byte, []byte, error) {
 	return etype, flag, buf, nil
 }
 
-func (r *walReader) decodeSeries(flag byte, b []byte, res *[]RefSeries) error {
+func (r *walReader) decodeSeries(flag byte, b []byte, res *[]record.RefSeries) error {
 	dec := encoding.Decbuf{B: b}
 
 	for len(dec.B) > 0 && dec.Err() == nil {
@@ -1142,7 +1129,7 @@ func (r *walReader) decodeSeries(flag byte, b []byte, res *[]RefSeries) error {
 		}
 		sort.Sort(lset)
 
-		*res = append(*res, RefSeries{
+		*res = append(*res, record.RefSeries{
 			Ref:    ref,
 			Labels: lset,
 		})
@@ -1156,7 +1143,7 @@ func (r *walReader) decodeSeries(flag byte, b []byte, res *[]RefSeries) error {
 	return nil
 }
 
-func (r *walReader) decodeSamples(flag byte, b []byte, res *[]RefSample) error {
+func (r *walReader) decodeSamples(flag byte, b []byte, res *[]record.RefSample) error {
 	if len(b) == 0 {
 		return nil
 	}
@@ -1172,7 +1159,7 @@ func (r *walReader) decodeSamples(flag byte, b []byte, res *[]RefSample) error {
 		dtime := dec.Varint64()
 		val := dec.Be64()
 
-		*res = append(*res, RefSample{
+		*res = append(*res, record.RefSample{
 			Ref: uint64(int64(baseRef) + dref),
 			T:   baseTime + dtime,
 			V:   math.Float64frombits(val),
@@ -1188,13 +1175,13 @@ func (r *walReader) decodeSamples(flag byte, b []byte, res *[]RefSample) error {
 	return nil
 }
 
-func (r *walReader) decodeDeletes(flag byte, b []byte, res *[]Stone) error {
+func (r *walReader) decodeDeletes(flag byte, b []byte, res *[]tombstones.Stone) error {
 	dec := &encoding.Decbuf{B: b}
 
 	for dec.Len() > 0 && dec.Err() == nil {
-		*res = append(*res, Stone{
-			ref: dec.Be64(),
-			intervals: Intervals{
+		*res = append(*res, tombstones.Stone{
+			Ref: dec.Be64(),
+			Intervals: tombstones.Intervals{
 				{Mint: dec.Varint64(), Maxt: dec.Varint64()},
 			},
 		})
@@ -1274,23 +1261,23 @@ func MigrateWAL(logger log.Logger, dir string) (err error) {
 	rdr := w.Reader()
 
 	var (
-		enc RecordEncoder
+		enc record.Encoder
 		b   []byte
 	)
 	decErr := rdr.Read(
-		func(s []RefSeries) {
+		func(s []record.RefSeries) {
 			if err != nil {
 				return
 			}
 			err = repl.Log(enc.Series(s, b[:0]))
 		},
-		func(s []RefSample) {
+		func(s []record.RefSample) {
 			if err != nil {
 				return
 			}
 			err = repl.Log(enc.Samples(s, b[:0]))
 		},
-		func(s []Stone) {
+		func(s []tombstones.Stone) {
 			if err != nil {
 				return
 			}

--- a/tsdb/wal/checkpoint_test.go
+++ b/tsdb/wal/checkpoint_test.go
@@ -185,7 +185,7 @@ func TestCheckpoint(t *testing.T) {
 				}
 			}
 			testutil.Ok(t, r.Err())
-			testutil.Equals(t, []record.Series{
+			testutil.Equals(t, []record.RefSeries{
 				{Ref: 0, Labels: labels.FromStrings("a", "b", "c", "0")},
 				{Ref: 2, Labels: labels.FromStrings("a", "b", "c", "2")},
 				{Ref: 4, Labels: labels.FromStrings("a", "b", "c", "4")},

--- a/tsdb/wal/reader_test.go
+++ b/tsdb/wal/reader_test.go
@@ -41,7 +41,7 @@ type reader interface {
 	Offset() int64
 }
 
-type record struct {
+type rec struct {
 	t recType
 	b []byte
 }
@@ -59,13 +59,13 @@ var readerConstructors = map[string]func(io.Reader) reader{
 
 var data = make([]byte, 100000)
 var testReaderCases = []struct {
-	t    []record
+	t    []rec
 	exp  [][]byte
 	fail bool
 }{
 	// Sequence of valid records.
 	{
-		t: []record{
+		t: []rec{
 			{recFull, data[0:200]},
 			{recFirst, data[200:300]},
 			{recLast, data[300:400]},
@@ -89,7 +89,7 @@ var testReaderCases = []struct {
 	},
 	// Exactly at the limit of one page minus the header size
 	{
-		t: []record{
+		t: []rec{
 			{recFull, data[0 : pageSize-recordHeaderSize]},
 		},
 		exp: [][]byte{
@@ -99,7 +99,7 @@ var testReaderCases = []struct {
 	// More than a full page, this exceeds our buffer and can never happen
 	// when written by the WAL.
 	{
-		t: []record{
+		t: []rec{
 			{recFull, data[0 : pageSize+1]},
 		},
 		fail: true,
@@ -108,7 +108,7 @@ var testReaderCases = []struct {
 	// NB currently the non-live reader succeeds on this. I think this is a bug.
 	// but we've seen it in production.
 	{
-		t: []record{
+		t: []rec{
 			{recFull, data[:pageSize/2]},
 			{recFull, data[:pageSize/2]},
 		},
@@ -119,22 +119,22 @@ var testReaderCases = []struct {
 	},
 	// Invalid orders of record types.
 	{
-		t:    []record{{recMiddle, data[:200]}},
+		t:    []rec{{recMiddle, data[:200]}},
 		fail: true,
 	},
 	{
-		t:    []record{{recLast, data[:200]}},
+		t:    []rec{{recLast, data[:200]}},
 		fail: true,
 	},
 	{
-		t: []record{
+		t: []rec{
 			{recFirst, data[:200]},
 			{recFull, data[200:400]},
 		},
 		fail: true,
 	},
 	{
-		t: []record{
+		t: []rec{
 			{recFirst, data[:100]},
 			{recMiddle, data[100:200]},
 			{recFull, data[200:400]},
@@ -143,7 +143,7 @@ var testReaderCases = []struct {
 	},
 	// Non-zero data after page termination.
 	{
-		t: []record{
+		t: []rec{
 			{recFull, data[:100]},
 			{recPageTerm, append(make([]byte, pageSize-recordHeaderSize-102), 1)},
 		},

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package remote
+package wal
 
 import (
 	"fmt"
@@ -28,79 +28,42 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/tsdb"
-	"github.com/prometheus/prometheus/tsdb/fileutil"
-	"github.com/prometheus/prometheus/tsdb/wal"
-
 	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/prometheus/prometheus/tsdb/fileutil"
+	"github.com/prometheus/prometheus/tsdb/record"
 )
 
 const (
 	readPeriod         = 10 * time.Millisecond
 	checkpointPeriod   = 5 * time.Second
 	segmentCheckPeriod = 100 * time.Millisecond
+	consumer           = "consumer"
 )
 
-var (
-	watcherRecordsRead = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "prometheus",
-			Subsystem: "wal_watcher",
-			Name:      "records_read_total",
-			Help:      "Number of records read by the WAL watcher from the WAL.",
-		},
-		[]string{queue, "type"},
-	)
-	watcherRecordDecodeFails = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "prometheus",
-			Subsystem: "wal_watcher",
-			Name:      "record_decode_failures_total",
-			Help:      "Number of records read by the WAL watcher that resulted in an error when decoding.",
-		},
-		[]string{queue},
-	)
-	watcherSamplesSentPreTailing = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "prometheus",
-			Subsystem: "wal_watcher",
-			Name:      "samples_sent_pre_tailing_total",
-			Help:      "Number of sample records read by the WAL watcher and sent to remote write during replay of existing WAL.",
-		},
-		[]string{queue},
-	)
-	watcherCurrentSegment = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "prometheus",
-			Subsystem: "wal_watcher",
-			Name:      "current_segment",
-			Help:      "Current segment the WAL watcher is reading records from.",
-		},
-		[]string{queue},
-	)
-	liveReaderMetrics = wal.NewLiveReaderMetrics(prometheus.DefaultRegisterer)
-)
-
-func init() {
-	prometheus.MustRegister(watcherRecordsRead)
-	prometheus.MustRegister(watcherRecordDecodeFails)
-	prometheus.MustRegister(watcherSamplesSentPreTailing)
-	prometheus.MustRegister(watcherCurrentSegment)
-}
-
-type writeTo interface {
-	Append([]tsdb.RefSample) bool
-	StoreSeries([]tsdb.RefSeries, int)
+// WriteTo is an interface used by the Watcher to send the samples it's read
+// from the WAL on to somewhere else.
+type WriteTo interface {
+	Append([]record.RefSample) bool
+	StoreSeries([]record.RefSeries, int)
 	SeriesReset(int)
 }
 
-// WALWatcher watches the TSDB WAL for a given WriteTo.
-type WALWatcher struct {
+type WatcherMetrics struct {
+	recordsRead           *prometheus.CounterVec
+	recordDecodeFails     *prometheus.CounterVec
+	samplesSentPreTailing *prometheus.CounterVec
+	currentSegment        *prometheus.GaugeVec
+}
+
+// Watcher watches the TSDB WAL for a given WriteTo.
+type Watcher struct {
 	name           string
-	writer         writeTo
+	writer         WriteTo
 	logger         log.Logger
 	walDir         string
 	lastCheckpoint string
+	metrics        *WatcherMetrics
+	readerMetrics  *liveReaderMetrics
 
 	startTime int64
 
@@ -116,57 +79,109 @@ type WALWatcher struct {
 	maxSegment int
 }
 
-// NewWALWatcher creates a new WAL watcher for a given WriteTo.
-func NewWALWatcher(logger log.Logger, name string, writer writeTo, walDir string) *WALWatcher {
+func NewWatcherMetrics(reg prometheus.Registerer) *WatcherMetrics {
+	m := &WatcherMetrics{
+		recordsRead: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "prometheus",
+				Subsystem: "wal_watcher",
+				Name:      "records_read_total",
+				Help:      "Number of records read by the WAL watcher from the WAL.",
+			},
+			[]string{consumer, "type"},
+		),
+		recordDecodeFails: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "prometheus",
+				Subsystem: "wal_watcher",
+				Name:      "record_decode_failures_total",
+				Help:      "Number of records read by the WAL watcher that resulted in an error when decoding.",
+			},
+			[]string{consumer},
+		),
+		samplesSentPreTailing: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "prometheus",
+				Subsystem: "wal_watcher",
+				Name:      "samples_sent_pre_tailing_total",
+				Help:      "Number of sample records read by the WAL watcher and sent to remote write during replay of existing WAL.",
+			},
+			[]string{consumer},
+		),
+		currentSegment: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "prometheus",
+				Subsystem: "wal_watcher",
+				Name:      "current_segment",
+				Help:      "Current segment the WAL watcher is reading records from.",
+			},
+			[]string{consumer},
+		),
+	}
+
+	if reg != nil {
+		reg.MustRegister(m.recordsRead)
+		reg.MustRegister(m.recordDecodeFails)
+		reg.MustRegister(m.samplesSentPreTailing)
+		reg.MustRegister(m.currentSegment)
+	}
+
+	return m
+}
+
+// NewWatcher creates a new WAL watcher for a given WriteTo.
+func NewWatcher(reg prometheus.Registerer, metrics *WatcherMetrics, logger log.Logger, name string, writer WriteTo, walDir string) *Watcher {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
-	return &WALWatcher{
-		logger: logger,
-		writer: writer,
-		walDir: path.Join(walDir, "wal"),
-		name:   name,
-		quit:   make(chan struct{}),
-		done:   make(chan struct{}),
+	return &Watcher{
+		logger:        logger,
+		writer:        writer,
+		metrics:       metrics,
+		readerMetrics: NewLiveReaderMetrics(reg),
+		walDir:        path.Join(walDir, "wal"),
+		name:          name,
+		quit:          make(chan struct{}),
+		done:          make(chan struct{}),
 
 		maxSegment: -1,
 	}
 }
 
-func (w *WALWatcher) setMetrics() {
+func (w *Watcher) setMetrics() {
 	// Setup the WAL Watchers metrics. We do this here rather than in the
 	// constructor because of the ordering of creating Queue Managers's,
 	// stopping them, and then starting new ones in storage/remote/storage.go ApplyConfig.
-	w.recordsReadMetric = watcherRecordsRead.MustCurryWith(prometheus.Labels{queue: w.name})
-	w.recordDecodeFailsMetric = watcherRecordDecodeFails.WithLabelValues(w.name)
-	w.samplesSentPreTailing = watcherSamplesSentPreTailing.WithLabelValues(w.name)
-	w.currentSegmentMetric = watcherCurrentSegment.WithLabelValues(w.name)
+	w.recordsReadMetric = w.metrics.recordsRead.MustCurryWith(prometheus.Labels{consumer: w.name})
+	w.recordDecodeFailsMetric = w.metrics.recordDecodeFails.WithLabelValues(w.name)
+	w.samplesSentPreTailing = w.metrics.samplesSentPreTailing.WithLabelValues(w.name)
+	w.currentSegmentMetric = w.metrics.currentSegment.WithLabelValues(w.name)
 }
 
-// Start the WALWatcher.
-func (w *WALWatcher) Start() {
+// Start the Watcher.
+func (w *Watcher) Start() {
 	w.setMetrics()
 	level.Info(w.logger).Log("msg", "starting WAL watcher", "queue", w.name)
 
 	go w.loop()
 }
 
-// Stop the WALWatcher.
-func (w *WALWatcher) Stop() {
+// Stop the Watcher.
+func (w *Watcher) Stop() {
 	close(w.quit)
 	<-w.done
 
 	// Records read metric has series and samples.
-	watcherRecordsRead.DeleteLabelValues(w.name, "series")
-	watcherRecordsRead.DeleteLabelValues(w.name, "samples")
-	watcherRecordDecodeFails.DeleteLabelValues(w.name)
-	watcherSamplesSentPreTailing.DeleteLabelValues(w.name)
-	watcherCurrentSegment.DeleteLabelValues(w.name)
+	w.metrics.recordsRead.DeleteLabelValues(w.name, "series")
+	w.metrics.recordsRead.DeleteLabelValues(w.name, "samples")
+	w.metrics.recordDecodeFails.DeleteLabelValues(w.name)
+	w.metrics.samplesSentPreTailing.DeleteLabelValues(w.name)
+	w.metrics.currentSegment.DeleteLabelValues(w.name)
 
 	level.Info(w.logger).Log("msg", "WAL watcher stopped", "queue", w.name)
 }
 
-func (w *WALWatcher) loop() {
+func (w *Watcher) loop() {
 	defer close(w.done)
 
 	// We may encounter failures processing the WAL; we should wait and retry.
@@ -184,15 +199,15 @@ func (w *WALWatcher) loop() {
 	}
 }
 
-func (w *WALWatcher) run() error {
+func (w *Watcher) run() error {
 	_, lastSegment, err := w.firstAndLast()
 	if err != nil {
 		return errors.Wrap(err, "wal.Segments")
 	}
 
 	// Backfill from the checkpoint first if it exists.
-	lastCheckpoint, checkpointIndex, err := tsdb.LastCheckpoint(w.walDir)
-	if err != nil && err != tsdb.ErrNotFound {
+	lastCheckpoint, checkpointIndex, err := LastCheckpoint(w.walDir)
+	if err != nil && err != record.ErrNotFound {
 		return errors.Wrap(err, "tsdb.LastCheckpoint")
 	}
 
@@ -231,7 +246,7 @@ func (w *WALWatcher) run() error {
 }
 
 // findSegmentForIndex finds the first segment greater than or equal to index.
-func (w *WALWatcher) findSegmentForIndex(index int) (int, error) {
+func (w *Watcher) findSegmentForIndex(index int) (int, error) {
 	refs, err := w.segments(w.walDir)
 	if err != nil {
 		return -1, err
@@ -246,7 +261,7 @@ func (w *WALWatcher) findSegmentForIndex(index int) (int, error) {
 	return -1, errors.New("failed to find segment for index")
 }
 
-func (w *WALWatcher) firstAndLast() (int, int, error) {
+func (w *Watcher) firstAndLast() (int, int, error) {
 	refs, err := w.segments(w.walDir)
 	if err != nil {
 		return -1, -1, err
@@ -260,7 +275,7 @@ func (w *WALWatcher) firstAndLast() (int, int, error) {
 
 // Copied from tsdb/wal/wal.go so we do not have to open a WAL.
 // Plan is to move WAL watcher to TSDB and dedupe these implementations.
-func (w *WALWatcher) segments(dir string) ([]int, error) {
+func (w *Watcher) segments(dir string) ([]int, error) {
 	files, err := fileutil.ReadDir(dir)
 	if err != nil {
 		return nil, err
@@ -287,14 +302,14 @@ func (w *WALWatcher) segments(dir string) ([]int, error) {
 // Use tail true to indicate that the reader is currently on a segment that is
 // actively being written to. If false, assume it's a full segment and we're
 // replaying it on start to cache the series records.
-func (w *WALWatcher) watch(segmentNum int, tail bool) error {
-	segment, err := wal.OpenReadSegment(wal.SegmentName(w.walDir, segmentNum))
+func (w *Watcher) watch(segmentNum int, tail bool) error {
+	segment, err := OpenReadSegment(SegmentName(w.walDir, segmentNum))
 	if err != nil {
 		return err
 	}
 	defer segment.Close()
 
-	reader := wal.NewLiveReader(w.logger, liveReaderMetrics, segment)
+	reader := NewLiveReader(w.logger, w.readerMetrics, segment)
 
 	readTicker := time.NewTicker(readPeriod)
 	defer readTicker.Stop()
@@ -382,9 +397,9 @@ func (w *WALWatcher) watch(segmentNum int, tail bool) error {
 	}
 }
 
-func (w *WALWatcher) garbageCollectSeries(segmentNum int) error {
-	dir, _, err := tsdb.LastCheckpoint(w.walDir)
-	if err != nil && err != tsdb.ErrNotFound {
+func (w *Watcher) garbageCollectSeries(segmentNum int) error {
+	dir, _, err := LastCheckpoint(w.walDir)
+	if err != nil && err != record.ErrNotFound {
 		return errors.Wrap(err, "tsdb.LastCheckpoint")
 	}
 
@@ -414,12 +429,12 @@ func (w *WALWatcher) garbageCollectSeries(segmentNum int) error {
 	return nil
 }
 
-func (w *WALWatcher) readSegment(r *wal.LiveReader, segmentNum int, tail bool) error {
+func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 	var (
-		dec     tsdb.RecordDecoder
-		series  []tsdb.RefSeries
-		samples []tsdb.RefSample
-		send    []tsdb.RefSample
+		dec     record.Decoder
+		series  []record.RefSeries
+		samples []record.RefSample
+		send    []record.RefSample
 	)
 
 	for r.Next() && !isClosed(w.quit) {
@@ -427,7 +442,7 @@ func (w *WALWatcher) readSegment(r *wal.LiveReader, segmentNum int, tail bool) e
 		w.recordsReadMetric.WithLabelValues(recordType(dec.Type(rec))).Inc()
 
 		switch dec.Type(rec) {
-		case tsdb.RecordSeries:
+		case record.Series:
 			series, err := dec.Series(rec, series[:0])
 			if err != nil {
 				w.recordDecodeFailsMetric.Inc()
@@ -435,7 +450,7 @@ func (w *WALWatcher) readSegment(r *wal.LiveReader, segmentNum int, tail bool) e
 			}
 			w.writer.StoreSeries(series, segmentNum)
 
-		case tsdb.RecordSamples:
+		case record.Samples:
 			// If we're not tailing a segment we can ignore any samples records we see.
 			// This speeds up replay of the WAL by > 10x.
 			if !tail {
@@ -457,9 +472,9 @@ func (w *WALWatcher) readSegment(r *wal.LiveReader, segmentNum int, tail bool) e
 				send = send[:0]
 			}
 
-		case tsdb.RecordTombstones:
+		case record.Tombstones:
 			// noop
-		case tsdb.RecordInvalid:
+		case record.Invalid:
 			return errors.New("invalid record")
 
 		default:
@@ -470,15 +485,15 @@ func (w *WALWatcher) readSegment(r *wal.LiveReader, segmentNum int, tail bool) e
 	return r.Err()
 }
 
-func recordType(rt tsdb.RecordType) string {
+func recordType(rt record.Type) string {
 	switch rt {
-	case tsdb.RecordInvalid:
+	case record.Invalid:
 		return "invalid"
-	case tsdb.RecordSeries:
+	case record.Series:
 		return "series"
-	case tsdb.RecordSamples:
+	case record.Samples:
 		return "samples"
-	case tsdb.RecordTombstones:
+	case record.Tombstones:
 		return "tombstones"
 	default:
 		return "unknown"
@@ -486,7 +501,7 @@ func recordType(rt tsdb.RecordType) string {
 }
 
 // Read all the series records from a Checkpoint directory.
-func (w *WALWatcher) readCheckpoint(checkpointDir string) error {
+func (w *Watcher) readCheckpoint(checkpointDir string) error {
 	level.Debug(w.logger).Log("msg", "reading checkpoint", "dir", checkpointDir)
 	index, err := checkpointNum(checkpointDir)
 	if err != nil {
@@ -504,13 +519,13 @@ func (w *WALWatcher) readCheckpoint(checkpointDir string) error {
 			return errors.Wrap(err, "getSegmentSize")
 		}
 
-		sr, err := wal.OpenReadSegment(wal.SegmentName(checkpointDir, seg))
+		sr, err := OpenReadSegment(SegmentName(checkpointDir, seg))
 		if err != nil {
 			return errors.Wrap(err, "unable to open segment")
 		}
 		defer sr.Close()
 
-		r := wal.NewLiveReader(w.logger, liveReaderMetrics, sr)
+		r := NewLiveReader(w.logger, w.readerMetrics, sr)
 		if err := w.readSegment(r, index, false); err != io.EOF && err != nil {
 			return errors.Wrap(err, "readSegment")
 		}
@@ -543,7 +558,7 @@ func checkpointNum(dir string) (int, error) {
 // Get size of segment.
 func getSegmentSize(dir string, index int) (int64, error) {
 	i := int64(-1)
-	fi, err := os.Stat(wal.SegmentName(dir, index))
+	fi, err := os.Stat(SegmentName(dir, index))
 	if err == nil {
 		i = fi.Size()
 	}

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -120,10 +120,10 @@ func NewWatcherMetrics(reg prometheus.Registerer) *WatcherMetrics {
 	}
 
 	if reg != nil {
-		reg.Register(m.recordsRead)
-		reg.Register(m.recordDecodeFails)
-		reg.Register(m.samplesSentPreTailing)
-		reg.Register(m.currentSegment)
+		_ = reg.Register(m.recordsRead)
+		_ = reg.Register(m.recordDecodeFails)
+		_ = reg.Register(m.samplesSentPreTailing)
+		_ = reg.Register(m.currentSegment)
 	}
 
 	return m

--- a/tsdb/wal/watcher_test.go
+++ b/tsdb/wal/watcher_test.go
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package remote
+package wal
 
 import (
 	"fmt"
@@ -22,9 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/labels"
-	"github.com/prometheus/prometheus/tsdb/wal"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -105,7 +103,7 @@ func TestTailSamples(t *testing.T) {
 			testutil.Ok(t, err)
 
 			enc := tsdb.RecordEncoder{}
-			w, err := wal.NewSize(nil, nil, wdir, 128*pageSize, compress)
+			w, err := NewSize(nil, nil, wdir, 128*pageSize, compress)
 			testutil.Ok(t, err)
 
 			// Write to the initial segment then checkpoint.
@@ -137,17 +135,17 @@ func TestTailSamples(t *testing.T) {
 			testutil.Ok(t, err)
 
 			wt := newWriteToMock()
-			watcher := NewWALWatcher(nil, "", wt, dir)
+			watcher := NewWatcher(nil, "", wt, dir)
 			watcher.startTime = now.UnixNano()
 
 			// Set the Watcher's metrics so they're not nil pointers.
 			watcher.setMetrics()
 			for i := first; i <= last; i++ {
-				segment, err := wal.OpenReadSegment(wal.SegmentName(watcher.walDir, i))
+				segment, err := OpenReadSegment(SegmentName(watcher.walDir, i))
 				testutil.Ok(t, err)
 				defer segment.Close()
 
-				reader := wal.NewLiveReader(nil, liveReaderMetrics, segment)
+				reader := NewLiveReader(nil, liveReaderMetrics, segment)
 				// Use tail true so we can ensure we got the right number of samples.
 				watcher.readSegment(reader, i, true)
 			}
@@ -177,7 +175,7 @@ func TestReadToEndNoCheckpoint(t *testing.T) {
 			err = os.Mkdir(wdir, 0777)
 			testutil.Ok(t, err)
 
-			w, err := wal.NewSize(nil, nil, wdir, 128*pageSize, compress)
+			w, err := NewSize(nil, nil, wdir, 128*pageSize, compress)
 			testutil.Ok(t, err)
 
 			var recs [][]byte
@@ -247,7 +245,7 @@ func TestReadToEndWithCheckpoint(t *testing.T) {
 			testutil.Ok(t, err)
 
 			enc := tsdb.RecordEncoder{}
-			w, err := wal.NewSize(nil, nil, wdir, segmentSize, compress)
+			w, err := NewSize(nil, nil, wdir, segmentSize, compress)
 			testutil.Ok(t, err)
 
 			// Write to the initial segment then checkpoint.
@@ -330,10 +328,10 @@ func TestReadCheckpoint(t *testing.T) {
 			err = os.Mkdir(wdir, 0777)
 			testutil.Ok(t, err)
 
-			os.Create(wal.SegmentName(wdir, 30))
+			os.Create(SegmentName(wdir, 30))
 
 			enc := tsdb.RecordEncoder{}
-			w, err := wal.NewSize(nil, nil, wdir, 128*pageSize, compress)
+			w, err := NewSize(nil, nil, wdir, 128*pageSize, compress)
 			testutil.Ok(t, err)
 
 			// Write to the initial segment then checkpoint.
@@ -399,7 +397,7 @@ func TestReadCheckpointMultipleSegments(t *testing.T) {
 			testutil.Ok(t, err)
 
 			enc := tsdb.RecordEncoder{}
-			w, err := wal.NewSize(nil, nil, wdir, pageSize, compress)
+			w, err := NewSize(nil, nil, wdir, pageSize, compress)
 			testutil.Ok(t, err)
 
 			// Write a bunch of data.
@@ -433,7 +431,7 @@ func TestReadCheckpointMultipleSegments(t *testing.T) {
 			err = os.Mkdir(checkpointDir, 0777)
 			testutil.Ok(t, err)
 			for i := 0; i <= 4; i++ {
-				err := os.Rename(wal.SegmentName(dir+"/wal", i), wal.SegmentName(checkpointDir, i))
+				err := os.Rename(SegmentName(dir+"/wal", i), SegmentName(checkpointDir, i))
 				testutil.Ok(t, err)
 			}
 
@@ -478,7 +476,7 @@ func TestCheckpointSeriesReset(t *testing.T) {
 			testutil.Ok(t, err)
 
 			enc := tsdb.RecordEncoder{}
-			w, err := wal.NewSize(nil, nil, wdir, segmentSize, tc.compress)
+			w, err := NewSize(nil, nil, wdir, segmentSize, tc.compress)
 			testutil.Ok(t, err)
 
 			// Write to the initial segment, then checkpoint later.

--- a/tsdb/wal_test.go
+++ b/tsdb/wal_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/tsdb/wal"
 	"github.com/prometheus/prometheus/util/testutil"
 )
@@ -95,10 +97,10 @@ func TestSegmentWAL_Truncate(t *testing.T) {
 	w.segmentSize = 10000
 
 	for i := 0; i < numMetrics; i += batch {
-		var rs []RefSeries
+		var rs []record.RefSeries
 
 		for j, s := range series[i : i+batch] {
-			rs = append(rs, RefSeries{Labels: s, Ref: uint64(i+j) + 1})
+			rs = append(rs, record.RefSeries{Labels: s, Ref: uint64(i+j) + 1})
 		}
 		err := w.LogSeries(rs)
 		testutil.Ok(t, err)
@@ -125,11 +127,11 @@ func TestSegmentWAL_Truncate(t *testing.T) {
 	err = w.Truncate(1000, keepf)
 	testutil.Ok(t, err)
 
-	var expected []RefSeries
+	var expected []record.RefSeries
 
 	for i := 1; i <= numMetrics; i++ {
 		if i%2 == 1 || uint64(i) >= boundarySeries {
-			expected = append(expected, RefSeries{Ref: uint64(i), Labels: series[i-1]})
+			expected = append(expected, record.RefSeries{Ref: uint64(i), Labels: series[i-1]})
 		}
 	}
 
@@ -143,10 +145,10 @@ func TestSegmentWAL_Truncate(t *testing.T) {
 	w, err = OpenSegmentWAL(dir, nil, 0, nil)
 	testutil.Ok(t, err)
 
-	var readSeries []RefSeries
+	var readSeries []record.RefSeries
 	r := w.Reader()
 
-	testutil.Ok(t, r.Read(func(s []RefSeries) {
+	testutil.Ok(t, r.Read(func(s []record.RefSeries) {
 		readSeries = append(readSeries, s...)
 	}, nil, nil))
 
@@ -172,9 +174,9 @@ func TestSegmentWAL_Log_Restore(t *testing.T) {
 	}()
 
 	var (
-		recordedSeries  [][]RefSeries
-		recordedSamples [][]RefSample
-		recordedDeletes [][]Stone
+		recordedSeries  [][]record.RefSeries
+		recordedSamples [][]record.RefSample
+		recordedDeletes [][]tombstones.Stone
 	)
 	var totalSamples int
 
@@ -190,29 +192,29 @@ func TestSegmentWAL_Log_Restore(t *testing.T) {
 		r := w.Reader()
 
 		var (
-			resultSeries  [][]RefSeries
-			resultSamples [][]RefSample
-			resultDeletes [][]Stone
+			resultSeries  [][]record.RefSeries
+			resultSamples [][]record.RefSample
+			resultDeletes [][]tombstones.Stone
 		)
 
-		serf := func(series []RefSeries) {
+		serf := func(series []record.RefSeries) {
 			if len(series) > 0 {
-				clsets := make([]RefSeries, len(series))
+				clsets := make([]record.RefSeries, len(series))
 				copy(clsets, series)
 				resultSeries = append(resultSeries, clsets)
 			}
 		}
-		smplf := func(smpls []RefSample) {
+		smplf := func(smpls []record.RefSample) {
 			if len(smpls) > 0 {
-				csmpls := make([]RefSample, len(smpls))
+				csmpls := make([]record.RefSample, len(smpls))
 				copy(csmpls, smpls)
 				resultSamples = append(resultSamples, csmpls)
 			}
 		}
 
-		delf := func(stones []Stone) {
+		delf := func(stones []tombstones.Stone) {
 			if len(stones) > 0 {
-				cst := make([]Stone, len(stones))
+				cst := make([]tombstones.Stone, len(stones))
 				copy(cst, stones)
 				resultDeletes = append(resultDeletes, cst)
 			}
@@ -228,11 +230,11 @@ func TestSegmentWAL_Log_Restore(t *testing.T) {
 
 		// Insert in batches and generate different amounts of samples for each.
 		for i := 0; i < len(series); i += stepSize {
-			var samples []RefSample
-			var stones []Stone
+			var samples []record.RefSample
+			var stones []tombstones.Stone
 
 			for j := 0; j < i*10; j++ {
-				samples = append(samples, RefSample{
+				samples = append(samples, record.RefSample{
 					Ref: uint64(j % 10000),
 					T:   int64(j * 2),
 					V:   rand.Float64(),
@@ -241,13 +243,13 @@ func TestSegmentWAL_Log_Restore(t *testing.T) {
 
 			for j := 0; j < i*20; j++ {
 				ts := rand.Int63()
-				stones = append(stones, Stone{rand.Uint64(), Intervals{{ts, ts + rand.Int63n(10000)}}})
+				stones = append(stones, tombstones.Stone{Ref: rand.Uint64(), Intervals: tombstones.Intervals{{ts, ts + rand.Int63n(10000)}}})
 			}
 
 			lbls := series[i : i+stepSize]
-			series := make([]RefSeries, 0, len(series))
+			series := make([]record.RefSeries, 0, len(series))
 			for j, l := range lbls {
-				series = append(series, RefSeries{
+				series = append(series, record.RefSeries{
 					Ref:    uint64(i + j),
 					Labels: l,
 				})
@@ -382,8 +384,8 @@ func TestWALRestoreCorrupted(t *testing.T) {
 			w, err := OpenSegmentWAL(dir, nil, 0, nil)
 			testutil.Ok(t, err)
 
-			testutil.Ok(t, w.LogSamples([]RefSample{{T: 1, V: 2}}))
-			testutil.Ok(t, w.LogSamples([]RefSample{{T: 2, V: 3}}))
+			testutil.Ok(t, w.LogSamples([]record.RefSample{{T: 1, V: 2}}))
+			testutil.Ok(t, w.LogSamples([]record.RefSample{{T: 2, V: 3}}))
 
 			testutil.Ok(t, w.cut())
 
@@ -392,8 +394,8 @@ func TestWALRestoreCorrupted(t *testing.T) {
 			// Hopefully cut will complete by 2 seconds.
 			time.Sleep(2 * time.Second)
 
-			testutil.Ok(t, w.LogSamples([]RefSample{{T: 3, V: 4}}))
-			testutil.Ok(t, w.LogSamples([]RefSample{{T: 5, V: 6}}))
+			testutil.Ok(t, w.LogSamples([]record.RefSample{{T: 3, V: 4}}))
+			testutil.Ok(t, w.LogSamples([]record.RefSample{{T: 5, V: 6}}))
 
 			testutil.Ok(t, w.Close())
 
@@ -414,24 +416,24 @@ func TestWALRestoreCorrupted(t *testing.T) {
 
 			r := w2.Reader()
 
-			serf := func(l []RefSeries) {
+			serf := func(l []record.RefSeries) {
 				testutil.Equals(t, 0, len(l))
 			}
 
 			// Weird hack to check order of reads.
 			i := 0
-			samplf := func(s []RefSample) {
+			samplf := func(s []record.RefSample) {
 				if i == 0 {
-					testutil.Equals(t, []RefSample{{T: 1, V: 2}}, s)
+					testutil.Equals(t, []record.RefSample{{T: 1, V: 2}}, s)
 					i++
 				} else {
-					testutil.Equals(t, []RefSample{{T: 99, V: 100}}, s)
+					testutil.Equals(t, []record.RefSample{{T: 99, V: 100}}, s)
 				}
 			}
 
 			testutil.Ok(t, r.Read(serf, samplf, nil))
 
-			testutil.Ok(t, w2.LogSamples([]RefSample{{T: 99, V: 100}}))
+			testutil.Ok(t, w2.LogSamples([]record.RefSample{{T: 99, V: 100}}))
 			testutil.Ok(t, w2.Close())
 
 			// We should see the first valid entry and the new one, everything after
@@ -482,23 +484,23 @@ func TestMigrateWAL_Fuzz(t *testing.T) {
 	testutil.Ok(t, err)
 
 	// Write some data.
-	testutil.Ok(t, oldWAL.LogSeries([]RefSeries{
+	testutil.Ok(t, oldWAL.LogSeries([]record.RefSeries{
 		{Ref: 100, Labels: labels.FromStrings("abc", "def", "123", "456")},
 		{Ref: 1, Labels: labels.FromStrings("abc", "def2", "1234", "4567")},
 	}))
-	testutil.Ok(t, oldWAL.LogSamples([]RefSample{
+	testutil.Ok(t, oldWAL.LogSamples([]record.RefSample{
 		{Ref: 1, T: 100, V: 200},
 		{Ref: 2, T: 300, V: 400},
 	}))
-	testutil.Ok(t, oldWAL.LogSeries([]RefSeries{
+	testutil.Ok(t, oldWAL.LogSeries([]record.RefSeries{
 		{Ref: 200, Labels: labels.FromStrings("xyz", "def", "foo", "bar")},
 	}))
-	testutil.Ok(t, oldWAL.LogSamples([]RefSample{
+	testutil.Ok(t, oldWAL.LogSamples([]record.RefSample{
 		{Ref: 3, T: 100, V: 200},
 		{Ref: 4, T: 300, V: 400},
 	}))
-	testutil.Ok(t, oldWAL.LogDeletes([]Stone{
-		{ref: 1, intervals: []Interval{{100, 200}}},
+	testutil.Ok(t, oldWAL.LogDeletes([]tombstones.Stone{
+		{Ref: 1, Intervals: []tombstones.Interval{{100, 200}}},
 	}))
 
 	testutil.Ok(t, oldWAL.Close())
@@ -510,8 +512,8 @@ func TestMigrateWAL_Fuzz(t *testing.T) {
 	testutil.Ok(t, err)
 
 	// We can properly write some new data after migration.
-	var enc RecordEncoder
-	testutil.Ok(t, w.Log(enc.Samples([]RefSample{
+	var enc record.Encoder
+	testutil.Ok(t, w.Log(enc.Samples([]record.RefSample{
 		{Ref: 500, T: 1, V: 1},
 	}, nil)))
 
@@ -523,21 +525,21 @@ func TestMigrateWAL_Fuzz(t *testing.T) {
 
 	r := wal.NewReader(sr)
 	var res []interface{}
-	var dec RecordDecoder
+	var dec record.Decoder
 
 	for r.Next() {
 		rec := r.Record()
 
 		switch dec.Type(rec) {
-		case RecordSeries:
+		case record.Series:
 			s, err := dec.Series(rec, nil)
 			testutil.Ok(t, err)
 			res = append(res, s)
-		case RecordSamples:
+		case record.Samples:
 			s, err := dec.Samples(rec, nil)
 			testutil.Ok(t, err)
 			res = append(res, s)
-		case RecordTombstones:
+		case record.Tombstones:
 			s, err := dec.Tombstones(rec, nil)
 			testutil.Ok(t, err)
 			res = append(res, s)
@@ -548,17 +550,17 @@ func TestMigrateWAL_Fuzz(t *testing.T) {
 	testutil.Ok(t, r.Err())
 
 	testutil.Equals(t, []interface{}{
-		[]RefSeries{
+		[]record.RefSeries{
 			{Ref: 100, Labels: labels.FromStrings("abc", "def", "123", "456")},
 			{Ref: 1, Labels: labels.FromStrings("abc", "def2", "1234", "4567")},
 		},
-		[]RefSample{{Ref: 1, T: 100, V: 200}, {Ref: 2, T: 300, V: 400}},
-		[]RefSeries{
+		[]record.RefSample{{Ref: 1, T: 100, V: 200}, {Ref: 2, T: 300, V: 400}},
+		[]record.RefSeries{
 			{Ref: 200, Labels: labels.FromStrings("xyz", "def", "foo", "bar")},
 		},
-		[]RefSample{{Ref: 3, T: 100, V: 200}, {Ref: 4, T: 300, V: 400}},
-		[]Stone{{ref: 1, intervals: []Interval{{100, 200}}}},
-		[]RefSample{{Ref: 500, T: 1, V: 1}},
+		[]record.RefSample{{Ref: 3, T: 100, V: 200}, {Ref: 4, T: 300, V: 400}},
+		[]tombstones.Stone{{Ref: 1, Intervals: []tombstones.Interval{{100, 200}}}},
+		[]record.RefSample{{Ref: 500, T: 1, V: 1}},
 	}, res)
 
 	// Migrating an already migrated WAL shouldn't do anything.

--- a/tsdb/wal_test.go
+++ b/tsdb/wal_test.go
@@ -243,7 +243,7 @@ func TestSegmentWAL_Log_Restore(t *testing.T) {
 
 			for j := 0; j < i*20; j++ {
 				ts := rand.Int63()
-				stones = append(stones, tombstones.Stone{Ref: rand.Uint64(), Intervals: tombstones.Intervals{{ts, ts + rand.Int63n(10000)}}})
+				stones = append(stones, tombstones.Stone{Ref: rand.Uint64(), Intervals: tombstones.Intervals{{Mint: ts, Maxt: ts + rand.Int63n(10000)}}})
 			}
 
 			lbls := series[i : i+stepSize]
@@ -500,7 +500,7 @@ func TestMigrateWAL_Fuzz(t *testing.T) {
 		{Ref: 4, T: 300, V: 400},
 	}))
 	testutil.Ok(t, oldWAL.LogDeletes([]tombstones.Stone{
-		{Ref: 1, Intervals: []tombstones.Interval{{100, 200}}},
+		{Ref: 1, Intervals: []tombstones.Interval{{Mint: 100, Maxt: 200}}},
 	}))
 
 	testutil.Ok(t, oldWAL.Close())
@@ -559,7 +559,7 @@ func TestMigrateWAL_Fuzz(t *testing.T) {
 			{Ref: 200, Labels: labels.FromStrings("xyz", "def", "foo", "bar")},
 		},
 		[]record.RefSample{{Ref: 3, T: 100, V: 200}, {Ref: 4, T: 300, V: 400}},
-		[]tombstones.Stone{{Ref: 1, Intervals: []tombstones.Interval{{100, 200}}}},
+		[]tombstones.Stone{{Ref: 1, Intervals: []tombstones.Interval{{Mint: 100, Maxt: 200}}}},
 		[]record.RefSample{{Ref: 500, T: 1, V: 1}},
 	}, res)
 


### PR DESCRIPTION
The TSDB port happened while I was away on vacation so I'm reopening this as a prometheus/prometheus PR. 

Moving the WAL watcher code into the WAL package requires moving some code from the root tsdb package. Specifically the Watcher uses RefSeries and RefSample. Moving those requires a bunch of other code to be moved as well.

Pinging the same people that reviewed last time @csmarchbanks @bwplotka @codesome 

Signed-off-by: Callum Styan <callumstyan@gmail.com>