### PR TITLE
Trim TSDB head chunks after being cut, to reduce inuse memory

### DIFF
--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -49,6 +49,7 @@ type Chunk interface {
 	// be re-used or a new iterator can be allocated.
 	Iterator(Iterator) Iterator
 	NumSamples() int
+	Compact()
 }
 
 // Appender adds sample pairs to a chunk.

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -41,14 +41,28 @@ const (
 
 // Chunk holds a sequence of sample pairs that can be iterated over and appended to.
 type Chunk interface {
+	// Bytes returns the underlying byte slice of the chunk.
 	Bytes() []byte
+
+	// Encoding returns the encoding type of the chunk.
 	Encoding() Encoding
+
+	// Appender returns an appender to append samples to the chunk.
 	Appender() (Appender, error)
+
 	// The iterator passed as argument is for re-use.
 	// Depending on implementation, the iterator can
 	// be re-used or a new iterator can be allocated.
 	Iterator(Iterator) Iterator
+
+	// NumSamples returns the number of samples in the chunk.
 	NumSamples() int
+
+	// Compact is called whenever a chunk is expected to be complete (no more
+	// samples appended) and the underlying implementation can eventually
+	// optimize the chunk.
+	// There's no strong guarantee that no samples will be appended once
+	// Compact() is called. Implementing this function is optional.
 	Compact()
 }
 

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -49,6 +49,10 @@ import (
 	"math/bits"
 )
 
+const (
+	chunkCompactCapacityThreshold = 32
+)
+
 // XORChunk holds XOR encoded sample data.
 type XORChunk struct {
 	b bstream
@@ -73,6 +77,14 @@ func (c *XORChunk) Bytes() []byte {
 // NumSamples returns the number of samples in the chunk.
 func (c *XORChunk) NumSamples() int {
 	return int(binary.BigEndian.Uint16(c.Bytes()))
+}
+
+func (c *XORChunk) Compact() {
+	if l := len(c.b.stream); cap(c.b.stream) > l+chunkCompactCapacityThreshold {
+		buf := make([]byte, l)
+		copy(buf, c.b.stream)
+		c.b.stream = buf
+	}
 }
 
 // Appender implements the Chunk interface.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1691,6 +1691,11 @@ func (s *memSeries) cut(mint int64) *memChunk {
 	s.chunks = append(s.chunks, c)
 	s.headChunk = c
 
+	// Remove exceeding capacity from the previous chunk byte slice to save memory.
+	if l := len(s.chunks); l > 1 {
+		s.chunks[l-2].chunk.Compact()
+	}
+
 	// Set upper bound on when the next chunk must be started. An earlier timestamp
 	// may be chosen dynamically at a later point.
 	s.nextAt = rangeForTimestamp(mint, s.chunkRange)


### PR DESCRIPTION
I'm currently working on a new experimental storage in Cortex based on TSDB (and Thanos). While benchmarking it and comparing the **inuse memory**, I've noticed that for the same exact series TSDB uses more memory than the Cortex chunks storage.

While profiling it I've found that part of such difference is given by an optimization we have in Cortex but doesn't exist in TSDB: chunks are not trimmed after being cut in the TSDB head.

In particular, a chunk byte slice is allocated in TSDB with an initial capacity of 128 bytes and then it double each time it's full:
https://github.com/prometheus/prometheus/blob/master/tsdb/chunkenc/xor.go#L58-L61

When a chunk is cut, the extra capacity of that `[]byte` is never reclaimed and we may end up (theoretically) wasting 2x space. It's not 2x space in the real world, but it may be significant. In the Cortex chunks storage, we check it and compact the `[]byte` if the capacity exceed 32 bytes.

I've applied the same optimization in TSDB and, according to our preliminary tests, it has reduced the memory used by TSDB by about -11% in our test cluster. More accurate benchmarks are required.

The change proposed in this PR is a trade-off between inuse memory and allocations: we're doing more allocations to reduce the inuse memory. For example, running the `BenchmarkLoadWAL` with `-benchmem` we can see:

```
benchmark                                                                  old ns/op      new ns/op      delta
BenchmarkLoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200-4     686987166      697524794      +1.53%
BenchmarkLoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50-4     1113564403     1128349782     +1.33%
BenchmarkLoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480-4     481137676      476783942      -0.90%

benchmark                                                                  old allocs     new allocs     delta
BenchmarkLoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200-4     640057         710074         +10.94%
BenchmarkLoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50-4     2395984        2395953        -0.00%
BenchmarkLoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480-4     569179         609208         +7.03%

benchmark                                                                  old bytes     new bytes     delta
BenchmarkLoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200-4     57155592      71857912      +25.72%
BenchmarkLoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50-4     365385744     364694736     -0.19%
BenchmarkLoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480-4     67557674      75518242      +11.78%
```