### PR TITLE
tsdb: fix typo

### DIFF
--- a/tsdb/repair.go
+++ b/tsdb/repair.go
@@ -41,7 +41,7 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 		return errors.Wrapf(err, "block dir: %q", d)
 	}
 
-	tmpFiles := make([]string, 0, len(dir))
+	tmpFiles := make([]string, 0, len(dirs))
 	defer func() {
 		for _, tmp := range tmpFiles {
 			if err := os.RemoveAll(tmp); err != nil {


### PR DESCRIPTION
Fix typo here.

The cap of `tmpFiles` is the number of `dirs` not length of string `dir`.

@codesome 