### PR TITLE
testutil: Fail tests in ErrorEqual

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -755,9 +755,8 @@ func TestRecoverEvaluatorRuntime(t *testing.T) {
 	//nolint:govet
 	a[123] = 1
 
-	if err.Error() != "unexpected error" {
-		t.Fatalf("wrong error message: %q, expected %q", err, "unexpected error")
-	}
+	unexpectedErr := errors.New("unexpected error")
+	testutil.ErrorsEqual(t, unexpectedErr, err)
 }
 
 func TestRecoverEvaluatorError(t *testing.T) {
@@ -767,9 +766,7 @@ func TestRecoverEvaluatorError(t *testing.T) {
 	e := errors.New("custom error")
 
 	defer func() {
-		if err.Error() != e.Error() {
-			t.Fatalf("wrong error message: %q, expected %q", err, e)
-		}
+		testutil.ErrorsEqual(t, e, err)
 	}()
 	defer ev.recover(&err)
 

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -215,7 +215,7 @@ func TestPopulateLabels(t *testing.T) {
 		in := c.in.Copy()
 
 		res, orig, err := populateLabels(c.in, c.cfg)
-		testutil.ErrorEqual(err, c.err)
+		testutil.ErrorsEqual(t, c.err, err)
 		testutil.Equals(t, c.in, in)
 		testutil.Equals(t, c.res, res)
 		testutil.Equals(t, c.resOrig, orig)

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -54,7 +54,7 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
+	for _, test := range tests {
 		server := httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, longErrMessage, test.code)
@@ -75,9 +75,7 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 		}
 
 		err = c.Store(context.Background(), []byte{})
-		if !testutil.ErrorEqual(err, test.err) {
-			t.Errorf("%d. Unexpected error; want %v, got %v", i, test.err, err)
-		}
+		testutil.ErrorsEqual(t, test.err, err)
 
 		server.Close()
 	}

--- a/util/testutil/error.go
+++ b/util/testutil/error.go
@@ -13,15 +13,11 @@
 
 package testutil
 
-// ErrorEqual compares Go errors for equality.
-func ErrorEqual(left, right error) bool {
-	if left == right {
-		return true
+// ErrorsEqual fails when Go errors are not equal.
+func ErrorsEqual(tb TB, exp, act error) {
+	if exp != nil && act != nil {
+		if exp.Error() != act.Error() {
+			tb.Fatalf("\033[31munexp error; want %v, got %v\033[39m\n", exp, act)
+		}
 	}
-
-	if left != nil && right != nil {
-		return left.Error() == right.Error()
-	}
-
-	return false
 }

--- a/util/testutil/error.go
+++ b/util/testutil/error.go
@@ -15,9 +15,17 @@ package testutil
 
 // ErrorsEqual fails when Go errors are not equal.
 func ErrorsEqual(tb TB, exp, act error) {
+	if exp == act {
+		return
+	}
+
 	if exp != nil && act != nil {
 		if exp.Error() != act.Error() {
-			tb.Fatalf("\033[31munexp error; want %v, got %v\033[39m\n", exp, act)
+			tb.Fatalf("\033[31munexpected error; want %v, got %v\033[39m\n", exp, act)
 		}
+		return
 	}
+
+	// One of errors is nil
+	tb.Fatalf("\033[31munexpected error; want %v, got %v\033[39m\n", exp, act)
 }


### PR DESCRIPTION
ErrorEqual is renamed to ErrorsEqual and converted to fail tests just
like other functions in testuil package (e.g. `Ok` and `Assert`). This
allow to simplify test code and also fixes vain check in
scrape/manager_test.go.

Signed-off-by: Alex Dzyoba <alex@dzyoba.com>