### PR TITLE
Move global /graph settings to navbar

### DIFF
--- a/web/ui/react-app/src/App.tsx
+++ b/web/ui/react-app/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import Navigation from './Navbar';
 import { Container } from 'reactstrap';
 
@@ -8,9 +8,11 @@ import { Alerts, Config, Flags, Rules, Services, Status, Targets, TSDBStatus, Pa
 import PathPrefixProps from './types/PathPrefixProps';
 
 const App: FC<PathPrefixProps> = ({ pathPrefix }) => {
+  const [extraNavItem, setExtraNavItem] = useState<React.ReactNode>(null);
+
   return (
     <>
-      <Navigation pathPrefix={pathPrefix} />
+      <Navigation pathPrefix={pathPrefix} extraNavItem={extraNavItem} />
       <Container fluid style={{ paddingTop: 70 }}>
         <Router basepath={`${pathPrefix}/new`}>
           <Redirect from="/" to={`${pathPrefix}/new/graph`} />
@@ -19,7 +21,7 @@ const App: FC<PathPrefixProps> = ({ pathPrefix }) => {
             NOTE: Any route added here needs to also be added to the list of
             React-handled router paths ("reactRouterPaths") in /web/web.go.
           */}
-          <PanelList path="/graph" pathPrefix={pathPrefix} />
+          <PanelList path="/graph" pathPrefix={pathPrefix} setExtraNavItem={setExtraNavItem} />
           <Alerts path="/alerts" pathPrefix={pathPrefix} />
           <Config path="/config" pathPrefix={pathPrefix} />
           <Flags path="/flags" pathPrefix={pathPrefix} />

--- a/web/ui/react-app/src/Navbar.tsx
+++ b/web/ui/react-app/src/Navbar.tsx
@@ -14,9 +14,14 @@ import {
 } from 'reactstrap';
 import PathPrefixProps from './types/PathPrefixProps';
 
-const Navigation: FC<PathPrefixProps> = ({ pathPrefix }) => {
+interface NavigationProps {
+  extraNavItem: React.ReactNode;
+}
+
+const Navigation: FC<PathPrefixProps & NavigationProps> = ({ pathPrefix, extraNavItem }) => {
   const [isOpen, setIsOpen] = useState(false);
   const toggle = () => setIsOpen(!isOpen);
+
   return (
     <Navbar className="mb-3" dark color="dark" expand="md" fixed="top">
       <NavbarToggler onClick={toggle} />
@@ -70,6 +75,7 @@ const Navigation: FC<PathPrefixProps> = ({ pathPrefix }) => {
             <NavLink href={`${pathPrefix}/`}>Classic UI</NavLink>
           </NavItem>
         </Nav>
+        {extraNavItem}
       </Collapse>
     </Navbar>
   );


### PR DESCRIPTION
This saves precious space at the top and makes the page look less
awkward.

Signed-off-by: Julius Volz <julius.volz@gmail.com>

Screenshots:

**Closed:**

![topsettings](https://user-images.githubusercontent.com/538008/73112196-c296aa00-3f0d-11ea-91de-7f97ead25ad9.png)

**Open:**

![topsettings_open](https://user-images.githubusercontent.com/538008/73112195-c296aa00-3f0d-11ea-9036-9db14d0352c0.png)

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->