### PR TITLE
Make sure the remote write storage uses a dedupe logger.

### DIFF
--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -52,8 +52,8 @@ func NewStorage(l log.Logger, reg prometheus.Registerer, stCallback startTimeCal
 	s := &Storage{
 		logger:                 logging.Dedupe(l, 1*time.Minute),
 		localStartTimeCallback: stCallback,
-		rws:                    NewWriteStorage(l, walDir, flushDeadline),
 	}
+	s.rws = NewWriteStorage(s.logger, walDir, flushDeadline)
 	return s
 }
 


### PR DESCRIPTION
I think the remote storage changes here: https://github.com/prometheus/prometheus/commit/a38a54fa117442c8d8c80020421941bf5c4145be unintentionally removed the dedupe wrapper from the remote write logger.

@csmarchbanks 

Signed-off-by: Callum Styan <callumstyan@gmail.com>