### PR TITLE
Add unit test for Has in pkg/labels/labels.go

### DIFF
--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -453,3 +453,35 @@ func TestLabels_Compare(t *testing.T) {
 		testutil.Equals(t, test.expected, got, "unexpected comparison result for test case %d", i)
 	}
 }
+
+func TestLabels_Has(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			input:    "foo",
+			expected: false,
+		},
+		{
+			input:    "aaa",
+			expected: true,
+		},
+	}
+
+	labelsSet := Labels{
+		{
+			Name:  "aaa",
+			Value: "111",
+		},
+		{
+			Name:  "bbb",
+			Value: "222",
+		},
+	}
+
+	for i, test := range tests {
+		got := labelsSet.Has(test.input)
+		testutil.Equals(t, test.expected, got, "unexpected comparison result for test case %d", i)
+	}
+}


### PR DESCRIPTION
This PR is about adding a unit test for Has in pkg/labels/labels.go.

Signed-off-by: Hu Shuai <hus.fnst@cn.fujitsu.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->