### PR TITLE
Add prometheus version into block meta

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/version"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -156,6 +157,9 @@ type BlockMeta struct {
 
 	// Version of the index format.
 	Version int `json:"version"`
+
+	// Version of Prometheus at the time the block was written.
+	PrometheusVersion string `json:"prometheus_version"`
 }
 
 // BlockStats contains stats about contents of a block.
@@ -214,6 +218,7 @@ func readMetaFile(dir string) (*BlockMeta, int64, error) {
 
 func writeMetaFile(logger log.Logger, dir string, meta *BlockMeta) (int64, error) {
 	meta.Version = metaVersion1
+	meta.PrometheusVersion = version.Version
 
 	// Make any changes to the file appear atomic.
 	path := filepath.Join(dir, metaFilename)


### PR DESCRIPTION
Should we introduce regressions in the blocks at some point in the
future, this new meta option will easily point us the blocks that need
repair/adaptation.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->