### PR TITLE
Remove unused env var CLUSTER_NAME in funcbench workflow.

### DIFF
--- a/.github/workflows/funcbench.yml
+++ b/.github/workflows/funcbench.yml
@@ -9,7 +9,6 @@ jobs:
       AUTH_FILE: ${{ secrets.TEST_INFRA_GKE_AUTH }}
       BRANCH: ${{ github.event.client_payload.BRANCH }}
       BENCH_FUNC_REGEX: ${{ github.event.client_payload.BENCH_FUNC_REGEX }}
-      CLUSTER_NAME: test-infra
       GITHUB_TOKEN: ${{ secrets.PROMBOT_TOKEN }}
       GITHUB_ORG: prometheus
       GITHUB_REPO: prometheus


### PR DESCRIPTION
https://github.com/prometheus/test-infra/pull/368 removed the use of `CLUSTER_NAME` variable in funcbench deployment.

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>