### PR TITLE
Consul: Reduce WatchTimeout to 2m and set it as timeout for requests

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	watchTimeout  = 10 * time.Minute
+	watchTimeout  = 2 * time.Minute
 	retryInterval = 15 * time.Second
 
 	// addressLabel is the name for the label containing a target's address.
@@ -184,7 +184,7 @@ func NewDiscovery(conf *SDConfig, logger log.Logger) (*Discovery, error) {
 	}
 	wrapper := &http.Client{
 		Transport: transport,
-		Timeout:   35 * time.Second,
+		Timeout:   time.Duration(watchTimeout) + 15*time.Second,
 	}
 
 	clientConf := &consul.Config{

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -223,20 +223,20 @@ func newServer(t *testing.T) (*httptest.Server, *SDConfig) {
 		switch r.URL.String() {
 		case "/v1/agent/self":
 			response = AgentAnswer
-		case "/v1/health/service/test?node-meta=rack_name%3A2304&stale=&tag=tag1&wait=600000ms":
+		case "/v1/health/service/test?node-meta=rack_name%3A2304&stale=&tag=tag1&wait=120000ms":
 			response = ServiceTestAnswer
-		case "/v1/health/service/test?wait=600000ms":
+		case "/v1/health/service/test?wait=120000ms":
 			response = ServiceTestAnswer
-		case "/v1/health/service/other?wait=600000ms":
+		case "/v1/health/service/other?wait=120000ms":
 			response = `[]`
-		case "/v1/catalog/services?node-meta=rack_name%3A2304&stale=&wait=600000ms":
+		case "/v1/catalog/services?node-meta=rack_name%3A2304&stale=&wait=120000ms":
 			response = ServicesTestAnswer
-		case "/v1/catalog/services?wait=600000ms":
+		case "/v1/catalog/services?wait=120000ms":
 			response = ServicesTestAnswer
-		case "/v1/catalog/services?index=1&node-meta=rack_name%3A2304&stale=&wait=600000ms":
+		case "/v1/catalog/services?index=1&node-meta=rack_name%3A2304&stale=&wait=120000ms":
 			time.Sleep(5 * time.Second)
 			response = ServicesTestAnswer
-		case "/v1/catalog/services?index=1&wait=600000ms":
+		case "/v1/catalog/services?index=1&wait=120000ms":
 			time.Sleep(5 * time.Second)
 			response = ServicesTestAnswer
 		default:


### PR DESCRIPTION
#7423 raised the watch to 10m but the timeout was still 35 seconds.

This PR downgrades the watch to 2m and the timeout to 2m15s. The reason for NOT keeping 10m is that the client.Timeout applies to ALL the consul calls, even the /agent/self and the initial non-blocking calls.

Because of that, 2m is a good balance.

closes #7626

@beorn7 Please consider this for a 2.20.1. This is harmless for users as the discovery works BUT generates a LOT of logs and SD failure counter is incremented all the time.


Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->