### PR TITLE
Enhanced WAL replay for duplicate series record

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1466,7 +1466,11 @@ type memChunk struct {
 
 // OverlapsClosedInterval returns true if the chunk overlaps [mint, maxt].
 func (mc *memChunk) OverlapsClosedInterval(mint, maxt int64) bool {
-	return mc.minTime <= maxt && mint <= mc.maxTime
+	return overlapsClosedInterval(mc.minTime, mc.maxTime, mint, maxt)
+}
+
+func overlapsClosedInterval(mint1, maxt1, mint2, maxt2 int64) bool {
+	return mint1 <= maxt2 && mint2 <= maxt1
 }
 
 type mmappedChunk struct {
@@ -1477,7 +1481,7 @@ type mmappedChunk struct {
 
 // Returns true if the chunk overlaps [mint, maxt].
 func (mc *mmappedChunk) OverlapsClosedInterval(mint, maxt int64) bool {
-	return mc.minTime <= maxt && mint <= mc.maxTime
+	return overlapsClosedInterval(mc.minTime, mc.maxTime, mint, maxt)
 }
 
 type noopSeriesLifecycleCallback struct{}


### PR DESCRIPTION
In this PR I fix a TODO I had put before `// TODO(codesome) Discard old samples and mmapped chunks and use mmap chunks for the new series ID.`

Assertion:
Basically, if there is a duplicate series record in the WAL, it means that the compaction happened in between and the series including all it's samples were compacted before this duplicate record. Hence, we can discard all that we have replayed till now for that series when we come across a duplicate record. 