### PR TITLE
Use local tsdb for federation metrics

### DIFF
--- a/web/federate.go
+++ b/web/federate.go
@@ -75,7 +75,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 	)
 	w.Header().Set("Content-Type", string(format))
 
-	q, err := h.storage.Querier(req.Context(), mint, maxt)
+	q, err := h.localStorage.Querier(req.Context(), mint, maxt)
 	if err != nil {
 		federationErrors.Inc()
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -209,10 +209,10 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 		// Attach global labels if they do not exist yet.
 		for _, ln := range externalLabelNames {
 			lv := externalLabels[ln]
-			if _, ok := globalUsed[string(ln)]; !ok {
+			if _, ok := globalUsed[ln]; !ok {
 				protMetric.Label = append(protMetric.Label, &dto.LabelPair{
-					Name:  proto.String(string(ln)),
-					Value: proto.String(string(lv)),
+					Name:  proto.String(ln),
+					Value: proto.String(lv),
 				})
 			}
 		}

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -199,8 +199,7 @@ func TestFederation(t *testing.T) {
 	}
 
 	h := &Handler{
-		storage:       suite.Storage(),
-		queryEngine:   suite.QueryEngine(),
+		localStorage:  suite.Storage(),
 		lookbackDelta: 5 * time.Minute,
 		now:           func() model.Time { return 101 * 60 * 1000 }, // 101min after epoch.
 		config: &config.Config{

--- a/web/web.go
+++ b/web/web.go
@@ -180,6 +180,7 @@ type Handler struct {
 	context       context.Context
 	tsdb          func() *tsdb.DB
 	storage       storage.Storage
+	localStorage  storage.Storage
 	notifier      *notifier.Manager
 
 	apiV1 *api_v1.API
@@ -289,6 +290,10 @@ func New(logger log.Logger, o *Options) *Handler {
 		now: model.Now,
 
 		ready: 0,
+	}
+
+	if h.tsdb != nil {
+		h.localStorage = h.tsdb()
 	}
 
 	h.apiV1 = api_v1.NewAPI(h.queryEngine, h.storage, h.scrapeManager, h.notifier,

--- a/web/web.go
+++ b/web/web.go
@@ -285,15 +285,12 @@ func New(logger log.Logger, o *Options) *Handler {
 		lookbackDelta: o.LookbackDelta,
 		tsdb:          o.TSDB,
 		storage:       o.Storage,
+		localStorage:  o.TSDB(),
 		notifier:      o.Notifier,
 
 		now: model.Now,
 
 		ready: 0,
-	}
-
-	if h.tsdb != nil {
-		h.localStorage = h.tsdb()
 	}
 
 	h.apiV1 = api_v1.NewAPI(h.queryEngine, h.storage, h.scrapeManager, h.notifier,

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -399,6 +399,7 @@ func TestDebugHandler(t *testing.T) {
 				Host:   "localhost.localdomain:9090",
 				Scheme: "http",
 			},
+			TSDB: func() *tsdb.DB { return nil },
 		}
 		handler := New(nil, opts)
 		handler.Ready()
@@ -425,6 +426,7 @@ func TestHTTPMetrics(t *testing.T) {
 			Host:   "localhost.localdomain:9090",
 			Scheme: "http",
 		},
+		TSDB: func() *tsdb.DB { return nil },
 	})
 	getReady := func() int {
 		t.Helper()


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Fixes #4270