### PR TITLE
tsdb/chunks: fix bug of data race(#7643).

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -260,7 +260,7 @@ func (cdm *ChunkDiskMapper) WriteChunk(seriesRef uint64, mint, maxt int64, chk c
 
 	// The upper 4 bytes are for the head chunk file index and
 	// the lower 4 bytes are for the head chunk file offset where to start reading this chunk.
-	chkRef = chunkRef(uint64(cdm.curFileSequence), uint64(cdm.curFileNumBytes))
+	chkRef = chunkRef(uint64(cdm.curFileSequence), uint64(cdm.curFileSize()))
 
 	binary.BigEndian.PutUint64(cdm.byteBuf[bytesWritten:], seriesRef)
 	bytesWritten += SeriesRefSize
@@ -308,8 +308,8 @@ func chunkRef(seq, offset uint64) (chunkRef uint64) {
 // Size retention: because depending on the system architecture, there is a limit on how big of a file we can m-map.
 // Time retention: so that we can delete old chunks with some time guarantee in low load environments.
 func (cdm *ChunkDiskMapper) shouldCutNewFile(chunkSize int) bool {
-	return cdm.curFileNumBytes == 0 || // First head chunk file.
-		cdm.curFileNumBytes+int64(chunkSize+MaxHeadChunkMetaSize) > MaxHeadChunkFileSize // Exceeds the max head chunk file size.
+	return cdm.curFileSize() == 0 || // First head chunk file.
+		cdm.curFileSize()+int64(chunkSize+MaxHeadChunkMetaSize) > MaxHeadChunkFileSize // Exceeds the max head chunk file size.
 }
 
 // CutNewFile creates a new m-mapped file.
@@ -342,7 +342,7 @@ func (cdm *ChunkDiskMapper) cut() (returnErr error) {
 		}
 	}()
 
-	cdm.size += cdm.curFileNumBytes
+	cdm.size += cdm.curFileSize()
 	atomic.StoreInt64(&cdm.curFileNumBytes, int64(n))
 
 	if cdm.curFile != nil {
@@ -558,7 +558,7 @@ func (cdm *ChunkDiskMapper) IterateAllChunks(f func(seriesRef, chunkRef uint64, 
 		mmapFile := cdm.mmappedChunkFiles[segID]
 		fileEnd := mmapFile.byteSlice.Len()
 		if segID == cdm.curFileSequence {
-			fileEnd = int(cdm.curFileNumBytes)
+			fileEnd = int(cdm.curFileSize())
 		}
 		idx := HeadChunkFileHeaderSize
 		for idx < fileEnd {
@@ -681,7 +681,7 @@ func (cdm *ChunkDiskMapper) Truncate(mint int64) error {
 
 	var merr tsdb_errors.MultiError
 	// Cut a new file only if the current file has some chunks.
-	if cdm.curFileNumBytes > HeadChunkFileHeaderSize {
+	if cdm.curFileSize() > HeadChunkFileHeaderSize {
 		merr.Add(cdm.CutNewFile())
 	}
 	merr.Add(cdm.deleteFiles(removedFiles))
@@ -732,8 +732,11 @@ func (cdm *ChunkDiskMapper) DeleteCorrupted(originalErr error) error {
 
 // Size returns the size of the chunk files.
 func (cdm *ChunkDiskMapper) Size() int64 {
-	n := atomic.LoadInt64(&cdm.curFileNumBytes)
-	return cdm.size + n
+	return cdm.size + cdm.curFileSize()
+}
+
+func (cdm *ChunkDiskMapper) curFileSize() int64 {
+	return atomic.LoadInt64(&cdm.curFileNumBytes)
 }
 
 // Close closes all the open files in ChunkDiskMapper.


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/7643

Read operation of `cdm.curFileNumBytes` are frequent, so add a method `curFileSize` for convenience.

Test result:
```
level=info ts=2020-07-23T03:22:29.270816Z caller=head.go:644 msg="Replaying on-disk memory mappable chunks if any"
level=info ts=2020-07-23T03:22:29.270937Z caller=head.go:658 msg="On-disk memory mappable chunks replay completed" duration=11.759µs
level=info ts=2020-07-23T03:22:29.270967Z caller=head.go:664 msg="Replaying WAL, this may take a while"
level=info ts=2020-07-23T03:22:29.272415Z caller=head.go:716 msg="WAL segment loaded" segment=0 maxSegment=0
level=info ts=2020-07-23T03:22:29.272468Z caller=head.go:719 msg="WAL replay completed" checkpoint_replay_duration=55.54µs wal_replay_duration=1.420602ms total_replay_duration=1.544369ms
>> start stage=readData
>> completed stage=readData duration=477.891979ms
>> start stage=ingestScrapes
level=info ts=2020-07-23T03:22:38.935827Z caller=compact.go:495 msg="write block" mint=30000 maxt=7200000 ulid=01EDWV3BGQ2JQ36J1VACKZ8JYG duration=4.543850478s
level=info ts=2020-07-23T03:22:39.108095Z caller=head.go:807 msg="Head GC completed" duration=116.043688ms
level=info ts=2020-07-23T03:22:45.199103Z caller=compact.go:495 msg="write block" mint=7200000 maxt=14400000 ulid=01EDWV3G9BNJW1H8WHTBNER5XQ duration=5.923184809s
level=info ts=2020-07-23T03:22:45.338261Z caller=head.go:807 msg="Head GC completed" duration=77.553065ms
level=info ts=2020-07-23T03:22:51.568058Z caller=compact.go:495 msg="write block" mint=14400000 maxt=21600000 ulid=01EDWV3P9WK5HA5JA7ZSV16AX4 duration=6.131173086s
level=info ts=2020-07-23T03:22:51.720686Z caller=head.go:807 msg="Head GC completed" duration=100.029852ms
level=info ts=2020-07-23T03:22:56.664591Z caller=compact.go:495 msg="write block" mint=21600000 maxt=28800000 ulid=01EDWV3WGQC2PJWMV8TY28K5M0 duration=4.864885893s
level=info ts=2020-07-23T03:22:56.814205Z caller=head.go:807 msg="Head GC completed" duration=106.847809ms
level=info ts=2020-07-23T03:22:56.903989Z caller=checkpoint.go:96 msg="Creating checkpoint" from_segment=0 to_segment=1 mint=28800000
level=info ts=2020-07-23T03:23:12.133597Z caller=head.go:887 msg="WAL checkpoint complete" first=0 last=1 duration=15.231154162s
level=info ts=2020-07-23T03:23:16.920081Z caller=compact.go:495 msg="write block" mint=28800000 maxt=36000000 ulid=01EDWV4GDYFZGKG3VTBRY4C0FX duration=4.729999392s
level=info ts=2020-07-23T03:23:17.064574Z caller=head.go:807 msg="Head GC completed" duration=69.535094ms
level=info ts=2020-07-23T03:23:21.903786Z caller=compact.go:495 msg="write block" mint=36000000 maxt=43200000 ulid=01EDWV4N8DGGBZ3DKKVZGASZ5H duration=4.770139846s
level=info ts=2020-07-23T03:23:22.087908Z caller=head.go:807 msg="Head GC completed" duration=76.818341ms
level=info ts=2020-07-23T03:23:22.13164Z caller=checkpoint.go:96 msg="Creating checkpoint" from_segment=2 to_segment=3 mint=43200000
ingestion completed
>> completed stage=ingestScrapes duration=53.523904642s
 > total samples: 30000000
 > samples/sec: 560496.9097849042
>> start stage=stopStorage
level=info ts=2020-07-23T03:23:28.504545Z caller=head.go:887 msg="WAL checkpoint complete" first=2 last=3 duration=6.376835761s
>> completed stage=stopStorage duration=5.550007143s
```
