### PR TITLE
Add per scrape-config targets limit

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -373,8 +373,11 @@ type ScrapeConfig struct {
 	MetricsPath string `yaml:"metrics_path,omitempty"`
 	// The URL scheme with which to fetch metrics from targets.
 	Scheme string `yaml:"scheme,omitempty"`
-	// More than this many samples post metric-relabelling will cause the scrape to fail.
+	// More than this many samples post metric-relabeling will cause the scrape to fail.
 	SampleLimit uint `yaml:"sample_limit,omitempty"`
+	// More than this many targets after the relabeling phase will cause the
+	// scrapes to fail.
+	TargetLimit uint `yaml:"target_limit,omitempty"`
 
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.

--- a/config/config.go
+++ b/config/config.go
@@ -375,7 +375,7 @@ type ScrapeConfig struct {
 	Scheme string `yaml:"scheme,omitempty"`
 	// More than this many samples post metric-relabeling will cause the scrape to fail.
 	SampleLimit uint `yaml:"sample_limit,omitempty"`
-	// More than this many targets after the relabeling phase will cause the
+	// More than this many targets after the target relabeling will cause the
 	// scrapes to fail.
 	TargetLimit uint `yaml:"target_limit,omitempty"`
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -252,9 +252,15 @@ metric_relabel_configs:
   [ - <relabel_config> ... ]
 
 # Per-scrape limit on number of scraped samples that will be accepted.
-# If more than this number of samples are present after metric relabelling
+# If more than this number of samples are present after metric relabeling
 # the entire scrape will be treated as failed. 0 means no limit.
 [ sample_limit: <int> | default = 0 ]
+
+# Per-scrape config limit on number of unique targets that will be accepted.
+# If more than this number of targets are present after the relabeling phase,
+# Prometheus will mark the targets as failed without scraping them.
+# 0 means no limit.
+[ target_limit: <int> | default = 0 ]
 ```
 
 Where `<job_name>` must be unique across all scrape configurations.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -257,7 +257,7 @@ metric_relabel_configs:
 [ sample_limit: <int> | default = 0 ]
 
 # Per-scrape config limit on number of unique targets that will be
-# accepted. If more than this number of targets are present after the target
+# accepted. If more than this number of targets are present after target
 # relabeling, Prometheus will mark the targets as failed without scraping them.
 # 0 means no limit. This is an experimental feature, this behaviour could
 # change in the future.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -256,10 +256,11 @@ metric_relabel_configs:
 # the entire scrape will be treated as failed. 0 means no limit.
 [ sample_limit: <int> | default = 0 ]
 
-# Per-scrape config limit on number of unique targets that will be accepted.
-# If more than this number of targets are present after the relabeling phase,
-# Prometheus will mark the targets as failed without scraping them.
-# 0 means no limit.
+# Per-scrape config limit on number of unique targets that will be
+# accepted. If more than this number of targets are present after the target
+# relabeling, Prometheus will mark the targets as failed without scraping them.
+# 0 means no limit. This is an experimental feature, this behaviour could
+# change in the future.
 [ target_limit: <int> | default = 0 ]
 ```
 

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -259,6 +259,20 @@
               description: 'Prometheus %(prometheusName)s has missed {{ printf "%%.0f" $value }} rule group evaluations in the last 5m.' % $._config,
             },
           },
