### PR TITLE
queue_manager: Use buffered channel to avoid blocking

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -676,7 +676,7 @@ func (t *QueueManager) reshardLoop() {
 func (t *QueueManager) newShards() *shards {
 	s := &shards{
 		qm:   t,
-		done: make(chan struct{}),
+		done: make(chan struct{}, 1),
 	}
 	return s
 }
@@ -722,7 +722,7 @@ func (s *shards) start(n int) {
 	hardShutdownCtx, s.hardShutdown = context.WithCancel(context.Background())
 	s.softShutdown = make(chan struct{})
 	s.running = int32(n)
-	s.done = make(chan struct{})
+	s.done = make(chan struct{}, 1)
 	for i := 0; i < n; i++ {
 		go s.runShard(hardShutdownCtx, i, newQueues[i])
 	}

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -756,7 +756,6 @@ func (s *shards) stop() {
 
 	// Force an unclean shutdown.
 	s.hardShutdown()
-	<-s.done
 }
 
 // enqueue a sample.  If we are currently in the process of shutting down or resharding,


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

The send operation to the channel done will certainly be executed, but the receive operation may not, if the goroutine times out. Hence the goroutine might get stuck and cause a leak. A simple fix is to use a buffered channel so that the goroutine can write to it without having to care if there's a reader or not. This PR converts the channel to a buffered channel.