### PR TITLE
cmd/promtool: improve output for PromQL tests

### DIFF
--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -321,7 +321,7 @@ Outer:
 		got, err := query(suite.Context(), testCase.Expr, mint.Add(testCase.EvalTime),
 			suite.QueryEngine(), suite.Queryable())
 		if err != nil {
-			errs = append(errs, errors.Errorf("    expr:'%s', time:%s, err:%s", testCase.Expr,
+			errs = append(errs, errors.Errorf("    expr: %q, time: %s, err: %s", testCase.Expr,
 				testCase.EvalTime.String(), err.Error()))
 			continue
 		}
@@ -338,7 +338,8 @@ Outer:
 		for _, s := range testCase.ExpSamples {
 			lb, err := promql.ParseMetric(s.Labels)
 			if err != nil {
-				errs = append(errs, errors.Errorf("    expr:'%s', time:%s, err:%s", testCase.Expr,
+				err = errors.Wrapf(err, "labels %q", s.Labels)
+				errs = append(errs, errors.Errorf("    expr: %q, time: %s, err: %s", testCase.Expr,
 					testCase.EvalTime.String(), err.Error()))
 				continue Outer
 			}
@@ -355,7 +356,7 @@ Outer:
 			return labels.Compare(gotSamples[i].Labels, gotSamples[j].Labels) <= 0
 		})
 		if !reflect.DeepEqual(expSamples, gotSamples) {
-			errs = append(errs, errors.Errorf("    expr:'%s', time:%s, \n        exp:%#v, \n        got:%#v", testCase.Expr,
+			errs = append(errs, errors.Errorf("    expr: %q, time: %s,\n        exp:%#v\n        got:%#v", testCase.Expr,
 				testCase.EvalTime.String(), parsedSamplesString(expSamples), parsedSamplesString(gotSamples)))
 		}
 	}
@@ -510,7 +511,7 @@ func parsedSamplesString(pss []parsedSample) string {
 		return "nil"
 	}
 	s := pss[0].String()
-	for _, ps := range pss[0:] {
+	for _, ps := range pss[1:] {
 		s += ", " + ps.String()
 	}
 	return s


### PR DESCRIPTION
Before

```
Unit Testing:  test/unit.yml
  FAILED:
    expr:'rate(foo[5m])', time:5m0s, err:parse error at char 28: could not parse remaining input "x"...
    expr:'rate(foo[5m])', time:6m0s, 
        exp:"{instance=\"localhost:8080\"} 1E+00, {instance=\"localhost:8080\"} 1E+00", 
        got:"{instance=\"localhost:8080\"} 0E+00, {instance=\"localhost:8080\"} 0E+00"
```

After

```
Unit Testing:  test/unit.yml
  FAILED:
    expr: "rate(foo[5m])", time: 5m0s, err: labels "{instance=\"localhost:8080\"}x": parse error at char 28: could not parse remaining input "x"...
    expr: "rate(foo[5m])", time: 6m0s,
        exp:"{instance=\"localhost:8080\"} 1E+00"
        got:"{instance=\"localhost:8080\"} 0E+00"
```