### PR TITLE
Chore: Log segment number when segment read failed

### DIFF
--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -391,7 +391,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 
 			// Ignore errors reading to end of segment whilst replaying the WAL.
 			if !tail {
-				if err != nil && err != io.EOF {
+				if err != nil && errors.Cause(err) != io.EOF {
 					level.Warn(w.logger).Log("msg", "Ignoring error reading to end of segment, may have dropped data", "err", err)
 				} else if reader.Offset() != size {
 					level.Warn(w.logger).Log("msg", "Expected to have read whole segment, may have dropped data", "segment", segmentNum, "read", reader.Offset(), "size", size)
@@ -400,8 +400,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 			}
 
 			// Otherwise, when we are tailing, non-EOFs are fatal.
-			if err != io.EOF {
-				level.Error(w.logger).Log("msg", "error reading segment", "err", err, "segment num", segmentNum)
+			if errors.Cause(err) != io.EOF {
 				return err
 			}
 
@@ -412,7 +411,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 
 			// Ignore all errors reading to end of segment whilst replaying the WAL.
 			if !tail {
-				if err != nil && err != io.EOF {
+				if err != nil && errors.Cause(err) != io.EOF {
 					level.Warn(w.logger).Log("msg", "Ignoring error reading to end of segment, may have dropped data", "segment", segmentNum, "err", err)
 				} else if reader.Offset() != size {
 					level.Warn(w.logger).Log("msg", "Expected to have read whole segment, may have dropped data", "segment", segmentNum, "read", reader.Offset(), "size", size)
@@ -421,8 +420,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 			}
 
 			// Otherwise, when we are tailing, non-EOFs are fatal.
-			if err != io.EOF {
-				level.Error(w.logger).Log("msg", "error reading segment", "err", err, "segment num", segmentNum)
+			if errors.Cause(err) != io.EOF {
 				return err
 			}
 		}
@@ -518,7 +516,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			return errors.New("unknown TSDB record type")
 		}
 	}
-	return r.Err()
+	return errors.Wrapf(r.Err(), "segment %d: %v", segmentNum, r.Err())
 }
 
 func (w *Watcher) SetStartTime(t time.Time) {
@@ -567,8 +565,7 @@ func (w *Watcher) readCheckpoint(checkpointDir string) error {
 		defer sr.Close()
 
 		r := NewLiveReader(w.logger, w.readerMetrics, sr)
-		if err := w.readSegment(r, index, false); err != io.EOF && err != nil {
-			level.Error(w.logger).Log("msg", "error reading segment", "err", err, "segment num", seg)
+		if err := w.readSegment(r, index, false); errors.Cause(err) != io.EOF && err != nil {
 			return errors.Wrap(err, "readSegment")
 		}
 

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -401,6 +401,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 
 			// Otherwise, when we are tailing, non-EOFs are fatal.
 			if err != io.EOF {
+				level.Error(w.logger).Log("msg", "error reading segment", "err", err, "segment num", segmentNum)
 				return err
 			}
 
@@ -421,6 +422,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 
 			// Otherwise, when we are tailing, non-EOFs are fatal.
 			if err != io.EOF {
+				level.Error(w.logger).Log("msg", "error reading segment", "err", err, "segment num", segmentNum)
 				return err
 			}
 		}
@@ -566,6 +568,7 @@ func (w *Watcher) readCheckpoint(checkpointDir string) error {
 
 		r := NewLiveReader(w.logger, w.readerMetrics, sr)
 		if err := w.readSegment(r, index, false); err != io.EOF && err != nil {
+			level.Error(w.logger).Log("msg", "error reading segment", "err", err, "segment num", seg)
 			return errors.Wrap(err, "readSegment")
 		}
 


### PR DESCRIPTION
To manually fix the WAL files, it is good to know where the corrupt
happened so we should log the segment number when the read failed.

Related Issue #7506

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->