### PR TITLE
Preallocate m-map file only for Windows

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -188,7 +188,7 @@ func (cdm *ChunkDiskMapper) openMMapFiles() (returnErr error) {
 	for seq, fn := range files {
 		f, err := fileutil.OpenMmapFile(fn)
 		if err != nil {
-			return errors.Wrap(err, "mmap files")
+			return errors.Wrapf(err, "mmap files, file: %s", fn)
 		}
 		cdm.closers[seq] = f
 		cdm.mmappedChunkFiles[seq] = &mmappedChunkFile{byteSlice: realByteSlice(f.Bytes())}
@@ -337,7 +337,7 @@ func (cdm *ChunkDiskMapper) cut(mint int64) (returnErr error) {
 		return err
 	}
 
-	n, newFile, seq, err := cutSegmentFile(cdm.dir, MagicHeadChunks, headChunksFormatV1, int64(MaxHeadChunkFileSize))
+	n, newFile, seq, err := cutSegmentFile(cdm.dir, MagicHeadChunks, headChunksFormatV1, HeadChunkFilePreallocationSize)
 	if err != nil {
 		return err
 	}

--- a/tsdb/chunks/head_chunks_other.go
+++ b/tsdb/chunks/head_chunks_other.go
@@ -1,0 +1,22 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package chunks
+
+var (
+	// HeadChunkFilePreallocationSize is the size to which the m-map file should be preallocated when a new file is cut.
+	// Windows needs pre-allocations while the other OS does not.
+	HeadChunkFilePreallocationSize int64
+)

--- a/tsdb/chunks/head_chunks_windows.go
+++ b/tsdb/chunks/head_chunks_windows.go
@@ -1,0 +1,20 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunks
+
+var (
+	// HeadChunkFilePreallocationSize is the size to which the m-map file should be preallocated when a new file is cut.
+	// Windows needs pre-allocation to m-map the file.
+	HeadChunkFilePreallocationSize int64 = MaxHeadChunkFileSize
+)


### PR DESCRIPTION
Closes https://github.com/prometheus/prometheus/issues/7284 and https://github.com/prometheus/prometheus/issues/7305

This PR makes pre-allocations of m-map file only necessary for Windows, as it has issues m-mapping an empty file with arbitrary m-map size.

For #7284: Parallel allocations of lots of 512MB files caused the disk to fill up. Tests are now able to run in my local machine which used to run out of space. Can you test this @roidelapluie?

For #7305: it's the same reason, but additionally, if the WAL contains a lot of not-in-sync samples, it causes a lot of unnecessary new m-map files because of hitting the 40m time cap for a file (consider 4 chunks with their maxt appearing in order 5m 50m 5m 50m, that would cause 2 files for just 2 chunks) and hence fill up the disk.

Sorry Windows users.