### PR TITLE
TSDB: Error when we commit/rollback twice

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -521,7 +521,6 @@ func TestDB_Snapshot(t *testing.T) {
 		testutil.Ok(t, err)
 	}
 	testutil.Ok(t, app.Commit())
-	testutil.Ok(t, app.Rollback())
 
 	// create snapshot
 	snap, err := ioutil.TempDir("", "snap")
@@ -571,7 +570,6 @@ func TestDB_Snapshot_ChunksOutsideOfCompactedRange(t *testing.T) {
 		testutil.Ok(t, err)
 	}
 	testutil.Ok(t, app.Commit())
-	testutil.Ok(t, app.Rollback())
 
 	snap, err := ioutil.TempDir("", "snap")
 	testutil.Ok(t, err)
@@ -939,10 +937,14 @@ func TestWALSegmentSizeOptions(t *testing.T) {
 			opts.WALSegmentSize = segmentSize
 			db := openTestDB(t, opts, nil)
 
-			app := db.Appender()
 			for i := int64(0); i < 155; i++ {
-				_, err := app.Add(labels.Labels{labels.Label{Name: "wal", Value: "size"}}, i, rand.Float64())
+				app := db.Appender()
+				ref, err := app.Add(labels.Labels{labels.Label{Name: "wal" + fmt.Sprintf("%d", i), Value: "size"}}, i, rand.Float64())
 				testutil.Ok(t, err)
+				for j := int64(1); j <= 78; j++ {
+					err := app.AddFast(ref, i+j, rand.Float64())
+					testutil.Ok(t, err)
+				}
 				testutil.Ok(t, app.Commit())
 			}
 
@@ -2325,6 +2327,7 @@ func TestBlockRanges(t *testing.T) {
 
 	// Test that wal records are skipped when an existing block covers the same time ranges
 	// and compaction doesn't create an overlapping block.
+	app = db.Appender()
 	db.DisableCompactions()
 	_, err = app.Add(lbl, secondBlockMaxt+1, rand.Float64())
 	testutil.Ok(t, err)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1852,3 +1852,39 @@ func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 		})
 	}
 }
+
+func TestErrReuseAppender(t *testing.T) {
+	head, _ := newTestHead(t, 1000, false)
+	defer func() {
+		testutil.Ok(t, head.Close())
+	}()
+
+	app := head.Appender()
+	_, err := app.Add(labels.Labels{{Name: "test", Value: "test"}}, 0, 0)
+	testutil.Ok(t, err)
+	testutil.Ok(t, app.Commit())
+	testutil.NotOk(t, app.Commit())
+	testutil.NotOk(t, app.Rollback())
+
+	app = head.Appender()
+	_, err = app.Add(labels.Labels{{Name: "test", Value: "test"}}, 1, 0)
+	testutil.Ok(t, err)
+	testutil.Ok(t, app.Rollback())
+	testutil.NotOk(t, app.Rollback())
+	testutil.NotOk(t, app.Commit())
+	app = head.Appender()
+
+	app = head.Appender()
+	_, err = app.Add(labels.Labels{{Name: "test", Value: "test"}}, 2, 0)
+	testutil.Ok(t, err)
+	testutil.Ok(t, app.Commit())
+	testutil.NotOk(t, app.Rollback())
+	testutil.NotOk(t, app.Commit())
+	app = head.Appender()
+
+	_, err = app.Add(labels.Labels{{Name: "test", Value: "test"}}, 3, 0)
+	testutil.Ok(t, err)
+	testutil.Ok(t, app.Rollback())
+	testutil.NotOk(t, app.Commit())
+	testutil.NotOk(t, app.Rollback())
+}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1872,7 +1872,6 @@ func TestErrReuseAppender(t *testing.T) {
 	testutil.Ok(t, app.Rollback())
 	testutil.NotOk(t, app.Rollback())
 	testutil.NotOk(t, app.Commit())
-	app = head.Appender()
 
 	app = head.Appender()
 	_, err = app.Add(labels.Labels{{Name: "test", Value: "test"}}, 2, 0)
@@ -1880,8 +1879,8 @@ func TestErrReuseAppender(t *testing.T) {
 	testutil.Ok(t, app.Commit())
 	testutil.NotOk(t, app.Rollback())
 	testutil.NotOk(t, app.Commit())
-	app = head.Appender()
 
+	app = head.Appender()
 	_, err = app.Add(labels.Labels{{Name: "test", Value: "test"}}, 3, 0)
 	testutil.Ok(t, err)
 	testutil.Ok(t, app.Rollback())


### PR DESCRIPTION
Gathering feedback from TSDB people about this one. It looks like you can Commit or Rollback multiple times the same appender, which at least breaks isolation.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->