### PR TITLE
.circleci/config.yml: fix publish jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  prometheus: prometheus/prometheus@0.1.0
+  prometheus: prometheus/prometheus@0.3.0
 
 executors:
   # Whenever the Go version is updated here, .travis.yml and .promu.yml
@@ -82,6 +82,7 @@ workflows:
         filters:
           branches:
             only: master
+        image: circleci/golang-node
     - prometheus/publish_release:
         context: org-context
         requires:
@@ -92,6 +93,7 @@ workflows:
             only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
           branches:
             ignore: /.*/
+        image: circleci/golang-node
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
As a quick fix, the publish jobs will use an image with npm/yarn installed. Eventually we could use the license tarball from the `build` job.