### PR TITLE
Add {min,max}_over_time_last_timestamp

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -384,7 +384,6 @@ func funcCountOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNo
 	})
 }
 
-// === floor(Vector parser.ValueTypeVector) Vector ===
 // === max_over_time(Matrix parser.ValueTypeMatrix) Vector ===
 func funcMaxOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	return aggrOverTime(vals, enh, func(values []Point) float64 {
@@ -398,6 +397,21 @@ func funcMaxOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 	})
 }
 
+// === max_over_time_last_timestamp(Matrix parser.ValueTypeMatrix) Vector ===
+func funcMaxOverTimeLastTimestamp(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		max := values[0].V
+		maxTime := values[0].T
+		for _, v := range values {
+			if v.V >= max || math.IsNaN(max) {
+				max = v.V
+				maxTime = v.T
+			}
+		}
+		return float64(maxTime) / 1000
+	})
+}
+
 // === min_over_time(Matrix parser.ValueTypeMatrix) Vector ===
 func funcMinOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	return aggrOverTime(vals, enh, func(values []Point) float64 {
@@ -408,6 +422,21 @@ func funcMinOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 			}
 		}
 		return min
+	})
+}
+
+// === min_over_time_last_timestamp(Matrix parser.ValueTypeMatrix) Vector ===
+func funcMinOverTimeLastTimestamp(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		min := values[0].V
+		minTime := values[0].T
+		for _, v := range values {
+			if v.V <= min || math.IsNaN(min) {
+				min = v.V
+				minTime = v.T
+			}
+		}
+		return float64(minTime) / 1000
 	})
 }
 
@@ -889,53 +918,55 @@ func funcYear(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper)
 
 // FunctionCalls is a list of all functions supported by PromQL, including their types.
 var FunctionCalls = map[string]FunctionCall{
-	"abs":                funcAbs,
-	"absent":             funcAbsent,
-	"absent_over_time":   funcAbsentOverTime,
-	"avg_over_time":      funcAvgOverTime,
-	"ceil":               funcCeil,
-	"changes":            funcChanges,
-	"clamp_max":          funcClampMax,
-	"clamp_min":          funcClampMin,
-	"count_over_time":    funcCountOverTime,
-	"days_in_month":      funcDaysInMonth,
-	"day_of_month":       funcDayOfMonth,
-	"day_of_week":        funcDayOfWeek,
-	"delta":              funcDelta,
-	"deriv":              funcDeriv,
-	"exp":                funcExp,
-	"floor":              funcFloor,
-	"histogram_quantile": funcHistogramQuantile,
-	"holt_winters":       funcHoltWinters,
-	"hour":               funcHour,
-	"idelta":             funcIdelta,
-	"increase":           funcIncrease,
-	"irate":              funcIrate,
-	"label_replace":      funcLabelReplace,
-	"label_join":         funcLabelJoin,
-	"ln":                 funcLn,
-	"log10":              funcLog10,
-	"log2":               funcLog2,
-	"max_over_time":      funcMaxOverTime,
-	"min_over_time":      funcMinOverTime,
-	"minute":             funcMinute,
-	"month":              funcMonth,
-	"predict_linear":     funcPredictLinear,
-	"quantile_over_time": funcQuantileOverTime,
-	"rate":               funcRate,
-	"resets":             funcResets,
-	"round":              funcRound,
-	"scalar":             funcScalar,
-	"sort":               funcSort,
-	"sort_desc":          funcSortDesc,
-	"sqrt":               funcSqrt,
-	"stddev_over_time":   funcStddevOverTime,
-	"stdvar_over_time":   funcStdvarOverTime,
-	"sum_over_time":      funcSumOverTime,
-	"time":               funcTime,
-	"timestamp":          funcTimestamp,
-	"vector":             funcVector,
-	"year":               funcYear,
+	"abs":                          funcAbs,
+	"absent":                       funcAbsent,
+	"absent_over_time":             funcAbsentOverTime,
+	"avg_over_time":                funcAvgOverTime,
+	"ceil":                         funcCeil,
+	"changes":                      funcChanges,
+	"clamp_max":                    funcClampMax,
+	"clamp_min":                    funcClampMin,
+	"count_over_time":              funcCountOverTime,
+	"days_in_month":                funcDaysInMonth,
+	"day_of_month":                 funcDayOfMonth,
+	"day_of_week":                  funcDayOfWeek,
+	"delta":                        funcDelta,
+	"deriv":                        funcDeriv,
+	"exp":                          funcExp,
+	"floor":                        funcFloor,
+	"histogram_quantile":           funcHistogramQuantile,
+	"holt_winters":                 funcHoltWinters,
+	"hour":                         funcHour,
+	"idelta":                       funcIdelta,
+	"increase":                     funcIncrease,
+	"irate":                        funcIrate,
+	"label_replace":                funcLabelReplace,
+	"label_join":                   funcLabelJoin,
+	"ln":                           funcLn,
+	"log10":                        funcLog10,
+	"log2":                         funcLog2,
+	"max_over_time":                funcMaxOverTime,
+	"max_over_time_last_timestamp": funcMaxOverTimeLastTimestamp,
+	"min_over_time":                funcMinOverTime,
+	"min_over_time_last_timestamp": funcMinOverTimeLastTimestamp,
+	"minute":                       funcMinute,
+	"month":                        funcMonth,
+	"predict_linear":               funcPredictLinear,
+	"quantile_over_time":           funcQuantileOverTime,
+	"rate":                         funcRate,
+	"resets":                       funcResets,
+	"round":                        funcRound,
+	"scalar":                       funcScalar,
+	"sort":                         funcSort,
+	"sort_desc":                    funcSortDesc,
+	"sqrt":                         funcSqrt,
+	"stddev_over_time":             funcStddevOverTime,
+	"stdvar_over_time":             funcStdvarOverTime,
+	"sum_over_time":                funcSumOverTime,
+	"time":                         funcTime,
+	"timestamp":                    funcTimestamp,
+	"vector":                       funcVector,
+	"year":                         funcYear,
 }
 
 type vectorByValueHeap Vector

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -404,8 +404,10 @@ func funcMaxOverTimeLastTimestamp(vals []parser.Value, args parser.Expressions, 
 		maxTime := values[0].T
 		for _, v := range values {
 			if v.V >= max || math.IsNaN(max) {
+				if v.T > maxTime || v.V > max {
+					maxTime = v.T
+				}
 				max = v.V
-				maxTime = v.T
 			}
 		}
 		return float64(maxTime) / 1000
@@ -432,8 +434,10 @@ func funcMinOverTimeLastTimestamp(vals []parser.Value, args parser.Expressions, 
 		minTime := values[0].T
 		for _, v := range values {
 			if v.V <= min || math.IsNaN(min) {
+				if v.T > minTime || v.V < min {
+					minTime = v.T
+				}
 				min = v.V
-				minTime = v.T
 			}
 		}
 		return float64(minTime) / 1000

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -169,8 +169,18 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeMatrix},
 		ReturnType: ValueTypeVector,
 	},
