### PR TITLE
Function `last_over_time`

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -415,6 +415,19 @@ func funcMinOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector
 	})
 }
 
+// === last_over_time(Matrix ValueTypeMatrix) Vector ===
+func funcLastOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		last := values[0]
+		for _, v := range values {
+			if !math.IsNaN(v.V) && (v.T > last.T || math.IsNaN(last.V)) {
+				last = v
+			}
+		}
+		return last.V
+	})
+}
+
 // === sum_over_time(Matrix ValueTypeMatrix) Vector ===
 func funcSumOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 	return aggrOverTime(vals, enh, func(values []Point) float64 {
@@ -1092,6 +1105,12 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeMatrix},
 		ReturnType: ValueTypeVector,
 		Call:       funcMinOverTime,
+	},
+	"last_over_time": {
+		Name:       "last_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcLastOverTime,
 	},
 	"minute": {
 		Name:       "minute",

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -1507,6 +1507,30 @@ var testExpr = []struct {
 			},
 		},
 	}, {
+		input: `last_over_time(rate(foo{bar="baz"}[2s])[5m:5s])`,
+		expected: &Call{
+			Func: mustGetFunction("last_over_time"),
+			Args: Expressions{
+				&SubqueryExpr{
+					Expr: &Call{
+						Func: mustGetFunction("rate"),
+						Args: Expressions{
+							&MatrixSelector{
+								Name:  "foo",
+								Range: 2 * time.Second,
+								LabelMatchers: []*labels.Matcher{
+									mustLabelMatcher(labels.MatchEqual, "bar", "baz"),
+									mustLabelMatcher(labels.MatchEqual, string(model.MetricNameLabel), "foo"),
+								},
+							},
+						},
+					},
+					Range: 5 * time.Minute,
+					Step:  5 * time.Second,
+				},
+			},
+		},
+	}, {
 		input: `min_over_time(rate(foo{bar="baz"}[2s])[5m:])[4m:3s]`,
 		expected: &SubqueryExpr{
 			Expr: &Call{

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -546,3 +546,10 @@ eval instant at 1m max_over_time(data[1m])
 	{type="some_nan2"} 2
 	{type="some_nan3"} 1
 	{type="only_nan"} NaN
+
+eval instant at 1m last_over_time(data[1m])
+	{type="numbers"} 3
+	{type="some_nan"} 0
+	{type="some_nan2"} 1
+	{type="some_nan3"} 1
+	{type="only_nan"} NaN


### PR DESCRIPTION
We are managing IoT with Prometheus in a federated way and it works brilliant. However there's still some problem with Staleness. Our retranslator nodes have unstable connectivity and it's expected to loose connectivity to those. When it happens, the latest value immediately gets marked with a tombstone and it's a great solution in general. This function however is intended for use in more complicated cases where unreliability is expected to a certain degree. E.g. by running `last_over_time(metric[1h])` you are allowing a monitored node (federated Prometheus in our case) to go offline for up to 1 hour. Since it's a very explicit way to override staleness we believe it's a good addition to the built-in vector aggregation family.

Please note that we have read tons of discussions in this regard and we are aware of pushgateway and general staleness concept (nodes should have reliable connection and such) however all those ways require sidecars or intermediate retranslators for 0 reason. For instance, we are working with fish farms and they can't have good connectivity. Also because of physical limitation, the IoT gateway node has to be in the field as well. Currently we implemented a workaround by tunneling data to pushgateway via AMQP but that's really too much :).

P.S. Prometheus is amazing guys!