### PR TITLE
Removed compilation step inside main_test.

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
-var promPath string
 var promConfig = filepath.Join("..", "..", "documentation", "examples", "prometheus.yml")
 var promData = filepath.Join(os.TempDir(), "data")
 


### PR DESCRIPTION
Advantages:
* Speeds up the test slightly.
* One binary for the `main` function and test, which is how every other test works, and it ensures they are compiled identically.
* The test code is simpler.