### PR TITLE
Don't buffer up posting offset table in memory on compaction.

### DIFF
--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -852,8 +852,10 @@ func BenchmarkCompaction(b *testing.B) {
 
 			b.ResetTimer()
 			b.ReportAllocs()
-			_, err = c.Compact(dir, blockDirs, blocks)
-			testutil.Ok(b, err)
+			for i := 0; i < b.N; i++ {
+				_, err = c.Compact(dir, blockDirs, blocks)
+				testutil.Ok(b, err)
+			}
 		})
 	}
 }

--- a/tsdb/encoding/encoding.go
+++ b/tsdb/encoding/encoding.go
@@ -75,10 +75,20 @@ func (e *Encbuf) PutUvarintStr(s string) {
 // PutHash appends a hash over the buffers current contents to the buffer.
 func (e *Encbuf) PutHash(h hash.Hash) {
 	h.Reset()
+	e.WriteToHash(h)
+	e.PutHashSum(h)
+}
+
+// WriteToHash writes the current buffer contents to the given hash.
+func (e *Encbuf) WriteToHash(h hash.Hash) {
 	_, err := h.Write(e.B)
 	if err != nil {
 		panic(err) // The CRC32 implementation does not error
 	}
+}
+
+// PutHashSum writes the Sum of the given hash to the buffer.
+func (e *Encbuf) PutHashSum(h hash.Hash) {
 	e.B = h.Sum(e.B)
 }
 


### PR DESCRIPTION
We can instead write it as we go, and then go back and write in the
length at the end.

Also fix the compaction benchmark, which indicates no changes.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>