### PR TITLE
Update and re-work maintainers file.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,10 +1,21 @@
-Maintainers of this repository with their focus areas:
+@brian-brazil is the main/default maintainer, some parts of the codebase have other maintainers:
 
-* Brian Brazil <brian.brazil@robustperception.io> @brian-brazil: Console templates; semantics of PromQL, service discovery, and relabeling.
-* Fabian Reinartz <freinartz@google.com> @fabxc: PromQL parsing and evaluation; implementation of retrieval, alert notification, and service discovery.
-* Julius Volz <julius.volz@gmail.com> @juliusv: Web UI.
-* Krasi Georgiev <kgeorgie@redhat.com> @krasi-georgiev: TSDB - the storage engine.
-* Ganesh Vernekar <cs15btech11018@iith.ac.in> @codesome: TSDB - the storage engine.
-* Chris Marchbanks <csmarchbanks@gmail.com> @csmarchbanks: Remote write integration.
-* Callum Styan <callumstyan@gmail.com> @cstyan: Remote write integration.
-* Bartłomiej Płotka <bwplotka@gmail.com> @bwplotka: Remote read integration.
+* `cmd`
+  * `promtool`: @simonpasquier
+* `discovery`
+  * `k8s`: @brancz
+* `documentation`
+  * `prometheus-mixin`: @beorn7
+* `storage`
+  * `remote`: @csmarchbanks, @cstyan
+* `tsdb`: @codesome, @krasi-georgiev
+* `web`
+  * `ui`: @juliusv
+* `Makefile` and related build configuration: @simonpasquier, @SuperQ
+
+For the sake of brevity all subtrees are not explicitly listed. Due to the size
+of this repository, the natural changes in focus of maintainers over time, and
+nuances of where particular features live, this list will always be incomplete
+and out of date. However the listed maintainer(s) should be able to direct a
+PR/question to the right person.
+


### PR DESCRIPTION
For sanity I'm not going to try to distinguish the things I'm maintainer
for because I'm the right person (e.g. template) vs things I'm the
maintainer for because someone has to be (e.g. pkg). Also add a general
warning to handle that this is more nuanced than it's worth trying to
capture, and relatedly always going to be out of date.

I didn't put Bartek down for remote read, as particular functions of
particlar files seems a a bit fine grained.

Fixes #4714

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>