### PR TITLE
React UI: Fix tests harder

### DIFF
--- a/web/ui/react-app/src/ExpressionInput.test.tsx
+++ b/web/ui/react-app/src/ExpressionInput.test.tsx
@@ -178,7 +178,7 @@ describe('ExpressionInput', () => {
       const downshift = expressionInput.find(Downshift);
       const instance: any = expressionInput.instance();
       const spyBlur = jest.fn();
-      instance.exprInputRef.current = { blur: spyBlur };
+      instance.exprInputRef.current!.blur = spyBlur;
       const input = downshift.find(Input);
       downshift.setState({ isOpen: false });
       const event = getKeyEvent('Escape');

--- a/web/ui/react-app/src/ExpressionInput.test.tsx
+++ b/web/ui/react-app/src/ExpressionInput.test.tsx
@@ -178,7 +178,7 @@ describe('ExpressionInput', () => {
       const downshift = expressionInput.find(Downshift);
       const instance: any = expressionInput.instance();
       const spyBlur = jest.fn();
-      instance.exprInputRef.current!.blur = spyBlur;
+      instance.exprInputRef.current.blur = spyBlur;
       const input = downshift.find(Input);
       downshift.setState({ isOpen: false });
       const event = getKeyEvent('Escape');


### PR DESCRIPTION
Again not sure why this passed last time (?), but now I was getting an
error about 'NaN' not being a valid value to assign to the 'height'
property of the input element. This changes it so that only the blur()
function is actually mocked out on the active input element.

Signed-off-by: Julius Volz <julius.volz@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->