### PR TITLE
Refactor remote write queue tracking/restarts

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -40,7 +40,7 @@ var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 
 // Client allows reading and writing from/to a remote HTTP endpoint.
 type Client struct {
-	index   int // Used to differentiate clients in metrics.
+	hash    string // Used to differentiate clients in metrics.
 	url     *config_util.URL
 	client  *http.Client
 	timeout time.Duration
@@ -54,14 +54,14 @@ type ClientConfig struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(index int, conf *ClientConfig) (*Client, error) {
+func NewClient(hash string, conf *ClientConfig) (*Client, error) {
 	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage", false)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
-		index:   index,
+		hash:    hash,
 		url:     conf.URL,
 		client:  httpClient,
 		timeout: time.Duration(conf.Timeout),
@@ -117,7 +117,7 @@ func (c *Client) Store(ctx context.Context, req []byte) error {
 
 // Name identifies the client.
 func (c Client) Name() string {
-	return fmt.Sprintf("%d:%s", c.index, c.url)
+	return fmt.Sprintf("%s:%s", c.hash, c.url)
 }
 
 // Read reads from a remote endpoint.

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -65,11 +65,15 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		c, err := NewClient(0, &ClientConfig{
+		conf := &ClientConfig{
 			URL:     &config_util.URL{URL: serverURL},
 			Timeout: model.Duration(time.Second),
-		})
+		}
+		hash, err := toHash(conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c, err := NewClient(hash, conf)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -14,6 +14,9 @@
 package remote
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -537,4 +540,14 @@ func labelsToLabelsProto(labels labels.Labels, buf []prompb.Label) []prompb.Labe
 		})
 	}
 	return result
+}
+
+// Used for hashing configs and diff'ing hashes in ApplyConfig.
+func toHash(data interface{}) (string, error) {
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	hash := md5.Sum(bytes)
+	return hex.EncodeToString(hash[:]), nil
 }

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -68,8 +68,13 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 
 	// Update read clients
 	queryables := make([]storage.Queryable, 0, len(conf.RemoteReadConfigs))
-	for i, rrConf := range conf.RemoteReadConfigs {
-		c, err := NewClient(i, &ClientConfig{
+	for _, rrConf := range conf.RemoteReadConfigs {
+		hash, err := toHash(rrConf)
+		if err != nil {
+			return nil
+		}
+
+		c, err := NewClient(hash, &ClientConfig{
 			URL:              rrConf.URL,
 			Timeout:          rrConf.RemoteTimeout,
 			HTTPClientConfig: rrConf.HTTPClientConfig,

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -14,8 +14,6 @@
 package remote
 
 import (
-	"crypto/md5"
-	"encoding/json"
 	"sync"
 	"time"
 
@@ -50,11 +48,10 @@ type WriteStorage struct {
 	logger log.Logger
 	mtx    sync.Mutex
 
-	configHash        [16]byte
-	externalLabelHash [16]byte
+	configHash        string
+	externalLabelHash string
 	walDir            string
-	queues            []*QueueManager
-	hashes            [][16]byte
+	queues            map[string]*QueueManager
 	samplesIn         *ewmaRate
 	flushDeadline     time.Duration
 }
@@ -65,6 +62,7 @@ func NewWriteStorage(logger log.Logger, walDir string, flushDeadline time.Durati
 		logger = log.NewNopLogger()
 	}
 	rws := &WriteStorage{
+		queues:        make(map[string]*QueueManager),
 		logger:        logger,
 		flushDeadline: flushDeadline,
 		samplesIn:     newEWMARate(ewmaWeight, shardUpdateDuration),
@@ -88,20 +86,17 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 	rws.mtx.Lock()
 	defer rws.mtx.Unlock()
 
-	// Remote write queues only need to change if the remote write config or
-	// external labels change. Hash these together and only reload if the hash
-	// changes.
-	cfgBytes, err := json.Marshal(conf.RemoteWriteConfigs)
+	configHash, err := toHash(conf.RemoteWriteConfigs)
 	if err != nil {
 		return err
 	}
-	externalLabelBytes, err := json.Marshal(conf.GlobalConfig.ExternalLabels)
+	externalLabelHash, err := toHash(conf.GlobalConfig.ExternalLabels)
 	if err != nil {
 		return err
 	}
 
-	configHash := md5.Sum(cfgBytes)
-	externalLabelHash := md5.Sum(externalLabelBytes)
+	// Remote write queues only need to change if the remote write config or
+	// external labels change.
 	externalLabelUnchanged := externalLabelHash == rws.externalLabelHash
 	if configHash == rws.configHash && externalLabelUnchanged {
 		level.Debug(rws.logger).Log("msg", "remote write config has not changed, no need to restart QueueManagers")
@@ -111,28 +106,23 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 	rws.configHash = configHash
 	rws.externalLabelHash = externalLabelHash
 
-	// Update write queues
-	newQueues := []*QueueManager{}
-	newHashes := [][16]byte{}
-	newClientIndexes := []int{}
-	for i, rwConf := range conf.RemoteWriteConfigs {
-		b, err := json.Marshal(rwConf)
+	newQueues := make(map[string]*QueueManager)
+	newHashes := []string{}
+	for _, rwConf := range conf.RemoteWriteConfigs {
+		hash, err := toHash(rwConf)
 		if err != nil {
 			return err
 		}
 
-		// Use RemoteWriteConfigs and its index to get hash. So if its index changed,
-		// the correspoinding queue should also be restarted.
-		hash := md5.Sum(b)
-		if i < len(rws.queues) && rws.hashes[i] == hash && externalLabelUnchanged {
-			// The RemoteWriteConfig and index both not changed, keep the queue.
-			newQueues = append(newQueues, rws.queues[i])
-			newHashes = append(newHashes, hash)
-			rws.queues[i] = nil
+		// If the hash exists in the current queues map, we only need
+		// to restart queue if the external labels have changed.
+		if queue, ok := rws.queues[hash]; ok && externalLabelUnchanged {
+			newQueues[hash] = queue
+			delete(rws.queues, hash)
 			continue
 		}
-		// Otherwise create a new queue.
-		c, err := NewClient(i, &ClientConfig{
+
+		c, err := NewClient(hash, &ClientConfig{
 			URL:              rwConf.URL,
 			Timeout:          rwConf.RemoteTimeout,
 			HTTPClientConfig: rwConf.HTTPClientConfig,
@@ -140,7 +130,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 		if err != nil {
 			return err
 		}
-		newQueues = append(newQueues, NewQueueManager(
+		newQueues[hash] = NewQueueManager(
 			prometheus.DefaultRegisterer,
 			rws.logger,
 			rws.walDir,
@@ -150,24 +140,22 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			rwConf.WriteRelabelConfigs,
 			c,
 			rws.flushDeadline,
-		))
+		)
+		// Keep track of which queues are new so we know which to start.
 		newHashes = append(newHashes, hash)
-		newClientIndexes = append(newClientIndexes, i)
 	}
 
+	// Anything remaining in rws.queues is a queue who's config has
+	// changed or was removed from the overall remote write config.
 	for _, q := range rws.queues {
-		// A nil queue means that queue has been reused.
-		if q != nil {
-			q.Stop()
-		}
+		q.Stop()
 	}
 
-	for _, index := range newClientIndexes {
-		newQueues[index].Start()
+	for _, hash := range newHashes {
+		newQueues[hash].Start()
 	}
 
 	rws.queues = newQueues
-	rws.hashes = newHashes
 
 	return nil
 }


### PR DESCRIPTION
Track remote write queues via a map so we don't have to track the index in the remote write array. The queue names in metrics now contain the hash as a string instead of the index in the config array, so they look like this:
```
prometheus_remote_storage_dropped_samples_total{queue="4d50f478186c47dfcffff29ffbc4b5d4:http://localhost:1235/receive"} 0
prometheus_remote_storage_dropped_samples_total{queue="97f072436c72649a7547e91184322b58:http://localhost:1234/receive"} 0
```

@csmarchbanks @YaoZengzeng 
cc @tomwilkie 