### PR TITLE
promql/engine: Introduce SelectManager to control execution of .Select requests

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -210,6 +210,20 @@ func contextErr(err error, env string) error {
 	}
 }
 
+// Selector handles execution of the Selects against a Querier.
+type Selector interface {
+	// Select adds given select request to selector.
+	Select(selectRequest func() (storage.Warnings, error)) error
+
+	// Run processes the aggregated requests. Should only be called once.
+	Run(ctx context.Context) (storage.Warnings, error)
+}
+
+// A SelectManager produces a Selector to used per query.
+type SelectManager interface {
+	NewSelector() Selector
+}
+
 // EngineOpts contains configuration options used when creating a new Engine.
 type EngineOpts struct {
 	Logger             log.Logger
@@ -220,6 +234,9 @@ type EngineOpts struct {
 	// LookbackDelta determines the time since the last sample after which a time
 	// series is considered stale.
 	LookbackDelta time.Duration
+	SelectManager SelectManager
+	// MaxConcurrentSelect determines the maximum number of concurrent Selects per query.
+	MaxConcurrentSelect int
 }
 
 // Engine handles the lifetime of queries from beginning to end.
@@ -233,6 +250,7 @@ type Engine struct {
 	queryLogger        QueryLogger
 	queryLoggerLock    sync.RWMutex
 	lookbackDelta      time.Duration
+	selectManager      SelectManager
 }
 
 // NewEngine returns a new engine.
@@ -313,6 +331,14 @@ func NewEngine(opts EngineOpts) *Engine {
 		}
 	}
 
+	if opts.SelectManager == nil {
+		if opts.MaxConcurrentSelect > 1 {
+			opts.SelectManager = NewConcurrentSelectManager(opts.MaxConcurrentSelect)
+		} else {
+			opts.SelectManager = NewSequentialSelectManager()
+		}
+	}
+
 	if opts.Reg != nil {
 		opts.Reg.MustRegister(
 			metrics.currentQueries,
@@ -333,6 +359,7 @@ func NewEngine(opts EngineOpts) *Engine {
 		maxSamplesPerQuery: opts.MaxSamples,
 		activeQueryTracker: opts.ActiveQueryTracker,
 		lookbackDelta:      opts.LookbackDelta,
+		selectManager:      opts.SelectManager,
 	}
 }
 
@@ -654,13 +681,10 @@ func (ng *Engine) populateSeries(ctx context.Context, querier storage.Querier, s
 		// The evaluation of the VectorSelector inside then evaluates the given range and unsets
 		// the variable.
 		evalRange time.Duration
-		warnings  storage.Warnings
-		err       error
+		selector  = ng.selectManager.NewSelector()
 	)
 
 	parser.Inspect(s.Expr, func(node parser.Node, path []parser.Node) error {
-		var set storage.SeriesSet
-		var wrn storage.Warnings
 		hints := &storage.SelectHints{
 			Start: timestamp.FromTime(s.Start),
 			End:   timestamp.FromTime(s.End),
@@ -695,20 +719,25 @@ func (ng *Engine) populateSeries(ctx context.Context, querier storage.Querier, s
 				hints.End = hints.End - offsetMilliseconds
 			}
 
-			set, wrn, err = querier.Select(false, hints, n.LabelMatchers...)
-			warnings = append(warnings, wrn...)
-			if err != nil {
-				level.Error(ng.logger).Log("msg", "error selecting series set", "err", err)
+			if err := selector.Select(func() (storage.Warnings, error) {
+				set, wrn, err := querier.Select(false, hints, n.LabelMatchers...)
+				if err != nil {
+					level.Error(ng.logger).Log("msg", "error selecting series set", "err", err)
+					return wrn, err
+				}
+				n.UnexpandedSeriesSet = set
+
+				return wrn, nil
+			}); err != nil {
+				level.Error(ng.logger).Log("msg", "error submitting series set for select", "err", err)
 				return err
 			}
-			n.UnexpandedSeriesSet = set
-
 		case *parser.MatrixSelector:
 			evalRange = n.Range
 		}
 		return nil
 	})
-	return warnings, err
+	return selector.Run(ctx)
 }
 
 // extractFuncFromPath walks up the path and searches for the first instance of

--- a/promql/select_manager.go
+++ b/promql/select_manager.go
@@ -1,0 +1,121 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/prometheus/pkg/gate"
+	"github.com/prometheus/prometheus/storage"
+)
+
+type selectManagerFunc func() Selector
+
+func (f selectManagerFunc) NewSelector() Selector { return f() }
+
+// A sequentialSelector processes added select requests immediately by the given order.
+type sequentialSelector struct {
+	warnings storage.Warnings
+	err      error
+}
+
+// NewSequentialSelectManager creates a new sequential select manager.
+func NewSequentialSelectManager() SelectManager {
+	return selectManagerFunc(func() Selector { return &sequentialSelector{} })
+}
+
+func (qm *sequentialSelector) Select(req func() (storage.Warnings, error)) error {
+	wrn, err := req()
+	qm.warnings, qm.err = append(qm.warnings, wrn...), err
+	return err
+}
+
+func (qm *sequentialSelector) Run(ctx context.Context) (storage.Warnings, error) {
+	warnings, err := qm.warnings, qm.err
+	qm.warnings, qm.err = nil, nil
+	return warnings, err
+}
+
+// A concurrentSelector processes added select requests concurrently.
+// It limits amount of requests executed at the same time by the given concurrency limit.
+type concurrentSelector struct {
+	selectGate *gate.Gate
+	requests   []func() (storage.Warnings, error)
+}
+
+// NewConcurrentSelectManager creates a new concurrent select manager.
+func NewConcurrentSelectManager(concurrencyLimit int) SelectManager {
+	return selectManagerFunc(func() Selector { return &concurrentSelector{selectGate: gate.New(concurrencyLimit)} })
+}
+
+func (qm *concurrentSelector) Select(req func() (storage.Warnings, error)) error {
+	qm.requests = append(qm.requests, req)
+	return nil
+}
+
+func (qm *concurrentSelector) Run(ctx context.Context) (storage.Warnings, error) {
+	defer func() { qm.requests = nil }()
+
+	reqSize := len(qm.requests)
+	if reqSize == 0 {
+		return nil, nil
+	}
+	if reqSize == 1 {
+		return qm.requests[0]()
+	}
+
+	type response struct {
+		warnings storage.Warnings
+		err      error
+	}
+
+	var (
+		wg        sync.WaitGroup
+		responses = make(chan response, reqSize)
+	)
+
+	wg.Add(reqSize)
+	for _, req := range qm.requests {
+		go func(req func() (storage.Warnings, error)) {
+			defer wg.Done()
+
+			if err := qm.selectGate.Start(ctx); err != nil {
+				responses <- response{nil, err}
+				return
+			}
+			defer qm.selectGate.Done()
+
+			if wrn, err := req(); err != nil {
+				responses <- response{wrn, err}
+			}
+		}(req)
+	}
+	wg.Wait()
+	close(responses)
+
+	var (
+		warnings storage.Warnings
+		err      error
+	)
+	for res := range responses {
+		if res.warnings != nil {
+			warnings = append(warnings, res.warnings...)
+		}
+		if err != nil {
+			err = res.err
+		}
+	}
+	return warnings, err
+}

