### PR TITLE
textparse: reject duplicate labels

### DIFF
--- a/pkg/textparse/openmetricsparse.go
+++ b/pkg/textparse/openmetricsparse.go
@@ -411,6 +411,7 @@ func (p *OpenMetricsParser) parseComment() error {
 }
 
 func (p *OpenMetricsParser) parseLVals() ([]int, error) {
+	var labels [][]byte
 	var offsets []int
 	first := true
 	for {
@@ -435,10 +436,17 @@ func (p *OpenMetricsParser) parseLVals() ([]int, error) {
 				return nil, parseError("expected label name or left brace", t)
 			}
 			return nil, parseError("expected comma or left brace", t)
-
 		}
 		first = false
 		// t is now a label name.
+
+		label := p.l.b[p.l.start:p.l.i]
+		for _, l := range labels {
+			if bytes.Compare(l, label) == 0 {
+				return nil, errors.Errorf(`duplicate label "%s"`, string(l))
+			}
+		}
+		labels = append(labels, label)
 
 		offsets = append(offsets, p.l.start, p.l.i)
 

--- a/pkg/textparse/openmetricsparse.go
+++ b/pkg/textparse/openmetricsparse.go
@@ -442,7 +442,7 @@ func (p *OpenMetricsParser) parseLVals() ([]int, error) {
 
 		label := p.l.b[p.l.start:p.l.i]
 		for _, l := range labels {
-			if bytes.Compare(l, label) == 0 {
+			if bytes.Equal(l, label) {
 				return nil, errors.Errorf(`duplicate label "%s"`, string(l))
 			}
 		}

--- a/pkg/textparse/openmetricsparse_test.go
+++ b/pkg/textparse/openmetricsparse_test.go
@@ -498,6 +498,10 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 			input: `custom_metric_total 1 # {aa=\"\xff\"} 9.0`,
 			err:   "expected label value, got \"INVALID\"",
 		},
+		{
+			input: "custom_metric_total{b=\"c\",b=\"d\"} 1\nEOF",
+			err:   "duplicate label \"b\"",
+		},
 	}
 
 	for i, c := range cases {

--- a/pkg/textparse/openmetricsparse_test.go
+++ b/pkg/textparse/openmetricsparse_test.go
@@ -443,6 +443,10 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 			err:   "expected label name or left brace, got \"EQUAL\"",
 		},
 		{
+			input: "custom_metric_total{a=\"a\":} 1\nEOF",
+			err:   "expected comma or left brace, got \"INVALID\"",
+		},
+		{
 			input: "foo 1_2\n\n# EOF\n",
 			err:   "unsupported character in float",
 		},

--- a/pkg/textparse/promparse.go
+++ b/pkg/textparse/promparse.go
@@ -380,7 +380,7 @@ func (p *PromParser) parseLVals() error {
 		case tLName:
 			label := p.l.b[p.l.start:p.l.i]
 			for _, l := range labels {
-				if bytes.Compare(l, label) == 0 {
+				if bytes.Equal(l, label) {
 					return errors.Errorf(`duplicate label "%s"`, string(l))
 				}
 			}

--- a/pkg/textparse/promparse.go
+++ b/pkg/textparse/promparse.go
@@ -17,6 +17,7 @@
 package textparse
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"math"
@@ -370,12 +371,20 @@ func (p *PromParser) Next() (Entry, error) {
 }
 
 func (p *PromParser) parseLVals() error {
+	labels := [][]byte{}
 	t := p.nextToken()
 	for {
 		switch t {
 		case tBraceClose:
 			return nil
 		case tLName:
+			label := p.l.b[p.l.start:p.l.i]
+			for _, l := range labels {
+				if bytes.Compare(l, label) == 0 {
+					return errors.Errorf(`duplicate label "%s"`, string(l))
+				}
+			}
+			labels = append(labels, label)
 		default:
 			return parseError("expected label name", t)
 		}

--- a/pkg/textparse/promparse_test.go
+++ b/pkg/textparse/promparse_test.go
@@ -226,6 +226,10 @@ func TestPromParseErrors(t *testing.T) {
 			err:   "expected label value, got \"INVALID\"",
 		},
 		{
+			input: "a{b=\"c\",b=\"d\"} 1\n",
+			err:   "duplicate label \"b\"",
+		},
+		{
 			input: "a{b=\n",
 			err:   "expected label value, got \"INVALID\"",
 		},


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->