### PR TITLE
scrape: fix typo.

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1086,7 +1086,7 @@ func (sl *scrapeLoop) scrapeAndReport(interval, timeout time.Duration, last time
 			sl.lastScrapeSize = len(b)
 		}
 	} else {
-		level.Debug(sl.l).Log("msg", "Scrape failed", "err", scrapeErr.Error())
+		level.Debug(sl.l).Log("msg", "Scrape failed", "err", scrapeErr)
 		if errc != nil {
 			errc <- scrapeErr
 		}


### PR DESCRIPTION
```
var err, appErr, scrapeErr error

level.Debug(sl.l).Log("msg", "Scrape failed", "err", scrapeErr.Error())
level.Debug(sl.l).Log("msg", "Append failed", "err", appErr)
```

No need to call `Error()` of `error` when using go-kit log.