### PR TITLE
rules: use evalTimestamp more accurate.

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -296,7 +296,7 @@ func (g *Group) run(ctx context.Context) {
 
 		g.metrics.iterationDuration.Observe(timeSinceStart.Seconds())
 		g.setEvaluationDuration(timeSinceStart)
-		g.setEvaluationTimestamp(start)
+		g.setEvaluationTimestamp(evalTimestamp)
 	}
 
 	// The assumption here is that since the ticker was started after having
@@ -512,7 +512,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 				since := time.Since(t)
 				g.metrics.evalDuration.Observe(since.Seconds())
 				rule.SetEvaluationDuration(since)
-				rule.SetEvaluationTimestamp(t)
+				rule.SetEvaluationTimestamp(ts)
 			}(time.Now())
 
 			g.metrics.evalTotal.Inc()


### PR DESCRIPTION
The `evaluationTimestamp`field of `Group` should use **evaluation timestamp** instead of **start** time. Because **start** time is not the real one to prometheus query engine.

https://github.com/prometheus/prometheus/blob/0a0a228db380c3d68decd720016ba568af8b4b6d/rules/manager.go#L229

https://github.com/prometheus/prometheus/blob/0a0a228db380c3d68decd720016ba568af8b4b6d/rules/manager.go#L290-L299

The estimation time for storing rules in the query engine is better, because the startup time in rule manager is not actually the query time of the metric query engine. Meanwhile, the current value is the latest evaluation time of the group or rule.