### PR TITLE
Add more information in error log while parsing metrics

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -927,7 +927,7 @@ mainLoop:
 		// we still call sl.append to trigger stale markers.
 		total, added, seriesAdded, appErr := sl.append(b, contentType, start)
 		if appErr != nil {
-			level.Warn(sl.l).Log("msg", "append failed", "err", appErr)
+			level.Warn(sl.l).Log("msg", "append failed", "err", appErr, "total", total, "added", added)
 			// The append failed, probably due to a parse error or sample limit.
 			// Call sl.append again with an empty scrape to trigger stale markers.
 			if _, _, _, err := sl.append([]byte{}, "", start); err != nil {


### PR DESCRIPTION
Add the total and added metrics to indicate where to start the
investigation (added metrics + 1 will be the culprit)

Instead of logging:
`level=warn ts=2020-01-03T17:45:37.205Z caller=scrape.go:930 component="scrape manager" scrape_pool=prometheus target=http://localhost:8080/metrics msg="append failed" err="expected equal, got \"INVALID\""`

You'll get
`level=warn ts=2020-01-03T17:45:37.205Z caller=scrape.go:930 component="scrape manager" scrape_pool=prometheus target=http://localhost:8080/metrics msg="append failed" err="expected equal, got \"INVALID\"" total=8 added=8`

This would fix #6549