### PR TITLE
Add unit test case for func Type in record.go

### DIFF
--- a/tsdb/record/record_test.go
+++ b/tsdb/record/record_test.go
@@ -117,3 +117,26 @@ func TestRecord_Corrupted(t *testing.T) {
 		testutil.Equals(t, err, encoding.ErrInvalidSize)
 	})
 }
+
+func TestRecord_Type(t *testing.T) {
+	var enc Encoder
+	var dec Decoder
+
+	series := []RefSeries{{Ref: 100, Labels: labels.FromStrings("abc", "123")}}
+	recordType := dec.Type(enc.Series(series, nil))
+	testutil.Equals(t, Series, recordType)
+
+	samples := []RefSample{{Ref: 123, T: 12345, V: 1.2345}}
+	recordType = dec.Type(enc.Samples(samples, nil))
+	testutil.Equals(t, Samples, recordType)
+
+	tstones := []tombstones.Stone{{Ref: 1, Intervals: tombstones.Intervals{{Mint: 1, Maxt: 2}}}}
+	recordType = dec.Type(enc.Tombstones(tstones, nil))
+	testutil.Equals(t, Tombstones, recordType)
+
+	recordType = dec.Type(nil)
+	testutil.Equals(t, Invalid, recordType)
+
+	recordType = dec.Type([]byte{0})
+	testutil.Equals(t, Invalid, recordType)
+}


### PR DESCRIPTION
Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->