### PR TITLE
Checkpoints with series chunks

### DIFF
--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -62,7 +62,7 @@ func NewXORChunk() *XORChunk {
 
 // NewXORChunk returns a new chunk with XOR encoding of the given size.
 func NewXORChunkFromBytes(b []byte) *XORChunk {
-	return &XORChunk{b: bstream{stream: b, count: 0}}
+	return &XORChunk{b: newBReader(b)}
 }
 
 // Encoding returns the encoding type.

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -60,6 +60,11 @@ func NewXORChunk() *XORChunk {
 	return &XORChunk{b: bstream{stream: b, count: 0}}
 }
 
+// NewXORChunk returns a new chunk with XOR encoding of the given size.
+func NewXORChunkFromBytes(b []byte) *XORChunk {
+	return &XORChunk{b: newBReader(b)}
+}
+
 // Encoding returns the encoding type.
 func (c *XORChunk) Encoding() Encoding {
 	return EncXOR

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -62,7 +62,7 @@ func NewXORChunk() *XORChunk {
 
 // NewXORChunk returns a new chunk with XOR encoding of the given size.
 func NewXORChunkFromBytes(b []byte) *XORChunk {
-	return &XORChunk{b: newBReader(b)}
+	return &XORChunk{b: bstream{stream: b, count: 0}}
 }
 
 // Encoding returns the encoding type.

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1012,7 +1012,7 @@ func TestDeleteCompactionBlockAfterFailedReload(t *testing.T) {
 			for _, m := range blocks {
 				createBlock(t, db.Dir(), genSeries(1, 1, m.MinTime, m.MaxTime))
 			}
-			testutil.Ok(t, db.reload())
+			testutil.Ok(t, db.reload(false))
 			testutil.Equals(t, len(blocks), len(db.Blocks()), "unexpected block count after a reload")
 
 			return len(blocks)

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -548,9 +548,6 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 		return nil, err
 	}
 
-	if err := db.reload(false); err != nil {
-		return nil, err
-	}
 	// Set the min valid time for the ingested samples
 	// to be no lower than the maxt of the last block.
 	blocks := db.Blocks()
@@ -565,6 +562,12 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 		if err := wlog.Repair(initErr); err != nil {
 			return nil, errors.Wrap(err, "repair corrupted WAL")
 		}
+	}
+
+	// Reloading after initing the head deletes the data before minValidTime
+	// from the head.
+	if err := db.reload(false); err != nil {
+		return nil, err
 	}
 
 	go db.run()

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -100,7 +100,7 @@ func TestDB_reloadOrder(t *testing.T) {
 		createBlock(t, db.Dir(), genSeries(1, 1, m.MinTime, m.MaxTime))
 	}
 
-	testutil.Ok(t, db.reload())
+	testutil.Ok(t, db.reload(false))
 	blocks := db.Blocks()
 	testutil.Equals(t, 3, len(blocks))
 	testutil.Equals(t, metas[1].MinTime, blocks[0].Meta().MinTime)
@@ -1075,11 +1075,11 @@ func TestTimeRetention(t *testing.T) {
 		createBlock(t, db.Dir(), genSeries(10, 10, m.MinTime, m.MaxTime))
 	}
 
-	testutil.Ok(t, db.reload())                       // Reload the db to register the new blocks.
+	testutil.Ok(t, db.reload(false))                  // Reload the db to register the new blocks.
 	testutil.Equals(t, len(blocks), len(db.Blocks())) // Ensure all blocks are registered.
 
 	db.opts.RetentionDuration = uint64(blocks[2].MaxTime - blocks[1].MinTime)
-	testutil.Ok(t, db.reload())
+	testutil.Ok(t, db.reload(false))
 
 	expBlocks := blocks[1:]
 	actBlocks := db.Blocks()
@@ -1112,7 +1112,7 @@ func TestSizeRetention(t *testing.T) {
 	}
 
 	// Test that registered size matches the actual disk size.
-	testutil.Ok(t, db.reload())                                       // Reload the db to register the new db size.
+	testutil.Ok(t, db.reload(false))                                  // Reload the db to register the new db size.
 	testutil.Equals(t, len(blocks), len(db.Blocks()))                 // Ensure all blocks are registered.
 	expSize := int64(prom_testutil.ToFloat64(db.metrics.blocksBytes)) // Use the actual internal metrics.
 	actSize := testutil.DirSize(t, db.Dir())
@@ -1122,8 +1122,8 @@ func TestSizeRetention(t *testing.T) {
 	// Check total size, total count and check that the oldest block was deleted.
 	firstBlockSize := db.Blocks()[0].Size()
 	sizeLimit := actSize - firstBlockSize
-	db.opts.MaxBytes = sizeLimit // Set the new db size limit one block smaller that the actual size.
-	testutil.Ok(t, db.reload())  // Reload the db to register the new db size.
+	db.opts.MaxBytes = sizeLimit     // Set the new db size limit one block smaller that the actual size.
+	testutil.Ok(t, db.reload(false)) // Reload the db to register the new db size.
 
 	expBlocks := blocks[1:]
 	actBlocks := db.Blocks()
@@ -1641,7 +1641,7 @@ func TestNoEmptyBlocks(t *testing.T) {
 		}
 
 		oldBlocks := db.Blocks()
-		testutil.Ok(t, db.reload())                                      // Reload the db to register the new blocks.
+		testutil.Ok(t, db.reload(false))                                 // Reload the db to register the new blocks.
 		testutil.Equals(t, len(blocks)+len(oldBlocks), len(db.Blocks())) // Ensure all blocks are registered.
 		testutil.Ok(t, db.Delete(math.MinInt64, math.MaxInt64, defaultMatcher))
 		testutil.Ok(t, db.compact())

--- a/tsdb/encoding/encoding.go
+++ b/tsdb/encoding/encoding.go
@@ -187,7 +187,8 @@ func (d *Decbuf) UvarintBytes(b []byte) []byte {
 	if cap(b) < int(l) {
 		b = make([]byte, 0, l)
 	}
-	copy(b[:0], d.B[:l])
+	b = b[:l]
+	copy(b, d.B[:l])
 	d.B = d.B[l:]
 	return b
 }

--- a/tsdb/encoding/encoding.go
+++ b/tsdb/encoding/encoding.go
@@ -184,10 +184,11 @@ func (d *Decbuf) UvarintBytes(b []byte) []byte {
 		d.E = ErrInvalidSize
 		return b[:0]
 	}
-	if uint64(cap(b)) < l {
+	if cap(b) < int(l) {
 		b = make([]byte, 0, l)
 	}
 	copy(b[:0], d.B[:l])
+	d.B = d.B[l:]
 	return b
 }
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1700,10 +1700,10 @@ func (s *memSeries) encodeSeries(b []byte) []byte {
 		buf.PutUvarintStr(l.Value)
 	}
 	buf.PutBE64int64(s.chunkRange)
-	buf.PutBE64int64(s.nextAt)
 
 	// Chunks.
 	s.Lock()
+	buf.PutBE64int64(s.nextAt)
 	buf.PutUvarint(len(s.chunks))
 	for _, c := range s.chunks {
 		buf.PutBE64int64(c.minTime)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -589,7 +589,7 @@ func (h *Head) Init(minValidTime int64) error {
 	go func() {
 		defer h.wg.Done()
 
-		tick := time.NewTicker(1 * time.Minute)
+		tick := time.NewTicker(30 * time.Second)
 		for {
 			select {
 			case <-tick.C:
@@ -1854,6 +1854,13 @@ func (s *memSeries) truncateChunksBefore(mint int64) (removed int) {
 		s.headChunk = nil
 	} else {
 		s.headChunk = s.chunks[len(s.chunks)-1]
+		if s.app == nil {
+			app, err := s.headChunk.chunk.Appender()
+			if err != nil {
+				panic(err)
+			}
+			s.app = app
+		}
 	}
 
 	return k

--- a/tsdb/head_chunkpoint.go
+++ b/tsdb/head_chunkpoint.go
@@ -1,0 +1,154 @@
+// Copyright 2018 The Prometheus Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	"github.com/prometheus/prometheus/tsdb/fileutil"
+	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/wal"
+)
+
+// ChunkpointStats returns stats about a created chunkpoint.
+type ChunkpointStats struct {
+	TotalSeries int // Processed series.
+}
+
+// LastChunkpoint returns the directory name and index of the most recent chunkpoint.
+// If dir does not contain any chunkpoints, ErrNotFound is returned.
+func LastChunkpoint(dir string) (string, int, error) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return "", 0, err
+	}
+	// Traverse list backwards since there may be multiple chunkpoints left.
+	for i := len(files) - 1; i >= 0; i-- {
+		fi := files[i]
+
+		if !strings.HasPrefix(fi.Name(), chunkpointPrefix) {
+			continue
+		}
+		if !fi.IsDir() {
+			return "", 0, errors.Errorf("chunkpoint %s is not a directory", fi.Name())
+		}
+		idx, err := strconv.Atoi(fi.Name()[len(chunkpointPrefix):])
+		if err != nil {
+			continue
+		}
+		return filepath.Join(dir, fi.Name()), idx, nil
+	}
+	return "", 0, record.ErrNotFound
+}
+
+// DeleteChunkpoints deletes all chunkpoints in a directory below a given index.
+func DeleteChunkpoints(dir string, maxIndex int) error {
+	var errs tsdb_errors.MultiError
+
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, fi := range files {
+		if !strings.HasPrefix(fi.Name(), chunkpointPrefix) {
+			continue
+		}
+		index, err := strconv.Atoi(fi.Name()[len(chunkpointPrefix):])
+		if err != nil || index >= maxIndex {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(dir, fi.Name())); err != nil {
+			errs.Add(err)
+		}
+	}
+	return errs.Err()
+}
+
+const chunkpointPrefix = "chunkpoint."
+
+// Chunkpoint creates a compacted checkpoint of all the series in the head.
+// It deletes the old chunkpoints if the chunkpoint creation is successful.
+//
+// The chunkpoint is stored in a directory named chunkpoint.N in the same
+// segmented format as the original WAL itself.
+// This makes it easy to read it through the WAL package.
+func Chunkpoint(h *Head) (*ChunkpointStats, error) {
+	stats := &ChunkpointStats{}
+
+	_, last, err := LastChunkpoint(h.wal.Dir())
+	cpdir := filepath.Join(h.wal.Dir(), fmt.Sprintf(chunkpointPrefix+"%06d", last+1))
+	cpdirtmp := cpdir + ".tmp"
+
+	if err := os.MkdirAll(cpdirtmp, 0777); err != nil {
+		return nil, errors.Wrap(err, "create chunkpoint dir")
+	}
+	cp, err := wal.New(nil, nil, cpdirtmp, h.wal.CompressionEnabled())
+	if err != nil {
+		return nil, errors.Wrap(err, "open chunkpoint")
+	}
+
+	// Ensures that an early return caused by an error doesn't leave any tmp files.
+	defer func() {
+		cp.Close()
+		os.RemoveAll(cpdirtmp)
+	}()
+
+	var (
+		buf  []byte
+		recs [][]byte
+	)
+	for i := 0; i < stripeSize; i++ {
+		h.series.locks[i].RLock()
+
+		for _, s := range h.series.series[i] {
+			start := len(buf)
+			buf = s.encodeSeries(buf)
+			if len(buf[start:]) == 0 {
+				continue // All contents discarded.
+			}
+			recs = append(recs, buf[start:])
+			// Flush records in 10 MB increments.
+			if len(buf) > 10*1024*1024 {
+				if err := cp.Log(recs...); err != nil {
+					return nil, errors.Wrap(err, "flush records")
+				}
+				buf, recs = buf[:0], recs[:0]
+			}
+		}
+		stats.TotalSeries += len(h.series.series[i])
+
+		h.series.locks[i].RUnlock()
+	}
+
+	// Flush remaining records.
+	if err := cp.Log(recs...); err != nil {
+		return nil, errors.Wrap(err, "flush records")
+	}
+	if err := cp.Close(); err != nil {
+		return nil, errors.Wrap(err, "close chunkpoint")
+	}
+	if err := fileutil.Replace(cpdirtmp, cpdir); err != nil {
+		return nil, errors.Wrap(err, "rename chunkpoint directory")
+	}
+
+	return stats, DeleteChunkpoints(h.wal.Dir(), last)
+}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -187,7 +187,7 @@ func TestHead_WALMultiRef(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, app.Commit())
 
-	testutil.Ok(t, head.Truncate(200))
+	testutil.Ok(t, head.Truncate(200, true))
 
 	app = head.Appender()
 	ref2, err := app.Add(labels.FromStrings("foo", "bar"), 300, 2)
@@ -242,9 +242,9 @@ func TestHead_Truncate(t *testing.T) {
 	s4.chunks = []*memChunk{}
 
 	// Truncation need not be aligned.
-	testutil.Ok(t, h.Truncate(1))
+	testutil.Ok(t, h.Truncate(1, true))
 
-	testutil.Ok(t, h.Truncate(2000))
+	testutil.Ok(t, h.Truncate(2000, true))
 
 	testutil.Equals(t, []*memChunk{
 		{minTime: 2000, maxTime: 2999},
@@ -589,11 +589,11 @@ func TestDeletedSamplesAndSeriesStillInWALAfterCheckpoint(t *testing.T) {
 		testutil.Ok(t, app.Commit())
 	}
 	testutil.Ok(t, hb.Delete(0, int64(numSamples), labels.NewEqualMatcher("a", "b")))
-	testutil.Ok(t, hb.Truncate(1))
+	testutil.Ok(t, hb.Truncate(1, true))
 	testutil.Ok(t, hb.Close())
 
 	// Confirm there's been a checkpoint.
-	cdir, _, err := wal.LastCheckpoint(dir)
+	cdir, _, err := LastChunkpoint(dir)
 	testutil.Ok(t, err)
 	// Read in checkpoint and WAL.
 	recs := readTestWAL(t, cdir)
@@ -925,7 +925,7 @@ func TestGCChunkAccess(t *testing.T) {
 	_, err = cr.Chunk(chunks[1].Ref)
 	testutil.Ok(t, err)
 
-	testutil.Ok(t, h.Truncate(1500)) // Remove a chunk.
+	testutil.Ok(t, h.Truncate(1500, true)) // Remove a chunk.
 
 	_, err = cr.Chunk(chunks[0].Ref)
 	testutil.Equals(t, ErrNotFound, err)
@@ -965,7 +965,7 @@ func TestGCSeriesAccess(t *testing.T) {
 	_, err = cr.Chunk(chunks[1].Ref)
 	testutil.Ok(t, err)
 
-	testutil.Ok(t, h.Truncate(2000)) // Remove the series.
+	testutil.Ok(t, h.Truncate(2000, true)) // Remove the series.
 
 	testutil.Equals(t, (*memSeries)(nil), h.series.getByID(1))
 
@@ -987,7 +987,7 @@ func TestUncommittedSamplesNotLostOnTruncate(t *testing.T) {
 	_, err = app.Add(lset, 2100, 1)
 	testutil.Ok(t, err)
 
-	testutil.Ok(t, h.Truncate(2000))
+	testutil.Ok(t, h.Truncate(2000, true))
 	testutil.Assert(t, nil != h.series.getByHash(lset.Hash(), lset), "series should not have been garbage collected")
 
 	testutil.Ok(t, app.Commit())
@@ -1014,7 +1014,7 @@ func TestRemoveSeriesAfterRollbackAndTruncate(t *testing.T) {
 	_, err = app.Add(lset, 2100, 1)
 	testutil.Ok(t, err)
 
-	testutil.Ok(t, h.Truncate(2000))
+	testutil.Ok(t, h.Truncate(2000, true))
 	testutil.Assert(t, nil != h.series.getByHash(lset.Hash(), lset), "series should not have been garbage collected")
 
 	testutil.Ok(t, app.Rollback())
@@ -1029,7 +1029,7 @@ func TestRemoveSeriesAfterRollbackAndTruncate(t *testing.T) {
 	testutil.Equals(t, false, ss.Next())
 
 	// Truncate again, this time the series should be deleted
-	testutil.Ok(t, h.Truncate(2050))
+	testutil.Ok(t, h.Truncate(2050, true))
 	testutil.Equals(t, (*memSeries)(nil), h.series.getByHash(lset.Hash(), lset))
 }
 
@@ -1198,13 +1198,13 @@ func TestNewWalSegmentOnTruncate(t *testing.T) {
 	testutil.Equals(t, 0, last)
 
 	add(1)
-	testutil.Ok(t, h.Truncate(1))
+	testutil.Ok(t, h.Truncate(1, true))
 	_, last, err = wlog.Segments()
 	testutil.Ok(t, err)
 	testutil.Equals(t, 1, last)
 
 	add(2)
-	testutil.Ok(t, h.Truncate(2))
+	testutil.Ok(t, h.Truncate(2, true))
 	_, last, err = wlog.Segments()
 	testutil.Ok(t, err)
 	testutil.Equals(t, 2, last)


### PR DESCRIPTION
I am currently exploring the idea of having the chunks of series written down into the checkpoint rather than the records and checkpointing regularly (every 10-15m).

This is similar to what I am doing in https://github.com/cortexproject/cortex/pull/1103, and I have seen some good WAL replay times with this and without much increase in avg disk writes.