### PR TITLE
PromQL: Add a new random() function.

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -325,6 +325,11 @@ regression](https://en.wikipedia.org/wiki/Simple_linear_regression).
 
 `predict_linear` should only be used with gauges.
 
+## `random()`
+
+`random()` returns a pseudo-random scalar in [0.0,1.0). This
+function returns different values in consecutive identical queries.
+
 ## `rate()`
 
 `rate(v range-vector)` calculates the per-second average rate of increase of the

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -15,6 +15,7 @@ package promql
 
 import (
 	"math"
+	"math/rand"
 	"regexp"
 	"sort"
 	"strconv"
@@ -27,6 +28,10 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
 
 // FunctionCall is the type of a PromQL function implementation
 //
@@ -44,6 +49,13 @@ import (
 //     metrics, the timestamp are not needed.
 // Scalar results should be returned as the value of a sample in a Vector.
 type FunctionCall func(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector
+
+// === random() float64 ===
+func funcRandom(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return Vector{Sample{Point: Point{
+		V: rand.Float64(),
+	}}}
+}
 
 // === time() float64 ===
 func funcTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
@@ -905,6 +917,7 @@ var FunctionCalls = map[string]FunctionCall{
 	"month":              funcMonth,
 	"predict_linear":     funcPredictLinear,
 	"quantile_over_time": funcQuantileOverTime,
+	"random":             funcRandom,
 	"rate":               funcRate,
 	"resets":             funcResets,
 	"round":              funcRound,

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -196,6 +196,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeScalar, ValueTypeMatrix},
 		ReturnType: ValueTypeVector,
 	},
+	"random": {
+		Name:       "random",
+		ArgTypes:   []ValueType{},
+		ReturnType: ValueTypeScalar,
+	},
 	"rate": {
 		Name:       "rate",
 		ArgTypes:   []ValueType{ValueTypeMatrix},

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -637,3 +637,8 @@ eval instant at 5m absent_over_time({job="ingress"}[4m])
 
 eval instant at 10m absent_over_time({job="ingress"}[4m])
 	{job="ingress"} 1
+
+# Test for random.
+
+eval instant at 10m count(count_values("rand",label_replace(vector(random()) >= 0 < 1,"r","1","","") or label_replace(vector(random()) >= 0 < 1,"r","2","","") ))
+	{} 2


### PR DESCRIPTION
This function is primilarily intended for demos, simulation, exemples.

Randomness has other uses. Notably, I have used in real
situation a very complex variation of this with time() to hide the
source of some metrics by slightly altering their actual values.

Note that Prometheus has all the necessary methods to get variants of
this, e.g. ceil(vector(10*random()))

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->