### PR TITLE
Web: Scroll hash-fragment links with navbar height

### DIFF
--- a/web/ui/react-app/src/App.css
+++ b/web/ui/react-app/src/App.css
@@ -1,3 +1,9 @@
+html {
+  /* https://github.com/prometheus/prometheus/issues/7434 */
+  /* Scroll to hash-fragment-links counting the fixed navbar 40px tall with 16px padding */
+  scroll-padding-top: 56px;
+}
+
 .panel {
   margin-bottom: 20px;
 }

--- a/web/ui/static/css/prometheus.css
+++ b/web/ui/static/css/prometheus.css
@@ -1,3 +1,9 @@
+html {
+  /* https://github.com/prometheus/prometheus/issues/7434 */
+  /* Scroll to hash-fragment-links counting the fixed navbar 40px tall + 16px padding */
+  scroll-padding-top: 56px;
+}
+
 /* Move down content because we have a fixed navbar that is 50px tall with 20px padding */
 body {
   padding-top: 70px;


### PR DESCRIPTION
Previously, hash-fragment links like this:
http://mark-t510:9090/targets#job-alertmanager

Would scroll to have the header at the top, obscured by the nav bar.

Tested in both old and new UIs.

Fixes #7434