### PR TITLE
Add DNS (TXT) auto discovery

### DIFF
--- a/discovery/dns/dns_test.go
+++ b/discovery/dns/dns_test.go
@@ -60,6 +60,33 @@ func TestDNS(t *testing.T) {
 			lookup: func(name string, qtype uint16, logger log.Logger) (*dns.Msg, error) {
 				return &dns.Msg{
 						Answer: []dns.RR{
+							&dns.TXT{Txt: []string{"https://my-txt-target.example.com/api"}},
+						},
+					},
+					nil
+			},
+			expected: []*targetgroup.Group{
+				{
+					Source: "web.example.com.",
+					Targets: []model.LabelSet{
+						{
+							"__address__":     "https://my-txt-target.example.com/api",
+							"__meta_dns_name": "web.example.com.",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "TXT record query",
+			config: SDConfig{
+				Names:           []string{"web.example.com."},
+				RefreshInterval: model.Duration(time.Minute),
+				Type:            "TXT",
+			},
+			lookup: func(name string, qtype uint16, logger log.Logger) (*dns.Msg, error) {
+				return &dns.Msg{
+						Answer: []dns.RR{
 							&dns.TXT{Txt: []string{"my-txt-target.example.com"}},
 						},
 					},
@@ -70,10 +97,8 @@ func TestDNS(t *testing.T) {
 					Source: "web.example.com.",
 					Targets: []model.LabelSet{
 						{
-							"__address__":     "",
-							"__param_target":  "my-txt-target.example.com",
+							"__address__":     "my-txt-target.example.com",
 							"__meta_dns_name": "web.example.com.",
-							"instance":        "my-txt-target.example.com",
 						},
 					},
 				},

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -414,10 +414,10 @@ names:
 Where `<domain_name>` is a valid DNS domain name.
 Where `<query_type>` is `SRV`, `TXT`, `A`, or `AAAA`.
 
-If you use `TXT` query type, that will do request by default to /metrics&target=<your_target_result>
-This has been designed to have dns auto discovery feature for blackbox-exporter.
+Using `TXT` query type allow you to specify sub URLs and protocol in target.
+This feature has been designed to allow dns auto discovery for blackbox-exporter.
 
-Below is an example of configuration file to configure blackbox address
+Below is an example with TXT DNS service discovery according to [Blackbox documentation](https://github.com/prometheus/blackbox_exporter#prometheus-configuration)
 
 ```yaml
 scrape_configs:
@@ -432,14 +432,12 @@ scrape_configs:
         type: TXT
         refresh_interval: 10s
     relabel_configs:
-      - source_labels: []
-        regex: .*
-        target_label: __address__
-        replacement: blackbox.example.com:9115
-      - source_labels: []
-        regex: .*
-        target_label: module
-        replacement: http_2xx
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: 127.0.0.1:9115  # The blackbox exporter's real hostname:port.
 ```
 
 ### `<ec2_sd_config>`

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -412,7 +412,35 @@ names:
 ```
 
 Where `<domain_name>` is a valid DNS domain name.
-Where `<query_type>` is `SRV`, `A`, or `AAAA`.
+Where `<query_type>` is `SRV`, `TXT`, `A`, or `AAAA`.
+
+If you use `TXT` query type, that will do request by default to /metrics&target=<your_target_result>
+This has been designed to have dns auto discovery feature for blackbox-exporter.
+
+Below is an example of configuration file to configure blackbox address
+
+```yaml
+scrape_configs:
+  - job_name: 'blackbox'
+    scrape_interval: 5s
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    dns_sd_configs:
+      - names:
+         - your-record.example.com.
+        type: TXT
+        refresh_interval: 10s
+    relabel_configs:
+      - source_labels: []
+        regex: .*
+        target_label: __address__
+        replacement: blackbox.example.com:9115
+      - source_labels: []
+        regex: .*
+        target_label: module
+        replacement: http_2xx
+```
 
 ### `<ec2_sd_config>`
 


### PR DESCRIPTION
Hello,

Today, Prometheus has DNS auto discovery feature with A, AAAA and SRV record. These kind of record works well to discover layer4 and layer5 services/equipments, based on IPs or FQDN. (i.e. test.com)

The "problem" is, we can't do DNS auto discovery with protocol or sub path URL, like blackbox do to probe for example HTTP services with path.

So that's impossible to auto discover targets like http://test.com/api/v2 with DNS Service Discovery, which can be usefull for blackbox for example. (layer 7 services)
`GET 127.0.0.1:9115/probe?target=http://test.com/api/v2&module=http`

Having sub URLs and protocol is possible by using TXT records.

So I just added the TXT record to retrieve text from dns and be able to use it as target parameter with relabel_configs.

I have done the feature this way, but we are open to discuss about the changes I proposed if necessary.

