### PR TITLE
PromQL engine refactoring

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -321,7 +321,6 @@ func main() {
 		}
 	}
 
-	promql.LookbackDelta = time.Duration(cfg.lookbackDelta)
 	promql.SetDefaultEvaluationInterval(time.Duration(config.DefaultGlobalConfig.EvaluationInterval))
 
 	// Above level 6, the k8s client would log bearer tokens in clear-text.
@@ -360,6 +359,7 @@ func main() {
 			MaxSamples:         cfg.queryMaxSamples,
 			Timeout:            time.Duration(cfg.queryTimeout),
 			ActiveQueryTracker: promql.NewActiveQueryTracker(cfg.localStoragePath, cfg.queryConcurrency, log.With(logger, "component", "activeQueryTracker")),
+			LookbackDelta:      time.Duration(cfg.lookbackDelta),
 		}
 
 		queryEngine = promql.NewEngine(opts)

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -321,8 +321,6 @@ func main() {
 		}
 	}
 
-	promql.SetDefaultEvaluationInterval(time.Duration(config.DefaultGlobalConfig.EvaluationInterval))
-
 	// Above level 6, the k8s client would log bearer tokens in clear-text.
 	klog.ClampLevel(6)
 	klog.SetLogger(log.With(logger, "component", "k8s_client_runtime"))
