### PR TITLE
WIP: Fixes empty segments creation in tsdb when presence of a very old block

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -607,7 +607,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	// to be no lower than the maxt of the last block.
 	blocks := db.Blocks()
 	minValidTime := int64(math.MinInt64)
-	var sampleFound bool
+	var samplesFound bool
 	if _, err := os.Stat(filepath.Join(dir, "wal")); os.IsExist(err) {
 		sr, err := wal.NewSegmentsReader(filepath.Join(dir, "wal"))
 		if err != nil {
@@ -624,11 +624,12 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 					return nil, errors.Wrap(err, "samples append")
 				}
 				minValidTime = samples[0].T
+				samplesFound = true
 				break
 			}
 		}
 	}
-	if !sampleFound && len(blocks) > 0 {
+	if !samplesFound && len(blocks) > 0 {
 		minValidTime = blocks[len(blocks)-1].Meta().MaxTime
 	}
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -607,7 +607,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	// to be no lower than the maxt of the last block.
 	blocks := db.Blocks()
 	minValidTime := int64(math.MinInt64)
-
+	var sampleFound bool
 	if _, err := os.Stat(filepath.Join(dir, "wal")); os.IsExist(err) {
 		sr, err := wal.NewSegmentsReader(filepath.Join(dir, "wal"))
 		if err != nil {
@@ -615,7 +615,6 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		}
 		reader := wal.NewReader(sr)
 		dec := record.Decoder{}
-		var sampleFound bool
 		for reader.Next() {
 			currRecord := reader.Record()
 			if record.Samples == dec.Type(currRecord) {
@@ -628,9 +627,9 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 				break
 			}
 		}
-		if !sampleFound && len(blocks) > 0 {
-			minValidTime = blocks[len(blocks)-1].Meta().MaxTime
-		}
+	}
+	if !sampleFound && len(blocks) > 0 {
+		minValidTime = blocks[len(blocks)-1].Meta().MaxTime
 	}
 
 	if initErr := db.head.Init(minValidTime); initErr != nil {


### PR DESCRIPTION
Signed-off-by: Harkishen Singh <harkishensingh@hotmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Fixes: #6359

Fixes empty segments creation when the most recent block is old. If no segments found, the `minTime` is shifted to the maxTime of the last block.

**Note:** Unit-test cases are not updated yet. Expect CI tests to fail.