### PR TITLE
Fix minor error in file_sd_config docs

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -628,7 +628,7 @@ discovery mechanism.
 
 ```yaml
 # Patterns for files from which target groups are extracted.
-files:
+- files:
   [ - <filename_pattern> ... ]
 
 # Refresh interval to re-read the files.


### PR DESCRIPTION
Minor error in `file_sd_config` docs.

```yml
    file_sd_configs:
      files:
        - test.yml
```
is incorrect and yields
```
  FAILED: parsing YAML file .\prometheus.yml: yaml: unmarshal errors:
  line 33: cannot unmarshal !!map into []*file.SDConfig
```

Has to be:
```yml
    file_sd_configs:
    - files:
      - test.yml
```
as seen [in this example](https://github.com/prometheus/docs/blob/master/content/docs/guides/file-sd.md).

@brian-brazil 

(Not sure if this really needs @'tting but [`CONTRIBUTING`](https://github.com/prometheus/docs/blob/master/CONTRIBUTING.md) says so ¯\\_(ツ)_/¯