### PR TITLE
Optimize away label=~".*" matchers.

### DIFF
--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -608,6 +608,16 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 			}
 		}
 
+		// remove label matchers doing regex match on ".*" -- that matches everything, incl. nothing, so it's a no-op
+		for ix := 0; ix < len(n.LabelMatchers); ix++ {
+			m := n.LabelMatchers[ix]
+			if m.Type == labels.MatchRegexp && m.Value == ".*" {
+				// There must be some other matcher matching non-empty string as well,
+				// so we cannot end up in a situation that this was the last matcher and it was just removed.
+				n.LabelMatchers = append(n.LabelMatchers[:ix], n.LabelMatchers[ix+1:]...)
+			}
+		}
+
 	case *NumberLiteral, *StringLiteral:
 		// Nothing to do for terminals.
 

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -2576,6 +2576,18 @@ var testExpr = []struct {
 		input:  `(foo + bar{nm="val"})[5m:][10m:5s]`,
 		fail:   true,
 		errMsg: `1:1: parse error: subquery is only allowed on instant vector, got matrix in "(foo + bar{nm=\"val\"})[5m:][10m:5s]" instead`,
+	}, {
+		input: `hello{label=~".*"}`,
+		expected: &VectorSelector{
+			Name: "hello",
+			LabelMatchers: []*labels.Matcher{
+				mustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "hello"),
+			},
+			PosRange: PositionRange{
+				Start: 0,
+				End:   18,
+			},
+		},
 	},
 }
 


### PR DESCRIPTION
These are useless, and just add extra work. By removing them from AST (instead of doing this optimization at TSDB layer), this also automatically applies to other engines that don't use TSDB backend.
