### PR TITLE
Add missing newline before inline-code block (#7401)

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1047,6 +1047,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_triton_machine_id`: the UUID of the target
 
 See below for the configuration options for Triton discovery:
+
 ```yaml
 # The information to access the Triton discovery API.
 


### PR DESCRIPTION
Sections with three backticks require a blank line before them.

Signed-off-by: Alex Vandiver <alex@chmrr.net>


**Cherry Picking as it is a visible issue in the docs**

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->