### PR TITLE
promql: Implement yyLexer interface

### DIFF
--- a/promql/parse.go
+++ b/promql/parse.go
@@ -337,6 +337,33 @@ func (p *parser) recover(errp *error) {
 	p.lex.close()
 }
 
+// yySymType is the Type the yacc generated parser expects for lexer items.
+//
+// For more information, see https://godoc.org/golang.org/x/tools/cmd/goyacc.
+type yySymType item
+
+// Lex is expected by the yyLexer interface of the yacc generated parser.
+// It writes the next item provided by the lexer to the provided pointer address.
+// Comments are skipped.
+//
+// The yyLexer interface is currently implemented by the parser to allow
+// the generated and non-generated parts to work together with regards to lookahead
+// and error handling.
+//
+// For more information, see https://godoc.org/golang.org/x/tools/cmd/goyacc.
+func (p *parser) Lex(lval *yySymType) int {
+	*lval = yySymType(p.next())
+
+	return int(item(*lval).typ)
+}
+
+// Error is expected by the yyLexer interface of the yacc generated parser.
+//
+// For more information, see https://godoc.org/golang.org/x/tools/cmd/goyacc.
+func (p *parser) Error(e string) {
+	p.errorf(e)
+}
+
 // expr parses any expression.
 func (p *parser) expr() Expr {
 	// Parse the starting expression.


### PR DESCRIPTION
This is the first step towards a generated lexer as described in #6256.

It adds methods to the parser struct, that make it implement the yyLexer interface required by a yacc generated parser, as descibed here: https://godoc.org/golang.org/x/tools/cmd/goyacc

The yyLexer interface is implemented by the parser struct instead of the lexer struct for the following reasons:

* Both parsers have a lookahead that the lexer does not know about. This solution makes it possible to synchronize these lookaheads when switching parsers.
* The routines to handle parser errors are not accessible to the lexer.

Signed-off-by: Tobias Guggenmos <tguggenm@redhat.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->