### PR TITLE
Trace Remote Write requests

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -888,7 +888,6 @@ func (s *shards) sendSamplesWithBackoff(ctx context.Context, samples []prompb.Ti
 		if err != nil {
 			// If the error is unrecoverable, we should not retry.
 			if _, ok := err.(recoverableError); !ok {
-				level.Error(s.qm.logger).Log("msg", "Failed to send batch, unrecoverable error, will not retry", "err", err)
 				return err
 			}
 

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -872,14 +872,14 @@ func (s *shards) sendSamplesWithBackoff(ctx context.Context, samples []prompb.Ti
 }
 
 func (s *shards) attemptSendSamples(ctx context.Context, samples []prompb.TimeSeries, req *[]byte, highest int64, try int) error {
-	req_size := len(*req)
-	sample_count := len(samples)
+	reqSize := len(*req)
+	sampleCount := len(samples)
 
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Remote Send Batch")
 	defer span.Finish()
 
-	span.SetTag("samples", sample_count)
-	span.SetTag("requestSize", req_size)
+	span.SetTag("samples", sampleCount)
+	span.SetTag("requestSize", reqSize)
 	span.SetTag("try", try)
 	span.SetTag("remote_name", s.qm.storeClient.Name())
 	span.SetTag("remote_url", s.qm.storeClient.Endpoint())
@@ -890,8 +890,8 @@ func (s *shards) attemptSendSamples(ctx context.Context, samples []prompb.TimeSe
 	s.qm.metrics.sentBatchDuration.Observe(time.Since(begin).Seconds())
 
 	if err == nil {
-		s.qm.metrics.succeededSamplesTotal.Add(float64(sample_count))
-		s.qm.metrics.bytesSent.Add(float64(req_size))
+		s.qm.metrics.succeededSamplesTotal.Add(float64(sampleCount))
+		s.qm.metrics.bytesSent.Add(float64(reqSize))
 		s.qm.metrics.highestSentTimestamp.Set(float64(highest / 1000))
 		return nil
 	}
@@ -901,7 +901,7 @@ func (s *shards) attemptSendSamples(ctx context.Context, samples []prompb.TimeSe
 		ext.Error.Set(span, true)
 		return err
 	}
-	s.qm.metrics.retriedSamplesTotal.Add(float64(sample_count))
+	s.qm.metrics.retriedSamplesTotal.Add(float64(sampleCount))
 	span.LogKV("error", err)
 	ext.Error.Set(span, true)
 	level.Warn(s.qm.logger).Log("msg", "Failed to send batch, retrying", "err", err)


### PR DESCRIPTION
Continuing the recent work on pulling in Jaeger and instrumenting remote queries, we figured we would also instrument remote writes.

This currently only spits out one root span for each call to `sendSamples`, and is mostly valuable as a starting point for upstream systems receiving the sample batches that may have their own tracing in place.

Kept it simple and didn't use the pattern in `utils/query_stats.go` since it seemed overkill for the simple case of remote writes. Also, we didn't instrument `remote.Client.Store` because remote writes can retry forever, and we end up with potentially infinite spans under a root-less trace (since the root span never finishes).

![Screenshot from 2020-05-05 14-12-13](https://user-images.githubusercontent.com/3492944/81111544-7d095600-8eda-11ea-8cc4-771447bf0a33.png)
