### PR TITLE
Cleanup: remove function that does not do anything

### DIFF
--- a/promql/lex.go
+++ b/promql/lex.go
@@ -343,13 +343,6 @@ func (l *Lexer) run() {
 	}
 }
 
-// Release resources used by lexer.
-func (l *Lexer) close() {
-	for range l.Items {
-		// Consume.
-	}
-}
-
 // lineComment is the character that starts a line comment.
 const lineComment = "#"
 

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -206,7 +206,6 @@ func (p *parser) recover(errp *error) {
 	} else if e != nil {
 		*errp = e.(error)
 	}
-	p.lex.close()
 }
 
 // Lex is expected by the yyLexer interface of the yacc generated parser.


### PR DESCRIPTION
This removes a function that became a no-op during the parser rewrite.

Signed-off-by: Tobias Guggenmos <tguggenm@redhat.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->