### PR TITLE
Fix unknown symbol error during head compaction

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1692,8 +1692,6 @@ func (h *Head) getOrCreateWithID(id, hash uint64, lset labels.Labels) (*memSerie
 	h.metrics.seriesCreated.Inc()
 	atomic.AddUint64(&h.numSeries, 1)
 
-	h.postings.Add(id, lset)
-
 	h.symMtx.Lock()
 	defer h.symMtx.Unlock()
 
@@ -1708,6 +1706,10 @@ func (h *Head) getOrCreateWithID(id, hash uint64, lset labels.Labels) (*memSerie
 		h.symbols[l.Name] = struct{}{}
 		h.symbols[l.Value] = struct{}{}
 	}
+
+	// Postings should be set after setting the symbols (or after holding
+	// the symbol mtx) to avoid race during compaction of seeing partial symbols.
+	h.postings.Add(id, lset)
 
 	return s, true, nil
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1876,65 +1876,65 @@ func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 	}
 }
 
-func TestHeadCompactionRace(t *testing.T) {
-	for i := 0; i < 10; i++ {
-		t.Run(fmt.Sprintf("run %d", i), func(t *testing.T) {
-			tsdbCfg := &Options{
-				RetentionDuration: 100000000,
-				NoLockfile:        true,
-				MinBlockDuration:  1000000,
-				MaxBlockDuration:  1000000,
-			}
-
-			db, closer := openTestDB(t, tsdbCfg, []int64{1000000})
-			t.Cleanup(closer)
-			t.Cleanup(func() {
-				testutil.Ok(t, db.Close())
-			})
-
-			head := db.Head()
-
-			// Get past the init appender phase here.
-			app := head.Appender()
-			_, err := app.Add(labels.Labels{labels.Label{Name: "n", Value: "v"}}, 10, 10)
-			testutil.Ok(t, err)
-			testutil.Ok(t, app.Commit())
-
-			wait := make(chan struct{})
-			var wg sync.WaitGroup
-
-			// Prepare to execute concurrent appends.
-			wg.Add(100)
-			for i := 0; i < 100; i++ {
-				go func(idx int) {
-					defer wg.Done()
-					app := head.Appender()
-					<-wait
-
-					for j := 0; j < 100; j++ {
-						// After compaction this will return out of bound, so this is a best effort append.
-						app.Add(labels.Labels{labels.Label{
-							Name:  fmt.Sprintf("n%d", idx*100+j),
-							Value: fmt.Sprintf("v%d", idx*100+j),
-						}}, 1000, 10)
-					}
-
-					testutil.Ok(t, app.Commit())
-				}(i)
-			}
-
-			// Prepare for head compaction.
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				<-wait
-				testutil.Ok(t, db.CompactHead(NewRangeHead(head, 0, 10000000)))
-			}()
-
-			// Run concurrent appends and compaction.
-			close(wait)
-
-			wg.Wait()
-		})
-	}
-}
+//func TestHeadCompactionRace(t *testing.T) {
+//	for i := 0; i < 10; i++ {
+//		t.Run(fmt.Sprintf("run %d", i), func(t *testing.T) {
+//			tsdbCfg := &Options{
+//				RetentionDuration: 100000000,
+//				NoLockfile:        true,
+//				MinBlockDuration:  1000000,
+//				MaxBlockDuration:  1000000,
+//			}
+//
+//			db, closer := openTestDB(t, tsdbCfg, []int64{1000000})
+//			t.Cleanup(closer)
+//			t.Cleanup(func() {
+//				testutil.Ok(t, db.Close())
+//			})
+//
+//			head := db.Head()
+//
+//			// Get past the init appender phase here.
+//			app := head.Appender()
+//			_, err := app.Add(labels.Labels{labels.Label{Name: "n", Value: "v"}}, 10, 10)
+//			testutil.Ok(t, err)
+//			testutil.Ok(t, app.Commit())
+//
+//			wait := make(chan struct{})
+//			var wg sync.WaitGroup
+//
+//			// Prepare to execute concurrent appends.
+//			wg.Add(100)
+//			for i := 0; i < 100; i++ {
+//				go func(idx int) {
+//					defer wg.Done()
+//					app := head.Appender()
+//					<-wait
+//
+//					for j := 0; j < 100; j++ {
+//						// After compaction this will return out of bound, so this is a best effort append.
+//						app.Add(labels.Labels{labels.Label{
+//							Name:  fmt.Sprintf("n%d", idx*100+j),
+//							Value: fmt.Sprintf("v%d", idx*100+j),
+//						}}, 1000, 10)
+//					}
+//
+//					testutil.Ok(t, app.Commit())
+//				}(i)
+//			}
+//
+//			// Prepare for head compaction.
+//			wg.Add(1)
+//			go func() {
+//				defer wg.Done()
+//				<-wait
+//				testutil.Ok(t, db.CompactHead(NewRangeHead(head, 0, 10000000)))
+//			}()
+//
+//			// Run concurrent appends and compaction.
+//			close(wait)
+//
+//			wg.Wait()
+//		})
+//	}
+//}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1876,65 +1876,69 @@ func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 	}
 }
 
