### PR TITLE
Fix curl args for data-urlencode in docs

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -236,7 +236,7 @@ The following example returns all series that match either of the selectors
 `up` or `process_start_time_seconds{job="prometheus"}`:
 
 ```json
-$ curl -g 'http://localhost:9090/api/v1/series?' --data-urlencode='match[]=up' --data-urlencode='match[]=process_start_time_seconds{job="prometheus"}'
+$ curl -g 'http://localhost:9090/api/v1/series?' --data-urlencode 'match[]=up' --data-urlencode 'match[]=process_start_time_seconds{job="prometheus"}'
 {
    "status" : "success",
    "data" : [


### PR DESCRIPTION
The curl argument `--data-urlencode` doesn't accept equal signs between the arg and the value, but needs whitespace instead.