+          {
+            alert: 'PrometheusTargetLimitHit',
+            expr: |||
+              prometheus_target_scrape_pool_targets_added{%(prometheusSelector)s} > prometheus_target_scrape_pool_targets_added{%(prometheusSelector)s} > 0
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Prometheus job has hit the configured target_limit.',
+              description: 'Prometheus %(prometheusName)s has {{ printf "%%.0f" $value }} targets for the job {{ $labels.scrape_job }}, which is higher than the configured target_limit.' % $._config,
+            },
+          },
         ],
       },
     ],

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -269,7 +269,7 @@
               severity: 'warning',
             },
             annotations: {
-              summary: 'Prometheus has dropped targets because some jobs have exceeded the targets limit.',
+              summary: 'Prometheus has dropped targets because some scrape configs have exceeded the targets limit.',
               description: 'Prometheus %(prometheusName)s has dropped {{ printf "%%.0f" $value }} targets because the number of targets exceeded the configured target_limit.' % $._config,
             },
           },

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -262,15 +262,15 @@
           {
             alert: 'PrometheusTargetLimitHit',
             expr: |||
-              prometheus_target_scrape_pool_targets_added{%(prometheusSelector)s} > prometheus_target_scrape_pool_targets_added{%(prometheusSelector)s} > 0
+              increase(prometheus_target_scrape_pool_exceeded_target_limit_total{%(prometheusSelector)s}[5m]) > 0
             ||| % $._config,
             'for': '15m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              summary: 'Prometheus job has hit the configured target_limit.',
-              description: 'Prometheus %(prometheusName)s has {{ printf "%%.0f" $value }} targets for the job {{ $labels.scrape_job }}, which is higher than the configured target_limit.' % $._config,
+              summary: 'Prometheus has dropped targets because some jobs have exceeded the targets limit.',
+              description: 'Prometheus %(prometheusName)s has dropped {{ printf "%%.0f" $value }} targets because the number of targets exceeded the configured target_limit.' % $._config,
             },
           },
         ],

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -390,12 +390,13 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 // Sync converts target groups into actual scrape targets and synchronizes
 // the currently running scraper with the resulting set and returns all scraped and dropped targets.
 func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
+	sp.mtx.Lock()
+	defer sp.mtx.Unlock()
+
 	start := time.Now()
 
 	var all []*Target
-	sp.mtx.Lock()
 	sp.droppedTargets = []*Target{}
-	defer sp.mtx.Unlock()
 	for _, tg := range tgs {
 		targets, err := targetsFromGroup(tg, sp.config)
 		if err != nil {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -99,14 +99,14 @@ var (
 	targetScrapePoolTargetLimit = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "prometheus_target_scrape_pool_target_limit",
-			Help: "Maximum number of targets allowed for this scrape pool.",
+			Help: "Maximum number of targets allowed in this scrape pool.",
 		},
 		[]string{"scrape_job"},
 	)
 	targetScrapePoolTargetsAdded = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "prometheus_target_scrape_pool_targets_added",
-			Help: "Current number of targets actually added for this scrape pool.",
+			Name: "prometheus_target_scrape_pool_targets",
+			Help: "Current number of targets in this scrape pool.",
 		},
 		[]string{"scrape_job"},
 	)

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -506,7 +506,8 @@ func (sp *scrapePool) getForcedError() error {
 		return nil
 	}
 	var err error
