### PR TITLE
Adjust React query stats font

### DIFF
--- a/web/ui/react-app/src/QueryStatsView.css
+++ b/web/ui/react-app/src/QueryStatsView.css
@@ -1,5 +1,5 @@
 .query-stats{
     flex-grow: 1;
-    font-size: 9px;
-    color: #999;
+    font-size: 0.7rem;
+    color: #71808e;
 }


### PR DESCRIPTION
* Use root relative font size rather than px to avoid hidpi issues.
* Darken to 50% saturation of base font color.

Signed-off-by: Ben Kochie <superq@gmail.com>