### PR TITLE
Fix order of testutil.Equals

### DIFF
--- a/discovery/openstack/hypervisor_test.go
+++ b/discovery/openstack/hypervisor_test.go
@@ -65,21 +65,29 @@ func TestOpenstackSDHypervisorRefresh(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Assert(t, tg != nil, "")
 	testutil.Assert(t, tg.Targets != nil, "")
-	testutil.Assert(t, len(tg.Targets) == 2, "")
+	testutil.Equals(t, 2, len(tg.Targets))
 
-	testutil.Equals(t, tg.Targets[0]["__address__"], model.LabelValue("172.16.70.14:0"))
-	testutil.Equals(t, tg.Targets[0]["__meta_openstack_hypervisor_hostname"], model.LabelValue("nc14.cloud.com"))
-	testutil.Equals(t, tg.Targets[0]["__meta_openstack_hypervisor_type"], model.LabelValue("QEMU"))
-	testutil.Equals(t, tg.Targets[0]["__meta_openstack_hypervisor_host_ip"], model.LabelValue("172.16.70.14"))
-	testutil.Equals(t, tg.Targets[0]["__meta_openstack_hypervisor_state"], model.LabelValue("up"))
-	testutil.Equals(t, tg.Targets[0]["__meta_openstack_hypervisor_status"], model.LabelValue("enabled"))
+	for l, v := range map[string]string{
+		"__address__":                          "172.16.70.14:0",
+		"__meta_openstack_hypervisor_hostname": "nc14.cloud.com",
+		"__meta_openstack_hypervisor_type":     "QEMU",
+		"__meta_openstack_hypervisor_host_ip":  "172.16.70.14",
+		"__meta_openstack_hypervisor_state":    "up",
+		"__meta_openstack_hypervisor_status":   "enabled",
+	} {
+		testutil.Equals(t, model.LabelValue(v), tg.Targets[0][model.LabelName(l)])
+	}
 
-	testutil.Equals(t, tg.Targets[1]["__address__"], model.LabelValue("172.16.70.13:0"))
-	testutil.Equals(t, tg.Targets[1]["__meta_openstack_hypervisor_hostname"], model.LabelValue("cc13.cloud.com"))
-	testutil.Equals(t, tg.Targets[1]["__meta_openstack_hypervisor_type"], model.LabelValue("QEMU"))
-	testutil.Equals(t, tg.Targets[1]["__meta_openstack_hypervisor_host_ip"], model.LabelValue("172.16.70.13"))
-	testutil.Equals(t, tg.Targets[1]["__meta_openstack_hypervisor_state"], model.LabelValue("up"))
-	testutil.Equals(t, tg.Targets[1]["__meta_openstack_hypervisor_status"], model.LabelValue("enabled"))
+	for l, v := range map[string]string{
+		"__address__":                          "172.16.70.13:0",
+		"__meta_openstack_hypervisor_hostname": "cc13.cloud.com",
+		"__meta_openstack_hypervisor_type":     "QEMU",
+		"__meta_openstack_hypervisor_host_ip":  "172.16.70.13",
+		"__meta_openstack_hypervisor_state":    "up",
+		"__meta_openstack_hypervisor_status":   "enabled",
+	} {
+		testutil.Equals(t, model.LabelValue(v), tg.Targets[1][model.LabelName(l)])
+	}
 
 	mock.TearDownSuite()
 }

--- a/pkg/textparse/promparse_test.go
+++ b/pkg/textparse/promparse_test.go
@@ -209,7 +209,7 @@ testmetric{label="\"bar\""} 1`
 
 		i++
 	}
-	testutil.Equals(t, i, len(exp))
+	testutil.Equals(t, len(exp), i)
 }
 
 func TestPromParseErrors(t *testing.T) {

--- a/pkg/textparse/promparse_test.go
+++ b/pkg/textparse/promparse_test.go
@@ -209,7 +209,7 @@ testmetric{label="\"bar\""} 1`
 
 		i++
 	}
