### PR TITLE
support modify alert-rule by http post/put/delete

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -455,6 +455,9 @@ func main() {
 				cfg.GlobalConfig.ExternalLabels,
 			)
 		},
+		func(cfg *config.Config) error {
+			return ruleManager.StartRule(cfg.MysqlRuleConfig,cfg.GlobalConfig.ExternalLabels)
+		},
 	}
 
 	prometheus.MustRegister(configSuccess)
@@ -820,10 +823,13 @@ func sendAlerts(s sender, externalURL string) rules.NotifyFunc {
 		var res []*notifier.Alert
 
 		for _, alert := range alerts {
+			ss := alert.State.String()
 			a := &notifier.Alert{
 				StartsAt:     alert.FiredAt,
 				Labels:       alert.Labels,
 				Annotations:  alert.Annotations,
+				Value:        alert.Value,
+				Status:        ss,
 				GeneratorURL: externalURL + strutil.TableLinkForExpression(expr),
 			}
 			if !alert.ResolvedAt.IsZero() {

--- a/config/config.go
+++ b/config/config.go
@@ -140,6 +140,8 @@ type Config struct {
 
 	// original is the input from which the config was parsed.
 	original string
+
+	MysqlRuleConfig MysqlRuleConfig `yaml:"rule_mysql_config"`
 }
 
 // resolveFilepaths joins all relative paths in a configuration
@@ -301,6 +303,14 @@ type GlobalConfig struct {
 	EvaluationInterval model.Duration `yaml:"evaluation_interval,omitempty"`
 	// The labels to add to any timeseries that this Prometheus instance scrapes.
 	ExternalLabels labels.Labels `yaml:"external_labels,omitempty"`
+}
+
+type MysqlRuleConfig struct {
+	Host string `yaml:"host"`
+	Port string `yaml:"port"`
+	Db   string `yaml:"db"`
+	User string `yaml:"user"`
+	Passwd string `yaml:"password"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/go-kit/kit v0.9.0
 	github.com/go-logfmt/logfmt v0.4.0
 	github.com/go-openapi/strfmt v0.19.2
+	github.com/go-sql-driver/mysql v1.4.1
+	github.com/go-xorm/xorm v0.7.9
 	github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48
 	github.com/golang/snappy v0.0.1
 	github.com/google/pprof v0.0.0-20190723021845-34ac40c74b70

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -67,6 +67,9 @@ type Alert struct {
 	// Extra key/value information which does not define alert identity.
 	Annotations labels.Labels `json:"annotations"`
 
+	Value float64
+
+	Status string
 	// The known time range for this alert. Both ends are optional.
 	StartsAt     time.Time `json:"startsAt,omitempty"`
 	EndsAt       time.Time `json:"endsAt,omitempty"`

--- a/rules/model.go
+++ b/rules/model.go
@@ -1,0 +1,94 @@
+package rules
+
+import (
+	"fmt"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-xorm/xorm"
+	"github.com/prometheus/prometheus/config"
+)
+
+var (
+	Engine *xorm.Engine
+)
+
+func NewEngine(c config.MysqlRuleConfig) {
+	var err error
+	str := fmt.Sprintf("%v:%v@(%v:%v)/%v?charset=utf8", c.User, c.Passwd, c.Host, c.Port, c.Db)
+
+	Engine, err = xorm.NewEngine("mysql", str)
+
+	if err != nil {
+		return
+	}
+
+	go func() {
+		for {
+			select {
+			case <-time.After(time.Minute * time.Duration(5)):
+				Engine.Ping()
+			}
+		}
+	}()
+}
+
+type AlertRule struct {
+	Id         int `xorm:"pk autoincr int(11)"`
+	Name       string
+	Expr       string
+	Severity   string
+	Descd      string
+	Inter      string
+	CreateTime time.Time `DateTime xorm:"created"`
+	Status     bool
+	ForInter   string
+}
+
+type RuleHistory struct {
+	Id         int `xorm:"pk autoincr int(11)"`
+	Name       string
+	Expr       string
+	Severity   string
+	Descd      string
+	Inter      string
+	CreateTime time.Time `DateTime xorm:"created"`
+	Optype     string
+	ForInter   string
+}
+
+func NewHistory(a *AlertRule, opType string) {
+	r := &RuleHistory{}
+	r.Name = a.Name
+	r.Expr = a.Expr
+	r.Severity = a.Severity
+	r.Descd = a.Descd
+	r.Inter = a.Inter
+	r.CreateTime = time.Now()
+	r.Optype = opType
+	r.ForInter = a.ForInter
+	Engine.Insert(r)
+}
+
+var sql = `CREATE TABLE alert_rule  ( 
+    id   INT PRIMARY KEY AUTO_INCREMENT, 
+    name VARCHAR (600) NOT NULL,
+    expr text NOT NULL,
+    severity VARCHAR (500) NOT NULL,
+    descd TEXT NOT NULL,
+    inter VARCHAR (500) NOT NULL,
+    create_time datetime DEFAULT NULL,
+    status tinyint(1) DEFAULT 1
+);`
+
+var sqlHistory = `CREATE TABLE rule_history  ( 
+    id   INT PRIMARY KEY AUTO_INCREMENT, 
+    name VARCHAR (600) NOT NULL,
+    expr text NOT NULL,
+    severity VARCHAR (500) NOT NULL,
+    descd TEXT NOT NULL,
+    inter VARCHAR (500) NOT NULL,
+    create_time datetime DEFAULT NULL,
+    status tinyint(1) DEFAULT 1,
+    optype VARCHAR (600) NOT NULL
+);`

--- a/rules/mysql_alert.go
+++ b/rules/mysql_alert.go
@@ -1,0 +1,384 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.f
+
+package rules
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql"
+)
+
+var (
+	customManager   *MysqlALert
+	WorkerNum       = 10
+	deafultInterval = "1m"
+)
+
+type MysqlALert struct {
+	opts       *ManagerOptions
+	mysqlGroup []*MysqlGroup
+	logger     log.Logger
+}
+
+type MysqlGroup struct {
+	index                int
+	rules                map[int]Rule
+	workerChan           chan *AlertRule
+	opts                 *ManagerOptions
+	interval             time.Duration
+	seriesInPreviousEval []map[string]labels.Labels
+	logger               log.Logger
+	externalLabels       labels.Labels
+}
+
+func NewMysqlALert(o *ManagerOptions, cfg config.MysqlRuleConfig, m *MysqlALert, externalLabels labels.Labels) *MysqlALert {
+
+	if m == nil {
+		m = &MysqlALert{
+			opts:       o,
+			logger:     o.Logger,
+			mysqlGroup: []*MysqlGroup{},
+		}
+		NewEngine(cfg)
+
+		var k int
+		for k = 0; k < WorkerNum; k++ {
+			cg := newMysqlGroup(k, m.opts, deafultInterval, externalLabels)
+			go cg.Run()
+			m.mysqlGroup = append(m.mysqlGroup, cg)
+		}
+		customManager = m
+		m.LoadRule()
+	}
+	return m
+}
+
+func newMysqlGroup(index int, opts *ManagerOptions, timeStr string, externalLabels labels.Labels) *MysqlGroup {
+	n := &MysqlGroup{}
+	n.index = index
+	n.rules = map[int]Rule{}
+	n.workerChan = make(chan *AlertRule, 1000)
+	n.opts = opts
+	n.interval, _ = time.ParseDuration(timeStr)
+	n.externalLabels = externalLabels
+	n.logger = log.With(opts.Logger, "group", fmt.Sprintf("worker-%d", n.index))
+	return n
+}
+
+func (g *MysqlGroup) hash() uint64 {
+	l := labels.New(
+		labels.Label{"name", fmt.Sprintf("worker-%d", g.index)},
+	)
+	return l.Hash()
+}
+
+func (m *MysqlGroup) evalTimestamp() time.Time {
+	var (
+		offset = int64(m.hash() % uint64(m.interval))
+		now    = time.Now().UnixNano()
+		adjNow = now - offset
+		base   = adjNow - (adjNow % int64(m.interval))
+	)
+
+	return time.Unix(0, base+offset)
+}
+
+func (m *MysqlGroup) RunRule() {
+
+	evalTimestamp := m.evalTimestamp().Add(m.interval)
+
+	app, err := m.opts.Appendable.Appender()
+	if err != nil {
+		fmt.Printf("get append fail:%v\n", err)
+		return
+	}
+
+	for k, _ := range m.rules {
+		rule := m.rules[k]
+		vector, err := rule.EvalC(m.opts.Context, evalTimestamp, m.opts.QueryFunc, m.opts.ExternalURL)
+		if err != nil {
+			fmt.Printf("rule.Eval error:%v\n", err)
+			continue
+		}
+
+		if ar, ok := rule.(*AlertingRule); ok {
+			ar.sendAlertsC(m.opts.Context, evalTimestamp, m.opts.ResendDelay, m.interval, m.opts.NotifyFunc)
+		}
+
+		for _, s := range vector {
+			app.Add(s.Metric, s.T, s.V)
+		}
+
+	}
+}
+
+func (m *MysqlGroup) AddRule(r *AlertRule) {
+	m.workerChan <- r
+}
+
+func (m *MysqlGroup) fetchRule(r *AlertRule) *AlertingRule {
+	expr, _ := promql.ParseExpr(r.Expr)
+
+	tt, err := time.ParseDuration(r.Inter)
+	if err != nil {
+		tt, _ = time.ParseDuration("60m")
+	}
+
+	forDuration, err := time.ParseDuration(r.ForInter)
+	if err != nil {
+		tt, _ = time.ParseDuration("1m")
+	}
+
+	rule := NewAlertingRule(
+		r.Name,
+		expr,
+		forDuration,
+		tt,
+		labels.FromMap(map[string]string{"severity": r.Severity}),
+		labels.FromMap(map[string]string{"description": r.Descd}),
+		m.externalLabels,
+		true,
+		log.With(m.logger, "alert", r.Name),
+	)
+	return rule
+}
+
+func (m *MysqlGroup) Run() {
+
+	for {
+		select {
+		case <-time.After(time.Minute * time.Duration(1)):
+			m.RunRule()
+		case ruleModel := <-m.workerChan:
+			ruleObject := m.fetchRule(ruleModel)
+			_, ok := m.rules[ruleModel.Id]
+
+			if ruleModel.Expr == "" {
+				delete(m.rules, ruleModel.Id)
+			} else {
+				if ok {
+					ruleObject.SetActive(m.rules[ruleModel.Id].GetActive(), ruleModel.Name)
+				}
+				m.rules[ruleModel.Id] = ruleObject
+			}
+
+		}
+	}
+}
+
+func (m *MysqlALert) LoadRule() {
+	l := []AlertRule{}
+	Engine.Find(&l)
+	for k, _ := range l {
+		m.AddRule(&l[k])
+	}
+}
+
+func (m *MysqlALert) AddRule(r *AlertRule) {
+
+	h := fnv.New32a()
+	ss := strconv.Itoa(r.Id)
+	h.Write([]byte(ss))
+	indexNum := int(h.Sum32()) % WorkerNum
+	m.mysqlGroup[indexNum].AddRule(r)
+}
+
+type RuleJson struct {
+	Id          int    `json:"id"`
+	Name        string `json:"name"`
+	Expr        string `json:"expr"`
+	Severity    string `json:"severity"`
+	Description string `json:"description"`
+	Interval    string `json:"sendInterval"`
+	Index       int    `json:"index"`
+	PageSize    int    `json:"pagesize"`
+	For         string `json:"for"`
+}
+
+func ListAlert(rule *RuleJson) map[string]interface{} {
+	l := []AlertRule{}
+
+	dd := Engine.OrderBy("-id")
+	cc := Engine.OrderBy("-id")
+
+	if rule.Name != "" {
+		dd = dd.Where("name like ?", "%"+rule.Name+"%")
+		cc = cc.Where("name like ?", "%"+rule.Name+"%")
+	}
+
+	if rule.Expr != "" {
+		dd = dd.Where("expr like ?", "%"+rule.Expr+"%")
+		cc = cc.Where("expr like ?", "%"+rule.Expr+"%")
+	}
+
+	if rule.Description != "" {
+		dd = dd.Where("descd like ?", "%"+rule.Description+"%")
+		cc = cc.Where("descd like ?", "%"+rule.Description+"%")
+	}
+
+	if rule.PageSize != 0 {
+		dd.Limit(rule.PageSize, (rule.Index-1)*rule.PageSize).Find(&l)
+	} else {
+		dd.Find(&l)
+	}
+
+	noListC := AlertRule{}
+	counts, _ := cc.Count(&noListC)
+
+	tmp := map[string]interface{}{}
+
+	tmp["content"] = l
+	tmp["totalLen"] = counts
+	tmp["index"] = rule.Index
+
+	return tmp
+}
+
+func DeleteAlert(rule *RuleJson) error {
+
+	a := &AlertRule{}
+	has, err := Engine.Where("id=?", rule.Id).Get(a)
+	if has == false || err != nil {
+		return errors.New("rule not exist")
+	}
+
+	a.Expr = ""
+	_, err = Engine.Delete(&AlertRule{Id: a.Id})
+	if err != nil {
+		return err
+	}
+
+	NewHistory(a, "delete")
+
+	customManager.AddRule(a)
+	return nil
+}
+
+func ModifyAlert(rule *RuleJson) error {
+
+	name := TrimeName(rule.Name)
+
+	a := &AlertRule{}
+	has, err := Engine.Where("id=?", rule.Id).Get(a)
+	if has == false || err != nil {
+		return errors.New("alert not exist")
+	}
+	a.Name = name
+	Engine.Id(a.Id).Cols("name").Update(&AlertRule{Name: a.Name})
+
+	_, err = promql.ParseExpr(rule.Expr)
+	if err != nil {
+		return err
+	}
+
+	a.Expr = rule.Expr
+	Engine.Id(a.Id).Cols("expr").Update(&AlertRule{Expr: rule.Expr})
+
+	serv := rule.Severity
+	a.Severity = serv
+	Engine.Id(a.Id).Cols("severity").Update(&AlertRule{Severity: rule.Severity})
+
+	a.Descd = rule.Description
+	Engine.Id(a.Id).Cols("descd").Update(&AlertRule{Descd: rule.Description})
+
+	a.Inter = rule.Interval
+	Engine.Id(a.Id).Cols("inter").Update(&AlertRule{Inter: a.Inter})
+
+	a.ForInter = rule.For
+	Engine.Id(a.Id).Cols("for_inter").Update(&AlertRule{ForInter: a.ForInter})
+
+	NewHistory(a, "modify")
+
+	customManager.AddRule(a)
+	return nil
+}
+
+func AddRule(rule *RuleJson) error {
+
+	a := &AlertRule{}
+
+	name := TrimeName(rule.Name)
+	if name == "" {
+		return errors.New("name is null")
+	}
+	a.Name = name
+
+	_, err := promql.ParseExpr(rule.Expr)
+	if err != nil {
+		return err
+	}
+
+	a.Expr = rule.Expr
+
+	serv := rule.Severity
+	a.Severity = serv
+	a.Descd = rule.Description
+
+	a.Inter = rule.Interval
+	a.CreateTime = time.Now()
+	a.Status = true
+	a.ForInter = rule.For
+
+	b := &AlertRule{}
+	has, err := Engine.Where("name=? and expr=? and status=1", a.Name, a.Expr).Get(b)
+	if err != nil {
+		fmt.Printf("name and  expr duplicate:%v\n", err)
+		return err
+	}
+
+	if has == true {
+		return errors.New("name + expr exist")
+	}
+
+	_, err = Engine.Insert(a)
+	if err != nil {
+		return err
+	}
+
+	NewHistory(a, "add")
+
+	has, err = Engine.Where("name=? and expr=? and status=1", a.Name, a.Expr).Get(b)
+	if has == false || err != nil {
+		fmt.Printf("add new but fetch fail:%v\n", err)
+		return nil
+	}
+
+	customManager.AddRule(b)
+	return nil
+}
+
+var (
+	SpaceTrim, _ = regexp.Compile(`\s`)
+)
+
+func TrimeName(name string) string {
+	c := SpaceTrim.ReplaceAllString(name, "")
+	ret := []byte{}
+	for k, _ := range c {
+		a1, _ := regexp.Match(`[\d\w-\*]`, []byte{c[k]})
+		if a1 == true {
+			ret = append(ret, c[k])
+		}
+	}
+	retS := string(ret)
+	return retS
+}

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -71,6 +71,18 @@ func (rule *RecordingRule) Labels() labels.Labels {
 	return rule.labels
 }
 
+func (r *RecordingRule) GetActive() map[uint64]*Alert {
+	tmp := map[uint64]*Alert{}
+	return tmp
+}
+
+func (r *RecordingRule) SetActive(tmp map[uint64]*Alert,name string)  {
+}
+
+func (rule *RecordingRule) EvalC(ctx context.Context, ts time.Time, query QueryFunc, _ *url.URL) (promql.Vector, error) {
+	return nil, nil
+}
+
 // Eval evaluates the rule and then overrides the metric names and labels accordingly.
 func (rule *RecordingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, _ *url.URL) (promql.Vector, error) {
 	vector, err := query(ctx, rule.vector.String(), ts)


### PR DESCRIPTION
privode http post/put/delete method to enable alert rule instead of config map
storage config in mysql

post / put / delete  http://127.0.0.1:9090/api/v1/alertRule
{
	"Id": 0,     //mysql alert_rule id,modify or delete rule through id
	"name": "example",
	"expr": "sum (absent (example{job=\"example\"})) by (job_name)==1",
	"severity": "critical",
	"for": "1m",
	"sendInterval": "2m",
	"description": "example no data alert"
}

"Id": the primary id of the alert-rule which storage in mysql, can modify or delete a rule through it
"for": an alert will stay with pending-state util a "for"-time expire and change to firing
"sendInterval": an alert state duration, will not send util the time expire

when modify a rule alert, the origin alert state will be hold


fetch all rule:  http://127.0.0.1:9090/api/v1/ruleList POST, will look up all the rules match the query below
{
	"Id": 0,     //mysql alert_rule id,modify or delete rule through id
	"name": "example",
	"expr": "sum (absent (example{job=\"example\"})) by (job_name)==1",
	"severity": "critical",
	"for": "1m",
	"sendInterval": "2m",
	"description": "example no data alert"
}


enable the mysql config in prometheus.yml
rule_mysql_config:
  host: ""
  port: ""
  db: ""
  user: ""
  password: ""