### PR TITLE
Use $GO for go:generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ assets: $(REACT_APP_OUTPUT_DIR)
 	# Un-setting GOOS and GOARCH here because the generated Go code is always the same,
 	# but the cached object code is incompatible between architectures and OSes (which
 	# breaks cross-building for different combinations on CI in the same container).
-	cd web/ui && GO111MODULE=$(GO111MODULE) GOOS= GOARCH= $(GO) generate -x -v $(GOOPTS)
+	cd web/ui && GO111MODULE=$(GO111MODULE) GOOS= GOARCH= GO=$(GO) $(GO) generate -x -v $(GOOPTS)
 	@$(GOFMT) -w ./web/ui
 
 .PHONY: react-app-lint

--- a/pkg/textparse/openmetricsparse.go
+++ b/pkg/textparse/openmetricsparse.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go get -u modernc.org/golex
+//go:generate $GO get -u modernc.org/golex
 //go:generate golex -o=openmetricslex.l.go openmetricslex.l
 
 package textparse

--- a/pkg/textparse/promparse.go
+++ b/pkg/textparse/promparse.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go get -u modernc.org/golex
+//go:generate $GO get -u modernc.org/golex
 //go:generate golex -o=promlex.l.go promlex.l
 
 package textparse

--- a/web/ui/doc.go
+++ b/web/ui/doc.go
@@ -21,4 +21,4 @@ import (
 	_ "github.com/shurcooL/vfsgen"
 )
 
-//go:generate go run -mod=vendor assets_generate.go
+//go:generate $GO run -mod=vendor assets_generate.go


### PR DESCRIPTION
I'm trying to compile prometheus with go1.14-rc.1 and found that $GO env variable is not respected in go:generate rules. 