### PR TITLE
promtool: Ensure alert rules are marked as restored in unit tests

### DIFF
--- a/cmd/promtool/testdata/unittest.yml
+++ b/cmd/promtool/testdata/unittest.yml
@@ -8,6 +8,14 @@ tests:
     input_series:
       - series: 'up{job="prometheus", instance="localhost:9090"}'
         values: "0+0x1440"
+
+    promql_expr_test:
+      - expr: count(ALERTS) by (alertname, alertstate)
+        eval_time: 4m
+        exp_samples:
+        - labels: '{alertname="InstanceDown",alertstate="pending"}'
+          value: 1
+
     alert_rule_test:
       - eval_time: 1d
         alertname: InstanceDown

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -221,6 +221,16 @@ func (tg *testGroup) test(mint, maxt time.Time, evalInterval time.Duration, grou
 	// Current index in alertEvalTimes what we are looking at.
 	curr := 0
 
+	for _, g := range groups {
+		for _, r := range g.Rules() {
+			if alertRule, ok := r.(*rules.AlertingRule); ok {
+				// Mark alerting rules as restored, to ensure the ALERTS timeseries is
+				// created when they run.
+				alertRule.SetRestored(true)
+			}
+		}
+	}
+
 	var errs []error
 	for ts := mint; ts.Before(maxt); ts = ts.Add(evalInterval) {
 		// Collects the alerts asked for unit testing.


### PR DESCRIPTION
This makes sure the ALERTS timeseries is created when unit testing
alerting rules.

Signed-off-by: David Leadbeater <dgl@dgl.cx>