### PR TITLE
Add tsdb startup duration metric

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -112,6 +112,7 @@ type headMetrics struct {
 	outOfOrderSamples        prometheus.Counter
 	walTruncateDuration      prometheus.Summary
 	walCorruptionsTotal      prometheus.Counter
+	walTotalReplayDuration   prometheus.Gauge
 	headTruncateFail         prometheus.Counter
 	headTruncateTotal        prometheus.Counter
 	checkpointDeleteFail     prometheus.Counter
@@ -169,6 +170,10 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			Name: "prometheus_tsdb_wal_corruptions_total",
 			Help: "Total number of WAL corruptions.",
 		}),
+		walTotalReplayDuration: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "prometheus_tsdb_wal_total_replay_duration_seconds",
+			Help: "Duration of WAL to replay.",
+		}),
 		samplesAppended: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_head_samples_appended_total",
 			Help: "Total number of appended samples.",
@@ -224,6 +229,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.gcDuration,
 			m.walTruncateDuration,
 			m.walCorruptionsTotal,
+			m.walTotalReplayDuration,
 			m.samplesAppended,
 			m.outOfBoundSamples,
 			m.outOfOrderSamples,
@@ -716,11 +722,13 @@ func (h *Head) Init(minValidTime int64) error {
 		level.Info(h.logger).Log("msg", "WAL segment loaded", "segment", i, "maxSegment", last)
 	}
 
+	walReplayDuration := time.Since(start)
+	h.metrics.walTotalReplayDuration.Set(walReplayDuration.Seconds())
 	level.Info(h.logger).Log(
 		"msg", "WAL replay completed",
 		"checkpoint_replay_duration", checkpointReplayDuration.String(),
 		"wal_replay_duration", time.Since(walReplayStart).String(),
-		"total_replay_duration", time.Since(start).String(),
+		"total_replay_duration", walReplayDuration.String(),
 	)
 
 	return nil

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -171,8 +171,8 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			Help: "Total number of WAL corruptions.",
 		}),
 		walTotalReplayDuration: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "prometheus_tsdb_wal_total_replay_duration_seconds",
-			Help: "Duration of WAL to replay.",
+			Name: "prometheus_tsdb_data_replay_duration_seconds",
+			Help: "Time taken to replay the data on disk.",
 		}),
 		samplesAppended: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_head_samples_appended_total",


### PR DESCRIPTION
Fixes #7703 

I created a new metric `prometheus_tsdb_startup_duration_seconds`.
Other possible solution may be exposing the [total_replay_duration](https://github.com/prometheus/prometheus/blob/master/tsdb/head.go#L723) as metric, since the time is spent mostly on WAL load. 

Signed-off-by: Maxim Neverov neverov.max@gmail.com

@bwplotka  please take a look