### PR TITLE
added EC2 InstanceLifecycle info as label (new label called lifecycle)

### DIFF
--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -52,6 +52,7 @@ const (
 	ec2LabelSubnetID        = ec2Label + "subnet_id"
 	ec2LabelTag             = ec2Label + "tag_"
 	ec2LabelVPCID           = ec2Label + "vpc_id"
+	ec2LabelLifecycle       = ec2Label + "lifecycle"
 	subnetSeparator         = ","
 )
 
@@ -234,6 +235,13 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 						subnetSeparator +
 							strings.Join(subnets, subnetSeparator) +
 							subnetSeparator)
+				}
+
+				//Only if the istance is a spot one, InstanceLifecycle parameter is shown on the output ec2 description
+				if inst.InstanceLifecycle != nil {
+					labels[ec2LabelLifecycle] = model.LabelValue(*inst.InstanceLifecycle)
+				} else {
+					labels[ec2LabelLifecycle] = "normal"
 				}
 
 				for _, t := range inst.Tags {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -436,6 +436,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_ec2_subnet_id`: comma separated list of subnets IDs in which the instance is running, if available
 * `__meta_ec2_tag_<tagkey>`: each tag value of the instance
 * `__meta_ec2_vpc_id`: the ID of the VPC in which the instance is running, if available
+* `__meta_ec2_lifecycle`: the instance lifecycle of the instance, it can be "spot" or "normal"
 
 See below for the configuration options for EC2 discovery:
 

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 	github.com/prometheus/common v0.6.0
+	github.com/prometheus/procfs v0.0.4 // indirect
 	github.com/samuel/go-zookeeper v0.0.0-20190810000440-0ceca61e4d75
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd

--- a/go.sum
+++ b/go.sum
@@ -377,6 +377,8 @@ github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.3 h1:CTwfnzjQ+8dS6MhHHu4YswVAD99sL2wjPqP+VkURmKE=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
+github.com/prometheus/procfs v0.0.4 h1:w8DjqFMJDjuVwdZBQoOozr4MVWOnwF7RcL/7uxBjY78=
+github.com/prometheus/procfs v0.0.4/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=


### PR DESCRIPTION
Signed-off-by: aesiliato

NB:
AWS API shows InstanceLifecycle in ec2 describe instances result only if the instance is a spot one. The new feature set value of lifecycle label = normal if InstanceLifecycle doesn't exist on describe instances results.


<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->