### PR TITLE
PromQL: Parse Series descriptions using the generated parser

### DIFF
--- a/promql/generated_parser.y
+++ b/promql/generated_parser.y
@@ -312,6 +312,8 @@ series_values   :
                         { $$ = append($1, $3...) }
                 | series_values SPACE
                         { $$ = $1 }
+                | error
+                        { yylex.(*parser).unexpected("series values", "") }
                 ;
 
 series_item     :

--- a/promql/generated_parser.y
+++ b/promql/generated_parser.y
@@ -143,7 +143,7 @@ start           : START_LABELS label_matchers
                      { yylex.(*parser).generatedParserResult = $2 }
                 | START_GROUPING_LABELS grouping_labels
                      { yylex.(*parser).generatedParserResult = $2 }
-                | START_SERIES_DESCRIPTION { yylex.(*parser).generatedParserResult = &seriesDescription{}} series_description
+                | START_SERIES_DESCRIPTION series_description
                 | start EOF
                 | error /* If none of the more detailed error messages are triggered, we fall back to this. */
                         { yylex.(*parser).unexpected("","") }
@@ -193,8 +193,8 @@ metric          :
                         { $$ = append($2, labels.Label{Name: labels.MetricName, Value: $1.Val}); sort.Sort($$) }
                 | label_set 
                         {$$ = $1}
-                | error
-                        { yylex.(*parser).errorf("missing metric name or metric selector")}
+              /*| error
+                        { yylex.(*parser).errorf("missing metric name or metric selector")} */
                 ;
 
 metric_identifier

--- a/promql/generated_parser.y
+++ b/promql/generated_parser.y
@@ -113,7 +113,6 @@
 %token	startSymbolsStart
 // Start symbols for the generated parser.
 %token START_LABELS
-%token START_LABEL_SET
 %token START_METRIC
 %token START_GROUPING_LABELS
 %token START_SERIES_DESCRIPTION
@@ -137,8 +136,6 @@
 
 start           : START_LABELS label_matchers
                      {yylex.(*parser).generatedParserResult.(*VectorSelector).LabelMatchers = $2}
-                | START_LABEL_SET label_set 
-                     { yylex.(*parser).generatedParserResult = $2 }
                 | START_METRIC metric
                      { yylex.(*parser).generatedParserResult = $2 }
                 | START_GROUPING_LABELS grouping_labels

--- a/promql/generated_parser.y
+++ b/promql/generated_parser.y
@@ -143,7 +143,7 @@ start           : START_LABELS label_matchers
                      { yylex.(*parser).generatedParserResult = $2 }
                 | START_GROUPING_LABELS grouping_labels
                      { yylex.(*parser).generatedParserResult = $2 }
-                | START_SERIES_DESCRIPTION { yylex.(*parser).generatedParserResult = &parseSeriesDescResult{}} series_description
+                | START_SERIES_DESCRIPTION { yylex.(*parser).generatedParserResult = &seriesDescription{}} series_description
                 | start EOF
                 | error /* If none of the more detailed error messages are triggered, we fall back to this. */
                         { yylex.(*parser).unexpected("","") }
