### PR TITLE
Query Logging styling

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -423,14 +423,16 @@ func main() {
 		webHandler.ApplyConfig,
 		func(cfg *config.Config) error {
 			if cfg.GlobalConfig.QueryLogFile == "" {
-				return queryEngine.SetQueryLogger(nil)
+				queryEngine.SetQueryLogger(nil)
+				return nil
 			}
 
 			l, err := logging.NewJSONFileLogger(cfg.GlobalConfig.QueryLogFile)
 			if err != nil {
 				return err
 			}
-			return queryEngine.SetQueryLogger(l)
+			queryEngine.SetQueryLogger(l)
+			return nil
 		},
 		// The Scrape and notifier managers need to reload before the Discovery manager as
 		// they need to read the most updated config when receiving the new targets list.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -333,7 +333,7 @@ func NewEngine(opts EngineOpts) *Engine {
 }
 
 // SetQueryLogger sets the query logger.
-func (ng *Engine) SetQueryLogger(l QueryLogger) error {
+func (ng *Engine) SetQueryLogger(l QueryLogger) {
 	ng.queryLoggerLock.Lock()
 	defer ng.queryLoggerLock.Unlock()
 
@@ -353,8 +353,6 @@ func (ng *Engine) SetQueryLogger(l QueryLogger) error {
 	} else {
 		ng.metrics.queryLogEnabled.Set(0)
 	}
-
-	return nil
 }
 
 // NewInstantQuery returns an evaluation query for the given expression at the given time.

--- a/promql/query_logger.go
+++ b/promql/query_logger.go
@@ -41,8 +41,8 @@ const (
 	entrySize int = 1000
 )
 
-func parseBrokenJson(brokenJson []byte) (bool, string) {
-	queries := strings.ReplaceAll(string(brokenJson), "\x00", "")
+func parseBrokenJSON(brokenJSON []byte) (bool, string) {
+	queries := strings.ReplaceAll(string(brokenJSON), "\x00", "")
 	if len(queries) > 0 {
 		queries = queries[:len(queries)-1] + "]"
 	}
@@ -63,14 +63,14 @@ func logUnfinishedQueries(filename string, filesize int, logger log.Logger) {
 			return
 		}
 
-		brokenJson := make([]byte, filesize)
-		_, err = fd.Read(brokenJson)
+		brokenJSON := make([]byte, filesize)
+		_, err = fd.Read(brokenJSON)
 		if err != nil {
 			level.Error(logger).Log("msg", "Failed to read query log file", "err", err)
 			return
 		}
 
-		queriesExist, queries := parseBrokenJson(brokenJson)
+		queriesExist, queries := parseBrokenJSON(brokenJSON)
 		if !queriesExist {
 			return
 		}
@@ -141,7 +141,7 @@ func trimStringByBytes(str string, size int) string {
 	return string(bytesStr[:trimIndex])
 }
 
-func _newJsonEntry(query string, timestamp int64, logger log.Logger) []byte {
+func _newJSONEntry(query string, timestamp int64, logger log.Logger) []byte {
 	entry := Entry{query, timestamp}
 	jsonEntry, err := json.Marshal(entry)
 
@@ -153,12 +153,12 @@ func _newJsonEntry(query string, timestamp int64, logger log.Logger) []byte {
 	return jsonEntry
 }
 
-func newJsonEntry(query string, logger log.Logger) []byte {
+func newJSONEntry(query string, logger log.Logger) []byte {
 	timestamp := time.Now().Unix()
-	minEntryJson := _newJsonEntry("", timestamp, logger)
+	minEntryJSON := _newJSONEntry("", timestamp, logger)
 
-	query = trimStringByBytes(query, entrySize-(len(minEntryJson)+1))
-	jsonEntry := _newJsonEntry(query, timestamp, logger)
+	query = trimStringByBytes(query, entrySize-(len(minEntryJSON)+1))
+	jsonEntry := _newJSONEntry(query, timestamp, logger)
 
 	return jsonEntry
 }
@@ -176,7 +176,7 @@ func (tracker ActiveQueryTracker) Delete(insertIndex int) {
 
 func (tracker ActiveQueryTracker) Insert(query string) int {
 	i, fileBytes := <-tracker.getNextIndex, tracker.mmapedFile
-	entry := newJsonEntry(query, tracker.logger)
+	entry := newJSONEntry(query, tracker.logger)
 	start, end := i, i+entrySize
 
 	copy(fileBytes[start:], entry)

--- a/promql/query_logger_test.go
+++ b/promql/query_logger_test.go
@@ -133,7 +133,7 @@ func TestMMapFile(t *testing.T) {
 	}
 }
 
-func TestParseBrokenJson(t *testing.T) {
+func TestParseBrokenJSON(t *testing.T) {
 	for _, tc := range []struct {
 		b []byte
 
@@ -161,7 +161,7 @@ func TestParseBrokenJson(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			ok, out := parseBrokenJson(tc.b)
+			ok, out := parseBrokenJSON(tc.b)
 			if tc.ok != ok {
 				t.Fatalf("expected %t, got %t", tc.ok, ok)
 				return


### PR DESCRIPTION
- Fix Json vs JSON in activequerylogger
- Fix SetQueryLogger always returns nil

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->