### PR TITLE
[WIP] storage/remote: use YAML data instead of JSON for MD5 hash

### DIFF
--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -17,12 +17,12 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -174,7 +174,7 @@ func labelsToEqualityMatchers(ls model.LabelSet) []*labels.Matcher {
 
 // Used for hashing configs and diff'ing hashes in ApplyConfig.
 func toHash(data interface{}) (string, error) {
-	bytes, err := json.Marshal(data)
+	bytes, err := yaml.Marshal(data)
 	if err != nil {
 		return "", err
 	}

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -52,7 +52,7 @@ func TestStorageLifecycle(t *testing.T) {
 		},
 	}
 
-	s.ApplyConfig(conf)
+	testutil.Ok(t, s.ApplyConfig(conf))
 
 	// make sure remote write has a queue.
 	testutil.Equals(t, 1, len(s.rws.queues))
@@ -74,13 +74,13 @@ func TestUpdateRemoteReadConfigs(t *testing.T) {
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},
 	}
-	s.ApplyConfig(conf)
+	testutil.Ok(t, s.ApplyConfig(conf))
 	testutil.Equals(t, 0, len(s.queryables))
 
 	conf.RemoteReadConfigs = []*config.RemoteReadConfig{
 		&config.DefaultRemoteReadConfig,
 	}
-	s.ApplyConfig(conf)
+	testutil.Ok(t, s.ApplyConfig(conf))
 	testutil.Equals(t, 1, len(s.queryables))
 
 	err = s.Close()

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -248,10 +249,18 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 	c0 := &config.RemoteWriteConfig{
 		RemoteTimeout: model.Duration(10 * time.Second),
 		QueueConfig:   config.DefaultQueueConfig,
+		WriteRelabelConfigs: []*relabel.Config{
+			&relabel.Config{
+				Regex: relabel.MustNewRegexp(".+"),
+			},
+		},
 	}
 	c1 := &config.RemoteWriteConfig{
 		RemoteTimeout: model.Duration(20 * time.Second),
 		QueueConfig:   config.DefaultQueueConfig,
+		HTTPClientConfig: config_util.HTTPClientConfig{
+			BearerToken: "foo",
+		},
 	}
 	c2 := &config.RemoteWriteConfig{
 		RemoteTimeout: model.Duration(30 * time.Second),
@@ -263,43 +272,58 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{c0, c1, c2},
 	}
 	// We need to set URL's so that metric creation doesn't panic.
-	conf.RemoteWriteConfigs[0].URL = &common_config.URL{
-		URL: &url.URL{
-			Host: "http://test-storage.com",
-		},
+	for i := range conf.RemoteWriteConfigs {
+		conf.RemoteWriteConfigs[i].URL = &common_config.URL{
+			URL: &url.URL{
+				Host: "http://test-storage.com",
+			},
+		}
 	}
-	conf.RemoteWriteConfigs[1].URL = &common_config.URL{
-		URL: &url.URL{
-			Host: "http://test-storage.com",
-		},
-	}
-	conf.RemoteWriteConfigs[2].URL = &common_config.URL{
-		URL: &url.URL{
-			Host: "http://test-storage.com",
-		},
-	}
-	s.ApplyConfig(conf)
+	testutil.Ok(t, s.ApplyConfig(conf))
 	testutil.Equals(t, 3, len(s.queues))
 
-	c0Hash, err := toHash(c0)
-	testutil.Ok(t, err)
-	c1Hash, err := toHash(c1)
-	testutil.Ok(t, err)
-	// q := s.queues[1]
+	hashes := make([]string, len(conf.RemoteWriteConfigs))
+	storeHashes := func() {
+		for i := range conf.RemoteWriteConfigs {
+			hash, err := toHash(conf.RemoteWriteConfigs[i])
+			testutil.Ok(t, err)
+			hashes[i] = hash
+		}
+	}
 
+	storeHashes()
 	// Update c0 and c2.
-	c0.RemoteTimeout = model.Duration(40 * time.Second)
+	c0.WriteRelabelConfigs[0] = &relabel.Config{Regex: relabel.MustNewRegexp("foo")}
 	c2.RemoteTimeout = model.Duration(50 * time.Second)
 	conf = &config.Config{
 		GlobalConfig:       config.GlobalConfig{},
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{c0, c1, c2},
 	}
-	s.ApplyConfig(conf)
+	testutil.Ok(t, s.ApplyConfig(conf))
 	testutil.Equals(t, 3, len(s.queues))
 
-	_, hashExists := s.queues[c1Hash]
+	_, hashExists := s.queues[hashes[0]]
+	testutil.Assert(t, !hashExists, "The queue for the first remote write configuration should have been restarted because the relabel configuration has changed.")
+	_, hashExists = s.queues[hashes[1]]
+	testutil.Assert(t, hashExists, "Pointer of unchanged queue should have remained the same")
+	_, hashExists = s.queues[hashes[2]]
+	testutil.Assert(t, !hashExists, "The queue for the third remote write configuration should have been restarted because the timeout has changed.")
+
+	storeHashes()
+	// Update c1.
+	c1.HTTPClientConfig.BearerToken = "bar"
+	err = s.ApplyConfig(conf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 3, len(s.queues))
+
+	_, hashExists = s.queues[hashes[0]]
+	testutil.Assert(t, hashExists, "Pointer of unchanged queue should have remained the same")
+	_, hashExists = s.queues[hashes[1]]
+	testutil.Assert(t, !hashExists, "The queue for the second remote write configuration should have been restarted because the HTTP configuration has changed.")
+	_, hashExists = s.queues[hashes[2]]
 	testutil.Assert(t, hashExists, "Pointer of unchanged queue should have remained the same")
 
+	storeHashes()
 	// Delete c0.
 	conf = &config.Config{
 		GlobalConfig:       config.GlobalConfig{},
@@ -308,8 +332,12 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 	s.ApplyConfig(conf)
 	testutil.Equals(t, 2, len(s.queues))
 
-	_, hashExists = s.queues[c0Hash]
+	_, hashExists = s.queues[hashes[0]]
 	testutil.Assert(t, !hashExists, "If the index changed, the queue should be stopped and recreated.")
+	_, hashExists = s.queues[hashes[1]]
+	testutil.Assert(t, hashExists, "Pointer of unchanged queue should have remained the same")
+	_, hashExists = s.queues[hashes[2]]
+	testutil.Assert(t, hashExists, "Pointer of unchanged queue should have remained the same")
 
 	err = s.Close()
 	testutil.Ok(t, err)


### PR DESCRIPTION
The configuration structs don't have JSON field tags so there's no guarantee that different configurations produce different JSON data. This isn't the case for YAML.

This is similar to https://github.com/prometheus/prometheus/pull/6455.