### PR TITLE
Compare querier storage to primary storage via reflect.DeepEqual.

### DIFF
--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -16,6 +16,7 @@ package storage
 import (
 	"container/heap"
 	"context"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -290,7 +291,7 @@ func (q *mergeGenericQuerier) Select(sortSeries bool, hints *SelectHints, matche
 		if qryResult.selectError != nil {
 			q.failedQueriers[qryResult.qr] = struct{}{}
 			// If the error source isn't the primary querier, return the error as a warning and continue.
-			if qryResult.qr != q.primaryQuerier {
+			if !reflect.DeepEqual(qryResult.qr, q.primaryQuerier) {
 				warnings = append(warnings, qryResult.selectError)
 			} else {
 				priErr = qryResult.selectError


### PR DESCRIPTION
This is meant to fix a test failure introduced in #7005. I believe the issue is related to wrapping of the base primary storage struct in other types with the new Querier types, but I could be wrong. Essentially, the comparison of `qryResult.qr != q.primaryQuerier` no longer works.

Signed-off-by: Callum Styan <callumstyan@gmail.com>