### PR TITLE
[OpenStack SD] Add HypervisorID meta labels and OpenStack Api version…

### DIFF
--- a/discovery/openstack/hypervisor.go
+++ b/discovery/openstack/hypervisor.go
@@ -30,6 +30,7 @@ import (
 )
 
 const (
+	openstackLabelHypervisorID       = openstackLabelPrefix + "hypervisor_id"
 	openstackLabelHypervisorHostIP   = openstackLabelPrefix + "hypervisor_host_ip"
 	openstackLabelHypervisorHostName = openstackLabelPrefix + "hypervisor_hostname"
 	openstackLabelHypervisorStatus   = openstackLabelPrefix + "hypervisor_status"
@@ -39,18 +40,19 @@ const (
 
 // HypervisorDiscovery discovers OpenStack hypervisors.
 type HypervisorDiscovery struct {
-	provider *gophercloud.ProviderClient
-	authOpts *gophercloud.AuthOptions
-	region   string
-	logger   log.Logger
-	port     int
+	provider   *gophercloud.ProviderClient
+	authOpts   *gophercloud.AuthOptions
+	region     string
+	logger     log.Logger
+	port       int
+	apiVersion string
 }
 
 // newHypervisorDiscovery returns a new hypervisor discovery.
 func newHypervisorDiscovery(provider *gophercloud.ProviderClient, opts *gophercloud.AuthOptions,
-	port int, region string, l log.Logger) *HypervisorDiscovery {
+	port int, region string, apiVersion string, l log.Logger) *HypervisorDiscovery {
 	return &HypervisorDiscovery{provider: provider, authOpts: opts,
-		region: region, port: port, logger: l}
+		region: region, port: port, apiVersion: apiVersion, logger: l}
 }
 
 func (h *HypervisorDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
@@ -65,6 +67,7 @@ func (h *HypervisorDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create OpenStack compute session")
 	}
+	client.Microversion = h.apiVersion
 
 	tg := &targetgroup.Group{
 		Source: fmt.Sprintf("OS_" + h.region),
@@ -81,6 +84,7 @@ func (h *HypervisorDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group
 			labels := model.LabelSet{}
 			addr := net.JoinHostPort(hypervisor.HostIP, fmt.Sprintf("%d", h.port))
 			labels[model.AddressLabel] = model.LabelValue(addr)
+			labels[openstackLabelHypervisorID] = model.LabelValue(hypervisor.ID)
 			labels[openstackLabelHypervisorHostName] = model.LabelValue(hypervisor.HypervisorHostname)
 			labels[openstackLabelHypervisorHostIP] = model.LabelValue(hypervisor.HostIP)
 			labels[openstackLabelHypervisorStatus] = model.LabelValue(hypervisor.Status)

--- a/discovery/openstack/hypervisor_test.go
+++ b/discovery/openstack/hypervisor_test.go
@@ -35,7 +35,6 @@ func (s *OpenstackSDHypervisorTestSuite) SetupTest(t *testing.T) {
 	s.Mock.Setup()
 
 	s.Mock.HandleHypervisorListSuccessfully()
-
 	s.Mock.HandleVersionsSuccessfully()
 	s.Mock.HandleAuthSuccessfully()
 }
@@ -48,6 +47,7 @@ func (s *OpenstackSDHypervisorTestSuite) openstackAuthSuccess() (refresher, erro
 		DomainName:       "12345",
 		Region:           "RegionOne",
 		Role:             "hypervisor",
+		ApiVersion:       "2.53",
 	}
 	return newRefresher(&conf, nil)
 }
@@ -74,6 +74,7 @@ func TestOpenstackSDHypervisorRefresh(t *testing.T) {
 		"__meta_openstack_hypervisor_host_ip":  "172.16.70.14",
 		"__meta_openstack_hypervisor_state":    "up",
 		"__meta_openstack_hypervisor_status":   "enabled",
+		"__meta_openstack_hypervisor_id":       "45bf0f54-7d29-4345-88d9-1e28e917c4f6",
 	} {
 		testutil.Equals(t, model.LabelValue(v), tg.Targets[0][model.LabelName(l)])
 	}
@@ -85,6 +86,7 @@ func TestOpenstackSDHypervisorRefresh(t *testing.T) {
 		"__meta_openstack_hypervisor_host_ip":  "172.16.70.13",
 		"__meta_openstack_hypervisor_state":    "up",
 		"__meta_openstack_hypervisor_status":   "enabled",
+		"__meta_openstack_hypervisor_id":       "7d1fdea5-e111-40bf-8cce-4231aab6586a",
 	} {
 		testutil.Equals(t, model.LabelValue(v), tg.Targets[1][model.LabelName(l)])
 	}

--- a/discovery/openstack/instance.go
+++ b/discovery/openstack/instance.go
@@ -53,16 +53,17 @@ type InstanceDiscovery struct {
 	logger     log.Logger
 	port       int
 	allTenants bool
+	apiVersion string
 }
 
 // NewInstanceDiscovery returns a new instance discovery.
 func newInstanceDiscovery(provider *gophercloud.ProviderClient, opts *gophercloud.AuthOptions,
-	port int, region string, allTenants bool, l log.Logger) *InstanceDiscovery {
+	port int, region string, allTenants bool, apiVersion string, l log.Logger) *InstanceDiscovery {
 	if l == nil {
 		l = log.NewNopLogger()
 	}
 	return &InstanceDiscovery{provider: provider, authOpts: opts,
-		region: region, port: port, allTenants: allTenants, logger: l}
+		region: region, port: port, allTenants: allTenants, apiVersion: apiVersion, logger: l}
 }
 
 type floatingIPKey struct {
@@ -82,6 +83,7 @@ func (i *InstanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create OpenStack compute session")
 	}
+	client.Microversion = i.apiVersion
 
 	// OpenStack API reference
 	// https://developer.openstack.org/api-ref/compute/#list-floating-ips

--- a/discovery/openstack/mock_test.go
+++ b/discovery/openstack/mock_test.go
@@ -190,7 +190,7 @@ const hypervisorListBody = `
             "service": {
                 "host": "nc14.cloud.com",
                 "disabled_reason": null,
-                "id": 16
+                "id": "b027b100-3ea8-4843-804b-b4edc2d4029d"
             },
             "vcpus_used": 18,
             "hypervisor_type": "QEMU",
@@ -209,14 +209,14 @@ const hypervisorListBody = `
             "disk_available_least": 304,
             "local_gb": 399,
             "free_ram_mb": 72420,
-            "id": 1
+            "id": "45bf0f54-7d29-4345-88d9-1e28e917c4f6"
         },
         {
             "status": "enabled",
             "service": {
                 "host": "cc13.cloud.com",
                 "disabled_reason": null,
-                "id": 17
+                "id": "be08b9c5-eeb9-4f1e-9ed9-d91c0fe67608"
             },
             "vcpus_used": 1,
             "hypervisor_type": "QEMU",
@@ -235,7 +235,7 @@ const hypervisorListBody = `
             "disk_available_least": 384,
             "local_gb": 399,
             "free_ram_mb": 93924,
-            "id": 721
+            "id": "7d1fdea5-e111-40bf-8cce-4231aab6586a"
         }
     ]
 }`

--- a/discovery/openstack/openstack.go
+++ b/discovery/openstack/openstack.go
@@ -55,6 +55,7 @@ type SDConfig struct {
 	Port                        int                   `yaml:"port"`
 	AllTenants                  bool                  `yaml:"all_tenants,omitempty"`
 	TLSConfig                   config_util.TLSConfig `yaml:"tls_config,omitempty"`
+	ApiVersion                  string                `yaml:"api_version"`
 }
 
 // Role is the role of the target in OpenStack.
@@ -163,9 +164,9 @@ func newRefresher(conf *SDConfig, l log.Logger) (refresher, error) {
 	}
 	switch conf.Role {
 	case OpenStackRoleHypervisor:
-		return newHypervisorDiscovery(client, &opts, conf.Port, conf.Region, l), nil
+		return newHypervisorDiscovery(client, &opts, conf.Port, conf.Region, conf.ApiVersion, l), nil
 	case OpenStackRoleInstance:
-		return newInstanceDiscovery(client, &opts, conf.Port, conf.Region, conf.AllTenants, l), nil
+		return newInstanceDiscovery(client, &opts, conf.Port, conf.Region, conf.AllTenants, conf.ApiVersion, l), nil
 	}
 	return nil, errors.New("unknown OpenStack discovery role")
 }


### PR DESCRIPTION
… SDConfig

Add extra meta labels which will be useful in the case
Prometheus discovery hypervisor from all projects.
The id of the hypervisor as id Available until version 2.52,
The id of the hypervisor as a UUID New in version 2.53
Distinguish between different OpenStack Api versions.
maintain the backward compatibility.