### PR TITLE
fix recording inconsistency due to duplicate labels

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -304,72 +304,40 @@ func checkRules(filename string) (int, []error) {
 		numRules += len(rg.Rules)
 	}
 
-	showWarning := false
-	dLabels, dMetrics, nLabels, nMetrics := checkDuplicates(rgs.Groups)
-	if dLabels != 0 {
-		showWarning = true
-		fmt.Printf("%d duplicate label(s) found.\n", dLabels)
-		for _, n := range nLabels {
-			fmt.Println(n)
+	dRules := checkDuplicates(rgs.Groups)
+	if len(dRules) != 0 {
+		fmt.Printf("%d duplicate rules(s) found.\n", len(dRules))
+		for _, n := range dRules {
+			fmt.Printf("Metric: %s\nLabel(s):\n", n.metric)
+			for i, l := range n.label {
+				fmt.Printf("\t%s: %s\n", i, l)
+			}
 		}
-	}
-	if dMetrics != 0 {
-		showWarning = true
-		fmt.Printf("%d duplicate metric(s) found.\n", dMetrics)
-		for _, n := range nMetrics {
-			fmt.Println(n)
-		}
-	}
-	if showWarning {
 		fmt.Println("Might cause inconsistency while recording expressions.")
 	}
 
 	return numRules, nil
 }
 
-func checkDuplicates(r []rulefmt.RuleGroup) (int, int, []string, []string) {
-	duplicateLabels, duplicateMetrics := 0, 0
-	labelNames, metricName := []string{}, []string{}
-	for _, rule := range r {
-		var stackLabels []map[string]string
-		var stackMetrics []string
-		for _, props := range rule.Rules {
-			for _, labels := range stackLabels {
-				if reflect.DeepEqual(labels, props.Labels) {
-					duplicateLabels++
-					found := false
-					for _, inst := range labelNames {
-						if inst == labels["label"] {
-							found = true
-							break
-						}
-					}
-					if !found {
-						labelNames = append(labelNames, labels["label"])
-					}
-				}
-			}
-			stackLabels = append(stackLabels, props.Labels)
+type duplicateRules struct {
+	metric string
+	label  map[string]string
+}
 
-			for _, mname := range stackMetrics {
-				if reflect.DeepEqual(mname, props.Record) {
-					duplicateMetrics++
-					found := false
-					for _, inst := range metricName {
-						if inst == mname {
-							found = true
-							break
-						}
-					}
-					if !found {
-						metricName = append(metricName, mname)
-					}
+func checkDuplicates(r []rulefmt.RuleGroup) []duplicateRules {
+	var stack, stackDuplicates []duplicateRules
+
+	for _, rule := range r {
+		for _, props := range rule.Rules {
+			for _, inst := range stack {
+				if reflect.DeepEqual(inst, duplicateRules{metric: props.Record, label: props.Labels}) {
+					stackDuplicates = append(stackDuplicates, duplicateRules{metric: props.Record, label: props.Labels})
 				}
 			}
-			stackMetrics = append(stackMetrics, props.Record)
+			stack = append(stack, duplicateRules{metric: props.Record, label: props.Labels})
 		}
 	}
-	return duplicateLabels, duplicateMetrics, labelNames, metricName
+	return stackDuplicates
 }
 
 var checkMetricsUsage = strings.TrimSpace(`

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -303,7 +304,28 @@ func checkRules(filename string) (int, []error) {
 		numRules += len(rg.Rules)
 	}
 
+	duplicateLabels := checkDuplicateLabels(rgs.Groups)
+	if duplicateLabels != 0 {
+		fmt.Printf("%d duplicate label(s) found. Might cause inconsistency while recording expressions.\n", duplicateLabels)
+	}
+
 	return numRules, nil
+}
+
+func checkDuplicateLabels(r []rulefmt.RuleGroup) int {
+	duplicateLabels := 0
+	for _, rule := range r {
+		var stackLabels []map[string]string
+		for _, props := range rule.Rules {
+			for _, labels := range stackLabels {
+				if reflect.DeepEqual(labels, props.Labels) {
+					duplicateLabels++
+				}
+			}
+			stackLabels = append(stackLabels, props.Labels)
+		}
+	}
+	return duplicateLabels
 }
 
 var checkMetricsUsage = strings.TrimSpace(`

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -327,10 +327,10 @@ type duplicateRules struct {
 func checkDuplicates(r []rulefmt.RuleGroup) []duplicateRules {
 	var stack, stackDuplicates []duplicateRules
 
-	for _, rule := range r {
-		for _, props := range rule.Rules {
-			for _, inst := range stack {
-				if reflect.DeepEqual(inst, duplicateRules{metric: props.Record, label: props.Labels}) {
+	for rindex := range r {
+		for _, props := range r[rindex].Rules {
+			for i := range stack {
+				if reflect.DeepEqual(stack[i], duplicateRules{metric: props.Record, label: props.Labels}) {
 					stackDuplicates = append(stackDuplicates, duplicateRules{metric: props.Record, label: props.Labels})
 				}
 			}

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -319,25 +319,32 @@ func checkRules(filename string) (int, []error) {
 	return numRules, nil
 }
 
-type duplicateRules struct {
+type compareRuleType struct {
 	metric string
 	label  map[string]string
 }
 
-func checkDuplicates(r []rulefmt.RuleGroup) []duplicateRules {
-	var stack, stackDuplicates []duplicateRules
+func checkDuplicates(r []rulefmt.RuleGroup) []compareRuleType {
+	var duplicates []compareRuleType
 
 	for rindex := range r {
-		for _, props := range r[rindex].Rules {
-			for i := range stack {
-				if reflect.DeepEqual(stack[i], duplicateRules{metric: props.Record, label: props.Labels}) {
-					stackDuplicates = append(stackDuplicates, duplicateRules{metric: props.Record, label: props.Labels})
+		for index, props := range r[rindex].Rules {
+			inst := compareRuleType{
+				metric: props.Record,
+				label:  props.Labels,
+			}
+			for i := 0; i < index; i++ {
+				t := compareRuleType{
+					metric: r[rindex].Rules[i].Record,
+					label:  r[rindex].Rules[i].Labels,
+				}
+				if reflect.DeepEqual(t, inst) {
+					duplicates = append(duplicates, t)
 				}
 			}
-			stack = append(stack, duplicateRules{metric: props.Record, label: props.Labels})
 		}
 	}
-	return stackDuplicates
+	return duplicates
 }
 
 var checkMetricsUsage = strings.TrimSpace(`


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
Refers #5529. It **warns** the user from inconsistent data which might occur if more than one labels in the same group are found.
  