### PR TITLE
Cleanup tempfiles

### DIFF
--- a/pkg/logging/file_test.go
+++ b/pkg/logging/file_test.go
@@ -24,9 +24,12 @@ import (
 )
 
 func TestJSONFileLogger_basic(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := ioutil.TempFile("", "logging")
 	testutil.Ok(t, err)
-	defer f.Close()
+	defer func() {
+		testutil.Ok(t, f.Close())
+		testutil.Ok(t, os.Remove(f.Name()))
+	}()
 
 	l, err := NewJSONFileLogger(f.Name())
 	testutil.Ok(t, err)
@@ -50,9 +53,12 @@ func TestJSONFileLogger_basic(t *testing.T) {
 }
 
 func TestJSONFileLogger_parallel(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := ioutil.TempFile("", "logging")
 	testutil.Ok(t, err)
-	defer f.Close()
+	defer func() {
+		testutil.Ok(t, f.Close())
+		testutil.Ok(t, os.Remove(f.Name()))
+	}()
 
 	l, err := NewJSONFileLogger(f.Name())
 	testutil.Ok(t, err)

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2282,7 +2282,7 @@ func TestAdminEndpoints(t *testing.T) {
 		tc := tc
 		t.Run("", func(t *testing.T) {
 			dir, _ := ioutil.TempDir("", "fakeDB")
-			defer testutil.Ok(t, os.RemoveAll(dir))
+			defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
 			api := &API{
 				db:          tc.db,

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -103,7 +103,7 @@ func TestReadyAndHealthy(t *testing.T) {
 
 	dbDir, err := ioutil.TempDir("", "tsdb-ready")
 	testutil.Ok(t, err)
-	defer testutil.Ok(t, os.RemoveAll(dbDir))
+	defer func() { testutil.Ok(t, os.RemoveAll(dbDir)) }()
 
 	db, err := tsdb.Open(dbDir, nil, nil, nil)
 	testutil.Ok(t, err)
@@ -295,7 +295,7 @@ func TestRoutePrefix(t *testing.T) {
 	t.Parallel()
 	dbDir, err := ioutil.TempDir("", "tsdb-ready")
 	testutil.Ok(t, err)
-	defer testutil.Ok(t, os.RemoveAll(dbDir))
+	defer func() { testutil.Ok(t, os.RemoveAll(dbDir)) }()
 
 	db, err := tsdb.Open(dbDir, nil, nil, nil)
 	testutil.Ok(t, err)


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->