### PR TITLE
Update link to SaltStack formula

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -94,4 +94,4 @@ the following third-party contributions:
 
 ### SaltStack
 
-* [bechtoldt/saltstack-prometheus-formula](https://github.com/bechtoldt/saltstack-prometheus-formula)
+* [saltstack-formulas/prometheus-formula](https://github.com/saltstack-formulas/prometheus-formula)


### PR DESCRIPTION
Use the "official" saltstack-formulas version. The existing one hasn't
been updated since 2015.

Signed-off-by: Ben Kochie <superq@gmail.com>