### PR TITLE
API_V1: Extract time param parsing logic

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1452,7 +1452,7 @@ func parseTimeParam(r *http.Request, paramName string, defaultValue time.Time) (
 	}
 	result, err := parseTime(val)
 	if err != nil {
-		return time.Time{}, errors.Wrapf(err, "Invalid parameters '%s'", paramName)
+		return time.Time{}, errors.Wrapf(err, "Invalid time value for '%s'", paramName)
 	}
 	return result, nil
 }

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -317,18 +317,10 @@ func (api *API) options(r *http.Request) apiFuncResult {
 }
 
 func (api *API) query(r *http.Request) apiFuncResult {
-	var ts time.Time
-	if t := r.FormValue("time"); t != "" {
-		var err error
-		ts, err = parseTime(t)
-		if err != nil {
-			err = errors.Wrapf(err, "invalid parameter 'time'")
-			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
-		}
-	} else {
-		ts = api.now()
+	_, ts, err := parseTimeParam(r, "time", api.now())
+	if err != nil {
+		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
-
 	ctx := r.Context()
 	if to := r.FormValue("timeout"); to != "" {
 		var cancel context.CancelFunc
@@ -372,14 +364,12 @@ func (api *API) query(r *http.Request) apiFuncResult {
 }
 
 func (api *API) queryRange(r *http.Request) apiFuncResult {
-	start, err := parseTime(r.FormValue("start"))
+	_, start, err := parseTimeParam(r, "start", minTime)
 	if err != nil {
-		err = errors.Wrapf(err, "invalid parameter 'start'")
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
-	end, err := parseTime(r.FormValue("end"))
+	_, end, err := parseTimeParam(r, "end", maxTime)
 	if err != nil {
-		err = errors.Wrapf(err, "invalid parameter 'end'")
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
 	if end.Before(start) {
@@ -517,26 +507,13 @@ func (api *API) series(r *http.Request) apiFuncResult {
 		return apiFuncResult{nil, &apiError{errorBadData, errors.New("no match[] parameter provided")}, nil, nil}
 	}
 
-	var start time.Time
-	if t := r.FormValue("start"); t != "" {
-		var err error
-		start, err = parseTime(t)
-		if err != nil {
-			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
-		}
-	} else {
-		start = minTime
+	start, _, err := parseTimeParam(r, "start", minTime)
+	if err != nil {
+		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
-
-	var end time.Time
-	if t := r.FormValue("end"); t != "" {
-		var err error
-		end, err = parseTime(t)
-		if err != nil {
-			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
-		}
-	} else {
-		end = maxTime
+	end, _, err := parseTimeParam(r, "end", maxTime)
+	if err != nil {
+		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
 
 	var matcherSets [][]*labels.Matcher
@@ -548,7 +525,7 @@ func (api *API) series(r *http.Request) apiFuncResult {
 		matcherSets = append(matcherSets, matchers)
 	}
 
-	q, err := api.Queryable.Querier(r.Context(), timestamp.FromTime(start), timestamp.FromTime(end))
+	q, err := api.Queryable.Querier(r.Context(), start, end)
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorExec, err}, nil, nil}
 	}
@@ -1325,26 +1302,13 @@ func (api *API) deleteSeries(r *http.Request) apiFuncResult {
 		return apiFuncResult{nil, &apiError{errorBadData, errors.New("no match[] parameter provided")}, nil, nil}
 	}
 
-	var start time.Time
-	if t := r.FormValue("start"); t != "" {
-		var err error
-		start, err = parseTime(t)
-		if err != nil {
-			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
-		}
-	} else {
-		start = minTime
+	start, _, err := parseTimeParam(r, "start", minTime)
+	if err != nil {
+		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
-
-	var end time.Time
-	if t := r.FormValue("end"); t != "" {
-		var err error
-		end, err = parseTime(t)
-		if err != nil {
-			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
-		}
-	} else {
-		end = maxTime
+	end, _, err := parseTimeParam(r, "end", maxTime)
+	if err != nil {
+		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
 
 	for _, s := range r.Form["match[]"] {
@@ -1353,7 +1317,7 @@ func (api *API) deleteSeries(r *http.Request) apiFuncResult {
 			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 		}
 
-		if err := db.Delete(timestamp.FromTime(start), timestamp.FromTime(end), matchers...); err != nil {
+		if err := db.Delete(start, end, matchers...); err != nil {
 			return apiFuncResult{nil, &apiError{errorInternal, err}, nil, nil}
 		}
 	}
@@ -1477,6 +1441,18 @@ func (api *API) respondError(w http.ResponseWriter, apiErr *apiError, data inter
 	if n, err := w.Write(b); err != nil {
 		level.Error(api.logger).Log("msg", "error writing response", "bytesWritten", n, "err", err)
 	}
+}
+
+func parseTimeParam(r *http.Request, paramName string, defaultValue time.Time) (int64, time.Time, error) {
+	val := r.FormValue(paramName)
+	if val != "" {
+		result, err := parseTime(val)
+		if err != nil {
+			return -1, time.Time{}, errors.Wrapf(err, "Invalid parameters '%s'", paramName)
+		}
+		return timestamp.FromTime(result), result, nil
+	}
+	return timestamp.FromTime(defaultValue), defaultValue, nil
 }
 
 func parseTime(s string) (time.Time, error) {

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2183,7 +2183,7 @@ func TestParseTimeParam(t *testing.T) {
 		defaultValue time.Time
 		result       resultType
 	}{
-		{ // When data is valid
+		{ // When data is valid.
 			paramName:    "start",
 			paramValue:   "1582468023986",
 			defaultValue: minTime,
@@ -2192,7 +2192,7 @@ func TestParseTimeParam(t *testing.T) {
 				asError: nil,
 			},
 		},
-		{ // When data is empty string
+		{ // When data is empty string.
 			paramName:    "end",
 			paramValue:   "",
 			defaultValue: maxTime,
@@ -2201,7 +2201,7 @@ func TestParseTimeParam(t *testing.T) {
 				asError: nil,
 			},
 		},
-		{ // When data is not valid
+		{ // When data is not valid.
 			paramName:    "foo",
 			paramValue:   "baz",
 			defaultValue: maxTime,

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2172,42 +2172,42 @@ func TestRespondError(t *testing.T) {
 	}
 }
 func TestParseTimeParam(t *testing.T) {
-	type resultType struct{
-		asTime time.Time;
-		asError func() error;
+	type resultType struct {
+		asTime  time.Time
+		asError func() error
 	}
 	ts, _ := parseTime("1582468023986")
-	var tests = []struct{
-		paramName string;
-		paramValue string;
-		defaultValue time.Time;
-		result resultType;
+	var tests = []struct {
+		paramName    string
+		paramValue   string
+		defaultValue time.Time
+		result       resultType
 	}{
-		{// When data is valid
-			paramName: "start",
-			paramValue: "1582468023986",
+		{ // When data is valid
+			paramName:    "start",
+			paramValue:   "1582468023986",
 			defaultValue: minTime,
 			result: resultType{
-				asTime: ts,
+				asTime:  ts,
 				asError: nil,
 			},
 		},
-		{// When data is empty string
-			paramName: "end",
-			paramValue: "",
+		{ // When data is empty string
+			paramName:    "end",
+			paramValue:   "",
 			defaultValue: maxTime,
 			result: resultType{
-				asTime: maxTime,
+				asTime:  maxTime,
 				asError: nil,
 			},
 		},
-		{// When data is not valid
-			paramName: "foo",
-			paramValue: "baz",
+		{ // When data is not valid
+			paramName:    "foo",
+			paramValue:   "baz",
 			defaultValue: maxTime,
 			result: resultType{
 				asTime: time.Time{},
-				asError: func () error {
+				asError: func() error {
 					_, err := parseTime("baz")
 					return errPkg.Wrapf(err, "Invalid parameters '%s'", "foo")
 				},
@@ -2215,7 +2215,7 @@ func TestParseTimeParam(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		req, err := http.NewRequest("GET", "localhost:42/foo?" + test.paramName + "=" + test.paramValue, nil)
+		req, err := http.NewRequest("GET", "localhost:42/foo?"+test.paramName+"="+test.paramValue, nil)
 		if err != nil {
 			panic(err)
 		}
@@ -2227,7 +2227,7 @@ func TestParseTimeParam(t *testing.T) {
 				Expected error message doesn't match the one from the result.
 					Expected: %s.
 					Actual: %s`,
-					result.asError().Error(), err.Error(),
+				result.asError().Error(), err.Error(),
 			)
 		} else {
 			if !asTime.Equal(result.asTime) {

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2230,7 +2230,6 @@ func TestParseTimeParam(t *testing.T) {
 		} else {
 			testutil.Assert(t, asTime.Equal(result.asTime), "time as return value: %s not parsed correctly. Expected %s. Actual %s", test.paramValue, result.asTime, asTime)
 		}
-
 	}
 }
 

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2173,7 +2173,6 @@ func TestRespondError(t *testing.T) {
 }
 func TestParseTimeParam(t *testing.T) {
 	type resultType struct{
-		asInt int64;
 		asTime time.Time;
 		asError func() error;
 	}
@@ -2189,7 +2188,6 @@ func TestParseTimeParam(t *testing.T) {
 			paramValue: "1582468023986",
 			defaultValue: minTime,
 			result: resultType{
-				asInt: 1582468023986000,
 				asTime: ts,
 				asError: nil,
 			},
@@ -2199,7 +2197,6 @@ func TestParseTimeParam(t *testing.T) {
 			paramValue: "",
 			defaultValue: maxTime,
 			result: resultType{
-				asInt: timestamp.FromTime(maxTime),
 				asTime: maxTime,
 				asError: nil,
 			},
@@ -2209,7 +2206,6 @@ func TestParseTimeParam(t *testing.T) {
 			paramValue: "baz",
 			defaultValue: maxTime,
 			result: resultType{
-				asInt: -1,
 				asTime: time.Time{},
 				asError: func () error {
 					_, err := parseTime("baz")
@@ -2224,7 +2220,7 @@ func TestParseTimeParam(t *testing.T) {
 			panic(err)
 		}
 		result := test.result
-		asInt, asTime, err := parseTimeParam(req, test.paramName, test.defaultValue)
+		asTime, err := parseTimeParam(req, test.paramName, test.defaultValue)
 		if err != nil && err.Error() != result.asError().Error() {
 			t.Log(err.Error(), result.asError().Error())
 			t.Errorf(`
@@ -2234,14 +2230,6 @@ func TestParseTimeParam(t *testing.T) {
 					result.asError().Error(), err.Error(),
 			)
 		} else {
-			if asInt != result.asInt {
-				t.Errorf(`
-					int64 as return value: %s not parsed correctly.
-						Expected: %d.
-						Actual: %d`,
-						test.paramValue, result.asInt, asInt,
-				)
-			}
 			if !asTime.Equal(result.asTime) {
 				t.Errorf(`
 					Time as return value: %s not parsed correctly. Expected %s. Actual %s`,

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2209,7 +2209,7 @@ func TestParseTimeParam(t *testing.T) {
 				asTime: time.Time{},
 				asError: func() error {
 					_, err := parseTime("baz")
-					return errPkg.Wrapf(err, "Invalid parameters '%s'", "foo")
+					return errPkg.Wrapf(err, "Invalid time value for '%s'", "foo")
 				},
 			},
 		},

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2219,26 +2219,16 @@ func TestParseTimeParam(t *testing.T) {
 	}
 	for _, test := range tests {
 		req, err := http.NewRequest("GET", "localhost:42/foo?"+test.paramName+"="+test.paramValue, nil)
-		if err != nil {
-			panic(err)
-		}
+
+		testutil.Ok(t, err)
+
 		result := test.result
 		asTime, err := parseTimeParam(req, test.paramName, test.defaultValue)
-		if err != nil && err.Error() != result.asError().Error() {
-			t.Log(err.Error(), result.asError().Error())
-			t.Errorf(`
-				Expected error message doesn't match the one from the result.
-					Expected: %s.
-					Actual: %s`,
-				result.asError().Error(), err.Error(),
-			)
+
+		if err != nil {
+			testutil.ErrorEqual(t, result.asError(), err)
 		} else {
-			if !asTime.Equal(result.asTime) {
-				t.Errorf(`
-					Time as return value: %s not parsed correctly. Expected %s. Actual %s`,
-					test.paramValue, result.asTime, asTime,
-				)
-			}
+			testutil.Assert(t, asTime.Equal(result.asTime), "time as return value: %s not parsed correctly. Expected %s. Actual %s", test.paramValue, result.asTime, asTime)
 		}
 
 	}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -41,7 +40,7 @@ import (
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/route"
 
-	errPkg "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/gate"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -2171,12 +2170,16 @@ func TestRespondError(t *testing.T) {
 		t.Fatalf("Expected response \n%v\n but got \n%v\n", res, exp)
 	}
 }
+
 func TestParseTimeParam(t *testing.T) {
 	type resultType struct {
 		asTime  time.Time
 		asError func() error
 	}
-	ts, _ := parseTime("1582468023986")
+	ts, err := parseTime("1582468023986")
+
+	testutil.Ok(t, err)
+
 	var tests = []struct {
 		paramName    string
 		paramValue   string
@@ -2209,7 +2212,7 @@ func TestParseTimeParam(t *testing.T) {
 				asTime: time.Time{},
 				asError: func() error {
 					_, err := parseTime("baz")
-					return errPkg.Wrapf(err, "Invalid time value for '%s'", "foo")
+					return errors.Wrapf(err, "Invalid time value for '%s'", "foo")
 				},
 			},
 		},

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2176,8 +2176,8 @@ func TestParseTimeParam(t *testing.T) {
 		asTime  time.Time
 		asError func() error
 	}
-	ts, err := parseTime("1582468023986")
 
+	ts, err := parseTime("1582468023986")
 	testutil.Ok(t, err)
 
 	var tests = []struct {
@@ -2217,9 +2217,9 @@ func TestParseTimeParam(t *testing.T) {
 			},
 		},
 	}
+
 	for _, test := range tests {
 		req, err := http.NewRequest("GET", "localhost:42/foo?"+test.paramName+"="+test.paramValue, nil)
-
 		testutil.Ok(t, err)
 
 		result := test.result


### PR DESCRIPTION
Moving all the changes related to time param parsing from this [PR](https://github.com/prometheus/prometheus/pull/6837) into its own since different parts of the API, not related to what the PR should do are affected.

@juliusv 
@krasi-georgiev Please review