### PR TITLE
PromQL: Reduce Code duplication in AST traversion

### DIFF
--- a/promql/ast.go
+++ b/promql/ast.go
@@ -248,61 +248,10 @@ func Walk(v Visitor, node Node, path []Node) error {
 	}
 	path = append(path, node)
 
-	switch n := node.(type) {
-	case *EvalStmt:
-		if err := Walk(v, n.Expr, path); err != nil {
+	for _, e := range Children(node) {
+		if err := Walk(v, e, path); err != nil {
 			return err
 		}
-
-	case Expressions:
-		for _, e := range n {
-			if err := Walk(v, e, path); err != nil {
-				return err
-			}
-		}
-	case *AggregateExpr:
-		if n.Param != nil {
-			if err := Walk(v, n.Param, path); err != nil {
-				return err
-			}
-		}
-		if err := Walk(v, n.Expr, path); err != nil {
-			return err
-		}
-
-	case *BinaryExpr:
-		if err := Walk(v, n.LHS, path); err != nil {
-			return err
-		}
-		if err := Walk(v, n.RHS, path); err != nil {
-			return err
-		}
-
-	case *Call:
-		if err := Walk(v, n.Args, path); err != nil {
-			return err
-		}
-
-	case *SubqueryExpr:
-		if err := Walk(v, n.Expr, path); err != nil {
-			return err
-		}
-
-	case *ParenExpr:
-		if err := Walk(v, n.Expr, path); err != nil {
-			return err
-		}
-
-	case *UnaryExpr:
-		if err := Walk(v, n.Expr, path); err != nil {
-			return err
-		}
-
-	case *MatrixSelector, *NumberLiteral, *StringLiteral, *VectorSelector:
-		// nothing to do
-
-	default:
-		panic(errors.Errorf("promql.Walk: unhandled node type %T", node))
 	}
 
 	_, err = v.Visit(nil, nil)
@@ -369,7 +318,7 @@ func Children(node Node) []Node {
 		return []Node{n.Expr}
 	case *MatrixSelector, *NumberLiteral, *StringLiteral, *VectorSelector:
 		// nothing to do
-
+		return []Node{}
 	default:
 		panic(errors.Errorf("promql.Children: unhandled node type %T", node))
 	}

--- a/promql/printer.go
+++ b/promql/printer.go
@@ -38,39 +38,10 @@ func tree(node Node, level string) string {
 
 	level += " · · ·"
 
-	switch n := node.(type) {
-	case *EvalStmt:
-		t += tree(n.Expr, level)
-
-	case Expressions:
-		for _, e := range n {
-			t += tree(e, level)
-		}
-	case *AggregateExpr:
-		t += tree(n.Expr, level)
-
-	case *BinaryExpr:
-		t += tree(n.LHS, level)
-		t += tree(n.RHS, level)
-
-	case *Call:
-		t += tree(n.Args, level)
-
-	case *ParenExpr:
-		t += tree(n.Expr, level)
-
-	case *UnaryExpr:
-		t += tree(n.Expr, level)
-
-	case *SubqueryExpr:
-		t += tree(n.Expr, level)
-
-	case *MatrixSelector, *NumberLiteral, *StringLiteral, *VectorSelector:
-		// nothing to do
-
-	default:
-		panic("promql.Tree: not all node types covered")
+	for _, e := range Children(node) {
+		t += tree(e, level)
 	}
+
 	return t
 }
 


### PR DESCRIPTION
This PR adds a new Children() function that returns the Children of an AST Node. 

By changing existing AST traversing code to use this new function, code duplication is reduced.

This new function is also used by the language server.

This PR is the better version of #6205, which will be closed in favour of this one.