### PR TITLE
Optimise lowWatermark in Isolation

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -255,9 +255,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 				Name: "prometheus_tsdb_isolation_high_watermark",
 				Help: "The highest TSDB append ID that has been given out.",
 			}, func() float64 {
-				h.iso.appendMtx.Lock()
-				defer h.iso.appendMtx.Unlock()
-				return float64(h.iso.lastAppendID)
+				return float64(h.iso.lastAppendID())
 			}),
 		)
 	}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1677,7 +1677,7 @@ func TestIsolationWithoutAdd(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, app.Commit())
 
-	testutil.Equals(t, hb.iso.lastAppendID, hb.iso.lowWatermark(), "High watermark should be equal to the low watermark")
+	testutil.Equals(t, hb.iso.lastAppendID(), hb.iso.lowWatermark(), "High watermark should be equal to the low watermark")
 }
 
 func TestOutOfOrderSamplesMetric(t *testing.T) {

--- a/tsdb/isolation.go
+++ b/tsdb/isolation.go
@@ -51,6 +51,8 @@ type isolation struct {
 	// Which appends are currently in progress.
 	appendsOpen map[uint64]*isolationAppender
 	// New appenders with higher appendID are added to the end. First element keeps lastAppendId.
+	// appendsOpenList.next points to the first element and appendsOpenList.prev points to the last element.
+	// If there are no appenders, both point back to appendsOpenList.
 	appendsOpenList *isolationAppender
 	// Pool of reusable *isolationAppender to save on allocations.
 	appendersPool sync.Pool

--- a/tsdb/isolation_test.go
+++ b/tsdb/isolation_test.go
@@ -14,52 +14,38 @@
 package tsdb
 
 import (
+	"strconv"
 	"sync"
 	"testing"
 )
 
-func TestIsolation(t *testing.T) {
-}
+func BenchmarkIsolation(b *testing.B) {
+	for _, goroutines := range []int{10, 100, 1000, 10000} {
+		b.Run(strconv.Itoa(goroutines), func(b *testing.B) {
+			iso := newIsolation()
 
-func BenchmarkIsolation_10(b *testing.B) {
-	benchmarkIsolation(b, 10)
-}
+			wg := sync.WaitGroup{}
+			start := make(chan struct{})
 
-func BenchmarkIsolation_100(b *testing.B) {
-	benchmarkIsolation(b, 100)
-}
+			for g := 0; g < goroutines; g++ {
+				wg.Add(1)
 
-func BenchmarkIsolation_1000(b *testing.B) {
-	benchmarkIsolation(b, 1000)
-}
+				go func() {
+					defer wg.Done()
+					<-start
 
-func BenchmarkIsolation_10000(b *testing.B) {
-	benchmarkIsolation(b, 10000)
-}
+					for i := 0; i < b.N; i++ {
+						appendID := iso.newAppendID()
+						_ = iso.lowWatermark()
 
-func benchmarkIsolation(b *testing.B, goroutines int) {
-	iso := newIsolation()
-
-	wg := sync.WaitGroup{}
-	start := make(chan struct{})
-
-	for g := 0; g < goroutines; g++ {
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-			<-start
-
-			for i := 0; i < b.N; i++ {
-				appendID := iso.newAppendID()
-				_ = iso.lowWatermark()
-
-				iso.closeAppend(appendID)
+						iso.closeAppend(appendID)
+					}
+				}()
 			}
-		}()
-	}
 
-	b.ResetTimer()
-	close(start)
-	wg.Wait()
+			b.ResetTimer()
+			close(start)
+			wg.Wait()
+		})
+	}
 }

--- a/tsdb/isolation_test.go
+++ b/tsdb/isolation_test.go
@@ -1,3 +1,16 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tsdb
 
 import (

--- a/tsdb/isolation_test.go
+++ b/tsdb/isolation_test.go
@@ -1,0 +1,52 @@
+package tsdb
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestIsolation(t *testing.T) {
+}
+
+func BenchmarkIsolation_10(b *testing.B) {
+	benchmarkIsolation(b, 10)
+}
+
+func BenchmarkIsolation_100(b *testing.B) {
+	benchmarkIsolation(b, 100)
+}
+
+func BenchmarkIsolation_1000(b *testing.B) {
+	benchmarkIsolation(b, 1000)
+}
+
+func BenchmarkIsolation_10000(b *testing.B) {
+	benchmarkIsolation(b, 10000)
+}
+
+func benchmarkIsolation(b *testing.B, goroutines int) {
+	iso := newIsolation()
+
+	wg := sync.WaitGroup{}
+	start := make(chan struct{})
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			<-start
+
+			for i := 0; i < b.N; i++ {
+				appendID := iso.newAppendID()
+				_ = iso.lowWatermark()
+
+				iso.closeAppend(appendID)
+			}
+		}()
+	}
+
+	b.ResetTimer()
+	close(start)
+	wg.Wait()
+}


### PR DESCRIPTION
We have identified contention on `appendMtx` to be a major bottleneck when many (thousands) goroutines try to append data at the same time. Main problem is that each appender needs new appender ID and then also asks for "low watermark". Low watermark however needs to iterate through all existing appenders (while holding the `appendMtx` lock), making it slower as number of concurrent appenders grows (if there are no readers at the moment).

This PR modifies `isolation` struct to optimize `lowWatermark` to work in O(1) time, by storing appenders in doubly-linked list. As new appenders are added at the end, `lowWatermark` can always find the lowest appender ID by checking single element only.

It also does additional modifications:
- use RWLocks for both `appendMtx` and `readMtx`. `lowWatermark` only needs read lock
- `lastAppendId` is now stored in the head of `appendsOpenList` list.
- New `lastAppendID()` method introduced, used from metrics, also needs read lock only (we couldn't get metrics during heavy contention)
- `appendsOpen` map is still used for deletes
- uses pool for new `isolationAppender` structs to avoid allocations

Without this patch, we were unable to roll out Cortex with recent Prometheus master (a1355eb7c780) to our monitoring cluster (~9 Mil series, 500K samples/sec). O(N) iteration in `lowWatermark` while holding the `appendMtx` lock caused hundreds of thousands goroutines being stuck in getting locks in `newAppendId` or `lowWatermark` methods.

Benchmarks:

Before:
```
goos: darwin
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
BenchmarkIsolation
BenchmarkIsolation/10
BenchmarkIsolation/10-4         	  244636	      4147 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsolation/10-4         	  309141	      4016 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsolation/10-4         	  312873	      4062 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsolation/10-4         	  328452	      4009 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsolation/10-4         	  254854	      3991 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsolation/100
BenchmarkIsolation/100-4        	   10000	    135353 ns/op	       7 B/op	       0 allocs/op
BenchmarkIsolation/100-4        	   10000	    138396 ns/op	       7 B/op	       0 allocs/op
BenchmarkIsolation/100-4        	   10000	    136097 ns/op	       8 B/op	       0 allocs/op
BenchmarkIsolation/100-4        	   10000	    137777 ns/op	       9 B/op	       0 allocs/op
BenchmarkIsolation/100-4        	   10000	    137682 ns/op	       7 B/op	       0 allocs/op
BenchmarkIsolation/1000
BenchmarkIsolation/1000-4       	     100	  17026459 ns/op	     907 B/op	       4 allocs/op
BenchmarkIsolation/1000-4       	     100	  16462889 ns/op	     929 B/op	       5 allocs/op
BenchmarkIsolation/1000-4       	     100	  17074721 ns/op	    1218 B/op	       8 allocs/op
BenchmarkIsolation/1000-4       	     100	  16872999 ns/op	    1227 B/op	       8 allocs/op
BenchmarkIsolation/1000-4       	     100	  16783318 ns/op	    1196 B/op	       8 allocs/op
BenchmarkIsolation/10000
BenchmarkIsolation/10000-4      	      22	1358201838 ns/op	   33241 B/op	     168 allocs/op
BenchmarkIsolation/10000-4      	      21	1354016474 ns/op	   31321 B/op	     144 allocs/op
BenchmarkIsolation/10000-4      	      22	1363599479 ns/op	   28658 B/op	     125 allocs/op
BenchmarkIsolation/10000-4      	      27	1446761285 ns/op	   26041 B/op	     127 allocs/op
BenchmarkIsolation/10000-4      	      22	1356981099 ns/op	   27426 B/op	     113 allocs/op
PASS
```

After:
```
goos: darwin
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
BenchmarkIsolation
BenchmarkIsolation/10
BenchmarkIsolation/10-4         	  462649	      2466 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsolation/10-4         	  502462	      2462 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsolation/10-4         	  467749	      2521 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsolation/10-4         	  501038	      2480 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsolation/10-4         	  493560	      2475 ns/op	       0 B/op	       0 allocs/op
BenchmarkIsolation/100
BenchmarkIsolation/100-4        	   45438	     26639 ns/op	       7 B/op	       0 allocs/op
BenchmarkIsolation/100-4        	   44721	     26700 ns/op	       8 B/op	       0 allocs/op
BenchmarkIsolation/100-4        	   44983	     27136 ns/op	       7 B/op	       0 allocs/op
BenchmarkIsolation/100-4        	   45330	     26820 ns/op	       7 B/op	       0 allocs/op
BenchmarkIsolation/100-4        	   45626	     26759 ns/op	       7 B/op	       0 allocs/op
BenchmarkIsolation/1000
BenchmarkIsolation/1000-4       	    3991	    340784 ns/op	     153 B/op	       0 allocs/op
BenchmarkIsolation/1000-4       	    3932	    342621 ns/op	     164 B/op	       0 allocs/op
BenchmarkIsolation/1000-4       	    4009	    343251 ns/op	     154 B/op	       0 allocs/op
BenchmarkIsolation/1000-4       	    3928	    337262 ns/op	     163 B/op	       0 allocs/op
BenchmarkIsolation/1000-4       	    3997	    344401 ns/op	     146 B/op	       0 allocs/op
BenchmarkIsolation/10000
BenchmarkIsolation/10000-4      	     351	   3553209 ns/op	    4051 B/op	      30 allocs/op
BenchmarkIsolation/10000-4      	     364	   3589619 ns/op	    3959 B/op	      30 allocs/op
BenchmarkIsolation/10000-4      	     354	   3584581 ns/op	    3966 B/op	      28 allocs/op
BenchmarkIsolation/10000-4      	     345	   3576536 ns/op	    4089 B/op	      29 allocs/op
BenchmarkIsolation/10000-4      	     349	   3704317 ns/op	    3870 B/op	      29 allocs/op
PASS
```

Diff:
```
name               old time/op    new time/op    delta
Isolation/10-4       4.04µs ± 3%    2.48µs ± 2%   -38.67%  (p=0.008 n=5+5)
Isolation/100-4       137µs ± 1%      27µs ± 1%   -80.44%  (p=0.008 n=5+5)
Isolation/1000-4     16.8ms ± 2%     0.3ms ± 1%   -97.97%  (p=0.008 n=5+5)
Isolation/10000-4     1.36s ± 0%     0.00s ± 3%   -99.73%  (p=0.016 n=4+5)

name               old alloc/op   new alloc/op   delta
Isolation/10-4        0.00B          0.00B           ~     (all equal)
Isolation/100-4       7.60B ±18%     7.00B ± 0%      ~     (p=0.333 n=5+4)
Isolation/1000-4     1.10kB ±17%    0.16kB ± 6%   -85.76%  (p=0.008 n=5+5)
Isolation/10000-4    29.3kB ±13%     4.0kB ± 3%   -86.41%  (p=0.008 n=5+5)

name               old allocs/op  new allocs/op  delta
Isolation/10-4         0.00           0.00           ~     (all equal)
Isolation/100-4        0.00           0.00           ~     (all equal)
Isolation/1000-4       6.60 ±39%      0.00       -100.00%  (p=0.008 n=5+5)
Isolation/10000-4       135 ±24%        29 ± 4%   -78.43%  (p=0.008 n=5+5)
```

/cc @codesome (Thanks for help!)