### PR TITLE
Clarify error messaging when a rule group name is empty

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -68,7 +68,7 @@ func (g *RuleGroups) Validate(node ruleGroups) (errs []error) {
 
 	for j, g := range g.Groups {
 		if g.Name == "" {
-			errs = append(errs, errors.Errorf("%d:%d: Groupname should not be empty", node.Groups[j].Line, node.Groups[j].Column))
+			errs = append(errs, errors.Errorf("%d:%d: Groupname must not be empty", node.Groups[j].Line, node.Groups[j].Column))
 		}
 
 		if _, ok := set[g.Name]; ok {


### PR DESCRIPTION
As far as I can tell, without looking at the logs there's no way to see failures of loading rules files. It would be nice to have a metric for this so it can be alerted on. I noticed that it seems none of our `Manager` types have their own metrics, if that's by design let me know.

I also modified the wording of an error message, 'should' was being used in a case where it seems the word used should be 'must'. 

cc @gouthamve and @beorn7 since you've both modified this area most recently

Signed-off-by: Callum Styan <callumstyan@gmail.com>