### PR TITLE
Pass groupName as context value in call to Appender

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -52,7 +52,11 @@ const (
 const namespace = "prometheus"
 
 // Typed string for passing group information to storage.Appendable
-const RuleGroupKey = "ruleGroup"
+type RuleGroupInfo string
+
+const (
+	RuleGroupKey RuleGroupInfo = "ruleGroup"
+)
 
 // Metrics for rule evaluation.
 type Metrics struct {

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -588,7 +588,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 				numDuplicates = 0
 			)
 
-			app := g.opts.Appendable.Appender(ctx)
+			app := g.opts.Appendable.Appender(context.WithValue(ctx, "groupName", g.name))
 			seriesReturned := make(map[string]labels.Labels, len(g.seriesInPreviousEval[i]))
 			defer func() {
 				if err := app.Commit(); err != nil {

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -51,6 +51,9 @@ const (
 // Constants for instrumentation.
 const namespace = "prometheus"
 
+// Typed string for passing group information to storage.Appendable
+const RuleGroupKey = "ruleGroup"
+
 // Metrics for rule evaluation.
 type Metrics struct {
 	evalDuration        prometheus.Summary
@@ -588,7 +591,8 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 				numDuplicates = 0
 			)
 
-			app := g.opts.Appendable.Appender(context.WithValue(ctx, "groupName", g.name))
+			appenderCtx := context.WithValue(ctx, RuleGroupKey, g.file+"/"+g.name)
+			app := g.opts.Appendable.Appender(appenderCtx)
 			seriesReturned := make(map[string]labels.Labels, len(g.seriesInPreviousEval[i]))
 			defer func() {
 				if err := app.Commit(); err != nil {


### PR DESCRIPTION
As a follow up action from this comment https://github.com/prometheus/prometheus/pull/7660#issuecomment-664317496, I'd like to propose the following change to pass `groupName` as a context value, in the call to `Appender()` from `group.run()`. 

This will enable us to choose group spec Appenders in the Cortex Ruler.

Signed-off-by: Annanay <annanayagarwal@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->