### PR TITLE
Revert "Add armv6 docker image (#6605)"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@ data/
 .tarballs/
 
 !.build/linux-amd64/
-!.build/linux-armv6/
 !.build/linux-armv7/
 !.build/linux-arm64/
 !.build/linux-s390x/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64 armv6 armv7 arm64 s390x
+DOCKER_ARCHS ?= amd64 armv7 arm64 s390x
 
 REACT_APP_PATH = web/ui/react-app
 REACT_APP_SOURCE_FILES = $(wildcard $(REACT_APP_PATH)/public/* $(REACT_APP_PATH)/src/* $(REACT_APP_PATH)/tsconfig.json)


### PR DESCRIPTION
This reverts commit 6ba8565619c7d97478a6012ad2410126ab5ce377.

We need to add an armv6 image to prometheus/busybox first.