-	testutil.Equals(t, len(exp), i)
+	testutil.Equals(t, i, len(exp))
 }
 
 func TestPromParseErrors(t *testing.T) {

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -149,7 +149,7 @@ func TestQueryCancel(t *testing.T) {
 	<-processing
 
 	testutil.NotOk(t, res.Err, "expected cancellation error for query1 but got none")
-	testutil.Equals(t, res.Err, errQueryCanceled)
+	testutil.Equals(t, errQueryCanceled, res.Err)
 
 	// Canceling a query before starting it must have no effect.
 	query2 := engine.newTestQuery(func(ctx context.Context) error {
@@ -203,14 +203,14 @@ func TestQueryError(t *testing.T) {
 
 	res := vectorQuery.Exec(ctx)
 	testutil.NotOk(t, res.Err, "expected error on failed select but got none")
-	testutil.Equals(t, res.Err, errStorage)
+	testutil.Equals(t, errStorage, res.Err)
 
 	matrixQuery, err := engine.NewInstantQuery(queryable, "foo[1m]", time.Unix(1, 0))
 	testutil.Ok(t, err)
 
 	res = matrixQuery.Exec(ctx)
 	testutil.NotOk(t, res.Err, "expected error on failed select but got none")
-	testutil.Equals(t, res.Err, errStorage)
+	testutil.Equals(t, errStorage, res.Err)
 }
 
 // paramCheckerQuerier implements storage.Querier which checks the start and end times
@@ -486,7 +486,7 @@ func TestEngineShutdown(t *testing.T) {
 	<-processing
 
 	testutil.NotOk(t, res.Err, "expected error on shutdown during query but got none")
-	testutil.Equals(t, res.Err, errQueryCanceled)
+	testutil.Equals(t, errQueryCanceled, res.Err)
 
 	query2 := engine.newTestQuery(func(context.Context) error {
 		t.Fatalf("reached query execution unexpectedly")
@@ -599,7 +599,7 @@ load 10s
 		}
 
 		testutil.Ok(t, res.Err)
-		testutil.Equals(t, res.Value, c.Result)
+		testutil.Equals(t, c.Result, res.Value)
 	}
 
 }
@@ -816,8 +816,8 @@ load 10s
 		testutil.Ok(t, err)
 
 		res := qry.Exec(test.Context())
-		testutil.Equals(t, res.Err, c.Result.Err)
-		testutil.Equals(t, res.Value, c.Result.Value)
+		testutil.Equals(t, c.Result.Err, res.Err)
+		testutil.Equals(t, c.Result.Value, res.Value)
 	}
 }
 
@@ -1100,8 +1100,8 @@ func TestSubquerySelector(t *testing.T) {
 			testutil.Ok(t, err)
 
 			res := qry.Exec(test.Context())
-			testutil.Equals(t, res.Err, c.Result.Err)
-			testutil.Equals(t, res.Value, c.Result.Value)
+			testutil.Equals(t, c.Result.Err, res.Err)
+			testutil.Equals(t, c.Result.Value, res.Value)
 		}
 	}
 }

--- a/promql/lex_test.go
+++ b/promql/lex_test.go
@@ -730,7 +730,7 @@ func TestLexer(t *testing.T) {
 				testutil.Equals(t, lastItem, eofItem, "%d: input %q", i, test.input)
 
 				out = out[:len(out)-1]
-				testutil.Equals(t, out, test.expected, "%d: input %q", i, test.input)
+				testutil.Equals(t, test.expected, out, "%d: input %q", i, test.input)
 			}
 		})
 	}

