### PR TITLE
Fuzz: limit input size

### DIFF
--- a/promql/fuzz.go
+++ b/promql/fuzz.go
@@ -48,6 +48,11 @@ const (
 	fuzzInteresting = 1
 	fuzzMeh         = 0
 	fuzzDiscard     = -1
+
+	// Input size above which we know that Prometheus would consume too much
+	// memory. The recommended way to deal with it is check input size.
+	// https://google.github.io/oss-fuzz/getting-started/new-project-guide/#input-size
+	maxInputSize = 10240
 )
 
 func fuzzParseMetricWithContentType(in []byte, contentType string) int {
@@ -84,6 +89,9 @@ func FuzzParseOpenMetric(in []byte) int {
 
 // Fuzz the metric selector parser.
 func FuzzParseMetricSelector(in []byte) int {
+	if len(in) > maxInputSize {
+		return fuzzMeh
+	}
 	_, err := parser.ParseMetricSelector(string(in))
 	if err == nil {
 		return fuzzInteresting
@@ -94,6 +102,9 @@ func FuzzParseMetricSelector(in []byte) int {
 
 // Fuzz the expression parser.
 func FuzzParseExpr(in []byte) int {
+	if len(in) > maxInputSize {
+		return fuzzMeh
+	}
 	_, err := parser.ParseExpr(string(in))
 	if err == nil {
 		return fuzzInteresting


### PR DESCRIPTION
We know that fuzzParseExpr and fuzzParseMetricSelector make use of heavy
things like regexes, which take a fairly big amount of memory.

OSS-Fuzz does not offer a proper way to increase the memory [1], therefore
we limit the input size [2].

[1] https://google.github.io/oss-fuzz/faq/#how-do-you-handle-timeouts-and-ooms
[2] https://google.github.io/oss-fuzz/getting-started/new-project-guide/#input-size

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->