### PR TITLE
Snapshot in-memory chunks on shutdown for faster restarts

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -149,6 +149,9 @@ func (c *flagConfig) setFeatureListOptions(logger log.Logger) error {
 			case "exemplar-storage":
 				c.tsdb.EnableExemplarStorage = true
 				level.Info(logger).Log("msg", "Experimental in-memory exemplar storage enabled")
+			case "memory-snapshot-on-shutdown":
+				c.tsdb.EnableMemorySnapshotOnShutdown = true
+				level.Info(logger).Log("msg", "Experimental memory snapshot on shutdown enabled")
 			case "":
 				continue
 			default:
@@ -309,7 +312,7 @@ func main() {
 	a.Flag("query.max-samples", "Maximum number of samples a single query can load into memory. Note that queries will fail if they try to load more samples than this into memory, so this also limits the number of samples a query can return.").
 		Default("50000000").IntVar(&cfg.queryMaxSamples)
 
-	a.Flag("enable-feature", "Comma separated feature names to enable. Valid options: promql-at-modifier, promql-negative-offset, remote-write-receiver, exemplar-storage, expand-external-labels. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details.").
+	a.Flag("enable-feature", "Comma separated feature names to enable. Valid options: exemplar-storage, expand-external-labels, memory-snapshot-on-shutdown, promql-at-modifier, promql-negative-offset, remote-write-receiver. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details.").
 		Default("").StringsVar(&cfg.featureList)
 
 	promlogflag.AddFlags(a, &cfg.promlogConfig)
@@ -1263,34 +1266,36 @@ func (rm *readyScrapeManager) Get() (*scrape.Manager, error) {
 // tsdbOptions is tsdb.Option version with defined units.
 // This is required as tsdb.Option fields are unit agnostic (time).
 type tsdbOptions struct {
-	WALSegmentSize           units.Base2Bytes
-	MaxBlockChunkSegmentSize units.Base2Bytes
-	RetentionDuration        model.Duration
-	MaxBytes                 units.Base2Bytes
-	NoLockfile               bool
-	AllowOverlappingBlocks   bool
-	WALCompression           bool
-	StripeSize               int
-	MinBlockDuration         model.Duration
-	MaxBlockDuration         model.Duration
-	EnableExemplarStorage    bool
-	MaxExemplars             int64
+	WALSegmentSize                 units.Base2Bytes
+	MaxBlockChunkSegmentSize       units.Base2Bytes
+	RetentionDuration              model.Duration
+	MaxBytes                       units.Base2Bytes
+	NoLockfile                     bool
+	AllowOverlappingBlocks         bool
+	WALCompression                 bool
+	StripeSize                     int
+	MinBlockDuration               model.Duration
+	MaxBlockDuration               model.Duration
+	EnableExemplarStorage          bool
+	MaxExemplars                   int64
+	EnableMemorySnapshotOnShutdown bool
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 	return tsdb.Options{
-		WALSegmentSize:           int(opts.WALSegmentSize),
-		MaxBlockChunkSegmentSize: int64(opts.MaxBlockChunkSegmentSize),
-		RetentionDuration:        int64(time.Duration(opts.RetentionDuration) / time.Millisecond),
-		MaxBytes:                 int64(opts.MaxBytes),
-		NoLockfile:               opts.NoLockfile,
-		AllowOverlappingBlocks:   opts.AllowOverlappingBlocks,
-		WALCompression:           opts.WALCompression,
-		StripeSize:               opts.StripeSize,
-		MinBlockDuration:         int64(time.Duration(opts.MinBlockDuration) / time.Millisecond),
-		MaxBlockDuration:         int64(time.Duration(opts.MaxBlockDuration) / time.Millisecond),
-		EnableExemplarStorage:    opts.EnableExemplarStorage,
-		MaxExemplars:             opts.MaxExemplars,
+		WALSegmentSize:                 int(opts.WALSegmentSize),
+		MaxBlockChunkSegmentSize:       int64(opts.MaxBlockChunkSegmentSize),
+		RetentionDuration:              int64(time.Duration(opts.RetentionDuration) / time.Millisecond),
+		MaxBytes:                       int64(opts.MaxBytes),
+		NoLockfile:                     opts.NoLockfile,
+		AllowOverlappingBlocks:         opts.AllowOverlappingBlocks,
+		WALCompression:                 opts.WALCompression,
+		StripeSize:                     opts.StripeSize,
+		MinBlockDuration:               int64(time.Duration(opts.MinBlockDuration) / time.Millisecond),
+		MaxBlockDuration:               int64(time.Duration(opts.MaxBlockDuration) / time.Millisecond),
+		EnableExemplarStorage:          opts.EnableExemplarStorage,
+		MaxExemplars:                   opts.MaxExemplars,
+		EnableMemorySnapshotOnShutdown: opts.EnableMemorySnapshotOnShutdown,
 	}
 }
 

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -40,7 +40,7 @@ with more recent data.
 
 More details can be found [here](querying/basics.md#offset-modifier).
 
-## Remote Write Receiver
+## Remote Write Receiver
 
 `--enable-feature=remote-write-receiver`
 
@@ -53,3 +53,11 @@ The remote write receiver allows Prometheus to accept remote write requests from
 [OpenMetrics](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars) introduces the ability for scrape targets to add exemplars to certain metrics. Exemplars are references to data outside of the MetricSet. A common use case are IDs of program traces.
 
 Exemplar storage is implemented as a fixed size circular buffer that stores exemplars in memory for all series. Enabling this feature will enable the storage of exemplars scraped by Prometheus. The flag `storage.exemplars.exemplars-limit` can be used to control the size of circular buffer by # of exemplars. An exemplar with just a `traceID=<jaeger-trace-id>` uses roughly 100 bytes of memory via the in-memory exemplar storage. If the exemplar storage is enabled, we will also append the exemplars to WAL for local persistence (for WAL duration).
+
+## Memory Snapshot on Shutdown
+
+`--enable-feature=memory-snapshot-on-shutdown`
+
+This takes the snapshot of the chunks that are in memory along with the series information when shutting down and stores
+it on disk. This will reduce the startup time since the memory state can be restored with this snapshot and m-mapped 
+chunks without the need of WAL replay.

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -151,6 +151,9 @@ type Options struct {
 	// Enables the in memory exemplar storage,.
 	EnableExemplarStorage bool
 
+	// Enables the snapshot of in-memory chunks on shutdown. This makes restarts faster.
+	EnableMemorySnapshotOnShutdown bool
+
 	// MaxExemplars sets the size, in # of exemplars stored, of the single circular buffer used to store exemplars in memory.
 	// See tsdb/exemplar.go, specifically the CircularExemplarStorage struct and it's constructor NewCircularExemplarStorage.
 	MaxExemplars int64
@@ -722,6 +725,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	headOpts.SeriesCallback = opts.SeriesLifecycleCallback
 	headOpts.EnableExemplarStorage = opts.EnableExemplarStorage
 	headOpts.MaxExemplars.Store(opts.MaxExemplars)
+	headOpts.EnableMemorySnapshotOnShutdown = opts.EnableMemorySnapshotOnShutdown
 	db.head, err = NewHead(r, l, wlog, headOpts, stats.Head)
 	if err != nil {
 		return nil, err

--- a/tsdb/docs/format/README.md
+++ b/tsdb/docs/format/README.md
@@ -5,3 +5,4 @@
 * [Head Chunks](head_chunks.md)
 * [Tombstones](tombstones.md)
 * [Wal](wal.md)
+* [Memory Snapshot](memory_snapshot.md)

--- a/tsdb/docs/format/memory_snapshot.md
+++ b/tsdb/docs/format/memory_snapshot.md
@@ -1,0 +1,62 @@
+# Memory Snapshot Format
+
+Memory snapshot uses the WAL package and writes each series as a WAL record.
+Below are the formats of the individual records.
+
+### Series records
+
+This record is a snapshot of a single series. Only one series exists per record.
+It includes the metadata of the series and the in-memory chunk data if it exists.
+The sampleBuf is the last 4 samples in the in-memory chunk.
+
+```
+┌──────────────────────────┬────────────────────────────┐
+│     Record Type <byte>   │   Series Ref <uint64>      │
+├──────────────────────────┴────────────────────────────┤
+│               Number of Labels <uvarint>              │
+├──────────────────────────────┬────────────────────────┤
+│     len(name_1) <uvarint>    │    name_1 <bytes>      │
+├──────────────────────────────┼────────────────────────┤
+│     len(val_1) <uvarint>     │    val_1 <bytes>       │
+├──────────────────────────────┴────────────────────────┤
+│                         . . .                         │
+├──────────────────────────────┬────────────────────────┤
+│     len(name_N) <uvarint>    │    name_N <bytes>      │
+├──────────────────────────────┼────────────────────────┤
+│     len(val_N) <uvarint>     │    val_N <bytes>       │
+├──────────────────────────────┴────────────────────────┤
+│                  Chunk Range <int64>                  │
+├───────────────────────────────────────────────────────┤
+│                 Chunk Exists <uvarint>                │
+│ # 1 if head chunk exists, 0 otherwise to detect a nil |
+| # chunk. Below fields exists only when it's 1 here.   |
+├───────────────────────────┬───────────────────────────┤
+│     Chunk Mint <int64>    │    Chunk Maxt <int64>     │
+├───────────────────────────┴───────────────────────────┤
+│                 Chunk Encoding <byte>                 │
+├──────────────────────────────┬────────────────────────┤
+│      len(Chunk) <uvarint>    │    Chunk <bytes>       │
+├──────────────────────────┬───┴────────────────────────┤
+|  sampleBuf[0].t <int64>  |  sampleBuf[0].v <float64>  | 
+├──────────────────────────┼────────────────────────────┤
+|  sampleBuf[1].t <int64>  |  sampleBuf[1].v <float64>  | 
+├──────────────────────────┼────────────────────────────┤
+|  sampleBuf[2].t <int64>  |  sampleBuf[2].v <float64>  | 
+├──────────────────────────┼────────────────────────────┤
+|  sampleBuf[3].t <int64>  |  sampleBuf[3].v <float64>  | 
+└──────────────────────────┴────────────────────────────┘
+```
+
+### Tombstone record
+
+This includes all the tombstones in the Head block. A single record is written into
+the snapshot for all the tombstones. The encoded tombstones uses the same encoding
+as tombstone file in blocks.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Record Type <byte>                       │
+├───────────────────────────────────┬─────────────────────────────┤
+│ len(Encoded Tombstones) <uvarint> │ Encoded Tombstones <bytes>  │
+└───────────────────────────────────┴─────────────────────────────┘
+```


### PR DESCRIPTION
This PR is based on this design doc: https://docs.google.com/document/d/1c90BmhErybHH94hoGNsgJC9pyaUTU3dgHoyD3dm6Kw4/edit?usp=sharing (the doc is a little outdated after some discussions here)

Snapshot happens during shutdown and not at regular intervals to avoid write amplification.

The snapshot name is of the format `chunk_snapshot.<last WAL segment>.<offset in the segment>`. The offset in the WAL segment gives us more precision on where to continue the snapshot and avoids unnecessary replay of entire WAL segment.

**Format of the snapshot**
Starts with series records. Each series gets 1 record.

```
┌────────────────────────────┬────────────────────────────┐
│      Record Type <byte>    │    Series Ref <uint64>     │
├────────────────────────────┴────────────────────────────┤
│                Number of  Labels <uvarint>              │
├────────────────────────────┬────────────────────────────┤
│    len(name_1) <uvarint>   │      name_1 <bytes>        │
├────────────────────────────┼────────────────────────────┤
│    len(val_1) <uvarint>    │      val_1 <bytes>         │
├────────────────────────────┴────────────────────────────┤
│                          . . .                          │
├────────────────────────────┬────────────────────────────┤
│    len(name_N) <uvarint>   │      name_N <bytes>        │
├────────────────────────────┼────────────────────────────┤
│    len(val_N) <uvarint>    │      val_N <bytes>         │
├────────────────────────────┴────────────────────────────┤
│                   Chunk Range <int64>                   │
├─────────────────────────────────────────────────────────┤
│                  Chunk Exists <uvarint>                 │
│  # 1 if head chunk exists, 0 otherwise to detect a nil  |
|  # chunk. Below fields exists only when it's 1 here.    |
├────────────────────────────┬────────────────────────────┤
│      Chunk Mint <int64>    │     Chunk Maxt <int64>     │
├────────────────────────────┴────────────────────────────┤
│                  Chunk Encoding <byte>                  │
├────────────────────────────┬────────────────────────────┤
│     len(Chunk) <uvarint>   │     Chunk <bytes>          │
├────────────────────────────┼────────────────────────────┤
|   sampleBuf[0].t <int64>   |  sampleBuf[0].v <float64>  | 
├────────────────────────────┼────────────────────────────┤
|   sampleBuf[1].t <int64>   |  sampleBuf[1].v <float64>  | 
├────────────────────────────┼────────────────────────────┤
|   sampleBuf[2].t <int64>   |  sampleBuf[2].v <float64>  | 
├────────────────────────────┼────────────────────────────┤
|   sampleBuf[3].t <int64>   |  sampleBuf[3].v <float64>  | 
└────────────────────────────┴────────────────────────────┘
```

Ends with a single record for tombstones. The encoded tombstones uses the same encoding as tombstone file in blocks.

```
┌─────────────────────────────────────────────────────────────────┐
│                        Record Type <byte>                       │
├───────────────────────────────────┬─────────────────────────────┤
│ len(Encoded Tombstones) <uvarint> │ Encoded Tombstones <bytes>  │
└───────────────────────────────────┴─────────────────────────────┘
```