### PR TITLE
add os.RemoveAll err verification

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -35,7 +35,9 @@ func TestQueryConcurrency(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "test_concurrency")
 	testutil.Ok(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		testutil.Ok(t, os.RemoveAll(dir))
+	}()
 	queryTracker := NewActiveQueryTracker(dir, maxConcurrency, nil)
 
 	opts := EngineOpts{

--- a/promql/query_logger.go
+++ b/promql/query_logger.go
@@ -64,6 +64,12 @@ func logUnfinishedQueries(filename string, filesize int, logger log.Logger) {
 			level.Error(logger).Log("msg", "Failed to open query log file", "err", err)
 			return
 		}
+		defer func() {
+			err := fd.Close()
+			if err != nil {
+				level.Error(logger).Log("msg", "Failed to close query log file", "err", err)
+			}
+		}()
 
 		brokenJSON := make([]byte, filesize)
 		_, err = fd.Read(brokenJSON)

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -536,7 +536,9 @@ func BenchmarkSampleDelivery(b *testing.B) {
 
 	dir, err := ioutil.TempDir("", "BenchmarkSampleDelivery")
 	testutil.Ok(b, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		testutil.Ok(b, os.RemoveAll(dir))
+	}()
 
 	metrics := newQueueManagerMetrics(nil, "", "")
 	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, nil, nil, c, defaultFlushDeadline)

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -34,7 +34,9 @@ import (
 func TestNoDuplicateReadConfigs(t *testing.T) {
 	dir, err := ioutil.TempDir("", "TestNoDuplicateReadConfigs")
 	testutil.Ok(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		testutil.Ok(t, os.RemoveAll(dir))
+	}()
 
 	cfg1 := config.RemoteReadConfig{
 		Name: "write-1",

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -27,7 +27,9 @@ import (
 func TestStorageLifecycle(t *testing.T) {
 	dir, err := ioutil.TempDir("", "TestStorageLifecycle")
 	testutil.Ok(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		testutil.Ok(t, os.RemoveAll(dir))
+	}()
 
 	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline)
 	conf := &config.Config{
@@ -66,7 +68,9 @@ func TestStorageLifecycle(t *testing.T) {
 func TestUpdateRemoteReadConfigs(t *testing.T) {
 	dir, err := ioutil.TempDir("", "TestUpdateRemoteReadConfigs")
 	testutil.Ok(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		testutil.Ok(t, os.RemoveAll(dir))
+	}()
 
 	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline)
 

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -358,7 +358,9 @@ func TestEndpoints(t *testing.T) {
 
 		dbDir, err := ioutil.TempDir("", "tsdb-api-ready")
 		testutil.Ok(t, err)
-		defer os.RemoveAll(dbDir)
+		defer func() {
+			testutil.Ok(t, os.RemoveAll(dbDir))
+		}()
 
 		remote := remote.NewStorage(promlog.New(&promlogConfig), prometheus.DefaultRegisterer, nil, dbDir, 1*time.Second)
 


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
1. Add err judgment to all os.RemoveAll in the code.
2. Fix the detected errors.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>