### PR TITLE
[service discovery] marathon: Expose containerPort as __meta label for marathon_sd_config

### DIFF
--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -47,13 +47,12 @@ const (
 	// containerPortLabel is the label that is used for the docker container port .
 	containerPortLabel model.LabelName = metaLabelPrefix + "container_port"
 	// imageLabel is the label that is used for the docker image running the service.
-	imageLabel         model.LabelName = metaLabelPrefix + "image"
+	imageLabel model.LabelName = metaLabelPrefix + "image"
 	// portIndexLabel is the integer port index when multiple ports are defined;
 	// e.g. PORT1 would have a value of '1'
 	portIndexLabel model.LabelName = metaLabelPrefix + "port_index"
 	// taskLabel contains the mesos task name of the app instance.
 	taskLabel model.LabelName = metaLabelPrefix + "task"
-
 	// portMappingLabelPrefix is the prefix for the application portMappings labels.
 	portMappingLabelPrefix = metaLabelPrefix + "port_mapping_label_"
 	// portDefinitionLabelPrefix is the prefix for the application portDefinitions labels.

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -44,8 +44,10 @@ const (
 
 	// appLabel is used for the name of the app in Marathon.
 	appLabel model.LabelName = metaLabelPrefix + "app"
+	// containerPortLabel is the label that is used for the docker container port .
+	containerPortLabel model.LabelName = metaLabelPrefix + "container_port"
 	// imageLabel is the label that is used for the docker image running the service.
-	imageLabel model.LabelName = metaLabelPrefix + "image"
+	imageLabel         model.LabelName = metaLabelPrefix + "image"
 	// portIndexLabel is the integer port index when multiple ports are defined;
 	// e.g. PORT1 would have a value of '1'
 	portIndexLabel model.LabelName = metaLabelPrefix + "port_index"
@@ -429,6 +431,7 @@ func targetsForApp(app *app) []model.LabelSet {
 			target := model.LabelSet{
 				model.AddressLabel: model.LabelValue(targetAddress),
 				taskLabel:          model.LabelValue(t.ID),
+				containerPortLabel: model.LabelValue(strconv.FormatUint(uint64(port), 10)),
 				portIndexLabel:     model.LabelValue(strconv.Itoa(i)),
 			}
 

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -354,6 +354,9 @@ func TestMarathonSDSendGroupWithPortDefinitions(t *testing.T) {
 	if tgt[model.AddressLabel] != "mesos-slave1:1234" {
 		t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
 	}
+	if tgt[model.LabelName(containerPortLabel)] != "1234" {
+		t.Fatalf("Wrong container port: %s", tgt[model.LabelName(containerPortLabel)])
+	}
 	if tgt[model.LabelName(portMappingLabelPrefix+"prometheus")] != "" {
 		t.Fatalf("Wrong first portMappings label from the first port: %s", tgt[model.AddressLabel])
 	}
@@ -425,6 +428,9 @@ func TestMarathonSDSendGroupWithPortDefinitionsRequirePorts(t *testing.T) {
 	tgt := tg.Targets[0]
 	if tgt[model.AddressLabel] != "mesos-slave1:31000" {
 		t.Fatalf("Wrong target address: %s", tgt[model.AddressLabel])
+	}
+	if tgt[model.LabelName(containerPortLabel)] != "31000" {
+		t.Fatalf("Wrong container port: %s", tgt[model.LabelName(containerPortLabel)])
 	}
 	if tgt[model.LabelName(portMappingLabelPrefix+"prometheus")] != "" {
 		t.Fatalf("Wrong first portMappings label from the first port: %s", tgt[model.AddressLabel])

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -896,6 +896,7 @@ create a target group for every app that has at least one healthy task.
 The following meta labels are available on targets during [relabeling](#relabel_config):
 
 * `__meta_marathon_app`: the name of the app (with slashes replaced by dashes)
+* `__meta_marathon_container_port`: the docker container port
 * `__meta_marathon_image`: the name of the Docker image used (if available)
 * `__meta_marathon_task`: the ID of the Mesos task
 * `__meta_marathon_app_label_<labelname>`: any Marathon labels attached to the app


### PR DESCRIPTION
https://github.com/prometheus/prometheus/issues/4310
Signed-off-by: fuling <fuling.lgz@alibaba-inc.com>