### PR TITLE
added marshal function for targetgroup.Group

### DIFF
--- a/discovery/targetgroup/targetgroup.go
+++ b/discovery/targetgroup/targetgroup.go
@@ -108,7 +108,7 @@ func (tg *Group) MarshalJSON() ([]byte, error) {
 
 	// return `"labels":[]` if LabelSet is empty, would be `"labels":null` instead
 	if g.Labels == nil {
-		g.Labels = make(model.LabelSet, 0)
+		g.Labels = make(model.LabelSet)
 	}
 
 	return json.Marshal(g)

--- a/discovery/targetgroup/targetgroup.go
+++ b/discovery/targetgroup/targetgroup.go
@@ -91,3 +91,25 @@ func (tg *Group) UnmarshalJSON(b []byte) error {
 	tg.Labels = g.Labels
 	return nil
 }
+
+// MarshalJSON implements the json.Marshaler interface.
+func (tg *Group) MarshalJSON() ([]byte, error) {
+	g := struct {
+		Targets []string       `json:"targets"`
+		Labels  model.LabelSet `json:"labels"`
+	}{
+		Targets: make([]string, 0, len(tg.Targets)),
+		Labels:  tg.Labels,
+	}
+
+	for _, t := range tg.Targets {
+		g.Targets = append(g.Targets, string(t[model.AddressLabel]))
+	}
+
+	// return `"labels":[]` if LabelSet is empty, would be `"labels":null` instead
+	if g.Labels == nil {
+		g.Labels = make(model.LabelSet, 0)
+	}
+
+	return json.Marshal(g)
+}

--- a/discovery/targetgroup/targetgroup_test.go
+++ b/discovery/targetgroup/targetgroup_test.go
@@ -23,6 +23,36 @@ import (
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
+func TestTargetGroupJSONMarshal(t *testing.T) {
+	tests := []struct {
+		expectedJSON string
+		expectedErr  error
+		group        Group
+	}{
+		{
+			// labels should be omitted if empty.
+			group:        Group{},
+			expectedJSON: `{"targets":[],"labels":{}}`,
+			expectedErr:  nil,
+		},
+		{
+			// targets only exposes addresses.
+			group: Group{Targets: []model.LabelSet{
+				model.LabelSet{"__address__": "localhost:9090"},
+				model.LabelSet{"__address__": "localhost:9091"}},
+				Labels: model.LabelSet{"foo": "bar", "bar": "baz"}},
+			expectedJSON: `{"targets":["localhost:9090","localhost:9091"],"labels":{"bar":"baz","foo":"bar"}}`,
+			expectedErr:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := test.group.MarshalJSON()
+		testutil.Equals(t, test.expectedErr, err)
+		testutil.Equals(t, test.expectedJSON, string(actual))
+	}
+}
+
 func TestTargetGroupStrictJsonUnmarshal(t *testing.T) {
 	tests := []struct {
 		json          string


### PR DESCRIPTION
This PR adds a custom marshal function for JSON to ensure that targetgroup.Group is properly formatted.

Currently the default behavior of json.Marshal() for a targetgroup.Group results in a map with `{"__address__":"<address>"}` which is not parsed back into a targetgroup because a []string is expected. This results in file_sd files generated using targegroup.Group being incompatible with Prometheus. Since yaml has both functions already it is not affected.