### PR TITLE
Change rule index numbering from 0 to n+1 on errors found in rule files

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -90,7 +90,7 @@ func (g *RuleGroups) Validate(node ruleGroups) (errs []error) {
 				}
 				errs = append(errs, &Error{
 					Group:    g.Name,
-					Rule:     i,
+					Rule:     i+1,
 					RuleName: ruleName.Value,
 					Err:      node,
 				})

--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -90,7 +90,7 @@ func (g *RuleGroups) Validate(node ruleGroups) (errs []error) {
 				}
 				errs = append(errs, &Error{
 					Group:    g.Name,
-					Rule:     i+1,
+					Rule:     i + 1,
 					RuleName: ruleName.Value,
 					Err:      node,
 				})


### PR DESCRIPTION
This PR changes the rule index number from starting with `1` instead of  `0` on reported errors with `promtool`.

Given this rule file (`service-alerts.yml`) with an error on rule `2`:
```
groups:
  - name: serivce.rules
    rules:
      - alert: ServiceDown
        expr: service_up == 0
        for: 5m
        labels:
          severity: critical
        annotations:
          summary: "Service down (instance {{ $labels.instance }})"
          description: "Service down\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"

      - alert: ServiceAlertExample
        expr: example(wrong_thing_here)
        for: 5m
        labels:
          severity: critical
        annotations:
          summary: "A summary"
          description: "A description"
``` 

Running `promtool check rules service-alerts.yml` outputs the following:
```
Checking service-alerts.yml
  FAILED:
service-alerts.yml: 14:15: group "serivce.rules", rule 1, "ServiceAlertExample": could not parse expression: 1:1: parse error: unknown function with name "example"
```
and with this minor fix we'll instead get the following output:
```
Checking service-alerts.yml
  FAILED:
service-alerts.yml: 14:15: group "serivce.rules", rule 2, "ServiceAlertExample": could not parse expression: 1:1: parse error: unknown function with name "example"
```