### PR TITLE
repo_sync: fix variable names

### DIFF
--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -59,10 +59,10 @@ process_repo() {
 
   local needs_update=0
   for source_file in ${SYNC_FILES}; do
-    source_checksum="$(sha256sum "${souce_dir}/${source_file}" | cut -d' ' -f1)"
+    source_checksum="$(sha256sum "${source_dir}/${source_file}" | cut -d' ' -f1)"
 
     target_file="$(curl -s --fail "https://raw.githubusercontent.com/${org_repo}/master/${source_file}")"
-    if [[ -z "${target_makefile}" ]]; then
+    if [[ -z "${target_file}" ]]; then
       echo "${source_file} doesn't exist in ${org_repo}"
       continue
     fi


### PR DESCRIPTION

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->