### PR TITLE
Expose EC2 instance lifecycle as label

### DIFF
--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -37,22 +37,23 @@ import (
 )
 
 const (
-	ec2Label                = model.MetaLabelPrefix + "ec2_"
-	ec2LabelAZ              = ec2Label + "availability_zone"
-	ec2LabelInstanceID      = ec2Label + "instance_id"
-	ec2LabelInstanceState   = ec2Label + "instance_state"
-	ec2LabelInstanceType    = ec2Label + "instance_type"
-	ec2LabelOwnerID         = ec2Label + "owner_id"
-	ec2LabelPlatform        = ec2Label + "platform"
-	ec2LabelPublicDNS       = ec2Label + "public_dns_name"
-	ec2LabelPublicIP        = ec2Label + "public_ip"
-	ec2LabelPrivateDNS      = ec2Label + "private_dns_name"
-	ec2LabelPrivateIP       = ec2Label + "private_ip"
-	ec2LabelPrimarySubnetID = ec2Label + "primary_subnet_id"
-	ec2LabelSubnetID        = ec2Label + "subnet_id"
-	ec2LabelTag             = ec2Label + "tag_"
-	ec2LabelVPCID           = ec2Label + "vpc_id"
-	subnetSeparator         = ","
+	ec2Label                  = model.MetaLabelPrefix + "ec2_"
+	ec2LabelAZ                = ec2Label + "availability_zone"
+	ec2LabelInstanceID        = ec2Label + "instance_id"
+	ec2LabelInstanceState     = ec2Label + "instance_state"
+	ec2LabelInstanceType      = ec2Label + "instance_type"
+	ec2LabelInstanceLifecycle = ec2Label + "instance_lifecycle"
+	ec2LabelOwnerID           = ec2Label + "owner_id"
+	ec2LabelPlatform          = ec2Label + "platform"
+	ec2LabelPublicDNS         = ec2Label + "public_dns_name"
+	ec2LabelPublicIP          = ec2Label + "public_ip"
+	ec2LabelPrivateDNS        = ec2Label + "private_dns_name"
+	ec2LabelPrivateIP         = ec2Label + "private_ip"
+	ec2LabelPrimarySubnetID   = ec2Label + "primary_subnet_id"
+	ec2LabelSubnetID          = ec2Label + "subnet_id"
+	ec2LabelTag               = ec2Label + "tag_"
+	ec2LabelVPCID             = ec2Label + "vpc_id"
+	subnetSeparator           = ","
 )
 
 // DefaultSDConfig is the default EC2 SD configuration.
@@ -213,6 +214,10 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 				labels[ec2LabelAZ] = model.LabelValue(*inst.Placement.AvailabilityZone)
 				labels[ec2LabelInstanceState] = model.LabelValue(*inst.State.Name)
 				labels[ec2LabelInstanceType] = model.LabelValue(*inst.InstanceType)
+
+				if inst.InstanceLifecycle != nil {
+					labels[ec2LabelInstanceLifecycle] = model.LabelValue(*inst.InstanceLifecycle)
+				}
 
 				if inst.VpcId != nil {
 					labels[ec2LabelVPCID] = model.LabelValue(*inst.VpcId)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -428,6 +428,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 
 * `__meta_ec2_availability_zone`: the availability zone in which the instance is running
 * `__meta_ec2_instance_id`: the EC2 instance ID
+* `__meta_ec2_instance_lifecycle`: the lifecycle of the EC2 instance, set only for 'spot' or 'scheduled' instances, absent otherwise
 * `__meta_ec2_instance_state`: the state of the EC2 instance
 * `__meta_ec2_instance_type`: the type of the EC2 instance
 * `__meta_ec2_owner_id`: the ID of the AWS account that owns the EC2 instance


### PR DESCRIPTION
Signed-off-by: Alex Gaganov <alex.gaganov@fiverr.com>

This change exposes the `InstanceLifecycle` attribute during EC2 service discovery and makes it available as a `__meta_ec2_instance_lifecycle` label. The attribute's value can be either `spot` or `scheduled`. In the case of "regular" instance, the attribute will be `nil`.
The new label will come in handy when there's a need to distinguish between `spot` and `on-demand` instances.

There was an attempt to address this in #6017, however, the PR has some pending comments and got stale due to inactivity :-(  

@brian-brazil your input would be greatly appreciated.