### PR TITLE
Added time range parameters to labelNames API

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -268,6 +268,12 @@ GET /api/v1/labels
 POST /api/v1/labels
 ```
 
+URL query parameters:
+
+- `start=<rfc3339 | unix_timestamp>`: Start timestamp. Optional.
+- `end=<rfc3339 | unix_timestamp>`: End timestamp. Optional.
+
+
 The `data` section of the JSON response is a list of string label names.
 
 Here is an example.
@@ -309,6 +315,12 @@ The following endpoint returns a list of label values for a provided label name:
 ```
 GET /api/v1/label/<label_name>/values
 ```
+
+URL query parameters:
+
+- `start=<rfc3339 | unix_timestamp>`: Start timestamp. Optional.
+- `end=<rfc3339 | unix_timestamp>`: End timestamp. Optional.
+
 
 The `data` section of the JSON response is a list of string label values.
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1555,6 +1555,11 @@ func (h *headIndexReader) LabelValues(name string) ([]string, error) {
 func (h *headIndexReader) LabelNames() ([]string, error) {
 	h.head.symMtx.RLock()
 	defer h.head.symMtx.RUnlock()
+
+	if h.maxt < h.head.MinTime() || h.mint > h.head.MaxTime() {
+		return []string{}, nil
+	}
+
 	labelNames := make([]string, 0, len(h.head.values))
 	for name := range h.head.values {
 		if name == "" {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1539,7 +1539,8 @@ func (h *headIndexReader) Symbols() index.StringIter {
 	return index.NewStringListIter(res)
 }
 
-// LabelValues returns the possible label values
+// LabelValues returns label values present in the head for the
+// specific label name that are within the time range mint to maxt.
 func (h *headIndexReader) LabelValues(name string) ([]string, error) {
 	h.head.symMtx.RLock()
 	if h.maxt < h.head.MinTime() || h.mint > h.head.MaxTime() {
@@ -1555,7 +1556,8 @@ func (h *headIndexReader) LabelValues(name string) ([]string, error) {
 	return sl, nil
 }
 
-// LabelNames returns all the unique label names present in the head.
+// LabelNames returns all the unique label names present in the head
+// that are within the time range mint to maxt.
 func (h *headIndexReader) LabelNames() ([]string, error) {
 	h.head.symMtx.RLock()
 	defer h.head.symMtx.RUnlock()

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1543,7 +1543,9 @@ func (h *headIndexReader) Symbols() index.StringIter {
 // specific label name that are within the time range mint to maxt.
 func (h *headIndexReader) LabelValues(name string) ([]string, error) {
 	h.head.symMtx.RLock()
+
 	if h.maxt < h.head.MinTime() || h.mint > h.head.MaxTime() {
+		h.head.symMtx.RUnlock()
 		return []string{}, nil
 	}
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1542,6 +1542,10 @@ func (h *headIndexReader) Symbols() index.StringIter {
 // LabelValues returns the possible label values
 func (h *headIndexReader) LabelValues(name string) ([]string, error) {
 	h.head.symMtx.RLock()
+	if h.maxt < h.head.MinTime() || h.mint > h.head.MaxTime() {
+		return []string{}, nil
+	}
+
 	sl := make([]string, 0, len(h.head.values[name]))
 	for s := range h.head.values[name] {
 		sl = append(sl, s)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1813,9 +1813,9 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 
 func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 	head, _, closer := newTestHead(t, 1000, false)
+	defer closer()
 	defer func() {
-		closer()
-		testutil.Ok(t, head.Close())
+		testutil.Ok(t, hb.Close())
 	}()
 
 	const (

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1884,7 +1884,7 @@ func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 	// of head timestamps
 	{
 		mint := head.MaxTime() + 10
-		maxt := head.MinTime() + 10
+		maxt := head.MinTime() - 10
 		headIdxReader := head.indexRange(mint, maxt)
 		actualLabelNames, err := headIdxReader.LabelNames()
 		testutil.Ok(t, err)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1842,15 +1842,16 @@ func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 	testutil.Equals(t, head.MaxTime(), lastSeriesTimestamp)
 
 	var testCases = []struct {
-		name     string
-		mint     int64
-		maxt     int64
-		expected []string
+		name           string
+		mint           int64
+		maxt           int64
+		expectedNames  []string
+		expectedValues []string
 	}{
-		{"maxt less than head min", head.MaxTime() - 10, head.MinTime() - 10, []string{}},
-		{"mint less than head max", head.MaxTime() + 10, head.MinTime() + 10, []string{}},
-		{"mint and maxt outside head", head.MaxTime() + 10, head.MinTime() - 10, []string{}},
-		{"mint and maxt within head", head.MaxTime() - 10, head.MinTime() + 10, expectedLabelNames},
+		{"maxt less than head min", head.MaxTime() - 10, head.MinTime() - 10, []string{}, []string{}},
+		{"mint less than head max", head.MaxTime() + 10, head.MinTime() + 10, []string{}, []string{}},
+		{"mint and maxt outside head", head.MaxTime() + 10, head.MinTime() - 10, []string{}, []string{}},
+		{"mint and maxt within head", head.MaxTime() - 10, head.MinTime() + 10, expectedLabelNames, expectedLabelValues},
 	}
 
 	for _, tt := range testCases {
@@ -1858,11 +1859,13 @@ func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 			headIdxReader := head.indexRange(tt.mint, tt.maxt)
 			actualLabelNames, err := headIdxReader.LabelNames()
 			testutil.Ok(t, err)
-			testutil.Equals(t, tt.expected, actualLabelNames)
-			for i, name := range actualLabelNames {
-				actualLabelValue, err := headIdxReader.LabelValues(name)
-				testutil.Ok(t, err)
-				testutil.Equals(t, []string{expectedLabelValues[i]}, actualLabelValue)
+			testutil.Equals(t, tt.expectedNames, actualLabelNames)
+			if len(tt.expectedValues) > 0 {
+				for i, name := range expectedLabelNames {
+					actualLabelValue, err := headIdxReader.LabelValues(name)
+					testutil.Ok(t, err)
+					testutil.Equals(t, []string{tt.expectedValues[i]}, actualLabelValue)
+				}
 			}
 		})
 	}

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -64,7 +64,7 @@ func (q *querier) LabelNames() ([]string, storage.Warnings, error) {
 
 func (q *querier) lvals(qs []storage.Querier, n string) ([]string, storage.Warnings, error) {
 	if len(qs) == 0 {
-		return nil, nil, nil
+		return []string{}, nil, nil
 	}
 	if len(qs) == 1 {
 		return qs[0].LabelValues(n)
@@ -75,12 +75,12 @@ func (q *querier) lvals(qs []storage.Querier, n string) ([]string, storage.Warni
 	s1, w, err := q.lvals(qs[:l], n)
 	ws = append(ws, w...)
 	if err != nil {
-		return nil, ws, err
+		return []string{}, ws, err
 	}
 	s2, ws, err := q.lvals(qs[l:], n)
 	ws = append(ws, w...)
 	if err != nil {
-		return nil, ws, err
+		return []string{}, ws, err
 	}
 	return mergeStrings(s1, s2), ws, nil
 }

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -484,13 +484,11 @@ func returnAPIError(err error) *apiError {
 func (api *API) labelNames(r *http.Request) apiFuncResult {
 	start, err := parseTimeParam(r, "start", minTime)
 	if err != nil {
-		err = errors.Wrap(err, "invalid parameter 'start'")
-		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorBadData, errors.Wrap(err, "invalid parameter 'start'")}, nil, nil}
 	}
 	end, err := parseTimeParam(r, "end", maxTime)
 	if err != nil {
-		err = errors.Wrap(err, "invalid parameter 'end'")
-		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorBadData, errors.Wrap(err, "invalid parameter 'end'")}, nil, nil}
 	}
 
 	q, err := api.Queryable.Querier(r.Context(), timestamp.FromTime(start), timestamp.FromTime(end))

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -514,7 +514,18 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 		return apiFuncResult{nil, &apiError{errorBadData, errors.Errorf("invalid label name: %q", name)}, nil, nil}
 	}
 
-	q, err := api.Queryable.Querier(ctx, math.MinInt64, math.MaxInt64)
+	start, err := parseTimeParam(r, "start", minTime)
+	if err != nil {
+		err = errors.Wrap(err, "invalid parameter 'start'")
+		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
+	}
+	end, err := parseTimeParam(r, "end", maxTime)
+	if err != nil {
+		err = errors.Wrap(err, "invalid parameter 'end'")
+		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
+	}
+
+	q, err := api.Queryable.Querier(r.Context(), timestamp.FromTime(start), timestamp.FromTime(end))
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorExec, err}, nil, nil}
 	}

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -484,12 +484,12 @@ func returnAPIError(err error) *apiError {
 func (api *API) labelNames(r *http.Request) apiFuncResult {
 	start, err := parseTimeParam(r, "start", minTime)
 	if err != nil {
-		err = errors.Wrapf(err, "invalid parameter 'start'")
+		err = errors.Wrap(err, "invalid parameter 'start'")
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
 	end, err := parseTimeParam(r, "end", maxTime)
 	if err != nil {
-		err = errors.Wrapf(err, "invalid parameter 'end'")
+		err = errors.Wrap(err, "invalid parameter 'end'")
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
 

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -516,13 +516,11 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 
 	start, err := parseTimeParam(r, "start", minTime)
 	if err != nil {
-		err = errors.Wrap(err, "invalid parameter 'start'")
-		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorBadData, errors.Wrap(err, "invalid parameter 'start'")}, nil, nil}
 	}
 	end, err := parseTimeParam(r, "end", maxTime)
 	if err != nil {
-		err = errors.Wrap(err, "invalid parameter 'end'")
-		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorBadData, errors.Wrap(err, "invalid parameter 'end'")}, nil, nil}
 	}
 
 	q, err := api.Queryable.Querier(r.Context(), timestamp.FromTime(start), timestamp.FromTime(end))

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1474,6 +1474,18 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				},
 				errType: errorBadData,
 			},
+			// Start and end before LabelValues starts.
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"start": []string{"-2"},
+					"end":   []string{"-1"},
+				},
+				response: []string{},
+			},
 			// Start and end within LabelValues.
 			{
 				endpoint: api.labelValues,
@@ -1497,7 +1509,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				},
 				query: url.Values{
 					"start": []string{"-1"},
-					"end":   []string{"1"},
+					"end":   []string{"3"},
 				},
 				response: []string{
 					"bar",
@@ -1511,15 +1523,15 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"name": "foo",
 				},
 				query: url.Values{
-					"start": []string{"-1"},
-					"end":   []string{"100000"},
+					"start": []string{"1969-12-31T00:00:00Z"},
+					"end":   []string{"1970-02-01T00:02:03Z"},
 				},
 				response: []string{
 					"bar",
 					"boo",
 				},
 			},
-			// Start with bad data for LabelValues, end within LabelValues.
+			// Start with bad data, end within LabelValues.
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{
@@ -1558,18 +1570,35 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				},
 				response: []string{},
 			},
-			// Start and end before LabelValues starts.
+			// Only provide Start within LabelValues, don't provide an end time.
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{
 					"name": "foo",
 				},
 				query: url.Values{
-					"start": []string{"-2"},
-					"end":   []string{"-1"},
+					"start": []string{"2"},
 				},
-				response: []string{},
+				response: []string{
+					"bar",
+					"boo",
+				},
 			},
+			// Only provide end within LabelValues, don't provide a start time.
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"end": []string{"100"},
+				},
+				response: []string{
+					"bar",
+					"boo",
+				},
+			},
+
 			// Label names.
 			{
 				endpoint: api.labelNames,
@@ -1598,7 +1627,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				endpoint: api.labelNames,
 				query: url.Values{
 					"start": []string{"-1"},
-					"end":   []string{"1"},
+					"end":   []string{"10"},
 				},
 				response: []string{"__name__", "foo"},
 			},
@@ -1626,7 +1655,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				endpoint: api.labelNames,
 				query: url.Values{
 					"start": []string{"1"},
-					"end":   []string{"100000000"},
+					"end":   []string{"1000000006"},
 				},
 				response: []string{"__name__", "foo"},
 			},
@@ -1638,6 +1667,22 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"end":   []string{"148966367200.972"},
 				},
 				response: []string{},
+			},
+			// Only provide Start within Label names, don't provide an end time.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"start": []string{"4"},
+				},
+				response: []string{"__name__", "foo"},
+			},
+			// Only provide End within Label names, don't provide a start time.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"end": []string{"20"},
+				},
+				response: []string{"__name__", "foo"},
 			},
 		}...)
 	}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1530,21 +1530,18 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				endpoint: api.labelNames,
 				query: url.Values{
 					"start": []string{"1"},
-					"end":   []string{"100000"},
+					"end":   []string{"100000000"},
 				},
 				response: []string{"__name__", "foo"},
 			},
 			// Start and end after Label names ends.
-			// fixme: currently failing, got ["__name__","foo"]
-			// question: how do we know what the min/max timestamp is of
-			// the block that contains this data?
 			{
 				endpoint: api.labelNames,
 				query: url.Values{
-					"start": []string{"1000000"},
-					"end":   []string{"1000001"},
+					"start": []string{"148966367200.372"},
+					"end":   []string{"148966367200.972"},
 				},
-				response: []labels.Labels{},
+				response: []string{},
 			},
 		}...)
 	}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1474,6 +1474,102 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				},
 				errType: errorBadData,
 			},
+			// Start and end within LabelValues.
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"start": []string{"1"},
+					"end":   []string{"100"},
+				},
+				response: []string{
+					"bar",
+					"boo",
+				},
+			},
+			// Start before LabelValues, end within LabelValues.
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"start": []string{"-1"},
+					"end":   []string{"1"},
+				},
+				response: []string{
+					"bar",
+					"boo",
+				},
+			},
+			// Start before LabelValues starts, end after LabelValues ends.
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"start": []string{"-1"},
+					"end":   []string{"100000"},
+				},
+				response: []string{
+					"bar",
+					"boo",
+				},
+			},
+			// Start with bad data for LabelValues, end within LabelValues.
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"start": []string{"boop"},
+					"end":   []string{"1"},
+				},
+				errType: errorBadData,
+			},
+			// Start within LabelValues, end after.
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"start": []string{"1"},
+					"end":   []string{"100000000"},
+				},
+				response: []string{
+					"bar",
+					"boo",
+				},
+			},
+			// Start and end after LabelValues ends.
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"start": []string{"148966367200.372"},
+					"end":   []string{"148966367200.972"},
+				},
+				response: []string{},
+			},
+			// Start and end before LabelValues starts.
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"start": []string{"-2"},
+					"end":   []string{"-1"},
+				},
+				response: []string{},
+			},
 			// Label names.
 			{
 				endpoint: api.labelNames,

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1479,6 +1479,73 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				endpoint: api.labelNames,
 				response: []string{"__name__", "foo"},
 			},
+			// Start and end before Label names starts.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"start": []string{"-2"},
+					"end":   []string{"-1"},
+				},
+				response: []string{},
+			},
+			// Start and end within Label names.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"start": []string{"1"},
+					"end":   []string{"100"},
+				},
+				response: []string{"__name__", "foo"},
+			},
+			// Start before Label names, end within Label names.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"start": []string{"-1"},
+					"end":   []string{"1"},
+				},
+				response: []string{"__name__", "foo"},
+			},
+
+			// Start before Label names starts, end after Label names ends.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"start": []string{"-1"},
+					"end":   []string{"100000"},
+				},
+				response: []string{"__name__", "foo"},
+			},
+			// Start with bad data for Label names, end within Label names.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"start": []string{"boop"},
+					"end":   []string{"1"},
+				},
+				errType: errorBadData,
+			},
+			// Start within Label names, end after.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"start": []string{"1"},
+					"end":   []string{"100000"},
+				},
+				response: []string{"__name__", "foo"},
+			},
+			// Start and end after Label names ends.
+			// fixme: currently failing, got ["__name__","foo"]
+			// question: how do we know what the min/max timestamp is of
+			// the block that contains this data?
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"start": []string{"1000000"},
+					"end":   []string{"1000001"},
+				},
+				response: []labels.Labels{},
+			},
 		}...)
 	}
 


### PR DESCRIPTION
This PR is for issue: https://github.com/prometheus/prometheus/issues/6865

This PR adds the ability to pass a `start` and `end` time range parameter to the `api/v1/label` and `/api/v1/label/<label_name>/values` route.  

- for simplicity, this change does not add any matchers functionality
- this change does not use the `series` api ([ref](https://github.com/prometheus/prometheus/issues/6865#issuecomment-590714724))
- this "keeps it simple and allow for false positives when the time doesn't exactly align with a block" ([ref](https://github.com/prometheus/prometheus/issues/6865#issuecomment-590348567))
- the start/end parameters are optional and API backwards compatibility is maintained

Other implementation details:
- It turns out the head index reader was ignoring the timestamps passed from the Querier mint(start)/maxt(end) ([ref](https://github.com/prometheus/prometheus/blob/4658ce60d1f21529a7ffe35ab0a30baeefbe1a04/tsdb/head.go#L1554-L1567)). This PR adds logic so that the head index reader evaluates these times now.  If the start is after the last item in the head or if the end is less than the first item in the head, no labels will be returned. This means we are saying the official "end" of the head block - is the maximum-seen sample timestamp for that in the head.

Open questions:
- Should we change `maxt >= db.head.MinTime()` to ` if maxt >= db.head.MinTime() && mint <= db.head.MaxTime()` in `tsdb/db.go/db.Querier` ([ref](https://github.com/prometheus/prometheus/blob/4658ce60d1f21529a7ffe35ab0a30baeefbe1a04/tsdb/db.go#L1305-L1311))?  Generally there is a hierarchical filtering structure, with the mint/maxt being passed all the way down... in db.go if we can already detect the entire head doesn't overlap, I don't think we need to append the head there. And then the mint/maxt within the actual blocks/head should could mainly be used for more finer-grained checks (where its possible - we decided against that for LabelNames() for now and only evaluate at the full block)
- Since the head index reader was ignoring the timestamps passed from the Querier mint(start)/maxt(end) ([ref](https://github.com/prometheus/prometheus/blob/4658ce60d1f21529a7ffe35ab0a30baeefbe1a04/tsdb/head.go#L1554-L1567)),  it would just be good to apply the same check systematically in other places where it is applicable (other metadata methods, etc.). Should we make that change in this PR or save those fixes for another PR?