### PR TITLE
Updated contexts for GitHub actions Status updates.

### DIFF
--- a/.github/workflows/prombench.yml
+++ b/.github/workflows/prombench.yml
@@ -14,7 +14,7 @@ jobs:
         curl -i -X POST
         -H "Authorization: Bearer $GITHUB_TOKEN"
         -H "Content-Type: application/json"
-        --data '{"state":"pending",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        --data '{"state":"pending",  "context": "prombench-status-update-start", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
         "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
     - name: Run make deploy to start test
       id: make_deploy
@@ -43,7 +43,7 @@ jobs:
         curl -i -X POST
         -H "Authorization: Bearer $GITHUB_TOKEN"
         -H "Content-Type: application/json"
-        --data '{"state":"failure",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        --data '{"state":"failure",  "context": "prombench-status-update-start", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
         "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
     - name: Update status to success
       if: success()
@@ -54,7 +54,7 @@ jobs:
         curl -i -X POST
         -H "Authorization: Bearer $GITHUB_TOKEN"
         -H "Content-Type: application/json"
-        --data '{"state":"success",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        --data '{"state":"success",  "context": "prombench-status-update-start", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
         "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
   #############################
   # Jobs for stopping benchmark
@@ -72,7 +72,7 @@ jobs:
         curl -i -X POST
         -H "Authorization: Bearer $GITHUB_TOKEN"
         -H "Content-Type: application/json"
-        --data '{"state":"pending",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        --data '{"state":"pending",  "context": "prombench-status-update-cancel", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
         "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
     - name: Run make clean to stop test
       id: make_clean
@@ -97,7 +97,7 @@ jobs:
         curl -i -X POST
         -H "Authorization: Bearer $GITHUB_TOKEN"
         -H "Content-Type: application/json"
-        --data '{"state":"failure",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        --data '{"state":"failure",  "context": "prombench-status-update-cancel", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
         "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
     - name: Update status to success
       if: success()
@@ -108,7 +108,7 @@ jobs:
         curl -i -X POST
         -H "Authorization: Bearer $GITHUB_TOKEN"
         -H "Content-Type: application/json"
-        --data '{"state":"success",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        --data '{"state":"success",  "context": "prombench-status-update-cancel", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
         "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
   ###############################
   # Jobs for restarting benchmark
@@ -126,7 +126,7 @@ jobs:
         curl -i -X POST
         -H "Authorization: Bearer $GITHUB_TOKEN"
         -H "Content-Type: application/json"
-        --data '{"state":"pending",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        --data '{"state":"pending",  "context": "prombench-status-update-restart", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
         "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
     - name: Run make clean then make deploy to restart test
       id: make_restart
@@ -157,7 +157,7 @@ jobs:
         curl -i -X POST
         -H "Authorization: Bearer $GITHUB_TOKEN"
         -H "Content-Type: application/json"
-        --data '{"state":"failure",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        --data '{"state":"failure",  "context": "prombench-status-update-restart", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
         "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
     - name: Update status to success
       if: success()
@@ -168,5 +168,5 @@ jobs:
         curl -i -X POST
         -H "Authorization: Bearer $GITHUB_TOKEN"
         -H "Content-Type: application/json"
-        --data '{"state":"success",  "context": "prombench-status-update", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
+        --data '{"state":"success",  "context": "prombench-status-update-restart", "target_url": "https://github.com/'$GITHUB_REPOSITORY'/actions"}'
         "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"


### PR DESCRIPTION
Updates status contexts with better context names to avoid confusion till [GitHub Actions adds run id support.](https://github.community/t5/GitHub-Actions/Getting-the-run-id-of-a-run-in-Github-Actions/m-p/41270/highlight/true#M4553)

related: #6704 

cc: @krasi-georgiev @codesome 

Signed-off-by: Hrishikesh Barman <plain.hrishikeshbman@gmail.com>