### PR TITLE
PromQL: Fix broken regression tests

### DIFF
--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -2164,18 +2164,6 @@ var testExpr = []struct {
 		input:  "a>b()",
 		fail:   true,
 		errMsg: `unknown function`,
-	}, {
-		input:  "rate(avg)",
-		fail:   true,
-		errMsg: `unexpected ")"`,
-	}, {
-		input:  "sum(sum)",
-		fail:   true,
-		errMsg: `unexpected ")"`,
-	}, {
-		input:  "a + sum",
-		fail:   true,
-		errMsg: `unexpected end of input`,
 	},
 	// String quoting and escape sequence interpretation tests.
 	{

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -2164,6 +2164,55 @@ var testExpr = []struct {
 		input:  "a>b()",
 		fail:   true,
 		errMsg: `unknown function`,
+	}, {
+		input:  "rate(avg)",
+		fail:   true,
+		errMsg: `expected type range vector`,
+	}, {
+		input: "sum(sum)",
+		expected: &AggregateExpr{
+			Op: SUM,
+			Expr: &VectorSelector{
+				Name: "sum",
+				LabelMatchers: []*labels.Matcher{
+					mustLabelMatcher(labels.MatchEqual, string(model.MetricNameLabel), "sum"),
+				},
+				PosRange: PositionRange{
+					Start: 4,
+					End:   7,
+				},
+			},
+			PosRange: PositionRange{
+				Start: 0,
+				End:   8,
+			},
+		},
+	}, {
+		input: "a + sum",
+		expected: &BinaryExpr{
+			Op: ADD,
+			LHS: &VectorSelector{
+				Name: "a",
+				LabelMatchers: []*labels.Matcher{
+					mustLabelMatcher(labels.MatchEqual, string(model.MetricNameLabel), "a"),
+				},
+				PosRange: PositionRange{
+					Start: 0,
+					End:   1,
+				},
+			},
+			RHS: &VectorSelector{
+				Name: "sum",
+				LabelMatchers: []*labels.Matcher{
+					mustLabelMatcher(labels.MatchEqual, string(model.MetricNameLabel), "sum"),
+				},
+				PosRange: PositionRange{
+					Start: 4,
+					End:   7,
+				},
+			},
+			VectorMatching: &VectorMatching{},
+		},
 	},
 	// String quoting and escape sequence interpretation tests.
 	{


### PR DESCRIPTION
This PR removes the regression tests for the issue fixed in #6931 .

The reason for that is that all known queries that triggered the regression have become more or less valid syntax in #6933 (they might still fail type checking).

Signed-off-by: Tobias Guggenmos <tobias.guggenmos@uni-ulm.de>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->