### PR TITLE
Optimized bstream reader used by XORChunk iterator

### DIFF
--- a/tsdb/chunkenc/bstream.go
+++ b/tsdb/chunkenc/bstream.go
@@ -110,7 +110,7 @@ func (b *bstream) writeBits(u uint64, nbits int) {
 }
 
 type bstreamReader struct {
-	stream []byte
+	stream       []byte
 	streamOffset int
 
 	buffer uint64
@@ -200,17 +200,17 @@ func (b *bstreamReader) loadNextBuffer() bool {
 	}
 
 	// Handle the most common case in a optimized way.
-	if b.streamOffset + 8 <= len(b.stream) {
+	if b.streamOffset+8 <= len(b.stream) {
 		// This is ugly, but significantly faster.
 		b.buffer =
 			((uint64(b.stream[b.streamOffset])) << 56) |
-			((uint64(b.stream[b.streamOffset+1])) << 48) |
-			((uint64(b.stream[b.streamOffset+2])) << 40) |
-			((uint64(b.stream[b.streamOffset+3])) << 32) |
-			((uint64(b.stream[b.streamOffset+4])) << 24) |
-			((uint64(b.stream[b.streamOffset+5])) << 16) |
-			((uint64(b.stream[b.streamOffset+6])) << 8) |
-			uint64(b.stream[b.streamOffset+7])
+				((uint64(b.stream[b.streamOffset+1])) << 48) |
+				((uint64(b.stream[b.streamOffset+2])) << 40) |
+				((uint64(b.stream[b.streamOffset+3])) << 32) |
+				((uint64(b.stream[b.streamOffset+4])) << 24) |
+				((uint64(b.stream[b.streamOffset+5])) << 16) |
+				((uint64(b.stream[b.streamOffset+6])) << 8) |
+				uint64(b.stream[b.streamOffset+7])
 
 		b.streamOffset += 8
 		b.valid = 64

--- a/tsdb/chunkenc/bstream.go
+++ b/tsdb/chunkenc/bstream.go
@@ -223,7 +223,7 @@ func (b *bstreamReader) loadNextBuffer() bool {
 	curr := uint64(0)
 
 	for out := 0; in < len(b.stream) && out < 64; out += 8 {
-		curr = curr | (uint64(b.stream[in]) << (64 - out - 8))
+		curr = curr | (uint64(b.stream[in]) << uint(64 - out - 8))
 		in++
 	}
 

--- a/tsdb/chunkenc/bstream.go
+++ b/tsdb/chunkenc/bstream.go
@@ -114,7 +114,7 @@ type bstreamReader struct {
 	streamOffset int
 
 	buffer uint64
-	valid  uint8 // how many bits are valid in current buffer
+	valid  uint8 // The number of bits valid to read (from left) in the current buffer.
 }
 
 func newBReader(b []byte) bstreamReader {
@@ -228,8 +228,11 @@ func (b *bstreamReader) loadNextBuffer() bool {
 	}
 
 	b.buffer = curr
-	b.valid = 64 // Even if read less we have always to set it to the full buffer size because bits are written starting from the left.
 	b.streamOffset = in
+
+	// Even if read less we have always to set it to the full buffer size because bits
+	// are written starting from the left.
+	b.valid = 64
 
 	return true
 }

--- a/tsdb/chunkenc/bstream_test.go
+++ b/tsdb/chunkenc/bstream_test.go
@@ -1,3 +1,44 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The code in this file was largely written by Damian Gryski as part of
+// https://github.com/dgryski/go-tsz and published under the license below.
+// It received minor modifications to suit Prometheus's needs.
+
+// Copyright (c) 2015,2016 Damian Gryski <damian@gryski.com>
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 package chunkenc
 
 import (

--- a/tsdb/chunkenc/bstream_test.go
+++ b/tsdb/chunkenc/bstream_test.go
@@ -1,0 +1,48 @@
+package chunkenc
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestBstreamReader(t *testing.T) {
+	// Write to the bit stream.
+	w := bstream{}
+	for _, bit := range []bit{true, false} {
+		w.writeBit(bit)
+	}
+	for nbits := 1; nbits <= 64; nbits++ {
+		w.writeBits(uint64(nbits), nbits)
+	}
+	for v := 1; v < 10000; v += 123 {
+		w.writeBits(uint64(v), 29)
+	}
+
+	// Read back.
+	r := newBReader(w.bytes())
+	for _, bit := range []bit{true, false} {
+		v, err := r.readBitFast()
+		if err != nil {
+			v, err = r.readBit()
+		}
+		testutil.Ok(t, err)
+		testutil.Equals(t, bit, v)
+	}
+	for nbits := uint8(1); nbits <= 64; nbits++ {
+		v, err := r.readBitsFast(nbits)
+		if err != nil {
+			v, err = r.readBits(nbits)
+		}
+		testutil.Ok(t, err)
+		testutil.Equals(t, uint64(nbits), v, "nbits=%d", nbits)
+	}
+	for v := 1; v < 10000; v += 123 {
+		actual, err := r.readBitsFast(29)
+		if err != nil {
+			actual, err = r.readBits(29)
+		}
+		testutil.Ok(t, err)
+		testutil.Equals(t, uint64(v), actual, "v=%d", v)
+	}
+}

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -118,7 +118,8 @@ func (c *XORChunk) iterator(it Iterator) *xorIterator {
 	// Should iterators guarantee to act on a copy of the data so it doesn't lock append?
 	// When using striped locks to guard access to chunks, probably yes.
 	// Could only copy data if the chunk is not completed yet.
-	if xorIter, ok := it.(*xorIterator); ok {
+	xorIter, ok := it.(*xorIterator)
+	if ok {
 		xorIter.Reset(c.b.bytes())
 		return xorIter
 	}
@@ -240,7 +241,7 @@ func (a *xorAppender) writeVDelta(v float64) {
 }
 
 type xorIterator struct {
-	br       bstream
+	br       bstreamReader
 	numTotal uint16
 	numRead  uint16
 
@@ -328,7 +329,10 @@ func (it *xorIterator) Next() bool {
 	// read delta-of-delta
 	for i := 0; i < 4; i++ {
 		d <<= 1
-		bit, err := it.br.readBit()
+		bit, err := it.br.readBitFast()
+		if err != nil {
+			bit, err = it.br.readBit()
+		}
 		if err != nil {
 			it.err = err
 			return false
@@ -350,6 +354,7 @@ func (it *xorIterator) Next() bool {
 	case 0x0e:
 		sz = 20
 	case 0x0f:
+		// Do not use fast because it's very unlikely it will succeed.
 		bits, err := it.br.readBits(64)
 		if err != nil {
 			it.err = err
@@ -360,7 +365,10 @@ func (it *xorIterator) Next() bool {
 	}
 
 	if sz != 0 {
-		bits, err := it.br.readBits(int(sz))
+		bits, err := it.br.readBitsFast(sz)
+		if err != nil {
+			bits, err = it.br.readBits(sz)
+		}
 		if err != nil {
 			it.err = err
 			return false
@@ -379,7 +387,10 @@ func (it *xorIterator) Next() bool {
 }
 
 func (it *xorIterator) readValue() bool {
-	bit, err := it.br.readBit()
+	bit, err := it.br.readBitFast()
+	if err != nil {
+		bit, err = it.br.readBit()
+	}
 	if err != nil {
 		it.err = err
 		return false
@@ -388,7 +399,10 @@ func (it *xorIterator) readValue() bool {
 	if bit == zero {
 		// it.val = it.val
 	} else {
-		bit, err := it.br.readBit()
+		bit, err := it.br.readBitFast()
+		if err != nil {
+			bit, err = it.br.readBit()
+		}
 		if err != nil {
 			it.err = err
 			return false
@@ -397,14 +411,20 @@ func (it *xorIterator) readValue() bool {
 			// reuse leading/trailing zero bits
 			// it.leading, it.trailing = it.leading, it.trailing
 		} else {
-			bits, err := it.br.readBits(5)
+			bits, err := it.br.readBitsFast(5)
+			if err != nil {
+				bits, err = it.br.readBits(5)
+			}
 			if err != nil {
 				it.err = err
 				return false
 			}
 			it.leading = uint8(bits)
 
-			bits, err = it.br.readBits(6)
+			bits, err = it.br.readBitsFast(6)
+			if err != nil {
+				bits, err = it.br.readBits(6)
+			}
 			if err != nil {
 				it.err = err
 				return false
@@ -417,14 +437,17 @@ func (it *xorIterator) readValue() bool {
 			it.trailing = 64 - it.leading - mbits
 		}
 
-		mbits := int(64 - it.leading - it.trailing)
-		bits, err := it.br.readBits(mbits)
+		mbits := 64 - it.leading - it.trailing
+		bits, err := it.br.readBitsFast(mbits)
+		if err != nil {
+			bits, err = it.br.readBits(mbits)
+		}
 		if err != nil {
 			it.err = err
 			return false
 		}
 		vbits := math.Float64bits(it.val)
-		vbits ^= (bits << it.trailing)
+		vbits ^= bits << it.trailing
 		it.val = math.Float64frombits(vbits)
 	}
 

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -118,8 +118,7 @@ func (c *XORChunk) iterator(it Iterator) *xorIterator {
 	// Should iterators guarantee to act on a copy of the data so it doesn't lock append?
 	// When using striped locks to guard access to chunks, probably yes.
 	// Could only copy data if the chunk is not completed yet.
-	xorIter, ok := it.(*xorIterator)
-	if ok {
+	if xorIter, ok := it.(*xorIterator); ok {
 		xorIter.Reset(c.b.bytes())
 		return xorIter
 	}


### PR DESCRIPTION
I spent the last couple of days investigating query performances and I've noticed that, for several queries we see in production, a significant amount of time is spent iterating series and sample. In this analysis, I've noticed most of the time spent iterating samples is in the `XORChunk` iterator and further benchmarks showed that the `bstream` reader introduces a significant bottleneck.

I've tried different approaches to optimise the `bstream` reader and in this PR I'm proposing the optimisation I've found having the least downsides. The optimisation is split into two parts:
1. Work with a `uint64` buffer in order to optimise bit-wise operations (assuming most production architectures are 64 bit).
2. Introduce `Fast()` version of read bit/bits which get inlined by the compiler. These functions must be leafs and super small, reason why may return an error in case the current buffer  doesn't contain enough bits to satify the request. In case a `Fast()` function returns error, it must be retried using the normal (but slower) one.

The following show the result of a couple of benchmarks. I've measured similar query reduction times running benchmarks in Cortex too.

## BenchmarkXORIterator

```
benchmark                  old ns/op     new ns/op     delta
BenchmarkXORIterator-4     33.0          22.7          -31.21%

benchmark                  old allocs     new allocs     delta
BenchmarkXORIterator-4     0              0              +0.00%

benchmark                  old bytes     new bytes     delta
BenchmarkXORIterator-4     1             1             +0.00%
```

## BenchmarkRangeQuery

```
benchmark                                                                                                             old ns/op      new ns/op      delta
BenchmarkRangeQuery/expr=a_one,steps=1-4                                                                              15400          14621          -5.06%
BenchmarkRangeQuery/expr=a_one,steps=10-4                                                                             15519          14847          -4.33%
BenchmarkRangeQuery/expr=a_one,steps=100-4                                                                            23341          22079          -5.41%
BenchmarkRangeQuery/expr=a_one,steps=1000-4                                                                           86703          76500          -11.77%
BenchmarkRangeQuery/expr=a_ten,steps=1-4                                                                              74669          65145          -12.75%
BenchmarkRangeQuery/expr=a_ten,steps=10-4                                                                             74867          66844          -10.72%
BenchmarkRangeQuery/expr=a_ten,steps=100-4                                                                            155213         135659         -12.60%
BenchmarkRangeQuery/expr=a_ten,steps=1000-4                                                                           806163         677584         -15.95%
BenchmarkRangeQuery/expr=a_hundred,steps=1-4                                                                          669575         591655         -11.64%
BenchmarkRangeQuery/expr=a_hundred,steps=10-4                                                                         700674         611782         -12.69%
BenchmarkRangeQuery/expr=a_hundred,steps=100-4                                                                        1486458        1288216        -13.34%
BenchmarkRangeQuery/expr=a_hundred,steps=1000-4                                                                       7768523        7145822        -8.02%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1-4                                                                    20325          22230          +9.37%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10-4                                                                   20893          20294          -2.87%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=100-4                                                                  37490          35440          -5.47%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1000-4                                                                 180701         171688         -4.99%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1-4                                                                    86529          103029         +19.07%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10-4                                                                   95056          86269          -9.24%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=100-4                                                                  262109         238824         -8.88%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1000-4                                                                 1676112        1558172        -7.04%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1-4                                                                767740         680518         -11.36%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10-4                                                               850676         763378         -10.26%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=100-4                                                              2518193        2312135        -8.18%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1000-4                                                             16866493       15626329       -7.35%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10000-4                                                                1757881        1628398        -7.37%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10000-4                                                                17663023       16271589       -7.88%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10000-4                                                            176791209      167930543      -5.01%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-4                                                  1063990        905986         -14.85%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-4                                                 1552706        1491273        -3.96%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-4                                                7085431        7204762        +1.68%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-4                                               61933174       65780593       +6.21%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-4                                                  7894814        7235089        -8.36%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-4                                                 13234773       12788289       -3.37%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-4                                                68093442       69590476       +2.20%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-4                                               618915485      618714002      -0.03%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-4                                              76510891       71662853       -6.34%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-4                                             131000752      126201633      -3.66%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-4                                            682868528      675057878      -1.14%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-4                                           6175974854     6163384524     -0.20%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1-4                                                                 786677         697475         -11.34%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=10-4                                                                901140         823530         -8.61%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=100-4                                                               2198667        2090834        -4.90%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1000-4                                                              15027356       14562326       -3.09%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1-4                                                                 6713828        6039313        -10.05%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=10-4                                                                8024832        7257989        -9.56%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=100-4                                                               20749802       20713857       -0.17%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1000-4                                                              146725258      148036247      +0.89%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1-4                                                             70492000       60882484       -13.63%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=10-4                                                            80649745       75537762       -6.34%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=100-4                                                           204409961      200998441      -1.67%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1000-4                                                          1485385132     1430361710     -3.70%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1-4                                                                    772884         702164         -9.15%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=10-4                                                                   878062         807307         -8.06%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=100-4                                                                  1807130        1769447        -2.09%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1000-4                                                                 11319035       11566698       +2.19%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1-4                                                                    6634299        5886025        -11.28%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=10-4                                                                   7636080        6883710        -9.85%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=100-4                                                                  17109581       16688852       -2.46%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1000-4                                                                 115557933      114689321      -0.75%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1-4                                                                68881042       58882513       -14.52%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=10-4                                                               75608469       69002832       -8.74%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=100-4                                                              172455230      166723770      -3.32%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1000-4                                                             1116699262     1130067522     +1.20%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1-4                                                        765051         689753         -9.84%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=10-4                                                       792220         699104         -11.75%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=100-4                                                      974001         938348         -3.66%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-4                                                     2941349        2900340        -1.39%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-4                                                        6492439        5790869        -10.81%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-4                                                       6686766        6298659        -5.80%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-4                                                      8694462        8021394        -7.74%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-4                                                     29239262       28524790       -2.44%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-4                                                    64543960       59829165       -7.30%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-4                                                   67137306       59977760       -10.66%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-4                                                  86524211       80345788       -7.14%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-4                                                 300418993      277779066      -7.54%
BenchmarkRangeQuery/expr=-a_one,steps=1-4                                                                             16456          16735          +1.70%
BenchmarkRangeQuery/expr=-a_one,steps=10-4                                                                            16695          16050          -3.86%
BenchmarkRangeQuery/expr=-a_one,steps=100-4                                                                           24839          23202          -6.59%
BenchmarkRangeQuery/expr=-a_one,steps=1000-4                                                                          89277          78638          -11.92%
BenchmarkRangeQuery/expr=-a_ten,steps=1-4                                                                             78491          69795          -11.08%
BenchmarkRangeQuery/expr=-a_ten,steps=10-4                                                                            78819          71975          -8.68%
BenchmarkRangeQuery/expr=-a_ten,steps=100-4                                                                           159161         140882         -11.48%
BenchmarkRangeQuery/expr=-a_ten,steps=1000-4                                                                          801945         694778         -13.36%
BenchmarkRangeQuery/expr=-a_hundred,steps=1-4                                                                         706523         620035         -12.24%
BenchmarkRangeQuery/expr=-a_hundred,steps=10-4                                                                        720904         647710         -10.15%
BenchmarkRangeQuery/expr=-a_hundred,steps=100-4                                                                       1542401        1371822        -11.06%
BenchmarkRangeQuery/expr=-a_hundred,steps=1000-4                                                                      8060421        7002051        -13.13%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1-4                                                                      35447          28724          -18.97%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10-4                                                                     36085          34845          -3.44%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=100-4                                                                    116549         108541         -6.87%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1000-4                                                                   827950         821716         -0.75%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1-4                                                                      176675         155699         -11.87%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10-4                                                                     230650         220550         -4.38%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=100-4                                                                    956533         925933         -3.20%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1000-4                                                                   7899870        7653202        -3.12%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1-4                                                              1635885        1510476        -7.67%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10-4                                                             2349669        2179525        -7.24%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=100-4                                                            10513118       10200682       -2.97%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1000-4                                                           87691862       86684269       -1.15%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10000-4                                                                  8076090        8140884        +0.80%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10000-4                                                                  79371745       78038306       -1.68%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10000-4                                                          943532697      895252727      -5.12%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-4                                                     72105          66640          -7.58%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-4                                                    75355          70512          -6.43%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-4                                                   106632         105914         -0.67%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-4                                                  448776         426228         -5.02%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-4                                                     175281         163049         -6.98%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-4                                                    203009         193321         -4.77%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-4                                                   573151         544609         -4.98%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-4                                                  4025428        3859601        -4.12%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-4                                             1249123        1093012        -12.50%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-4                                            1542008        1440204        -6.60%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-4                                           5964734        5595421        -6.19%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                          46254448       44385735       -4.04%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-4                                                      67085          66567          -0.77%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-4                                                     74959          71288          -4.90%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-4                                                    119478         119410         -0.06%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-4                                                   585065         575341         -1.66%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-4                                                      178416         165969         -6.98%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-4                                                     221067         210659         -4.71%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-4                                                    717292         683672         -4.69%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-4                                                   5387227        5227994        -2.96%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-4                                              1240898        1126196        -9.24%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-4                                             1679079        1594439        -5.04%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-4                                            7168674        6871012        -4.15%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                           58510842       57471543       -1.78%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-4                                                  68115          67249          -1.27%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-4                                                 72735          71516          -1.68%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-4                                                118939         117945         -0.84%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-4                                               570343         566716         -0.64%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-4                                                  176098         172572         -2.00%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-4                                                 201438         188375         -6.48%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-4                                                569708         544934         -4.35%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-4                                               3926318        3892059        -0.87%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-4                                          1207153        1083595        -10.24%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-4                                         1593065        1451949        -8.86%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-4                                        5867791        5613302        -4.34%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                       45963268       44406108       -3.39%
BenchmarkRangeQuery/expr=abs(a_one),steps=1-4                                                                         19434          18618          -4.20%
BenchmarkRangeQuery/expr=abs(a_one),steps=10-4                                                                        21861          21188          -3.08%
BenchmarkRangeQuery/expr=abs(a_one),steps=100-4                                                                       53124          51238          -3.55%
BenchmarkRangeQuery/expr=abs(a_one),steps=1000-4                                                                      344363         331806         -3.65%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1-4                                                                         90068          80980          -10.09%
BenchmarkRangeQuery/expr=abs(a_ten),steps=10-4                                                                        114466         106868         -6.64%
BenchmarkRangeQuery/expr=abs(a_ten),steps=100-4                                                                       431310         415896         -3.57%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1000-4                                                                      3390819        3366215        -0.73%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1-4                                                                     805456         716113         -11.09%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=10-4                                                                    1059055        985472         -6.95%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=100-4                                                                   4484766        4242883        -5.39%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1000-4                                                                  36297457       35017428       -3.53%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-4                                      30992          31989          +3.22%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-4                                     35268          34188          -3.06%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-4                                    85913          83198          -3.16%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4                                   549070         539693         -1.71%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-4                                      106063         101689         -4.12%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-4                                     137373         128578         -6.40%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-4                                    501847         477578         -4.84%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4                                   4004561        3848689        -3.89%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-4                                  867861         781314         -9.97%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-4                                 1171920        1099037        -6.22%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-4                                4872275        4643292        -4.70%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4                               39776309       39000325       -1.95%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-4                                             25204          24224          -3.89%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-4                                            30565          30150          -1.36%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-4                                           91334          90229          -1.21%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-4                                          682284         685373         +0.45%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-4                                             98403          89466          -9.08%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-4                                            128573         124115         -3.47%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-4                                           506128         486581         -3.86%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-4                                          4138056        4009186        -3.11%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-4                                         833919         749894         -10.08%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-4                                        1136884        1083081        -4.73%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-4                                       4930509        4721121        -4.25%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-4                                      40588809       39572382       -2.50%
BenchmarkRangeQuery/expr=sum(a_one),steps=1-4                                                                         19420          18510          -4.69%
BenchmarkRangeQuery/expr=sum(a_one),steps=10-4                                                                        25874          25289          -2.26%
BenchmarkRangeQuery/expr=sum(a_one),steps=100-4                                                                       91992          90765          -1.33%
BenchmarkRangeQuery/expr=sum(a_one),steps=1000-4                                                                      747223         735803         -1.53%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1-4                                                                         77973          69982          -10.25%
BenchmarkRangeQuery/expr=sum(a_ten),steps=10-4                                                                        97005          81243          -16.25%
BenchmarkRangeQuery/expr=sum(a_ten),steps=100-4                                                                       255016         236541         -7.24%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1000-4                                                                      1735711        1643396        -5.32%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1-4                                                                     712614         586010         -17.77%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=10-4                                                                    708765         641978         -9.42%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=100-4                                                                   1847589        1679646        -9.09%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1000-4                                                                  11903275       11013781       -7.47%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1-4                                                             99277          90689          -8.65%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=10-4                                                            158538         152126         -4.04%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=100-4                                                           818533         806419         -1.48%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1000-4                                                          7293432        7142112        -2.07%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1-4                                                             738061         650412         -11.88%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=10-4                                                            905093         818073         -9.61%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=100-4                                                           3154896        3015926        -4.40%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1000-4                                                          24043192       23130816       -3.79%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1-4                                                         7855065        6959253        -11.40%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=10-4                                                        9099682        8091213        -11.08%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=100-4                                                       27363148       25459791       -6.96%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-4                                                      204635129      194043282      -5.18%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1-4                                                            86699          76137          -12.18%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=10-4                                                           100145         91276          -8.86%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=100-4                                                          307597         286226         -6.95%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1000-4                                                         2192764        2094289        -4.49%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1-4                                                            739469         637630         -13.77%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=10-4                                                           865117         799561         -7.58%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=100-4                                                          2945784        2773258        -5.86%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1000-4                                                         22152676       21159430       -4.48%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1-4                                                        8060690        7229873        -10.31%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=10-4                                                       9396733        8626366        -8.20%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=100-4                                                      31241776       29085633       -6.90%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-4                                                     236866807      229681766      -3.03%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1-4                                                                  85617          76919          -10.16%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=10-4                                                                 99209          91148          -8.13%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=100-4                                                                307709         288953         -6.10%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1000-4                                                               2178118        2092269        -3.94%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1-4                                                                  737994         643118         -12.86%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=10-4                                                                 878643         774044         -11.90%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=100-4                                                                2866407        2649549        -7.57%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1000-4                                                               21091908       20482877       -2.89%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1-4                                                              8319716        7148972        -14.07%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=10-4                                                             9413069        8466969        -10.05%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=100-4                                                            31581743       28751619       -8.96%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-4                                                           233009402      220655063      -5.30%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1-4                                                                 100228         90988          -9.22%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=10-4                                                                154426         146488         -5.14%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=100-4                                                               771753         754046         -2.29%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1000-4                                                              6760266        6672272        -1.30%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1-4                                                                 752419         646747         -14.04%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=10-4                                                                888727         811147         -8.73%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=100-4                                                               3132388        2975022        -5.02%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1000-4                                                              24031555       23082636       -3.95%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1-4                                                             7918007        6995609        -11.65%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=10-4                                                            8947656        8267458        -7.60%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=100-4                                                           34130370       26275100       -23.02%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-4                                                          207874018      197015634      -5.22%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-4                                                  38212          35886          -6.09%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-4                                                 45104          44840          -0.59%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-4                                                133357         127201         -4.62%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-4                                               944983         936494         -0.90%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-4                                                  196146         176470         -10.03%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-4                                                 266885         244692         -8.32%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-4                                                1078129        1038992        -3.63%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-4                                               8695853        8599290        -1.11%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-4                                          1762434        1678592        -4.76%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-4                                         2490843        2424476        -2.66%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-4                                        11473516       11987511       +4.48%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-4                                       96112750       94553690       -1.62%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-4                                                   24457          24884          +1.75%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-4                                                  32499          31360          -3.50%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-4                                                 112862         112890         +0.02%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-4                                                895661         873975         -2.42%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-4                                                   91894          87913          -4.33%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-4                                                  113544         104312         -8.13%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-4                                                 385205         373047         -3.16%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-4                                                2855448        2721066        -4.71%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-4                                               773114         710041         -8.16%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-4                                              922946         812459         -11.97%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-4                                             2986303        2758305        -7.63%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-4                                            21811781       20663620       -5.26%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-4                46395          45573          -1.77%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-4               66312          64979          -2.01%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-4              281080         274168         -2.46%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-4             2351753        2347276        -0.19%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-4                182915         163193         -10.78%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-4               233744         211974         -9.31%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-4              852197         768549         -9.82%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-4             6452308        6080277        -5.77%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-4        1602052        1359919        -15.11%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-4       1876938        1643285        -12.45%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-4      6158938        5614979        -8.83%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-4     44285238       41730780       -5.77%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-4                                           110101         100247         -8.95%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-4                                          147605         145017         -1.75%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-4                                         579649         567144         -2.16%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-4                                        4907521        4637637        -5.50%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-4                                           962035         845117         -12.15%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-4                                          1417943        1311680        -7.49%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-4                                         6495497        6219237        -4.25%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-4                                        56263067       54384392       -3.34%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-4                                       9867296        8980733        -8.98%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-4                                      14564313       13463806       -7.56%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-4                                     68098311       63766919       -6.36%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-4                                    589221174      554238194      -5.94%

benchmark                                                                                                             old allocs     new allocs     delta
BenchmarkRangeQuery/expr=a_one,steps=1-4                                                                              98             98             +0.00%
BenchmarkRangeQuery/expr=a_one,steps=10-4                                                                             98             98             +0.00%
BenchmarkRangeQuery/expr=a_one,steps=100-4                                                                            104            104            +0.00%
BenchmarkRangeQuery/expr=a_one,steps=1000-4                                                                           131            131            +0.00%
BenchmarkRangeQuery/expr=a_ten,steps=1-4                                                                              192            192            +0.00%
BenchmarkRangeQuery/expr=a_ten,steps=10-4                                                                             192            192            +0.00%
BenchmarkRangeQuery/expr=a_ten,steps=100-4                                                                            243            243            +0.00%
BenchmarkRangeQuery/expr=a_ten,steps=1000-4                                                                           486            486            +0.00%
BenchmarkRangeQuery/expr=a_hundred,steps=1-4                                                                          1095           1095           +0.00%
BenchmarkRangeQuery/expr=a_hundred,steps=10-4                                                                         1095           1095           +0.00%
BenchmarkRangeQuery/expr=a_hundred,steps=100-4                                                                        1596           1596           +0.00%
BenchmarkRangeQuery/expr=a_hundred,steps=1000-4                                                                       3999           3999           +0.00%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1-4                                                                    125            125            +0.00%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10-4                                                                   125            125            +0.00%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=100-4                                                                  131            131            +0.00%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1000-4                                                                 155            155            +0.00%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1-4                                                                    256            256            +0.00%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10-4                                                                   256            256            +0.00%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=100-4                                                                  307            307            +0.00%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1000-4                                                                 520            520            +0.00%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1-4                                                                1525           1525           +0.00%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10-4                                                               1525           1525           +0.00%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=100-4                                                              2026           2026           +0.00%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1000-4                                                             4130           4130           +0.00%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10000-4                                                                718            718            +0.00%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10000-4                                                                5819           5819           +0.00%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10000-4                                                            56855          56854          -0.00%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-4                                                  651            651            +0.00%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-4                                                 651            651            +0.00%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-4                                                658            658            +0.00%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-4                                               708            708            +0.00%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-4                                                  4971           4971           +0.00%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-4                                                 4967           4968           +0.02%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-4                                                5035           5035           +0.00%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-4                                               5536           5533           -0.05%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-4                                              48085          48085          +0.00%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-4                                             48081          48079          -0.00%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-4                                            48796          48797          +0.00%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-4                                           54051          54054          +0.01%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1-4                                                                 607            607            +0.00%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=10-4                                                                607            607            +0.00%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=100-4                                                               614            614            +0.00%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1000-4                                                              663            663            +0.00%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1-4                                                                 4923           4923           +0.00%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=10-4                                                                4923           4923           +0.00%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=100-4                                                               4994           4994           +0.00%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1000-4                                                              5490           5489           -0.02%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1-4                                                             48037          48037          +0.00%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=10-4                                                            48039          48038          -0.00%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=100-4                                                           48744          48739          -0.01%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1000-4                                                          53959          53950          -0.02%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1-4                                                                    607            607            +0.00%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=10-4                                                                   607            607            +0.00%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=100-4                                                                  614            614            +0.00%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1000-4                                                                 664            663            -0.15%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1-4                                                                    4924           4923           -0.02%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=10-4                                                                   4923           4923           +0.00%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=100-4                                                                  4993           4993           +0.00%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1000-4                                                                 5488           5488           +0.00%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1-4                                                                48037          48038          +0.00%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=10-4                                                               48041          48038          -0.01%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=100-4                                                              48745          48741          -0.01%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1000-4                                                             53924          53931          +0.01%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1-4                                                        607            607            +0.00%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=10-4                                                       607            607            +0.00%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=100-4                                                      614            614            +0.00%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-4                                                     663            663            +0.00%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-4                                                        4922           4922           +0.00%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-4                                                       4922           4922           +0.00%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-4                                                      4992           4992           +0.00%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-4                                                     5483           5483           +0.00%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-4                                                    48030          48028          -0.00%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-4                                                   48031          48031          +0.00%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-4                                                  48730          48732          +0.00%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-4                                                 53638          53634          -0.01%
BenchmarkRangeQuery/expr=-a_one,steps=1-4                                                                             108            108            +0.00%
BenchmarkRangeQuery/expr=-a_one,steps=10-4                                                                            108            108            +0.00%
BenchmarkRangeQuery/expr=-a_one,steps=100-4                                                                           114            114            +0.00%
BenchmarkRangeQuery/expr=-a_one,steps=1000-4                                                                          141            141            +0.00%
BenchmarkRangeQuery/expr=-a_ten,steps=1-4                                                                             239            239            +0.00%
BenchmarkRangeQuery/expr=-a_ten,steps=10-4                                                                            239            239            +0.00%
BenchmarkRangeQuery/expr=-a_ten,steps=100-4                                                                           290            290            +0.00%
BenchmarkRangeQuery/expr=-a_ten,steps=1000-4                                                                          533            533            +0.00%
BenchmarkRangeQuery/expr=-a_hundred,steps=1-4                                                                         1508           1508           +0.00%
BenchmarkRangeQuery/expr=-a_hundred,steps=10-4                                                                        1508           1508           +0.00%
BenchmarkRangeQuery/expr=-a_hundred,steps=100-4                                                                       2009           2009           +0.00%
BenchmarkRangeQuery/expr=-a_hundred,steps=1000-4                                                                      4412           4412           +0.00%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1-4                                                                      181            181            +0.00%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10-4                                                                     217            217            +0.00%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=100-4                                                                    589            589            +0.00%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1000-4                                                                   4243           4243           +0.00%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1-4                                                                      486            486            +0.00%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10-4                                                                     532            532            +0.00%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=100-4                                                                    1096           1097           +0.09%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1000-4                                                                   6218           6200           -0.29%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1-4                                                              3419           3419           +0.00%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10-4                                                             3540           3539           -0.03%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=100-4                                                            5764           5742           -0.38%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1000-4                                                           22672          22350          -1.42%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10000-4                                                                  41357          41357          +0.00%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10000-4                                                                  62464          63205          +1.19%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10000-4                                                          267072         246868         -7.57%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-4                                                     257            257            +0.00%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-4                                                    293            293            +0.00%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-4                                                   659            659            +0.00%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-4                                                  4286           4286           +0.00%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-4                                                     477            477            +0.00%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-4                                                    513            513            +0.00%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-4                                                   950            950            +0.00%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-4                                                  4916           4916           +0.00%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-4                                             2449           2449           +0.00%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-4                                            2582           2582           +0.00%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-4                                           4660           4660           +0.00%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                          21536          21566          +0.14%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-4                                                      259            259            +0.00%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-4                                                     295            295            +0.00%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-4                                                    661            661            +0.00%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-4                                                   4288           4288           +0.00%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-4                                                      486            486            +0.00%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-4                                                     541            541            +0.00%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-4                                                    1168           1168           +0.00%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-4                                                   7032           7031           -0.01%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-4                                              2511           2511           +0.00%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-4                                             2689           2689           +0.00%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-4                                            5216           5219           +0.06%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                           26609          26610          +0.00%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-4                                                  259            259            +0.00%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-4                                                 295            295            +0.00%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-4                                                661            661            +0.00%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-4                                               4288           4288           +0.00%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-4                                                  477            477            +0.00%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-4                                                 513            513            +0.00%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-4                                                950            950            +0.00%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-4                                               4916           4916           +0.00%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-4                                          2449           2449           +0.00%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-4                                         2582           2582           +0.00%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-4                                        4660           4659           -0.02%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                       21509          21543          +0.16%
BenchmarkRangeQuery/expr=abs(a_one),steps=1-4                                                                         126            126            +0.00%
BenchmarkRangeQuery/expr=abs(a_one),steps=10-4                                                                        135            135            +0.00%
BenchmarkRangeQuery/expr=abs(a_one),steps=100-4                                                                       231            231            +0.00%
BenchmarkRangeQuery/expr=abs(a_one),steps=1000-4                                                                      1158           1158           +0.00%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1-4                                                                         269            269            +0.00%
BenchmarkRangeQuery/expr=abs(a_ten),steps=10-4                                                                        288            288            +0.00%
BenchmarkRangeQuery/expr=abs(a_ten),steps=100-4                                                                       526            526            +0.00%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1000-4                                                                      2647           2646           -0.04%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1-4                                                                     1645           1646           +0.06%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=10-4                                                                    1720           1720           +0.00%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=100-4                                                                   2968           2968           +0.00%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1000-4                                                                  12858          12831          -0.21%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-4                                      207            207            +0.00%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-4                                     252            252            +0.00%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-4                                    708            708            +0.00%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4                                   5235           5235           +0.00%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-4                                      379            379            +0.00%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-4                                     434            434            +0.00%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-4                                    1032           1032           +0.00%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4                                   6754           6754           +0.00%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-4                                  2116           2116           +0.00%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-4                                 2226           2226           +0.00%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-4                                3834           3835           +0.03%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4                               17305          17306          +0.01%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-4                                             167            167            +0.00%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-4                                            230            230            +0.00%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-4                                           866            866            +0.00%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-4                                          7193           7193           +0.00%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-4                                             328            328            +0.00%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-4                                            401            401            +0.00%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-4                                           1179           1179           +0.00%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-4                                          8701           8700           -0.01%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-4                                         1885           1884           -0.05%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-4                                        2013           2013           +0.00%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-4                                       3801           3800           -0.03%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-4                                      19081          19078          -0.02%
BenchmarkRangeQuery/expr=sum(a_one),steps=1-4                                                                         128            128            +0.00%
BenchmarkRangeQuery/expr=sum(a_one),steps=10-4                                                                        182            182            +0.00%
BenchmarkRangeQuery/expr=sum(a_one),steps=100-4                                                                       728            728            +0.00%
BenchmarkRangeQuery/expr=sum(a_one),steps=1000-4                                                                      6155           6155           +0.00%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1-4                                                                         223            223            +0.00%
BenchmarkRangeQuery/expr=sum(a_ten),steps=10-4                                                                        277            277            +0.00%
BenchmarkRangeQuery/expr=sum(a_ten),steps=100-4                                                                       868            868            +0.00%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1000-4                                                                      6511           6511           +0.00%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1-4                                                                     1127           1127           +0.00%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=10-4                                                                    1181           1181           +0.00%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=100-4                                                                   2222           2222           +0.00%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1000-4                                                                  10025          10025          +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1-4                                                             312            312            +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=10-4                                                            675            675            +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=100-4                                                           4361           4361           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1000-4                                                          40925          40921          -0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1-4                                                             1306           1306           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=10-4                                                            1669           1669           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=100-4                                                           5850           5850           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1000-4                                                          44791          44786          -0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1-4                                                         11211          11211          +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=10-4                                                        11574          11574          +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=100-4                                                       20707          20705          -0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-4                                                      83403          83429          +0.03%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1-4                                                            238            238            +0.00%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=10-4                                                           310            310            +0.00%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=100-4                                                          1086           1086           +0.00%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1000-4                                                         8553           8553           +0.00%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1-4                                                            1299           1299           +0.00%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=10-4                                                           1633           1633           +0.00%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=100-4                                                          5524           5524           +0.00%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1000-4                                                         41566          41570          +0.01%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1-4                                                        11861          11861          +0.00%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=10-4                                                       14749          14750          +0.01%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=100-4                                                      49119          49122          +0.01%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-4                                                     364161         364194         +0.01%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1-4                                                                  238            238            +0.00%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=10-4                                                                 310            310            +0.00%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=100-4                                                                1086           1086           +0.00%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1000-4                                                               8553           8553           +0.00%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1-4                                                                  1299           1299           +0.00%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=10-4                                                                 1633           1633           +0.00%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=100-4                                                                5523           5524           +0.02%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1000-4                                                               41570          41563          -0.02%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1-4                                                              11861          11861          +0.00%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=10-4                                                             14749          14747          -0.01%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=100-4                                                            49125          49114          -0.02%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-4                                                           364211         364192         -0.01%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1-4                                                                 312            312            +0.00%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=10-4                                                                675            675            +0.00%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=100-4                                                               4361           4361           +0.00%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1000-4                                                              40924          40924          +0.00%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1-4                                                                 1306           1306           +0.00%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=10-4                                                                1669           1669           +0.00%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=100-4                                                               5850           5850           +0.00%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1000-4                                                              44786          44789          +0.01%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1-4                                                             11211          11211          +0.00%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=10-4                                                            11575          11574          -0.01%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=100-4                                                           20706          20708          +0.01%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-4                                                          83398          83417          +0.02%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-4                                                  225            225            +0.00%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-4                                                 261            261            +0.00%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-4                                                633            633            +0.00%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-4                                               4281           4281           +0.00%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-4                                                  569            569            +0.00%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-4                                                 615            615            +0.00%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-4                                                1179           1179           +0.00%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-4                                               6246           6213           -0.53%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-4                                          3871           3871           +0.00%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-4                                         3990           3991           +0.03%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-4                                        6189           6194           +0.08%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-4                                       21813          22628          +3.74%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-4                                                   156            156            +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-4                                                  219            219            +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-4                                                 855            855            +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-4                                                7179           7179           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-4                                                   290            290            +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-4                                                  362            362            +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-4                                                 1133           1133           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-4                                                8546           8546           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-4                                               1560           1560           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-4                                              1632           1632           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-4                                             2853           2853           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-4                                            12157          12157          +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-4                291            291            +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-4               453            453            +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-4              2085           2085           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-4             18333          18333          +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-4                559            559            +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-4               739            739            +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-4              2641           2641           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-4             21068          21068          +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-4        3100           3100           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-4       3279           3279           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-4      6082           6082           +0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-4     28290          28290          +0.00%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-4                                           371            371            +0.00%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-4                                          614            614            +0.00%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-4                                         3100           3100           +0.00%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-4                                        27668          27668          +0.00%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-4                                           2499           2499           +0.00%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-4                                          5604           5604           +0.00%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-4                                         37214          37214          +0.00%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-4                                        350442         350446         +0.00%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-4                                       23502          23502          +0.00%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-4                                      54202          54203          +0.00%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-4                                     366728         366737         +0.00%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-4                                    3463263        3463346        +0.00%

benchmark                                                                                                             old bytes     new bytes     delta
BenchmarkRangeQuery/expr=a_one,steps=1-4                                                                              5107          5123          +0.31%
BenchmarkRangeQuery/expr=a_one,steps=10-4                                                                             5106          5122          +0.31%
BenchmarkRangeQuery/expr=a_one,steps=100-4                                                                            5330          5346          +0.30%
BenchmarkRangeQuery/expr=a_one,steps=1000-4                                                                           7430          7446          +0.22%
BenchmarkRangeQuery/expr=a_ten,steps=1-4                                                                              11988         12148         +1.33%
BenchmarkRangeQuery/expr=a_ten,steps=10-4                                                                             11988         12147         +1.33%
BenchmarkRangeQuery/expr=a_ten,steps=100-4                                                                            13508         13670         +1.20%
BenchmarkRangeQuery/expr=a_ten,steps=1000-4                                                                           24396         24563         +0.68%
BenchmarkRangeQuery/expr=a_hundred,steps=1-4                                                                          79281         80829         +1.95%
BenchmarkRangeQuery/expr=a_hundred,steps=10-4                                                                         79315         80772         +1.84%
BenchmarkRangeQuery/expr=a_hundred,steps=100-4                                                                        93502         95114         +1.72%
BenchmarkRangeQuery/expr=a_hundred,steps=1000-4                                                                       192377        194117        +0.90%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1-4                                                                    5834          5851          +0.29%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10-4                                                                   5834          5851          +0.29%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=100-4                                                                  6064          6074          +0.16%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1000-4                                                                 8086          8101          +0.19%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1-4                                                                    15950         16115         +1.03%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10-4                                                                   15953         16107         +0.97%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=100-4                                                                  17483         17631         +0.85%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1000-4                                                                 27528         27689         +0.58%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1-4                                                                114813        116436        +1.41%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10-4                                                               114869        116382        +1.32%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=100-4                                                              129373        131050        +1.30%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1000-4                                                             221751        223580        +0.82%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10000-4                                                                49113         49256         +0.29%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10000-4                                                                240799        241786        +0.41%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10000-4                                                            2141497       2112102       -1.37%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-4                                                  1185949       1185886       -0.01%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-4                                                 1185748       1185884       +0.01%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-4                                                1187832       1188122       +0.02%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-4                                               1208247       1205359       -0.24%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-4                                                  1320359       1320874       +0.04%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-4                                                 1321104       1321644       +0.04%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-4                                                1298533       1301442       +0.22%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-4                                               1371308       1350748       -1.50%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-4                                              2663746       2665379       +0.06%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-4                                             2659165       2660718       +0.06%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-4                                            2686764       2708900       +0.82%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-4                                           5766880       5772528       +0.10%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1-4                                                                 555505        556988        +0.27%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=10-4                                                                556142        556677        +0.10%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=100-4                                                               555732        555355        -0.07%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1000-4                                                              564401        556724        -1.36%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1-4                                                                 692608        691854        -0.11%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=10-4                                                                688925        692851        +0.57%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=100-4                                                               712726        703083        -1.35%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1000-4                                                              804736        798002        -0.84%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1-4                                                             2030149       2064551       +1.69%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=10-4                                                            2078359       2034683       -2.10%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=100-4                                                           2173444       2156612       -0.77%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1000-4                                                          5515688       5536760       +0.38%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1-4                                                                    555554        556853        +0.23%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=10-4                                                                   555618        555211        -0.07%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=100-4                                                                  558185        555673        -0.45%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1000-4                                                                 563333        563511        +0.03%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1-4                                                                    696866        692270        -0.66%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=10-4                                                                   688631        689493        +0.13%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=100-4                                                                  690981        691085        +0.02%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1000-4                                                                 782439        782652        +0.03%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1-4                                                                2064985       2066077       +0.05%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=10-4                                                               2077961       2073446       -0.22%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=100-4                                                              2169516       2140896       -1.32%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1000-4                                                             4821544       4903416       +1.70%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1-4                                                        556632        556729        +0.02%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=10-4                                                       557767        556903        -0.15%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=100-4                                                      558104        558843        +0.13%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-4                                                     572334        574324        +0.35%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-4                                                        692090        688512        -0.52%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-4                                                       693803        690425        -0.49%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-4                                                      712918        712751        -0.02%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-4                                                     888060        887181        -0.10%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-4                                                    2064714       2030844       -1.64%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-4                                                   2116369       2113906       -0.12%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-4                                                  2313946       2314653       +0.03%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-4                                                 4005246       3849558       -3.89%
BenchmarkRangeQuery/expr=-a_one,steps=1-4                                                                             5570          5586          +0.29%
BenchmarkRangeQuery/expr=-a_one,steps=10-4                                                                            5570          5586          +0.29%
BenchmarkRangeQuery/expr=-a_one,steps=100-4                                                                           5794          5810          +0.28%
BenchmarkRangeQuery/expr=-a_one,steps=1000-4                                                                          7891          7910          +0.24%
BenchmarkRangeQuery/expr=-a_ten,steps=1-4                                                                             15671         15831         +1.02%
BenchmarkRangeQuery/expr=-a_ten,steps=10-4                                                                            15671         15831         +1.02%
BenchmarkRangeQuery/expr=-a_ten,steps=100-4                                                                           17193         17354         +0.94%
BenchmarkRangeQuery/expr=-a_ten,steps=1000-4                                                                          28091         28262         +0.61%
BenchmarkRangeQuery/expr=-a_hundred,steps=1-4                                                                         114462        116045        +1.38%
BenchmarkRangeQuery/expr=-a_hundred,steps=10-4                                                                        114460        116055        +1.39%
BenchmarkRangeQuery/expr=-a_hundred,steps=100-4                                                                       128966        130556        +1.23%
BenchmarkRangeQuery/expr=-a_hundred,steps=1000-4                                                                      227726        229434        +0.75%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1-4                                                                      11147         11179         +0.29%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10-4                                                                     12587         12619         +0.25%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=100-4                                                                    27440         27470         +0.11%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1000-4                                                                   175673        175686        +0.01%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1-4                                                                      37182         37510         +0.88%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10-4                                                                     40224         40540         +0.79%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=100-4                                                                    73678         74197         +0.70%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1000-4                                                                   402868        403456        +0.15%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1-4                                                              303908        307063        +1.04%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10-4                                                             328727        331685        +0.90%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=100-4                                                            610569        605118        -0.89%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1000-4                                                           3386145       3219413       -4.92%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10000-4                                                                  1698011       1699197       +0.07%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10000-4                                                                  3722623       4067193       +9.26%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10000-4                                                          40324024      30800560      -23.62%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-4                                                     18676         18681         +0.03%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-4                                                    20114         20135         +0.10%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-4                                                   34759         34775         +0.05%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-4                                                  181071        181064        -0.00%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-4                                                     37167         37398         +0.62%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-4                                                    38613         38874         +0.68%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-4                                                   55332         55597         +0.48%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-4                                                  216918        217035        +0.05%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-4                                             212028        214455        +1.14%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-4                                            242085        244436        +0.97%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-4                                           563939        566657        +0.48%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                          3711994       3718885       +0.19%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-4                                                      18743         18761         +0.10%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-4                                                     20194         20200         +0.03%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-4                                                    34831         34846         +0.04%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-4                                                   181150        181128        -0.01%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-4                                                      38498         38720         +0.58%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-4                                                     44024         44240         +0.49%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-4                                                    101706        101933        +0.22%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-4                                                   671915        672466        +0.08%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-4                                              223937        226433        +1.11%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-4                                             287792        290040        +0.78%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-4                                            945150        947631        +0.26%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                           7455109       7449341       -0.08%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-4                                                  18746         18763         +0.09%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-4                                                 20194         20212         +0.09%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-4                                                34835         34855         +0.06%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-4                                               181030        181212        +0.10%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-4                                                  37164         37388         +0.60%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-4                                                 38603         38810         +0.54%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-4                                                55334         55575         +0.44%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-4                                               216487        216697        +0.10%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-4                                          212165        214399        +1.05%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-4                                         241975        244543        +1.06%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-4                                        564069        566184        +0.37%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                       3714730       3713787       -0.03%
BenchmarkRangeQuery/expr=abs(a_one),steps=1-4                                                                         6562          6578          +0.24%
BenchmarkRangeQuery/expr=abs(a_one),steps=10-4                                                                        6850          6866          +0.23%
BenchmarkRangeQuery/expr=abs(a_one),steps=100-4                                                                       9956          9972          +0.16%
BenchmarkRangeQuery/expr=abs(a_one),steps=1000-4                                                                      40861         40897         +0.09%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1-4                                                                         20333         20496         +0.80%
BenchmarkRangeQuery/expr=abs(a_ten),steps=10-4                                                                        22094         22250         +0.71%
BenchmarkRangeQuery/expr=abs(a_ten),steps=100-4                                                                       41181         41345         +0.40%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1000-4                                                                      227915        227986        +0.03%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1-4                                                                     157332        158971        +1.04%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=10-4                                                                    172583        174192        +0.93%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=100-4                                                                   339313        340901        +0.47%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1000-4                                                                  1963225       1962441       -0.04%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-4                                      11171         11187         +0.14%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-4                                     12612         12627         +0.12%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-4                                    27241         27256         +0.06%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4                                   173392        173373        -0.01%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-4                                      26590         26750         +0.60%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-4                                     29502         29660         +0.54%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-4                                    60129         60295         +0.28%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4                                   362130        362297        +0.05%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-4                                  179493        181042        +0.86%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-4                                 195794        197459        +0.85%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-4                                374137        375677        +0.41%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4                               2110281       2112039       +0.08%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-4                                             8426          8442          +0.19%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-4                                            10443         10459         +0.15%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-4                                           30833         30848         +0.05%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-4                                          234583        234603        +0.01%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-4                                             23447         23606         +0.68%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-4                                            26932         27095         +0.61%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-4                                           63327         63477         +0.24%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-4                                          422962        423031        +0.02%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-4                                         172495        174047        +0.90%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-4                                        189421        191005        +0.84%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-4                                       373366        374970        +0.43%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-4                                      2168786       2170102       +0.06%
BenchmarkRangeQuery/expr=sum(a_one),steps=1-4                                                                         6786          6802          +0.24%
BenchmarkRangeQuery/expr=sum(a_one),steps=10-4                                                                        10675         10691         +0.15%
BenchmarkRangeQuery/expr=sum(a_one),steps=100-4                                                                       49785         49803         +0.04%
BenchmarkRangeQuery/expr=sum(a_one),steps=1000-4                                                                      440764        440801        +0.01%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1-4                                                                         15860         16020         +1.01%
BenchmarkRangeQuery/expr=sum(a_ten),steps=10-4                                                                        19748         19909         +0.82%
BenchmarkRangeQuery/expr=sum(a_ten),steps=100-4                                                                       60160         60318         +0.26%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1000-4                                                                      459982        460115        +0.03%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1-4                                                                     101851        103452        +1.57%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=10-4                                                                    105753        107346        +1.51%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=100-4                                                                   159093        160758        +1.05%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1000-4                                                                  647389        648660        +0.20%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1-4                                                             22635         22813         +0.79%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=10-4                                                            48878         49055         +0.36%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=100-4                                                           313018        313172        +0.05%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1000-4                                                          2949532       2949154       -0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1-4                                                             129260        131024        +1.36%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=10-4                                                            158686        160434        +1.10%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=100-4                                                           468776        470556        +0.38%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1000-4                                                          3519200       3520752       +0.04%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1-4                                                         1170160       1187762       +1.50%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=10-4                                                        1199224       1217089       +1.49%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=100-4                                                       1653655       1671200       +1.06%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-4                                                      5681249       5695168       +0.24%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1-4                                                            16980         17158         +1.05%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=10-4                                                           21737         21911         +0.80%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=100-4                                                          70928         71107         +0.25%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1000-4                                                         558107        558306        +0.04%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1-4                                                            128650        130418        +1.37%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=10-4                                                           155967        157703        +1.11%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=100-4                                                          444682        446474        +0.40%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1000-4                                                         3281721       3283949       +0.07%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1-4                                                        1229961       1247261       +1.41%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=10-4                                                       1497370       1514915       +1.17%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=100-4                                                      4329339       4347023       +0.41%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-4                                                     32090800      32111873      +0.07%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1-4                                                                  16917         17093         +1.04%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=10-4                                                                 21382         21559         +0.83%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=100-4                                                                67702         67872         +0.25%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1000-4                                                               526013        526238        +0.04%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1-4                                                                  127377        129142        +1.39%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=10-4                                                                 148900        150673        +1.19%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=100-4                                                                380043        381775        +0.46%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1000-4                                                               2640673       2642273       +0.06%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1-4                                                              1217273       1234473       +1.41%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=10-4                                                             1426938       1443952       +1.19%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=100-4                                                            3681825       3698439       +0.45%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-4                                                           25687758      25706115      +0.07%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1-4                                                                 21934         22108         +0.79%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=10-4                                                                45011         45181         +0.38%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=100-4                                                               277448        277595        +0.05%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1000-4                                                              2596813       2596940       +0.00%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1-4                                                                 127851        129623        +1.39%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=10-4                                                                150936        152708        +1.17%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=100-4                                                               397676        399409        +0.44%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1000-4                                                              2814234       2816433       +0.08%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1-4                                                             1168239       1186079       +1.53%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=10-4                                                            1191632       1208860       +1.45%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=100-4                                                           1583096       1603082       +1.26%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-4                                                          4976448       4991870       +0.31%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-4                                                  12265         12288         +0.19%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-4                                                 13698         13737         +0.28%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-4                                                28577         28601         +0.08%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-4                                               176874        176809        -0.04%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-4                                                  40780         41086         +0.75%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-4                                                 43818         44109         +0.66%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-4                                                77399         77801         +0.52%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-4                                               409735        401497        -2.01%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-4                                          335844        339202        +1.00%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-4                                         360284        364394        +1.14%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-4                                        631778        635808        +0.64%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-4                                       3010327       3252777       +8.05%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-4                                                   7534          7550          +0.21%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-4                                                  11711         11731         +0.17%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-4                                                 53755         53774         +0.04%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-4                                                473822        473668        -0.03%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-4                                                   19910         20064         +0.77%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-4                                                  24393         24528         +0.55%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-4                                                 70593         70709         +0.16%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-4                                                527579        527536        -0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-4                                               137749        139411        +1.21%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-4                                              142233        143801        +1.10%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-4                                             201547        203014        +0.73%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-4                                            739716        741771        +0.28%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-4                16170         16197         +0.17%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-4               25967         26015         +0.18%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-4              124505        124503        -0.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-4             1108805       1108650       -0.01%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-4                40903         41259         +0.87%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-4               51290         51603         +0.61%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-4              158140        158479        +0.21%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-4             1216170       1217063       +0.07%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-4        276670        279888        +1.16%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-4       286827        290201        +1.18%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-4      420249        423205        +0.70%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-4     1641737       1646630       +0.30%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-4                                           24990         25175         +0.74%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-4                                          36232         36415         +0.51%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-4                                         150334        150526        +0.13%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-4                                        1286826       1286749       -0.01%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-4                                           207881        209670        +0.86%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-4                                          344511        346148        +0.48%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-4                                         1726690       1729087       +0.14%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-4                                        15502807      15503823      +0.01%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-4                                       2001993       2021040       +0.95%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-4                                      3371359       3388621       +0.51%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-4                                     17210736      17224171      +0.08%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-4                                    154699748     154714368     +0.01%
```
