### PR TITLE
extend remote read client to support stream type

### DIFF
--- a/storage/remote/chunked.go
+++ b/storage/remote/chunked.go
@@ -152,3 +152,9 @@ func (r *ChunkedReader) NextProto(pb proto.Message) error {
 	}
 	return proto.Unmarshal(rec, pb)
 }
+
+// AtProto consumes current available record and decodes it into the protobuf with
+// proto.Unmarshal.
+func (r *ChunkedReader) AtProto(pb proto.Message) error {
+	return proto.Unmarshal(r.data, pb)
+}


### PR DESCRIPTION
fixes : #5926

Signed-off-by: YaoZengzeng <yaozengzeng@huawei.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->