### PR TITLE
[WIP] mixin: generic alerts to notify about cardinality explosion

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -259,6 +259,43 @@
               description: 'Prometheus %(prometheusName)s has missed {{ printf "%%.0f" $value }} rule group evaluations in the last 5m.' % $._config,
             },
           },
+          {
+            alert: 'PrometheusTSDBHeadSeriesCardinality',
+            expr: |||
+              rate(prometheus_tsdb_head_series_created_total[1h]) > 1
+            ||| % $._config,
+            'for': '30m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'Prometheus scrape samples cardinality is exceeding server abilities.',
+              description: 'Prometheus %(prometheusName)s has {{ printf "%%.0f" $value }} scrape samples for {{$labels.job}} job in last 30m.' % $._config,
+            },
+          },
+          {
+            alert: 'PrometheusScrapeSamplesExplodingCardinality',
+            expr: |||
+              (
+                deriv(scrape_samples_scraped[1h]) > 3*0.1
+                and
+                deriv(scrape_samples_scraped[5m]) > 3*0.1
+              )
+              or
+              (
+                deriv(scrape_samples_scraped[6h]) > 0.1
+                and
+                deriv(scrape_samples_scraped[30m]) > 0.1
+              )
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Prometheus scrape samples cardinality is exploding.',
+              description: 'Prometheus %(prometheusName)s has {{ printf "%%.0f" $value }} scrape samples for {{$labels.job}} job in last 30m.' % $._config,
+            },
+          },
         ],
       },
     ],


### PR DESCRIPTION
It would be nice to notify user about cardinality explosion when it happens and not only wait for prometheus to be dead. With currently exposed data it is possible to set a few generic alerts:
1) Critical alert when too many series and/or samples are collected. We can experimentally find a sane default threshold for this alert and maybe expose it as a jsonnet variable so others can adjust it. (@csmarchbanks could you find it?)
2) Multiple burn rate alert as a warning about increasing cardinality. For this, it would be nice to correlate `deriv(scrape_series_added)` or `deriv(scrape_samples_added)` with some other metrics. However, due to a lack of ideas from my side, I can only experimentally find a threshold and use it in a similar way as in the previous point.
3) (Possible future work) Alerts using `predict_linear` to notify about possible prometheus service degradation due to increasing cardinality

I am open to other ideas :)

I also wonder if it would be possible to reuse @metalmatze [slo-libsonnet](https://github.com/metalmatze/slo-libsonnet) for some of those alerts.

Note: This PR is more like food for thought and definitely not a finished solution.

Signed-off-by: paulfantom <pawel@krupa.net.pl>