### PR TITLE
Fixed returned API status code on error

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -469,16 +469,13 @@ func returnAPIError(err error) *apiError {
 		return nil
 	}
 
-	// The error may have been wrapped, so we should also check the parent ones.
-	for cause := err; cause != nil; cause = errors.Unwrap(cause) {
-		switch cause.(type) {
-		case promql.ErrQueryCanceled:
-			return &apiError{errorCanceled, cause}
-		case promql.ErrQueryTimeout:
-			return &apiError{errorTimeout, cause}
-		case promql.ErrStorage:
-			return &apiError{errorInternal, cause}
-		}
+	switch errors.Cause(err).(type) {
+	case promql.ErrQueryCanceled:
+		return &apiError{errorCanceled, err}
+	case promql.ErrQueryTimeout:
+		return &apiError{errorTimeout, err}
+	case promql.ErrStorage:
+		return &apiError{errorInternal, err}
 	}
 
 	return &apiError{errorExec, err}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1193,7 +1193,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				},
 			},
 			response: map[string][]metadata{
-				"go_threads": []metadata{
+				"go_threads": {
 					{textparse.MetricTypeGauge, "Number of OS threads created", ""},
 					{textparse.MetricTypeGauge, "Number of OS threads that were created.", ""},
 				},
@@ -1279,7 +1279,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				},
 			},
 			response: map[string][]metadata{
-				"go_threads": []metadata{
+				"go_threads": {
 					{textparse.MetricTypeGauge, "Number of OS threads created", ""},
 					{textparse.MetricTypeGauge, "Number of OS threads that were created.", ""},
 				},
@@ -2721,29 +2721,29 @@ func TestTSDBStatus(t *testing.T) {
 
 func TestReturnAPIError(t *testing.T) {
 	cases := []struct {
-		err error
+		err      error
 		expected errorType
 	}{
 		{
-			err: promql.ErrStorage{Err: errors.New("storage error")},
+			err:      promql.ErrStorage{Err: errors.New("storage error")},
 			expected: errorInternal,
-		},{
-			err: errors.Wrap(promql.ErrStorage{Err: errors.New("storage error")}, "wrapped"),
+		}, {
+			err:      errors.Wrap(promql.ErrStorage{Err: errors.New("storage error")}, "wrapped"),
 			expected: errorInternal,
-		},{
-			err: promql.ErrQueryTimeout("timeout error"),
+		}, {
+			err:      promql.ErrQueryTimeout("timeout error"),
 			expected: errorTimeout,
-		},{
-			err: errors.Wrap(promql.ErrQueryTimeout("timeout error"), "wrapped"),
+		}, {
+			err:      errors.Wrap(promql.ErrQueryTimeout("timeout error"), "wrapped"),
 			expected: errorTimeout,
-		},{
-			err: promql.ErrQueryCanceled("canceled error"),
+		}, {
+			err:      promql.ErrQueryCanceled("canceled error"),
 			expected: errorCanceled,
-		},{
-			err: errors.Wrap(promql.ErrQueryCanceled("canceled error"), "wrapped"),
+		}, {
+			err:      errors.Wrap(promql.ErrQueryCanceled("canceled error"), "wrapped"),
 			expected: errorCanceled,
-		},{
-			err: errors.New("exec error"),
+		}, {
+			err:      errors.New("exec error"),
 			expected: errorExec,
 		},
 	}


### PR DESCRIPTION
The PR https://github.com/prometheus/prometheus/pull/7251 has introduced the wrapping of `Select()` error (ie. [see this](https://github.com/prometheus/prometheus/pull/7251/files#diff-83539908220a826e39b7ba3a4f27d5d6R1115-R1119)). This change causes `returnAPIError()`   to return `errorExec`, which turns into having the API response status code 422 in case of a `promql.ErrStorage` (this error is used by Cortex in several circumstances).

This PR fixes it.