### PR TITLE
Scrape: do not put staleness marker when cache is reused

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -314,6 +314,7 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 	for fp, oldLoop := range sp.loops {
 		var cache *scrapeCache
 		if oc := oldLoop.getCache(); reuseCache && oc != nil {
+			oldLoop.disableStalenessMarkers()
 			cache = oc
 		} else {
 			cache = newScrapeCache()
@@ -593,6 +594,7 @@ type loop interface {
 	run(interval, timeout time.Duration, errc chan<- error)
 	stop()
 	getCache() *scrapeCache
+	disableStalenessMarkers()
 }
 
 type cacheEntry struct {
@@ -615,10 +617,11 @@ type scrapeLoop struct {
 	sampleMutator       labelsMutator
 	reportSampleMutator labelsMutator
 
-	parentCtx context.Context
-	ctx       context.Context
-	cancel    func()
-	stopped   chan struct{}
+	parentCtx                context.Context
+	ctx                      context.Context
+	cancel                   func()
+	stopped                  chan struct{}
+	disabledStalenessMarkers bool
 }
 
 // scrapeCache tracks mappings of exposed metric strings to label sets and
@@ -996,7 +999,9 @@ mainLoop:
 
 	close(sl.stopped)
 
-	sl.endOfRunStaleness(last, ticker, interval)
+	if !sl.disabledStalenessMarkers {
+		sl.endOfRunStaleness(last, ticker, interval)
+	}
 }
 
 func (sl *scrapeLoop) endOfRunStaleness(last time.Time, ticker *time.Ticker, interval time.Duration) {
@@ -1052,6 +1057,10 @@ func (sl *scrapeLoop) endOfRunStaleness(last time.Time, ticker *time.Ticker, int
 func (sl *scrapeLoop) stop() {
 	sl.cancel()
 	<-sl.stopped
+}
+
+func (sl *scrapeLoop) disableStalenessMarkers() {
+	sl.disabledStalenessMarkers = true
 }
 
 func (sl *scrapeLoop) getCache() *scrapeCache {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -141,7 +141,7 @@ func (l *testLoop) run(interval, timeout time.Duration, errc chan<- error) {
 	l.startFunc(interval, timeout, errc)
 }
 
-func (l *testLoop) disableStalenessMarkers() {
+func (l *testLoop) disableEndOfRunStalenessMarkers() {
 }
 
 func (l *testLoop) stop() {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -141,6 +141,9 @@ func (l *testLoop) run(interval, timeout time.Duration, errc chan<- error) {
 	l.startFunc(interval, timeout, errc)
 }
 
+func (l *testLoop) disableStalenessMarkers() {
+}
+
 func (l *testLoop) stop() {
 	l.stopFunc()
 }


### PR DESCRIPTION
Fixes #6997 

When we reuse a cache, it makes no sense to track staleness after the loop is closed.

Because at the time we track staleness, the cache is poisoned and it would attempt to create wrong staleness markers.

It also means that we might have concurrency on the maps used by the cache.

I need to think how to produce an effective test for this.

NOTE: This approach is better than adding mutexes all around the place IMO and also more semantically correct.

cc @beorn7 @brian-brazil 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->