### PR TITLE
docs: minor corrections to the docker documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,9 +27,9 @@ prom/prometheus`. This starts Prometheus with a sample
 configuration and exposes it on port 9090.
 
 The Prometheus image uses a volume to store the actual metrics. For
-production deployments it is highly recommended to use the
-[Data Volume Container](https://docs.docker.com/engine/admin/volumes/volumes/)
-pattern to ease managing the data on Prometheus upgrades.
+production deployments it is highly recommended to use a
+[named volume](https://docs.docker.com/storage/volumes/)
+to ease managing the data on Prometheus upgrades.
 
 To provide your own configuration, there are several options. Here are
 two examples.
@@ -41,11 +41,12 @@ Bind-mount your `prometheus.yml` from the host by running:
 ```bash
 docker run \
     -p 9090:9090 \
-    -v /tmp/prometheus.yml:/etc/prometheus/prometheus.yml \
+    -v /path/to/prometheus.yml:/etc/prometheus/prometheus.yml \
     prom/prometheus
 ```
 
-Or use an additional volume for the config:
+Or bind-mount the directory containing `prometheus.yml` onto
+`/etc/prometheus` by running:
 
 ```bash
 docker run \


### PR DESCRIPTION
The documentation referenced "data volume containers", which were
superseded by named volume support in Docker several years ago.

There were to bind-mounting examples in the docs that are effectively
doing the same thing, but the description of the second was somewhat
erroneous.


<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->