### PR TITLE
scrape: Add metrics to track bytes and entries in the metadata cache

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -27,11 +27,78 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 )
+
+var targetMetadataCache = newMetadataMetricsCollector()
+
+// MetadataMetricsCollector is a Custom Collector for the metadata cache metrics.
+type MetadataMetricsCollector struct {
+	CacheEntries *prometheus.Desc
+	CacheBytes   *prometheus.Desc
+
+	scrapeManager *Manager
+}
+
+func newMetadataMetricsCollector() *MetadataMetricsCollector {
+	return &MetadataMetricsCollector{
+		CacheEntries: prometheus.NewDesc(
+			"prometheus_target_metadata_cache_entries",
+			"Total number of metric metadata entries in the cache",
+			[]string{"scrape_job"},
+			nil,
+		),
+		CacheBytes: prometheus.NewDesc(
+			"prometheus_target_metadata_cache_bytes",
+			"The number of bytes that are currently used for storing metric metadata in the cache",
+			[]string{"scrape_job"},
+			nil,
+		),
+	}
+}
+
+func (mc *MetadataMetricsCollector) registerManager(m *Manager) {
+	mc.scrapeManager = m
+}
+
+// Describe sends the metrics descriptions to the channel.
+func (mc *MetadataMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- mc.CacheEntries
+	ch <- mc.CacheBytes
+}
+
+// Collect creates and sends the metrics for the metadata cache.
+func (mc *MetadataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	if mc.scrapeManager == nil {
+		return
+	}
+
+	for tset, targets := range mc.scrapeManager.TargetsActive() {
+		var size, length int
+		for _, t := range targets {
+			size += t.MetadataSize()
+			length += t.MetadataLength()
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			mc.CacheEntries,
+			prometheus.GaugeValue,
+			float64(length),
+			tset,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			mc.CacheBytes,
+			prometheus.GaugeValue,
+			float64(size),
+			tset,
+		)
+	}
+}
 
 // Appendable returns an Appender.
 type Appendable interface {

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -43,7 +43,7 @@ func NewManager(logger log.Logger, app Appendable) *Manager {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
-	return &Manager{
+	m := &Manager{
 		append:        app,
 		logger:        logger,
 		scrapeConfigs: make(map[string]*config.ScrapeConfig),
@@ -51,6 +51,8 @@ func NewManager(logger log.Logger, app Appendable) *Manager {
 		graceShut:     make(chan struct{}),
 		triggerReload: make(chan struct{}, 1),
 	}
+
+	return m
 }
 
 // Manager maintains a set of scrape pools and manages start/stop cycles
@@ -134,6 +136,7 @@ func (m *Manager) reload() {
 		}(m.scrapePools[setName], groups)
 
 	}
+	targetMetadataCache.registerManager(m)
 	m.mtxScrape.Unlock()
 	wg.Wait()
 }

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -51,6 +51,7 @@ func NewManager(logger log.Logger, app Appendable) *Manager {
 		graceShut:     make(chan struct{}),
 		triggerReload: make(chan struct{}, 1),
 	}
+	targetMetadataCache.registerManager(m)
 
 	return m
 }
@@ -136,7 +137,6 @@ func (m *Manager) reload() {
 		}(m.scrapePools[setName], groups)
 
 	}
