### PR TITLE
Jaeger: Create child span for remote read

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -163,7 +163,12 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query) (*prompb.QueryRe
 
 	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
 		var ht *nethttp.Tracer
-		httpReq, ht = nethttp.TraceRequest(parentSpan.Tracer(), httpReq)
+		httpReq, ht = nethttp.TraceRequest(
+			parentSpan.Tracer(),
+			httpReq,
+			nethttp.OperationName("Remote Read"),
+			nethttp.ClientTrace(false),
+		)
 		defer ht.Finish()
 	}
 

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -151,7 +151,12 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query) (*prompb.QueryRe
 	httpReq.Header.Set("User-Agent", userAgent)
 	httpReq.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
 
-	if span := opentracing.SpanFromContext(ctx); span != nil {
+	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
+		span := opentracing.StartSpan(
+			"Remote Read",
+			opentracing.ChildOf(parentSpan.Context()),
+		)
+		defer span.Finish()
 		ext.SpanKindRPCClient.Set(span)
 		ext.HTTPUrl.Set(span, httpReq.URL.String())
 		ext.HTTPMethod.Set(span, httpReq.Method)

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -27,12 +27,12 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 	"github.com/pkg/errors"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/prometheus/prometheus/prompb"
 )
 
@@ -60,6 +60,11 @@ func NewClient(remoteName string, conf *ClientConfig) (*Client, error) {
 	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage", false)
 	if err != nil {
 		return nil, err
+	}
+
+	t := httpClient.Transport
+	httpClient.Transport = &nethttp.Transport{
+		RoundTripper: t,
 	}
 
 	return &Client{
@@ -151,37 +156,20 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query) (*prompb.QueryRe
 	httpReq.Header.Set("User-Agent", userAgent)
 	httpReq.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
 
-	var span opentracing.Span
-	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
-		span = opentracing.StartSpan(
-			"Remote Read",
-			opentracing.ChildOf(parentSpan.Context()),
-		)
-		defer func() {
-			if span != nil {
-				span.Finish()
-			}
-		}()
-		ext.SpanKindRPCClient.Set(span)
-		ext.HTTPUrl.Set(span, httpReq.URL.String())
-		ext.HTTPMethod.Set(span, httpReq.Method)
-		_ = span.Tracer().Inject(
-			span.Context(),
-			opentracing.HTTPHeaders,
-			opentracing.HTTPHeadersCarrier(httpReq.Header),
-		)
-	}
-
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
-	httpResp, err := c.client.Do(httpReq.WithContext(ctx))
+	httpReq = httpReq.WithContext(ctx)
+
+	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
+		var ht *nethttp.Tracer
+		httpReq, ht = nethttp.TraceRequest(parentSpan.Tracer(), httpReq)
+		defer ht.Finish()
+	}
+
+	httpResp, err := c.client.Do(httpReq)
 	if err != nil {
 		return nil, errors.Wrap(err, "error sending request")
-	}
-	if span != nil {
-		span.Finish()
-		span = nil
 	}
 	defer func() {
 		io.Copy(ioutil.Discard, httpResp.Body)


### PR DESCRIPTION
This creates a child span for remote read calls instead of modifying the parent span.

The previous version would change the values of the parent span:
![remread](https://user-images.githubusercontent.com/291750/80756522-f7308800-8b32-11ea-92bc-cbb8721871c5.png)

Which is problematic because parent span is about the engine itself and should not get the http properties, + would be erased if we have multiple remote reads.

The new behaviour is to have a clean remote read span and a clear http post span:

![remread](https://user-images.githubusercontent.com/291750/80756852-85a50980-8b33-11ea-9df7-1bea39a845a3.png)



Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->