### PR TITLE
Add tsdb/tsdb to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 /prometheus
 /promtool
+/tsdb/tsdb
 benchmark.txt
 /data
 /cmd/prometheus/data


### PR DESCRIPTION
This is built this way by the Makefile. One might ask if that's the
correct location for the `tsdb` tool or if it should be placed
top-level together with `prometheus` and `promtool`. But for now, it
should be excluded from Git like the latter two.

Signed-off-by: beorn7 <beorn@grafana.com>
