### PR TITLE
Fix race in tsdb

### DIFF
--- a/discovery/kubernetes/client_metrics.go
+++ b/discovery/kubernetes/client_metrics.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/client-go/tools/metrics"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -158,26 +157,5 @@ func (f *clientGoWorkqueueMetricsProvider) NewLongestRunningProcessorSecondsMetr
 }
 func (clientGoWorkqueueMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
 	// Retries are not used so the metric is omitted.
-	return noopMetric{}
-}
-func (clientGoWorkqueueMetricsProvider) NewDeprecatedDepthMetric(name string) workqueue.GaugeMetric {
-	return noopMetric{}
-}
-func (clientGoWorkqueueMetricsProvider) NewDeprecatedAddsMetric(name string) workqueue.CounterMetric {
-	return noopMetric{}
-}
-func (clientGoWorkqueueMetricsProvider) NewDeprecatedLatencyMetric(name string) workqueue.SummaryMetric {
-	return noopMetric{}
-}
-func (f *clientGoWorkqueueMetricsProvider) NewDeprecatedWorkDurationMetric(name string) workqueue.SummaryMetric {
-	return noopMetric{}
-}
-func (f *clientGoWorkqueueMetricsProvider) NewDeprecatedUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
-	return noopMetric{}
-}
-func (f *clientGoWorkqueueMetricsProvider) NewDeprecatedLongestRunningProcessorMicrosecondsMetric(name string) workqueue.SettableGaugeMetric {
-	return noopMetric{}
-}
-func (clientGoWorkqueueMetricsProvider) NewDeprecatedRetriesMetric(name string) workqueue.CounterMetric {
 	return noopMetric{}
 }

--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -17,11 +17,12 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 func makeEndpoints() *v1.Endpoints {

--- a/discovery/kubernetes/ingress_test.go
+++ b/discovery/kubernetes/ingress_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 type TLSMode int

--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -20,12 +20,13 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
-	"github.com/prometheus/prometheus/util/testutil"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/testutil"
 )
 
 // makeDiscovery creates a kubernetes.Discovery instance for testing.

