### PR TITLE
tsdb: remove unnecessary WALSegmentSize check

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -57,9 +57,8 @@ var DefaultOptions = &Options{
 // Options of the DB storage.
 type Options struct {
 	// Segments (wal files) max size.
-	// WALSegmentSize = 0, segment size is default size.
+	// WALSegmentSize <= 0, segment size is default size.
 	// WALSegmentSize > 0, segment size is WALSegmentSize.
-	// WALSegmentSize < 0, wal is disabled.
 	WALSegmentSize int
 
 	// Duration of persisted data to keep.
@@ -531,16 +530,13 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 
 	var wlog *wal.WAL
 	segmentSize := wal.DefaultSegmentSize
-	// Wal is enabled.
-	if opts.WALSegmentSize >= 0 {
-		// Wal is set to a custom size.
-		if opts.WALSegmentSize > 0 {
-			segmentSize = opts.WALSegmentSize
-		}
-		wlog, err = wal.NewSize(l, r, filepath.Join(dir, "wal"), segmentSize, opts.WALCompression)
-		if err != nil {
-			return nil, err
-		}
+	// Wal is set to a custom size.
+	if opts.WALSegmentSize > 0 {
+		segmentSize = opts.WALSegmentSize
+	}
+	wlog, err = wal.NewSize(l, r, filepath.Join(dir, "wal"), segmentSize, opts.WALCompression)
+	if err != nil {
+		return nil, err
 	}
 
 	db.head, err = NewHead(r, l, wlog, opts.BlockRanges[0])

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -847,12 +847,6 @@ func TestWALSegmentSizeOptions(t *testing.T) {
 			lastFile := files[len(files)-1]
 			testutil.Assert(t, int64(segmentSize) > lastFile.Size(), "last WAL file size is not smaller than the WALSegmentSize option, filename: %v", lastFile.Name())
 		},
-		// Wal disabled.
-		-1: func(dbDir string, segmentSize int) {
-			if _, err := os.Stat(filepath.Join(dbDir, "wal")); !os.IsNotExist(err) {
-				t.Fatal("wal directory is present when the wal is disabled")
-			}
-		},
 	}
 	for segmentSize, testFunc := range tests {
 		t.Run(fmt.Sprintf("WALSegmentSize %d test", segmentSize), func(t *testing.T) {


### PR DESCRIPTION
WALSegmentSize is always non-negative. The outer if statement seems unnecessary.

Signed-off-by: huanggze <loganhuang@yunify.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->