### PR TITLE
Fix relabaling collision when using exported labels

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -451,9 +451,9 @@ func mutateSampleLabels(lset labels.Labels, target *Target, honor bool, rc []*re
 		for _, l := range target.Labels() {
 			// existingValue will be empty if l.Name doesn't exist.
 			existingValue := lset.Get(l.Name)
-			// Because setting a label with an empty value is a no-op,
-			// this will only create the prefixed label if necessary.
-			lb.Set(model.ExportedLabelPrefix+l.Name, existingValue)
+			if existingValue != "" {
+				lb.Set(model.ExportedLabelPrefix+l.Name, existingValue)
+			}
 			// It is now safe to set the target label.
 			lb.Set(l.Name, l.Value)
 		}

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -936,6 +936,15 @@ func TestScrapeLoopAppend(t *testing.T) {
 			expLset:         labels.FromStrings("__name__", "metric", "exported_n", "1", "n", "2"),
 			expValue:        0,
 		}, {
+			// When "honor_labels" is not set
+			// exported label from discovery don't get overwritten
+			title:           "Label name collision",
+			honorLabels:     false,
+			scrapeLabels:    `metric 0`,
+			discoveryLabels: []string{"n", "2", "exported_n", "2"},
+			expLset:         labels.FromStrings("__name__", "metric", "n", "2", "exported_n", "2"),
+			expValue:        0,
+		}, {
 			// Labels with no value need to be removed as these should not be ingested.
 			title:           "Delete Empty labels",
 			honorLabels:     false,


### PR DESCRIPTION
Linked to #5845 

When merging target labels and sample labels, we now check first if the label exists before creating the exported one. The previous behaviour was causing a label for no obvious reason.

The issue was:
```
target_labels : {foo: "val", exported_foo: "another_val"}
sample_labels: {}
```
After ingestion it became:
```
sample_labels : {foo: "val"}
```

This is due to the fact that Prometheus will first process `exported_foo`:
```
sample_labels : {foo: "val", exported_foo: "another_val", exported_foo: ""}
```
then foo:
```
sample_labels : {foo: "val", exported_foo: "", exported_foo: ""}
```
resulting in:
```
sample_labels : {foo: "val"}
```

Note that since labels are computed in order, the labels wouldn't be impacted for this set of labels:
```
target_labels : {bar: "val", exported_bar: "another_val"}
```


