### PR TITLE
Support environment variable for global.external_labels

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -667,6 +668,15 @@ func TestLoadConfig(t *testing.T) {
 
 	expectedConf.original = c.original
 	testutil.Equals(t, expectedConf, c)
+}
+
+func TestExternalLabelValueFromEnv(t *testing.T) {
+	defer os.Unsetenv("envbar")
+	expectedValue := "envbar"
+	os.Setenv("bar", expectedValue)
+	c, err := LoadFile("testdata/external_label_value_from_env.yaml")
+	testutil.Ok(t, err)
+	testutil.Equals(t, expectedValue, c.GlobalConfig.ExternalLabels.Get("foo"))
 }
 
 func TestScrapeIntervalLarger(t *testing.T) {

--- a/config/testdata/external_label_value_from_env.yaml
+++ b/config/testdata/external_label_value_from_env.yaml
@@ -1,0 +1,3 @@
+global:
+  external_labels:
+    foo: $bar


### PR DESCRIPTION
Prometheus team declined to enable environment variable support in config file due to security concerns. However, it is not convenient when deploy Prometheus HA cluster. For example, deploying 3 replicas of prometheus and remote_write to cortex. Cortex will perform de-duplication based on external labels.

This change will enable environment variable expanding only for global.external_labels, so that the security risk is minimized, and deployment convenience is satisfied.

How to use:
In prometheus configuration file, you can have the following:

```
global:
  external_labels:
    __replica__: $POD_NAME

```
$POD_NAME will be replaced by environment variable value.