### PR TITLE
React UI: Change the dynamic react key with static id

### DIFF
--- a/web/ui/react-app/src/pages/PanelList.tsx
+++ b/web/ui/react-app/src/pages/PanelList.tsx
@@ -34,7 +34,7 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
   }
 
   componentDidMount() {
-    !this.state.panels.length && this.addPanel()
+    !this.state.panels.length && this.addPanel();
     fetch(`${this.props.pathPrefix}/api/v1/label/__name__/values`, { cache: 'no-store' })
       .then(resp => {
         if (resp.ok) {

--- a/web/ui/react-app/src/pages/PanelList.tsx
+++ b/web/ui/react-app/src/pages/PanelList.tsx
@@ -20,29 +20,21 @@ interface PanelListState {
   timeDriftError: string | null;
 }
 
-const initialPanel = {
-  id: generateID(),
-  key: '0',
-  options: PanelDefaultOptions,
-};
-
 class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelListState> {
   constructor(props: PathPrefixProps) {
     super(props);
 
-    const urlPanels = decodePanelOptionsFromQueryString(window.location.search);
-
     this.state = {
-      panels: urlPanels.length ? urlPanels : [initialPanel],
+      panels: decodePanelOptionsFromQueryString(window.location.search),
       pastQueries: [],
       metricNames: [],
       fetchMetricsError: null,
       timeDriftError: null,
     };
-    !urlPanels.length && this.updateURL();
   }
 
   componentDidMount() {
+    !this.state.panels.length && this.addPanel()
     fetch(`${this.props.pathPrefix}/api/v1/label/__name__/values`, { cache: 'no-store' })
       .then(resp => {
         if (resp.ok) {

--- a/web/ui/react-app/src/pages/PanelList.tsx
+++ b/web/ui/react-app/src/pages/PanelList.tsx
@@ -135,7 +135,7 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
   updateURL() {
     const query = encodePanelOptionsToQueryString(this.state.panels);
     window.history.pushState({}, '', query);
-  };
+  }
 
   addPanel = () => {
     const { panels } = this.state;

--- a/web/ui/react-app/src/pages/PanelList.tsx
+++ b/web/ui/react-app/src/pages/PanelList.tsx
@@ -21,7 +21,7 @@ interface PanelListState {
 }
 
 class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelListState> {
-  constructor(props: PathPrefixProps) {
+  constructor(props: RouteComponentProps & PathPrefixProps) {
     super(props);
 
     this.state = {
@@ -112,38 +112,34 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
     this.updatePastQueries();
   };
 
-  handleOptionsChanged = (key: string, options: PanelOptions) => {
-    this.setState(
-      {
-        panels: this.state.panels.map(p => {
-          return key === p.key ? { ...p, options } : p;
-        }),
-      },
-      this.updateURL
-    );
-  };
-
   updateURL() {
     const query = encodePanelOptionsToQueryString(this.state.panels);
     window.history.pushState({}, '', query);
   }
 
-  addPanel = () => {
-    const { panels } = this.state;
-    const addedPanel = {
-      id: generateID(),
-      key: `${panels.length}`,
-      options: PanelDefaultOptions,
-    };
-    this.setState({ panels: [...panels, addedPanel] }, this.updateURL);
+  handleOptionsChanged = (id: string, options: PanelOptions) => {
+    const updatedPanels = this.state.panels.map(p => (id === p.id ? { ...p, options } : p));
+    this.setState({ panels: updatedPanels }, this.updateURL);
   };
 
-  removePanel = (key: string) => {
-    let newKey = 0;
+  addPanel = () => {
+    const { panels } = this.state;
+    const nextPanels = [
+      ...panels,
+      {
+        id: generateID(),
+        key: `${panels.length}`,
+        options: PanelDefaultOptions,
+      },
+    ];
+    this.setState({ panels: nextPanels }, this.updateURL);
+  };
+
+  removePanel = (id: string) => {
     this.setState(
       {
         panels: this.state.panels.reduce<PanelMeta[]>((acc, panel) => {
-          return panel.key !== key ? [...acc, { ...panel, key: `${newKey++}` }] : acc;
+          return panel.id !== id ? [...acc, { ...panel, key: `${acc.length}` }] : acc;
         }, []),
       },
       this.updateURL
@@ -183,13 +179,13 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
             )}
           </Col>
         </Row>
-        {panels.map(({ id, options, key }) => (
+        {panels.map(({ id, options }) => (
           <Panel
             onExecuteQuery={this.handleQueryHistory}
             key={id}
             options={options}
-            onOptionsChanged={opts => this.handleOptionsChanged(key, opts)}
-            removePanel={() => this.removePanel(key)}
+            onOptionsChanged={opts => this.handleOptionsChanged(id, opts)}
+            removePanel={() => this.removePanel(id)}
             metricNames={metricNames}
             pastQueries={pastQueries}
             pathPrefix={pathPrefix}

--- a/web/ui/react-app/src/pages/PanelList.tsx
+++ b/web/ui/react-app/src/pages/PanelList.tsx
@@ -73,7 +73,7 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
 
     window.onpopstate = () => {
       const panels = decodePanelOptionsFromQueryString(window.location.search);
-      if (panels.length) {
+      if (panels.length > 0) {
         this.setState({ panels });
       }
     };
@@ -113,15 +113,14 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
   };
 
   handleOptionsChanged = (key: string, options: PanelOptions) => {
-    const panels = this.state.panels.map(panel => {
-      return key === panel.key
-        ? {
-            ...panel,
-            options,
-          }
-        : panel;
-    });
-    this.setState({ panels }, this.updateURL);
+    this.setState(
+      {
+        panels: this.state.panels.map(p => {
+          return key === p.key ? { ...p, options } : p;
+        }),
+      },
+      this.updateURL
+    );
   };
 
   updateURL() {
@@ -141,10 +140,14 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
 
   removePanel = (key: string) => {
     let newKey = 0;
-    const panels = this.state.panels.reduce<PanelMeta[]>((acc, panel) => {
-      return panel.key !== key ? [...acc, { ...panel, key: `${newKey++}` }] : acc;
-    }, []);
-    this.setState({ panels }, this.updateURL);
+    this.setState(
+      {
+        panels: this.state.panels.reduce<PanelMeta[]>((acc, panel) => {
+          return panel.key !== key ? [...acc, { ...panel, key: `${newKey++}` }] : acc;
+        }, []),
+      },
+      this.updateURL
+    );
   };
 
   render() {

--- a/web/ui/react-app/src/utils/func.ts
+++ b/web/ui/react-app/src/utils/func.ts
@@ -1,5 +1,9 @@
-export const generateID = () =>
-  '_' +
-  Math.random()
+export const generateID = () => {
+  return `_${Math.random()
     .toString(36)
-    .substr(2, 9);
+    .substr(2, 9)}`;
+};
+
+export const byEmptyString = (p: string) => p.length > 0;
+
+export const isPresent = <T>(obj: T): obj is NonNullable<T> => obj !== null && obj !== undefined;

--- a/web/ui/react-app/src/utils/func.ts
+++ b/web/ui/react-app/src/utils/func.ts
@@ -1,0 +1,5 @@
+export const generateID = () =>
+  '_' +
+  Math.random()
+    .toString(36)
+    .substr(2, 9);

--- a/web/ui/react-app/src/utils/urlParams.test.ts
+++ b/web/ui/react-app/src/utils/urlParams.test.ts
@@ -1,5 +1,6 @@
-import { decodePanelOptionsFromQueryString, encodePanelOptionsToQueryString } from './urlParams';
+import { decodePanelOptionsFromQueryString, encodePanelOptionsToQueryString, parseOption, toQueryString } from './urlParams';
 import { PanelType } from '../Panel';
+import moment from 'moment';
 
 const panels: any = [
   {
@@ -34,6 +35,60 @@ describe('decodePanelOptionsFromQueryString', () => {
   });
   it('returns and array of parsed params when query string is non-empty', () => {
     expect(decodePanelOptionsFromQueryString(query)).toMatchObject(panels);
+  });
+});
+
+describe('parseOption', () => {
+  it('should return empty object for invalid param', () => {
+    expect(parseOption('invalid_prop=foo')).toEqual({});
+  });
+  it('should parse expr param', () => {
+    expect(parseOption('expr=foo')).toEqual({ expr: 'foo' });
+  });
+  it('should parse stacked', () => {
+    expect(parseOption('stacked=1')).toEqual({ stacked: true });
+  });
+  it('should parse end_input', () => {
+    expect(parseOption('end_input=2019-10-25%2023%3A37')).toEqual({ endTime: moment.utc('2019-10-25 23:37').valueOf() });
+  });
+  it('should parse moment_input', () => {
+    expect(parseOption('moment_input=2019-10-25%2023%3A37')).toEqual({ endTime: moment.utc('2019-10-25 23:37').valueOf() });
+  });
+  describe('step_input', () => {
+    it('should return step_input parsed if > 0', () => {
+      expect(parseOption('step_input=2')).toEqual({ resolution: 2 });
+    });
+    it('should return empty object if step is equal 0', () => {
+      expect(parseOption('step_input=0')).toEqual({});
+    });
+  });
+  describe('range_input', () => {
+    it('should return range parsed if its ot null', () => {
+      expect(parseOption('range_input=2h')).toEqual({ range: 7200 });
+    });
+    it('should return empty object for invalid value', () => {
+      expect(parseOption('range_input=h')).toEqual({});
+    });
+  });
+  describe('Parse type param', () => {
+    it('should return "graph" if tab value is 0', () => {
+      expect(parseOption('tab=0')).toEqual({ type: 'graph' });
+    });
+    it('should return "table" if tab value is 1', () => {
+      expect(parseOption('tab=0')).toEqual({ type: 'graph' });
+    });
+  });
+});
+
+describe('toQueryString', () => {
+  it('should generate query string from panels options', () => {
+    expect(
+      toQueryString({
+        id: 'asdf',
+        key: '0',
+        options: { expr: 'foo', type: PanelType.Graph, stacked: true, range: 0, endTime: null, resolution: 1 },
+      })
+    ).toEqual('g0.expr=foo&g0.tab=0&g0.stacked=1&g0.range_input=0y&g0.step_input=1');
   });
 });
 

--- a/web/ui/react-app/src/utils/urlParams.test.ts
+++ b/web/ui/react-app/src/utils/urlParams.test.ts
@@ -1,7 +1,7 @@
 import { decodePanelOptionsFromQueryString, encodePanelOptionsToQueryString } from './urlParams';
 import { PanelType } from '../Panel';
 
-const panels = [
+const panels: any = [
   {
     key: '0',
     options: {
@@ -33,7 +33,7 @@ describe('decodePanelOptionsFromQueryString', () => {
     expect(decodePanelOptionsFromQueryString('')).toEqual([]);
   });
   it('returns and array of parsed params when query string is non-empty', () => {
-    expect(decodePanelOptionsFromQueryString(query)).toEqual(panels);
+    expect(decodePanelOptionsFromQueryString(query)).toMatchObject(panels);
   });
 });
 

--- a/web/ui/react-app/src/utils/urlParams.test.ts
+++ b/web/ui/react-app/src/utils/urlParams.test.ts
@@ -63,7 +63,7 @@ describe('parseOption', () => {
     });
   });
   describe('range_input', () => {
-    it('should return range parsed if its ot null', () => {
+    it('should return range parsed if its not null', () => {
       expect(parseOption('range_input=2h')).toEqual({ range: 7200 });
     });
     it('should return empty object for invalid value', () => {
@@ -71,17 +71,17 @@ describe('parseOption', () => {
     });
   });
   describe('Parse type param', () => {
-    it('should return "graph" if tab value is 0', () => {
-      expect(parseOption('tab=0')).toEqual({ type: 'graph' });
+    it('should return panel type "graph" if tab=0', () => {
+      expect(parseOption('tab=0')).toEqual({ type: PanelType.Graph });
     });
-    it('should return "table" if tab value is 1', () => {
-      expect(parseOption('tab=0')).toEqual({ type: 'graph' });
+    it('should return panel type "table" if tab=1', () => {
+      expect(parseOption('tab=1')).toEqual({ type: PanelType.Table });
     });
   });
 });
 
 describe('toQueryString', () => {
-  it('should generate query string from panels options', () => {
+  it('should generate query string from panel options', () => {
     expect(
       toQueryString({
         id: 'asdf',

--- a/web/ui/react-app/src/utils/urlParams.ts
+++ b/web/ui/react-app/src/utils/urlParams.ts
@@ -68,12 +68,13 @@ export const formatParam = (key: string) => (paramName: string, value: number | 
 export const toQueryString = ({ key, options }: PanelMeta) => {
   const formatWithKey = formatParam(key);
   const { expr, type, stacked, range, endTime, resolution } = options;
+  const time = isPresent(endTime) ? formatTime(endTime) : false;
   const urlParams = [
     formatWithKey('expr', expr),
     formatWithKey('tab', type === PanelType.Graph ? 0 : 1),
     formatWithKey('stacked', stacked ? 1 : 0),
-    formatWithKey('range_input', range),
-    isPresent(endTime) ? `${formatWithKey('end_input', endTime)}&${formatWithKey('moment_input', endTime)}` : '',
+    formatWithKey('range_input', formatRange(range)),
+    time ? `${formatWithKey('end_input', time)}&${formatWithKey('moment_input', time)}` : '',
     isPresent(resolution) ? formatWithKey('step_input', resolution) : '',
   ];
   return urlParams.filter(byEmptyString).join('&');


### PR DESCRIPTION
In this PR the dynamic react keys for the panels on the graph page are changed with static ID's. During refactoring I found another bug in parseParams which causes removing on the last panel. This is fixed as well. All other changes are just cosmetic changes and nothing functional is touched there. @juliusv 