### PR TITLE
Fix data race in query log test

### DIFF
--- a/cmd/prometheus/query_log_test.go
+++ b/cmd/prometheus/query_log_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -244,9 +245,15 @@ func (p *queryLogTest) run(t *testing.T) {
 	// Log stderr in case of failure.
 	stderr, err := prom.StderrPipe()
 	testutil.Ok(t, err)
+
+	// We use a WaitGroup to avoid calling t.Log after the test is done.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	defer wg.Wait()
 	go func() {
 		slurp, _ := ioutil.ReadAll(stderr)
 		t.Log(string(slurp))
+		wg.Done()
 	}()
 
 	testutil.Ok(t, prom.Start())


### PR DESCRIPTION
Otherwise we have data race when tests are run locally

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->