### PR TITLE
Fix remote write not updating when relabel configs change

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -237,8 +237,10 @@ type QueueManager struct {
 	cfg            config.QueueConfig
 	externalLabels labels.Labels
 	relabelConfigs []*relabel.Config
-	client         StorageClient
 	watcher        *wal.Watcher
+
+	clientMtx   sync.RWMutex
+	storeClient StorageClient
 
 	seriesMtx            sync.Mutex
 	seriesLabels         map[uint64]labels.Labels
@@ -283,7 +285,7 @@ func NewQueueManager(metrics *queueManagerMetrics, watcherMetrics *wal.WatcherMe
 		cfg:            cfg,
 		externalLabels: externalLabels,
 		relabelConfigs: relabelConfigs,
-		client:         client,
+		storeClient:    client,
 
 		seriesLabels:         make(map[uint64]labels.Labels),
 		seriesSegmentIndexes: make(map[uint64]int),
@@ -358,8 +360,8 @@ func (t *QueueManager) Start() {
 	// Setup the QueueManagers metrics. We do this here rather than in the
 	// constructor because of the ordering of creating Queue Managers's, stopping them,
 	// and then starting new ones in storage/remote/storage.go ApplyConfig.
-	name := t.client.Name()
-	ep := t.client.Endpoint()
+	name := t.client().Name()
+	ep := t.client().Endpoint()
 	t.highestSentTimestampMetric = &maxGauge{
 		Gauge: t.metrics.queueHighestSentTimestamp.WithLabelValues(name, ep),
 	}
@@ -413,8 +415,8 @@ func (t *QueueManager) Stop() {
 	}
 	t.seriesMtx.Unlock()
 	// Delete metrics so we don't have alerts for queues that are gone.
-	name := t.client.Name()
-	ep := t.client.Endpoint()
+	name := t.client().Name()
+	ep := t.client().Endpoint()
 	t.metrics.queueHighestSentTimestamp.DeleteLabelValues(name, ep)
 	t.metrics.queuePendingSamples.DeleteLabelValues(name, ep)
 	t.metrics.enqueueRetriesTotal.DeleteLabelValues(name, ep)
@@ -470,6 +472,20 @@ func (t *QueueManager) SeriesReset(index int) {
 			delete(t.droppedSeries, k)
 		}
 	}
+}
+
+// SetClient updates the client used by a queue. Used when only client specific
+// fields are updated to avoid restarting the queue.
+func (t *QueueManager) SetClient(c StorageClient) {
+	t.clientMtx.Lock()
+	t.storeClient = c
+	t.clientMtx.Unlock()
+}
+
+func (t *QueueManager) client() StorageClient {
+	t.clientMtx.RLock()
+	defer t.clientMtx.RUnlock()
+	return t.storeClient
 }
 
 func internLabels(lbls labels.Labels) {
@@ -865,7 +881,7 @@ func (s *shards) sendSamplesWithBackoff(ctx context.Context, samples []prompb.Ti
 		default:
 		}
 		begin := time.Now()
-		err := s.qm.client.Store(ctx, req)
+		err := s.qm.client().Store(ctx, req)
 
 		s.qm.sentBatchDuration.Observe(time.Since(begin).Seconds())
 

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -17,12 +17,12 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -174,7 +174,7 @@ func labelsToEqualityMatchers(ls model.LabelSet) []*labels.Matcher {
 
 // Used for hashing configs and diff'ing hashes in ApplyConfig.
 func toHash(data interface{}) (string, error) {
-	bytes, err := json.Marshal(data)
+	bytes, err := yaml.Marshal(data)
 	if err != nil {
 		return "", err
 	}

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -51,7 +51,7 @@ func TestStorageLifecycle(t *testing.T) {
 		},
 	}
 
-	s.ApplyConfig(conf)
+	testutil.Ok(t, s.ApplyConfig(conf))
 
 	// make sure remote write has a queue.
 	testutil.Equals(t, 1, len(s.rws.queues))
@@ -73,13 +73,13 @@ func TestUpdateRemoteReadConfigs(t *testing.T) {
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},
 	}
-	s.ApplyConfig(conf)
+	testutil.Ok(t, s.ApplyConfig(conf))
 	testutil.Equals(t, 0, len(s.queryables))
 
 	conf.RemoteReadConfigs = []*config.RemoteReadConfig{
 		&config.DefaultRemoteReadConfig,
 	}
-	s.ApplyConfig(conf)
+	testutil.Ok(t, s.ApplyConfig(conf))
 	testutil.Equals(t, 1, len(s.queryables))
 
 	err = s.Close()

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/config"
@@ -53,8 +52,7 @@ type WriteStorage struct {
 	queueMetrics      *queueManagerMetrics
 	watcherMetrics    *wal.WatcherMetrics
 	liveReaderMetrics *wal.LiveReaderMetrics
-	configHash        string
-	externalLabelHash string
+	externalLabels    labels.Labels
 	walDir            string
 	queues            map[string]*QueueManager
 	samplesIn         *ewmaRate
@@ -94,25 +92,10 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 	rws.mtx.Lock()
 	defer rws.mtx.Unlock()
 
-	configHash, err := toHash(conf.RemoteWriteConfigs)
-	if err != nil {
-		return err
-	}
-	externalLabelHash, err := toHash(conf.GlobalConfig.ExternalLabels)
-	if err != nil {
-		return err
-	}
-
 	// Remote write queues only need to change if the remote write config or
 	// external labels change.
-	externalLabelUnchanged := externalLabelHash == rws.externalLabelHash
-	if configHash == rws.configHash && externalLabelUnchanged {
-		level.Debug(rws.logger).Log("msg", "Remote write config has not changed, no need to restart QueueManagers")
-		return nil
-	}
-
-	rws.configHash = configHash
-	rws.externalLabelHash = externalLabelHash
+	externalLabelUnchanged := labels.Equal(conf.GlobalConfig.ExternalLabels, rws.externalLabels)
+	rws.externalLabels = conf.GlobalConfig.ExternalLabels
 
 	newQueues := make(map[string]*QueueManager)
 	newHashes := []string{}
@@ -120,6 +103,11 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 		hash, err := toHash(rwConf)
 		if err != nil {
 			return err
+		}
+
+		// Don't allow duplicate remote write configs.
+		if _, ok := newQueues[hash]; ok {
+			return fmt.Errorf("duplicate remote write configs are not allowed, found duplicate for URL: %s", rwConf.URL)
 		}
 
 		// Set the queue name to the config hash if the user has not set
@@ -130,22 +118,6 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			name = rwConf.Name
 		}
 
-		// Don't allow duplicate remote write configs.
-		if _, ok := newQueues[hash]; ok {
-			return fmt.Errorf("duplicate remote write configs are not allowed, found duplicate for URL: %s", rwConf.URL)
-		}
-
-		var nameUnchanged bool
-		queue, ok := rws.queues[hash]
-		if ok {
-			nameUnchanged = queue.client.Name() == name
-		}
-		if externalLabelUnchanged && nameUnchanged {
-			newQueues[hash] = queue
-			delete(rws.queues, hash)
-			continue
-		}
-
 		c, err := NewClient(name, &ClientConfig{
 			URL:              rwConf.URL,
 			Timeout:          rwConf.RemoteTimeout,
@@ -154,6 +126,16 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 		if err != nil {
 			return err
 		}
+
+		queue, ok := rws.queues[hash]
+		if externalLabelUnchanged && ok {
+			// Update the client in case any secret configuration has changed.
+			queue.SetClient(c)
+			newQueues[hash] = queue
+			delete(rws.queues, hash)
+			continue
+		}
+
 		newQueues[hash] = NewQueueManager(
 			rws.queueMetrics,
 			rws.watcherMetrics,

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -247,10 +248,18 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 	c0 := &config.RemoteWriteConfig{
 		RemoteTimeout: model.Duration(10 * time.Second),
 		QueueConfig:   config.DefaultQueueConfig,
+		WriteRelabelConfigs: []*relabel.Config{
+			&relabel.Config{
+				Regex: relabel.MustNewRegexp(".+"),
+			},
+		},
 	}
 	c1 := &config.RemoteWriteConfig{
 		RemoteTimeout: model.Duration(20 * time.Second),
 		QueueConfig:   config.DefaultQueueConfig,
+		HTTPClientConfig: config_util.HTTPClientConfig{
+			BearerToken: "foo",
+		},
 	}
 	c2 := &config.RemoteWriteConfig{
 		RemoteTimeout: model.Duration(30 * time.Second),
@@ -262,43 +271,58 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{c0, c1, c2},
 	}
 	// We need to set URL's so that metric creation doesn't panic.
-	conf.RemoteWriteConfigs[0].URL = &common_config.URL{
-		URL: &url.URL{
-			Host: "http://test-storage.com",
-		},
+	for i := range conf.RemoteWriteConfigs {
+		conf.RemoteWriteConfigs[i].URL = &common_config.URL{
+			URL: &url.URL{
+				Host: "http://test-storage.com",
+			},
+		}
 	}
-	conf.RemoteWriteConfigs[1].URL = &common_config.URL{
-		URL: &url.URL{
-			Host: "http://test-storage.com",
-		},
-	}
-	conf.RemoteWriteConfigs[2].URL = &common_config.URL{
-		URL: &url.URL{
-			Host: "http://test-storage.com",
-		},
-	}
-	s.ApplyConfig(conf)
+	testutil.Ok(t, s.ApplyConfig(conf))
 	testutil.Equals(t, 3, len(s.queues))
 
-	c0Hash, err := toHash(c0)
-	testutil.Ok(t, err)
-	c1Hash, err := toHash(c1)
-	testutil.Ok(t, err)
-	// q := s.queues[1]
+	hashes := make([]string, len(conf.RemoteWriteConfigs))
+	storeHashes := func() {
+		for i := range conf.RemoteWriteConfigs {
+			hash, err := toHash(conf.RemoteWriteConfigs[i])
+			testutil.Ok(t, err)
+			hashes[i] = hash
+		}
+	}
 
+	storeHashes()
 	// Update c0 and c2.
-	c0.RemoteTimeout = model.Duration(40 * time.Second)
+	c0.WriteRelabelConfigs[0] = &relabel.Config{Regex: relabel.MustNewRegexp("foo")}
 	c2.RemoteTimeout = model.Duration(50 * time.Second)
 	conf = &config.Config{
 		GlobalConfig:       config.GlobalConfig{},
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{c0, c1, c2},
 	}
-	s.ApplyConfig(conf)
+	testutil.Ok(t, s.ApplyConfig(conf))
 	testutil.Equals(t, 3, len(s.queues))
 
-	_, hashExists := s.queues[c1Hash]
+	_, hashExists := s.queues[hashes[0]]
+	testutil.Assert(t, !hashExists, "The queue for the first remote write configuration should have been restarted because the relabel configuration has changed.")
+	_, hashExists = s.queues[hashes[1]]
+	testutil.Assert(t, hashExists, "Pointer of unchanged queue should have remained the same")
+	_, hashExists = s.queues[hashes[2]]
+	testutil.Assert(t, !hashExists, "The queue for the third remote write configuration should have been restarted because the timeout has changed.")
+
+	storeHashes()
+	// Update c1.
+	c1.HTTPClientConfig.BearerToken = "bar"
+	err = s.ApplyConfig(conf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 3, len(s.queues))
+
+	_, hashExists = s.queues[hashes[0]]
+	testutil.Assert(t, hashExists, "Pointer of unchanged queue should have remained the same")
+	_, hashExists = s.queues[hashes[1]]
+	testutil.Assert(t, !hashExists, "The queue for the second remote write configuration should have been restarted because the HTTP configuration has changed.")
+	_, hashExists = s.queues[hashes[2]]
 	testutil.Assert(t, hashExists, "Pointer of unchanged queue should have remained the same")
 
+	storeHashes()
 	// Delete c0.
 	conf = &config.Config{
 		GlobalConfig:       config.GlobalConfig{},
@@ -307,8 +331,12 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 	s.ApplyConfig(conf)
 	testutil.Equals(t, 2, len(s.queues))
 
-	_, hashExists = s.queues[c0Hash]
+	_, hashExists = s.queues[hashes[0]]
 	testutil.Assert(t, !hashExists, "If the index changed, the queue should be stopped and recreated.")
+	_, hashExists = s.queues[hashes[1]]
+	testutil.Assert(t, hashExists, "Pointer of unchanged queue should have remained the same")
+	_, hashExists = s.queues[hashes[2]]
+	testutil.Assert(t, hashExists, "Pointer of unchanged queue should have remained the same")
 
 	err = s.Close()
 	testutil.Ok(t, err)


### PR DESCRIPTION
This PR builds on top of #6456, by addressing the broken test. I am always updating the client for every reused queue in order to make sure we don't miss any secrets in the http client confs.

Please merge these commits rather than squash them as @simonpasquier contributed the first two.

cc: @cstyan 

Fixes #6545