--- a/promql/parse_test.go
+++ b/promql/parse_test.go
@@ -2488,7 +2488,7 @@ func TestParseExpressions(t *testing.T) {
 
 		if !test.fail {
 			testutil.Ok(t, err)
-			testutil.Equals(t, expr, test.expected, "error on input '%s'", test.input)
+			testutil.Equals(t, test.expected, expr, "error on input '%s'", test.input)
 		} else {
 			testutil.NotOk(t, err)
 			testutil.Assert(t, strings.Contains(err.Error(), test.errMsg), "unexpected error on input '%s', expected '%s', got '%s'", test.input, test.errMsg, err.Error())
@@ -2635,7 +2635,7 @@ func TestRecoverParserRuntime(t *testing.T) {
 	var err error
 
 	defer func() {
-		testutil.Equals(t, err, errUnexpected)
+		testutil.Equals(t, errUnexpected, err)
 	}()
 	defer p.recover(&err)
 	// Cause a runtime panic.
@@ -2651,7 +2651,7 @@ func TestRecoverParserError(t *testing.T) {
 	e := errors.New("custom error")
 
 	defer func() {
-		testutil.Equals(t, err.Error(), e.Error())
+		testutil.Equals(t, e.Error(), err.Error())
 	}()
 	defer p.recover(&err)
 

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -138,7 +138,7 @@ func TestAlertingRuleLabelsUpdate(t *testing.T) {
 				filteredRes = append(filteredRes, smpl)
 			} else {
 				// If not 'ALERTS', it has to be 'ALERTS_FOR_STATE'.
-				testutil.Equals(t, smplName, "ALERTS_FOR_STATE")
+				testutil.Equals(t, "ALERTS_FOR_STATE", smplName)
 			}
 		}
 
@@ -217,7 +217,7 @@ func TestAlertingRuleExternalLabelsInTemplate(t *testing.T) {
 			filteredRes = append(filteredRes, smpl)
 		} else {
 			// If not 'ALERTS', it has to be 'ALERTS_FOR_STATE'.
-			testutil.Equals(t, smplName, "ALERTS_FOR_STATE")
+			testutil.Equals(t, "ALERTS_FOR_STATE", smplName)
 		}
 	}
 
@@ -231,7 +231,7 @@ func TestAlertingRuleExternalLabelsInTemplate(t *testing.T) {
 			filteredRes = append(filteredRes, smpl)
 		} else {
 			// If not 'ALERTS', it has to be 'ALERTS_FOR_STATE'.
-			testutil.Equals(t, smplName, "ALERTS_FOR_STATE")
+			testutil.Equals(t, "ALERTS_FOR_STATE", smplName)
 		}
 	}
 
@@ -287,7 +287,7 @@ func TestAlertingRuleEmptyLabelFromTemplate(t *testing.T) {
 			filteredRes = append(filteredRes, smpl)
 		} else {
 			// If not 'ALERTS', it has to be 'ALERTS_FOR_STATE'.
-			testutil.Equals(t, smplName, "ALERTS_FOR_STATE")
+			testutil.Equals(t, "ALERTS_FOR_STATE", smplName)
 		}
 	}
 	testutil.Equals(t, result, filteredRes)

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -74,7 +74,7 @@ func TestRuleEval(t *testing.T) {
 		rule := NewRecordingRule(test.name, test.expr, test.labels)
 		result, err := rule.Eval(ctx, now, EngineQueryFunc(engine, storage), nil)
 		testutil.Ok(t, err)
-		testutil.Equals(t, result, test.result)
+		testutil.Equals(t, test.result, result)
 	}
 }
 

--- a/storage/remote/intern_test.go
+++ b/storage/remote/intern_test.go
@@ -32,7 +32,7 @@ func TestIntern(t *testing.T) {
 	interner.intern(testString)
 	interned, ok := interner.pool[testString]
 
-	testutil.Equals(t, ok, true)
+	testutil.Equals(t, true, ok)
 	testutil.Assert(t, interned.refs == 1, fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs))
 }
 
@@ -42,13 +42,13 @@ func TestIntern_MultiRef(t *testing.T) {
 	interner.intern(testString)
 	interned, ok := interner.pool[testString]
 
-	testutil.Equals(t, ok, true)
+	testutil.Equals(t, true, ok)
 	testutil.Assert(t, interned.refs == 1, fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs))
 
 	interner.intern(testString)
 	interned, ok = interner.pool[testString]
 
-	testutil.Equals(t, ok, true)
+	testutil.Equals(t, true, ok)
 	testutil.Assert(t, interned.refs == 2, fmt.Sprintf("expected refs to be 2 but it was %d", interned.refs))
 }
 
@@ -58,12 +58,12 @@ func TestIntern_DeleteRef(t *testing.T) {
 	interner.intern(testString)
 	interned, ok := interner.pool[testString]
 
-	testutil.Equals(t, ok, true)
+	testutil.Equals(t, true, ok)
 	testutil.Assert(t, interned.refs == 1, fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs))
 
 	interner.release(testString)
 	_, ok = interner.pool[testString]
-	testutil.Equals(t, ok, false)
+	testutil.Equals(t, false, ok)
 }
 
 func TestIntern_MultiRef_Concurrent(t *testing.T) {
@@ -71,7 +71,7 @@ func TestIntern_MultiRef_Concurrent(t *testing.T) {
 
 	interner.intern(testString)
 	interned, ok := interner.pool[testString]
-	testutil.Equals(t, ok, true)
+	testutil.Equals(t, true, ok)
 	testutil.Assert(t, interned.refs == 1, fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs))
 
 	go interner.release(testString)
@@ -83,6 +83,6 @@ func TestIntern_MultiRef_Concurrent(t *testing.T) {
 	interner.mtx.RLock()
 	interned, ok = interner.pool[testString]
 	interner.mtx.RUnlock()
-	testutil.Equals(t, ok, true)
+	testutil.Equals(t, true, ok)
 	testutil.Assert(t, atomic.LoadInt64(&interned.refs) == 1, fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs))
 }


### PR DESCRIPTION
Equals takes the expected value as first parameter, and the actual value
as second parameter.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->