### PR TITLE
Make discovery independent of the azure dependencies

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -52,6 +52,8 @@ import (
 	promlogflag "github.com/prometheus/common/promlog/flag"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
+
+	_ "github.com/prometheus/prometheus/discovery/azure"
 	sd_config "github.com/prometheus/prometheus/discovery/config"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/pkg/labels"

--- a/discovery/azure/config/config.go
+++ b/discovery/azure/config/config.go
@@ -1,0 +1,85 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	AuthMethodOAuth           = "OAuth"
+	AuthMethodManagedIdentity = "ManagedIdentity"
+)
+
+// DefaultSDConfig is the default Azure SD configuration.
+var DefaultSDConfig = SDConfig{
+	Port:                 80,
+	RefreshInterval:      model.Duration(5 * time.Minute),
+	AuthenticationMethod: AuthMethodOAuth,
+}
+
+// SDConfig is the configuration for Azure based service discovery.
+type SDConfig struct {
+	Environment          string             `yaml:"environment,omitempty"`
+	Port                 int                `yaml:"port"`
+	SubscriptionID       string             `yaml:"subscription_id"`
+	TenantID             string             `yaml:"tenant_id,omitempty"`
+	ClientID             string             `yaml:"client_id,omitempty"`
+	ClientSecret         config_util.Secret `yaml:"client_secret,omitempty"`
+	RefreshInterval      model.Duration     `yaml:"refresh_interval,omitempty"`
+	AuthenticationMethod string             `yaml:"authentication_method,omitempty"`
+}
+
+func validateAuthParam(param, name string) error {
+	if len(param) == 0 {
+		return errors.Errorf("azure SD configuration requires a %s", name)
+	}
+	return nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultSDConfig
+	type plain SDConfig
+	err := unmarshal((*plain)(c))
+	if err != nil {
+		return err
+	}
+
+	if err = validateAuthParam(c.SubscriptionID, "subscription_id"); err != nil {
+		return err
+	}
+
+	if c.AuthenticationMethod == AuthMethodOAuth {
+		if err = validateAuthParam(c.TenantID, "tenant_id"); err != nil {
+			return err
+		}
+		if err = validateAuthParam(c.ClientID, "client_id"); err != nil {
+			return err
+		}
+		if err = validateAuthParam(string(c.ClientSecret), "client_secret"); err != nil {
+			return err
+		}
+	}
+
+	if c.AuthenticationMethod != AuthMethodOAuth && c.AuthenticationMethod != AuthMethodManagedIdentity {
+		return errors.Errorf("unknown authentication_type %q. Supported types are %q or %q", c.AuthenticationMethod, AuthMethodOAuth, AuthMethodManagedIdentity)
+	}
+
+	return nil
+}

--- a/discovery/config/config.go
+++ b/discovery/config/config.go
@@ -16,7 +16,7 @@ package config
 import (
 	"github.com/pkg/errors"
 
-	"github.com/prometheus/prometheus/discovery/azure"
+	azure "github.com/prometheus/prometheus/discovery/azure/config"
 	"github.com/prometheus/prometheus/discovery/consul"
 	"github.com/prometheus/prometheus/discovery/digitalocean"
 	"github.com/prometheus/prometheus/discovery/dns"


### PR DESCRIPTION
For #7107

@bwplotka what do you think of this approach?

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->