### PR TITLE
Do not merge: Test showing race of compact vs append (with our reverted "fix")

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -656,7 +656,9 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 	defer func() {
 		var merr tsdb_errors.MultiError
 		merr.Add(err)
-		merr.Add(closeAll(closers))
+		if cerr := closeAll(closers); cerr != nil {
+			merr.Add(errors.Wrap(err, "close"))
+		}
 		err = merr.Err()
 		c.metrics.populatingBlocks.Set(0)
 	}()
@@ -708,7 +710,6 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 
 		s := newCompactionSeriesSet(indexr, chunkr, tombsr, all)
 		syms := indexr.Symbols()
-
 		if i == 0 {
 			set = s
 			symbols = syms


### PR DESCRIPTION
This is showcasing why our initial fix was not working: https://github.com/prometheus/prometheus/issues/7373 

Reproducing: https://github.com/prometheus/prometheus/issues/7373

cc @codesome 

Had to have this test without those hacks.. wonder if we can modify code to allow mocking for this :thinking: 

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

