### PR TITLE
Fix flaky windows test

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -99,7 +99,7 @@ func TestQueryTimeout(t *testing.T) {
 	defer cancelCtx()
 
 	query := engine.newTestQuery(func(ctx context.Context) error {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		return contextDone(ctx, "test statement execution")
 	})
 


### PR DESCRIPTION
The windows clock is sometime off by 25ms, and as precise as 15ms.

Let's give it more time to avoid flaky tests.

Fix #6672

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->