### PR TITLE
discovery: check for nil triton_sd_config

### DIFF
--- a/discovery/config/config.go
+++ b/discovery/config/config.go
@@ -138,5 +138,10 @@ func (c *ServiceDiscoveryConfig) Validate() error {
 			return errors.New("empty or null section in static_configs")
 		}
 	}
+	for _, cfg := range c.TritonSDConfigs {
+		if cfg == nil {
+			return errors.New("empty or null section in triton_sd_configs")
+		}
+	}
 	return nil
 }

--- a/discovery/config/config_test.go
+++ b/discovery/config/config_test.go
@@ -23,7 +23,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TestForNil(t *testing.T) {
+func TestForNilSDConfig(t *testing.T) {
 	// Get all the yaml fields names of the ServiceDiscoveryConfig struct.
 	s := reflect.ValueOf(ServiceDiscoveryConfig{})
 	configType := s.Type()

--- a/discovery/config/config_test.go
+++ b/discovery/config/config_test.go
@@ -1,0 +1,58 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/util/testutil"
+	"gopkg.in/yaml.v2"
+)
+
+func TestForNil(t *testing.T) {
+	// Get all the yaml fields names of the ServiceDiscoveryConfig struct.
+	s := reflect.ValueOf(ServiceDiscoveryConfig{})
+	configType := s.Type()
+	n := s.NumField()
+	fieldsSlice := make([]string, n)
+	for i := 0; i < n; i++ {
+		field := configType.Field(i)
+		tag := field.Tag.Get("yaml")
+		tag = strings.Split(tag, ",")[0]
+		fieldsSlice = append(fieldsSlice, tag)
+	}
+
+	// Unmarshall all possible yaml keys and validate errors check upon nil
+	// SD config.
+	for _, f := range fieldsSlice {
+		if f == "" {
+			continue
+		}
+		t.Run(f, func(t *testing.T) {
+			c := &ServiceDiscoveryConfig{}
+			err := yaml.Unmarshal([]byte(fmt.Sprintf(`
+---
+%s:
+-
+`, f)), c)
+			testutil.Ok(t, err)
+			err = c.Validate()
+			testutil.NotOk(t, err)
+			testutil.Equals(t, fmt.Sprintf("empty or null section in %s", f), err.Error())
+		})
+	}
+}

--- a/discovery/config/config_test.go
+++ b/discovery/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The Prometheus Authors
+// Copyright 2020 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
Note: this was discovered thanks to the added test.
The test is pretty low-level but also effective.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->