### PR TITLE
[Doc] Fix wrong description in kubernetes expamle

### DIFF
--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -264,8 +264,6 @@ scrape_configs:
   #
   # Example relabel to scrape only single, desired port for the pod
   # based on pod "example.io/scrape_port = <port>" annotation.
-  # Note that __address__ is modified here, so if pod containers' ports
-  # are declared, they all will be ignored.
   #  - source_labels: [__address__, __meta_kubernetes_pod_annotation_example_io_scrape_port]
   #    action: replace
   #    regex: ([^:]+)(?::\d+)?;(\d+)


### PR DESCRIPTION
**What type of PR is this?**
Fix wrong description in [prometheus-kubernetes.yml](https://github.com/prometheus/prometheus/blob/8fa4ada9ae4c0125d0607cf31b65ed9ea1886a28/documentation/examples/prometheus-kubernetes.yml#L267)

**What this PR does / why we need it:**
Now the [regex](https://github.com/prometheus/prometheus/blob/8fa4ada9ae4c0125d0607cf31b65ed9ea1886a28/documentation/examples/prometheus-kubernetes.yml#L271) `([^:]+)(?::\d+)?;(\d+)` of kubernetes-pod `__address__` relabel can match address `pod_ip:pod_port` and address `pod_ip`, remove the note.