### PR TITLE
Don't return error in ContextFromRequest function.

### DIFF
--- a/util/httputil/context.go
+++ b/util/httputil/context.go
@@ -34,23 +34,20 @@ func ContextWithPath(ctx context.Context, path string) context.Context {
 // ContextFromRequest returns a new context with identifiers of
 // the request to be used later when logging the query.
 func ContextFromRequest(ctx context.Context, r *http.Request) context.Context {
-	reqCtxVal := map[string]string{
-		"method": r.Method,
+	var ip string
+	if r.RemoteAddr != "" {
+		// r.RemoteAddr has no defined format, so don't return error if we cannot split it into IP:Port.
+		ip, _, _ = net.SplitHostPort(r.RemoteAddr)
 	}
-
-	// r.RemoteAddr has no defined format, so don't return error if we cannot split it into IP:Port.
-	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
-	if ip != "" {
-		reqCtxVal["clientIP"] = ip
-	}
-
 	var path string
 	if v := ctx.Value(pathParam); v != nil {
 		path = v.(string)
-		reqCtxVal["path"] = path
 	}
-
 	return promql.NewOriginContext(ctx, map[string]interface{}{
-		"httpRequest": reqCtxVal,
+		"httpRequest": map[string]string{
+			"clientIP": ip,
+			"method":   r.Method,
+			"path":     path,
+		},
 	})
 }

--- a/util/httputil/context.go
+++ b/util/httputil/context.go
@@ -31,7 +31,7 @@ func ContextWithPath(ctx context.Context, path string) context.Context {
 	return context.WithValue(ctx, pathParam, path)
 }
 
-// ContextFromRequest returns a new context from a requests with identifiers of
+// ContextFromRequest returns a new context with identifiers of
 // the request to be used later when logging the query.
 func ContextFromRequest(ctx context.Context, r *http.Request) context.Context {
 	reqCtxVal := map[string]string{

--- a/util/httputil/context.go
+++ b/util/httputil/context.go
@@ -34,23 +34,23 @@ func ContextWithPath(ctx context.Context, path string) context.Context {
 // ContextFromRequest returns a new context from a requests with identifiers of
 // the request to be used later when logging the query.
 func ContextFromRequest(ctx context.Context, r *http.Request) context.Context {
-	m := map[string]string{
+	reqCtxVal := map[string]string{
 		"method": r.Method,
 	}
 
 	// r.RemoteAddr has no defined format, so don't return error if we cannot split it into IP:Port.
 	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
 	if ip != "" {
-		m["clientIP"] = ip
+		reqCtxVal["clientIP"] = ip
 	}
 
 	var path string
 	if v := ctx.Value(pathParam); v != nil {
 		path = v.(string)
-		m["path"] = path
+		reqCtxVal["path"] = path
 	}
 
 	return promql.NewOriginContext(ctx, map[string]interface{}{
-		"httpRequest": m,
+		"httpRequest": reqCtxVal,
 	})
 }

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -348,10 +348,7 @@ func (api *API) query(r *http.Request) apiFuncResult {
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
 
-	ctx, err = httputil.ContextFromRequest(ctx, r)
-	if err != nil {
-		return apiFuncResult{nil, returnAPIError(err), nil, nil}
-	}
+	ctx = httputil.ContextFromRequest(ctx, r)
 
 	res := qry.Exec(ctx)
 	if res.Err != nil {
@@ -423,10 +420,7 @@ func (api *API) queryRange(r *http.Request) apiFuncResult {
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
 
-	ctx, err = httputil.ContextFromRequest(ctx, r)
-	if err != nil {
-		return apiFuncResult{nil, returnAPIError(err), nil, nil}
-	}
+	ctx = httputil.ContextFromRequest(ctx, r)
 
 	res := qry.Exec(ctx)
 	if res.Err != nil {

--- a/web/web.go
+++ b/web/web.go
@@ -653,11 +653,7 @@ func (h *Handler) consoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, err = httputil.ContextFromRequest(ctx, r)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	ctx = httputil.ContextFromRequest(ctx, r)
 
 	// Provide URL parameters as a map for easy use. Advanced users may have need for
 	// parameters beyond the first, so provide RawParams.


### PR DESCRIPTION
Previously `httputil.ContextFromRequest` function could return error if `http.Request.RemoteAddr` field didn't have correct format, but since this field explicitly has no defined format, that was little too strict.

We have run into this issue when integrating [Prometheus 2.16.0 into Cortex](https://github.com/cortexproject/cortex/pull/2088).
