### PR TITLE
Reread index series rather than storing in memory.

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -54,10 +54,6 @@ type IndexWriter interface {
 	// The passed in values chained tuples of strings of the length of names.
 	WriteLabelIndex(names []string, values []string) error
 
-	// WritePostings writes a postings list for a single label pair.
-	// The Postings here contain refs to the series that were added.
-	WritePostings(name, value string, it index.Postings) error
-
 	// Close writes any finalization and closes the resources associated with
 	// the underlying writer.
 	Close() error

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -727,11 +727,9 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		}
 	}
 
-	// We fully rebuild the postings list index from merged series.
 	var (
-		postings = index.NewMemPostings()
-		values   = map[string]stringset{}
-		i        = uint64(0)
+		values = map[string]stringset{}
+		ref    = uint64(0)
 	)
 
 	if err := indexw.AddSymbols(allSymbols); err != nil {
@@ -822,7 +820,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 			return errors.Wrap(err, "write chunks")
 		}
 
-		if err := indexw.AddSeries(i, lset, mergedChks...); err != nil {
+		if err := indexw.AddSeries(ref, lset, mergedChks...); err != nil {
 			return errors.Wrap(err, "add series")
 		}
 
@@ -846,9 +844,8 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 			}
 			valset.set(l.Value)
 		}
-		postings.Add(i, lset)
 
-		i++
+		ref++
 	}
 	if set.Err() != nil {
 		return errors.Wrap(set.Err(), "iterate compaction set")
@@ -866,11 +863,6 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		}
 	}
 
-	for _, l := range postings.SortedKeys() {
-		if err := indexw.WritePostings(l.Name, l.Value, postings.Get(l.Name, l.Value)); err != nil {
-			return errors.Wrap(err, "write postings")
-		}
-	}
 	return nil
 }
 

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -569,7 +569,7 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockRe
 		}
 	}
 
-	indexw, err := index.NewWriter(filepath.Join(tmp, indexFilename))
+	indexw, err := index.NewWriter(c.ctx, filepath.Join(tmp, indexFilename))
 	if err != nil {
 		return errors.Wrap(err, "open index writer")
 	}

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -956,8 +956,8 @@ func TestCancelCompactions(t *testing.T) {
 	}()
 
 	// Create some blocks to fall within the compaction range.
-	createBlock(t, tmpdir, genSeries(10, 10000, 0, 1000))
-	createBlock(t, tmpdir, genSeries(10, 10000, 1000, 2000))
+	createBlock(t, tmpdir, genSeries(1, 10000, 0, 1000))
+	createBlock(t, tmpdir, genSeries(1, 10000, 1000, 2000))
 	createBlock(t, tmpdir, genSeries(1, 1, 2000, 2001)) // The most recent block is ignored so can be e small one.
 
 	// Copy the db so we have an exact copy to compare compaction times.

--- a/tsdb/encoding/encoding.go
+++ b/tsdb/encoding/encoding.go
@@ -268,7 +268,7 @@ func (d *Decbuf) Byte() byte {
 	return x
 }
 
