### PR TITLE
Make head Postings only return series in time range

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -112,7 +112,7 @@ type ChunkReader interface {
 // BlockReader provides reading access to a data block.
 type BlockReader interface {
 	// Index returns an IndexReader over the block's data.
-	Index() (IndexReader, error)
+	Index(mint, maxt int64) (IndexReader, error)
 
 	// Chunks returns a ChunkReader over the block's data.
 	Chunks() (ChunkReader, error)
@@ -372,7 +372,7 @@ func (pb *Block) startRead() error {
 }
 
 // Index returns a new IndexReader against the block data.
-func (pb *Block) Index() (IndexReader, error) {
+func (pb *Block) Index(mint, maxt int64) (IndexReader, error) {
 	if err := pb.startRead(); err != nil {
 		return nil, err
 	}

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -111,7 +111,8 @@ type ChunkReader interface {
 
 // BlockReader provides reading access to a data block.
 type BlockReader interface {
-	// Index returns an IndexReader over the block's data.
+	// Index returns an IndexReader over the block's data within the specified
+	// timeframe.
 	Index(mint, maxt int64) (IndexReader, error)
 
 	// Chunks returns a ChunkReader over the block's data.

--- a/tsdb/cmd/tsdb/main.go
+++ b/tsdb/cmd/tsdb/main.go
@@ -470,7 +470,7 @@ func analyzeBlock(b tsdb.BlockReader, limit int) error {
 	// Presume 1ms resolution that Prometheus uses.
 	fmt.Printf("Duration: %s\n", (time.Duration(meta.MaxTime-meta.MinTime) * 1e6).String())
 	fmt.Printf("Series: %d\n", meta.Stats.NumSeries)
-	ir, err := b.Index()
+	ir, err := b.Index(math.MinInt64, math.MaxInt64)
 	if err != nil {
 		return err
 	}

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -683,7 +683,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 			}
 		}
 
-		indexr, err := b.Index(math.MinInt64, math.MaxInt64)
+		indexr, err := b.Index(math.MinInt64, globalMaxt)
 		if err != nil {
 			return errors.Wrapf(err, "open index reader for block %s", b)
 		}

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -683,7 +683,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 			}
 		}
 
-		indexr, err := b.Index()
+		indexr, err := b.Index(math.MinInt64, math.MaxInt64)
 		if err != nil {
 			return errors.Wrapf(err, "open index reader for block %s", b)
 		}

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -456,10 +456,10 @@ func metaRange(name string, mint, maxt int64, stats *BlockStats) dirMeta {
 
 type erringBReader struct{}
 
-func (erringBReader) Index() (IndexReader, error)            { return nil, errors.New("index") }
-func (erringBReader) Chunks() (ChunkReader, error)           { return nil, errors.New("chunks") }
-func (erringBReader) Tombstones() (tombstones.Reader, error) { return nil, errors.New("tombstones") }
-func (erringBReader) Meta() BlockMeta                        { return BlockMeta{} }
+func (erringBReader) Index(int64, int64) (IndexReader, error) { return nil, errors.New("index") }
+func (erringBReader) Chunks() (ChunkReader, error)            { return nil, errors.New("chunks") }
+func (erringBReader) Tombstones() (tombstones.Reader, error)  { return nil, errors.New("tombstones") }
+func (erringBReader) Meta() BlockMeta                         { return BlockMeta{} }
 
 type nopChunkWriter struct{}
 
@@ -652,7 +652,7 @@ func TestCompaction_populateBlock(t *testing.T) {
 			expErr:         errors.New("found chunk with minTime: 10 maxTime: 30 outside of compacted minTime: 0 maxTime: 20"),
 		},
 		{
-			// Introduced by https://github.com/prometheus/prometheus/tsdb/issues/347.
+			// Introduced by https://github.com/prometheus/tsdb/issues/347.
 			title: "Populate from single block containing extra chunk",
 			inputSeriesSamples: [][]seriesSamples{
 				{
@@ -692,7 +692,7 @@ func TestCompaction_populateBlock(t *testing.T) {
 			},
 		},
 		{
-			// Introduced by https://github.com/prometheus/prometheus/tsdb/pull/539.
+			// Introduced by https://github.com/prometheus/tsdb/pull/539.
 			title: "Populate from three blocks that the last two are overlapping.",
 			inputSeriesSamples: [][]seriesSamples{
 				{

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1384,7 +1384,7 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 	}, OverlappingBlocks(nc1))
 }
 
-// Regression test for https://github.com/prometheus/prometheus/tsdb/issues/347
+// Regression test for https://github.com/prometheus/tsdb/issues/347
 func TestChunkAtBlockBoundary(t *testing.T) {
 	db, closeFn := openTestDB(t, nil, nil)
 	defer func() {
@@ -1411,7 +1411,7 @@ func TestChunkAtBlockBoundary(t *testing.T) {
 	testutil.Ok(t, err)
 
 	for _, block := range db.Blocks() {
-		r, err := block.Index()
+		r, err := block.Index(math.MinInt64, math.MaxInt64)
 		testutil.Ok(t, err)
 		defer r.Close()
 
@@ -1761,7 +1761,7 @@ func TestDB_LabelNames(t *testing.T) {
 		appendSamples(db, 0, 4, tst.sampleLabels1)
 
 		// Testing head.
-		headIndexr, err := db.head.Index()
+		headIndexr, err := db.head.Index(math.MinInt64, math.MaxInt64)
 		testutil.Ok(t, err)
 		labelNames, err := headIndexr.LabelNames()
 		testutil.Ok(t, err)
@@ -1774,7 +1774,7 @@ func TestDB_LabelNames(t *testing.T) {
 		// All blocks have same label names, hence check them individually.
 		// No need to aggregate and check.
 		for _, b := range db.Blocks() {
-			blockIndexr, err := b.Index()
+			blockIndexr, err := b.Index(math.MinInt64, math.MaxInt64)
 			testutil.Ok(t, err)
 			labelNames, err = blockIndexr.LabelNames()
 			testutil.Ok(t, err)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -754,7 +754,7 @@ type RangeHead struct {
 	mint, maxt int64
 }
 
-// NewRangeHead returns a *rangeHead.
+// NewRangeHead returns a *RangeHead.
 func NewRangeHead(head *Head, mint, maxt int64) *RangeHead {
 	return &RangeHead{
 		head: head,
@@ -764,7 +764,14 @@ func NewRangeHead(head *Head, mint, maxt int64) *RangeHead {
 }
 
 func (h *RangeHead) Index(mint, maxt int64) (IndexReader, error) {
-	return h.head.indexRange(h.mint, h.maxt), nil
+	// rangeHead guarantees that the series returned are within its range.
+	if mint < h.mint {
+		mint = h.mint
+	}
+	if maxt > h.maxt {
+		maxt = h.maxt
+	}
+	return h.head.indexRange(mint, maxt), nil
 }
 
 func (h *RangeHead) Chunks() (ChunkReader, error) {
@@ -1347,9 +1354,17 @@ func (h *headIndexReader) LabelNames() ([]string, error) {
 
 // Postings returns the postings list iterator for the label pairs.
 func (h *headIndexReader) Postings(name string, values ...string) (index.Postings, error) {
+	fullRange := h.mint <= h.head.MinTime() && h.maxt >= h.head.MaxTime()
 	res := make([]index.Postings, 0, len(values))
 	for _, value := range values {
 		p := h.head.postings.Get(name, value)
+		if fullRange {
+			// The head timerange covers the full index reader timerange.
+			// All the series can the be appended without filtering.
+			res = append(res, p)
+			continue
+		}
+
 		// Filter out series not in the time range, to avoid
 		// later on building up all the chunk metadata just to
 		// discard it.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -763,7 +763,7 @@ func NewRangeHead(head *Head, mint, maxt int64) *RangeHead {
 	}
 }
 
-func (h *RangeHead) Index() (IndexReader, error) {
+func (h *RangeHead) Index(mint, maxt int64) (IndexReader, error) {
 	return h.head.indexRange(h.mint, h.maxt), nil
 }
 
@@ -1162,8 +1162,8 @@ func (h *Head) Tombstones() (tombstones.Reader, error) {
 }
 
 // Index returns an IndexReader against the block.
-func (h *Head) Index() (IndexReader, error) {
-	return h.indexRange(math.MinInt64, math.MaxInt64), nil
+func (h *Head) Index(mint, maxt int64) (IndexReader, error) {
+	return h.indexRange(mint, maxt), nil
 }
 
 func (h *Head) indexRange(mint, maxt int64) *headIndexReader {
@@ -1349,7 +1349,25 @@ func (h *headIndexReader) LabelNames() ([]string, error) {
 func (h *headIndexReader) Postings(name string, values ...string) (index.Postings, error) {
 	res := make([]index.Postings, 0, len(values))
 	for _, value := range values {
-		res = append(res, h.head.postings.Get(name, value))
+		p := h.head.postings.Get(name, value)
+		// Filter out series not in the time range, to avoid
+		// later on building up all the chunk metadata just to
+		// discard it.
+		filtered := []uint64{}
+		for p.Next() {
+			s := h.head.series.getByID(p.At())
+			if s == nil {
+				level.Debug(h.head.logger).Log("msg", "looked up series not found")
+				continue
+			}
+			if s.minTime() <= h.maxt && s.maxTime() >= h.mint {
+				filtered = append(filtered, p.At())
+			}
+		}
+		if p.Err() != nil {
+			return nil, p.Err()
+		}
+		res = append(res, index.NewListPostings(filtered))
 	}
 	return index.Merge(res...), nil
 }

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -14,6 +14,7 @@
 package tsdb
 
 import (
+	"fmt"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -47,4 +48,36 @@ func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 			h.getOrCreate(uint64(i), labels.FromStrings("a", strconv.Itoa(int(i))))
 		}
 	})
+}
+
+func BenchmarkHeadSeries(b *testing.B) {
+	h, err := NewHead(nil, nil, nil, 1000)
+	testutil.Ok(b, err)
+	defer h.Close()
+	app := h.Appender()
+	numSeries := 1000000
+	for i := 0; i < numSeries; i++ {
+		app.Add(labels.FromStrings("foo", "bar", "i", strconv.Itoa(i)), int64(i), 0)
+	}
+	testutil.Ok(b, app.Commit())
+
+	matcher := labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")
+
+	for s := 1; s <= numSeries; s *= 10 {
+		b.Run(fmt.Sprintf("%dof%d", s, numSeries), func(b *testing.B) {
+			q, err := NewBlockQuerier(h, 0, int64(s-1))
+			testutil.Ok(b, err)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ss, err := q.Select(matcher)
+				testutil.Ok(b, err)
+				for ss.Next() {
+				}
+				testutil.Ok(b, ss.Err())
+			}
+			q.Close()
+		})
+
+	}
 }

--- a/tsdb/mocks_test.go
+++ b/tsdb/mocks_test.go
@@ -71,8 +71,8 @@ type mockBReader struct {
 	maxt int64
 }
 
-func (r *mockBReader) Index() (IndexReader, error)  { return r.ir, nil }
-func (r *mockBReader) Chunks() (ChunkReader, error) { return r.cr, nil }
+func (r *mockBReader) Index(mint, maxt int64) (IndexReader, error) { return r.ir, nil }
+func (r *mockBReader) Chunks() (ChunkReader, error)                { return r.cr, nil }
 func (r *mockBReader) Tombstones() (tombstones.Reader, error) {
 	return tombstones.NewMemTombstones(), nil
 }

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -160,7 +160,7 @@ func (q *verticalQuerier) sel(p *storage.SelectParams, qs []storage.Querier, ms 
 
 // NewBlockQuerier returns a querier against the reader.
 func NewBlockQuerier(b BlockReader, mint, maxt int64) (storage.Querier, error) {
-	indexr, err := b.Index()
+	indexr, err := b.Index(mint, maxt)
 	if err != nil {
 		return nil, errors.Wrapf(err, "open index reader")
 	}

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -16,6 +16,7 @@ package tsdb
 import (
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"strconv"
 	"testing"
@@ -54,7 +55,7 @@ func BenchmarkPostingsForMatchers(b *testing.B) {
 	}
 	testutil.Ok(b, app.Commit())
 
-	ir, err := h.Index()
+	ir, err := h.Index(math.MinInt64, math.MaxInt64)
 	testutil.Ok(b, err)
 	b.Run("Head", func(b *testing.B) {
 		benchmarkPostingsForMatchers(b, ir)
@@ -72,7 +73,7 @@ func BenchmarkPostingsForMatchers(b *testing.B) {
 	defer func() {
 		testutil.Ok(b, block.Close())
 	}()
-	ir, err = block.Index()
+	ir, err = block.Index(math.MinInt64, math.MaxInt64)
 	testutil.Ok(b, err)
 	defer ir.Close()
 	b.Run("Block", func(b *testing.B) {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1044,7 +1044,7 @@ func TestSeriesIterator(t *testing.T) {
 	})
 }
 
-// Regression for: https://github.com/prometheus/prometheus/tsdb/pull/97
+// Regression for: https://github.com/prometheus/tsdb/pull/97
 func TestChunkSeriesIterator_DoubleSeek(t *testing.T) {
 	chkMetas := []chunks.Meta{
 		tsdbutil.ChunkFromSamples([]tsdbutil.Sample{}),
@@ -2137,7 +2137,7 @@ func TestPostingsForMatchers(t *testing.T) {
 		},
 	}
 
-	ir, err := h.Index()
+	ir, err := h.Index(math.MinInt64, math.MaxInt64)
 	testutil.Ok(t, err)
 
 	for _, c := range cases {

--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -49,7 +49,7 @@ func TestWALRepair_ReadingError(t *testing.T) {
 		},
 		// Ensures that the page buffer is big enough to fit
 		// an entire page size without panicking.
-		// https://github.com/prometheus/prometheus/tsdb/pull/414
+		// https://github.com/prometheus/tsdb/pull/414
 		"bad_header": {
 			1,
 			func(f *os.File) {


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Reworks and closes #6458