### PR TITLE
Query Log: add origin of the rules

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -287,6 +287,12 @@ func (g *Group) run(ctx context.Context) {
 		return
 	}
 
+	ctx = promql.NewOriginContext(ctx, map[string]string{
+		"groupFile":          g.File(),
+		"groupName":          g.Name(),
+		"evaluationInterval": g.Interval().String(),
+	})
+
 	iter := func() {
 		g.metrics.iterationsScheduled.Inc()
 
@@ -612,7 +618,6 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 			g.staleSeries = nil
 		}
 	}
-
 }
 
 // RestoreForState restores the 'for' state of the alerts

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -288,9 +288,8 @@ func (g *Group) run(ctx context.Context) {
 	}
 
 	ctx = promql.NewOriginContext(ctx, map[string]string{
-		"groupFile":          g.File(),
-		"groupName":          g.Name(),
-		"evaluationInterval": g.Interval().String(),
+		"groupFile": g.File(),
+		"groupName": g.Name(),
 	})
 
 	iter := func() {


### PR DESCRIPTION
We don't set rule name and rule kind because the added value would be
quite low, given we have now the file, the group and the query.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->