@@ -298,7 +298,7 @@ maybe_label     :
 series_description:
                 metric series_values
                         {
-                        yylex.(*parser).generatedParserResult = &parseSeriesDescResult{
+                        yylex.(*parser).generatedParserResult = &seriesDescription{
                                 labels: $1,
                                 values: $2,
                         }

--- a/promql/generated_parser.y
+++ b/promql/generated_parser.y
@@ -12,16 +12,16 @@
 // limitations under the License.
 
 %{
-    package promql
+package promql
 
-    import (
+import (
         "math"
         "sort"
         "strconv"
 
         "github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/pkg/value"
-    )
+        "github.com/prometheus/prometheus/pkg/value"
+)
 %}
 
 %union {
@@ -190,8 +190,6 @@ metric          :
                         { $$ = append($2, labels.Label{Name: labels.MetricName, Value: $1.Val}); sort.Sort($$) }
                 | label_set 
                         {$$ = $1}
-              /*| error
-                        { yylex.(*parser).errorf("missing metric name or metric selector")} */
                 ;
 
 metric_identifier
@@ -292,6 +290,7 @@ maybe_label     :
                 | BOOL
                 ;
 
+// The series description grammar is only used inside unit tests.
 series_description:
                 metric series_values
                         {

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -190,119 +190,109 @@ var yyExca = [...]int{
 	-1, 1,
 	1, -1,
 	-2, 0,
-	-1, 4,
-	1, 31,
-	5, 31,
-	-2, 0,
 	-1, 22,
-	1, 31,
-	5, 31,
-	24, 31,
-	-2, 0,
-	-1, 63,
-	1, 72,
-	5, 72,
-	24, 72,
+	1, 70,
+	5, 70,
+	24, 70,
 	-2, 0,
 }
 
 const yyPrivate = 57344
 
-const yyLast = 160
+const yyLast = 147
 
 var yyAct = [...]int{
 
-	108, 98, 99, 38, 36, 30, 25, 77, 39, 40,
-	97, 91, 104, 13, 93, 102, 101, 111, 103, 7,
-	109, 90, 100, 100, 86, 95, 12, 75, 8, 102,
-	101, 10, 41, 42, 43, 68, 63, 73, 89, 76,
-	74, 85, 82, 62, 22, 1, 44, 45, 46, 47,
-	48, 49, 50, 51, 52, 53, 54, 96, 94, 55,
-	56, 81, 57, 58, 59, 60, 61, 69, 70, 34,
-	80, 38, 84, 71, 72, 21, 39, 40, 78, 35,
-	88, 66, 20, 79, 92, 2, 3, 4, 5, 6,
-	19, 64, 15, 28, 65, 37, 11, 14, 67, 105,
-	41, 42, 43, 106, 107, 110, 23, 33, 9, 0,
-	0, 0, 112, 0, 44, 45, 46, 47, 48, 49,
-	50, 51, 52, 53, 54, 0, 0, 55, 56, 0,
-	57, 58, 59, 60, 61, 32, 27, 0, 16, 0,
-	31, 26, 0, 18, 17, 87, 83, 12, 32, 27,
-	0, 0, 0, 31, 26, 0, 0, 0, 29, 24,
+	106, 96, 97, 38, 36, 25, 68, 95, 39, 40,
+	30, 90, 7, 102, 107, 81, 100, 99, 109, 101,
+	98, 8, 93, 98, 89, 77, 100, 99, 12, 80,
+	75, 10, 41, 42, 43, 63, 21, 78, 69, 70,
+	73, 88, 79, 74, 71, 72, 44, 45, 46, 47,
+	48, 49, 50, 51, 52, 53, 54, 76, 1, 55,
+	56, 20, 57, 58, 59, 60, 61, 94, 19, 38,
+	85, 83, 92, 66, 39, 40, 62, 35, 2, 3,
+	4, 5, 6, 64, 91, 87, 65, 84, 13, 15,
+	17, 16, 34, 11, 12, 22, 18, 103, 41, 42,
+	43, 104, 105, 108, 33, 28, 37, 14, 67, 23,
+	110, 9, 44, 45, 46, 47, 48, 49, 50, 51,
+	52, 53, 54, 0, 0, 55, 56, 0, 57, 58,
+	59, 60, 61, 32, 27, 32, 27, 0, 31, 26,
+	31, 26, 0, 86, 82, 29, 24,
 }
 var yyPact = [...]int{
 
-	17, 23, 20, 15, 136, 73, -1000, -1000, -1000, -1000,
-	147, -1000, 146, -1000, 15, -1000, -1000, -1000, -1000, -1000,
-	69, -1000, 136, 79, -1000, -1000, 33, -1000, 25, -1000,
-	-1000, 5, -1000, -1000, 68, -1000, -1000, -1000, -1000, -1000,
+	10, 16, 20, 17, 83, 59, 83, -1000, -1000, -1000,
+	134, -1000, 133, -1000, 17, -1000, -1000, -1000, -1000, 67,
+	-1000, -1000, 33, 71, -1000, -1000, 4, -1000, 28, -1000,
+	-1000, 23, -1000, -1000, 27, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, -1000, -1000, 40, -1000, 134, -1000, 22, -1000, -1000,
-	-1000, -1000, -1000, -1000, 133, -1000, 19, -1000, -1000, 1,
-	-1000, -10, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, -1000, -1000, 3, -1000, -5, -11, -1000, -1000, -1000,
-	-1000, 2, 2, 0, 0, -6, -1000, -1000, -1000, -1000,
-	-1000, 0, -1000,
+	-1000, -1000, -9, -1000, -1000, 132, -1000, 68, -1000, -1000,
+	-1000, -1000, -1000, -1000, 131, -1000, 22, -1000, -1000, 1,
+	-1000, 0, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	-1000, -1000, -1000, -4, -10, -1000, -1000, -1000, -1000, 3,
+	3, -6, -6, -5, -1000, -1000, -1000, -1000, -1000, -6,
+	-1000,
 }
 var yyPgo = [...]int{
 
-	0, 108, 106, 6, 98, 97, 4, 95, 93, 92,
-	13, 5, 90, 69, 61, 58, 0, 57, 2, 1,
-	45, 44, 43,
+	0, 111, 109, 5, 108, 107, 4, 106, 105, 89,
+	88, 10, 96, 92, 76, 72, 0, 67, 2, 1,
+	58, 36,
 }
 var yyR1 = [...]int{
 
-	0, 20, 20, 20, 20, 21, 20, 20, 20, 1,
-	1, 1, 2, 2, 2, 3, 3, 3, 3, 4,
-	4, 4, 4, 10, 10, 10, 5, 5, 9, 9,
-	9, 9, 8, 8, 8, 11, 11, 11, 11, 12,
-	12, 12, 12, 13, 13, 13, 6, 6, 7, 7,
+	0, 20, 20, 20, 20, 20, 20, 20, 1, 1,
+	1, 2, 2, 2, 3, 3, 3, 3, 4, 4,
+	4, 4, 10, 10, 5, 5, 9, 9, 9, 9,
+	8, 8, 8, 11, 11, 11, 11, 12, 12, 12,
+	12, 13, 13, 13, 6, 6, 7, 7, 7, 7,
 	7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-	7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-	7, 22, 14, 14, 14, 14, 15, 15, 15, 15,
-	15, 16, 18, 18, 17, 17, 17, 19,
+	7, 7, 7, 7, 7, 7, 7, 7, 7, 21,
+	14, 14, 14, 14, 15, 15, 15, 15, 15, 16,
+	18, 18, 17, 17, 17, 19,
 }
 var yyR2 = [...]int{
 
-	0, 2, 2, 2, 2, 0, 3, 2, 1, 3,
-	4, 2, 3, 1, 2, 3, 3, 2, 1, 1,
-	1, 1, 1, 2, 1, 1, 1, 1, 3, 4,
-	2, 0, 3, 1, 2, 3, 3, 2, 1, 3,
-	4, 2, 1, 3, 1, 2, 1, 1, 1, 1,
+	0, 2, 2, 2, 2, 2, 2, 1, 3, 4,
+	2, 3, 1, 2, 3, 3, 2, 1, 1, 1,
+	1, 1, 2, 1, 1, 1, 3, 4, 2, 0,
+	3, 1, 2, 3, 3, 2, 1, 3, 4, 2,
+	1, 3, 1, 2, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 2, 0, 3, 2, 1, 1, 3, 1, 3,
-	4, 1, 2, 2, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 2,
+	0, 3, 2, 1, 1, 3, 1, 3, 4, 1,
+	2, 2, 1, 1, 1, 1,
 }
 var yyChk = [...]int{
 
 	-1000, -20, 68, 69, 70, 71, 72, 2, 5, -1,
-	11, -9, 11, -10, -5, -9, 2, 8, 7, -12,
-	9, 2, -21, -2, 12, -3, 7, 2, -8, 12,
+	11, -9, 11, -10, -5, -9, 8, 7, -12, 9,
+	2, -21, -10, -2, 12, -3, 7, 2, -8, 12,
 	-11, 7, 2, -9, -13, 10, -6, -7, 2, 7,
 	8, 31, 32, 33, 45, 46, 47, 48, 49, 50,
 	51, 52, 53, 54, 55, 58, 59, 61, 62, 63,
-	64, 65, -22, -10, 12, 15, 2, -4, 2, 34,
+	64, 65, -14, 2, 12, 15, 2, -4, 2, 34,
 	35, 40, 41, 12, 15, 2, 34, 2, 10, 15,
-	2, -14, 2, 12, -3, 19, 2, 12, -11, 19,
-	2, 10, -6, 24, -15, 22, -17, 7, -19, -18,
-	20, 27, 26, 23, 23, -18, -19, -19, -16, 20,
-	-16, 23, -16,
+	2, 24, 12, -3, 19, 2, 12, -11, 19, 2,
+	10, -6, -15, 22, -17, 7, -19, -18, 20, 27,
+	26, 23, 23, -18, -19, -19, -16, 20, -16, 23,
+	-16,
 }
 var yyDef = [...]int{
 
-	0, -2, 0, 31, -2, 0, 5, 8, 7, 1,
-	0, 2, 0, 3, 31, 24, 25, 26, 27, 4,
-	0, 42, -2, 0, 11, 13, 0, 18, 0, 30,
-	33, 0, 38, 23, 0, 41, 44, 46, 47, 48,
-	49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
-	59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
-	69, 70, 6, -2, 9, 0, 14, 0, 17, 19,
-	20, 21, 22, 28, 0, 34, 0, 37, 39, 0,
-	45, 71, 75, 10, 12, 15, 16, 29, 32, 35,
-	36, 40, 43, 74, 73, 76, 78, 84, 85, 86,
-	87, 0, 0, 0, 0, 0, 82, 83, 77, 81,
-	79, 0, 80,
+	0, -2, 0, 29, 29, 0, 29, 7, 6, 1,
+	0, 2, 0, 3, 29, 23, 24, 25, 4, 0,
+	40, 5, -2, 0, 10, 12, 0, 17, 0, 28,
+	31, 0, 36, 22, 0, 39, 42, 44, 45, 46,
+	47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
+	57, 58, 59, 60, 61, 62, 63, 64, 65, 66,
+	67, 68, 69, 73, 8, 0, 13, 0, 16, 18,
+	19, 20, 21, 26, 0, 32, 0, 35, 37, 0,
+	43, 72, 9, 11, 14, 15, 27, 30, 33, 34,
+	38, 41, 71, 74, 76, 82, 83, 84, 85, 0,
+	0, 0, 0, 0, 80, 81, 75, 79, 77, 0,
+	78,
 }
 var yyTok1 = [...]int{
 
@@ -684,242 +674,230 @@ yydefault:
 		{
 			yylex.(*parser).generatedParserResult = yyDollar[2].strings
 		}
-	case 5:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:146
-		{
-			yylex.(*parser).generatedParserResult = &seriesDescription{}
-		}
-	case 8:
+	case 7:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:149
 		{
 			yylex.(*parser).unexpected("", "")
 		}
-	case 9:
+	case 8:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:155
 		{
 			yyVAL.matchers = yyDollar[2].matchers
 		}
-	case 10:
+	case 9:
 		yyDollar = yyS[yypt-4 : yypt+1]
 //line promql/generated_parser.y:157
 		{
 			yyVAL.matchers = yyDollar[2].matchers
 		}
-	case 11:
+	case 10:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:159
 		{
 			yyVAL.matchers = []*labels.Matcher{}
 		}
-	case 12:
+	case 11:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:165
 		{
 			yyVAL.matchers = append(yyDollar[1].matchers, yyDollar[3].matcher)
 		}
-	case 13:
+	case 12:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:167
 		{
 			yyVAL.matchers = []*labels.Matcher{yyDollar[1].matcher}
 		}
-	case 14:
+	case 13:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:169
 		{
 			yylex.(*parser).unexpected("label matching", "\",\" or \"}\"")
 		}
-	case 15:
+	case 14:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:174
 		{
 			yyVAL.matcher = yylex.(*parser).newLabelMatcher(yyDollar[1].item, yyDollar[2].item, yyDollar[3].item)
 		}
-	case 16:
+	case 15:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:176
 		{
 			yylex.(*parser).unexpected("label matching", "string")
 		}
-	case 17:
+	case 16:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:178
 		{
 			yylex.(*parser).unexpected("label matching", "label matching operator")
 		}
-	case 18:
+	case 17:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:180
 		{
 			yylex.(*parser).unexpected("label matching", "identifier or \"}\"")
 		}
-	case 19:
+	case 18:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:184
 		{
 			yyVAL.item = yyDollar[1].item
 		}
-	case 20:
+	case 19:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:185
 		{
 			yyVAL.item = yyDollar[1].item
 		}
-	case 21:
+	case 20:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:186
 		{
 			yyVAL.item = yyDollar[1].item
 		}
-	case 22:
+	case 21:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:187
 		{
 			yyVAL.item = yyDollar[1].item
 		}
-	case 23:
+	case 22:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:193
 		{
 			yyVAL.labels = append(yyDollar[2].labels, labels.Label{Name: labels.MetricName, Value: yyDollar[1].item.Val})
 			sort.Sort(yyVAL.labels)
 		}
-	case 24:
+	case 23:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:195
 		{
 			yyVAL.labels = yyDollar[1].labels
 		}
-	case 25:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:197
-		{
-			yylex.(*parser).errorf("missing metric name or metric selector")
-		}
-	case 26:
+	case 24:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:202
 		{
 			yyVAL.item = yyDollar[1].item
 		}
-	case 27:
+	case 25:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:203
 		{
 			yyVAL.item = yyDollar[1].item
 		}
-	case 28:
+	case 26:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:207
 		{
 			yyVAL.labels = labels.New(yyDollar[2].labels...)
 		}
-	case 29:
+	case 27:
 		yyDollar = yyS[yypt-4 : yypt+1]
 //line promql/generated_parser.y:209
 		{
 			yyVAL.labels = labels.New(yyDollar[2].labels...)
 		}
-	case 30:
+	case 28:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:211
 		{
 			yyVAL.labels = labels.New()
 		}
-	case 31:
+	case 29:
 		yyDollar = yyS[yypt-0 : yypt+1]
 //line promql/generated_parser.y:213
 		{
 			yyVAL.labels = labels.New()
 		}
-	case 32:
+	case 30:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:218
 		{
 			yyVAL.labels = append(yyDollar[1].labels, yyDollar[3].label)
 		}
-	case 33:
+	case 31:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:220
 		{
 			yyVAL.labels = []labels.Label{yyDollar[1].label}
 		}
-	case 34:
+	case 32:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:222
 		{
 			yylex.(*parser).unexpected("label set", "\",\" or \"}\"")
 		}
-	case 35:
+	case 33:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:228
 		{
 			yyVAL.label = labels.Label{Name: yyDollar[1].item.Val, Value: yylex.(*parser).unquoteString(yyDollar[3].item.Val)}
 		}
-	case 36:
+	case 34:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:230
 		{
 			yylex.(*parser).unexpected("label set", "string")
 		}
-	case 37:
+	case 35:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:232
 		{
 			yylex.(*parser).unexpected("label set", "\"=\"")
 		}
-	case 38:
+	case 36:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:234
 		{
 			yylex.(*parser).unexpected("label set", "identifier or \"}\"")
 		}
-	case 39:
+	case 37:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:239
 		{
 			yyVAL.strings = yyDollar[2].strings
 		}
-	case 40:
+	case 38:
 		yyDollar = yyS[yypt-4 : yypt+1]
 //line promql/generated_parser.y:241
 		{
 			yyVAL.strings = yyDollar[2].strings
 		}
-	case 41:
+	case 39:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:243
 		{
 			yyVAL.strings = []string{}
 		}
-	case 42:
+	case 40:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:245
 		{
 			yylex.(*parser).unexpected("grouping opts", "\"(\"")
 		}
-	case 43:
+	case 41:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:251
 		{
 			yyVAL.strings = append(yyDollar[1].strings, yyDollar[3].item.Val)
 		}
-	case 44:
+	case 42:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:253
 		{
 			yyVAL.strings = []string{yyDollar[1].item.Val}
 		}
-	case 45:
+	case 43:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:255
 		{
 			yylex.(*parser).unexpected("grouping opts", "\",\" or \"}\"")
 		}
-	case 46:
+	case 44:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:260
 		{
@@ -928,13 +906,13 @@ yydefault:
 			}
 			yyVAL.item = yyDollar[1].item
 		}
-	case 47:
+	case 45:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:267
 		{
 			yylex.(*parser).unexpected("grouping opts", "label")
 		}
-	case 71:
+	case 69:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:300
 		{
@@ -943,37 +921,37 @@ yydefault:
 				values: yyDollar[2].series,
 			}
 		}
-	case 72:
+	case 70:
 		yyDollar = yyS[yypt-0 : yypt+1]
 //line promql/generated_parser.y:310
 		{
 			yyVAL.series = []sequenceValue{}
 		}
-	case 73:
+	case 71:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:312
 		{
 			yyVAL.series = append(yyDollar[1].series, yyDollar[3].series...)
 		}
-	case 74:
+	case 72:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:314
 		{
 			yyVAL.series = yyDollar[1].series
 		}
-	case 75:
+	case 73:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:316
 		{
 			yylex.(*parser).unexpected("series values", "")
 		}
-	case 76:
+	case 74:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:321
 		{
 			yyVAL.series = []sequenceValue{{omitted: true}}
 		}
-	case 77:
+	case 75:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:323
 		{
@@ -982,13 +960,13 @@ yydefault:
 				yyVAL.series = append(yyVAL.series, sequenceValue{omitted: true})
 			}
 		}
-	case 78:
+	case 76:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:330
 		{
 			yyVAL.series = []sequenceValue{{value: yyDollar[1].float}}
 		}
-	case 79:
+	case 77:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:332
 		{
@@ -997,7 +975,7 @@ yydefault:
 				yyVAL.series = append(yyVAL.series, sequenceValue{value: yyDollar[1].float})
 			}
 		}
-	case 80:
+	case 78:
 		yyDollar = yyS[yypt-4 : yypt+1]
 //line promql/generated_parser.y:339
 		{
@@ -1007,7 +985,7 @@ yydefault:
 				yyDollar[1].float += yyDollar[2].float
 			}
 		}