--- a/discovery/kubernetes/node_test.go
+++ b/discovery/kubernetes/node_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 func makeNode(name, address string, labels map[string]string, annotations map[string]string) *v1.Node {

--- a/discovery/kubernetes/pod_test.go
+++ b/discovery/kubernetes/pod_test.go
@@ -18,10 +18,11 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 func makeOptionalBool(v bool) *bool {

--- a/discovery/kubernetes/service_test.go
+++ b/discovery/kubernetes/service_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 func makeMultiPortService() *v1.Service {

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -65,7 +65,7 @@ type Metrics struct {
 	groupRules          *prometheus.GaugeVec
 }
 
-// NewGroupMetrics makes a new Metrics and registers them with the provided registerer,
+// NewGroupMetrics creates a new instance of Metrics and registers it with the provided registerer,
 // if not nil.
 func NewGroupMetrics(reg prometheus.Registerer) *Metrics {
 	m := &Metrics{

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -681,9 +681,11 @@ func (h *Head) Truncate(mint int64) (err error) {
 	if last < 0 {
 		return nil // no segments yet.
 	}
-	// The lower third of segments should contain mostly obsolete samples.
-	// If we have less than three segments, it's not worth checkpointing yet.
-	last = first + (last-first)/3
+	// The lower two thirds of segments should contain mostly obsolete samples.
+	// If we have less than two segments, it's not worth checkpointing yet.
+	// With the default 2h blocks, this will keeping up to around 3h worth
+	// of WAL segments.
+	last = first + (last-first)*2/3
 	if last <= first {
 		return nil
 	}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -168,7 +168,7 @@ func (p *MemPostings) EnsureOrder() {
 	wg.Add(n)
 
 	for i := 0; i < n; i++ {
-		go func(i interface{}) {
+		go func(i int) {
 			for l := range workc {
 				sort.Slice(l, func(i, j int) bool { return l[i] < l[j] })
 			}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -173,7 +173,7 @@ func (p *MemPostings) EnsureOrder() {
 				sort.Slice(l, func(a, b int) bool { return l[a] < l[b] })
 			}
 			wg.Done()
-		}(i)
+		}()
 	}
 
 	for _, e := range p.m {

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -168,7 +168,7 @@ func (p *MemPostings) EnsureOrder() {
 	wg.Add(n)
 
 	for i := 0; i < n; i++ {
-		go func(i int) {
+		go func() {
 			for l := range workc {
 				sort.Slice(l, func(a, b int) bool { return l[a] < l[b] })
 			}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -168,12 +168,12 @@ func (p *MemPostings) EnsureOrder() {
 	wg.Add(n)
 
 	for i := 0; i < n; i++ {
-		go func() {
+		go func(i interface{}) {
 			for l := range workc {
 				sort.Slice(l, func(i, j int) bool { return l[i] < l[j] })
 			}
 			wg.Done()
-		}()
+		}(i)
 	}
 
 	for _, e := range p.m {

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -170,7 +170,7 @@ func (p *MemPostings) EnsureOrder() {
 	for i := 0; i < n; i++ {
 		go func(i int) {
 			for l := range workc {
-				sort.Slice(l, func(i, j int) bool { return l[i] < l[j] })
+				sort.Slice(l, func(a, b int) bool { return l[a] < l[b] })
 			}
 			wg.Done()
 		}(i)

--- a/web/federate.go
+++ b/web/federate.go
@@ -75,7 +75,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 	)
 	w.Header().Set("Content-Type", string(format))
 
-	q, err := h.storage.Querier(req.Context(), mint, maxt)
+	q, err := h.localStorage.Querier(req.Context(), mint, maxt)
 	if err != nil {
 		federationErrors.Inc()
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -209,10 +209,10 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 		// Attach global labels if they do not exist yet.
 		for _, ln := range externalLabelNames {
 			lv := externalLabels[ln]
-			if _, ok := globalUsed[string(ln)]; !ok {
+			if _, ok := globalUsed[ln]; !ok {
 				protMetric.Label = append(protMetric.Label, &dto.LabelPair{
-					Name:  proto.String(string(ln)),
-					Value: proto.String(string(lv)),
+					Name:  proto.String(ln),
+					Value: proto.String(lv),
 				})
 			}
 		}

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -199,8 +199,7 @@ func TestFederation(t *testing.T) {
 	}
 
 	h := &Handler{
-		storage:       suite.Storage(),
-		queryEngine:   suite.QueryEngine(),
+		localStorage:  suite.Storage(),
 		lookbackDelta: 5 * time.Minute,
 		now:           func() model.Time { return 101 * 60 * 1000 }, // 101min after epoch.
 		config: &config.Config{

--- a/web/web.go
+++ b/web/web.go
@@ -180,6 +180,7 @@ type Handler struct {
 	context       context.Context
 	tsdb          func() *tsdb.DB
 	storage       storage.Storage
+	localStorage  storage.Storage
 	notifier      *notifier.Manager
 
 	apiV1 *api_v1.API
@@ -284,6 +285,7 @@ func New(logger log.Logger, o *Options) *Handler {
 		lookbackDelta: o.LookbackDelta,
 		tsdb:          o.TSDB,
 		storage:       o.Storage,
+		localStorage:  o.TSDB(),
 		notifier:      o.Notifier,
 
 		now: model.Now,

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -399,6 +399,7 @@ func TestDebugHandler(t *testing.T) {
 				Host:   "localhost.localdomain:9090",
 				Scheme: "http",
 			},
+			TSDB: func() *tsdb.DB { return nil },
 		}
 		handler := New(nil, opts)
 		handler.Ready()
@@ -425,6 +426,7 @@ func TestHTTPMetrics(t *testing.T) {
 			Host:   "localhost.localdomain:9090",
 			Scheme: "http",
 		},
+		TSDB: func() *tsdb.DB { return nil },
 	})
 	getReady := func() int {
 		t.Helper()


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

When a go loop launches goroutines, it is a common mistake to assume
that the routines can reference the loop value from their specific loop
iteration. Actually, all goroutines share the same reference to the loop
veriable, and they typically all see the last value. To correct this, the loop variable must be captured as a parameter to the anonymous func.
