### PR TITLE
Revert "Docker image for s390x"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,3 @@ data/
 !.build/linux-amd64/
 !.build/linux-armv7/
 !.build/linux-arm64/
-!.build/linux-s390x/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64 armv7 arm64 s390x
+DOCKER_ARCHS ?= amd64 armv7 arm64
 
 REACT_APP_PATH = web/ui/react-app
 REACT_APP_SOURCE_FILES = $(wildcard $(REACT_APP_PATH)/public/* $(REACT_APP_PATH)/src/* $(REACT_APP_PATH)/tsconfig.json)


### PR DESCRIPTION
Reverts prometheus/prometheus#6307

The build of the container image for `s390x` fails, see https://app.circleci.com/jobs/github/prometheus/prometheus/20736. This needs further investigation so reverting in the meantime.