### PR TITLE
increase the remote write bucket range

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -115,7 +115,7 @@ func newQueueManagerMetrics(r prometheus.Registerer, rn, e string) *queueManager
 		Subsystem:   subsystem,
 		Name:        "sent_batch_duration_seconds",
 		Help:        "Duration of sample batch send calls to the remote storage.",
-		Buckets:     append(prometheus.DefBuckets, 20, 45, 60, 150, 300),
+		Buckets:     append(prometheus.DefBuckets, 25, 60, 120, 300),
 		ConstLabels: constLabels,
 	})
 	m.highestSentTimestamp = &maxGauge{

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -115,7 +115,7 @@ func newQueueManagerMetrics(r prometheus.Registerer, rn, e string) *queueManager
 		Subsystem:   subsystem,
 		Name:        "sent_batch_duration_seconds",
 		Help:        "Duration of sample batch send calls to the remote storage.",
-		Buckets:     prometheus.DefBuckets,
+		Buckets:     prometheus.ExponentialBuckets(.03125, 2, 15),
 		ConstLabels: constLabels,
 	})
 	m.highestSentTimestamp = &maxGauge{

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -115,7 +115,7 @@ func newQueueManagerMetrics(r prometheus.Registerer, rn, e string) *queueManager
 		Subsystem:   subsystem,
 		Name:        "sent_batch_duration_seconds",
 		Help:        "Duration of sample batch send calls to the remote storage.",
-		Buckets:     prometheus.ExponentialBuckets(.03125, 2, 15),
+		Buckets:     append(prometheus.DefBuckets, 20, 45, 60, 150, 300),
 		ConstLabels: constLabels,
 	})
 	m.highestSentTimestamp = &maxGauge{


### PR DESCRIPTION
Increase the range of remote write buckets to capture times above 10s for laggy scenarios
Buckets had been: {.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
Buckets are now: {0.03125, 0.0625, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
