### PR TITLE
Fix panic when parsing varags

### DIFF
--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -544,6 +544,11 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 
 		for i, arg := range n.Args {
 			if i >= len(n.Func.ArgTypes) {
+				if n.Func.Variadic == 0 {
+					// This is not a vararg function so we should not check the
+					// type of the extra arguments.
+					break
+				}
 				i = len(n.Func.ArgTypes) - 1
 			}
 			p.expectType(arg, n.Func.ArgTypes[i], fmt.Sprintf("call to function %q", n.Func.Name))

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -2131,9 +2131,21 @@ var testExpr = []struct {
 		fail:   true,
 		errMsg: "expected 1 argument(s) in call to \"floor\", got 2",
 	}, {
+		input:  "floor(some_metric, 1)",
+		fail:   true,
+		errMsg: "expected 1 argument(s) in call to \"floor\", got 2",
+	}, {
 		input:  "floor(1)",
 		fail:   true,
 		errMsg: "expected type instant vector in call to function \"floor\", got scalar",
+	}, {
+		input:  "hour(some_metric, some_metric, some_metric)",
+		fail:   true,
+		errMsg: "expected at most 1 argument(s) in call to \"hour\", got 3",
+	}, {
+		input:  "time(some_metric)",
+		fail:   true,
+		errMsg: "expected 0 argument(s) in call to \"time\", got 1",
 	}, {
 		input:  "non_existent_function_far_bar()",
 		fail:   true,


### PR DESCRIPTION
Fix #6939 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->