### PR TITLE
remove needless break.

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -618,7 +618,6 @@ func main() {
 			func() error {
 				select {
 				case <-dbOpen:
-					break
 				// In case a shutdown is initiated before the dbOpen is released
 				case <-cancel:
 					reloadReady.Close()


### PR DESCRIPTION
It's no need to add `break` here.