### PR TITLE
Include tsdb tool in builds

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -10,6 +10,8 @@ build:
           path: ./cmd/prometheus
         - name: promtool
           path: ./cmd/promtool
+        - name: tsdb
+          path: ./tsdb/cmd/tsdb
     flags: -mod=vendor -a -tags netgo
     ldflags: |
         -X github.com/prometheus/common/version.Version={{.Version}}


### PR DESCRIPTION
Add the tsdb tool to promu so that it's included in the release
tarballs.

Fixes: https://github.com/prometheus/prometheus/issues/5870

Signed-off-by: Ben Kochie <superq@gmail.com>