### PR TITLE
Exemplars store in-memory storage interface

### DIFF
--- a/pkg/exemplar/interface.go
+++ b/pkg/exemplar/interface.go
@@ -17,6 +17,15 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
+// TsExemplar is an exemplar alongside a timestamp.
+type TsExemplar struct {
+	Ts       int64
+	Exemplar Exemplar
+}
+
+// SeriesExemplar is a time series of exemplar values.
+type SeriesExemplar []TsExemplar
+
 // The following are similar to those of `storage/interfaces.go`:
 // https://github.com/prometheus/prometheus/blob/91d7175eaac18b00e370965f3a8186cc40bf9f55/storage/interface.go#L31-L65
 
@@ -26,9 +35,10 @@ type Exemplars interface {
 	// and timestamp provided (so this can be O(1) lookup).
 	Get(l labels.Labels, t int64) (Exemplar, bool, error)
 
-	// Query is a query to find an exemplars with exact matches on labels
-	// and timestamp ranges provided (this is a range query).
-	Query(l labels.Labels, start, end int64) ([]Exemplar, error)
+	// Query is a query to find an exemplars with partial matches on labels
+	// and timestamp ranges provided (this is a range query). Query returns
+	// a list of SeriesExemplar for each label match.
+	Query(l labels.Labels, start, end int64) ([]SeriesExemplar, error)
 
 	// Add an exemplar, it will be retained based on configuration at
 	// the construction of the exmplar storage.

--- a/pkg/exemplar/interface.go
+++ b/pkg/exemplar/interface.go
@@ -36,4 +36,4 @@ type Exemplars interface {
 
 	// Close the storage.
 	Close() error
-} 
+}

--- a/pkg/exemplar/interface.go
+++ b/pkg/exemplar/interface.go
@@ -17,28 +17,16 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
-// TsExemplar is an exemplar alongside a timestamp.
-type TsExemplar struct {
-	Ts       int64
-	Exemplar Exemplar
-}
-
-// SeriesExemplar is a time series of exemplar values.
-type SeriesExemplar []TsExemplar
-
-// The following are similar to those of `storage/interfaces.go`:
-// https://github.com/prometheus/prometheus/blob/91d7175eaac18b00e370965f3a8186cc40bf9f55/storage/interface.go#L31-L65
-
 // Exemplars is an exemplar storage backend.
 type Exemplars interface {
 	// Get is a fast lookup to find an exemplar with an exact match on labels
 	// and timestamp provided (so this can be O(1) lookup).
 	Get(l labels.Labels, t int64) (Exemplar, bool, error)
 
-	// Query is a query to find an exemplars with partial matches on labels
+	// GetRange is a query to find exemplars with exact matches on labels
 	// and timestamp ranges provided (this is a range query). Query returns
-	// a list of SeriesExemplar for each label match.
-	Query(l labels.Labels, start, end int64) ([]SeriesExemplar, error)
+	// a list of Exemplar for the label match.
+	GetRange(l labels.Labels, start, end int64) ([]Exemplar, error)
 
 	// Add an exemplar, it will be retained based on configuration at
 	// the construction of the exmplar storage.

--- a/pkg/exemplar/interface.go
+++ b/pkg/exemplar/interface.go
@@ -1,0 +1,39 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exemplar
+
+import (
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// The following are similar to those of `storage/interfaces.go`:
+// https://github.com/prometheus/prometheus/blob/91d7175eaac18b00e370965f3a8186cc40bf9f55/storage/interface.go#L31-L65
+
+// Exemplars is an exemplar storage backend.
+type Exemplars interface {
+	// Get is a fast lookup to find an exemplar with an exact match on labels
+	// and timestamp provided (so this can be O(1) lookup).
+	Get(l labels.Labels, t int64) (Exemplar, bool, error)
+
+	// Query is a query to find an exemplars with exact matches on labels
+	// and timestamp ranges provided (this is a range query).
+	Query(l labels.Labels, start, end int64) ([]Exemplar, error)
+
+	// Add an exemplar, it will be retained based on configuration at
+	// the construction of the exmplar storage.
+	Add(l labels.Labels, t int64, e Exemplar) error
+
+	// Close the storage.
+	Close() error
+} 


### PR DESCRIPTION
Initial pass at passing exemplars through the scrape logic. 

This is one option we could take by changing the `Appender` interface `Add`, `AddFast` methods. The current draft shows the changes involved at a high level. Still need to deal with optimally handling the no exemplar case. 

An alternate approach we could take is to not change the current Appender interface, but add a new interface `AppenderWithExemplars` and then upcast the appender provided.. `appender, ok := Appender.(AppenderWithExemplar)` and decide whether to handle exemplars based on what type of appender has been configure.. 

There are few cases to take care of here

1. Metric does not have exemplar, appender does not support exemplar
2. Metric has exemplar, appender does not support exemplars - we should ideally not even parse and propagate the exemplar.
3. Metric has exemplar, appender supports exemplars - push the exemplars through the scraper