### PR TITLE
[ENHANCEMENT] remote storage: When the matcher does not contain regular expressions, convert the value of type from RE to EQ

### DIFF
--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -132,6 +132,11 @@ func isRegexString(text string) bool {
 		!strings.Contains(text, ".+") &&
 		!strings.Contains(text, "?") &&
 		!strings.Contains(text, "\\") &&
+		!strings.Contains(text, "[") &&
+		!strings.Contains(text, "]") &&
+		!strings.Contains(text, "{") &&
+		!strings.Contains(text, "}") &&
+		!strings.Contains(text, "*") &&
 		!strings.Contains(text, "|") {
 		return true
 	}

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -112,11 +112,11 @@ func optMatcher(matchers []*prompb.LabelMatcher) {
 	for _, m := range matchers {
 		switch m.Type {
 		case prompb.LabelMatcher_RE:
-			if isRegexString(m.Value) {
+			if !isRegexString(m.Value) {
 				m.Type = prompb.LabelMatcher_EQ
 			}
 		case prompb.LabelMatcher_NRE:
-			if isRegexString(m.Value) {
+			if !isRegexString(m.Value) {
 				m.Type = prompb.LabelMatcher_NEQ
 			}
 		}
@@ -125,7 +125,7 @@ func optMatcher(matchers []*prompb.LabelMatcher) {
 
 //from tsdb querier.go
 func isRegexString(pattern string) bool {
-	for i := 4; i < len(pattern)-2; i++ {
+	for i := 0; i < len(pattern); i++ {
 		if isRegexMetaCharacter(pattern[i]) {
 			return true
 		}

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -210,3 +210,65 @@ func TestNegotiateResponseType(t *testing.T) {
 	testutil.NotOk(t, err, "expected error due to not supported requested response types")
 	testutil.Equals(t, "server does not support any of the requested response types: [20]; supported: map[SAMPLES:{} STREAMED_XOR_CHUNKS:{}]", err.Error())
 }
+
+func TestOptMatcher(t *testing.T) {
+
+	tests := []struct {
+		provided *prompb.LabelMatcher
+		expected *prompb.LabelMatcher
+	}{
+		{
+			provided: &prompb.LabelMatcher{
+				Type:  prompb.LabelMatcher_RE,
+				Name:  "Instance1",
+				Value: "buy2.*",
+			},
+			expected: &prompb.LabelMatcher{
+				Type:  prompb.LabelMatcher_RE,
+				Name:  "Instance1",
+				Value: "buy2.*",
+			},
+		},
+		{
+			provided: &prompb.LabelMatcher{
+				Type:  prompb.LabelMatcher_RE,
+				Name:  "Instance2",
+				Value: "buy2shop",
+			},
+			expected: &prompb.LabelMatcher{
+				Type:  prompb.LabelMatcher_EQ,
+				Name:  "Instance2",
+				Value: "buy2shop",
+			},
+		},
+		{
+			provided: &prompb.LabelMatcher{
+				Type:  prompb.LabelMatcher_RE,
+				Name:  "Instance3",
+				Value: "buy2|itemcenter2",
+			},
+			expected: &prompb.LabelMatcher{
+				Type:  prompb.LabelMatcher_RE,
+				Name:  "Instance3",
+				Value: "buy2|itemcenter2",
+			},
+		},
+		{
+			provided: &prompb.LabelMatcher{
+				Type:  prompb.LabelMatcher_RE,
+				Name:  "Instance4",
+				Value: "buy2",
+			},
+			expected: &prompb.LabelMatcher{
+				Type:  prompb.LabelMatcher_EQ,
+				Name:  "Instance4",
+				Value: "buy2",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		optMatcher([]*prompb.LabelMatcher{test.provided})
+		testutil.Equals(t, test.provided, test.expected, "unexpected LabelMatcher for test case %d", i)
+	}
+}


### PR DESCRIPTION
Improve the query performance of remote storage. When the matcher does not contain regular expressions, convert the value of type from RE to EQ 

example：
ori promQL ：node_load5{instance=~"192.168.0.127:9100"}
new promQL：node_load5{instance="192.168.0.127:9100"}

case：
The multiple selection box in the upper left corner of grafana often has one or more conditions, which leads to invalid regular expression query in the following chart when a condition exists. This is generally very man-made

why？
The code modification in PR reduces our query performance of grafana from 10 seconds to 1 second.
Because the performance of regular expressions in each remote storage is very low.
This PR should also be meaningful to other users of remote storage.

![image](https://user-images.githubusercontent.com/9583245/74083119-7a45c300-4a9b-11ea-887f-46c25bbaf7a2.png)




