### PR TITLE
tsdb: fix goroutine leak on channel stopC

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -548,7 +548,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		opts:        opts,
 		compactc:    make(chan struct{}, 1),
 		donec:       make(chan struct{}),
-		stopc:       make(chan struct{}),
+		stopc:       make(chan struct{}, 1),
 		autoCompact: true,
 		chunkPool:   chunkenc.NewPool(),
 	}


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

In the function: func (db *DB) run() {} , select listens on 2 channels with a timeout. The channel: db.compactC is a buffered channel however the other channel db.stopC is not buffered. In case some goroutine is trying to write to it but is timed out, it can cause leak. The PR converts the db.stopC to a buffered channel just like the db.compactC .