### PR TITLE
tsdb: add log when compress ignored.

### DIFF
--- a/tsdb/wal/wal.go
+++ b/tsdb/wal/wal.go
@@ -622,6 +622,8 @@ func (w *WAL) log(rec []byte, final bool) error {
 		if len(w.snappyBuf) < len(rec) {
 			rec = w.snappyBuf
 			compressed = true
+		} else {
+			level.Warn(w.logger).Log("msg", "record compress ignored")
 		}
 	}
 


### PR DESCRIPTION
Add log output when the record compression ignored, which's unusual to get larger data after compression.  Look at the proportions in the actual environment.



