### PR TITLE
tsdb: cleanup: remove anonymous single statement defer functs

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -41,9 +41,7 @@ import (
 func TestBlockMetaMustNeverBeVersion2(t *testing.T) {
 	dir, err := ioutil.TempDir("", "metaversion")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 
 	_, err = writeMetaFile(log.NewNopLogger(), dir, &BlockMeta{})
 	testutil.Ok(t, err)
@@ -56,9 +54,7 @@ func TestBlockMetaMustNeverBeVersion2(t *testing.T) {
 func TestSetCompactionFailed(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(tmpdir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(tmpdir))
 
 	blockDir := createBlock(t, tmpdir, genSeries(1, 1, 0, 1))
 	b, err := OpenBlock(nil, blockDir, nil)
@@ -77,9 +73,7 @@ func TestSetCompactionFailed(t *testing.T) {
 func TestCreateBlock(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(tmpdir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(tmpdir))
 	b, err := OpenBlock(nil, createBlock(t, tmpdir, genSeries(1, 1, 0, 10)), nil)
 	if err == nil {
 		testutil.Ok(t, b.Close())
@@ -175,9 +169,7 @@ func TestCorruptedChunk(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tmpdir, err := ioutil.TempDir("", "test_open_block_chunk_corrupted")
 			testutil.Ok(t, err)
-			defer func() {
-				testutil.Ok(t, os.RemoveAll(tmpdir))
-			}()
+			defer testutil.Ok(t, os.RemoveAll(tmpdir))
 
 			series := newSeries(map[string]string{"a": "b"}, []tsdbutil.Sample{sample{1, 1}})
 			blockDir := createBlock(t, tmpdir, []storage.Series{series})
@@ -198,11 +190,11 @@ func TestCorruptedChunk(t *testing.T) {
 				testutil.Equals(t, test.openErr.Error(), err.Error())
 				return
 			}
-			defer func() { testutil.Ok(t, b.Close()) }()
+			defer testutil.Ok(t, b.Close())
 
 			querier, err := NewBlockQuerier(b, 0, 1)
 			testutil.Ok(t, err)
-			defer func() { testutil.Ok(t, querier.Close()) }()
+			defer testutil.Ok(t, querier.Close())
 			set := querier.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
 
 			// Check query err.
@@ -216,9 +208,7 @@ func TestCorruptedChunk(t *testing.T) {
 func TestBlockSize(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test_blockSize")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(tmpdir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(tmpdir))
 
 	var (
 		blockInit    *Block
@@ -231,9 +221,7 @@ func TestBlockSize(t *testing.T) {
 		blockDirInit = createBlock(t, tmpdir, genSeries(10, 1, 1, 100))
 		blockInit, err = OpenBlock(nil, blockDirInit, nil)
 		testutil.Ok(t, err)
-		defer func() {
-			testutil.Ok(t, blockInit.Close())
-		}()
+		defer testutil.Ok(t, blockInit.Close())
 		expSizeInit = blockInit.Size()
 		actSizeInit, err := fileutil.DirSize(blockInit.Dir())
 		testutil.Ok(t, err)
@@ -255,9 +243,7 @@ func TestBlockSize(t *testing.T) {
 		testutil.Ok(t, err)
 		blockAfterCompact, err := OpenBlock(nil, filepath.Join(tmpdir, blockDirAfterCompact.String()), nil)
 		testutil.Ok(t, err)
-		defer func() {
-			testutil.Ok(t, blockAfterCompact.Close())
-		}()
+		defer testutil.Ok(t, blockAfterCompact.Close())
 		expAfterCompact := blockAfterCompact.Size()
 		actAfterCompact, err := fileutil.DirSize(blockAfterCompact.Dir())
 		testutil.Ok(t, err)
@@ -305,9 +291,9 @@ func TestReadIndexFormatV1(t *testing.T) {
 func createBlock(tb testing.TB, dir string, series []storage.Series) string {
 	chunkDir, err := ioutil.TempDir("", "chunk_dir")
 	testutil.Ok(tb, err)
-	defer func() { testutil.Ok(tb, os.RemoveAll(chunkDir)) }()
+	defer testutil.Ok(tb, os.RemoveAll(chunkDir))
 	head := createHead(tb, series, chunkDir)
-	defer func() { testutil.Ok(tb, head.Close()) }()
+	defer testutil.Ok(tb, head.Close())
 	return createBlockFromHead(tb, dir, head)
 }
 

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -434,9 +434,7 @@ func TestCompactionFailWillCleanUpTempDir(t *testing.T) {
 
 	tmpdir, err := ioutil.TempDir("", "test")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(tmpdir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(tmpdir))
 
 	testutil.NotOk(t, compactor.write(tmpdir, &BlockMeta{}, erringBReader{}))
 	_, err = os.Stat(filepath.Join(tmpdir, BlockMeta{}.ULID.String()) + ".tmp")
@@ -832,18 +830,14 @@ func BenchmarkCompaction(b *testing.B) {
 		b.Run(fmt.Sprintf("type=%s,blocks=%d,series=%d,samplesPerSeriesPerBlock=%d", c.compactionType, nBlocks, nSeries, c.ranges[0][1]-c.ranges[0][0]+1), func(b *testing.B) {
 			dir, err := ioutil.TempDir("", "bench_compaction")
 			testutil.Ok(b, err)
-			defer func() {
-				testutil.Ok(b, os.RemoveAll(dir))
-			}()
+			defer testutil.Ok(b, os.RemoveAll(dir))
 			blockDirs := make([]string, 0, len(c.ranges))
 			var blocks []*Block
 			for _, r := range c.ranges {
 				block, err := OpenBlock(nil, createBlock(b, dir, genSeries(nSeries, 10, r[0], r[1])), nil)
 				testutil.Ok(b, err)
 				blocks = append(blocks, block)
-				defer func() {
-					testutil.Ok(b, block.Close())
-				}()
+				defer testutil.Ok(b, block.Close())
 				blockDirs = append(blockDirs, block.Dir())
 			}
 
@@ -863,18 +857,14 @@ func BenchmarkCompaction(b *testing.B) {
 func BenchmarkCompactionFromHead(b *testing.B) {
 	dir, err := ioutil.TempDir("", "bench_compaction_from_head")
 	testutil.Ok(b, err)
-	defer func() {
-		testutil.Ok(b, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(b, os.RemoveAll(dir))
 	totalSeries := 100000
 	for labelNames := 1; labelNames < totalSeries; labelNames *= 10 {
 		labelValues := totalSeries / labelNames
 		b.Run(fmt.Sprintf("labelnames=%d,labelvalues=%d", labelNames, labelValues), func(b *testing.B) {
 			chunkDir, err := ioutil.TempDir("", "chunk_dir")
 			testutil.Ok(b, err)
-			defer func() {
-				testutil.Ok(b, os.RemoveAll(chunkDir))
-			}()
+			defer testutil.Ok(b, os.RemoveAll(chunkDir))
 			h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, DefaultStripeSize, nil)
 			testutil.Ok(b, err)
 			for ln := 0; ln < labelNames; ln++ {
@@ -956,9 +946,7 @@ func TestDisableAutoCompactions(t *testing.T) {
 func TestCancelCompactions(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "testCancelCompaction")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(tmpdir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(tmpdir))
 
 	// Create some blocks to fall within the compaction range.
 	createBlock(t, tmpdir, genSeries(1, 10000, 0, 1000))
@@ -969,9 +957,7 @@ func TestCancelCompactions(t *testing.T) {
 	tmpdirCopy := tmpdir + "Copy"
 	err = fileutil.CopyDirs(tmpdir, tmpdirCopy)
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(tmpdirCopy))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(tmpdirCopy))
 
 	// Measure the compaction time without interrupting it.
 	var timeCompactionUninterrupted time.Duration

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -27,9 +27,7 @@ import (
 func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 	chunkDir, err := ioutil.TempDir("", "chunk_dir")
 	testutil.Ok(b, err)
-	defer func() {
-		testutil.Ok(b, os.RemoveAll(chunkDir))
-	}()
+	defer testutil.Ok(b, os.RemoveAll(chunkDir))
 	// Put a series, select it. GC it and then access it.
 	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, DefaultStripeSize, nil)
 	testutil.Ok(b, err)
@@ -43,9 +41,7 @@ func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 	chunkDir, err := ioutil.TempDir("", "chunk_dir")
 	testutil.Ok(b, err)
-	defer func() {
-		testutil.Ok(b, os.RemoveAll(chunkDir))
-	}()
+	defer testutil.Ok(b, os.RemoveAll(chunkDir))
 	// Put a series, select it. GC it and then access it.
 	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, DefaultStripeSize, nil)
 	testutil.Ok(b, err)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -43,9 +43,7 @@ func BenchmarkCreateSeries(b *testing.B) {
 	series := genSeries(b.N, 10, 0, 0)
 	h, _, closer := newTestHead(b, 10000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(b, h.Close())
-	}()
+	defer testutil.Ok(b, h.Close())
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -131,9 +129,7 @@ func BenchmarkLoadWAL(b *testing.B) {
 			func(b *testing.B) {
 				dir, err := ioutil.TempDir("", "test_load_wal")
 				testutil.Ok(b, err)
-				defer func() {
-					testutil.Ok(b, os.RemoveAll(dir))
-				}()
+				defer testutil.Ok(b, os.RemoveAll(dir))
 
 				w, err := wal.New(nil, nil, dir, false)
 				testutil.Ok(b, err)
@@ -212,9 +208,7 @@ func TestHead_ReadWAL(t *testing.T) {
 
 			head, w, closer := newTestHead(t, 1000, compress)
 			defer closer()
-			defer func() {
-				testutil.Ok(t, head.Close())
-			}()
+			defer testutil.Ok(t, head.Close())
 
 			populateTestWAL(t, w, entries)
 
@@ -289,9 +283,7 @@ func TestHead_WALMultiRef(t *testing.T) {
 	head, err = NewHead(nil, nil, w, 1000, w.Dir(), nil, DefaultStripeSize, nil)
 	testutil.Ok(t, err)
 	testutil.Ok(t, head.Init(0))
-	defer func() {
-		testutil.Ok(t, head.Close())
-	}()
+	defer testutil.Ok(t, head.Close())
 
 	q, err := NewBlockQuerier(head, 0, 2100)
 	testutil.Ok(t, err)
@@ -307,9 +299,7 @@ func TestHead_WALMultiRef(t *testing.T) {
 func TestHead_Truncate(t *testing.T) {
 	h, _, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, h.Close())
-	}()
+	defer testutil.Ok(t, h.Close())
 
 	h.initTime(0)
 
@@ -385,15 +375,11 @@ func TestHead_Truncate(t *testing.T) {
 func TestMemSeries_truncateChunks(t *testing.T) {
 	dir, err := ioutil.TempDir("", "truncate_chunks")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 	// This is usually taken from the Head, but passing manually here.
 	chunkDiskMapper, err := chunks.NewChunkDiskMapper(dir, chunkenc.NewPool())
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, chunkDiskMapper.Close())
-	}()
+	defer testutil.Ok(t, chunkDiskMapper.Close())
 
 	memChunkPool := sync.Pool{
 		New: func() interface{} {
@@ -459,9 +445,7 @@ func TestHeadDeleteSeriesWithoutSamples(t *testing.T) {
 			}
 			head, w, closer := newTestHead(t, 1000, compress)
 			defer closer()
-			defer func() {
-				testutil.Ok(t, head.Close())
-			}()
+			defer testutil.Ok(t, head.Close())
 
 			populateTestWAL(t, w, entries)
 
@@ -605,9 +589,7 @@ func TestHeadDeleteSimple(t *testing.T) {
 func TestDeleteUntilCurMax(t *testing.T) {
 	hb, _, closer := newTestHead(t, 1000000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, hb.Close())
-	}()
+	defer testutil.Ok(t, hb.Close())
 
 	numSamples := int64(10)
 	app := hb.Appender()
@@ -750,9 +732,7 @@ func TestDelete_e2e(t *testing.T) {
 
 	hb, _, closer := newTestHead(t, 100000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, hb.Close())
-	}()
+	defer testutil.Ok(t, hb.Close())
 
 	app := hb.Appender()
 	for _, l := range lbls {
@@ -935,15 +915,11 @@ func TestComputeChunkEndTime(t *testing.T) {
 func TestMemSeries_append(t *testing.T) {
 	dir, err := ioutil.TempDir("", "append")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 	// This is usually taken from the Head, but passing manually here.
 	chunkDiskMapper, err := chunks.NewChunkDiskMapper(dir, chunkenc.NewPool())
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, chunkDiskMapper.Close())
-	}()
+	defer testutil.Ok(t, chunkDiskMapper.Close())
 
 	s := newMemSeries(labels.Labels{}, 1, 500, nil)
 
@@ -991,9 +967,7 @@ func TestGCChunkAccess(t *testing.T) {
 	// Put a chunk, select it. GC it and then access it.
 	h, _, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, h.Close())
-	}()
+	defer testutil.Ok(t, h.Close())
 
 	h.initTime(0)
 
@@ -1046,9 +1020,7 @@ func TestGCSeriesAccess(t *testing.T) {
 	// Put a series, select it. GC it and then access it.
 	h, _, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, h.Close())
-	}()
+	defer testutil.Ok(t, h.Close())
 
 	h.initTime(0)
 
@@ -1102,9 +1074,7 @@ func TestGCSeriesAccess(t *testing.T) {
 func TestUncommittedSamplesNotLostOnTruncate(t *testing.T) {
 	h, _, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, h.Close())
-	}()
+	defer testutil.Ok(t, h.Close())
 
 	h.initTime(0)
 
@@ -1133,9 +1103,7 @@ func TestUncommittedSamplesNotLostOnTruncate(t *testing.T) {
 func TestRemoveSeriesAfterRollbackAndTruncate(t *testing.T) {
 	h, _, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, h.Close())
-	}()
+	defer testutil.Ok(t, h.Close())
 
 	h.initTime(0)
 
@@ -1167,9 +1135,7 @@ func TestHead_LogRollback(t *testing.T) {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
 			h, w, closer := newTestHead(t, 1000, compress)
 			defer closer()
-			defer func() {
-				testutil.Ok(t, h.Close())
-			}()
+			defer testutil.Ok(t, h.Close())
 
 			app := h.Appender()
 			_, err := app.Add(labels.FromStrings("a", "b"), 1, 2)
@@ -1238,9 +1204,7 @@ func TestWalRepair_DecodingError(t *testing.T) {
 			t.Run(fmt.Sprintf("%s,compress=%t", name, compress), func(t *testing.T) {
 				dir, err := ioutil.TempDir("", "wal_repair")
 				testutil.Ok(t, err)
-				defer func() {
-					testutil.Ok(t, os.RemoveAll(dir))
-				}()
+				defer testutil.Ok(t, os.RemoveAll(dir))
 
 				// Fill the wal and corrupt it.
 				{
@@ -1271,9 +1235,7 @@ func TestWalRepair_DecodingError(t *testing.T) {
 				{
 					db, err := Open(dir, nil, nil, DefaultOptions())
 					testutil.Ok(t, err)
-					defer func() {
-						testutil.Ok(t, db.Close())
-					}()
+					defer testutil.Ok(t, db.Close())
 					testutil.Equals(t, 1.0, prom_testutil.ToFloat64(db.head.metrics.walCorruptionsTotal))
 				}
 
@@ -1299,9 +1261,7 @@ func TestWalRepair_DecodingError(t *testing.T) {
 func TestHeadReadWriterRepair(t *testing.T) {
 	dir, err := ioutil.TempDir("", "head_read_writer_repair")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 
 	const chunkRange = 1000
 
@@ -1348,9 +1308,7 @@ func TestHeadReadWriterRepair(t *testing.T) {
 	{
 		db, err := Open(dir, nil, nil, DefaultOptions())
 		testutil.Ok(t, err)
-		defer func() {
-			testutil.Ok(t, db.Close())
-		}()
+		defer testutil.Ok(t, db.Close())
 		testutil.Equals(t, 1.0, prom_testutil.ToFloat64(db.head.metrics.mmapChunkCorruptionTotal))
 	}
 
@@ -1366,9 +1324,7 @@ func TestHeadReadWriterRepair(t *testing.T) {
 func TestNewWalSegmentOnTruncate(t *testing.T) {
 	h, wlog, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, h.Close())
-	}()
+	defer testutil.Ok(t, h.Close())
 	add := func(ts int64) {
 		app := h.Appender()
 		_, err := app.Add(labels.Labels{{Name: "a", Value: "b"}}, ts, 0)
@@ -1397,9 +1353,7 @@ func TestNewWalSegmentOnTruncate(t *testing.T) {
 func TestAddDuplicateLabelName(t *testing.T) {
 	h, _, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, h.Close())
-	}()
+	defer testutil.Ok(t, h.Close())
 
 	add := func(labels labels.Labels, labelName string) {
 		app := h.Appender()
@@ -1543,7 +1497,7 @@ func TestMemSeriesIsolation(t *testing.T) {
 	wlog, err := wal.NewSize(nil, nil, w.Dir(), 32768, false)
 	testutil.Ok(t, err)
 	hb, err = NewHead(nil, nil, wlog, 1000, wlog.Dir(), nil, DefaultStripeSize, nil)
-	defer func() { testutil.Ok(t, hb.Close()) }()
+	defer testutil.Ok(t, hb.Close())
 	testutil.Ok(t, err)
 	testutil.Ok(t, hb.Init(0))
 
@@ -1584,9 +1538,7 @@ func TestIsolationRollback(t *testing.T) {
 	// Rollback after a failed append and test if the low watermark has progressed anyway.
 	hb, _, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, hb.Close())
-	}()
+	defer testutil.Ok(t, hb.Close())
 
 	app := hb.Appender()
 	_, err := app.Add(labels.FromStrings("foo", "bar"), 0, 0)
@@ -1612,9 +1564,7 @@ func TestIsolationRollback(t *testing.T) {
 func TestIsolationLowWatermarkMonotonous(t *testing.T) {
 	hb, _, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, hb.Close())
-	}()
+	defer testutil.Ok(t, hb.Close())
 
 	app1 := hb.Appender()
 	_, err := app1.Add(labels.FromStrings("foo", "bar"), 0, 0)
@@ -1646,9 +1596,7 @@ func TestIsolationLowWatermarkMonotonous(t *testing.T) {
 func TestIsolationAppendIDZeroIsNoop(t *testing.T) {
 	h, _, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, h.Close())
-	}()
+	defer testutil.Ok(t, h.Close())
 
 	h.initTime(0)
 
@@ -1668,9 +1616,7 @@ func TestHeadSeriesChunkRace(t *testing.T) {
 func TestIsolationWithoutAdd(t *testing.T) {
 	hb, _, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, hb.Close())
-	}()
+	defer testutil.Ok(t, hb.Close())
 
 	app := hb.Appender()
 	testutil.Ok(t, app.Commit())
@@ -1686,15 +1632,11 @@ func TestIsolationWithoutAdd(t *testing.T) {
 func TestOutOfOrderSamplesMetric(t *testing.T) {
 	dir, err := ioutil.TempDir("", "test")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 
 	db, err := Open(dir, nil, nil, DefaultOptions())
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, db.Close())
-	}()
+	defer testutil.Ok(t, db.Close())
 	db.DisableCompactions()
 
 	app := db.Appender()
@@ -1767,9 +1709,7 @@ func TestOutOfOrderSamplesMetric(t *testing.T) {
 func testHeadSeriesChunkRace(t *testing.T) {
 	h, _, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, h.Close())
-	}()
+	defer testutil.Ok(t, h.Close())
 	testutil.Ok(t, h.Init(0))
 	app := h.Appender()
 
@@ -1819,9 +1759,7 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 	head, _, closer := newTestHead(t, 1000, false)
 	defer closer()
-	defer func() {
-		testutil.Ok(t, head.Close())
-	}()
+	defer testutil.Ok(t, head.Close())
 
 	const (
 		firstSeriesTimestamp  int64 = 100

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -32,14 +32,10 @@ const (
 func BenchmarkPostingsForMatchers(b *testing.B) {
 	chunkDir, err := ioutil.TempDir("", "chunk_dir")
 	testutil.Ok(b, err)
-	defer func() {
-		testutil.Ok(b, os.RemoveAll(chunkDir))
-	}()
+	defer testutil.Ok(b, os.RemoveAll(chunkDir))
 	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, DefaultStripeSize, nil)
 	testutil.Ok(b, err)
-	defer func() {
-		testutil.Ok(b, h.Close())
-	}()
+	defer testutil.Ok(b, h.Close())
 
 	app := h.Appender()
 	addSeries := func(l labels.Labels) {
@@ -66,16 +62,12 @@ func BenchmarkPostingsForMatchers(b *testing.B) {
 
 	tmpdir, err := ioutil.TempDir("", "test_benchpostingsformatchers")
 	testutil.Ok(b, err)
-	defer func() {
-		testutil.Ok(b, os.RemoveAll(tmpdir))
-	}()
+	defer testutil.Ok(b, os.RemoveAll(tmpdir))
 
 	blockdir := createBlockFromHead(b, tmpdir, h)
 	block, err := OpenBlock(nil, blockdir, nil)
 	testutil.Ok(b, err)
-	defer func() {
-		testutil.Ok(b, block.Close())
-	}()
+	defer testutil.Ok(b, block.Close())
 	ir, err = block.Index()
 	testutil.Ok(b, err)
 	defer ir.Close()
@@ -137,9 +129,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 func BenchmarkQuerierSelect(b *testing.B) {
 	chunkDir, err := ioutil.TempDir("", "chunk_dir")
 	testutil.Ok(b, err)
-	defer func() {
-		testutil.Ok(b, os.RemoveAll(chunkDir))
-	}()
+	defer testutil.Ok(b, os.RemoveAll(chunkDir))
 	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, DefaultStripeSize, nil)
 	testutil.Ok(b, err)
 	defer h.Close()
@@ -178,16 +168,12 @@ func BenchmarkQuerierSelect(b *testing.B) {
 
 	tmpdir, err := ioutil.TempDir("", "test_benchquerierselect")
 	testutil.Ok(b, err)
-	defer func() {
-		testutil.Ok(b, os.RemoveAll(tmpdir))
-	}()
+	defer testutil.Ok(b, os.RemoveAll(tmpdir))
 
 	blockdir := createBlockFromHead(b, tmpdir, h)
 	block, err := OpenBlock(nil, blockdir, nil)
 	testutil.Ok(b, err)
-	defer func() {
-		testutil.Ok(b, block.Close())
-	}()
+	defer testutil.Ok(b, block.Close())
 
 	b.Run("Block", func(b *testing.B) {
 		bench(b, block, false)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1534,9 +1534,7 @@ func BenchmarkQueryIterator(b *testing.B) {
 			b.Run(benchMsg, func(b *testing.B) {
 				dir, err := ioutil.TempDir("", "bench_query_iterator")
 				testutil.Ok(b, err)
-				defer func() {
-					testutil.Ok(b, os.RemoveAll(dir))
-				}()
+				defer testutil.Ok(b, os.RemoveAll(dir))
 
 				var (
 					blocks          []*Block
@@ -1608,9 +1606,7 @@ func BenchmarkQuerySeek(b *testing.B) {
 			b.Run(benchMsg, func(b *testing.B) {
 				dir, err := ioutil.TempDir("", "bench_query_iterator")
 				testutil.Ok(b, err)
-				defer func() {
-					testutil.Ok(b, os.RemoveAll(dir))
-				}()
+				defer testutil.Ok(b, os.RemoveAll(dir))
 
 				var (
 					blocks          []*Block
@@ -1756,9 +1752,7 @@ func BenchmarkSetMatcher(b *testing.B) {
 	for _, c := range cases {
 		dir, err := ioutil.TempDir("", "bench_postings_for_matchers")
 		testutil.Ok(b, err)
-		defer func() {
-			testutil.Ok(b, os.RemoveAll(dir))
-		}()
+		defer testutil.Ok(b, os.RemoveAll(dir))
 
 		var (
 			blocks          []*Block
@@ -1866,14 +1860,10 @@ func TestFindSetMatches(t *testing.T) {
 func TestPostingsForMatchers(t *testing.T) {
 	chunkDir, err := ioutil.TempDir("", "chunk_dir")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(chunkDir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(chunkDir))
 	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, DefaultStripeSize, nil)
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, h.Close())
-	}()
+	defer testutil.Ok(t, h.Close())
 
 	app := h.Appender()
 	app.Add(labels.FromStrings("n", "1"), 0, 0)
@@ -2127,9 +2117,7 @@ func TestClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Opening test dir failed: %s", err)
 	}
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 
 	createBlock(t, dir, genSeries(1, 1, 0, 10))
 	createBlock(t, dir, genSeries(1, 1, 10, 20))
@@ -2138,9 +2126,7 @@ func TestClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Opening test storage failed: %s", err)
 	}
-	defer func() {
-		testutil.Ok(t, db.Close())
-	}()
+	defer testutil.Ok(t, db.Close())
 
 	q, err := db.Querier(context.TODO(), 0, 20)
 	testutil.Ok(t, err)
@@ -2192,9 +2178,7 @@ func BenchmarkQueries(b *testing.B) {
 			for _, nSamples := range []int64{1000, 10000, 100000} {
 				dir, err := ioutil.TempDir("", "test_persisted_query")
 				testutil.Ok(b, err)
-				defer func() {
-					testutil.Ok(b, os.RemoveAll(dir))
-				}()
+				defer testutil.Ok(b, os.RemoveAll(dir))
 
 				series := genSeries(nSeries, 5, 1, int64(nSamples))
 
@@ -2234,9 +2218,7 @@ func BenchmarkQueries(b *testing.B) {
 
 				chunkDir, err := ioutil.TempDir("", "chunk_dir")
 				testutil.Ok(b, err)
-				defer func() {
-					testutil.Ok(b, os.RemoveAll(chunkDir))
-				}()
+				defer testutil.Ok(b, os.RemoveAll(chunkDir))
 				head := createHead(b, series, chunkDir)
 				qHead, err := NewBlockQuerier(head, 1, int64(nSamples))
 				testutil.Ok(b, err)

--- a/tsdb/repair_test.go
+++ b/tsdb/repair_test.go
@@ -70,9 +70,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 
 	// Touch chunks dir in block.
 	testutil.Ok(t, os.MkdirAll(filepath.Join(dbDir, "chunks"), 0777))
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(filepath.Join(dbDir, "chunks")))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(filepath.Join(dbDir, "chunks")))
 
 	r, err := index.NewFileReader(filepath.Join(dbDir, indexFilename))
 	testutil.Ok(t, err)
@@ -91,9 +89,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	if err = fileutil.CopyDirs(dbDir, tmpDbDir); err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(tmpDir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(tmpDir))
 	// On DB opening all blocks in the base dir should be repaired.
 	db, err := Open(tmpDir, nil, nil, nil)
 	testutil.Ok(t, err)

--- a/tsdb/wal/reader_test.go
+++ b/tsdb/wal/reader_test.go
@@ -314,9 +314,7 @@ func TestReaderFuzz(t *testing.T) {
 			t.Run(fmt.Sprintf("%s,compress=%t", name, compress), func(t *testing.T) {
 				dir, err := ioutil.TempDir("", "wal_fuzz_live")
 				testutil.Ok(t, err)
-				defer func() {
-					testutil.Ok(t, os.RemoveAll(dir))
-				}()
+				defer testutil.Ok(t, os.RemoveAll(dir))
 
 				w, err := NewSize(nil, nil, dir, 128*pageSize, compress)
 				testutil.Ok(t, err)
@@ -351,9 +349,7 @@ func TestReaderFuzz_Live(t *testing.T) {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
 			dir, err := ioutil.TempDir("", "wal_fuzz_live")
 			testutil.Ok(t, err)
-			defer func() {
-				testutil.Ok(t, os.RemoveAll(dir))
-			}()
+			defer testutil.Ok(t, os.RemoveAll(dir))
 
 			w, err := NewSize(nil, nil, dir, 128*pageSize, compress)
 			testutil.Ok(t, err)
@@ -436,9 +432,7 @@ func TestLiveReaderCorrupt_ShortFile(t *testing.T) {
 	logger := testutil.NewLogger(t)
 	dir, err := ioutil.TempDir("", "wal_live_corrupt")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 
 	w, err := NewSize(nil, nil, dir, pageSize, false)
 	testutil.Ok(t, err)
@@ -480,9 +474,7 @@ func TestLiveReaderCorrupt_RecordTooLongAndShort(t *testing.T) {
 	logger := testutil.NewLogger(t)
 	dir, err := ioutil.TempDir("", "wal_live_corrupt")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 
 	w, err := NewSize(nil, nil, dir, pageSize*2, false)
 	testutil.Ok(t, err)

--- a/tsdb/wal_test.go
+++ b/tsdb/wal_test.go
@@ -37,9 +37,7 @@ import (
 func TestSegmentWAL_cut(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test_wal_cut")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(tmpdir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(tmpdir))
 
 	// This calls cut() implicitly the first time without a previous tail.
 	w, err := OpenSegmentWAL(tmpdir, nil, 0, nil)
@@ -87,9 +85,7 @@ func TestSegmentWAL_Truncate(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "test_wal_log_truncate")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 
 	w, err := OpenSegmentWAL(dir, nil, 0, nil)
 	testutil.Ok(t, err)
@@ -168,9 +164,7 @@ func TestSegmentWAL_Log_Restore(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "test_wal_log_restore")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 
 	var (
 		recordedSeries  [][]record.RefSeries
@@ -277,9 +271,7 @@ func TestSegmentWAL_Log_Restore(t *testing.T) {
 func TestWALRestoreCorrupted_invalidSegment(t *testing.T) {
 	dir, err := ioutil.TempDir("", "test_wal_log_restore")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 
 	wal, err := OpenSegmentWAL(dir, nil, 0, nil)
 	testutil.Ok(t, err)
@@ -380,9 +372,7 @@ func TestWALRestoreCorrupted(t *testing.T) {
 			// for the purpose of this test.
 			dir, err := ioutil.TempDir("", "test_corrupted")
 			testutil.Ok(t, err)
-			defer func() {
-				testutil.Ok(t, os.RemoveAll(dir))
-			}()
+			defer testutil.Ok(t, os.RemoveAll(dir))
 
 			w, err := OpenSegmentWAL(dir, nil, 0, nil)
 			testutil.Ok(t, err)
@@ -457,9 +447,7 @@ func TestMigrateWAL_Empty(t *testing.T) {
 	// which is valid in the new format.
 	dir, err := ioutil.TempDir("", "walmigrate")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 
 	wdir := path.Join(dir, "wal")
 
@@ -474,9 +462,7 @@ func TestMigrateWAL_Empty(t *testing.T) {
 func TestMigrateWAL_Fuzz(t *testing.T) {
 	dir, err := ioutil.TempDir("", "walmigrate")
 	testutil.Ok(t, err)
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(dir))
-	}()
+	defer testutil.Ok(t, os.RemoveAll(dir))
 
 	wdir := path.Join(dir, "wal")
 


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->