### PR TITLE
6178 matchers with label values

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -321,7 +321,7 @@ URL query parameters:
 - `start=<rfc3339 | unix_timestamp>`: Start timestamp. Optional.
 - `end=<rfc3339 | unix_timestamp>`: End timestamp. Optional.
 - `match[]=<series_selector>`: Repeated series selector argument that selects the
-  series from which to read the label's values 
+  series from which to read the label values 
 
 
 The `data` section of the JSON response is a list of string label values.

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -320,6 +320,8 @@ URL query parameters:
 
 - `start=<rfc3339 | unix_timestamp>`: Start timestamp. Optional.
 - `end=<rfc3339 | unix_timestamp>`: End timestamp. Optional.
+- `match[]=<series_selector>`: Repeated series selector argument that selects the
+  series from which to read the label's values 
 
 
 The `data` section of the JSON response is a list of string label values.

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -521,6 +521,14 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorBadData, errors.Wrap(err, "invalid parameter 'end'")}, nil, nil}
 	}
+	var matcherSets [][]*labels.Matcher
+	for _, s := range r.Form["match[]"] {
+		matchers, err := parser.ParseMetricSelector(s)
+		if err != nil {
+			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
+		}
+		matcherSets = append(matcherSets, matchers)
+	}
 
 	q, err := api.Queryable.Querier(r.Context(), timestamp.FromTime(start), timestamp.FromTime(end))
 	if err != nil {
@@ -538,12 +546,54 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 		q.Close()
 	}
 
-	vals, warnings, err := q.LabelValues(name)
+	var vals []string
+	var warnings storage.Warnings
+	if len(r.Form["match[]"]) > 0 {
+		// get all series which match
+		var sets []storage.SeriesSet
+		for _, mset := range matcherSets {
+			s := q.Select(false, nil, mset...)
+			sets = append(sets, s)
+		}
+		vals, warnings, err = labelValuesByMatchers(sets, name)
+	} else {
+		vals, warnings, err = q.LabelValues(name)
+	}
+
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorExec, err}, warnings, closer}
 	}
 
 	return apiFuncResult{vals, nil, warnings, closer}
