### PR TITLE
[OpenStack SD] Add HypervisorID meta labels about id

### DIFF
--- a/discovery/openstack/hypervisor.go
+++ b/discovery/openstack/hypervisor.go
@@ -30,6 +30,7 @@ import (
 )
 
 const (
+	openstackLabelHypervisorID       = openstackLabelPrefix + "hypervisor_id"
 	openstackLabelHypervisorHostIP   = openstackLabelPrefix + "hypervisor_host_ip"
 	openstackLabelHypervisorHostName = openstackLabelPrefix + "hypervisor_hostname"
 	openstackLabelHypervisorStatus   = openstackLabelPrefix + "hypervisor_status"
@@ -81,6 +82,7 @@ func (h *HypervisorDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group
 			labels := model.LabelSet{}
 			addr := net.JoinHostPort(hypervisor.HostIP, fmt.Sprintf("%d", h.port))
 			labels[model.AddressLabel] = model.LabelValue(addr)
+			labels[openstackLabelHypervisorID] = model.LabelValue(hypervisor.ID)
 			labels[openstackLabelHypervisorHostName] = model.LabelValue(hypervisor.HypervisorHostname)
 			labels[openstackLabelHypervisorHostIP] = model.LabelValue(hypervisor.HostIP)
 			labels[openstackLabelHypervisorStatus] = model.LabelValue(hypervisor.Status)

--- a/discovery/openstack/hypervisor_test.go
+++ b/discovery/openstack/hypervisor_test.go
@@ -35,7 +35,6 @@ func (s *OpenstackSDHypervisorTestSuite) SetupTest(t *testing.T) {
 	s.Mock.Setup()
 
 	s.Mock.HandleHypervisorListSuccessfully()
-
 	s.Mock.HandleVersionsSuccessfully()
 	s.Mock.HandleAuthSuccessfully()
 }
@@ -74,6 +73,7 @@ func TestOpenstackSDHypervisorRefresh(t *testing.T) {
 		"__meta_openstack_hypervisor_host_ip":  "172.16.70.14",
 		"__meta_openstack_hypervisor_state":    "up",
 		"__meta_openstack_hypervisor_status":   "enabled",
+		"__meta_openstack_hypervisor_id":       "1",
 	} {
 		testutil.Equals(t, model.LabelValue(v), tg.Targets[0][model.LabelName(l)])
 	}
@@ -85,6 +85,7 @@ func TestOpenstackSDHypervisorRefresh(t *testing.T) {
 		"__meta_openstack_hypervisor_host_ip":  "172.16.70.13",
 		"__meta_openstack_hypervisor_state":    "up",
 		"__meta_openstack_hypervisor_status":   "enabled",
+		"__meta_openstack_hypervisor_id":       "721",
 	} {
 		testutil.Equals(t, model.LabelValue(v), tg.Targets[1][model.LabelName(l)])
 	}

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -499,6 +499,7 @@ address defaults to the `host_ip` attribute of the hypervisor.
 The following meta labels are available on targets during [relabeling](#relabel_config):
 
 * `__meta_openstack_hypervisor_host_ip`: the hypervisor node's IP address.
+* `__meta_openstack_hypervisor_id`: the hypervisor node's ID.
 * `__meta_openstack_hypervisor_name`: the hypervisor node's name.
 * `__meta_openstack_hypervisor_state`: the hypervisor node's state.
 * `__meta_openstack_hypervisor_status`: the hypervisor node's status.


### PR DESCRIPTION
Add extra meta labels which will be useful in the case
Prometheus discovery hypervisor .

Signed-off-by: pzqu <pzqu@qq.com>
