### PR TITLE
Add an ignore_annotations option for unit testing

### DIFF
--- a/cmd/promtool/testdata/alerts.rules
+++ b/cmd/promtool/testdata/alerts.rules
@@ -1,0 +1,10 @@
+groups:
+  - name: my-group-name
+    rules:
+      - alert: InstanceDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          description: "stuff's happening with {{ $labels.service }}"

--- a/cmd/promtool/testdata/ignore_annotations.bad.yml
+++ b/cmd/promtool/testdata/ignore_annotations.bad.yml
@@ -1,0 +1,19 @@
+rule_files:
+  - alerts.rules
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: up{service="my-service"}
+        values: 1 1 1 0 0 0 1 1 1
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: InstanceDown
+        ignore_annotations: true
+        exp_alerts:
+          - exp_labels:
+              service: my-service
+              severity: critical
+            exp_annotations:
+              some: annotation

--- a/cmd/promtool/testdata/ignore_annotations.good.yml
+++ b/cmd/promtool/testdata/ignore_annotations.good.yml
@@ -1,0 +1,31 @@
+rule_files:
+  - alerts.rules
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: up{service="my-service"}
+        values: 1 1 1 0 0 0 1 1 1
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: InstanceDown
+        ignore_annotations: true
+        exp_alerts:
+          - exp_labels:
+              service: my-service
+              severity: critical
+
+  - interval: 1m
+    ignore_annotations: true
+    input_series:
+      - series: up{service="my-service"}
+        values: 1 1 1 0 0 0 1 1 1
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: InstanceDown
+        exp_alerts:
+          - exp_labels:
+              service: my-service
+              severity: critical

--- a/cmd/promtool/testdata/simple.yml
+++ b/cmd/promtool/testdata/simple.yml
@@ -1,0 +1,21 @@
+rule_files:
+  - alerts.rules
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: up{service="my-service"}
+        values: 1 1 1 0 0 0 1 1 1
+
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: InstanceDown
+
+      - eval_time: 5m
+        alertname: InstanceDown
+        exp_alerts:
+          - exp_labels:
+              service: my-service
+              severity: critical
+            exp_annotations:
+              description: "stuff's happening with my-service"

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -1,0 +1,37 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+func TestBad(t *testing.T) {
+	for _, file := range []string{
+		"testdata/ignore_annotations.bad.yml",
+	} {
+		if ruleUnitTest(file) == nil {
+			t.Error("expected", file, "to have errors, but none was returned")
+		}
+	}
+}
+
+func TestGood(t *testing.T) {
+	for _, file := range []string{
+		"testdata/ignore_annotations.good.yml",
+		"testdata/simple.yml",
+	} {
+		if err := ruleUnitTest(file); err != nil {
+			t.Error("unexpected errors in", file, ":", err)
+		}
+	}
+}

--- a/docs/configuration/unit_testing_rules.md
+++ b/docs/configuration/unit_testing_rules.md
@@ -57,6 +57,10 @@ promql_expr_test:
 # External labels accessible to the alert template.
 external_labels:
   [ <labelname>: <string> ... ]
+
+# If set to true, annotations are ignored during comparison if no annotations
+# are specified in the test data. Optional, defaults to false.
+ignore_annotations: <bool>
 ```
 
 ### `<series>`
@@ -88,6 +92,10 @@ eval_time: <duration>
 
 # Name of the alert to be tested.
 alertname: <string>
+
+# If set to true, annotations are ignored during comparison if no annotations
+# are specified in the test data. Optional, defaults to false.
+ignore_annotations: <bool>
 
 # List of expected alerts which are firing under the given alertname at
 # given evaluation time. If you want to test if an alerting rule should


### PR DESCRIPTION
This changes the behavior of `promtool` so that any `<alert>` that has no `exp_annotations` field set and that is part of a `<test_group>` or an `<alert_test_case>` that has `ignore_annotations` set to `true` will not have annotations checked as part of the test.

The idea is that while it’s generally a good idea to test that both labels and annotations have expected values, it is sometimes impractical to do so, for instance if you have an annotation that contains the value of the signal that triggered an alert or if you have stuff that is very verbose and you just end up copying and pasting things from the alert definition to the test file, which is annoying and kind of defeats the purpose of the test.

Of course, we keep the existing behavior as the default. Thoughts?