+}
+
+// LabelValuesByMatchers uses matchers to filter out the series
+// from which we get the label values
+func labelValuesByMatchers(sets []storage.SeriesSet, name string) ([]string, storage.Warnings, error) {
+	// get all the labels in the selected series
+	set := storage.NewMergeSeriesSet(sets, storage.ChainedSeriesMerge)
+	labelValuesMap := make(map[string]string)
+	for set.Next() {
+		series := set.At()
+		labelValue := series.Labels().Get(name)
+		// to avoid duplicates, any better way?
+		_, ok := labelValuesMap[labelValue]
+		if !ok && labelValue != ""  {
+			labelValuesMap[labelValue] = labelValue
+		}
+	}
+
+	warnings := set.Warnings()
+	if set.Err() != nil {
+		return nil, warnings, set.Err()
+	}
+	// convert map to array
+	labelValues := []string{}
+	for key := range labelValuesMap {
+		labelValues = append(labelValues, key)
+	}
+	sort.Strings(labelValues)
+	return labelValues, warnings, nil
 }
 
 var (

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -570,14 +570,12 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 // LabelValuesByMatchers uses matchers to filter out matching series, then label values are extracted.
 func labelValuesByMatchers(sets []storage.SeriesSet, name string) ([]string, storage.Warnings, error) {
 	set := storage.NewMergeSeriesSet(sets, storage.ChainedSeriesMerge)
-	labelValuesMap := make(map[string]string)
+	labelValuesSet := make(map[string]struct{})
 	for set.Next() {
 		series := set.At()
 		labelValue := series.Labels().Get(name)
-		// This is to avoid duplicates.
-		_, ok := labelValuesMap[labelValue]
-		if !ok && labelValue != ""  {
-			labelValuesMap[labelValue] = labelValue
+		if labelValue != ""  {
+			labelValuesSet[labelValue] = struct{}{}
 		}
 	}
 
@@ -587,7 +585,7 @@ func labelValuesByMatchers(sets []storage.SeriesSet, name string) ([]string, sto
 	}
 	// Convert the map to an array.
 	labelValues := []string{}
-	for key := range labelValuesMap {
+	for key := range labelValuesSet {
 		labelValues = append(labelValues, key)
 	}
 	sort.Strings(labelValues)

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -574,9 +574,7 @@ func labelValuesByMatchers(sets []storage.SeriesSet, name string) ([]string, sto
 	for set.Next() {
 		series := set.At()
 		labelValue := series.Labels().Get(name)
-		if labelValue != ""  {
-			labelValuesSet[labelValue] = struct{}{}
-		}
+		labelValuesSet[labelValue] = struct{}{}
 	}
 
 	warnings := set.Warnings()

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -549,7 +549,7 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 	var vals []string
 	var warnings storage.Warnings
 	if len(r.Form["match[]"]) > 0 {
-		// get all series which match
+		// Get all series which match matchers.
 		var sets []storage.SeriesSet
 		for _, mset := range matcherSets {
 			s := q.Select(false, nil, mset...)
@@ -567,16 +567,14 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 	return apiFuncResult{vals, nil, warnings, closer}
 }
 
-// LabelValuesByMatchers uses matchers to filter out the series
-// from which we get the label values
+// LabelValuesByMatchers uses matchers to filter out matching series, then label values are extracted.
 func labelValuesByMatchers(sets []storage.SeriesSet, name string) ([]string, storage.Warnings, error) {
-	// get all the labels in the selected series
 	set := storage.NewMergeSeriesSet(sets, storage.ChainedSeriesMerge)
 	labelValuesMap := make(map[string]string)
 	for set.Next() {
 		series := set.At()
 		labelValue := series.Labels().Get(name)
-		// to avoid duplicates, any better way?
+		// This is to avoid duplicates.
 		_, ok := labelValuesMap[labelValue]
 		if !ok && labelValue != ""  {
 			labelValuesMap[labelValue] = labelValue
@@ -587,7 +585,7 @@ func labelValuesByMatchers(sets []storage.SeriesSet, name string) ([]string, sto
 	if set.Err() != nil {
 		return nil, warnings, set.Err()
 	}
-	// convert map to array
+	// Convert the map to an array.
 	labelValues := []string{}
 	for key := range labelValuesMap {
 		labelValues = append(labelValues, key)

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1593,6 +1593,35 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				},
 			},
 
+			//Should only return label value of matching metric name and label name
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"match[]": []string{`test_metric2`},
+				},
+				response: []string{
+					"boo",
+				},
+			},
+
+			// Should only return label value of matching metric name and label name
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"match[]": []string{`test_metric1`},
+				},
+				response: []string{
+					"bar",
+					"boo",
+				},
+			},
+
 			// Label names.
 			{
 				endpoint: api.labelNames,

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1592,8 +1592,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
-
-			//Should only return label value of matching metric name and label name
+			// Label values with matcher
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{
@@ -1606,8 +1605,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
-
-			// Should only return label value of matching metric name and label name
+			// Label values with matcher
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{
@@ -1621,7 +1619,35 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
-
+			// Label values with matcher using label filter
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"match[]": []string{`test_metric1{foo="bar"}`},
+				},
+				response: []string{
+					"bar",
+				},
+			},
+			// Label values with matcher and time range
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"match[]": []string{`test_metric1`},
+					"start": []string{"1"},
+					"end":   []string{"100000000"},
+				},
+				response: []string{
+					"bar",
+					"boo",
+				},
+			},
 			// Label names.
 			{
 				endpoint: api.labelNames,

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1592,7 +1592,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
-			// Label values with matcher
+			// Label values with matcher.
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{
@@ -1605,7 +1605,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
-			// Label values with matcher
+			// Label values with matcher.
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{
@@ -1619,7 +1619,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
-			// Label values with matcher using label filter
+			// Label values with matcher using label filter.
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{
@@ -1632,7 +1632,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"bar",
 				},
 			},
-			// Label values with matcher and time range
+			// Label values with matcher and time range.
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{


### PR DESCRIPTION
This PR is for issue #6178

This adds the ability to pass the ´match[]´ parameter to ´/api/v1/label/<label_name>/values´ endpoint.

Example:
> curl -s 'http://localhost:9090/api/v1/label/code/values?match[]=promhttp_metric_handler_requests_total%7Bcode%3D%22200%22%7D'

( url decoded: promhttp_metric_handler_requests_total{code="200"}  )

```
{
  "status": "success",
  "data": [
    "200"
  ]
}

```

Questions:
* Should `labelValuesByMatchers` be a method of the queriers to be consistent with `LabelValues`? I tried that out but ran in to issues, but could have another go at it.
* Is a seperate unittest for `labelValuesByMatchers` a good idea? From what I see tests are not run on specific functions of `api.go`. I did feel like having more labels in my tests but also didn't want to mess with all the other tests cases in `api_test.go`
* Build fails, but seems to be unrelated?

```
Unable to find image 'quay.io/prometheus/golang-builder:1.14-base' locally

Error response from daemon: Get https://quay.io/v2/prometheus/golang-builder/manifests/1.14-base: Get https://quay.io/v2/auth?scope=repository%3Aprometheus%2Fgolang-builder%3Apull&service=quay.io: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)

!! exit status 1

```
