### PR TITLE
fix: README Makefile target: build binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You can also clone the repository yourself and build using `make`:
 
 The Makefile provides several targets:
 
-  * *build*: build the `prometheus` and `promtool` binaries
+  * *build*: build the `prometheus`, `promtool` and `tsdb` binaries
   * *test*: run the tests
   * *test-short*: run the short tests
   * *format*: format the source code


### PR DESCRIPTION
According to https://github.com/prometheus/prometheus/pull/6089

Obvious fix.
Signed-off-by: Georgy hypno.cat40000@gmail.com

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->