### PR TITLE
CI: Stash the yarn cache, not the node_modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ jobs:
         key: v1
     - restore_cache:
         keys:
-        - v1-npm-deps-{{ checksum "web/ui/react-app/yarn.lock" }}
-        - v1-npm-deps-
+        - v3-npm-deps-{{ checksum "web/ui/react-app/yarn.lock" }}
+        - v3-npm-deps-
     - run:
         command: make
         environment:
@@ -49,9 +49,9 @@ jobs:
     - go/save-cache:
         key: v1
     - save_cache:
-        key: v1-npm-deps-{{ checksum "web/ui/react-app/yarn.lock" }}
+        key: v3-npm-deps-{{ checksum "web/ui/react-app/yarn.lock" }}
         paths:
-        - web/ui/react-app/node_modules
+        - /home/circleci/.cache/yarn
     - store_test_results:
         path: test-results
   test_windows:


### PR DESCRIPTION
cc @juliusv @simonpasquier 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->