### PR TITLE
Pass over scrape cache to the next scrape

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -315,7 +315,7 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 	for fp, oldLoop := range sp.loops {
 		var cache *scrapeCache
 		if oc := oldLoop.getCache(); reuseCache && oc != nil {
-			cache = oldLoop.getCache()
+			cache = oc
 		} else {
 			cache = newScrapeCache()
 		}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"math"
 	"net/http"
+	"reflect"
 	"sync"
 	"time"
 	"unsafe"
@@ -176,6 +177,7 @@ type scrapeLoopOptions struct {
 	honorLabels     bool
 	honorTimestamps bool
 	mrc             []*relabel.Config
+	cache           *scrapeCache
 }
 
 const maxAheadTime = 10 * time.Minute
@@ -208,7 +210,10 @@ func newScrapePool(cfg *config.ScrapeConfig, app Appendable, jitterSeed uint64, 
 	}
 	sp.newLoop = func(opts scrapeLoopOptions) loop {
 		// Update the targets retrieval function for metadata to a new scrape cache.
-		cache := newScrapeCache()
+		cache := opts.cache
+		if cache == nil {
+			cache = newScrapeCache()
+		}
 		opts.target.SetMetadataStore(cache)
 
 		return newScrapeLoop(
@@ -291,6 +296,8 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 		targetScrapePoolReloadsFailed.Inc()
 		return errors.Wrap(err, "error creating HTTP client")
 	}
+
+	reuseCache := reusableCache(sp.config, cfg)
 	sp.config = cfg
 	oldClient := sp.client
 	sp.client = client
@@ -306,6 +313,12 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 	)
 
 	for fp, oldLoop := range sp.loops {
+		var cache *scrapeCache
+		if oc := oldLoop.getCache(); reuseCache && oc != nil {
+			cache = oldLoop.getCache()
+		} else {
+			cache = newScrapeCache()
+		}
 		var (
 			t       = sp.activeTargets[fp]
 			s       = &targetScraper{Target: t, client: sp.client, timeout: timeout}
@@ -316,6 +329,7 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 				honorLabels:     honorLabels,
 				honorTimestamps: honorTimestamps,
 				mrc:             mrc,
+				cache:           cache,
 			})
 		)
 		wg.Add(1)
