### PR TITLE
Defer finalizer

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -249,15 +249,15 @@ func (api *API) Register(r *route.Router) {
 		hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			httputil.SetCORS(w, api.CORSOrigin, r)
 			result := f(r)
+			if result.finalizer != nil {
+				defer result.finalizer()
+			}
 			if result.err != nil {
 				api.respondError(w, result.err, result.data)
 			} else if result.data != nil {
 				api.respond(w, result.data, result.warnings)
 			} else {
 				w.WriteHeader(http.StatusNoContent)
-			}
-			if result.finalizer != nil {
-				result.finalizer()
 			}
 		})
 		return api.ready(httputil.CompressionHandler{


### PR DESCRIPTION
If we panic during the api response, we could in theory not close the queriers.

Could be related to #7120 ?

cc @beorn7 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->