### PR TITLE
Fix new targets page not loading

### DIFF
--- a/web/ui/react-app/src/pages/targets/TargetLabels.test.tsx
+++ b/web/ui/react-app/src/pages/targets/TargetLabels.test.tsx
@@ -25,7 +25,7 @@ describe('targetLabels', () => {
   it('renders a div of series labels', () => {
     const div = targetLabels.find('div').filterWhere(elem => elem.hasClass('series-labels-container'));
     expect(div).toHaveLength(1);
-    expect(div.prop('id')).toEqual('series-labels-cortex\\/node-exporter_group\\/0-1');
+    expect(div.prop('id')).toEqual('series-labels-cortex/node-exporter_group/0-1');
   });
 
   it('wraps each label in a label badge', () => {

--- a/web/ui/react-app/src/pages/targets/TargetLabels.tsx
+++ b/web/ui/react-app/src/pages/targets/TargetLabels.tsx
@@ -20,7 +20,7 @@ const TargetLabels: FC<TargetLabelsProps> = ({ discoveredLabels, labels, idx, sc
   const [tooltipOpen, setTooltipOpen] = useState(false);
 
   const toggle = (): void => setTooltipOpen(!tooltipOpen);
-  const id = `series-labels-${CSS.escape(scrapePool)}-${idx}`;
+  const id = `series-labels-${scrapePool}-${idx}`;
 
   return (
     <>
@@ -33,7 +33,7 @@ const TargetLabels: FC<TargetLabelsProps> = ({ discoveredLabels, labels, idx, sc
           );
         })}
       </div>
-      <Tooltip isOpen={tooltipOpen} target={id} toggle={toggle} style={{ maxWidth: 'none', textAlign: 'left' }}>
+      <Tooltip isOpen={tooltipOpen} target={CSS.escape(id)} toggle={toggle} style={{ maxWidth: 'none', textAlign: 'left' }}>
         <b>Before relabeling:</b>
         {formatLabels(discoveredLabels).map((s: string, idx: number) => (
           <Fragment key={idx}>

--- a/web/ui/react-app/src/pages/targets/__snapshots__/TargetLabels.test.tsx.snap
+++ b/web/ui/react-app/src/pages/targets/__snapshots__/TargetLabels.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`targetLabels renders discovered labels 1`] = `
 <Fragment>
   <div
     className="series-labels-container"
-    id="series-labels-cortex\\\\/node-exporter_group\\\\/0-1"
+    id="series-labels-cortex/node-exporter_group/0-1"
   >
     <Badge
       className="mr-1 instance"


### PR DESCRIPTION
This fixes an issue where the /new/targets page will not load when there
are jobs with invalid CSS characters in them, such as the
namespace/service/0 form used by the Prometheus Operator.

Example console error for a job named `monitoring/alertmanager/0` such
as commonly added by the Prometheus operator.
```
DOMException: Failed to execute 'querySelectorAll' on 'Document':
'series-labels-monitoring\/alertmanager\/0-0' is not a valid selector.
```

Hopefully Fixes #6732 for real this time.