### PR TITLE
Openstack: Reduce timeouts

### DIFF
--- a/discovery/openstack/openstack.go
+++ b/discovery/openstack/openstack.go
@@ -51,7 +51,7 @@ type SDConfig struct {
 	ApplicationCredentialSecret config_util.Secret    `yaml:"application_credential_secret"`
 	Role                        Role                  `yaml:"role"`
 	Region                      string                `yaml:"region"`
-	RefreshInterval             model.Duration        `yaml:"refresh_interval,omitempty"`
+	RefreshInterval             model.Duration        `yaml:"refresh_interval"`
 	Port                        int                   `yaml:"port"`
 	AllTenants                  bool                  `yaml:"all_tenants,omitempty"`
 	TLSConfig                   config_util.TLSConfig `yaml:"tls_config,omitempty"`
@@ -152,14 +152,14 @@ func newRefresher(conf *SDConfig, l log.Logger) (refresher, error) {
 	}
 	client.HTTPClient = http.Client{
 		Transport: &http.Transport{
-			IdleConnTimeout: 5 * time.Duration(conf.RefreshInterval),
+			IdleConnTimeout: 2 * time.Duration(conf.RefreshInterval),
 			TLSClientConfig: tls,
 			DialContext: conntrack.NewDialContextFunc(
 				conntrack.DialWithTracing(),
 				conntrack.DialWithName("openstack_sd"),
 			),
 		},
-		Timeout: 5 * time.Duration(conf.RefreshInterval),
+		Timeout: time.Duration(conf.RefreshInterval),
 	}
 	switch conf.Role {
 	case OpenStackRoleHypervisor:


### PR DESCRIPTION
Set saner values for openstack timeouts

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->