### PR TITLE
Add OpenMmapFileWithSize method

### DIFF
--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -25,16 +25,23 @@ type MmapFile struct {
 }
 
 func OpenMmapFile(path string) (*MmapFile, error) {
+	return OpenMmapFileWithSize(path, 0)
+}
+
+func OpenMmapFileWithSize(path string, size int) (*MmapFile, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "try lock file")
 	}
-	info, err := f.Stat()
-	if err != nil {
-		return nil, errors.Wrap(err, "stat")
+	if size <= 0 {
+		info, err := f.Stat()
+		if err != nil {
+			return nil, errors.Wrap(err, "stat")
+		}
+		size = int(info.Size())
 	}
 
-	b, err := mmap(f, int(info.Size()))
+	b, err := mmap(f, size)
 	if err != nil {
 		return nil, errors.Wrap(err, "mmap")
 	}


### PR DESCRIPTION
This is a broken down piece of #6679

`OpenMmapFileWithSize` will help open a file with an arbitrary size. This is required for the file in which chunks are being appended in the PR mentioned above. 