### PR TITLE
OpenMetrics parse: avoid setting prev token

### DIFF
--- a/pkg/textparse/openmetricsparse.go
+++ b/pkg/textparse/openmetricsparse.go
@@ -90,7 +90,6 @@ type OpenMetricsParser struct {
 	hasTS   bool
 	start   int
 	offsets []int
-	prev    token
 
 	eOffsets      []int
 	exemplar      []byte
@@ -233,19 +232,14 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 	p.exemplarVal = 0
 	p.hasExemplarTs = false
 
-	t := p.nextToken()
-	defer func() { p.prev = t }()
-	switch t {
+	switch t := p.nextToken(); t {
 	case tEofWord:
 		if t := p.nextToken(); t != tEOF {
 			return EntryInvalid, errors.New("unexpected data after # EOF")
 		}
 		return EntryInvalid, io.EOF
 	case tEOF:
-		if p.prev != tEofWord {
-			return EntryInvalid, errors.New("data does not end with # EOF")
-		}
-		return EntryInvalid, io.EOF
+		return EntryInvalid, errors.New("data does not end with # EOF")
 	case tHelp, tType, tUnit:
 		switch t := p.nextToken(); t {
 		case tMName:


### PR DESCRIPTION
We can avoid setting a prev token in the OM parser. The previous
coundition that checked for prev was unreacheable.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->