### PR TITLE
Bump jquery to fix secuirty warning

### DIFF
--- a/web/ui/react-app/package.json
+++ b/web/ui/react-app/package.json
@@ -24,7 +24,7 @@
     "fuzzy": "^0.1.3",
     "i": "^0.3.6",
     "jest-fetch-mock": "^2.1.2",
-    "jquery": "^3.3.1",
+    "jquery": "^3.5",
     "jquery.flot.tooltip": "^0.9.0",
     "jsdom": "^15.2.0",
     "moment": "^2.24.0",

--- a/web/ui/react-app/yarn.lock
+++ b/web/ui/react-app/yarn.lock
@@ -6484,10 +6484,10 @@ jquery.flot.tooltip@^0.9.0:
   resolved "https://registry.yarnpkg.com/jquery.flot.tooltip/-/jquery.flot.tooltip-0.9.0.tgz#ae16bf94b26c2ed9ab4db167bba52dfdb615c1df"
   integrity sha1-rha/lLJsLtmrTbFnu6Ut/bYVwd8=
 
-jquery@^3.0, jquery@^3.3.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+jquery@^3.0, jquery@^3.5:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
* Use major version dependency to make updates easier.
* Pin to >= 3.5.

Signed-off-by: Ben Kochie <superq@gmail.com>
