### PR TITLE
rules: Use narrower interface for rule manager loading of for state

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -379,7 +379,7 @@ func main() {
 
 		ruleManager = rules.NewManager(&rules.ManagerOptions{
 			Appendable:      fanoutStorage,
-			TSDB:            localStorage,
+			Queryable:       localStorage,
 			QueryFunc:       rules.EngineQueryFunc(queryEngine, fanoutStorage),
 			NotifyFunc:      sendAlerts(notifierManager, cfg.web.ExternalURL.String()),
 			Context:         ctxRule,

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -670,7 +670,7 @@ func (g *Group) RestoreForState(ts time.Time) {
 	// We allow restoration only if alerts were active before after certain time.
 	mint := ts.Add(-g.opts.OutageTolerance)
 	mintMS := int64(model.TimeFromUnixNano(mint.UnixNano()))
-	q, err := g.opts.TSDB.Querier(g.opts.Context, mintMS, maxtMS)
+	q, err := g.opts.Queryable.Querier(g.opts.Context, mintMS, maxtMS)
 	if err != nil {
 		level.Error(g.logger).Log("msg", "Failed to get Querier", "err", err)
 		return
@@ -846,7 +846,7 @@ type ManagerOptions struct {
 	NotifyFunc      NotifyFunc
 	Context         context.Context
 	Appendable      storage.Appendable
-	TSDB            storage.Storage
+	Queryable       storage.Queryable
 	Logger          log.Logger
 	Registerer      prometheus.Registerer
 	OutageTolerance time.Duration

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -359,7 +359,7 @@ func TestForStateRestore(t *testing.T) {
 	opts := &ManagerOptions{
 		QueryFunc:       EngineQueryFunc(suite.QueryEngine(), suite.Storage()),
 		Appendable:      suite.Storage(),
-		TSDB:            suite.Storage(),
+		Queryable:       suite.Storage(),
 		Context:         context.Background(),
 		Logger:          log.NewNopLogger(),
 		NotifyFunc:      func(ctx context.Context, expr string, alerts ...*Alert) {},
@@ -524,7 +524,7 @@ func TestStaleness(t *testing.T) {
 	opts := &ManagerOptions{
 		QueryFunc:  EngineQueryFunc(engine, st),
 		Appendable: st,
-		TSDB:       st,
+		Queryable:  st,
 		Context:    context.Background(),
 		Logger:     log.NewNopLogger(),
 	}
@@ -711,7 +711,7 @@ func TestUpdate(t *testing.T) {
 	engine := promql.NewEngine(opts)
 	ruleManager := NewManager(&ManagerOptions{
 		Appendable: st,
-		TSDB:       st,
+		Queryable:  st,
 		QueryFunc:  EngineQueryFunc(engine, st),
 		Context:    context.Background(),
 		Logger:     log.NewNopLogger(),
@@ -847,7 +847,7 @@ func TestNotify(t *testing.T) {
 	opts := &ManagerOptions{
 		QueryFunc:   EngineQueryFunc(engine, storage),
 		Appendable:  storage,
-		TSDB:        storage,
+		Queryable:   storage,
 		Context:     context.Background(),
 		Logger:      log.NewNopLogger(),
 		NotifyFunc:  notifyFunc,
@@ -917,7 +917,7 @@ func TestMetricsUpdate(t *testing.T) {
 	engine := promql.NewEngine(opts)
 	ruleManager := NewManager(&ManagerOptions{
 		Appendable: storage,
-		TSDB:       storage,
+		Queryable:  storage,
 		QueryFunc:  EngineQueryFunc(engine, storage),
 		Context:    context.Background(),
 		Logger:     log.NewNopLogger(),
@@ -991,7 +991,7 @@ func TestGroupStalenessOnRemoval(t *testing.T) {
 	engine := promql.NewEngine(opts)
 	ruleManager := NewManager(&ManagerOptions{
 		Appendable: storage,
-		TSDB:       storage,
+		Queryable:  storage,
 		QueryFunc:  EngineQueryFunc(engine, storage),
 		Context:    context.Background(),
 		Logger:     log.NewNopLogger(),
@@ -1068,7 +1068,7 @@ func TestMetricsStalenessOnManagerShutdown(t *testing.T) {
 	engine := promql.NewEngine(opts)
 	ruleManager := NewManager(&ManagerOptions{
 		Appendable: storage,
-		TSDB:       storage,
+		Queryable:  storage,
 		QueryFunc:  EngineQueryFunc(engine, storage),
 		Context:    context.Background(),
 		Logger:     log.NewNopLogger(),


### PR DESCRIPTION
To load ALERT_FOR_STATE only `storage.Queryable` interface is required,
so this patch uses this narrower interface for to perform this.

@brian-brazil @bwplotka @codesome @gouthamve 