### PR TITLE
Fix avg_over_time for nan and float64 overflows

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2013,7 +2013,7 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 					break
 				}
 				if !math.IsInf(s.V, 0) && !math.IsNaN(s.V) {
-					// At this stage, the mean is an infinite. It the added
+					// At this stage, the mean is an infinite. If the added
 					// value is neither an Inf or a Nan, we can keep that mean
 					// value.
 					// This is required because our calculation below removes

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2008,14 +2008,17 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 			if math.IsInf(group.mean, 0) {
 				if math.IsInf(s.V, 0) && (group.mean > 0) == (s.V > 0) {
 					// The `mean` and `s.V` values are `Inf` of the same sign.  They
-					// can't be substracted, but the value of `mean` is correct
-					// already.  Continue the loop. `break` can not be used because
-					// if an opposite `Inf` is met later, `mean` must become `NaN`.
+					// can't be subtracted, but the value of `mean` is correct
+					// already.
 					break
 				}
 				if !math.IsInf(s.V, 0) && !math.IsNaN(s.V) {
-					// It the mean is an `Inf`, avoid removing an `Inf` with
-					// itself.
+					// At this stage, the mean is an infinite. It the added
+					// value is neither an Inf or a Nan, we can keep that mean
+					// value.
+					// This is required because our calculation below removes
+					// the mean value, which would look like Inf += x - Inf and
+					// end up as a NaN.
 					break
 				}
 			}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -354,7 +354,15 @@ func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 		var mean, count float64
 		for _, v := range values {
 			count++
-			mean += (v.V - mean) / count
+			if math.IsInf(mean, 0) && math.IsInf(v.V, 0) && (mean > 0) == (v.V > 0) {
+				// The `mean` and `v.V` values are `Inf` of the same sign.  They
+				// can't be substracted, but the value of `mean` is correct
+				// already.  Continue the loop. `break` can not be used because
+				// if an opposite `Inf` is met later, `mean` must become `NaN`.
+				continue
+			}
+			// Divide each side of the `-` by `count` to avoid float64 overflows.
+			mean += v.V/count - mean/count
 		}
 		return mean
 	})

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -357,14 +357,18 @@ func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 			if math.IsInf(mean, 0) {
 				if math.IsInf(v.V, 0) && (mean > 0) == (v.V > 0) {
 					// The `mean` and `v.V` values are `Inf` of the same sign.  They
-					// can't be substracted, but the value of `mean` is correct
+					// can't be subtracted, but the value of `mean` is correct
 					// already.  Continue the loop. `break` can not be used because
 					// if an opposite `Inf` is met later, `mean` must become `NaN`.
 					continue
 				}
 				if !math.IsInf(v.V, 0) && !math.IsNaN(v.V) {
-					// It the mean is an `Inf`, avoid removing an `Inf` with
-					// itself.
+					// At this stage, the mean is an infinite. It the added
+					// value is neither an Inf or a Nan, we can keep that mean
+					// value.
+					// This is required because our calculation below removes
+					// the mean value, which would look like Inf += x - Inf and
+					// end up as a NaN.
 					continue
 				}
 			}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -362,7 +362,7 @@ func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 					continue
 				}
 				if !math.IsInf(v.V, 0) && !math.IsNaN(v.V) {
-					// At this stage, the mean is an infinite. It the added
+					// At this stage, the mean is an infinite. If the added
 					// value is neither an Inf or a Nan, we can keep that mean
 					// value.
 					// This is required because our calculation below removes

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -358,8 +358,7 @@ func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 				if math.IsInf(v.V, 0) && (mean > 0) == (v.V > 0) {
 					// The `mean` and `v.V` values are `Inf` of the same sign.  They
 					// can't be subtracted, but the value of `mean` is correct
-					// already.  Continue the loop. `break` can not be used because
-					// if an opposite `Inf` is met later, `mean` must become `NaN`.
+					// already.
 					continue
 				}
 				if !math.IsInf(v.V, 0) && !math.IsNaN(v.V) {

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -354,14 +354,20 @@ func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 		var mean, count float64
 		for _, v := range values {
 			count++
-			if math.IsInf(mean, 0) && math.IsInf(v.V, 0) && (mean > 0) == (v.V > 0) {
-				// The `mean` and `v.V` values are `Inf` of the same sign.  They
-				// can't be substracted, but the value of `mean` is correct
-				// already.  Continue the loop. `break` can not be used because
-				// if an opposite `Inf` is met later, `mean` must become `NaN`.
-				continue
+			if math.IsInf(mean, 0) {
+				if math.IsInf(v.V, 0) && (mean > 0) == (v.V > 0) {
+					// The `mean` and `v.V` values are `Inf` of the same sign.  They
+					// can't be substracted, but the value of `mean` is correct
+					// already.  Continue the loop. `break` can not be used because
+					// if an opposite `Inf` is met later, `mean` must become `NaN`.
+					continue
+				}
+				if !math.IsInf(v.V, 0) && !math.IsNaN(v.V) {
+					// It the mean is an `Inf`, avoid removing an `Inf` with
+					// itself.
+					continue
+				}
 			}
-			// Divide each side of the `-` by `count` to avoid float64 overflows.
 			mean += v.V/count - mean/count
 		}
 		return mean

--- a/promql/testdata/aggregators.test
+++ b/promql/testdata/aggregators.test
@@ -320,3 +320,66 @@ eval instant at 1m group without(point)(data)
 
 eval instant at 1m group(foo)
 	{} 1
+
+# Tests for avg.
+clear
+
+load 10s
+	data{test="ten",point="a"} 8
+	data{test="ten",point="b"} 10
+	data{test="ten",point="c"} 12
+	data{test="inf",point="a"} 0
+	data{test="inf",point="b"} Inf
+	data{test="inf",point="d"} Inf
+	data{test="inf",point="c"} 0
+	data{test="-inf",point="a"} -Inf
+	data{test="-inf",point="b"} -Inf
+	data{test="-inf",point="c"} 0
+	data{test="inf2",point="a"} Inf
+	data{test="inf2",point="b"} 0
+	data{test="inf2",point="c"} Inf
+	data{test="-inf2",point="a"} -Inf
+	data{test="-inf2",point="b"} 0
+	data{test="-inf2",point="c"} -Inf
+	data{test="nan",point="a"} -Inf
+	data{test="nan",point="b"} 0
+	data{test="nan",point="c"} Inf
+	data{test="big",point="a"} 9.988465674311579e+307
+	data{test="big",point="b"} 9.988465674311579e+307
+	data{test="big",point="c"} 9.988465674311579e+307
+	data{test="big",point="d"} 9.988465674311579e+307
+	data{test="-big",point="a"} -9.988465674311579e+307
+	data{test="-big",point="b"} -9.988465674311579e+307
+	data{test="-big",point="c"} -9.988465674311579e+307
+	data{test="-big",point="d"} -9.988465674311579e+307
+	data{test="bigzero",point="a"} -9.988465674311579e+307
+	data{test="bigzero",point="b"} -9.988465674311579e+307
+	data{test="bigzero",point="c"} 9.988465674311579e+307
+	data{test="bigzero",point="d"} 9.988465674311579e+307
+
+eval instant at 1m avg(data{test="ten"})
+	{} 10
+
+eval instant at 1m avg(data{test="inf"})
+	{} Inf
+
+eval instant at 1m avg(data{test="inf2"})
+	{} Inf
+
+eval instant at 1m avg(data{test="-inf"})
+	{} -Inf
+
+eval instant at 1m avg(data{test="-inf2"})
+	{} -Inf
+
+eval instant at 1m avg(data{test="nan"})
+	{} NaN
+
+eval instant at 1m avg(data{test="big"})
+	{} 9.988465674311579e+307
+
+eval instant at 1m avg(data{test="-big"})
+	{} -9.988465674311579e+307
+
+eval instant at 1m avg(data{test="bigzero"})
+	{} 0

--- a/promql/testdata/aggregators.test
+++ b/promql/testdata/aggregators.test
@@ -341,6 +341,14 @@ load 10s
 	data{test="-inf2",point="a"} -Inf
 	data{test="-inf2",point="b"} 0
 	data{test="-inf2",point="c"} -Inf
+	data{test="inf3",point="b"} Inf
+	data{test="inf3",point="d"} Inf
+	data{test="inf3",point="c"} Inf
+	data{test="inf3",point="d"} -Inf
+	data{test="-inf3",point="b"} -Inf
+	data{test="-inf3",point="d"} -Inf
+	data{test="-inf3",point="c"} -Inf
+	data{test="-inf3",point="c"} Inf
 	data{test="nan",point="a"} -Inf
 	data{test="nan",point="b"} 0
 	data{test="nan",point="c"} Inf
@@ -366,11 +374,17 @@ eval instant at 1m avg(data{test="inf"})
 eval instant at 1m avg(data{test="inf2"})
 	{} Inf
 
+eval instant at 1m avg(data{test="inf3"})
+	{} NaN
+
 eval instant at 1m avg(data{test="-inf"})
 	{} -Inf
 
 eval instant at 1m avg(data{test="-inf2"})
 	{} -Inf
+
+eval instant at 1m avg(data{test="-inf3"})
+	{} NaN
 
 eval instant at 1m avg(data{test="nan"})
 	{} NaN

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -398,8 +398,10 @@ load 10s
   metric2 1 2 3 4 Inf
   metric3 1 2 3 4 -Inf
   metric4 1 2 3 Inf -Inf
-  metric5 1 2 3 Inf Inf
+  metric5 Inf 0 Inf
+  metric5b Inf 0 Inf
   metric6 1 2 3 -Inf -Inf
+  metric6b -Inf 0 -Inf
   metric7 1 2 -Inf -Inf Inf
   metric8 9.988465674311579e+307 9.988465674311579e+307
   metric9 -9.988465674311579e+307 -9.988465674311579e+307 -9.988465674311579e+307
@@ -435,10 +437,22 @@ eval instant at 1m avg_over_time(metric5[1m])
 eval instant at 1m sum_over_time(metric5[1m])/count_over_time(metric5[1m])
   {} Inf
 
+eval instant at 1m avg_over_time(metric5b[1m])
+  {} Inf
+
+eval instant at 1m sum_over_time(metric5b[1m])/count_over_time(metric5b[1m])
+  {} Inf
+
 eval instant at 1m avg_over_time(metric6[1m])
   {} -Inf
 
 eval instant at 1m sum_over_time(metric6[1m])/count_over_time(metric6[1m])
+  {} -Inf
+
+eval instant at 1m avg_over_time(metric6b[1m])
+  {} -Inf
+
+eval instant at 1m sum_over_time(metric6b[1m])/count_over_time(metric6[1m])
   {} -Inf
 
 eval instant at 1m avg_over_time(metric7[1m])

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -395,9 +395,77 @@ eval instant at 8000s holt_winters(http_requests[1m], 0.01, 0.1)
 clear
 load 10s
   metric 1 2 3 4 5
+  metric2 1 2 3 4 Inf
+  metric3 1 2 3 4 -Inf
+  metric4 1 2 3 Inf -Inf
+  metric5 1 2 3 Inf Inf
+  metric6 1 2 3 -Inf -Inf
+  metric7 1 2 -Inf -Inf Inf
+  metric8 9.988465674311579e+307 9.988465674311579e+307
+  metric9 -9.988465674311579e+307 -9.988465674311579e+307 -9.988465674311579e+307
+  metric10 -9.988465674311579e+307 9.988465674311579e+307
 
 eval instant at 1m avg_over_time(metric[1m])
   {} 3
+
+eval instant at 1m sum_over_time(metric[1m])/count_over_time(metric[1m])
+  {} 3
+
+eval instant at 1m avg_over_time(metric2[1m])
+  {} Inf
+
+eval instant at 1m sum_over_time(metric2[1m])/count_over_time(metric2[1m])
+  {} Inf
+
+eval instant at 1m avg_over_time(metric3[1m])
+  {} -Inf
+
+eval instant at 1m sum_over_time(metric3[1m])/count_over_time(metric3[1m])
+  {} -Inf
+
+eval instant at 1m avg_over_time(metric4[1m])
+  {} NaN
+
+eval instant at 1m sum_over_time(metric4[1m])/count_over_time(metric4[1m])
+  {} NaN
+
+eval instant at 1m avg_over_time(metric5[1m])
+  {} Inf
+
+eval instant at 1m sum_over_time(metric5[1m])/count_over_time(metric5[1m])
+  {} Inf
+
+eval instant at 1m avg_over_time(metric6[1m])
+  {} -Inf
+
+eval instant at 1m sum_over_time(metric6[1m])/count_over_time(metric6[1m])
+  {} -Inf
+
+eval instant at 1m avg_over_time(metric7[1m])
+  {} NaN
+
+eval instant at 1m sum_over_time(metric7[1m])/count_over_time(metric7[1m])
+  {} NaN
+
+eval instant at 1m avg_over_time(metric8[1m])
+  {} 9.988465674311579e+307
+
+# This overflows float64.
+eval instant at 1m sum_over_time(metric8[1m])/count_over_time(metric8[1m])
+  {} Inf
+
+eval instant at 1m avg_over_time(metric9[1m])
+  {} -9.988465674311579e+307
+
+# This overflows float64.
+eval instant at 1m sum_over_time(metric9[1m])/count_over_time(metric9[1m])
+  {} -Inf
+
+eval instant at 1m avg_over_time(metric10[1m])
+  {} 0
+
+eval instant at 1m sum_over_time(metric10[1m])/count_over_time(metric10[1m])
+  {} 0
 
 # Tests for stddev_over_time and stdvar_over_time.
 clear

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -400,8 +400,10 @@ load 10s
   metric4 1 2 3 Inf -Inf
   metric5 Inf 0 Inf
   metric5b Inf 0 Inf
+  metric5c Inf Inf Inf -Inf
   metric6 1 2 3 -Inf -Inf
   metric6b -Inf 0 -Inf
+  metric6c -Inf -Inf -Inf Inf
   metric7 1 2 -Inf -Inf Inf
   metric8 9.988465674311579e+307 9.988465674311579e+307
   metric9 -9.988465674311579e+307 -9.988465674311579e+307 -9.988465674311579e+307
@@ -443,6 +445,12 @@ eval instant at 1m avg_over_time(metric5b[1m])
 eval instant at 1m sum_over_time(metric5b[1m])/count_over_time(metric5b[1m])
   {} Inf
 
+eval instant at 1m avg_over_time(metric5c[1m])
+  {} NaN
+
+eval instant at 1m sum_over_time(metric5c[1m])/count_over_time(metric5c[1m])
+  {} NaN
+
 eval instant at 1m avg_over_time(metric6[1m])
   {} -Inf
 
@@ -452,8 +460,15 @@ eval instant at 1m sum_over_time(metric6[1m])/count_over_time(metric6[1m])
 eval instant at 1m avg_over_time(metric6b[1m])
   {} -Inf
 
-eval instant at 1m sum_over_time(metric6b[1m])/count_over_time(metric6[1m])
+eval instant at 1m sum_over_time(metric6b[1m])/count_over_time(metric6b[1m])
   {} -Inf
+
+eval instant at 1m avg_over_time(metric6c[1m])
+  {} NaN
+
+eval instant at 1m sum_over_time(metric6c[1m])/count_over_time(metric6c[1m])
+  {} NaN
+
 
 eval instant at 1m avg_over_time(metric7[1m])
   {} NaN


### PR DESCRIPTION

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->