### PR TITLE
ensure RuleGroups can be marshaled into YAML

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -128,6 +128,19 @@ type RuleNode struct {
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 }
 
+// MarshalYAML implements yaml.Marshaler. It is required to encode the RuleGroup
+// struct back into yaml.
+func (r RuleNode) MarshalYAML() (interface{}, error) {
+	return &Rule{
+		Record:      r.Record.Value,
+		Alert:       r.Alert.Value,
+		Expr:        r.Expr.Value,
+		For:         r.For,
+		Labels:      r.Labels,
+		Annotations: r.Annotations,
+	}, nil
+}
+
 // Validate the rule and return a list of encountered errors.
 func (r *RuleNode) Validate() (nodes []WrappedError) {
 	if r.Record.Value != "" && r.Alert.Value != "" {


### PR DESCRIPTION
In [Cortex](https://github.com/cortexproject/cortex/pull/2088) we need to be able to marshal RuleGroups from the `rulefmt` package back into YAML. With the recent upgrade to utilize the `yaml.Node` struct in the `rulefmt.RuleNode` we are unable to do this.

This PR adds a `MarshalYAML` function to the `rulefmt.RuleNode` in order to make it possible to encode it back into yaml. A corresponding unit test that ensures the reencoded yaml matches the original has been added as well.

Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->