### PR TITLE
Add missing newline before inline-code block

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1048,6 +1048,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_triton_machine_id`: the UUID of the target
 
 See below for the configuration options for Triton discovery:
+
 ```yaml
 # The information to access the Triton discovery API.
 


### PR DESCRIPTION
Sections with three backticks require a blank line before them.

Otherwise, https://prometheus.io/docs/prometheus/latest/configuration/configuration/#triton_sd_config looks like:
![Screen Shot 2020-06-15 at 5 34 44 PM](https://user-images.githubusercontent.com/28347/84718821-90263180-af2e-11ea-859b-643611af5296.png)

@brian-brazil