### PR TITLE
Change Scrape Loop mtx to Mutex

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -161,7 +161,7 @@ type scrapePool struct {
 	appendable storage.Appendable
 	logger     log.Logger
 
-	mtx    sync.RWMutex
+	mtx    sync.Mutex
 	config *config.ScrapeConfig
 	client *http.Client
 	// Targets and loops must always be synchronized to have the same
@@ -1188,7 +1188,7 @@ loop:
 		}
 
 		// Increment added even if there's an error so we correctly report the
-		// number of samples remaining after relabelling.
+		// number of samples remaining after relabeling.
 		added++
 
 	}


### PR DESCRIPTION
It was still RWLock but we never use the read lock..

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->