### PR TITLE
Split linux and non linux builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,18 @@ workflows:
           tags:
             only: /.*/
     - prometheus/build:
-        name: build
+        name: build-linux
+        pre-steps:
+          - run:
+                command: awk -i inplace 'go != 1 {print} go==1 && /linux/ {print} /platforms:/ {go=1}' .promu.yml
+        filters:
+          tags:
+            only: /.*/
+    - prometheus/build:
+        name: build-nonlinux
+        pre-steps:
+          - run:
+                command: awk -i inplace 'go != 1 {print} go==1 && !/linux/ {print} /platforms:/ {go=1}' .promu.yml
         filters:
           tags:
             only: /.*/
@@ -118,7 +129,8 @@ workflows:
         context: org-context
         requires:
         - test
-        - build
+        - build-linux
+        - build-nonlinux
         filters:
           branches:
             only: master
@@ -127,7 +139,8 @@ workflows:
         context: org-context
         requires:
         - test
-        - build
+        - build-linux
+        - build-nonlinux
         filters:
           tags:
             only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->