### PR TITLE
WIP: MVP exemplars storage via tsdb memseries

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -34,6 +34,7 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
@@ -114,6 +115,8 @@ type Appender interface {
 
 	// Rollback rolls back all modifications made in the appender so far.
 	Rollback() error
+
+	AddExemplar(l labels.Labels, t int64, e exemplar.Exemplar) error
 }
 
 // DB handles reads and writes of time series falling into

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1433,7 +1433,7 @@ func TestChunkAtBlockBoundary(t *testing.T) {
 		chunkCount := 0
 
 		for p.Next() {
-			err = r.Series(p.At(), &lset, &chks)
+			err = r.Series(p.At(), &lset, &chks, nil)
 			testutil.Ok(t, err)
 			for _, c := range chks {
 				testutil.Assert(t, meta.MinTime <= c.MinTime && c.MaxTime <= meta.MaxTime,

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -30,6 +30,7 @@ import (
 	"unsafe"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/encoding"
@@ -1441,7 +1442,7 @@ func (emptyStringTuples) At(i int) ([]string, error) { return nil, nil }
 func (emptyStringTuples) Len() int                   { return 0 }
 
 // Series reads the series with the given ID and writes its labels and chunks into lbls and chks.
-func (r *Reader) Series(id uint64, lbls *labels.Labels, chks *[]chunks.Meta) error {
+func (r *Reader) Series(id uint64, lbls *labels.Labels, chks *[]chunks.Meta, exemplars *[]exemplar.Exemplar) error {
 	offset := id
 	// In version 2 series IDs are no longer exact references but series are 16-byte padded
 	// and the ID is the multiple of 16 of the actual position.

--- a/tsdb/repair_test.go
+++ b/tsdb/repair_test.go
@@ -82,7 +82,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 		t.Logf("next ID %d", p.At())
 
 		var lset labels.Labels
-		testutil.NotOk(t, r.Series(p.At(), &lset, nil))
+		testutil.NotOk(t, r.Series(p.At(), &lset, nil, nil))
 	}
 	testutil.Ok(t, p.Err())
 	testutil.Ok(t, r.Close())
@@ -111,7 +111,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 
 		var lset labels.Labels
 		var chks []chunks.Meta
-		testutil.Ok(t, r.Series(p.At(), &lset, &chks))
+		testutil.Ok(t, r.Series(p.At(), &lset, &chks, nil))
 		res = append(res, lset)
 	}
 


### PR DESCRIPTION
Mostly an experiment, but would be interested in feedback of others who have worked on TSDB code. 

This PR unfortunately touches a lot of code/interfaces we probably don't want to change, but achieves the goals of not having to come up with an additional storage structure or new index for exemplar data by reusing `memSeries`. Goutham also has an idea for getting the same benefits without changing existing TSDB interfaces that I'm also going to try out.

cc @gouthamve 

Signed-off-by: Callum Styan <callumstyan@gmail.com>
