### PR TITLE
prometheus-mixin: improve description of sample alerts

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -149,7 +149,7 @@
             },
             annotations: {
               summary: 'Prometheus is dropping samples with duplicate timestamps.',
-              description: 'Prometheus %(prometheusName)s is dropping {{$value | humanize}} samples/s with different values but duplicated timestamp.' % $._config,
+              description: 'Prometheus %(prometheusName)s is dropping {{ printf "%%.4g" $value  }} samples/s with different values but duplicated timestamp.' % $._config,
             },
           },
           {
@@ -163,7 +163,7 @@
             },
             annotations: {
               summary: 'Prometheus drops samples with out-of-order timestamps.',
-              description: 'Prometheus %(prometheusName)s is dropping {{$value | humanize}} samples/s with timestamps arriving out of order.' % $._config,
+              description: 'Prometheus %(prometheusName)s is dropping {{ printf "%%.4g" $value  }} samples/s with timestamps arriving out of order.' % $._config,
             },
           },
           {


### PR DESCRIPTION
Before:

"Prometheus openshift-monitoring/prometheus-k8s-1 is dropping **908.4m samples/s** ..."

After:

"Prometheus openshift-monitoring/prometheus-k8s-1 is dropping **0.9084 samples/s** ..."