### PR TITLE
tsdb: Do a full rollback upon commit error

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -116,7 +116,10 @@ type Appender interface {
 	// faster than adding a sample by providing its full label set.
 	AddFast(ref uint64, t int64, v float64) error
 
-	// Commit submits the collected samples and purges the batch.
+	// Commit submits the collected samples and purges the batch. If Commit
+	// returns a non-nil error, it also rolls back all modifications made in
+	// the appender so far, as Rollback would do. In any case, an Appender
+	// must not be used anymore after Commit has been called.
 	Commit() error
 
 	// Rollback rolls back all modifications made in the appender so far.


### PR DESCRIPTION
I think the previous behavior is problematic as it will leave
`memSeries` around that still have `pendingCommit` set to `true`.

The only case where this can happen in this code path is a failure to
write to the WAL, in which case we are probably in trouble anyway. I
believe, however, we should still try to do the right thing and do the
full rollback. This will implicitly try to write to the WAL again, but
this time without samples, which may even succeed. (But we propagate
the previous error in any case.)

This is another thing I ran into while staring at code for the isolation implementation.