### PR TITLE
synchronize makefile.common for community

### DIFF
--- a/scripts/sync_makefiles.sh
+++ b/scripts/sync_makefiles.sh
@@ -11,7 +11,7 @@ branch="makefile_common"
 commit_msg="makefile: update Makefile.common with newer version"
 pr_title="Synchronize Makefile.common from prometheus/prometheus"
 pr_msg="Propagating changes from master Makefile.common located in prometheus/prometheus."
-org="prometheus"
+orgs="prometheus prometheus-community"
 
 GITHUB_TOKEN="${GITHUB_TOKEN:-}"
 if [ -z "${GITHUB_TOKEN}" ]; then
@@ -28,43 +28,46 @@ source_checksum="$(sha256sum Makefile.common | cut -d' ' -f1)"
 tmp_dir=$(mktemp -d)
 trap "rm -rf ${tmp_dir}" EXIT
 
-# Iterate over all repositories in ${org}. The GitHub API can return 100 items
-# at most but it should be enough for us as there are less than 40 repositories
-# currently.
-curl --retry 5 --silent -u "${git_user}:${GITHUB_TOKEN}" https://api.github.com/users/${org}/repos?per_page=100 2>/dev/null | jq -r '.[] | select( .name != "prometheus" ) | .name' | while read -r; do
-	repo="${REPLY}"
-	echo -e "\e[32mAnalyzing '${repo}'\e[0m"
+for org in $orgs
+do
+	# Iterate over all repositories in ${org}. The GitHub API can return 100 items
+	# at most but it should be enough for us as there are less than 40 repositories
+	# currently.
+	curl --retry 5 --silent -u "${git_user}:${GITHUB_TOKEN}" https://api.github.com/users/${org}/repos?per_page=100 2>/dev/null | jq -r '.[] | select( .name != "prometheus" ) | .name' | while read -r; do
+		repo="${REPLY}"
+		echo -e "\e[32mAnalyzing '${repo}'\e[0m"
 
-	target_makefile="$(curl -s --fail "https://raw.githubusercontent.com/${org}/${repo}/master/Makefile.common")"
-	if [ -z "${target_makefile}" ]; then
-		echo "Makefile.common doesn't exist in ${repo}"
-		continue
-	fi
-	target_checksum="$(echo ${target_makefile} | sha256sum | cut -d' ' -f1)"
-	if [ "${source_checksum}" == "${target_checksum}" ]; then
-		echo "Makefile.common is already in sync."
-		continue
-	fi
-
-	# Clone target repo to temporary directory and checkout to new branch
-	git clone --quiet "https://github.com/${org}/${repo}.git" "${tmp_dir}/${repo}"
-	cd "${tmp_dir}/${repo}"
-	git checkout -b "${branch}"
-
-	# Replace Makefile.common in target repo by one from prometheus/prometheus
-	cp -f "${source_makefile}" ./
-	if [ -n "$(git status --porcelain)" ]; then
-		git config user.email "${git_mail}"
-		git config user.name "${git_user}"
-		git add .
-		git commit -s -m "${commit_msg}"
-		# stdout and stderr are redirected to /dev/null otherwise git-push could leak the token in the logs.
-		if git push --quiet "https://${GITHUB_TOKEN}:@github.com/${org}/${repo}" --set-upstream "${branch}" 1>/dev/null 2>&1; then
-			curl --show-error --silent \
-				-u "${git_user}:${GITHUB_TOKEN}" \
-				-X POST \
-				-d "{\"title\":\"${pr_title}\",\"base\":\"master\",\"head\":\"${branch}\",\"body\":\"${pr_msg}\"}" \
-				"https://api.github.com/repos/${org}/${repo}/pulls"
+		target_makefile="$(curl -s --fail "https://raw.githubusercontent.com/${org}/${repo}/master/Makefile.common")"
+		if [ -z "${target_makefile}" ]; then
+			echo "Makefile.common doesn't exist in ${repo}"
+			continue
 		fi
-	fi
+		target_checksum="$(echo ${target_makefile} | sha256sum | cut -d' ' -f1)"
+		if [ "${source_checksum}" == "${target_checksum}" ]; then
+			echo "Makefile.common is already in sync."
+			continue
+		fi
+
+		# Clone target repo to temporary directory and checkout to new branch
+		git clone --quiet "https://github.com/${org}/${repo}.git" "${tmp_dir}/${repo}"
+		cd "${tmp_dir}/${repo}"
+		git checkout -b "${branch}"
+
+		# Replace Makefile.common in target repo by one from prometheus/prometheus
+		cp -f "${source_makefile}" ./
+		if [ -n "$(git status --porcelain)" ]; then
+			git config user.email "${git_mail}"
+			git config user.name "${git_user}"
+			git add .
+			git commit -s -m "${commit_msg}"
+			# stdout and stderr are redirected to /dev/null otherwise git-push could leak the token in the logs.
+			if git push --quiet "https://${GITHUB_TOKEN}:@github.com/${org}/${repo}" --set-upstream "${branch}" 1>/dev/null 2>&1; then
+				curl --show-error --silent \
+					-u "${git_user}:${GITHUB_TOKEN}" \
+					-X POST \
+					-d "{\"title\":\"${pr_title}\",\"base\":\"master\",\"head\":\"${branch}\",\"body\":\"${pr_msg}\"}" \
+					"https://api.github.com/repos/${org}/${repo}/pulls"
+			fi
+		fi
+	done
 done


### PR DESCRIPTION
cc @simonpasquier 

some repos in community use this: https://github.com/prometheus-community/stackdriver_exporter/blob/master/Makefile.common

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->