### PR TITLE
Added GitHub actions workflow for prombench.

### DIFF
--- a/.github/workflows/prombench.yml
+++ b/.github/workflows/prombench.yml
@@ -1,0 +1,205 @@
+on: issue_comment
+name: Prombench Workflow
+jobs:
+  # We need a `pre_benchmark_*` job because if conditionals are not yet supported for steps, see:
+  # https://github.community/t5/GitHub-Actions/Github-Actions-Contexts-and-steps-if-conditionals-are-unusable/m-p/29669/highlight/true#M8294
+  #############################
+  # Jobs for starting benchmark
+  #############################
+  pre_benchmark_start:
+    name: Pre Benchmark Start
+    runs-on: ubuntu-latest
+    steps:
+    - name: Validate comment
+      id: validate_comment
+      uses: docker://prombench/comment-monitor:0.0.1
+      env:
+        COMMENT_TEMPLATE: |
+          ⏱️ Welcome to Prometheus Benchmarking Tool. ⏱️
+
+          **Compared versions:** [**`PR-{{ index . "PR_NUMBER" }}`**](http://{{ index . "DOMAIN_NAME" }}/{{ index . "PR_NUMBER" }}/prometheus-pr) and [**`{{ index . "RELEASE" }}`**](http://{{ index . "DOMAIN_NAME" }}/{{ index . "PR_NUMBER" }}/prometheus-release)
+
+          **GitHub Actions logs:**  [{{ index . "GITHUB_SHA" }}/checks](https://github.com/{{ index . "GITHUB_REPOSITORY" }}/commit/{{ index . "GITHUB_SHA" }}/checks)
+
+          After successful deployment, the benchmarking metrics can be viewed at:
+
+          - [Prometheus Meta](http://{{ index . "DOMAIN_NAME" }}/prometheus-meta/graph?g0.expr={namespace%3D"prombench-{{ index . "PR_NUMBER" }}"}&g0.tab=1)
+          - [Grafana Home](http://{{ index . "DOMAIN_NAME" }}/grafana)
+          - [Grafana Exlorer, Loki logs](http://{{ index . "DOMAIN_NAME" }}/grafana/explore)
+
+          **Other Commands:**
+          To stop benchmark: `/prombench cancel`
+          To restart benchmark: `/prombench restart v2.12.0`
+        LABEL_NAME: prombench
+        DOMAIN_NAME: prombench.prometheus.io
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: >-
+          "(?mi)^/prombench\s*(?P<RELEASE>master|v[0-9]+\.[0-9]+\.[0-9]+\S*)\s*$"
+  benchmark_start:
+    name: Benchmark Start
+    needs: pre_benchmark_start
+    runs-on: ubuntu-latest
+    steps:
+    - name: Extract arguments
+      id: extract_arguments
+      uses: docker://prombench/comment-monitor:0.0.1
+      with:
+        args: >-
+          "(?mi)^/prombench\s*(?P<RELEASE>master|v[0-9]+\.[0-9]+\.[0-9]+\S*)\s*$"
+    - name: Run make deploy to start test
+      id: make_deploy
+      uses: docker://prombench/prombench:2.0.2
+      env:
+        AUTH_FILE: ${{ secrets.AUTH_FILE }}
+        PROJECT_ID: macro-mile-203600
+        CLUSTER_NAME: prombench
+        ZONE: us-central1-a
+        DOMAIN_NAME: prombench.prometheus.io
+        TEST_INFRA_REPO: https://github.com/prometheus/prombench.git
+        GITHUB_ORG: prometheus
+        GITHUB_REPO: prometheus
+      with:
+        args: >-
+          export RELEASE=$(cat /github/home/commentMonitor/RELEASE);
+          export PR_NUMBER=$(cat /github/home/commentMonitor/PR_NUMBER);
+          until make all_nodepools_deleted; do echo "waiting for nodepools to be deleted"; sleep 10; done;
+          make deploy;
+    - name: Post comment if make deploy failed
+      id: fail_notification
+      if: failure()
+      uses: docker://prombench/comment-monitor:0.0.1
+      env:
+        COMMENT_TEMPLATE: |
+          Prombench test **start** failed. Please see logs for more info.
+
+          **GitHub Actions logs:**  [{{ index . "GITHUB_SHA" }}/checks](https://github.com/{{ index . "GITHUB_REPOSITORY" }}/commit/{{ index . "GITHUB_SHA" }}/checks)
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #############################
+  # Jobs for stopping benchmark  
+  #############################
+  pre_benchmark_cancel:
+    name: Pre Benchmark Cancel
+    runs-on: ubuntu-latest
+    steps:
+    - name: Validate comment
+      id: validate_comment
+      uses: docker://prombench/comment-monitor:0.0.1
+      env:
+        COMMENT_TEMPLATE: |
+          Benchmark cancel is in progress.
+
+          **GitHub Actions logs:**  [{{ index . "GITHUB_SHA" }}/checks](https://github.com/{{ index . "GITHUB_REPOSITORY" }}/commit/{{ index . "GITHUB_SHA" }}/checks)
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: >-
+          "(?mi)^/prombench\s+cancel\s*$"
+  benchmark_cancel:
+    name: Benchmark Cancel
+    needs: pre_benchmark_cancel
+    runs-on: ubuntu-latest
+    steps:
+    - name: Extract arguments
+      id: extract_arguments
+      uses: docker://prombench/comment-monitor:0.0.1
+      with:
+        args: >-
+          "(?mi)^/prombench\s+cancel\s*$"
+    - name: Run make clean to stop test
+      id: make_clean
+      uses: docker://prombench/prombench:2.0.2
+      env:
+        AUTH_FILE: ${{ secrets.AUTH_FILE }}
+        PROJECT_ID: macro-mile-203600
+        CLUSTER_NAME: prombench
+        ZONE: us-central1-a
+        TEST_INFRA_REPO: https://github.com/prometheus/prombench.git
+      with:
+        args: >-
+          export PR_NUMBER=$(cat /github/home/commentMonitor/PR_NUMBER);
+          until make all_nodepools_running; do echo "waiting for nodepools to be created"; sleep 10; done;
+          make clean;
+    - name: Post comment if make clean failed
+      id: fail_notification
+      if: failure()
+      uses: docker://prombench/comment-monitor:0.0.1
+      env:
+        COMMENT_TEMPLATE: |
+          Prombench test **cancel** failed. Please see logs for more info."
+
+          **GitHub Actions logs:**  [{{ index . "GITHUB_SHA" }}/checks](https://github.com/{{ index . "GITHUB_REPOSITORY" }}/commit/{{ index . "GITHUB_SHA" }}/checks)
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  ###############################
+  # Jobs for restarting benchmark  
+  ###############################
+  pre_benchmark_restart:
+    name: Pre Benchmark Restart
+    runs-on: ubuntu-latest
+    steps:
+    - name: Validate comment
+      id: validate_comment
+      uses: docker://prombench/comment-monitor:0.0.1
+      env:
+        COMMENT_TEMPLATE: |
+          ⏱️ Welcome to Prometheus Benchmarking Tool. ⏱️
+
+          **Compared versions:** [**`PR-{{ index . "PR_NUMBER" }}`**](http://{{ index . "DOMAIN_NAME" }}/{{ index . "PR_NUMBER" }}/prometheus-pr) and [**`{{ index . "RELEASE" }}`**](http://{{ index . "DOMAIN_NAME" }}/{{ index . "PR_NUMBER" }}/prometheus-release)
+
+          **GitHub Actions logs:**  [{{ index . "GITHUB_SHA" }}/checks](https://github.com/{{ index . "GITHUB_REPOSITORY" }}/commit/{{ index . "GITHUB_SHA" }}/checks)'
+
+          After successful deployment, the benchmarking metrics can be viewed at:
+
+          - [Prometheus Meta](http://{{ index . "DOMAIN_NAME" }}/prometheus-meta/graph?g0.expr={namespace%3D"prombench-{{ index . "PR_NUMBER" }}"}&g0.tab=1)
+          - [Grafana Home](http://{{ index . "DOMAIN_NAME" }}/grafana)
+          - [Grafana Exlorer, Loki logs](http://{{ index . "DOMAIN_NAME" }}/grafana/explore)
+
+          **Other Commands:**
+          To stop benchmark: `/prombench cancel`
+          To restart benchmark: `/prombench restart v2.12.0`
+        LABEL_NAME: prombench
+        DOMAIN_NAME: prombench.prometheus.io
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: >-
+          "(?mi)^/prombench\s+restart\s+(?P<RELEASE>master|v[0-9]+\.[0-9]+\.[0-9]+\S*)\s*$"
+  benchmark_restart:
+    name: Benchmark Restart
+    needs: pre_benchmark_restart
+    runs-on: ubuntu-latest
+    steps:
+    - name: Extract arguments
+      id: extract_arguments
+      uses: docker://prombench/comment-monitor:0.0.1
+      with:
+        args: >-
+          "(?mi)^/prombench\s+restart\s+(?P<RELEASE>master|v[0-9]+\.[0-9]+\.[0-9]+\S*)\s*$"
+    - name: Run make clean then make deploy to restart test
+      id: make_restart
+      uses: docker://prombench/prombench:2.0.2
+      env:
+        AUTH_FILE: ${{ secrets.AUTH_FILE }}
+        PROJECT_ID: macro-mile-203600
+        CLUSTER_NAME: prombench
+        ZONE: us-central1-a
+        DOMAIN_NAME: prombench.prometheus.io
+        TEST_INFRA_REPO: https://github.com/prometheus/prombench.git
+        GITHUB_ORG: prometheus
+        GITHUB_REPO: prometheus
+      with:
+        args: >-
+          export RELEASE=$(cat /github/home/commentMonitor/RELEASE);
+          export PR_NUMBER=$(cat /github/home/commentMonitor/PR_NUMBER);
+          until make all_nodepools_running; do echo "waiting for nodepools to be created"; sleep 10; done;
+          make clean;
+          until make all_nodepools_deleted; do echo "waiting for nodepools to be deleted"; sleep 10; done;
+          make deploy;
+    - name: Post comment if make deploy failed
+      id: fail_notification
+      if: failure()
+      uses: docker://prombench/comment-monitor:0.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COMMENT_TEMPLATE: |
+          Prombench test **restart** failed. Please see logs for more info."
+
+          **GitHub Actions logs:**  [{{ index . "GITHUB_SHA" }}/checks](https://github.com/{{ index . "GITHUB_REPOSITORY" }}/commit/{{ index . "GITHUB_SHA" }}/checks)


### PR DESCRIPTION

This workflow files adds the following GitHub actions jobs to handle `/prombench` commands
- `pre_benchmark_start`
- `benchmark_start`
- `pre_benchmark_cancel`
- `benchmark_cancel`
- `pre_benchmark_restart`
- `benchmark_restart`

cc @krasi-georgiev 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>