### PR TITLE
get labels from config for interpolation in annotations

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -319,7 +319,12 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 		for _, lbl := range smpl.Metric {
 			l[lbl.Name] = lbl.Value
 		}
-
+		// get labels from config if the evaluation did not return any label
+		if len(l) == 0 && len(r.labels) > 1 {
+			for _, lbl := range r.labels {
+				l[lbl.Name] = lbl.Value
+			}
+		}
 		tmplData := template.AlertTemplateData(l, r.externalLabels, smpl.V)
 		// Inject some convenience variables that are easier to remember for users
 		// who are not used to Go's templating system.


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
When an alert fire, you may or may not get labels, depending on the expression used return a metrics or just a value. 

The labels configured inside the alerts definition are effectively passed to the alert manager and can be used to route the alert.

But in the alert template rendering,  the labels comes from the metrics only, which results in poor alerts Summary, Dashboard etc.  

Example :

```
  - alert: TestLabels
    expr: |
      sum(requests_total) > 1
    for: 1m
    labels:
      team: example
      job: example-runner
      instance: dev
      severity: critical
    annotations:
      summary: "job {{ $labels.job }} total requests = {{ $value }}"
      dashboard: "https://example-dashboard/example?var-env={{ $labels.instance }}&var-team={{ $labels.team }}&var-service={{ $labels.job }}"
```

Without the patch, the alert payload is :
```
    {
      "labels": {
        "alertname": "TestLabels",
        "instance": "dev",
        "job": "example-runner",
        "severity": "critical",
        "team": "example"
      },
      "annotations": {
        "dashboard": "https://example-dashboard/example?var-env=&var-team=&var-service=",
        "summary": "job total requests = 1614"
      },
```

With the patch :
```
    {
      "labels": {
        "alertname": "TestLabels",
        "instance": "dev",
        "job": "example-runner",
        "severity": "critical",
        "team": "example"
      },
      "annotations": {
        "dashboard": "https://example-dashboard/example?var-env=dev&var-team=example&var-service=example-runner",
        "summary": "job example-runner total requests = 1614"
      },
```

I ran the tests successfully
