### PR TITLE
Bump golangci-lint to v1.18.0

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -74,7 +74,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.17.1
+GOLANGCI_LINT_VERSION ?= v1.18.0
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))


### PR DESCRIPTION
It is required to support Go 1.13 (see https://github.com/golangci/golangci-lint/issues/652).