### PR TITLE
openstack tests: use new test.Cleanup function

### DIFF
--- a/discovery/openstack/hypervisor_test.go
+++ b/discovery/openstack/hypervisor_test.go
@@ -26,10 +26,6 @@ type OpenstackSDHypervisorTestSuite struct {
 	Mock *SDMock
 }
 
-func (s *OpenstackSDHypervisorTestSuite) TearDownSuite() {
-	s.Mock.ShutdownServer()
-}
-
 func (s *OpenstackSDHypervisorTestSuite) SetupTest(t *testing.T) {
 	s.Mock = NewSDMock(t)
 	s.Mock.Setup()
@@ -89,8 +85,6 @@ func TestOpenstackSDHypervisorRefresh(t *testing.T) {
 	} {
 		testutil.Equals(t, model.LabelValue(v), tg.Targets[1][model.LabelName(l)])
 	}
-
-	mock.TearDownSuite()
 }
 
 func TestOpenstackSDHypervisorRefreshWithDoneContext(t *testing.T) {
@@ -103,6 +97,4 @@ func TestOpenstackSDHypervisorRefreshWithDoneContext(t *testing.T) {
 	_, err := hypervisor.refresh(ctx)
 	testutil.NotOk(t, err)
 	testutil.Assert(t, strings.Contains(err.Error(), context.Canceled.Error()), "%q doesn't contain %q", err, context.Canceled)
-
-	mock.TearDownSuite()
 }

--- a/discovery/openstack/instance_test.go
+++ b/discovery/openstack/instance_test.go
@@ -27,10 +27,6 @@ type OpenstackSDInstanceTestSuite struct {
 	Mock *SDMock
 }
 
-func (s *OpenstackSDInstanceTestSuite) TearDownSuite() {
-	s.Mock.ShutdownServer()
-}
-
 func (s *OpenstackSDInstanceTestSuite) SetupTest(t *testing.T) {
 	s.Mock = NewSDMock(t)
 	s.Mock.Setup()
@@ -128,8 +124,6 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 			testutil.Equals(t, lbls, tg.Targets[i])
 		})
 	}
-
-	mock.TearDownSuite()
 }
 
 func TestOpenstackSDInstanceRefreshWithDoneContext(t *testing.T) {
@@ -142,6 +136,4 @@ func TestOpenstackSDInstanceRefreshWithDoneContext(t *testing.T) {
 	_, err := hypervisor.refresh(ctx)
 	testutil.NotOk(t, err)
 	testutil.Assert(t, strings.Contains(err.Error(), context.Canceled.Error()), "%q doesn't contain %q", err, context.Canceled)
-
-	mock.TearDownSuite()
 }

--- a/discovery/openstack/mock_test.go
+++ b/discovery/openstack/mock_test.go
@@ -43,11 +43,7 @@ func (m *SDMock) Endpoint() string {
 func (m *SDMock) Setup() {
 	m.Mux = http.NewServeMux()
 	m.Server = httptest.NewServer(m.Mux)
-}
-
-// ShutdownServer creates the mock server
-func (m *SDMock) ShutdownServer() {
-	m.Server.Close()
+	m.t.Cleanup(m.Server.Close)
 }
 
 const tokenID = "cbc36478b0bd8e67e89469c7749d4127"


### PR DESCRIPTION
Since we dependend on go1.14 now, we can use T.Cleanup
https://golang.org/pkg/testing/#T.Cleanup

This provides a nicer approach to shut down the test server.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->