### PR TITLE
ui: handle null response properly

### DIFF
--- a/web/ui/static/js/graph/index.js
+++ b/web/ui/static/js/graph/index.js
@@ -271,7 +271,7 @@ Prometheus.Graph.prototype.populateInsertableMetrics = function() {
           return;
         }
 
-        pageConfig.allMetrics = json.data; // todo: do we need self.allMetrics? Or can it just live on the page
+        pageConfig.allMetrics = json.data || []; // todo: do we need self.allMetrics? Or can it just live on the page
         for (var i = 0; i < pageConfig.allMetrics.length; i++) {
           self.insertMetric[0].options.add(new Option(pageConfig.allMetrics[i], pageConfig.allMetrics[i]));
         }


### PR DESCRIPTION
The call of `/api/v1/label/__name__/values` might sometimes return the
following:

```
{"status":"success","data":null}
```

Then the `index.js` file assumes that `data` is not `null`. However,
that assumption fails and then we get this error in the console:

```
graph.js?v=foo:317 Uncaught TypeError: Cannot read property 'length' of null
    at Object.success (graph.js?v=foo:317)
...
```

Then it becomes impossible to, for example, send a simple query like
`time()` and graph the results.

Fix it by using an empty array as the result if it is `null`.

Haven't checked all `LabelValues()` implementations but in theory this is possible. This small patch comes from the Thanos world. Also, the same logic is applied when accessing the local storage to get the history so I don't see why this should not be used here as well.