### PR TITLE
Cherry-pick three bugfixes from master to release-2.17

### DIFF
--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -169,6 +169,7 @@ func newParser(input string) *parser {
 
 	p.injecting = false
 	p.parseErrors = nil
+	p.generatedParserResult = nil
 
 	// Clear lexer struct before reusing.
 	p.lex = Lexer{

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -249,15 +249,15 @@ func (api *API) Register(r *route.Router) {
 		hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			httputil.SetCORS(w, api.CORSOrigin, r)
 			result := f(r)
+			if result.finalizer != nil {
+				defer result.finalizer()
+			}
 			if result.err != nil {
 				api.respondError(w, result.err, result.data)
 			} else if result.data != nil {
 				api.respond(w, result.data, result.warnings)
 			} else {
 				w.WriteHeader(http.StatusNoContent)
-			}
-			if result.finalizer != nil {
-				result.finalizer()
 			}
 		})
 		return api.ready(httputil.CompressionHandler{

--- a/web/federate.go
+++ b/web/federate.go
@@ -44,6 +44,10 @@ var (
 	})
 )
 
+func registerFederationMetrics(r prometheus.Registerer) {
+	r.MustRegister(federationWarnings, federationErrors)
+}
+
 func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 	h.mtx.RLock()
 	defer h.mtx.RUnlock()

--- a/web/web.go
+++ b/web/web.go
@@ -139,6 +139,7 @@ func newMetrics(r prometheus.Registerer) *metrics {
 
 	if r != nil {
 		r.MustRegister(m.requestCounter, m.requestDuration, m.responseSize)
+		registerFederationMetrics(r)
 	}
 	return m
 }


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->