### PR TITLE
Correct the default max block duratioh value

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -53,7 +53,7 @@ For further details on file format, see [TSDB format](https://github.com/prometh
 
 The initial two-hour blocks are eventually compacted into longer blocks in the background.
 
-Compaction will create larger blocks up to 10% of the retention time, or 21 days, whichever is smaller.
+Compaction will create larger blocks up to 10% of the retention time, or 31 days, whichever is smaller.
 
 ## Operational aspects
 


### PR DESCRIPTION
The default value is 31 days. [1]

[1] https://github.com/prometheus/prometheus/blob/master/cmd/prometheus/main.go#L312

Signed-off-by: Kien Nguyen <kiennt2609@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->