@@ -420,7 +418,9 @@ func main() {
 	reloaders := []func(cfg *config.Config) error{
 		remoteStorage.ApplyConfig,
 		webHandler.ApplyConfig,
+		// Query engine.
 		func(cfg *config.Config) error {
+			queryEngine.SetDefaultEvaluationInterval(time.Duration(cfg.GlobalConfig.EvaluationInterval))
 			if cfg.GlobalConfig.QueryLogFile == "" {
 				queryEngine.SetQueryLogger(nil)
 				return nil
@@ -771,7 +771,6 @@ func reloadConfig(filename string, logger log.Logger, rls ...func(*config.Config
 		return errors.Errorf("one or more errors occurred while applying the new configuration (--config.file=%q)", filename)
 	}
 
-	promql.SetDefaultEvaluationInterval(time.Duration(conf.GlobalConfig.EvaluationInterval))
 	level.Info(logger).Log("msg", "Completed loading of configuration file", "filename", filename)
 	return nil
 }

--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -29,10 +29,11 @@ func BenchmarkRangeQuery(b *testing.B) {
 	storage := teststorage.New(b)
 	defer storage.Close()
 	opts := EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 50000000,
-		Timeout:    100 * time.Second,
+		Logger:        nil,
+		Reg:           nil,
+		MaxSamples:    50000000,
+		Timeout:       100 * time.Second,
+		LookbackDelta: 5 * time.Minute,
 	}
 	engine := NewEngine(opts)
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -44,6 +44,7 @@ func TestQueryConcurrency(t *testing.T) {
 		MaxSamples:         10,
 		Timeout:            100 * time.Second,
 		ActiveQueryTracker: queryTracker,
+		LookbackDelta:      5 * time.Minute,
 	}
 
 	engine := NewEngine(opts)
@@ -98,10 +99,11 @@ func TestQueryConcurrency(t *testing.T) {
 
 func TestQueryTimeout(t *testing.T) {
 	opts := EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10,
-		Timeout:    5 * time.Millisecond,
+		Logger:        nil,
+		Reg:           nil,
+		MaxSamples:    10,
+		Timeout:       5 * time.Millisecond,
+		LookbackDelta: 5 * time.Minute,
 	}
 	engine := NewEngine(opts)
 	ctx, cancelCtx := context.WithCancel(context.Background())
@@ -125,10 +127,11 @@ const errQueryCanceled = ErrQueryCanceled("test statement execution")
 
 func TestQueryCancel(t *testing.T) {
 	opts := EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10,
-		Timeout:    10 * time.Second,
+		Logger:        nil,
+		Reg:           nil,
+		MaxSamples:    10,
+		Timeout:       10 * time.Second,
+		LookbackDelta: 5 * time.Minute,
 	}
 	engine := NewEngine(opts)
 	ctx, cancelCtx := context.WithCancel(context.Background())
@@ -195,10 +198,11 @@ func (e errSeriesSet) Err() error       { return e.err }
 
 func TestQueryError(t *testing.T) {
 	opts := EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10,
-		Timeout:    10 * time.Second,
+		Logger:        nil,
+		Reg:           nil,
+		MaxSamples:    10,
+		Timeout:       10 * time.Second,
+		LookbackDelta: 5 * time.Minute,
 	}
 	engine := NewEngine(opts)
 	errStorage := ErrStorage{errors.New("storage error")}
@@ -257,18 +261,12 @@ func (*paramCheckerQuerier) Close() error                                    { r
 
 func TestParamsSetCorrectly(t *testing.T) {
 	opts := EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10,
-		Timeout:    10 * time.Second,
+		Logger:        nil,
+		Reg:           nil,
+		MaxSamples:    10,
+		Timeout:       10 * time.Second,
+		LookbackDelta: 5 * time.Second,
 	}
-
-	// Set the lookback to be smaller and reset at the end.
-	currLookback := LookbackDelta
-	LookbackDelta = 5 * time.Second
-	defer func() {
-		LookbackDelta = currLookback
-	}()
 
 	cases := []struct {
 		query string
@@ -1143,10 +1141,11 @@ func (f *FakeQueryLogger) Log(l ...interface{}) error {
 
 func TestQueryLogger_basic(t *testing.T) {
 	opts := EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10,
-		Timeout:    10 * time.Second,
+		Logger:        nil,
+		Reg:           nil,
+		MaxSamples:    10,
+		Timeout:       10 * time.Second,
+		LookbackDelta: 5 * time.Minute,
 	}
 	engine := NewEngine(opts)
 
@@ -1194,10 +1193,11 @@ func TestQueryLogger_basic(t *testing.T) {
 
 func TestQueryLogger_fields(t *testing.T) {
 	opts := EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10,
-		Timeout:    10 * time.Second,
+		Logger:        nil,
+		Reg:           nil,
+		MaxSamples:    10,
+		Timeout:       10 * time.Second,
+		LookbackDelta: 5 * time.Minute,
 	}
 	engine := NewEngine(opts)
 
@@ -1223,10 +1223,11 @@ func TestQueryLogger_fields(t *testing.T) {
 
 func TestQueryLogger_error(t *testing.T) {
 	opts := EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10,
-		Timeout:    10 * time.Second,
+		Logger:        nil,
+		Reg:           nil,
+		MaxSamples:    10,
+		Timeout:       10 * time.Second,
+		LookbackDelta: 5 * time.Minute,
 	}
 	engine := NewEngine(opts)
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -1090,7 +1090,6 @@ func TestSubquerySelector(t *testing.T) {
 		},
 	}
 
-	SetDefaultEvaluationInterval(1 * time.Minute)
 	for _, tst := range tests {
 		test, err := NewTest(t, tst.loadString)
 		testutil.Ok(t, err)

--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -31,10 +31,11 @@ func TestDeriv(t *testing.T) {
 	storage := teststorage.New(t)
 	defer storage.Close()
 	opts := EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10000,
-		Timeout:    10 * time.Second,
+		Logger:        nil,
+		Reg:           nil,
+		MaxSamples:    10000,
+		Timeout:       10 * time.Second,
+		LookbackDelta: 5 * time.Minute,
 	}
 	engine := NewEngine(opts)
 

--- a/promql/test.go
+++ b/promql/test.go
@@ -516,11 +516,12 @@ func (t *Test) clear() {
 	t.storage = teststorage.New(t)
 
 	opts := EngineOpts{
-		Logger:        nil,
-		Reg:           nil,
-		MaxSamples:    10000,
-		Timeout:       100 * time.Second,
-		LookbackDelta: 5 * time.Minute,
+		Logger:                    nil,
+		Reg:                       nil,
+		MaxSamples:                10000,
+		Timeout:                   100 * time.Second,
+		LookbackDelta:             5 * time.Minute,
+		DefaultEvaluationInterval: durationToInt64Millis(1 * time.Minute),
 	}
 
 	t.queryEngine = NewEngine(opts)
@@ -630,11 +631,12 @@ func (ll *LazyLoader) clear() {
 	ll.storage = teststorage.New(ll)
 
 	opts := EngineOpts{
-		Logger:        nil,
-		Reg:           nil,
-		MaxSamples:    10000,
-		Timeout:       100 * time.Second,
-		LookbackDelta: 5 * time.Minute,
+		Logger:                    nil,
+		Reg:                       nil,
+		MaxSamples:                10000,
+		Timeout:                   100 * time.Second,
+		LookbackDelta:             5 * time.Minute,
+		DefaultEvaluationInterval: durationToInt64Millis(1 * time.Minute),
 	}
 
 	ll.queryEngine = NewEngine(opts)

--- a/promql/test.go
+++ b/promql/test.go
@@ -516,10 +516,11 @@ func (t *Test) clear() {
 	t.storage = teststorage.New(t)
 
 	opts := EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10000,
-		Timeout:    100 * time.Second,
+		Logger:        nil,
+		Reg:           nil,
+		MaxSamples:    10000,
+		Timeout:       100 * time.Second,
+		LookbackDelta: 5 * time.Minute,
 	}
 
 	t.queryEngine = NewEngine(opts)
@@ -629,10 +630,11 @@ func (ll *LazyLoader) clear() {
 	ll.storage = teststorage.New(ll)
 
 	opts := EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10000,
-		Timeout:    100 * time.Second,
+		Logger:        nil,
+		Reg:           nil,
+		MaxSamples:    10000,
+		Timeout:       100 * time.Second,
+		LookbackDelta: 5 * time.Minute,
 	}
 
 	ll.queryEngine = NewEngine(opts)

--- a/web/federate.go
+++ b/web/federate.go
@@ -63,7 +63,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var (
-		mint   = timestamp.FromTime(h.now().Time().Add(-promql.LookbackDelta))
+		mint   = timestamp.FromTime(h.now().Time().Add(-h.queryEngine.GetLookbackDelta()))
 		maxt   = timestamp.FromTime(h.now().Time())
 		format = expfmt.Negotiate(req.Header)
 		enc    = expfmt.NewEncoder(w, format)
@@ -101,7 +101,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 	}
 
 	set := storage.NewMergeSeriesSet(sets, nil)
-	it := storage.NewBuffer(int64(promql.LookbackDelta / 1e6))
+	it := storage.NewBuffer(int64(h.queryEngine.GetLookbackDelta() / 1e6))
 	for set.Next() {
 		s := set.At()
 


### PR DESCRIPTION
## Change 1

Following https://golang.org/pkg/context/:
 Do not store Contexts inside a struct type; instead, pass a Context
explicitly to each function that needs it. The Context should be the
first parameter, typically named ctx.

I have seen no obvious reason not to do so in the engine.

## Change 2 and 3

Remove LookbackDelta and DefaultEvaluationInterval from the global variables of promql

closes  #6739 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->