### PR TITLE
fix: flaky test for api/v1/targets/metadata.

### DIFF
--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -540,7 +540,7 @@ func testEndpoints(t *testing.T, api *API, testLabelAPI bool) {
 		query    url.Values
 		response interface{}
 		errType  errorType
-		sorter   func(interface{}) interface{}
+		sorter   func(interface{})
 	}
 
 	var tests = []test{
@@ -1011,10 +1011,11 @@ func testEndpoints(t *testing.T, api *API, testLabelAPI bool) {
 					Unit:   "",
 				},
 			},
-			sorter: func(m interface{}) interface{} {
-				metrics := m.([]metricMetadata)
-				sort.Slice(metrics, func(i, j int) bool { return metrics[i].Metric < metrics[j].Metric })
-				return metrics
+			sorter: func(m interface{}) {
+				sort.Slice(m.([]metricMetadata), func(i, j int) bool {
+					s := m.([]metricMetadata)
+					return s[i].Metric < s[j].Metric
+				})
 			},
 		},
 		// Without a matching metric.
@@ -1170,12 +1171,11 @@ func testEndpoints(t *testing.T, api *API, testLabelAPI bool) {
 			res := test.endpoint(req.WithContext(ctx))
 			assertAPIError(t, res.err, test.errType)
 
-			data := res.data
 			if test.sorter != nil {
-				data = test.sorter(data)
+				test.sorter(res.data)
 			}
 
-			assertAPIResponse(t, data, test.response)
+			assertAPIResponse(t, res.data, test.response)
 		}
 	}
 }

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1198,6 +1198,8 @@ func assertAPIError(t *testing.T, got *apiError, exp errorType) {
 }
 
 func assertAPIResponse(t *testing.T, got interface{}, exp interface{}) {
+	t.Helper()
+
 	if !reflect.DeepEqual(exp, got) {
 		respJSON, err := json.Marshal(got)
 		if err != nil {


### PR DESCRIPTION
Fixes flaky test for api/v1/targets/metadata.

Allows sorting of responses from the API. For our tests to be deterministic, we need to ensure the response from the API follows an order. This structure allows us to define one.

Fixes #6431

Signed-off-by: gotjosh <josue@grafana.com>
