### PR TITLE
OpenMetrics: force input to end with # EOF

### DIFF
--- a/pkg/textparse/openmetricsparse.go
+++ b/pkg/textparse/openmetricsparse.go
@@ -90,6 +90,7 @@ type OpenMetricsParser struct {
 	hasTS   bool
 	start   int
 	offsets []int
+	prev    token
 
 	eOffsets      []int
 	exemplar      []byte
@@ -232,13 +233,18 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 	p.exemplarVal = 0
 	p.hasExemplarTs = false
 
-	switch t := p.nextToken(); t {
+	t := p.nextToken()
+	defer func() { p.prev = t }()
+	switch t {
 	case tEofWord:
 		if t := p.nextToken(); t != tEOF {
 			return EntryInvalid, errors.New("unexpected data after # EOF")
 		}
 		return EntryInvalid, io.EOF
 	case tEOF:
+		if p.prev != tEofWord {
+			return EntryInvalid, errors.New("data does not end with # EOF")
+		}
 		return EntryInvalid, io.EOF
 	case tHelp, tType, tUnit:
 		switch t := p.nextToken(); t {
@@ -322,7 +328,7 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 		p.hasTS = false
 		switch t2 := p.nextToken(); t2 {
 		case tEOF:
-			return EntryInvalid, io.EOF
+			return EntryInvalid, errors.New("data does not end with # EOF")
 		case tLinebreak:
 			break
 		case tComment:
@@ -382,7 +388,7 @@ func (p *OpenMetricsParser) parseComment() error {
 	p.hasExemplarTs = false
 	switch t2 := p.nextToken(); t2 {
 	case tEOF:
-		return io.EOF
+		return errors.New("data does not end with # EOF")
 	case tLinebreak:
 		break
 	case tTimestamp:

--- a/pkg/textparse/openmetricsparse_test.go
+++ b/pkg/textparse/openmetricsparse_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The OMetheus Authors
+// Copyright 2017 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -271,72 +271,103 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 		input string
 		err   string
 	}{
+		// Happy cases. EOF is returned by the parser at the end of valid
+		// data.
 		{
-			input: "",
+			input: "# EOF",
 			err:   "EOF",
 		},
 		{
-			input: "a",
-			err:   "expected value after metric, got \"EOF\"",
+			input: "# EOF\n",
+			err:   "EOF",
+		},
+		// Unhappy cases.
+		{
+			input: "",
+			err:   "data does not end with # EOF",
 		},
 		{
 			input: "\n",
 			err:   "\"INVALID\" \"\\n\" is not a valid start token",
 		},
 		{
-			input: " a 1\n",
-			err:   "\"INVALID\" \" \" is not a valid start token",
+			input: "metric",
+			err:   "expected value after metric, got \"EOF\"",
 		},
 		{
-			input: "9\n",
-			err:   "\"INVALID\" \"9\" is not a valid start token",
+			input: "metric 1",
+			err:   "data does not end with # EOF",
 		},
 		{
-			input: "# TYPE u untyped\n",
-			err:   "invalid metric type \"untyped\"",
+			input: "metric 1\n",
+			err:   "data does not end with # EOF",
 		},
 		{
-			input: "# TYPE c counter \n",
-			err:   "invalid metric type \"counter \"",
+			input: "metric_total 1 # {aa=\"bb\"} 4",
+			err:   "data does not end with # EOF",
 		},
 		{
-			input: "#  TYPE c counter\n",
-			err:   "\"INVALID\" \" \" is not a valid start token",
-		},
-		{
-			input: "# UNIT metric suffix\n",
-			err:   "unit not a suffix of metric \"metric\"",
-		},
-		{
-			input: "# UNIT metricsuffix suffix\n",
-			err:   "unit not a suffix of metric \"metricsuffix\"",
-		},
-		{
-			input: "# UNIT m suffix\n",
-			err:   "unit not a suffix of metric \"m\"",
-		},
-		{
-			input: "# HELP m\n",
-			err:   "expected text in HELP, got \"INVALID\"",
-		},
-		{
-			input: "a\t1\n",
+			input: "a\n#EOF\n",
 			err:   "expected value after metric, got \"INVALID\"",
 		},
 		{
-			input: "a 1\t2\n",
+			input: "\n\n#EOF\n",
+			err:   "\"INVALID\" \"\\n\" is not a valid start token",
+		},
+		{
+			input: " a 1\n#EOF\n",
+			err:   "\"INVALID\" \" \" is not a valid start token",
+		},
+		{
+			input: "9\n#EOF\n",
+			err:   "\"INVALID\" \"9\" is not a valid start token",
+		},
+		{
+			input: "# TYPE u untyped\n#EOF\n",
+			err:   "invalid metric type \"untyped\"",
+		},
+		{
+			input: "# TYPE c counter \n#EOF\n",
+			err:   "invalid metric type \"counter \"",
+		},
+		{
+			input: "#  TYPE c counter\n#EOF\n",
+			err:   "\"INVALID\" \" \" is not a valid start token",
+		},
+		{
+			input: "# UNIT metric suffix\n#EOF\n",
+			err:   "unit not a suffix of metric \"metric\"",
+		},
+		{
+			input: "# UNIT metricsuffix suffix\n#EOF\n",
+			err:   "unit not a suffix of metric \"metricsuffix\"",
+		},
+		{
+			input: "# UNIT m suffix\n#EOF\n",
+			err:   "unit not a suffix of metric \"m\"",
+		},
+		{
+			input: "# HELP m\n#EOF\n",
+			err:   "expected text in HELP, got \"INVALID\"",
+		},
+		{
+			input: "a\t1\n#EOF\n",
+			err:   "expected value after metric, got \"INVALID\"",
+		},
+		{
+			input: "a 1\t2\n#EOF\n",
 			err:   "strconv.ParseFloat: parsing \"1\\t2\": invalid syntax",
 		},
 		{
-			input: "a 1 2 \n",
+			input: "a 1 2 \n#EOF\n",
 			err:   "expected next entry after timestamp, got \"INVALID\"",
 		},
 		{
-			input: "a 1 2 #\n",
+			input: "a 1 2 #\n#EOF\n",
 			err:   "expected next entry after timestamp, got \"TIMESTAMP\"",
 		},
 		{
-			input: "a 1 1z\n",
+			input: "a 1 1z\n#EOF\n",
 			err:   "strconv.ParseFloat: parsing \"1z\": invalid syntax",
 		},
 		{
@@ -364,39 +395,39 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 			err:   "invalid metric type \" counter\"",
 		},
 		{
-			input: "a 1 1 1\n",
+			input: "a 1 1 1\n# EOF\n",
 			err:   "expected next entry after timestamp, got \"TIMESTAMP\"",
 		},
 		{
-			input: "a{b='c'} 1\n",
+			input: "a{b='c'} 1\n# EOF\n",
 			err:   "expected label value, got \"INVALID\"",
 		},
 		{
-			input: "a{b=\"c\",} 1\n",
+			input: "a{b=\"c\",} 1\n# EOF\n",
 			err:   "expected label name, got \"BCLOSE\"",
 		},
 		{
-			input: "a{,b=\"c\"} 1\n",
+			input: "a{,b=\"c\"} 1\n# EOF\n",
 			err:   "expected label name or left brace, got \"COMMA\"",
 		},
 		{
-			input: "a{b=\"c\"d=\"e\"} 1\n",
+			input: "a{b=\"c\"d=\"e\"} 1\n# EOF\n",
 			err:   "expected comma, got \"LNAME\"",
 		},
 		{
-			input: "a{b=\"c\",,d=\"e\"} 1\n",
+			input: "a{b=\"c\",,d=\"e\"} 1\n# EOF\n",
 			err:   "expected label name, got \"COMMA\"",
 		},
 		{
-			input: "a{b=\n",
+			input: "a{b=\n# EOF\n",
 			err:   "expected label value, got \"INVALID\"",
 		},
 		{
-			input: "a{\xff=\"foo\"} 1\n",
+			input: "a{\xff=\"foo\"} 1\n# EOF\n",
 			err:   "expected label name or left brace, got \"INVALID\"",
 		},
 		{
-			input: "a{b=\"\xff\"} 1\n",
+			input: "a{b=\"\xff\"} 1\n# EOF\n",
 			err:   "invalid UTF-8 label value",
 		},
 		{
@@ -404,32 +435,36 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 			err:   "strconv.ParseFloat: parsing \"true\": invalid syntax",
 		},
 		{
-			input: "something_weird{problem=\"",
+			input: "something_weird{problem=\"\n# EOF\n",
 			err:   "expected label value, got \"INVALID\"",
 		},
 		{
-			input: "empty_label_name{=\"\"} 0",
+			input: "empty_label_name{=\"\"} 0\n# EOF\n",
 			err:   "expected label name or left brace, got \"EQUAL\"",
 		},
 		{
-			input: "foo 1_2\n",
+			input: "foo 1_2\n\n# EOF\n",
 			err:   "unsupported character in float",
 		},
 		{
-			input: "foo 0x1p-3\n",
+			input: "foo 0x1p-3\n\n# EOF\n",
 			err:   "unsupported character in float",
 		},
 		{
-			input: "foo 0x1P-3\n",
+			input: "foo 0x1P-3\n\n# EOF\n",
 			err:   "unsupported character in float",
 		},
 		{
-			input: "foo 0 1_2\n",
+			input: "foo 0 1_2\n\n# EOF\n",
 			err:   "unsupported character in float",
 		},
 		{
-			input: "custom_metric_total 1 # {aa=bb}",
+			input: "custom_metric_total 1 # {aa=bb}\n# EOF\n",
 			err:   "expected label value, got \"INVALID\"",
+		},
+		{
+			input: "custom_metric_total 1 # {aa=\"bb\"}\n# EOF\n",
+			err:   "expected value after exemplar labels, got \"INVALID\"",
 		},
 		{
 			input: `custom_metric_total 1 # {aa="bb"}`,
@@ -471,7 +506,7 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 		for err == nil {
 			_, err = p.Next()
 		}
-		testutil.Equals(t, c.err, err.Error(), "test %d", i)
+		testutil.Equals(t, c.err, err.Error(), "test %d: %s", i, c.input)
 	}
 }
 


### PR DESCRIPTION
Fixes #1169

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->