### PR TITLE
PromQL: Use more standart format for error positions

### DIFF
--- a/promql/parse.go
+++ b/promql/parse.go
@@ -53,10 +53,7 @@ type ParseErr struct {
 }
 
 func (e *ParseErr) Error() string {
-	if e.Line == 0 {
-		return fmt.Sprintf("parse error at char %d: %s", e.Pos, e.Err)
-	}
-	return fmt.Sprintf("parse error at line %d, char %d: %s", e.Line, e.Pos, e.Err)
+	return fmt.Sprintf("%d:%d: parse error: %s", e.Line+1, e.Pos, e.Err)
 }
 
 // ParseExpr returns the expression parsed from the input.

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -219,7 +219,7 @@ var testExpr = []struct {
 	}, {
 		input:  "1 == 1",
 		fail:   true,
-		errMsg: "parse error at char 7: comparisons between scalars must use BOOL modifier",
+		errMsg: "1:7: parse error: comparisons between scalars must use BOOL modifier",
 	}, {
 		input:  "1 or 1",
 		fail:   true,
@@ -255,7 +255,7 @@ var testExpr = []struct {
 	}, {
 		input:  "a - on(b) ignoring(c) d",
 		fail:   true,
-		errMsg: "parse error at char 11: no valid expression found",
+		errMsg: "1:11: parse error: no valid expression found",
 	},
 	// Vector binary operations.
 	{
@@ -919,7 +919,7 @@ var testExpr = []struct {
 	}, {
 		input:  "some_metric{a=\"\xff\"}",
 		fail:   true,
-		errMsg: "parse error at char 15: invalid UTF-8 rune",
+		errMsg: "1:15: parse error: invalid UTF-8 rune",
 	}, {
 		input:  `foo{gibberish}`,
 		fail:   true,
@@ -1057,11 +1057,11 @@ var testExpr = []struct {
 	}, {
 		input:  `some_metric OFFSET 1m[5m]`,
 		fail:   true,
-		errMsg: "parse error at char 25: unexpected \"]\" in subquery selector, expected \":\"",
+		errMsg: "1:25: parse error: unexpected \"]\" in subquery selector, expected \":\"",
 	}, {
 		input:  `(foo + bar)[5m]`,
 		fail:   true,
-		errMsg: "parse error at char 15: unexpected \"]\" in subquery selector, expected \":\"",
+		errMsg: "1:15: parse error: unexpected \"]\" in subquery selector, expected \":\"",
 	},
 	// Test aggregation.
 	{
@@ -1222,7 +1222,7 @@ var testExpr = []struct {
 	}, {
 		input:  "MIN keep_common (some_metric)",
 		fail:   true,
-		errMsg: "parse error at char 5: unexpected identifier \"keep_common\" in aggregation, expected \"(\"",
+		errMsg: "1:5: parse error: unexpected identifier \"keep_common\" in aggregation, expected \"(\"",
 	}, {
 		input:  "MIN (some_metric) keep_common",
 		fail:   true,
@@ -1238,15 +1238,15 @@ var testExpr = []struct {
 	}, {
 		input:  `topk(some_metric)`,
 		fail:   true,
-		errMsg: "parse error at char 17: unexpected \")\" in aggregation, expected \",\"",
+		errMsg: "1:17: parse error: unexpected \")\" in aggregation, expected \",\"",
 	}, {
 		input:  `topk(some_metric, other_metric)`,
 		fail:   true,
-		errMsg: "parse error at char 32: expected type scalar in aggregation parameter, got instant vector",
+		errMsg: "1:32: parse error: expected type scalar in aggregation parameter, got instant vector",
 	}, {
 		input:  `count_values(5, other_metric)`,
 		fail:   true,
-		errMsg: "parse error at char 30: expected type string in aggregation parameter, got scalar",
+		errMsg: "1:30: parse error: expected type string in aggregation parameter, got scalar",
 	},
 	// Test function calls.
 	{
@@ -1332,7 +1332,7 @@ var testExpr = []struct {
 	}, {
 		input:  "label_replace(a, `b`, `c\xff`, `d`, `.*`)",
 		fail:   true,
-		errMsg: "parse error at char 23: invalid UTF-8 rune",
+		errMsg: "1:23: parse error: invalid UTF-8 rune",
 	},
 	// Fuzzing regression tests.
 	{
@@ -1586,11 +1586,11 @@ var testExpr = []struct {
 	}, {
 		input:  "test[5d] OFFSET 10s [10m:5s]",
 		fail:   true,
-		errMsg: "parse error at char 29: subquery is only allowed on instant vector, got matrix in \"test[5d] offset 10s[10m:5s]\"",
+		errMsg: "1:29: parse error: subquery is only allowed on instant vector, got matrix in \"test[5d] offset 10s[10m:5s]\"",
 	}, {
 		input:  `(foo + bar{nm="val"})[5m:][10m:5s]`,
 		fail:   true,
-		errMsg: "parse error at char 27: could not parse remaining input \"[10m:5s]\"...",
+		errMsg: "1:27: parse error: could not parse remaining input \"[10m:5s]\"...",
 	},
 }
 

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -45,13 +45,13 @@ var scenarios = map[string]struct {
 	"invalid params from the beginning": {
 		params: "match[]=-not-a-valid-metric-name",
 		code:   400,
-		body: `parse error at char 1: vector selector must contain label matchers or metric name
+		body: `1:1: parse error: vector selector must contain label matchers or metric name
 `,
 	},
 	"invalid params somewhere in the middle": {
 		params: "match[]=not-a-valid-metric-name",
 		code:   400,
-		body: `parse error at char 4: could not parse remaining input "-a-valid-metric"...
+		body: `1:4: parse error: could not parse remaining input "-a-valid-metric"...
 `,
 	},
 	"test_metric1": {


### PR DESCRIPTION
The most common format (used by go, gcc and clang) for compiler error positions seems to be

`filename:line:char:` or `line:char:` if the filename is unknown.

This PR adapts the PromQL parser to use this convention.

Signed-off-by: Tobias Guggenmos <tguggenm@redhat.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->