### PR TITLE
Separate scrape add error checking out into it's own function.

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1071,7 +1071,6 @@ func (sl *scrapeLoop) append(b []byte, contentType string, ts time.Time) (total,
 		defTime        = timestamp.FromTime(ts)
 		appErrs        = appendErrors{}
 		sampleLimitErr error
-		sampleAdded    bool
 	)
 
 	defer func() {
@@ -1089,7 +1088,10 @@ func (sl *scrapeLoop) append(b []byte, contentType string, ts time.Time) (total,
 
 loop:
 	for {
-		var et textparse.Entry
+		var (
+			et          textparse.Entry
+			sampleAdded bool
+		)
 		if et, err = p.Next(); err != nil {
 			if err == io.EOF {
 				err = nil

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1157,7 +1157,6 @@ loop:
 
 			var ref uint64
 			ref, err = app.Add(lset, t, v)
-			// call new check error function here
 			sampleAdded, err = sl.checkAddError(nil, met, tp, err, &sampleLimitErr, appErrs)
 			if err != nil {
 				if err != storage.ErrNotFound {
@@ -1176,7 +1175,7 @@ loop:
 			}
 		}
 
-		// Match the previous behaviour, increment added even if there's a sampleLimitErr.
+		// Increment added even if there's a sampleLimitErr so we correctly report the number of samples scraped.
 		if sampleAdded || sampleLimitErr != nil {
 			added++
 		}

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1011,6 +1011,48 @@ func TestScrapeLoopAppend(t *testing.T) {
 	}
 }
 
+func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
+	// collectResultAppender's AddFast always returns ErrNotFound if we don't give it a next
+	app := &collectResultAppender{}
+
+	sl := newScrapeLoop(context.Background(),
+		nil, nil, nil,
+		nopMutator,
+		nopMutator,
+		func() storage.Appender { return app },
+		nil,
+		0,
+		true,
+	)
+
+	fakeRef := uint64(1)
+	expValue := float64(1)
+	metric := `metric{n="1"} 1`
+	p := textparse.New([]byte(metric), "")
+
+	var lset labels.Labels
+	p.Next()
+	mets := p.Metric(&lset)
+	hash := lset.Hash()
+
+	// Create a fake entry in the cache
+	sl.cache.addRef(mets, fakeRef, lset, hash)
+	now := time.Now()
+
+	_, _, _, err := sl.append([]byte(metric), "", now)
+	testutil.Ok(t, err)
+
+	expected := []sample{
+		{
+			metric: lset,
+			t:      timestamp.FromTime(now),
+			v:      expValue,
+		},
+	}
+
+	testutil.Equals(t, expected, app.result)
+}
+
 func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 	resApp := &collectResultAppender{}
 	app := &limitAppender{Appender: resApp, limit: 1}

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1012,7 +1012,7 @@ func TestScrapeLoopAppend(t *testing.T) {
 }
 
 func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
-	// collectResultAppender's AddFast always returns ErrNotFound if we don't give it a next
+	// collectResultAppender's AddFast always returns ErrNotFound if we don't give it a next.
 	app := &collectResultAppender{}
 
 	sl := newScrapeLoop(context.Background(),


### PR DESCRIPTION
While working on the exemplars implementation I wanted a simpler way to know whether adding a sample had succeeded to be able to simplify the conditional check for adding an exemplar. Rather than making a change as part of that work, I'm opening this PR to refactor the error checking for the calls to `Appender`'s `add/addFast` functions.

I think the behaviour here remains the same, with the addition of a conditional check if the error was nil for the no cache entry/create new series path, but in that case `checkAddError` will be passed a nil pointer to a `cacheEntry` and so again the behaviour should not have changed.

I went with two bools and an error as the return values but we could also pass `sampleLimitError` in.

Signed-off-by: Callum Styan <callumstyan@gmail.com>