### PR TITLE
API: Allow `TargetRetriever` to receive a Context

### DIFF
--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -163,6 +163,12 @@ func (t *testTargetRetriever) ResetMetadataStore() {
 	}
 }
 
+func (t *testTargetRetriever) toFactory() func(context.Context) TargetRetriever {
+	return func(context.Context) TargetRetriever {
+		return t
+	}
+}
+
 type testAlertmanagerRetriever struct{}
 
 func (t testAlertmanagerRetriever) Alertmanagers() []*url.URL {
@@ -311,7 +317,7 @@ func TestEndpoints(t *testing.T) {
 		api := &API{
 			Queryable:             suite.Storage(),
 			QueryEngine:           suite.QueryEngine(),
-			targetRetriever:       testTargetRetriever,
+			targetRetriever:       testTargetRetriever.toFactory(),
 			alertmanagerRetriever: testAlertmanagerRetriever{},
 			flagsMap:              sampleFlagMap,
 			now:                   func() time.Time { return now },
@@ -375,7 +381,7 @@ func TestEndpoints(t *testing.T) {
 		api := &API{
 			Queryable:             remote,
 			QueryEngine:           suite.QueryEngine(),
-			targetRetriever:       testTargetRetriever,
+			targetRetriever:       testTargetRetriever.toFactory(),
 			alertmanagerRetriever: testAlertmanagerRetriever{},
 			flagsMap:              sampleFlagMap,
 			now:                   func() time.Time { return now },

--- a/web/web.go
+++ b/web/web.go
@@ -293,7 +293,10 @@ func New(logger log.Logger, o *Options) *Handler {
 		ready: 0,
 	}
 
-	h.apiV1 = api_v1.NewAPI(h.queryEngine, h.storage, h.scrapeManager, h.notifier,
+	factoryTr := func(_ context.Context) api_v1.TargetRetriever {
+		return h.scrapeManager
+	}
+	h.apiV1 = api_v1.NewAPI(h.queryEngine, h.storage, factoryTr, h.notifier,
 		func() config.Config {
 			h.mtx.RLock()
 			defer h.mtx.RUnlock()


### PR DESCRIPTION
Fixes #7103

I only changed `TargetRetriever` as that is the originally agreed scope on the issue, but the same could be applied to the other dependencies.

Signed-off-by: gotjosh <josue@grafana.com>