### PR TITLE
promql: Clean up parser struct

### DIFF
--- a/promql/parse.go
+++ b/promql/parse.go
@@ -32,9 +32,9 @@ import (
 )
 
 type parser struct {
-	lex       *lexer
-	token     [3]item
-	peekCount int
+	lex     *lexer
+	token   item
+	peeking bool
 }
 
 // ParseErr wraps a parsing error with line and position context.
@@ -245,41 +245,41 @@ func (p *parser) typecheck(node Node) (err error) {
 
 // next returns the next token.
 func (p *parser) next() item {
-	if p.peekCount > 0 {
-		p.peekCount--
+	if p.peeking {
+		p.peeking = false
 	} else {
 		t := p.lex.nextItem()
 		// Skip comments.
 		for t.typ == ItemComment {
 			t = p.lex.nextItem()
 		}
-		p.token[0] = t
+		p.token = t
 	}
-	if p.token[p.peekCount].typ == ItemError {
-		p.errorf("%s", p.token[p.peekCount].val)
+	if p.token.typ == ItemError {
+		p.errorf("%s", p.token.val)
 	}
-	return p.token[p.peekCount]
+	return p.token
 }
 
 // peek returns but does not consume the next token.
 func (p *parser) peek() item {
-	if p.peekCount > 0 {
-		return p.token[p.peekCount-1]
+	if p.peeking {
+		return p.token
 	}
-	p.peekCount = 1
+	p.peeking = true
 
 	t := p.lex.nextItem()
 	// Skip comments.
 	for t.typ == ItemComment {
 		t = p.lex.nextItem()
 	}
-	p.token[0] = t
-	return p.token[0]
+	p.token = t
+	return p.token
 }
 
 // backup backs the input stream up one token.
 func (p *parser) backup() {
-	p.peekCount++
+	p.peeking = true
 }
 
 // errorf formats the error and terminates processing.

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -245,9 +245,7 @@ func (p *parser) typecheck(node Node) (err error) {
 
 // next returns the next token.
 func (p *parser) next() item {
-	if p.peeking {
-		p.peeking = false
-	} else {
+	if !p.peeking {
 		t := p.lex.nextItem()
 		// Skip comments.
 		for t.typ == ItemComment {
@@ -255,6 +253,9 @@ func (p *parser) next() item {
 		}
 		p.token = t
 	}
+
+	p.peeking = false
+
 	if p.token.typ == ItemError {
 		p.errorf("%s", p.token.val)
 	}


### PR DESCRIPTION
The parser struct used two have two somewhat misused fields:

peekCount int
token     [3]item

By reading the code carefully one notices, that peekCount always has the value 0 or 1 and that only the first element of token is ever accessed.

To make this clearer, this commit replaces the token array with a single variable and the peekCount int with a boolean.

Signed-off-by: Tobias Guggenmos <tguggenm@redhat.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->