### PR TITLE
made stripe size configurable

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -320,7 +320,7 @@ func createBlockFromHead(tb testing.TB, dir string, head *Head) string {
 }
 
 func createHead(tb testing.TB, series []Series) *Head {
-	head, err := NewHead(nil, nil, nil, 2*60*60*1000)
+	head, err := NewHead(nil, nil, nil, 2*60*60*1000, DefaultStripeSize)
 	testutil.Ok(tb, err)
 	defer head.Close()
 

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -870,7 +870,7 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 	for labelNames := 1; labelNames < totalSeries; labelNames *= 10 {
 		labelValues := totalSeries / labelNames
 		b.Run(fmt.Sprintf("labelnames=%d,labelvalues=%d", labelNames, labelValues), func(b *testing.B) {
-			h, err := NewHead(nil, nil, nil, 1000)
+			h, err := NewHead(nil, nil, nil, 1000, DefaultStripeSize)
 			testutil.Ok(b, err)
 			for ln := 0; ln < labelNames; ln++ {
 				app := h.Appender()

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -57,6 +57,7 @@ var DefaultOptions = &Options{
 	NoLockfile:             false,
 	AllowOverlappingBlocks: false,
 	WALCompression:         false,
+	StripeSize:             DefaultStripeSize,
 }
 
 // Options of the DB storage.
@@ -89,6 +90,9 @@ type Options struct {
 
 	// WALCompression will turn on Snappy compression for records on the WAL.
 	WALCompression bool
+
+	// StripeSize is the size in entries of the series hash map. Reducing the size will save memory but impact perfomance.
+	StripeSize int
 }
 
 // Appender allows appending a batch of data. It must be completed with a
@@ -308,7 +312,7 @@ func (db *DBReadOnly) FlushWAL(dir string) error {
 	if err != nil {
 		return err
 	}
-	head, err := NewHead(nil, db.logger, w, 1)
+	head, err := NewHead(nil, db.logger, w, 1, DefaultStripeSize)
 	if err != nil {
 		return err
 	}
@@ -355,7 +359,7 @@ func (db *DBReadOnly) Querier(mint, maxt int64) (Querier, error) {
 		blocks[i] = b
 	}
 
-	head, err := NewHead(nil, db.logger, nil, 1)
+	head, err := NewHead(nil, db.logger, nil, 1, DefaultStripeSize)
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +374,7 @@ func (db *DBReadOnly) Querier(mint, maxt int64) (Querier, error) {
 		if err != nil {
 			return nil, err
 		}
-		head, err = NewHead(nil, db.logger, w, 1)
+		head, err = NewHead(nil, db.logger, w, 1, DefaultStripeSize)
 		if err != nil {
 			return nil, err
 		}
@@ -487,6 +491,9 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 	if opts == nil {
 		opts = DefaultOptions
 	}
+	if opts.StripeSize <= 0 {
+		opts.StripeSize = DefaultStripeSize
+	}
 	// Fixup bad format written by Prometheus 2.1.
 	if err := repairBadIndexVersion(l, dir); err != nil {
 		return nil, err
@@ -548,7 +555,7 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 		}
 	}
 
-	db.head, err = NewHead(r, l, wlog, opts.BlockRanges[0])
+	db.head, err = NewHead(r, l, wlog, opts.BlockRanges[0], opts.StripeSize)
 	if err != nil {
 		return nil, err
 	}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -255,7 +255,10 @@ func (h *Head) PostingsCardinalityStats(statsByLabelName string) *index.Postings
 }
 
 // NewHead opens the head block in dir.
-func NewHead(r prometheus.Registerer, l log.Logger, wal *wal.WAL, chunkRange int64) (*Head, error) {
+// stripeSize sets the number of entries in the hash map, it must be a power of 2.
+// A larger stripeSize will allocate more memory up-front, but will increase performance when handling a large number of series.
+// A smaller stripeSize reduces the memory allocated, but can decrease performance with large number of series.
+func NewHead(r prometheus.Registerer, l log.Logger, wal *wal.WAL, chunkRange int64, stripeSize int) (*Head, error) {
 	if l == nil {
 		l = log.NewNopLogger()
 	}
@@ -268,7 +271,7 @@ func NewHead(r prometheus.Registerer, l log.Logger, wal *wal.WAL, chunkRange int
 		chunkRange: chunkRange,
 		minTime:    math.MaxInt64,
 		maxTime:    math.MinInt64,
-		series:     newStripeSeries(),
+		series:     newStripeSeries(stripeSize),
 		values:     map[string]stringset{},
 		symbols:    map[string]struct{}{},
 		postings:   index.NewUnorderedMemPostings(),
@@ -1537,20 +1540,21 @@ func (m seriesHashmap) del(hash uint64, lset labels.Labels) {
 	}
 }
 
+const (
+	// DefaultStripeSize is the default number of entries to allocate in the stripeSeries hash map.
+	DefaultStripeSize = 1 << 14
+)
+
 // stripeSeries locks modulo ranges of IDs and hashes to reduce lock contention.
 // The locks are padded to not be on the same cache line. Filling the padded space
 // with the maps was profiled to be slower – likely due to the additional pointer
 // dereferences.
 type stripeSeries struct {
-	series [stripeSize]map[uint64]*memSeries
-	hashes [stripeSize]seriesHashmap
-	locks  [stripeSize]stripeLock
+	size   int
+	series []map[uint64]*memSeries
+	hashes []seriesHashmap
+	locks  []stripeLock
 }
-
-const (
-	stripeSize = 1 << 14
-	stripeMask = stripeSize - 1
-)
 
 type stripeLock struct {
 	sync.RWMutex
@@ -1558,8 +1562,13 @@ type stripeLock struct {
 	_ [40]byte
 }
 
-func newStripeSeries() *stripeSeries {
-	s := &stripeSeries{}
+func newStripeSeries(stripeSize int) *stripeSeries {
+	s := &stripeSeries{
+		size:   stripeSize,
+		series: make([]map[uint64]*memSeries, stripeSize),
+		hashes: make([]seriesHashmap, stripeSize),
+		locks:  make([]stripeLock, stripeSize),
+	}
 
 	for i := range s.series {
 		s.series[i] = map[uint64]*memSeries{}
@@ -1579,7 +1588,7 @@ func (s *stripeSeries) gc(mint int64) (map[uint64]struct{}, int) {
 	)
 	// Run through all series and truncate old chunks. Mark those with no
 	// chunks left as deleted and store their ID.
-	for i := 0; i < stripeSize; i++ {
+	for i := 0; i < s.size; i++ {
 		s.locks[i].Lock()
 
 		for hash, all := range s.hashes[i] {
@@ -1597,7 +1606,7 @@ func (s *stripeSeries) gc(mint int64) (map[uint64]struct{}, int) {
 				// series alike.
 				// If we don't hold them all, there's a very small chance that a series receives
 				// samples again while we are half-way into deleting it.
-				j := int(series.ref & stripeMask)
+				j := int(series.ref) & (s.size - 1)
 
 				if i != j {
 					s.locks[j].Lock()
@@ -1622,7 +1631,7 @@ func (s *stripeSeries) gc(mint int64) (map[uint64]struct{}, int) {
 }
 
 func (s *stripeSeries) getByID(id uint64) *memSeries {
-	i := id & stripeMask
+	i := id & uint64(s.size-1)
 
 	s.locks[i].RLock()
 	series := s.series[i][id]
@@ -1632,7 +1641,7 @@ func (s *stripeSeries) getByID(id uint64) *memSeries {
 }
 
 func (s *stripeSeries) getByHash(hash uint64, lset labels.Labels) *memSeries {
-	i := hash & stripeMask
+	i := hash & uint64(s.size-1)
 
 	s.locks[i].RLock()
 	series := s.hashes[i].get(hash, lset)
@@ -1642,7 +1651,7 @@ func (s *stripeSeries) getByHash(hash uint64, lset labels.Labels) *memSeries {
 }
 
 func (s *stripeSeries) getOrSet(hash uint64, series *memSeries) (*memSeries, bool) {
-	i := hash & stripeMask
+	i := hash & uint64(s.size-1)
 
 	s.locks[i].Lock()
 
@@ -1653,7 +1662,7 @@ func (s *stripeSeries) getOrSet(hash uint64, series *memSeries) (*memSeries, boo
 	s.hashes[i].set(hash, series)
 	s.locks[i].Unlock()
 
-	i = series.ref & stripeMask
+	i = series.ref & uint64(s.size-1)
 
 	s.locks[i].Lock()
 	s.series[i][series.ref] = series

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -24,7 +24,7 @@ import (
 
 func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 	// Put a series, select it. GC it and then access it.
-	h, err := NewHead(nil, nil, nil, 1000)
+	h, err := NewHead(nil, nil, nil, 1000, DefaultStripeSize)
 	testutil.Ok(b, err)
 	defer h.Close()
 
@@ -35,7 +35,7 @@ func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 
 func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 	// Put a series, select it. GC it and then access it.
-	h, err := NewHead(nil, nil, nil, 1000)
+	h, err := NewHead(nil, nil, nil, 1000, DefaultStripeSize)
 	testutil.Ok(b, err)
 	defer h.Close()
 

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -30,7 +30,7 @@ const (
 )
 
 func BenchmarkPostingsForMatchers(b *testing.B) {
-	h, err := NewHead(nil, nil, nil, 1000)
+	h, err := NewHead(nil, nil, nil, 1000, DefaultStripeSize)
 	testutil.Ok(b, err)
 	defer func() {
 		testutil.Ok(b, h.Close())
@@ -126,7 +126,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 }
 
 func BenchmarkQuerierSelect(b *testing.B) {
-	h, err := NewHead(nil, nil, nil, 1000)
+	h, err := NewHead(nil, nil, nil, 1000, DefaultStripeSize)
 	testutil.Ok(b, err)
 	defer h.Close()
 	app := h.Appender()

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1812,7 +1812,7 @@ func TestFindSetMatches(t *testing.T) {
 }
 
 func TestPostingsForMatchers(t *testing.T) {
-	h, err := NewHead(nil, nil, nil, 1000)
+	h, err := NewHead(nil, nil, nil, 1000, DefaultStripeSize)
 	testutil.Ok(t, err)
 	defer func() {
 		testutil.Ok(t, h.Close())

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -16,10 +16,11 @@ package tsdb
 import (
 	"context"
 	"fmt"
-	"github.com/go-kit/kit/log"
-	"github.com/prometheus/prometheus/pkg/labels"
 	"os"
 	"path/filepath"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/prometheus/pkg/labels"
 )
 
 var InvalidTimesError = fmt.Errorf("max time is lesser than min time")
@@ -32,7 +33,7 @@ type MetricSample struct {
 
 // CreateHead creates a TSDB writer head to write the sample data to.
 func CreateHead(samples []*MetricSample, chunkRange int64, logger log.Logger) (*Head, error) {
-	head, err := NewHead(nil, logger, nil, chunkRange)
+	head, err := NewHead(nil, logger, nil, chunkRange, DefaultStripeSize)
 	if err != nil {
 		return nil, err
 	}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1875,7 +1875,7 @@ func (f *fakeDB) Dir() string {
 }
 func (f *fakeDB) Snapshot(dir string, withHead bool) error { return f.err }
 func (f *fakeDB) Head() *tsdb.Head {
-	h, _ := tsdb.NewHead(nil, nil, nil, 1000)
+	h, _ := tsdb.NewHead(nil, nil, nil, 1000, tsdb.DefaultStripeSize)
 	return h
 }
 


### PR DESCRIPTION
This changes exposes the `stripeSize` const as a configurable option in tsdb. Not passing in the option will result in the tsdb using the default stripe size that is uses today.

This is an important change for Cortex's new experimental TSDB feature as it allows us to reduce the memory footprint of TSDB's as they are scaled to many nodes. More info about this memory usage can be found [here](https://github.com/cortexproject/cortex/pull/1947)

@codesome @krasi-georgiev 