### PR TITLE
Add armv6 docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@ data/
 .tarballs/
 
 !.build/linux-amd64/
+!.build/linux-armv6/
 !.build/linux-armv7/
 !.build/linux-arm64/
 !.build/linux-s390x/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64 armv7 arm64 s390x
+DOCKER_ARCHS ?= amd64 armv6 armv7 arm64 s390x
 
 REACT_APP_PATH = web/ui/react-app
 REACT_APP_SOURCE_FILES = $(wildcard $(REACT_APP_PATH)/public/* $(REACT_APP_PATH)/src/* $(REACT_APP_PATH)/tsconfig.json)


### PR DESCRIPTION
This follows the approach used to generate armv7 images.

It was all so nicely factored already that I just had to update two
parts of the code.

Addresses #6604