### PR TITLE
Sample limit relabeling

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -221,6 +221,10 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed 
 		}
 		opts.target.SetMetadataStore(cache)
 
+		limit := opts.target.SampleLimit()
+		if limit == 0 {
+			limit = opts.limit
+		}
 		return newScrapeLoop(
 			ctx,
 			opts.scraper,
@@ -230,7 +234,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed 
 				return mutateSampleLabels(l, opts.target, opts.honorLabels, opts.mrc)
 			},
 			func(l labels.Labels) labels.Labels { return mutateReportSampleLabels(l, opts.target) },
-			func() storage.Appender { return appender(app.Appender(), opts.limit) },
+			func() storage.Appender { return appender(app.Appender(), limit) },
 			cache,
 			jitterSeed,
 			opts.honorTimestamps,

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -18,6 +18,7 @@ import (
 	"hash/fnv"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -222,6 +223,18 @@ func (t *Target) URL() *url.URL {
 		Path:     t.labels.Get(model.MetricsPathLabel),
 		RawQuery: params.Encode(),
 	}
+}
+
+func (t *Target) SampleLimit() int {
+	limit := t.labels.Get(model.SampleLimitLabel)
+	if limit == "" {
+		return 0
+	}
+	convertedLimit, err := strconv.Atoi(limit)
+	if err != nil {
+		return 0
+	}
+	return convertedLimit
 }
 
 // Report sets target data about the last scrape.

--- a/vendor/github.com/prometheus/common/model/labels.go
+++ b/vendor/github.com/prometheus/common/model/labels.go
@@ -45,6 +45,10 @@ const (
 	// scrape a target.
 	MetricsPathLabel = "__metrics_path__"
 
+	// SampleLimitLabel is the name of the label that holds quantity of time series
+	// that can be collected from target.
+	SampleLimitLabel = "__sample_limit__"
+
 	// ReservedLabelPrefix is a prefix which is not legal in user-supplied
 	// label names.
 	ReservedLabelPrefix = "__"


### PR DESCRIPTION
Add the ability to relabel sample_limit setting. It is convenient to use with service discovery. 

1. Applications now can tell you "If I give you more then 1k samples, I'm broken!"
2. You can define sample limits individually for namespaces (or environments) and reduce boilerplate code.

Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>