### PR TITLE
Changed labelvalues method names for readers

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -514,7 +514,7 @@ func analyzeBlock(path, blockID string, limit int) error {
 
 	postingInfos = postingInfos[:0]
 	for _, n := range allLabelNames {
-		values, err := ir.SortedLabelValues(n)
+		values, err := ir.LabelValues(n)
 		if err != nil {
 			return err
 		}
@@ -530,7 +530,7 @@ func analyzeBlock(path, blockID string, limit int) error {
 
 	postingInfos = postingInfos[:0]
 	for _, n := range allLabelNames {
-		lv, err := ir.SortedLabelValues(n)
+		lv, err := ir.LabelValues(n)
 		if err != nil {
 			return err
 		}
@@ -540,7 +540,7 @@ func analyzeBlock(path, blockID string, limit int) error {
 	printInfo(postingInfos)
 
 	postingInfos = postingInfos[:0]
-	lv, err := ir.SortedLabelValues("__name__")
+	lv, err := ir.LabelValues("__name__")
 	if err != nil {
 		return err
 	}

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -514,7 +514,7 @@ func analyzeBlock(path, blockID string, limit int) error {
 
 	postingInfos = postingInfos[:0]
 	for _, n := range allLabelNames {
-		values, err := ir.LabelValues(n)
+		values, err := ir.LabelValues(n, true)
 		if err != nil {
 			return err
 		}
@@ -530,7 +530,7 @@ func analyzeBlock(path, blockID string, limit int) error {
 
 	postingInfos = postingInfos[:0]
 	for _, n := range allLabelNames {
-		lv, err := ir.LabelValues(n)
+		lv, err := ir.LabelValues(n, true)
 		if err != nil {
 			return err
 		}
@@ -540,7 +540,7 @@ func analyzeBlock(path, blockID string, limit int) error {
 	printInfo(postingInfos)
 
 	postingInfos = postingInfos[:0]
-	lv, err := ir.LabelValues("__name__")
+	lv, err := ir.LabelValues("__name__", true)
 	if err != nil {
 		return err
 	}

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -61,11 +61,11 @@ type IndexReader interface {
 	// beyond the lifetime of the index reader.
 	Symbols() index.StringIter
 
-	// SortedLabelValues returns sorted possible label values.
-	SortedLabelValues(name string) ([]string, error)
-
-	// LabelValues returns possible label values which may not be sorted.
+	// LabelValues returns sorted possible label values.
 	LabelValues(name string) ([]string, error)
+
+	// UnsortedLabelValues returns possible label values which may not be sorted.
+	UnsortedLabelValues(name string) ([]string, error)
 
 	// Postings returns the postings list iterator for the label pairs.
 	// The Postings here contain the offsets to the series inside the index.
@@ -421,13 +421,13 @@ func (r blockIndexReader) Symbols() index.StringIter {
 	return r.ir.Symbols()
 }
 
-func (r blockIndexReader) SortedLabelValues(name string) ([]string, error) {
-	st, err := r.ir.SortedLabelValues(name)
+func (r blockIndexReader) LabelValues(name string) ([]string, error) {
+	st, err := r.ir.LabelValues(name)
 	return st, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
 }
 
-func (r blockIndexReader) LabelValues(name string) ([]string, error) {
-	st, err := r.ir.LabelValues(name)
+func (r blockIndexReader) UnsortedLabelValues(name string) ([]string, error) {
+	st, err := r.ir.UnsortedLabelValues(name)
 	return st, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
 }
 

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -64,9 +64,6 @@ type IndexReader interface {
 	// LabelValues returns sorted possible label values.
 	LabelValues(name string, sortedValues bool) ([]string, error)
 
-	// UnsortedLabelValues returns possible label values which may not be sorted.
-	//UnsortedLabelValues(name string) ([]string, error)
-
 	// Postings returns the postings list iterator for the label pairs.
 	// The Postings here contain the offsets to the series inside the index.
 	// Found IDs are not strictly required to point to a valid Series, e.g.
@@ -425,11 +422,6 @@ func (r blockIndexReader) LabelValues(name string, sortedValues bool) ([]string,
 	st, err := r.ir.LabelValues(name, sortedValues)
 	return st, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
 }
-
-// func (r blockIndexReader) UnsortedLabelValues(name string) ([]string, error) {
-// 	st, err := r.ir.UnsortedLabelValues(name)
-// 	return st, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
-// }
 
 func (r blockIndexReader) Postings(name string, values ...string) (index.Postings, error) {
 	p, err := r.ir.Postings(name, values...)

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -62,10 +62,10 @@ type IndexReader interface {
 	Symbols() index.StringIter
 
 	// LabelValues returns sorted possible label values.
-	LabelValues(name string) ([]string, error)
+	LabelValues(name string, sortedValues bool) ([]string, error)
 
 	// UnsortedLabelValues returns possible label values which may not be sorted.
-	UnsortedLabelValues(name string) ([]string, error)
+	//UnsortedLabelValues(name string) ([]string, error)
 
 	// Postings returns the postings list iterator for the label pairs.
 	// The Postings here contain the offsets to the series inside the index.
@@ -421,15 +421,15 @@ func (r blockIndexReader) Symbols() index.StringIter {
 	return r.ir.Symbols()
 }
 
-func (r blockIndexReader) LabelValues(name string) ([]string, error) {
-	st, err := r.ir.LabelValues(name)
+func (r blockIndexReader) LabelValues(name string, sortedValues bool) ([]string, error) {
+	st, err := r.ir.LabelValues(name, sortedValues)
 	return st, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
 }
 
-func (r blockIndexReader) UnsortedLabelValues(name string) ([]string, error) {
-	st, err := r.ir.UnsortedLabelValues(name)
-	return st, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
-}
+// func (r blockIndexReader) UnsortedLabelValues(name string) ([]string, error) {
+// 	st, err := r.ir.UnsortedLabelValues(name)
+// 	return st, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
+// }
 
 func (r blockIndexReader) Postings(name string, values ...string) (index.Postings, error) {
 	p, err := r.ir.Postings(name, values...)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1558,19 +1558,19 @@ func (h *headIndexReader) Symbols() index.StringIter {
 	return index.NewStringListIter(res)
 }
 
-// SortedLabelValues returns label values present in the head for the
+// LabelValues returns label values present in the head for the
 // specific label name that are within the time range mint to maxt.
-func (h *headIndexReader) SortedLabelValues(name string) ([]string, error) {
-	values, err := h.LabelValues(name)
+func (h *headIndexReader) LabelValues(name string) ([]string, error) {
+	values, err := h.UnsortedLabelValues(name)
 	if err == nil {
 		sort.Strings(values)
 	}
 	return values, err
 }
 
-// LabelValues returns label values present in the head for the
+// UnsortedLabelValues returns label values present in the head for the
 // specific label name that are within the time range mint to maxt.
-func (h *headIndexReader) LabelValues(name string) ([]string, error) {
+func (h *headIndexReader) UnsortedLabelValues(name string) ([]string, error) {
 	h.head.symMtx.RLock()
 
 	if h.maxt < h.head.MinTime() || h.mint > h.head.MaxTime() {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1560,9 +1560,9 @@ func (h *headIndexReader) Symbols() index.StringIter {
 
 // LabelValues returns label values present in the head for the
 // specific label name that are within the time range mint to maxt.
-func (h *headIndexReader) LabelValues(name string) ([]string, error) {
+func (h *headIndexReader) LabelValues(name string, sortedValues bool) ([]string, error) {
 	values, err := h.UnsortedLabelValues(name)
-	if err == nil {
+	if err == nil && sortedValues {
 		sort.Strings(values)
 	}
 	return values, err

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1846,7 +1846,7 @@ func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 			testutil.Equals(t, tt.expectedNames, actualLabelNames)
 			if len(tt.expectedValues) > 0 {
 				for i, name := range expectedLabelNames {
-					actualLabelValue, err := headIdxReader.LabelValues(name)
+					actualLabelValue, err := headIdxReader.LabelValues(name, true)
 					testutil.Ok(t, err)
 					testutil.Equals(t, []string{tt.expectedValues[i]}, actualLabelValue)
 				}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1846,7 +1846,7 @@ func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 			testutil.Equals(t, tt.expectedNames, actualLabelNames)
 			if len(tt.expectedValues) > 0 {
 				for i, name := range expectedLabelNames {
-					actualLabelValue, err := headIdxReader.SortedLabelValues(name)
+					actualLabelValue, err := headIdxReader.LabelValues(name)
 					testutil.Ok(t, err)
 					testutil.Equals(t, []string{tt.expectedValues[i]}, actualLabelValue)
 				}

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1418,21 +1418,21 @@ func (r *Reader) SymbolTableSize() uint64 {
 	return uint64(r.symbols.Size())
 }
 
-// SortedLabelValues returns value tuples that exist for the given label name.
+// LabelValues returns value tuples that exist for the given label name.
 // It is not safe to use the return value beyond the lifetime of the byte slice
 // passed into the Reader.
-func (r *Reader) SortedLabelValues(name string) ([]string, error) {
-	values, err := r.LabelValues(name)
+func (r *Reader) LabelValues(name string) ([]string, error) {
+	values, err := r.UnsortedLabelValues(name)
 	if err == nil && r.version == FormatV1 {
 		sort.Strings(values)
 	}
 	return values, err
 }
 
-// LabelValues returns value tuples that exist for the given label name.
+// UnsortedLabelValues returns value tuples that exist for the given label name.
 // It is not safe to use the return value beyond the lifetime of the byte slice
 // passed into the Reader.
-func (r *Reader) LabelValues(name string) ([]string, error) {
+func (r *Reader) UnsortedLabelValues(name string) ([]string, error) {
 	if r.version == FormatV1 {
 		e, ok := r.postingsV1[name]
 		if !ok {

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1421,9 +1421,9 @@ func (r *Reader) SymbolTableSize() uint64 {
 // LabelValues returns value tuples that exist for the given label name.
 // It is not safe to use the return value beyond the lifetime of the byte slice
 // passed into the Reader.
-func (r *Reader) LabelValues(name string) ([]string, error) {
+func (r *Reader) LabelValues(name string, sortedValues bool) ([]string, error) {
 	values, err := r.UnsortedLabelValues(name)
-	if err == nil && r.version == FormatV1 {
+	if err == nil && r.version == FormatV1 && sortedValues {
 		sort.Strings(values)
 	}
 	return values, err

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -458,7 +458,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 	for k, v := range labelPairs {
 		sort.Strings(v)
 
-		res, err := ir.SortedLabelValues(k)
+		res, err := ir.LabelValues(k)
 		testutil.Ok(t, err)
 
 		testutil.Equals(t, len(v), len(res))

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -91,12 +91,15 @@ func (m mockIndex) Close() error {
 	return nil
 }
 
-func (m mockIndex) LabelValues(name string) ([]string, error) {
+func (m mockIndex) LabelValues(name string, sortedValues bool) ([]string, error) {
 	values := []string{}
 	for l := range m.postings {
 		if l.Name == name {
 			values = append(values, l.Value)
 		}
+	}
+	if sortedValues {
+		sort.Strings(values)
 	}
 	return values, nil
 }
@@ -458,7 +461,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 	for k, v := range labelPairs {
 		sort.Strings(v)
 
-		res, err := ir.LabelValues(k)
+		res, err := ir.LabelValues(k, true)
 		testutil.Ok(t, err)
 
 		testutil.Equals(t, len(v), len(res))

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -309,7 +309,7 @@ func postingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, erro
 		}
 	}
 
-	vals, err := ix.LabelValues(m.Name)
+	vals, err := ix.LabelValues(m.Name, true)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +338,7 @@ func postingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, erro
 
 // inversePostingsForMatcher returns the postings for the series with the label name set but not matching the matcher.
 func inversePostingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, error) {
-	vals, err := ix.LabelValues(m.Name)
+	vals, err := ix.LabelValues(m.Name, true)
 	if err != nil {
 		return nil, err
 	}

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -83,7 +83,7 @@ func newBlockBaseQuerier(b BlockReader, mint, maxt int64) (*blockBaseQuerier, er
 }
 
 func (q *blockBaseQuerier) LabelValues(name string) ([]string, storage.Warnings, error) {
-	res, err := q.index.SortedLabelValues(name)
+	res, err := q.index.LabelValues(name, true)
 	return res, nil, err
 }
 

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1145,7 +1145,7 @@ func (m mockIndex) Close() error {
 }
 
 func (m mockIndex) LabelValues(name string) ([]string, error) {
-	values, _ := m.LabelValues(name)
+	values, _ := m.UnsortedLabelValues(name)
 	sort.Strings(values)
 	return values, nil
 }

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1144,9 +1144,11 @@ func (m mockIndex) Close() error {
 	return nil
 }
 
-func (m mockIndex) LabelValues(name string) ([]string, error) {
+func (m mockIndex) LabelValues(name string, sortedValues bool) ([]string, error) {
 	values, _ := m.UnsortedLabelValues(name)
-	sort.Strings(values)
+	if sortedValues {
+		sort.Strings(values)
+	}
 	return values, nil
 }
 
@@ -1964,7 +1966,7 @@ func (m mockMatcherIndex) Symbols() index.StringIter { return nil }
 func (m mockMatcherIndex) Close() error { return nil }
 
 // LabelValues will return error if it is called.
-func (m mockMatcherIndex) LabelValues(name string) ([]string, error) {
+func (m mockMatcherIndex) LabelValues(name string, sortedValues bool) ([]string, error) {
 	return []string{}, errors.New("sorted label values called")
 }
 

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1144,13 +1144,13 @@ func (m mockIndex) Close() error {
 	return nil
 }
 
-func (m mockIndex) SortedLabelValues(name string) ([]string, error) {
+func (m mockIndex) LabelValues(name string) ([]string, error) {
 	values, _ := m.LabelValues(name)
 	sort.Strings(values)
 	return values, nil
 }
 
-func (m mockIndex) LabelValues(name string) ([]string, error) {
+func (m mockIndex) UnsortedLabelValues(name string) ([]string, error) {
 	values := []string{}
 	for l := range m.postings {
 		if l.Name == name {
@@ -1963,13 +1963,13 @@ func (m mockMatcherIndex) Symbols() index.StringIter { return nil }
 
 func (m mockMatcherIndex) Close() error { return nil }
 
-// SortedLabelValues will return error if it is called.
-func (m mockMatcherIndex) SortedLabelValues(name string) ([]string, error) {
+// LabelValues will return error if it is called.
+func (m mockMatcherIndex) LabelValues(name string) ([]string, error) {
 	return []string{}, errors.New("sorted label values called")
 }
 
-// LabelValues will return error if it is called.
-func (m mockMatcherIndex) LabelValues(name string) ([]string, error) {
+// UnsortedLabelValues will return error if it is called.
+func (m mockMatcherIndex) UnsortedLabelValues(name string) ([]string, error) {
 	return []string{}, errors.New("label values called")
 }
 


### PR DESCRIPTION
Implements #7478 

SortedLabelValues changed to LabelValues
LabelValues changed to UnsortedLabelValues

for IndexReader interface implemented by:
headIndexReader, Reader and blockIndexReader
