### PR TITLE
tsdb/chunkenc: fix typo of return error.

### DIFF
--- a/tsdb/CHANGELOG.md
+++ b/tsdb/CHANGELOG.md
@@ -33,7 +33,7 @@
  - [BUGFIX] Don't panic and recover nicely when running out of disk space.
  - [BUGFIX] Correctly handle empty labels.
  - [BUGFIX] Don't crash on an unknown tombstone ref.
- - [ENHANCEMENT] Re-add FromData function to create a chunk from bytes. It is used by Cortex and Thanos.
+ - [ENHANCEMENT] Re-add `FromData` function to create a chunk from bytes. It is used by Cortex and Thanos.
  - [ENHANCEMENT] Simplify mergedPostings.Seek.
  - [FEATURE]  Added `currentSegment` metric for the current WAL segment it is being written to.
 

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -14,7 +14,6 @@
 package chunkenc
 
 import (
-	"fmt"
 	"math"
 	"sync"
 
@@ -132,7 +131,7 @@ func (p *pool) Get(e Encoding, b []byte) (Chunk, error) {
 		c.b.count = 0
 		return c, nil
 	}
-	return nil, errors.Errorf("invalid encoding %q", e)
+	return nil, errors.Errorf("invalid chunk encoding %q", e)
 }
 
 func (p *pool) Put(c Chunk) error {
@@ -149,7 +148,7 @@ func (p *pool) Put(c Chunk) error {
 		xc.b.count = 0
 		p.xor.Put(c)
 	default:
-		return errors.Errorf("invalid encoding %q", c.Encoding())
+		return errors.Errorf("invalid chunk encoding %q", c.Encoding())
 	}
 	return nil
 }
@@ -162,5 +161,5 @@ func FromData(e Encoding, d []byte) (Chunk, error) {
 	case EncXOR:
 		return &XORChunk{b: bstream{count: 0, stream: d}}, nil
 	}
-	return nil, fmt.Errorf("unknown chunk encoding: %d", e)
+	return nil, errors.Errorf("invalid chunk encoding %q", e)
 }


### PR DESCRIPTION
Fix the content of the return error. 

In the `pool.Get()` method, the error is more exact. 
Although the `FromData` is not used mostly, it's better to refactor the return error to consistent with `pool.Get`
