### PR TITLE
added chunk breaking functionality

### DIFF
--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -737,6 +737,126 @@ func TestCompaction_populateBlock(t *testing.T) {
 				},
 			},
 		},
+		{
+			title: "Break chunks that are greater than 120 in size.",
+			inputSeriesSamples: [][]seriesSamples{
+				{
+					{
+						lset: map[string]string{"a": "b"},
+						chunks: func() [][]sample {
+							chunkOne := make([]sample, 120)
+							for i := 0; i < 120; i++ {
+								chunkOne[i] = sample{t: int64(i + 1)}
+							}
+							chunkTwo := make([]sample, 42)
+							for i := 0; i < 42; i++ {
+								chunkTwo[i] = sample{t: int64(i + 1 + 200)}
+							}
+							chunkThree := make([]sample, 70)
+							for i := 0; i < 70; i++ {
+								chunkThree[i] = sample{t: int64(i + 1 + 300)}
+							}
+							chunkFour := make([]sample, 120)
+							for i := 0; i < 120; i++ {
+								chunkFour[i] = sample{t: int64(i + 1 + 500)}
+							}
+							chunkFive := make([]sample, 120) // tricky test case of 3 chunks overlapping 1:1 with more than 120 samples
+							for i := 0; i < 60; i++ {
+								chunkFive[i] = sample{t: int64(i + 1 + 940)}
+							}
+							for i, j := 60, 0; i < 70; i, j = i+1, j+1 {
+								chunkFive[i] = sample{t: int64(j + 1 + 1100)}
+							}
+							for i, j := 70, 0; i < 120; i, j = i+1, j+1 {
+								chunkFive[i] = sample{t: int64(j + 1 + 1220)}
+							}
+							chunks := [][]sample{chunkOne, chunkTwo, chunkThree, chunkFour, chunkFive}
+							return chunks
+						}(),
+					},
+				},
+				{
+					{
+						lset: map[string]string{"a": "b"},
+						chunks: func() [][]sample {
+
+							chunkOne := make([]sample, 70)
+							for i := 0; i < 70; i++ {
+								chunkOne[i] = sample{t: int64(i + 1 + 300 + 60)}
+							}
+							chunkTwo := make([]sample, 120)
+							for i := 0; i < 120; i++ {
+								chunkTwo[i] = sample{t: int64(i + 1 + 500 + 118)}
+							}
+							chunkThree := make([]sample, 120)
+							for i := 0; i < 120; i++ {
+								chunkThree[i] = sample{t: int64(i + 1 + 1000)}
+							}
+							chunks := [][]sample{chunkOne, chunkTwo, chunkThree}
+							return chunks
+						}(),
+					},
+				},
+				{
+					{
+						lset: map[string]string{"a": "b"},
+						chunks: func() [][]sample {
+							chunkOne := make([]sample, 120)
+							for i := 0; i < 120; i++ {
+								chunkOne[i] = sample{t: int64(i + 1 + 1100)}
+							}
+							chunks := [][]sample{chunkOne}
+							return chunks
+						}(),
+					},
+				},
+			},
+			expSeriesSamples: []seriesSamples{
+				{
+					lset: map[string]string{"a": "b"},
+					chunks: func() [][]sample {
+						chunkOne := make([]sample, 120)
+						for i := 0; i < 120; i++ {
+							chunkOne[i] = sample{t: int64(i + 1)}
+						}
+						chunkTwo := make([]sample, 42)
+						for i := 0; i < 42; i++ {
+							chunkTwo[i] = sample{t: int64(i + 1 + 200)}
+						}
+						chunkThree := make([]sample, 120)
+						for i := 0; i < 120; i++ {
+							chunkThree[i] = sample{t: int64(i + 1 + 300)}
+						}
+						chunkFour := make([]sample, 10)
+						for i := 0; i < 10; i++ {
+							chunkFour[i] = sample{t: int64(i + 1 + 300 + 120)}
+						}
+						chunkFive := make([]sample, 120)
+						for i := 0; i < 120; i++ {
+							chunkFive[i] = sample{t: int64(i + 1 + 500)}
+						}
+						chunkSix := make([]sample, 118)
+						for i := 0; i < 118; i++ {
+							chunkSix[i] = sample{t: int64(i + 1 + 620)}
+						}
+						chunkSeven := make([]sample, 120)
+						for i := 0; i < 120; i++ {
+							chunkSeven[i] = sample{t: int64(i + 1 + 940)}
+						}
+						chunkEight := make([]sample, 120)
+						for i := 0; i < 120; i++ {
+							chunkEight[i] = sample{t: int64(i + 1 + 1060)}
+						}
+						chunkNine := make([]sample, 90)
+						for i := 0; i < 90; i++ {
+							chunkNine[i] = sample{t: int64(i + 1 + 1180)}
+						}
+						chunks := [][]sample{chunkOne, chunkTwo, chunkThree, chunkFour, chunkFive, chunkSix, chunkSeven, chunkEight, chunkNine}
+						return chunks
+					}(),
+				},
+			},
+		},
 	}
 
 	for _, tc := range populateBlocksCases {


### PR DESCRIPTION
Breaking a chunk if its greater than a particular size. The best compression ratio is with a maximum of 120 samples per chunk.

With respect to [this](https://github.com/prometheus/prometheus/issues/5862) issue.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->