### PR TITLE
tsdb: Do not reuse the same crc32 hash between Chunk() calls

### DIFF
--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -456,16 +456,15 @@ func (b realByteSlice) Sub(start, end int) ByteSlice {
 type Reader struct {
 	// The underlying bytes holding the encoded series data.
 	// Each slice holds the data for a different segment.
-	bs    []ByteSlice
-	cs    []io.Closer // Closers for resources behind the byte slices.
-	size  int64       // The total size of bytes in the reader.
-	pool  chunkenc.Pool
-	crc32 hash.Hash
-	buf   [binary.MaxVarintLen32]byte
+	bs   []ByteSlice
+	cs   []io.Closer // Closers for resources behind the byte slices.
+	size int64       // The total size of bytes in the reader.
+	pool chunkenc.Pool
+	buf  [binary.MaxVarintLen32]byte
 }
 
 func newReader(bs []ByteSlice, cs []io.Closer, pool chunkenc.Pool) (*Reader, error) {
-	cr := Reader{pool: pool, bs: bs, cs: cs, crc32: newCRC32()}
+	cr := Reader{pool: pool, bs: bs, cs: cs}
 	var totalSize int64
 
 	for i, b := range cr.bs {
@@ -541,6 +540,8 @@ func (s *Reader) Chunk(ref uint64) (chunkenc.Chunk, error) {
 		// Get the lower 4 bytes.
 		// These contain the segment offset where the data for this chunk starts.
 		chkStart = int((ref << 32) >> 32)
+		// chkCRC32 is a CRC32 used to verify the integrity of the chunk.
+		chkCRC32 = newCRC32()
 	)
 
 	if sgmIndex >= len(s.bs) {
@@ -569,12 +570,11 @@ func (s *Reader) Chunk(ref uint64) (chunkenc.Chunk, error) {
 		return nil, errors.Errorf("segment doesn't include enough bytes to read the chunk - required:%v, available:%v", chkEnd, sgmBytes.Len())
 	}
 
-	sum := sgmBytes.Range(chkEnd-crc32.Size, chkEnd)
-	s.crc32.Reset()
-	if _, err := s.crc32.Write(sgmBytes.Range(chkEncStart, chkDataEnd)); err != nil {
+	sum := sgmBytes.Range(chkDataEnd, chkEnd)
+	if _, err := chkCRC32.Write(sgmBytes.Range(chkEncStart, chkDataEnd)); err != nil {
 		return nil, err
 	}
-	if act := s.crc32.Sum(s.buf[:0]); !bytes.Equal(act, sum) {
+	if act := chkCRC32.Sum(s.buf[:0]); !bytes.Equal(act, sum) {
 		return nil, errors.Errorf("checksum mismatch expected:%x, actual:%x", sum, act)
 	}
 


### PR DESCRIPTION
The same crc32 object was called concurrently between chunks. As this
object is only used in that function, create a new one each time the
function is run.

See #6512

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->