-func (d *Decbuf) EatPadding() {
+func (d *Decbuf) ConsumePadding() {
 	if d.E != nil {
 		return
 	}
@@ -279,7 +279,6 @@ func (d *Decbuf) EatPadding() {
 		d.E = ErrInvalidSize
 		return
 	}
-	return
 }
 
 func (d *Decbuf) Err() error  { return d.E }

--- a/tsdb/encoding/encoding.go
+++ b/tsdb/encoding/encoding.go
@@ -277,7 +277,6 @@ func (d *Decbuf) ConsumePadding() {
 	}
 	if len(d.B) < 1 {
 		d.E = ErrInvalidSize
-		return
 	}
 }
 

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -14,6 +14,7 @@
 package index
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -155,7 +156,7 @@ func TestIndexRW_Create_Open(t *testing.T) {
 	fn := filepath.Join(dir, indexFilename)
 
 	// An empty index must still result in a readable file.
-	iw, err := NewWriter(fn)
+	iw, err := NewWriter(context.Background(), fn)
 	testutil.Ok(t, err)
 	testutil.Ok(t, iw.Close())
 
@@ -183,7 +184,7 @@ func TestIndexRW_Postings(t *testing.T) {
 
 	fn := filepath.Join(dir, indexFilename)
 
-	iw, err := NewWriter(fn)
+	iw, err := NewWriter(context.Background(), fn)
 	testutil.Ok(t, err)
 
 	series := []labels.Labels{
@@ -247,7 +248,7 @@ func TestPostingsMany(t *testing.T) {
 
 	fn := filepath.Join(dir, indexFilename)
 
-	iw, err := NewWriter(fn)
+	iw, err := NewWriter(context.Background(), fn)
 	testutil.Ok(t, err)
 
 	// Create a label in the index which has 999 values.
@@ -368,7 +369,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 		})
 	}
 
-	iw, err := NewWriter(filepath.Join(dir, indexFilename))
+	iw, err := NewWriter(context.Background(), filepath.Join(dir, indexFilename))
 	testutil.Ok(t, err)
 
 	testutil.Ok(t, iw.AddSymbols(symbols))

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -49,6 +49,7 @@ func newMockIndex() mockIndex {
 		postings:   make(map[labels.Label][]uint64),
 		symbols:    make(map[string]struct{}),
 	}
+	ix.postings[allPostingsKey] = []uint64{}
 	return ix
 }
 
@@ -63,7 +64,12 @@ func (m mockIndex) AddSeries(ref uint64, l labels.Labels, chunks ...chunks.Meta)
 	for _, lbl := range l {
 		m.symbols[lbl.Name] = struct{}{}
 		m.symbols[lbl.Value] = struct{}{}
+		if _, ok := m.postings[lbl]; !ok {
+			m.postings[lbl] = []uint64{}
+		}
+		m.postings[lbl] = append(m.postings[lbl], ref)
 	}
+	m.postings[allPostingsKey] = append(m.postings[allPostingsKey], ref)
 
 	s := series{l: l}
 	// Actual chunk data is not stored in the index.
@@ -86,19 +92,6 @@ func (m mockIndex) WriteLabelIndex(names []string, values []string) error {
 	return nil
 }
 
-func (m mockIndex) WritePostings(name, value string, it Postings) error {
-	l := labels.Label{Name: name, Value: value}
-	if _, ok := m.postings[l]; ok {
-		return errors.Errorf("postings for %s already added", l)
-	}
-	ep, err := ExpandPostings(it)
-	if err != nil {
-		return err
-	}
-	m.postings[l] = ep
-	return nil
-}
-
 func (m mockIndex) Close() error {
 	return nil
 }
@@ -116,7 +109,7 @@ func (m mockIndex) Postings(name string, values ...string) (Postings, error) {
 	p := []Postings{}
 	for _, value := range values {
 		l := labels.Label{Name: name, Value: value}
-		p = append(p, NewListPostings(m.postings[l]))
+		p = append(p, m.SortedPostings(NewListPostings(m.postings[l])))
 	}
 	return Merge(p...), nil
 }
