### PR TITLE
Cleanup bstream based on post-merge feedback received on 7390

### DIFF
--- a/tsdb/chunkenc/bstream.go
+++ b/tsdb/chunkenc/bstream.go
@@ -41,7 +41,10 @@
 
 package chunkenc
 
-import "io"
+import (
+	"encoding/binary"
+	"io"
+)
 
 // bstream is a stream of bits.
 type bstream struct {
@@ -209,17 +212,7 @@ func (b *bstreamReader) loadNextBuffer(nbits uint8) bool {
 	// very last byte of the stream (which suffers race conditions due to concurrent
 	// writes).
 	if b.streamOffset+8 < len(b.stream) {
-		// This is ugly, but significantly faster.
-		b.buffer =
-			((uint64(b.stream[b.streamOffset])) << 56) |
-				((uint64(b.stream[b.streamOffset+1])) << 48) |
-				((uint64(b.stream[b.streamOffset+2])) << 40) |
-				((uint64(b.stream[b.streamOffset+3])) << 32) |
-				((uint64(b.stream[b.streamOffset+4])) << 24) |
-				((uint64(b.stream[b.streamOffset+5])) << 16) |
-				((uint64(b.stream[b.streamOffset+6])) << 8) |
-				uint64(b.stream[b.streamOffset+7])
-
+		b.buffer = binary.BigEndian.Uint64(b.stream[b.streamOffset:])
 		b.streamOffset += 8
 		b.valid = 64
 		return true

--- a/tsdb/chunkenc/bstream_test.go
+++ b/tsdb/chunkenc/bstream_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Prometheus Authors
+// Copyright 2020 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/tsdb/chunkenc/bstream_test.go
+++ b/tsdb/chunkenc/bstream_test.go
@@ -11,34 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The code in this file was largely written by Damian Gryski as part of
-// https://github.com/dgryski/go-tsz and published under the license below.
-// It received minor modifications to suit Prometheus's needs.
-
-// Copyright (c) 2015,2016 Damian Gryski <damian@gryski.com>
-// All rights reserved.
-
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-
-// * Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-//
-// * Redistributions in binary form must reproduce the above copyright notice,
-// this list of conditions and the following disclaimer in the documentation
-// and/or other materials provided with the distribution.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 package chunkenc
 
 import (


### PR DESCRIPTION
@codesome left some valuable feedback to #7390 after getting it merged. In this PR I'm addressing the feedback.

We also agreed offline to not address [this comment](https://github.com/prometheus/prometheus/pull/7390#discussion_r440571574) because it's hard to know whether the `Fast()` version of a function is expected to return an error or not for every single call.