### PR TITLE
Add myself (@cstyan) as 2.16 release shepherd.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,8 @@ Release cadence of first pre-releases being cut is 6 weeks.
 | v2.13          | 2019-09-25                                 | Krasi Georgiev (GitHub: @krasi-georgiev)    |
 | v2.14          | 2019-11-06                                 | Chris Marchbanks (GitHub: @csmarchbanks)    |
 | v2.15          | 2019-12-18                                 | Bartek Plotka (GitHub: @bwplotka)           |
-| v2.16          | 2020-01-29                                 | **searching for volunteer**                 |
+| v2.16          | 2020-01-29                                 | Callum Styan (GitHub: @cstyan)              |
+| v2.17          | 2020-03-11                                 | **searching for volunteer**                 |
 
 If you are interested in volunteering please create a pull request against the [prometheus/prometheus](https://github.com/prometheus/prometheus) repository and propose yourself for the release series of your choice.
 


### PR DESCRIPTION
Note that I also changed the date of the release from the 29th to the 27th to leave the whole week open for release related work instead of just three-ish days.

Signed-off-by: Callum Styan <callumstyan@gmail.com>