### PR TITLE
scrape/target_test.go: remove deprecated function BuildNameToCertificate()

### DIFF
--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -257,7 +257,6 @@ func TestNewHTTPClientCert(t *testing.T) {
 	tlsConfig := newTLSConfig("server", t)
 	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	tlsConfig.ClientCAs = tlsConfig.RootCAs
-	tlsConfig.BuildNameToCertificate()
 	server.TLS = tlsConfig
 	server.StartTLS()
 	defer server.Close()
@@ -354,7 +353,6 @@ func newTLSConfig(certName string, t *testing.T) *tls.Config {
 		t.Errorf("Unable to use specified server cert (%s) & key (%v): %s", certPath, keyPath, err)
 	}
 	tlsConfig.Certificates = []tls.Certificate{cert}
-	tlsConfig.BuildNameToCertificate()
 	return tlsConfig
 }
 


### PR DESCRIPTION
This fix a staticcheck issue related to go1.14 function deprecation.
See the change here: https://github.com/golang/go/commit/eb93c684d40de4924fc0664d7d9e98a84d5a100b

See the error message,
```
$ go version
go version go1.14 linux/amd64
$ make lint
>> running golangci-lint
GO111MODULE=on go list -e -compiled -test=true -export=false -deps=true -find=false -tags= -- ./... > /dev/null
GO111MODULE=on /home/mt/go/packages/bin/golangci-lint run  ./...
scrape/target_test.go:260:2: SA1019: tlsConfig.BuildNameToCertificate is deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates.  (staticcheck)
	tlsConfig.BuildNameToCertificate()
	^
scrape/target_test.go:357:2: SA1019: tlsConfig.BuildNameToCertificate is deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates.  (staticcheck)
	tlsConfig.BuildNameToCertificate()
	^
make: *** [Makefile.common:181: common-lint] Error 1
```
Signed-off-by: Mario Trangoni <mjtrangoni@gmail.com>