### PR TITLE
consul: support reading token from a file

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -339,6 +339,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 # as the Consul documentation requires.
 [ server: <host> | default = "localhost:8500" ]
 [ token: <secret> ]
+[ token_file: <filename> ]
 [ datacenter: <string> ]
 [ scheme: <string> | default = "http" ]
 [ username: <string> ]


### PR DESCRIPTION
Closes #6140 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->