### PR TITLE
tsdb: add check for mint and maxt.

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -355,7 +355,7 @@ const (
 
 // genSeries generates series with a given number of labels and values.
 func genSeries(totalSeries, labelCount int, mint, maxt int64) []storage.Series {
-	if totalSeries == 0 || labelCount == 0 {
+	if totalSeries == 0 || labelCount == 0 || mint > maxt {
 		return nil
 	}
 


### PR DESCRIPTION
Add a check for `mint` and `maxt`. The case that `mint` is bigger one leads to no samples created.