### PR TITLE
config: add test case for global scrape timeout.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -664,6 +664,15 @@ func TestLoadConfig(t *testing.T) {
 	testutil.Equals(t, expectedConf, c)
 }
 
+func TestScrapeIntervalLarger(t *testing.T) {
+	c, err := LoadFile("testdata/scrape_interval_larger.good.yml")
+	testutil.Ok(t, err)
+	testutil.Equals(t, 1, len(c.ScrapeConfigs))
+	for _, sc := range c.ScrapeConfigs {
+		testutil.Equals(t, true, sc.ScrapeInterval >= sc.ScrapeTimeout)
+	}
+}
+
 // YAML marshaling must not reveal authentication credentials.
 func TestElideSecrets(t *testing.T) {
 	c, err := LoadFile("testdata/conf.good.yml")

--- a/config/testdata/scrape_interval_larger.good.yml
+++ b/config/testdata/scrape_interval_larger.good.yml
@@ -1,0 +1,16 @@
+global:
+  scrape_interval:     15s
+  scrape_timeout:      15s
+
+scrape_configs:
+- job_name: prometheus
+
+  scrape_interval: 5s
+
+  dns_sd_configs:
+    - refresh_interval: 15s
+      names:
+        - first.dns.address.domain.com
+        - second.dns.address.domain.com
+    - names:
+        - first.dns.address.domain.com


### PR DESCRIPTION
no test code coverage:

https://github.com/prometheus/prometheus/blob/a6a55c433cb9735923eebe52292b18db289c7f8a/config/config.go#L257