### PR TITLE
[log] ServiceDiscovery: Add debug log when target has duplicate source

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -298,6 +298,10 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
 			if _, ok := m.targets[poolKey]; !ok {
 				m.targets[poolKey] = make(map[string]*targetgroup.Group)
 			}
+			oldTg, ok := m.targets[poolKey][tg.Source]
+			if ok {
+				level.Debug(m.logger).Log("msg", "updateGroup Duplicate source", "source", tg.Source, "targets", tg.Targets, "oldTarget.targets", oldTg.Targets)
+			}
 			m.targets[poolKey][tg.Source] = tg
 		}
 	}


### PR DESCRIPTION
Add debug log when target has duplicate source.

---- why?
We implement  ECS service discovery through the way of custom service discovery. Yesterday, our customers reported that there were 175 ECS, but we only found 14 ECSS.

In order to help customers solve the problem, we added logs for troubleshooting
----debug log code.
![image](https://user-images.githubusercontent.com/9583245/75602092-e648a380-5afc-11ea-99f2-d958b4d5d9c8.png)
(EcsDiscoverer result log)
![image](https://user-images.githubusercontent.com/9583245/75602109-1132f780-5afd-11ea-82f6-2ab71059a635.png)
(Ecs Adapter result log)
----log
2020-02-28 03:20:52   - find ecs size : 175
2020-02-28 03:20:55   -  a.groups.len : 14
2020-02-28 03:20:55   -  a.arr.len : 14

----Why more than 131 ECCS are missing？
By debugging the Prometheus source code, we find that target will be discarded when the source is the same
![image](https://user-images.githubusercontent.com/9583245/75602159-9f0ee280-5afd-11ea-93b1-cdb250073afa.png)

---review our custom service discovery
![image](https://user-images.githubusercontent.com/9583245/75602228-28261980-5afe-11ea-908d-6a0546c4b5f9.png)

Finally, by consulting our customers to confirm whether there is an ECS with the same InstanceName. 
Customer feedback: the name of ECS generated by k8s is the same。
----fix
Finally, we solve this problem by changing the value of source to instanceid
![image](https://user-images.githubusercontent.com/9583245/75602248-5ad01200-5afe-11ea-92dc-a689e341db24.png)

----Review of problems
We can't rule out that there may be duplicate instanceid in the future, or other Prometheus users may also encounter this problem, 
so it is recommended that when servicediscovery discards target, there is a log to remind our operation and maintenance personnel


