### PR TITLE
Adding a shouldReshard function to modularize logic for the QueueManager deciding if it should shard or not

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -292,16 +292,14 @@ func TestReleaseNoninternedString(t *testing.T) {
 	testutil.Assert(t, metric == 0, "expected there to be no calls to release for strings that were not already interned: %d", int(metric))
 }
 
-func TestCalculateDesiredsShards(t *testing.T) {
+func TestShouldReshard(t *testing.T) {
 	type testcase struct {
 		startingShards        int
-		samplesIn, samplesOut int64
 		reshard               bool
+		samplesIn, samplesOut int64
 	}
 	cases := []testcase{
 		{
-			// Test that ensures that if we haven't successfully sent a
-			// sample recently the queue will not reshard.
 			startingShards: 10,
 			reshard:        false,
 			samplesIn:      1000,
@@ -329,8 +327,9 @@ func TestCalculateDesiredsShards(t *testing.T) {
 		}
 		m.Start()
 		desiredShards := m.calculateDesiredShards()
+		shouldReshard := m.shouldReshard(desiredShards)
 		m.Stop()
-		if !c.reshard {
+		if !(c.reshard == shouldReshard) {
 			testutil.Assert(t, desiredShards == m.numShards, "expected calculateDesiredShards to not want to reshard, wants to change from %d to %d shards", m.numShards, desiredShards)
 		} else {
 			testutil.Assert(t, desiredShards != m.numShards, "expected calculateDesiredShards to want to reshard, wants to change from %d to %d shards", m.numShards, desiredShards)

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -331,7 +331,7 @@ func TestShouldReshard(t *testing.T) {
 
 		m.Stop()
 
-		testutil.Assert(t, shouldReshard == c.expectedToReshard, "shouldReshard set to %t, expected %t", shouldReshard, c.expectedToReshard)
+		testutil.Equals(t, c.expectedToReshard, shouldReshard)
 	}
 }
 


### PR DESCRIPTION
This is a fix for https://github.com/prometheus/prometheus/issues/7124

The function calculateDesiredShards() should only do what it says. Calculate the number of desired shards.

From the description of the function:

```
// calculateDesiredShards returns the number of desired shards, which will be
// the current QueueManager.numShards if resharding should not occur for reasons
// outlined in this functions implementation. It is up to the caller to reshard, or not,
// based on the return value.
```

- Moved around some logic on deciding whether or not the QueueManager should reshard from updateShardsLoop() and calculateDesiredShards() into a new function called shouldReshard(). Mostly it's just copy pasting if statements from the first two functions into the new function.
- Renamed TestCalculateDesiredsShards to TestShouldReshard to more accurately reflect the purpose of that test.

With these changes we move the logic to decide whether or not to reshard to a higher level in the code.