### PR TITLE
cleanup: unexport internal method

### DIFF
--- a/discovery/kubernetes/endpoints.go
+++ b/discovery/kubernetes/endpoints.go
@@ -124,7 +124,7 @@ func (e *Endpoints) enqueue(obj interface{}) {
 }
 
 // Run implements the Discoverer interface.
-func (e *Endpoints) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+func (e *Endpoints) run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	defer e.queue.ShutDown()
 
 	if !cache.WaitForCacheSync(ctx.Done(), e.endpointsInf.HasSynced, e.serviceInf.HasSynced, e.podInf.HasSynced) {

--- a/discovery/kubernetes/ingress.go
+++ b/discovery/kubernetes/ingress.go
@@ -66,7 +66,7 @@ func (i *Ingress) enqueue(obj interface{}) {
 }
 
 // Run implements the Discoverer interface.
-func (i *Ingress) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+func (i *Ingress) run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	defer i.queue.ShutDown()
 
 	if !cache.WaitForCacheSync(ctx.Done(), i.informer.HasSynced) {

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -149,7 +149,7 @@ func init() {
 
 // This is only for internal use.
 type discoverer interface {
-	Run(ctx context.Context, up chan<- []*targetgroup.Group)
+	run(ctx context.Context, up chan<- []*targetgroup.Group)
 }
 
 // Discovery implements the discoverer interface for discovering
@@ -340,7 +340,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 		wg.Add(1)
 		go func(d discoverer) {
 			defer wg.Done()
-			d.Run(ctx, ch)
+			d.run(ctx, ch)
 		}(dd)
 	}
 

--- a/discovery/kubernetes/node.go
+++ b/discovery/kubernetes/node.go
@@ -75,7 +75,7 @@ func (n *Node) enqueue(obj interface{}) {
 }
 
 // Run implements the Discoverer interface.
-func (n *Node) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+func (n *Node) run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	defer n.queue.ShutDown()
 
 	if !cache.WaitForCacheSync(ctx.Done(), n.informer.HasSynced) {

--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -78,7 +78,7 @@ func (p *Pod) enqueue(obj interface{}) {
 }
 
 // Run implements the Discoverer interface.
-func (p *Pod) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+func (p *Pod) run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	defer p.queue.ShutDown()
 
 	if !cache.WaitForCacheSync(ctx.Done(), p.informer.HasSynced) {

--- a/discovery/kubernetes/service.go
+++ b/discovery/kubernetes/service.go
@@ -71,7 +71,7 @@ func (s *Service) enqueue(obj interface{}) {
 }
 
 // Run implements the Discoverer interface.
-func (s *Service) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+func (s *Service) run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	defer s.queue.ShutDown()
 
 	if !cache.WaitForCacheSync(ctx.Done(), s.informer.HasSynced) {


### PR DESCRIPTION
The method `run` defined in interface `discoverer` is for internal use.

Signed-off-by: huanggze <loganhuang@yunify.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->