### PR TITLE
change labelset comparison in promql engine to avoid false positive during detection of duplicates

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"sort"
 	"strconv"
-	"unsafe"
 
 	"github.com/cespare/xxhash"
 )
@@ -63,36 +62,10 @@ func (ls Labels) String() string {
 	return b.String()
 }
 
-// NoRenderString returns ls as a string.
-// It uses an byte invalid character as a separator and so
-// should not be used for printing.
-func (ls Labels) NoRenderString(b *bytes.Buffer) string {
-	b.Reset()
-	b.WriteByte('{')
-	for i, l := range ls {
-		if i > 0 {
-			b.WriteByte(',')
-			b.WriteByte(' ')
-		}
-		b.WriteString(l.Name)
-		b.WriteByte('=')
-		b.WriteByte(sep)
-		b.WriteString(l.Value)
-		b.WriteByte(sep)
-	}
-	b.WriteByte('}')
-	return b.String()
-}
-
-func yoloString(b []byte) string {
-	return *((*string)(unsafe.Pointer(&b)))
-}
-
-// YoloString returns ls as an unsafe pointer to b's bytes casted to a string.
-// This is done to save on allocations that would happen during b.String() calls.
+// Bytes returns ls as a byte slice.
 // It uses an byte invalid character as a separator and so should not be used for printing.
