### PR TITLE
fix typo seperator

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1777,7 +1777,7 @@ func TestDB_LabelNames(t *testing.T) {
 		err = db.compact()
 		testutil.Ok(t, err)
 		// All blocks have same label names, hence check them individually.
-		// No need to aggregrate and check.
+		// No need to aggregate and check.
 		for _, b := range db.Blocks() {
 			blockIndexr, err := b.Index()
 			testutil.Ok(t, err)
@@ -1787,7 +1787,7 @@ func TestDB_LabelNames(t *testing.T) {
 			testutil.Ok(t, blockIndexr.Close())
 		}
 
-		// Addings more samples to head with new label names
+		// Adding more samples to head with new label names
 		// so that we can test (head+disk).LabelNames() (the union).
 		appendSamples(db, 5, 9, tst.sampleLabels2)
 

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -45,7 +45,7 @@ const (
 	// FormatV2 represents 2 version of index.
 	FormatV2 = 2
 
-	labelNameSeperator = "\xff"
+	labelNameSeparator = "\xff"
 
 	indexFilename = "index"
 )
@@ -866,7 +866,7 @@ func (r *Reader) SymbolTableSize() uint64 {
 // LabelValues returns value tuples that exist for the given label name tuples.
 func (r *Reader) LabelValues(names ...string) (StringTuples, error) {
 
-	key := strings.Join(names, labelNameSeperator)
+	key := strings.Join(names, labelNameSeparator)
 	off, ok := r.labels[key]
 	if !ok {
 		// XXX(fabxc): hot fix. Should return a partial data error and handle cases
@@ -901,7 +901,7 @@ func (emptyStringTuples) Len() int                   { return 0 }
 func (r *Reader) LabelIndices() ([][]string, error) {
 	var res [][]string
 	for s := range r.labels {
-		res = append(res, strings.Split(s, labelNameSeperator))
+		res = append(res, strings.Split(s, labelNameSeparator))
 	}
 	return res, nil
 }
@@ -958,8 +958,8 @@ func (r *Reader) LabelNames() ([]string, error) {
 	labelNamesMap := make(map[string]struct{}, len(r.labels))
 	for key := range r.labels {
 		// 'key' contains the label names concatenated with the
-		// delimiter 'labelNameSeperator'.
-		names := strings.Split(key, labelNameSeperator)
+		// delimiter 'labelNameSeparator'.
+		names := strings.Split(key, labelNameSeparator)
 		for _, name := range names {
 			if name == allPostingsKey.Name {
 				// This is not from any metric.


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Fix a typo seperator -> separator

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->