### PR TITLE
Remove duplicate test in labels_test.go

### DIFF
--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -562,10 +562,6 @@ func TestLabels_WithoutLabels(t *testing.T) {
 	testutil.Equals(t, Labels{{"aaa", "111"}}, Labels{{"aaa", "111"}, {"bbb", "222"}, {MetricName, "333"}}.WithoutLabels("bbb"))
 }
 
-func TestLabels_FromStrings(t *testing.T) {
-	testutil.Equals(t, Labels{{"aaa", "111"}, {"bbb", "222"}}, FromStrings("aaa", "111", "bbb", "222"))
-}
-
 func TestBulider_NewBulider(t *testing.T) {
 	testutil.Equals(
 		t,


### PR DESCRIPTION
The logic in this test is covered by the test with the same name at https://github.com/prometheus/prometheus/blob/master/pkg/labels/labels_test.go#L371. Having two tests with the same name is causing builds to fail.