### PR TITLE
PromQL: Fix params for series expansion

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -678,6 +678,7 @@ func (ng *Engine) populateSeries(ctx context.Context, q storage.Queryable, s *Ev
 		case *VectorSelector:
 			if evalRange == 0 {
 				params.Start = params.Start - durationMilliseconds(LookbackDelta)
+				params.By, params.Grouping = extractGroupsFromPath(path)
 			} else {
 				params.Range = durationMilliseconds(evalRange)
 				// For all matrix queries we want to ensure that we have (end-start) + range selected
@@ -687,7 +688,6 @@ func (ng *Engine) populateSeries(ctx context.Context, q storage.Queryable, s *Ev
 			}
 
 			params.Func = extractFuncFromPath(path)
-			params.By, params.Grouping = extractGroupsFromPath(path)
 			if n.Offset > 0 {
 				offsetMilliseconds := durationMilliseconds(n.Offset)
 				params.Start = params.Start - offsetMilliseconds


### PR DESCRIPTION
One of the refactorings in #6590 causes the parameters for series expansion in the engine to be set incorrectly.

This might be (part of) the cause for #6771.

Signed-off-by: Tobias Guggenmos <tguggenm@redhat.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->