### PR TITLE
cleanup: refactor web handler

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -613,7 +613,6 @@ func main() {
 
 				reloadReady.Close()
 
-				webHandler.Ready()
 				level.Info(logger).Log("msg", "Server is ready to receive web requests.")
 				<-cancel
 				return nil
@@ -691,6 +690,7 @@ func main() {
 		// Web handler.
 		g.Add(
 			func() error {
+				<-reloadReady.C
 				if err := webHandler.Run(ctxWeb); err != nil {
 					return errors.Wrapf(err, "error starting web server")
 				}

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -174,7 +174,6 @@ type API struct {
 	now                   func() time.Time
 	config                func() config.Config
 	flagsMap              map[string]string
-	ready                 func(http.HandlerFunc) http.HandlerFunc
 
 	db                        func() TSDBAdmin
 	enableAdmin               bool
@@ -200,7 +199,6 @@ func NewAPI(
 	ar alertmanagerRetriever,
 	configFunc func() config.Config,
 	flagsMap map[string]string,
-	readyFunc func(http.HandlerFunc) http.HandlerFunc,
 	db func() TSDBAdmin,
 	enableAdmin bool,
 	logger log.Logger,
@@ -221,7 +219,6 @@ func NewAPI(
 		now:                       time.Now,
 		config:                    configFunc,
 		flagsMap:                  flagsMap,
-		ready:                     readyFunc,
 		db:                        db,
 		enableAdmin:               enableAdmin,
 		rulesRetriever:            rr,
@@ -252,9 +249,9 @@ func (api *API) Register(r *route.Router) {
 				result.finalizer()
 			}
 		})
-		return api.ready(httputil.CompressionHandler{
+		return httputil.CompressionHandler{
 			Handler: hf,
-		}.ServeHTTP)
+		}.ServeHTTP
 	}
 
 	r.Options("/*path", wrap(api.options))
@@ -283,7 +280,7 @@ func (api *API) Register(r *route.Router) {
 	r.Get("/status/buildinfo", wrap(api.serveBuildInfo))
 	r.Get("/status/flags", wrap(api.serveFlags))
 	r.Get("/status/tsdb", wrap(api.serveTSDBStatus))
-	r.Post("/read", api.ready(http.HandlerFunc(api.remoteRead)))
+	r.Post("/read", http.HandlerFunc(api.remoteRead))
 
 	r.Get("/alerts", wrap(api.alerts))
 	r.Get("/rules", wrap(api.rules))

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -306,7 +306,6 @@ func TestEndpoints(t *testing.T) {
 			flagsMap:              sampleFlagMap,
 			now:                   func() time.Time { return now },
 			config:                func() config.Config { return samplePrometheusCfg },
-			ready:                 func(f http.HandlerFunc) http.HandlerFunc { return f },
 			rulesRetriever:        algr,
 		}
 
@@ -370,7 +369,6 @@ func TestEndpoints(t *testing.T) {
 			flagsMap:              sampleFlagMap,
 			now:                   func() time.Time { return now },
 			config:                func() config.Config { return samplePrometheusCfg },
-			ready:                 func(f http.HandlerFunc) http.HandlerFunc { return f },
 			rulesRetriever:        algr,
 		}
 
@@ -2045,7 +2043,6 @@ func TestAdminEndpoints(t *testing.T) {
 					}
 					return nil
 				},
-				ready:       func(f http.HandlerFunc) http.HandlerFunc { return f },
 				enableAdmin: tc.enableAdmin,
 			}
 			defer func() {
@@ -2262,7 +2259,7 @@ func TestParseDuration(t *testing.T) {
 
 func TestOptionsMethod(t *testing.T) {
 	r := route.New()
-	api := &API{ready: func(f http.HandlerFunc) http.HandlerFunc { return f }}
+	api := &API{}
 	api.Register(r)
 
 	s := httptest.NewServer(r)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -212,9 +212,6 @@ func TestReadyAndHealthy(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Equals(t, http.StatusServiceUnavailable, resp.StatusCode)
 
-	// Set to ready.
-	webHandler.Ready()
-
 	resp, err = http.Get("http://localhost:9090/-/healthy")
 
 	testutil.Ok(t, err)
@@ -347,9 +344,6 @@ func TestRoutePrefix(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Equals(t, http.StatusServiceUnavailable, resp.StatusCode)
 
-	// Set to ready.
-	webHandler.Ready()
-
 	resp, err = http.Get("http://localhost:9091" + opts.RoutePrefix + "/-/healthy")
 
 	testutil.Ok(t, err)
@@ -394,7 +388,6 @@ func TestDebugHandler(t *testing.T) {
 			RoutePrefix: tc.prefix,
 		}
 		handler := New(nil, opts)
-		handler.Ready()
 
 		w := httptest.NewRecorder()
 
@@ -428,7 +421,6 @@ func TestHTTPMetrics(t *testing.T) {
 	counter := handler.metrics.requestCounter
 	testutil.Equals(t, 1, int(prom_testutil.ToFloat64(counter.WithLabelValues("/-/ready", strconv.Itoa(http.StatusServiceUnavailable)))))
 
-	handler.Ready()
 	for range [2]int{} {
 		code = getReady()
 		testutil.Equals(t, http.StatusOK, code)


### PR DESCRIPTION
Delay web handler launch until initial configuration loading is ready, so that we can avoid ready test for API calls.

Signed-off-by: huanggze <loganhuang@yunify.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->