### PR TITLE
fix subquery with offset handling in rules

### DIFF
--- a/promql/printer.go
+++ b/promql/printer.go
@@ -128,7 +128,11 @@ func (node *SubqueryExpr) String() string {
 	if node.Step != 0 {
 		step = model.Duration(node.Step).String()
 	}
-	return fmt.Sprintf("%s[%s:%s]", node.Expr.String(), model.Duration(node.Range), step)
+	offset := ""
+	if node.Offset != time.Duration(0) {
+		offset = fmt.Sprintf(" offset %s", model.Duration(node.Offset))
+	}
+	return fmt.Sprintf("%s[%s:%s]%s", node.Expr.String(), model.Duration(node.Range), step, offset)
 }
 
 func (node *NumberLiteral) String() string {

--- a/promql/printer_test.go
+++ b/promql/printer_test.go
@@ -84,6 +84,9 @@ func TestExprString(t *testing.T) {
 			in: `a[5m] offset 1m`,
 		},
 		{
+			in: `a[1h:5m] offset 1m`,
+		},
+		{
 			in: `{__name__="a"}`,
 		},
 	}


### PR DESCRIPTION

Hi,
Currently any rule that contains subquery with offset is incorrectly executed and displayed.
The offset part is completely missing from query in such case.

This PR seems to fix this

@fabxc  @bwplotka 