### PR TITLE
cleanup: remove unnacessary nil check before range

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -302,11 +302,9 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 				labels[azureLabelMachineScaleSet] = model.LabelValue(vm.ScaleSet)
 			}
 
-			if vm.Tags != nil {
-				for k, v := range vm.Tags {
-					name := strutil.SanitizeLabelName(k)
-					labels[azureLabelMachineTag+model.LabelName(name)] = model.LabelValue(*v)
-				}
+			for k, v := range vm.Tags {
+				name := strutil.SanitizeLabelName(k)
+				labels[azureLabelMachineTag+model.LabelName(name)] = model.LabelValue(*v)
 			}
 
 			// Get the IP address information via separate call to the network provider.


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
Map or slice nil check before range is not necessary, so let's remove the if..nil check.