### PR TITLE
PromQL: Fix parser benchmark

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -250,7 +250,7 @@ func BenchmarkParser(b *testing.B) {
 		b.Run(c, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				ParseMetric(c)
+				ParseExpr(c)
 			}
 		})
 	}
@@ -259,7 +259,7 @@ func BenchmarkParser(b *testing.B) {
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				ParseMetric(c)
+				ParseExpr(c)
 			}
 		})
 	}


### PR DESCRIPTION
The parser benchmarks called the `ParseMetric` function instead of the `ParseExpr` function, which resulted in parsing failing every time.

This means only the case of PromQL parser failure was benchmarked.

Signed-off-by: Tobias Guggenmos <tguggenm@redhat.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->