### PR TITLE
Allocate the shards only once while reading WAL

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -368,6 +368,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64) (err error) {
 		samples   []record.RefSample
 		tstones   []tombstones.Stone
 		allStones = tombstones.NewMemTombstones()
+		shards    = make([][]record.RefSample, n)
 	)
 	defer func() {
 		if err := allStones.Close(); err != nil {
@@ -421,7 +422,6 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64) (err error) {
 				if len(samples) < m {
 					m = len(samples)
 				}
-				shards := make([][]record.RefSample, n)
 				for i := 0; i < n; i++ {
 					var buf []record.RefSample
 					select {


### PR DESCRIPTION
The first level of the 2D slice need not be allocated multiple times as only the 2nd level slice is moved around.
Benchmark (the `ns/op` and `B/op` seem to jump quite a bit with repeated tests):
```
benchmark                                                                    old ns/op      new ns/op      delta
BenchmarkLoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=100000-8     6590119060     6156305331     -6.58%
BenchmarkLoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=100-8      1245573574     1315054689     +5.58%
BenchmarkLoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=10000-8     6200068172     5907548411     -4.72%

benchmark                                                                    old allocs     new allocs     delta
BenchmarkLoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=100000-8     7079462        6079513        -14.12%
BenchmarkLoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=100-8      2466872        2464654        -0.09%
BenchmarkLoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=10000-8     6429524        6329664        -1.55%

benchmark                                                                    old bytes     new bytes     delta
BenchmarkLoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=100000-8     830975392     638984648     -23.10%
BenchmarkLoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=100-8      360086352     350880864     -2.56%
BenchmarkLoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=10000-8     798231440     779473256     -2.35%
```

As expected the savings are when there are more records with samples.