### PR TITLE
TSDB: Isolation: avoid creating appenderId's without appender

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -803,8 +803,6 @@ func (h *RangeHead) Meta() BlockMeta {
 type initAppender struct {
 	app  storage.Appender
 	head *Head
-
-	appendID, cleanupAppendIDsBelow uint64
 }
 
 func (a *initAppender) Add(lset labels.Labels, t int64, v float64) (uint64, error) {
@@ -812,7 +810,10 @@ func (a *initAppender) Add(lset labels.Labels, t int64, v float64) (uint64, erro
 		return a.app.Add(lset, t, v)
 	}
 	a.head.initTime(t)
-	a.app = a.head.appender(a.appendID, a.cleanupAppendIDsBelow)
+	appendID := a.head.iso.newAppendID()
+	cleanupAppendIDsBelow := a.head.iso.lowWatermark()
+
+	a.app = a.head.appender(appendID, cleanupAppendIDsBelow)
 
 	return a.app.Add(lset, t, v)
 }
@@ -842,18 +843,17 @@ func (a *initAppender) Rollback() error {
 func (h *Head) Appender() storage.Appender {
 	h.metrics.activeAppenders.Inc()
 
-	appendID := h.iso.newAppendID()
-	cleanupAppendIDsBelow := h.iso.lowWatermark()
-
 	// The head cache might not have a starting point yet. The init appender
 	// picks up the first appended timestamp as the base.
 	if h.MinTime() == math.MaxInt64 {
 		return &initAppender{
-			head:                  h,
-			appendID:              appendID,
-			cleanupAppendIDsBelow: cleanupAppendIDsBelow,
+			head: h,
 		}
 	}
+
+	appendID := h.iso.newAppendID()
+	cleanupAppendIDsBelow := h.iso.lowWatermark()
+
 	return h.appender(appendID, cleanupAppendIDsBelow)
 }
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -810,10 +810,7 @@ func (a *initAppender) Add(lset labels.Labels, t int64, v float64) (uint64, erro
 		return a.app.Add(lset, t, v)
 	}
 	a.head.initTime(t)
-	appendID := a.head.iso.newAppendID()
-	cleanupAppendIDsBelow := a.head.iso.lowWatermark()
-
-	a.app = a.head.appender(appendID, cleanupAppendIDsBelow)
+	a.app = a.head.appender()
 
 	return a.app.Add(lset, t, v)
 }
@@ -850,14 +847,10 @@ func (h *Head) Appender() storage.Appender {
 			head: h,
 		}
 	}
-
-	appendID := h.iso.newAppendID()
-	cleanupAppendIDsBelow := h.iso.lowWatermark()
-
-	return h.appender(appendID, cleanupAppendIDsBelow)
+	return h.appender()
 }
 
-func (h *Head) appender(appendID, cleanupAppendIDsBelow uint64) *headAppender {
+func (h *Head) appender() *headAppender {
 	return &headAppender{
 		head: h,
 		// Set the minimum valid time to whichever is greater the head min valid time or the compaction window.
@@ -867,8 +860,8 @@ func (h *Head) appender(appendID, cleanupAppendIDsBelow uint64) *headAppender {
 		maxt:                  math.MinInt64,
 		samples:               h.getAppendBuffer(),
 		sampleSeries:          h.getSeriesBuffer(),
-		appendID:              appendID,
-		cleanupAppendIDsBelow: cleanupAppendIDsBelow,
+		appendID:              h.iso.newAppendID(),
+		cleanupAppendIDsBelow: h.iso.lowWatermark(),
 	}
 }
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -851,6 +851,9 @@ func (h *Head) Appender() storage.Appender {
 }
 
 func (h *Head) appender() *headAppender {
+	appendID := h.iso.newAppendID()
+	cleanupAppendIDsBelow := h.iso.lowWatermark()
+
 	return &headAppender{
 		head: h,
 		// Set the minimum valid time to whichever is greater the head min valid time or the compaction window.
@@ -860,8 +863,8 @@ func (h *Head) appender() *headAppender {
 		maxt:                  math.MinInt64,
 		samples:               h.getAppendBuffer(),
 		sampleSeries:          h.getSeriesBuffer(),
-		appendID:              h.iso.newAppendID(),
-		cleanupAppendIDsBelow: h.iso.lowWatermark(),
+		appendID:              appendID,
+		cleanupAppendIDsBelow: cleanupAppendIDsBelow,
 	}
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1375,9 +1375,9 @@ func TestMemSeriesIsolation(t *testing.T) {
 		if hb.MinTime() == math.MaxInt64 {
 			app = &initAppender{head: hb}
 		} else {
-			_app := hb.appender()
-			_app.cleanupAppendIDsBelow = 0
-			app = _app
+			a := hb.appender()
+			a.cleanupAppendIDsBelow = 0
+			app = a
 		}
 
 		_, err := app.Add(labels.FromStrings("foo", "bar"), int64(i), float64(i))


### PR DESCRIPTION
Prior to this commit we could have situations where we are creating an
appenderId but never creating an appender to go with it, therefore
blocking the low watermak.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->