### PR TITLE
doc: Add documentation about comments in PromQL

### DIFF
--- a/docs/querying/basics.md
+++ b/docs/querying/basics.md
@@ -32,6 +32,12 @@ expression), only some of these types are legal as the result from a
 user-specified expression. For example, an expression that returns an instant
 vector is the only type that can be directly graphed.
 
+## Comments
+
+PromQL supports line comments that start with `#`. Example:
+
+        # This is a comment
+
 ## Literals
 
 ### String literals


### PR DESCRIPTION
Signed-off-by: Tobias Guggenmos <tguggenm@redhat.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

TIL that prometheus actually supports comments, while reading the parser code. This is  also mentioned  in #2855. 

This PR documents this.

However this feature isn't tested in  the parser tests, so it might make sense to add such tests before telling everybody about it.