### PR TITLE
Add release shepherds for 2.21 and 2.22

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,7 +25,9 @@ Release cadence of first pre-releases being cut is 6 weeks.
 | v2.18          | 2020-04-22                                 | Bartek Plotka (GitHub: @bwplotka)           |
 | v2.19          | 2020-06-03                                 | Ganesh Vernekar (GitHub: @codesome)         |
 | v2.20          | 2020-07-15                                 | Björn Rabenstein (GitHub: @beorn7)          |
-| v2.21          | 2020-08-26                                 | **searching for volunteer**                 |
+| v2.21          | 2020-08-26                                 | Julien Pivotto (GitHub: @roidelapluie)      |
+| v2.22          | 2020-10-07                                 | Frederic Branczyk (GitHub: @brancz)         |
+| v2.23          | 2020-11-18                                 | **searching for volunteer**                 |
 
 If you are interested in volunteering please create a pull request against the [prometheus/prometheus](https://github.com/prometheus/prometheus) repository and propose yourself for the release series of your choice.
 


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->