### PR TITLE
Fix golint warning in labels.go

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -200,7 +200,7 @@ func (ls Labels) Has(name string) bool {
 	return false
 }
 
-// HasDuplicateLabels returns whether ls has duplicate label names.
+// HasDuplicateLabelNames returns whether ls has duplicate label names.
 // It assumes that the labelset is sorted.
 func (ls Labels) HasDuplicateLabelNames() (string, bool) {
 	for i, l := range ls {


### PR DESCRIPTION
Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->