### PR TITLE
Delete prometheus_rule_group metrics when groups are removed

### DIFF
--- a/rules/fixtures/rules2.yaml
+++ b/rules/fixtures/rules2.yaml
@@ -1,0 +1,5 @@
+groups:
+  - name: test_2
+    rules:
+    - record: test_2
+      expr: vector(2)

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -872,7 +872,7 @@ func (m *Manager) Update(interval time.Duration, files []string, externalLabels 
 		// check if new group equals with the old group, if yes then skip it.
 		// If not equals, stop it and wait for it to finish the current iteration.
 		// Then copy it into the new group.
-		gn := groupKey(newg.name, newg.file)
+		gn := groupKey(newg.file, newg.name)
 		oldg, ok := m.groups[gn]
 		delete(m.groups, gn)
 
@@ -899,8 +899,13 @@ func (m *Manager) Update(interval time.Duration, files []string, externalLabels 
 	}
 
 	// Stop remaining old groups.
-	for _, oldg := range m.groups {
+	for n, oldg := range m.groups {
 		oldg.stop()
+		if m := oldg.metrics; m != nil {
+			m.groupLastEvalTime.DeleteLabelValues(n)
+			m.groupLastDuration.DeleteLabelValues(n)
+			m.groupRules.DeleteLabelValues(n)
+		}
 	}
 
 	wg.Wait()
@@ -956,7 +961,7 @@ func (m *Manager) LoadGroups(
 				))
 			}
 
-			groups[groupKey(rg.Name, fn)] = NewGroup(rg.Name, fn, itv, rules, shouldRestore, m.opts)
+			groups[groupKey(fn, rg.Name)] = NewGroup(rg.Name, fn, itv, rules, shouldRestore, m.opts)
 		}
 	}
 
@@ -964,8 +969,8 @@ func (m *Manager) LoadGroups(
 }
 
 // Group names need not be unique across filenames.
-func groupKey(name, file string) string {
-	return name + ";" + file
+func groupKey(file, name string) string {
+	return file + ";" + name
 }
 
 // RuleGroups returns the list of manager's rule groups.

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -945,10 +945,10 @@ func TestMetricsUpdate(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
+	for i, c := range cases {
 		err := ruleManager.Update(time.Second, c.files, nil)
 		testutil.Ok(t, err)
 		time.Sleep(2 * time.Second)
-		testutil.Equals(t, c.metrics, countMetrics(), "invalid count of metrics prefixed by prometheus_rule_group_")
+		testutil.Equals(t, c.metrics, countMetrics(), "test %d: invalid count of metrics", i)
 	}
 }


### PR DESCRIPTION
Closes #6693 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->