### PR TITLE
util/httputil: use const string instead of variable int.

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -152,9 +152,9 @@ type query struct {
 	ng *Engine
 }
 
-type queryCtx int
+type queryCtx string
 
-var queryOrigin queryCtx
+const queryOrigin queryCtx = "origin"
 
 // Statement implements the Query interface.
 func (q *query) Statement() parser.Statement {

--- a/util/httputil/context.go
+++ b/util/httputil/context.go
@@ -21,9 +21,9 @@ import (
 	"github.com/prometheus/prometheus/promql"
 )
 
-type ctxParam int
+type ctxParam string
 
-var pathParam ctxParam
+const pathParam ctxParam = "path"
 
 // ContextWithPath returns a new context with the given path to be used later
 // when logging the query.


### PR DESCRIPTION
It's better to use const string than variable int.

Because `pathParam` is only visible in a package, it's not a bug but an improvement.
