### PR TITLE
fix multiselect legend on mac

### DIFF
--- a/web/ui/react-app/src/pages/graph/Legend.tsx
+++ b/web/ui/react-app/src/pages/graph/Legend.tsx
@@ -23,12 +23,12 @@ export class Legend extends PureComponent<LegendProps, LegendState> {
       this.setState({ selectedIndexes: [] });
     }
   }
-  handleSeriesSelect = (index: number) => (ev: any) => {
+  handleSeriesSelect = (index: number) => (ev: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     // TODO: add proper event type
     const { selectedIndexes } = this.state;
 
     let selected = [index];
-    if (ev.ctrlKey) {
+    if (ev.ctrlKey || ev.metaKey) {
       const { chartData } = this.props;
       if (selectedIndexes.includes(index)) {
         selected = selectedIndexes.filter(idx => idx !== index);
@@ -68,7 +68,7 @@ export class Legend extends PureComponent<LegendProps, LegendState> {
         ))}
         {chartData.length > 1 && (
           <div className="pl-1 mt-1 text-muted" style={{ fontSize: 13 }}>
-            Click: select series, CTRL + click: toggle multiple series
+            Click: select series, {navigator.platform.includes('Mac') ? 'CMD' : 'CTRL'} + click: toggle multiple series
           </div>
         )}
       </div>


### PR DESCRIPTION
On mac, the modifier for multi-select is CMD and not CTRL (CTRL + Click equals to a right click)

this this PR fixes the label and click handler to work on mac

<img width="1278" alt="Screenshot 2020-02-26 at 19 29 33" src="https://user-images.githubusercontent.com/4562878/75375582-a8fece80-58ce-11ea-966d-dacfe37fc860.png">


