### PR TITLE
Fix incorrect arguments order in TestExprString

### DIFF
--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -100,6 +100,6 @@ func TestExprString(t *testing.T) {
 			exp = test.out
 		}
 
-		testutil.Equals(t, expr.String(), exp)
+		testutil.Equals(t, exp, expr.String())
 	}
 }


### PR DESCRIPTION
Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>