### PR TITLE
Only add slices with real backing memory to the point pool.

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1284,8 +1284,10 @@ func getPointSlice(sz int) []Point {
 }
 
 func putPointSlice(p []Point) {
-	//lint:ignore SA6002 relax staticcheck verification.
-	pointPool.Put(p[:0])
+	if cap(p) > 0 {
+		//lint:ignore SA6002 relax staticcheck verification.
+		pointPool.Put(p[:0])
+	}
 }
 
 // matrixSelector evaluates a *MatrixSelector expression.


### PR DESCRIPTION
This seemed like a possible optimisation, on the other hand these slices are usually allocated with a capacity greater zero so it might not be effective.

I've run the promql benchmarks on master and this branch. I'm attaching the results of `benchcmp bench-master.txt bench-ignore-zero-cap.txt | grep -v '[+-]0[.]\d\d%'` (i.e. excluding results with less than 1% variation)

[bench-cmp.txt](https://github.com/prometheus/prometheus/files/3939523/bench-cmp.txt)
