### PR TITLE
Change bounds for WALSegmentSize flag value

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -655,8 +655,10 @@ func main() {
 		g.Add(
 			func() error {
 				level.Info(logger).Log("msg", "Starting TSDB ...")
-				if cfg.tsdb.WALSegmentSize > 256*1024*1024 {
-					return errors.New("flag 'storage.tsdb.wal-segment-size' must be less than 256MB")
+				if cfg.tsdb.WALSegmentSize > 0 {
+					if cfg.tsdb.WALSegmentSize < 10*1024*1024 || cfg.tsdb.WALSegmentSize > 256*1024*1024 {
+						return errors.New("flag 'storage.tsdb.wal-segment-size' must be set between 10MB and 256MB")
+					}
 				}
 				db, err := tsdb.Open(
 					cfg.localStoragePath,

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -655,10 +655,8 @@ func main() {
 		g.Add(
 			func() error {
 				level.Info(logger).Log("msg", "Starting TSDB ...")
-				if cfg.tsdb.WALSegmentSize != 0 {
-					if cfg.tsdb.WALSegmentSize < 10*1024*1024 || cfg.tsdb.WALSegmentSize > 256*1024*1024 {
-						return errors.New("flag 'storage.tsdb.wal-segment-size' must be set between 10MB and 256MB")
-					}
+				if cfg.tsdb.WALSegmentSize > 256*1024*1024 {
+					return errors.New("flag 'storage.tsdb.wal-segment-size' must be less than 256MB")
 				}
 				db, err := tsdb.Open(
 					cfg.localStoragePath,


### PR DESCRIPTION
This allows the flag sets `WALSegmentSize` to be negative, which allows the user to disable the WAL. I saw that in tsdb/db.go:60 there is a comment stating that setting the segment size to anything less than zero will actually disable the WAL, but in the main file, the flag is restricted to a value between 10 and 256 MB. I wanted to expose this setting through the flag because the WAL can use a significant amount of RAM and for some users I think it may be worth disabling the WAL to avoid the OOM crash cycle as described in this comment: https://github.com/prometheus/prometheus/issues/5560#issuecomment-537210222

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->