### PR TITLE
Use the same appender for scrape and report

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -612,7 +612,7 @@ func TestScrapeLoopMetadata(t *testing.T) {
 	)
 	defer cancel()
 
-	total, _, _, err := sl.append([]byte(`# TYPE test_metric counter
+	total, _, _, _, err := sl.append([]byte(`# TYPE test_metric counter
 # HELP test_metric some help text
 # UNIT test_metric metric
 test_metric 1
@@ -661,13 +661,13 @@ func TestScrapeLoopSeriesAdded(t *testing.T) {
 	)
 	defer cancel()
 
-	total, added, seriesAdded, err := sl.append([]byte("test_metric 1\n"), "", time.Time{})
+	total, added, seriesAdded, _, err := sl.append([]byte("test_metric 1\n"), "", time.Time{})
 	testutil.Ok(t, err)
 	testutil.Equals(t, 1, total)
 	testutil.Equals(t, 1, added)
 	testutil.Equals(t, 1, seriesAdded)
 
-	total, added, seriesAdded, err = sl.append([]byte("test_metric 1\n"), "", time.Time{})
+	total, added, seriesAdded, _, err = sl.append([]byte("test_metric 1\n"), "", time.Time{})
 	testutil.Ok(t, err)
 	testutil.Equals(t, 1, total)
 	testutil.Equals(t, 1, added)
@@ -854,9 +854,7 @@ func TestScrapeLoopCache(t *testing.T) {
 
 	// 1 successfully scraped sample, 1 stale marker after first fail, 5 report samples for
 	// each scrape successful or not.
-	if len(appender.result) != 26 {
-		t.Fatalf("Appended samples not as expected. Wanted: %d samples Got: %d", 26, len(appender.result))
-	}
+	testutil.Equals(t, 26, len(appender.result), "Appended samples not as expected")
 }
 
 func TestScrapeLoopCacheMemoryExhaustionProtection(t *testing.T) {
@@ -992,8 +990,9 @@ func TestScrapeLoopAppend(t *testing.T) {
 
 		now := time.Now()
 
-		_, _, _, err := sl.append([]byte(test.scrapeLabels), "", now)
+		_, _, _, slApp, err := sl.append([]byte(test.scrapeLabels), "", now)
 		testutil.Ok(t, err)
+		testutil.Ok(t, slApp.Commit())
 
 		expected := []sample{
 			{
@@ -1043,8 +1042,9 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 	sl.cache.addRef(mets, fakeRef, lset, hash)
 	now := time.Now()
 
-	_, _, _, err := sl.append([]byte(metric), "", now)
+	_, _, _, slApp, err := sl.append([]byte(metric), "", now)
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 
 	expected := []sample{
 		{
@@ -1084,7 +1084,7 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 	beforeMetricValue := beforeMetric.GetCounter().GetValue()
 
 	now := time.Now()
-	total, added, seriesAdded, err := sl.append([]byte("metric_a 1\nmetric_b 1\nmetric_c 1\n"), "", now)
+	total, added, seriesAdded, slApp, err := sl.append([]byte("metric_a 1\nmetric_b 1\nmetric_c 1\n"), "", now)
 	if err != errSampleLimit {
 		t.Fatalf("Did not see expected sample limit error: %s", err)
 	}
@@ -1110,10 +1110,11 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 			v:      1,
 		},
 	}
-	testutil.Equals(t, want, resApp.result, "Appended samples not as expected")
+	testutil.Equals(t, want, resApp.tmpresult, "Appended samples not as expected")
+	testutil.Ok(t, slApp.Rollback())
 
 	now = time.Now()
-	total, added, seriesAdded, err = sl.append([]byte("metric_a 1\nmetric_b 1\nmetric_c{deleteme=\"yes\"} 1\nmetric_d 1\nmetric_e 1\nmetric_f 1\nmetric_g 1\nmetric_h{deleteme=\"yes\"} 1\nmetric_i{deleteme=\"yes\"} 1\n"), "", now)
+	total, added, seriesAdded, _, err = sl.append([]byte("metric_a 1\nmetric_b 1\nmetric_c{deleteme=\"yes\"} 1\nmetric_d 1\nmetric_e 1\nmetric_f 1\nmetric_g 1\nmetric_h{deleteme=\"yes\"} 1\nmetric_i{deleteme=\"yes\"} 1\n"), "", now)
 	if err != errSampleLimit {
 		t.Fatalf("Did not see expected sample limit error: %s", err)
 	}
@@ -1144,11 +1145,13 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 	)
 
 	now := time.Now()
-	_, _, _, err := sl.append([]byte(`metric_a{a="1",b="1"} 1`), "", now)
+	_, _, _, slApp, err := sl.append([]byte(`metric_a{a="1",b="1"} 1`), "", now)
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 
-	_, _, _, err = sl.append([]byte(`metric_a{b="1",a="1"} 2`), "", now.Add(time.Minute))
+	_, _, _, slApp, err = sl.append([]byte(`metric_a{b="1",a="1"} 2`), "", now.Add(time.Minute))
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 
 	// DeepEqual will report NaNs as being different, so replace with a different value.
 	want := []sample{
@@ -1180,11 +1183,13 @@ func TestScrapeLoopAppendStaleness(t *testing.T) {
 	)
 
 	now := time.Now()
-	_, _, _, err := sl.append([]byte("metric_a 1\n"), "", now)
+	_, _, _, slApp, err := sl.append([]byte("metric_a 1\n"), "", now)
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 
-	_, _, _, err = sl.append([]byte(""), "", now.Add(time.Second))
+	_, _, _, slApp, err = sl.append([]byte(""), "", now.Add(time.Second))
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 
 	ingestedNaN := math.Float64bits(app.result[1].v)
 	testutil.Equals(t, value.StaleNaN, ingestedNaN, "Appended stale sample wasn't as expected")
@@ -1219,11 +1224,13 @@ func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
 	)
 
 	now := time.Now()
-	_, _, _, err := sl.append([]byte("metric_a 1 1000\n"), "", now)
+	_, _, _, slApp, err := sl.append([]byte("metric_a 1 1000\n"), "", now)
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 
-	_, _, _, err = sl.append([]byte(""), "", now.Add(time.Second))
+	_, _, _, slApp, err = sl.append([]byte(""), "", now.Add(time.Second))
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 
 	want := []sample{
 		{
@@ -1328,8 +1335,9 @@ func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T
 	)
 
 	now := time.Unix(1, 0)
-	total, added, seriesAdded, err := sl.append([]byte("out_of_order 1\namend 1\nnormal 1\nout_of_bounds 1\n"), "", now)
+	total, added, seriesAdded, slApp, err := sl.append([]byte("out_of_order 1\namend 1\nnormal 1\nout_of_bounds 1\n"), "", now)
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 
 	want := []sample{
 		{
@@ -1363,12 +1371,13 @@ func TestScrapeLoopOutOfBoundsTimeError(t *testing.T) {
 	)
 
 	now := time.Now().Add(20 * time.Minute)
-	total, added, seriesAdded, err := sl.append([]byte("normal 1\n"), "", now)
+	total, added, seriesAdded, slApp, err := sl.append([]byte("normal 1\n"), "", now)
+	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 	testutil.Equals(t, 1, total)
 	testutil.Equals(t, 1, added)
 	testutil.Equals(t, 0, seriesAdded)
 
-	testutil.Ok(t, err)
 }
 
 func TestTargetScraperScrapeOK(t *testing.T) {
@@ -1548,8 +1557,9 @@ func TestScrapeLoop_RespectTimestamps(t *testing.T) {
 	)
 
 	now := time.Now()
-	_, _, _, err := sl.append([]byte(`metric_a{a="1",b="1"} 1 0`), "", now)
+	_, _, _, slApp, err := sl.append([]byte(`metric_a{a="1",b="1"} 1 0`), "", now)
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 
 	want := []sample{
 		{
@@ -1579,8 +1589,9 @@ func TestScrapeLoop_DiscardTimestamps(t *testing.T) {
 	)
 
 	now := time.Now()
-	_, _, _, err := sl.append([]byte(`metric_a{a="1",b="1"} 1 0`), "", now)
+	_, _, _, slApp, err := sl.append([]byte(`metric_a{a="1",b="1"} 1 0`), "", now)
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 
 	want := []sample{
 		{
@@ -1612,8 +1623,9 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 	defer cancel()
 
 	// We add a good and a bad metric to check that both are discarded.
-	_, _, _, err := sl.append([]byte("test_metric{le=\"500\"} 1\ntest_metric{le=\"600\",le=\"700\"} 1\n"), "", time.Time{})
+	_, _, _, slApp, err := sl.append([]byte("test_metric{le=\"500\"} 1\ntest_metric{le=\"600\",le=\"700\"} 1\n"), "", time.Time{})
 	testutil.NotOk(t, err)
+	testutil.Ok(t, slApp.Rollback())
 
 	q, err := s.Querier(ctx, time.Time{}.UnixNano(), 0)
 	testutil.Ok(t, err)
@@ -1622,8 +1634,9 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 	testutil.Ok(t, series.Err())
 
 	// We add a good metric to check that it is recorded.
-	_, _, _, err = sl.append([]byte("test_metric{le=\"500\"} 1\n"), "", time.Time{})
+	_, _, _, slApp, err = sl.append([]byte("test_metric{le=\"500\"} 1\n"), "", time.Time{})
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 
 	q, err = s.Querier(ctx, time.Time{}.UnixNano(), 0)
 	testutil.Ok(t, err)
@@ -1657,8 +1670,9 @@ func TestScrapeLoopDiscardUnnamedMetrics(t *testing.T) {
 	)
 	defer cancel()
 
-	_, _, _, err := sl.append([]byte("nok 1\nnok2{drop=\"drop\"} 1\n"), "", time.Time{})
+	_, _, _, slApp, err := sl.append([]byte("nok 1\nnok2{drop=\"drop\"} 1\n"), "", time.Time{})
 	testutil.NotOk(t, err)
+	testutil.Ok(t, slApp.Rollback())
 	testutil.Equals(t, errNameLabelMandatory, err)
 
 	q, err := s.Querier(ctx, time.Time{}.UnixNano(), 0)
@@ -1873,8 +1887,9 @@ func TestScrapeAddFast(t *testing.T) {
 	)
 	defer cancel()
 
-	_, _, _, err := sl.append([]byte("up 1\n"), "", time.Time{})
+	_, _, _, slApp, err := sl.append([]byte("up 1\n"), "", time.Time{})
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 
 	// Poison the cache. There is just one entry, and one series in the
 	// storage. Changing the ref will create a 'not found' error.
@@ -1882,8 +1897,9 @@ func TestScrapeAddFast(t *testing.T) {
 		v.ref++
 	}
 
-	_, _, _, err = sl.append([]byte("up 1\n"), "", time.Time{}.Add(time.Second))
+	_, _, _, slApp, err = sl.append([]byte("up 1\n"), "", time.Time{}.Add(time.Second))
 	testutil.Ok(t, err)
+	testutil.Ok(t, slApp.Commit())
 }
 
 func TestReuseCacheRace(t *testing.T) {


### PR DESCRIPTION
Attempt to fix  #7085 
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->