### PR TITLE
Replace time.After with time.NewTimer

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -588,9 +588,9 @@ func (db *DB) run() {
 			return
 		case <-time.After(backoff):
 		}
-
+		timer := time.NewTimer(1 * time.Minute)
 		select {
-		case <-time.After(1 * time.Minute):
+		case <-timer.C:
 			select {
 			case db.compactc <- struct{}{}:
 			default:
@@ -611,8 +611,10 @@ func (db *DB) run() {
 			}
 			db.autoCompactMtx.Unlock()
 		case <-db.stopc:
+			timer.Stop()
 			return
 		}
+		timer.Stop()
 	}
 }
 


### PR DESCRIPTION
If the rate of compaction is high we might leave a lot of stray timers.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->