### PR TITLE
Replaced test validations with testutils on storage/remote/codec_test.go

### DIFF
--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -113,8 +113,10 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			err := validateLabelsAndMetricName(test.input)
-			if test.expectedErr != "" || err != nil {
+			if test.expectedErr != "" {
 				testutil.NotOk(t, err)
+			}
+			if err != nil {
 				testutil.Equals(t, test.expectedErr, err.Error())
 			}
 		})

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -115,9 +115,9 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 			err := validateLabelsAndMetricName(test.input)
 			if test.expectedErr != "" {
 				testutil.NotOk(t, err)
-			}
-			if err != nil {
 				testutil.Equals(t, test.expectedErr, err.Error())
+			} else {
+				testutil.Ok(t, err)
 			}
 		})
 	}

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -146,11 +146,11 @@ func TestConcreteSeriesSet(t *testing.T) {
 	c := &concreteSeriesSet{
 		series: []storage.Series{series1, series2},
 	}
-	testutil.Assert(t,c.Next(),"Expected Next() to be true.")
+	testutil.Assert(t, c.Next(), "Expected Next() to be true.")
 	testutil.Equals(t, series1, c.At(), "Unexpected series returned.")
-	testutil.Assert(t,c.Next(),"Expected Next() to be true.")
+	testutil.Assert(t, c.Next(), "Expected Next() to be true.")
 	testutil.Equals(t, series2, c.At(), "Unexpected series returned.")
-	testutil.Assert(t,!c.Next(),"Expected Next() to be false.")
+	testutil.Assert(t, !c.Next(), "Expected Next() to be false.")
 }
 
 func TestConcreteSeriesClonesLabels(t *testing.T) {

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -27,7 +27,6 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 	tests := []struct {
 		input       labels.Labels
 		expectedErr string
-		shouldPass  bool
 		description string
 	}{
 		{
@@ -36,7 +35,6 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"labelName", "labelValue",
 			),
 			expectedErr: "",
-			shouldPass:  true,
 			description: "regular labels",
 		},
 		{
@@ -45,7 +43,6 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"_labelName", "labelValue",
 			),
 			expectedErr: "",
-			shouldPass:  true,
 			description: "label name with _",
 		},
 		{
@@ -54,7 +51,6 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"@labelName", "labelValue",
 			),
 			expectedErr: "invalid label name: @labelName",
-			shouldPass:  false,
 			description: "label name with @",
 		},
 		{
@@ -63,7 +59,6 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"123labelName", "labelValue",
 			),
 			expectedErr: "invalid label name: 123labelName",
-			shouldPass:  false,
 			description: "label name starts with numbers",
 		},
 		{
@@ -72,7 +67,6 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"", "labelValue",
 			),
 			expectedErr: "invalid label name: ",
-			shouldPass:  false,
 			description: "label name is empty string",
 		},
 		{
@@ -81,7 +75,6 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"labelName", string([]byte{0xff}),
 			),
 			expectedErr: "invalid label value: " + string([]byte{0xff}),
-			shouldPass:  false,
 			description: "label value is an invalid UTF-8 value",
 		},
 		{
@@ -89,7 +82,6 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"__name__", "@invalid_name",
 			),
 			expectedErr: "invalid metric name: @invalid_name",
-			shouldPass:  false,
 			description: "metric name starts with @",
 		},
 		{
@@ -98,7 +90,6 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"__name__", "name2",
 			),
 			expectedErr: "duplicate label with name: __name__",
-			shouldPass:  false,
 			description: "duplicate label names",
 		},
 		{
@@ -107,7 +98,6 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"label2", "name",
 			),
 			expectedErr: "",
-			shouldPass:  true,
 			description: "duplicate label values",
 		},
 		{
@@ -116,7 +106,6 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 				"label2", "name",
 			),
 			expectedErr: "invalid label name: ",
-			shouldPass:  false,
 			description: "don't report as duplicate label name",
 		},
 	}
@@ -124,10 +113,8 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			err := validateLabelsAndMetricName(test.input)
-			if err == nil {
-				testutil.Assert(t, test.shouldPass, "Test should fail, but passed instead.")
-			} else {
-				testutil.Assert(t, !test.shouldPass, "Test should pass, got unexpected error: %v", err)
+			if test.expectedErr != "" || err != nil {
+				testutil.NotOk(t, err)
 				testutil.Equals(t, test.expectedErr, err.Error())
 			}
 		})

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -125,15 +125,10 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			err := validateLabelsAndMetricName(test.input)
 			if err == nil {
-				if !test.shouldPass {
-					t.Fatalf("Test should fail, but passed instead.")
-				}
+				testutil.Assert(t, test.shouldPass, "Test should fail, but passed instead.")
 			} else {
-				if test.shouldPass {
-					t.Fatalf("Test should pass, got unexpected error: %v", err)
-				} else if err.Error() != test.expectedErr {
-					t.Fatalf("Test should fail with: %s got unexpected error instead: %v", test.expectedErr, err)
-				}
+				testutil.Assert(t, !test.shouldPass, "Test should pass, got unexpected error: %v", err)
+				testutil.Equals(t, test.expectedErr, err.Error())
 			}
 		})
 	}
@@ -151,21 +146,11 @@ func TestConcreteSeriesSet(t *testing.T) {
 	c := &concreteSeriesSet{
 		series: []storage.Series{series1, series2},
 	}
-	if !c.Next() {
-		t.Fatalf("Expected Next() to be true.")
-	}
-	if c.At() != series1 {
-		t.Fatalf("Unexpected series returned.")
-	}
-	if !c.Next() {
-		t.Fatalf("Expected Next() to be true.")
-	}
-	if c.At() != series2 {
-		t.Fatalf("Unexpected series returned.")
-	}
-	if c.Next() {
-		t.Fatalf("Expected Next() to be false.")
-	}
+	testutil.Assert(t,c.Next(),"Expected Next() to be true.")
+	testutil.Equals(t, series1, c.At(), "Unexpected series returned.")
+	testutil.Assert(t,c.Next(),"Expected Next() to be true.")
+	testutil.Equals(t, series2, c.At(), "Unexpected series returned.")
+	testutil.Assert(t,!c.Next(),"Expected Next() to be false.")
 }
 
 func TestConcreteSeriesClonesLabels(t *testing.T) {


### PR DESCRIPTION
- [x] storage/remote/codec_test.go

https://github.com/prometheus/prometheus/issues/3242#issuecomment-422754266
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->