### PR TITLE
promql: use explicit type declare instead of string.

### DIFF
--- a/promql/parser/value.go
+++ b/promql/parser/value.go
@@ -24,20 +24,20 @@ type ValueType string
 
 // The valid value types.
 const (
-	ValueTypeNone   = "none"
-	ValueTypeVector = "vector"
-	ValueTypeScalar = "scalar"
-	ValueTypeMatrix = "matrix"
-	ValueTypeString = "string"
+	ValueTypeNone   ValueType = "none"
+	ValueTypeVector ValueType = "vector"
+	ValueTypeScalar ValueType = "scalar"
+	ValueTypeMatrix ValueType = "matrix"
+	ValueTypeString ValueType = "string"
 )
 
 // DocumentedType returns the internal type to the equivalent
 // user facing terminology as defined in the documentation.
 func DocumentedType(t ValueType) string {
 	switch t {
-	case "vector":
+	case ValueTypeVector:
 		return "instant vector"
-	case "matrix":
+	case ValueTypeMatrix:
 		return "range vector"
 	default:
 		return string(t)


### PR DESCRIPTION
The type of `ValueTypeNone` and so on are `ValueType` actually.

https://github.com/prometheus/prometheus/blob/ff0ea1c1acbf4f108b692f818477b76c0f642cf8/promql/parser/value.go#L23-L32

Use `ValueType` explicitly is better than string.
