### PR TITLE
Add a unit test for newAzureResourceFromID in discovery/azure/azure.go.

### DIFF
--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -201,3 +201,24 @@ func TestMapFromVMScaleSetVMWithTags(t *testing.T) {
 		t.Errorf("Expected %v got %v", expectedVM, actualVM)
 	}
 }
+
+func TestNewAzureResourceFromID(t *testing.T) {
+	for _, tc := range []struct {
+		id       string
+		expected azureResource
+	}{
+		{
+			id:       "/a/b/c/group/d/e/f/name",
+			expected: azureResource{"name", "group"},
+		},
+		{
+			id:       "/a/b/c/group/d/e/f/name/g/h",
+			expected: azureResource{"name", "group"},
+		},
+	} {
+		actual, _ := newAzureResourceFromID(tc.id, nil)
+		if !reflect.DeepEqual(tc.expected, actual) {
+			t.Errorf("Expected %v got %v", tc.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
This PR is about adding a unit test for newAzureResourceFromID in discovery/azure/azure.go.

Signed-off-by: Hu Shuai <hus.fnst@cn.fujitsu.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->