### PR TITLE
Fixed race between compact (gc, populate) and head append causing unknown symbol error.

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -656,7 +656,9 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 	defer func() {
 		var merr tsdb_errors.MultiError
 		merr.Add(err)
-		merr.Add(closeAll(closers))
+		if cerr := closeAll(closers); cerr != nil {
+			merr.Add(errors.Wrap(err, "close"))
+		}
 		err = merr.Err()
 		c.metrics.populatingBlocks.Set(0)
 	}()
@@ -708,7 +710,6 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 
 		s := newCompactionSeriesSet(indexr, chunkr, tombsr, all)
 		syms := indexr.Symbols()
-
 		if i == 0 {
 			set = s
 			symbols = syms

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -657,7 +657,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		var merr tsdb_errors.MultiError
 		merr.Add(err)
 		if cerr := closeAll(closers); cerr != nil {
-			merr.Add(errors.Wrap(err, "close"))
+			merr.Add(errors.Wrap(cerr, "close"))
 		}
 		err = merr.Err()
 		c.metrics.populatingBlocks.Set(0)


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/7373

Hopefully improved version of https://github.com/prometheus/prometheus/pull/7556
Why https://github.com/prometheus/prometheus/pull/7556 was not working is explained here: https://github.com/prometheus/prometheus/pull/7559

@codesome feel free to use this `branch` to test yourself things. It would be nice to add some test, but it's kind of impossible unless we rewrite things allowing better race mocks.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

