### PR TITLE
Added CreateBlock and CreateHead functions to new file

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -43,12 +43,17 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// Default duration of a block in milliseconds - 2h.
+const (
+	DefaultBlockDuration = int64(2 * 60 * 60 * 1000)
+)
+
 // DefaultOptions used for the DB. They are sane for setups using
 // millisecond precision timestamps.
 var DefaultOptions = &Options{
 	WALSegmentSize:         wal.DefaultSegmentSize,
 	RetentionDuration:      15 * 24 * 60 * 60 * 1000, // 15 days in milliseconds
-	BlockRanges:            ExponentialBlockRanges(int64(2*time.Hour)/1e6, 3, 5),
+	BlockRanges:            ExponentialBlockRanges(DefaultBlockDuration, 3, 5),
 	NoLockfile:             false,
 	AllowOverlappingBlocks: false,
 	WALCompression:         false,

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -78,5 +78,6 @@ func CreateBlock(samples []*MetricSample, dir string, mint, maxt int64, logger l
 	if err != nil {
 		return "", err
 	}
+
 	return filepath.Join(dir, ulid.String()), nil
 }

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-kit/kit/log"
-	tsdb_labels "github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"os"
 	"path/filepath"
 )
@@ -27,7 +27,7 @@ var InvalidTimesError = fmt.Errorf("max time is lesser than min time")
 type MetricSample struct {
 	TimestampMs int64
 	Value       float64
-	Labels      tsdb_labels.Labels
+	Labels      labels.Labels
 }
 
 // CreateHead creates a TSDB writer head to write the sample data to.

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -1,0 +1,82 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-kit/kit/log"
+	tsdb_labels "github.com/prometheus/prometheus/tsdb/labels"
+	"os"
+	"path/filepath"
+)
+
+var InvalidTimesError = fmt.Errorf("max time is lesser than min time")
+
+type MetricSample struct {
+	TimestampMs int64
+	Value       float64
+	Labels      tsdb_labels.Labels
+}
+
+// CreateHead creates a TSDB writer head to write the sample data to.
+func CreateHead(samples []*MetricSample, chunkRange int64, logger log.Logger) (*Head, error) {
+	head, err := NewHead(nil, logger, nil, chunkRange)
+	if err != nil {
+		return nil, err
+	}
+	app := head.Appender()
+	for _, sample := range samples {
+		_, err = app.Add(sample.Labels, sample.TimestampMs, sample.Value)
+		if err != nil {
+			return nil, err
+		}
+	}
+	err = app.Commit()
+	if err != nil {
+		return nil, err
+	}
+	return head, nil
+}
+
+// CreateBlock creates a chunkrange block from the samples passed to it, and writes it to disk.
+func CreateBlock(samples []*MetricSample, dir string, mint, maxt int64, logger log.Logger) (string, error) {
+	chunkRange := maxt - mint
+	if chunkRange == 0 {
+		chunkRange = DefaultBlockDuration
+	}
+	if chunkRange < 0 {
+		return "", InvalidTimesError
+	}
+	head, err := CreateHead(samples, chunkRange, logger)
+	if err != nil {
+		return "", err
+	}
+
+	compactor, err := NewLeveledCompactor(context.Background(), nil, logger, DefaultOptions.BlockRanges, nil)
+	if err != nil {
+		return "", err
+	}
+
+	err = os.MkdirAll(dir, 0777)
+	if err != nil {
+		return "", err
+	}
+
+	ulid, err := compactor.Write(dir, head, mint, maxt, nil)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ulid.String()), nil
+}


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Exposing `CreateBlock`, `CreateHead` functions from #5887 as a new PR - per @krasi-georgiev 's request.