### PR TITLE
Export RecoverableError

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -140,7 +140,7 @@ func NewWriteClient(name string, conf *ClientConfig) (WriteClient, error) {
 	}, nil
 }
 
-type recoverableError struct {
+type RecoverableError struct {
 	error
 }
 
@@ -177,7 +177,7 @@ func (c *client) Store(ctx context.Context, req []byte) error {
 	if err != nil {
 		// Errors from client.Do are from (for example) network errors, so are
 		// recoverable.
-		return recoverableError{err}
+		return RecoverableError{err}
 	}
 	defer func() {
 		io.Copy(ioutil.Discard, httpResp.Body)
@@ -193,7 +193,7 @@ func (c *client) Store(ctx context.Context, req []byte) error {
 		err = errors.Errorf("server returned HTTP status %s: %s", httpResp.Status, line)
 	}
 	if httpResp.StatusCode/100 == 5 {
-		return recoverableError{err}
+		return RecoverableError{err}
 	}
 	return err
 }

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -49,7 +49,7 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 		},
 		{
 			code: 500,
-			err:  recoverableError{errors.New("server returned HTTP status 500 Internal Server Error: " + longErrMessage[:maxErrMsgLen])},
+			err:  RecoverableError{errors.New("server returned HTTP status 500 Internal Server Error: " + longErrMessage[:maxErrMsgLen])},
 		},
 	}
 

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -902,7 +902,7 @@ func (s *shards) sendSamplesWithBackoff(ctx context.Context, samples []prompb.Ti
 
 		if err != nil {
 			// If the error is unrecoverable, we should not retry.
-			if _, ok := err.(recoverableError); !ok {
+			if _, ok := err.(RecoverableError); !ok {
 				return err
 			}
 


### PR DESCRIPTION
This PR simply exports RecoverableError from the remote package.  This allows callers of the exported method `WriteClient.Store` method to distinguish between recoverable and not recoverable errors.