-//func TestHeadCompactionRace(t *testing.T) {
-//	for i := 0; i < 10; i++ {
-//		t.Run(fmt.Sprintf("run %d", i), func(t *testing.T) {
-//			tsdbCfg := &Options{
-//				RetentionDuration: 100000000,
-//				NoLockfile:        true,
-//				MinBlockDuration:  1000000,
-//				MaxBlockDuration:  1000000,
-//			}
-//
-//			db, closer := openTestDB(t, tsdbCfg, []int64{1000000})
-//			t.Cleanup(closer)
-//			t.Cleanup(func() {
-//				testutil.Ok(t, db.Close())
-//			})
-//
-//			head := db.Head()
-//
-//			// Get past the init appender phase here.
-//			app := head.Appender()
-//			_, err := app.Add(labels.Labels{labels.Label{Name: "n", Value: "v"}}, 10, 10)
-//			testutil.Ok(t, err)
-//			testutil.Ok(t, app.Commit())
-//
-//			wait := make(chan struct{})
-//			var wg sync.WaitGroup
-//
-//			// Prepare to execute concurrent appends.
-//			wg.Add(100)
-//			for i := 0; i < 100; i++ {
-//				go func(idx int) {
-//					defer wg.Done()
-//					app := head.Appender()
-//					<-wait
-//
-//					for j := 0; j < 100; j++ {
-//						// After compaction this will return out of bound, so this is a best effort append.
-//						app.Add(labels.Labels{labels.Label{
-//							Name:  fmt.Sprintf("n%d", idx*100+j),
-//							Value: fmt.Sprintf("v%d", idx*100+j),
-//						}}, 1000, 10)
-//					}
-//
-//					testutil.Ok(t, app.Commit())
-//				}(i)
-//			}
-//
-//			// Prepare for head compaction.
-//			wg.Add(1)
-//			go func() {
-//				defer wg.Done()
-//				<-wait
-//				testutil.Ok(t, db.CompactHead(NewRangeHead(head, 0, 10000000)))
-//			}()
-//
-//			// Run concurrent appends and compaction.
-//			close(wait)
-//
-//			wg.Wait()
-//		})
-//	}
-//}
+func TestHeadCompactionRace(t *testing.T) {
+	// There are still some races to be fixed. Hence skipping this test
+	// for now to not cause flaky CI failures.
+	t.Skip()
+
+	for i := 0; i < 10; i++ {
+		t.Run(fmt.Sprintf("run %d", i), func(t *testing.T) {
+			tsdbCfg := &Options{
+				RetentionDuration: 100000000,
+				NoLockfile:        true,
+				MinBlockDuration:  1000000,
+				MaxBlockDuration:  1000000,
+			}
+
+			db, closer := openTestDB(t, tsdbCfg, []int64{1000000})
+			t.Cleanup(closer)
+			t.Cleanup(func() {
+				testutil.Ok(t, db.Close())
+			})
+
+			head := db.Head()
+
+			// Get past the init appender phase here.
+			app := head.Appender()
+			_, err := app.Add(labels.Labels{labels.Label{Name: "n", Value: "v"}}, 10, 10)
+			testutil.Ok(t, err)
+			testutil.Ok(t, app.Commit())
+
+			wait := make(chan struct{})
+			var wg sync.WaitGroup
+
+			// Prepare to execute concurrent appends.
+			wg.Add(100)
+			for i := 0; i < 100; i++ {
+				go func(idx int) {
+					defer wg.Done()
+					app := head.Appender()
+					<-wait
+
+					for j := 0; j < 100; j++ {
+						// After compaction this will return out of bound, so this is a best effort append.
+						app.Add(labels.Labels{labels.Label{
+							Name:  fmt.Sprintf("n%d", idx*100+j),
+							Value: fmt.Sprintf("v%d", idx*100+j),
+						}}, 1000, 10)
+					}
+
+					testutil.Ok(t, app.Commit())
+				}(i)
+			}
+
+			// Prepare for head compaction.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-wait
+				testutil.Ok(t, db.CompactHead(NewRangeHead(head, 0, 10000000)))
+			}()
+
+			// Run concurrent appends and compaction.
+			close(wait)
+
+			wg.Wait()
+		})
+	}
+}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1875,3 +1875,66 @@ func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 		})
 	}
 }
