### PR TITLE
Add unit test case to improve test coverage for matcher.go

### DIFF
--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -89,6 +89,15 @@ func TestExprString(t *testing.T) {
 		{
 			in: `{__name__="a"}`,
 		},
+		{
+			in: `a{b!="c"}[1m]`,
+		},
+		{
+			in: `a{b=~"c"}[1m]`,
+		},
+		{
+			in: `a{b!~"c"}[1m]`,
+		},
 	}
 
 	for _, test := range inputs {


### PR DESCRIPTION
Cover untested line L34 ~ L36.
https://github.com/prometheus/prometheus/blob/93e9c010f3aaf9e683574991080e85a428d554ee/pkg/labels/matcher.go#L34

Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>