### PR TITLE
cmd/promtool: add tests to alert unit testing

### DIFF
--- a/cmd/promtool/testdata/alerts.yml
+++ b/cmd/promtool/testdata/alerts.yml
@@ -1,0 +1,23 @@
+groups:
+- name: example
+  rules:
+  - alert: InstanceDown
+    expr: up == 0
+    for: 5m
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.instance }} down"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} in {{ .ExternalLabels.dc }} has been down for more than 5 minutes."
+
+  - alert: AnotherInstanceDown
+    expr: up == 0
+    for: 10m
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.instance }} down"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes."
+
+  - record: job:up:count
+    expr: count by (job) (up)

--- a/cmd/promtool/testdata/duplicate_group_eval_order.yml
+++ b/cmd/promtool/testdata/duplicate_group_eval_order.yml
@@ -1,0 +1,28 @@
+rule_files:
+    - alerts.yml
+
+evaluation_interval: 1m
+
+group_eval_order:
+- example
+- example
+
+tests:
+    - interval: 1m
+      input_series:
+          - series: 'up{job="prometheus", instance="localhost:9090"}'
+            values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+          - series: 'up{job="node_exporter", instance="localhost:9100"}'
+            values: '1+0x6 0 0 0 0 0 0 0 0' # 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
+
+      alert_rule_test:
+          - eval_time: 10m
+            alertname: InstanceDown
+            exp_alerts:
+                - exp_labels:
+                      severity: page
+                      instance: localhost:9090
+                      job: prometheus
+                  exp_annotations:
+                      summary: "Instance localhost:9090 down"
+                      description: "localhost:9090 of job prometheus has been down for more than 5 minutes."

--- a/cmd/promtool/testdata/empty.yml
+++ b/cmd/promtool/testdata/empty.yml
@@ -1,0 +1,1 @@
+# Empty unit test

--- a/cmd/promtool/testdata/empty_alertname.yml
+++ b/cmd/promtool/testdata/empty_alertname.yml
@@ -1,0 +1,14 @@
+rule_files:
+    - alerts.yml
+
+evaluation_interval: 1m
+
+tests:
+    - interval: 1m
+      input_series:
+          - series: 'up{job="prometheus", instance="localhost:9090"}'
+            values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+
+      alert_rule_test:
+          - eval_time: 10m
+            alertname: ""

--- a/cmd/promtool/testdata/failed_alert_test.yml
+++ b/cmd/promtool/testdata/failed_alert_test.yml
@@ -1,0 +1,41 @@
+rule_files:
+    - alerts.yml
+
+evaluation_interval: 1m
+
+tests:
+    - interval: 1m
+      input_series:
+          - series: 'up{job="prometheus", instance="localhost:9090"}'
+            values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+          - series: 'up{job="node_exporter", instance="localhost:9100"}'
+            values: '1+0x6 0 0 0 0 0 0 0 0' # 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
+
+      alert_rule_test:
+          # Alert not firing.
+          - eval_time: 5m
+            alertname: AnotherInstanceDown
+            exp_alerts:
+                - exp_labels:
+                      severity: page
+                      instance: localhost:9090
+                      job: prometheus
+                  exp_annotations:
+                      summary: "Instance localhost:9090 down"
+                      description: "localhost:9090 of job prometheus has been down for more than 5 minutes."
+          # Labels not matching.
+          - eval_time: 5m
+            alertname: InstanceDown
+            exp_alerts:
+                - exp_labels:
+                      instance: localhost:9100
+                      job: prometheus
+                  exp_annotations:
+                      summary: "Instance localhost:9090 down"
+                      description: "localhost:9090 of job prometheus has been down for more than 5 minutes."
+          # Alert not defined.
+          - eval_time: 5m
+            alertname: NotDefined
+            exp_alerts:
+                - exp_labels: {}
+                  exp_annotations: {}

