### PR TITLE
discovery/kubernetes: fix client metrics

### DIFF
--- a/discovery/kubernetes/client_metrics.go
+++ b/discovery/kubernetes/client_metrics.go
@@ -19,15 +19,11 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/metrics"
 	"k8s.io/client-go/util/workqueue"
 )
 
-const (
-	cacheMetricsNamespace     = metricsNamespace + "_cache"
-	workqueueMetricsNamespace = metricsNamespace + "_workqueue"
-)
+const workqueueMetricsNamespace = metricsNamespace + "_workqueue"
 
 var (
 	// Metrics for client-go's HTTP requests.
@@ -47,68 +43,6 @@ var (
 			Objectives: map[float64]float64{},
 		},
 		[]string{"endpoint"},
-	)
-
-	// Definition of metrics for client-go cache metrics provider.
-	clientGoCacheListTotalMetric = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: cacheMetricsNamespace,
-			Name:      "list_total",
-			Help:      "Total number of list operations.",
-		},
-	)
-	clientGoCacheListDurationMetric = prometheus.NewSummary(
-		prometheus.SummaryOpts{
-			Namespace:  cacheMetricsNamespace,
-			Name:       "list_duration_seconds",
-			Help:       "Duration of a Kubernetes API call in seconds.",
-			Objectives: map[float64]float64{},
-		},
-	)
-	clientGoCacheItemsInListCountMetric = prometheus.NewSummary(
-		prometheus.SummaryOpts{
-			Namespace:  cacheMetricsNamespace,
-			Name:       "list_items",
-			Help:       "Count of items in a list from the Kubernetes API.",
-			Objectives: map[float64]float64{},
-		},
-	)
-	clientGoCacheWatchesCountMetric = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: cacheMetricsNamespace,
-			Name:      "watches_total",
-			Help:      "Total number of watch operations.",
-		},
-	)
-	clientGoCacheShortWatchesCountMetric = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: cacheMetricsNamespace,
-			Name:      "short_watches_total",
-			Help:      "Total number of short watch operations.",
-		},
-	)
-	clientGoCacheWatchesDurationMetric = prometheus.NewSummary(
-		prometheus.SummaryOpts{
-			Namespace:  cacheMetricsNamespace,
-			Name:       "watch_duration_seconds",
-			Help:       "Duration of watches on the Kubernetes API.",
-			Objectives: map[float64]float64{},
-		},
-	)
-	clientGoCacheItemsInWatchesCountMetric = prometheus.NewSummary(
-		prometheus.SummaryOpts{
-			Namespace:  cacheMetricsNamespace,
-			Name:       "watch_events",
-			Help:       "Number of items in watches on the Kubernetes API.",
-			Objectives: map[float64]float64{},
-		},
-	)
-	clientGoCacheLastResourceVersionMetric = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: cacheMetricsNamespace,
-			Name:      "last_resource_version",
-			Help:      "Last resource version from the Kubernetes API.",
-		},
 	)
 
 	// Definition of metrics for client-go workflow metrics provider
@@ -189,47 +123,6 @@ func (clientGoRequestMetricAdapter) Observe(verb string, u url.URL, latency time
 	clientGoRequestLatencyMetricVec.WithLabelValues(u.EscapedPath()).Observe(latency.Seconds())
 }
 
