### PR TITLE
manager: add full stops on comments

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -743,7 +743,7 @@ func (g *Group) RestoreForState(ts time.Time) {
 
 }
 
-// Equals return if two groups are the same
+// Equals return if two groups are the same.
 func (g *Group) Equals(ng *Group) bool {
 	if g.name != ng.name {
 		return false

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -742,7 +742,7 @@ func TestUpdate(t *testing.T) {
 		ogs[h] = g
 	}
 
-	// Update interval and reload
+	// Update interval and reload.
 	for i, g := range rgs.Groups {
 		if g.Interval != 0 {
 			rgs.Groups[i].Interval = g.Interval * 2
@@ -753,7 +753,7 @@ func TestUpdate(t *testing.T) {
 	}
 	reloadAndValidate(rgs, t, tmpFile, ruleManager, expected, ogs)
 
-	// Change group rules and reload
+	// Change group rules and reload.
 	for i, g := range rgs.Groups {
 		for j, r := range g.Rules {
 			rgs.Groups[i].Rules[j].Expr = fmt.Sprintf("%s * 0", r.Expr)


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->