### PR TITLE
Use 10m timeouts for watches

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	watchTimeout  = 30 * time.Second
+	watchTimeout  = 10 * time.Minute
 	retryInterval = 15 * time.Second
 
 	// addressLabel is the name for the label containing a target's address.
@@ -95,7 +95,7 @@ var (
 		Scheme:          "http",
 		Server:          "localhost:8500",
 		AllowStale:      true,
-		RefreshInterval: model.Duration(watchTimeout),
+		RefreshInterval: model.Duration(30 * time.Second),
 	}
 )
 
@@ -175,7 +175,7 @@ func NewDiscovery(conf *SDConfig, logger log.Logger) (*Discovery, error) {
 		return nil, err
 	}
 	transport := &http.Transport{
-		IdleConnTimeout: 5 * time.Duration(conf.RefreshInterval),
+		IdleConnTimeout: 2 * time.Duration(watchTimeout),
 		TLSClientConfig: tls,
 		DialContext: conntrack.NewDialContextFunc(
 			conntrack.DialWithTracing(),

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -223,20 +223,20 @@ func newServer(t *testing.T) (*httptest.Server, *SDConfig) {
 		switch r.URL.String() {
 		case "/v1/agent/self":
 			response = AgentAnswer
-		case "/v1/health/service/test?node-meta=rack_name%3A2304&stale=&tag=tag1&wait=30000ms":
+		case "/v1/health/service/test?node-meta=rack_name%3A2304&stale=&tag=tag1&wait=600000ms":
 			response = ServiceTestAnswer
-		case "/v1/health/service/test?wait=30000ms":
+		case "/v1/health/service/test?wait=600000ms":
 			response = ServiceTestAnswer
-		case "/v1/health/service/other?wait=30000ms":
+		case "/v1/health/service/other?wait=600000ms":
 			response = `[]`
-		case "/v1/catalog/services?node-meta=rack_name%3A2304&stale=&wait=30000ms":
+		case "/v1/catalog/services?node-meta=rack_name%3A2304&stale=&wait=600000ms":
 			response = ServicesTestAnswer
-		case "/v1/catalog/services?wait=30000ms":
+		case "/v1/catalog/services?wait=600000ms":
 			response = ServicesTestAnswer
-		case "/v1/catalog/services?index=1&node-meta=rack_name%3A2304&stale=&wait=30000ms":
+		case "/v1/catalog/services?index=1&node-meta=rack_name%3A2304&stale=&wait=600000ms":
 			time.Sleep(5 * time.Second)
 			response = ServicesTestAnswer
-		case "/v1/catalog/services?index=1&wait=30000ms":
+		case "/v1/catalog/services?index=1&wait=600000ms":
 			time.Sleep(5 * time.Second)
 			response = ServicesTestAnswer
 		default:


### PR DESCRIPTION
use ?wait=10m will give results as fast as usual when data is changing
but will perform far fewer requests when services do not change.

On large infrastructure, this will reduce quite a lot the number of
queries/s on Consul servers while having the same performance for freshness
of results.