### PR TITLE
tsdb: add tombstonesHeaderSize constant

### DIFF
--- a/tsdb/tombstones/tombstones.go
+++ b/tsdb/tombstones/tombstones.go
@@ -38,7 +38,8 @@ const (
 	// MagicTombstone is 4 bytes at the head of a tombstone file.
 	MagicTombstone = 0x0130BA30
 
-	tombstoneFormatV1 = 1
+	tombstoneFormatV1    = 1
+	tombstonesHeaderSize = 5
 )
 
 // The table gets initialized with sync.Once but may still cause a race
@@ -158,7 +159,7 @@ func ReadTombstones(dir string) (Reader, int64, error) {
 		return nil, 0, err
 	}
 
-	if len(b) < 5 {
+	if len(b) < tombstonesHeaderSize {
 		return nil, 0, errors.Wrap(encoding.ErrInvalidSize, "tombstones header")
 	}
 


### PR DESCRIPTION
Signed-off-by: zhulongcheng <zhulongcheng.dev@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->