### PR TITLE
Optimise labels regex matchers containing a literal within the pattern

### DIFF
--- a/pkg/labels/regexp.go
+++ b/pkg/labels/regexp.go
@@ -20,9 +20,9 @@ import (
 )
 
 type FastRegexMatcher struct {
-	re     *regexp.Regexp
-	prefix string
-	suffix string
+	re       *regexp.Regexp
+	prefix   string
+	suffix   string
 	contains string
 }
 
@@ -96,7 +96,7 @@ func optimizeConcatRegex(r *syntax.Regexp) (prefix, suffix, contains string) {
 	// If contains any literal which is not a prefix/suffix, we keep the
 	// 1st one. We do not keep the whole list of literals to simplify the
 	// fast path.
-	for i := 1; i < len(sub) - 1; i++ {
+	for i := 1; i < len(sub)-1; i++ {
 		if sub[i].Op == syntax.OpLiteral {
 			contains = string(sub[i].Rune)
 			break

--- a/pkg/labels/regexp_test.go
+++ b/pkg/labels/regexp_test.go
@@ -61,9 +61,9 @@ func TestNewFastRegexMatcher(t *testing.T) {
 
 func TestOptimizeConcatRegex(t *testing.T) {
 	cases := []struct {
-		regex  string
-		prefix string
-		suffix string
+		regex    string
+		prefix   string
+		suffix   string
 		contains string
 	}{
 		{regex: "foo(hello|bar)", prefix: "foo", suffix: "", contains: ""},

--- a/pkg/labels/regexp_test.go
+++ b/pkg/labels/regexp_test.go
@@ -42,6 +42,11 @@ func TestNewFastRegexMatcher(t *testing.T) {
 		{regex: ".*foo", value: "\nfoo", expected: false},
 		{regex: "foo.*", value: "foo\n", expected: false},
 		{regex: "foo\n.*", value: "foo\n", expected: true},
+		{regex: ".*foo.*", value: "foo", expected: true},
+		{regex: ".*foo.*", value: "foo bar", expected: true},
+		{regex: ".*foo.*", value: "hello foo world", expected: true},
+		{regex: ".*foo.*", value: "hello foo\n world", expected: false},
+		{regex: ".*foo\n.*", value: "hello foo\n world", expected: true},
 		{regex: ".*", value: "foo", expected: true},
 		{regex: "", value: "foo", expected: false},
 		{regex: "", value: "", expected: true},
@@ -59,21 +64,27 @@ func TestOptimizeConcatRegex(t *testing.T) {
 		regex  string
 		prefix string
 		suffix string
+		contains string
 	}{
-		{regex: "foo(hello|bar)", prefix: "foo", suffix: ""},
-		{regex: "foo(hello|bar)world", prefix: "foo", suffix: "world"},
-		{regex: "foo.*", prefix: "foo", suffix: ""},
-		{regex: "foo.*hello.*bar", prefix: "foo", suffix: "bar"},
-		{regex: ".*foo", prefix: "", suffix: "foo"},
-		{regex: "^.*foo$", prefix: "", suffix: "foo"},
+		{regex: "foo(hello|bar)", prefix: "foo", suffix: "", contains: ""},
+		{regex: "foo(hello|bar)world", prefix: "foo", suffix: "world", contains: ""},
+		{regex: "foo.*", prefix: "foo", suffix: "", contains: ""},
+		{regex: "foo.*hello.*bar", prefix: "foo", suffix: "bar", contains: "hello"},
+		{regex: ".*foo", prefix: "", suffix: "foo", contains: ""},
+		{regex: "^.*foo$", prefix: "", suffix: "foo", contains: ""},
+		{regex: ".*foo.*", prefix: "", suffix: "", contains: "foo"},
+		{regex: ".*foo.*bar.*", prefix: "", suffix: "", contains: "foo"},
+		{regex: ".*(foo|bar).*", prefix: "", suffix: "", contains: ""},
+		{regex: ".*[abc].*", prefix: "", suffix: "", contains: ""},
 	}
 
 	for _, c := range cases {
 		parsed, err := syntax.Parse(c.regex, syntax.Perl)
 		testutil.Ok(t, err)
 
-		prefix, suffix := optimizeConcatRegex(parsed)
+		prefix, suffix, contains := optimizeConcatRegex(parsed)
 		testutil.Equals(t, c.prefix, prefix)
 		testutil.Equals(t, c.suffix, suffix)
+		testutil.Equals(t, c.contains, contains)
 	}
 }

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -93,12 +93,14 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 	iStar := labels.MustNewMatcher(labels.MatchRegexp, "i", "^.*$")
 	i1Star := labels.MustNewMatcher(labels.MatchRegexp, "i", "^1.*$")
 	iStar1 := labels.MustNewMatcher(labels.MatchRegexp, "i", "^.*1$")
+	iStar1Star := labels.MustNewMatcher(labels.MatchRegexp, "i", "^.*1.*$")
 	iPlus := labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")
 	i1Plus := labels.MustNewMatcher(labels.MatchRegexp, "i", "^1.+$")
 	iEmptyRe := labels.MustNewMatcher(labels.MatchRegexp, "i", "^$")
 	iNotEmpty := labels.MustNewMatcher(labels.MatchNotEqual, "i", "")
 	iNot2 := labels.MustNewMatcher(labels.MatchNotEqual, "n", "2"+postingsBenchSuffix)
 	iNot2Star := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^2.*$")
+	iNotStar2Star := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^.*2.*$")
 
 	cases := []struct {
 		name     string
@@ -120,8 +122,10 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 		{`n="1",i!="",j="foo"`, []*labels.Matcher{n1, iNotEmpty, jFoo}},
 		{`n="1",i=~".+",j="foo"`, []*labels.Matcher{n1, iPlus, jFoo}},
 		{`n="1",i=~"1.+",j="foo"`, []*labels.Matcher{n1, i1Plus, jFoo}},
+		{`n="1",i=~".*1.*",j="foo"`, []*labels.Matcher{n1, iStar1Star, jFoo}},
 		{`n="1",i=~".+",i!="2",j="foo"`, []*labels.Matcher{n1, iPlus, iNot2, jFoo}},
 		{`n="1",i=~".+",i!~"2.*",j="foo"`, []*labels.Matcher{n1, iPlus, iNot2Star, jFoo}},
+		{`n="1",i=~".+",i!~".*2.*",j="foo"`, []*labels.Matcher{n1, iPlus, iNotStar2Star, jFoo}},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
This PR is a follow up of #7453. In this PR I'm proposing to add a 3rd optimisation for the case `.*literal.*`.

Given it's not my intention to add complexity over complexity to cover any single regex case, according to my analysis of the query traffic for some large customers I've noticed that `.*literal.*` (and its variants) is somewhat a common use case (at least, this is what I've observed).

### Benchmark

Unfortunately my (old) MacBook performances are not much stable for long running benchmarks. I tried multiple runs, but I'm always getting an high variance. If you want I can try to run tests reducing the data set size.

New specific cases added:
```
BenchmarkPostingsForMatchers/Head/n="1",i=~".*1.*",j="foo"-4              167244267     110242319     -34.08%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",i!~".*2.*",j="foo"-4      344874436     282198213     -18.17%
BenchmarkPostingsForMatchers/Block/n="1",i=~".*1.*",j="foo"-4             249815868     82852860      -66.83%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",i!~".*2.*",j="foo"-4     260242345     190596429     -26.76%
```

Full benchmark output:
```
benchmark                                                                 old ns/op     new ns/op     delta
BenchmarkPostingsForMatchers/Head/n="1"-4                                 801           832           +3.87%
BenchmarkPostingsForMatchers/Head/n="1",j="foo"-4                         1088          1103          +1.38%
BenchmarkPostingsForMatchers/Head/j="foo",n="1"-4                         1091          1091          +0.00%
BenchmarkPostingsForMatchers/Head/n="1",j!="foo"-4                        1420          1265          -10.92%
BenchmarkPostingsForMatchers/Head/i=~".*"-4                               104663749     101616508     -2.91%
BenchmarkPostingsForMatchers/Head/i=~"1.*"-4                              24899729      23310209      -6.38%
BenchmarkPostingsForMatchers/Head/i=~".*1"-4                              7700854       10396696      +35.01%
BenchmarkPostingsForMatchers/Head/i=~".+"-4                               166667565     171366144     +2.82%
BenchmarkPostingsForMatchers/Head/i=~""-4                                 92675194      93963717      +1.39%
BenchmarkPostingsForMatchers/Head/i!=""-4                                 75357601      77601314      +2.98%
BenchmarkPostingsForMatchers/Head/n="1",i=~".*",j="foo"-4                 98324105      101806837     +3.54%
BenchmarkPostingsForMatchers/Head/n="1",i=~".*",i!="2",j="foo"-4          98244147      103231677     +5.08%
BenchmarkPostingsForMatchers/Head/n="1",i!=""-4                           85828426      75309155      -12.26%
BenchmarkPostingsForMatchers/Head/n="1",i!="",j="foo"-4                   76175910      81379616      +6.83%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",j="foo"-4                 169482843     172469646     +1.76%
BenchmarkPostingsForMatchers/Head/n="1",i=~"1.+",j="foo"-4                22790607      22804615      +0.06%
BenchmarkPostingsForMatchers/Head/n="1",i=~".*1.*",j="foo"-4              167244267     110242319     -34.08%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",i!="2",j="foo"-4          176527593     171933464     -2.60%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",i!~"2.*",j="foo"-4        191155853     199452071     +4.34%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",i!~".*2.*",j="foo"-4      344874436     282198213     -18.17%
BenchmarkPostingsForMatchers/Block/n="1"-4                                35505         35032         -1.33%
BenchmarkPostingsForMatchers/Block/n="1",j="foo"-4                        733485        628260        -14.35%
BenchmarkPostingsForMatchers/Block/j="foo",n="1"-4                        621731        639762        +2.90%
BenchmarkPostingsForMatchers/Block/n="1",j!="foo"-4                       642911        629954        -2.02%
BenchmarkPostingsForMatchers/Block/i=~".*"-4                              96451731      89163429      -7.56%
BenchmarkPostingsForMatchers/Block/i=~"1.*"-4                             25304473      15038679      -40.57%
BenchmarkPostingsForMatchers/Block/i=~".*1"-4                             5877846       3703443       -36.99%
BenchmarkPostingsForMatchers/Block/i=~".+"-4                              112655493     105471940     -6.38%
BenchmarkPostingsForMatchers/Block/i=~""-4                                49825368      29964917      -39.86%
BenchmarkPostingsForMatchers/Block/i!=""-4                                32806545      22419981      -31.66%
BenchmarkPostingsForMatchers/Block/n="1",i=~".*",j="foo"-4                90918483      89103804      -2.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".*",i!="2",j="foo"-4         88212019      88321810      +0.12%
BenchmarkPostingsForMatchers/Block/n="1",i!=""-4                          26526911      22258632      -16.09%
BenchmarkPostingsForMatchers/Block/n="1",i!="",j="foo"-4                  23889103      23369320      -2.18%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",j="foo"-4                112305664     107175099     -4.57%
BenchmarkPostingsForMatchers/Block/n="1",i=~"1.+",j="foo"-4               16232774      15517274      -4.41%
BenchmarkPostingsForMatchers/Block/n="1",i=~".*1.*",j="foo"-4             249815868     82852860      -66.83%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",i!="2",j="foo"-4         137138260     107154062     -21.86%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",i!~"2.*",j="foo"-4       122420097     125207095     +2.28%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",i!~".*2.*",j="foo"-4     260242345     190596429     -26.76%

benchmark                                                                 old allocs     new allocs     delta
BenchmarkPostingsForMatchers/Head/n="1"-4                                 6              6              +0.00%
BenchmarkPostingsForMatchers/Head/n="1",j="foo"-4                         11             11             +0.00%
BenchmarkPostingsForMatchers/Head/j="foo",n="1"-4                         11             11             +0.00%
BenchmarkPostingsForMatchers/Head/n="1",j!="foo"-4                        12             12             +0.00%
BenchmarkPostingsForMatchers/Head/i=~".*"-4                               9              9              +0.00%
BenchmarkPostingsForMatchers/Head/i=~"1.*"-4                              11140          11140          +0.00%
BenchmarkPostingsForMatchers/Head/i=~".*1"-4                              6              6              +0.00%
BenchmarkPostingsForMatchers/Head/i=~".+"-4                               100039         100039         +0.00%
BenchmarkPostingsForMatchers/Head/i=~""-4                                 100043         100043         +0.00%
BenchmarkPostingsForMatchers/Head/i!=""-4                                 100039         100039         +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".*",j="foo"-4                 14             14             +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".*",i!="2",j="foo"-4          20             20             +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i!=""-4                           100044         100044         +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i!="",j="foo"-4                   100048         100048         +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",j="foo"-4                 100048         100048         +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~"1.+",j="foo"-4                11149          11149          +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".*1.*",j="foo"-4              40995          40995          +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",i!="2",j="foo"-4          100054         100054         +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",i!~"2.*",j="foo"-4        111250         111250         +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",i!~".*2.*",j="foo"-4      141101         141102         +0.00%
BenchmarkPostingsForMatchers/Block/n="1"-4                                6              6              +0.00%
BenchmarkPostingsForMatchers/Block/n="1",j="foo"-4                        11             11             +0.00%
BenchmarkPostingsForMatchers/Block/j="foo",n="1"-4                        11             11             +0.00%
BenchmarkPostingsForMatchers/Block/n="1",j!="foo"-4                       13             13             +0.00%
BenchmarkPostingsForMatchers/Block/i=~".*"-4                              10             10             +0.00%
BenchmarkPostingsForMatchers/Block/i=~"1.*"-4                             11140          11140          +0.00%
BenchmarkPostingsForMatchers/Block/i=~".*1"-4                             7              7              +0.00%
BenchmarkPostingsForMatchers/Block/i=~".+"-4                              100039         100039         +0.00%
BenchmarkPostingsForMatchers/Block/i=~""-4                                100043         100043         +0.00%
BenchmarkPostingsForMatchers/Block/i!=""-4                                100039         100039         +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".*",j="foo"-4                15             15             +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".*",i!="2",j="foo"-4         21             21             +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i!=""-4                          100044         100044         +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i!="",j="foo"-4                  100048         100048         +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",j="foo"-4                100048         100048         +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~"1.+",j="foo"-4               11149          11149          +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".*1.*",j="foo"-4             40995          40995          +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",i!="2",j="foo"-4         100054         100054         +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",i!~"2.*",j="foo"-4       111250         111250         +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",i!~".*2.*",j="foo"-4     141101         141101         +0.00%

benchmark                                                                 old bytes     new bytes     delta
BenchmarkPostingsForMatchers/Head/n="1"-4                                 296           296           +0.00%
BenchmarkPostingsForMatchers/Head/n="1",j="foo"-4                         424           424           +0.00%
BenchmarkPostingsForMatchers/Head/j="foo",n="1"-4                         424           424           +0.00%
BenchmarkPostingsForMatchers/Head/n="1",j!="foo"-4                        456           456           +0.00%
BenchmarkPostingsForMatchers/Head/i=~".*"-4                               1606021       1606023       +0.00%
BenchmarkPostingsForMatchers/Head/i=~"1.*"-4                              3147974       3147970       -0.00%
BenchmarkPostingsForMatchers/Head/i=~".*1"-4                              1605912       1605912       +0.00%
BenchmarkPostingsForMatchers/Head/i=~".+"-4                               17264675      17264705      +0.00%
BenchmarkPostingsForMatchers/Head/i=~""-4                                 17264747      17264744      -0.00%
BenchmarkPostingsForMatchers/Head/i!=""-4                                 17264616      17264616      +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".*",j="foo"-4                 1606139       1606132       -0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".*",i!="2",j="foo"-4          1606331       1606332       +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i!=""-4                           17264744      17264744      +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i!="",j="foo"-4                   17264872      17264873      +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",j="foo"-4                 17264945      17264974      +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~"1.+",j="foo"-4                3148228       3148230       +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".*1.*",j="foo"-4              7885868       7879660       -0.08%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",i!="2",j="foo"-4          17265134      17265153      +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",i!~"2.*",j="foo"-4        20417838      20417841      +0.00%
BenchmarkPostingsForMatchers/Head/n="1",i=~".+",i!~".*2.*",j="foo"-4      25162744      25159570      -0.01%
BenchmarkPostingsForMatchers/Block/n="1"-4                                296           296           +0.00%
BenchmarkPostingsForMatchers/Block/n="1",j="foo"-4                        424           424           +0.00%
BenchmarkPostingsForMatchers/Block/j="foo",n="1"-4                        424           424           +0.00%
BenchmarkPostingsForMatchers/Block/n="1",j!="foo"-4                       1464          1464          +0.00%
BenchmarkPostingsForMatchers/Block/i=~".*"-4                              1606028       1606019       -0.00%
BenchmarkPostingsForMatchers/Block/i=~"1.*"-4                             3147956       3147952       -0.00%
BenchmarkPostingsForMatchers/Block/i=~".*1"-4                             1605928       1605928       +0.00%
BenchmarkPostingsForMatchers/Block/i=~".+"-4                              17264653      17264645      -0.00%
BenchmarkPostingsForMatchers/Block/i=~""-4                                17264696      17264696      +0.00%
BenchmarkPostingsForMatchers/Block/i!=""-4                                17264600      17264600      +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".*",j="foo"-4                1606152       1606147       -0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".*",i!="2",j="foo"-4         1606339       1606344       +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i!=""-4                          17264728      17264728      +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i!="",j="foo"-4                  17264856      17264856      +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",j="foo"-4                17264901      17264892      -0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~"1.+",j="foo"-4               3148208       3148209       +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".*1.*",j="foo"-4             7879667       7882481       +0.04%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",i!="2",j="foo"-4         17265093      17265068      -0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",i!~"2.*",j="foo"-4       20417762      20417773      +0.00%
BenchmarkPostingsForMatchers/Block/n="1",i=~".+",i!~".*2.*",j="foo"-4     25159558      25162532      +0.01%
```