+
+func TestHeadCompactionRace(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		t.Run(fmt.Sprintf("run %d", i), func(t *testing.T) {
+			tsdbCfg := &Options{
+				RetentionDuration: 100000000,
+				NoLockfile:        true,
+				MinBlockDuration:  1000000,
+				MaxBlockDuration:  1000000,
+			}
+
+			db, closer := openTestDB(t, tsdbCfg, []int64{1000000})
+			t.Cleanup(closer)
+			t.Cleanup(func() {
+				testutil.Ok(t, db.Close())
+			})
+
+			head := db.Head()
+
+			// Get past the init appender phase here.
+			app := head.Appender()
+			_, err := app.Add(labels.Labels{labels.Label{Name: "n", Value: "v"}}, 10, 10)
+			testutil.Ok(t, err)
+			testutil.Ok(t, app.Commit())
+
+			wait := make(chan struct{})
+			var wg sync.WaitGroup
+
+			// Prepare to execute concurrent appends.
+			wg.Add(100)
+			for i := 0; i < 100; i++ {
+				go func(idx int) {
+					defer wg.Done()
+					app := head.Appender()
+					<-wait
+
+					for j := 0; j < 100; j++ {
+						// After compaction this will return out of bound, so this is a best effort append.
+						app.Add(labels.Labels{labels.Label{
+							Name:  fmt.Sprintf("n%d", idx*100+j),
+							Value: fmt.Sprintf("v%d", idx*100+j),
+						}}, 1000, 10)
+					}
+
+					testutil.Ok(t, app.Commit())
+				}(i)
+			}
+
+			// Prepare for head compaction.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-wait
+				testutil.Ok(t, db.CompactHead(NewRangeHead(head, 0, 10000000)))
+			}()
+
+			// Run concurrent appends and compaction.
+			close(wait)
+
+			wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/7373

At this particular point here in compaction

https://github.com/prometheus/prometheus/blob/9875afc491983cc7462fef336ab1c6b67da45020/tsdb/compact.go#L702-L710

We are getting the postings first and then the symbols. If you see the fix, previously we were adding postings first and symbols later separately in the head, so there is a race here where we capture the new series in compaction and get the old symbols. In this fix, we just add the postings in the head only after capturing the symbols.

I have added the test to re-produce this and the unknown symbol error disappeared after this fix.

Interestingly, this test reproduces another bug which we have seen before - `unexpected error: persist head block: write compaction: add series: out-of-order series added with label set "{n414=\"v414\"}"` - which this PR does not fix and it leads to a flaky test. So, either I will fix it in the same PR if I find it, or remove the test and add it back when I have a fix for that.