### PR TITLE
Docker image for s390x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  prometheus: prometheus/prometheus@0.3.0
+  prometheus: prometheus/prometheus@0.4.0
   go: circleci/go@0.2.0
 
 executors:

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ data/
 !.build/linux-amd64/
 !.build/linux-armv7/
 !.build/linux-arm64/
+!.build/linux-s390x/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64 armv7 arm64
+DOCKER_ARCHS ?= amd64 armv7 arm64 s390x
 
 REACT_APP_PATH = web/ui/react-app
 REACT_APP_SOURCE_FILES = $(wildcard $(REACT_APP_PATH)/public/* $(REACT_APP_PATH)/src/* $(REACT_APP_PATH)/tsconfig.json)


### PR DESCRIPTION
Fixes [#6478](https://github.com/prometheus/prometheus/pull/6478)

Added changes required for building s390x docker image.