### PR TITLE
Better evaluate impact in memory of range selection

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -608,6 +608,10 @@ func TestMaxQuerySamples(t *testing.T) {
 	test, err := NewTest(t, `
 load 10s
   metric 1 2
+  metric2{a="1"} 1 2
+  metric2{a="2"} 2 2
+  metric2{a="3"} 3 2
+  metric2{a="4"} 4 2
 `)
 	testutil.Ok(t, err)
 	defer test.Close()
@@ -665,6 +669,33 @@ load 10s
 				nil,
 			},
 			Start: time.Unix(1, 0),
+		},
+		{
+			Query:      "sort(max_over_time(metric2[20s]))",
+			MaxSamples: 8,
+			Result: Result{
+				nil,
+				Vector{
+					Sample{
+						Point:  Point{V: 1, T: 5000},
+						Metric: labels.FromStrings("a", "1"),
+					},
+					Sample{
+						Point:  Point{V: 2, T: 5000},
+						Metric: labels.FromStrings("a", "2"),
+					},
+					Sample{
+						Point:  Point{V: 3, T: 5000},
+						Metric: labels.FromStrings("a", "3"),
+					},
+					Sample{
+						Point:  Point{V: 4, T: 5000},
+						Metric: labels.FromStrings("a", "4"),
+					},
+				},
+				nil,
+			},
+			Start: time.Unix(5, 0),
 		},
 		{
 			Query:      "metric[20s]",


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->