### PR TITLE
React UI: Fix left/right icons in the time picker

### DIFF
--- a/web/ui/react-app/src/TimeInput.tsx
+++ b/web/ui/react-app/src/TimeInput.tsx
@@ -19,7 +19,7 @@ import {
   faTimes,
 } from '@fortawesome/free-solid-svg-icons';
 
-library.add(faCalendarCheck, faArrowUp, faArrowDown, faTimes);
+library.add(faChevronLeft, faChevronRight, faCalendarCheck, faArrowUp, faArrowDown, faTimes);
 // Sadly needed to also replace <i> within the date picker, since it's not a React component.
 dom.watch();
 


### PR DESCRIPTION
https://github.com/prometheus/prometheus/pull/6193 removed these icons
from the font library, but the non-React timepicker library requires
these.

Signed-off-by: Julius Volz <julius.volz@gmail.com>

**Broken:**

![timepicker_bad](https://user-images.githubusercontent.com/538008/68204800-122d9f80-ffc9-11e9-8fb1-a347aa859f7a.png)

**Fixed:**

![timepicker_good](https://user-images.githubusercontent.com/538008/68204801-122d9f80-ffc9-11e9-8605-64a2f0b5de4b.png)


<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->