-func (ls Labels) YoloString(b *bytes.Buffer) string {
-	b.Reset()
+func (ls Labels) Bytes(buf []byte) []byte {
+	b := bytes.NewBuffer(buf[:0])
 	b.WriteByte('{')
 	for i, l := range ls {
 		if i > 0 {
@@ -106,7 +79,7 @@ func (ls Labels) YoloString(b *bytes.Buffer) string {
 		b.WriteByte(sep)
 	}
 	b.WriteByte('}')
-	return yoloString(b.Bytes())
+	return b.Bytes()
 }
 
 // MarshalJSON implements json.Marshaler.

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -173,6 +173,7 @@ func (ls Labels) HashWithoutLabels(b []byte, names ...string) (uint64, []byte) {
 }
 
 // WithLabels returns a new labels.Labels from ls that only contains labels matching names.
+// 'names' have to be sorted in ascending order.
 func (ls Labels) WithLabels(names ...string) Labels {
 	var ret Labels
 	i, j := 0, 0
@@ -190,6 +191,8 @@ func (ls Labels) WithLabels(names ...string) Labels {
 	return ret
 }
 
+// WithLabels returns a new labels.Labels from ls that contains labels not matching names.
+// 'names' have to be sorted in ascending order.
 func (ls Labels) WithoutLabels(names ...string) Labels {
 	var ret Labels
 	j := 0

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -172,6 +172,39 @@ func (ls Labels) HashWithoutLabels(b []byte, names ...string) (uint64, []byte) {
 	return xxhash.Sum64(b), b
 }
 
+// WithLabels returns a new labels.Labels from ls that only contains labels matching names.
+func (ls Labels) WithLabels(names ...string) Labels {
+	var ret Labels
+	i, j := 0, 0
+	for i < len(ls) && j < len(names) {
+		if names[j] < ls[i].Name {
+			j++
+		} else if ls[i].Name < names[j] {
+			i++
+		} else {
+			ret = append(ret, ls[i])
+			i++
+			j++
+		}
+	}
+	return ret
+}
+
+func (ls Labels) WithoutLabels(names ...string) Labels {
+	var ret Labels
+	j := 0
+	for i := range ls {
+		for j < len(names) && names[j] < ls[i].Name {
+			j++
+		}
+		if ls[i].Name == MetricName || (j < len(names) && ls[i].Name == names[j]) {
+			continue
+		}
+		ret = append(ret, ls[i])
+	}
+	return ret
+}
+
 // Copy returns a copy of the labels.
 func (ls Labels) Copy() Labels {
 	res := make(Labels, len(ls))

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -22,14 +22,15 @@ import (
 	"github.com/cespare/xxhash"
 )
 
-const sep = '\xff'
-
 // Well-known label names used by Prometheus components.
 const (
 	MetricName   = "__name__"
 	AlertName    = "alertname"
 	BucketLabel  = "le"
 	InstanceName = "instance"
+
+	sep      = '\xff'
+	labelSep = '\xfe'
 )
 
 // Label is a key/value pair of strings.
@@ -66,19 +67,16 @@ func (ls Labels) String() string {
 // It uses an byte invalid character as a separator and so should not be used for printing.
 func (ls Labels) Bytes(buf []byte) []byte {
 	b := bytes.NewBuffer(buf[:0])
-	b.WriteByte('{')
+	b.WriteByte(labelSep)
 	for i, l := range ls {
 		if i > 0 {
-			b.WriteByte(',')
-			b.WriteByte(' ')
+			b.WriteByte(sep)
 		}
 		b.WriteString(l.Name)
-		b.WriteByte('=')
 		b.WriteByte(sep)
 		b.WriteString(l.Value)
-		b.WriteByte(sep)
 	}
-	b.WriteByte('}')
+	b.WriteByte(labelSep)
 	return b.Bytes()
 }
 

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -76,7 +76,6 @@ func (ls Labels) Bytes(buf []byte) []byte {
 		b.WriteByte(sep)
 		b.WriteString(l.Value)
 	}
-	b.WriteByte(labelSep)
 	return b.Bytes()
 }
 

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -14,7 +14,6 @@
 package labels
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/prometheus/prometheus/util/testutil"
@@ -518,40 +517,4 @@ func TestLabels_Has(t *testing.T) {
 		got := labelsSet.Has(test.input)
 		testutil.Equals(t, test.expected, got, "unexpected comparison result for test case %d", i)
 	}
-}
-
-func BenchmarkLabelsString(b *testing.B) {
-	metrics := []Labels{}
-	metrics = append(metrics, FromStrings("__name__", "a_one"))
-	metrics = append(metrics, FromStrings("__name__", "b_one"))
-	for j := 0; j < 10; j++ {
-		metrics = append(metrics, FromStrings("__name__", "h_one", "le", strconv.Itoa(j)))
-	}
-	metrics = append(metrics, FromStrings("__name__", "h_one", "le", "+Inf"))
-
-	for i := 0; i < 10; i++ {
-		metrics = append(metrics, FromStrings("__name__", "a_ten", "l", strconv.Itoa(i)))
-		metrics = append(metrics, FromStrings("__name__", "b_ten", "l", strconv.Itoa(i)))
-		for j := 0; j < 10; j++ {
-			metrics = append(metrics, FromStrings("__name__", "h_ten", "l", strconv.Itoa(i), "le", strconv.Itoa(j)))
-		}
-		metrics = append(metrics, FromStrings("__name__", "h_ten", "l", strconv.Itoa(i), "le", "+Inf"))
-	}
-
-	for i := 0; i < 100; i++ {
-		metrics = append(metrics, FromStrings("__name__", "a_hundred", "l", strconv.Itoa(i)))
-		metrics = append(metrics, FromStrings("__name__", "b_hundred", "l", strconv.Itoa(i)))
-		for j := 0; j < 10; j++ {
-			metrics = append(metrics, FromStrings("__name__", "h_hundred", "l", strconv.Itoa(i), "le", strconv.Itoa(j)))
-		}
-		metrics = append(metrics, FromStrings("__name__", "h_hundred", "l", strconv.Itoa(i), "le", "+Inf"))
-	}
-	m := make(map[string]struct{})
-	b.Run("stringBenchmark", func(b *testing.B) {
-		b.ReportAllocs()
-		for _, ls := range metrics {
-			// fmt.Println("string: ", ls.String())
-			m[ls.String()] = struct{}{}
-		}
-	})
 }

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -14,6 +14,7 @@
 package labels
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/prometheus/prometheus/util/testutil"
@@ -517,4 +518,40 @@ func TestLabels_Has(t *testing.T) {
 		got := labelsSet.Has(test.input)
 		testutil.Equals(t, test.expected, got, "unexpected comparison result for test case %d", i)
 	}
+}
+
+func BenchmarkLabelsString(b *testing.B) {
+	metrics := []Labels{}
+	metrics = append(metrics, FromStrings("__name__", "a_one"))
+	metrics = append(metrics, FromStrings("__name__", "b_one"))
+	for j := 0; j < 10; j++ {
+		metrics = append(metrics, FromStrings("__name__", "h_one", "le", strconv.Itoa(j)))
+	}
+	metrics = append(metrics, FromStrings("__name__", "h_one", "le", "+Inf"))
+
+	for i := 0; i < 10; i++ {
+		metrics = append(metrics, FromStrings("__name__", "a_ten", "l", strconv.Itoa(i)))
+		metrics = append(metrics, FromStrings("__name__", "b_ten", "l", strconv.Itoa(i)))
+		for j := 0; j < 10; j++ {
+			metrics = append(metrics, FromStrings("__name__", "h_ten", "l", strconv.Itoa(i), "le", strconv.Itoa(j)))
+		}
+		metrics = append(metrics, FromStrings("__name__", "h_ten", "l", strconv.Itoa(i), "le", "+Inf"))
+	}
+
+	for i := 0; i < 100; i++ {
+		metrics = append(metrics, FromStrings("__name__", "a_hundred", "l", strconv.Itoa(i)))
+		metrics = append(metrics, FromStrings("__name__", "b_hundred", "l", strconv.Itoa(i)))
+		for j := 0; j < 10; j++ {
+			metrics = append(metrics, FromStrings("__name__", "h_hundred", "l", strconv.Itoa(i), "le", strconv.Itoa(j)))
+		}
+		metrics = append(metrics, FromStrings("__name__", "h_hundred", "l", strconv.Itoa(i), "le", "+Inf"))
+	}
+	m := make(map[string]struct{})
+	b.Run("stringBenchmark", func(b *testing.B) {
+		b.ReportAllocs()
+		for _, ls := range metrics {
+			// fmt.Println("string: ", ls.String())
+			m[ls.String()] = struct{}{}
+		}
+	})
 }

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1726,7 +1726,9 @@ func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.V
 		enh.resultMetric = make(map[string]labels.Labels, len(enh.out))
 	}
 
-	if ret, ok := enh.resultMetric[lhs.String()+rhs.String()]; ok {
+	key := lhs.String() + rhs.String()
+
+	if ret, ok := enh.resultMetric[key]; ok {
 		return ret
 	}
 
@@ -1761,7 +1763,7 @@ func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.V
 	}
 
 	ret := lb.Labels()
-	enh.resultMetric[lhs.String()+rhs.String()] = ret
+	enh.resultMetric[key] = ret
 	return ret
 }
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1713,12 +1713,13 @@ func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.V
 	if enh.resultMetric == nil {
 		enh.resultMetric = make(map[string]labels.Labels, len(enh.out))
 	}
+
 	if enh.lb == nil {
 		enh.lb = labels.NewBuilder(lhs)
 	} else {
 		enh.lb.Reset(lhs)
 	}
-	// enh.lblBuf.Reset()
+
 	buf := bytes.NewBuffer(enh.lblResultBuf[:0])
 	enh.lblBuf = lhs.Bytes(enh.lblBuf)
 	buf.Write(enh.lblBuf)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -17,6 +17,7 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
+	"hash/maphash"
 	"math"
 	"regexp"
 	"runtime"
@@ -1662,7 +1663,6 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 			continue
 		}
 		metric := resultMetric(ls.Metric, rs.Metric, op, matching, enh)
-
 		insertedSigs, exists := matchedSigs[sig]
 		if matching.Card == parser.CardOneToOne {
 			if exists {
@@ -1718,9 +1718,11 @@ func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.V
 	// there's no need to include them in the hash key.
 	// If the lhs and rhs are the same then the xor would be 0,
 	// so add in one side to protect against that.
-	lh := lhs.Hash()
-	h := (lh ^ rhs.Hash()) + lh
-	if ret, ok := enh.resultMetric[h]; ok {
+	h := maphash.Hash{}
+	h.WriteString(lhs.String())
+	h.WriteString(rhs.String())
+	finalHash := h.Sum64()
+	if ret, ok := enh.resultMetric[finalHash]; ok {
 		return ret
 	}
 
@@ -1755,7 +1757,7 @@ func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.V
 	}
 
 	ret := lb.Labels()
-	enh.resultMetric[h] = ret
+	enh.resultMetric[finalHash] = ret
 	return ret
 }
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -831,9 +831,9 @@ type EvalNodeHelper struct {
 	// dropMetricName and label_*.
 	dmn map[uint64]labels.Labels
 	// signatureFunc.
-	sigf map[uint64]uint64
+	sigf map[string]string
 	// funcHistogramQuantile.
-	signatureToMetricWithBuckets map[uint64]*metricWithBuckets
+	signatureToMetricWithBuckets map[string]*metricWithBuckets
 	// label_replace.
 	regex *regexp.Regexp
 
@@ -858,20 +858,19 @@ func (enh *EvalNodeHelper) dropMetricName(l labels.Labels) labels.Labels {
 	return ret
 }
 
-// signatureFunc is a cached version of signatureFunc.
-func (enh *EvalNodeHelper) signatureFunc(on bool, names ...string) func(labels.Labels) uint64 {
+// signatureFunc is a cached version of signatureFuncString.
+func (enh *EvalNodeHelper) signatureFunc(on bool, names ...string) func(labels.Labels) string {
 	if enh.sigf == nil {
-		enh.sigf = make(map[uint64]uint64, len(enh.out))
+		enh.sigf = make(map[string]string, len(enh.out))
 	}
-	f := signatureFunc(on, names...)
-	return func(l labels.Labels) uint64 {
-		h := l.Hash()
-		ret, ok := enh.sigf[h]
+	f := signatureFuncString(on, names...)
+	return func(l labels.Labels) string {
+		ret, ok := enh.sigf[l.String()]
 		if ok {
 			return ret
 		}
 		ret = f(l)
-		enh.sigf[h] = ret
+		enh.sigf[l.String()] = ret
 		return ret
 	}
 }
@@ -1527,7 +1526,7 @@ func (ev *evaluator) VectorAnd(lhs, rhs Vector, matching *parser.VectorMatching,
 	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
 
 	// The set of signatures for the right-hand side Vector.
-	rightSigs := map[uint64]struct{}{}
+	rightSigs := map[string]struct{}{}
 	// Add all rhs samples to a map so we can easily find matches later.
 	for _, rs := range rhs {
 		rightSigs[sigf(rs.Metric)] = struct{}{}
@@ -1548,7 +1547,7 @@ func (ev *evaluator) VectorOr(lhs, rhs Vector, matching *parser.VectorMatching, 
 	}
 	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
 
-	leftSigs := map[uint64]struct{}{}
+	leftSigs := map[string]struct{}{}
 	// Add everything from the left-hand-side Vector.
 	for _, ls := range lhs {
 		leftSigs[sigf(ls.Metric)] = struct{}{}
@@ -1569,7 +1568,7 @@ func (ev *evaluator) VectorUnless(lhs, rhs Vector, matching *parser.VectorMatchi
 	}
 	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
 
-	rightSigs := map[uint64]struct{}{}
+	rightSigs := map[string]struct{}{}
 	for _, rs := range rhs {
 		rightSigs[sigf(rs.Metric)] = struct{}{}
 	}
@@ -1587,7 +1586,7 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 	if matching.Card == parser.CardManyToMany {
 		panic("many-to-many only allowed for set operators")
 	}
-	sigf := signatureFuncString(matching.On, matching.MatchingLabels...)
+	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
 
 	// The control flow below handles one-to-one or many-to-one matching.
 	// For one-to-many, swap sidedness and account for the swap when calculating
@@ -1689,22 +1688,6 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 		})
 	}
 	return enh.out
-}
-
-// signatureFunc returns a function that calculates the signature for a metric
-// ignoring the provided labels. If on, then the given labels are only used instead.
-func signatureFunc(on bool, names ...string) func(labels.Labels) uint64 {
-	sort.Strings(names)
-	if on {
-		return func(lset labels.Labels) uint64 {
-			h, _ := lset.HashForLabels(make([]byte, 0, 1024), names...)
-			return h
-		}
-	}
-	return func(lset labels.Labels) uint64 {
-		h, _ := lset.HashWithoutLabels(make([]byte, 0, 1024), names...)
-		return h
-	}
 }
 
 func signatureFuncString(on bool, names ...string) func(labels.Labels) string {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -861,20 +862,23 @@ func (enh *EvalNodeHelper) dropMetricName(l labels.Labels) labels.Labels {
 	return ret
 }
 
-// signatureFunc is a cached version of signatureFuncString.
+func yoloString(b []byte) string {
+	return *((*string)(unsafe.Pointer(&b)))
+}
+
 func (enh *EvalNodeHelper) signatureFunc(on bool, names ...string) func(labels.Labels) string {
 	if enh.sigf == nil {
 		enh.sigf = make(map[string]string, len(enh.out))
 	}
 	f := signatureFuncString(on, names...)
 	return func(l labels.Labels) string {
-		ls := l.String()
+		ls := l.YoloString()
 		ret, ok := enh.sigf[ls]
 		if ok {
 			return ret
 		}
 		ret = f(l)
-		enh.sigf[ls] = ret
+		enh.sigf[l.NoRenderString()] = ret
 		return ret
 	}
 }
@@ -1698,11 +1702,11 @@ func signatureFuncString(on bool, names ...string) func(labels.Labels) string {
 	sort.Strings(names)
 	if on {
 		return func(lset labels.Labels) string {
-			return lset.WithLabels(names...).String()
+			return lset.WithLabels(names...).NoRenderString()
 		}
 	}
 	return func(lset labels.Labels) string {
-		return lset.WithoutLabels(names...).String()
+		return lset.WithoutLabels(names...).NoRenderString()
 	}
 }
 
@@ -1725,14 +1729,17 @@ func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.V
 		enh.lb.Reset(lhs)
 	}
 	reuseStr := labelsPool.Get().(*bytes.Buffer)
-	reuseStr.Write([]byte(lhs.String()))
-	reuseStr.Write([]byte(rhs.String()))
-	str := reuseStr.String()
-	reuseStr.Reset()
-	labelsPool.Put(reuseStr)
-	if ret, ok := enh.resultMetric[string(str)]; ok {
+	reuseStr.Write([]byte(lhs.YoloString()))
+	reuseStr.Write([]byte(rhs.YoloString()))
+	str := yoloString(reuseStr.Bytes())
+	defer func() {
+		reuseStr.Reset()
+		labelsPool.Put(reuseStr)
+	}()
+	if ret, ok := enh.resultMetric[str]; ok {
 		return ret
 	}
+	str = reuseStr.String()
 
 	if shouldDropMetricName(op) {
 		enh.lb.Del(labels.MetricName)

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -14,6 +14,7 @@
 package promql
 
 import (
+	"bytes"
 	"math"
 	"regexp"
 	"sort"
@@ -598,7 +599,8 @@ func funcPredictLinear(vals []parser.Value, args parser.Expressions, enh *EvalNo
 func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	q := vals[0].(Vector)[0].V
 	inVec := vals[1].(Vector)
-	sigf := signatureFuncString(false, excludedLabels...)
+	b := bytes.Buffer{}
+	sigf := signatureFunc(false, &b, excludedLabels...)
 
 	if enh.signatureToMetricWithBuckets == nil {
 		enh.signatureToMetricWithBuckets = map[string]*metricWithBuckets{}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -14,7 +14,6 @@
 package promql
 
 import (
-	"bytes"
 	"math"
 	"regexp"
 	"sort"
@@ -599,8 +598,7 @@ func funcPredictLinear(vals []parser.Value, args parser.Expressions, enh *EvalNo
 func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	q := vals[0].(Vector)[0].V
 	inVec := vals[1].(Vector)
-	b := bytes.Buffer{}
-	sigf := signatureFunc(false, &b, excludedLabels...)
+	sigf := signatureFunc(false, &enh.lblBuf, excludedLabels...)
 
 	if enh.signatureToMetricWithBuckets == nil {
 		enh.signatureToMetricWithBuckets = map[string]*metricWithBuckets{}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -598,10 +598,10 @@ func funcPredictLinear(vals []parser.Value, args parser.Expressions, enh *EvalNo
 func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	q := vals[0].(Vector)[0].V
 	inVec := vals[1].(Vector)
-	sigf := enh.signatureFunc(false, excludedLabels...)
+	sigf := signatureFuncString(false, excludedLabels...)
 
 	if enh.signatureToMetricWithBuckets == nil {
-		enh.signatureToMetricWithBuckets = map[uint64]*metricWithBuckets{}
+		enh.signatureToMetricWithBuckets = map[string]*metricWithBuckets{}
 	} else {
 		for _, v := range enh.signatureToMetricWithBuckets {
 			v.buckets = v.buckets[:0]
@@ -616,16 +616,16 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 			// TODO(beorn7): Issue a warning somehow.
 			continue
 		}
-		hash := sigf(el.Metric)
+		l := sigf(el.Metric)
 
-		mb, ok := enh.signatureToMetricWithBuckets[hash]
+		mb, ok := enh.signatureToMetricWithBuckets[l]
 		if !ok {
 			el.Metric = labels.NewBuilder(el.Metric).
 				Del(labels.BucketLabel, labels.MetricName).
 				Labels()
 
 			mb = &metricWithBuckets{el.Metric, nil}
-			enh.signatureToMetricWithBuckets[hash] = mb
+			enh.signatureToMetricWithBuckets[l] = mb
 		}
 		mb.buckets = append(mb.buckets, bucket{upperBound, el.V})
 	}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -598,7 +598,7 @@ func funcPredictLinear(vals []parser.Value, args parser.Expressions, enh *EvalNo
 func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	q := vals[0].(Vector)[0].V
 	inVec := vals[1].(Vector)
-	sigf := signatureFunc(false, &enh.lblBuf, excludedLabels...)
+	sigf := signatureFunc(false, enh.lblBuf, excludedLabels...)
 
 	if enh.signatureToMetricWithBuckets == nil {
 		enh.signatureToMetricWithBuckets = map[string]*metricWithBuckets{}

--- a/promql/testdata/collision.test
+++ b/promql/testdata/collision.test
@@ -1,0 +1,11 @@
+
+load 1s
+      node_namespace_pod:kube_pod_info:{namespace="observability",node="gke-search-infra-custom-96-253440-fli-d135b119-jx00",pod="node-exporter-l454v"} 1
+      node_cpu_seconds_total{cpu="10",endpoint="https",instance="10.253.57.87:9100",job="node-exporter",mode="idle",namespace="observability",pod="node-exporter-l454v",service="node-exporter"} 449
+      node_cpu_seconds_total{cpu="35",endpoint="https",instance="10.253.57.87:9100",job="node-exporter",mode="idle",namespace="observability",pod="node-exporter-l454v",service="node-exporter"} 449
+      node_cpu_seconds_total{cpu="89",endpoint="https",instance="10.253.57.87:9100",job="node-exporter",mode="idle",namespace="observability",pod="node-exporter-l454v",service="node-exporter"} 449
+
+eval instant at 4s count by(namespace, pod, cpu) (node_cpu_seconds_total{cpu=~".*",job="node-exporter",mode="idle",namespace="observability",pod="node-exporter-l454v"}) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{namespace="observability",pod="node-exporter-l454v"}
+    {cpu="10",namespace="observability",node="gke-search-infra-custom-96-253440-fli-d135b119-jx00",pod="node-exporter-l454v"} 1
+    {cpu="35",namespace="observability",node="gke-search-infra-custom-96-253440-fli-d135b119-jx00",pod="node-exporter-l454v"} 1
+    {cpu="89",namespace="observability",node="gke-search-infra-custom-96-253440-fli-d135b119-jx00",pod="node-exporter-l454v"} 1


### PR DESCRIPTION
This PR changes from using hashes to compare labelsets to see if labelsets on each side of a promql query are dupicated to just using strings of `labels.Labels`.

Signed-off-by: Callum Styan <callumstyan@gmail.com>