### PR TITLE
React UI: Fix issue when changing query then time, the old query executed

### DIFF
--- a/web/ui/react-app/src/ExpressionInput.test.tsx
+++ b/web/ui/react-app/src/ExpressionInput.test.tsx
@@ -23,6 +23,7 @@ describe('ExpressionInput', () => {
       'Metric Names': metricNames,
     },
     executeQuery: (): void => {},
+    onExpressionChange: (): void => {},
     loading: false,
   };
 
@@ -62,7 +63,7 @@ describe('ExpressionInput', () => {
     expect(input.prop('type')).toEqual('textarea');
     expect(input.prop('rows')).toEqual('1');
     expect(input.prop('placeholder')).toEqual('Expression (press Shift+Enter for newlines)');
-    expect(expressionInput.state('value')).toEqual('node_cpu');
+    expect(input.prop('value')).toEqual('node_cpu');
   });
 
   describe('when autosuggest is closed', () => {
@@ -94,6 +95,14 @@ describe('ExpressionInput', () => {
       instance.handleInput();
       expect(stateSpy).toHaveBeenCalled();
     });
+    it('should call onExpressionChange', () => {
+      const spyOnExpressionChange = jest.fn();
+      const props = { ...expressionInputProps, onExpressionChange: spyOnExpressionChange };
+      const wrapper = mount(<ExpressionInput {...props} />);
+      const input = wrapper.find(Input);
+      input.simulate('input', { target: { value: 'prometheus_engine_' } });
+      expect(spyOnExpressionChange).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('onSelect', () => {
@@ -101,7 +110,18 @@ describe('ExpressionInput', () => {
       const instance: any = expressionInput.instance();
       const stateSpy = jest.spyOn(instance, 'setState');
       instance.setValue('foo');
-      expect(stateSpy).toHaveBeenCalledWith({ value: 'foo', height: 'auto' }, expect.anything());
+      expect(stateSpy).toHaveBeenCalledWith({ height: 'auto' }, expect.anything());
+    });
+  });
+
+  describe('onClick', () => {
+    it('executes the query', () => {
+      const spyExecuteQuery = jest.fn();
+      const props = { ...expressionInputProps, executeQuery: spyExecuteQuery };
+      const wrapper = mount(<ExpressionInput {...props} />);
+      const btn = wrapper.find(Button).filterWhere(btn => btn.hasClass('execute-btn'));
+      btn.simulate('click');
+      expect(spyExecuteQuery).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/web/ui/react-app/src/ExpressionInput.tsx
+++ b/web/ui/react-app/src/ExpressionInput.tsx
@@ -10,14 +10,14 @@ import { faSearch, faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 interface ExpressionInputProps {
   value: string;
+  onExpressionChange: (expr: string) => void;
   autocompleteSections: { [key: string]: string[] };
-  executeQuery: (expr: string) => void;
+  executeQuery: () => void;
   loading: boolean;
 }
 
 interface ExpressionInputState {
   height: number | string;
-  value: string;
 }
 
 class ExpressionInput extends Component<ExpressionInputProps, ExpressionInputState> {
@@ -26,7 +26,6 @@ class ExpressionInput extends Component<ExpressionInputProps, ExpressionInputSta
   constructor(props: ExpressionInputProps) {
     super(props);
     this.state = {
-      value: props.value,
       height: 'auto',
     };
   }
@@ -46,7 +45,9 @@ class ExpressionInput extends Component<ExpressionInputProps, ExpressionInputSta
   };
 
   setValue = (value: string) => {
-    this.setState({ value, height: 'auto' }, this.setHeight);
+    const { onExpressionChange } = this.props;
+    onExpressionChange(value);
+    this.setState({ height: 'auto' }, this.setHeight);
   };
 
   componentDidUpdate(prevProps: ExpressionInputProps) {
@@ -57,13 +58,12 @@ class ExpressionInput extends Component<ExpressionInputProps, ExpressionInputSta
   }
 
   handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const { executeQuery } = this.props;
     if (event.key === 'Enter' && !event.shiftKey) {
-      this.executeQuery();
+      executeQuery();
       event.preventDefault();
     }
   };
-
-  executeQuery = () => this.props.executeQuery(this.exprInputRef.current!.value);
 
   getSearchMatches = (input: string, expressions: string[]) => {
     return fuzzy.filter(input.replace(/ /g, ''), expressions, {
@@ -125,7 +125,8 @@ class ExpressionInput extends Component<ExpressionInputProps, ExpressionInputSta
   };
 
   render() {
-    const { value, height } = this.state;
+    const { executeQuery, value } = this.props;
+    const { height } = this.state;
     return (
       <Downshift onSelect={this.setValue}>
         {downshift => (
@@ -175,7 +176,7 @@ class ExpressionInput extends Component<ExpressionInputProps, ExpressionInputSta
                 value={value}
               />
               <InputGroupAddon addonType="append">
-                <Button className="execute-btn" color="primary" onClick={this.executeQuery}>
+                <Button className="execute-btn" color="primary" onClick={executeQuery}>
                   Execute
                 </Button>
               </InputGroupAddon>

--- a/web/ui/react-app/src/Panel.tsx
+++ b/web/ui/react-app/src/Panel.tsx
@@ -68,14 +68,15 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
     };
   }
 
-  componentDidUpdate(prevProps: PanelProps, prevState: PanelState) {
-    const prevOpts = prevProps.options;
-    const opts = this.props.options;
-    if (prevOpts.type !== opts.type) {
-      // If the other options change, we still want to show the old data until the new
-      // query completes, but this is not a good idea when we actually change between
-      // table and graph view, since not all queries work well in both.
-      this.setState({ data: null });
+  componentDidUpdate({ options: prevOpts }: PanelProps) {
+    const { endTime, range, resolution, type } = this.props.options;
+    if (
+      prevOpts.endTime !== endTime ||
+      prevOpts.range !== range ||
+      prevOpts.resolution !== resolution ||
+      prevOpts.type !== type
+    ) {
+      this.executeQuery();
     }
   }
 
@@ -181,7 +182,6 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
 
   handleChangeRange = (range: number): void => {
     this.setOptions({ range: range });
-    this.executeQuery();
   };
 
   getEndTime = (): number | moment.Moment => {
@@ -193,21 +193,19 @@ class Panel extends Component<PanelProps & PathPrefixProps, PanelState> {
 
   handleChangeEndTime = (endTime: number | null) => {
     this.setOptions({ endTime: endTime });
-    this.executeQuery();
   };
 
   handleChangeResolution = (resolution: number | null) => {
     this.setOptions({ resolution: resolution });
-    this.executeQuery();
   };
 
   handleChangeType = (type: PanelType) => {
+    this.setState({ data: null });
     this.setOptions({ type: type });
   };
 
   handleChangeStacking = (stacked: boolean) => {
     this.setOptions({ stacked: stacked });
-    this.executeQuery();
   };
 
   render() {

--- a/web/ui/react-app/src/TimeInput.tsx
+++ b/web/ui/react-app/src/TimeInput.tsx
@@ -27,7 +27,6 @@ interface TimeInputProps {
   time: number | null; // Timestamp in milliseconds.
   range: number; // Range in seconds.
   placeholder: string;
-
   onChangeTime: (time: number | null) => void;
 }
 

--- a/web/ui/react-app/src/pages/PanelList.test.tsx
+++ b/web/ui/react-app/src/pages/PanelList.test.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { mount, shallow } from 'enzyme';
-import PanelList from './pages/PanelList';
-import Checkbox from './Checkbox';
+import PanelList from './PanelList';
+import Checkbox from '../Checkbox';
 import { Alert, Button } from 'reactstrap';
-import Panel from './Panel';
+import Panel, { PanelDefaultOptions } from '../Panel';
+import { decodePanelOptionsFromQueryString } from '../utils/urlParams';
+import ExpressionInput from '../ExpressionInput';
 
 describe('PanelList', () => {
   it('renders a query history checkbox', () => {
@@ -36,5 +38,13 @@ describe('PanelList', () => {
     const btn = panelList.find(Button).filterWhere(btn => btn.prop('className') === 'add-panel-btn');
     expect(btn.prop('color')).toEqual('primary');
     expect(btn.children().text()).toEqual('Add Panel');
+  });
+
+  it('updatesURL when a query is executed', () => {
+    const panelList = mount(<PanelList />);
+    const instance: any = panelList.instance();
+    const updateURLSpy = jest.spyOn(instance, 'updateURL');
+    instance.onExecuteQuery('new');
+    expect(updateURLSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/ui/react-app/src/pages/PanelList.test.tsx
+++ b/web/ui/react-app/src/pages/PanelList.test.tsx
@@ -40,11 +40,11 @@ describe('PanelList', () => {
     expect(btn.children().text()).toEqual('Add Panel');
   });
 
-  it('updatesURL when a query is executed', () => {
+  it('updates URL when a query is executed', () => {
     const panelList = mount(<PanelList />);
     const instance: any = panelList.instance();
     const updateURLSpy = jest.spyOn(instance, 'updateURL');
-    instance.onExecuteQuery('new');
+    instance.handleExecuteQuery('new');
     expect(updateURLSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/ui/react-app/src/pages/PanelList.tsx
+++ b/web/ui/react-app/src/pages/PanelList.tsx
@@ -96,7 +96,7 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
     });
   };
 
-  handleQueryHistory = (query: string) => {
+  onExecuteQuery = (query: string) => {
     const isSimpleMetric = this.state.metricNames.indexOf(query) !== -1;
     if (isSimpleMetric || !query.length) {
       return;
@@ -110,6 +110,7 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
     );
     localStorage.setItem('history', JSON.stringify(extendedItems.slice(0, 50)));
     this.updatePastQueries();
+    this.updateURL();
   };
 
   updateURL() {
@@ -119,7 +120,7 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
 
   handleOptionsChanged = (id: string, options: PanelOptions) => {
     const updatedPanels = this.state.panels.map(p => (id === p.id ? { ...p, options } : p));
-    this.setState({ panels: updatedPanels }, this.updateURL);
+    this.setState({ panels: updatedPanels });
   };
 
   addPanel = () => {
@@ -181,7 +182,7 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
         </Row>
         {panels.map(({ id, options }) => (
           <Panel
-            onExecuteQuery={this.handleQueryHistory}
+            onExecuteQuery={this.onExecuteQuery}
             key={id}
             options={options}
             onOptionsChanged={opts => this.handleOptionsChanged(id, opts)}

--- a/web/ui/react-app/src/pages/PanelList.tsx
+++ b/web/ui/react-app/src/pages/PanelList.tsx
@@ -96,7 +96,7 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
     });
   };
 
-  onExecuteQuery = (query: string) => {
+  handleExecuteQuery = (query: string) => {
     const isSimpleMetric = this.state.metricNames.indexOf(query) !== -1;
     if (isSimpleMetric || !query.length) {
       return;
@@ -182,7 +182,7 @@ class PanelList extends Component<RouteComponentProps & PathPrefixProps, PanelLi
         </Row>
         {panels.map(({ id, options }) => (
           <Panel
-            onExecuteQuery={this.onExecuteQuery}
+            onExecuteQuery={this.handleExecuteQuery}
             key={id}
             options={options}
             onOptionsChanged={opts => this.handleOptionsChanged(id, opts)}


### PR DESCRIPTION
This Pull Request fixes a bug in the querying behavior of the new React UI. The bug is described in the linked issue.

The root cause of the bug was the state management strategy in `ExpressionInput`. Previously, the query expression was passed into `ExpressionInput` as a prop, then stored as internal component state. When the query expression was changed, the parent components (which actually do the fetching) were not aware of the state changes. So when they performed a fetch, they sometimes used a stale query expression. Specifically, the query expression was stale whenever a query was executed without using the Execute button.

The solution I propose here is to lift the state management back into the parent components—`Panel` and `PanelList`— so that they know when the query expression changes and fetch using up-to-date values. In addition, I decouple state changes from querying so that each expression input keystroke does _not_ issue a new query. State changes that should perform queries do so in the lifecycle method `componentDidUpdate`. And every time a query is executed, the url is updated. This matches the behavior of the existing classic ui.

Fixes #6405