### PR TITLE
Refactor dockerswarm refresh for testing

### DIFF
--- a/discovery/dockerswarm/nodes_test.go
+++ b/discovery/dockerswarm/nodes_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/util/testutil"
+	"gopkg.in/yaml.v2"
 )
 
 func TestDockerSwarmNodesSDRefresh(t *testing.T) {
@@ -28,14 +29,20 @@ func TestDockerSwarmNodesSDRefresh(t *testing.T) {
 	sdmock.Setup()
 
 	e := sdmock.Endpoint()
-	cfg := DefaultSDConfig
-	cfg.Host = e[:len(e)-1]
+	url := e[:len(e)-1]
+	cfgString := fmt.Sprintf(`
+---
+role: nodes
+host: %s
+`, url)
+	var cfg SDConfig
+	testutil.Ok(t, yaml.Unmarshal([]byte(cfgString), &cfg))
 
 	d, err := NewDiscovery(&cfg, log.NewNopLogger())
 	testutil.Ok(t, err)
 
 	ctx := context.Background()
-	tgs, err := d.refreshNodes(ctx)
+	tgs, err := d.refresh(ctx)
 	testutil.Ok(t, err)
 
 	testutil.Equals(t, 1, len(tgs))

--- a/discovery/dockerswarm/tasks_test.go
+++ b/discovery/dockerswarm/tasks_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/util/testutil"
+	"gopkg.in/yaml.v2"
 )
 
 func TestDockerSwarmTasksSDRefresh(t *testing.T) {
@@ -28,14 +29,20 @@ func TestDockerSwarmTasksSDRefresh(t *testing.T) {
 	sdmock.Setup()
 
 	e := sdmock.Endpoint()
-	cfg := DefaultSDConfig
-	cfg.Host = e[:len(e)-1]
+	url := e[:len(e)-1]
+	cfgString := fmt.Sprintf(`
+---
+role: tasks
+host: %s
+`, url)
+	var cfg SDConfig
+	testutil.Ok(t, yaml.Unmarshal([]byte(cfgString), &cfg))
 
 	d, err := NewDiscovery(&cfg, log.NewNopLogger())
 	testutil.Ok(t, err)
 
 	ctx := context.Background()
-	tgs, err := d.refreshTasks(ctx)
+	tgs, err := d.refresh(ctx)
 	testutil.Ok(t, err)
 
 	testutil.Equals(t, 1, len(tgs))


### PR DESCRIPTION
We were missing testing on the behaviour of the configuration
unmarshalling.

This PR adds a refresh command that can be used to test that we
use the correct refresh function.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->