### PR TITLE
cleanup redundant code of `TestEndpoints`

### DIFF
--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -224,21 +224,12 @@ func TestEndpoints(t *testing.T) {
 			test_metric1{foo="boo"} 1+0x100
 			test_metric2{foo="boo"} 1+0x100
 	`)
-	if err != nil {
-		t.Fatal(err)
-	}
+	testutil.Ok(t, err)
 	defer suite.Close()
 
-	if err := suite.Run(); err != nil {
-		t.Fatal(err)
-	}
+	testutil.Ok(t, suite.Run())
 
 	now := time.Now()
-
-	var algr rulesRetrieverMock
-	algr.testing = t
-	algr.AlertingRules()
-	algr.RuleGroups()
 
 	t.Run("local", func(t *testing.T) {
 		var algr rulesRetrieverMock
@@ -271,19 +262,13 @@ func TestEndpoints(t *testing.T) {
 		defer server.Close()
 
 		u, err := url.Parse(server.URL)
-		if err != nil {
-			t.Fatal(err)
-		}
+		testutil.Ok(t, err)
 
 		al := promlog.AllowedLevel{}
-		if err := al.Set("debug"); err != nil {
-			t.Fatal(err)
-		}
+		testutil.Ok(t, al.Set("debug"))
 
 		af := promlog.AllowedFormat{}
-		if err := af.Set("logfmt"); err != nil {
-			t.Fatal(err)
-		}
+		testutil.Ok(t, af.Set("logfmt"))
 
 		promlogConfig := promlog.Config{
 			Level:  &al,
@@ -294,7 +279,6 @@ func TestEndpoints(t *testing.T) {
 		testutil.Ok(t, err)
 		defer os.RemoveAll(dbDir)
 
-		testutil.Ok(t, err)
 		remote := remote.NewStorage(promlog.New(&promlogConfig), prometheus.DefaultRegisterer, func() (int64, error) {
 			return 0, nil
 		}, dbDir, 1*time.Second)
@@ -308,9 +292,7 @@ func TestEndpoints(t *testing.T) {
 				},
 			},
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		testutil.Ok(t, err)
 
 		var algr rulesRetrieverMock
 		algr.testing = t


### PR DESCRIPTION
It's hard to test remote read client in `storage/remote` without import cycle, ref: #5974 

Inspired by `TestEndpoints` in `web/api/v1/api_test.go`, it's easy to solve the problem.

Also this PR is the preparation work for testing streamed remote read client, ref: #5926 

@bwplotka PTAL :)

Signed-off-by: YaoZengzeng <yaozengzeng@zju.edu.cn>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->