### PR TITLE
[check-syntax] adds a command for checking config file syntax

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -56,6 +56,12 @@ func main() {
 		"The config files to check.",
 	).Required().ExistingFiles()
 
+	checkSyntaxCmd := checkCmd.Command("syntax", "Check if the config files have valid syntax or not. Does not check if files exist.")
+	syntaxFiles := checkSyntaxCmd.Arg(
+		"config-files",
+		"The config files to check syntax.",
+	).Required().ExistingFiles()
+
 	checkRulesCmd := checkCmd.Command("rules", "Check if the rule files are valid or not.")
 	ruleFiles := checkRulesCmd.Arg(
 		"rule-files",
@@ -117,6 +123,9 @@ func main() {
 	case checkConfigCmd.FullCommand():
 		os.Exit(CheckConfig(*configFiles...))
 
+	case checkSyntaxCmd.FullCommand():
+		os.Exit(CheckSyntax(*syntaxFiles...))
+
 	case checkRulesCmd.FullCommand():
 		os.Exit(CheckRules(*ruleFiles...))
 
@@ -147,6 +156,27 @@ func main() {
 	case testRulesCmd.FullCommand():
 		os.Exit(RulesUnitTest(*testRulesFiles...))
 	}
+}
+
+// CheckSyntax checks the config files for valid prometheus config syntax
+func CheckSyntax(files ...string) int {
+	failed := false
+
+	for _, f := range files {
+		fmt.Println("Checking syntax for", f)
+		_, err := config.LoadFile(f)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "  FAILED:", err)
+			failed = true
+		} else {
+			fmt.Printf("  SUCCESS: %s has valid syntax", f)
+		}
+		fmt.Println()
+	}
+	if failed {
+		return 1
+	}
+	return 0
 }
 
 // CheckConfig validates configuration files.


### PR DESCRIPTION
In order to make testing syntax in CI easier, we need a way to check syntax without checking if all the files exist. This PR adds a `check syntax` command to promtool that just loads the config from files and returns success if they load fine, or the error if the config is not valid. This replaces #5223 and is the fix for #5222 

Signed-off-by: glightfoot <glightfoot@rsglab.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->