### PR TITLE
rules: Add rulesNoLock to avoid double RLock.

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -1065,9 +1065,6 @@ func (m *Manager) Rules() []Rule {
 
 // AlertingRules returns the list of the manager's alerting rules.
 func (m *Manager) AlertingRules() []*AlertingRule {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-
 	alerts := []*AlertingRule{}
 	for _, rule := range m.Rules() {
 		if alertingRule, ok := rule.(*AlertingRule); ok {


### PR DESCRIPTION
**- What I did**
Fix a double RLock in `AlertingRules()` in rules/manager.go.

**- How I did it**
Add a new function `rulesNoLock()` which has all the content of the original `Rules()` except the lock. Then make `Rules()` call the NoLock version with lock protection. Replace the call to `Rules()` in `AlertingRules()` with the NoLock version.

**- How to verify it**
As the [https://golang.org/pkg/sync/](https://golang.org/pkg/sync/) says about RLock:
`It should not be used for recursive read locking; a blocked Lock call excludes new readers from acquiring the lock.`
So double read lock should also be avoided.

The first lock is in `AlertingRules()`. Then it calls `Rules()`, where the second lock resides.

After the patch, the second lock is removed.