@@ -217,7 +210,8 @@ func TestIndexRW_Postings(t *testing.T) {
 	testutil.Ok(t, iw.AddSeries(3, series[2]))
 	testutil.Ok(t, iw.AddSeries(4, series[3]))
 
-	err = iw.WritePostings("a", "1", newListPostings(1, 2, 3, 4))
+	err = iw.WriteLabelIndex([]string{"a"}, []string{"1"})
+	err = iw.WriteLabelIndex([]string{"b"}, []string{"1", "2", "3", "4"})
 	testutil.Ok(t, err)
 
 	testutil.Ok(t, iw.Close())
@@ -271,9 +265,7 @@ func TestPostingsMany(t *testing.T) {
 	for i, s := range series {
 		testutil.Ok(t, iw.AddSeries(uint64(i), s))
 	}
-	for i, s := range series {
-		testutil.Ok(t, iw.WritePostings("i", s.Get("i"), newListPostings(uint64(i))))
-	}
+	err = iw.WriteLabelIndex([]string{"foo"}, []string{"bar"})
 	testutil.Ok(t, iw.Close())
 
 	ir, err := NewFileReader(fn)
@@ -414,20 +406,6 @@ func TestPersistence_index_e2e(t *testing.T) {
 		testutil.Ok(t, mi.WriteLabelIndex([]string{k}, vals))
 	}
 
-	all := make([]uint64, len(lbls))
-	for i := range all {
-		all[i] = uint64(i)
-	}
-	err = iw.WritePostings("", "", newListPostings(all...))
-	testutil.Ok(t, err)
-	testutil.Ok(t, mi.WritePostings("", "", newListPostings(all...)))
-
-	for _, l := range postings.SortedKeys() {
-		err := iw.WritePostings(l.Name, l.Value, postings.Get(l.Name, l.Value))
-		testutil.Ok(t, err)
-		mi.WritePostings(l.Name, l.Value, postings.Get(l.Name, l.Value))
-	}
-
 	err = iw.Close()
 	testutil.Ok(t, err)
 
@@ -457,7 +435,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 			testutil.Equals(t, explset, lset)
 			testutil.Equals(t, expchks, chks)
 		}
-		testutil.Assert(t, expp.Next() == false, "Unexpected Next() for "+p.Name+" "+p.Value)
+		testutil.Assert(t, expp.Next() == false, "Expected no more postings for %q=%q", p.Name, p.Value)
 		testutil.Ok(t, gotp.Err())
 	}
 

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -211,6 +211,7 @@ func TestIndexRW_Postings(t *testing.T) {
 	testutil.Ok(t, iw.AddSeries(4, series[3]))
 
 	err = iw.WriteLabelIndex([]string{"a"}, []string{"1"})
+	testutil.Ok(t, err)
 	err = iw.WriteLabelIndex([]string{"b"}, []string{"1", "2", "3", "4"})
 	testutil.Ok(t, err)
 
@@ -266,6 +267,7 @@ func TestPostingsMany(t *testing.T) {
 		testutil.Ok(t, iw.AddSeries(uint64(i), s))
 	}
 	err = iw.WriteLabelIndex([]string{"foo"}, []string{"bar"})
+	testutil.Ok(t, err)
 	testutil.Ok(t, iw.Close())
 
 	ir, err := NewFileReader(fn)

--- a/tsdb/mocks_test.go
+++ b/tsdb/mocks_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
-	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
 )
 
@@ -62,9 +61,9 @@ func (m *mockIndexWriter) AddSeries(ref uint64, l labels.Labels, chunks ...chunk
 	return nil
 }
 
-func (mockIndexWriter) WriteLabelIndex(names []string, values []string) error     { return nil }
-func (mockIndexWriter) WritePostings(name, value string, it index.Postings) error { return nil }
-func (mockIndexWriter) Close() error                                              { return nil }
+func (mockIndexWriter) WriteLabelIndex(names []string, values []string) error { return nil }
+func (mockIndexWriter) WritePostings() error                                  { return nil }
+func (mockIndexWriter) Close() error                                          { return nil }
 
 type mockBReader struct {
 	ir   IndexReader

--- a/tsdb/mocks_test.go
+++ b/tsdb/mocks_test.go
@@ -62,7 +62,6 @@ func (m *mockIndexWriter) AddSeries(ref uint64, l labels.Labels, chunks ...chunk
 }
 
 func (mockIndexWriter) WriteLabelIndex(names []string, values []string) error { return nil }
-func (mockIndexWriter) WritePostings() error                                  { return nil }
 func (mockIndexWriter) Close() error                                          { return nil }
 
 type mockBReader struct {


### PR DESCRIPTION
Rather than building up a 2nd copy of all the posting
tables, construct it from the data we've already written
to disk. Benchmarks and more details in individual commits.

This saves memory, and also happens to be slightly faster.