### PR TITLE
Add Github Actions workflow to run Prombench

### DIFF
--- a/.github/workflows/prombench.yml
+++ b/.github/workflows/prombench.yml
@@ -82,7 +82,7 @@ jobs:
         PROJECT_ID: macro-mile-203600
         CLUSTER_NAME: prombench
         ZONE: europe-west3-a
-        TEST_INFRA_REPO: https://github.com/testpromorg/prombench.git
+        TEST_INFRA_REPO: https://github.com/prometheus/prombench.git
         PR_NUMBER: ${{ github.event.client_payload.PR_NUMBER }}
       with:
         args: >-

--- a/.github/workflows/prombench.yml
+++ b/.github/workflows/prombench.yml
@@ -1,0 +1,172 @@
+on: repository_dispatch
+name: Prombench Workflow
+jobs:
+  benchmark_start:
+    name: Benchmark Start
+    if: github.event.action == 'prombench_start'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update status to pending
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LAST_COMMIT_SHA: ${{ github.event.client_payload.LAST_COMMIT_SHA }}
+      run: >-
+        curl -i -X POST
+        -H "Authorization: Bearer $GITHUB_TOKEN"
+        -H "Content-Type: application/json"
+        --data '{"state":"pending",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
+    - name: Run make deploy to start test
+      id: make_deploy
+      uses: docker://prombench/prombench:2.0.2
+      env:
+        AUTH_FILE: ${{ secrets.PROMBENCH_GKE_AUTH }}
+        PROJECT_ID: macro-mile-203600
+        CLUSTER_NAME: prombench
+        ZONE: europe-west3-a
+        DOMAIN_NAME: prombench.prometheus.io
+        TEST_INFRA_REPO: https://github.com/prometheus/prombench.git
+        GITHUB_ORG: prometheus
+        GITHUB_REPO: prometheus
+        PR_NUMBER: ${{ github.event.client_payload.PR_NUMBER }}
+        RELEASE: ${{ github.event.client_payload.RELEASE }}
+      with:
+        args: >-
+          until make all_nodepools_deleted; do echo "waiting for nodepools to be deleted"; sleep 10; done;
+          make deploy;
+    - name: Update status to failure
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LAST_COMMIT_SHA: ${{ github.event.client_payload.LAST_COMMIT_SHA }}
+      run: >-
+        curl -i -X POST
+        -H "Authorization: Bearer $GITHUB_TOKEN"
+        -H "Content-Type: application/json"
+        --data '{"state":"failure",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
+    - name: Update status to success
+      if: success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LAST_COMMIT_SHA: ${{ github.event.client_payload.LAST_COMMIT_SHA }}
+      run: >-
+        curl -i -X POST
+        -H "Authorization: Bearer $GITHUB_TOKEN"
+        -H "Content-Type: application/json"
+        --data '{"state":"success",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
+  #############################
+  # Jobs for stopping benchmark
+  #############################
+  benchmark_cancel:
+    name: Benchmark Cancel
+    if: github.event.action == 'prombench_stop'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update status to pending
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LAST_COMMIT_SHA: ${{ github.event.client_payload.LAST_COMMIT_SHA }}
+      run: >-
+        curl -i -X POST
+        -H "Authorization: Bearer $GITHUB_TOKEN"
+        -H "Content-Type: application/json"
+        --data '{"state":"pending",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
+    - name: Run make clean to stop test
+      id: make_clean
+      uses: docker://prombench/prombench:2.0.2
+      env:
+        AUTH_FILE: ${{ secrets.PROMBENCH_GKE_AUTH }}
+        PROJECT_ID: macro-mile-203600
+        CLUSTER_NAME: prombench
+        ZONE: europe-west3-a
+        TEST_INFRA_REPO: https://github.com/testpromorg/prombench.git
+        PR_NUMBER: ${{ github.event.client_payload.PR_NUMBER }}
+      with:
+        args: >-
+          until make all_nodepools_running; do echo "waiting for nodepools to be created"; sleep 10; done;
+          make clean;
+    - name: Update status to failure
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LAST_COMMIT_SHA: ${{ github.event.client_payload.LAST_COMMIT_SHA }}
+      run: >-
+        curl -i -X POST
+        -H "Authorization: Bearer $GITHUB_TOKEN"
+        -H "Content-Type: application/json"
+        --data '{"state":"failure",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
+    - name: Update status to success
+      if: success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LAST_COMMIT_SHA: ${{ github.event.client_payload.LAST_COMMIT_SHA }}
+      run: >-
+        curl -i -X POST
+        -H "Authorization: Bearer $GITHUB_TOKEN"
+        -H "Content-Type: application/json"
+        --data '{"state":"success",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
+  ###############################
+  # Jobs for restarting benchmark
+  ###############################
+  benchmark_restart:
+    name: Benchmark Restart
+    if: github.event.action == 'prombench_restart'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update status to pending
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LAST_COMMIT_SHA: ${{ github.event.client_payload.LAST_COMMIT_SHA }}
+      run: >-
+        curl -i -X POST
+        -H "Authorization: Bearer $GITHUB_TOKEN"
+        -H "Content-Type: application/json"
+        --data '{"state":"pending",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
+    - name: Run make clean then make deploy to restart test
+      id: make_restart
+      uses: docker://prombench/prombench:2.0.2
+      env:
+        AUTH_FILE: ${{ secrets.PROMBENCH_GKE_AUTH }}
+        PROJECT_ID: macro-mile-203600
+        CLUSTER_NAME: prombench
+        ZONE: europe-west3-a
+        DOMAIN_NAME: prombench.prometheus.io
+        TEST_INFRA_REPO: https://github.com/prometheus/prombench.git
+        GITHUB_ORG: prometheus
+        GITHUB_REPO: prometheus
+        PR_NUMBER: ${{ github.event.client_payload.PR_NUMBER }}
+        RELEASE: ${{ github.event.client_payload.RELEASE }}
+      with:
+        args: >-
+          until make all_nodepools_running; do echo "waiting for nodepools to be created"; sleep 10; done;
+          make clean;
+          until make all_nodepools_deleted; do echo "waiting for nodepools to be deleted"; sleep 10; done;
+          make deploy;
+    - name: Update status to failure
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LAST_COMMIT_SHA: ${{ github.event.client_payload.LAST_COMMIT_SHA }}
+      run: >-
+        curl -i -X POST
+        -H "Authorization: Bearer $GITHUB_TOKEN"
+        -H "Content-Type: application/json"
+        --data '{"state":"failure",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
+    - name: Update status to success
+      if: success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LAST_COMMIT_SHA: ${{ github.event.client_payload.LAST_COMMIT_SHA }}
+      run: >-
+        curl -i -X POST
+        -H "Authorization: Bearer $GITHUB_TOKEN"
+        -H "Content-Type: application/json"
+        --data '{"state":"success",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"


### PR DESCRIPTION
Moving from [Prow](https://github.com/kubernetes/test-infra/tree/master/prow), this PR adds Github Actions workflow file `prombench.yml` that allows starting, stopping and restarting of benchmarks.


cc: @krasi-georgiev 

Signed-off-by: Hrishikesh Barman <plain.hrishikeshbman@gmail.com>