### PR TITLE
Refactor calculateDesiredShards + don't reshard if we're having issues sending samples.

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -533,10 +533,10 @@ func (t *QueueManager) calculateDesiredShards() int {
 
 	// We shouldn't reshard if Prometheus hasn't been able to send to the
 	// remote endpoint successfully within some period of time.
-	lts := atomic.LoadInt64(&t.lastSendTimestamp)
-	skip := (time.Now().Unix() - lts) > int64(2*time.Duration(t.cfg.BatchSendDeadline)/time.Second)
-	if skip {
-		level.Warn(t.logger).Log("msg", "Skipping resharding, last successful send was beyond threshold")
+	minSendTimestamp := time.Now().Add(-2 * time.Duration(t.cfg.BatchSendDeadline)).Unix()
+	lsts := atomic.LoadInt64(&t.lastSendTimestamp)
+	if lsts < minSendTimestamp {
+		level.Warn(t.logger).Log("msg", "Skipping resharding, last successful send was beyond threshold", "lastSendTimestamp", lsts, "minSendTimestamp", minSendTimestamp)
 		return t.numShards
 	}
 

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -281,6 +281,49 @@ func TestReleaseNoninternedString(t *testing.T) {
 	testutil.Assert(t, metric == 0, "expected there to be no calls to release for strings that were not already interned: %d", int(metric))
 }
 
+func TestCalculateDesiredsShards(t *testing.T) {
+	type testcase struct {
+		startingShards int
+		reshard        bool
+	}
+	cases := []testcase{
+		{
+			// Test that ensures that if we haven't successfully sent a
+			// sample recently the queue will not reshard.
+			startingShards: 10,
+			reshard:        false,
+		},
+		{
+			startingShards: 5,
+			reshard:        true,
+		},
+	}
+	for _, c := range cases {
+		client := NewTestStorageClient()
+		m := NewQueueManager(nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), config.DefaultQueueConfig, nil, nil, client, defaultFlushDeadline)
+		m.numShards = c.startingShards
+		// Fake the samples in/out rates and the last sent timestamp so the reshard calculation has some numbers to use.
+		m.samplesIn.incr(1000)
+		m.samplesOut.incr(10)
+		m.lastSendTimestamp = time.Now().Unix()
+
+		// Resharding shouldn't take place if the last successful send was > batch send deadline*2 seconds ago.
+		if !c.reshard {
+			m.lastSendTimestamp = m.lastSendTimestamp - int64(3*time.Duration(config.DefaultQueueConfig.BatchSendDeadline)/time.Second)
+		}
+		m.Start()
+		desiredShards := m.calculateDesiredShards()
+		m.Stop()
+		if !c.reshard {
+			testutil.Assert(t, desiredShards == m.numShards, "expected calculateDesiredShards to not want to reshard, wants to change from %d to %d shards", m.numShards, desiredShards)
+		} else {
+			testutil.Assert(t, desiredShards != m.numShards, "expected calculateDesiredShards to want to reshard, wants to change from %d to %d shards", m.numShards, desiredShards)
+
+		}
+	}
+
+}
+
 func createTimeseries(n int) ([]record.RefSample, []record.RefSeries) {
 	samples := make([]record.RefSample, 0, n)
 	series := make([]record.RefSeries, 0, n)


### PR DESCRIPTION
This refactors calculateDesiredShards to return an int instead of sending on the `reshardChan` itself. It also re-introduces logic to skip resharding if we haven't successfully sent samples in `2*cfg.BatchSendDeadline`, which I believe was mistakenly removed in this commit: https://github.com/prometheus/prometheus/commit/67da8e7b460ffaba049334961b09569866c3e02e#diff-b3f7e4329d3b8d9712dd10086f0c27d9L414-L419 as part of refactoring metrics in remote write.

I'll think about any possible addition of tests overnight and add them in the morning.

@csmarchbanks I think the later might have been part of the issue in #6095 

Signed-off-by: Callum Styan <callumstyan@gmail.com>

cc @tomwilkie 