### PR TITLE
Add WAL interface and use noopWAL in all tests

### DIFF
--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -870,7 +870,10 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 	for labelNames := 1; labelNames < totalSeries; labelNames *= 10 {
 		labelValues := totalSeries / labelNames
 		b.Run(fmt.Sprintf("labelnames=%d,labelvalues=%d", labelNames, labelValues), func(b *testing.B) {
-			h, err := NewHead(nil, nil, nil, 1000, DefaultStripeSize)
+			w, close := newTestNoopWal(b)
+			defer close()
+
+			h, err := NewHead(nil, nil, w, 1000, DefaultStripeSize)
 			testutil.Ok(b, err)
 			for ln := 0; ln < labelNames; ln++ {
 				app := h.Appender()

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -542,7 +542,7 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 	}
 	db.compactCancel = cancel
 
-	var wlog *wal.WAL
+	var wlog wal.WAL
 	segmentSize := wal.DefaultSegmentSize
 	// Wal is enabled.
 	if opts.WALSegmentSize >= 0 {
@@ -554,6 +554,8 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		wlog = wal.NewNoopWAL(dir)
 	}
 
 	db.head, err = NewHead(r, l, wlog, opts.BlockRanges[0], opts.StripeSize)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -69,7 +69,7 @@ type Head struct {
 	lastSeriesID     uint64
 
 	metrics    *headMetrics
-	wal        *wal.WAL
+	wal        wal.WAL
 	logger     log.Logger
 	appendPool sync.Pool
 	seriesPool sync.Pool
@@ -260,7 +260,7 @@ func (h *Head) PostingsCardinalityStats(statsByLabelName string) *index.Postings
 // stripeSize sets the number of entries in the hash map, it must be a power of 2.
 // A larger stripeSize will allocate more memory up-front, but will increase performance when handling a large number of series.
 // A smaller stripeSize reduces the memory allocated, but can decrease performance with large number of series.
-func NewHead(r prometheus.Registerer, l log.Logger, wal *wal.WAL, chunkRange int64, stripeSize int) (*Head, error) {
+func NewHead(r prometheus.Registerer, l log.Logger, wal wal.WAL, chunkRange int64, stripeSize int) (*Head, error) {
 	if l == nil {
 		l = log.NewNopLogger()
 	}

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -23,8 +23,11 @@ import (
 )
 
 func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
+	w, close := newTestNoopWal(b)
+	defer close()
+
 	// Put a series, select it. GC it and then access it.
-	h, err := NewHead(nil, nil, nil, 1000, DefaultStripeSize)
+	h, err := NewHead(nil, nil, w, 1000, DefaultStripeSize)
 	testutil.Ok(b, err)
 	defer h.Close()
 
@@ -34,8 +37,11 @@ func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 }
 
 func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
+	w, close := newTestNoopWal(b)
+	defer close()
+
 	// Put a series, select it. GC it and then access it.
-	h, err := NewHead(nil, nil, nil, 1000, DefaultStripeSize)
+	h, err := NewHead(nil, nil, w, 1000, DefaultStripeSize)
 	testutil.Ok(b, err)
 	defer h.Close()
 

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -30,7 +30,10 @@ const (
 )
 
 func BenchmarkPostingsForMatchers(b *testing.B) {
-	h, err := NewHead(nil, nil, nil, 1000, DefaultStripeSize)
+	w, close := newTestNoopWal(b)
+	defer close()
+
+	h, err := NewHead(nil, nil, w, 1000, DefaultStripeSize)
 	testutil.Ok(b, err)
 	defer func() {
 		testutil.Ok(b, h.Close())
@@ -126,7 +129,10 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 }
 
 func BenchmarkQuerierSelect(b *testing.B) {
-	h, err := NewHead(nil, nil, nil, 1000, DefaultStripeSize)
+	w, close := newTestNoopWal(b)
+	defer close()
+
+	h, err := NewHead(nil, nil, w, 1000, DefaultStripeSize)
 	testutil.Ok(b, err)
 	defer h.Close()
 	app := h.Appender()

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1811,7 +1811,10 @@ func TestFindSetMatches(t *testing.T) {
 }
 
 func TestPostingsForMatchers(t *testing.T) {
-	h, err := NewHead(nil, nil, nil, 1000, DefaultStripeSize)
+	w, close := newTestNoopWal(t)
+	defer close()
+
+	h, err := NewHead(nil, nil, w, 1000, DefaultStripeSize)
 	testutil.Ok(t, err)
 	defer func() {
 		testutil.Ok(t, h.Close())
@@ -2174,7 +2177,10 @@ func BenchmarkQueries(b *testing.B) {
 				queryTypes["_3-Blocks"] = &querier{blocks: qs[0:3]}
 				queryTypes["_10-Blocks"] = &querier{blocks: qs}
 
-				head := createHead(b, series)
+				w, close := newTestNoopWal(b)
+				defer close()
+
+				head := createHead(b, series, w)
 				qHead, err := NewBlockQuerier(head, 1, int64(nSamples))
 				testutil.Ok(b, err)
 				queryTypes["_Head"] = qHead
@@ -2186,6 +2192,7 @@ func BenchmarkQueries(b *testing.B) {
 						benchQuery(b, expExpansions, querier, selectors)
 					})
 				}
+				testutil.Ok(b, head.Close())
 			}
 		}
 	}

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/tsdb/wal"
 )
 
 var InvalidTimesError = fmt.Errorf("max time is lesser than min time")
@@ -32,8 +33,9 @@ type MetricSample struct {
 }
 
 // CreateHead creates a TSDB writer head to write the sample data to.
-func CreateHead(samples []*MetricSample, chunkRange int64, logger log.Logger) (*Head, error) {
-	head, err := NewHead(nil, logger, nil, chunkRange, DefaultStripeSize)
+func CreateHead(samples []*MetricSample, chunkRange int64, dir string, logger log.Logger) (*Head, error) {
+	w := wal.NewNoopWAL(dir)
+	head, err := NewHead(nil, logger, w, chunkRange, DefaultStripeSize)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +62,7 @@ func CreateBlock(samples []*MetricSample, dir string, mint, maxt int64, logger l
 	if chunkRange < 0 {
 		return "", InvalidTimesError
 	}
-	head, err := CreateHead(samples, chunkRange, logger)
+	head, err := CreateHead(samples, chunkRange, dir, logger)
 	if err != nil {
 		return "", err
 	}

--- a/tsdb/wal/checkpoint.go
+++ b/tsdb/wal/checkpoint.go
@@ -100,7 +100,7 @@ const checkpointPrefix = "checkpoint."
 // segmented format as the original WAL itself.
 // This makes it easy to read it through the WAL package and concatenate
 // it with the original WAL.
-func Checkpoint(w *WAL, from, to int, keep func(id uint64) bool, mint int64) (*CheckpointStats, error) {
+func Checkpoint(w WAL, from, to int, keep func(id uint64) bool, mint int64) (*CheckpointStats, error) {
 	stats := &CheckpointStats{}
 	var sgmReader io.ReadCloser
 

--- a/tsdb/wal/reader_test.go
+++ b/tsdb/wal/reader_test.go
@@ -237,7 +237,7 @@ func TestReader_Live(t *testing.T) {
 
 const fuzzLen = 500
 
-func generateRandomEntries(w *WAL, records chan []byte) error {
+func generateRandomEntries(w WAL, records chan []byte) error {
 	var recs [][]byte
 	for i := 0; i < fuzzLen; i++ {
 		var sz int64

--- a/tsdb/wal/wal.go
+++ b/tsdb/wal/wal.go
@@ -153,7 +153,31 @@ func OpenReadSegment(fn string) (*Segment, error) {
 	return &Segment{File: f, i: k, dir: filepath.Dir(fn)}, nil
 }
 
-// WAL is a write ahead log that stores records in segment files.
+// WAL defines the basic operations needed for the Write-Ahead-Log (WAL).
+type WAL interface {
+	// CompressionEnabled returns if compression is enabled on this WAL.
+	CompressionEnabled() bool
+	// Dir returns the directory of the WAL.
+	Dir() string
+	// Repair attempts to repair the WAL based on the error.
+	Repair(origErr error) error
+	// NextSegment creates the next segment and closes the previous one.
+	NextSegment() error
+	// Log writes the records into the log.
+	// Multiple records can be passed at once to reduce writes and increase throughput.
+	Log(recs ...[]byte) error
+	// Segments returns the range [first, n] of currently existing segments.
+	// If no segments are found, first and n are -1.
+	Segments() (first, last int, err error)
+	// Truncate drops all segments before i.
+	Truncate(i int) (err error)
+	// Close flushes all writes and closes active segment.
+	Close() (err error)
+	// Size returns the size of the WAL on disk.
+	Size() (int64, error)
+}
+
+// WALImplementation is a write ahead log that stores records in segment files.
 // It must be read from start to end once before logging new data.
 // If an error occurs during read, the repair procedure must be called
 // before it's safe to do further writes.
@@ -163,7 +187,7 @@ func OpenReadSegment(fn string) (*Segment, error) {
 // Records are never split across segments to allow full segments to be
 // safely truncated. It also ensures that torn writes never corrupt records
 // beyond the most recent segment.
-type WAL struct {
+type WALImplementation struct {
 	dir         string
 	logger      log.Logger
 	segmentSize int
@@ -190,7 +214,7 @@ type walMetrics struct {
 	writesFailed    prometheus.Counter
 }
 
-func newWALMetrics(w *WAL, r prometheus.Registerer) *walMetrics {
+func newWALMetrics(w *WALImplementation, r prometheus.Registerer) *walMetrics {
 	m := &walMetrics{}
 
 	m.fsyncDuration = prometheus.NewSummary(prometheus.SummaryOpts{
@@ -239,13 +263,13 @@ func newWALMetrics(w *WAL, r prometheus.Registerer) *walMetrics {
 }
 
 // New returns a new WAL over the given directory.
-func New(logger log.Logger, reg prometheus.Registerer, dir string, compress bool) (*WAL, error) {
+func New(logger log.Logger, reg prometheus.Registerer, dir string, compress bool) (WAL, error) {
 	return NewSize(logger, reg, dir, DefaultSegmentSize, compress)
 }
 
 // NewSize returns a new WAL over the given directory.
 // New segments are created with the specified size.
-func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSize int, compress bool) (*WAL, error) {
+func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSize int, compress bool) (WAL, error) {
 	if segmentSize%pageSize != 0 {
 		return nil, errors.New("invalid segment size")
 	}
@@ -255,7 +279,7 @@ func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSi
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
-	w := &WAL{
+	w := &WALImplementation{
 		dir:         dir,
 		logger:      logger,
 		segmentSize: segmentSize,
@@ -293,11 +317,11 @@ func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSi
 }
 
 // Open an existing WAL.
-func Open(logger log.Logger, reg prometheus.Registerer, dir string) (*WAL, error) {
+func Open(logger log.Logger, reg prometheus.Registerer, dir string) (*WALImplementation, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
-	w := &WAL{
+	w := &WALImplementation{
 		dir:    dir,
 		logger: logger,
 	}
@@ -306,16 +330,16 @@ func Open(logger log.Logger, reg prometheus.Registerer, dir string) (*WAL, error
 }
 
 // CompressionEnabled returns if compression is enabled on this WAL.
-func (w *WAL) CompressionEnabled() bool {
+func (w *WALImplementation) CompressionEnabled() bool {
 	return w.compress
 }
 
 // Dir returns the directory of the WAL.
-func (w *WAL) Dir() string {
+func (w *WALImplementation) Dir() string {
 	return w.dir
 }
 
-func (w *WAL) run() {
+func (w *WALImplementation) run() {
 Loop:
 	for {
 		select {
@@ -335,7 +359,7 @@ Loop:
 
 // Repair attempts to repair the WAL based on the error.
 // It discards all data after the corruption.
-func (w *WAL) Repair(origErr error) error {
+func (w *WALImplementation) Repair(origErr error) error {
 	// We could probably have a mode that only discards torn records right around
 	// the corruption to preserve as data much as possible.
 	// But that's not generally applicable if the records have any kind of causality.
@@ -453,14 +477,14 @@ func SegmentName(dir string, i int) string {
 }
 
 // NextSegment creates the next segment and closes the previous one.
-func (w *WAL) NextSegment() error {
+func (w *WALImplementation) NextSegment() error {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
 	return w.nextSegment()
 }
 
 // nextSegment creates the next segment and closes the previous one.
-func (w *WAL) nextSegment() error {
+func (w *WALImplementation) nextSegment() error {
 	// Only flush the current page if it actually holds data.
 	if w.page.alloc > 0 {
 		if err := w.flushPage(true); err != nil {
@@ -488,7 +512,7 @@ func (w *WAL) nextSegment() error {
 	return nil
 }
 
-func (w *WAL) setSegment(segment *Segment) error {
+func (w *WALImplementation) setSegment(segment *Segment) error {
 	w.segment = segment
 
 	// Correctly initialize donePages.
@@ -504,7 +528,7 @@ func (w *WAL) setSegment(segment *Segment) error {
 // flushPage writes the new contents of the page to disk. If no more records will fit into
 // the page, the remaining bytes will be set to zero and a new page will be started.
 // If clear is true, this is enforced regardless of how many bytes are left in the page.
-func (w *WAL) flushPage(clear bool) error {
+func (w *WALImplementation) flushPage(clear bool) error {
 	w.metrics.pageFlushes.Inc()
 
 	p := w.page
@@ -568,13 +592,13 @@ func (t recType) String() string {
 	}
 }
 
-func (w *WAL) pagesPerSegment() int {
+func (w *WALImplementation) pagesPerSegment() int {
 	return w.segmentSize / pageSize
 }
 
 // Log writes the records into the log.
 // Multiple records can be passed at once to reduce writes and increase throughput.
-func (w *WAL) Log(recs ...[]byte) error {
+func (w *WALImplementation) Log(recs ...[]byte) error {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
 	// Callers could just implement their own list record format but adding
@@ -592,7 +616,7 @@ func (w *WAL) Log(recs ...[]byte) error {
 // - the final record of a batch
 // - the record is bigger than the page size
 // - the current page is full.
-func (w *WAL) log(rec []byte, final bool) error {
+func (w *WALImplementation) log(rec []byte, final bool) error {
 	// When the last page flush failed the page will remain full.
 	// When the page is full, need to flush it before trying to add more records to it.
 	if w.page.full() {
@@ -680,7 +704,7 @@ func (w *WAL) log(rec []byte, final bool) error {
 
 // Segments returns the range [first, n] of currently existing segments.
 // If no segments are found, first and n are -1.
-func (w *WAL) Segments() (first, last int, err error) {
+func (w *WALImplementation) Segments() (first, last int, err error) {
 	refs, err := listSegments(w.dir)
 	if err != nil {
 		return 0, 0, err
@@ -692,7 +716,7 @@ func (w *WAL) Segments() (first, last int, err error) {
 }
 
 // Truncate drops all segments before i.
-func (w *WAL) Truncate(i int) (err error) {
+func (w *WALImplementation) Truncate(i int) (err error) {
 	w.metrics.truncateTotal.Inc()
 	defer func() {
 		if err != nil {
@@ -714,7 +738,7 @@ func (w *WAL) Truncate(i int) (err error) {
 	return nil
 }
 
-func (w *WAL) fsync(f *Segment) error {
+func (w *WALImplementation) fsync(f *Segment) error {
 	start := time.Now()
 	err := f.File.Sync()
 	w.metrics.fsyncDuration.Observe(time.Since(start).Seconds())
@@ -722,7 +746,7 @@ func (w *WAL) fsync(f *Segment) error {
 }
 
 // Close flushes all writes and closes active segment.
-func (w *WAL) Close() (err error) {
+func (w *WALImplementation) Close() (err error) {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
 
@@ -886,6 +910,25 @@ func (r *segmentBufReader) Read(b []byte) (n int, err error) {
 
 // Computing size of the WAL.
 // We do this by adding the sizes of all the files under the WAL dir.
-func (w *WAL) Size() (int64, error) {
+func (w *WALImplementation) Size() (int64, error) {
 	return fileutil.DirSize(w.Dir())
 }
+
+// NewNoopWAL returns a no-op WAL.
+func NewNoopWAL(dir string) WAL {
+	return &noopWAL{dir: dir}
+}
+
+type noopWAL struct {
+	dir string
+}
+
+func (w *noopWAL) CompressionEnabled() bool               { return false }
+func (w *noopWAL) Dir() string                            { return w.dir }
+func (w *noopWAL) Repair(_ error) error                   { return nil }
+func (w *noopWAL) NextSegment() error                     { return nil }
+func (w *noopWAL) Log(recs ...[]byte) error               { return nil }
+func (w *noopWAL) Segments() (first, last int, err error) { return -1, -1, nil }
+func (w *noopWAL) Truncate(i int) (err error)             { return nil }
+func (w *noopWAL) Close() (err error)                     { return nil }
+func (w *noopWAL) Size() (int64, error)                   { return 0, nil }

--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -302,9 +302,11 @@ func TestCorruptAndCarryOn(t *testing.T) {
 		err = w.Repair(corruptionErr)
 		testutil.Ok(t, err)
 
+		wOriginal, ok := w.(*WALImplementation)
+		testutil.Assert(t, ok, "Expected type WAL")
 		// Ensure that we have a completely clean slate after repairing.
-		testutil.Equals(t, w.segment.Index(), 1) // We corrupted segment 0.
-		testutil.Equals(t, w.donePages, 0)
+		testutil.Equals(t, wOriginal.segment.Index(), 1) // We corrupted segment 0.
+		testutil.Equals(t, wOriginal.donePages, 0)
 
 		for i := 0; i < 5; i++ {
 			buf := make([]byte, recordSize)
@@ -363,7 +365,9 @@ func TestSegmentMetric(t *testing.T) {
 	w, err := NewSize(nil, nil, dir, segmentSize, false)
 	testutil.Ok(t, err)
 
-	initialSegment := client_testutil.ToFloat64(w.metrics.currentSegment)
+	wOriginal, ok := w.(*WALImplementation)
+	testutil.Assert(t, ok, "Expected type WAL")
+	initialSegment := client_testutil.ToFloat64(wOriginal.metrics.currentSegment)
 
 	// Write 3 records, each of which is half the segment size, meaning we should rotate to the next segment.
 	for i := 0; i < 3; i++ {
@@ -374,7 +378,7 @@ func TestSegmentMetric(t *testing.T) {
 		err = w.Log(buf)
 		testutil.Ok(t, err)
 	}
-	testutil.Assert(t, client_testutil.ToFloat64(w.metrics.currentSegment) == initialSegment+1, "segment metric did not increment after segment rotation")
+	testutil.Assert(t, client_testutil.ToFloat64(wOriginal.metrics.currentSegment) == initialSegment+1, "segment metric did not increment after segment rotation")
 	testutil.Ok(t, w.Close())
 }
 


### PR DESCRIPTION
This is a broken down piece of https://github.com/prometheus/prometheus/pull/6679

1. The interface is required so that we can pass a `noopWAL` to head.
2. We need WAL for all the Head instances as the mmapped chunks logic depends on the dir that it gets from the WAL. I had not added the logic of assigning the noopWAL inside `NewHead` as the temp dir has to come from tests, and doing it like this will avoid passing both dir and WAL in `NewHead`.