### PR TITLE
Revert "Fix race condition in Rule manager.Update() function"

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -921,7 +921,7 @@ func (m *Manager) Update(interval time.Duration, files []string, externalLabels 
 		}
 
 		wg.Add(1)
-		go func(newg *Group, oldg *Group) {
+		go func(newg *Group) {
 			if ok {
 				oldg.stop()
 				newg.CopyState(oldg)
@@ -934,7 +934,7 @@ func (m *Manager) Update(interval time.Duration, files []string, externalLabels 
 				newg.run(m.opts.Context)
 			}()
 			wg.Done()
-		}(newg, oldg)
+		}(newg)
 	}
 
 	// Stop remaining old groups.


### PR DESCRIPTION
This reverts commit 8b11d2cfb6f9a7ae37bd402ca5176da034c572f8.

oldg is scoped to the inner loop so there is no race here.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->