--- a/cmd/promtool/testdata/failed_promql_test.yml
+++ b/cmd/promtool/testdata/failed_promql_test.yml
@@ -1,0 +1,37 @@
+rule_files:
+    - alerts.yml
+
+evaluation_interval: 1m
+
+tests:
+    - interval: 1m
+      input_series:
+          - series: 'go_goroutines{job="prometheus", instance="localhost:9090"}'
+            values: '10+10x2 30+20x5' # 10 20 30 30 50 70 90 110 130
+          - series: 'go_goroutines{job="node_exporter", instance="localhost:9100"}'
+            values: '10+10x7 10+30x4' # 10 20 30 40 50 60 70 80 10 40 70 100 130
+
+      promql_expr_test:
+          # Query returning no data.
+          - expr: go_goroutines >= 50
+            eval_time: 1m
+            exp_samples:
+                - labels: 'go_goroutines{job="prometheus",instance="localhost:9090"}'
+                  value: 50
+                - labels: 'go_goroutines{job="node_exporter",instance="localhost:9100"}'
+                  value: 50
+          # Missing sample.
+          - expr: go_goroutines >= 50
+            eval_time: 4m
+            exp_samples:
+                - labels: 'go_goroutines{job="prometheus",instance="localhost:9090"}'
+                  value: 50
+          # Wrong values.
+          - expr: go_goroutines >= 50
+            eval_time: 5m
+            exp_samples:
+                - labels: 'go_goroutines{job="prometheus",instance="localhost:9090"}'
+                  value: 50
+                - labels: 'go_goroutines{job="node_exporter",instance="localhost:9100"}'
+                  value: 50
+

--- a/cmd/promtool/testdata/good.yml
+++ b/cmd/promtool/testdata/good.yml
@@ -1,0 +1,50 @@
+rule_files:
+- alerts.yml
+
+evaluation_interval: 1m
+
+group_eval_order:
+- example
+
+tests:
+- interval: 1m
+  input_series:
+  - series: 'up{job="prometheus", instance="localhost:9090"}'
+    values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+  - series: 'up{job="node_exporter", instance="localhost:9100"}'
+    values: '1+0x6 0 0 0 0 0 0 0 0' # 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
+  - series: 'go_goroutines{job="prometheus", instance="localhost:9090"}'
+    values: '10+10x2 30+20x5' # 10 20 30 30 50 70 90 110 130
+  - series: 'go_goroutines{job="node_exporter", instance="localhost:9100"}'
+    values: '10+10x7 10+30x4' # 10 20 30 40 50 60 70 80 10 40 70 100 130
+
+  external_labels:
+    dc: dc1
+
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: InstanceDown
+    exp_alerts:
+    - exp_labels:
+        severity: page
+        instance: localhost:9090
+        job: prometheus
+      exp_annotations:
+        summary: "Instance localhost:9090 down"
+        description: "localhost:9090 of job prometheus in dc1 has been down for more than 5 minutes."
+
+  promql_expr_test:
+  - expr: go_goroutines > 5
+    eval_time: 4m
+    exp_samples:
+    - labels: 'go_goroutines{job="prometheus",instance="localhost:9090"}'
+      value: 50
+    - labels: 'go_goroutines{job="node_exporter",instance="localhost:9100"}'
+      value: 50
+  - expr: job:up:count
+    eval_time: 5m
+    exp_samples:
+    - labels: 'job:up:count{job="prometheus"}'
+      value: 1
+    - labels: 'job:up:count{job="node_exporter"}'
+      value: 1

--- a/cmd/promtool/testdata/invalid_alert_expression.yml
+++ b/cmd/promtool/testdata/invalid_alert_expression.yml
@@ -1,0 +1,24 @@
+rule_files:
+- invalid_alerts.yml
+
+evaluation_interval: 1m
+
+tests:
+- interval: 1m
+  input_series:
+  - series: 'up{job="prometheus", instance="localhost:9090"}'
+    values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+  - series: 'up{job="node_exporter", instance="localhost:9100"}'
+    values: '1+0x6 0 0 0 0 0 0 0 0' # 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
+
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: InstanceDown
+    exp_alerts:
+    - exp_labels:
+        severity: page
+        instance: localhost:9090
+        job: prometheus
+      exp_annotations:
+        summary: "Instance localhost:9090 down"
+        description: "localhost:9090 of job prometheus in dc1 has been down for more than 5 minutes."

--- a/cmd/promtool/testdata/invalid_alerts.yml
+++ b/cmd/promtool/testdata/invalid_alerts.yml
@@ -1,0 +1,11 @@
+groups:
+- name: example
+  rules:
+  - alert: InstanceDown
+    expr: up ==
+    for: 5m
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.instance }} down"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} in {{ .ExternalLabels.dc }} has been down for more than 5 minutes."

--- a/cmd/promtool/testdata/invalid_input_series.yml
+++ b/cmd/promtool/testdata/invalid_input_series.yml
@@ -1,0 +1,10 @@
+rule_files:
+    - alerts.yml
+
+evaluation_interval: 1m
+
+tests:
+    - interval: 1m
+      input_series:
+          - series: 'up{job="prometheus", instance="localhost:9090"}'
+            values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 c'

