### PR TITLE
PromQL: Various small improvements in the parser

### DIFF
--- a/promql/ast.go
+++ b/promql/ast.go
@@ -114,7 +114,7 @@ type Call struct {
 // MatrixSelector represents a Matrix selection.
 type MatrixSelector struct {
 	// It is safe to assume that this is an VectorSelector
-	// if the parser hasn't returned an error
+	// if the parser hasn't returned an error.
 	VectorSelector Expr
 	Range          time.Duration
 

--- a/promql/ast.go
+++ b/promql/ast.go
@@ -113,7 +113,9 @@ type Call struct {
 
 // MatrixSelector represents a Matrix selection.
 type MatrixSelector struct {
-	VectorSelector *VectorSelector
+	// It is safe to assume that this is an VectorSelector
+	// if the parser hasn't returned an error
+	VectorSelector Expr
 	Range          time.Duration
 
 	EndPos Pos

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -64,11 +64,12 @@ func funcTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
 // the result as either per-second (if isRate is true) or overall.
 func extrapolatedRate(vals []Value, args Expressions, enh *EvalNodeHelper, isCounter bool, isRate bool) Vector {
 	ms := args[0].(*MatrixSelector)
+	vs := ms.VectorSelector.(*VectorSelector)
 
 	var (
 		samples    = vals[0].(Matrix)[0]
-		rangeStart = enh.ts - durationMilliseconds(ms.Range+ms.VectorSelector.Offset)
-		rangeEnd   = enh.ts - durationMilliseconds(ms.VectorSelector.Offset)
+		rangeStart = enh.ts - durationMilliseconds(ms.Range+vs.Offset)
+		rangeEnd   = enh.ts - durationMilliseconds(vs.Offset)
 	)
 
 	// No sense in trying to compute a rate without at least two points. Drop
@@ -1243,7 +1244,7 @@ func createLabelsForAbsentFunction(expr Expr) labels.Labels {
 	case *VectorSelector:
 		lm = n.LabelMatchers
 	case *MatrixSelector:
-		lm = n.VectorSelector.LabelMatchers
+		lm = n.VectorSelector.(*VectorSelector).LabelMatchers
 	default:
 		return m
 	}

--- a/promql/generated_parser.y
+++ b/promql/generated_parser.y
@@ -40,7 +40,7 @@ import (
 }
 
 
-%token <item> 
+%token <item>
 ASSIGN
 BLANK
 COLON
@@ -159,7 +159,7 @@ START_METRIC_SELECTOR
 
 %%
 
-start           : 
+start           :
                 START_METRIC metric
                         { yylex.(*parser).generatedParserResult = $2 }
                 | START_SERIES_DESCRIPTION series_description
@@ -167,7 +167,7 @@ start           :
                         { yylex.(*parser).addParseErrf(PositionRange{}, "no expression found in input")}
                 | START_EXPRESSION expr
                         { yylex.(*parser).generatedParserResult = $2 }
-                | START_METRIC_SELECTOR vector_selector 
+                | START_METRIC_SELECTOR vector_selector
                         { yylex.(*parser).generatedParserResult = $2 }
                 | start EOF
                 | error /* If none of the more detailed error messages are triggered, we fall back to this. */
@@ -240,7 +240,7 @@ binary_expr     : expr ADD     bin_modifier expr { $$ = yylex.(*parser).newBinar
                 | expr SUB     bin_modifier expr { $$ = yylex.(*parser).newBinaryExpression($1, $2, $3, $4) }
                 ;
 
-// Using left recursion for the modifier rules, helps to keep the parser stack small and 
+// Using left recursion for the modifier rules, helps to keep the parser stack small and
 // reduces allocations
 bin_modifier    : group_modifiers;
 
@@ -261,13 +261,13 @@ on_or_ignoring  : bool_modifier IGNORING grouping_labels
                         {
                         $$ = $1
                         $$.(*BinaryExpr).VectorMatching.MatchingLabels = $3
-                        } 
+                        }
                 | bool_modifier ON grouping_labels
                         {
                         $$ = $1
                         $$.(*BinaryExpr).VectorMatching.MatchingLabels = $3
                         $$.(*BinaryExpr).VectorMatching.On = true
-                        } 
+                        }
                 ;
 
 group_modifiers: bool_modifier /* empty */
@@ -321,13 +321,13 @@ grouping_label  : maybe_label
 /*
  * Function calls.
  */
-                
+
 function_call   : IDENTIFIER function_call_body
                         {
                         fn, exist := getFunction($1.Val)
                         if !exist{
                                 yylex.(*parser).addParseErrf($1.PositionRange(),"unknown function with name %q", $1.Val)
-                        } 
+                        }
                         $$ = &Call{
                                 Func: fn,
                                 Args: $2.(Expressions),
@@ -347,7 +347,7 @@ function_call_body: LEFT_PAREN function_call_args RIGHT_PAREN
 
 function_call_args: function_call_args COMMA expr
                         { $$ = append($1.(Expressions), $3.(Expr)) }
-                | expr 
+                | expr
                         { $$ = Expressions{$1.(Expr)} }
                 | function_call_args COMMA
                         {
@@ -410,7 +410,7 @@ subquery_expr   : expr LEFT_BRACKET duration COLON maybe_duration RIGHT_BRACKET
                                 Expr:  $1.(Expr),
                                 Range: $3,
                                 Step:  $5,
-                                
+
                                 EndPos: $6.Pos + 1,
                         }
                         }
@@ -430,7 +430,7 @@ subquery_expr   : expr LEFT_BRACKET duration COLON maybe_duration RIGHT_BRACKET
 
 unary_expr      :
                 /* gives the rule the same precedence as MUL. This aligns with mathematical conventions */
-                unary_op expr %prec MUL 
+                unary_op expr %prec MUL
                         {
                         if nl, ok := $2.(*NumberLiteral); ok {
                                 if $1.Typ == SUB {
@@ -449,15 +449,15 @@ unary_expr      :
  */
 
 vector_selector: metric_identifier label_matchers
-                        { 
+                        {
                         vs := $2.(*VectorSelector)
-                        vs.PosRange = mergeRanges(&$1, vs) 
+                        vs.PosRange = mergeRanges(&$1, vs)
                         vs.Name = $1.Val
                         yylex.(*parser).assembleVectorSelector(vs)
                         $$ = vs
                         }
-                | metric_identifier 
-                        { 
+                | metric_identifier
+                        {
                         vs := &VectorSelector{
                                 Name: $1.Val,
                                 LabelMatchers: []*labels.Matcher{},
@@ -467,7 +467,7 @@ vector_selector: metric_identifier label_matchers
                         $$ = vs
                         }
                 | label_matchers
-                        { 
+                        {
                         vs := $1.(*VectorSelector)
                         yylex.(*parser).assembleVectorSelector(vs)
                         $$ = vs
@@ -498,7 +498,7 @@ label_matchers  : LEFT_BRACE label_match_list RIGHT_BRACE
                 ;
 
 label_match_list: label_match_list COMMA label_matcher
-                        { 
+                        {
                         if $1 != nil{
                                 $$ = append($1, $3)
                         } else {
@@ -515,19 +515,19 @@ label_matcher   : IDENTIFIER match_op STRING
                         { $$ = yylex.(*parser).newLabelMatcher($1, $2, $3);  }
                 | IDENTIFIER match_op error
                         { yylex.(*parser).unexpected("label matching", "string"); $$ = nil}
-                | IDENTIFIER error 
-                        { yylex.(*parser).unexpected("label matching", "label matching operator"); $$ = nil } 
+                | IDENTIFIER error
+                        { yylex.(*parser).unexpected("label matching", "label matching operator"); $$ = nil }
                 | error
                         { yylex.(*parser).unexpected("label matching", "identifier or \"}\""); $$ = nil}
                 ;
-                        
+
 /*
  * Metric descriptions.
  */
 
 metric          : metric_identifier label_set
                         { $$ = append($2, labels.Label{Name: labels.MetricName, Value: $1.Val}); sort.Sort($$) }
-                | label_set 
+                | label_set
                         {$$ = $1}
                 ;
 
@@ -550,11 +550,11 @@ label_set_list  : label_set_list COMMA label_set_item
                         { $$ = []labels.Label{$1} }
                 | label_set_list error
                         { yylex.(*parser).unexpected("label set", "\",\" or \"}\"", ); $$ = $1 }
-                
+
                 ;
 
 label_set_item  : IDENTIFIER EQL STRING
-                        { $$ = labels.Label{Name: $1.Val, Value: yylex.(*parser).unquoteString($3.Val) } } 
+                        { $$ = labels.Label{Name: $1.Val, Value: yylex.(*parser).unquoteString($3.Val) } }
                 | IDENTIFIER EQL error
                         { yylex.(*parser).unexpected("label set", "string"); $$ = labels.Label{}}
                 | IDENTIFIER error
@@ -645,7 +645,7 @@ match_op        : EQL | NEQ | EQL_REGEX | NEQ_REGEX ;
  * Literals.
  */
 
-number_literal  : NUMBER 
+number_literal  : NUMBER
                         {
                         $$ = &NumberLiteral{
                                 Val:           yylex.(*parser).number($1.Val),

--- a/promql/generated_parser.y
+++ b/promql/generated_parser.y
@@ -164,7 +164,7 @@ start           :
                         { yylex.(*parser).generatedParserResult = $2 }
                 | START_SERIES_DESCRIPTION series_description
                 | START_EXPRESSION /* empty */ EOF
-                        { yylex.(*parser).failf(PositionRange{}, "no expression found in input")}
+                        { yylex.(*parser).addParseErrf(PositionRange{}, "no expression found in input")}
                 | START_EXPRESSION expr
                         { yylex.(*parser).generatedParserResult = $2 }
                 | START_METRIC_SELECTOR vector_selector 
@@ -326,7 +326,7 @@ function_call   : IDENTIFIER function_call_body
                         {
                         fn, exist := getFunction($1.Val)
                         if !exist{
-                                yylex.(*parser).failf($1.PositionRange(),"unknown function with name %q", $1.Val)
+                                yylex.(*parser).addParseErrf($1.PositionRange(),"unknown function with name %q", $1.Val)
                         } 
                         $$ = &Call{
                                 Func: fn,
@@ -351,7 +351,7 @@ function_call_args: function_call_args COMMA expr
                         { $$ = Expressions{$1.(Expr)} }
                 | function_call_args COMMA
                         {
-                        yylex.(*parser).failf($2.PositionRange(), "trailing commas not allowed in function call args")
+                        yylex.(*parser).addParseErrf($2.PositionRange(), "trailing commas not allowed in function call args")
                         $$ = $1
                         }
                 ;
@@ -393,7 +393,7 @@ matrix_selector : expr LEFT_BRACKET duration RIGHT_BRACKET
 
                         if errMsg != ""{
                                 errRange := mergeRanges(&$2, &$4)
-                                yylex.(*parser).failf(errRange, errMsg)
+                                yylex.(*parser).addParseErrf(errRange, errMsg)
                         }
 
                         $$ = &MatrixSelector{
@@ -665,7 +665,7 @@ uint            : NUMBER
                         var err error
                         $$, err = strconv.ParseUint($1.Val, 10, 64)
                         if err != nil {
-                                yylex.(*parser).failf($1.PositionRange(), "invalid repetition in series values: %s", err)
+                                yylex.(*parser).addParseErrf($1.PositionRange(), "invalid repetition in series values: %s", err)
                         }
                         }
                 ;
@@ -675,7 +675,7 @@ duration        : DURATION
                         var err error
                         $$, err = parseDuration($1.Val)
                         if err != nil {
-                                yylex.(*parser).fail($1.PositionRange(), err)
+                                yylex.(*parser).addParseErr($1.PositionRange(), err)
                         }
                         }
                 ;

--- a/promql/generated_parser.y
+++ b/promql/generated_parser.y
@@ -397,7 +397,7 @@ matrix_selector : expr LEFT_BRACKET duration RIGHT_BRACKET
                         }
 
                         $$ = &MatrixSelector{
-                                VectorSelector: vs,
+                                VectorSelector: $1.(Expr),
                                 Range: $3,
                                 EndPos: yylex.(*parser).lastClosing,
                         }

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -794,7 +794,7 @@ yydefault:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:167
 		{
-			yylex.(*parser).failf(PositionRange{}, "no expression found in input")
+			yylex.(*parser).addParseErrf(PositionRange{}, "no expression found in input")
 		}
 	case 4:
 		yyDollar = yyS[yypt-2 : yypt+1]
@@ -1060,7 +1060,7 @@ yydefault:
 		{
 			fn, exist := getFunction(yyDollar[1].item.Val)
 			if !exist {
-				yylex.(*parser).failf(yyDollar[1].item.PositionRange(), "unknown function with name %q", yyDollar[1].item.Val)
+				yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "unknown function with name %q", yyDollar[1].item.Val)
 			}
 			yyVAL.node = &Call{
 				Func: fn,
@@ -1099,7 +1099,7 @@ yydefault:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line promql/generated_parser.y:353
 		{
-			yylex.(*parser).failf(yyDollar[2].item.PositionRange(), "trailing commas not allowed in function call args")
+			yylex.(*parser).addParseErrf(yyDollar[2].item.PositionRange(), "trailing commas not allowed in function call args")
 			yyVAL.node = yyDollar[1].node
 		}
 	case 64:
@@ -1136,7 +1136,7 @@ yydefault:
 
 			if errMsg != "" {
 				errRange := mergeRanges(&yyDollar[2].item, &yyDollar[4].item)
-				yylex.(*parser).failf(errRange, errMsg)
+				yylex.(*parser).addParseErrf(errRange, errMsg)
 			}
 
 			yyVAL.node = &MatrixSelector{
@@ -1506,7 +1506,7 @@ yydefault:
 			var err error
 			yyVAL.uint, err = strconv.ParseUint(yyDollar[1].item.Val, 10, 64)
 			if err != nil {
-				yylex.(*parser).failf(yyDollar[1].item.PositionRange(), "invalid repetition in series values: %s", err)
+				yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "invalid repetition in series values: %s", err)
 			}
 		}
 	case 160:
@@ -1516,7 +1516,7 @@ yydefault:
 			var err error
 			yyVAL.duration, err = parseDuration(yyDollar[1].item.Val)
 			if err != nil {
-				yylex.(*parser).fail(yyDollar[1].item.PositionRange(), err)
+				yylex.(*parser).addParseErr(yyDollar[1].item.PositionRange(), err)
 			}
 		}
 	case 161:

--- a/promql/generated_parser.y.go
+++ b/promql/generated_parser.y.go
@@ -1140,7 +1140,7 @@ yydefault:
 			}
 
 			yyVAL.node = &MatrixSelector{
-				VectorSelector: vs,
+				VectorSelector: yyDollar[1].node.(Expr),
 				Range:          yyDollar[3].duration,
 				EndPos:         yylex.(*parser).lastClosing,
 			}

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -420,11 +420,7 @@ func (p *parser) expectType(node Node, want ValueType, context string) {
 	}
 }
 
-// check the types of the children of each node and raise an error
-// if they do not form a valid node.
-//
-// Some of these checks are redundant as the parsing stage does not allow
-// them, but the costs are small and might reveal errors when making changes.
+// checkAST checks the sanity of the provided AST. This includes type checking.
 func (p *parser) checkAST(node Node) (typ ValueType) {
 	// For expressions the type is determined by their Type function.
 	// Lists do not have a type but are not invalid either.

--- a/promql/parse.go
+++ b/promql/parse.go
@@ -675,7 +675,9 @@ func (p *parser) addOffset(e Node, offset time.Duration) {
 		offsetp = &s.Offset
 		endPosp = &s.PosRange.End
 	case *MatrixSelector:
-		offsetp = &s.VectorSelector.Offset
+		if vs, ok := s.VectorSelector.(*VectorSelector); ok {
+			offsetp = &vs.Offset
+		}
 		endPosp = &s.EndPos
 	case *SubqueryExpr:
 		offsetp = &s.Offset
@@ -688,7 +690,7 @@ func (p *parser) addOffset(e Node, offset time.Duration) {
 	// it is already ensured by parseDuration func that there never will be a zero offset modifier
 	if *offsetp != 0 {
 		p.failf(e.PositionRange(), "offset may not be set multiple times")
-	} else {
+	} else if offsetp != nil {
 		*offsetp = offset
 	}
 

--- a/promql/printer.go
+++ b/promql/printer.go
@@ -113,7 +113,7 @@ func (node *Call) String() string {
 
 func (node *MatrixSelector) String() string {
 	// Copy the Vector selector before changing the offset
-	var vecSelector VectorSelector = *node.VectorSelector
+	var vecSelector VectorSelector = *node.VectorSelector.(*VectorSelector)
 	offset := ""
 	if vecSelector.Offset != time.Duration(0) {
 		offset = fmt.Sprintf(" offset %s", model.Duration(vecSelector.Offset))


### PR DESCRIPTION
Includes:
* Move AST consistency checking to a later stage where appropriate (see https://github.com/prometheus/prometheus/pull/6650#issue-364101026).
* Rename some non public functions to better names.
* Make the Child of a `MatrixSelector` of type `Expr` instead of `VectorSelector` so that part of the syntax tree is still there for use by the language server.