### PR TITLE
Fix bug that allows for sample enqueuing to shards that are being shutdown

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -791,7 +791,10 @@ func (s *shards) runShard(ctx context.Context, shardID int, queue chan sample) {
 		select {
 		case <-ctx.Done():
 			return
+		default:
+		}
 
+		select {
 		case sample, ok := <-queue:
 			if !ok {
 				if nPending > 0 {


### PR DESCRIPTION
We need to check ctx.Done in it's own select call since `select` ordering is non-deterministic. Without doing this, it's possible that even though `hardShutdown` has been initiated, the previous select block could have still chosen to allow new samples to be enqueued. The test I've added will fail consistently on master.

I think this is at least part of the cause of #6952 

cc @roidelapluie @Seitanas

Signed-off-by: Callum Styan <callumstyan@gmail.com>