### PR TITLE
digitalocean: use a safer pagination method

### DIFF
--- a/discovery/digitalocean/digitalocean.go
+++ b/discovery/digitalocean/digitalocean.go
@@ -176,7 +176,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 func (d *Discovery) listDroplets() ([]godo.Droplet, error) {
 	var (
 		droplets []godo.Droplet
-		opts     = &godo.ListOptions{Page: 1}
+		opts     = &godo.ListOptions{}
 	)
 	for {
 		paginatedDroplets, resp, err := d.client.Droplets.List(context.Background(), opts)
@@ -187,7 +187,13 @@ func (d *Discovery) listDroplets() ([]godo.Droplet, error) {
 		if resp.Links == nil || resp.Links.IsLastPage() {
 			break
 		}
-		opts.Page++
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		opts.Page = page + 1
 	}
 	return droplets, nil
 }


### PR DESCRIPTION
this method is documented here: https://github.com/digitalocean/godo

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->