### PR TITLE
Formatting short tables for readability

### DIFF
--- a/web/ui/react-app/src/pages/graph/DataTable.test.tsx
+++ b/web/ui/react-app/src/pages/graph/DataTable.test.tsx
@@ -113,6 +113,35 @@ describe('DataTable', () => {
     });
   });
 
+  describe('when resultType is vector and size is more than maximum limit of formatting', () => {
+    const dataTableProps: QueryResult = {
+      data: {
+        resultType: 'vector',
+        result: Array.from(Array(1001).keys()).map(i => {
+          return {
+            metric: {
+              __name__: `metric_name_${i}`,
+              label1: 'value_1',
+              labeln: 'value_n',
+            },
+            value: [1572098246.599, `${i}`],
+          };
+        }),
+      },
+    };
+    const dataTable = shallow(<DataTable {...dataTableProps} />);
+
+    it('renders a warning', () => {
+      const alerts = dataTable.find(Alert);
+      expect(
+        alerts
+          .first()
+          .render()
+          .text()
+      ).toEqual('Notice: Showing more than 1000 series, turning off label formatting for performance reasons.');
+    });
+  });
+
   describe('when result type is a matrix', () => {
     const dataTableProps: QueryResult = {
       data: {

--- a/web/ui/react-app/src/pages/graph/DataTable.test.tsx
+++ b/web/ui/react-app/src/pages/graph/DataTable.test.tsx
@@ -103,8 +103,8 @@ describe('DataTable', () => {
     });
 
     it('renders a warning', () => {
-      const alert = dataTable.find(Alert);
-      expect(alert.render().text()).toEqual('Warning: Fetched 10001 metrics, only displaying first 10000.');
+      const alerts = dataTable.find(Alert);
+      expect(alerts.first().render().text()).toEqual('Warning: Fetched 10001 metrics, only displaying first 10000.');
     });
   });
 

--- a/web/ui/react-app/src/pages/graph/DataTable.test.tsx
+++ b/web/ui/react-app/src/pages/graph/DataTable.test.tsx
@@ -104,7 +104,12 @@ describe('DataTable', () => {
 
     it('renders a warning', () => {
       const alerts = dataTable.find(Alert);
-      expect(alerts.first().render().text()).toEqual('Warning: Fetched 10001 metrics, only displaying first 10000.');
+      expect(
+        alerts
+          .first()
+          .render()
+          .text()
+      ).toEqual('Warning: Fetched 10001 metrics, only displaying first 10000.');
     });
   });
 

--- a/web/ui/react-app/src/pages/graph/DataTable.tsx
+++ b/web/ui/react-app/src/pages/graph/DataTable.tsx
@@ -56,10 +56,10 @@ const DataTable: FC<QueryResult> = ({ data }) => {
     return <Alert color="secondary">Empty query result</Alert>;
   }
 
-  const maxFormattableSize = 100;
+  const maxFormattableSize = 1000;
   let rows: ReactNode[] = [];
   let limited = false;
-  const toFormatStyle = data.result.length <= maxFormattableSize;
+  const doFormat = data.result.length <= maxFormattableSize;
   switch (data.resultType) {
     case 'vector':
       rows = (limitSeries(data.result) as InstantSample[]).map(
@@ -67,7 +67,7 @@ const DataTable: FC<QueryResult> = ({ data }) => {
           return (
             <tr key={index}>
               <td>
-                <SeriesName labels={s.metric} format={toFormatStyle} />
+                <SeriesName labels={s.metric} format={doFormat} />
               </td>
               <td>{s.value[1]}</td>
             </tr>
@@ -86,7 +86,7 @@ const DataTable: FC<QueryResult> = ({ data }) => {
         return (
           <tr style={{ whiteSpace: 'pre' }} key={index}>
             <td>
-              <SeriesName labels={s.metric} format={toFormatStyle} />
+              <SeriesName labels={s.metric} format={doFormat} />
             </td>
             <td>{valueText}</td>
           </tr>
@@ -121,7 +121,7 @@ const DataTable: FC<QueryResult> = ({ data }) => {
           <strong>Warning:</strong> Fetched {data.result.length} metrics, only displaying first {rows.length}.
         </Alert>
       )}
-      {rows.length > maxFormattableSize && (
+      {!doFormat && (
         <Alert color="secondary">
           <strong>Notice:</strong> Showing more than {maxFormattableSize} series, turning off label formatting for
           performance reasons.

--- a/web/ui/react-app/src/pages/graph/DataTable.tsx
+++ b/web/ui/react-app/src/pages/graph/DataTable.tsx
@@ -56,10 +56,10 @@ const DataTable: FC<QueryResult> = ({ data }) => {
     return <Alert color="secondary">Empty query result</Alert>;
   }
 
-  let maxFormattableSize = 100
+  const maxFormattableSize = 100;
   let rows: ReactNode[] = [];
   let limited = false;
-  let toFormatStyle = data.result.length <= maxFormattableSize;
+  const toFormatStyle = data.result.length <= maxFormattableSize;
   switch (data.resultType) {
     case 'vector':
       rows = (limitSeries(data.result) as InstantSample[]).map(
@@ -123,7 +123,8 @@ const DataTable: FC<QueryResult> = ({ data }) => {
       )}
       {rows.length > maxFormattableSize && (
         <Alert color="secondary">
-          <strong>Notice:</strong> Showing more than {maxFormattableSize} series, turning off label formatting for performance reasons.
+          <strong>Notice:</strong> Showing more than {maxFormattableSize} series, turning off label formatting for
+          performance reasons.
         </Alert>
       )}
       <Table hover size="sm" className="data-table">

--- a/web/ui/react-app/src/pages/graph/DataTable.tsx
+++ b/web/ui/react-app/src/pages/graph/DataTable.tsx
@@ -56,8 +56,10 @@ const DataTable: FC<QueryResult> = ({ data }) => {
     return <Alert color="secondary">Empty query result</Alert>;
   }
 
+  let maxFormattableSize = 100
   let rows: ReactNode[] = [];
   let limited = false;
+  let toFormatStyle = data.result.length <= maxFormattableSize;
   switch (data.resultType) {
     case 'vector':
       rows = (limitSeries(data.result) as InstantSample[]).map(
@@ -65,7 +67,7 @@ const DataTable: FC<QueryResult> = ({ data }) => {
           return (
             <tr key={index}>
               <td>
-                <SeriesName labels={s.metric} format={false} />
+                <SeriesName labels={s.metric} format={toFormatStyle} />
               </td>
               <td>{s.value[1]}</td>
             </tr>
@@ -84,7 +86,7 @@ const DataTable: FC<QueryResult> = ({ data }) => {
         return (
           <tr style={{ whiteSpace: 'pre' }} key={index}>
             <td>
-              <SeriesName labels={s.metric} format={false} />
+              <SeriesName labels={s.metric} format={toFormatStyle} />
             </td>
             <td>{valueText}</td>
           </tr>
@@ -117,6 +119,11 @@ const DataTable: FC<QueryResult> = ({ data }) => {
       {limited && (
         <Alert color="danger">
           <strong>Warning:</strong> Fetched {data.result.length} metrics, only displaying first {rows.length}.
+        </Alert>
+      )}
+      {rows.length > maxFormattableSize && (
+        <Alert color="secondary">
+          <strong>Notice:</strong> Showing more than {maxFormattableSize} series, turning off label formatting for performance reasons.
         </Alert>
       )}
       <Table hover size="sm" className="data-table">


### PR DESCRIPTION
Signed-off-by: Drumil Patel <drumilpatel720@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Fixes #6722 
### Formatting Short Tables
![Screenshot from 2020-02-06 04-00-19](https://user-images.githubusercontent.com/42701709/73889319-6e88af80-4895-11ea-8ecc-e6fd993404cc.png)
### Long Tables
**Note** This for only display purpose If limit exceeds desirable limit than how will be changes affect by default it is `maxFormattableSize = 100` but to check how will large tables look, I have used `maxFormattableSize = 5`
![Screenshot from 2020-02-06 04-01-37](https://user-images.githubusercontent.com/42701709/73889323-6fb9dc80-4895-11ea-8931-91f1cbd0d95a.png)

