### PR TITLE
Add two unit tests

### DIFF
--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -161,6 +161,43 @@ func TestBufferedSeriesIteratorNoBadAt(t *testing.T) {
 	it.Next()
 }
 
+func TestBufferReduceDelta(t *testing.T) {
+	for _, tc := range []struct {
+		input    int64
+		r        *sampleRing
+		expexted bool
+	}{
+		{
+			input: 2,
+			r: &sampleRing{
+				delta: 1,
+			},
+			expexted: false,
+		},
+		{
+			input: 2,
+			r: &sampleRing{
+				delta: 4,
+				l:     0,
+			},
+			expexted: true,
+		},
+		{
+			input: 2,
+			r: &sampleRing{
+				delta: 4,
+				buf:   []sample{{1, 2}, {2, 4}, {3, 6}, {4, 8}},
+				i:     3,
+				f:     0,
+				l:     4,
+			},
+			expexted: true,
+		},
+	} {
+		testutil.Equals(t, tc.expexted, tc.r.reduceDelta(tc.input))
+	}
+}
+
 func BenchmarkBufferedSeriesIterator(b *testing.B) {
 	// Simulate a 5 minute rate.
 	it := NewBufferIterator(newFakeSeriesIterator(int64(b.N), 30), 5*60)

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -553,3 +553,14 @@ func TestSymbols(t *testing.T) {
 	}
 	testutil.Ok(t, iter.Err())
 }
+
+func TestLabelNames(t *testing.T) {
+	got, _ := (&Reader{
+		postings: map[string][]postingOffset{
+			"aaa": {{"111", 0}, {"222", 1}},
+			"ccc": {{"111", 0}, {"222", 1}},
+			"bbb": {{"111", 0}, {"222", 1}},
+		},
+	}).LabelNames()
+	testutil.Equals(t, []string{"aaa", "bbb", "ccc"}, got)
+}


### PR DESCRIPTION
This PR is about adding a unit test for storage/buffer.go and a unit test for tsdb/index/index.go

Signed-off-by: Hu Shuai <hus.fnst@cn.fujitsu.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->