### PR TITLE
storage: Removed SelectSorted method while maintaining logic; Simplified interface.

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -656,7 +656,7 @@ func (ng *Engine) populateSeries(ctx context.Context, q storage.Queryable, s *pa
 	parser.Inspect(s.Expr, func(node parser.Node, path []parser.Node) error {
 		var set storage.SeriesSet
 		var wrn storage.Warnings
-		params := &storage.SelectParams{
+		hints := &storage.SelectHints{
 			Start: timestamp.FromTime(s.Start),
 			End:   timestamp.FromTime(s.End),
 			Step:  durationToInt64Millis(s.Interval),
@@ -668,29 +668,29 @@ func (ng *Engine) populateSeries(ctx context.Context, q storage.Queryable, s *pa
 		// from end also.
 		subqOffset := ng.cumulativeSubqueryOffset(path)
 		offsetMilliseconds := durationMilliseconds(subqOffset)
-		params.Start = params.Start - offsetMilliseconds
+		hints.Start = hints.Start - offsetMilliseconds
 
 		switch n := node.(type) {
 		case *parser.VectorSelector:
 			if evalRange == 0 {
-				params.Start = params.Start - durationMilliseconds(ng.lookbackDelta)
+				hints.Start = hints.Start - durationMilliseconds(ng.lookbackDelta)
 			} else {
-				params.Range = durationMilliseconds(evalRange)
+				hints.Range = durationMilliseconds(evalRange)
 				// For all matrix queries we want to ensure that we have (end-start) + range selected
 				// this way we have `range` data before the start time
-				params.Start = params.Start - durationMilliseconds(evalRange)
+				hints.Start = hints.Start - durationMilliseconds(evalRange)
 				evalRange = 0
 			}
 
-			params.Func = extractFuncFromPath(path)
-			params.By, params.Grouping = extractGroupsFromPath(path)
+			hints.Func = extractFuncFromPath(path)
+			hints.By, hints.Grouping = extractGroupsFromPath(path)
 			if n.Offset > 0 {
 				offsetMilliseconds := durationMilliseconds(n.Offset)
-				params.Start = params.Start - offsetMilliseconds
-				params.End = params.End - offsetMilliseconds
+				hints.Start = hints.Start - offsetMilliseconds
+				hints.End = hints.End - offsetMilliseconds
 			}
 
-			set, wrn, err = querier.Select(params, n.LabelMatchers...)
+			set, wrn, err = querier.Select(false, hints, n.LabelMatchers...)
 			warnings = append(warnings, wrn...)
 			if err != nil {
 				level.Error(ng.logger).Log("msg", "error selecting series set", "err", err)

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -175,15 +175,12 @@ type errQuerier struct {
 	err error
 }
 
-func (q *errQuerier) Select(*storage.SelectParams, ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+func (q *errQuerier) Select(bool, *storage.SelectHints, ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
 	return errSeriesSet{err: q.err}, nil, q.err
 }
-func (q *errQuerier) SelectSorted(*storage.SelectParams, ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
-	return errSeriesSet{err: q.err}, nil, q.err
-}
-func (*errQuerier) LabelValues(name string) ([]string, storage.Warnings, error) { return nil, nil, nil }
-func (*errQuerier) LabelNames() ([]string, storage.Warnings, error)             { return nil, nil, nil }
-func (*errQuerier) Close() error                                                { return nil }
+func (*errQuerier) LabelValues(string) ([]string, storage.Warnings, error) { return nil, nil, nil }
+func (*errQuerier) LabelNames() ([]string, storage.Warnings, error)        { return nil, nil, nil }
+func (*errQuerier) Close() error                                           { return nil }
 
 // errSeriesSet implements storage.SeriesSet which always returns error.
 type errSeriesSet struct {
@@ -224,9 +221,9 @@ func TestQueryError(t *testing.T) {
 	testutil.Equals(t, errStorage, res.Err)
 }
 
-// paramCheckerQuerier implements storage.Querier which checks the start and end times
-// in params.
-type paramCheckerQuerier struct {
+// hintCheckerQuerier implements storage.Querier which checks the start and end times
+// in hints.
+type hintCheckerQuerier struct {
 	start    int64
 	end      int64
 	grouping []string
@@ -237,10 +234,7 @@ type paramCheckerQuerier struct {
 	t *testing.T
 }
 
-func (q *paramCheckerQuerier) Select(sp *storage.SelectParams, m ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
-	return q.SelectSorted(sp, m...)
-}
-func (q *paramCheckerQuerier) SelectSorted(sp *storage.SelectParams, _ ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+func (q *hintCheckerQuerier) Select(_ bool, sp *storage.SelectHints, _ ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
 	testutil.Equals(q.t, q.start, sp.Start)
 	testutil.Equals(q.t, q.end, sp.End)
 	testutil.Equals(q.t, q.grouping, sp.Grouping)
@@ -250,11 +244,11 @@ func (q *paramCheckerQuerier) SelectSorted(sp *storage.SelectParams, _ ...*label
 
 	return errSeriesSet{err: nil}, nil, nil
 }
-func (*paramCheckerQuerier) LabelValues(name string) ([]string, storage.Warnings, error) {
+func (*hintCheckerQuerier) LabelValues(string) ([]string, storage.Warnings, error) {
 	return nil, nil, nil
 }
-func (*paramCheckerQuerier) LabelNames() ([]string, storage.Warnings, error) { return nil, nil, nil }
-func (*paramCheckerQuerier) Close() error                                    { return nil }
+func (*hintCheckerQuerier) LabelNames() ([]string, storage.Warnings, error) { return nil, nil, nil }
+func (*hintCheckerQuerier) Close() error                                    { return nil }
 
 func TestParamsSetCorrectly(t *testing.T) {
 	opts := EngineOpts{
@@ -435,7 +429,7 @@ func TestParamsSetCorrectly(t *testing.T) {
 	for _, tc := range cases {
 		engine := NewEngine(opts)
 		queryable := storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
-			return &paramCheckerQuerier{start: tc.paramStart * 1000, end: tc.paramEnd * 1000, grouping: tc.paramGrouping, by: tc.paramBy, selRange: tc.paramRange, function: tc.paramFunc, t: t}, nil
+			return &hintCheckerQuerier{start: tc.paramStart * 1000, end: tc.paramEnd * 1000, grouping: tc.paramGrouping, by: tc.paramBy, selRange: tc.paramRange, function: tc.paramFunc, t: t}, nil
 		})
 
 		var (

--- a/promql/test_test.go
+++ b/promql/test_test.go
@@ -133,7 +133,7 @@ func TestLazyLoader_WithSamplesTill(t *testing.T) {
 					}
 
 					// Get the series for the matcher.
-					ss, _, err := querier.Select(nil, matchers...)
+					ss, _, err := querier.Select(false, nil, matchers...)
 					testutil.Ok(t, err)
 					testutil.Assert(t, ss.Next(), "")
 					storageSeries := ss.At()

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -705,7 +705,7 @@ func (g *Group) RestoreForState(ts time.Time) {
 				matchers = append(matchers, mt)
 			}
 
-			sset, err, _ := q.Select(nil, matchers...)
+			sset, err, _ := q.Select(false, nil, matchers...)
 			if err != nil {
 				level.Error(g.logger).Log("msg", "Failed to restore 'for' state",
 					labels.AlertName, alertRule.Name(), "stage", "Select", "err", err)

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1571,7 +1571,7 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 
 	q, err := s.Querier(ctx, time.Time{}.UnixNano(), 0)
 	testutil.Ok(t, err)
-	series, _, err := q.Select(&storage.SelectParams{}, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
+	series, _, err := q.Select(false, nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
 	testutil.Ok(t, err)
 	testutil.Equals(t, false, series.Next(), "series found in tsdb")
 
@@ -1581,7 +1581,7 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 
 	q, err = s.Querier(ctx, time.Time{}.UnixNano(), 0)
 	testutil.Ok(t, err)
-	series, _, err = q.Select(&storage.SelectParams{}, labels.MustNewMatcher(labels.MatchEqual, "le", "500"))
+	series, _, err = q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "le", "500"))
 	testutil.Ok(t, err)
 	testutil.Equals(t, true, series.Next(), "series not found in tsdb")
 	testutil.Equals(t, false, series.Next(), "more than one series found in tsdb")
@@ -1617,7 +1617,7 @@ func TestScrapeLoopDiscardUnnamedMetrics(t *testing.T) {
 
 	q, err := s.Querier(ctx, time.Time{}.UnixNano(), 0)
 	testutil.Ok(t, err)
-	series, _, err := q.Select(&storage.SelectParams{}, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
+	series, _, err := q.Select(false, nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
 	testutil.Ok(t, err)
 	testutil.Equals(t, false, series.Next(), "series found in tsdb")
 }

--- a/storage/fanout/fanout_test.go
+++ b/storage/fanout/fanout_test.go
@@ -79,7 +79,7 @@ func TestSelectSorted(t *testing.T) {
 	matcher, err := labels.NewMatcher(labels.MatchEqual, model.MetricNameLabel, "a")
 	testutil.Ok(t, err)
 
-	seriesSet, _, err := querier.Select(false, nil, matcher)
+	seriesSet, _, err := querier.Select(true, nil, matcher)
 	testutil.Ok(t, err)
 
 	result := make(map[int64]float64)

--- a/storage/fanout/fanout_test.go
+++ b/storage/fanout/fanout_test.go
@@ -79,7 +79,7 @@ func TestSelectSorted(t *testing.T) {
 	matcher, err := labels.NewMatcher(labels.MatchEqual, model.MetricNameLabel, "a")
 	testutil.Ok(t, err)
 
-	seriesSet, _, err := querier.SelectSorted(nil, matcher)
+	seriesSet, _, err := querier.Select(false, nil, matcher)
 	testutil.Ok(t, err)
 
 	result := make(map[int64]float64)

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -60,10 +60,9 @@ type Queryable interface {
 // time range.
 type Querier interface {
 	// Select returns a set of series that matches the given label matchers.
-	Select(*SelectParams, ...*labels.Matcher) (SeriesSet, Warnings, error)
-
-	// SelectSorted returns a sorted set of series that matches the given label matchers.
-	SelectSorted(*SelectParams, ...*labels.Matcher) (SeriesSet, Warnings, error)
+	// Caller can specify if it requires returned series to be sorted. Prefer not requiring sorting for better performance.
+	// It allows passing hints that can help in optimising select, but it's up to implementation how this is used if used at all.
+	Select(sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) (SeriesSet, Warnings, error)
 
 	// LabelValues returns all potential values for a label name.
 	// It is not safe to use the strings beyond the lifefime of the querier.
@@ -76,8 +75,9 @@ type Querier interface {
 	Close() error
 }
 
-// SelectParams specifies parameters passed to data selections.
-type SelectParams struct {
+// SelectHints specifies hints passed for data selections.
+// This is used only as an option for implementation to use.
+type SelectHints struct {
 	Start int64 // Start time in milliseconds for this select.
 	End   int64 // End time in milliseconds for this select.
 

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -24,11 +24,7 @@ func NoopQuerier() Querier {
 	return noopQuerier{}
 }
 
-func (noopQuerier) Select(*SelectParams, ...*labels.Matcher) (SeriesSet, Warnings, error) {
-	return NoopSeriesSet(), nil, nil
-}
-
-func (noopQuerier) SelectSorted(*SelectParams, ...*labels.Matcher) (SeriesSet, Warnings, error) {
+func (noopQuerier) Select(bool, *SelectHints, ...*labels.Matcher) (SeriesSet, Warnings, error) {
 	return NoopSeriesSet(), nil, nil
 }
 

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -178,7 +178,7 @@ func TestFromQueryResultWithDuplicates(t *testing.T) {
 		},
 	}
 
-	series := FromQueryResult(&res)
+	series := FromQueryResult(false, &res)
 
 	errSeries, isErrSeriesSet := series.(errSeriesSet)
 

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -117,7 +117,7 @@ func TestExternalLabelsQuerierSelect(t *testing.T) {
 		},
 	}
 	want := newSeriesSetFilter(mockSeriesSet{}, q.externalLabels)
-	have, _, err := q.Select(nil, matchers...)
+	have, _, err := q.Select(false, nil, matchers...)
 	if err != nil {
 		t.Error(err)
 	}
@@ -219,7 +219,7 @@ func TestSeriesSetFilter(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		filtered := newSeriesSetFilter(FromQueryResult(tc.in), tc.toRemove)
+		filtered := newSeriesSetFilter(FromQueryResult(true, tc.in), tc.toRemove)
 		have, err := ToQueryResult(filtered, 1e6)
 		if err != nil {
 			t.Fatal(err)
@@ -242,7 +242,7 @@ type mockSeriesSet struct {
 	storage.SeriesSet
 }
 
-func (mockQuerier) Select(*storage.SelectParams, ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+func (mockQuerier) Select(bool, *storage.SelectHints, ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
 	return mockSeriesSet{}, nil, nil
 }
 
@@ -398,7 +398,7 @@ func TestRequiredLabelsQuerierSelect(t *testing.T) {
 			requiredMatchers: test.requiredMatchers,
 		}
 
-		have, _, err := q.Select(nil, test.matchers...)
+		have, _, err := q.Select(false, nil, test.matchers...)
 		if err != nil {
 			t.Error(err)
 		}

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -203,7 +203,7 @@ func TestCorruptedChunk(t *testing.T) {
 			querier, err := NewBlockQuerier(b, 0, 1)
 			testutil.Ok(t, err)
 			defer func() { testutil.Ok(t, querier.Close()) }()
-			set, ws, err := querier.Select(nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
+			set, ws, err := querier.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
 			testutil.Ok(t, err)
 			testutil.Equals(t, 0, len(ws))
 

--- a/tsdb/cmd/tsdb/main.go
+++ b/tsdb/cmd/tsdb/main.go
@@ -616,7 +616,7 @@ func dumpSamples(db *tsdb.DBReadOnly, mint, maxt int64) (err error) {
 		err = merr.Err()
 	}()
 
-	ss, ws, err := q.Select(nil, labels.MustNewMatcher(labels.MatchRegexp, "", ".*"))
+	ss, ws, err := q.Select(false, nil, labels.MustNewMatcher(labels.MatchRegexp, "", ".*"))
 	if err != nil {
 		return err
 	}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -565,7 +565,7 @@ func TestHeadDeleteSimple(t *testing.T) {
 				for _, h := range []*Head{head, reloadedHead} {
 					q, err := NewBlockQuerier(h, h.MinTime(), h.MaxTime())
 					testutil.Ok(t, err)
-					actSeriesSet, ws, err := q.Select(nil, labels.MustNewMatcher(labels.MatchEqual, lblDefault.Name, lblDefault.Value))
+					actSeriesSet, ws, err := q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, lblDefault.Name, lblDefault.Value))
 					testutil.Ok(t, err)
 					testutil.Equals(t, 0, len(ws))
 
@@ -612,7 +612,7 @@ func TestDeleteUntilCurMax(t *testing.T) {
 	// Test the series returns no samples. The series is cleared only after compaction.
 	q, err := NewBlockQuerier(hb, 0, 100000)
 	testutil.Ok(t, err)
-	res, ws, err := q.Select(nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
+	res, ws, err := q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
 	testutil.Ok(t, err)
 	testutil.Equals(t, 0, len(ws))
 	testutil.Assert(t, res.Next(), "series is not present")
@@ -627,7 +627,7 @@ func TestDeleteUntilCurMax(t *testing.T) {
 	testutil.Ok(t, app.Commit())
 	q, err = NewBlockQuerier(hb, 0, 100000)
 	testutil.Ok(t, err)
-	res, ws, err = q.Select(nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
+	res, ws, err = q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
 	testutil.Ok(t, err)
 	testutil.Equals(t, 0, len(ws))
 	testutil.Assert(t, res.Next(), "series don't exist")
@@ -803,7 +803,7 @@ func TestDelete_e2e(t *testing.T) {
 			q, err := NewBlockQuerier(hb, 0, 100000)
 			testutil.Ok(t, err)
 			defer q.Close()
-			ss, ws, err := q.SelectSorted(nil, del.ms...)
+			ss, ws, err := q.Select(true, nil, del.ms...)
 			testutil.Ok(t, err)
 			testutil.Equals(t, 0, len(ws))
 			// Build the mockSeriesSet.
@@ -1091,7 +1091,7 @@ func TestUncommittedSamplesNotLostOnTruncate(t *testing.T) {
 	testutil.Ok(t, err)
 	defer q.Close()
 
-	ss, ws, err := q.Select(nil, labels.MustNewMatcher(labels.MatchEqual, "a", "1"))
+	ss, ws, err := q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "1"))
 	testutil.Ok(t, err)
 	testutil.Equals(t, 0, len(ws))
 
@@ -1119,7 +1119,7 @@ func TestRemoveSeriesAfterRollbackAndTruncate(t *testing.T) {
 	testutil.Ok(t, err)
 	defer q.Close()
 
-	ss, ws, err := q.Select(nil, labels.MustNewMatcher(labels.MatchEqual, "a", "1"))
+	ss, ws, err := q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "1"))
 	testutil.Ok(t, err)
 	testutil.Equals(t, 0, len(ws))
 
@@ -1403,7 +1403,7 @@ func TestHeadSeriesWithTimeBoundaries(t *testing.T) {
 
 		seriesCount := 0
 		samplesCount := 0
-		ss, _, err := q.Select(nil, matcher)
+		ss, _, err := q.Select(false, nil, matcher)
 		testutil.Ok(t, err)
 		for ss.Next() {
 			i := ss.At().Iterator()
@@ -1443,7 +1443,7 @@ func TestMemSeriesIsolation(t *testing.T) {
 		testutil.Ok(t, err)
 		defer querier.Close()
 
-		ss, _, err := querier.Select(nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		ss, _, err := querier.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 		testutil.Ok(t, err)
 
 		_, seriesSet, err := expandSeriesSet(ss)

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -98,7 +98,7 @@ func (q *querier) Select(sortSeries bool, hints *storage.SelectHints, ms ...*lab
 	for i, b := range q.blocks {
 		// Sorting Head series is slow, and unneeded when only the
 		// Head is being queried. Sorting blocks is a noop.
-		// Still we have to sort if blocks > 1 as Merged Series requires.
+		// Still we have to sort if blocks > 1 as MergedSeriesSet requires it.
 		s, w, err := b.Select(true, hints, ms...)
 		ws = append(ws, w...)
 		if err != nil {

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -90,15 +90,15 @@ func (q *querier) Select(sortSeries bool, hints *storage.SelectHints, ms ...*lab
 		return storage.EmptySeriesSet(), nil, nil
 	}
 	if len(q.blocks) == 1 {
+		// Sorting Head series is slow, and unneeded when only the
+		// Head is being queried.
 		return q.blocks[0].Select(sortSeries, hints, ms...)
 	}
 
 	ss := make([]storage.SeriesSet, len(q.blocks))
 	var ws storage.Warnings
 	for i, b := range q.blocks {
-		// Sorting Head series is slow, and unneeded when only the
-		// Head is being queried. Sorting blocks is a noop.
-		// Still we have to sort if blocks > 1 as MergedSeriesSet requires it.
+		// We have to sort if blocks > 1 as MergedSeriesSet requires it.
 		s, w, err := b.Select(true, hints, ms...)
 		ws = append(ws, w...)
 		if err != nil {

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -85,23 +85,21 @@ func (q *querier) lvals(qs []storage.Querier, n string) ([]string, storage.Warni
 	return mergeStrings(s1, s2), ws, nil
 }
 
-func (q *querier) Select(p *storage.SelectParams, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
-	if len(q.blocks) != 1 {
-		return q.SelectSorted(p, ms...)
-	}
-	// Sorting Head series is slow, and unneeded when only the
-	// Head is being queried. Sorting blocks is a noop.
-	return q.blocks[0].Select(p, ms...)
-}
-
-func (q *querier) SelectSorted(p *storage.SelectParams, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+func (q *querier) Select(sortSeries bool, hints *storage.SelectHints, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
 	if len(q.blocks) == 0 {
 		return storage.EmptySeriesSet(), nil, nil
 	}
+	if len(q.blocks) == 1 {
+		return q.blocks[0].Select(sortSeries, hints, ms...)
+	}
+
 	ss := make([]storage.SeriesSet, len(q.blocks))
 	var ws storage.Warnings
 	for i, b := range q.blocks {
-		s, w, err := b.SelectSorted(p, ms...)
+		// Sorting Head series is slow, and unneeded when only the
+		// Head is being queried. Sorting blocks is a noop.
+		// Still we have to sort if blocks > 1 as Merged Series requires.
+		s, w, err := b.Select(true, hints, ms...)
 		ws = append(ws, w...)
 		if err != nil {
 			return nil, ws, err
@@ -127,30 +125,26 @@ type verticalQuerier struct {
 	querier
 }
 
-func (q *verticalQuerier) Select(p *storage.SelectParams, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
-	return q.sel(p, q.blocks, ms)
+func (q *verticalQuerier) Select(sortSeries bool, hints *storage.SelectHints, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	return q.sel(sortSeries, hints, q.blocks, ms)
 }
 
-func (q *verticalQuerier) SelectSorted(p *storage.SelectParams, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
-	return q.sel(p, q.blocks, ms)
-}
-
-func (q *verticalQuerier) sel(p *storage.SelectParams, qs []storage.Querier, ms []*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+func (q *verticalQuerier) sel(sortSeries bool, hints *storage.SelectHints, qs []storage.Querier, ms []*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
 	if len(qs) == 0 {
 		return storage.EmptySeriesSet(), nil, nil
 	}
 	if len(qs) == 1 {
-		return qs[0].SelectSorted(p, ms...)
+		return qs[0].Select(sortSeries, hints, ms...)
 	}
 	l := len(qs) / 2
 
 	var ws storage.Warnings
-	a, w, err := q.sel(p, qs[:l], ms)
+	a, w, err := q.sel(sortSeries, hints, qs[:l], ms)
 	ws = append(ws, w...)
 	if err != nil {
 		return nil, ws, err
 	}
-	b, w, err := q.sel(p, qs[l:], ms)
+	b, w, err := q.sel(sortSeries, hints, qs[l:], ms)
 	ws = append(ws, w...)
 	if err != nil {
 		return nil, ws, err
@@ -195,42 +189,24 @@ type blockQuerier struct {
 	mint, maxt int64
 }
 
-func (q *blockQuerier) Select(p *storage.SelectParams, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
-	base, err := LookupChunkSeries(q.index, q.tombstones, ms...)
+func (q *blockQuerier) Select(sortSeries bool, hints *storage.SelectHints, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	var base storage.ChunkSeriesSet
+	var err error
+
+	if sortSeries {
+		base, err = LookupChunkSeriesSorted(q.index, q.tombstones, ms...)
+	} else {
+		base, err = LookupChunkSeries(q.index, q.tombstones, ms...)
+	}
 	if err != nil {
 		return nil, nil, err
 	}
 
 	mint := q.mint
 	maxt := q.maxt
-	if p != nil {
-		mint = p.Start
-		maxt = p.End
-	}
-	return &blockSeriesSet{
-		set: &populatedChunkSeries{
-			set:    base,
-			chunks: q.chunks,
-			mint:   mint,
-			maxt:   maxt,
-		},
-
-		mint: mint,
-		maxt: maxt,
-	}, nil, nil
-}
-
-func (q *blockQuerier) SelectSorted(p *storage.SelectParams, ms ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
-	base, err := LookupChunkSeriesSorted(q.index, q.tombstones, ms...)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	mint := q.mint
-	maxt := q.maxt
-	if p != nil {
-		mint = p.Start
-		maxt = p.End
+	if hints != nil {
+		mint = hints.Start
+		maxt = hints.End
 	}
 	return &blockSeriesSet{
 		set: &populatedChunkSeries{

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -147,12 +146,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					var ss storage.SeriesSet
-					if sorted {
-						ss, _, err = q.SelectSorted(nil, matcher)
-					} else {
-						ss, _, err = q.Select(nil, matcher)
-					}
+					ss, _, err := q.Select(sorted, nil, matcher)
 					testutil.Ok(b, err)
 					for ss.Next() {
 					}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -373,7 +373,7 @@ Outer:
 			maxt: c.maxt,
 		}
 
-		res, ws, err := querier.Select(nil, c.ms...)
+		res, ws, err := querier.Select(false, nil, c.ms...)
 		testutil.Ok(t, err)
 		testutil.Equals(t, 0, len(ws))
 
@@ -536,7 +536,7 @@ Outer:
 			maxt: c.maxt,
 		}
 
-		res, ws, err := querier.Select(nil, c.ms...)
+		res, ws, err := querier.Select(false, nil, c.ms...)
 		testutil.Ok(t, err)
 		testutil.Equals(t, 0, len(ws))
 
@@ -1710,7 +1710,7 @@ func BenchmarkQuerySeek(b *testing.B) {
 				b.ResetTimer()
 				b.ReportAllocs()
 
-				ss, ws, err := sq.Select(nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
+				ss, ws, err := sq.Select(false, nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
 				for ss.Next() {
 					it := ss.At().Iterator()
 					for t := mint; t <= maxt; t++ {
@@ -1848,7 +1848,7 @@ func BenchmarkSetMatcher(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for n := 0; n < b.N; n++ {
-				_, ws, err := que.Select(nil, labels.MustNewMatcher(labels.MatchRegexp, "test", c.pattern))
+				_, ws, err := que.Select(false, nil, labels.MustNewMatcher(labels.MatchRegexp, "test", c.pattern))
 				testutil.Ok(b, err)
 				testutil.Equals(b, 0, len(ws))
 			}
@@ -2297,7 +2297,7 @@ func benchQuery(b *testing.B, expExpansions int, q storage.Querier, selectors la
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		ss, ws, err := q.Select(nil, selectors...)
+		ss, ws, err := q.Select(false, nil, selectors...)
 		testutil.Ok(b, err)
 		testutil.Equals(b, 0, len(ws))
 		var actualExpansions int

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -488,9 +488,9 @@ func setupRemote(s storage.Storage) *httptest.Server {
 				return
 			}
 
-			var selectParams *storage.SelectParams
+			var hints *storage.SelectHints
 			if query.Hints != nil {
-				selectParams = &storage.SelectParams{
+				hints = &storage.SelectHints{
 					Start: query.Hints.StartMs,
 					End:   query.Hints.EndMs,
 					Step:  query.Hints.StepMs,
@@ -505,7 +505,7 @@ func setupRemote(s storage.Storage) *httptest.Server {
 			}
 			defer querier.Close()
 
-			set, _, err := querier.Select(selectParams, matchers...)
+			set, _, err := querier.Select(false, hints, matchers...)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -1615,7 +1615,7 @@ func TestSampledReadEndpoint(t *testing.T) {
 	matcher2, err := labels.NewMatcher(labels.MatchEqual, "d", "e")
 	testutil.Ok(t, err)
 
-	query, err := remote.ToQuery(0, 1, []*labels.Matcher{matcher1, matcher2}, &storage.SelectParams{Step: 0, Func: "avg"})
+	query, err := remote.ToQuery(0, 1, []*labels.Matcher{matcher1, matcher2}, &storage.SelectHints{Step: 0, Func: "avg"})
 	testutil.Ok(t, err)
 
 	req := &prompb.ReadRequest{Queries: []*prompb.Query{query}}
@@ -1714,7 +1714,7 @@ func TestStreamReadEndpoint(t *testing.T) {
 	matcher3, err := labels.NewMatcher(labels.MatchEqual, "foo", "bar1")
 	testutil.Ok(t, err)
 
-	query1, err := remote.ToQuery(0, 14400001, []*labels.Matcher{matcher1, matcher2}, &storage.SelectParams{
+	query1, err := remote.ToQuery(0, 14400001, []*labels.Matcher{matcher1, matcher2}, &storage.SelectHints{
 		Step:  1,
 		Func:  "avg",
 		Start: 0,
@@ -1722,7 +1722,7 @@ func TestStreamReadEndpoint(t *testing.T) {
 	})
 	testutil.Ok(t, err)
 
-	query2, err := remote.ToQuery(0, 14400001, []*labels.Matcher{matcher1, matcher3}, &storage.SelectParams{
+	query2, err := remote.ToQuery(0, 14400001, []*labels.Matcher{matcher1, matcher3}, &storage.SelectHints{
 		Step:  1,
 		Func:  "avg",
 		Start: 0,

--- a/web/federate.go
+++ b/web/federate.go
@@ -81,14 +81,11 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 
 	vec := make(promql.Vector, 0, 8000)
 
-	params := &storage.SelectParams{
-		Start: mint,
-		End:   maxt,
-	}
+	hints := &storage.SelectHints{Start: mint, End: maxt}
 
 	var sets []storage.SeriesSet
 	for _, mset := range matcherSets {
-		s, wrns, err := q.Select(params, mset...)
+		s, wrns, err := q.Select(false, hints, mset...)
 		if wrns != nil {
 			level.Debug(h.logger).Log("msg", "federation select returned warnings", "warnings", wrns)
 			federationWarnings.Add(float64(len(wrns)))


### PR DESCRIPTION
I found during work on https://github.com/prometheus/prometheus/pull/5882 that
we do so many repetitions because of this, for no good reason. I think
I found a good balance between convenience and readability with just one method.
Smaller the interface = better.

Also, I don't know what TestSelectSorted was testing, but now it's testing sorting.

cc @beorn7 @brian-brazil 

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>
