### PR TITLE
Promtool range query should exit when fail to parse time

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -453,11 +453,13 @@ func QueryRange(url string, headers map[string]string, query, start, end string,
 		stime, err = parseTime(start)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "error parsing start time:", err)
+			return 1
 		}
 	}
 
 	if !stime.Before(etime) {
 		fmt.Fprintln(os.Stderr, "start time is not before end time")
+		return 1
 	}
 
 	if step == 0 {


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

When it fails to parse start time or end time is before start time, I think it should return 1 instead of continuing.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->