### PR TITLE
Do not attempt isolation for appendID == 0

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1847,7 +1847,8 @@ func (s *memSeries) truncateChunksBefore(mint int64) (removed int) {
 }
 
 // append adds the sample (t, v) to the series. The caller also has to provide
-// the appendID for isolation.
+// the appendID for isolation. (The appendID can be zero, which results in no
+// isolation for this append.)
 func (s *memSeries) append(t int64, v float64, appendID uint64) (success, chunkCreated bool) {
 	// Based on Gorilla white papers this offers near-optimal compression ratio
 	// so anything bigger that this has diminishing returns and increases
@@ -1885,7 +1886,9 @@ func (s *memSeries) append(t int64, v float64, appendID uint64) (success, chunkC
 	s.sampleBuf[2] = s.sampleBuf[3]
 	s.sampleBuf[3] = sample{t: t, v: v}
 
-	s.txs.add(appendID)
+	if appendID > 0 {
+		s.txs.add(appendID)
+	}
 
 	return true, chunkCreated
 }

--- a/tsdb/isolation.go
+++ b/tsdb/isolation.go
@@ -110,7 +110,8 @@ func (i *isolation) State() *isolationState {
 	return isoState
 }
 
-// newAppendID increments the transaction counter and returns a new transaction ID.
+// newAppendID increments the transaction counter and returns a new transaction
+// ID. The first ID returned is 1.
 func (i *isolation) newAppendID() uint64 {
 	i.appendMtx.Lock()
 	defer i.appendMtx.Unlock()


### PR DESCRIPTION
Easy fix.

Now the memory usage on my production server is 7.7GB vs 6.5GB (`container_memory_working_set_bytes`), 18% increase. That's more what we expected. (Heap size is currently even smaller, but that might change after longer runtime.)

