### PR TITLE
bump go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/prometheus/prometheus
 
-go 1.12
-
-replace k8s.io/klog => github.com/simonpasquier/klog-gokit v0.1.0
+go 1.13
 
 require (
 	cloud.google.com/go v0.44.1 // indirect
@@ -83,4 +81,7 @@ require (
 	k8s.io/utils v0.0.0-20190809000727-6c36bc71fc4a // indirect
 )
 
-replace github.com/golang/lint => golang.org/x/lint v0.0.0-20190409202823-959b441ac422
+replace (
+	github.com/golang/lint => golang.org/x/lint v0.0.0-20190409202823-959b441ac422
+	k8s.io/klog => github.com/simonpasquier/klog-gokit v0.1.0
+)


### PR DESCRIPTION
Bumping go mod's go version to `1.13` since prometheus recommends the use of golang 1.13.