### PR TITLE
Pass reference to checkAddError so appendErrors is updated.

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1140,7 +1140,7 @@ loop:
 
 		if ok {
 			err = app.AddFast(ce.ref, t, v)
-			sampleAdded, err = sl.checkAddError(ce, met, tp, err, &sampleLimitErr, appErrs)
+			sampleAdded, err = sl.checkAddError(ce, met, tp, err, &sampleLimitErr, &appErrs)
 			// In theory this should never happen.
 			if err == storage.ErrNotFound {
 				ok = false
@@ -1169,7 +1169,7 @@ loop:
 
 			var ref uint64
 			ref, err = app.Add(lset, t, v)
-			sampleAdded, err = sl.checkAddError(nil, met, tp, err, &sampleLimitErr, appErrs)
+			sampleAdded, err = sl.checkAddError(nil, met, tp, err, &sampleLimitErr, &appErrs)
 			if err != nil {
 				if err != storage.ErrNotFound {
 					level.Debug(sl.l).Log("msg", "Unexpected error", "series", string(met), "err", err)
@@ -1231,7 +1231,7 @@ func yoloString(b []byte) string {
 // Adds samples to the appender, checking the error, and then returns the # of samples added,
 // whether the caller should continue to process more samples, and any sample limit errors.
 
-func (sl *scrapeLoop) checkAddError(ce *cacheEntry, met []byte, tp *int64, err error, sampleLimitErr *error, appErrs appendErrors) (bool, error) {
+func (sl *scrapeLoop) checkAddError(ce *cacheEntry, met []byte, tp *int64, err error, sampleLimitErr *error, appErrs *appendErrors) (bool, error) {
 	switch errors.Cause(err) {
 	case nil:
 		if tp == nil && ce != nil {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
 	config_util "github.com/prometheus/common/config"
@@ -1919,4 +1920,11 @@ func TestReuseCacheRace(t *testing.T) {
 			SampleLimit:    i,
 		})
 	}
+}
+
+func TestCheckAddError(t *testing.T) {
+	var appErrs appendErrors
+	sl := scrapeLoop{l: log.NewNopLogger()}
+	sl.checkAddError(nil, nil, nil, storage.ErrOutOfOrderSample, nil, &appErrs)
+	testutil.Equals(t, 1, appErrs.numOutOfOrder)
 }


### PR DESCRIPTION
This was preventing the warnings from being logged.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>
