### PR TITLE
Improve PromQL parser performance by making it non-concurrent

### DIFF
--- a/promql/lex_test.go
+++ b/promql/lex_test.go
@@ -695,15 +695,11 @@ func TestLexer(t *testing.T) {
 			for i, test := range typ.tests {
 				l := &lexer{
 					input:      test.input,
-					items:      make(chan item),
 					seriesDesc: test.seriesDesc,
 				}
-				go l.run()
+				l.run()
 
-				out := []item{}
-				for it := range l.items {
-					out = append(out, it)
-				}
+				out := l.items
 
 				lastItem := out[len(out)-1]
 				if test.fail {

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -1741,9 +1741,6 @@ func TestRecoverParserRuntime(t *testing.T) {
 
 	defer func() {
 		testutil.Equals(t, err, errUnexpected)
-
-		_, ok := <-p.lex.items
-		testutil.Assert(t, !ok, "lex.items was not closed")
 	}()
 	defer p.recover(&err)
 	// Cause a runtime panic.


### PR DESCRIPTION
Before this commit, the PromQL parser ran in two goroutines:
* The lexer goroutine that splits the input into tokens and sent them over a channel to
* the parser goroutine which produces the abstract syntax tree

The Problem with this approach is that the parser spends more time on goroutine creation
and synchronisation than on actual parsing.

This commit removes that concurrency and replaces the channel by a slice based buffer.

Benchmarks show that this makes the parser up to 7 times faster than before.

Signed-off-by: Tobias Guggenmos <tguggenm@redhat.com>

Benchmark results (based on the #6355): https://gist.github.com/slrtbtfs/24a4d92de43ad4ae871714840dab2d76