### PR TITLE
ui: Display unknown and failing alerts

### DIFF
--- a/web/ui/react-app/src/pages/alerts/AlertContents.tsx
+++ b/web/ui/react-app/src/pages/alerts/AlertContents.tsx
@@ -10,7 +10,7 @@ export interface Rule {
   alerts: Alert[];
   annotations: Record<string, string>;
   duration: number;
-  health: string;
+  health: RuleState;
   labels: Record<string, string>;
   name: string;
   query: string;
@@ -22,6 +22,9 @@ export interface RuleStatus<T> {
   firing: T;
   pending: T;
   inactive: T;
+  unknown: T;
+  err: T;
+  ok: T;
 }
 
 export interface AlertsProps {
@@ -35,6 +38,7 @@ interface Alert {
   value: string;
   annotations: Record<string, string>;
   activeAt: string;
+  health: string;
 }
 
 interface RuleGroup {
@@ -49,6 +53,9 @@ const AlertsContent: FC<AlertsProps> = ({ groups = [], statsCount }) => {
     firing: true,
     pending: true,
     inactive: true,
+    unknown: false,
+    err: false,
+    ok: false,
   });
   const [showAnnotations, setShowAnnotations] = useState(false);
 
@@ -111,11 +118,15 @@ const StatusBadges: FC<StatusBadgesProps> = ({ rules, children }) => {
       return {
         ...acc,
         [r.state]: acc[r.state] + r.alerts.length,
+        [r.health]: acc[r.health] + 1,
       };
     },
     {
       firing: 0,
       pending: 0,
+      unknown: 0,
+      err: 0,
+      ok: 0,
     }
   );
 
@@ -126,6 +137,8 @@ const StatusBadges: FC<StatusBadgesProps> = ({ rules, children }) => {
         {isPresent(statesCounter.inactive) && <Badge color="success">inactive</Badge>}
         {statesCounter.pending > 0 && <Badge color="warning">pending ({statesCounter.pending})</Badge>}
         {statesCounter.firing > 0 && <Badge color="danger">firing ({statesCounter.firing})</Badge>}
+        {statesCounter.unknown > 0 && <Badge color="primary">unknown</Badge>}
+        {statesCounter.err > 0 && <Badge color="danger">error</Badge>}
       </div>
     </div>
   );

--- a/web/ui/react-app/src/pages/alerts/Alerts.tsx
+++ b/web/ui/react-app/src/pages/alerts/Alerts.tsx
@@ -14,6 +14,9 @@ const Alerts: FC<RouteComponentProps & PathPrefixProps> = ({ pathPrefix = '' }) 
     inactive: 0,
     pending: 0,
     firing: 0,
+    unknown: 0,
+    err: 0,
+    ok: 0,
   };
 
   if (response.data && response.data.groups) {

--- a/web/ui/react-app/src/pages/alerts/CollapsibleAlertPanel.tsx
+++ b/web/ui/react-app/src/pages/alerts/CollapsibleAlertPanel.tsx
@@ -14,6 +14,9 @@ const alertColors: RuleStatus<string> = {
   firing: 'danger',
   pending: 'warning',
   inactive: 'success',
+  unknown: 'primary',
+  err: 'danger',
+  ok: 'success',
 };
 
 const createExpressionLink = (expr: string) => {
@@ -25,9 +28,15 @@ const CollapsibleAlertPanel: FC<CollapsibleAlertPanelProps> = ({ rule, showAnnot
 
   return (
     <>
-      <Alert fade={false} onClick={() => toggle(!open)} color={alertColors[rule.state]} style={{ cursor: 'pointer' }}>
+      <Alert
+        fade={false}
+        onClick={() => toggle(!open)}
+        color={alertColors[rule.health === 'ok' ? rule.state : rule.health]}
+        style={{ cursor: 'pointer' }}
+      >
         <FontAwesomeIcon icon={open ? faChevronDown : faChevronRight} fixedWidth />
-        <strong>{rule.name}</strong> ({`${rule.alerts.length} active`})
+        <strong>{rule.name}</strong> ({rule.alerts.length} active){rule.health === 'unknown' ? ' (unknown)' : ''}
+        {rule.health === 'err' ? ' (failing)' : ''}
       </Alert>
       <Collapse isOpen={open} className="mb-2">
         <pre style={{ background: '#f5f5f5', padding: 15 }}>


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

![prom](https://user-images.githubusercontent.com/291750/71191703-41e9eb80-2287-11ea-855d-94b962a03483.png)


<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->