### PR TITLE
Remove redundant/accidental line in query doc

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -179,8 +179,6 @@ for each of the given times in UTC. Returned values are from 0 to 23.
 
 ## `idelta()`
 
-`idelta(v range-vector)`
-
 `idelta(v range-vector)` calculates the difference between the last two samples
 in the range vector `v`, returning an instant vector with the given deltas and
 equivalent labels.


### PR DESCRIPTION
Removing that line makes it consistent with the other functions.