-	case 81:
+	case 79:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:348
 		{
@@ -1017,19 +995,19 @@ yydefault:
 				yylex.(*parser).errorf("invalid repitition in series values: %s", err)
 			}
 		}
-	case 82:
+	case 80:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:359
 		{
 			yyVAL.float = yyDollar[2].float
 		}
-	case 83:
+	case 81:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:361
 		{
 			yyVAL.float = -yyDollar[2].float
 		}
-	case 84:
+	case 82:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:366
 		{
@@ -1038,19 +1016,19 @@ yydefault:
 			}
 			yyVAL.float = math.Float64frombits(value.StaleNaN)
 		}
-	case 85:
+	case 83:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:373
 		{
 			yyVAL.float = yyDollar[1].float
 		}
-	case 86:
+	case 84:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:375
 		{
 			yyVAL.float = yyDollar[1].float
 		}
-	case 87:
+	case 85:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:382
 		{

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -183,7 +183,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line promql/generated_parser.y:383
+//line promql/generated_parser.y:385
 
 //line yacctab:1
 var yyExca = [...]int{
@@ -199,51 +199,56 @@ var yyExca = [...]int{
 	5, 31,
 	24, 31,
 	-2, 0,
+	-1, 63,
+	1, 72,
+	5, 72,
+	24, 72,
+	-2, 0,
 }
 
 const yyPrivate = 57344
 
-const yyLast = 159
+const yyLast = 160
 
 var yyAct = [...]int{
 
-	107, 97, 98, 38, 36, 25, 68, 96, 39, 40,
-	30, 90, 103, 7, 92, 101, 100, 110, 102, 13,
-	99, 12, 94, 108, 89, 77, 101, 100, 99, 10,
-	75, 8, 41, 42, 43, 62, 22, 1, 69, 70,
-	73, 88, 63, 74, 71, 72, 44, 45, 46, 47,
-	48, 49, 50, 51, 52, 53, 54, 76, 95, 55,
-	56, 21, 57, 58, 59, 60, 61, 93, 20, 85,
-	38, 83, 81, 34, 19, 39, 40, 66, 35, 2,
-	3, 4, 5, 6, 91, 87, 84, 64, 28, 37,
-	65, 15, 14, 67, 23, 11, 9, 80, 104, 41,
-	42, 43, 105, 106, 109, 78, 33, 0, 0, 0,
-	79, 111, 0, 44, 45, 46, 47, 48, 49, 50,
-	51, 52, 53, 54, 0, 0, 55, 56, 0, 57,
-	58, 59, 60, 61, 32, 27, 0, 16, 0, 31,
-	26, 0, 18, 17, 86, 82, 12, 32, 27, 0,
-	0, 0, 31, 26, 0, 0, 0, 29, 24,
+	108, 98, 99, 38, 36, 30, 25, 77, 39, 40,
+	97, 91, 104, 13, 93, 102, 101, 111, 103, 7,
+	109, 90, 100, 100, 86, 95, 12, 75, 8, 102,
+	101, 10, 41, 42, 43, 68, 63, 73, 89, 76,
+	74, 85, 82, 62, 22, 1, 44, 45, 46, 47,
+	48, 49, 50, 51, 52, 53, 54, 96, 94, 55,
+	56, 81, 57, 58, 59, 60, 61, 69, 70, 34,
+	80, 38, 84, 71, 72, 21, 39, 40, 78, 35,
+	88, 66, 20, 79, 92, 2, 3, 4, 5, 6,
+	19, 64, 15, 28, 65, 37, 11, 14, 67, 105,
+	41, 42, 43, 106, 107, 110, 23, 33, 9, 0,
+	0, 0, 112, 0, 44, 45, 46, 47, 48, 49,
+	50, 51, 52, 53, 54, 0, 0, 55, 56, 0,
+	57, 58, 59, 60, 61, 32, 27, 0, 16, 0,
+	31, 26, 0, 18, 17, 87, 83, 12, 32, 27,
+	0, 0, 0, 31, 26, 0, 0, 0, 29, 24,
 }
 var yyPact = [...]int{
 
-	11, 26, 18, 10, 135, 59, -1000, -1000, -1000, -1000,
-	146, -1000, 145, -1000, 10, -1000, -1000, -1000, -1000, -1000,
-	68, -1000, 135, 75, -1000, -1000, 4, -1000, 28, -1000,
-	-1000, 23, -1000, -1000, 95, -1000, -1000, -1000, -1000, -1000,
+	17, 23, 20, 15, 136, 73, -1000, -1000, -1000, -1000,
+	147, -1000, 146, -1000, 15, -1000, -1000, -1000, -1000, -1000,
+	69, -1000, 136, 79, -1000, -1000, 33, -1000, 25, -1000,
+	-1000, 5, -1000, -1000, 68, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, -1000, -1000, -1000, -1000, 133, -1000, 67, -1000, -1000,
-	-1000, -1000, -1000, -1000, 132, -1000, 22, -1000, -1000, 1,
+	-1000, -1000, -1000, 40, -1000, 134, -1000, 22, -1000, -1000,
+	-1000, -1000, -1000, -1000, 133, -1000, 19, -1000, -1000, 1,
 	-1000, -10, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, -1000, 0, -1000, -5, -11, -1000, -1000, -1000, -1000,
-	8, 8, 3, 3, -6, -1000, -1000, -1000, -1000, -1000,
-	3, -1000,
+	-1000, -1000, -1000, 3, -1000, -5, -11, -1000, -1000, -1000,
+	-1000, 2, 2, 0, 0, -6, -1000, -1000, -1000, -1000,
+	-1000, 0, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 96, 94, 5, 93, 92, 4, 89, 88, 91,
-	19, 10, 74, 73, 72, 67, 0, 58, 2, 1,
-	37, 36, 35,
+	0, 108, 106, 6, 98, 97, 4, 95, 93, 92,
+	13, 5, 90, 69, 61, 58, 0, 57, 2, 1,
+	45, 44, 43,
 }
 var yyR1 = [...]int{
 
@@ -254,8 +259,8 @@ var yyR1 = [...]int{
 	12, 12, 12, 13, 13, 13, 6, 6, 7, 7,
 	7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
 	7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-	7, 22, 14, 14, 14, 15, 15, 15, 15, 15,
-	16, 18, 18, 17, 17, 17, 19,
+	7, 22, 14, 14, 14, 14, 15, 15, 15, 15,
+	15, 16, 18, 18, 17, 17, 17, 19,
 }
 var yyR2 = [...]int{
 
@@ -266,8 +271,8 @@ var yyR2 = [...]int{
 	4, 2, 1, 3, 1, 2, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 2, 0, 3, 2, 1, 3, 1, 3, 4,
-	1, 2, 2, 1, 1, 1, 1,
+	1, 2, 0, 3, 2, 1, 1, 3, 1, 3,
+	4, 1, 2, 2, 1, 1, 1, 1,
 }
 var yyChk = [...]int{
 
@@ -279,10 +284,10 @@ var yyChk = [...]int{
 	51, 52, 53, 54, 55, 58, 59, 61, 62, 63,
 	64, 65, -22, -10, 12, 15, 2, -4, 2, 34,
 	35, 40, 41, 12, 15, 2, 34, 2, 10, 15,
-	2, -14, 12, -3, 19, 2, 12, -11, 19, 2,
-	10, -6, 24, -15, 22, -17, 7, -19, -18, 20,
-	27, 26, 23, 23, -18, -19, -19, -16, 20, -16,
-	23, -16,
+	2, -14, 2, 12, -3, 19, 2, 12, -11, 19,
+	2, 10, -6, 24, -15, 22, -17, 7, -19, -18,
+	20, 27, 26, 23, 23, -18, -19, -19, -16, 20,
+	-16, 23, -16,
 }
 var yyDef = [...]int{
 
@@ -292,12 +297,12 @@ var yyDef = [...]int{
 	33, 0, 38, 23, 0, 41, 44, 46, 47, 48,
 	49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
 	59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
-	69, 70, 6, 72, 9, 0, 14, 0, 17, 19,
+	69, 70, 6, -2, 9, 0, 14, 0, 17, 19,
 	20, 21, 22, 28, 0, 34, 0, 37, 39, 0,
-	45, 71, 10, 12, 15, 16, 29, 32, 35, 36,
-	40, 43, 74, 73, 75, 77, 83, 84, 85, 86,
-	0, 0, 0, 0, 0, 81, 82, 76, 80, 78,
-	0, 79,
+	45, 71, 75, 10, 12, 15, 16, 29, 32, 35,
+	36, 40, 43, 74, 73, 76, 78, 84, 85, 86,
+	87, 0, 0, 0, 0, 0, 82, 83, 77, 81,
+	79, 0, 80,
 }
 var yyTok1 = [...]int{
 
@@ -958,37 +963,43 @@ yydefault:
 		}
 	case 75:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:319
+//line promql/generated_parser.y:316
+		{
+			yylex.(*parser).unexpected("series values", "")
+		}
+	case 76:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:321
 		{
 			yyVAL.series = []sequenceValue{{omitted: true}}
 		}
-	case 76:
+	case 77:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:321
+//line promql/generated_parser.y:323
 		{
 			yyVAL.series = []sequenceValue{}
 			for i := uint64(0); i < yyDollar[3].uint; i++ {
 				yyVAL.series = append(yyVAL.series, sequenceValue{omitted: true})
 			}
 		}
-	case 77:
+	case 78:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:328
+//line promql/generated_parser.y:330
 		{
 			yyVAL.series = []sequenceValue{{value: yyDollar[1].float}}
 		}
-	case 78:
+	case 79:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:330
+//line promql/generated_parser.y:332
 		{
 			yyVAL.series = []sequenceValue{}
 			for i := uint64(0); i <= yyDollar[3].uint; i++ {
 				yyVAL.series = append(yyVAL.series, sequenceValue{value: yyDollar[1].float})
 			}
 		}
-	case 79:
+	case 80:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line promql/generated_parser.y:337
+//line promql/generated_parser.y:339
 		{
 			yyVAL.series = []sequenceValue{}
 			for i := uint64(0); i <= yyDollar[4].uint; i++ {
@@ -996,9 +1007,9 @@ yydefault:
 				yyDollar[1].float += yyDollar[2].float
 			}
 		}
-	case 80:
+	case 81:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:346
+//line promql/generated_parser.y:348
 		{
 			var err error
 			yyVAL.uint, err = strconv.ParseUint(yyDollar[1].item.Val, 10, 64)
@@ -1006,32 +1017,26 @@ yydefault:
 				yylex.(*parser).errorf("invalid repitition in series values: %s", err)
 			}
 		}
-	case 81:
-		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:357
-		{
-			yyVAL.float = yyDollar[2].float
-		}
 	case 82:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:359
 		{
-			yyVAL.float = -yyDollar[2].float
+			yyVAL.float = yyDollar[2].float
 		}
 	case 83:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:361
+		{
+			yyVAL.float = -yyDollar[2].float
+		}
+	case 84:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:364
+//line promql/generated_parser.y:366
 		{
 			if yyDollar[1].item.Val != "stale" {
 				yylex.(*parser).unexpected("series values", "number or \"stale\"")
 			}
 			yyVAL.float = math.Float64frombits(value.StaleNaN)
-		}
-	case 84:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:371
-		{
-			yyVAL.float = yyDollar[1].float
 		}
 	case 85:
 		yyDollar = yyS[yypt-1 : yypt+1]
@@ -1041,7 +1046,13 @@ yydefault:
 		}
 	case 86:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:380
+//line promql/generated_parser.y:375
+		{
+			yyVAL.float = yyDollar[1].float
+		}
+	case 87:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:382
 		{
 			yyVAL.float = yylex.(*parser).number(yyDollar[1].item.Val)
 		}

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -683,7 +683,7 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:146
 		{
-			yylex.(*parser).generatedParserResult = &parseSeriesDescResult{}
+			yylex.(*parser).generatedParserResult = &seriesDescription{}
 		}
 	case 8:
 		yyDollar = yyS[yypt-1 : yypt+1]
@@ -933,7 +933,7 @@ yydefault:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:300
 		{
-			yylex.(*parser).generatedParserResult = &parseSeriesDescResult{
+			yylex.(*parser).generatedParserResult = &seriesDescription{
 				labels: yyDollar[1].labels,
 				values: yyDollar[2].series,
 			}

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -96,11 +96,10 @@ const BOOL = 57407
 const keywordsEnd = 57408
 const startSymbolsStart = 57409
 const START_LABELS = 57410
-const START_LABEL_SET = 57411
-const START_METRIC = 57412
-const START_GROUPING_LABELS = 57413
-const START_SERIES_DESCRIPTION = 57414
-const startSymbolsEnd = 57415
+const START_METRIC = 57411
+const START_GROUPING_LABELS = 57412
+const START_SERIES_DESCRIPTION = 57413
+const startSymbolsEnd = 57414
 
 var yyToknames = [...]string{
 	"$end",
@@ -171,7 +170,6 @@ var yyToknames = [...]string{
 	"keywordsEnd",
 	"startSymbolsStart",
 	"START_LABELS",
-	"START_LABEL_SET",
 	"START_METRIC",
 	"START_GROUPING_LABELS",
 	"START_SERIES_DESCRIPTION",
@@ -183,116 +181,113 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line promql/generated_parser.y:385
+//line promql/generated_parser.y:382
 
 //line yacctab:1
 var yyExca = [...]int{
 	-1, 1,
 	1, -1,
 	-2, 0,
-	-1, 22,
-	1, 70,
-	5, 70,
-	24, 70,
+	-1, 20,
+	1, 69,
+	5, 69,
+	24, 69,
 	-2, 0,
 }
 
 const yyPrivate = 57344
 
-const yyLast = 147
+const yyLast = 144
 
 var yyAct = [...]int{
 
-	106, 96, 97, 38, 36, 25, 68, 95, 39, 40,
-	30, 90, 7, 102, 107, 81, 100, 99, 109, 101,
-	98, 8, 93, 98, 89, 77, 100, 99, 12, 80,
-	75, 10, 41, 42, 43, 63, 21, 78, 69, 70,
-	73, 88, 79, 74, 71, 72, 44, 45, 46, 47,
-	48, 49, 50, 51, 52, 53, 54, 76, 1, 55,
-	56, 20, 57, 58, 59, 60, 61, 94, 19, 38,
-	85, 83, 92, 66, 39, 40, 62, 35, 2, 3,
-	4, 5, 6, 64, 91, 87, 65, 84, 13, 15,
-	17, 16, 34, 11, 12, 22, 18, 103, 41, 42,
-	43, 104, 105, 108, 33, 28, 37, 14, 67, 23,
-	110, 9, 44, 45, 46, 47, 48, 49, 50, 51,
-	52, 53, 54, 0, 0, 55, 56, 0, 57, 58,
-	59, 60, 61, 32, 27, 32, 27, 0, 31, 26,
-	31, 26, 0, 86, 82, 29, 24,
+	104, 94, 95, 36, 34, 23, 66, 29, 37, 38,
+	6, 88, 79, 107, 100, 99, 93, 98, 97, 105,
+	96, 15, 9, 87, 83, 75, 14, 13, 61, 96,
+	15, 91, 39, 40, 41, 98, 97, 10, 67, 68,
+	86, 82, 7, 20, 69, 70, 42, 43, 44, 45,
+	46, 47, 48, 49, 50, 51, 52, 74, 73, 53,
+	54, 19, 55, 56, 57, 58, 59, 36, 71, 81,
+	1, 72, 37, 38, 64, 33, 2, 3, 4, 5,
+	85, 78, 89, 31, 62, 18, 92, 63, 30, 76,
+	12, 90, 17, 84, 77, 101, 39, 40, 41, 102,
+	103, 106, 26, 60, 32, 16, 27, 35, 108, 11,
+	42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
+	52, 65, 21, 53, 54, 8, 55, 56, 57, 58,
+	59, 25, 31, 25, 0, 0, 24, 30, 24, 0,
+	0, 80, 28, 22,
 }
 var yyPact = [...]int{
 
-	10, 16, 20, 17, 83, 59, 83, -1000, -1000, -1000,
-	134, -1000, 133, -1000, 17, -1000, -1000, -1000, -1000, 67,
-	-1000, -1000, 33, 71, -1000, -1000, 4, -1000, 28, -1000,
-	-1000, 23, -1000, -1000, 27, -1000, -1000, -1000, -1000, -1000,
+	8, 37, 11, 19, 83, 19, -1000, -1000, -1000, 131,
+	-1000, 10, -1000, -1000, -1000, 130, -1000, 65, -1000, -1000,
+	26, 72, -1000, -1000, 4, -1000, -1000, 56, -1000, -1000,
+	23, -1000, 79, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, -1000, -9, -1000, -1000, 132, -1000, 68, -1000, -1000,
-	-1000, -1000, -1000, -1000, 131, -1000, 22, -1000, -1000, 1,
-	-1000, 0, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, -1000, -1000, -4, -10, -1000, -1000, -1000, -1000, 3,
-	3, -6, -6, -5, -1000, -1000, -1000, -1000, -1000, -6,
-	-1000,
+	-12, -1000, -1000, 129, -1000, 22, -1000, -1000, -1000, -1000,
+	-1000, -1000, 81, -1000, 21, -1000, -1000, 1, -1000, 9,
+	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	-1000, -8, -9, -1000, -1000, -1000, -1000, 0, 0, -1,
+	-1, -10, -1000, -1000, -1000, -1000, -1000, -1, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 111, 109, 5, 108, 107, 4, 106, 105, 89,
-	88, 10, 96, 92, 76, 72, 0, 67, 2, 1,
-	58, 36,
+	0, 125, 122, 5, 121, 109, 4, 107, 106, 90,
+	37, 7, 105, 104, 103, 91, 0, 86, 2, 1,
+	70, 61,
 }
 var yyR1 = [...]int{
 
-	0, 20, 20, 20, 20, 20, 20, 20, 1, 1,
-	1, 2, 2, 2, 3, 3, 3, 3, 4, 4,
-	4, 4, 10, 10, 5, 5, 9, 9, 9, 9,
-	8, 8, 8, 11, 11, 11, 11, 12, 12, 12,
-	12, 13, 13, 13, 6, 6, 7, 7, 7, 7,
+	0, 20, 20, 20, 20, 20, 20, 1, 1, 1,
+	2, 2, 2, 3, 3, 3, 3, 4, 4, 4,
+	4, 10, 10, 5, 5, 9, 9, 9, 9, 8,
+	8, 8, 11, 11, 11, 11, 12, 12, 12, 12,
+	13, 13, 13, 6, 6, 7, 7, 7, 7, 7,
 	7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-	7, 7, 7, 7, 7, 7, 7, 7, 7, 21,
-	14, 14, 14, 14, 15, 15, 15, 15, 15, 16,
-	18, 18, 17, 17, 17, 19,
+	7, 7, 7, 7, 7, 7, 7, 7, 21, 14,
+	14, 14, 14, 15, 15, 15, 15, 15, 16, 18,
+	18, 17, 17, 17, 19,
 }
 var yyR2 = [...]int{
 
-	0, 2, 2, 2, 2, 2, 2, 1, 3, 4,
-	2, 3, 1, 2, 3, 3, 2, 1, 1, 1,
-	1, 1, 2, 1, 1, 1, 3, 4, 2, 0,
-	3, 1, 2, 3, 3, 2, 1, 3, 4, 2,
-	1, 3, 1, 2, 1, 1, 1, 1, 1, 1,
+	0, 2, 2, 2, 2, 2, 1, 3, 4, 2,
+	3, 1, 2, 3, 3, 2, 1, 1, 1, 1,
+	1, 2, 1, 1, 1, 3, 4, 2, 0, 3,
+	1, 2, 3, 3, 2, 1, 3, 4, 2, 1,
+	3, 1, 2, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 2,
-	0, 3, 2, 1, 1, 3, 1, 3, 4, 1,
-	2, 2, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 2, 0,
+	3, 2, 1, 1, 3, 1, 3, 4, 1, 2,
+	2, 1, 1, 1, 1,
 }
 var yyChk = [...]int{
 
-	-1000, -20, 68, 69, 70, 71, 72, 2, 5, -1,
-	11, -9, 11, -10, -5, -9, 8, 7, -12, 9,
-	2, -21, -10, -2, 12, -3, 7, 2, -8, 12,
-	-11, 7, 2, -9, -13, 10, -6, -7, 2, 7,
-	8, 31, 32, 33, 45, 46, 47, 48, 49, 50,
-	51, 52, 53, 54, 55, 58, 59, 61, 62, 63,
-	64, 65, -14, 2, 12, 15, 2, -4, 2, 34,
-	35, 40, 41, 12, 15, 2, 34, 2, 10, 15,
-	2, 24, 12, -3, 19, 2, 12, -11, 19, 2,
-	10, -6, -15, 22, -17, 7, -19, -18, 20, 27,
-	26, 23, 23, -18, -19, -19, -16, 20, -16, 23,
-	-16,
+	-1000, -20, 68, 69, 70, 71, 2, 5, -1, 11,
+	-10, -5, -9, 8, 7, 11, -12, 9, 2, -21,
+	-10, -2, 12, -3, 7, 2, -9, -8, 12, -11,
+	7, 2, -13, 10, -6, -7, 2, 7, 8, 31,
+	32, 33, 45, 46, 47, 48, 49, 50, 51, 52,
+	53, 54, 55, 58, 59, 61, 62, 63, 64, 65,
+	-14, 2, 12, 15, 2, -4, 2, 34, 35, 40,
+	41, 12, 15, 2, 34, 2, 10, 15, 2, 24,
+	12, -3, 19, 2, 12, -11, 19, 2, 10, -6,
+	-15, 22, -17, 7, -19, -18, 20, 27, 26, 23,
+	23, -18, -19, -19, -16, 20, -16, 23, -16,
 }
 var yyDef = [...]int{
 
-	0, -2, 0, 29, 29, 0, 29, 7, 6, 1,
-	0, 2, 0, 3, 29, 23, 24, 25, 4, 0,
-	40, 5, -2, 0, 10, 12, 0, 17, 0, 28,
-	31, 0, 36, 22, 0, 39, 42, 44, 45, 46,
-	47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
-	57, 58, 59, 60, 61, 62, 63, 64, 65, 66,
-	67, 68, 69, 73, 8, 0, 13, 0, 16, 18,
-	19, 20, 21, 26, 0, 32, 0, 35, 37, 0,
-	43, 72, 9, 11, 14, 15, 27, 30, 33, 34,
-	38, 41, 71, 74, 76, 82, 83, 84, 85, 0,
-	0, 0, 0, 0, 80, 81, 75, 79, 77, 0,
-	78,
+	0, -2, 0, 28, 0, 28, 6, 5, 1, 0,
+	2, 28, 22, 23, 24, 0, 3, 0, 39, 4,
+	-2, 0, 9, 11, 0, 16, 21, 0, 27, 30,
+	0, 35, 0, 38, 41, 43, 44, 45, 46, 47,
+	48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+	58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
+	68, 72, 7, 0, 12, 0, 15, 17, 18, 19,
+	20, 25, 0, 31, 0, 34, 36, 0, 42, 71,
+	8, 10, 13, 14, 26, 29, 32, 33, 37, 40,
+	70, 73, 75, 81, 82, 83, 84, 0, 0, 0,
+	0, 0, 79, 80, 74, 78, 76, 0, 77,
 }
 var yyTok1 = [...]int{
 
@@ -307,7 +302,7 @@ var yyTok2 = [...]int{
 	42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
 	52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
 	62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
-	72, 73,
+	72,
 }
 var yyTok3 = [...]int{
 	0,
@@ -652,332 +647,326 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:139
+//line promql/generated_parser.y:138
 		{
 			yylex.(*parser).generatedParserResult.(*VectorSelector).LabelMatchers = yyDollar[2].matchers
 		}
 	case 2:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:141
+//line promql/generated_parser.y:140
 		{
 			yylex.(*parser).generatedParserResult = yyDollar[2].labels
 		}
 	case 3:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:143
-		{
-			yylex.(*parser).generatedParserResult = yyDollar[2].labels
-		}
-	case 4:
-		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:145
+//line promql/generated_parser.y:142
 		{
 			yylex.(*parser).generatedParserResult = yyDollar[2].strings
 		}
-	case 7:
+	case 6:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:149
+//line promql/generated_parser.y:146
 		{
 			yylex.(*parser).unexpected("", "")
 		}
-	case 8:
+	case 7:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:155
+//line promql/generated_parser.y:152
+		{
+			yyVAL.matchers = yyDollar[2].matchers
+		}
+	case 8:
+		yyDollar = yyS[yypt-4 : yypt+1]
+//line promql/generated_parser.y:154
 		{
 			yyVAL.matchers = yyDollar[2].matchers
 		}
 	case 9:
-		yyDollar = yyS[yypt-4 : yypt+1]
-//line promql/generated_parser.y:157
-		{
-			yyVAL.matchers = yyDollar[2].matchers
-		}
-	case 10:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:159
+//line promql/generated_parser.y:156
 		{
 			yyVAL.matchers = []*labels.Matcher{}
 		}
-	case 11:
+	case 10:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:165
+//line promql/generated_parser.y:162
 		{
 			yyVAL.matchers = append(yyDollar[1].matchers, yyDollar[3].matcher)
 		}
-	case 12:
+	case 11:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:167
+//line promql/generated_parser.y:164
 		{
 			yyVAL.matchers = []*labels.Matcher{yyDollar[1].matcher}
 		}
-	case 13:
+	case 12:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:169
+//line promql/generated_parser.y:166
 		{
 			yylex.(*parser).unexpected("label matching", "\",\" or \"}\"")
 		}
-	case 14:
+	case 13:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:174
+//line promql/generated_parser.y:171
 		{
 			yyVAL.matcher = yylex.(*parser).newLabelMatcher(yyDollar[1].item, yyDollar[2].item, yyDollar[3].item)
 		}
-	case 15:
+	case 14:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:176
+//line promql/generated_parser.y:173
 		{
 			yylex.(*parser).unexpected("label matching", "string")
 		}
-	case 16:
+	case 15:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:178
+//line promql/generated_parser.y:175
 		{
 			yylex.(*parser).unexpected("label matching", "label matching operator")
 		}
-	case 17:
+	case 16:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:180
+//line promql/generated_parser.y:177
 		{
 			yylex.(*parser).unexpected("label matching", "identifier or \"}\"")
 		}
+	case 17:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:181
+		{
+			yyVAL.item = yyDollar[1].item
+		}
 	case 18:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:184
+//line promql/generated_parser.y:182
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 19:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:185
+//line promql/generated_parser.y:183
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 20:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:186
+//line promql/generated_parser.y:184
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 21:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:187
-		{
-			yyVAL.item = yyDollar[1].item
-		}
-	case 22:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:193
+//line promql/generated_parser.y:190
 		{
 			yyVAL.labels = append(yyDollar[2].labels, labels.Label{Name: labels.MetricName, Value: yyDollar[1].item.Val})
 			sort.Sort(yyVAL.labels)
 		}
-	case 23:
+	case 22:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:195
+//line promql/generated_parser.y:192
 		{
 			yyVAL.labels = yyDollar[1].labels
 		}
+	case 23:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:199
+		{
+			yyVAL.item = yyDollar[1].item
+		}
 	case 24:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:202
+//line promql/generated_parser.y:200
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 25:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:203
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:204
 		{
-			yyVAL.item = yyDollar[1].item
+			yyVAL.labels = labels.New(yyDollar[2].labels...)
 		}
 	case 26:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:207
+		yyDollar = yyS[yypt-4 : yypt+1]
+//line promql/generated_parser.y:206
 		{
 			yyVAL.labels = labels.New(yyDollar[2].labels...)
 		}
 	case 27:
-		yyDollar = yyS[yypt-4 : yypt+1]
-//line promql/generated_parser.y:209
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:208
 		{
-			yyVAL.labels = labels.New(yyDollar[2].labels...)
+			yyVAL.labels = labels.New()
 		}
 	case 28:
-		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:211
+		yyDollar = yyS[yypt-0 : yypt+1]
+//line promql/generated_parser.y:210
 		{
 			yyVAL.labels = labels.New()
 		}
 	case 29:
-		yyDollar = yyS[yypt-0 : yypt+1]
-//line promql/generated_parser.y:213
-		{
-			yyVAL.labels = labels.New()
-		}
-	case 30:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:218
+//line promql/generated_parser.y:215
 		{
 			yyVAL.labels = append(yyDollar[1].labels, yyDollar[3].label)
 		}
-	case 31:
+	case 30:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:220
+//line promql/generated_parser.y:217
 		{
 			yyVAL.labels = []labels.Label{yyDollar[1].label}
 		}
-	case 32:
+	case 31:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:222
+//line promql/generated_parser.y:219
 		{
 			yylex.(*parser).unexpected("label set", "\",\" or \"}\"")
 		}
-	case 33:
+	case 32:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:228
+//line promql/generated_parser.y:225
 		{
 			yyVAL.label = labels.Label{Name: yyDollar[1].item.Val, Value: yylex.(*parser).unquoteString(yyDollar[3].item.Val)}
 		}
-	case 34:
+	case 33:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:230
+//line promql/generated_parser.y:227
 		{
 			yylex.(*parser).unexpected("label set", "string")
 		}
-	case 35:
+	case 34:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:232
+//line promql/generated_parser.y:229
 		{
 			yylex.(*parser).unexpected("label set", "\"=\"")
 		}
-	case 36:
+	case 35:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:234
+//line promql/generated_parser.y:231
 		{
 			yylex.(*parser).unexpected("label set", "identifier or \"}\"")
 		}
-	case 37:
+	case 36:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:239
+//line promql/generated_parser.y:236
+		{
+			yyVAL.strings = yyDollar[2].strings
+		}
+	case 37:
+		yyDollar = yyS[yypt-4 : yypt+1]
+//line promql/generated_parser.y:238
 		{
 			yyVAL.strings = yyDollar[2].strings
 		}
 	case 38:
-		yyDollar = yyS[yypt-4 : yypt+1]
-//line promql/generated_parser.y:241
-		{
-			yyVAL.strings = yyDollar[2].strings
-		}
-	case 39:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:243
+//line promql/generated_parser.y:240
 		{
 			yyVAL.strings = []string{}
 		}
-	case 40:
+	case 39:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:245
+//line promql/generated_parser.y:242
 		{
 			yylex.(*parser).unexpected("grouping opts", "\"(\"")
 		}
-	case 41:
+	case 40:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:251
+//line promql/generated_parser.y:248
 		{
 			yyVAL.strings = append(yyDollar[1].strings, yyDollar[3].item.Val)
 		}
-	case 42:
+	case 41:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:253
+//line promql/generated_parser.y:250
 		{
 			yyVAL.strings = []string{yyDollar[1].item.Val}
 		}
-	case 43:
+	case 42:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:255
+//line promql/generated_parser.y:252
 		{
 			yylex.(*parser).unexpected("grouping opts", "\",\" or \"}\"")
 		}
-	case 44:
+	case 43:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:260
+//line promql/generated_parser.y:257
 		{
 			if !isLabel(yyDollar[1].item.Val) {
 				yylex.(*parser).unexpected("grouping opts", "label")
 			}
 			yyVAL.item = yyDollar[1].item
 		}
-	case 45:
+	case 44:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:267
+//line promql/generated_parser.y:264
 		{
 			yylex.(*parser).unexpected("grouping opts", "label")
 		}
-	case 69:
+	case 68:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:300
+//line promql/generated_parser.y:297
 		{
 			yylex.(*parser).generatedParserResult = &seriesDescription{
 				labels: yyDollar[1].labels,
 				values: yyDollar[2].series,
 			}
 		}
-	case 70:
+	case 69:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line promql/generated_parser.y:310
+//line promql/generated_parser.y:307
 		{
 			yyVAL.series = []sequenceValue{}
 		}
-	case 71:
+	case 70:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:312
+//line promql/generated_parser.y:309
 		{
 			yyVAL.series = append(yyDollar[1].series, yyDollar[3].series...)
 		}
-	case 72:
+	case 71:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:314
+//line promql/generated_parser.y:311
 		{
 			yyVAL.series = yyDollar[1].series
 		}
-	case 73:
+	case 72:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:316
+//line promql/generated_parser.y:313
 		{
 			yylex.(*parser).unexpected("series values", "")
 		}
-	case 74:
+	case 73:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:321
+//line promql/generated_parser.y:318
 		{
 			yyVAL.series = []sequenceValue{{omitted: true}}
 		}
-	case 75:
+	case 74:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:323
+//line promql/generated_parser.y:320
 		{
 			yyVAL.series = []sequenceValue{}
 			for i := uint64(0); i < yyDollar[3].uint; i++ {
 				yyVAL.series = append(yyVAL.series, sequenceValue{omitted: true})
 			}
 		}
-	case 76:
+	case 75:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:330
+//line promql/generated_parser.y:327
 		{
 			yyVAL.series = []sequenceValue{{value: yyDollar[1].float}}
 		}
-	case 77:
+	case 76:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:332
+//line promql/generated_parser.y:329
 		{
 			yyVAL.series = []sequenceValue{}
 			for i := uint64(0); i <= yyDollar[3].uint; i++ {
 				yyVAL.series = append(yyVAL.series, sequenceValue{value: yyDollar[1].float})
 			}
 		}
-	case 78:
+	case 77:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line promql/generated_parser.y:339
+//line promql/generated_parser.y:336
 		{
 			yyVAL.series = []sequenceValue{}
 			for i := uint64(0); i <= yyDollar[4].uint; i++ {
@@ -985,9 +974,9 @@ yydefault:
 				yyDollar[1].float += yyDollar[2].float
 			}
 		}
-	case 79:
+	case 78:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:348
+//line promql/generated_parser.y:345
 		{
 			var err error
 			yyVAL.uint, err = strconv.ParseUint(yyDollar[1].item.Val, 10, 64)
@@ -995,42 +984,42 @@ yydefault:
 				yylex.(*parser).errorf("invalid repitition in series values: %s", err)
 			}
 		}
-	case 80:
+	case 79:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:359
+//line promql/generated_parser.y:356
 		{
 			yyVAL.float = yyDollar[2].float
 		}
-	case 81:
+	case 80:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:361
+//line promql/generated_parser.y:358
 		{
 			yyVAL.float = -yyDollar[2].float
 		}
-	case 82:
+	case 81:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:366
+//line promql/generated_parser.y:363
 		{
 			if yyDollar[1].item.Val != "stale" {
 				yylex.(*parser).unexpected("series values", "number or \"stale\"")
 			}
 			yyVAL.float = math.Float64frombits(value.StaleNaN)
 		}
+	case 82:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:370
+		{
+			yyVAL.float = yyDollar[1].float
+		}
 	case 83:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:373
+//line promql/generated_parser.y:372
 		{
 			yyVAL.float = yyDollar[1].float
 		}
 	case 84:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:375
-		{
-			yyVAL.float = yyDollar[1].float
-		}
-	case 85:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:382
+//line promql/generated_parser.y:379
 		{
 			yyVAL.float = yylex.(*parser).number(yyDollar[1].item.Val)
 		}

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -8,12 +8,15 @@ import __yyfmt__ "fmt"
 //line promql/generated_parser.y:15
 
 import (
+	"math"
 	"sort"
+	"strconv"
 
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/value"
 )
 
-//line promql/generated_parser.y:24
+//line promql/generated_parser.y:27
 type yySymType struct {
 	yys      int
 	node     Node
@@ -23,6 +26,9 @@ type yySymType struct {
 	label    labels.Label
 	labels   labels.Labels
 	strings  []string
+	series   []sequenceValue
+	uint     uint64
+	float    float64
 }
 
 const ERROR = 57346
@@ -93,7 +99,8 @@ const START_LABELS = 57410
 const START_LABEL_SET = 57411
 const START_METRIC = 57412
 const START_GROUPING_LABELS = 57413
-const startSymbolsEnd = 57414
+const START_SERIES_DESCRIPTION = 57414
+const startSymbolsEnd = 57415
 
 var yyToknames = [...]string{
 	"$end",
@@ -167,6 +174,7 @@ var yyToknames = [...]string{
 	"START_LABEL_SET",
 	"START_METRIC",
 	"START_GROUPING_LABELS",
+	"START_SERIES_DESCRIPTION",
 	"startSymbolsEnd",
 }
 var yyStatenames = [...]string{}
@@ -175,7 +183,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line promql/generated_parser.y:286
+//line promql/generated_parser.y:383
 
 //line yacctab:1
 var yyExca = [...]int{
@@ -183,92 +191,113 @@ var yyExca = [...]int{
 	1, -1,
 	-2, 0,
 	-1, 4,
-	1, 28,
+	1, 31,
+	5, 31,
+	-2, 0,
+	-1, 22,
+	1, 31,
+	5, 31,
+	24, 31,
 	-2, 0,
 }
 
 const yyPrivate = 57344
 
-const yyLast = 142
+const yyLast = 159
 
 var yyAct = [...]int{
 
-	35, 27, 33, 63, 22, 36, 37, 6, 84, 83,
-	79, 75, 1, 29, 10, 70, 31, 8, 28, 73,
-	17, 11, 72, 80, 74, 68, 82, 78, 69, 38,
-	39, 40, 19, 25, 34, 64, 65, 12, 62, 18,
-	20, 66, 67, 41, 42, 43, 44, 45, 46, 47,
-	48, 49, 50, 51, 71, 7, 52, 53, 0, 54,
-	55, 56, 57, 58, 35, 77, 0, 0, 61, 36,
-	37, 81, 32, 2, 3, 4, 5, 85, 59, 24,
-	29, 60, 24, 0, 23, 28, 0, 23, 0, 76,
-	26, 14, 21, 38, 39, 40, 16, 15, 0, 0,
-	10, 0, 0, 0, 0, 0, 0, 41, 42, 43,
-	44, 45, 46, 47, 48, 49, 50, 51, 0, 0,
-	52, 53, 0, 54, 55, 56, 57, 58, 9, 0,
-	0, 0, 0, 13, 0, 0, 0, 0, 0, 0,
-	0, 30,
+	107, 97, 98, 38, 36, 25, 68, 96, 39, 40,
+	30, 90, 103, 7, 92, 101, 100, 110, 102, 13,
+	99, 12, 94, 108, 89, 77, 101, 100, 99, 10,
+	75, 8, 41, 42, 43, 62, 22, 1, 69, 70,
+	73, 88, 63, 74, 71, 72, 44, 45, 46, 47,
+	48, 49, 50, 51, 52, 53, 54, 76, 95, 55,
+	56, 21, 57, 58, 59, 60, 61, 93, 20, 85,
+	38, 83, 81, 34, 19, 39, 40, 66, 35, 2,
+	3, 4, 5, 6, 91, 87, 84, 64, 28, 37,
+	65, 15, 14, 67, 23, 11, 9, 80, 104, 41,
+	42, 43, 105, 106, 109, 78, 33, 0, 0, 0,
+	79, 111, 0, 44, 45, 46, 47, 48, 49, 50,
+	51, 52, 53, 54, 0, 0, 55, 56, 0, 57,
+	58, 59, 60, 61, 32, 27, 0, 16, 0, 31,
+	26, 0, 18, 17, 86, 82, 12, 32, 27, 0,
+	0, 0, 31, 26, 0, 0, 0, 29, 24,
 }
 var yyPact = [...]int{
 
-	5, -1000, 6, 3, 89, 30, -1000, -1000, 80, -1000,
-	78, -1000, 3, -1000, -1000, -1000, -1000, -1000, 62, -1000,
-	66, -1000, -1000, 1, -1000, 13, -1000, -1000, 20, -1000,
-	-1000, 9, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	11, 26, 18, 10, 135, 59, -1000, -1000, -1000, -1000,
+	146, -1000, 145, -1000, 10, -1000, -1000, -1000, -1000, -1000,
+	68, -1000, 135, 75, -1000, -1000, 4, -1000, 28, -1000,
+	-1000, 23, -1000, -1000, 95, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	77, -1000, 8, -1000, -1000, -1000, -1000, -1000, -1000, 11,
-	-1000, 7, -1000, -1000, -2, -1000, -1000, -1000, -1000, -1000,
-	-1000, -1000, -1000, -1000, -1000, -1000,
+	-1000, -1000, -1000, -1000, -1000, 133, -1000, 67, -1000, -1000,
+	-1000, -1000, -1000, -1000, 132, -1000, 22, -1000, -1000, 1,
+	-1000, -10, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	-1000, -1000, 0, -1000, -5, -11, -1000, -1000, -1000, -1000,
+	8, 8, 3, 3, -6, -1000, -1000, -1000, -1000, -1000,
+	3, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 55, 40, 4, 38, 37, 2, 34, 33, 128,
-	21, 1, 20, 16, 12,
+	0, 96, 94, 5, 93, 92, 4, 89, 88, 91,
+	19, 10, 74, 73, 72, 67, 0, 58, 2, 1,
+	37, 36, 35,
 }
 var yyR1 = [...]int{
 
-	0, 14, 14, 14, 14, 14, 1, 1, 1, 2,
-	2, 2, 3, 3, 3, 3, 4, 4, 4, 4,
-	10, 10, 10, 5, 5, 9, 9, 9, 9, 8,
-	8, 8, 11, 11, 11, 11, 12, 12, 12, 12,
-	13, 13, 13, 6, 6, 7, 7, 7, 7, 7,
+	0, 20, 20, 20, 20, 21, 20, 20, 20, 1,
+	1, 1, 2, 2, 2, 3, 3, 3, 3, 4,
+	4, 4, 4, 10, 10, 10, 5, 5, 9, 9,
+	9, 9, 8, 8, 8, 11, 11, 11, 11, 12,
+	12, 12, 12, 13, 13, 13, 6, 6, 7, 7,
 	7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-	7, 7, 7, 7, 7, 7, 7, 7,
+	7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+	7, 22, 14, 14, 14, 15, 15, 15, 15, 15,
+	16, 18, 18, 17, 17, 17, 19,
 }
 var yyR2 = [...]int{
 
-	0, 2, 2, 2, 2, 1, 3, 4, 2, 3,
-	1, 2, 3, 3, 2, 1, 1, 1, 1, 1,
-	2, 1, 1, 1, 1, 3, 4, 2, 0, 3,
-	1, 2, 3, 3, 2, 1, 3, 4, 2, 1,
-	3, 1, 2, 1, 1, 1, 1, 1, 1, 1,
+	0, 2, 2, 2, 2, 0, 3, 2, 1, 3,
+	4, 2, 3, 1, 2, 3, 3, 2, 1, 1,
+	1, 1, 1, 2, 1, 1, 1, 1, 3, 4,
+	2, 0, 3, 1, 2, 3, 3, 2, 1, 3,
+	4, 2, 1, 3, 1, 2, 1, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 2, 0, 3, 2, 1, 3, 1, 3, 4,
+	1, 2, 2, 1, 1, 1, 1,
 }
 var yyChk = [...]int{
 
-	-1000, -14, 68, 69, 70, 71, 2, -1, 11, -9,
-	11, -10, -5, -9, 2, 8, 7, -12, 9, 2,
-	-2, 12, -3, 7, 2, -8, 12, -11, 7, 2,
-	-9, -13, 10, -6, -7, 2, 7, 8, 31, 32,
-	33, 45, 46, 47, 48, 49, 50, 51, 52, 53,
-	54, 55, 58, 59, 61, 62, 63, 64, 65, 12,
-	15, 2, -4, 2, 34, 35, 40, 41, 12, 15,
-	2, 34, 2, 10, 15, 2, 12, -3, 19, 2,
-	12, -11, 19, 2, 10, -6,
+	-1000, -20, 68, 69, 70, 71, 72, 2, 5, -1,
+	11, -9, 11, -10, -5, -9, 2, 8, 7, -12,
+	9, 2, -21, -2, 12, -3, 7, 2, -8, 12,
+	-11, 7, 2, -9, -13, 10, -6, -7, 2, 7,
+	8, 31, 32, 33, 45, 46, 47, 48, 49, 50,
+	51, 52, 53, 54, 55, 58, 59, 61, 62, 63,
+	64, 65, -22, -10, 12, 15, 2, -4, 2, 34,
+	35, 40, 41, 12, 15, 2, 34, 2, 10, 15,
+	2, -14, 12, -3, 19, 2, 12, -11, 19, 2,
+	10, -6, 24, -15, 22, -17, 7, -19, -18, 20,
+	27, 26, 23, 23, -18, -19, -19, -16, 20, -16,
+	23, -16,
 }
 var yyDef = [...]int{
 
-	0, -2, 0, 28, -2, 0, 5, 1, 0, 2,
-	0, 3, 28, 21, 22, 23, 24, 4, 0, 39,
-	0, 8, 10, 0, 15, 0, 27, 30, 0, 35,
-	20, 0, 38, 41, 43, 44, 45, 46, 47, 48,
+	0, -2, 0, 31, -2, 0, 5, 8, 7, 1,
+	0, 2, 0, 3, 31, 24, 25, 26, 27, 4,
+	0, 42, -2, 0, 11, 13, 0, 18, 0, 30,
+	33, 0, 38, 23, 0, 41, 44, 46, 47, 48,
 	49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
-	59, 60, 61, 62, 63, 64, 65, 66, 67, 6,
-	0, 11, 0, 14, 16, 17, 18, 19, 25, 0,
-	31, 0, 34, 36, 0, 42, 7, 9, 12, 13,
-	26, 29, 32, 33, 37, 40,
+	59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
+	69, 70, 6, 72, 9, 0, 14, 0, 17, 19,
+	20, 21, 22, 28, 0, 34, 0, 37, 39, 0,
+	45, 71, 10, 12, 15, 16, 29, 32, 35, 36,
+	40, 43, 74, 73, 75, 77, 83, 84, 85, 86,
+	0, 0, 0, 0, 0, 81, 82, 76, 80, 78,
+	0, 79,
 }
 var yyTok1 = [...]int{
 
@@ -283,7 +312,7 @@ var yyTok2 = [...]int{
 	42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
 	52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
 	62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
-	72,
+	72, 73,
 }
 var yyTok3 = [...]int{
 	0,
@@ -628,271 +657,393 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:129
+//line promql/generated_parser.y:139
 		{
 			yylex.(*parser).generatedParserResult.(*VectorSelector).LabelMatchers = yyDollar[2].matchers
 		}
 	case 2:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:131
+//line promql/generated_parser.y:141
 		{
 			yylex.(*parser).generatedParserResult = yyDollar[2].labels
 		}
 	case 3:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:133
+//line promql/generated_parser.y:143
 		{
 			yylex.(*parser).generatedParserResult = yyDollar[2].labels
 		}
 	case 4:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:135
+//line promql/generated_parser.y:145
 		{
 			yylex.(*parser).generatedParserResult = yyDollar[2].strings
 		}
 	case 5:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:137
+//line promql/generated_parser.y:146
+		{
+			yylex.(*parser).generatedParserResult = &parseSeriesDescResult{}
+		}
+	case 8:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:149
 		{
 			yylex.(*parser).unexpected("", "")
 		}
-	case 6:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:143
-		{
-			yyVAL.matchers = yyDollar[2].matchers
-		}
-	case 7:
-		yyDollar = yyS[yypt-4 : yypt+1]
-//line promql/generated_parser.y:145
-		{
-			yyVAL.matchers = yyDollar[2].matchers
-		}
-	case 8:
-		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:147
-		{
-			yyVAL.matchers = []*labels.Matcher{}
-		}
 	case 9:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:153
-		{
-			yyVAL.matchers = append(yyDollar[1].matchers, yyDollar[3].matcher)
-		}
-	case 10:
-		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:155
 		{
-			yyVAL.matchers = []*labels.Matcher{yyDollar[1].matcher}
+			yyVAL.matchers = yyDollar[2].matchers
+		}
+	case 10:
+		yyDollar = yyS[yypt-4 : yypt+1]
+//line promql/generated_parser.y:157
+		{
+			yyVAL.matchers = yyDollar[2].matchers
 		}
 	case 11:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:157
+//line promql/generated_parser.y:159
 		{
-			yylex.(*parser).unexpected("label matching", "\",\" or \"}\"")
+			yyVAL.matchers = []*labels.Matcher{}
 		}
 	case 12:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:162
+//line promql/generated_parser.y:165
 		{
-			yyVAL.matcher = yylex.(*parser).newLabelMatcher(yyDollar[1].item, yyDollar[2].item, yyDollar[3].item)
+			yyVAL.matchers = append(yyDollar[1].matchers, yyDollar[3].matcher)
 		}
 	case 13:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:164
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:167
 		{
-			yylex.(*parser).unexpected("label matching", "string")
+			yyVAL.matchers = []*labels.Matcher{yyDollar[1].matcher}
 		}
 	case 14:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:166
+//line promql/generated_parser.y:169
+		{
+			yylex.(*parser).unexpected("label matching", "\",\" or \"}\"")
+		}
+	case 15:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:174
+		{
+			yyVAL.matcher = yylex.(*parser).newLabelMatcher(yyDollar[1].item, yyDollar[2].item, yyDollar[3].item)
+		}
+	case 16:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:176
+		{
+			yylex.(*parser).unexpected("label matching", "string")
+		}
+	case 17:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:178
 		{
 			yylex.(*parser).unexpected("label matching", "label matching operator")
 		}
-	case 15:
+	case 18:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:168
+//line promql/generated_parser.y:180
 		{
 			yylex.(*parser).unexpected("label matching", "identifier or \"}\"")
 		}
-	case 16:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:172
-		{
-			yyVAL.item = yyDollar[1].item
-		}
-	case 17:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:173
-		{
-			yyVAL.item = yyDollar[1].item
-		}
-	case 18:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:174
-		{
-			yyVAL.item = yyDollar[1].item
-		}
 	case 19:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:175
+//line promql/generated_parser.y:184
 		{
 			yyVAL.item = yyDollar[1].item
 		}
 	case 20:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:185
+		{
+			yyVAL.item = yyDollar[1].item
+		}
+	case 21:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:186
+		{
+			yyVAL.item = yyDollar[1].item
+		}
+	case 22:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:187
+		{
+			yyVAL.item = yyDollar[1].item
+		}
+	case 23:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:181
+//line promql/generated_parser.y:193
 		{
 			yyVAL.labels = append(yyDollar[2].labels, labels.Label{Name: labels.MetricName, Value: yyDollar[1].item.Val})
 			sort.Sort(yyVAL.labels)
 		}
-	case 21:
+	case 24:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:183
+//line promql/generated_parser.y:195
 		{
 			yyVAL.labels = yyDollar[1].labels
 		}
-	case 22:
+	case 25:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:185
+//line promql/generated_parser.y:197
 		{
 			yylex.(*parser).errorf("missing metric name or metric selector")
 		}
-	case 23:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:190
-		{
-			yyVAL.item = yyDollar[1].item
-		}
-	case 24:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:191
-		{
-			yyVAL.item = yyDollar[1].item
-		}
-	case 25:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:195
-		{
-			yyVAL.labels = labels.New(yyDollar[2].labels...)
-		}
 	case 26:
-		yyDollar = yyS[yypt-4 : yypt+1]
-//line promql/generated_parser.y:197
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:202
 		{
-			yyVAL.labels = labels.New(yyDollar[2].labels...)
+			yyVAL.item = yyDollar[1].item
 		}
 	case 27:
-		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:199
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:203
 		{
-			yyVAL.labels = labels.New()
+			yyVAL.item = yyDollar[1].item
 		}
 	case 28:
-		yyDollar = yyS[yypt-0 : yypt+1]
-//line promql/generated_parser.y:201
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:207
+		{
+			yyVAL.labels = labels.New(yyDollar[2].labels...)
+		}
+	case 29:
+		yyDollar = yyS[yypt-4 : yypt+1]
+//line promql/generated_parser.y:209
+		{
+			yyVAL.labels = labels.New(yyDollar[2].labels...)
+		}
+	case 30:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:211
 		{
 			yyVAL.labels = labels.New()
 		}
-	case 29:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:206
-		{
-			yyVAL.labels = append(yyDollar[1].labels, yyDollar[3].label)
-		}
-	case 30:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:208
-		{
-			yyVAL.labels = []labels.Label{yyDollar[1].label}
-		}
 	case 31:
-		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:210
+		yyDollar = yyS[yypt-0 : yypt+1]
+//line promql/generated_parser.y:213
 		{
-			yylex.(*parser).unexpected("label set", "\",\" or \"}\"")
+			yyVAL.labels = labels.New()
 		}
 	case 32:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:216
-		{
-			yyVAL.label = labels.Label{Name: yyDollar[1].item.Val, Value: yylex.(*parser).unquoteString(yyDollar[3].item.Val)}
-		}
-	case 33:
-		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:218
 		{
-			yylex.(*parser).unexpected("label set", "string")
+			yyVAL.labels = append(yyDollar[1].labels, yyDollar[3].label)
+		}
+	case 33:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:220
+		{
+			yyVAL.labels = []labels.Label{yyDollar[1].label}
 		}
 	case 34:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:220
-		{
-			yylex.(*parser).unexpected("label set", "\"=\"")
-		}
-	case 35:
-		yyDollar = yyS[yypt-1 : yypt+1]
 //line promql/generated_parser.y:222
 		{
-			yylex.(*parser).unexpected("label set", "identifier or \"}\"")
+			yylex.(*parser).unexpected("label set", "\",\" or \"}\"")
+		}
+	case 35:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:228
+		{
+			yyVAL.label = labels.Label{Name: yyDollar[1].item.Val, Value: yylex.(*parser).unquoteString(yyDollar[3].item.Val)}
 		}
 	case 36:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line promql/generated_parser.y:227
+//line promql/generated_parser.y:230
 		{
-			yyVAL.strings = yyDollar[2].strings
+			yylex.(*parser).unexpected("label set", "string")
 		}
 	case 37:
-		yyDollar = yyS[yypt-4 : yypt+1]
-//line promql/generated_parser.y:229
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:232
 		{
-			yyVAL.strings = yyDollar[2].strings
+			yylex.(*parser).unexpected("label set", "\"=\"")
 		}
 	case 38:
-		yyDollar = yyS[yypt-2 : yypt+1]
-//line promql/generated_parser.y:231
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:234
 		{
-			yyVAL.strings = []string{}
+			yylex.(*parser).unexpected("label set", "identifier or \"}\"")
 		}
 	case 39:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:233
-		{
-			yylex.(*parser).unexpected("grouping opts", "\"(\"")
-		}
-	case 40:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line promql/generated_parser.y:239
 		{
-			yyVAL.strings = append(yyDollar[1].strings, yyDollar[3].item.Val)
+			yyVAL.strings = yyDollar[2].strings
 		}
-	case 41:
-		yyDollar = yyS[yypt-1 : yypt+1]
+	case 40:
+		yyDollar = yyS[yypt-4 : yypt+1]
 //line promql/generated_parser.y:241
 		{
-			yyVAL.strings = []string{yyDollar[1].item.Val}
+			yyVAL.strings = yyDollar[2].strings
 		}
-	case 42:
+	case 41:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:243
 		{
-			yylex.(*parser).unexpected("grouping opts", "\",\" or \"}\"")
+			yyVAL.strings = []string{}
+		}
+	case 42:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:245
+		{
+			yylex.(*parser).unexpected("grouping opts", "\"(\"")
 		}
 	case 43:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:251
+		{
+			yyVAL.strings = append(yyDollar[1].strings, yyDollar[3].item.Val)
+		}
+	case 44:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:248
+//line promql/generated_parser.y:253
+		{
+			yyVAL.strings = []string{yyDollar[1].item.Val}
+		}
+	case 45:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:255
+		{
+			yylex.(*parser).unexpected("grouping opts", "\",\" or \"}\"")
+		}
+	case 46:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:260
 		{
 			if !isLabel(yyDollar[1].item.Val) {
 				yylex.(*parser).unexpected("grouping opts", "label")
 			}
 			yyVAL.item = yyDollar[1].item
 		}
-	case 44:
+	case 47:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line promql/generated_parser.y:255
+//line promql/generated_parser.y:267
 		{
 			yylex.(*parser).unexpected("grouping opts", "label")
+		}
+	case 71:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:300
+		{
+			yylex.(*parser).generatedParserResult = &parseSeriesDescResult{
+				labels: yyDollar[1].labels,
+				values: yyDollar[2].series,
+			}
+		}
+	case 72:
+		yyDollar = yyS[yypt-0 : yypt+1]
+//line promql/generated_parser.y:310
+		{
+			yyVAL.series = []sequenceValue{}
+		}
+	case 73:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:312
+		{
+			yyVAL.series = append(yyDollar[1].series, yyDollar[3].series...)
+		}
+	case 74:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:314
+		{
+			yyVAL.series = yyDollar[1].series
+		}
+	case 75:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:319
+		{
+			yyVAL.series = []sequenceValue{{omitted: true}}
+		}
+	case 76:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:321
+		{
+			yyVAL.series = []sequenceValue{}
+			for i := uint64(0); i < yyDollar[3].uint; i++ {
+				yyVAL.series = append(yyVAL.series, sequenceValue{omitted: true})
+			}
+		}
+	case 77:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:328
+		{
+			yyVAL.series = []sequenceValue{{value: yyDollar[1].float}}
+		}
+	case 78:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line promql/generated_parser.y:330
+		{
+			yyVAL.series = []sequenceValue{}
+			for i := uint64(0); i <= yyDollar[3].uint; i++ {
+				yyVAL.series = append(yyVAL.series, sequenceValue{value: yyDollar[1].float})
+			}
+		}
+	case 79:
+		yyDollar = yyS[yypt-4 : yypt+1]
+//line promql/generated_parser.y:337
+		{
+			yyVAL.series = []sequenceValue{}
+			for i := uint64(0); i <= yyDollar[4].uint; i++ {
+				yyVAL.series = append(yyVAL.series, sequenceValue{value: yyDollar[1].float})
+				yyDollar[1].float += yyDollar[2].float
+			}
+		}
+	case 80:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:346
+		{
+			var err error
+			yyVAL.uint, err = strconv.ParseUint(yyDollar[1].item.Val, 10, 64)
+			if err != nil {
+				yylex.(*parser).errorf("invalid repitition in series values: %s", err)
+			}
+		}
+	case 81:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:357
+		{
+			yyVAL.float = yyDollar[2].float
+		}
+	case 82:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line promql/generated_parser.y:359
+		{
+			yyVAL.float = -yyDollar[2].float
+		}
+	case 83:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:364
+		{
+			if yyDollar[1].item.Val != "stale" {
+				yylex.(*parser).unexpected("series values", "number or \"stale\"")
+			}
+			yyVAL.float = math.Float64frombits(value.StaleNaN)
+		}
+	case 84:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:371
+		{
+			yyVAL.float = yyDollar[1].float
+		}
+	case 85:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:373
+		{
+			yyVAL.float = yyDollar[1].float
+		}
+	case 86:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line promql/generated_parser.y:380
+		{
+			yyVAL.float = yylex.(*parser).number(yyDollar[1].item.Val)
 		}
 	}
 	goto yystack /* stack new state and value */

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -128,7 +128,7 @@ func (v sequenceValue) String() string {
 	return fmt.Sprintf("%f", v.value)
 }
 
-type parseSeriesDescResult struct {
+type seriesDescription struct {
 	labels labels.Labels
 	values []sequenceValue
 }
@@ -141,7 +141,7 @@ func parseSeriesDesc(input string) (labels labels.Labels, values []sequenceValue
 
 	defer p.recover(&err)
 
-	result := p.parseGenerated(START_SERIES_DESCRIPTION, []ItemType{EOF}).(*parseSeriesDescResult)
+	result := p.parseGenerated(START_SERIES_DESCRIPTION, []ItemType{EOF}).(*seriesDescription)
 
 	labels = result.labels
 	values = result.values

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -131,12 +131,25 @@ func (v sequenceValue) String() string {
 	return fmt.Sprintf("%f", v.value)
 }
 
+type parseSeriesDescResult struct {
+	labels labels.Labels
+	values []sequenceValue
+}
+
 // parseSeriesDesc parses the description of a time series.
-func parseSeriesDesc(input string) (labels.Labels, []sequenceValue, error) {
+func parseSeriesDesc(input string) (labels labels.Labels, values []sequenceValue, err error) {
+
 	p := newParser(input)
 	p.lex.seriesDesc = true
 
-	return p.parseSeriesDesc()
+	defer p.recover(&err)
+
+	result := p.parseGenerated(START_SERIES_DESCRIPTION, []ItemType{EOF}).(*parseSeriesDescResult)
+
+	labels = result.labels
+	values = result.values
+
+	return
 }
 
 // parseSeriesDesc parses a description of a time series into its metric and value sequence.

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -14,7 +14,6 @@
 package promql
 
 import (
-	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -1798,7 +1797,6 @@ func TestParseSeries(t *testing.T) {
 		testutil.Assert(t, err != errUnexpected, "unexpected error occurred")
 
 		if !test.fail {
-			fmt.Println(test.input)
 			testutil.Ok(t, err)
 			testutil.Equals(t, test.expectedMetric, metric, "error on input '%s'", test.input)
 			testutil.Equals(t, test.expectedValues, vals, "error in input '%s'", test.input)

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -14,6 +14,7 @@
 package promql
 
 import (
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -1797,6 +1798,7 @@ func TestParseSeries(t *testing.T) {
 		testutil.Assert(t, err != errUnexpected, "unexpected error occurred")
 
 		if !test.fail {
+			fmt.Println(test.input)
 			testutil.Ok(t, err)
 			testutil.Equals(t, test.expectedMetric, metric, "error on input '%s'", test.input)
 			testutil.Equals(t, test.expectedValues, vals, "error in input '%s'", test.input)


### PR DESCRIPTION
This PR extends the generated parser (#6256) to parse series descriptions.

The series description format is quite complex, so this PR is relatively large.

However, since series descriptions are only ever parsed inside unit test, there is no risk of breaking any production usage of the parser this time.

cc @brian-brazil @simonpasquier 

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->