### PR TITLE
PromQL: Parse label sets using the generated parser

### DIFF
--- a/promql/generated_parser.y
+++ b/promql/generated_parser.y
@@ -140,6 +140,8 @@ label_match_list:
 label_matchers  : 
                 LEFT_BRACE label_match_list RIGHT_BRACE
                         { $$ = $2 }
+                | LEFT_BRACE label_match_list COMMA RIGHT_BRACE
+                        { $$ = $2 }
                 | LEFT_BRACE RIGHT_BRACE
                         { $$ = []*labels.Matcher{} }
 
@@ -163,6 +165,8 @@ match_op        :
 
 label_set       :
                 LEFT_BRACE label_set_list RIGHT_BRACE
+                        { $$ = labels.New($2...) }
+                | LEFT_BRACE label_set_list COMMA RIGHT_BRACE
                         { $$ = labels.New($2...) }
                 | LEFT_BRACE RIGHT_BRACE
                         { $$ = labels.New() }

--- a/promql/generated_parser.y
+++ b/promql/generated_parser.y
@@ -152,6 +152,8 @@ label_matcher   :
                         { $$ = yylex.(*parser).newLabelMatcher($1, $2, $3) }
                 | IDENTIFIER match_op error
                         { yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())}
+                | error
+                        { yylex.(*parser).errorf("unexpected %v in label matching, expected identifier or \"}\"", yylex.(*parser).token.desc()) }
                 ;
 
 match_op        :
@@ -177,6 +179,9 @@ label_set_list  :
                         { $$ = append($1, $3) }
                 | label_set_item
                         { $$ = []labels.Label{$1} }
+                | label_set_list error
+                        { yylex.(*parser).errorf("unexpected %v in label matching, expected \",\" or \"}\"", yylex.(*parser).token.desc()) }
+                
                 ;
 
 label_set_item  :
@@ -186,6 +191,8 @@ label_set_item  :
                         { yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())}
                 | IDENTIFIER error
                         { yylex.(*parser).errorf("expected \"=\" but got %s", yylex.(*parser).token.desc())}
+                | error
+                        { yylex.(*parser).errorf("unexpected %v in label matching, expected identifier or \"}\"", yylex.(*parser).token.desc()) }
                 ;
 
                 

--- a/promql/generated_parser.y
+++ b/promql/generated_parser.y
@@ -155,7 +155,7 @@ label_matcher   :
                 | IDENTIFIER match_op error
                         { yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())}
                 | IDENTIFIER error 
-                        { yylex.(*parser).errorf("expected label matching operator but got %s", yylex.(*parser).token.Val) } 
+                        { yylex.(*parser).errorf("unexpected %v in label matching, expected label matching operator", yylex.(*parser).token.Val) } 
                 | error
                         { yylex.(*parser).errorf("unexpected %v in label matching, expected identifier or \"}\"", yylex.(*parser).token.desc()) }
                 ;
@@ -190,11 +190,11 @@ label_set_item  :
                 IDENTIFIER EQL STRING
                         { $$ = labels.Label{Name: $1.Val, Value: yylex.(*parser).unquoteString($3.Val) } } 
                 | IDENTIFIER EQL error
-                        { yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())}
+                        { yylex.(*parser).errorf("unexpected %v in label set, expected string", yylex.(*parser).token.desc())}
                 | IDENTIFIER error
-                        { yylex.(*parser).errorf("expected \"=\" but got %s", yylex.(*parser).token.desc())}
+                        { yylex.(*parser).errorf("unexpected %v in label set, expected \"=\"", yylex.(*parser).token.desc())}
                 | error
-                        { yylex.(*parser).errorf("unexpected %s in label matching, expected identifier or \"}\"", yylex.(*parser).token.desc()) }
+                        { yylex.(*parser).errorf("unexpected %v in label set, expected identifier or \"}\"", yylex.(*parser).token.desc()) }
                 ;
 
                 

--- a/promql/generated_parser.y
+++ b/promql/generated_parser.y
@@ -20,12 +20,13 @@
 %}
 
 %union {
-    node Node
-    item Item
-    matchers []*labels.Matcher
-    matcher  *labels.Matcher
-    labelSet []labels.Label
+    node      Node
+    item      Item
+    matchers  []*labels.Matcher
+    matcher   *labels.Matcher
+    labelSet  []labels.Label
     label     labels.Label
+    labels    labels.Labels
 }
 
 
@@ -112,7 +113,8 @@
 
 %type <item> match_op
 
-%type <labelSet> label_set label_set_list
+%type <labels> label_set
+%type <labelSet> label_set_list
 %type <label> label_set_item    
 
 %start start
@@ -122,6 +124,7 @@
 start           : START_LABELS label_matchers
                      {yylex.(*parser).generatedParserResult.(*VectorSelector).LabelMatchers = $2}
                 | START_LABEL_SET label_set
+                     { yylex.(*parser).generatedParserResult = $2 }
                 | error 
                         { yylex.(*parser).errorf("unknown syntax error after parsing %v", yylex.(*parser).token.desc()) }
                 ;
@@ -160,9 +163,9 @@ match_op        :
 
 label_set       :
                 LEFT_BRACE label_set_list RIGHT_BRACE
-                        { $$ = $2 }
+                        { $$ = labels.New($2...) }
                 | LEFT_BRACE RIGHT_BRACE
-                        { $$ = []labels.Label{} }
+                        { $$ = labels.New() }
                 ;
 
 label_set_list  :

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -18,6 +18,8 @@ type yySymType struct {
 	item     Item
 	matchers []*labels.Matcher
 	matcher  *labels.Matcher
+	labelSet []labels.Label
+	label    labels.Label
 }
 
 const ERROR = 57346
@@ -85,7 +87,8 @@ const BOOL = 57407
 const keywordsEnd = 57408
 const startSymbolsStart = 57409
 const START_LABELS = 57410
