### PR TITLE
React UI: Improve styling of autocomplete sections

### DIFF
--- a/web/ui/react-app/src/App.css
+++ b/web/ui/react-app/src/App.css
@@ -62,21 +62,17 @@ button.execute-btn {
 .autosuggest-dropdown {
     position: absolute;
     border: 1px solid #ced4da;
-    border-radius: .25rem;
     background-color: #fff;
     color: #495057;
     font-size: 1rem;
     z-index: 1000;
-    min-width: 10rem;
-    top: 100%;
     left: 56px;
-    float: left;
-    margin: -5px;
+    margin-top: -6px;
 }
 
 .autosuggest-dropdown-list {
     padding: 0;
-    margin: 0 0 5px 0;
+    margin: 0;
     list-style: none;
 }
 
@@ -91,13 +87,11 @@ button.execute-btn {
 }
 
 .autosuggest-dropdown-list li.autosuggest-dropdown-header {
-    margin-bottom: 5px;
     background-color: #bfdeff;
-    height: 25px;
     font-size: 10px;
-    display: flex;
-    align-items: center;
+    line-height: 1.5;
     text-transform: uppercase;
+    text-align: center;
 }
 
 .graph-controls, .table-controls {

--- a/web/ui/react-app/src/App.css
+++ b/web/ui/react-app/src/App.css
@@ -72,10 +72,15 @@ button.execute-btn {
     left: 56px;
     float: left;
     margin: -5px;
+}
+
+.autosuggest-dropdown-list {
+    padding: 0;
+    margin: 0 0 5px 0;
     list-style: none;
 }
 
-.autosuggest-dropdown li {
+.autosuggest-dropdown-list li {
     width: 100%;
     padding: .25rem 1.5rem;
     clear: both;
@@ -85,9 +90,11 @@ button.execute-btn {
     display: block;
 }
 
-.autosuggest-dropdown .card-header {
-    background: rgba(240, 230, 140, 0.4);
-    height: 30px;
+.autosuggest-dropdown-list li.autosuggest-dropdown-header {
+    margin-bottom: 5px;
+    background-color: #bfdeff;
+    height: 25px;
+    font-size: 10px;
     display: flex;
     align-items: center;
     text-transform: uppercase;

--- a/web/ui/react-app/src/ExpressionInput.test.tsx
+++ b/web/ui/react-app/src/ExpressionInput.test.tsx
@@ -127,7 +127,7 @@ describe('ExpressionInput', () => {
       const downshift = expressionInput.find(Downshift);
       downshift.setState({ isOpen: true });
       const ul = downshift.find('ul');
-      expect(ul.prop('className')).toEqual('card list-group');
+      expect(ul.prop('className')).toEqual('autosuggest-dropdown-list');
       const items = ul.find(SanitizeHTML);
       expect(items.map(item => item.text()).join(', ')).toEqual(
         'node_cpu_guest_seconds_total, node_cpu_seconds_total, instance:node_cpu_utilisation:rate1m'

--- a/web/ui/react-app/src/ExpressionInput.tsx
+++ b/web/ui/react-app/src/ExpressionInput.tsx
@@ -1,15 +1,5 @@
 import React, { Component } from 'react';
-import {
-  Button,
-  InputGroup,
-  InputGroupAddon,
-  InputGroupText,
-  Input,
-  ListGroup,
-  ListGroupItem,
-  Card,
-  CardHeader,
-} from 'reactstrap';
+import { Button, InputGroup, InputGroupAddon, InputGroupText, Input } from 'reactstrap';
 
 import Downshift, { ControllerStateAndHelpers } from 'downshift';
 import fuzzy from 'fuzzy';
@@ -93,8 +83,8 @@ class ExpressionInput extends Component<ExpressionInputProps, ExpressionInputSta
               ? acc
               : [
                   ...acc,
-                  <Card tag={ListGroup} key={title}>
-                    <CardHeader style={{ fontSize: 13 }}>{title}</CardHeader>
+                  <ul className="autosuggest-dropdown-list" key={title}>
+                    <li className="autosuggest-dropdown-header">{title}</li>
                     {matches
                       .slice(0, 100) // Limit DOM rendering to 100 results, as DOM rendering is sloooow.
                       .map(({ original, string }) => {
@@ -107,12 +97,12 @@ class ExpressionInput extends Component<ExpressionInputProps, ExpressionInputSta
                           },
                         });
                         return (
-                          <SanitizeHTML tag={ListGroupItem} {...itemProps} allowedTags={['strong']}>
+                          <SanitizeHTML tag={'li'} {...itemProps} allowedTags={['strong']}>
                             {string}
                           </SanitizeHTML>
                         );
                       })}
-                  </Card>,
+                  </ul>,
                 ];
           },
           [] as JSX.Element[]

--- a/web/ui/react-app/src/ExpressionInput.tsx
+++ b/web/ui/react-app/src/ExpressionInput.tsx
@@ -97,7 +97,7 @@ class ExpressionInput extends Component<ExpressionInputProps, ExpressionInputSta
                           },
                         });
                         return (
-                          <SanitizeHTML tag={'li'} {...itemProps} allowedTags={['strong']}>
+                          <SanitizeHTML tag="li" {...itemProps} allowedTags={['strong']}>
                             {string}
                           </SanitizeHTML>
                         );


### PR DESCRIPTION
I removed the Card-related components and went back to normal `<ul>`/`<li>`,
since the style that Cards added just got in the way (like adding extra
borders and rounding, etc.), and from the examples at
https://getbootstrap.com/docs/4.3/components/card/, it doesn't seem like
multiple Cards are meant to be used as part of a larger list
(style-wise).

Signed-off-by: Julius Volz <julius.volz@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->