### PR TITLE
A bit more explict detail about comparison operators and alert templates

### DIFF
--- a/docs/configuration/alerting_rules.md
+++ b/docs/configuration/alerting_rules.md
@@ -79,6 +79,10 @@ groups:
       description: "{{ $labels.instance }} has a median request latency above 1s (current value: {{ $value }}s)"
 ```
 
+Remember that [comparison operators](https://prometheus.io/docs/prometheus/latest/querying/operators/#comparison-binary-operators)
+are filters by default, so `$value` for the expression `api_http_request_latencies_second{quantile="0.5"} > 1` will be a number,
+not a boolean.
+
 ### Inspecting alerts during runtime
 
 To manually inspect which alerts are active (pending or firing), navigate to

--- a/docs/querying/operators.md
+++ b/docs/querying/operators.md
@@ -52,8 +52,9 @@ The following binary comparison operators exist in Prometheus:
 * `<=` (less-or-equal)
 
 Comparison operators are defined between scalar/scalar, vector/scalar,
-and vector/vector value pairs. By default they filter. Their behavior can be
-modified by providing `bool` after the operator, which will return `0` or `1`
+and vector/vector value pairs. By default they filter: for example, the value of
+`x > 10` will be `x` if its value is more than 10, or no result if not. Their behavior
+can be modified by providing `bool` after the operator, which will return `0` or `1`
 for the value rather than filtering.
 
 **Between two scalars**, the `bool` modifier must be provided and these


### PR DESCRIPTION
@brian-brazil

From the discussion here: https://groups.google.com/forum/#!topic/prometheus-users/-aC42iqeTgo

The Prometheus comparison operators work differently from most comparison opeators
in the world. It makes total sense that they work this way (filtering instead of
resulting in a boolean value), but it can be confusing for newbies. This is why
I thought that $value in the template would always be true! So this is just a few
sentences to be more explicit about how they work.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->