### PR TITLE
Improve docker swarm configuration exemple

### DIFF
--- a/documentation/examples/prometheus-dockerswarm.yml
+++ b/documentation/examples/prometheus-dockerswarm.yml
@@ -1,15 +1,5 @@
 # A example scrape configuration for running Prometheus with
 # Docker Swarm.
-#
-# This example works with cadvisor deployed with:
-# docker service create --name cadvisor -l prometheus-job=cadvisor
-#     --mode=global --publish published=8080,target=8080,mode=host
-#     --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,ro
-#     --mount type=bind,src=/,dst=/rootfs,ro
-#     --mount type=bind,src=/var/run,dst=/var/run
-#     --mount type=bind,src=/sys,dst=/sys,ro
-#     --mount type=bind,src=/var/lib/docker,dst=/var/lib/docker,ro
-#     google/cadvisor -docker_only
 
 scrape_configs:
 
@@ -18,10 +8,35 @@ scrape_configs:
     static_configs:
     - targets: ['localhost:9090']
 
+  # Create a job for Docker daemons.
+  #
+  # This exemple requires Docker daemons to be configured to expose
+  # Prometheus metrics, as documented here:
+  # https://docs.docker.com/config/daemon/prometheus/
+  - job_name: 'docker'
+    dockerswarm_sd_configs:
+      - host: unix:///var/run/docker.sock # You can also use http/https to connect to the Docker daemon.
+        role: nodes
+    relabel_configs:
+      # Fetch metrics on port 9323.
+      - source_labels: [__meta_dockerswarm_node_address]
+        target_label: __address__
+        replacement: $1:9323
+
   # Create a job for Docker Swarm containers.
+  #
+  # This example works with cadvisor deployed with:
+  # docker service create --name cadvisor -l prometheus-job=cadvisor
+  #     --mode=global --publish published=8080,target=8080,mode=host
+  #     --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,ro
+  #     --mount type=bind,src=/,dst=/rootfs,ro
+  #     --mount type=bind,src=/var/run,dst=/var/run
+  #     --mount type=bind,src=/sys,dst=/sys,ro
+  #     --mount type=bind,src=/var/lib/docker,dst=/var/lib/docker,ro
+  #     google/cadvisor -docker_only
   - job_name: 'dockerswarm'
     dockerswarm_sd_configs:
-      - host: http://127.0.0.1:2375
+      - host: unix:///var/run/docker.sock # You can also use http/https to connect to the Docker daemon.
         role: tasks
     relabel_configs:
       # Only keep containers that should be running.


### PR DESCRIPTION
Improve to use the unix socket as this is what is enabled by default. Also fetch metrics from docker daemons.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->