### PR TITLE
WIP: Add checkpointing within remote write; 

### DIFF
--- a/storage/remote/checkpoint.go
+++ b/storage/remote/checkpoint.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+)
+
+// A checkpoint file for remote write to use on restart/config reload
+// in attempt to minimize the chance of missing data in the remote system.
+type rwCheckpoint struct {
+	f *os.File
+}
+
+// NewRemoteWriteCheckpoint creates a new file for the
+// queue's remote write checkpoint if it doesn't already
+// have one, otherwise it returns the timestamp that was
+// contained in the existing file.
+func NewRemoteWriteCheckpoint(name string) (rwCheckpoint, int64, error) {
+	var c rwCheckpoint
+
+	_, err := os.Stat(name)
+	if err == nil {
+		f, err := os.OpenFile(name, os.O_WRONLY, 0666)
+		if err != nil {
+			return rwCheckpoint{}, 0, err
+		}
+		c.f = f
+		ts, err := c.readCheckpoint()
+		return c, ts, err
+	}
+	f, err := os.OpenFile(name, os.O_CREATE|os.O_RDWR, 0666)
+	if err != nil {
+		return rwCheckpoint{}, 0, err
+	}
+	c.f = f
+	return c, 0, nil
+}
+
+func (c *rwCheckpoint) writeCheckpoint(ts int64) error {
+	err := c.f.Truncate(0)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.f.WriteAt([]byte(strconv.FormatInt(ts, 10)), 0)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *rwCheckpoint) readCheckpoint() (int64, error) {
+	b, err := ioutil.ReadFile(c.f.Name())
+	if err != nil {
+		return 0, err
+	}
+
+	ts, err := strconv.ParseInt(string(b), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return ts, nil
+}
+
+func (c *rwCheckpoint) close() error {
+	return c.f.Close()
+}

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -140,7 +140,8 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 		if err != nil {
 			return err
 		}
-		newQueues = append(newQueues, NewQueueManager(
+
+		newQueue, err := NewQueueManager(
 			prometheus.DefaultRegisterer,
 			rws.logger,
 			rws.walDir,
@@ -150,7 +151,12 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			rwConf.WriteRelabelConfigs,
 			c,
 			rws.flushDeadline,
-		))
+			hash,
+		)
+		if err != nil {
+			return err
+		}
+		newQueues = append(newQueues, newQueue)
 		newHashes = append(newHashes, hash)
 		newClientIndexes = append(newClientIndexes, i)
 	}


### PR DESCRIPTION
For #6333, this PR adds a file per queue with the highest timestamp from a sample that has been sent by that queue. This allows the queue to restart from that point in the event of a restart, potentially decreasing the number of samples lost in the case of remote write being far behind or not able to flush when it shutdown last.

Feel free to ignore `queue_manager_test.go` for now. Once https://github.com/prometheus/prometheus/pull/6043 is merged the naming of the queue and therefore the naming of it's checkpoint file will be much simpler.

@csmarchbanks 

Signed-off-by: Callum Styan <callumstyan@gmail.com>
