### PR TITLE
Fix #6999 : Add archiecture meta label for EC2

### DIFF
--- a/discovery/ec2/ec2.go
+++ b/discovery/ec2/ec2.go
@@ -39,6 +39,7 @@ import (
 const (
 	ec2Label                  = model.MetaLabelPrefix + "ec2_"
 	ec2LabelAZ                = ec2Label + "availability_zone"
+	ec2LabelArch              = ec2Label + "architecture"
 	ec2LabelInstanceID        = ec2Label + "instance_id"
 	ec2LabelInstanceState     = ec2Label + "instance_state"
 	ec2LabelInstanceType      = ec2Label + "instance_type"
@@ -217,6 +218,10 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 				if inst.InstanceLifecycle != nil {
 					labels[ec2LabelInstanceLifecycle] = model.LabelValue(*inst.InstanceLifecycle)
+				}
+
+				if inst.Architecture != nil {
+					labels[ec2LabelArch] = model.LabelValue(*inst.Architecture)
 				}
 
 				if inst.VpcId != nil {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -426,6 +426,7 @@ the public IP address with relabeling.
 
 The following meta labels are available on targets during [relabeling](#relabel_config):
 
+* `__meta_ec2_architecture`: the architecture of the instance
 * `__meta_ec2_availability_zone`: the availability zone in which the instance is running
 * `__meta_ec2_instance_id`: the EC2 instance ID
 * `__meta_ec2_instance_lifecycle`: the lifecycle of the EC2 instance, set only for 'spot' or 'scheduled' instances, absent otherwise


### PR DESCRIPTION
This PR adds architecture meta labels for EC2 instances

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->