### PR TITLE
fix bash script shellcheck warnings

### DIFF
--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -5,12 +5,12 @@
 set -e
 set -u
 
-if ! [[ "$0" =~ "scripts/genproto.sh" ]]; then
+if ! [[ "$0" =~ scripts/genproto.sh ]]; then
 	echo "must be run from repository root"
 	exit 255
 fi
 
-if ! [[ $(protoc --version) =~ "3.5.1" ]]; then
+if ! [[ $(protoc --version) =~ 3.5.1 ]]; then
 	echo "could not find protoc 3.5.1, is it installed + in PATH?"
 	exit 255
 fi


### PR DESCRIPTION

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->