### PR TITLE
React UI: Simplify query history setting code

### DIFF
--- a/web/ui/react-app/src/PanelList.tsx
+++ b/web/ui/react-app/src/PanelList.tsx
@@ -50,7 +50,7 @@ class PanelList extends Component<any, PanelListState> {
       }
     })
     .then(json => {
-      this.setMetrics(json.data);
+      this.setState({metricNames: json.data});
     })
     .catch(error => this.setState({ fetchMetricsError: error.message }));
 
@@ -87,18 +87,17 @@ class PanelList extends Component<any, PanelListState> {
 
   toggleQueryHistory = (e: ChangeEvent<HTMLInputElement>) => {
     localStorage.setItem('enable-query-history', `${e.target.checked}`);
-    this.setMetrics();
+    this.updatePastQueries();
   }
 
-  setMetrics = (metricNames: string[] = this.state.metricNames) => {
+  updatePastQueries = () => {
     this.setState({
-      pastQueries: this.isHistoryEnabled() ? this.getHistoryItems() : [],
-      metricNames
+      pastQueries: this.isHistoryEnabled() ? this.getHistoryItems() : []
     });
   }
 
   handleQueryHistory = (query: string) => {
-    const isSimpleMetric = this.state.metricNames.indexOf(query) !== -1;            
+    const isSimpleMetric = this.state.metricNames.indexOf(query) !== -1;
     if (isSimpleMetric || !query.length) {
       return;
     }
@@ -107,7 +106,7 @@ class PanelList extends Component<any, PanelListState> {
       return metric === query ? acc : [...acc, metric]; // Prevent adding query twice.
     }, [query]);
     localStorage.setItem('history', JSON.stringify(extendedItems.slice(0, 50)));
-    this.setMetrics();
+    this.updatePastQueries();
   }
 
   getKey(): string {


### PR DESCRIPTION
The metric names only get loaded once initially, so there is no reason
to mix them up with the handling of ongoing query history.

Signed-off-by: Julius Volz <julius.volz@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->