### PR TITLE
Increments wal corruption metric on error during checkpointing

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -837,6 +837,7 @@ func (h *Head) Truncate(mint int64) (err error) {
 	h.metrics.checkpointCreationTotal.Inc()
 	if _, err = wal.Checkpoint(h.wal, first, last, keep, mint); err != nil {
 		h.metrics.checkpointCreationFail.Inc()
+		h.metrics.walCorruptionsTotal.Inc()
 		return errors.Wrap(err, "create checkpoint")
 	}
 	if err := h.wal.Truncate(last + 1); err != nil {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -837,7 +837,9 @@ func (h *Head) Truncate(mint int64) (err error) {
 	h.metrics.checkpointCreationTotal.Inc()
 	if _, err = wal.Checkpoint(h.wal, first, last, keep, mint); err != nil {
 		h.metrics.checkpointCreationFail.Inc()
-		h.metrics.walCorruptionsTotal.Inc()
+		if _, ok := errors.Cause(err).(*wal.CorruptionErr); ok {
+			h.metrics.walCorruptionsTotal.Inc()
+		}
 		return errors.Wrap(err, "create checkpoint")
 	}
 	if err := h.wal.Truncate(last + 1); err != nil {


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Fixes: #7443 