### PR TITLE
Correctly track points no longer used by matrixIterSlice's slice.

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1120,6 +1120,7 @@ func (ev *evaluator) eval(expr parser.Expr) parser.Value {
 		// Process all the calls for one time series at a time.
 		it := storage.NewBuffer(selRange)
 		for i, s := range selVS.Series {
+			ev.currentSamples -= len(points)
 			points = points[:0]
 			it.Reset(s.Iterator())
 			ss := Series{
@@ -1170,6 +1171,7 @@ func (ev *evaluator) eval(expr parser.Expr) parser.Value {
 			}
 		}
 
+		ev.currentSamples -= len(points)
 		putPointSlice(points)
 
 		// The absent_over_time function returns 0 or 1 series. So far, the matrix
@@ -1480,11 +1482,13 @@ func (ev *evaluator) matrixIterSlice(it *storage.BufferedSeriesIterator, mint, m
 		var drop int
 		for drop = 0; out[drop].T < mint; drop++ {
 		}
+		ev.currentSamples -= drop
 		copy(out, out[drop:])
 		out = out[:len(out)-drop]
 		// Only append points with timestamps after the last timestamp we have.
 		mint = out[len(out)-1].T + 1
 	} else {
+		ev.currentSamples -= len(out)
 		out = out[:0]
 	}
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -608,6 +608,8 @@ func TestMaxQuerySamples(t *testing.T) {
 	test, err := NewTest(t, `
 load 10s
   metric 1 2
+  bigmetric{a="1"} 1 2
+  bigmetric{a="2"} 1 2
 `)
 	testutil.Ok(t, err)
 	defer test.Close()
@@ -793,6 +795,18 @@ load 10s
 			Result: Result{
 				ErrTooManySamples(env),
 				nil,
+				nil,
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(10, 0),
+			Interval: 5 * time.Second,
+		},
+		{
+			Query:      "rate(bigmetric[1s])",
+			MaxSamples: 1,
+			Result: Result{
+				nil,
+				Matrix{},
 				nil,
 			},
 			Start:    time.Unix(0, 0),


### PR DESCRIPTION
Another approach to #7285 

@roidelapluie 