### PR TITLE
Update gh-workflow to trigger only on specific events

### DIFF
--- a/.github/workflows/funcbench.yml
+++ b/.github/workflows/funcbench.yml
@@ -1,4 +1,6 @@
 on: repository_dispatch
+  repository_dispatch:
+    types: [funcbench_start]
 name: Funcbench Workflow
 jobs:
   run_funcbench:

--- a/.github/workflows/prombench.yml
+++ b/.github/workflows/prombench.yml
@@ -1,4 +1,6 @@
 on: repository_dispatch
+  repository_dispatch:
+    types: [prombench_start,prombench_restart,prombench_stop]
 name: Prombench Workflow
 env:
   AUTH_FILE: ${{ secrets.TEST_INFRA_GKE_AUTH }}


### PR DESCRIPTION
Currently both the prombench and funcbench workflow are executed and one of them is ignored based on the command run. This PR fixes that.

See: https://github.com/prometheus/test-infra/issues/418

![image](https://user-images.githubusercontent.com/12918431/89337592-cd9a7600-d6b8-11ea-81d7-6ef19a6ec7f5.png)

cc: @krasi-georgiev @roidelapluie 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>