### PR TITLE
tsdb/chunks: remove un-used code.

### DIFF
--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -457,10 +457,6 @@ func (b realByteSlice) Range(start, end int) []byte {
 	return b[start:end]
 }
 
-func (b realByteSlice) Sub(start, end int) ByteSlice {
-	return b[start:end]
-}
-
 // Reader implements a ChunkReader for a serialized byte stream
 // of series data.
 type Reader struct {


### PR DESCRIPTION
This code below is not used. If not used in the future, it is better to delete it.

https://github.com/prometheus/prometheus/blob/0a27df92f091a7d7eb6087892f307c72e70b2f0d/tsdb/chunks/chunks.go#L460-L462

It's not a bug.