@@ -579,6 +593,7 @@ func (s *targetScraper) scrape(ctx context.Context, w io.Writer) (string, error)
 type loop interface {
 	run(interval, timeout time.Duration, errc chan<- error)
 	stop()
+	getCache() *scrapeCache
 }
 
 type cacheEntry struct {
@@ -1016,6 +1031,10 @@ func (sl *scrapeLoop) stop() {
 	<-sl.stopped
 }
 
+func (sl *scrapeLoop) getCache() *scrapeCache {
+	return sl.cache
+}
+
 func (sl *scrapeLoop) append(b []byte, contentType string, ts time.Time) (total, added, seriesAdded int, err error) {
 	var (
 		app            = sl.appender()
@@ -1311,4 +1330,26 @@ func (sl *scrapeLoop) addReportSample(app storage.Appender, s string, t int64, v
 	default:
 		return err
 	}
+}
+
+// zeroConfig returns a new scrape config that only contains configuration items
+// that alter metrics.
+func zeroConfig(c *config.ScrapeConfig) *config.ScrapeConfig {
+	z := *c
+	// We zero out the fields that for sure don't affect scrape.
+	z.HonorTimestamps = false
+	z.ScrapeInterval = 0
+	z.ScrapeTimeout = 0
+	z.SampleLimit = 0
+	z.HTTPClientConfig = config_util.HTTPClientConfig{}
+	return &z
+}
+
+// reusableCache compares two scrape config and tells wheter the cache is stoll
+// valid.
+func reusableCache(r, l *config.ScrapeConfig) bool {
+	if r == nil || l == nil {
+		return false
+	}
+	return reflect.DeepEqual(zeroConfig(r), zeroConfig(l))
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1337,7 +1337,6 @@ func (sl *scrapeLoop) addReportSample(app storage.Appender, s string, t int64, v
 func zeroConfig(c *config.ScrapeConfig) *config.ScrapeConfig {
 	z := *c
 	// We zero out the fields that for sure don't affect scrape.
-	z.HonorTimestamps = false
 	z.ScrapeInterval = 0
 	z.ScrapeTimeout = 0
 	z.SampleLimit = 0

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1351,8 +1351,5 @@ func reusableCache(r, l *config.ScrapeConfig) bool {
 	if r == nil || l == nil {
 		return false
 	}
-	fmt.Printf("%v\n", zeroConfig(r))
-	fmt.Printf("%v\n", zeroConfig(l))
-	fmt.Printf("%v\n", reflect.DeepEqual(zeroConfig(r), zeroConfig(l)))
 	return reflect.DeepEqual(zeroConfig(r), zeroConfig(l))
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1351,5 +1351,8 @@ func reusableCache(r, l *config.ScrapeConfig) bool {
 	if r == nil || l == nil {
 		return false
 	}
+	fmt.Printf("%v\n", zeroConfig(r))
+	fmt.Printf("%v\n", zeroConfig(l))
+	fmt.Printf("%v\n", reflect.DeepEqual(zeroConfig(r), zeroConfig(l)))
 	return reflect.DeepEqual(zeroConfig(r), zeroConfig(l))
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1344,7 +1344,7 @@ func zeroConfig(c *config.ScrapeConfig) *config.ScrapeConfig {
 	return &z
 }
 
-// reusableCache compares two scrape config and tells wheter the cache is stoll
+// reusableCache compares two scrape config and tells wheter the cache is still
 // valid.
 func reusableCache(r, l *config.ScrapeConfig) bool {
 	if r == nil || l == nil {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
+	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/config"
@@ -1666,6 +1667,7 @@ func TestReuseScrapeCache(t *testing.T) {
 				},
 			},
 		}
+		proxyURL, _ = url.Parse("http://localhost:2128")
 	)
 	sp.sync([]*Target{t1})
 
@@ -1702,10 +1704,10 @@ func TestReuseScrapeCache(t *testing.T) {
 			},
 		},
 		{
-			keep: true,
+			keep: false,
 			newConfig: &config.ScrapeConfig{
 				JobName:         "Prometheus",
-				HonorTimestamps: false,
+				HonorTimestamps: true,
 				SampleLimit:     400,
 				ScrapeInterval:  model.Duration(5 * time.Second),
 				ScrapeTimeout:   model.Duration(15 * time.Second),
@@ -1713,10 +1715,24 @@ func TestReuseScrapeCache(t *testing.T) {
 			},
 		},
 		{
+			keep: true,
+			newConfig: &config.ScrapeConfig{
+				JobName:         "Prometheus",
+				HonorTimestamps: true,
+				SampleLimit:     400,
+				HTTPClientConfig: config_util.HTTPClientConfig{
+					ProxyURL: config_util.URL{URL: proxyURL},
+				},
+				ScrapeInterval: model.Duration(5 * time.Second),
+				ScrapeTimeout:  model.Duration(15 * time.Second),
+				MetricsPath:    "/metrics2",
+			},
+		},
+		{
 			keep: false,
 			newConfig: &config.ScrapeConfig{
 				JobName:         "Prometheus",
-				HonorTimestamps: false,
+				HonorTimestamps: true,
 				HonorLabels:     true,
 				SampleLimit:     400,
 				ScrapeInterval:  model.Duration(5 * time.Second),

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1691,6 +1691,39 @@ func TestReuseScrapeCache(t *testing.T) {
 				MetricsPath:    "/metrics2",
 			},
 		},
+		{
+			keep: true,
+			newConfig: &config.ScrapeConfig{
+				JobName:        "Prometheus",
+				SampleLimit:    400,
+				ScrapeInterval: model.Duration(5 * time.Second),
+				ScrapeTimeout:  model.Duration(15 * time.Second),
+				MetricsPath:    "/metrics2",
+			},
+		},
+		{
+			keep: true,
+			newConfig: &config.ScrapeConfig{
+				JobName:         "Prometheus",
+				HonorTimestamps: false,
+				SampleLimit:     400,
+				ScrapeInterval:  model.Duration(5 * time.Second),
+				ScrapeTimeout:   model.Duration(15 * time.Second),
+				MetricsPath:     "/metrics2",
+			},
+		},
+		{
+			keep: false,
+			newConfig: &config.ScrapeConfig{
+				JobName:         "Prometheus",
+				HonorTimestamps: false,
+				HonorLabels:     true,
+				SampleLimit:     400,
+				ScrapeInterval:  model.Duration(5 * time.Second),
+				ScrapeTimeout:   model.Duration(15 * time.Second),
+				MetricsPath:     "/metrics2",
+			},
+		},
 	}
 
 	for i, s := range steps {


### PR DESCRIPTION
Replaces and closes #3861
Closes #3112

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->