-	if sp.targetLimitHit = l > int(sp.config.TargetLimit); sp.targetLimitHit {
+	sp.targetLimitHit = l > int(sp.config.TargetLimit)
+	if sp.targetLimitHit {
 		targetScrapePoolExceededTargetLimit.Inc()
 		err = fmt.Errorf("target_limit exceeded (number of targets: %d, limit: %d)", l, sp.config.TargetLimit)
 	}
@@ -1046,7 +1047,7 @@ func (sl *scrapeLoop) scrapeAndReport(interval, timeout time.Duration, last time
 	}()
 	if forcedErr := sl.getForcedError(); forcedErr != nil {
 		appErr = forcedErr
-		// Add stale markers
+		// Add stale markers.
 		if _, _, _, err := sl.append(app, []byte{}, "", start); err != nil {
 			app.Rollback()
 			app = sl.appender()

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -302,6 +302,13 @@ func (sp *scrapePool) stop() {
 	}
 	wg.Wait()
 	sp.client.CloseIdleConnections()
+
+	if sp.config != nil {
+		targetScrapePoolSyncsCounter.DeleteLabelValues(sp.config.JobName)
+		targetScrapePoolTargetLimit.DeleteLabelValues(sp.config.JobName)
+		targetScrapePoolTargetsAdded.DeleteLabelValues(sp.config.JobName)
+		targetSyncIntervalLength.DeleteLabelValues(sp.config.JobName)
+	}
 }
 
 // reload the scrape pool with the given scrape configuration. The target state is preserved

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -134,8 +134,10 @@ func TestDiscoveredLabelsUpdate(t *testing.T) {
 }
 
 type testLoop struct {
-	startFunc func(interval, timeout time.Duration, errc chan<- error)
-	stopFunc  func()
+	startFunc    func(interval, timeout time.Duration, errc chan<- error)
+	stopFunc     func()
+	forcedErr    error
+	forcedErrMtx sync.Mutex
 }
 
 func (l *testLoop) run(interval, timeout time.Duration, errc chan<- error) {
@@ -143,6 +145,18 @@ func (l *testLoop) run(interval, timeout time.Duration, errc chan<- error) {
 }
 
 func (l *testLoop) disableEndOfRunStalenessMarkers() {
+}
+
+func (l *testLoop) setForcedError(err error) {
+	l.forcedErrMtx.Lock()
+	defer l.forcedErrMtx.Unlock()
+	l.forcedErr = err
+}
+
+func (l *testLoop) getForcedError() error {
+	l.forcedErrMtx.Lock()
+	defer l.forcedErrMtx.Unlock()
+	return l.forcedErr
 }
 
 func (l *testLoop) stop() {
@@ -295,6 +309,92 @@ func TestScrapePoolReload(t *testing.T) {
 
 	testutil.Equals(t, sp.activeTargets, beforeTargets, "Reloading affected target states unexpectedly")
 	testutil.Equals(t, numTargets, len(sp.loops), "Unexpected number of stopped loops after reload")
+}
+
+func TestScrapePoolTargetLimit(t *testing.T) {
+	// On starting to run, new loops created on reload check whether their preceding
+	// equivalents have been stopped.
+	newLoop := func(opts scrapeLoopOptions) loop {
+		l := &testLoop{
+			startFunc: func(interval, timeout time.Duration, errc chan<- error) {},
+			stopFunc:  func() {},
+		}
+		return l
+	}
+	sp := &scrapePool{
+		appendable:    &nopAppendable{},
+		activeTargets: map[uint64]*Target{},
+		loops:         map[uint64]loop{},
+		newLoop:       newLoop,
+		logger:        nil,
+		client:        http.DefaultClient,
+	}
+
+	var tgs = []*targetgroup.Group{}
+	for i := 0; i < 50; i++ {
+		tgs = append(tgs,
+			&targetgroup.Group{
+				Targets: []model.LabelSet{
+					{model.AddressLabel: model.LabelValue(fmt.Sprintf("127.0.0.1:%d", 9090+i))},
+				},
+			},
+		)
+	}
+
+	var limit uint
+	reloadWithLimit := func(l uint) {
+		limit = l
+		testutil.Ok(t, sp.reload(&config.ScrapeConfig{
+			ScrapeInterval: model.Duration(3 * time.Second),
+			ScrapeTimeout:  model.Duration(2 * time.Second),
+			TargetLimit:    l,
+		}))
+	}
+
+	var targets int
+	loadTargets := func(n int) {
+		targets = n
+		sp.Sync(tgs[:n])
+	}
+
+	validateErrorMessage := func(shouldErr bool) {
+		for _, l := range sp.loops {
+			lerr := l.(*testLoop).getForcedError()
+			if shouldErr {
+				testutil.Assert(t, lerr != nil, "error was expected for %d targets with a limit of %d", targets, limit)
+				testutil.Equals(t, fmt.Sprintf("target_limit exceeded (number of targets: %d, limit: %d)", targets, limit), lerr.Error())
+			} else {
+				testutil.Equals(t, nil, lerr)
+			}
+		}
+	}
+
+	reloadWithLimit(0)
+	loadTargets(50)
+
+	// Simulate an initial config with a limit.
+	sp.config.TargetLimit = 30
+	limit = 30
+	loadTargets(50)
+	validateErrorMessage(true)
+
+	reloadWithLimit(50)
+	validateErrorMessage(false)
+
+	reloadWithLimit(40)
+	validateErrorMessage(true)
+
+	loadTargets(30)
+	validateErrorMessage(false)
+
+	loadTargets(40)
+	validateErrorMessage(false)
+
+	loadTargets(41)
+	validateErrorMessage(true)
+
+	reloadWithLimit(51)
+	validateErrorMessage(false)
 }
 
 func TestScrapePoolAppender(t *testing.T) {


### PR DESCRIPTION
Fix #7340

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->