### PR TITLE
Document that Clean Tombstones may need extra disk space

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -1006,7 +1006,7 @@ $ curl -X POST \
 *New in v2.1 and supports PUT from v2.9*
 
 ### Clean Tombstones
-CleanTombstones removes the deleted data from disk and cleans up the existing tombstones. This can be used after deleting series to free up space. This process involves rerwiting existing blocks that have tombstones which requires free disk space (upto double the used space if all blocks have tombstones).
+CleanTombstones removes the deleted data from disk and cleans up the existing tombstones. This can be used after deleting series to free up space. This process involves rewriting existing blocks that have tombstones (aka normal compaction). Note that like normal compaction, this requires some extra disk space (one more TSDB block maximum).
 
 If successful, a `204` is returned.
 

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -1006,7 +1006,7 @@ $ curl -X POST \
 *New in v2.1 and supports PUT from v2.9*
 
 ### Clean Tombstones
-CleanTombstones removes the deleted data from disk and cleans up the existing tombstones. This can be used after deleting series to free up space.
+CleanTombstones removes the deleted data from disk and cleans up the existing tombstones. This can be used after deleting series to free up space. This process involves rerwiting existing blocks that have tombstones which requires free disk space (upto double the used space if all blocks have tombstones).
 
 If successful, a `204` is returned.
 


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

For a process that is designed to reduce disk usage this I feel this is an important bit of information