### PR TITLE
Fix queue in alerts annotation

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -187,7 +187,7 @@
             },
             annotations: {
               summary: 'Prometheus fails to send samples to remote storage.',
-              description: 'Prometheus %(prometheusName)s failed to send {{ printf "%%.1f" $value }}%% of the samples to queue {{$labels.queue}}.' % $._config,
+              description: 'Prometheus %(prometheusName)s failed to send {{ printf "%%.1f" $value }}%% of the samples to {{ if $labels.queue }}{{ $labels.queue }}{{ else }}{{ $labels.url }}{{ end }}.' % $._config,
             },
           },
           {
@@ -208,7 +208,7 @@
             },
             annotations: {
               summary: 'Prometheus remote write is behind.',
-              description: 'Prometheus %(prometheusName)s remote write is {{ printf "%%.1f" $value }}s behind for queue {{$labels.queue}}.' % $._config,
+              description: 'Prometheus %(prometheusName)s remote write is {{ printf "%%.1f" $value }}s behind for {{ if $labels.queue }}{{ $labels.queue }}{{ else }}{{ $labels.url }}{{ end }}.' % $._config,
             },
           },
           {


### PR DESCRIPTION
Prometheus `2.15.0` has introduced this change:
> Remote write: Changed query label on prometheus_remote_storage_* metrics to remote_name and url. #6043

In this PR I'm changing the annotations in the remote write alerts, in order to work with both `queue` and `url` labels.