### PR TITLE
Add additional tag/log to rules Manager Eval trace span.

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -576,6 +576,8 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 				if _, ok := err.(promql.ErrQueryCanceled); !ok {
 					level.Warn(g.logger).Log("msg", "Evaluating rule failed", "rule", rule, "err", err)
 				}
+				sp.SetTag("error", true)
+				sp.LogKV("error", err)
 				g.metrics.evalFailures.WithLabelValues(groupKey(g.File(), g.Name())).Inc()
 				return
 			}


### PR DESCRIPTION
Adds a tag to the span that says whether the evaluation succeeded, and a log line to the span with the error message in the result of failure.

Signed-off-by: Callum Styan <callumstyan@gmail.com>