### PR TITLE
Use .UTC everywhere we use time.Unix

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -571,7 +571,7 @@ func QueryLabels(url *url.URL, name string, p printer) int {
 func parseTime(s string) (time.Time, error) {
 	if t, err := strconv.ParseFloat(s, 64); err == nil {
 		s, ns := math.Modf(t)
-		return time.Unix(int64(s), int64(ns*float64(time.Second))), nil
+		return time.Unix(int64(s), int64(ns*float64(time.Second))).UTC(), nil
 	}
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 		return t, nil

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -80,7 +80,7 @@ func ruleUnitTest(filename string) []error {
 	}
 
 	// Bounds for evaluating the rules.
-	mint := time.Unix(0, 0)
+	mint := time.Unix(0, 0).UTC()
 	maxd := unitTestInp.maxEvalTime()
 	maxt := mint.Add(maxd)
 	// Rounding off to nearest Eval time (> maxt).
@@ -232,7 +232,7 @@ func (tg *testGroup) test(mint, maxt time.Time, evalInterval time.Duration, grou
 				for _, r := range g.Rules() {
 					if r.LastError() != nil {
 						errs = append(errs, errors.Errorf("    rule: %s, time: %s, err: %v",
-							r.Name(), ts.Sub(time.Unix(0, 0)), r.LastError()))
+							r.Name(), ts.Sub(time.Unix(0, 0).UTC()), r.LastError()))
 					}
 				}
 			}

--- a/pkg/timestamp/timestamp.go
+++ b/pkg/timestamp/timestamp.go
@@ -22,5 +22,5 @@ func FromTime(t time.Time) int64 {
 
 // Time returns a new time.Time object from a millisecond timestamp.
 func Time(ts int64) time.Time {
-	return time.Unix(ts/1000, (ts%1000)*int64(time.Millisecond))
+	return time.Unix(ts/1000, (ts%1000)*int64(time.Millisecond)).UTC()
 }

--- a/promql/test.go
+++ b/promql/test.go
@@ -45,7 +45,7 @@ const (
 	epsilon = 0.000001 // Relative error allowed for sample values.
 )
 
-var testStartTime = time.Unix(0, 0)
+var testStartTime = time.Unix(0, 0).UTC()
 
 // Test is a sequence of read and write commands that are run
 // against a test storage.
@@ -660,7 +660,7 @@ func (ll *LazyLoader) appendTill(ts int64) error {
 
 // WithSamplesTill loads the samples till given timestamp and executes the given function.
 func (ll *LazyLoader) WithSamplesTill(ts time.Time, fn func(error)) {
-	tsMilli := ts.Sub(time.Unix(0, 0)) / time.Millisecond
+	tsMilli := ts.Sub(time.Unix(0, 0).UTC()) / time.Millisecond
 	fn(ll.appendTill(int64(tsMilli)))
 }
 

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -487,7 +487,7 @@ func (g *Group) evalTimestamp() time.Time {
 		base   = adjNow - (adjNow % int64(g.interval))
 	)
 
-	return time.Unix(0, base+offset)
+	return time.Unix(0, base+offset).UTC()
 }
 
 func nameAndLabels(rule Rule) string {
@@ -745,8 +745,8 @@ func (g *Group) RestoreForState(ts time.Time) {
 				return
 			}
 
-			downAt := time.Unix(t/1000, 0)
-			restoredActiveAt := time.Unix(int64(v), 0)
+			downAt := time.Unix(t/1000, 0).UTC()
+			restoredActiveAt := time.Unix(int64(v), 0).UTC()
 			timeSpentPending := downAt.Sub(restoredActiveAt)
 			timeRemainingPending := alertHoldDuration - timeSpentPending
 

--- a/tsdb/cmd/tsdb/main.go
+++ b/tsdb/cmd/tsdb/main.go
@@ -459,7 +459,7 @@ func printBlocks(blocks []tsdb.BlockReader, humanReadable *bool) {
 
 func getFormatedTime(timestamp int64, humanReadable *bool) string {
 	if *humanReadable {
-		return time.Unix(timestamp/1000, 0).String()
+		return time.Unix(timestamp/1000, 0).UTC().String()
 	}
 	return strconv.FormatInt(timestamp, 10)
 }

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1457,7 +1457,7 @@ func parseTime(s string) (time.Time, error) {
 	if t, err := strconv.ParseFloat(s, 64); err == nil {
 		s, ns := math.Modf(t)
 		ns = math.Round(ns*1000) / 1000
-		return time.Unix(int64(s), int64(ns*float64(time.Second))), nil
+		return time.Unix(int64(s), int64(ns*float64(time.Second))).UTC(), nil
 	}
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 		return t, nil

--- a/web/api/v2/api.go
+++ b/web/api/v2/api.go
@@ -104,8 +104,8 @@ func extractTimeRange(min, max *time.Time) (mint, maxt time.Time, err error) {
 }
 
 var (
-	minTime = time.Unix(math.MinInt64/1000+62135596801, 0)
-	maxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999)
+	minTime = time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
+	maxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
 )
 
 var (

--- a/web/ui/templates/status.html
+++ b/web/ui/templates/status.html
@@ -7,7 +7,7 @@
       <tbody>
         <tr>
           <th>Uptime</th>
-          <td>{{.Birth.UTC}}</td>
+          <td>{{.Birth}}</td>
         </tr>
         <tr>
           <th>Working Directory</th>
@@ -19,7 +19,7 @@
         </tr>
         <tr>
           <th>Last successful configuration reload</th>
-          <td>{{.LastConfigTime.UTC}}</td>
+          <td>{{.LastConfigTime}}</td>
         </tr>
         <tr>
           <th>WAL corruptions</th>

--- a/web/web.go
+++ b/web/web.go
@@ -272,7 +272,7 @@ func New(logger log.Logger, o *Options) *Handler {
 		reloadCh:    make(chan chan error),
 		options:     o,
 		versionInfo: o.Version,
-		birth:       time.Now(),
+		birth:       time.Now().UTC(),
 		cwd:         cwd,
 		flagsMap:    o.Flags,
 
@@ -780,7 +780,7 @@ func (h *Handler) status(w http.ResponseWriter, r *http.Request) {
 		case "prometheus_config_last_reload_successful":
 			status.ReloadConfigSuccess = toFloat64(mF) != 0
 		case "prometheus_config_last_reload_success_timestamp_seconds":
-			status.LastConfigTime = time.Unix(int64(toFloat64(mF)), 0)
+			status.LastConfigTime = time.Unix(int64(toFloat64(mF)), 0).UTC()
 		}
 	}
 	db := h.tsdb()
@@ -829,7 +829,7 @@ func (h *Handler) runtimeInfo() (api_v1.RuntimeInfo, error) {
 		case "prometheus_config_last_reload_successful":
 			status.ReloadConfigSuccess = toFloat64(mF) != 0
 		case "prometheus_config_last_reload_success_timestamp_seconds":
-			status.LastConfigTime = time.Unix(int64(toFloat64(mF)), 0)
+			status.LastConfigTime = time.Unix(int64(toFloat64(mF)), 0).UTC()
 		}
 	}
 	return status, nil


### PR DESCRIPTION
time.Unix attaches the local timezone, which can then
leak out (e.g. in the alert json). While this is harmless,
we should be consistent.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>
