### PR TITLE
Configurable minValidTime for TSDB

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -325,7 +325,12 @@ func createBlockFromHead(tb testing.TB, dir string, head *Head) string {
 }
 
 func createHead(tb testing.TB, series []storage.Series, chunkDir string) *Head {
-	head, err := NewHead(nil, nil, nil, 2*60*60*1000, chunkDir, nil, DefaultStripeSize, nil)
+	headOpts := &HeadOptions{
+		ChunkRange:   2 * 60 * 60 * 1000,
+		ChunkRootDir: chunkDir,
+		StripeSize:   DefaultStripeSize,
+	}
+	head, err := NewHead(nil, nil, nil, nil, headOpts)
 	testutil.Ok(tb, err)
 
 	app := head.Appender()

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -875,7 +875,12 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 			defer func() {
 				testutil.Ok(b, os.RemoveAll(chunkDir))
 			}()
-			h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, DefaultStripeSize, nil)
+			headOpts := &HeadOptions{
+				ChunkRange:   1000,
+				ChunkRootDir: chunkDir,
+				StripeSize:   DefaultStripeSize,
+			}
+			h, err := NewHead(nil, nil, nil, nil, headOpts)
 			testutil.Ok(b, err)
 			for ln := 0; ln < labelNames; ln++ {
 				app := h.Appender()

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -118,6 +118,10 @@ type Options struct {
 	// SeriesLifecycleCallback specifies a list of callbacks that will be called during a lifecycle of a series.
 	// It is always a no-op in Prometheus and mainly meant for external users who import TSDB.
 	SeriesLifecycleCallback SeriesLifecycleCallback
+
+	// MinValidTimeGracePeriod is the additional grace period w.r.t the current min valid time
+	// for samples to be appended before they are considered out of bound.
+	MinValidTimeGracePeriod int64
 }
 
 // DB handles reads and writes of time series falling into
@@ -618,6 +622,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		ChunkRootDir:            dir,
 		StripeSize:              opts.StripeSize,
 		SeriesLifecycleCallback: opts.SeriesLifecycleCallback,
+		MinValidTimeGracePeriod: opts.MinValidTimeGracePeriod,
 	}
 	db.head, err = NewHead(r, l, wlog, db.chunkPool, headOpts)
 	if err != nil {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -313,7 +313,12 @@ func (db *DBReadOnly) FlushWAL(dir string) (returnErr error) {
 	if err != nil {
 		return err
 	}
-	head, err := NewHead(nil, db.logger, w, 1, db.dir, nil, DefaultStripeSize, nil)
+	headOpts := &HeadOptions{
+		ChunkRange:   1,
+		ChunkRootDir: db.dir,
+		StripeSize:   DefaultStripeSize,
+	}
+	head, err := NewHead(nil, db.logger, w, nil, headOpts)
 	if err != nil {
 		return err
 	}
@@ -372,7 +377,12 @@ func (db *DBReadOnly) Querier(ctx context.Context, mint, maxt int64) (storage.Qu
 		blocks[i] = b
 	}
 
-	head, err := NewHead(nil, db.logger, nil, 1, db.dir, nil, DefaultStripeSize, nil)
+	headOpts := &HeadOptions{
+		ChunkRange:   1,
+		ChunkRootDir: db.dir,
+		StripeSize:   DefaultStripeSize,
+	}
+	head, err := NewHead(nil, db.logger, nil, nil, headOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +400,7 @@ func (db *DBReadOnly) Querier(ctx context.Context, mint, maxt int64) (storage.Qu
 		if err != nil {
 			return nil, err
 		}
-		head, err = NewHead(nil, db.logger, w, 1, db.dir, nil, DefaultStripeSize, nil)
+		head, err = NewHead(nil, db.logger, w, nil, headOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -603,7 +613,13 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		}
 	}
 
-	db.head, err = NewHead(r, l, wlog, rngs[0], dir, db.chunkPool, opts.StripeSize, opts.SeriesLifecycleCallback)
+	headOpts := &HeadOptions{
+		ChunkRange:              rngs[0],
+		ChunkRootDir:            dir,
+		StripeSize:              opts.StripeSize,
+		SeriesLifecycleCallback: opts.SeriesLifecycleCallback,
+	}
+	db.head, err = NewHead(r, l, wlog, db.chunkPool, headOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -761,7 +761,7 @@ func (db *DB) Compact() (err error) {
 			break
 		}
 		mint := db.head.MinTime()
-		maxt := rangeForTimestamp(mint, db.head.chunkRange)
+		maxt := rangeForTimestamp(mint, db.head.opts.ChunkRange)
 
 		// Wrap head into a range that bounds all reads to it.
 		// We remove 1 millisecond from maxt because block

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1436,13 +1436,6 @@ func (h *Head) MaxTime() int64 {
 	return atomic.LoadInt64(&h.maxTime)
 }
 
-// compactable returns whether the head has a compactable range.
-// The head has a compactable range when the head time range is 1.5 times the chunk range.
-// The 0.5 acts as a buffer of the appendable window.
-func (h *Head) compactable() bool {
-	return h.MaxTime()-h.MinTime() > h.opts.ChunkRange/2*3
-}
-
 // Close flushes the WAL and closes the head.
 func (h *Head) Close() error {
 	h.closedMtx.Lock()

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -30,8 +30,13 @@ func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 	defer func() {
 		testutil.Ok(b, os.RemoveAll(chunkDir))
 	}()
+	headOpts := &HeadOptions{
+		ChunkRange:   1000,
+		ChunkRootDir: chunkDir,
+		StripeSize:   DefaultStripeSize,
+	}
 	// Put a series, select it. GC it and then access it.
-	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, DefaultStripeSize, nil)
+	h, err := NewHead(nil, nil, nil, nil, headOpts)
 	testutil.Ok(b, err)
 	defer h.Close()
 
@@ -46,8 +51,13 @@ func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 	defer func() {
 		testutil.Ok(b, os.RemoveAll(chunkDir))
 	}()
+	headOpts := &HeadOptions{
+		ChunkRange:   1000,
+		ChunkRootDir: chunkDir,
+		StripeSize:   DefaultStripeSize,
+	}
 	// Put a series, select it. GC it and then access it.
-	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, DefaultStripeSize, nil)
+	h, err := NewHead(nil, nil, nil, nil, headOpts)
 	testutil.Ok(b, err)
 	defer h.Close()
 

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -35,7 +35,12 @@ func BenchmarkPostingsForMatchers(b *testing.B) {
 	defer func() {
 		testutil.Ok(b, os.RemoveAll(chunkDir))
 	}()
-	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, DefaultStripeSize, nil)
+	headOpts := &HeadOptions{
+		ChunkRange:   1000,
+		ChunkRootDir: chunkDir,
+		StripeSize:   DefaultStripeSize,
+	}
+	h, err := NewHead(nil, nil, nil, nil, headOpts)
 	testutil.Ok(b, err)
 	defer func() {
 		testutil.Ok(b, h.Close())
@@ -136,7 +141,12 @@ func BenchmarkQuerierSelect(b *testing.B) {
 	defer func() {
 		testutil.Ok(b, os.RemoveAll(chunkDir))
 	}()
-	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, DefaultStripeSize, nil)
+	headOpts := &HeadOptions{
+		ChunkRange:   1000,
+		ChunkRootDir: chunkDir,
+		StripeSize:   DefaultStripeSize,
+	}
+	h, err := NewHead(nil, nil, nil, nil, headOpts)
 	testutil.Ok(b, err)
 	defer h.Close()
 	app := h.Appender()

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1864,7 +1864,12 @@ func TestPostingsForMatchers(t *testing.T) {
 	defer func() {
 		testutil.Ok(t, os.RemoveAll(chunkDir))
 	}()
-	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, DefaultStripeSize, nil)
+	headOpts := &HeadOptions{
+		ChunkRange:   1000,
+		ChunkRootDir: chunkDir,
+		StripeSize:   DefaultStripeSize,
+	}
+	h, err := NewHead(nil, nil, nil, nil, headOpts)
 	testutil.Ok(t, err)
 	defer func() {
 		testutil.Ok(t, h.Close())

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -33,7 +33,12 @@ type MetricSample struct {
 
 // CreateHead creates a TSDB writer head to write the sample data to.
 func CreateHead(samples []*MetricSample, chunkRange int64, chunkDir string, logger log.Logger) (*Head, error) {
-	head, err := NewHead(nil, logger, nil, chunkRange, chunkDir, nil, DefaultStripeSize, nil)
+	headOpts := &HeadOptions{
+		ChunkRange:   chunkRange,
+		ChunkRootDir: chunkDir,
+		StripeSize:   DefaultStripeSize,
+	}
+	head, err := NewHead(nil, logger, nil, nil, headOpts)
 
 	if err != nil {
 		return nil, err

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2116,7 +2116,12 @@ func (f *fakeDB) Stats(statsByLabelName string) (_ *tsdb.Stats, retErr error) {
 			retErr = err
 		}
 	}()
-	h, _ := tsdb.NewHead(nil, nil, nil, 1000, "", nil, tsdb.DefaultStripeSize, nil)
+	headOpts := &tsdb.HeadOptions{
+		ChunkRange:   1000,
+		ChunkRootDir: dbDir,
+		StripeSize:   tsdb.DefaultStripeSize,
+	}
+	h, _ := tsdb.NewHead(nil, nil, nil, nil, headOpts)
 	return h.Stats(statsByLabelName), nil
 }
 


### PR DESCRIPTION
Closes https://github.com/prometheus/prometheus/issues/7396

Stuff that this PR adds/changes:
1. `HeadOptions` for the head block to cut down on arguments for `NewHead()`
2. `SetMinValidTime` method for Head.
3. `MinValidTimeGracePeriod` as described in the linked issue. 
4. Updates the head compaction logic.
5. Adds `prometheus_tsdb_head_compactions_triggered_total` to know exactly how many times the head compaction was triggered.

TODO:
- [x] Unit tests
- [ ] Test it in Cortex to find any issues