### PR TITLE
feat promtool: added start_time_offset to rule tests

### DIFF
--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -79,7 +79,7 @@ func ruleUnitTest(filename string) []error {
 	}
 
 	// Bounds for evaluating the rules.
-	mint := time.Unix(0, 0)
+	mint := time.Unix(0, 0).Add(unitTestInp.StartTimeOffset)
 	maxd := unitTestInp.maxEvalTime()
 	maxt := mint.Add(maxd)
 	// Rounding off to nearest Eval time (> maxt).
@@ -115,6 +115,7 @@ func ruleUnitTest(filename string) []error {
 type unitTestFile struct {
 	RuleFiles          []string      `yaml:"rule_files"`
 	EvaluationInterval time.Duration `yaml:"evaluation_interval,omitempty"`
+	StartTimeOffset    time.Duration `yaml:"start_time_offset,omitempty"`
 	GroupEvalOrder     []string      `yaml:"group_eval_order"`
 	Tests              []testGroup   `yaml:"tests"`
 }

--- a/docs/configuration/unit_testing_rules.md
+++ b/docs/configuration/unit_testing_rules.md
@@ -25,6 +25,11 @@ rule_files:
 # optional, default = 1m
 evaluation_interval: <duration>
 
+# optional, default = 0m
+# By default the time is mocked and starts from 0 timestamp.
+# Here you can add start time offset duration to shift the evaluation.
+start_time_offset: <duration>
+
 # The order in which group names are listed below will be the order of evaluation of
 # rule groups (at a given evaluation time). The order is guaranteed only for the groups mentioned below.
 # All the groups need not be mentioned below.


### PR DESCRIPTION
Hi, we use some recording rules and alerts for alert inhibitions during holidays etc (inspired by https://github.com/roidelapluie/prometheus-timezone-holidays) and would like to write tests for it. Unfortunately to write for example test for Christmas we need to record whole year of data to get it tested which takes quite a while to record whole year of data. This way we can set the offset to the Christmas and omit the whole year of recording the data.
This would allow to shift the evaluation start time from 0 timestamp using added duration.

I know this is probably edge case but does not hurt to have the possibility and by default does not change the behavior.