### PR TITLE
Link example when the main config file is first referenced in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ read its web assets from local filesystem directories under `web/ui/static` and
 from the root of the cloned repository. Note also that these directories do not include the
 new experimental React UI unless it has been built explicitly using `make assets` or `make build`.
 
+An example of the above configuration file can be found [here.](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus.yml)
+
 You can also clone the repository yourself and build using `make build`, which will compile in
 the web assets so that Prometheus can be run from anywhere:
 


### PR DESCRIPTION
I didn't have a configuration file handy, and it was not immediately obvious to me where to find one. I only knew that it was specifying the main config as I've used prometheus before, so it would be a good idea to point new folks in the right direction. :)

Contributing asks me to link a maintainer for minor changes, so, cc @juliusv