### PR TITLE
scrape_test: fix send-to-closed-channel bugs

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -432,7 +432,6 @@ func TestScrapeLoopStop(t *testing.T) {
 		scraper  = &testScraper{}
 		app      = func() storage.Appender { return appender }
 	)
-	defer close(signal)
 
 	sl := newScrapeLoop(context.Background(),
 		scraper,
@@ -498,7 +497,6 @@ func TestScrapeLoopRun(t *testing.T) {
 		scraper = &testScraper{}
 		app     = func() storage.Appender { return &nopAppender{} }
 	)
-	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sl := newScrapeLoop(ctx,
@@ -679,7 +677,6 @@ func TestScrapeLoopRunCreatesStaleMarkersOnFailedScrape(t *testing.T) {
 		scraper = &testScraper{}
 		app     = func() storage.Appender { return appender }
 	)
-	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sl := newScrapeLoop(ctx,
@@ -734,7 +731,6 @@ func TestScrapeLoopRunCreatesStaleMarkersOnParseFailure(t *testing.T) {
 		app        = func() storage.Appender { return appender }
 		numScrapes = 0
 	)
-	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sl := newScrapeLoop(ctx,
@@ -795,7 +791,6 @@ func TestScrapeLoopCache(t *testing.T) {
 		scraper = &testScraper{}
 		app     = func() storage.Appender { return appender }
 	)
-	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sl := newScrapeLoop(ctx,
@@ -872,7 +867,6 @@ func TestScrapeLoopCacheMemoryExhaustionProtection(t *testing.T) {
 		scraper = &testScraper{}
 		app     = func() storage.Appender { return appender }
 	)
-	defer close(signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sl := newScrapeLoop(ctx,


### PR DESCRIPTION
Although seven bugs are reported in PR [6812](https://github.com/prometheus/prometheus/pull/6812), only the last one is a goroutine leak. The first six bugs are caused by sending a message to a closed channel. We did not propose correct patches for the first six bugs in the pull request (forgot to remove the `defer close`). Correct patches for them are in this PR.
```
//scrape/scrape_test.go
func TestScrapeLoopStop(t *testing.T) {
	var (
-		signal   = make(chan struct{})
+		signal   = make(chan struct{}, 1)
		appender = &collectResultAppender{}
		scraper  = &testScraper{}
		app      = func() storage.Appender { return appender }
	)
-	defer close(signal)   // --- line 0

	

	go func() {
		sl.run(10*time.Millisecond, time.Hour, nil)
		signal <- struct{}{} // -- line 1
	}()

	select {
	case <-signal:  // -- line 2
	case <-time.After(5 * time.Second): // line 3
		t.Fatalf("Scrape wasn't stopped.")
	}

	...
}
```
If the parent goroutine chooses the second case at line 3 to execute, the defer close(signal) at line 0 is executed. Therefore, the sending operation by the child goroutine at line 1 is conducted on a closed goroutine, which can cause a panic. 

My feeling is that the defer close(signal) at line 0 is added to avoid goroutine leaks, but it actually causes another bug. 

The patch is to remove the defer at line 0 and increase the buffer size of channel signal from 0 to 1. After that, the sending operation at line 1 is not a blocking operation anymore. (We have already added one buffer in the last PR)