-	targetMetadataCache.registerManager(m)
 	m.mtxScrape.Unlock()
 	wg.Wait()
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -207,20 +207,22 @@ func (mc *MetadataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func init() {
-	prometheus.MustRegister(targetIntervalLength)
-	prometheus.MustRegister(targetReloadIntervalLength)
-	prometheus.MustRegister(targetScrapePools)
-	prometheus.MustRegister(targetScrapePoolsFailed)
-	prometheus.MustRegister(targetScrapePoolReloads)
-	prometheus.MustRegister(targetScrapePoolReloadsFailed)
-	prometheus.MustRegister(targetSyncIntervalLength)
-	prometheus.MustRegister(targetScrapePoolSyncsCounter)
-	prometheus.MustRegister(targetScrapeSampleLimit)
-	prometheus.MustRegister(targetScrapeSampleDuplicate)
-	prometheus.MustRegister(targetScrapeSampleOutOfOrder)
-	prometheus.MustRegister(targetScrapeSampleOutOfBounds)
-	prometheus.MustRegister(targetScrapeCacheFlushForced)
-	prometheus.MustRegister(targetMetadataCache)
+	prometheus.MustRegister(
+		targetIntervalLength,
+		targetReloadIntervalLength,
+		targetScrapePools,
+		targetScrapePoolsFailed,
+		targetScrapePoolReloads,
+		targetScrapePoolReloadsFailed,
+		targetSyncIntervalLength,
+		targetScrapePoolSyncsCounter,
+		targetScrapeSampleLimit,
+		targetScrapeSampleDuplicate,
+		targetScrapeSampleOutOfOrder,
+		targetScrapeSampleOutOfBounds,
+		targetScrapeCacheFlushForced,
+		targetMetadataCache,
+	)
 }
 
 // scrapePool manages scrapes for sets of targets.
@@ -288,7 +290,8 @@ func newScrapePool(cfg *config.ScrapeConfig, app Appendable, jitterSeed uint64, 
 		}
 		opts.target.SetMetadataStore(cache)
 
-		return newScrapeLoop(ctx,
+		return newScrapeLoop(
+			ctx,
 			opts.scraper,
 			log.With(logger, "target", opts.target),
 			buffers,

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -136,7 +136,7 @@ var (
 	targetMetadataCacheBytes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "prometheus_target_metadata_cache_bytes",
-			Help: "The number of bytes that are currently used for storing metric metadata of a target",
+			Help: "The number of bytes that are currently used for storing metric metadata in the cache",
 		},
 		[]string{"scrape_job"},
 	)

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -371,8 +371,7 @@ func TestScrapePoolRaces(t *testing.T) {
 func TestScrapeLoopStopBeforeRun(t *testing.T) {
 	scraper := &testScraper{}
 
-	sl := newScrapeLoop(&Target{},
-		context.Background(),
+	sl := newScrapeLoop(context.Background(),
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -435,8 +434,7 @@ func TestScrapeLoopStop(t *testing.T) {
 	)
 	defer close(signal)
 
-	sl := newScrapeLoop(&Target{},
-		context.Background(),
+	sl := newScrapeLoop(context.Background(),
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -503,8 +501,7 @@ func TestScrapeLoopRun(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(&Target{},
-		ctx,
+	sl := newScrapeLoop(ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -551,8 +548,7 @@ func TestScrapeLoopRun(t *testing.T) {
 	}
 
 	ctx, cancel = context.WithCancel(context.Background())
-	sl = newScrapeLoop(&Target{},
-		ctx,
+	sl = newScrapeLoop(ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -602,8 +598,7 @@ func TestScrapeLoopMetadata(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(&Target{},
-		ctx,
+	sl := newScrapeLoop(ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -653,8 +648,7 @@ func TestScrapeLoopSeriesAdded(t *testing.T) {
 	testutil.Ok(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(&Target{},
-		ctx,
+	sl := newScrapeLoop(ctx,
 		&testScraper{},
 		nil, nil,
 		nopMutator,
@@ -689,8 +683,7 @@ func TestScrapeLoopRunCreatesStaleMarkersOnFailedScrape(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(&Target{},
-		ctx,
+	sl := newScrapeLoop(ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -745,8 +738,7 @@ func TestScrapeLoopRunCreatesStaleMarkersOnParseFailure(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(&Target{},
-		ctx,
+	sl := newScrapeLoop(ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -808,8 +800,7 @@ func TestScrapeLoopCache(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(&Target{},
-		ctx,
+	sl := newScrapeLoop(ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -887,8 +878,7 @@ func TestScrapeLoopCacheMemoryExhaustionProtection(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(&Target{},
-		ctx,
+	sl := newScrapeLoop(ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -991,8 +981,7 @@ func TestScrapeLoopAppend(t *testing.T) {
 			labels: labels.FromStrings(test.discoveryLabels...),
 		}
 
-		sl := newScrapeLoop(&Target{},
-			context.Background(),
+		sl := newScrapeLoop(context.Background(),
 			nil, nil, nil,
 			func(l labels.Labels) labels.Labels {
 				return mutateSampleLabels(l, discoveryLabels, test.honorLabels, nil)
@@ -1035,8 +1024,7 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 	resApp := &collectResultAppender{}
 	app := &limitAppender{Appender: resApp, limit: 1}
 
-	sl := newScrapeLoop(&Target{},
-		context.Background(),
+	sl := newScrapeLoop(context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
@@ -1092,8 +1080,7 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 
 	capp := &collectResultAppender{next: app}
 
-	sl := newScrapeLoop(&Target{},
-		context.Background(),
+	sl := newScrapeLoop(context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
@@ -1129,8 +1116,7 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 func TestScrapeLoopAppendStaleness(t *testing.T) {
 	app := &collectResultAppender{}
 
-	sl := newScrapeLoop(&Target{},
-		context.Background(),
+	sl := newScrapeLoop(context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
@@ -1169,8 +1155,7 @@ func TestScrapeLoopAppendStaleness(t *testing.T) {
 
 func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
 	app := &collectResultAppender{}
-	sl := newScrapeLoop(&Target{},
-		context.Background(),
+	sl := newScrapeLoop(context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
@@ -1205,8 +1190,7 @@ func TestScrapeLoopRunReportsTargetDownOnScrapeError(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(&Target{},
-		ctx,
+	sl := newScrapeLoop(ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -1234,8 +1218,7 @@ func TestScrapeLoopRunReportsTargetDownOnInvalidUTF8(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(&Target{},
-		ctx,
+	sl := newScrapeLoop(ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -1280,8 +1263,7 @@ func (app *errorAppender) AddFast(lset labels.Labels, ref uint64, t int64, v flo
 func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T) {
 	app := &errorAppender{}
 
-	sl := newScrapeLoop(&Target{},
-		context.Background(),
+	sl := newScrapeLoop(context.Background(),
 		nil,
 		nil, nil,
 		nopMutator,
@@ -1311,8 +1293,7 @@ func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T
 
 func TestScrapeLoopOutOfBoundsTimeError(t *testing.T) {
 	app := &collectResultAppender{}
-	sl := newScrapeLoop(&Target{},
-		context.Background(),
+	sl := newScrapeLoop(context.Background(),
 		nil,
 		nil, nil,
 		nopMutator,
@@ -1504,8 +1485,7 @@ func TestScrapeLoop_RespectTimestamps(t *testing.T) {
 
 	capp := &collectResultAppender{next: app}
 
-	sl := newScrapeLoop(&Target{},
-		context.Background(),
+	sl := newScrapeLoop(context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
@@ -1537,8 +1517,7 @@ func TestScrapeLoop_DiscardTimestamps(t *testing.T) {
 
 	capp := &collectResultAppender{next: app}
 
-	sl := newScrapeLoop(&Target{},
-		context.Background(),
+	sl := newScrapeLoop(context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
@@ -1569,8 +1548,7 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 	testutil.Ok(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(&Target{},
-		ctx,
+	sl := newScrapeLoop(ctx,
 		&testScraper{},
 		nil, nil,
 		nopMutator,

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -371,7 +371,7 @@ func TestScrapePoolRaces(t *testing.T) {
 func TestScrapeLoopStopBeforeRun(t *testing.T) {
 	scraper := &testScraper{}
 
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		context.Background(),
 		scraper,
 		nil, nil,
@@ -435,7 +435,7 @@ func TestScrapeLoopStop(t *testing.T) {
 	)
 	defer close(signal)
 
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		context.Background(),
 		scraper,
 		nil, nil,
@@ -503,7 +503,7 @@ func TestScrapeLoopRun(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		ctx,
 		scraper,
 		nil, nil,
@@ -551,7 +551,7 @@ func TestScrapeLoopRun(t *testing.T) {
 	}
 
 	ctx, cancel = context.WithCancel(context.Background())
-	sl = newScrapeLoop("prom",
+	sl = newScrapeLoop(&Target{},
 		ctx,
 		scraper,
 		nil, nil,
@@ -602,7 +602,7 @@ func TestScrapeLoopMetadata(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		ctx,
 		scraper,
 		nil, nil,
@@ -653,7 +653,7 @@ func TestScrapeLoopSeriesAdded(t *testing.T) {
 	testutil.Ok(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		ctx,
 		&testScraper{},
 		nil, nil,
@@ -689,7 +689,7 @@ func TestScrapeLoopRunCreatesStaleMarkersOnFailedScrape(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		ctx,
 		scraper,
 		nil, nil,
@@ -745,7 +745,7 @@ func TestScrapeLoopRunCreatesStaleMarkersOnParseFailure(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		ctx,
 		scraper,
 		nil, nil,
@@ -808,7 +808,7 @@ func TestScrapeLoopCache(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		ctx,
 		scraper,
 		nil, nil,
@@ -887,7 +887,7 @@ func TestScrapeLoopCacheMemoryExhaustionProtection(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		ctx,
 		scraper,
 		nil, nil,
@@ -991,7 +991,7 @@ func TestScrapeLoopAppend(t *testing.T) {
 			labels: labels.FromStrings(test.discoveryLabels...),
 		}
 
-		sl := newScrapeLoop("prom",
+		sl := newScrapeLoop(&Target{},
 			context.Background(),
 			nil, nil, nil,
 			func(l labels.Labels) labels.Labels {
@@ -1035,7 +1035,7 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 	resApp := &collectResultAppender{}
 	app := &limitAppender{Appender: resApp, limit: 1}
 
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		context.Background(),
 		nil, nil, nil,
 		nopMutator,
@@ -1092,7 +1092,7 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 
 	capp := &collectResultAppender{next: app}
 
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		context.Background(),
 		nil, nil, nil,
 		nopMutator,
@@ -1129,7 +1129,7 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 func TestScrapeLoopAppendStaleness(t *testing.T) {
 	app := &collectResultAppender{}
 
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		context.Background(),
 		nil, nil, nil,
 		nopMutator,
@@ -1169,7 +1169,7 @@ func TestScrapeLoopAppendStaleness(t *testing.T) {
 
 func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
 	app := &collectResultAppender{}
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		context.Background(),
 		nil, nil, nil,
 		nopMutator,
@@ -1205,7 +1205,7 @@ func TestScrapeLoopRunReportsTargetDownOnScrapeError(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		ctx,
 		scraper,
 		nil, nil,
@@ -1234,7 +1234,7 @@ func TestScrapeLoopRunReportsTargetDownOnInvalidUTF8(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		ctx,
 		scraper,
 		nil, nil,
@@ -1280,7 +1280,7 @@ func (app *errorAppender) AddFast(lset labels.Labels, ref uint64, t int64, v flo
 func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T) {
 	app := &errorAppender{}
 
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		context.Background(),
 		nil,
 		nil, nil,
@@ -1311,7 +1311,7 @@ func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T
 
 func TestScrapeLoopOutOfBoundsTimeError(t *testing.T) {
 	app := &collectResultAppender{}
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		context.Background(),
 		nil,
 		nil, nil,
@@ -1504,7 +1504,7 @@ func TestScrapeLoop_RespectTimestamps(t *testing.T) {
 
 	capp := &collectResultAppender{next: app}
 
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		context.Background(),
 		nil, nil, nil,
 		nopMutator,
@@ -1537,7 +1537,7 @@ func TestScrapeLoop_DiscardTimestamps(t *testing.T) {
 
 	capp := &collectResultAppender{next: app}
 
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		context.Background(),
 		nil, nil, nil,
 		nopMutator,
@@ -1569,7 +1569,7 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 	testutil.Ok(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop("prom",
+	sl := newScrapeLoop(&Target{},
 		ctx,
 		&testScraper{},
 		nil, nil,

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -371,7 +371,8 @@ func TestScrapePoolRaces(t *testing.T) {
 func TestScrapeLoopStopBeforeRun(t *testing.T) {
 	scraper := &testScraper{}
 
-	sl := newScrapeLoop(context.Background(),
+	sl := newScrapeLoop("prom",
+		context.Background(),
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -434,7 +435,8 @@ func TestScrapeLoopStop(t *testing.T) {
 	)
 	defer close(signal)
 
-	sl := newScrapeLoop(context.Background(),
+	sl := newScrapeLoop("prom",
+		context.Background(),
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -501,7 +503,8 @@ func TestScrapeLoopRun(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
+	sl := newScrapeLoop("prom",
+		ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -548,7 +551,8 @@ func TestScrapeLoopRun(t *testing.T) {
 	}
 
 	ctx, cancel = context.WithCancel(context.Background())
-	sl = newScrapeLoop(ctx,
+	sl = newScrapeLoop("prom",
+		ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -598,7 +602,8 @@ func TestScrapeLoopMetadata(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
+	sl := newScrapeLoop("prom",
+		ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -648,7 +653,8 @@ func TestScrapeLoopSeriesAdded(t *testing.T) {
 	testutil.Ok(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
+	sl := newScrapeLoop("prom",
+		ctx,
 		&testScraper{},
 		nil, nil,
 		nopMutator,
@@ -683,7 +689,8 @@ func TestScrapeLoopRunCreatesStaleMarkersOnFailedScrape(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
+	sl := newScrapeLoop("prom",
+		ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -738,7 +745,8 @@ func TestScrapeLoopRunCreatesStaleMarkersOnParseFailure(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
+	sl := newScrapeLoop("prom",
+		ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -800,7 +808,8 @@ func TestScrapeLoopCache(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
+	sl := newScrapeLoop("prom",
+		ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -878,7 +887,8 @@ func TestScrapeLoopCacheMemoryExhaustionProtection(t *testing.T) {
 	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
+	sl := newScrapeLoop("prom",
+		ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -981,7 +991,8 @@ func TestScrapeLoopAppend(t *testing.T) {
 			labels: labels.FromStrings(test.discoveryLabels...),
 		}
 
-		sl := newScrapeLoop(context.Background(),
+		sl := newScrapeLoop("prom",
+			context.Background(),
 			nil, nil, nil,
 			func(l labels.Labels) labels.Labels {
 				return mutateSampleLabels(l, discoveryLabels, test.honorLabels, nil)
@@ -1024,7 +1035,8 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 	resApp := &collectResultAppender{}
 	app := &limitAppender{Appender: resApp, limit: 1}
 
-	sl := newScrapeLoop(context.Background(),
+	sl := newScrapeLoop("prom",
+		context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
@@ -1080,7 +1092,8 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 
 	capp := &collectResultAppender{next: app}
 
-	sl := newScrapeLoop(context.Background(),
+	sl := newScrapeLoop("prom",
+		context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
@@ -1116,7 +1129,8 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 func TestScrapeLoopAppendStaleness(t *testing.T) {
 	app := &collectResultAppender{}
 
-	sl := newScrapeLoop(context.Background(),
+	sl := newScrapeLoop("prom",
+		context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
@@ -1155,7 +1169,8 @@ func TestScrapeLoopAppendStaleness(t *testing.T) {
 
 func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
 	app := &collectResultAppender{}
-	sl := newScrapeLoop(context.Background(),
+	sl := newScrapeLoop("prom",
+		context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
@@ -1190,7 +1205,8 @@ func TestScrapeLoopRunReportsTargetDownOnScrapeError(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
+	sl := newScrapeLoop("prom",
+		ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -1218,7 +1234,8 @@ func TestScrapeLoopRunReportsTargetDownOnInvalidUTF8(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
+	sl := newScrapeLoop("prom",
+		ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
@@ -1263,7 +1280,8 @@ func (app *errorAppender) AddFast(lset labels.Labels, ref uint64, t int64, v flo
 func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T) {
 	app := &errorAppender{}
 
-	sl := newScrapeLoop(context.Background(),
+	sl := newScrapeLoop("prom",
+		context.Background(),
 		nil,
 		nil, nil,
 		nopMutator,
@@ -1293,7 +1311,8 @@ func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T
 
 func TestScrapeLoopOutOfBoundsTimeError(t *testing.T) {
 	app := &collectResultAppender{}
-	sl := newScrapeLoop(context.Background(),
+	sl := newScrapeLoop("prom",
+		context.Background(),
 		nil,
 		nil, nil,
 		nopMutator,
@@ -1485,7 +1504,8 @@ func TestScrapeLoop_RespectTimestamps(t *testing.T) {
 
 	capp := &collectResultAppender{next: app}
 
-	sl := newScrapeLoop(context.Background(),
+	sl := newScrapeLoop("prom",
+		context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
@@ -1517,7 +1537,8 @@ func TestScrapeLoop_DiscardTimestamps(t *testing.T) {
 
 	capp := &collectResultAppender{next: app}
 
-	sl := newScrapeLoop(context.Background(),
+	sl := newScrapeLoop("prom",
+		context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
@@ -1548,7 +1569,8 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 	testutil.Ok(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
+	sl := newScrapeLoop("prom",
+		ctx,
 		&testScraper{},
 		nil, nil,
 		nopMutator,

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -78,6 +78,8 @@ func (t *Target) String() string {
 type MetricMetadataStore interface {
 	ListMetadata() []MetricMetadata
 	GetMetadata(metric string) (MetricMetadata, bool)
+	SizeMetadata() int
+	LengthMetadata() int
 }
 
 // MetricMetadata is a piece of metadata for a metric.
@@ -96,6 +98,28 @@ func (t *Target) MetadataList() []MetricMetadata {
 		return nil
 	}
 	return t.metadata.ListMetadata()
+}
+
+func (t *Target) MetadataSize() int {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+
+	if t.metadata == nil {
+		return 0
+	}
+
+	return t.metadata.SizeMetadata()
+}
+
+func (t *Target) MetadataLength() int {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+
+	if t.metadata == nil {
+		return 0
+	}
+
+	return t.metadata.LengthMetadata()
 }
 
 // Metadata returns type and help metadata for the given metric.

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -77,6 +77,9 @@ func (s *testMetaStore) GetMetadata(metric string) (scrape.MetricMetadata, bool)
 	return scrape.MetricMetadata{}, false
 }
 
+func (s *testMetaStore) SizeMetadata() int   { return 0 }
+func (s *testMetaStore) LengthMetadata() int { return 0 }
+
 // testTargetRetriever represents a list of targets to scrape.
 // It is used to represent targets as part of test cases.
 type testTargetRetriever struct {


### PR DESCRIPTION
At the moment, we have low visibility in the usage and entries of the scrape metadata cache. With the inclusion of these metrics, we aim to understand how do the number of entries and cache size correlate in a Prometheus install given we have no limits around metadata. 

Signed-off-by: gotjosh <josue@grafana.com>