### PR TITLE
Defer call to iso.closeAppend

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1045,6 +1045,7 @@ func (a *headAppender) Commit() error {
 	defer a.head.metrics.activeAppenders.Dec()
 	defer a.head.putAppendBuffer(a.samples)
 	defer a.head.putSeriesBuffer(a.sampleSeries)
+	defer a.head.iso.closeAppend(a.appendID)
 
 	if err := a.log(); err != nil {
 		return errors.Wrap(err, "write to WAL")
@@ -1071,7 +1072,6 @@ func (a *headAppender) Commit() error {
 
 	a.head.metrics.samplesAppended.Add(float64(total))
 	a.head.updateMinMaxTime(a.mint, a.maxt)
-	a.head.iso.closeAppend(a.appendID)
 
 	return nil
 }


### PR DESCRIPTION
This is taken from #6918. Since we probably won't merge #6918 before
the relase, we have to do this bit of it as it fixes an actual bug
(iso.closeAppend is not called if the append fails because of an error
logging to the WAL).
