### PR TITLE
Add missing param to NewHead call in test.

### DIFF
--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1276,7 +1276,7 @@ func TestAddDuplicateLabelName(t *testing.T) {
 	wlog, err := wal.NewSize(nil, nil, dir, 32768, false)
 	testutil.Ok(t, err)
 
-	h, err := NewHead(nil, nil, wlog, 1000)
+	h, err := NewHead(nil, nil, wlog, 1000, DefaultStripeSize)
 	testutil.Ok(t, err)
 	defer h.Close()
 


### PR DESCRIPTION
A call to `NewHead` in head_test.go is missing a param, I believe this was introduced in https://github.com/prometheus/prometheus/pull/6644

Signed-off-by: Callum Styan <callumstyan@gmail.com>