### PR TITLE
DigitalOcean: limit refresh timeout

### DIFF
--- a/discovery/digitalocean/digitalocean.go
+++ b/discovery/digitalocean/digitalocean.go
@@ -58,7 +58,7 @@ var DefaultSDConfig = SDConfig{
 type SDConfig struct {
 	HTTPClientConfig config_util.HTTPClientConfig `yaml:",inline"`
 
-	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
+	RefreshInterval model.Duration `yaml:"refresh_interval"`
 	Port            int            `yaml:"port"`
 }
 
@@ -95,7 +95,7 @@ func NewDiscovery(conf *SDConfig, logger log.Logger) (*Discovery, error) {
 	d.client, err = godo.New(
 		&http.Client{
 			Transport: rt,
-			Timeout:   5 * time.Duration(conf.RefreshInterval),
+			Timeout:   time.Duration(conf.RefreshInterval),
 		},
 		godo.SetUserAgent(fmt.Sprintf("Prometheus/%s", version.Version)),
 	)


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->