### PR TITLE
Introduce a config option to customise TSDB entropy generator

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -251,7 +251,7 @@ func TestBlockSize(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Equals(t, expAfterDelete, actAfterDelete, "after a delete reported block size doesn't match actual disk size")
 
-		c, err := NewLeveledCompactor(context.Background(), nil, log.NewNopLogger(), []int64{0}, nil)
+		c, err := NewLeveledCompactor(context.Background(), nil, log.NewNopLogger(), []int64{0}, nil, nil)
 		testutil.Ok(t, err)
 		blockDirAfterCompact, err := c.Compact(tmpdir, []string{blockInit.Dir()}, nil)
 		testutil.Ok(t, err)
@@ -309,7 +309,7 @@ func createBlock(tb testing.TB, dir string, series []storage.Series) string {
 }
 
 func createBlockFromHead(tb testing.TB, dir string, head *Head) string {
-	compactor, err := NewLeveledCompactor(context.Background(), nil, log.NewNopLogger(), []int64{1000000}, nil)
+	compactor, err := NewLeveledCompactor(context.Background(), nil, log.NewNopLogger(), []int64{1000000}, nil, nil)
 	testutil.Ok(tb, err)
 
 	testutil.Ok(tb, os.MkdirAll(dir, 0777))

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -156,7 +156,7 @@ func TestNoPanicFor0Tombstones(t *testing.T) {
 		},
 	}
 
-	c, err := NewLeveledCompactor(context.Background(), nil, nil, []int64{50}, nil)
+	c, err := NewLeveledCompactor(context.Background(), nil, nil, []int64{50}, nil, nil)
 	testutil.Ok(t, err)
 
 	c.plan(metas)
@@ -170,7 +170,7 @@ func TestLeveledCompactor_plan(t *testing.T) {
 		180,
 		540,
 		1620,
-	}, nil)
+	}, nil, nil)
 	testutil.Ok(t, err)
 
 	cases := map[string]struct {
@@ -379,7 +379,7 @@ func TestRangeWithFailedCompactionWontGetSelected(t *testing.T) {
 		240,
 		720,
 		2160,
-	}, nil)
+	}, nil, nil)
 	testutil.Ok(t, err)
 
 	cases := []struct {
@@ -429,7 +429,7 @@ func TestCompactionFailWillCleanUpTempDir(t *testing.T) {
 		240,
 		720,
 		2160,
-	}, nil)
+	}, nil, nil)
 	testutil.Ok(t, err)
 
 	tmpdir, err := ioutil.TempDir("", "test")
@@ -747,7 +747,7 @@ func TestCompaction_populateBlock(t *testing.T) {
 				blocks = append(blocks, &mockBReader{ir: ir, cr: cr, mint: mint, maxt: maxt})
 			}
 
-			c, err := NewLeveledCompactor(context.Background(), nil, nil, []int64{0}, nil)
+			c, err := NewLeveledCompactor(context.Background(), nil, nil, []int64{0}, nil, nil)
 			testutil.Ok(t, err)
 
 			meta := &BlockMeta{
@@ -847,7 +847,7 @@ func BenchmarkCompaction(b *testing.B) {
 				blockDirs = append(blockDirs, block.Dir())
 			}
 
-			c, err := NewLeveledCompactor(context.Background(), nil, log.NewNopLogger(), []int64{0}, nil)
+			c, err := NewLeveledCompactor(context.Background(), nil, log.NewNopLogger(), []int64{0}, nil, nil)
 			testutil.Ok(b, err)
 
 			b.ResetTimer()

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -65,7 +65,7 @@ func CreateBlock(samples []*MetricSample, dir string, mint, maxt int64, logger l
 		return "", err
 	}
 
-	compactor, err := NewLeveledCompactor(context.Background(), nil, logger, ExponentialBlockRanges(DefaultBlockDuration, 3, 5), nil)
+	compactor, err := NewLeveledCompactor(context.Background(), nil, logger, ExponentialBlockRanges(DefaultBlockDuration, 3, 5), nil, nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The PR #6867 has been merged before I had the chance to address @bwplotka [comment](https://github.com/prometheus/prometheus/pull/6867/files#r383830627):

> Can we pass entropy to compactor instead?

In this PR:
- Added `Entropy` to DB options (nil value == default)
- Rollback default entropy generator to the one we had before PR #6867 was merged

Questions:
- `DBReadOnly` has no options support. Should we always use the default (as in this PR), pick the entropy in input or add options support to `DBReadOnly` too?