### PR TITLE
Add discovery support for triton global zones

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -590,8 +590,8 @@ var expectedConf = &Config{
 			ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
 				TritonSDConfigs: []*triton.SDConfig{
 					{
-
 						Account:         "testAccount",
+						Role:            "container",
 						DNSSuffix:       "triton.example.com",
 						Endpoint:        "triton.example.com",
 						Port:            9163,

--- a/discovery/triton/triton_test.go
+++ b/discovery/triton/triton_test.go
@@ -33,6 +33,7 @@ import (
 var (
 	conf = SDConfig{
 		Account:         "testAccount",
+		Role:            "container",
 		DNSSuffix:       "triton.example.com",
 		Endpoint:        "127.0.0.1",
 		Port:            443,
@@ -42,6 +43,7 @@ var (
 	}
 	badconf = SDConfig{
 		Account:         "badTestAccount",
+		Role:            "container",
 		DNSSuffix:       "bad.triton.example.com",
 		Endpoint:        "127.0.0.1",
 		Port:            443,
@@ -56,9 +58,20 @@ var (
 	}
 	groupsconf = SDConfig{
 		Account:         "testAccount",
+		Role:            "container",
 		DNSSuffix:       "triton.example.com",
 		Endpoint:        "127.0.0.1",
 		Groups:          []string{"foo", "bar"},
+		Port:            443,
+		Version:         1,
+		RefreshInterval: 1,
+		TLSConfig:       config.TLSConfig{InsecureSkipVerify: true},
+	}
+	cnconf = SDConfig{
+		Account:         "testAccount",
+		Role:            "cn",
+		DNSSuffix:       "triton.example.com",
+		Endpoint:        "127.0.0.1",
 		Port:            443,
 		Version:         1,
 		RefreshInterval: 1,
@@ -103,8 +116,22 @@ func TestTritonSDNewGroupsConfig(t *testing.T) {
 	testutil.Equals(t, groupsconf.Port, td.sdConfig.Port)
 }
 
+func TestTritonSDNewCNConfig(t *testing.T) {
+	td, err := newTritonDiscovery(cnconf)
+	testutil.Ok(t, err)
+	testutil.Assert(t, td != nil, "")
+	testutil.Assert(t, td.client != nil, "")
+	testutil.Assert(t, td.interval != 0, "")
+	testutil.Assert(t, td.sdConfig != nil, "")
+	testutil.Equals(t, cnconf.Role, td.sdConfig.Role)
+	testutil.Equals(t, cnconf.Account, td.sdConfig.Account)
+	testutil.Equals(t, cnconf.DNSSuffix, td.sdConfig.DNSSuffix)
+	testutil.Equals(t, cnconf.Endpoint, td.sdConfig.Endpoint)
+	testutil.Equals(t, cnconf.Port, td.sdConfig.Port)
+}
+
 func TestTritonSDRefreshNoTargets(t *testing.T) {
-	tgts := testTritonSDRefresh(t, "{\"containers\":[]}")
+	tgts := testTritonSDRefresh(t, conf, "{\"containers\":[]}")
 	testutil.Assert(t, tgts == nil, "")
 }
 
@@ -129,7 +156,7 @@ func TestTritonSDRefreshMultipleTargets(t *testing.T) {
 		}`
 	)
 
-	tgts := testTritonSDRefresh(t, dstr)
+	tgts := testTritonSDRefresh(t, conf, dstr)
 	testutil.Assert(t, tgts != nil, "")
 	testutil.Equals(t, 2, len(tgts))
 }
@@ -156,9 +183,45 @@ func TestTritonSDRefreshCancelled(t *testing.T) {
 	testutil.Equals(t, strings.Contains(err.Error(), context.Canceled.Error()), true)
 }
 
-func testTritonSDRefresh(t *testing.T, dstr string) []model.LabelSet {
+func TestTritonSDRefreshCNsUUIDOnly(t *testing.T) {
 	var (
-		td, _ = newTritonDiscovery(conf)
+		dstr = `{"cns":[
+		 	{
+				"server_uuid":"44454c4c-5000-104d-8037-b7c04f5a5131"
+			},
+			{
+				"server_uuid":"a5894692-bd32-4ca1-908a-e2dda3c3a5e6"
+			}]
+		}`
+	)
+
+	tgts := testTritonSDRefresh(t, cnconf, dstr)
+	testutil.Assert(t, tgts != nil, "")
+	testutil.Equals(t, 2, len(tgts))
+}
+
+func TestTritonSDRefreshCNsWithHostname(t *testing.T) {
+	var (
+		dstr = `{"cns":[
+		 	{
+				"server_uuid":"44454c4c-5000-104d-8037-b7c04f5a5131",
+				"server_hostname": "server01"
+			},
+			{
+				"server_uuid":"a5894692-bd32-4ca1-908a-e2dda3c3a5e6",
+				"server_hostname": "server02"
+			}]
+		}`
+	)
+
+	tgts := testTritonSDRefresh(t, cnconf, dstr)
+	testutil.Assert(t, tgts != nil, "")
+	testutil.Equals(t, 2, len(tgts))
+}
+
+func testTritonSDRefresh(t *testing.T, c SDConfig, dstr string) []model.LabelSet {
+	var (
+		td, _ = newTritonDiscovery(c)
 		s     = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintln(w, dstr)
 		}))

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1020,37 +1020,60 @@ Serverset data must be in the JSON format, the Thrift format is not currently su
 scrape targets from [Container Monitor](https://github.com/joyent/rfd/blob/master/rfd/0027/README.md)
 discovery endpoints.
 
-The following meta labels are available on targets during relabeling:
+One of the following `<triton_role>` types can be configured to discover targets:
+
+#### `container`
+
+The `container` role discovers one target per "virtual machine" owned by the `account`.
+These are SmartOS zones or lx/KVM/bhyve branded zones.
+
+The following meta labels are available on targets during [relabeling](#relabel_config):
 
 * `__meta_triton_groups`: the list of groups belonging to the target joined by a comma separator
 * `__meta_triton_machine_alias`: the alias of the target container
 * `__meta_triton_machine_brand`: the brand of the target container
 * `__meta_triton_machine_id`: the UUID of the target container
-* `__meta_triton_machine_image`: the target containers image type
-* `__meta_triton_server_id`: the server UUID for the target container
+* `__meta_triton_machine_image`: the target container's image type
+* `__meta_triton_server_id`: the server UUID the target container is running on
 
+#### `cn`
+
+The `cn` role discovers one target for per compute node (also known as "server" or "global zone") making up the Triton infrastructure.
+The `account` must be a Triton operator and is currently required to own at least one `container`.
+
+The following meta labels are available on targets during [relabeling](#relabel_config):
+
+* `__meta_triton_machine_alias`: the hostname of the target (requires triton-cmon 1.7.0 or newer)
+* `__meta_triton_machine_id`: the UUID of the target
+
+See below for the configuration options for Triton discovery:
 ```yaml
 # The information to access the Triton discovery API.
 
-# The account to use for discovering new target containers.
+# The account to use for discovering new targets.
 account: <string>
 
-# The DNS suffix which should be applied to target containers.
+# The type of targets to discover, can be set to:
+# * "container" to discover virtual machines (SmartOS zones, lx/KVM/bhyve branded zones) running on Triton
+# * "cn" to discover compute nodes (servers/global zones) making up the Triton infrastructure
+[ role : <string> | default = "container" ]
+
+# The DNS suffix which should be applied to target.
 dns_suffix: <string>
 
 # The Triton discovery endpoint (e.g. 'cmon.us-east-3b.triton.zone'). This is
 # often the same value as dns_suffix.
 endpoint: <string>
 
-# A list of groups for which targets are retrieved. If omitted, all containers
-# available to the requesting account are scraped.
+# A list of groups for which targets are retrieved, only supported when `role` == `container`.
+# If omitted all containers owned by the requesting account are scraped.
 groups:
   [ - <string> ... ]
 
 # The port to use for discovery and metric scraping.
 [ port: <int> | default = 9163 ]
 
-# The interval which should be used for refreshing target containers.
+# The interval which should be used for refreshing targets.
 [ refresh_interval: <duration> | default = 60s ]
 
 # The Triton discovery API version.


### PR DESCRIPTION
Added optional configuration item server_type, defaults to 'container'.
Setting server-type to 'gz' will discover global zones instead.

Human-friendly hostname discovery depends on cmon 1.7.0:
https://github.com/joyent/triton-cmon/commit/c1a2aeca36cc3c4e8b081a35a01a0b770d30e4ef

Adjust testcases to use discovery config per case as two different types are now supported.

Fixes #3871.