### PR TITLE
Don't sort postings if we only have one block.

### DIFF
--- a/prompb/remote.pb.go
+++ b/prompb/remote.pb.go
@@ -340,7 +340,7 @@ func (m *QueryResult) GetTimeseries() []*TimeSeries {
 // ChunkedReadResponse is a response when response_type equals STREAMED_XOR_CHUNKS.
 // We strictly stream full series after series, optionally split by time. This means that a single frame can contain
 // partition of the single series, but once a new series is started to be streamed it means that no more chunks will
-// be sent for previous one.
+// be sent for previous one. Series are returned sorted in the same way TSDB block are internally.
 type ChunkedReadResponse struct {
 	ChunkedSeries []*ChunkedSeries `protobuf:"bytes,1,rep,name=chunked_series,json=chunkedSeries,proto3" json:"chunked_series,omitempty"`
 	// query_index represents an index of the query from ReadRequest.queries these chunks relates to.

--- a/prompb/remote.proto
+++ b/prompb/remote.proto
@@ -73,7 +73,7 @@ message QueryResult {
 // ChunkedReadResponse is a response when response_type equals STREAMED_XOR_CHUNKS.
 // We strictly stream full series after series, optionally split by time. This means that a single frame can contain
 // partition of the single series, but once a new series is started to be streamed it means that no more chunks will
-// be sent for previous one.
+// be sent for previous one. Series are returned sorted in the same way TSDB block are internally.
 message ChunkedReadResponse {
   repeated prometheus.ChunkedSeries chunked_series = 1;
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -596,7 +596,6 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *EvalStmt) (
 		return nil, warnings, err
 	}
 
-	// TODO(fabxc): order ensured by storage?
 	// TODO(fabxc): where to ensure metric labels are a copy from the storage internals.
 	sortSpanTimer, _ := query.stats.GetSpanTimer(ctx, stats.ResultSortTime, ng.metrics.queryResultSort)
 	sort.Sort(mat)

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -18,8 +18,8 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"strings"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"sort"
 	"testing"
 	"time"
 
@@ -179,6 +180,9 @@ type errQuerier struct {
 func (q *errQuerier) Select(*storage.SelectParams, ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
 	return errSeriesSet{err: q.err}, nil, q.err
 }
+func (q *errQuerier) SelectSorted(*storage.SelectParams, ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	return errSeriesSet{err: q.err}, nil, q.err
+}
 func (*errQuerier) LabelValues(name string) ([]string, storage.Warnings, error) { return nil, nil, nil }
 func (*errQuerier) LabelNames() ([]string, storage.Warnings, error)             { return nil, nil, nil }
 func (*errQuerier) Close() error                                                { return nil }
@@ -236,7 +240,10 @@ type paramCheckerQuerier struct {
 	t *testing.T
 }
 
-func (q *paramCheckerQuerier) Select(sp *storage.SelectParams, _ ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+func (q *paramCheckerQuerier) Select(sp *storage.SelectParams, m ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	return q.SelectSorted(sp, m...)
+}
+func (q *paramCheckerQuerier) SelectSorted(sp *storage.SelectParams, _ ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
 	testutil.Equals(q.t, q.start, sp.Start)
 	testutil.Equals(q.t, q.end, sp.End)
 	testutil.Equals(q.t, q.grouping, sp.Grouping)
@@ -1111,7 +1118,9 @@ func TestSubquerySelector(t *testing.T) {
 
 			res := qry.Exec(test.Context())
 			testutil.Equals(t, c.Result.Err, res.Err)
-			testutil.Equals(t, c.Result.Value, res.Value)
+			mat := res.Value.(Matrix)
+			sort.Sort(mat)
+			testutil.Equals(t, c.Result.Value, mat)
 		}
 	}
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -54,6 +54,9 @@ type Querier interface {
 	// Select returns a set of series that matches the given label matchers.
 	Select(*SelectParams, ...*labels.Matcher) (SeriesSet, Warnings, error)
 
+	// SelectSorted returns a sorted set of series that matches the given label matchers.
+	SelectSorted(*SelectParams, ...*labels.Matcher) (SeriesSet, Warnings, error)
+
 	// LabelValues returns all potential values for a label name.
 	LabelValues(name string) ([]string, Warnings, error)
 

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -30,6 +30,10 @@ func (noopQuerier) Select(*SelectParams, ...*labels.Matcher) (SeriesSet, Warning
 	return NoopSeriesSet(), nil, nil
 }
 
+func (noopQuerier) SelectSorted(*SelectParams, ...*labels.Matcher) (SeriesSet, Warnings, error) {
+	return NoopSeriesSet(), nil, nil
+}
+
 func (noopQuerier) LabelValues(name string) ([]string, Warnings, error) {
 	return nil, nil, nil
 }

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -144,7 +144,7 @@ func ToQueryResult(ss storage.SeriesSet, sampleLimit int) (*prompb.QueryResult, 
 	return resp, nil
 }
 
-// FromQueryResult unpacks a QueryResult proto.
+// FromQueryResult unpacks and sorts a QueryResult proto.
 func FromQueryResult(res *prompb.QueryResult) storage.SeriesSet {
 	series := make([]storage.Series, 0, len(res.Timeseries))
 	for _, ts := range res.Timeseries {

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -60,6 +60,12 @@ type querier struct {
 // Select implements storage.Querier and uses the given matchers to read series
 // sets from the Client.
 func (q *querier) Select(p *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	return q.SelectSorted(p, matchers...)
+}
+
+// SelectSorted implements storage.Querier and uses the given matchers to read series
+// sets from the Client.
+func (q *querier) SelectSorted(p *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
 	query, err := ToQuery(q.mint, q.maxt, matchers, p)
 	if err != nil {
 		return nil, nil, err
@@ -74,6 +80,7 @@ func (q *querier) Select(p *storage.SelectParams, matchers ...*labels.Matcher) (
 		return nil, nil, fmt.Errorf("remote_read: %v", err)
 	}
 
+	// FromQueryResult sorts.
 	return FromQueryResult(res), nil, nil
 }
 

--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -250,6 +250,14 @@ func (q querier) Select(_ *storage.SelectParams, ms ...*labels.Matcher) (storage
 	return seriesSet{set: set}, nil, nil
 }
 
+func (q querier) SelectSorted(_ *storage.SelectParams, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	set, err := q.q.SelectSorted(ms...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return seriesSet{set: set}, nil, nil
+}
+
 func (q querier) LabelValues(name string) ([]string, storage.Warnings, error) {
 	v, err := q.q.LabelValues(name)
 	return v, nil, err

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -790,7 +790,7 @@ func TestDelete_e2e(t *testing.T) {
 			q, err := NewBlockQuerier(hb, 0, 100000)
 			testutil.Ok(t, err)
 			defer q.Close()
-			ss, err := q.Select(del.ms...)
+			ss, err := q.SelectSorted(del.ms...)
 			testutil.Ok(t, err)
 			// Build the mockSeriesSet.
 			matchedSeries := make([]Series, 0, len(matched))


### PR DESCRIPTION
This will make big queries that only touch the head faster,
though queries that touch both the head and a block will still
be the same speed. This probably won't help much with graphing
unless the range is under an hour, however it should make most
recording rules faster. 

PromQL benchmarks for histograms show only 2-3% improvement, but
they're only over 1k series. Looks like we'd be saving about 1s for a head-only
query that touches 1M series, so a 1M series histogram_quantile(rate(5m)) 
would go from around 12s to 11s.