### PR TITLE
promql: Removed global and add ability to have better interval for subqueries if not specified

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -335,8 +335,8 @@ func main() {
 		}
 	}
 
-	noStepSuqueryInterval := &safePromQLNoStepSubqueryInterval{}
-	noStepSuqueryInterval.Set(config.DefaultGlobalConfig.EvaluationInterval)
+	noStepSubqueryInterval := &safePromQLNoStepSubqueryInterval{}
+	noStepSubqueryInterval.Set(config.DefaultGlobalConfig.EvaluationInterval)
 
 	// Above level 6, the k8s client would log bearer tokens in clear-text.
 	klog.ClampLevel(6)
@@ -375,7 +375,7 @@ func main() {
 			Timeout:                  time.Duration(cfg.queryTimeout),
 			ActiveQueryTracker:       promql.NewActiveQueryTracker(cfg.localStoragePath, cfg.queryConcurrency, log.With(logger, "component", "activeQueryTracker")),
 			LookbackDelta:            time.Duration(cfg.lookbackDelta),
-			NoStepSubqueryIntervalFn: noStepSuqueryInterval.Get,
+			NoStepSubqueryIntervalFn: noStepSubqueryInterval.Get,
 		}
 
 		queryEngine = promql.NewEngine(opts)
@@ -609,11 +609,11 @@ func main() {
 				for {
 					select {
 					case <-hup:
-						if err := reloadConfig(cfg.configFile, logger, noStepSuqueryInterval, reloaders...); err != nil {
+						if err := reloadConfig(cfg.configFile, logger, noStepSubqueryInterval, reloaders...); err != nil {
 							level.Error(logger).Log("msg", "Error reloading config", "err", err)
 						}
 					case rc := <-webHandler.Reload():
-						if err := reloadConfig(cfg.configFile, logger, noStepSuqueryInterval, reloaders...); err != nil {
+						if err := reloadConfig(cfg.configFile, logger, noStepSubqueryInterval, reloaders...); err != nil {
 							level.Error(logger).Log("msg", "Error reloading config", "err", err)
 							rc <- err
 						} else {
@@ -645,7 +645,7 @@ func main() {
 					return nil
 				}
 
-				if err := reloadConfig(cfg.configFile, logger, noStepSuqueryInterval, reloaders...); err != nil {
+				if err := reloadConfig(cfg.configFile, logger, noStepSubqueryInterval, reloaders...); err != nil {
 					return errors.Wrapf(err, "error loading config from %q", cfg.configFile)
 				}
 

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -30,6 +30,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -334,7 +335,8 @@ func main() {
 		}
 	}
 
-	promql.SetDefaultEvaluationInterval(time.Duration(config.DefaultGlobalConfig.EvaluationInterval))
+	noStepSuqueryInterval := &safePromQLNoStepSubqueryInterval{}
+	noStepSuqueryInterval.Set(config.DefaultGlobalConfig.EvaluationInterval)
 
 	// Above level 6, the k8s client would log bearer tokens in clear-text.
 	klog.ClampLevel(6)
@@ -367,12 +369,13 @@ func main() {
 		scrapeManager = scrape.NewManager(log.With(logger, "component", "scrape manager"), fanoutStorage)
 
 		opts = promql.EngineOpts{
-			Logger:             log.With(logger, "component", "query engine"),
-			Reg:                prometheus.DefaultRegisterer,
-			MaxSamples:         cfg.queryMaxSamples,
-			Timeout:            time.Duration(cfg.queryTimeout),
-			ActiveQueryTracker: promql.NewActiveQueryTracker(cfg.localStoragePath, cfg.queryConcurrency, log.With(logger, "component", "activeQueryTracker")),
-			LookbackDelta:      time.Duration(cfg.lookbackDelta),
+			Logger:                   log.With(logger, "component", "query engine"),
+			Reg:                      prometheus.DefaultRegisterer,
+			MaxSamples:               cfg.queryMaxSamples,
+			Timeout:                  time.Duration(cfg.queryTimeout),
+			ActiveQueryTracker:       promql.NewActiveQueryTracker(cfg.localStoragePath, cfg.queryConcurrency, log.With(logger, "component", "activeQueryTracker")),
+			LookbackDelta:            time.Duration(cfg.lookbackDelta),
+			NoStepSubqueryIntervalFn: noStepSuqueryInterval.Get,
 		}
 
 		queryEngine = promql.NewEngine(opts)
@@ -606,11 +609,11 @@ func main() {
 				for {
 					select {
 					case <-hup:
-						if err := reloadConfig(cfg.configFile, logger, reloaders...); err != nil {
+						if err := reloadConfig(cfg.configFile, logger, noStepSuqueryInterval, reloaders...); err != nil {
 							level.Error(logger).Log("msg", "Error reloading config", "err", err)
 						}
 					case rc := <-webHandler.Reload():
-						if err := reloadConfig(cfg.configFile, logger, reloaders...); err != nil {
+						if err := reloadConfig(cfg.configFile, logger, noStepSuqueryInterval, reloaders...); err != nil {
 							level.Error(logger).Log("msg", "Error reloading config", "err", err)
 							rc <- err
 						} else {
@@ -642,7 +645,7 @@ func main() {
 					return nil
 				}
 
-				if err := reloadConfig(cfg.configFile, logger, reloaders...); err != nil {
+				if err := reloadConfig(cfg.configFile, logger, noStepSuqueryInterval, reloaders...); err != nil {
 					return errors.Wrapf(err, "error loading config from %q", cfg.configFile)
 				}
 
@@ -801,7 +804,22 @@ func openDBWithMetrics(dir string, logger log.Logger, reg prometheus.Registerer,
 	return db, nil
 }
 
-func reloadConfig(filename string, logger log.Logger, rls ...func(*config.Config) error) (err error) {
+type safePromQLNoStepSubqueryInterval struct {
+	value int64
+}
+
+func durationToInt64Millis(d time.Duration) int64 {
+	return int64(d / time.Millisecond)
+}
+func (i *safePromQLNoStepSubqueryInterval) Set(ev model.Duration) {
+	atomic.StoreInt64(&i.value, durationToInt64Millis(time.Duration(ev)))
+}
+
+func (i *safePromQLNoStepSubqueryInterval) Get(int64) int64 {
+	return atomic.LoadInt64(&i.value)
+}
+
+func reloadConfig(filename string, logger log.Logger, noStepSuqueryInterval *safePromQLNoStepSubqueryInterval, rls ...func(*config.Config) error) (err error) {
 	level.Info(logger).Log("msg", "Loading configuration file", "filename", filename)
 
 	defer func() {
@@ -829,7 +847,7 @@ func reloadConfig(filename string, logger log.Logger, rls ...func(*config.Config
 		return errors.Errorf("one or more errors occurred while applying the new configuration (--config.file=%q)", filename)
 	}
 
-	promql.SetDefaultEvaluationInterval(time.Duration(conf.GlobalConfig.EvaluationInterval))
+	noStepSuqueryInterval.Set(conf.GlobalConfig.EvaluationInterval)
 	level.Info(logger).Log("msg", "Completed loading of configuration file", "filename", filename)
 	return nil
 }

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -650,10 +650,9 @@ func (ng *Engine) populateSeries(querier storage.Querier, s *parser.EvalStmt) {
 			}
 
 			// We need to make sure we select the timerange selected by the subquery.
-			// The cumulativeSubqueryOffset function gives the sum of range and the offset.
-			// TODO(gouthamve): Consider optimising it by separating out the range and offsets, and subtracting the offsets
-			// from end also. See: https://github.com/prometheus/prometheus/issues/7629.
-			// TODO(bwplotka): Add support for better hints when subquerying. See: https://github.com/prometheus/prometheus/issues/7630.
+			// TODO(gouthamve): cumulativeSubqueryOffset gives the sum of range and the offset
+			// we can optimise it by separating out the range and offsets, and subtracting the offsets
+			// from end also.
 			subqOffset := ng.cumulativeSubqueryOffset(path)
 			offsetMilliseconds := durationMilliseconds(subqOffset)
 			hints.Start = hints.Start - offsetMilliseconds

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -652,8 +652,8 @@ func (ng *Engine) populateSeries(querier storage.Querier, s *parser.EvalStmt) {
 			// We need to make sure we select the timerange selected by the subquery.
 			// The cumulativeSubqueryOffset function gives the sum of range and the offset.
 			// TODO(gouthamve): Consider optimising it by separating out the range and offsets, and subtracting the offsets
-			// from end also.
-			// TODO(bwplotka): Add support for better hints when subquerying.
+			// from end also. See: https://github.com/prometheus/prometheus/issues/7629.
+			// TODO(bwplotka): Add support for better hints when subquerying. See: https://github.com/prometheus/prometheus/issues/7630.
 			subqOffset := ng.cumulativeSubqueryOffset(path)
 			offsetMilliseconds := durationMilliseconds(subqOffset)
 			hints.Start = hints.Start - offsetMilliseconds

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -55,22 +54,6 @@ const (
 	// The smallest SampleValue that can be converted to an int64 without underflow.
 	minInt64 = -9223372036854775808
 )
-
-var (
-	// DefaultEvaluationInterval is the default evaluation interval of
-	// a subquery in milliseconds.
-	DefaultEvaluationInterval int64
-)
-
-// SetDefaultEvaluationInterval sets DefaultEvaluationInterval.
-func SetDefaultEvaluationInterval(ev time.Duration) {
-	atomic.StoreInt64(&DefaultEvaluationInterval, durationToInt64Millis(ev))
-}
-
-// GetDefaultEvaluationInterval returns the DefaultEvaluationInterval as time.Duration.
-func GetDefaultEvaluationInterval() int64 {
-	return atomic.LoadInt64(&DefaultEvaluationInterval)
-}
 
 type engineMetrics struct {
 	currentQueries       prometheus.Gauge
@@ -221,19 +204,24 @@ type EngineOpts struct {
 	// LookbackDelta determines the time since the last sample after which a time
 	// series is considered stale.
 	LookbackDelta time.Duration
+
+	// NoStepSubqueryIntervalFn is the default evaluation interval of
+	// a subquery in milliseconds if no step in range vector was specified `[30m:<step>]`.
+	NoStepSubqueryIntervalFn func(rangeMillis int64) int64
 }
 
 // Engine handles the lifetime of queries from beginning to end.
 // It is connected to a querier.
 type Engine struct {
-	logger             log.Logger
-	metrics            *engineMetrics
-	timeout            time.Duration
-	maxSamplesPerQuery int
-	activeQueryTracker *ActiveQueryTracker
-	queryLogger        QueryLogger
-	queryLoggerLock    sync.RWMutex
-	lookbackDelta      time.Duration
+	logger                   log.Logger
+	metrics                  *engineMetrics
+	timeout                  time.Duration
+	maxSamplesPerQuery       int
+	activeQueryTracker       *ActiveQueryTracker
+	queryLogger              QueryLogger
+	queryLoggerLock          sync.RWMutex
+	lookbackDelta            time.Duration
+	noStepSubqueryIntervalFn func(rangeMillis int64) int64
 }
 
 // NewEngine returns a new engine.
@@ -328,12 +316,13 @@ func NewEngine(opts EngineOpts) *Engine {
 	}
 
 	return &Engine{
-		timeout:            opts.Timeout,
-		logger:             opts.Logger,
-		metrics:            metrics,
-		maxSamplesPerQuery: opts.MaxSamples,
-		activeQueryTracker: opts.ActiveQueryTracker,
-		lookbackDelta:      opts.LookbackDelta,
+		timeout:                  opts.Timeout,
+		logger:                   opts.Logger,
+		metrics:                  metrics,
+		maxSamplesPerQuery:       opts.MaxSamples,
+		activeQueryTracker:       opts.ActiveQueryTracker,
+		lookbackDelta:            opts.LookbackDelta,
+		noStepSubqueryIntervalFn: opts.NoStepSubqueryIntervalFn,
 	}
 }
 
@@ -525,14 +514,14 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *parser.Eval
 	if s.Start == s.End && s.Interval == 0 {
 		start := timeMilliseconds(s.Start)
 		evaluator := &evaluator{
-			startTimestamp:      start,
-			endTimestamp:        start,
-			interval:            1,
-			ctx:                 ctxInnerEval,
-			maxSamples:          ng.maxSamplesPerQuery,
-			defaultEvalInterval: GetDefaultEvaluationInterval(),
-			logger:              ng.logger,
-			lookbackDelta:       ng.lookbackDelta,
+			startTimestamp:           start,
+			endTimestamp:             start,
+			interval:                 1,
+			ctx:                      ctxInnerEval,
+			maxSamples:               ng.maxSamplesPerQuery,
+			logger:                   ng.logger,
+			lookbackDelta:            ng.lookbackDelta,
+			noStepSubqueryIntervalFn: ng.noStepSubqueryIntervalFn,
 		}
 
 		val, warnings, err := evaluator.Eval(s.Expr)
@@ -575,14 +564,14 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *parser.Eval
 
 	// Range evaluation.
 	evaluator := &evaluator{
-		startTimestamp:      timeMilliseconds(s.Start),
-		endTimestamp:        timeMilliseconds(s.End),
-		interval:            durationMilliseconds(s.Interval),
-		ctx:                 ctxInnerEval,
-		maxSamples:          ng.maxSamplesPerQuery,
-		defaultEvalInterval: GetDefaultEvaluationInterval(),
-		logger:              ng.logger,
-		lookbackDelta:       ng.lookbackDelta,
+		startTimestamp:           timeMilliseconds(s.Start),
+		endTimestamp:             timeMilliseconds(s.End),
+		interval:                 durationMilliseconds(s.Interval),
+		ctx:                      ctxInnerEval,
+		maxSamples:               ng.maxSamplesPerQuery,
+		logger:                   ng.logger,
+		lookbackDelta:            ng.lookbackDelta,
+		noStepSubqueryIntervalFn: ng.noStepSubqueryIntervalFn,
 	}
 	val, warnings, err := evaluator.Eval(s.Expr)
 	if err != nil {
@@ -657,13 +646,14 @@ func (ng *Engine) populateSeries(querier storage.Querier, s *parser.EvalStmt) {
 			hints := &storage.SelectHints{
 				Start: timestamp.FromTime(s.Start),
 				End:   timestamp.FromTime(s.End),
-				Step:  durationToInt64Millis(s.Interval),
+				Step:  durationMilliseconds(s.Interval),
 			}
 
 			// We need to make sure we select the timerange selected by the subquery.
-			// TODO(gouthamve): cumulativeSubqueryOffset gives the sum of range and the offset
-			// we can optimise it by separating out the range and offsets, and subtracting the offsets
+			// The cumulativeSubqueryOffset function gives the sum of range and the offset.
+			// TODO(gouthamve): Consider optimising it by separating out the range and offsets, and subtracting the offsets
 			// from end also.
+			// TODO(bwplotka): Add support for better hints when subquerying.
 			subqOffset := ng.cumulativeSubqueryOffset(path)
 			offsetMilliseconds := durationMilliseconds(subqOffset)
 			hints.Start = hints.Start - offsetMilliseconds
@@ -769,11 +759,11 @@ type evaluator struct {
 	endTimestamp   int64 // End time in milliseconds.
 	interval       int64 // Interval in milliseconds.
 
-	maxSamples          int
-	currentSamples      int
-	defaultEvalInterval int64
-	logger              log.Logger
-	lookbackDelta       time.Duration
+	maxSamples               int
+	currentSamples           int
+	logger                   log.Logger
+	lookbackDelta            time.Duration
+	noStepSubqueryIntervalFn func(rangeMillis int64) int64
 }
 
 // errorf causes a panic with the input formatted into an error.
@@ -1333,21 +1323,22 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 		return ev.matrixSelector(e)
 
 	case *parser.SubqueryExpr:
-		offsetMillis := durationToInt64Millis(e.Offset)
-		rangeMillis := durationToInt64Millis(e.Range)
+		offsetMillis := durationMilliseconds(e.Offset)
+		rangeMillis := durationMilliseconds(e.Range)
 		newEv := &evaluator{
-			endTimestamp:        ev.endTimestamp - offsetMillis,
-			interval:            ev.defaultEvalInterval,
-			ctx:                 ev.ctx,
-			currentSamples:      ev.currentSamples,
-			maxSamples:          ev.maxSamples,
-			defaultEvalInterval: ev.defaultEvalInterval,
-			logger:              ev.logger,
-			lookbackDelta:       ev.lookbackDelta,
+			endTimestamp:             ev.endTimestamp - offsetMillis,
+			ctx:                      ev.ctx,
+			currentSamples:           ev.currentSamples,
+			maxSamples:               ev.maxSamples,
+			logger:                   ev.logger,
+			lookbackDelta:            ev.lookbackDelta,
+			noStepSubqueryIntervalFn: ev.noStepSubqueryIntervalFn,
 		}
 
 		if e.Step != 0 {
-			newEv.interval = durationToInt64Millis(e.Step)
+			newEv.interval = durationMilliseconds(e.Step)
+		} else {
+			newEv.interval = ev.noStepSubqueryIntervalFn(rangeMillis)
 		}
 
 		// Start with the first timestamp after (ev.startTimestamp - offset - range)
@@ -1365,10 +1356,6 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 	}
 
 	panic(errors.Errorf("unhandled expression of type: %T", expr))
-}
-
-func durationToInt64Millis(d time.Duration) int64 {
-	return int64(d / time.Millisecond)
 }
 
 // vectorSelector evaluates a *parser.VectorSelector expression.

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/prometheus/prometheus/pkg/timestamp"
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -219,36 +220,26 @@ func TestQueryError(t *testing.T) {
 	testutil.Assert(t, errors.Is(res.Err, errStorage), "expected error doesn't match")
 }
 
-// hintCheckerQuerier implements storage.Querier which checks the start and end times
-// in hints.
-type hintCheckerQuerier struct {
-	start    int64
-	end      int64
-	grouping []string
-	by       bool
-	selRange int64
-	function string
-
-	t *testing.T
+type noopHintRecordingQueryable struct {
+	hints []*storage.SelectHints
 }
 
-func (q *hintCheckerQuerier) Select(_ bool, sp *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
-	testutil.Equals(q.t, q.start, sp.Start)
-	testutil.Equals(q.t, q.end, sp.End)
-	testutil.Equals(q.t, q.grouping, sp.Grouping)
-	testutil.Equals(q.t, q.by, sp.By)
-	testutil.Equals(q.t, q.selRange, sp.Range)
-	testutil.Equals(q.t, q.function, sp.Func)
-
-	return errSeriesSet{err: nil}
+func (h *noopHintRecordingQueryable) Querier(context.Context, int64, int64) (storage.Querier, error) {
+	return &hintRecordingQuerier{Querier: &errQuerier{}, h: h}, nil
 }
-func (*hintCheckerQuerier) LabelValues(string) ([]string, storage.Warnings, error) {
-	return nil, nil, nil
-}
-func (*hintCheckerQuerier) LabelNames() ([]string, storage.Warnings, error) { return nil, nil, nil }
-func (*hintCheckerQuerier) Close() error                                    { return nil }
 
-func TestParamsSetCorrectly(t *testing.T) {
+type hintRecordingQuerier struct {
+	storage.Querier
+
+	h *noopHintRecordingQueryable
+}
+
+func (h *hintRecordingQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	h.h.hints = append(h.h.hints, hints)
+	return h.Querier.Select(sortSeries, hints, matchers...)
+}
+
+func TestSelectHintsSetCorrectly(t *testing.T) {
 	opts := EngineOpts{
 		Logger:        nil,
 		Reg:           nil,
@@ -257,192 +248,139 @@ func TestParamsSetCorrectly(t *testing.T) {
 		LookbackDelta: 5 * time.Second,
 	}
 
-	cases := []struct {
+	for _, tc := range []struct {
 		query string
 
-		// All times are in seconds.
+		// All times are in milliseconds.
 		start int64
 		end   int64
 
-		paramStart int64
-		paramEnd   int64
-
-		paramGrouping []string
-		paramBy       bool
-		paramRange    int64
-		paramFunc     string
+		// TODO(bwplotka): Add support for better hints when subquerying.
+		expected []*storage.SelectHints
 	}{{
-		query: "foo",
-		start: 10,
-
-		paramStart: 5,
-		paramEnd:   10,
+		query: "foo", start: 10000,
+		expected: []*storage.SelectHints{
+			{Start: 5000, End: 10000},
+		},
 	}, {
-		query: "foo[2m]",
-		start: 200,
-
-		paramStart: 80, // 200 - 120
-		paramEnd:   200,
-		paramRange: 120000,
+		query: "foo[2m]", start: 200000,
+		expected: []*storage.SelectHints{
+			{Start: 80000, End: 200000, Range: 120000},
+		},
 	}, {
-		query: "foo[2m] offset 2m",
-		start: 300,
-
-		paramStart: 60,
-		paramEnd:   180,
-		paramRange: 120000,
+		query: "foo[2m] offset 2m", start: 300000,
+		expected: []*storage.SelectHints{
+			{Start: 60000, End: 180000, Range: 120000},
+		},
 	}, {
-		query: "foo[2m:1s]",
-		start: 300,
-
-		paramStart: 175, // 300 - 120 - 5
-		paramEnd:   300,
+		query: "foo[2m:1s]", start: 300000,
+		expected: []*storage.SelectHints{
+			{Start: 175000, End: 300000},
+		},
 	}, {
-		query: "count_over_time(foo[2m:1s])",
-		start: 300,
-
-		paramStart: 175, // 300 - 120 - 5
-		paramEnd:   300,
-		paramFunc:  "count_over_time",
+		query: "count_over_time(foo[2m:1s])", start: 300000,
+		expected: []*storage.SelectHints{
+			{Start: 175000, End: 300000, Func: "count_over_time"},
+		},
 	}, {
-		query: "count_over_time(foo[2m:1s] offset 10s)",
-		start: 300,
-
-		paramStart: 165, // 300 - 120 - 5 - 10
-		paramEnd:   300,
-		paramFunc:  "count_over_time",
+		query: "count_over_time(foo[2m:1s] offset 10s)", start: 300000,
+		expected: []*storage.SelectHints{
+			{Start: 165000, End: 300000, Func: "count_over_time"},
+		},
 	}, {
-		query: "count_over_time((foo offset 10s)[2m:1s] offset 10s)",
-		start: 300,
-
-		paramStart: 155, // 300 - 120 - 5 - 10 - 10
-		paramEnd:   290,
-		paramFunc:  "count_over_time",
+		query: "count_over_time((foo offset 10s)[2m:1s] offset 10s)", start: 300000,
+		expected: []*storage.SelectHints{
+			{Start: 155000, End: 290000, Func: "count_over_time"},
+		},
 	}, {
-		// Range queries now.
-		query: "foo",
-		start: 10,
-		end:   20,
 
-		paramStart: 5,
-		paramEnd:   20,
+		query: "foo", start: 10000, end: 20000,
+		expected: []*storage.SelectHints{
+			{Start: 5000, End: 20000, Step: 1000},
+		},
 	}, {
-		query: "rate(foo[2m])",
-		start: 200,
-		end:   500,
-
-		paramStart: 80, // 200 - 120
-		paramEnd:   500,
-		paramRange: 120000,
-		paramFunc:  "rate",
+		query: "rate(foo[2m])", start: 200000, end: 500000,
+		expected: []*storage.SelectHints{
+			{Start: 80000, End: 500000, Range: 120000, Func: "rate", Step: 1000},
+		},
 	}, {
-		query: "rate(foo[2m] offset 2m)",
-		start: 300,
-		end:   500,
-
-		paramStart: 60,
-		paramEnd:   380,
-		paramRange: 120000,
-		paramFunc:  "rate",
+		query: "rate(foo[2m] offset 2m)", start: 300000, end: 500000,
+		expected: []*storage.SelectHints{
+			{Start: 60000, End: 380000, Range: 120000, Func: "rate", Step: 1000},
+		},
 	}, {
-		query: "rate(foo[2m:1s])",
-		start: 300,
-		end:   500,
-
-		paramStart: 175, // 300 - 120 - 5
-		paramEnd:   500,
-		paramFunc:  "rate",
+		query: "rate(foo[2m:1s])", start: 300000, end: 500000,
+		expected: []*storage.SelectHints{
+			{Start: 175000, End: 500000, Func: "rate", Step: 1000},
+		},
 	}, {
-		query: "count_over_time(foo[2m:1s])",
-		start: 300,
-		end:   500,
-
-		paramStart: 175, // 300 - 120 - 5
-		paramEnd:   500,
-		paramFunc:  "count_over_time",
+		query: "count_over_time(foo[2m:1s])", start: 300000, end: 500000,
+		expected: []*storage.SelectHints{
+			{Start: 175000, End: 500000, Func: "count_over_time", Step: 1000},
+		},
 	}, {
-		query: "count_over_time(foo[2m:1s] offset 10s)",
-		start: 300,
-		end:   500,
-
-		paramStart: 165, // 300 - 120 - 5 - 10
-		paramEnd:   500,
-		paramFunc:  "count_over_time",
+		query: "count_over_time(foo[2m:1s] offset 10s)", start: 300000, end: 500000,
+		expected: []*storage.SelectHints{
+			{Start: 165000, End: 500000, Func: "count_over_time", Step: 1000},
+		},
 	}, {
-		query: "count_over_time((foo offset 10s)[2m:1s] offset 10s)",
-		start: 300,
-		end:   500,
-
-		paramStart: 155, // 300 - 120 - 5 - 10 - 10
-		paramEnd:   490,
-		paramFunc:  "count_over_time",
+		query: "count_over_time((foo offset 10s)[2m:1s] offset 10s)", start: 300000, end: 500000,
+		expected: []*storage.SelectHints{
+			{Start: 155000, End: 490000, Func: "count_over_time", Step: 1000},
+		},
 	}, {
-		query: "sum by (dim1) (foo)",
-		start: 10,
-
-		paramStart:    5,
-		paramEnd:      10,
-		paramGrouping: []string{"dim1"},
-		paramBy:       true,
-		paramFunc:     "sum",
+		query: "sum by (dim1) (foo)", start: 10000,
+		expected: []*storage.SelectHints{
+			{Start: 5000, End: 10000, Func: "sum", By: true, Grouping: []string{"dim1"}},
+		},
 	}, {
-		query: "sum without (dim1) (foo)",
-		start: 10,
-
-		paramStart:    5,
-		paramEnd:      10,
-		paramGrouping: []string{"dim1"},
-		paramBy:       false,
-		paramFunc:     "sum",
+		query: "sum without (dim1) (foo)", start: 10000,
+		expected: []*storage.SelectHints{
+			{Start: 5000, End: 10000, Func: "sum", Grouping: []string{"dim1"}},
+		},
 	}, {
-		query: "sum by (dim1) (avg_over_time(foo[1s]))",
-		start: 10,
-
-		paramStart:    9,
-		paramEnd:      10,
-		paramGrouping: nil,
-		paramBy:       false,
-		paramRange:    1000,
-		paramFunc:     "avg_over_time",
+		query: "sum by (dim1) (avg_over_time(foo[1s]))", start: 10000,
+		expected: []*storage.SelectHints{
+			{Start: 9000, End: 10000, Func: "avg_over_time", Range: 1000},
+		},
 	}, {
-		query: "sum by (dim1) (max by (dim2) (foo))",
-		start: 10,
-
-		paramStart:    5,
-		paramEnd:      10,
-		paramGrouping: []string{"dim2"},
-		paramBy:       true,
-		paramFunc:     "max",
+		query: "sum by (dim1) (max by (dim2) (foo))", start: 10000,
+		expected: []*storage.SelectHints{
+			{Start: 5000, End: 10000, Func: "max", By: true, Grouping: []string{"dim2"}},
+		},
 	}, {
-		query: "(max by (dim1) (foo))[5s:1s]",
-		start: 10,
+		query: "(max by (dim1) (foo))[5s:1s]", start: 10000,
+		expected: []*storage.SelectHints{
+			{Start: 0, End: 10000, Func: "max", By: true, Grouping: []string{"dim1"}},
+		},
+	}, {
+		query: "(sum(http_requests{group=~\"p.*\"})+max(http_requests{group=~\"c.*\"}))[20s:5s]", start: 120000,
+		expected: []*storage.SelectHints{
+			{Start: 95000, End: 120000, Func: "sum", By: true},
+			{Start: 95000, End: 120000, Func: "max", By: true},
+		},
+	}} {
+		t.Run(tc.query, func(t *testing.T) {
+			engine := NewEngine(opts)
+			hintsRecorder := &noopHintRecordingQueryable{}
 
-		paramStart:    0,
-		paramEnd:      10,
-		paramGrouping: []string{"dim1"},
-		paramBy:       true,
-		paramFunc:     "max",
-	}}
+			var (
+				query Query
+				err   error
+			)
+			if tc.end == 0 {
+				query, err = engine.NewInstantQuery(hintsRecorder, tc.query, timestamp.Time(tc.start))
+			} else {
+				query, err = engine.NewRangeQuery(hintsRecorder, tc.query, timestamp.Time(tc.start), timestamp.Time(tc.end), time.Second)
+			}
+			testutil.Ok(t, err)
 
-	for _, tc := range cases {
-		engine := NewEngine(opts)
-		queryable := storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
-			return &hintCheckerQuerier{start: tc.paramStart * 1000, end: tc.paramEnd * 1000, grouping: tc.paramGrouping, by: tc.paramBy, selRange: tc.paramRange, function: tc.paramFunc, t: t}, nil
+			res := query.Exec(context.Background())
+			testutil.Ok(t, res.Err)
+
+			testutil.Equals(t, tc.expected, hintsRecorder.hints)
 		})
 
-		var (
-			query Query
-			err   error
-		)
-		if tc.end == 0 {
-			query, err = engine.NewInstantQuery(queryable, tc.query, time.Unix(tc.start, 0))
-		} else {
-			query, err = engine.NewRangeQuery(queryable, tc.query, time.Unix(tc.start, 0), time.Unix(tc.end, 0), time.Second)
-		}
-		testutil.Ok(t, err)
-
-		res := query.Exec(context.Background())
-		testutil.Ok(t, res.Err)
 	}
 }
 
@@ -887,22 +825,20 @@ func TestRecoverEvaluatorErrorWithWarnings(t *testing.T) {
 }
 
 func TestSubquerySelector(t *testing.T) {
-	tests := []struct {
+	type caseType struct {
+		Query  string
+		Result Result
+		Start  time.Time
+	}
+
+	for _, tst := range []struct {
 		loadString string
-		cases      []struct {
-			Query  string
-			Result Result
-			Start  time.Time
-		}
+		cases      []caseType
 	}{
 		{
 			loadString: `load 10s
 							metric 1 2`,
-			cases: []struct {
-				Query  string
-				Result Result
-				Start  time.Time
-			}{
+			cases: []caseType{
 				{
 					Query: "metric[20s:10s]",
 					Result: Result{
@@ -1007,11 +943,7 @@ func TestSubquerySelector(t *testing.T) {
 							http_requests{job="api-server", instance="1", group="production"}	0+20x1000 200+30x1000
 							http_requests{job="api-server", instance="0", group="canary"}		0+30x1000 300+80x1000
 							http_requests{job="api-server", instance="1", group="canary"}		0+40x2000`,
-			cases: []struct {
-				Query  string
-				Result Result
-				Start  time.Time
-			}{
+			cases: []caseType{
 				{ // Normal selector.
 					Query: `http_requests{group=~"pro.*",instance="0"}[30s:10s]`,
 					Result: Result{
@@ -1112,32 +1044,33 @@ func TestSubquerySelector(t *testing.T) {
 				},
 			},
 		},
-	}
-
-	SetDefaultEvaluationInterval(1 * time.Minute)
-	for _, tst := range tests {
-		test, err := NewTest(t, tst.loadString)
-		testutil.Ok(t, err)
-
-		defer test.Close()
-
-		err = test.Run()
-		testutil.Ok(t, err)
-
-		engine := test.QueryEngine()
-		for _, c := range tst.cases {
-			var err error
-			var qry Query
-
-			qry, err = engine.NewInstantQuery(test.Queryable(), c.Query, c.Start)
+	} {
+		t.Run("", func(t *testing.T) {
+			test, err := NewTest(t, tst.loadString)
 			testutil.Ok(t, err)
 
-			res := qry.Exec(test.Context())
-			testutil.Equals(t, c.Result.Err, res.Err)
-			mat := res.Value.(Matrix)
-			sort.Sort(mat)
-			testutil.Equals(t, c.Result.Value, mat)
-		}
+			defer test.Close()
+
+			err = test.Run()
+			testutil.Ok(t, err)
+
+			engine := test.QueryEngine()
+			for _, c := range tst.cases {
+				t.Run(c.Query, func(t *testing.T) {
+					var err error
+					var qry Query
+
+					qry, err = engine.NewInstantQuery(test.Queryable(), c.Query, c.Start)
+					testutil.Ok(t, err)
+
+					res := qry.Exec(test.Context())
+					testutil.Equals(t, c.Result.Err, res.Err)
+					mat := res.Value.(Matrix)
+					sort.Sort(mat)
+					testutil.Equals(t, c.Result.Value, mat)
+				})
+			}
+		})
 	}
 }
 

--- a/promql/test.go
+++ b/promql/test.go
@@ -518,10 +518,11 @@ func (t *Test) clear() {
 	t.storage = teststorage.New(t)
 
 	opts := EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10000,
-		Timeout:    100 * time.Second,
+		Logger:                   nil,
+		Reg:                      nil,
+		MaxSamples:               10000,
+		Timeout:                  100 * time.Second,
+		NoStepSubqueryIntervalFn: func(int64) int64 { return durationMilliseconds(1 * time.Minute) },
 	}
 
 	t.queryEngine = NewEngine(opts)


### PR DESCRIPTION
## Changes

* Refactored tests for better hints testing
* Added various TODO in places to enhance.
* Moved DefaultEvalInterval global to opts with func(rangeMillis int64) int64 function instead

Motivation: At Thanos we would love to have better control over the subqueries step/interval.
This is important to choose proper resolution. I think having proper step also does not harm for
Prometheus and remote read users. Especially on stateless querier we do not know evaluation interval
and in fact putting global can be wrong to assume for Prometheus even.

I think ideally we could try to have at least 3 samples within the range, the same
way Prometheus UI and Grafana assumes.

Anyway this interfaces allows to decide on promQL user basis.

Open question: Is taking parent interval a smart move?

Motivation for removing global: I spent 1h fighting with:

```
=== RUN   TestEvaluations
    TestEvaluations: promql_test.go:31: unexpected error: error evaluating query "absent_over_time(rate(nonexistant[5m])[5m:])" (line 687): unexpected error: runtime error: integer divide by zero
--- FAIL: TestEvaluations (0.32s)
FAIL
```

At the end I found that this fails on most of the versions including current master if you run this test alone. If run together with many
other tests it passes. This is due to `SetDefaultEvaluationInterval(1 * time.Minute)`
in test that is ran before TestEvaluations. Thanks to globals (:

Let's fix it by dropping this global.

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>
