### PR TITLE
Replaced t.Fatalf() with testutil.Assert() in buffer_test.go

### DIFF
--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -77,8 +77,12 @@ func TestSampleRing(t *testing.T) {
 						break
 					}
 				}
-				testutil.Assert(t, sold.t < s.t-c.delta || found, "%d: expected sample %d to be in buffer but was not; buffer %v", i, sold.t, buffered)
-				testutil.Assert(t, sold.t >= s.t-c.delta || !found, "%d: unexpected sample %d in buffer; buffer %v", i, sold.t, buffered)
+
+				if found {
+					testutil.Assert(t, sold.t >= s.t-c.delta, "%d: unexpected sample %d in buffer; buffer %v", i, sold.t, buffered)
+				} else {
+					testutil.Assert(t, sold.t < s.t-c.delta, "%d: expected sample %d to be in buffer but was not; buffer %v", i, sold.t, buffered)
+				}
 			}
 		}
 	}

--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -78,10 +78,10 @@ func TestSampleRing(t *testing.T) {
 					}
 				}
 				if sold.t >= s.t-c.delta && !found {
-					t.Fatalf("%d: expected sample %d to be in buffer but was not; buffer %v", i, sold.t, buffered)
+					testutil.Fatal(t, "%d: expected sample %d to be in buffer but was not; buffer %v", i, sold.t, buffered)
 				}
 				if sold.t < s.t-c.delta && found {
-					t.Fatalf("%d: unexpected sample %d in buffer; buffer %v", i, sold.t, buffered)
+					testutil.Fatal(t, "%d: unexpected sample %d in buffer; buffer %v", i, sold.t, buffered)
 				}
 			}
 		}

--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -77,12 +77,8 @@ func TestSampleRing(t *testing.T) {
 						break
 					}
 				}
-				if sold.t >= s.t-c.delta && !found {
-					testutil.Fatal(t, "%d: expected sample %d to be in buffer but was not; buffer %v", i, sold.t, buffered)
-				}
-				if sold.t < s.t-c.delta && found {
-					testutil.Fatal(t, "%d: unexpected sample %d in buffer; buffer %v", i, sold.t, buffered)
-				}
+				testutil.Assert(t, sold.t < s.t-c.delta || found, "%d: expected sample %d to be in buffer but was not; buffer %v", i, sold.t, buffered)
+				testutil.Assert(t, sold.t >= s.t-c.delta || !found, "%d: unexpected sample %d in buffer; buffer %v", i, sold.t, buffered)
 			}
 		}
 	}

--- a/util/testutil/testing.go
+++ b/util/testutil/testing.go
@@ -71,7 +71,7 @@ func Equals(tb TB, exp, act interface{}, msgAndArgs ...interface{}) {
 	}
 }
 
-// Fatal fails the test immediately
+// Fatal fails the test immediately.
 func Fatal(tb TB, msgAndArgs ...interface{}) {
 	tb.Helper()
 	tb.Fatalf("\033[31m%s\033[39m\n", formatMessage(msgAndArgs))

--- a/util/testutil/testing.go
+++ b/util/testutil/testing.go
@@ -71,6 +71,12 @@ func Equals(tb TB, exp, act interface{}, msgAndArgs ...interface{}) {
 	}
 }
 
+// Fatal fails the test immediately
+func Fatal(tb TB, msgAndArgs ...interface{}) {
+	tb.Helper()
+	tb.Fatalf("\033[31m%s\033[39m\n", formatMessage(msgAndArgs))
+}
+
 func formatMessage(msgAndArgs []interface{}) string {
 	if len(msgAndArgs) == 0 {
 		return ""

--- a/util/testutil/testing.go
+++ b/util/testutil/testing.go
@@ -71,12 +71,6 @@ func Equals(tb TB, exp, act interface{}, msgAndArgs ...interface{}) {
 	}
 }
 
-// Fatal fails the test immediately.
-func Fatal(tb TB, msgAndArgs ...interface{}) {
-	tb.Helper()
-	tb.Fatalf("\033[31m%s\033[39m\n", formatMessage(msgAndArgs))
-}
-
 func formatMessage(msgAndArgs []interface{}) string {
 	if len(msgAndArgs) == 0 {
 		return ""


### PR DESCRIPTION
- Replaced t.Fataf() calls with testutil.Assert()'s
- Work toward finishing https://github.com/prometheus/prometheus/issues/3242