### PR TITLE
fix tsdb analyze limit not work expected

### DIFF
--- a/tsdb/cmd/tsdb/main.go
+++ b/tsdb/cmd/tsdb/main.go
@@ -493,10 +493,10 @@ func analyzeBlock(b tsdb.BlockReader, limit int) error {
 		sort.Slice(postingInfos, func(i, j int) bool { return postingInfos[i].metric > postingInfos[j].metric })
 
 		for i, pc := range postingInfos {
-			fmt.Printf("%d %s\n", pc.metric, pc.key)
 			if i >= limit {
 				break
 			}
+			fmt.Printf("%d %s\n", pc.metric, pc.key)
 		}
 	}
 


### PR DESCRIPTION
## fix tsdb analyze limit not work expected

Signed-off-by: joelei thezero12@hotmail.com

today when i first use tsdb cmd analyze a block, limit flag not work expect; when i dig the code,  it's a little bug, i think; so i initiate a pr to fix it，thanks all guy

before fix:
![image](https://user-images.githubusercontent.com/1853121/85222009-07563c80-b3eb-11ea-87de-878ef6407fae.png)

after fix:
![image](https://user-images.githubusercontent.com/1853121/85222366-eabb0400-b3ec-11ea-92d7-c6aff1472384.png)