--- a/storage/fanout_test.go
+++ b/storage/fanout_test.go
@@ -342,7 +342,7 @@ func TestMergeChunkQuerierWithNoVerticalChunkSeriesMerger(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var qs []ChunkQuerier
 			for _, in := range tc.chkQuerierSeries {
-				qs = append(qs, &mockChunkQurier{toReturn: in})
+				qs = append(qs, &mockChunkQuerier{toReturn: in})
 			}
 			qs = append(qs, tc.extraQueriers...)
 
@@ -387,7 +387,7 @@ func (m *mockQuerier) Select(sortSeries bool, _ *SelectHints, _ ...*labels.Match
 	return NewMockSeriesSet(cpy...), nil, nil
 }
 
-type mockChunkQurier struct {
+type mockChunkQuerier struct {
 	baseQuerier
 
 	toReturn []ChunkSeries
@@ -401,7 +401,7 @@ func (a chunkSeriesByLabel) Less(i, j int) bool {
 	return labels.Compare(a[i].Labels(), a[j].Labels()) < 0
 }
 
-func (m *mockChunkQurier) Select(sortSeries bool, _ *SelectHints, _ ...*labels.Matcher) (ChunkSeriesSet, Warnings, error) {
+func (m *mockChunkQuerier) Select(sortSeries bool, _ *SelectHints, _ ...*labels.Matcher) (ChunkSeriesSet, Warnings, error) {
 	cpy := make([]ChunkSeries, len(m.toReturn))
 	copy(cpy, m.toReturn)
 	if sortSeries {


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

This PR attempts to fix https://github.com/prometheus/prometheus/issues/6878

Currently, Prometheus executes PromQL “.Select” queries sequentially. Particularly for the remote storages, this implementation wastes CPU cycles while waiting for independent queries.

Requirements that gathered from the comments of https://github.com/prometheus/prometheus/issues/6878 and https://github.com/prometheus/prometheus/pull/6887.

#### Requirements
* Should NOT use all the available CPU.
  * Limit concurrency
* PromQL should not care about how the querier is implemented, it should always be the same logic.
* Should avoid introducing changes to LOCAL storage.
* Should avoid spawning goroutines if there is just a single selector.

This PR fulfils the requirements listed above by introducing a small component to regulate select requests against querier.

It still misses tests and also I'm gonna add benchmarks.

P.S: Regarding https://github.com/prometheus/prometheus/pull/7089#issuecomment-617132242 after checking out the comments, I decided a design doc might not be needed.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

### Benchmarks

#### Old
<details>Master
<p>

```
goos: darwin
goarch: amd64
pkg: github.com/prometheus/prometheus/promql
BenchmarkRangeQuery/expr=a_one,steps=1-12         	   75193	     17112 ns/op	    5235 B/op	     101 allocs/op
BenchmarkRangeQuery/expr=a_one,steps=10-12        	   74503	     17711 ns/op	    5235 B/op	     101 allocs/op
BenchmarkRangeQuery/expr=a_one,steps=100-12       	   50686	     23400 ns/op	    5394 B/op	     103 allocs/op
BenchmarkRangeQuery/expr=a_one,steps=1000-12      	   12404	     80742 ns/op	    7238 B/op	     114 allocs/op
BenchmarkRangeQuery/expr=a_ten,steps=1-12         	   13332	     89027 ns/op	   12116 B/op	     195 allocs/op
BenchmarkRangeQuery/expr=a_ten,steps=10-12        	   13372	     90231 ns/op	   12116 B/op	     195 allocs/op
BenchmarkRangeQuery/expr=a_ten,steps=100-12       	    7586	    166988 ns/op	   12998 B/op	     206 allocs/op
BenchmarkRangeQuery/expr=a_ten,steps=1000-12      	    1590	    741547 ns/op	   21344 B/op	     289 allocs/op
BenchmarkRangeQuery/expr=a_hundred,steps=1-12     	    1431	    854308 ns/op	   79258 B/op	    1098 allocs/op
BenchmarkRangeQuery/expr=a_hundred,steps=10-12    	    1293	    877883 ns/op	   79518 B/op	    1098 allocs/op
BenchmarkRangeQuery/expr=a_hundred,steps=100-12   	     759	   1609190 ns/op	   87226 B/op	    1199 allocs/op
BenchmarkRangeQuery/expr=a_hundred,steps=1000-12  	     162	   7309513 ns/op	  160699 B/op	    2002 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1-12         	   59626	     19912 ns/op	    6234 B/op	     132 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10-12        	   58015	     20682 ns/op	    6236 B/op	     132 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=100-12       	   33399	     35487 ns/op	    6395 B/op	     134 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1000-12      	    7819	    162192 ns/op	    8204 B/op	     144 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1-12         	   10000	    102998 ns/op	   16344 B/op	     263 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10-12        	   10000	    109723 ns/op	   16344 B/op	     263 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=100-12       	    4804	    257045 ns/op	   17227 B/op	     274 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1000-12      	     793	   1497840 ns/op	   25053 B/op	     347 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1-12     	    1270	    973073 ns/op	  115238 B/op	    1532 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10-12    	    1137	   1031542 ns/op	  115289 B/op	    1532 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=100-12   	     474	   2519348 ns/op	  123282 B/op	    1633 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1000-12  	      81	  14960258 ns/op	  192899 B/op	    2337 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10000-12     	     771	   1515496 ns/op	   40897 B/op	     273 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10000-12     	      82	  15242966 ns/op	  155918 B/op	    1306 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10000-12 	       7	 153293705 ns/op	 1301545 B/op	   11669 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12         	    1375	    867148 ns/op	 1178077 B/op	     270 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12        	     897	   1369617 ns/op	 1179225 B/op	     270 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12       	     199	   6211680 ns/op	 1180731 B/op	     271 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12      	      22	  52517652 ns/op	 1195297 B/op	     278 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12         	     180	   6701682 ns/op	 1247882 B/op	    1061 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12        	     100	  11082399 ns/op	 1249110 B/op	    1058 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12       	      20	  57866242 ns/op	 1227512 B/op	    1065 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12      	       2	 542526223 ns/op	 1279420 B/op	    1141 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12     	      18	  65587749 ns/op	 1933669 B/op	    8901 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12    	      10	 112111123 ns/op	 1935263 B/op	    8898 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12   	       2	 583285199 ns/op	 1952756 B/op	    9005 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12  	       1	5093915142 ns/op	 4953760 B/op	   10061 allocs/op
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1-12                        	    1728	    685480 ns/op	  548533 B/op	     222 allocs/op
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=10-12                       	    1450	    837450 ns/op	  548793 B/op	     222 allocs/op
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=100-12                      	     500	   2397921 ns/op	  549249 B/op	     223 allocs/op
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1000-12                     	      64	  17995964 ns/op	  557419 B/op	     230 allocs/op
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1-12                        	     199	   5945700 ns/op	  620237 B/op	    1010 allocs/op
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=10-12                       	     160	   7683115 ns/op	  620504 B/op	    1010 allocs/op
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=100-12                      	      51	  22780568 ns/op	  631275 B/op	    1021 allocs/op
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1000-12                     	       6	 179553652 ns/op	  740890 B/op	    1098 allocs/op
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1-12                    	      19	  58537583 ns/op	 1338492 B/op	    8851 allocs/op
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=10-12                   	      15	  73250833 ns/op	 1342248 B/op	    8851 allocs/op
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=100-12                  	       5	 228778356 ns/op	 1429876 B/op	    8955 allocs/op
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                 	       1	1712454614 ns/op	 4703576 B/op	    9956 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1-12                           	    1608	    660447 ns/op	  548736 B/op	     222 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=10-12                          	    1594	    756493 ns/op	  548283 B/op	     222 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=100-12                         	     698	   1723085 ns/op	  549081 B/op	     223 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1000-12                        	     100	  11224424 ns/op	  555193 B/op	     230 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1-12                           	     205	   5753162 ns/op	  616240 B/op	    1010 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=10-12                          	     180	   6672029 ns/op	  620452 B/op	    1010 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=100-12                         	      78	  16072713 ns/op	  632859 B/op	    1020 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1000-12                        	      10	 110484667 ns/op	  624317 B/op	    1091 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1-12                       	      21	  57354263 ns/op	 1302662 B/op	    8849 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=10-12                      	      18	  66431425 ns/op	 1305330 B/op	    8851 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=100-12                     	       7	 160115955 ns/op	 1315096 B/op	    8957 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                    	       1	1106999909 ns/op	 4718664 B/op	    9959 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12               	    1812	    644683 ns/op	  548963 B/op	     222 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12              	    1803	    672138 ns/op	  548655 B/op	     222 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12             	    1411	    854606 ns/op	  550780 B/op	     223 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12            	     441	   2567926 ns/op	  565235 B/op	     230 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12               	     214	   5675795 ns/op	  616283 B/op	    1009 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12              	     208	   5742605 ns/op	  617538 B/op	    1009 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12             	     158	   7548893 ns/op	  642463 B/op	    1019 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12            	      48	  24766373 ns/op	  801943 B/op	    1089 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12           	      21	  54814914 ns/op	 1302817 B/op	    8842 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12          	      20	  56648193 ns/op	 1348786 B/op	    8843 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12         	      15	  73846118 ns/op	 1532006 B/op	    8945 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12        	       5	 265731611 ns/op	 3147916 B/op	    9648 allocs/op
BenchmarkRangeQuery/expr=-a_one,steps=1-12                                    	   69477	     16949 ns/op	    5858 B/op	     113 allocs/op
BenchmarkRangeQuery/expr=-a_one,steps=10-12                                   	   69741	     16884 ns/op	    5858 B/op	     113 allocs/op
BenchmarkRangeQuery/expr=-a_one,steps=100-12                                  	   48648	     24271 ns/op	    6019 B/op	     115 allocs/op
BenchmarkRangeQuery/expr=-a_one,steps=1000-12                                 	   14346	     83263 ns/op	    7861 B/op	     126 allocs/op
BenchmarkRangeQuery/expr=-a_ten,steps=1-12                                    	   12710	     92901 ns/op	   15958 B/op	     244 allocs/op
BenchmarkRangeQuery/expr=-a_ten,steps=10-12                                   	   12649	     94328 ns/op	   15959 B/op	     244 allocs/op
BenchmarkRangeQuery/expr=-a_ten,steps=100-12                                  	    5576	    195339 ns/op	   16842 B/op	     255 allocs/op
BenchmarkRangeQuery/expr=-a_ten,steps=1000-12                                 	    1195	    953016 ns/op	   25159 B/op	     338 allocs/op
BenchmarkRangeQuery/expr=-a_hundred,steps=1-12                                	    1322	    906496 ns/op	  114733 B/op	    1513 allocs/op
BenchmarkRangeQuery/expr=-a_hundred,steps=10-12                               	    1284	    934493 ns/op	  114722 B/op	    1513 allocs/op
BenchmarkRangeQuery/expr=-a_hundred,steps=100-12                              	     711	   1654612 ns/op	  122818 B/op	    1614 allocs/op
BenchmarkRangeQuery/expr=-a_hundred,steps=1000-12                             	     162	   7413050 ns/op	  196071 B/op	    2417 allocs/op
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1-12                             	   39568	     29872 ns/op	   10603 B/op	     177 allocs/op
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10-12                            	   34824	     35231 ns/op	   11755 B/op	     213 allocs/op
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=100-12                           	   12328	     98679 ns/op	   23598 B/op	     577 allocs/op
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1000-12                          	    1797	    690077 ns/op	  142490 B/op	    4199 allocs/op
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1-12                             	    6111	    196129 ns/op	   34075 B/op	     418 allocs/op
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10-12                            	    4671	    241691 ns/op	   36810 B/op	     465 allocs/op
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=100-12                           	    1467	    836998 ns/op	   66053 B/op	     949 allocs/op
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1000-12                          	     186	   6439008 ns/op	  353251 B/op	    5724 allocs/op
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                     	     626	   1894298 ns/op	  273610 B/op	    2731 allocs/op
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                    	     506	   2390358 ns/op	  297081 B/op	    2856 allocs/op
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                   	     136	   9055245 ns/op	  544205 B/op	    4288 allocs/op
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                  	      15	  72868190 ns/op	 3011253 B/op	   18161 allocs/op
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10000-12                         	     177	   6682100 ns/op	 1360576 B/op	   40449 allocs/op
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10000-12                         	      18	  63847198 ns/op	 3460563 B/op	   53916 allocs/op
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                 	       2	 705876462 ns/op	28140180 B/op	  160997 allocs/op
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12            	   19167	     61298 ns/op	   18611 B/op	     259 allocs/op
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12           	   18962	     64943 ns/op	   19761 B/op	     295 allocs/op
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12          	   12788	     98916 ns/op	   31442 B/op	     657 allocs/op
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12         	    2928	    368821 ns/op	  148577 B/op	    4268 allocs/op
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12            	    6114	    186729 ns/op	   33838 B/op	     423 allocs/op
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12           	    5203	    208786 ns/op	   35017 B/op	     459 allocs/op
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12          	    2397	    510641 ns/op	   47968 B/op	     836 allocs/op
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12         	     374	   3324862 ns/op	  176376 B/op	    4562 allocs/op
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12    	     786	   1430395 ns/op	  176319 B/op	    1873 allocs/op
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12   	     675	   1660998 ns/op	  197480 B/op	    2051 allocs/op
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12  	     232	   5034437 ns/op	  422543 B/op	    3986 allocs/op
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12 	      32	  36894843 ns/op	 2662425 B/op	   23003 allocs/op
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12             	   19612	     61186 ns/op	   18683 B/op	     261 allocs/op
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12            	   18512	     65295 ns/op	   19840 B/op	     297 allocs/op
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12           	   10000	    105099 ns/op	   31543 B/op	     659 allocs/op
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12          	    2547	    500336 ns/op	  148696 B/op	    4270 allocs/op
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12             	    6331	    191200 ns/op	   34920 B/op	     432 allocs/op
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12            	    5515	    225364 ns/op	   38984 B/op	     488 allocs/op
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12           	    1982	    626781 ns/op	   81320 B/op	    1060 allocs/op
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12          	     266	   4803318 ns/op	  503720 B/op	    6739 allocs/op
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12     	     804	   1468828 ns/op	  186059 B/op	    1943 allocs/op
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12    	     676	   1830560 ns/op	  229726 B/op	    2202 allocs/op
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12   	     177	   6209363 ns/op	  679296 B/op	    4920 allocs/op
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12  	      22	  49143078 ns/op	 5171197 B/op	   31890 allocs/op
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12         	   19299	     62572 ns/op	   18684 B/op	     261 allocs/op
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12        	   18265	     65251 ns/op	   19842 B/op	     297 allocs/op
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12       	   10000	    109585 ns/op	   31535 B/op	     659 allocs/op
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12      	    2090	    493761 ns/op	  148687 B/op	    4270 allocs/op
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12         	    5968	    187582 ns/op	   33841 B/op	     423 allocs/op
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12        	    5698	    205004 ns/op	   34993 B/op	     459 allocs/op
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12       	    2446	    494279 ns/op	   47882 B/op	     836 allocs/op
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12      	     358	   3271752 ns/op	  176232 B/op	    4562 allocs/op
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12 	     820	   1438851 ns/op	  176409 B/op	    1874 allocs/op
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12         	     696	   1685799 ns/op	  197706 B/op	    2052 allocs/op
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12        	     224	   5089465 ns/op	  422752 B/op	    3986 allocs/op
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12       	      32	  36571269 ns/op	 2662665 B/op	   23014 allocs/op
BenchmarkRangeQuery/expr=abs(a_one),steps=1-12                                         	   60901	     19280 ns/op	    6803 B/op	     131 allocs/op
BenchmarkRangeQuery/expr=abs(a_one),steps=10-12                                        	   56594	     21750 ns/op	    7091 B/op	     140 allocs/op
BenchmarkRangeQuery/expr=abs(a_one),steps=100-12                                       	   23624	     49061 ns/op	   10132 B/op	     232 allocs/op
BenchmarkRangeQuery/expr=abs(a_one),steps=1000-12                                      	    4135	    321226 ns/op	   40782 B/op	    1143 allocs/op
BenchmarkRangeQuery/expr=abs(a_ten),steps=1-12                                         	   10000	    103098 ns/op	   20571 B/op	     274 allocs/op
BenchmarkRangeQuery/expr=abs(a_ten),steps=10-12                                        	    9520	    134193 ns/op	   22332 B/op	     293 allocs/op
BenchmarkRangeQuery/expr=abs(a_ten),steps=100-12                                       	    2823	    436456 ns/op	   40803 B/op	     491 allocs/op
BenchmarkRangeQuery/expr=abs(a_ten),steps=1000-12                                      	     403	   3049292 ns/op	  224998 B/op	    2453 allocs/op
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1-12                                     	    1286	    968146 ns/op	  157521 B/op	    1650 allocs/op
BenchmarkRangeQuery/expr=abs(a_hundred),steps=10-12                                    	     963	   1218998 ns/op	  172736 B/op	    1725 allocs/op
BenchmarkRangeQuery/expr=abs(a_hundred),steps=100-12                                   	     279	   4084301 ns/op	  333050 B/op	    2572 allocs/op
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1000-12                                  	      37	  32801575 ns/op	 1929678 B/op	   10857 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12      	   41626	     29255 ns/op	   12052 B/op	     220 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12     	   36237	     32938 ns/op	   13493 B/op	     265 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12    	   14623	     78162 ns/op	   28055 B/op	     717 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12   	    2174	    513416 ns/op	  173954 B/op	    5228 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12      	    9890	    119403 ns/op	   27474 B/op	     392 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12     	    7148	    145822 ns/op	   30382 B/op	     447 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12    	    2728	    476788 ns/op	   60360 B/op	    1005 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12   	     289	   3695293 ns/op	  359715 B/op	    6566 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12  	    1195	   1024405 ns/op	  180305 B/op	    2128 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12 	     946	   1323601 ns/op	  196640 B/op	    2239 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12         	     256	   4860746 ns/op	  368565 B/op	    3447 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12        	      33	  38193246 ns/op	 2080472 B/op	   15332 allocs/op
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                      	   48078	     27482 ns/op	    9307 B/op	     180 allocs/op
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                     	   38424	     40218 ns/op	   11324 B/op	     243 allocs/op
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                    	   10000	    101768 ns/op	   31650 B/op	     875 allocs/op
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                   	    1628	    764907 ns/op	  235147 B/op	    7186 allocs/op
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                      	   10000	    127185 ns/op	   24327 B/op	     341 allocs/op
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                     	    7594	    160110 ns/op	   27816 B/op	     414 allocs/op
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                    	    2013	    568622 ns/op	   63577 B/op	    1152 allocs/op
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                   	     276	   4477548 ns/op	  420531 B/op	    8513 allocs/op
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                  	    1107	   1088987 ns/op	  173278 B/op	    1897 allocs/op
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                 	     865	   1426076 ns/op	  190275 B/op	    2026 allocs/op
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                	     216	   5633564 ns/op	  367797 B/op	    3415 allocs/op
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12               	      26	  44274002 ns/op	 2137169 B/op	   17097 allocs/op
BenchmarkRangeQuery/expr=sum(a_one),steps=1-12                                                  	   60732	     20218 ns/op	    7027 B/op	     133 allocs/op
BenchmarkRangeQuery/expr=sum(a_one),steps=10-12                                                 	   44919	     26624 ns/op	   10916 B/op	     187 allocs/op
BenchmarkRangeQuery/expr=sum(a_one),steps=100-12                                                	   12486	     92385 ns/op	   49964 B/op	     729 allocs/op
BenchmarkRangeQuery/expr=sum(a_one),steps=1000-12                                               	    1644	    708748 ns/op	  440653 B/op	    6140 allocs/op
BenchmarkRangeQuery/expr=sum(a_ten),steps=1-12                                                  	   12068	    100101 ns/op	   16100 B/op	     228 allocs/op
BenchmarkRangeQuery/expr=sum(a_ten),steps=10-12                                                 	   10000	    114408 ns/op	   19989 B/op	     282 allocs/op
BenchmarkRangeQuery/expr=sum(a_ten),steps=100-12                                                	    3778	    293258 ns/op	   59760 B/op	     833 allocs/op
BenchmarkRangeQuery/expr=sum(a_ten),steps=1000-12                                               	     732	   1625595 ns/op	  456957 B/op	    6316 allocs/op
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1-12                                              	    1297	    998156 ns/op	  102087 B/op	    1132 allocs/op
BenchmarkRangeQuery/expr=sum(a_hundred),steps=10-12                                             	    1135	    986585 ns/op	  105969 B/op	    1186 allocs/op
BenchmarkRangeQuery/expr=sum(a_hundred),steps=100-12                                            	     624	   1978931 ns/op	  152948 B/op	    1827 allocs/op
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1000-12                                           	      94	  11084491 ns/op	  615426 B/op	    8030 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                      	    9787	    118737 ns/op	   22877 B/op	     317 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                     	    6951	    171781 ns/op	   49121 B/op	     680 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                    	    1536	    808945 ns/op	  312511 B/op	    4322 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                   	     172	   6961705 ns/op	 2945800 B/op	   40708 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                      	    1232	    988175 ns/op	  129482 B/op	    1311 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                     	    1071	   1102517 ns/op	  158919 B/op	    1674 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                    	     369	   3618381 ns/op	  462010 B/op	    5416 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                   	      50	  24553892 ns/op	 3484184 B/op	   42596 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                  	      79	  15724508 ns/op	 1169685 B/op	   11216 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                 	      72	  16635238 ns/op	 1200225 B/op	   11579 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                	      28	  35779021 ns/op	 1582689 B/op	   16312 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                               	       6	 178452726 ns/op	 5327720 B/op	   61422 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                     	   10000	    101223 ns/op	   17221 B/op	     243 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                    	   10000	    116317 ns/op	   21974 B/op	     315 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                   	    3338	    324984 ns/op	   70462 B/op	    1047 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                  	     567	   2066329 ns/op	  554824 B/op	    8338 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                     	    1380	    902459 ns/op	  128906 B/op	    1304 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                    	    1160	   1038819 ns/op	  156177 B/op	    1638 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                   	     404	   3171627 ns/op	  437892 B/op	    5089 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                  	      52	  20562295 ns/op	 3246026 B/op	   39371 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                 	      88	  14939120 ns/op	 1230453 B/op	   11866 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                	      72	  16547652 ns/op	 1496531 B/op	   14754 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                               	      26	  41051778 ns/op	 4256891 B/op	   44729 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                              	       5	 224929912 ns/op	31747515 B/op	  342229 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                           	   10000	    113518 ns/op	   17157 B/op	     243 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                          	   10000	    109670 ns/op	   21620 B/op	     315 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                         	    4186	    291820 ns/op	   67229 B/op	    1047 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                        	     582	   1895855 ns/op	  522751 B/op	    8338 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                           	    1348	    887202 ns/op	  127613 B/op	    1304 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                          	    1186	    990004 ns/op	  149136 B/op	    1638 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                         	     436	   2742304 ns/op	  373191 B/op	    5089 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                        	      63	  18505075 ns/op	 2605338 B/op	   39366 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                       	      99	  14510233 ns/op	 1216247 B/op	   11866 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                      	      69	  16097944 ns/op	 1426954 B/op	   14752 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                     	      32	  37142925 ns/op	 3607589 B/op	   44716 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                    	       6	 198575008 ns/op	25333300 B/op	  342151 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                          	   10000	    110473 ns/op	   22174 B/op	     317 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                         	    7929	    159144 ns/op	   45248 B/op	     680 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                        	    1794	    700179 ns/op	  276946 B/op	    4322 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                       	     198	   5944707 ns/op	 2593631 B/op	   40709 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                          	    1359	    885627 ns/op	  128074 B/op	    1311 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                         	    1179	   1050636 ns/op	  151173 B/op	    1674 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                        	     409	   3063803 ns/op	  390818 B/op	    5415 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                       	      55	  22037596 ns/op	 2779159 B/op	   42593 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                      	      96	  14391988 ns/op	 1167800 B/op	   11216 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                     	      73	  15688536 ns/op	 1192101 B/op	   11580 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                    	      30	  34950532 ns/op	 1512319 B/op	   16311 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                   	       6	 177920331 ns/op	 4623725 B/op	   61441 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                           	   33250	     36542 ns/op	   12442 B/op	     234 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                          	   27996	     42769 ns/op	   13595 B/op	     270 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                         	   10000	    111796 ns/op	   25447 B/op	     634 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                        	    1623	    798612 ns/op	  144234 B/op	    4254 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                           	    5758	    212103 ns/op	   41427 B/op	     548 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                          	    4549	    272197 ns/op	   44183 B/op	     594 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                         	    1291	    960443 ns/op	   73188 B/op	    1078 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                        	     157	   7137449 ns/op	  363830 B/op	    5840 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                   	     577	   2032402 ns/op	  336829 B/op	    3589 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                  	     452	   2693146 ns/op	  360353 B/op	    3714 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                 	     100	  10015140 ns/op	  618198 B/op	    5177 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                	      14	  81418870 ns/op	 2956612 B/op	   18635 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                            	   51144	     23985 ns/op	    8045 B/op	     165 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                           	   39805	     30533 ns/op	   12227 B/op	     228 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                          	   10000	    103588 ns/op	   54171 B/op	     860 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                         	    1532	    794212 ns/op	  473875 B/op	    7170 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                            	   10000	    108832 ns/op	   20425 B/op	     299 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                           	   10000	    122530 ns/op	   24881 B/op	     371 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                          	    3099	    358701 ns/op	   70428 B/op	    1102 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                         	     456	   2508569 ns/op	  525099 B/op	    8375 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                        	    1256	    951221 ns/op	  138257 B/op	    1569 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                       	    1095	   1045434 ns/op	  142781 B/op	    1641 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                      	     421	   2913452 ns/op	  195550 B/op	    2462 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                     	      61	  19544100 ns/op	  711182 B/op	   10366 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12         	   26353	     44447 ns/op	   16579 B/op	     304 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12        	   18656	     62008 ns/op	   26091 B/op	     466 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12       	    4869	    251057 ns/op	  121532 B/op	    2090 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12      	     606	   2102108 ns/op	 1075926 B/op	   18310 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12         	    5972	    210063 ns/op	   41312 B/op	     572 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12        	    4989	    248839 ns/op	   51428 B/op	     752 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12       	    1465	    774955 ns/op	  153931 B/op	    2574 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12      	     220	   5597363 ns/op	 1178971 B/op	   20720 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12 	     561	   1923176 ns/op	  277040 B/op	    3112 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12         	     555	   2148189 ns/op	  287034 B/op	    3292 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12        	     202	   5852346 ns/op	  404396 B/op	    5294 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12       	      30	  38906522 ns/op	 1553883 B/op	   24703 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                             	   10000	    119043 ns/op	   23918 B/op	     343 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                            	    8348	    148202 ns/op	   25665 B/op	     397 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                           	    2598	    485019 ns/op	   43940 B/op	     949 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                          	     328	   3664572 ns/op	  226052 B/op	    6440 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                             	    1146	   1089682 ns/op	  190217 B/op	    1872 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                            	     908	   1428592 ns/op	  196085 B/op	    2017 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                           	     266	   4596340 ns/op	  262862 B/op	    3574 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                          	      32	  36031822 ns/op	  923843 B/op	   18935 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                         	      90	  16558090 ns/op	 1792987 B/op	   16982 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                        	      58	  19454975 ns/op	 1837754 B/op	   17990 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                       	      22	  49651640 ns/op	 2380294 B/op	   29204 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                      	       3	 372656625 ns/op	 7729061 B/op	  139155 allocs/op
BenchmarkParser/a-12                                                                                                     	 2396730	       497 ns/op	     168 B/op	       3 allocs/op
BenchmarkParser/metric-12                                                                                                	 2224965	       521 ns/op	     168 B/op	       3 allocs/op
BenchmarkParser/1-12                                                                                                     	 3290452	       373 ns/op	      32 B/op	       1 allocs/op
BenchmarkParser/1_>=_bool_1-12                                                                                           	 1000000	      1063 ns/op	     192 B/op	       4 allocs/op
BenchmarkParser/1_+_2/(3*1)-12                                                                                           	  554241	      2233 ns/op	     544 B/op	      11 allocs/op
BenchmarkParser/foo_or_bar-12                                                                                            	  989458	      1174 ns/op	     464 B/op	       8 allocs/op
BenchmarkParser/foo_and_bar_unless_baz_or_qux-12                                                                         	  458454	      2761 ns/op	    1056 B/op	      18 allocs/op
BenchmarkParser/bar_+_on(foo)_bla_/_on(baz,_buz)_group_right(test)_blub-12                                               	  330055	      3553 ns/op	     840 B/op	      17 allocs/op
BenchmarkParser/foo_/_ignoring(test,blub)_group_left(blub)_bar-12                                                        	  528046	      2430 ns/op	     528 B/op	      11 allocs/op
BenchmarkParser/foo_-_ignoring(test,blub)_group_right(bar,foo)_bar-12                                                    	  471001	      2779 ns/op	     560 B/op	      12 allocs/op
BenchmarkParser/foo{a="b",_foo!="bar",_test=~"test",_bar!~"baz"}-12                                                      	  146353	      8178 ns/op	    5866 B/op	      98 allocs/op
BenchmarkParser/min_over_time(rate(foo{bar="baz"}[2s])[5m:])[4m:3s]-12                                                   	  224312	      5437 ns/op	    1178 B/op	      28 allocs/op
BenchmarkParser/sum_without(and,_by,_avg,_count,_alert,_annotations)(some_metric)_[30m:10s]-12                           	  273036	      5022 ns/op	     835 B/op	      15 allocs/op
BenchmarkParser/(_(should_fail)-12                                                                                       	  349974	      3251 ns/op	     448 B/op	       6 allocs/op
BenchmarkParser/}_(should_fail)-12                                                                                       	  445464	      2718 ns/op	     452 B/op	       7 allocs/op
BenchmarkParser/1_or_1_(should_fail)-12                                                                                  	  424410	      3064 ns/op	     680 B/op	      11 allocs/op
BenchmarkParser/1_or_on(bar)_foo_(should_fail)-12                                                                        	  227925	      5405 ns/op	    1329 B/op	      19 allocs/op
BenchmarkParser/foo_unless_on(bar)_group_left(baz)_bar_(should_fail)-12                                                  	  188469	      6494 ns/op	    1449 B/op	      22 allocs/op
BenchmarkParser/test[5d]_OFFSET_10s_[10m:5s]_(should_fail)-12                                                            	  125628	      9201 ns/op	    1582 B/op	      46 allocs/op
PASS
ok  	github.com/prometheus/prometheus/promql	448.249s

```

</p>
</details>

#### New
<details>New
<p>

```
goos: darwin
goarch: amd64
pkg: github.com/prometheus/prometheus/promql
BenchmarkRangeQuery/expr=a_one,steps=1-12         	   75003	     16011 ns/op	    5284 B/op	     101 allocs/op
BenchmarkRangeQuery/expr=a_one,steps=10-12        	   73868	     15971 ns/op	    5283 B/op	     101 allocs/op
BenchmarkRangeQuery/expr=a_one,steps=100-12       	   49726	     23700 ns/op	    5443 B/op	     103 allocs/op
BenchmarkRangeQuery/expr=a_one,steps=1000-12      	   14360	     83596 ns/op	    7285 B/op	     114 allocs/op
BenchmarkRangeQuery/expr=a_ten,steps=1-12         	   13237	     88245 ns/op	   12163 B/op	     195 allocs/op
BenchmarkRangeQuery/expr=a_ten,steps=10-12        	   13759	     88163 ns/op	   12163 B/op	     195 allocs/op
BenchmarkRangeQuery/expr=a_ten,steps=100-12       	    7765	    159867 ns/op	   13045 B/op	     206 allocs/op
BenchmarkRangeQuery/expr=a_ten,steps=1000-12      	    1682	    723450 ns/op	   21363 B/op	     289 allocs/op
BenchmarkRangeQuery/expr=a_hundred,steps=1-12     	    1322	    847492 ns/op	   79530 B/op	    1098 allocs/op
BenchmarkRangeQuery/expr=a_hundred,steps=10-12    	    1400	    831378 ns/op	   79539 B/op	    1098 allocs/op
BenchmarkRangeQuery/expr=a_hundred,steps=100-12   	     789	   1550858 ns/op	   87275 B/op	    1199 allocs/op
BenchmarkRangeQuery/expr=a_hundred,steps=1000-12  	     166	   7083243 ns/op	  160412 B/op	    2002 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1-12         	   61520	     19702 ns/op	    6284 B/op	     132 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10-12        	   59311	     20119 ns/op	    6284 B/op	     132 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=100-12       	   34675	     34025 ns/op	    6442 B/op	     134 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1000-12      	    8080	    158471 ns/op	    8246 B/op	     144 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1-12         	   12121	     99178 ns/op	   16399 B/op	     263 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10-12        	   10000	    106270 ns/op	   16400 B/op	     263 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=100-12       	    5041	    249124 ns/op	   17290 B/op	     274 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1000-12      	     835	   1483978 ns/op	   25100 B/op	     347 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1-12     	    1221	    943626 ns/op	  115257 B/op	    1532 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10-12    	    1191	   1000300 ns/op	  115326 B/op	    1532 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=100-12   	     496	   2453279 ns/op	  123330 B/op	    1633 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1000-12  	      81	  14921061 ns/op	  192917 B/op	    2336 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10000-12     	     727	   1505772 ns/op	   40891 B/op	     273 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10000-12     	      73	  15073879 ns/op	  155770 B/op	    1306 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10000-12 	       7	 152519036 ns/op	 1272133 B/op	   11666 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12         	    1392	    851987 ns/op	 1178906 B/op	     270 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12        	     925	   1312267 ns/op	 1178687 B/op	     270 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12       	     204	   5879521 ns/op	 1180956 B/op	     271 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12      	      22	  52572901 ns/op	 1197984 B/op	     278 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12         	     181	   6667296 ns/op	 1247235 B/op	    1061 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12        	     100	  11053190 ns/op	 1249181 B/op	    1058 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12       	      20	  57439308 ns/op	 1227585 B/op	    1065 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12      	       2	 520221767 ns/op	 1243300 B/op	    1138 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12     	      18	  64321834 ns/op	 1938476 B/op	    8902 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12    	      10	 110702641 ns/op	 1943703 B/op	    8901 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12   	       2	 579204044 ns/op	 1952964 B/op	    9011 allocs/op
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12  	       1	5127091023 ns/op	 5013200 B/op	   10065 allocs/op
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1-12                        	    1641	    688611 ns/op	  548837 B/op	     222 allocs/op
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=10-12                       	    1450	    827196 ns/op	  549106 B/op	     222 allocs/op
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=100-12                      	     507	   2354067 ns/op	  550214 B/op	     223 allocs/op
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1000-12                     	      70	  17678273 ns/op	  557114 B/op	     230 allocs/op
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1-12                        	     206	   5788050 ns/op	  619323 B/op	    1010 allocs/op
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=10-12                       	     162	   7478489 ns/op	  616096 B/op	    1010 allocs/op
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=100-12                      	      54	  22951726 ns/op	  629732 B/op	    1020 allocs/op
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1000-12                     	       6	 174855793 ns/op	  740913 B/op	    1097 allocs/op
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1-12                    	      18	  57800341 ns/op	 1307601 B/op	    8850 allocs/op
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=10-12                   	      15	  74439639 ns/op	 1347616 B/op	    8851 allocs/op
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=100-12                  	       5	 222856734 ns/op	 1434564 B/op	    8955 allocs/op
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                 	       1	1742876241 ns/op	 4753672 B/op	    9956 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1-12                           	    1791	    656508 ns/op	  548270 B/op	     222 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=10-12                          	    1610	    753338 ns/op	  548289 B/op	     222 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=100-12                         	     717	   1699937 ns/op	  549019 B/op	     223 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1000-12                        	     100	  11239359 ns/op	  548848 B/op	     230 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1-12                           	     208	   5674797 ns/op	  619691 B/op	    1010 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=10-12                          	     180	   6655413 ns/op	  616542 B/op	    1010 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=100-12                         	      75	  16141197 ns/op	  618315 B/op	    1021 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1000-12                        	      10	 115776369 ns/op	  632708 B/op	    1093 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1-12                       	      21	  57175300 ns/op	 1337390 B/op	    8852 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=10-12                      	      18	  66088968 ns/op	 1305334 B/op	    8851 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=100-12                     	       7	 159049483 ns/op	 1410515 B/op	    8956 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                    	       1	1098159846 ns/op	 4702024 B/op	    9953 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12               	    1819	    637595 ns/op	  548795 B/op	     222 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12              	    1860	    657933 ns/op	  549378 B/op	     222 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12             	    1454	    837495 ns/op	  550487 B/op	     223 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12            	     480	   2531153 ns/op	  566437 B/op	     230 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12               	     216	   5542614 ns/op	  619236 B/op	    1009 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12              	     210	   5655371 ns/op	  620941 B/op	    1009 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12             	     160	   7437740 ns/op	  638990 B/op	    1019 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12            	      48	  24617864 ns/op	  802869 B/op	    1090 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12           	      21	  54776882 ns/op	 1302865 B/op	    8842 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12          	      20	  56418999 ns/op	 1317379 B/op	    8842 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12         	      15	  73537492 ns/op	 1529285 B/op	    8944 allocs/op
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12        	       4	 261962628 ns/op	 3192190 B/op	    9652 allocs/op
BenchmarkRangeQuery/expr=-a_one,steps=1-12                                    	   69793	     16406 ns/op	    5906 B/op	     113 allocs/op
BenchmarkRangeQuery/expr=-a_one,steps=10-12                                   	   71355	     16535 ns/op	    5906 B/op	     113 allocs/op
BenchmarkRangeQuery/expr=-a_one,steps=100-12                                  	   48724	     24060 ns/op	    6066 B/op	     115 allocs/op
BenchmarkRangeQuery/expr=-a_one,steps=1000-12                                 	   14437	     87915 ns/op	    7912 B/op	     126 allocs/op
BenchmarkRangeQuery/expr=-a_ten,steps=1-12                                    	   13012	     92165 ns/op	   16007 B/op	     244 allocs/op
BenchmarkRangeQuery/expr=-a_ten,steps=10-12                                   	   12571	     94115 ns/op	   16007 B/op	     244 allocs/op
BenchmarkRangeQuery/expr=-a_ten,steps=100-12                                  	    7326	    165313 ns/op	   16888 B/op	     255 allocs/op
BenchmarkRangeQuery/expr=-a_ten,steps=1000-12                                 	    1606	    747554 ns/op	   25222 B/op	     338 allocs/op
BenchmarkRangeQuery/expr=-a_hundred,steps=1-12                                	    1347	    869013 ns/op	  114771 B/op	    1513 allocs/op
BenchmarkRangeQuery/expr=-a_hundred,steps=10-12                               	    1326	    886258 ns/op	  114785 B/op	    1513 allocs/op
BenchmarkRangeQuery/expr=-a_hundred,steps=100-12                              	     757	   1624355 ns/op	  122900 B/op	    1614 allocs/op
BenchmarkRangeQuery/expr=-a_hundred,steps=1000-12                             	     165	   7355824 ns/op	  196217 B/op	    2417 allocs/op
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1-12                             	   41096	     29575 ns/op	   10699 B/op	     178 allocs/op
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10-12                            	   35408	     34124 ns/op	   11851 B/op	     214 allocs/op
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=100-12                           	   12373	     96498 ns/op	   23694 B/op	     578 allocs/op
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1000-12                          	    1806	    694487 ns/op	  142591 B/op	    4200 allocs/op
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1-12                             	    6337	    192644 ns/op	   34165 B/op	     419 allocs/op
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10-12                            	    5167	    236157 ns/op	   36912 B/op	     466 allocs/op
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=100-12                           	    1329	    822605 ns/op	   65876 B/op	     949 allocs/op
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1000-12                          	     193	   6389255 ns/op	  353173 B/op	    5718 allocs/op
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                     	     639	   1881198 ns/op	  273632 B/op	    2732 allocs/op
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                    	     501	   2371960 ns/op	  297572 B/op	    2858 allocs/op
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                   	     132	   8667783 ns/op	  555302 B/op	    4320 allocs/op
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                  	      16	  72078532 ns/op	 2988902 B/op	   18206 allocs/op
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10000-12                         	     174	   6930477 ns/op	 1361633 B/op	   40450 allocs/op
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10000-12                         	      19	  61322978 ns/op	 3447943 B/op	   53893 allocs/op
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                 	       2	 671955062 ns/op	22618468 B/op	  140977 allocs/op
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12            	   19323	     61666 ns/op	   18697 B/op	     260 allocs/op
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12           	   18739	     64672 ns/op	   19851 B/op	     296 allocs/op
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12          	   12902	     92833 ns/op	   31553 B/op	     658 allocs/op
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12         	    2953	    362884 ns/op	  148650 B/op	    4269 allocs/op
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12            	    6804	    184219 ns/op	   33944 B/op	     424 allocs/op
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12           	    6144	    202853 ns/op	   35089 B/op	     460 allocs/op
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12          	    2475	    495297 ns/op	   48013 B/op	     837 allocs/op
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12         	     351	   3162035 ns/op	  176490 B/op	    4563 allocs/op
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12    	     868	   1398927 ns/op	  176496 B/op	    1875 allocs/op
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12   	     738	   1620433 ns/op	  197736 B/op	    2053 allocs/op
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12  	     240	   4961934 ns/op	  422583 B/op	    3986 allocs/op
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12 	      32	  35649453 ns/op	 2662319 B/op	   23037 allocs/op
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12             	   20013	     60727 ns/op	   18785 B/op	     262 allocs/op
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12            	   18626	     64687 ns/op	   19923 B/op	     298 allocs/op
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12           	   10000	    105285 ns/op	   31630 B/op	     660 allocs/op
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12          	    2577	    515008 ns/op	  148682 B/op	    4271 allocs/op
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12             	    6787	    186604 ns/op	   35024 B/op	     433 allocs/op
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12            	    5295	    228663 ns/op	   39083 B/op	     489 allocs/op
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12           	    1972	    649988 ns/op	   81425 B/op	    1061 allocs/op
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12          	     273	   4576411 ns/op	  504276 B/op	    6744 allocs/op
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12     	     847	   1466798 ns/op	  186024 B/op	    1944 allocs/op
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12    	     673	   1790420 ns/op	  229963 B/op	    2201 allocs/op
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12   	     193	   6150999 ns/op	  679911 B/op	    4930 allocs/op
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12  	      25	  51695120 ns/op	 5164230 B/op	   31821 allocs/op
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12         	   19285	     63507 ns/op	   18780 B/op	     262 allocs/op
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12        	   18693	     65210 ns/op	   19940 B/op	     298 allocs/op
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12       	   10000	    106519 ns/op	   31615 B/op	     660 allocs/op
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12      	    2384	    507562 ns/op	  148690 B/op	    4271 allocs/op
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12         	    5514	    189803 ns/op	   33947 B/op	     424 allocs/op
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12        	    5094	    206919 ns/op	   35101 B/op	     460 allocs/op
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12       	    2179	    507860 ns/op	   47958 B/op	     837 allocs/op
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12      	     358	   3288500 ns/op	  176369 B/op	    4563 allocs/op
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12 	     859	   1397931 ns/op	  176497 B/op	    1875 allocs/op
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12         	     730	   1632858 ns/op	  197715 B/op	    2052 allocs/op
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12        	     225	   5203664 ns/op	  423029 B/op	    3987 allocs/op
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12       	      32	  36342677 ns/op	 2660923 B/op	   23003 allocs/op
BenchmarkRangeQuery/expr=abs(a_one),steps=1-12                                         	   59466	     19160 ns/op	    6851 B/op	     131 allocs/op
BenchmarkRangeQuery/expr=abs(a_one),steps=10-12                                        	   49056	     25782 ns/op	    7139 B/op	     140 allocs/op
BenchmarkRangeQuery/expr=abs(a_one),steps=100-12                                       	   16959	     62150 ns/op	   10179 B/op	     232 allocs/op
BenchmarkRangeQuery/expr=abs(a_one),steps=1000-12                                      	    3234	    390584 ns/op	   40837 B/op	    1143 allocs/op
BenchmarkRangeQuery/expr=abs(a_ten),steps=1-12                                         	    9154	    120569 ns/op	   20623 B/op	     274 allocs/op
BenchmarkRangeQuery/expr=abs(a_ten),steps=10-12                                        	    8538	    140562 ns/op	   22380 B/op	     293 allocs/op
BenchmarkRangeQuery/expr=abs(a_ten),steps=100-12                                       	    2654	    486988 ns/op	   40835 B/op	     491 allocs/op
BenchmarkRangeQuery/expr=abs(a_ten),steps=1000-12                                      	     332	   3774071 ns/op	  225042 B/op	    2452 allocs/op
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1-12                                     	    1098	   1027061 ns/op	  157602 B/op	    1650 allocs/op
BenchmarkRangeQuery/expr=abs(a_hundred),steps=10-12                                    	     901	   1360361 ns/op	  172834 B/op	    1725 allocs/op
BenchmarkRangeQuery/expr=abs(a_hundred),steps=100-12                                   	     229	   5122289 ns/op	  333080 B/op	    2573 allocs/op
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1000-12                                  	      28	  41111047 ns/op	 1929743 B/op	   10841 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12      	   39064	     31059 ns/op	   12100 B/op	     220 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12     	   32750	     35722 ns/op	   13541 B/op	     265 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12    	   13219	     89546 ns/op	   28103 B/op	     717 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12   	    1826	    582833 ns/op	  173988 B/op	    5228 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12      	    9714	    127123 ns/op	   27520 B/op	     392 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12     	    7099	    162649 ns/op	   30431 B/op	     447 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12    	    2229	    555574 ns/op	   60413 B/op	    1005 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12   	     290	   4234072 ns/op	  359893 B/op	    6568 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12  	    1098	   1190604 ns/op	  180345 B/op	    2128 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12 	     820	   1443275 ns/op	  196709 B/op	    2239 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12         	     200	   5667893 ns/op	  368521 B/op	    3447 allocs/op
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12        	      25	  44780803 ns/op	 2081573 B/op	   15336 allocs/op
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                      	   46512	     25666 ns/op	    9355 B/op	     180 allocs/op
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                     	   38286	     31914 ns/op	   11371 B/op	     243 allocs/op
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                    	   12506	     95509 ns/op	   31696 B/op	     875 allocs/op
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                   	    1738	    733660 ns/op	  235191 B/op	    7186 allocs/op
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                      	   10000	    120245 ns/op	   24372 B/op	     341 allocs/op
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                     	    8510	    154332 ns/op	   27863 B/op	     414 allocs/op
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                    	    2256	    590584 ns/op	   63597 B/op	    1152 allocs/op
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                   	     264	   4738683 ns/op	  420647 B/op	    8512 allocs/op
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                  	    1125	   1067595 ns/op	  173394 B/op	    1897 allocs/op
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                 	     814	   1468449 ns/op	  190316 B/op	    2026 allocs/op
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                	     210	   5653922 ns/op	  367961 B/op	    3416 allocs/op
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12               	      26	  46592618 ns/op	 2137596 B/op	   17090 allocs/op
BenchmarkRangeQuery/expr=sum(a_one),steps=1-12                                                  	   59635	     20005 ns/op	    7075 B/op	     133 allocs/op
BenchmarkRangeQuery/expr=sum(a_one),steps=10-12                                                 	   46450	     28866 ns/op	   10964 B/op	     187 allocs/op
BenchmarkRangeQuery/expr=sum(a_one),steps=100-12                                                	   13744	     85835 ns/op	   50012 B/op	     729 allocs/op
BenchmarkRangeQuery/expr=sum(a_one),steps=1000-12                                               	    1801	    663917 ns/op	  440719 B/op	    6140 allocs/op
BenchmarkRangeQuery/expr=sum(a_ten),steps=1-12                                                  	   12888	     95995 ns/op	   16149 B/op	     228 allocs/op
BenchmarkRangeQuery/expr=sum(a_ten),steps=10-12                                                 	   10000	    102818 ns/op	   20038 B/op	     282 allocs/op
BenchmarkRangeQuery/expr=sum(a_ten),steps=100-12                                                	    4908	    246544 ns/op	   59805 B/op	     833 allocs/op
BenchmarkRangeQuery/expr=sum(a_ten),steps=1000-12                                               	     758	   1557259 ns/op	  457072 B/op	    6316 allocs/op
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1-12                                              	    1370	    854756 ns/op	  102138 B/op	    1132 allocs/op
BenchmarkRangeQuery/expr=sum(a_hundred),steps=10-12                                             	    1314	    878328 ns/op	  106036 B/op	    1186 allocs/op
BenchmarkRangeQuery/expr=sum(a_hundred),steps=100-12                                            	     626	   1903571 ns/op	  153013 B/op	    1827 allocs/op
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1000-12                                           	     100	  10822053 ns/op	  615255 B/op	    8030 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                      	   10000	    118907 ns/op	   22925 B/op	     317 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                     	    6930	    185288 ns/op	   49168 B/op	     680 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                    	    1417	    846173 ns/op	  312555 B/op	    4322 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                   	     171	   7764846 ns/op	 2945828 B/op	   40707 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                      	    1108	   1091024 ns/op	  129528 B/op	    1311 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                     	    1128	   1144020 ns/op	  158995 B/op	    1675 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                    	     343	   3128503 ns/op	  461928 B/op	    5414 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                   	      49	  22340075 ns/op	 3484417 B/op	   42598 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                  	      94	  14842644 ns/op	 1169307 B/op	   11216 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                 	      72	  16124493 ns/op	 1200278 B/op	   11579 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                	      32	  34481346 ns/op	 1585217 B/op	   16311 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                               	       6	 184925194 ns/op	 5325946 B/op	   61410 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                     	    9985	    105021 ns/op	   17268 B/op	     243 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                    	   10000	    110875 ns/op	   22022 B/op	     315 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                   	    3679	    297540 ns/op	   70512 B/op	    1047 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                  	     588	   2083138 ns/op	  554809 B/op	    8338 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                     	    1358	    882696 ns/op	  128958 B/op	    1304 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                    	    1219	   1006791 ns/op	  156212 B/op	    1638 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                   	     409	   2885760 ns/op	  437942 B/op	    5089 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                  	      58	  20297212 ns/op	 3246571 B/op	   39372 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                 	      94	  14504536 ns/op	 1229556 B/op	   11866 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                	      69	  16114636 ns/op	 1497333 B/op	   14754 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                               	      28	  38573351 ns/op	 4255478 B/op	   44719 allocs/op
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                              	       5	 207818853 ns/op	31744987 B/op	  342194 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                           	   12165	     99324 ns/op	   17203 B/op	     243 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                          	   10000	    109896 ns/op	   21668 B/op	     315 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                         	    3482	    287380 ns/op	   67282 B/op	    1047 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                        	     630	   1922480 ns/op	  522786 B/op	    8338 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                           	    1288	    880420 ns/op	  127658 B/op	    1304 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                          	    1231	    974953 ns/op	  149176 B/op	    1638 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                         	     436	   2745855 ns/op	  373206 B/op	    5088 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                        	      62	  18494416 ns/op	 2605843 B/op	   39373 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                       	      96	  14480698 ns/op	 1216711 B/op	   11866 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                      	      69	  16005750 ns/op	 1427384 B/op	   14754 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                     	      28	  36995343 ns/op	 3609185 B/op	   44720 allocs/op
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                    	       6	 205776778 ns/op	25337008 B/op	  342221 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                          	   10000	    111375 ns/op	   22220 B/op	     317 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                         	    7977	    158592 ns/op	   45301 B/op	     680 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                        	    1816	    699460 ns/op	  277030 B/op	    4322 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                       	     207	   6010262 ns/op	 2593703 B/op	   40710 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                          	    1352	    884376 ns/op	  128121 B/op	    1311 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                         	    1128	   1006481 ns/op	  151202 B/op	    1674 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                        	     404	   3039646 ns/op	  390886 B/op	    5415 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                       	      56	  20877214 ns/op	 2779128 B/op	   42588 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                      	     100	  14353796 ns/op	 1168407 B/op	   11216 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                     	      73	  15460069 ns/op	 1190587 B/op	   11579 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                    	      32	  34728869 ns/op	 1511005 B/op	   16312 allocs/op
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                   	       6	 178913057 ns/op	 4622789 B/op	   61407 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                           	   33541	     36098 ns/op	   12541 B/op	     235 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                          	   28398	     42191 ns/op	   13697 B/op	     271 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                         	   10000	    116060 ns/op	   25546 B/op	     635 allocs/op
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                        	    1501	    755534 ns/op	  144384 B/op	    4255 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                           	    5464	    212294 ns/op	   41518 B/op	     549 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                          	    4354	    266315 ns/op	   44255 B/op	     595 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                         	    1276	    966989 ns/op	   73560 B/op	    1080 allocs/op
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                        	     162	   7187969 ns/op	  364618 B/op	    5846 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                   	     600	   2080987 ns/op	  336776 B/op	    3590 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                  	     454	   2731990 ns/op	  360809 B/op	    3715 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                 	     100	  10713328 ns/op	  615681 B/op	    5163 allocs/op
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                	      14	  79947568 ns/op	 3065268 B/op	   18848 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                            	   50635	     23848 ns/op	    8096 B/op	     165 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                           	   39651	     31151 ns/op	   12271 B/op	     228 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                          	   10000	    108505 ns/op	   54236 B/op	     860 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                         	    1464	    823531 ns/op	  473928 B/op	    7170 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                            	   10000	    113234 ns/op	   20461 B/op	     299 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                           	    9747	    125230 ns/op	   24935 B/op	     371 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                          	    3324	    363623 ns/op	   70458 B/op	    1102 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                         	     444	   2558059 ns/op	  525258 B/op	    8375 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                        	    1203	    932940 ns/op	  138174 B/op	    1569 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                       	    1171	   1048365 ns/op	  142696 B/op	    1641 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                      	     421	   2858305 ns/op	  195567 B/op	    2462 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                     	      62	  19087037 ns/op	  712571 B/op	   10366 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12         	   26517	     44230 ns/op	   16678 B/op	     305 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12        	   19539	     62071 ns/op	   26190 B/op	     467 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12       	    5236	    243782 ns/op	  121605 B/op	    2091 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12      	     565	   2103590 ns/op	 1076045 B/op	   18311 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12         	    5559	    206451 ns/op	   41398 B/op	     573 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12        	    5110	    242678 ns/op	   51498 B/op	     753 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12       	    1603	    761995 ns/op	  154106 B/op	    2575 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12      	     217	   5555764 ns/op	 1178056 B/op	   20721 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12 	     646	   1861955 ns/op	  277034 B/op	    3114 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12         	     568	   2102041 ns/op	  287197 B/op	    3293 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12        	     202	   5962663 ns/op	  404303 B/op	    5295 allocs/op
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12       	      30	  39387724 ns/op	 1551659 B/op	   24703 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                             	   10000	    119884 ns/op	   23969 B/op	     343 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                            	    8198	    146549 ns/op	   25713 B/op	     397 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                           	    2400	    481852 ns/op	   44010 B/op	     949 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                          	     330	   3703760 ns/op	  226091 B/op	    6440 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                             	    1129	   1058521 ns/op	  190226 B/op	    1872 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                            	     903	   1343826 ns/op	  196037 B/op	    2017 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                           	     262	   4603611 ns/op	  262949 B/op	    3575 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                          	      32	  35895159 ns/op	  925443 B/op	   18939 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                         	      85	  16620039 ns/op	 1793522 B/op	   16980 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                        	      61	  19389805 ns/op	 1836273 B/op	   17991 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                       	      24	  50732014 ns/op	 2381057 B/op	   29197 allocs/op
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                      	       3	 369503253 ns/op	 7738416 B/op	  139068 allocs/op
BenchmarkParser/a-12                                                                                                     	 1994208	       571 ns/op	     168 B/op	       3 allocs/op
BenchmarkParser/metric-12                                                                                                	 2253879	       545 ns/op	     168 B/op	       3 allocs/op
BenchmarkParser/1-12                                                                                                     	 3344727	       369 ns/op	      32 B/op	       1 allocs/op
BenchmarkParser/1_>=_bool_1-12                                                                                           	 1000000	      1064 ns/op	     192 B/op	       4 allocs/op
BenchmarkParser/1_+_2/(3*1)-12                                                                                           	  460155	      2273 ns/op	     544 B/op	      11 allocs/op
BenchmarkParser/foo_or_bar-12                                                                                            	 1000000	      1219 ns/op	     464 B/op	       8 allocs/op
BenchmarkParser/foo_and_bar_unless_baz_or_qux-12                                                                         	  413842	      2743 ns/op	    1056 B/op	      18 allocs/op
BenchmarkParser/bar_+_on(foo)_bla_/_on(baz,_buz)_group_right(test)_blub-12                                               	  320990	      3538 ns/op	     840 B/op	      17 allocs/op
BenchmarkParser/foo_/_ignoring(test,blub)_group_left(blub)_bar-12                                                        	  518565	      2563 ns/op	     528 B/op	      11 allocs/op
BenchmarkParser/foo_-_ignoring(test,blub)_group_right(bar,foo)_bar-12                                                    	  415263	      2779 ns/op	     560 B/op	      12 allocs/op
BenchmarkParser/foo{a="b",_foo!="bar",_test=~"test",_bar!~"baz"}-12                                                      	  145369	      8211 ns/op	    5866 B/op	      98 allocs/op
BenchmarkParser/min_over_time(rate(foo{bar="baz"}[2s])[5m:])[4m:3s]-12                                                   	  227162	      5391 ns/op	    1181 B/op	      28 allocs/op
BenchmarkParser/sum_without(and,_by,_avg,_count,_alert,_annotations)(some_metric)_[30m:10s]-12                           	  268742	      4426 ns/op	     838 B/op	      15 allocs/op
BenchmarkParser/(_(should_fail)-12                                                                                       	  500706	      2368 ns/op	     448 B/op	       6 allocs/op
BenchmarkParser/}_(should_fail)-12                                                                                       	  442086	      2398 ns/op	     452 B/op	       7 allocs/op
BenchmarkParser/1_or_1_(should_fail)-12                                                                                  	  430657	      2742 ns/op	     680 B/op	      11 allocs/op
BenchmarkParser/1_or_on(bar)_foo_(should_fail)-12                                                                        	  252067	      4825 ns/op	    1329 B/op	      19 allocs/op
BenchmarkParser/foo_unless_on(bar)_group_left(baz)_bar_(should_fail)-12                                                  	  223282	      5527 ns/op	    1449 B/op	      22 allocs/op
BenchmarkParser/test[5d]_OFFSET_10s_[10m:5s]_(should_fail)-12                                                            	  144738	      8501 ns/op	    1590 B/op	      46 allocs/op
PASS
ok  	github.com/prometheus/prometheus/promql	446.692s

```

</p>
</details>

#### Comparison
<details>Comparison
<p>

```
benchmark                                                                                                              old ns/op      new ns/op      delta
BenchmarkParser/(_(should_fail)-12                                                                                     3251           2368           -27.16%
BenchmarkRangeQuery/expr=-a_ten,steps=1000-12                                                                          953016         747554         -21.56%
BenchmarkRangeQuery/expr=abs(a_one),steps=100-12                                                                       49061          62150          +26.68%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                                            40218          31914          -20.65%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=100-12                                                                   4084301        5122289        +25.41%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1000-12                                                                  32801575       41111047       +25.33%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1000-12                                                                      3049292        3774071        +23.77%
BenchmarkRangeQuery/expr=abs(a_one),steps=1000-12                                                                      321226         390584         +21.59%
BenchmarkRangeQuery/expr=sum(a_ten),steps=100-12                                                                       293258         246544         -15.93%
BenchmarkRangeQuery/expr=abs(a_one),steps=10-12                                                                        21750          25782          +18.54%
BenchmarkRangeQuery/expr=-a_ten,steps=100-12                                                                           195339         165313         -15.37%
BenchmarkParser/foo_unless_on(bar)_group_left(baz)_bar_(should_fail)-12                                                6494           5527           -14.89%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                               38193246       44780803       +17.25%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1-12                                                                         103098         120569         +16.95%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1-12                                                                     998156         854756         -14.37%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                4860746        5667893        +16.61%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    476788         555574         +16.52%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                  1024405        1190604        +16.22%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                                           3618381        3128503        -13.54%
BenchmarkParser/a-12                                                                                                   497            571            +14.89%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   3695293        4234072        +14.58%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    78162          89546          +14.56%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                                                  113518         99324          -12.50%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   513416         582833         +13.52%
BenchmarkParser/sum_without(and,_by,_avg,_count,_alert,_annotations)(some_metric)_[30m:10s]-12                         5022           4426           -11.87%
BenchmarkParser/}_(should_fail)-12                                                                                     2718           2398           -11.77%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=10-12                                                                    986585         878328         -10.97%
BenchmarkParser/1_or_on(bar)_foo_(should_fail)-12                                                                      5405           4825           -10.73%
BenchmarkParser/1_or_1_(should_fail)-12                                                                                3064           2742           -10.51%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=10-12                                                                    1218998        1360361        +11.60%
BenchmarkRangeQuery/expr=abs(a_ten),steps=100-12                                                                       436456         486988         +11.58%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                     145822         162649         +11.54%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                          6961705        7764846        +11.54%
BenchmarkRangeQuery/expr=sum(a_ten),steps=10-12                                                                        114408         102818         -10.13%
BenchmarkRangeQuery/expr=a_one,steps=10-12                                                                             17711          15971          -9.82%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                                             988175         1091024        +10.41%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                          24553892       22340075       -9.02%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                                          3171627        2885760        -9.01%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                                          324984         297540         -8.44%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                 1323601        1443275        +9.04%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                     32938          35722          +8.45%
BenchmarkRangeQuery/expr=sum(a_one),steps=10-12                                                                        26624          28866          +8.42%
BenchmarkParser/test[5d]_OFFSET_10s_[10m:5s]_(should_fail)-12                                                          9201           8501           -7.61%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                     224929912      207818853      -7.61%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                                            171781         185288         +7.86%
BenchmarkRangeQuery/expr=sum(a_one),steps=100-12                                                                       92385          85835          -7.09%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                                             27482          25666          -6.61%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                                        10015140       10713328       +6.97%
BenchmarkRangeQuery/expr=a_one,steps=1-12                                                                              17112          16011          -6.43%
BenchmarkRangeQuery/expr=sum(a_one),steps=1000-12                                                                      708748         663917         -6.33%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                                           101768         95509          -6.15%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12                                                   98916          92833          -6.15%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                      119403         127123         +6.47%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                                                      41051778       38573351       -6.04%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                          1428592        1343826        -5.93%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                      29255          31059          +6.17%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1-12                                                                     968146         1027061        +6.09%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                                         15724508       14842644       -5.61%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                                          4477548        4738683        +5.83%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                                             127185         120245         -5.46%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                                               798612         755534         -5.39%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12                                                6211680        5879521        -5.35%
BenchmarkRangeQuery/expr=a_hundred,steps=10-12                                                                         877883         831378         -5.30%
BenchmarkRangeQuery/expr=-a_one,steps=1000-12                                                                          83263          87915          +5.59%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                              22037596       20877214       -5.27%
BenchmarkParser/foo_/_ignoring(test,blub)_group_left(blub)_bar-12                                                      2430           2563           +5.47%
BenchmarkRangeQuery/expr=-a_hundred,steps=10-12                                                                        934493         886258         -5.16%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12                                      44274002       46592618       +5.24%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                           49143078       51695120       +5.19%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                  3324862        3162035        -4.90%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                                                          705876462      671955062      -4.81%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                   4803318        4576411        -4.72%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                                           116317         110875         -4.68%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1000-12                                                                 110484667      115776369      +4.79%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                                                 103588         108505         +4.75%
BenchmarkRangeQuery/expr=abs(a_ten),steps=10-12                                                                        134193         140562         +4.75%
BenchmarkParser/metric-12                                                                                              521            545            +4.61%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                                           808945         846173         +4.60%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                                                            9055245        8667783        -4.28%
BenchmarkRangeQuery/expr=a_ten,steps=100-12                                                                            166988         159867         -4.26%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1000-12                                                                      1625595        1557259        -4.20%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                                                1050636        1006481        -4.20%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12                                                 1369617        1312267        -4.19%
BenchmarkRangeQuery/expr=-a_hundred,steps=1-12                                                                         906496         869013         -4.13%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=100-12                                                                  35487          34025          -4.12%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12                                               542526223      520221767      -4.11%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1-12                                                                         100101         95995          -4.10%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                                          764907         733660         -4.09%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10000-12                                                                  63847198       61322978       -3.95%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                                                   108832         113234         +4.04%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=100-12                                                                   1978931        1903571        -3.81%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                                           568622         590584         +3.86%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1-12                                                                    102998         99178          -3.71%
BenchmarkParser/foo_or_bar-12                                                                                          1174           1219           +3.83%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                                                111796         116060         +3.81%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                                            1102517        1144020        +3.76%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                                       35779021       34481346       -3.63%
BenchmarkRangeQuery/expr=a_hundred,steps=100-12                                                                        1609190        1550858        -3.62%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                                            101223         105021         +3.75%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                                            160110         154332         -3.61%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10000-12                                                                  6682100        6930477        +3.72%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12                                                    626781         649988         +3.70%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                794212         823531         +3.69%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                      178452726      184925194      +3.63%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                           198575008      205776778      +3.63%
BenchmarkRangeQuery/expr=a_one,steps=1000-12                                                                           80742          83596          +3.53%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                          36894843       35649453       -3.38%
BenchmarkRangeQuery/expr=-a_one,steps=1-12                                                                             16949          16406          -3.20%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12        1923176        1861955        -3.18%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10-12                                                                   109723         106270         -3.15%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10-12                                                                     35231          34124          -3.14%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12                                         1685799        1632858        -3.14%
BenchmarkRangeQuery/expr=a_hundred,steps=1000-12                                                                       7309513        7083243        -3.10%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                                           1038819        1006791        -3.08%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=100-12                                                                  257045         249124         -3.08%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                                        16635238       16124493       -3.07%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10-12                                                               1031542        1000300        -3.03%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1-12                                                                973073         943626         -3.03%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12                                                   510641         495297         -3.00%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                                        14939120       14504536       -2.91%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12              251057         243782         -2.90%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                                        1426076        1468449        +2.97%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                           1089682        1058521        -2.86%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12                                                   500336         515008         +2.93%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12                                          1438851        1397931        -2.84%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12                                                    208786         202853         -2.84%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12                                                109585         106519         -2.80%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10-12                                                                   20682          20119          -2.72%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12                                               493761         507562         +2.80%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12                                                494279         507860         +2.75%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=10-12                                                                7683115        7478489        -2.66%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1-12                                                                 5945700        5788050        -2.65%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=100-12                                                              2519348        2453279        -2.62%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                                       16547652       16114636       -2.62%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1000-12                                                              179553652      174855793      -2.62%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=100-12                                                           228778356      222856734      -2.59%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12               248839         242678         -2.48%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12                                            1660998        1620433        -2.44%
BenchmarkRangeQuery/expr=a_ten,steps=1000-12                                                                           741547         723450         -2.44%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12                                                      191200         186604         -2.40%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1000-12                                                                  11084491       10822053       -2.37%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12                                                        5675795        5542614        -2.35%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                            19544100       19087037       -2.34%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                                          2032402        2080987        +2.39%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1000-12                                                                 162192         158471         -2.29%
BenchmarkRangeQuery/expr=a_ten,steps=10-12                                                                             90231          88163          -2.29%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10-12                                                                     241691         236157         -2.29%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=100-12                                                                    98679          96498          -2.21%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12                                             1430395        1398927        -2.20%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12                                        5089465        5203664        +2.24%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12                                             1830560        1790420        -2.19%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                                            902459         882696         -2.19%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                                                 272197         266315         -2.16%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                                                  122530         125230         +2.20%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12       2148189        2102041        -2.15%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                     49651640       50732014       +2.18%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12                                                       672138         657933         -2.11%
BenchmarkRangeQuery/expr=-a_one,steps=10-12                                                                            16884          16535          -2.07%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12                                                      854606         837495         -2.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                                                  30533          31151          +2.02%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                                         1088987        1067595        -1.96%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                                2508569        2558059        +1.97%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12                                              65587749       64321834       -1.93%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                                               951221         932940         -1.92%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                                             2913452        2858305        -1.89%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12      5852346        5962663        +1.89%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=100-12                                                               2397921        2354067        -1.83%
BenchmarkRangeQuery/expr=-a_hundred,steps=100-12                                                                       1654612        1624355        -1.83%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                                       81418870       79947568       -1.81%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1-12                                                                      196129         192644         -1.78%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1000-12                                                              17995964       17678273       -1.77%
BenchmarkParser/1_+_2/(3*1)-12                                                                                         2233           2273           +1.79%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12                                                  867148         851987         -1.75%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                                                          1712454614     1742876241     +1.78%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=100-12                                                                    836998         822605         -1.72%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12                210063         206451         -1.72%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12              774955         761995         -1.67%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12                                                  368821         362884         -1.61%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=10-12                                                            73250833       74439639       +1.62%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                                                291820         287380         -1.52%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                                                 990004         974953         -1.52%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12                                                       5742605        5655371        -1.52%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12                                                      7548893        7437740        -1.47%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12                                                  62572          63507          +1.49%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                                            15688536       15460069       -1.46%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12                                                     225364         228663         +1.46%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12                                           5034437        4961934        -1.44%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12                                                     2567926        2531153        -1.43%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                                         2693146        2731990        +1.44%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12                                                 265731611      261962628      -1.42%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                               1895855        1922480        +1.40%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1-12                                                                    5753162        5674797        -1.36%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                                                 358701         363623         +1.37%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                                                 42769          42191          -1.35%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12                                                     186729         184219         -1.34%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=100-12                                                                  1723085        1699937        -1.34%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                         20562295       20297212       -1.29%
BenchmarkRangeQuery/expr=a_one,steps=100-12                                                                            23400          23700          +1.28%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1-12                                                             58537583       57800341       -1.26%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12                                             112111123      110702641      -1.26%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=10-12                                                                837450         827196         -1.22%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12     38906522       39387724       +1.24%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                                                  36542          36098          -1.22%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12                                                  187582         189803         +1.18%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                          148202         146549         -1.12%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10000-12                                                                15242966       15073879       -1.11%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12                                                        644683         637595         -1.10%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                              5944707        6010262        +1.10%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                                                           72868190       72078532       -1.08%
BenchmarkParser/1-12                                                                                                   373            369            -1.07%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                        3664572        3703760        +1.07%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1-12                                                                    19912          19702          -1.05%
BenchmarkRangeQuery/expr=sum(a_one),steps=1-12                                                                         20218          20005          -1.05%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1-12                                                                      29872          29575          -0.99%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12                                            6209363        6150999        -0.94%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12                                                     65295          64687          -0.93%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12                                                 205004         206919         +0.93%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1000-12                                                                 1497840        1483978        -0.93%
BenchmarkRangeQuery/expr=a_ten,steps=1-12                                                                              89027          88245          -0.88%
BenchmarkRangeQuery/expr=-a_one,steps=100-12                                                                           24271          24060          -0.87%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                    372656625      369503253      -0.85%
BenchmarkParser/min_over_time(rate(foo{bar="baz"}[2s])[5m:])[4m:3s]-12                                                 5437           5391           -0.85%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                                                 110473         111375         +0.82%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                         2066329        2083138        +0.81%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                                                             1106999909     1098159846     -0.80%
BenchmarkRangeQuery/expr=a_hundred,steps=1-12                                                                          854308         847492         -0.80%
BenchmarkRangeQuery/expr=-a_ten,steps=1-12                                                                             92901          92165          -0.79%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                                               3063803        3039646        -0.79%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1000-12                                                                   6439008        6389255        -0.77%
BenchmarkRangeQuery/expr=-a_hundred,steps=1000-12                                                                      7413050        7355824        -0.77%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                                                             2390358        2371960        -0.77%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                                                  887202         880420         -0.76%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12                                                      61186          60727          -0.75%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=100-12                                                               22780568       22951726       +0.75%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12             5597363        5555764        -0.74%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12                                                57866242       57439308       -0.74%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                                               7137449        7187969        +0.71%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                           119043         119884         +0.71%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12                                            583285199      579204044      -0.70%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                                                              1894298        1881198        -0.69%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                                                960443         966989         +0.68%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=100-12                                                              160115955      159049483      -0.67%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                         485019         481852         -0.65%
BenchmarkParser/foo_and_bar_unless_baz_or_qux-12                                                                       2761           2743           -0.65%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12                                           5093915142     5127091023     +0.65%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10000-12                                                                1515496        1505772        -0.64%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1000-12                                                                   690077         694487         +0.64%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                                           34950532       34728869       -0.63%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                       36571269       36342677       -0.63%
BenchmarkRangeQuery/expr=abs(a_one),steps=1-12                                                                         19280          19160          -0.62%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12                                                     24766373       24617864       -0.60%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12                                                     61298          61666          +0.60%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1-12                                                                    660447         656508         -0.60%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                                             16097944       16005750       -0.57%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                                                   23985          23848          -0.57%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                          177920331      178913057      +0.56%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=10-12                                                               66431425       66088968       -0.52%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12                                                  6701682        6667296        -0.51%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12                                               3271752        3288500        +0.51%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10000-12                                                            153293705      152519036      -0.51%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12                44447          44230          -0.49%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1-12                                                                 685480         688611         +0.46%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=100-12                                                                  16072713       16141197       +0.43%
BenchmarkParser/bar_+_on(foo)_bla_/_on(baz,_buz)_group_right(test)_blub-12                                             3553           3538           -0.42%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12                                                  73846118       73537492       -0.42%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12                                                    64943          64672          -0.42%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=10-12                                                                   756493         753338         -0.42%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12                                                   56648193       56418999       -0.40%
BenchmarkParser/foo{a="b",_foo!="bar",_test=~"test",_bar!~"baz"}-12                                                    8178           8211           +0.40%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                                            37142925       36995343       -0.40%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                        36031822       35895159       -0.38%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                       16558090       16620039       +0.37%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                                       5633564        5653922        +0.36%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                                                159144         158592         -0.35%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                      19454975       19389805       -0.33%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1-12                                                                57354263       57175300       -0.31%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                                              1045434        1048365        +0.28%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                                             14391988       14353796       -0.27%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12                                                 11082399       11053190       -0.26%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1000-12                                                             14960258       14921061       -0.26%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=10-12                                                                   6672029        6655413        -0.25%
BenchmarkRangeQuery/expr=-a_ten,steps=10-12                                                                            94328          94115          -0.23%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                                                 109670         109896         +0.21%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                                              14510233       14480698       -0.20%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12                                                    105099         105285         +0.18%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                         4596340        4603611        +0.16%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                                             118737         118907         +0.14%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                                                 885627         884376         -0.14%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12                                              1468828        1466798        -0.14%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1000-12                                                                 11224424       11239359       +0.13%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                                                2742304        2745855        +0.13%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12                                               52517652       52572901       +0.11%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                                               700179         699460         -0.10%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12               62008          62071          +0.10%
BenchmarkParser/1_>=_bool_1-12                                                                                         1063           1064           +0.09%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                                                  212103         212294         +0.09%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12             2102108        2103590        +0.07%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12                                                    54814914       54776882       -0.07%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12                                                 65251          65210          -0.06%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                               18505075       18494416       -0.06%

benchmark                                                                                                             old allocs     new allocs     delta
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                                                         160997         140977         -12.44%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                                      18635          18848          +1.14%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                                                           4288           4320           +0.75%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1-12                                                                     177            178            +0.56%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10-12                                                                    213            214            +0.47%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                                                 234            235            +0.43%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12                                                    259            260            +0.39%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12                                                     261            262            +0.38%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12                                                 261            262            +0.38%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                                                270            271            +0.37%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12                                                   295            296            +0.34%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12                                                    297            298            +0.34%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12                                                297            298            +0.34%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12               304            305            +0.33%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                                       5177           5163           -0.27%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12                                              1141           1138           -0.26%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                                                          18161          18206          +0.25%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1-12                                                                     418            419            +0.24%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12                                                    423            424            +0.24%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12                                                 423            424            +0.24%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12                                                     432            433            +0.23%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12                                                   459            460            +0.22%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12                                                459            460            +0.22%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                          31890          31821          -0.22%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10-12                                                                    465            466            +0.22%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12              466            467            +0.21%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12                                                    488            489            +0.20%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12                                           4920           4930           +0.20%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                                               1078           1080           +0.19%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1000-12                                                                1091           1093           +0.18%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                                                 548            549            +0.18%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12               572            573            +0.17%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=100-12                                                                   577            578            +0.17%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                                                594            595            +0.17%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                                               634            635            +0.16%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12                                                  657            658            +0.15%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12                                                   659            660            +0.15%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12                                               659            660            +0.15%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                         23003          23037          +0.15%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1000-12                                                                 10857          10841          -0.15%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12              752            753            +0.13%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12                                                  836            837            +0.12%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12                                               836            837            +0.12%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12                                            1873           1875           +0.11%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1000-12                                                                  5724           5718           -0.10%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                                              5840           5846           +0.10%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=100-12                                                              1021           1020           -0.10%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=100-12                                                                 1020           1021           +0.10%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12                                           2051           2053           +0.10%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12                                                   1060           1061           +0.09%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12                                                    1089           1090           +0.09%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1000-12                                                             1098           1097           -0.09%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                  6739           6744           +0.07%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                                                            2856           2858           +0.07%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12                                           9005           9011           +0.07%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12       3112           3114           +0.06%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                   139155         139068         -0.06%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                                                            9959           9953           -0.06%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                                           1674           1675           +0.06%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                         61441          61407          -0.06%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12                                         1874           1875           +0.05%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12                                             1943           1944           +0.05%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12             2090           2091           +0.05%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                      23014          23003          -0.05%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12                                            2202           2201           -0.05%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1000-12                                                            2337           2336           -0.04%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10000-12                                                                 53916          53893          -0.04%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12                                                9648           9652           +0.04%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12                                     17097          17090          -0.04%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1000-12                                                                     2453           2452           -0.04%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12                                          10061          10065          +0.04%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=100-12                                                                  2572           2573           +0.04%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12             2574           2575           +0.04%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                                          5416           5414           -0.04%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                                                             2731           2732           +0.04%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1-12                                                               8849           8852           +0.03%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12                                            8898           8901           +0.03%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                  6566           6568           +0.03%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12      3292           3293           +0.03%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                                      3415           3416           +0.03%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                        3574           3575           +0.03%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                                         3589           3590           +0.03%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                                        3714           3715           +0.03%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                              15332          15336          +0.03%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10000-12                                                           11669          11666          -0.03%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12                                       3986           3987           +0.03%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                    29204          29197          -0.02%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1000-12                                                                  4199           4200           +0.02%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                                              4254           4255           +0.02%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12                                                 4268           4269           +0.02%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12                                                  4270           4271           +0.02%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12                                              4270           4271           +0.02%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                                                     44729          44719          -0.02%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                 4562           4563           +0.02%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12                                              4562           4563           +0.02%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                       18935          18939          +0.02%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                          342151         342221         +0.02%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                                               5089           5088           -0.02%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                     61422          61410          -0.02%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12     5294           5295           +0.02%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                              39366          39373          +0.02%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                                            14752          14754          +0.01%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                      16982          16980          -0.01%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                                         8513           8512           -0.01%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                             42593          42588          -0.01%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12                                                  8843           8842           -0.01%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1-12                                                            8851           8850           -0.01%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12                                             8901           8902           +0.01%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12                                                 8945           8944           -0.01%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=100-12                                                             8957           8956           -0.01%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                    342229         342194         -0.01%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                                           44716          44720          +0.01%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                                           11580          11579          -0.01%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                                          16311          16312          +0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                                      16312          16311          -0.01%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                     17990          17991          +0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12            18310          18311          +0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12            20720          20721          +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                         42596          42598          +0.00%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                        39371          39372          +0.00%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10000-12                                                                 40449          40450          +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                         40708          40707          -0.00%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                             40709          40710          +0.00%

benchmark                                                                                                              old bytes     new bytes     delta
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                                                          28140180      22618468      -19.62%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=100-12                                                              1315096       1410515       +7.26%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                                       2956612       3065268       +3.68%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12                                               1279420       1243300       -2.82%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1-12                                                                1302662       1337390       +2.67%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12                                                   1348786       1317379       -2.33%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1-12                                                             1338492       1307601       -2.31%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=100-12                                                                  632859        618315        -2.30%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10000-12                                                            1301545       1272133       -2.26%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                                                            544205        555302        +2.04%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12                                                 3147916       3192190       +1.41%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1000-12                                                                 624317        632708        +1.34%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12                                           4953760       5013200       +1.20%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1000-12                                                                 555193        548848        -1.14%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                                                          4703576       4753672       +1.07%
BenchmarkRangeQuery/expr=a_one,steps=1-12                                                                              5235          5284          +0.94%
BenchmarkRangeQuery/expr=a_one,steps=10-12                                                                             5235          5283          +0.92%
BenchmarkRangeQuery/expr=a_one,steps=100-12                                                                            5394          5443          +0.91%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1-12                                                                      10603         10699         +0.91%
BenchmarkRangeQuery/expr=-a_one,steps=1-12                                                                             5858          5906          +0.82%
BenchmarkRangeQuery/expr=-a_one,steps=10-12                                                                            5858          5906          +0.82%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10-12                                                                     11755         11851         +0.82%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1-12                                                                    6234          6284          +0.80%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                                                  12442         12541         +0.80%
BenchmarkRangeQuery/expr=-a_one,steps=100-12                                                                           6019          6066          +0.78%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10-12                                                                   6236          6284          +0.77%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                                                 13595         13697         +0.75%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                                                           3011253       2988902       -0.74%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=100-12                                                                  6395          6442          +0.73%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=10-12                                                                620504        616096        -0.71%
BenchmarkRangeQuery/expr=abs(a_one),steps=1-12                                                                         6803          6851          +0.71%
BenchmarkRangeQuery/expr=sum(a_one),steps=1-12                                                                         7027          7075          +0.68%
BenchmarkRangeQuery/expr=abs(a_one),steps=10-12                                                                        7091          7139          +0.68%
BenchmarkRangeQuery/expr=a_one,steps=1000-12                                                                           7238          7285          +0.65%
BenchmarkRangeQuery/expr=-a_one,steps=1000-12                                                                          7861          7912          +0.65%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=10-12                                                                   620452        616542        -0.63%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                                                   8045          8096          +0.63%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12                16579         16678         +0.60%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1-12                                                                    616240        619691        +0.56%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12                                                       617538        620941        +0.55%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12                                                      18683         18785         +0.55%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12                                                      642463        638990        -0.54%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                                             9307          9355          +0.52%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12                                                  18684         18780         +0.51%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1000-12                                                                 8204          8246          +0.51%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                                                73188         73560         +0.51%
BenchmarkParser/test[5d]_OFFSET_10s_[10m:5s]_(should_fail)-12                                                          1582          1590          +0.51%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12                                                 19842         19940         +0.49%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12                                                        616283        619236        +0.48%
BenchmarkRangeQuery/expr=abs(a_one),steps=100-12                                                                       10132         10179         +0.46%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12                                                     18611         18697         +0.46%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12                                                    19761         19851         +0.46%
BenchmarkRangeQuery/expr=sum(a_one),steps=10-12                                                                        10916         10964         +0.44%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12                                             1935263       1943703       +0.44%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12                                                     19840         19923         +0.42%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                                            11324         11371         +0.42%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                                        618198        615681        -0.41%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=100-12                                                                    23598         23694         +0.41%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=10-12                                                            1342248       1347616       +0.40%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                      12052         12100         +0.40%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                                                25447         25546         +0.39%
BenchmarkRangeQuery/expr=a_ten,steps=1-12                                                                              12116         12163         +0.39%
BenchmarkRangeQuery/expr=a_ten,steps=10-12                                                                             12116         12163         +0.39%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12               26091         26190         +0.38%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10000-12                                                                  3460563       3447943       -0.36%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=100-12                                                                  17227         17290         +0.37%
BenchmarkRangeQuery/expr=a_ten,steps=100-12                                                                            12998         13045         +0.36%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                                                  12227         12271         +0.36%
BenchmarkParser/sum_without(and,_by,_avg,_count,_alert,_annotations)(some_metric)_[30m:10s]-12                         835           838           +0.36%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                     13493         13541         +0.36%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                                                             4718664       4702024       -0.35%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12                                                   31442         31553         +0.35%
BenchmarkRangeQuery/expr=a_hundred,steps=1-12                                                                          79258         79530         +0.34%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10-12                                                                   16344         16400         +0.34%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1-12                                                                    16344         16399         +0.34%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=100-12                                                           1429876       1434564       +0.33%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12                                                     33838         33944         +0.31%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12                                                  33841         33947         +0.31%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12                                                 34993         35101         +0.31%
BenchmarkRangeQuery/expr=-a_ten,steps=1-12                                                                             15958         16007         +0.31%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1-12                                                                         16100         16149         +0.30%
BenchmarkRangeQuery/expr=-a_ten,steps=10-12                                                                            15959         16007         +0.30%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12                                                      34920         35024         +0.30%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10-12                                                                     36810         36912         +0.28%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12                                                    31543         31630         +0.28%
BenchmarkRangeQuery/expr=-a_ten,steps=100-12                                                                           16842         16888         +0.27%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                                            17221         17268         +0.27%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=100-12                                                                    66053         65876         -0.27%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                                                  17157         17203         +0.27%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1-12                                                                      34075         34165         +0.26%
BenchmarkParser/min_over_time(rate(foo{bar="baz"}[2s])[5m:])[4m:3s]-12                                                 1178          1181          +0.25%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12                                                     38984         39083         +0.25%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12                                                31535         31615         +0.25%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1-12                                                                         20571         20623         +0.25%
BenchmarkRangeQuery/expr=-a_ten,steps=1000-12                                                                          25159         25222         +0.25%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12                                              1933669       1938476       +0.25%
BenchmarkRangeQuery/expr=sum(a_ten),steps=10-12                                                                        19989         20038         +0.25%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=100-12                                                               631275        629732        -0.24%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12                                               1195297       1197984       +0.22%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                                                 21620         21668         +0.22%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                                                  41427         41518         +0.22%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                                           21974         22022         +0.22%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                                                  24881         24935         +0.22%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                                               363830        364618        +0.22%
BenchmarkRangeQuery/expr=abs(a_ten),steps=10-12                                                                        22332         22380         +0.21%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                           23918         23969         +0.21%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12                                                     565235        566437        +0.21%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                                             22877         22925         +0.21%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12                41312         41398         +0.21%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                                                 22174         22220         +0.21%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12                                                    35017         35089         +0.21%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                            711182        712571        +0.20%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1000-12                                                                 25053         25100         +0.19%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                          25665         25713         +0.19%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                                             24327         24372         +0.18%
BenchmarkRangeQuery/expr=a_hundred,steps=1000-12                                                                       160699        160412        -0.18%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12                                                  1532006       1529285       -0.18%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                                                   20425         20461         +0.18%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=100-12                                                               549249        550214        +0.18%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                        923843        925443        +0.17%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    28055         28103         +0.17%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                                            27816         27863         +0.17%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                      27474         27520         +0.17%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                                                             297081        297572        +0.17%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                                                 44183         44255         +0.16%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                     30382         30431         +0.16%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                                       1582689       1585217       +0.16%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                         43940         44010         +0.16%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12                                                47882         47958         +0.16%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1-12                                                                 620237        619323        -0.15%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                                           31650         31696         +0.15%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12     1553883       1551659       -0.14%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12               51428         51498         +0.14%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                           5171197       5164230       -0.13%
BenchmarkRangeQuery/expr=abs(a_one),steps=1000-12                                                                      40782         40837         +0.13%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12                                                       548655        549378        +0.13%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12                                            197480        197736        +0.13%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12                                                    81320         81425         +0.13%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                                            1192101       1190587       -0.13%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                                         360353        360809        +0.13%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                    7729061       7738416       +0.12%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                                                 54171         54236         +0.12%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                                                45248         45301         +0.12%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12                                                     801943        802869        +0.12%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12              153931        154106        +0.11%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                   503720        504276        +0.11%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                                               144234        144384        +0.10%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12                                             229726        229963        +0.10%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12                                             176319        176496        +0.10%
BenchmarkRangeQuery/expr=sum(a_one),steps=100-12                                                                       49964         50012         +0.10%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                                            49121         49168         +0.10%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10000-12                                                                155918        155770        -0.09%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12                                                   47968         48013         +0.09%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12                                            679296        679911        +0.09%
BenchmarkRangeQuery/expr=a_ten,steps=1000-12                                                                           21344         21363         +0.09%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    60360         60413         +0.09%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                                           1512319       1511005       -0.09%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1-12                                                                    548736        548270        -0.08%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                      1837754       1836273       -0.08%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                                                67229         67282         +0.08%
BenchmarkRangeQuery/expr=abs(a_ten),steps=100-12                                                                       40803         40835         +0.08%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12                                               176232        176369        +0.08%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10000-12                                                                  1360576       1361633       +0.08%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12             1178971       1178056       -0.08%
BenchmarkRangeQuery/expr=sum(a_ten),steps=100-12                                                                       59760         59805         +0.08%
BenchmarkRangeQuery/expr=-a_hundred,steps=1000-12                                                                      196071        196217        +0.07%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                                        1230453       1229556       -0.07%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                                          70462         70512         +0.07%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1000-12                                                                   142490        142591        +0.07%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12                                                  1178077       1178906       +0.07%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                                         173278        173394        +0.07%
BenchmarkRangeQuery/expr=-a_hundred,steps=100-12                                                                       122818        122900        +0.07%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12                                        422752        423029        +0.07%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                       2662665       2660923       -0.07%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                  176376        176490        +0.06%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=10-12                                                                    105969        106036        +0.06%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                                               138257        138174        -0.06%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12              121532        121605        +0.06%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                                              142781        142696        -0.06%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=10-12                                                                548793        549106        +0.06%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12       287034        287197        +0.06%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=10-12                                                                    172736        172834        +0.06%
BenchmarkRangeQuery/expr=a_hundred,steps=100-12                                                                        87226         87275         +0.06%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1-12                                                                 548533        548837        +0.06%
BenchmarkRangeQuery/expr=-a_hundred,steps=10-12                                                                        114722        114785        +0.05%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1000-12                                                              557419        557114        -0.05%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                                       1496531       1497333       +0.05%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12                                                      550780        550487        -0.05%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                               2080472       2081573       +0.05%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                                             1167800       1168407       +0.05%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12                                                  1247882       1247235       -0.05%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1-12                                                                     157521        157602        +0.05%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1-12                                                                     102087        102138        +0.05%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12                                          176409        176497        +0.05%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   359715        359893        +0.05%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12                                                  148577        148650        +0.05%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                                            158919        158995        +0.05%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12                                                 1179225       1178687       -0.05%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                                       367797        367961        +0.04%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                                            3607589       3609185       +0.04%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                                                 70428         70458         +0.04%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=100-12                                                                   152948        153013        +0.04%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                                            128906        128958        +0.04%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=100-12                                                              123282        123330        +0.04%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                                              1216247       1216711       +0.04%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                                                 128074        128121        +0.04%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                                             129482        129528        +0.04%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                                                  127613        127658        +0.04%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                 196640        196709        +0.04%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                      5327720       5325946       -0.03%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                                                      4256891       4255478       -0.03%
BenchmarkRangeQuery/expr=-a_hundred,steps=1-12                                                                         114733        114771        +0.03%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                         262862        262949        +0.03%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                                         1169685       1169307       -0.03%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10-12                                                               115289        115326        +0.03%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                     2380294       2381057       +0.03%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                                           63577         63597         +0.03%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12                                                        548963        548795        -0.03%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                                               276946        277030        +0.03%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                                525099        525258        +0.03%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                                             1426954       1427384       +0.03%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                       1792987       1793522       +0.03%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1000-12                                                                  615426        615255        -0.03%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                                          420531        420647        +0.03%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                                                 149136        149176        +0.03%
BenchmarkRangeQuery/expr=a_hundred,steps=10-12                                                                         79518         79539         +0.03%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1000-12                                                                      456957        457072        +0.03%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                          196085        196037        -0.02%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12      404396        404303        -0.02%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                                           156177        156212        +0.02%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                  180305        180345        +0.02%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1000-12                                                                   353251        353173        -0.02%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                                        190275        190316        +0.02%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                          4623725       4622789       -0.02%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12                                      2137169       2137596       +0.02%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1000-12                                                                      224998        225042        +0.02%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   173954        173988        +0.02%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                               2605338       2605843       +0.02%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                                                151173        151202        +0.02%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12                                                1180731       1180956       +0.02%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12                                              186059        186024        -0.02%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                                          235147        235191        +0.02%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                                           462010        461928        -0.02%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                                               390818        390886        +0.02%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                        226052        226091        +0.02%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                         3246026       3246571       +0.02%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1-12                                                                115238        115257        +0.02%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                                          336829        336776        -0.02%
BenchmarkRangeQuery/expr=sum(a_one),steps=1000-12                                                                      440653        440719        +0.01%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10000-12                                                                40897         40891         -0.01%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                           25333300      25337008      +0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                                           312511        312555        +0.01%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                368565        368521        -0.01%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                                          437892        437942        +0.01%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=100-12                                                                  549081        549019        -0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                473875        473928        +0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12             1075926       1076045       +0.01%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12                                            1952756       1952964       +0.01%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12                                           422543        422583        +0.01%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12                                                   148696        148682        -0.01%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1000-12                                                             192899        192917        +0.01%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=100-12                                                                   333050        333080        +0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                                             195550        195567        +0.01%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                                                              273610        273632        +0.01%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                     31747515      31744987      -0.01%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                               522751        522786        +0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                          3484184       3484417       +0.01%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12                                                1227512       1227585       +0.01%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12                                                 1249110       1249181       +0.01%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                           190217        190226        +0.00%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12                                         197706        197715        +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                                        1200225       1200278       +0.00%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                                                373191        373206        +0.00%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                          2662425       2662319       -0.00%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12                                                    1302817       1302865       +0.00%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1000-12                                                                  1929678       1929743       +0.00%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1000-12                                                              740890        740913        +0.00%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                              2593631       2593703       +0.00%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                         554824        554809        -0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12        277040        277034        -0.00%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12                                               148687        148690        +0.00%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                              2779159       2779128       -0.00%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=10-12                                                                   548283        548289        +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                          2945800       2945828       +0.00%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=10-12                                                               1305330       1305334       +0.00%

```

</p>
</details>

cc @bwplotka @krasi-georgiev @slrtbtfs @liguozhong