### PR TITLE
Fix some typos in comments

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -332,7 +332,7 @@ func (c *GlobalConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-// isZero returns true iff the global config is the zero value.
+// isZero returns true if the global config is the zero value.
 func (c *GlobalConfig) isZero() bool {
 	return c.ExternalLabels == nil &&
 		c.ScrapeInterval == 0 &&

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -92,12 +92,12 @@ func (a *Alert) String() string {
 	return s + "[active]"
 }
 
-// Resolved returns true iff the activity interval ended in the past.
+// Resolved returns true if the activity interval ended in the past.
 func (a *Alert) Resolved() bool {
 	return a.ResolvedAt(time.Now())
 }
 
-// ResolvedAt returns true iff the activity interval ended before
+// ResolvedAt returns true if the activity interval ended before
 // the given timestamp.
 func (a *Alert) ResolvedAt(ts time.Time) bool {
 	if a.EndsAt.IsZero() {


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects while reading.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->