-const startSymbolsEnd = 57411
+const START_LABEL_SET = 57411
+const startSymbolsEnd = 57412
 
 var yyToknames = [...]string{
 	"$end",
@@ -156,6 +159,7 @@ var yyToknames = [...]string{
 	"keywordsEnd",
 	"startSymbolsStart",
 	"START_LABELS",
+	"START_LABEL_SET",
 	"startSymbolsEnd",
 }
 var yyStatenames = [...]string{}
@@ -164,7 +168,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line promql/generated_parser.y:155
+//line promql/generated_parser.y:187
 
 //line yacctab:1
 var yyExca = [...]int{
@@ -175,49 +179,54 @@ var yyExca = [...]int{
 
 const yyPrivate = 57344
 
-const yyLast = 67
+const yyLast = 68
 
 var yyAct = [...]int{
 
-	3, 17, 20, 11, 9, 5, 10, 8, 9, 7,
-	1, 12, 6, 4, 0, 0, 0, 0, 18, 19,
+	4, 24, 15, 28, 34, 31, 11, 25, 18, 1,
+	26, 17, 16, 12, 16, 8, 12, 14, 10, 6,
+	13, 33, 30, 7, 29, 19, 9, 5, 0, 32,
+	0, 0, 0, 20, 21, 27, 0, 0, 0, 22,
+	23, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 13, 14, 0, 0, 0, 0, 15,
-	16, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 2,
+	0, 0, 0, 0, 0, 0, 2, 3,
 }
 var yyPact = [...]int{
 
-	-2, -1000, -6, -1000, -1000, -3, -9, -1000, -1000, -1,
-	1, -1000, 0, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000,
+	-2, -1000, 8, 4, -1000, -1000, 6, -1000, 5, -4,
+	-1000, -1000, -1, -5, -1000, -1000, 1, 9, -1000, 3,
+	-1000, -1000, -1000, -1000, -1000, -1000, 7, 2, -1000, -1000,
+	-1000, -1000, -1000, -1000, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 13, 12, 7, 11, 10,
+	0, 27, 26, 6, 25, 23, 20, 2, 9,
 }
 var yyR1 = [...]int{
 
-	0, 5, 5, 2, 2, 1, 1, 3, 3, 4,
-	4, 4, 4, 4,
+	0, 8, 8, 8, 2, 2, 1, 1, 3, 3,
+	4, 4, 4, 4, 4, 5, 5, 6, 6, 7,
+	7, 7,
 }
 var yyR2 = [...]int{
 
-	0, 2, 1, 3, 1, 3, 2, 3, 3, 1,
-	1, 1, 1, 1,
+	0, 2, 2, 1, 3, 1, 3, 2, 3, 3,
+	1, 1, 1, 1, 1, 3, 2, 3, 1, 3,
+	3, 2,
 }
 var yyChk = [...]int{
 
-	-1000, -5, 68, 2, -1, 11, -2, 12, -3, 7,
-	15, 12, -4, 34, 35, 40, 41, 2, -3, 19,
-	2,
+	-1000, -8, 68, 69, 2, -1, 11, -5, 11, -2,
+	12, -3, 7, -6, 12, -7, 7, 15, 12, -4,
+	34, 35, 40, 41, 2, 12, 15, 34, 2, -3,
+	19, 2, -7, 19, 2,
 }
 var yyDef = [...]int{
 
-	0, -2, 0, 2, 1, 0, 0, 6, 4, 0,
-	0, 5, 0, 9, 10, 11, 12, 13, 3, 7,
-	8,
+	0, -2, 0, 0, 3, 1, 0, 2, 0, 0,
+	7, 5, 0, 0, 16, 18, 0, 0, 6, 0,
+	10, 11, 12, 13, 14, 15, 0, 0, 21, 4,
+	8, 9, 17, 19, 20,
 }
 var yyTok1 = [...]int{
 
@@ -231,7 +240,7 @@ var yyTok2 = [...]int{
 	32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
 	42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
 	52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
-	62, 63, 64, 65, 66, 67, 68, 69,
+	62, 63, 64, 65, 66, 67, 68, 69, 70,
 }
 var yyTok3 = [...]int{
 	0,
@@ -576,81 +585,123 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:117
+//line promql/generated_parser.y:123
 		{
 			yylex.(*parser).generatedParserResult.(*VectorSelector).LabelMatchers = yyDollar[2].matchers
 		}
-	case 2:
+	case 3:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:119
+//line promql/generated_parser.y:126
 		{
 			yylex.(*parser).errorf("unknown syntax error after parsing %v", yylex.(*parser).token.desc())
 		}
-	case 3:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:125
-		{
-			yyVAL.matchers = append(yyDollar[1].matchers, yyDollar[3].matcher)
-		}
 	case 4:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:127
-		{
-			yyVAL.matchers = []*labels.Matcher{yyDollar[1].matcher}
-		}
-	case 5:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:132
 		{
-			yyVAL.matchers = yyDollar[2].matchers
+			yyVAL.matchers = append(yyDollar[1].matchers, yyDollar[3].matcher)
+		}
+	case 5:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:134
+		{
+			yyVAL.matchers = []*labels.Matcher{yyDollar[1].matcher}
 		}
 	case 6:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:139
+		{
+			yyVAL.matchers = yyDollar[2].matchers
+		}
+	case 7:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:134
+//line promql/generated_parser.y:141
 		{
 			yyVAL.matchers = []*labels.Matcher{}
 		}
-	case 7:
+	case 8:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:140
+//line promql/generated_parser.y:147
 		{
 			yyVAL.matcher = yylex.(*parser).newLabelMatcher(yyDollar[1].item, yyDollar[2].item, yyDollar[3].item)
 		}
-	case 8:
+	case 9:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:142
+//line promql/generated_parser.y:149
 		{
 			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
 		}
-	case 9:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:146
-		{
-			yyVAL.item = yyDollar[1].item
-		}
 	case 10:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:147
+//line promql/generated_parser.y:153
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 11:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:148
+//line promql/generated_parser.y:154
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 12:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:149
+//line promql/generated_parser.y:155
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 13:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:151
+//line promql/generated_parser.y:156
+		{
+			yyVAL.item = yyDollar[1].item
+		}
+	case 14:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:158
 		{
 			yylex.(*parser).errorf("expected label matching operator but got %s", yylex.(*parser).token.Val)
+		}
+	case 15:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:163
+		{
+			yyVAL.labelSet = yyDollar[2].labelSet
+		}
+	case 16:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:165
+		{
+			yyVAL.labelSet = []labels.Label{}
+		}
+	case 17:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:170
+		{
+			yyVAL.labelSet = append(yyDollar[1].labelSet, yyDollar[3].label)
+		}
+	case 18:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:172
+		{
+			yyVAL.labelSet = []labels.Label{yyDollar[1].label}
+		}
+	case 19:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:177
+		{
+			yyVAL.label = labels.Label{Name: yyDollar[1].item.Val, Value: yylex.(*parser).unquoteString(yyDollar[3].item.Val)}
+		}
+	case 20:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:179
+		{
+			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
+		}
+	case 21:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:181
+		{
+			yylex.(*parser).errorf("expected \"=\" but got %s", yylex.(*parser).token.desc())
 		}
 	}
 	goto yystack /* stack new state and value */

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -184,52 +184,52 @@ const yyLast = 68
 
 var yyAct = [...]int{
 
-	4, 23, 16, 32, 40, 36, 11, 30, 18, 1,
-	14, 8, 7, 17, 20, 6, 22, 28, 37, 9,
-	29, 39, 35, 5, 21, 0, 33, 19, 0, 0,
-	0, 13, 38, 24, 25, 31, 12, 18, 13, 26,
-	27, 34, 17, 12, 0, 0, 0, 15, 10, 0,
+	4, 23, 16, 32, 11, 40, 36, 30, 21, 18,
+	1, 8, 14, 6, 17, 7, 22, 28, 19, 37,
+	29, 20, 39, 35, 9, 34, 13, 5, 0, 0,
+	0, 12, 38, 24, 25, 31, 33, 18, 13, 26,
+	27, 0, 17, 12, 0, 0, 0, 15, 10, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 2, 3,
 }
 var yyPact = [...]int{
 
-	-2, -1000, 4, 0, -1000, -1000, 36, -1000, 35, 12,
-	-1000, -1000, -1, -1000, 5, -1000, -1000, 1, -1000, 29,
-	-1000, -1000, 3, -1000, -1000, -1000, -1000, -1000, -1000, 6,
-	-1000, 2, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	-2, -1000, 2, 0, -1000, -1000, 36, -1000, 35, 6,
+	-1000, -1000, -1, -1000, 5, -1000, -1000, 1, -1000, -1000,
+	24, -1000, 4, -1000, -1000, -1000, -1000, -1000, -1000, 7,
+	-1000, 3, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
 	-1000,
 }
 var yyPgo = [...]int{
 
-	0, 23, 19, 6, 16, 12, 10, 2, 9,
+	0, 27, 24, 4, 16, 15, 12, 2, 10,
 }
 var yyR1 = [...]int{
 
-	0, 8, 8, 8, 2, 2, 2, 1, 1, 1,
+	0, 8, 8, 8, 1, 1, 1, 2, 2, 2,
 	3, 3, 3, 3, 4, 4, 4, 4, 5, 5,
 	5, 6, 6, 6, 7, 7, 7, 7,
 }
 var yyR2 = [...]int{
 
-	0, 2, 2, 1, 3, 1, 2, 3, 4, 2,
+	0, 2, 2, 1, 3, 4, 2, 3, 1, 2,
 	3, 3, 2, 1, 1, 1, 1, 1, 3, 4,
 	2, 3, 1, 2, 3, 3, 2, 1,
 }
 var yyChk = [...]int{
 
 	-1000, -8, 68, 69, 2, -1, 11, -5, 11, -2,
-	12, -3, 7, 2, -6, 12, -7, 7, 2, 15,
-	2, 12, -4, 2, 34, 35, 40, 41, 12, 15,
-	2, 34, 2, -3, 12, 19, 2, 12, -7, 19,
+	12, -3, 7, 2, -6, 12, -7, 7, 2, 12,
+	15, 2, -4, 2, 34, 35, 40, 41, 12, 15,
+	2, 34, 2, 12, -3, 19, 2, 12, -7, 19,
 	2,
 }
 var yyDef = [...]int{
 
 	0, -2, 0, 0, 3, 1, 0, 2, 0, 0,
-	9, 5, 0, 13, 0, 20, 22, 0, 27, 0,
-	6, 7, 0, 12, 14, 15, 16, 17, 18, 0,
-	23, 0, 26, 4, 8, 10, 11, 19, 21, 24,
+	6, 8, 0, 13, 0, 20, 22, 0, 27, 4,
+	0, 9, 0, 12, 14, 15, 16, 17, 18, 0,
+	23, 0, 26, 5, 7, 10, 11, 19, 21, 24,
 	25,
 }
 var yyTok1 = [...]int{
@@ -603,43 +603,43 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:129
 		{
-			yylex.(*parser).errorf("unknown syntax error after parsing %v", yylex.(*parser).token.desc())
+			yylex.(*parser).errorf("unexpected %v", yylex.(*parser).token.desc())
 		}
 	case 4:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:135
 		{
-			yyVAL.matchers = append(yyDollar[1].matchers, yyDollar[3].matcher)
+			yyVAL.matchers = yyDollar[2].matchers
 		}
 	case 5:
-		yyDollar = yyS[yypt-1 : yypt+1]
+		yyDollar = yyS[yypt-4 : yypt+1]
 //line promql/generated_parser.y:137
 		{
-			yyVAL.matchers = []*labels.Matcher{yyDollar[1].matcher}
+			yyVAL.matchers = yyDollar[2].matchers
 		}
 	case 6:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:139
 		{
-			yylex.(*parser).errorf("unexpected %v in label matching, expected \",\" or \"}\"", yylex.(*parser).token.desc())
+			yyVAL.matchers = []*labels.Matcher{}
 		}
 	case 7:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:144
+//line promql/generated_parser.y:145
 		{
-			yyVAL.matchers = yyDollar[2].matchers
+			yyVAL.matchers = append(yyDollar[1].matchers, yyDollar[3].matcher)
 		}
 	case 8:
-		yyDollar = yyS[yypt-4 : yypt+1]
-//line promql/generated_parser.y:146
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:147
 		{
-			yyVAL.matchers = yyDollar[2].matchers
+			yyVAL.matchers = []*labels.Matcher{yyDollar[1].matcher}
 		}
 	case 9:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:148
+//line promql/generated_parser.y:149
 		{
-			yyVAL.matchers = []*labels.Matcher{}
+			yylex.(*parser).errorf("unexpected %v in label matching, expected \",\" or \"}\"", yylex.(*parser).token.desc())
 		}
 	case 10:
 		yyDollar = yyS[yypt-3 : yypt+1]
@@ -657,7 +657,7 @@ yydefault:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:158
 		{
-			yylex.(*parser).errorf("expected label matching operator but got %s", yylex.(*parser).token.Val)
+			yylex.(*parser).errorf("unexpected %v in label matching, expected label matching operator", yylex.(*parser).token.Val)
 		}
 	case 13:
 		yyDollar = yyS[yypt-1 : yypt+1]
@@ -723,7 +723,7 @@ yydefault:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:185
 		{
-			yylex.(*parser).errorf("unexpected %v in label matching, expected \",\" or \"}\"", yylex.(*parser).token.desc())
+			yylex.(*parser).errorf("unexpected %v in label set, expected \",\" or \"}\"", yylex.(*parser).token.desc())
 		}
 	case 24:
 		yyDollar = yyS[yypt-3 : yypt+1]
@@ -735,19 +735,19 @@ yydefault:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:193
 		{
-			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
+			yylex.(*parser).errorf("unexpected %v in label set, expected string", yylex.(*parser).token.desc())
 		}
 	case 26:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:195
 		{
-			yylex.(*parser).errorf("expected \"=\" but got %s", yylex.(*parser).token.desc())
+			yylex.(*parser).errorf("unexpected %v in label set, expected \"=\"", yylex.(*parser).token.desc())
 		}
 	case 27:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:197
 		{
-			yylex.(*parser).errorf("unexpected %s in label matching, expected identifier or \"}\"", yylex.(*parser).token.desc())
+			yylex.(*parser).errorf("unexpected %v in label set, expected identifier or \"}\"", yylex.(*parser).token.desc())
 		}
 	}
 	goto yystack /* stack new state and value */

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -169,7 +169,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line promql/generated_parser.y:194
+//line promql/generated_parser.y:201
 
 //line yacctab:1
 var yyExca = [...]int{
@@ -184,50 +184,50 @@ const yyLast = 68
 
 var yyAct = [...]int{
 
-	4, 24, 15, 28, 36, 32, 11, 25, 18, 1,
-	26, 17, 16, 12, 16, 12, 13, 33, 30, 14,
-	10, 35, 31, 8, 29, 6, 7, 19, 9, 34,
-	5, 0, 0, 20, 21, 27, 0, 0, 0, 22,
-	23, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	4, 26, 16, 31, 39, 35, 11, 29, 20, 18,
+	1, 19, 14, 13, 17, 8, 7, 27, 12, 36,
+	28, 38, 34, 33, 6, 21, 32, 18, 9, 5,
+	0, 37, 17, 22, 23, 30, 13, 15, 0, 24,
+	25, 12, 0, 0, 0, 0, 10, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 2, 3,
 }
 var yyPact = [...]int{
 
-	-2, -1000, 14, 12, -1000, -1000, 8, -1000, 7, -4,
-	-1000, -1000, -1, -5, -1000, -1000, 1, 6, -1000, 3,
-	-1000, -1000, -1000, -1000, -1000, -1000, 5, 2, -1000, -1000,
-	-1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	-2, -1000, 13, 4, -1000, -1000, 34, -1000, 25, -4,
+	-1000, -1000, -1, -1000, 5, -1000, -1000, 1, -1000, 11,
+	-1000, 3, -1000, -1000, -1000, -1000, -1000, -1000, 7, -1000,
+	2, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 30, 28, 6, 27, 26, 16, 2, 9,
+	0, 29, 28, 6, 25, 16, 12, 2, 10,
 }
 var yyR1 = [...]int{
 
 	0, 8, 8, 8, 2, 2, 1, 1, 1, 3,
-	3, 4, 4, 4, 4, 4, 5, 5, 5, 6,
-	6, 7, 7, 7,
+	3, 3, 4, 4, 4, 4, 4, 5, 5, 5,
+	6, 6, 6, 7, 7, 7, 7,
 }
 var yyR2 = [...]int{
 
 	0, 2, 2, 1, 3, 1, 3, 4, 2, 3,
-	3, 1, 1, 1, 1, 1, 3, 4, 2, 3,
-	1, 3, 3, 2,
+	3, 1, 1, 1, 1, 1, 1, 3, 4, 2,
+	3, 1, 2, 3, 3, 2, 1,
 }
 var yyChk = [...]int{
 
 	-1000, -8, 68, 69, 2, -1, 11, -5, 11, -2,
-	12, -3, 7, -6, 12, -7, 7, 15, 12, -4,
-	34, 35, 40, 41, 2, 12, 15, 34, 2, -3,
-	12, 19, 2, 12, -7, 19, 2,
+	12, -3, 7, 2, -6, 12, -7, 7, 2, 15,
+	12, -4, 34, 35, 40, 41, 2, 12, 15, 2,
+	34, 2, -3, 12, 19, 2, 12, -7, 19, 2,
 }
 var yyDef = [...]int{
 
 	0, -2, 0, 0, 3, 1, 0, 2, 0, 0,
-	8, 5, 0, 0, 18, 20, 0, 0, 6, 0,
-	11, 12, 13, 14, 15, 16, 0, 0, 23, 4,
-	7, 9, 10, 17, 19, 21, 22,
+	8, 5, 0, 11, 0, 19, 21, 0, 26, 0,
+	6, 0, 12, 13, 14, 15, 16, 17, 0, 22,
+	0, 25, 4, 7, 9, 10, 18, 20, 23, 24,
 }
 var yyTok1 = [...]int{
 
@@ -646,25 +646,25 @@ yydefault:
 		}
 	case 11:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:158
+//line promql/generated_parser.y:156
 		{
-			yyVAL.item = yyDollar[1].item
+			yylex.(*parser).errorf("unexpected %v in label matching, expected identifier or \"}\"", yylex.(*parser).token.desc())
 		}
 	case 12:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:159
-		{
-			yyVAL.item = yyDollar[1].item
-		}
-	case 13:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:160
 		{
 			yyVAL.item = yyDollar[1].item
 		}
-	case 14:
+	case 13:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:161
+		{
+			yyVAL.item = yyDollar[1].item
+		}
+	case 14:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:162
 		{
 			yyVAL.item = yyDollar[1].item
 		}
@@ -672,55 +672,73 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:163
 		{
-			yylex.(*parser).errorf("expected label matching operator but got %s", yylex.(*parser).token.Val)
+			yyVAL.item = yyDollar[1].item
 		}
 	case 16:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:168
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:165
 		{
-			yyVAL.labels = labels.New(yyDollar[2].labelSet...)
+			yylex.(*parser).errorf("expected label matching operator but got %s", yylex.(*parser).token.Val)
 		}
 	case 17:
-		yyDollar = yyS[yypt-4 : yypt+1]
+		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:170
 		{
 			yyVAL.labels = labels.New(yyDollar[2].labelSet...)
 		}
 	case 18:
-		yyDollar = yyS[yypt-2 : yypt+1]
+		yyDollar = yyS[yypt-4 : yypt+1]
 //line promql/generated_parser.y:172
+		{
+			yyVAL.labels = labels.New(yyDollar[2].labelSet...)
+		}
+	case 19:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:174
 		{
 			yyVAL.labels = labels.New()
 		}
-	case 19:
+	case 20:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:177
+//line promql/generated_parser.y:179
 		{
 			yyVAL.labelSet = append(yyDollar[1].labelSet, yyDollar[3].label)
 		}
-	case 20:
+	case 21:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:179
+//line promql/generated_parser.y:181
 		{
 			yyVAL.labelSet = []labels.Label{yyDollar[1].label}
 		}
-	case 21:
+	case 22:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:183
+		{
+			yylex.(*parser).errorf("unexpected %v in label matching, expected \",\" or \"}\"", yylex.(*parser).token.desc())
+		}
+	case 23:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:184
+//line promql/generated_parser.y:189
 		{
 			yyVAL.label = labels.Label{Name: yyDollar[1].item.Val, Value: yylex.(*parser).unquoteString(yyDollar[3].item.Val)}
 		}
-	case 22:
+	case 24:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:186
+//line promql/generated_parser.y:191
 		{
 			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
 		}
-	case 23:
+	case 25:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:188
+//line promql/generated_parser.y:193
 		{
 			yylex.(*parser).errorf("expected \"=\" but got %s", yylex.(*parser).token.desc())
+		}
+	case 26:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:195
+		{
+			yylex.(*parser).errorf("unexpected %v in label matching, expected identifier or \"}\"", yylex.(*parser).token.desc())
 		}
 	}
 	goto yystack /* stack new state and value */

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -169,7 +169,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line promql/generated_parser.y:201
+//line promql/generated_parser.y:203
 
 //line yacctab:1
 var yyExca = [...]int{
@@ -184,50 +184,53 @@ const yyLast = 68
 
 var yyAct = [...]int{
 
-	4, 26, 16, 31, 39, 35, 11, 29, 20, 18,
-	1, 19, 14, 13, 17, 8, 7, 27, 12, 36,
-	28, 38, 34, 33, 6, 21, 32, 18, 9, 5,
-	0, 37, 17, 22, 23, 30, 13, 15, 0, 24,
-	25, 12, 0, 0, 0, 0, 10, 0, 0, 0,
+	4, 23, 16, 32, 40, 36, 11, 30, 18, 1,
+	14, 8, 7, 17, 20, 6, 22, 28, 37, 9,
+	29, 39, 35, 5, 21, 0, 33, 19, 0, 0,
+	0, 13, 38, 24, 25, 31, 12, 18, 13, 26,
+	27, 34, 17, 12, 0, 0, 0, 15, 10, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 2, 3,
 }
 var yyPact = [...]int{
 
-	-2, -1000, 13, 4, -1000, -1000, 34, -1000, 25, -4,
-	-1000, -1000, -1, -1000, 5, -1000, -1000, 1, -1000, 11,
-	-1000, 3, -1000, -1000, -1000, -1000, -1000, -1000, 7, -1000,
-	2, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	-2, -1000, 4, 0, -1000, -1000, 36, -1000, 35, 12,
+	-1000, -1000, -1, -1000, 5, -1000, -1000, 1, -1000, 29,
+	-1000, -1000, 3, -1000, -1000, -1000, -1000, -1000, -1000, 6,
+	-1000, 2, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	-1000,
 }
 var yyPgo = [...]int{
 
-	0, 29, 28, 6, 25, 16, 12, 2, 10,
+	0, 23, 19, 6, 16, 12, 10, 2, 9,
 }
 var yyR1 = [...]int{
 
-	0, 8, 8, 8, 2, 2, 1, 1, 1, 3,
-	3, 3, 4, 4, 4, 4, 4, 5, 5, 5,
-	6, 6, 6, 7, 7, 7, 7,
+	0, 8, 8, 8, 2, 2, 2, 1, 1, 1,
+	3, 3, 3, 3, 4, 4, 4, 4, 5, 5,
+	5, 6, 6, 6, 7, 7, 7, 7,
 }
 var yyR2 = [...]int{
 
-	0, 2, 2, 1, 3, 1, 3, 4, 2, 3,
-	3, 1, 1, 1, 1, 1, 1, 3, 4, 2,
-	3, 1, 2, 3, 3, 2, 1,
+	0, 2, 2, 1, 3, 1, 2, 3, 4, 2,
+	3, 3, 2, 1, 1, 1, 1, 1, 3, 4,
+	2, 3, 1, 2, 3, 3, 2, 1,
 }
 var yyChk = [...]int{
 
 	-1000, -8, 68, 69, 2, -1, 11, -5, 11, -2,
 	12, -3, 7, 2, -6, 12, -7, 7, 2, 15,
-	12, -4, 34, 35, 40, 41, 2, 12, 15, 2,
-	34, 2, -3, 12, 19, 2, 12, -7, 19, 2,
+	2, 12, -4, 2, 34, 35, 40, 41, 12, 15,
+	2, 34, 2, -3, 12, 19, 2, 12, -7, 19,
+	2,
 }
 var yyDef = [...]int{
 
 	0, -2, 0, 0, 3, 1, 0, 2, 0, 0,
-	8, 5, 0, 11, 0, 19, 21, 0, 26, 0,
-	6, 0, 12, 13, 14, 15, 16, 17, 0, 22,
-	0, 25, 4, 7, 9, 10, 18, 20, 23, 24,
+	9, 5, 0, 13, 0, 20, 22, 0, 27, 0,
+	6, 7, 0, 12, 14, 15, 16, 17, 18, 0,
+	23, 0, 26, 4, 8, 10, 11, 19, 21, 24,
+	25,
 }
 var yyTok1 = [...]int{
 
@@ -615,130 +618,136 @@ yydefault:
 			yyVAL.matchers = []*labels.Matcher{yyDollar[1].matcher}
 		}
 	case 6:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:142
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:139
 		{
-			yyVAL.matchers = yyDollar[2].matchers
+			yylex.(*parser).errorf("unexpected %v in label matching, expected \",\" or \"}\"", yylex.(*parser).token.desc())
 		}
 	case 7:
-		yyDollar = yyS[yypt-4 : yypt+1]
+		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:144
 		{
 			yyVAL.matchers = yyDollar[2].matchers
 		}
 	case 8:
-		yyDollar = yyS[yypt-2 : yypt+1]
+		yyDollar = yyS[yypt-4 : yypt+1]
 //line promql/generated_parser.y:146
 		{
-			yyVAL.matchers = []*labels.Matcher{}
+			yyVAL.matchers = yyDollar[2].matchers
 		}
 	case 9:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:152
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:148
 		{
-			yyVAL.matcher = yylex.(*parser).newLabelMatcher(yyDollar[1].item, yyDollar[2].item, yyDollar[3].item)
+			yyVAL.matchers = []*labels.Matcher{}
 		}
 	case 10:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:154
 		{
-			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
+			yyVAL.matcher = yylex.(*parser).newLabelMatcher(yyDollar[1].item, yyDollar[2].item, yyDollar[3].item)
 		}
 	case 11:
-		yyDollar = yyS[yypt-1 : yypt+1]
+		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:156
 		{
-			yylex.(*parser).errorf("unexpected %v in label matching, expected identifier or \"}\"", yylex.(*parser).token.desc())
+			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
 		}
 	case 12:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:160
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:158
 		{
-			yyVAL.item = yyDollar[1].item
+			yylex.(*parser).errorf("expected label matching operator but got %s", yylex.(*parser).token.Val)
 		}
 	case 13:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:161
+//line promql/generated_parser.y:160
 		{
-			yyVAL.item = yyDollar[1].item
+			yylex.(*parser).errorf("unexpected %v in label matching, expected identifier or \"}\"", yylex.(*parser).token.desc())
 		}
 	case 14:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:162
+//line promql/generated_parser.y:164
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 15:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:163
+//line promql/generated_parser.y:165
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 16:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:165
+//line promql/generated_parser.y:166
 		{
-			yylex.(*parser).errorf("expected label matching operator but got %s", yylex.(*parser).token.Val)
+			yyVAL.item = yyDollar[1].item
 		}
 	case 17:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:170
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:167
 		{
-			yyVAL.labels = labels.New(yyDollar[2].labelSet...)
+			yyVAL.item = yyDollar[1].item
 		}
 	case 18:
-		yyDollar = yyS[yypt-4 : yypt+1]
+		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:172
 		{
 			yyVAL.labels = labels.New(yyDollar[2].labelSet...)
 		}
 	case 19:
-		yyDollar = yyS[yypt-2 : yypt+1]
+		yyDollar = yyS[yypt-4 : yypt+1]
 //line promql/generated_parser.y:174
+		{
+			yyVAL.labels = labels.New(yyDollar[2].labelSet...)
+		}
+	case 20:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:176
 		{
 			yyVAL.labels = labels.New()
 		}
-	case 20:
+	case 21:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:179
+//line promql/generated_parser.y:181
 		{
 			yyVAL.labelSet = append(yyDollar[1].labelSet, yyDollar[3].label)
 		}
-	case 21:
+	case 22:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:181
+//line promql/generated_parser.y:183
 		{
 			yyVAL.labelSet = []labels.Label{yyDollar[1].label}
 		}
-	case 22:
+	case 23:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:183
+//line promql/generated_parser.y:185
 		{
 			yylex.(*parser).errorf("unexpected %v in label matching, expected \",\" or \"}\"", yylex.(*parser).token.desc())
-		}
-	case 23:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:189
-		{
-			yyVAL.label = labels.Label{Name: yyDollar[1].item.Val, Value: yylex.(*parser).unquoteString(yyDollar[3].item.Val)}
 		}
 	case 24:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:191
 		{
-			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
+			yyVAL.label = labels.Label{Name: yyDollar[1].item.Val, Value: yylex.(*parser).unquoteString(yyDollar[3].item.Val)}
 		}
 	case 25:
-		yyDollar = yyS[yypt-2 : yypt+1]
+		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:193
+		{
+			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
+		}
+	case 26:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:195
 		{
 			yylex.(*parser).errorf("expected \"=\" but got %s", yylex.(*parser).token.desc())
 		}
-	case 26:
+	case 27:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:195
+//line promql/generated_parser.y:197
 		{
-			yylex.(*parser).errorf("unexpected %v in label matching, expected identifier or \"}\"", yylex.(*parser).token.desc())
+			yylex.(*parser).errorf("unexpected %s in label matching, expected identifier or \"}\"", yylex.(*parser).token.desc())
 		}
 	}
 	goto yystack /* stack new state and value */

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -169,7 +169,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line promql/generated_parser.y:190
+//line promql/generated_parser.y:194
 
 //line yacctab:1
 var yyExca = [...]int{
@@ -184,50 +184,50 @@ const yyLast = 68
 
 var yyAct = [...]int{
 
-	4, 24, 15, 28, 34, 31, 11, 25, 18, 1,
-	26, 17, 16, 12, 16, 8, 12, 14, 10, 6,
-	13, 33, 30, 7, 29, 19, 9, 5, 0, 32,
-	0, 0, 0, 20, 21, 27, 0, 0, 0, 22,
+	4, 24, 15, 28, 36, 32, 11, 25, 18, 1,
+	26, 17, 16, 12, 16, 12, 13, 33, 30, 14,
+	10, 35, 31, 8, 29, 6, 7, 19, 9, 34,
+	5, 0, 0, 20, 21, 27, 0, 0, 0, 22,
 	23, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 2, 3,
 }
 var yyPact = [...]int{
 
-	-2, -1000, 8, 4, -1000, -1000, 6, -1000, 5, -4,
-	-1000, -1000, -1, -5, -1000, -1000, 1, 9, -1000, 3,
-	-1000, -1000, -1000, -1000, -1000, -1000, 7, 2, -1000, -1000,
-	-1000, -1000, -1000, -1000, -1000,
+	-2, -1000, 14, 12, -1000, -1000, 8, -1000, 7, -4,
+	-1000, -1000, -1, -5, -1000, -1000, 1, 6, -1000, 3,
+	-1000, -1000, -1000, -1000, -1000, -1000, 5, 2, -1000, -1000,
+	-1000, -1000, -1000, -1000, -1000, -1000, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 27, 26, 6, 25, 23, 20, 2, 9,
+	0, 30, 28, 6, 27, 26, 16, 2, 9,
 }
 var yyR1 = [...]int{
 
-	0, 8, 8, 8, 2, 2, 1, 1, 3, 3,
-	4, 4, 4, 4, 4, 5, 5, 6, 6, 7,
-	7, 7,
+	0, 8, 8, 8, 2, 2, 1, 1, 1, 3,
+	3, 4, 4, 4, 4, 4, 5, 5, 5, 6,
+	6, 7, 7, 7,
 }
 var yyR2 = [...]int{
 
-	0, 2, 2, 1, 3, 1, 3, 2, 3, 3,
-	1, 1, 1, 1, 1, 3, 2, 3, 1, 3,
-	3, 2,
+	0, 2, 2, 1, 3, 1, 3, 4, 2, 3,
+	3, 1, 1, 1, 1, 1, 3, 4, 2, 3,
+	1, 3, 3, 2,
 }
 var yyChk = [...]int{
 
 	-1000, -8, 68, 69, 2, -1, 11, -5, 11, -2,
 	12, -3, 7, -6, 12, -7, 7, 15, 12, -4,
 	34, 35, 40, 41, 2, 12, 15, 34, 2, -3,
-	19, 2, -7, 19, 2,
+	12, 19, 2, 12, -7, 19, 2,
 }
 var yyDef = [...]int{
 
 	0, -2, 0, 0, 3, 1, 0, 2, 0, 0,
-	7, 5, 0, 0, 16, 18, 0, 0, 6, 0,
-	10, 11, 12, 13, 14, 15, 0, 0, 21, 4,
-	8, 9, 17, 19, 20,
+	8, 5, 0, 0, 18, 20, 0, 0, 6, 0,
+	11, 12, 13, 14, 15, 16, 0, 0, 23, 4,
+	7, 9, 10, 17, 19, 21, 22,
 }
 var yyTok1 = [...]int{
 
@@ -621,44 +621,44 @@ yydefault:
 			yyVAL.matchers = yyDollar[2].matchers
 		}
 	case 7:
-		yyDollar = yyS[yypt-2 : yypt+1]
+		yyDollar = yyS[yypt-4 : yypt+1]
 //line promql/generated_parser.y:144
 		{
-			yyVAL.matchers = []*labels.Matcher{}
+			yyVAL.matchers = yyDollar[2].matchers
 		}
 	case 8:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:150
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:146
 		{
-			yyVAL.matcher = yylex.(*parser).newLabelMatcher(yyDollar[1].item, yyDollar[2].item, yyDollar[3].item)
+			yyVAL.matchers = []*labels.Matcher{}
 		}
 	case 9:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:152
 		{
-			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
+			yyVAL.matcher = yylex.(*parser).newLabelMatcher(yyDollar[1].item, yyDollar[2].item, yyDollar[3].item)
 		}
 	case 10:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:156
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:154
 		{
-			yyVAL.item = yyDollar[1].item
+			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
 		}
 	case 11:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:157
-		{
-			yyVAL.item = yyDollar[1].item
-		}
-	case 12:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:158
 		{
 			yyVAL.item = yyDollar[1].item
 		}
-	case 13:
+	case 12:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:159
+		{
+			yyVAL.item = yyDollar[1].item
+		}
+	case 13:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:160
 		{
 			yyVAL.item = yyDollar[1].item
 		}
@@ -666,47 +666,59 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:161
 		{
-			yylex.(*parser).errorf("expected label matching operator but got %s", yylex.(*parser).token.Val)
+			yyVAL.item = yyDollar[1].item
 		}
 	case 15:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:163
+		{
+			yylex.(*parser).errorf("expected label matching operator but got %s", yylex.(*parser).token.Val)
+		}
+	case 16:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:166
+//line promql/generated_parser.y:168
 		{
 			yyVAL.labels = labels.New(yyDollar[2].labelSet...)
 		}
-	case 16:
+	case 17:
+		yyDollar = yyS[yypt-4 : yypt+1]
+//line promql/generated_parser.y:170
+		{
+			yyVAL.labels = labels.New(yyDollar[2].labelSet...)
+		}
+	case 18:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:168
+//line promql/generated_parser.y:172
 		{
 			yyVAL.labels = labels.New()
 		}
-	case 17:
+	case 19:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:173
+//line promql/generated_parser.y:177
 		{
 			yyVAL.labelSet = append(yyDollar[1].labelSet, yyDollar[3].label)
 		}
-	case 18:
+	case 20:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:175
+//line promql/generated_parser.y:179
 		{
 			yyVAL.labelSet = []labels.Label{yyDollar[1].label}
 		}
-	case 19:
+	case 21:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:180
+//line promql/generated_parser.y:184
 		{
 			yyVAL.label = labels.Label{Name: yyDollar[1].item.Val, Value: yylex.(*parser).unquoteString(yyDollar[3].item.Val)}
 		}
-	case 20:
+	case 22:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:182
+//line promql/generated_parser.y:186
 		{
 			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
 		}
-	case 21:
+	case 23:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:184
+//line promql/generated_parser.y:188
 		{
 			yylex.(*parser).errorf("expected \"=\" but got %s", yylex.(*parser).token.desc())
 		}

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -20,6 +20,7 @@ type yySymType struct {
 	matcher  *labels.Matcher
 	labelSet []labels.Label
 	label    labels.Label
+	labels   labels.Labels
 }
 
 const ERROR = 57346
@@ -168,7 +169,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line promql/generated_parser.y:187
+//line promql/generated_parser.y:190
 
 //line yacctab:1
 var yyExca = [...]int{
@@ -585,121 +586,127 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:123
+//line promql/generated_parser.y:125
 		{
 			yylex.(*parser).generatedParserResult.(*VectorSelector).LabelMatchers = yyDollar[2].matchers
 		}
+	case 2:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:127
+		{
+			yylex.(*parser).generatedParserResult = yyDollar[2].labels
+		}
 	case 3:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:126
+//line promql/generated_parser.y:129
 		{
 			yylex.(*parser).errorf("unknown syntax error after parsing %v", yylex.(*parser).token.desc())
 		}
 	case 4:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:132
+//line promql/generated_parser.y:135
 		{
 			yyVAL.matchers = append(yyDollar[1].matchers, yyDollar[3].matcher)
 		}
 	case 5:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:134
+//line promql/generated_parser.y:137
 		{
 			yyVAL.matchers = []*labels.Matcher{yyDollar[1].matcher}
 		}
 	case 6:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:139
+//line promql/generated_parser.y:142
 		{
 			yyVAL.matchers = yyDollar[2].matchers
 		}
 	case 7:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:141
+//line promql/generated_parser.y:144
 		{
 			yyVAL.matchers = []*labels.Matcher{}
 		}
 	case 8:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:147
+//line promql/generated_parser.y:150
 		{
 			yyVAL.matcher = yylex.(*parser).newLabelMatcher(yyDollar[1].item, yyDollar[2].item, yyDollar[3].item)
 		}
 	case 9:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:149
+//line promql/generated_parser.y:152
 		{
 			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
 		}
 	case 10:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:153
+//line promql/generated_parser.y:156
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 11:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:154
+//line promql/generated_parser.y:157
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 12:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:155
+//line promql/generated_parser.y:158
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 13:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:156
+//line promql/generated_parser.y:159
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 14:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:158
+//line promql/generated_parser.y:161
 		{
 			yylex.(*parser).errorf("expected label matching operator but got %s", yylex.(*parser).token.Val)
 		}
 	case 15:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:163
+//line promql/generated_parser.y:166
 		{
-			yyVAL.labelSet = yyDollar[2].labelSet
+			yyVAL.labels = labels.New(yyDollar[2].labelSet...)
 		}
 	case 16:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:165
+//line promql/generated_parser.y:168
 		{
-			yyVAL.labelSet = []labels.Label{}
+			yyVAL.labels = labels.New()
 		}
 	case 17:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:170
+//line promql/generated_parser.y:173
 		{
 			yyVAL.labelSet = append(yyDollar[1].labelSet, yyDollar[3].label)
 		}
 	case 18:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:172
+//line promql/generated_parser.y:175
 		{
 			yyVAL.labelSet = []labels.Label{yyDollar[1].label}
 		}
 	case 19:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:177
+//line promql/generated_parser.y:180
 		{
 			yyVAL.label = labels.Label{Name: yyDollar[1].item.Val, Value: yylex.(*parser).unquoteString(yyDollar[3].item.Val)}
 		}
 	case 20:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:179
+//line promql/generated_parser.y:182
 		{
 			yylex.(*parser).errorf("unexpected %v in label matching, expected string", yylex.(*parser).token.desc())
 		}
 	case 21:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:181
+//line promql/generated_parser.y:184
 		{
 			yylex.(*parser).errorf("expected \"=\" but got %s", yylex.(*parser).token.desc())
 		}

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -965,6 +965,22 @@ var testExpr = []struct {
 		input:  `foo{__name__="bar"}`,
 		fail:   true,
 		errMsg: "metric name must not be set twice: \"foo\" or \"bar\"",
+	}, {
+		input:  `foo{__name__= =}`,
+		fail:   true,
+		errMsg: "unexpected <op:=> in label matching, expected string",
+	}, {
+		input:  `foo{,}`,
+		fail:   true,
+		errMsg: "unexpected \",\" in label matching, expected identifier or \"}\"",
+	}, {
+		input:  `foo{__name__ == "bar"}`,
+		fail:   true,
+		errMsg: "unexpected <op:=> in label matching, expected string",
+	}, {
+		input:  `foo{__name__="bar" lol}`,
+		fail:   true,
+		errMsg: "unexpected identifier \"lol\" in label matching, expected \",\" or \"}\"",
 	},
 	// Test matrix selector.
 	{
@@ -1619,7 +1635,7 @@ func TestParseExpressions(t *testing.T) {
 			testutil.Equals(t, expr, test.expected, "error on input '%s'", test.input)
 		} else {
 			testutil.NotOk(t, err)
-			testutil.Assert(t, strings.Contains(err.Error(), test.errMsg), "unexpected error on input '%s'", test.input)
+			testutil.Assert(t, strings.Contains(err.Error(), test.errMsg), "unexpected error on input '%s', expected '%s', got '%s'", test.input, test.errMsg, err.Error())
 		}
 	}
 }

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -964,7 +964,7 @@ var testExpr = []struct {
 	}, {
 		input:  `foo{__name__="bar"}`,
 		fail:   true,
-		errMsg: "metric name must not be set twice: \"foo\" or \"bar\"",
+		errMsg: `metric name must not be set twice: "foo" or "bar"`,
 	}, {
 		input:  `foo{__name__= =}`,
 		fail:   true,
@@ -972,7 +972,7 @@ var testExpr = []struct {
 	}, {
 		input:  `foo{,}`,
 		fail:   true,
-		errMsg: "unexpected \",\" in label matching, expected identifier or \"}\"",
+		errMsg: `unexpected "," in label matching, expected identifier or "}"`,
 	}, {
 		input:  `foo{__name__ == "bar"}`,
 		fail:   true,
@@ -980,7 +980,7 @@ var testExpr = []struct {
 	}, {
 		input:  `foo{__name__="bar" lol}`,
 		fail:   true,
-		errMsg: "unexpected identifier \"lol\" in label matching, expected \",\" or \"}\"",
+		errMsg: `unexpected identifier "lol" in label matching, expected "," or "}"`,
 	},
 	// Test matrix selector.
 	{

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -936,7 +936,7 @@ var testExpr = []struct {
 	}, {
 		input:  `foo{gibberish}`,
 		fail:   true,
-		errMsg: "expected label matching operator but got }",
+		errMsg: "unexpected } in label matching, expected label matching operator",
 	}, {
 		input:  `foo{1}`,
 		fail:   true,

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -883,6 +883,19 @@ var testExpr = []struct {
 			},
 		},
 	}, {
+		input: `foo{a="b", foo!="bar", test=~"test", bar!~"baz",}`,
+		expected: &VectorSelector{
+			Name:   "foo",
+			Offset: 0,
+			LabelMatchers: []*labels.Matcher{
+				mustLabelMatcher(labels.MatchEqual, "a", "b"),
+				mustLabelMatcher(labels.MatchNotEqual, "foo", "bar"),
+				mustLabelMatcher(labels.MatchRegexp, "test", "test"),
+				mustLabelMatcher(labels.MatchNotRegexp, "bar", "baz"),
+				mustLabelMatcher(labels.MatchEqual, string(model.MetricNameLabel), "foo"),
+			},
+		},
+	}, {
 		input:  `{`,
 		fail:   true,
 		errMsg: "unexpected end of input inside braces",


### PR DESCRIPTION
This PR extends the generated part of the PromQL parser to parse label sets.

This allows removing some unneeded parts of the old parser.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->