### PR TITLE
promql/parser: Cleanup generatedParserResult accross reuse

### DIFF
--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -168,6 +168,7 @@ func newParser(input string) *parser {
 
 	p.injecting = false
 	p.parseErrors = nil
+	p.generatedParserResult = nil
 
 	// Clear lexer struct before reusing.
 	p.lex = Lexer{


### PR DESCRIPTION
Reusing the same generatedParserResult ends up in strange panics:
See #7131 and #7127.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->