### PR TITLE
rules: Cleanup unused function alert.Duration

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -205,8 +205,8 @@ func (r *AlertingRule) Query() promql.Expr {
 	return r.vector
 }
 
-// Duration returns the hold duration of the alerting rule.
-func (r *AlertingRule) Duration() time.Duration {
+// HoldDuration returns the hold duration of the alerting rule.
+func (r *AlertingRule) HoldDuration() time.Duration {
 	return r.holdDuration
 }
 
@@ -546,9 +546,4 @@ func (r *AlertingRule) HTMLSnippet(pathPrefix string) html_template.HTML {
 		return html_template.HTML(fmt.Sprintf("error marshaling alerting rule: %q", html_template.HTMLEscapeString(err.Error())))
 	}
 	return html_template.HTML(byt)
-}
-
-// HoldDuration returns the holdDuration of the alerting rule.
-func (r *AlertingRule) HoldDuration() time.Duration {
-	return r.holdDuration
 }

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -972,7 +972,7 @@ func (api *API) rules(r *http.Request) apiFuncResult {
 					State:          rule.State().String(),
 					Name:           rule.Name(),
 					Query:          rule.Query().String(),
-					Duration:       rule.Duration().Seconds(),
+					Duration:       rule.HoldDuration().Seconds(),
 					Labels:         rule.Labels(),
 					Annotations:    rule.Annotations(),
 					Alerts:         rulesAlertsToAPIAlerts(rule.ActiveAlerts()),


### PR DESCRIPTION
The function HoldDuration and Duration did the exact same thing.

Let's only keep HoldDuration() as Duration() is more confusing.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->