--- a/cmd/promtool/testdata/invalid_promql_expression.yml
+++ b/cmd/promtool/testdata/invalid_promql_expression.yml
@@ -1,0 +1,15 @@
+evaluation_interval: 1m
+
+tests:
+    - interval: 1m
+      input_series:
+          - series: 'go_goroutines{job="prometheus", instance="localhost:9090"}'
+            values: '10+10x2 30+20x5' # 10 20 30 30 50 70 90 110 130
+
+      # Invalid PromQL expression.
+      promql_expr_test:
+          - expr: go_goroutines >
+            eval_time: 4m
+            exp_samples:
+                - labels: 'go_goroutines{job="prometheus",instance="localhost:9090"}'
+                  value: 50

--- a/cmd/promtool/testdata/invalid_sample_labels.yml
+++ b/cmd/promtool/testdata/invalid_sample_labels.yml
@@ -1,0 +1,15 @@
+evaluation_interval: 1m
+
+tests:
+    - interval: 1m
+      input_series:
+          - series: 'go_goroutines{job="node_exporter", instance="localhost:9100"}'
+            values: '10+10x7 10+30x4' # 10 20 30 40 50 60 70 80 10 40 70 100 130
+
+      promql_expr_test:
+          - expr: go_goroutines > 5
+            eval_time: 4m
+            exp_samples:
+                - labels: 'go_goroutines{job="prometheus"'
+                  value: 50
+

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -1,0 +1,136 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestUnmarshalUnitTestFile(t *testing.T) {
+	for _, tc := range []struct {
+		file   string
+		errMsg string
+	}{
+		{
+			file: "testdata/empty.yml",
+		},
+		{
+			file: "testdata/good.yml",
+		},
+		{
+			file:   "testdata/invalid_sample_labels.yml",
+			errMsg: "unexpected end of input inside braces",
+		},
+		{
+			file:   "testdata/empty_alertname.yml",
+			errMsg: "'alertname' can't be empty",
+		},
+		{
+			file:   "testdata/duplicate_group_eval_order.yml",
+			errMsg: "group name repeated",
+		},
+	} {
+		t.Run(tc.file, func(t *testing.T) {
+			b, err := ioutil.ReadFile(tc.file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var tf unitTestFile
+			err = yaml.UnmarshalStrict(b, &tf)
+			if tc.errMsg != "" {
+				if err == nil {
+					t.Fatal("expecting error but got nil")
+				}
+				if !strings.Contains(err.Error(), tc.errMsg) {
+					t.Fatalf("expecting error containing %q but got %v", tc.errMsg, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expecting no error but got %v", err)
+			}
+		})
+	}
+}
+
+func TestRunUnitTestFile(t *testing.T) {
+	for _, tc := range []struct {
+		file    string
+		errMsgs []string
+	}{
+		{
+			file: "testdata/good.yml",
+		},
+		{
+			file: "testdata/invalid_alert_expression.yml",
+			errMsgs: []string{
+				`"InstanceDown": could not parse expression`,
+			},
+		},
+		{
+			file: "testdata/invalid_promql_expression.yml",
+			errMsgs: []string{
+				`expr: "go_goroutines >", time: 4m0s, err: parse error`,
+			},
+		},
+		{
+			file: "testdata/failed_alert_test.yml",
+			errMsgs: []string{
+				`alertname: "AnotherInstanceDown", time: 5m0s`,
+				`alertname: "InstanceDown", time: 5m0s`,
+				`alertname: "NotDefined", time: 5m0s`,
+			},
+		},
+		{
+			file: "testdata/failed_promql_test.yml",
+			errMsgs: []string{
+				`expr: "go_goroutines >= 50", time: 1m0s`,
+				`expr: "go_goroutines >= 50", time: 4m0s`,
+				`expr: "go_goroutines >= 50", time: 5m0s`,
+			},
+		},
+		{
+			file: "testdata/invalid_input_series.yml",
+			errMsgs: []string{
+				"expected number or 'stale'",
+			},
+		},
+	} {
+		t.Run(tc.file, func(t *testing.T) {
+			errs := ruleUnitTest(tc.file)
+			if len(tc.errMsgs) > 0 {
+				if len(errs) != len(tc.errMsgs) {
+					t.Fatalf("expecting %d error(s) but got %d\n%#v", len(tc.errMsgs), len(errs), errs)
+				}
+			OuterLoop:
+				for _, msg := range tc.errMsgs {
+					for _, err := range errs {
+						if strings.Contains(err.Error(), msg) {
+							continue OuterLoop
+						}
+					}
+					t.Fatalf("expecting error containing %q but got\n%#v", msg, errs)
+				}
+				return
+			}
+			if len(errs) > 0 {
+				t.Fatalf("expecting no error but got %d\n%#v", len(errs), errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The change also refactors a bit the code to move some validation and setup logic from the test execution to YAML deserialization.