### PR TITLE
Adds support for expanding templates before rules check

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -15,8 +15,8 @@ package rulefmt
 
 import (
 	"context"
-	"io/ioutil"
 	"strings"
+	templ "text/template"
 	"time"
 
 	"github.com/pkg/errors"
@@ -273,9 +273,18 @@ func Parse(content []byte) (*RuleGroups, []error) {
 	return &groups, groups.Validate(node)
 }
 
+func expandTemplates(file string) ([]byte, error) {
+	tmp, err := templ.ParseFiles(file)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return []byte(tmp.Root.String()), nil
+}
+
 // ParseFile reads and parses rules from a file.
 func ParseFile(file string) (*RuleGroups, []error) {
-	b, err := ioutil.ReadFile(file)
+	b, err := expandTemplates(file)
 	if err != nil {
 		return nil, []error{errors.Wrap(err, file)}
 	}


### PR DESCRIPTION
Signed-off-by: Harkishen Singh <harkishensingh@hotmail.com>
Fixes: #6467 

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
Explanatory gif:

![expd](https://user-images.githubusercontent.com/33792202/75047436-c148a500-54ec-11ea-8f65-c2a7a6d83b28.gif)

Output before the patch:
```
Checking test.yml
  FAILED:
../../test.yml: yaml: line 11: could not find expected ':'
```

**test.yml**
```
groups:
    - name: test
      rules:
      - alert: Test Alert
        expr:  up == 0
        annotations:
          description: This is a test alert that should always fire
        labels:
          severity: warning
        {{define "test-macro"}}
            expr:  time() > {{.arg0}}
        {{end}}
```
