### PR TITLE
scrape: close manager gracefully at end.

### DIFF
--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -339,6 +339,7 @@ func TestManagerTargetsUpdates(t *testing.T) {
 
 	ts := make(chan map[string][]*targetgroup.Group)
 	go m.Run(ts)
+	defer m.Stop()
 
 	tgSent := make(map[string][]*targetgroup.Group)
 	for x := 0; x < 10; x++ {


### PR DESCRIPTION
`Manager` did not stop gracefully at the end and add test coverage.

https://github.com/prometheus/prometheus/blob/be9de64cda450fa2cb0c84a995fb0a76efbe4a36/scrape/manager_test.go#L337-L342