### PR TITLE
scrape tests: Make appenders more realistic

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -648,15 +648,13 @@ func TestScrapeLoopSeriesAdded(t *testing.T) {
 	s := teststorage.New(t)
 	defer s.Close()
 
-	app := s.Appender()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	sl := newScrapeLoop(ctx,
 		&testScraper{},
 		nil, nil,
 		nopMutator,
 		nopMutator,
-		func() storage.Appender { return app },
+		s.Appender,
 		nil,
 		0,
 		true,
@@ -793,13 +791,11 @@ func TestScrapeLoopCache(t *testing.T) {
 	s := teststorage.New(t)
 	defer s.Close()
 
-	sapp := s.Appender()
-
-	appender := &collectResultAppender{next: sapp}
+	appender := &collectResultAppender{}
 	var (
 		signal  = make(chan struct{}, 1)
 		scraper = &testScraper{}
-		app     = func() storage.Appender { return appender }
+		app     = func() storage.Appender { appender.next = s.Appender(); return appender }
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1141,15 +1137,13 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 	s := teststorage.New(t)
 	defer s.Close()
 
-	app := s.Appender()
-
-	capp := &collectResultAppender{next: app}
+	capp := &collectResultAppender{}
 
 	sl := newScrapeLoop(context.Background(),
 		nil, nil, nil,
 		nopMutator,
 		nopMutator,
-		func() storage.Appender { return capp },
+		func() storage.Appender { capp.next = s.Appender(); return capp },
 		nil,
 		0,
 		true,
@@ -1628,15 +1622,13 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 	s := teststorage.New(t)
 	defer s.Close()
 
-	app := s.Appender()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	sl := newScrapeLoop(ctx,
 		&testScraper{},
 		nil, nil,
 		nopMutator,
 		nopMutator,
-		func() storage.Appender { return app },
+		s.Appender,
 		nil,
 		0,
 		true,
@@ -1896,15 +1888,13 @@ func TestScrapeAddFast(t *testing.T) {
 	s := teststorage.New(t)
 	defer s.Close()
 
-	app := s.Appender()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	sl := newScrapeLoop(ctx,
 		&testScraper{},
 		nil, nil,
 		nopMutator,
 		nopMutator,
-		func() storage.Appender { return app },
+		s.Appender,
 		nil,
 		0,
 		true,


### PR DESCRIPTION
With this, the storage tests inside the scrape package are more
realistic.

Discovered with #7593, but fixed independently as #7593 will probably
take some time.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->