### PR TITLE
Add unit test for Get in pkg/labels/labels.go

### DIFF
--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -485,3 +485,16 @@ func TestLabels_Has(t *testing.T) {
 		testutil.Equals(t, test.expected, got, "unexpected comparison result for test case %d", i)
 	}
 }
+
+func TestLabels_Get(t *testing.T) {
+	testutil.Equals(t, "", Labels{{"aaa", "111"}, {"bbb", "222"}}.Get("foo"))
+	testutil.Equals(t, "111", Labels{{"aaa", "111"}, {"bbb", "222"}}.Get("aaa"))
+}
+
+func TestLabels_Copy(t *testing.T) {
+	testutil.Equals(t, Labels{{"aaa", "111"}, {"bbb", "222"}}, Labels{{"aaa", "111"}, {"bbb", "222"}}.Copy())
+}
+
+func TestLabels_Map(t *testing.T) {
+	testutil.Equals(t, map[string]string{"aaa": "111", "bbb": "222"}, Labels{{"aaa", "111"}, {"bbb", "222"}}.Map())
+}


### PR DESCRIPTION
This PR is about adding a unit test for Get in pkg/labels/labels.go.

Signed-off-by: Hu Shuai <hus.fnst@cn.fujitsu.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->