### PR TITLE
promql: delete redundant return value.

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -892,16 +892,13 @@ func (h *Head) Truncate(mint int64) (err error) {
 
 // initTime initializes a head with the first timestamp. This only needs to be called
 // for a completely fresh head with an empty WAL.
-// Returns true if the initialization took an effect.
-func (h *Head) initTime(t int64) (initialized bool) {
+func (h *Head) initTime(t int64) {
 	if !h.minTime.CAS(math.MaxInt64, t) {
-		return false
+		return
 	}
 	// Ensure that max time is initialized to at least the min time we just set.
 	// Concurrent appenders may already have set it to a higher value.
 	h.maxTime.CAS(math.MinInt64, t)
-
-	return true
 }
 
 type Stats struct {


### PR DESCRIPTION
The return value of the method `initTime` in `Head` has no reference. 

https://github.com/prometheus/prometheus/blob/e6d7cc5fa43716281bdf5d1cf40415f99a0e9623/tsdb/head.go#L896-L898

https://github.com/prometheus/prometheus/blob/e6d7cc5fa43716281bdf5d1cf40415f99a0e9623/tsdb/head.go#L904

The relative PR is https://github.com/prometheus/prometheus/commit/4f037da4620f417c842f53dbf579e2357c43bdd7. The condition is no used in this pr.