### PR TITLE
Use protobuf type in k8s client option

### DIFF
--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -130,13 +130,6 @@ func (c *NamespaceDiscovery) UnmarshalYAML(unmarshal func(interface{}) error) er
 func init() {
 	prometheus.MustRegister(eventCount)
 
-	// Initialize metric vectors.
-	for _, role := range []string{"endpoints", "node", "pod", "service", "ingress"} {
-		for _, evt := range []string{"add", "delete", "update"} {
-			eventCount.WithLabelValues(role, evt)
-		}
-	}
-
 	var (
 		clientGoRequestMetricAdapterInstance     = clientGoRequestMetricAdapter{}
 		clientGoWorkqueueMetricsProviderInstance = clientGoWorkqueueMetricsProvider{}
@@ -200,6 +193,8 @@ func New(l log.Logger, conf *SDConfig) (*Discovery, error) {
 	}
 
 	kcfg.UserAgent = "Prometheus/discovery"
+	kcfg.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	kcfg.ContentType = "application/vnd.kubernetes.protobuf"
 
 	c, err := kubernetes.NewForConfig(kcfg)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Protobuf has better performance than JSON