### PR TITLE
Add a unit test for labelsToOpenAPILabelSet in notifier/notifier.go.

### DIFF
--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/alertmanager/api/v2/models"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	yaml "gopkg.in/yaml.v2"
@@ -555,4 +556,8 @@ func makeInputTargetGroup() *targetgroup.Group {
 		},
 		Source: "testsource",
 	}
+}
+
+func TestLabelsToOpenAPILabelSet(t *testing.T) {
+	testutil.Equals(t, models.LabelSet{"aaa": "111", "bbb": "222"}, labelsToOpenAPILabelSet(labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}}))
 }


### PR DESCRIPTION
This PR is about adding a unit test for labelsToOpenAPILabelSet in notifier/notifier.go.

Signed-off-by: Hu Shuai <hus.fnst@cn.fujitsu.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->