### PR TITLE
scrape: Speed up scrape once we have reached sample_limit

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1111,8 +1111,8 @@ loop:
 				sampleLimitErr = err
 				added++
 
-				// Count the remaining samples in place, to avoid touching the
-				// storage layer.
+				// Only count the remaining samples in place, to speed-up
+				// the end of the scrape and minimize memory usage.
 				var remaining int
 				remaining, err = countRemainingSamples(p)
 				// Count of the remaining samples could return an error. If
@@ -1168,8 +1168,8 @@ loop:
 				sampleLimitErr = err
 				added++
 
-				// Count the remaining samples in place, to avoid touching the
-				// storage layer.
+				// Only count the remaining samples in place, to speed-up
+				// the end of the scrape and minimize memory usage.
 				var remaining int
 				remaining, err = countRemainingSamples(p)
 				// Count of the remaining samples could return an error. If


### PR DESCRIPTION
Fix #5690

As we reach the sample_limit, it is no longer needed to parse metrics
check cache & do relabelling -- we should just count the number of metrics left.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->