### PR TITLE
Optimise labels.Compare

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/cespare/xxhash"
 )
@@ -285,11 +284,19 @@ func Compare(a, b Labels) int {
 	}
 
 	for i := 0; i < l; i++ {
-		if d := strings.Compare(a[i].Name, b[i].Name); d != 0 {
-			return d
+		if a[i].Name != b[i].Name {
+			if a[i].Name < b[i].Name {
+				return -1
+			} else {
+				return 1
+			}
 		}
-		if d := strings.Compare(a[i].Value, b[i].Value); d != 0 {
-			return d
+		if a[i].Value != b[i].Value {
+			if a[i].Value < b[i].Value {
+				return -1
+			} else {
+				return 1
+			}
 		}
 	}
 	// If all labels so far were in common, the set with fewer labels comes first.


### PR DESCRIPTION
strings.Compare isn't meant to be used, and this way we save one
comparison which is thus very slightly cheaper.

benchmark                                     old ns/op     new ns/op delta
BenchmarkPostingsForMatchers/Head/n="1"-4     236305440     233515705 -1.18%

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>