### PR TITLE
documentation/prometheus-mixin: add dependency on grafonnet

### DIFF
--- a/documentation/prometheus-mixin/jsonnetfile.json
+++ b/documentation/prometheus-mixin/jsonnetfile.json
@@ -1,14 +1,24 @@
 {
-    "dependencies": [
-        {
-            "name": "grafana-builder",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/grafana/jsonnet-libs",
-                    "subdir": "grafana-builder"
-                }
-            },
-            "version": "master"
+  "dependencies": [
+    {
+      "name": "grafana-builder",
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs",
+          "subdir": "grafana-builder"
         }
-    ]
+      },
+      "version": "master"
+    },
+    {
+      "name": "grafonnet",
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    }
+  ]
 }


### PR DESCRIPTION
Running commands mentioned in mixin doc readme:
```
jb install
make dashboards_out
```
caused following error:
```
jsonnet -J vendor -m dashboards_out dashboards.jsonnet
RUNTIME ERROR: couldn't open import "grafonnet/grafana.libsonnet": no match locally or in the Jsonnet library paths.
        dashboards.libsonnet:2:17-53    thunk <grafana>
        dashboards.libsonnet:3:19-26    thunk <dashboard>
        dashboards.libsonnet:290:7-16   object <dashboards>
        dashboards.jsonnet:4:11-27      object <anonymous>
        During manifestation
make: *** [Makefile:14: dashboards_out] Error 1
```
due to lack of `grafonnet/grafana.libsonnet` dependency being installed by `jb`. This PR solves this issue. Formatting is automatically changed by latest `jb` version.

/cc @beorn7 