### PR TITLE
tsdb: don't allow ingesting empty labelsets

### DIFF
--- a/pkg/textparse/openmetricsparse_test.go
+++ b/pkg/textparse/openmetricsparse_test.go
@@ -498,6 +498,10 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 			input: `custom_metric_total 1 # {aa=\"\xff\"} 9.0`,
 			err:   "expected label value, got \"INVALID\"",
 		},
+		{
+			input: `{b="c",} 1`,
+			err:   `"INVALID" "{" is not a valid start token`,
+		},
 	}
 
 	for i, c := range cases {

--- a/pkg/textparse/promparse_test.go
+++ b/pkg/textparse/promparse_test.go
@@ -265,6 +265,10 @@ func TestPromParseErrors(t *testing.T) {
 			input: "foo 0 1_2\n",
 			err:   "expected next entry after timestamp, got \"MNAME\"",
 		},
+		{
+			input: `{a="ok"} 1`,
+			err:   `"INVALID" is not a valid start token`,
+		},
 	}
 
 	for i, c := range cases {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1154,6 +1154,11 @@ loop:
 				continue
 			}
 
+			if !lset.Has(labels.MetricName) {
+				app.Rollback()
+				return total, added, seriesAdded, errors.New("metric names are mandatory")
+			}
+
 			var ref uint64
 			ref, err = app.Add(lset, t, v)
 			switch err {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -47,6 +47,8 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
+var errNameLabelMandatory = fmt.Errorf("missing metric name (%s label)", labels.MetricName)
+
 var (
 	targetIntervalLength = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
@@ -1155,8 +1157,8 @@ loop:
 			}
 
 			if !lset.Has(labels.MetricName) {
-				app.Rollback()
-				return total, added, seriesAdded, errors.New("metric names are mandatory")
+				err = errNameLabelMandatory
+				break loop
 			}
 
 			var ref uint64

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -353,12 +353,12 @@ func TestAmendDatapointCausesError(t *testing.T) {
 	}()
 
 	app := db.Appender()
-	_, err := app.Add(labels.Labels{}, 0, 0)
+	_, err := app.Add(labels.Labels{{Name: "a", Value: "b"}}, 0, 0)
 	testutil.Ok(t, err)
 	testutil.Ok(t, app.Commit())
 
 	app = db.Appender()
-	_, err = app.Add(labels.Labels{}, 0, 1)
+	_, err = app.Add(labels.Labels{{Name: "a", Value: "b"}}, 0, 1)
 	testutil.Equals(t, ErrAmendSample, err)
 	testutil.Ok(t, app.Rollback())
 }
@@ -371,12 +371,12 @@ func TestDuplicateNaNDatapointNoAmendError(t *testing.T) {
 	}()
 
 	app := db.Appender()
-	_, err := app.Add(labels.Labels{}, 0, math.NaN())
+	_, err := app.Add(labels.Labels{{Name: "a", Value: "b"}}, 0, math.NaN())
 	testutil.Ok(t, err)
 	testutil.Ok(t, app.Commit())
 
 	app = db.Appender()
-	_, err = app.Add(labels.Labels{}, 0, math.NaN())
+	_, err = app.Add(labels.Labels{{Name: "a", Value: "b"}}, 0, math.NaN())
 	testutil.Ok(t, err)
 }
 
@@ -388,13 +388,26 @@ func TestNonDuplicateNaNDatapointsCausesAmendError(t *testing.T) {
 	}()
 
 	app := db.Appender()
-	_, err := app.Add(labels.Labels{}, 0, math.Float64frombits(0x7ff0000000000001))
+	_, err := app.Add(labels.Labels{{Name: "a", Value: "b"}}, 0, math.Float64frombits(0x7ff0000000000001))
 	testutil.Ok(t, err)
 	testutil.Ok(t, app.Commit())
 
 	app = db.Appender()
-	_, err = app.Add(labels.Labels{}, 0, math.Float64frombits(0x7ff0000000000002))
+	_, err = app.Add(labels.Labels{{Name: "a", Value: "b"}}, 0, math.Float64frombits(0x7ff0000000000002))
 	testutil.Equals(t, ErrAmendSample, err)
+}
+
+func TestEmptyLabelsetCausesError(t *testing.T) {
+	db, closeFn := openTestDB(t, nil, nil)
+	defer func() {
+		testutil.Ok(t, db.Close())
+		closeFn()
+	}()
+
+	app := db.Appender()
+	_, err := app.Add(labels.Labels{}, 0, 0)
+	testutil.NotOk(t, err)
+	testutil.Equals(t, "empty labelset: invalid sample", err.Error())
 }
 
 func TestSkippingInvalidValuesInSameTxn(t *testing.T) {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -932,6 +932,10 @@ func (a *headAppender) Add(lset labels.Labels, t int64, v float64) (uint64, erro
 	// Ensure no empty labels have gotten through.
 	lset = lset.WithoutEmpty()
 
+	if len(lset) == 0 {
+		return 0, errors.Wrap(ErrInvalidSample, "empty labelset")
+	}
+
 	if l, dup := lset.HasDuplicateLabelNames(); dup {
 		return 0, errors.Wrap(ErrInvalidSample, fmt.Sprintf(`label name "%s" is not unique`, l))
 	}


### PR DESCRIPTION
See #5617

When we ingest an empty labelset in the head, further blocks can not be
compacted, with the error:

```
level=error ts=2020-02-27T21:26:58.379Z caller=db.go:659 component=tsdb
msg="compaction failed" err="persist head block: write compaction:
add series: out-of-order series added with label set \"{}\" / prev:
\"{}\""
```

We should therefore reject those invalid empty labelsets upfront.

This can be reproduced with the following:

```
cat << END > prometheus.yml
scrape_configs:
  - job_name: 'prometheus'
    scrape_interval: 1s
    basic_auth:
      username: test
      password: test
    metric_relabel_configs:
    - regex: ".*"
      action: labeldrop

    static_configs:
    - targets:
      - 127.0.1.1:9090
END
./prometheus --storage.tsdb.min-block-duration=1m
```
And wait a few minutes.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->