### PR TITLE
Fix PrometheusRemoteWriteDesiredShards

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -218,7 +218,7 @@
               # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
               (
                 max_over_time(prometheus_remote_storage_shards_desired{%(prometheusSelector)s}[5m])
-              > on(job, instance) group_right
+              >
                 max_over_time(prometheus_remote_storage_shards_max{%(prometheusSelector)s}[5m])
               )
             ||| % $._config,


### PR DESCRIPTION
This rule has the queue label on both sides. `group_right` doesn't
help, we just need to do the comparison on `queue`, too.

@cstyan 