### PR TITLE
promtool: Add check for expression validation

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -387,7 +387,6 @@ func CheckMetrics() int {
 // CheckExpression validates if the input expression is a valid PromQL expression
 func CheckExpression(expr string) int {
 	_, err := promql.ParseExpr(expr)
-
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error while validating:", err)
 		return 1

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 )
@@ -77,4 +78,20 @@ func mockServer(code int, body string) (*httptest.Server, func() *http.Request) 
 		return req
 	}
 	return server, f
+}
+
+func TestCheckExpression(t *testing.T) {
+	// Temporarily move error output from CheckExpression calls
+	// to /dev/null, only return value is relevant
+	stderr := os.Stderr
+	defer func() { os.Stderr = stderr }()
+	os.Stderr = os.NewFile(0, os.DevNull)
+
+	if CheckExpression("test{query=\"hello\"}") != 0 {
+		t.Error()
+	}
+
+	if CheckExpression("i{am=\"incomplete\"") == 0 {
+		t.Error()
+	}
 }


### PR DESCRIPTION
Option to validate expression syntax through promtool, so a running Prometheus isn't required for syntax checking.