### PR TITLE
Optimize away label=~".*" matchers in TSDB layer.

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -16,6 +16,7 @@ package index
 import (
 	"container/heap"
 	"encoding/binary"
+	"fmt"
 	"runtime"
 	"sort"
 	"strings"
@@ -330,6 +331,12 @@ func (e errPostings) Next() bool       { return false }
 func (e errPostings) Seek(uint64) bool { return false }
 func (e errPostings) At() uint64       { return 0 }
 func (e errPostings) Err() error       { return e.err }
+func (e errPostings) String() string {
+	if e.err == nil {
+		return "emptyPostings"
+	}
+	return fmt.Sprintf("errPostings(%v)", e.err)
+}
 
 var emptyPostings = errPostings{}
 

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -16,7 +16,6 @@ package index
 import (
 	"container/heap"
 	"encoding/binary"
-	"fmt"
 	"runtime"
 	"sort"
 	"strings"
@@ -331,12 +330,6 @@ func (e errPostings) Next() bool       { return false }
 func (e errPostings) Seek(uint64) bool { return false }
 func (e errPostings) At() uint64       { return 0 }
 func (e errPostings) Err() error       { return e.err }
-func (e errPostings) String() string {
-	if e.err == nil {
-		return "emptyPostings"
-	}
-	return fmt.Sprintf("errPostings(%v)", e.err)
-}
 
 var emptyPostings = errPostings{}
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -314,6 +314,13 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 	}
 
 	for _, m := range ms {
+		if m.Type == labels.MatchRegexp && (m.Value == ".*" || m.Value == "^.*$") && len(ms) > 1 {
+			// Ignore this matcher completely. This matches anything, so it's a no-op.
+			// It's safe to ignore, because there must be some matcher matching non-empty string.
+			// Some tests only use single label=~".*" matcher, and for those, we include the length condition.
+			continue
+		}
+
 		if labelMustBeSet[m.Name] {
 			// If this matcher must be non-empty, we can be smarter.
 			matchesEmpty := m.Matches("")

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -378,7 +378,7 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 		}
 	}
 
-	// When doing substraction, add in everything and remove the notIts later.
+	// When doing subtraction, add in everything and remove the notIts later.
 	if len(notIts) > 0 {
 		all = true
 	}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2429,44 +2429,44 @@ func TestPostingsForMatcher(t *testing.T) {
 func TestPostingsForMatchersShortcuts(t *testing.T) {
 	for ix, tc := range []struct {
 		matchers []*labels.Matcher
-		expected string
+		expected index.Postings
 	}{
 		{
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", ".*")},
-			expected: "allPostings",
+			expected: &mockPosting{all: true},
 		},
 		{
 			// single allPostings
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", ".*"), labels.MustNewMatcher(labels.MatchRegexp, "i", "^.*$")},
-			expected: "allPostings",
+			expected: &mockPosting{all: true},
 		},
 		{
 			// this checks that "allPostings" were optimized away
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", "^.*$"), labels.MustNewMatcher(labels.MatchEqual, "i", "a")},
-			expected: "postings(i, values=[a])",
+			expected: &mockPosting{name: "i", values: []string{"a"}},
 		},
 		{
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotRegexp, "i", ".*")},
-			expected: "emptyPostings",
+			expected: index.EmptyPostings(),
 		},
 		{
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotRegexp, "n", "^.*$"), labels.MustNewMatcher(labels.MatchNotRegexp, "i", ".*")},
-			expected: "emptyPostings",
+			expected: index.EmptyPostings(),
 		},
 		{
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", ".*"), labels.MustNewMatcher(labels.MatchNotRegexp, "i", ".*")},
-			expected: "emptyPostings",
+			expected: index.EmptyPostings(),
 		},
 		{
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "n", "1"), labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^.*$")},
-			expected: "emptyPostings",
+			expected: index.EmptyPostings(),
 		},
 	} {
 		t.Run(fmt.Sprintf("%d", ix), func(t *testing.T) {
 			p, err := PostingsForMatchers(&mockIndexReader{}, tc.matchers...)
 			testutil.Ok(t, err)
 
-			testutil.Equals(t, tc.expected, fmt.Sprintf("%v", p))
+			testutil.Equals(t, tc.expected, p)
 		})
 	}
 }

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2048,9 +2048,42 @@ func TestPostingsForMatchers(t *testing.T) {
 				labels.FromStrings("n", "2.5"),
 			},
 		},
+		// Test shortcut for n=~".*" and i=~"^.*$"
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", ".*"), labels.MustNewMatcher(labels.MatchRegexp, "i", "^.*$")},
+			exp: []labels.Labels{
+				labels.FromStrings("n", "1"),
+				labels.FromStrings("n", "1", "i", "a"),
+				labels.FromStrings("n", "1", "i", "b"),
+				labels.FromStrings("n", "2"),
+				labels.FromStrings("n", "2.5"),
+			},
+		},
+		// Test shortcut for n=~"^.*$"
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", "^.*$"), labels.MustNewMatcher(labels.MatchEqual, "i", "a")},
+			exp: []labels.Labels{
+				labels.FromStrings("n", "1", "i", "a"),
+			},
+		},
 		// Test shortcut for i!~".*"
 		{
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotRegexp, "i", ".*")},
+			exp:      []labels.Labels{},
+		},
+		// Test shortcut for n!~"^.*$",  i!~".*". First one triggers empty result.
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotRegexp, "n", "^.*$"), labels.MustNewMatcher(labels.MatchNotRegexp, "i", ".*")},
+			exp:      []labels.Labels{},
+		},
+		// Test shortcut i!~".*"
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", ".*"), labels.MustNewMatcher(labels.MatchNotRegexp, "i", ".*")},
+			exp:      []labels.Labels{},
+		},
+		// Test shortcut i!~"^.*$"
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "n", "1"), labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^.*$")},
 			exp:      []labels.Labels{},
 		},
 		{

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2037,6 +2037,22 @@ func TestPostingsForMatchers(t *testing.T) {
 				labels.FromStrings("n", "1", "i", "b"),
 			},
 		},
+		// Test shortcut for i=~".*"
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", ".*")},
+			exp: []labels.Labels{
+				labels.FromStrings("n", "1"),
+				labels.FromStrings("n", "1", "i", "a"),
+				labels.FromStrings("n", "1", "i", "b"),
+				labels.FromStrings("n", "2"),
+				labels.FromStrings("n", "2.5"),
+			},
+		},
+		// Test shortcut for i!~".*"
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotRegexp, "i", ".*")},
+			exp:      []labels.Labels{},
+		},
 		{
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "n", "1"), labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")},
 			exp: []labels.Labels{


### PR DESCRIPTION
This is alternative to #6995, except it removes these useless matchers in TSDB layer.

Benchmarks in progress, will update the post when finished.

Update: well, first benchmarks show difference where you'd expect -- when using multiple matchers, one of them being `~= ".*"`. I need to let them run longer, and they block my computer, so I'll do that later.