### PR TITLE
tsdb: remove unnecessary wal-segment-size check

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -531,16 +531,13 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 
 	var wlog *wal.WAL
 	segmentSize := wal.DefaultSegmentSize
-	// Wal is enabled.
-	if opts.WALSegmentSize >= 0 {
-		// Wal is set to a custom size.
-		if opts.WALSegmentSize > 0 {
-			segmentSize = opts.WALSegmentSize
-		}
-		wlog, err = wal.NewSize(l, r, filepath.Join(dir, "wal"), segmentSize, opts.WALCompression)
-		if err != nil {
-			return nil, err
-		}
+	// Wal is set to a custom size.
+	if opts.WALSegmentSize > 0 {
+		segmentSize = opts.WALSegmentSize
+	}
+	wlog, err = wal.NewSize(l, r, filepath.Join(dir, "wal"), segmentSize, opts.WALCompression)
+	if err != nil {
+		return nil, err
 	}
 
 	db.head, err = NewHead(r, l, wlog, opts.BlockRanges[0])


### PR DESCRIPTION
WALSegmentSize is always non-negative. The outer if statement seems unnecessary.

Signed-off-by: huanggze <loganhuang@yunify.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->