### PR TITLE
Allow alerts to explicitly specify the ValidUntil field that is sent to alertmanager

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -97,6 +97,7 @@ type Rule struct {
 	Alert       string            `yaml:"alert,omitempty"`
 	Expr        string            `yaml:"expr"`
 	For         model.Duration    `yaml:"for,omitempty"`
+	ValidFor    model.Duration    `yaml:"validFor,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 }
@@ -121,6 +122,9 @@ func (r *Rule) Validate() (errs []error) {
 		}
 		if r.For != 0 {
 			errs = append(errs, errors.Errorf("invalid field 'for' in recording rule"))
+		}
+		if r.ValidFor != 0 {
+			errs = append(errs, errors.Errorf("invalid field 'validFor' in recording rule"))
 		}
 		if !model.IsValidMetricName(model.LabelValue(r.Record)) {
 			errs = append(errs, errors.Errorf("invalid recording rule name: %s", r.Record))

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -910,6 +910,7 @@ func (m *Manager) LoadGroups(
 						externalLabels,
 						m.restored,
 						log.With(m.logger, "alert", r.Alert),
+						time.Duration(r.ValidFor),
 					))
 					continue
 				}

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -52,7 +52,7 @@ func TestAlertingRule(t *testing.T) {
 		expr,
 		time.Minute,
 		labels.FromStrings("severity", "{{\"c\"}}ritical"),
-		nil, nil, true, nil,
+		nil, nil, true, nil, 0,
 	)
 	result := promql.Vector{
 		{
@@ -193,7 +193,7 @@ func TestForStateAddSamples(t *testing.T) {
 		expr,
 		time.Minute,
 		labels.FromStrings("severity", "{{\"c\"}}ritical"),
-		nil, nil, true, nil,
+		nil, nil, true, nil, 0,
 	)
 	result := promql.Vector{
 		{
@@ -367,7 +367,7 @@ func TestForStateRestore(t *testing.T) {
 		expr,
 		alertForDuration,
 		labels.FromStrings("severity", "critical"),
-		nil, nil, true, nil,
+		nil, nil, true, nil, 0,
 	)
 
 	group := NewGroup("default", "", time.Second, []Rule{rule}, true, opts)
@@ -427,7 +427,7 @@ func TestForStateRestore(t *testing.T) {
 			expr,
 			alertForDuration,
 			labels.FromStrings("severity", "critical"),
-			nil, nil, false, nil,
+			nil, nil, false, nil, 0,
 		)
 		newGroup := NewGroup("default", "", time.Second, []Rule{newRule}, true, opts)
 
@@ -582,13 +582,13 @@ func readSeriesSet(ss storage.SeriesSet) (map[string][]promql.Point, error) {
 func TestCopyState(t *testing.T) {
 	oldGroup := &Group{
 		rules: []Rule{
-			NewAlertingRule("alert", nil, 0, nil, nil, nil, true, nil),
+			NewAlertingRule("alert", nil, 0, nil, nil, nil, true, nil, 0),
 			NewRecordingRule("rule1", nil, nil),
 			NewRecordingRule("rule2", nil, nil),
 			NewRecordingRule("rule3", nil, labels.Labels{{Name: "l1", Value: "v1"}}),
 			NewRecordingRule("rule3", nil, labels.Labels{{Name: "l1", Value: "v2"}}),
 			NewRecordingRule("rule3", nil, labels.Labels{{Name: "l1", Value: "v3"}}),
-			NewAlertingRule("alert2", nil, 0, labels.Labels{{Name: "l2", Value: "v1"}}, nil, nil, true, nil),
+			NewAlertingRule("alert2", nil, 0, labels.Labels{{Name: "l2", Value: "v1"}}, nil, nil, true, nil, 0),
 		},
 		seriesInPreviousEval: []map[string]labels.Labels{
 			{},
@@ -607,10 +607,10 @@ func TestCopyState(t *testing.T) {
 			NewRecordingRule("rule3", nil, labels.Labels{{Name: "l1", Value: "v0"}}),
 			NewRecordingRule("rule3", nil, labels.Labels{{Name: "l1", Value: "v1"}}),
 			NewRecordingRule("rule3", nil, labels.Labels{{Name: "l1", Value: "v2"}}),
-			NewAlertingRule("alert", nil, 0, nil, nil, nil, true, nil),
+			NewAlertingRule("alert", nil, 0, nil, nil, nil, true, nil, 0),
 			NewRecordingRule("rule1", nil, nil),
-			NewAlertingRule("alert2", nil, 0, labels.Labels{{Name: "l2", Value: "v0"}}, nil, nil, true, nil),
-			NewAlertingRule("alert2", nil, 0, labels.Labels{{Name: "l2", Value: "v1"}}, nil, nil, true, nil),
+			NewAlertingRule("alert2", nil, 0, labels.Labels{{Name: "l2", Value: "v0"}}, nil, nil, true, nil, 0),
+			NewAlertingRule("alert2", nil, 0, labels.Labels{{Name: "l2", Value: "v1"}}, nil, nil, true, nil, 0),
 			NewRecordingRule("rule4", nil, nil),
 		},
 		seriesInPreviousEval: make([]map[string]labels.Labels, 8),
@@ -745,7 +745,7 @@ func TestNotify(t *testing.T) {
 
 	expr, err := promql.ParseExpr("a > 1")
 	testutil.Ok(t, err)
-	rule := NewAlertingRule("aTooHigh", expr, 0, labels.Labels{}, labels.Labels{}, nil, true, log.NewNopLogger())
+	rule := NewAlertingRule("aTooHigh", expr, 0, labels.Labels{}, labels.Labels{}, nil, true, log.NewNopLogger(), 0)
 	group := NewGroup("alert", "", time.Second, []Rule{rule}, true, opts)
 
 	app, _ := storage.Appender()

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -151,6 +151,7 @@ func (m rulesRetrieverMock) AlertingRules() []*rules.AlertingRule {
 		labels.Labels{},
 		true,
 		log.NewNopLogger(),
+		0,
 	)
 	rule2 := rules.NewAlertingRule(
 		"test_metric4",
@@ -161,6 +162,7 @@ func (m rulesRetrieverMock) AlertingRules() []*rules.AlertingRule {
 		labels.Labels{},
 		true,
 		log.NewNopLogger(),
+		0,
 	)
 	var r []*rules.AlertingRule
 	r = append(r, rule1)


### PR DESCRIPTION
Alerts EndsAt is being set to 3 multiplied by whatever value is larger between resendDelay and interval, this change will allow for explicitly setting EndsAt at an alert level.

The use case we ran into is that we don't want to throttle the alerts being sent from prometheus by a long period, and we have an alert with short evaluation interval, and still we would like alertmanager to consider the alert to be resolved only if it didn't receive it as firing for a period of 10 minutes, before PR#4550 that could have been accomplished by setting resolve_timeout, but after the changes in #4550, it is now coupled with resendDelay and interval, this PR will allow to have an alert with short evaluation interval, and higher validUntil value, without having to use resendDelay option.

Related PRs:
#4538
#4550

Signed-off-by: Shadi Abdelfatah <shadi.abdelfatah@gmail.com>
