### PR TITLE
[ENHANCEMENT] service discovery: Fewer configuration hash shard service discovery

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -443,6 +443,9 @@ func main() {
 				}
 				c[fmt.Sprintf("%x", md5.Sum(b))] = v.ServiceDiscoveryConfig
 			}
+
+			discoveryManagerScrape.Shards = cfg.GlobalConfig.Shards
+			discoveryManagerScrape.ShardIndex = cfg.GlobalConfig.ShardIndex
 			return discoveryManagerNotify.ApplyConfig(c)
 		},
 		func(cfg *config.Config) error {
@@ -551,7 +554,6 @@ func main() {
 				// It depends on the config being in sync with the discovery manager so
 				// we wait until the config is fully loaded.
 				<-reloadReady.C
-
 				err := scrapeManager.Run(discoveryManagerScrape.SyncCh())
 				level.Info(logger).Log("msg", "Scrape manager stopped")
 				return err

--- a/config/config.go
+++ b/config/config.go
@@ -289,6 +289,9 @@ type GlobalConfig struct {
 	EvaluationInterval model.Duration `yaml:"evaluation_interval,omitempty"`
 	// The labels to add to any timeseries that this Prometheus instance scrapes.
 	ExternalLabels labels.Labels `yaml:"external_labels,omitempty"`
+	//for shard scrape
+	Shards     uint64 `yaml:"shards,omitempty"`
+	ShardIndex uint64 `yaml:"shard_index,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -17,8 +17,6 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/pkg/relabel"
 	"reflect"
 	"sync"
 	"time"
@@ -26,6 +24,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 
 	sd_config "github.com/prometheus/prometheus/discovery/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -41,6 +40,7 @@ import (
 	"github.com/prometheus/prometheus/discovery/openstack"
 	"github.com/prometheus/prometheus/discovery/triton"
 	"github.com/prometheus/prometheus/discovery/zookeeper"
+	"github.com/prometheus/prometheus/pkg/relabel"
 )
 
 var (

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
-	"github.com/prometheus/prometheus/pkg/relabel"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -33,6 +32,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	sd_config "github.com/prometheus/prometheus/discovery/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"gopkg.in/yaml.v2"
 )
 

--- a/documentation/examples/prometheusShards.yml
+++ b/documentation/examples/prometheusShards.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+  shards: 2 # shard scrape = 2
+  shard_index: 0 # 0 or 1 <shards=2 . shard index =1 . mod = hash % shards
+scrape_configs:
+  - job_name: 'prometheusShards'
+    static_configs:
+    - targets: ['localhost:9090']

--- a/pkg/relabel/relabel.go
+++ b/pkg/relabel/relabel.go
@@ -226,7 +226,7 @@ func relabel(lset labels.Labels, cfg *Config) labels.Labels {
 		}
 		lb.Set(string(target), string(res))
 	case HashMod:
-		mod := sum64(md5.Sum([]byte(val))) % cfg.Modulus
+		mod := Sum64(md5.Sum([]byte(val))) % cfg.Modulus
 		lb.Set(cfg.TargetLabel, fmt.Sprintf("%d", mod))
 	case LabelMap:
 		for _, l := range lset {
@@ -255,7 +255,7 @@ func relabel(lset labels.Labels, cfg *Config) labels.Labels {
 }
 
 // sum64 sums the md5 hash to an uint64.
-func sum64(hash [md5.Size]byte) uint64 {
+func Sum64(hash [md5.Size]byte) uint64 {
 	var s uint64
 
 	for i, b := range hash {


### PR DESCRIPTION
##background：
   When we have 50 jobs, when using relabel+hashmod to do hash scrape, the prometheus.yaml configuration file becomes basically unmaintainable. So we want hash scrape to be simpler and less likely to make mistakes.

##solution：
old config：https://www.robustperception.io/scaling-and-federating-prometheus
![image](https://user-images.githubusercontent.com/9583245/66632623-7e6fea00-ec3b-11e9-9010-bffcec9792ac.png)
new config：
![image](https://user-images.githubusercontent.com/9583245/66632717-a95a3e00-ec3b-11e9-8cea-7c51c5f80ddf.png)

##detail
Relabel is a very powerful ETL feature, but when used as a hash scrape, it is difficult to operate, easy to make mistakes, and configured too long.

Our users need to understand the full lifecycle of a label (service discovery -> relabel -> scrape -> metric relabel. At the same time, scrape uses the label __addreass__ to fetch data, so there must be this label). Understand the configuration behind this relabel+hashmod configuration. And most of our customer scenarios can be done without relabel. So most of our users don't understand the configuration of hash scrape.
