### PR TITLE
Goleak in discoveries, scrape, rules

### DIFF
--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -18,7 +18,12 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestMapFromVMWithEmptyTags(t *testing.T) {
 	id := "test"

--- a/discovery/dns/dns_test.go
+++ b/discovery/dns/dns_test.go
@@ -22,12 +22,17 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/miekg/dns"
+	"go.uber.org/goleak"
 	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/util/testutil"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestDNS(t *testing.T) {
 	testCases := []struct {

--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -26,10 +26,15 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"go.uber.org/goleak"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/util/testutil"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 const defaultWait = time.Second
 

--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -29,6 +29,10 @@ import (
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
+func TestMain(m *testing.M) {
+	testutil.TolerantVerifyLeak(m)
+}
+
 // makeDiscovery creates a kubernetes.Discovery instance for testing.
 func makeDiscovery(role Role, nsDiscovery NamespaceDiscovery, objects ...runtime.Object) (*Discovery, kubernetes.Interface) {
 	clientset := fake.NewSimpleClientset(objects...)

--- a/discovery/refresh/refresh_test.go
+++ b/discovery/refresh/refresh_test.go
@@ -20,10 +20,15 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"go.uber.org/goleak"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/util/testutil"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestRefresh(t *testing.T) {
 	tg1 := []*targetgroup.Group{

--- a/discovery/zookeeper/zookeeper_test.go
+++ b/discovery/zookeeper/zookeeper_test.go
@@ -18,7 +18,12 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestNewDiscoveryError(t *testing.T) {
 	_, err := NewDiscovery(

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"go.uber.org/goleak"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -38,6 +39,10 @@ import (
 	"github.com/prometheus/prometheus/util/teststorage"
 	"github.com/prometheus/prometheus/util/testutil"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestAlertingRule(t *testing.T) {
 	suite, err := promql.NewTest(t, `

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -46,6 +46,10 @@ import (
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
+func TestMain(m *testing.M) {
+	testutil.TolerantVerifyLeak(m)
+}
+
 func TestNewScrapePool(t *testing.T) {
 	var (
 		app   = &nopAppendable{}
@@ -1785,6 +1789,7 @@ func TestReuseScrapeCache(t *testing.T) {
 		}
 		proxyURL, _ = url.Parse("http://localhost:2128")
 	)
+	defer sp.stop()
 	sp.sync([]*Target{t1})
 
 	steps := []struct {
@@ -1937,6 +1942,7 @@ func TestReuseCacheRace(t *testing.T) {
 			},
 		}
 	)
+	defer sp.stop()
 	sp.sync([]*Target{t1})
 
 	start := time.Now()


### PR DESCRIPTION
Nothing to mention but 2 fixed tests in scrape.

cc @bwplotka 

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->