+	"max_over_time_last_timestamp": {
+		Name:       "max_over_time_last_timestamp",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+	},
 	"min_over_time": {
 		Name:       "min_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+	},
+	"min_over_time_last_timestamp": {
+		Name:       "min_over_time_last_timestamp",
 		ArgTypes:   []ValueType{ValueTypeMatrix},
 		ReturnType: ValueTypeVector,
 	},

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -734,3 +734,46 @@ eval instant at 5m absent_over_time({job="ingress"}[4m])
 
 eval instant at 10m absent_over_time({job="ingress"}[4m])
 	{job="ingress"} 1
+
+# Tests for min_over_time_last_timestamp
+clear
+
+load 10s
+    data{test="a"} 0 1 2 3 4 5 6 7 8 2
+    data{test="b"} 0 0 2 3 4 5 6 7 8 2
+    data{test="c"} 0 1 2 0 4 5 6 7 8 2
+    data{test="d"} 1 1 NaN 3 4 5 6 7 8 2
+    data{test="e"} 0 1 NaN 3 4 5 0 7 8 2
+    data{test="f"} 0 1 NaN 3 4 5 1 7 8 -2
+    data{test="f"} 0 1 NaN 3 4 5 1 7 8 -2
+    data{test="g"} 10 -Inf NaN 3 4 5 1 7 +Inf 12
+
+eval instant at 2m min_over_time_last_timestamp(data[5m])
+    {test="a"} 0
+    {test="b"} 10
+    {test="c"} 30
+    {test="d"} 10
+    {test="e"} 60
+    {test="f"} 90
+    {test="g"} 10
+
+# Tests for mmax_over_time_last_timestamp
+clear
+
+load 10s
+	data{test="a"} 10 1 2 3 4 5 6 7 8 2
+	data{test="b"} 10 10 2 3 4 5 6 7 8 2
+	data{test="c"} 10 1 2 10 4 5 6 7 8 2
+	data{test="d"} 11 11 NaN 3 4 5 6 7 8 2
+	data{test="e"} 10 1 NaN 3 4 5 10 7 8 2
+	data{test="f"} 10 1 NaN 3 4 5 1 7 8 12
+	data{test="g"} 10 +Inf NaN 3 4 5 1 7 -Inf 12
+
+eval instant at 2m max_over_time_last_timestamp(data[5m])
+    {test="a"} 0
+    {test="b"} 10
+    {test="c"} 30
+    {test="d"} 10
+    {test="e"} 60
+    {test="f"} 90
+    {test="g"} 10


### PR DESCRIPTION
Fixes #5003 

It does not really make sense of other aggr over time, which actually alter data.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->