### PR TITLE
add: check for rule files existence

### DIFF
--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -145,6 +145,9 @@ func resolveAndGlobFilepaths(baseDir string, utf *unitTestFile) error {
 		if err != nil {
 			return err
 		}
+		if len(m) <= 0 {
+			fmt.Fprintln(os.Stderr, "  WARNING: no file match pattern", rf)
+		}
 		globbedFiles = append(globbedFiles, m...)
 	}
 	utf.RuleFiles = globbedFiles


### PR DESCRIPTION
Promtool outputs _got:nil_ when rule files are typed wrong or rules file does not exist. This is misleading as the message does not point developers to the issue. This commit aims to inform developers using promtool when rules files doesn’t matched any file.

Closes https://github.com/prometheus/prometheus/pull/6182