-// Definition of client-go cache metrics provider definition
-type clientGoCacheMetricsProvider struct{}
-
-func (f *clientGoCacheMetricsProvider) Register(registerer prometheus.Registerer) {
-	cache.SetReflectorMetricsProvider(f)
-	registerer.MustRegister(
-		clientGoCacheWatchesDurationMetric,
-		clientGoCacheWatchesCountMetric,
-		clientGoCacheListDurationMetric,
-		clientGoCacheListTotalMetric,
-		clientGoCacheLastResourceVersionMetric,
-		clientGoCacheShortWatchesCountMetric,
-		clientGoCacheItemsInWatchesCountMetric,
-		clientGoCacheItemsInListCountMetric,
-	)
-}
-func (clientGoCacheMetricsProvider) NewListsMetric(name string) cache.CounterMetric {
-	return clientGoCacheListTotalMetric
-}
-func (clientGoCacheMetricsProvider) NewListDurationMetric(name string) cache.SummaryMetric {
-	return clientGoCacheListDurationMetric
-}
-func (clientGoCacheMetricsProvider) NewItemsInListMetric(name string) cache.SummaryMetric {
-	return clientGoCacheItemsInListCountMetric
-}
-func (clientGoCacheMetricsProvider) NewWatchesMetric(name string) cache.CounterMetric {
-	return clientGoCacheWatchesCountMetric
-}
-func (clientGoCacheMetricsProvider) NewShortWatchesMetric(name string) cache.CounterMetric {
-	return clientGoCacheShortWatchesCountMetric
-}
-func (clientGoCacheMetricsProvider) NewWatchDurationMetric(name string) cache.SummaryMetric {
-	return clientGoCacheWatchesDurationMetric
-}
-func (clientGoCacheMetricsProvider) NewItemsInWatchMetric(name string) cache.SummaryMetric {
-	return clientGoCacheItemsInWatchesCountMetric
-}
-func (clientGoCacheMetricsProvider) NewLastResourceVersionMetric(name string) cache.GaugeMetric {
-	return clientGoCacheLastResourceVersionMetric
-}
-
 // Definition of client-go workqueue metrics provider definition
 type clientGoWorkqueueMetricsProvider struct{}
 
@@ -252,18 +145,10 @@ func (f *clientGoWorkqueueMetricsProvider) NewAddsMetric(name string) workqueue.
 	return clientGoWorkqueueAddsMetricVec.WithLabelValues(name)
 }
 func (f *clientGoWorkqueueMetricsProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
-	metric := clientGoWorkqueueLatencyMetricVec.WithLabelValues(name)
-	// Convert microseconds to seconds for consistency across metrics.
-	return prometheus.ObserverFunc(func(v float64) {
-		metric.Observe(v / 1e6)
-	})
+	return clientGoWorkqueueLatencyMetricVec.WithLabelValues(name)
 }
 func (f *clientGoWorkqueueMetricsProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
-	metric := clientGoWorkqueueWorkDurationMetricVec.WithLabelValues(name)
-	// Convert microseconds to seconds for consistency across metrics.
-	return prometheus.ObserverFunc(func(v float64) {
-		metric.Observe(v / 1e6)
-	})
+	return clientGoWorkqueueWorkDurationMetricVec.WithLabelValues(name)
 }
 func (f *clientGoWorkqueueMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
 	return clientGoWorkqueueUnfinishedWorkSecondsMetricVec.WithLabelValues(name)

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -139,12 +139,10 @@ func init() {
 
 	var (
 		clientGoRequestMetricAdapterInstance     = clientGoRequestMetricAdapter{}
-		clientGoCacheMetricsProviderInstance     = clientGoCacheMetricsProvider{}
 		clientGoWorkqueueMetricsProviderInstance = clientGoWorkqueueMetricsProvider{}
 	)
 
 	clientGoRequestMetricAdapterInstance.Register(prometheus.DefaultRegisterer)
-	clientGoCacheMetricsProviderInstance.Register(prometheus.DefaultRegisterer)
 	clientGoWorkqueueMetricsProviderInstance.Register(prometheus.DefaultRegisterer)
 
 }


### PR DESCRIPTION
The Kubernetes client records workqueue duration and latency metrics as seconds so there's no need to convert the values from microseconds to seconds anymore.

https://github.com/prometheus/prometheus/blob/eba5e0271837b00c6fd5c63ff1a3d0f9bafdaf11/vendor/k8s.io/client-go/util/workqueue/metrics.go#L123

https://github.com/prometheus/prometheus/blob/eba5e0271837b00c6fd5c63ff1a3d0f9bafdaf11/vendor/k8s.io/client-go/util/workqueue/metrics.go#L135

The cache metrics (prometheus_sd_kubernetes_cache_*) are removed because they aren't used anymore by the client though still exposed by its API. See https://github.com/kubernetes/client-go/commit/a1320a3a472a94bbf467d743f845b1269fc0398e.

