### PR TITLE
Add config option for remote job name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,9 @@
 package config
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -626,6 +629,19 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 	return c.HTTPClientConfig.Validate()
 }
 
+// ToHash generates a hash of the config struct minus it's name, as we consider configs
+// that are identical in all but name to still be identical.
+func (c *RemoteWriteConfig) ToHash() (string, error) {
+	temp := *c
+	temp.Name = ""
+	bytes, err := json.Marshal(temp)
+	if err != nil {
+		return "", err
+	}
+	hash := md5.Sum(bytes)
+	return hex.EncodeToString(hash[:]), nil
+}
+
 // QueueConfig is the configuration for the queue used to write to remote
 // storage.
 type QueueConfig struct {
@@ -680,4 +696,18 @@ func (c *RemoteReadConfig) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	// We cannot make it a pointer as the parser panics for inlined pointer structs.
 	// Thus we just do its validation here.
 	return c.HTTPClientConfig.Validate()
+}
+
+// ToHash generates a hash of the config struct minus it's name, as we consider configs
+// that are identical in all but name to still be identical.
+// Copy of RemoteWriteConfigs ToHash
+func (c *RemoteReadConfig) ToHash() (string, error) {
+	temp := *c
+	temp.Name = ""
+	bytes, err := json.Marshal(temp)
+	if err != nil {
+		return "", err
+	}
+	hash := md5.Sum(bytes)
+	return hex.EncodeToString(hash[:]), nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -14,9 +14,6 @@
 package config
 
 import (
-	"crypto/md5"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -629,19 +626,6 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 	return c.HTTPClientConfig.Validate()
 }
 
-// ToHash generates a hash of the config struct minus it's name, as we consider configs
-// that are identical in all but name to still be identical.
-func (c *RemoteWriteConfig) ToHash() (string, error) {
-	temp := *c
-	temp.Name = ""
-	bytes, err := json.Marshal(temp)
-	if err != nil {
-		return "", err
-	}
-	hash := md5.Sum(bytes)
-	return hex.EncodeToString(hash[:]), nil
-}
-
 // QueueConfig is the configuration for the queue used to write to remote
 // storage.
 type QueueConfig struct {
@@ -696,18 +680,4 @@ func (c *RemoteReadConfig) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	// We cannot make it a pointer as the parser panics for inlined pointer structs.
 	// Thus we just do its validation here.
 	return c.HTTPClientConfig.Validate()
-}
-
-// ToHash generates a hash of the config struct minus it's name, as we consider configs
-// that are identical in all but name to still be identical.
-// Copy of RemoteWriteConfigs ToHash
-func (c *RemoteReadConfig) ToHash() (string, error) {
-	temp := *c
-	temp.Name = ""
-	bytes, err := json.Marshal(temp)
-	if err != nil {
-		return "", err
-	}
-	hash := md5.Sum(bytes)
-	return hex.EncodeToString(hash[:]), nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -265,27 +265,27 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 		jobNames[scfg.JobName] = struct{}{}
 	}
-	rwJobNames := map[string]struct{}{}
+	rwNames := map[string]struct{}{}
 	for _, rwcfg := range c.RemoteWriteConfigs {
 		if rwcfg == nil {
 			return errors.New("empty or null remote write config section")
 		}
-		// Skip empty job names, we fill their name with their config hash in remote write code.
-		if _, ok := rwJobNames[rwcfg.JobName]; ok && rwcfg.JobName != "" {
-			return errors.Errorf("found multiple remote write configs with job name %q", rwcfg.JobName)
+		// Skip empty names, we fill their name with their config hash in remote write code.
+		if _, ok := rwNames[rwcfg.Name]; ok && rwcfg.Name != "" {
+			return errors.Errorf("found multiple remote write configs with job name %q", rwcfg.Name)
 		}
-		rwJobNames[rwcfg.JobName] = struct{}{}
+		rwNames[rwcfg.Name] = struct{}{}
 	}
-	rrJobNames := map[string]struct{}{}
+	rrNames := map[string]struct{}{}
 	for _, rrcfg := range c.RemoteReadConfigs {
 		if rrcfg == nil {
 			return errors.New("empty or null remote read config section")
 		}
-		// Skip empty job names, we fill their name with their config hash in remote read code.
-		if _, ok := rrJobNames[rrcfg.JobName]; ok && rrcfg.JobName != "" {
-			return errors.Errorf("found multiple remote read configs with job name %q", rrcfg.JobName)
+		// Skip empty names, we fill their name with their config hash in remote read code.
+		if _, ok := rrNames[rrcfg.Name]; ok && rrcfg.Name != "" {
+			return errors.Errorf("found multiple remote read configs with job name %q", rrcfg.Name)
 		}
-		rrJobNames[rrcfg.JobName] = struct{}{}
+		rrNames[rrcfg.Name] = struct{}{}
 	}
 	return nil
 }
@@ -596,7 +596,7 @@ type RemoteWriteConfig struct {
 	URL                 *config_util.URL  `yaml:"url"`
 	RemoteTimeout       model.Duration    `yaml:"remote_timeout,omitempty"`
 	WriteRelabelConfigs []*relabel.Config `yaml:"write_relabel_configs,omitempty"`
-	JobName             string            `yaml:"write_job_name,omitempty"`
+	Name                string            `yaml:"name,omitempty"`
 
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.
@@ -655,7 +655,7 @@ type RemoteReadConfig struct {
 	URL           *config_util.URL `yaml:"url"`
 	RemoteTimeout model.Duration   `yaml:"remote_timeout,omitempty"`
 	ReadRecent    bool             `yaml:"read_recent,omitempty"`
-	JobName       string           `yaml:"write_job_name,omitempty"`
+	Name          string           `yaml:"name,omitempty"`
 
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -825,6 +825,12 @@ var expectedErrors = []struct {
 	}, {
 		filename: "remote_write_url_missing.bad.yml",
 		errMsg:   `url for remote_write is empty`,
+	}, {
+		filename: "remote_write_dup.bad.yml",
+		errMsg:   `found multiple remote write configs with job name "queue1"`,
+	}, {
+		filename: "remote_read_dup.bad.yml",
+		errMsg:   `found multiple remote read configs with job name "queue1"`,
 	},
 	{
 		filename: "ec2_filters_empty_values.bad.yml",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -73,6 +73,7 @@ var expectedConf = &Config{
 		{
 			URL:           mustParseURL("http://remote1/push"),
 			RemoteTimeout: model.Duration(30 * time.Second),
+			Name:          "drop_expensive",
 			WriteRelabelConfigs: []*relabel.Config{
 				{
 					SourceLabels: model.LabelNames{"__name__"},
@@ -88,6 +89,7 @@ var expectedConf = &Config{
 			URL:           mustParseURL("http://remote2/push"),
 			RemoteTimeout: model.Duration(30 * time.Second),
 			QueueConfig:   DefaultQueueConfig,
+			Name:          "rw_tls",
 			HTTPClientConfig: config_util.HTTPClientConfig{
 				TLSConfig: config_util.TLSConfig{
 					CertFile: filepath.FromSlash("testdata/valid_cert_file"),
@@ -102,11 +104,13 @@ var expectedConf = &Config{
 			URL:           mustParseURL("http://remote1/read"),
 			RemoteTimeout: model.Duration(1 * time.Minute),
 			ReadRecent:    true,
+			Name:          "default",
 		},
 		{
 			URL:              mustParseURL("http://remote3/read"),
 			RemoteTimeout:    model.Duration(1 * time.Minute),
 			ReadRecent:       false,
+			Name:             "read_special",
 			RequiredMatchers: model.LabelSet{"job": "special"},
 			HTTPClientConfig: config_util.HTTPClientConfig{
 				TLSConfig: config_util.TLSConfig{

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -14,11 +14,13 @@ rule_files:
 
 remote_write:
   - url: http://remote1/push
+    name: drop_expensive
     write_relabel_configs:
     - source_labels: [__name__]
       regex:         expensive.*
       action:        drop
   - url: http://remote2/push
+    name: rw_tls
     tls_config:
       cert_file: valid_cert_file
       key_file: valid_key_file
@@ -26,8 +28,10 @@ remote_write:
 remote_read:
   - url: http://remote1/read
     read_recent: true
+    name: default
   - url: http://remote3/read
     read_recent: false
+    name: read_special
     required_matchers:
       job: special
     tls_config:

--- a/config/testdata/remote_read_dup.bad.yml
+++ b/config/testdata/remote_read_dup.bad.yml
@@ -1,5 +1,5 @@
 remote_read:
   - url: http://localhost:9090
-    write_job_name: queue1
+    name: queue1
   - url: localhost:9091
-    write_job_name: queue1
+    name: queue1

--- a/config/testdata/remote_read_dup.bad.yml
+++ b/config/testdata/remote_read_dup.bad.yml
@@ -1,0 +1,5 @@
+remote_read:
+  - url: http://localhost:9090
+    write_job_name: queue1
+  - url: localhost:9091
+    write_job_name: queue1

--- a/config/testdata/remote_write_dup.bad.yml
+++ b/config/testdata/remote_write_dup.bad.yml
@@ -1,0 +1,6 @@
+remote_write:
+  - url: localhost:9090
+    write_job_name: queue1
+  - url: localhost:9091
+    write_job_name: queue1
+

--- a/config/testdata/remote_write_dup.bad.yml
+++ b/config/testdata/remote_write_dup.bad.yml
@@ -1,6 +1,6 @@
 remote_write:
   - url: localhost:9090
-    write_job_name: queue1
+    name: queue1
   - url: localhost:9091
-    write_job_name: queue1
+    name: queue1
 

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -40,7 +40,7 @@ var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 
 // Client allows reading and writing from/to a remote HTTP endpoint.
 type Client struct {
-	index   int // Used to differentiate clients in metrics.
+	hash    string // Used to differentiate clients in metrics.
 	url     *config_util.URL
 	client  *http.Client
 	timeout time.Duration
@@ -54,14 +54,14 @@ type ClientConfig struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(index int, conf *ClientConfig) (*Client, error) {
+func NewClient(hash string, conf *ClientConfig) (*Client, error) {
 	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage", false)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
-		index:   index,
+		hash:    hash,
 		url:     conf.URL,
 		client:  httpClient,
 		timeout: time.Duration(conf.Timeout),
@@ -117,7 +117,7 @@ func (c *Client) Store(ctx context.Context, req []byte) error {
 
 // Name identifies the client.
 func (c Client) Name() string {
-	return fmt.Sprintf("%d:%s", c.index, c.url)
+	return fmt.Sprintf("%s:%s", c.hash, c.url)
 }
 
 // Read reads from a remote endpoint.

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -40,10 +40,10 @@ var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 
 // Client allows reading and writing from/to a remote HTTP endpoint.
 type Client struct {
-	name    string // Used to differentiate clients in metrics.
-	url     *config_util.URL
-	client  *http.Client
-	timeout time.Duration
+	remoteName string // Used to differentiate clients in metrics.
+	url        *config_util.URL
+	client     *http.Client
+	timeout    time.Duration
 }
 
 // ClientConfig configures a Client.
@@ -54,17 +54,17 @@ type ClientConfig struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(name string, conf *ClientConfig) (*Client, error) {
+func NewClient(remoteName string, conf *ClientConfig) (*Client, error) {
 	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage", false)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
-		name:    name,
-		url:     conf.URL,
-		client:  httpClient,
-		timeout: time.Duration(conf.Timeout),
+		remoteName: remoteName,
+		url:        conf.URL,
+		client:     httpClient,
+		timeout:    time.Duration(conf.Timeout),
 	}, nil
 }
 
@@ -115,9 +115,14 @@ func (c *Client) Store(ctx context.Context, req []byte) error {
 	return err
 }
 
-// Name identifies the client.
+// Name uniquely identifies the client.
 func (c Client) Name() string {
-	return fmt.Sprintf("%s:%s", c.name, c.url)
+	return c.remoteName
+}
+
+// Endpoint is the remote read or write endpoint.
+func (c Client) Endpoint() string {
+	return c.url.String()
 }
 
 // Read reads from a remote endpoint.

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -40,7 +40,7 @@ var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 
 // Client allows reading and writing from/to a remote HTTP endpoint.
 type Client struct {
-	hash    string // Used to differentiate clients in metrics.
+	name    string // Used to differentiate clients in metrics.
 	url     *config_util.URL
 	client  *http.Client
 	timeout time.Duration
@@ -54,14 +54,14 @@ type ClientConfig struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(hash string, conf *ClientConfig) (*Client, error) {
+func NewClient(name string, conf *ClientConfig) (*Client, error) {
 	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage", false)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
-		hash:    hash,
+		name:    name,
 		url:     conf.URL,
 		client:  httpClient,
 		timeout: time.Duration(conf.Timeout),
@@ -117,7 +117,7 @@ func (c *Client) Store(ctx context.Context, req []byte) error {
 
 // Name identifies the client.
 func (c Client) Name() string {
-	return fmt.Sprintf("%s:%s", c.hash, c.url)
+	return fmt.Sprintf("%s:%s", c.name, c.url)
 }
 
 // Read reads from a remote endpoint.

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -62,21 +62,17 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 		)
 
 		serverURL, err := url.Parse(server.URL)
-		if err != nil {
-			t.Fatal(err)
-		}
+		testutil.Ok(t, err)
+
 		conf := &ClientConfig{
 			URL:     &config_util.URL{URL: serverURL},
 			Timeout: model.Duration(time.Second),
 		}
+
 		hash, err := toHash(conf)
-		if err != nil {
-			t.Fatal(err)
-		}
+		testutil.Ok(t, err)
 		c, err := NewClient(hash, conf)
-		if err != nil {
-			t.Fatal(err)
-		}
+		testutil.Ok(t, err)
 
 		err = c.Store(context.Background(), []byte{})
 		if !testutil.ErrorEqual(err, test.err) {

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -65,11 +65,15 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		c, err := NewClient(0, &ClientConfig{
+		conf := &ClientConfig{
 			URL:     &config_util.URL{URL: serverURL},
 			Timeout: model.Duration(time.Second),
-		})
+		}
+		hash, err := toHash(conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c, err := NewClient(hash, conf)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -14,6 +14,9 @@
 package remote
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -537,4 +540,14 @@ func labelsToLabelsProto(labels labels.Labels, buf []prompb.Label) []prompb.Labe
 		})
 	}
 	return result
+}
+
+// Used for hashing configs and diff'ing hashes in ApplyConfig.
+func toHash(data interface{}) (string, error) {
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	hash := md5.Sum(bytes)
+	return hex.EncodeToString(hash[:]), nil
 }

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -14,9 +14,6 @@
 package remote
 
 import (
-	"crypto/md5"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -540,14 +537,4 @@ func labelsToLabelsProto(labels labels.Labels, buf []prompb.Label) []prompb.Labe
 		})
 	}
 	return result
-}
-
-// Used for hashing configs and diff'ing hashes in ApplyConfig.
-func toHash(data interface{}) (string, error) {
-	bytes, err := json.Marshal(data)
-	if err != nil {
-		return "", err
-	}
-	hash := md5.Sum(bytes)
-	return hex.EncodeToString(hash[:]), nil
 }

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -239,7 +239,6 @@ func NewQueueManager(reg prometheus.Registerer, logger log.Logger, walDir string
 		logger = log.NewNopLogger()
 	}
 
-	// name := client.Name()
 	logger = log.With(logger, remoteName, client.Name(), endpoint, client.Endpoint())
 	t := &QueueManager{
 		logger:         logger,

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -36,12 +36,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/wal"
 )
 
-// String constants for instrumentation.
 const (
-	namespace = "prometheus"
-	subsystem = "remote_storage"
-	queue     = "queue"
-
 	// We track samples in/out and how long pushes take using an Exponentially
 	// Weighted Moving Average.
 	ewmaWeight          = 0.2
@@ -59,7 +54,7 @@ var (
 			Name:      "succeeded_samples_total",
 			Help:      "Total number of samples successfully sent to remote storage.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	failedSamplesTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -68,7 +63,7 @@ var (
 			Name:      "failed_samples_total",
 			Help:      "Total number of samples which failed on send to remote storage, non-recoverable errors.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	retriedSamplesTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -77,7 +72,7 @@ var (
 			Name:      "retried_samples_total",
 			Help:      "Total number of samples which failed on send to remote storage but were retried because the send error was recoverable.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	droppedSamplesTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -86,7 +81,7 @@ var (
 			Name:      "dropped_samples_total",
 			Help:      "Total number of samples which were dropped after being read from the WAL before being sent via remote write.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	enqueueRetriesTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -95,7 +90,7 @@ var (
 			Name:      "enqueue_retries_total",
 			Help:      "Total number of times enqueue has failed because a shards queue was full.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	sentBatchDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -105,7 +100,7 @@ var (
 			Help:      "Duration of sample batch send calls to the remote storage.",
 			Buckets:   prometheus.DefBuckets,
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	queueHighestSentTimestamp = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -114,7 +109,7 @@ var (
 			Name:      "queue_highest_sent_timestamp_seconds",
 			Help:      "Timestamp from a WAL sample, the highest timestamp successfully sent by this queue, in seconds since epoch.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	queuePendingSamples = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -123,7 +118,7 @@ var (
 			Name:      "pending_samples",
 			Help:      "The number of samples pending in the queues shards to be sent to the remote storage.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	shardCapacity = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -132,7 +127,7 @@ var (
 			Name:      "shard_capacity",
 			Help:      "The capacity of each shard of the queue used for parallel sending to the remote storage.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	numShards = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -141,7 +136,7 @@ var (
 			Name:      "shards",
 			Help:      "The number of shards used for parallel sending to the remote storage.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	maxNumShards = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -150,7 +145,7 @@ var (
 			Name:      "shards_max",
 			Help:      "The maximum number of shards that the queue is allowed to run.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	minNumShards = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -159,7 +154,7 @@ var (
 			Name:      "shards_min",
 			Help:      "The minimum number of shards that the queue is allowed to run.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	desiredNumShards = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -168,7 +163,7 @@ var (
 			Name:      "shards_desired",
 			Help:      "The number of shards that the queues shard calculation wants to run based on the rate of samples in vs. samples out.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 	bytesSent = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -177,7 +172,7 @@ var (
 			Name:      "sent_bytes_total",
 			Help:      "The total number of bytes sent by the queue.",
 		},
-		[]string{queue},
+		[]string{remoteName, endpoint},
 	)
 )
 
@@ -186,8 +181,10 @@ var (
 type StorageClient interface {
 	// Store stores the given samples in the remote storage.
 	Store(context.Context, []byte) error
-	// Name identifies the remote storage implementation.
+	// Name uniquely identifies the remote storage.
 	Name() string
+	// Endpoint is the remote read or write endpoint for the storage client.
+	Endpoint() string
 }
 
 // QueueManager manages a queue of samples to be sent to the Storage
@@ -242,8 +239,8 @@ func NewQueueManager(reg prometheus.Registerer, logger log.Logger, walDir string
 		logger = log.NewNopLogger()
 	}
 
-	name := client.Name()
-	logger = log.With(logger, "queue", name)
+	// name := client.Name()
+	logger = log.With(logger, remoteName, client.Name(), endpoint, client.Endpoint())
 	t := &QueueManager{
 		logger:         logger,
 		flushDeadline:  flushDeadline,
@@ -266,7 +263,7 @@ func NewQueueManager(reg prometheus.Registerer, logger log.Logger, walDir string
 		samplesOutDuration: newEWMARate(ewmaWeight, shardUpdateDuration),
 	}
 
-	t.watcher = wal.NewWatcher(reg, wal.NewWatcherMetrics(reg), logger, name, t, walDir)
+	t.watcher = wal.NewWatcher(reg, wal.NewWatcherMetrics(reg), logger, client.Name(), t, walDir)
 	t.shards = t.newShards()
 
 	return t
@@ -326,22 +323,23 @@ func (t *QueueManager) Start() {
 	// constructor because of the ordering of creating Queue Managers's, stopping them,
 	// and then starting new ones in storage/remote/storage.go ApplyConfig.
 	name := t.client.Name()
+	ep := t.client.Endpoint()
 	t.highestSentTimestampMetric = &maxGauge{
-		Gauge: queueHighestSentTimestamp.WithLabelValues(name),
+		Gauge: queueHighestSentTimestamp.WithLabelValues(name, ep),
 	}
-	t.pendingSamplesMetric = queuePendingSamples.WithLabelValues(name)
-	t.enqueueRetriesMetric = enqueueRetriesTotal.WithLabelValues(name)
-	t.droppedSamplesTotal = droppedSamplesTotal.WithLabelValues(name)
-	t.numShardsMetric = numShards.WithLabelValues(name)
-	t.failedSamplesTotal = failedSamplesTotal.WithLabelValues(name)
-	t.sentBatchDuration = sentBatchDuration.WithLabelValues(name)
-	t.succeededSamplesTotal = succeededSamplesTotal.WithLabelValues(name)
-	t.retriedSamplesTotal = retriedSamplesTotal.WithLabelValues(name)
-	t.shardCapacity = shardCapacity.WithLabelValues(name)
-	t.maxNumShards = maxNumShards.WithLabelValues(name)
-	t.minNumShards = minNumShards.WithLabelValues(name)
-	t.desiredNumShards = desiredNumShards.WithLabelValues(name)
-	t.bytesSent = bytesSent.WithLabelValues(name)
+	t.pendingSamplesMetric = queuePendingSamples.WithLabelValues(name, ep)
+	t.enqueueRetriesMetric = enqueueRetriesTotal.WithLabelValues(name, ep)
+	t.droppedSamplesTotal = droppedSamplesTotal.WithLabelValues(name, ep)
+	t.numShardsMetric = numShards.WithLabelValues(name, ep)
+	t.failedSamplesTotal = failedSamplesTotal.WithLabelValues(name, ep)
+	t.sentBatchDuration = sentBatchDuration.WithLabelValues(name, ep)
+	t.succeededSamplesTotal = succeededSamplesTotal.WithLabelValues(name, ep)
+	t.retriedSamplesTotal = retriedSamplesTotal.WithLabelValues(name, ep)
+	t.shardCapacity = shardCapacity.WithLabelValues(name, ep)
+	t.maxNumShards = maxNumShards.WithLabelValues(name, ep)
+	t.minNumShards = minNumShards.WithLabelValues(name, ep)
+	t.desiredNumShards = desiredNumShards.WithLabelValues(name, ep)
+	t.bytesSent = bytesSent.WithLabelValues(name, ep)
 
 	// Initialise some metrics.
 	t.shardCapacity.Set(float64(t.cfg.Capacity))
@@ -380,19 +378,20 @@ func (t *QueueManager) Stop() {
 	t.seriesMtx.Unlock()
 	// Delete metrics so we don't have alerts for queues that are gone.
 	name := t.client.Name()
-	queueHighestSentTimestamp.DeleteLabelValues(name)
-	queuePendingSamples.DeleteLabelValues(name)
-	enqueueRetriesTotal.DeleteLabelValues(name)
-	droppedSamplesTotal.DeleteLabelValues(name)
-	numShards.DeleteLabelValues(name)
-	failedSamplesTotal.DeleteLabelValues(name)
-	sentBatchDuration.DeleteLabelValues(name)
-	succeededSamplesTotal.DeleteLabelValues(name)
-	retriedSamplesTotal.DeleteLabelValues(name)
-	shardCapacity.DeleteLabelValues(name)
-	maxNumShards.DeleteLabelValues(name)
-	minNumShards.DeleteLabelValues(name)
-	desiredNumShards.DeleteLabelValues(name)
+	ep := t.client.Endpoint()
+	queueHighestSentTimestamp.DeleteLabelValues(name, ep)
+	queuePendingSamples.DeleteLabelValues(name, ep)
+	enqueueRetriesTotal.DeleteLabelValues(name, ep)
+	droppedSamplesTotal.DeleteLabelValues(name, ep)
+	numShards.DeleteLabelValues(name, ep)
+	failedSamplesTotal.DeleteLabelValues(name, ep)
+	sentBatchDuration.DeleteLabelValues(name, ep)
+	succeededSamplesTotal.DeleteLabelValues(name, ep)
+	retriedSamplesTotal.DeleteLabelValues(name, ep)
+	shardCapacity.DeleteLabelValues(name, ep)
+	maxNumShards.DeleteLabelValues(name, ep)
+	minNumShards.DeleteLabelValues(name, ep)
+	desiredNumShards.DeleteLabelValues(name, ep)
 }
 
 // StoreSeries keeps track of which series we know about for lookups when sending samples to remote.

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -445,6 +445,10 @@ func (c *TestStorageClient) Name() string {
 	return "teststorageclient"
 }
 
+func (c *TestStorageClient) Endpoint() string {
+	return "http://test-remote.com/1234"
+}
+
 // TestBlockingStorageClient is a queue_manager StorageClient which will block
 // on any calls to Store(), until the request's Context is cancelled, at which
 // point the `numCalls` property will contain a count of how many times Store()
@@ -469,6 +473,10 @@ func (c *TestBlockingStorageClient) NumCalls() uint64 {
 
 func (c *TestBlockingStorageClient) Name() string {
 	return "testblockingstorageclient"
+}
+
+func (c *TestBlockingStorageClient) Endpoint() string {
+	return "http://test-remote-blocking.com/1234"
 }
 
 func BenchmarkSampleDelivery(b *testing.B) {

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -15,14 +15,60 @@ package remote
 
 import (
 	"context"
+	"io/ioutil"
+	"net/url"
+	"os"
 	"reflect"
 	"sort"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/testutil"
 )
+
+func TestNoDuplicateReadConfigs(t *testing.T) {
+	dir, err := ioutil.TempDir("", "TestNoDuplicateReadConfigs")
+	testutil.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	// Test that configs that are identical in all but name are considered identical.
+	cfg1 := config.RemoteReadConfig{
+		Name: "write-1",
+		URL: &config_util.URL{
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "localhost",
+			},
+		},
+	}
+	cfg2 := config.RemoteReadConfig{
+		Name: "write-2",
+		URL: &config_util.URL{
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "localhost",
+			},
+		},
+	}
+
+	s := NewStorage(nil, prometheus.DefaultRegisterer, nil, dir, defaultFlushDeadline)
+	conf := &config.Config{
+		GlobalConfig: config.DefaultGlobalConfig,
+		RemoteReadConfigs: []*config.RemoteReadConfig{
+			&cfg1,
+			&cfg2,
+		},
+	}
+	testutil.NotOk(t, s.ApplyConfig(conf))
+
+	err = s.Close()
+	testutil.Ok(t, err)
+}
 
 func TestExternalLabelsQuerierSelect(t *testing.T) {
 	matchers := []*labels.Matcher{

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -36,7 +36,6 @@ func TestNoDuplicateReadConfigs(t *testing.T) {
 	testutil.Ok(t, err)
 	defer os.RemoveAll(dir)
 
-	// Test that configs that are identical in all but name are considered identical.
 	cfg1 := config.RemoteReadConfig{
 		Name: "write-1",
 		URL: &config_util.URL{
@@ -55,19 +54,57 @@ func TestNoDuplicateReadConfigs(t *testing.T) {
 			},
 		},
 	}
-
-	s := NewStorage(nil, prometheus.DefaultRegisterer, nil, dir, defaultFlushDeadline)
-	conf := &config.Config{
-		GlobalConfig: config.DefaultGlobalConfig,
-		RemoteReadConfigs: []*config.RemoteReadConfig{
-			&cfg1,
-			&cfg2,
+	cfg3 := config.RemoteReadConfig{
+		URL: &config_util.URL{
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "localhost",
+			},
 		},
 	}
-	testutil.NotOk(t, s.ApplyConfig(conf))
 
-	err = s.Close()
-	testutil.Ok(t, err)
+	type testcase struct {
+		cfgs []*config.RemoteReadConfig
+		err  bool
+	}
+
+	cases := []testcase{
+		{ // Duplicates but with different names, we should not get an error.
+			cfgs: []*config.RemoteReadConfig{
+				&cfg1,
+				&cfg2,
+			},
+			err: false,
+		},
+		{ // Duplicates but one with no name, we should not get an error.
+			cfgs: []*config.RemoteReadConfig{
+				&cfg1,
+				&cfg3,
+			},
+			err: false,
+		},
+		{ // Duplicates both with no name, we should get an error.
+			cfgs: []*config.RemoteReadConfig{
+				&cfg3,
+				&cfg3,
+			},
+			err: true,
+		},
+	}
+
+	for _, tc := range cases {
+		s := NewStorage(nil, prometheus.DefaultRegisterer, nil, dir, defaultFlushDeadline)
+		conf := &config.Config{
+			GlobalConfig:      config.DefaultGlobalConfig,
+			RemoteReadConfigs: tc.cfgs,
+		}
+		err := s.ApplyConfig(conf)
+		gotError := err != nil
+		testutil.Equals(t, tc.err, gotError)
+
+		err = s.Close()
+		testutil.Ok(t, err)
+	}
 }
 
 func TestExternalLabelsQuerierSelect(t *testing.T) {

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -68,8 +68,13 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 
 	// Update read clients
 	queryables := make([]storage.Queryable, 0, len(conf.RemoteReadConfigs))
-	for i, rrConf := range conf.RemoteReadConfigs {
-		c, err := NewClient(i, &ClientConfig{
+	for _, rrConf := range conf.RemoteReadConfigs {
+		hash, err := toHash(rrConf)
+		if err != nil {
+			return nil
+		}
+
+		c, err := NewClient(hash, &ClientConfig{
 			URL:              rrConf.URL,
 			Timeout:          rrConf.RemoteTimeout,
 			HTTPClientConfig: rrConf.HTTPClientConfig,

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -28,6 +28,14 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
+// String constants for instrumentation.
+const (
+	namespace  = "prometheus"
+	subsystem  = "remote_storage"
+	remoteName = "remote_name"
+	endpoint   = "url"
+)
+
 // startTimeCallback is a callback func that return the oldest timestamp stored in a storage.
 type startTimeCallback func() (int64, error)
 

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -78,8 +78,8 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		// a name in their remote write config so we can still differentiate
 		// between queues that have the same remote write endpoint.
 		name := string(hash[:6])
-		if rrConf.JobName != "" {
-			name = rrConf.JobName
+		if rrConf.Name != "" {
+			name = rrConf.Name
 		}
 
 		c, err := NewClient(name, &ClientConfig{

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -82,7 +82,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 	readHashes := make(map[string]struct{})
 	queryables := make([]storage.Queryable, 0, len(conf.RemoteReadConfigs))
 	for _, rrConf := range conf.RemoteReadConfigs {
-		hash, err := rrConf.ToHash()
+		hash, err := toHash(rrConf)
 		if err != nil {
 			return nil
 		}

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -74,7 +74,15 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 			return nil
 		}
 
-		c, err := NewClient(hash, &ClientConfig{
+		// Set the queue name to the config hash if the user has not set
+		// a name in their remote write config so we can still differentiate
+		// between queues that have the same remote write endpoint.
+		name := string(hash[:6])
+		if rrConf.JobName != "" {
+			name = rrConf.JobName
+		}
+
+		c, err := NewClient(name, &ClientConfig{
 			URL:              rrConf.URL,
 			Timeout:          rrConf.RemoteTimeout,
 			HTTPClientConfig: rrConf.HTTPClientConfig,

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -15,10 +15,12 @@ package remote
 
 import (
 	"io/ioutil"
+	"net/url"
 	"os"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	common_config "github.com/prometheus/common/config"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/util/testutil"
 )
@@ -38,6 +40,18 @@ func TestStorageLifecycle(t *testing.T) {
 			&config.DefaultRemoteReadConfig,
 		},
 	}
+	// We need to set URL's so that metric creation doesn't panic.
+	conf.RemoteWriteConfigs[0].URL = &common_config.URL{
+		URL: &url.URL{
+			Host: "http://test-storage.com",
+		},
+	}
+	conf.RemoteReadConfigs[0].URL = &common_config.URL{
+		URL: &url.URL{
+			Host: "http://test-storage.com",
+		},
+	}
+
 	s.ApplyConfig(conf)
 
 	// make sure remote write has a queue.

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -122,7 +122,15 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			continue
 		}
 
-		c, err := NewClient(hash, &ClientConfig{
+		// Set the queue name to the config hash if the user has not set
+		// a name in their remote write config so we can still differentiate
+		// between queues that have the same remote write endpoint.
+		name := string(hash[:6])
+		if rwConf.JobName != "" {
+			name = rwConf.JobName
+		}
+
+		c, err := NewClient(name, &ClientConfig{
 			URL:              rwConf.URL,
 			Timeout:          rwConf.RemoteTimeout,
 			HTTPClientConfig: rwConf.HTTPClientConfig,

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -14,6 +14,7 @@
 package remote
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -109,9 +110,14 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 	newQueues := make(map[string]*QueueManager)
 	newHashes := []string{}
 	for _, rwConf := range conf.RemoteWriteConfigs {
-		hash, err := toHash(rwConf)
+		hash, err := rwConf.ToHash()
 		if err != nil {
 			return err
+		}
+
+		// Don't allow duplicate remote write configs.
+		if _, ok := newQueues[hash]; ok {
+			return fmt.Errorf("duplicate remote write configs are not allowed, found duplicate for URL: %s", rwConf.URL)
 		}
 
 		// If the hash exists in the current queues map, we only need

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -126,8 +126,8 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 		// a name in their remote write config so we can still differentiate
 		// between queues that have the same remote write endpoint.
 		name := string(hash[:6])
-		if rwConf.JobName != "" {
-			name = rwConf.JobName
+		if rwConf.Name != "" {
+			name = rwConf.Name
 		}
 
 		c, err := NewClient(name, &ClientConfig{

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -15,10 +15,12 @@ package remote
 
 import (
 	"io/ioutil"
+	"net/url"
 	"os"
 	"testing"
 	"time"
 
+	common_config "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -87,6 +89,12 @@ func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
 			&config.DefaultRemoteWriteConfig,
 		},
 	}
+	// We need to set URL's so that metric creation doesn't panic.
+	conf.RemoteWriteConfigs[0].URL = &common_config.URL{
+		URL: &url.URL{
+			Host: "http://test-storage.com",
+		},
+	}
 	hash, err := toHash(conf.RemoteWriteConfigs[0])
 	testutil.Ok(t, err)
 
@@ -125,6 +133,22 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 	conf := &config.Config{
 		GlobalConfig:       config.GlobalConfig{},
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{c0, c1, c2},
+	}
+	// We need to set URL's so that metric creation doesn't panic.
+	conf.RemoteWriteConfigs[0].URL = &common_config.URL{
+		URL: &url.URL{
+			Host: "http://test-storage.com",
+		},
+	}
+	conf.RemoteWriteConfigs[1].URL = &common_config.URL{
+		URL: &url.URL{
+			Host: "http://test-storage.com",
+		},
+	}
+	conf.RemoteWriteConfigs[2].URL = &common_config.URL{
+		URL: &url.URL{
+			Host: "http://test-storage.com",
+		},
 	}
 	s.ApplyConfig(conf)
 	testutil.Equals(t, 3, len(s.queues))


### PR DESCRIPTION
Track remote write queues via a map so we don't have to track the index in the remote write array. The queue names in metrics now contain the hash as a string instead of the index in the config array, so they look like this:

```
prometheus_remote_storage_dropped_samples_total{queue="4d50f478186c47dfcffff29ffbc4b5d4:http://localhost:1235/receive"} 0
prometheus_remote_storage_dropped_samples_total{queue="97f072436c72649a7547e91184322b58
```

Also adds the option of setting a job name for remote write/read in config. If not set, the name will default to the first 6 characters of the config's `md5.Sum()`. The config parsing does not allow for duplicate job names, the same as scrape jobs.

Note: the base commit is from another PR (#6041)

@csmarchbanks 