### PR TITLE
Fix promlint order algorithm not work issue

### DIFF
--- a/util/promlint/promlint.go
+++ b/util/promlint/promlint.go
@@ -87,6 +87,8 @@ func (l *Linter) Lint() ([]Problem, error) {
 	sort.SliceStable(problems, func(i, j int) bool {
 		if problems[i].Metric < problems[j].Metric {
 			return true
+		} else if problems[i].Metric > problems[j].Metric {
+			return false
 		}
 
 		return problems[i].Text < problems[j].Text


### PR DESCRIPTION
The less function provided to `sort.SliceStable` not work well. Since we should  start to compare `Text` **only if** the two `Metric ` are equal.
```golang
	// Ensure deterministic output.
	sort.SliceStable(problems, func(i, j int) bool {
		if problems[i].Metric < problems[j].Metric {
			return true
		} 

		return problems[i].Text < problems[j].Text
	})
```


Signed-off-by: RainbowMango <renhongcai@huawei.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->