### PR TITLE
no panic the head memseries has chunks in it

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2208,10 +2208,8 @@ func (s *memSeries) iterator(id int, isoState *isolationState, chunkDiskMapper *
 				previousSamples += int(d.numSamples)
 			}
 		}
-		// mmappedChunks does not contain the last chunk. Hence check it separately.
-		if len(s.mmappedChunks) < ix {
-			previousSamples += s.headChunk.chunk.NumSamples()
-		} else {
+
+		if s.headChunk != nil {
 			totalSamples += s.headChunk.chunk.NumSamples()
 		}
 


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/7548

I am now trying to figure out under what condition is this happening.

One theory is when the WAL is corrupted and loads series without any samples, but still unable to write a test that confirms this.