### PR TITLE
Use faillint to ensure that no restricted imports are being used

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -187,6 +187,7 @@ common-vet:
 .PHONY: common-restricted_imports
 common-restricted_imports:
 	@echo ">> verifying that we are not using restricted packages"
+	$(GO) get github.com/fatih/faillint
 	faillint -paths "sync/atomic=go.uber.org/atomic" ./...
 
 .PHONY: common-lint

--- a/Makefile.common
+++ b/Makefile.common
@@ -118,7 +118,7 @@ endif
 %: common-% ;
 
 .PHONY: common-all
-common-all: precheck style check_license lint unused build test
+common-all: precheck style check_license restricted_imports lint unused build test
 
 .PHONY: common-style
 common-style:
@@ -183,6 +183,11 @@ common-format:
 common-vet:
 	@echo ">> vetting code"
 	GO111MODULE=$(GO111MODULE) $(GO) vet $(GOOPTS) $(pkgs)
+
+.PHONY: common-restricted_imports
+common-restricted_imports:
+	@echo ">> verifying that we are not using restricted packages"
+	faillint -paths "sync/atomic=go.uber.org/atomic" ./...
 
 .PHONY: common-lint
 common-lint: $(GOLANGCI_LINT)

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200706150819-a40b877fbb9e+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/edsrzf/mmap-go v1.0.0
+	github.com/fatih/faillint v1.5.0
 	github.com/go-kit/kit v0.10.0
 	github.com/go-logfmt/logfmt v0.5.0
 	github.com/go-openapi/strfmt v0.19.5

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
+dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363 h1:o4lAkfETerCnr1kF9/qwkwjICnU+YLHNDCM8h2xj7as=
+dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363/go.mod h1:WG7q7swWsS2f9PYpt5DoEP/EBYWx8We5UoRltn9vJl8=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go v44.2.0+incompatible h1:d0WY8HTXhnurVBAkLXzv4bRpd+P5r3U/W17Z88PJWiI=
 github.com/Azure/azure-sdk-for-go v44.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -183,6 +185,8 @@ github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fatih/faillint v1.5.0 h1:fUolG+EsD6zdRW4rapzrM0tSf7VdpxWG3GLCPafUOcE=
+github.com/fatih/faillint v1.5.0/go.mod h1:e+3n7K3aI9fnZS4aNCggnoB+uBF4hwjqqR7BmA35PCE=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
@@ -1002,6 +1006,7 @@ golang.org/x/tools v0.0.0-20200122220014-bf1340f18c4a/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200204074204-1cc6d1ef6c74/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200207224406-61798d64f025/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=

--- a/scripts/tools.go
+++ b/scripts/tools.go
@@ -18,9 +18,9 @@
 package tools
 
 import (
+	_ "github.com/fatih/faillint"
 	_ "github.com/gogo/protobuf/protoc-gen-gogofast"
 	_ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway"
 	_ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger"
 	_ "golang.org/x/tools/cmd/goimports"
-	_ "github.com/fatih/faillint"
 )

--- a/scripts/tools.go
+++ b/scripts/tools.go
@@ -22,4 +22,5 @@ import (
 	_ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway"
 	_ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger"
 	_ "golang.org/x/tools/cmd/goimports"
+	_ "github.com/fatih/faillint"
 )

--- a/vendor/dmitri.shuralyov.com/go/generated/LICENSE
+++ b/vendor/dmitri.shuralyov.com/go/generated/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2017 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/dmitri.shuralyov.com/go/generated/generated.go
+++ b/vendor/dmitri.shuralyov.com/go/generated/generated.go
@@ -1,0 +1,80 @@
+// Package generated provides a function that parses a Go file and reports
+// whether it contains a "// Code generated … DO NOT EDIT." line comment.
+//
+// It implements the specification at https://golang.org/s/generatedcode.
+//
+// The first priority is correctness (no false negatives, no false positives).
+// It must return accurate results even if the input Go source code is not gofmted.
+//
+// The second priority is performance. The current version uses bufio.Reader and
+// ReadBytes. Performance can be optimized further by using lower level I/O
+// primitives and allocating less. That can be explored later. A lot of the time
+// is spent on reading the entire file without being able to stop early,
+// since the specification allows the comment to appear anywhere in the file.
+package generated
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+)
+
+// Parse parses the source code of a single Go source file
+// provided via src, and reports whether the file contains
+// a "// Code generated ... DO NOT EDIT." line comment
+// matching the specification at https://golang.org/s/generatedcode:
+//
+// 	Generated files are marked by a line of text that matches
+// 	the regular expression, in Go syntax:
+//
+// 		^// Code generated .* DO NOT EDIT\.$
+//
+// 	The .* means the tool can put whatever folderol it wants in there,
+// 	but the comment must be a single line and must start with Code generated
+// 	and end with DO NOT EDIT., with a period.
+//
+// 	The text may appear anywhere in the file.
+func Parse(src io.Reader) (hasGeneratedComment bool, err error) {
+	br := bufio.NewReader(src)
+	for {
+		s, err := br.ReadBytes('\n')
+		if err == io.EOF {
+			return containsComment(s), nil
+		} else if err != nil {
+			return false, err
+		}
+		if len(s) >= 2 && s[len(s)-2] == '\r' {
+			s = s[:len(s)-2] // Trim "\r\n".
+		} else {
+			s = s[:len(s)-1] // Trim "\n".
+		}
+		if containsComment(s) {
+			return true, nil
+		}
+	}
+}
+
+// containsComment reports whether a line of Go source code s (without newline character)
+// contains the generated comment.
+func containsComment(s []byte) bool {
+	return len(s) >= len(prefix)+len(suffix) &&
+		bytes.HasPrefix(s, prefix) &&
+		bytes.HasSuffix(s, suffix)
+}
+
+var (
+	prefix = []byte("// Code generated ")
+	suffix = []byte(" DO NOT EDIT.")
+)
+
+// ParseFile opens the file specified by filename and uses Parse to parse it.
+// If the source couldn't be read, the error indicates the specific failure.
+func ParseFile(filename string) (hasGeneratedComment bool, err error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	return Parse(f)
+}

--- a/vendor/github.com/fatih/faillint/.gitignore
+++ b/vendor/github.com/fatih/faillint/.gitignore
@@ -1,0 +1,17 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+faillint/testdata/pkg
+
+# IDE workspace files
+/.vscode/

--- a/vendor/github.com/fatih/faillint/LICENSE
+++ b/vendor/github.com/fatih/faillint/LICENSE
@@ -1,0 +1,62 @@
+BSD 3-Clause License
+
+Copyright (c) 2019, Fatih Arslan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This software includes some portions from Go. Go is used under the terms of the
+BSD like license.
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The Go gopher was designed by Renee French. http://reneefrench.blogspot.com/ The design is licensed under the Creative Commons 3.0 Attributions license. Read this article for more details: https://blog.golang.org/gopher

--- a/vendor/github.com/fatih/faillint/README.md
+++ b/vendor/github.com/fatih/faillint/README.md
@@ -1,0 +1,166 @@
+# faillint [![](https://github.com/fatih/faillint/workflows/build/badge.svg)](https://github.com/fatih/faillint/actions)
+
+Faillint is a simple Go linter that fails when a specific set of import paths
+or exported path's functions, constant, vars or types are used. It's meant to be
+used in CI/CD environments to catch rules you want to enforce in your projects.
+
+As an example, you could enforce the usage of `github.com/pkg/errors` instead
+of the `errors` package. To prevent the usage of the `errors` package, you can
+configure `faillint` to fail whenever someone imports the `errors` package in
+this case. To make sure `fmt.Errorf` is not used for creating errors as well,
+you can configure to fail on such single function of `fmt` as well.
+
+![faillint](https://user-images.githubusercontent.com/438920/74105802-f7158300-4b15-11ea-8e23-16be5cd3b971.gif)
+
+## Install
+
+```bash
+go get github.com/fatih/faillint
+```
+
+## Usage
+
+`faillint` works on a file, directory or a Go package:
+
+```sh
+$ faillint -paths "errors,fmt.{Errorf}" foo.go # pass a file
+$ faillint -paths "errors,fmt.{Errorf}" ./...  # recursively analyze all files
+$ faillint -paths "errors,fmt.{Errorf}" github.com/fatih/gomodifytags # or pass a package
+```
+
+By default, `faillint` will not check any import paths. You need to explicitly
+define it with the `-paths` flag, which is comma-separated list. Some examples are:
+
+```
+# Fail if the errors package is used.
+-paths "errors"
+
+# Fail if the old context package is imported.
+-paths "golang.org/x/net/context"
+
+# Fail both on stdlib log and errors package to enforce other internal libraries.
+-paths "log,errors"
+
+# Fail if any of Print, Printf of Println function were used from fmt library.
+-paths "fmt.{Print,Printf,Println}"
+
+# Fail if the package is imported including sub paths starting with
+  "golang.org/x/net/". In example: `golang.org/x/net/context`, 
+  `golang.org/x/net/nettest`, .nettest`, ...
+-paths "golang.org/x/net/..."
+```
+
+If you have a preferred import path to suggest, append the suggestion after a `=` character:
+
+```
+# Fail if the errors package is used and suggest to use github.com/pkg/errors.
+-paths "errors=github.com/pkg/errors"
+
+# Fail for the old context import path and suggest to use the stdlib context.
+-paths "golang.org/x/net/context=context"
+
+# Fail both on stdlib log and errors package to enforce other libraries.
+-paths "log=go.uber.org/zap,errors=github.com/pkg/errors"
+
+# Fail on fmt.Errorf and suggest the Errorf function from github.compkg/errors instead.
+-paths "fmt.{Errorf}=github.com/pkg/errors.{Errorf}"
+```
+
+### Ignoring problems
+
+If you want to ignore a problem reported by `faillint` you can add a lint directive based on [staticcheck](https://staticcheck.io)'s design.
+
+#### Line-based lint directives
+
+Line-based lint directives can be applied to imports or functions you want to tolerate.  The format is,
+
+```go
+//lint:ignore faillint reason
+```
+
+For example,
+
+```go
+package a
+
+import (
+        //lint:ignore faillint Whatever your reason is.
+        "errors"
+        "fmt" //lint:ignore faillint Whatever your reason is.
+)
+
+func foo() error {
+        //lint:ignore faillint Whatever your reason is.
+        return errors.New("bar!")
+}
+```
+
+#### File-based lint directives
+
+File-based lint directives can be applied to ignore `faillint` problems in a whole file.  The format is,
+
+```go
+//lint:file-ignore faillint reason
+```
+
+This may be placed anywhere in the file but conventionally it should be placed at, or near, the top of the file.
+
+For example,
+
+```go
+//lint:file-ignore faillint This file should be ignored by faillint.
+
+package a
+
+import (
+        "errors"
+)
+
+func foo() error {
+        return errors.New("bar!")
+}
+```
+
+## Example
+
+Assume we have the following file:
+
+```go
+package a
+
+import (
+        "errors"
+)
+
+func foo() error {
+        return errors.New("bar!")
+}
+```
+
+Let's run `faillint` to check if `errors` import is used and report it:
+
+```
+$ faillint -paths "errors=github.com/pkg/errors" a.go
+a.go:4:2: package "errors" shouldn't be imported, suggested: "github.com/pkg/errors"
+```
+
+## The need for this tool?
+
+Most of these checks should be probably detected during the review cycle. But
+it's totally normal to accidentally import them (we're all humans in the end).
+
+Second, tools like `goimports` favors certain packages. As an example going
+forward if you decided to use `github.com/pkg/errors` in you project, and write
+`errors.New()` in a new file, `goimports` will automatically import the
+`errors` package (and not `github.com/pkg/errors`). The code will perfectly
+compile. `faillint` would be able to detect and report it to you.
+
+## Credits
+
+This tool is built on top of the excellent `go/analysis` package that makes it
+easy to write custom analyzers in Go. If you're interested in writing a tool,
+check out my **[Using go/analysis to write a custom
+linter](https://arslan.io/2019/06/13/using-go-analysis-to-write-a-custom-linter/)**
+blog post.
+
+Part of the code is modified and based on [astutil.UsesImport](https://pkg.go.dev/golang.org/x/tools/go/ast/astutil?tab=doc#UsesImport)

--- a/vendor/github.com/fatih/faillint/faillint/faillint.go
+++ b/vendor/github.com/fatih/faillint/faillint/faillint.go
@@ -1,0 +1,341 @@
+// Package faillint defines an Analyzer that fails when a package is imported
+// that matches against a set of defined packages.
+package faillint
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"dmitri.shuralyov.com/go/generated"
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	// ignoreKey is used in a faillint directive to ignore a line-based problem.
+	ignoreKey = "ignore"
+	// fileIgnoreKey is used in a faillint directive to ignore a whole file.
+	fileIgnoreKey = "file-ignore"
+	// missingReasonTemplate is used when a faillint directive is missing a reason.
+	missingReasonTemplate = "missing reason on faillint:%s directive"
+	// unrecognizedOptionTemplate is used when a faillint directive has an option other than ignore or file-ignore.
+	unrecognizedOptionTemplate = "unrecognized option on faillint directive: %s"
+
+	unspecifiedUsage = "unspecified"
+)
+
+var (
+	// Analyzer is a global instance of the linter.
+	// DEPRECATED: Use faillint.New instead.
+	Analyzer = NewAnalyzer()
+
+	// pathsRegexp represents a regexp that is used to parse -paths flag.
+	// It parses flag content in set of 3 subgroups:
+	//
+	// * import: Mandatory part. Go import path in URL format to be unwanted or have unwanted declarations.
+	// * recursive: Optional part. Import paths in the form of foo/bar/... indicates that all recursive sub matchs should be also matched.
+	// * declarations: Optional declarations in `{ }`. If set, using the import is allowed expect give declarations.
+	// * suggestion: Optional suggestion to print when unwanted import or declaration is found.
+	pathsRegexp = regexp.MustCompile(`(?P<import>[\w/.-]+[\w])(/?(?P<recursive>\.\.\.)|)(\.?{(?P<declarations>[\w-,]+)}|)(=(?P<suggestion>[\w/.-]+[\w](\.?{[\w-,]+}|))|)`)
+)
+
+// path represents a single parsed directive parsed with the pathsRegexp regex
+type path struct {
+	// imp contains the full import path
+	imp string
+
+	// recursive is true if the import path should encapsulate all sub paths
+	// for the given import path as well.
+	recursive bool
+
+	// declarations contains the declarations to fail for the given import path
+	decls []string
+
+	// sugg defines the suggestion for a given import path
+	sugg string
+}
+
+type faillint struct {
+	paths       string // -paths flag
+	ignoretests bool   // -ignore-tests flag
+}
+
+// NewAnalyzer create a faillint analyzer.
+func NewAnalyzer() *analysis.Analyzer {
+	f := faillint{
+		paths:       "",
+		ignoretests: false,
+	}
+	a := &analysis.Analyzer{
+		Name:             "faillint",
+		Doc:              "Report unwanted import path or exported declaration usages",
+		Run:              f.run,
+		RunDespiteErrors: true,
+	}
+
+	a.Flags.StringVar(&f.paths, "paths", "", `import paths or exported declarations (i.e: functions, constant, types or variables) to fail. E.g.:
+
+Fail on the usage of errors and fmt.Errorf. Also suggest packages for the failures
+  --paths errors=github.com/pkg/errors,fmt.{Errorf}=github.com/pkg/errors.{Errorf}
+
+Fail on the usage of fmt.Println, fmt.Print and fmt.Printf
+  --paths fmt.{Println,Print,Printf}
+
+Fail on the usage of prometheus.DefaultGatherer and prometheus.MustRegister
+  --paths github.com/prometheus/client_golang/prometheus.{DefaultGatherer,MustRegister}
+
+Fail on the usage of errors, golang.org/x/net and all sub packages under golang.org/x/net
+  --paths errors,golang.org/x/net/...`)
+	a.Flags.BoolVar(&f.ignoretests, "ignore-tests", false, "ignore all _test.go files")
+	return a
+}
+
+func trimAllWhitespaces(str string) string {
+	var b strings.Builder
+	b.Grow(len(str))
+	for _, ch := range str {
+		if !unicode.IsSpace(ch) {
+			b.WriteRune(ch)
+		}
+	}
+	return b.String()
+}
+
+// run is the runner for an analysis pass.
+func (f *faillint) run(pass *analysis.Pass) (interface{}, error) {
+	if f.paths == "" {
+		return nil, nil
+	}
+
+	for _, file := range pass.Files {
+		filename := pass.Fset.File(file.Package).Name()
+		isGenerated, err := generated.ParseFile(filename)
+		if err != nil {
+			return nil, err
+		}
+
+		if isGenerated {
+			continue
+		}
+
+		if f.ignoretests && strings.Contains(pass.Fset.File(file.Package).Name(), "_test.go") {
+			continue
+		}
+		if anyHasDirective(pass, file.Comments, fileIgnoreKey) {
+			continue
+		}
+		commentMap := ast.NewCommentMap(pass.Fset, file, file.Comments)
+		for _, path := range parsePaths(f.paths) {
+			specs := importSpec(file, path.imp, path.recursive)
+			if len(specs) == 0 {
+				continue
+			}
+
+			for _, spec := range specs {
+				if usageHasDirective(pass, commentMap, spec, spec.Pos(), ignoreKey) {
+					continue
+				}
+
+				usages := importUsages(pass, commentMap, file, spec)
+				if len(usages) == 0 {
+					continue
+				}
+
+				if _, ok := usages[unspecifiedUsage]; ok || len(path.decls) == 0 {
+					// File using unwanted import. Report.
+					msg := fmt.Sprintf("package %q shouldn't be imported", importPath(spec))
+					if path.sugg != "" {
+						msg += fmt.Sprintf(", suggested: %q", path.sugg)
+					}
+					pass.Reportf(spec.Path.Pos(), msg)
+					continue
+				}
+
+				// Not all usages are forbidden. Report only unwanted declarations.
+				for _, declaration := range path.decls {
+					positions, ok := usages[declaration]
+					if !ok {
+						continue
+					}
+					msg := fmt.Sprintf("declaration %q from package %q shouldn't be used", declaration, importPath(spec))
+					if path.sugg != "" {
+						msg += fmt.Sprintf(", suggested: %q", path.sugg)
+					}
+					for _, pos := range positions {
+						pass.Reportf(pos, msg)
+					}
+				}
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// importUsages reports all exported declaration used for a given import.
+func importUsages(pass *analysis.Pass, commentMap ast.CommentMap, f *ast.File, spec *ast.ImportSpec) map[string][]token.Pos {
+	importRef := spec.Name.String()
+	switch importRef {
+	case "<nil>":
+		importRef, _ = strconv.Unquote(spec.Path.Value)
+		// If the package importRef is not explicitly specified,
+		// make an educated guess. This is not guaranteed to be correct.
+		lastSlash := strings.LastIndex(importRef, "/")
+		if lastSlash != -1 {
+			importRef = importRef[lastSlash+1:]
+		}
+	case "_", ".":
+		// Not sure if this import is used - on the side of caution, report special "unspecified" usage.
+		return map[string][]token.Pos{unspecifiedUsage: nil}
+	}
+	usages := map[string][]token.Pos{}
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if isTopName(sel.X, importRef) {
+			if usageHasDirective(pass, commentMap, n, sel.Sel.NamePos, ignoreKey) {
+				return true
+			}
+			usages[sel.Sel.Name] = append(usages[sel.Sel.Name], sel.Sel.NamePos)
+		}
+		return true
+	})
+	return usages
+}
+
+// importSpecs returns all import specs for f import statements importing path.
+func importSpec(f *ast.File, path string, recursive bool) (imports []*ast.ImportSpec) {
+	for _, s := range f.Imports {
+		impPath := importPath(s)
+		if impPath == path {
+			imports = append(imports, s)
+		} else if recursive && strings.HasPrefix(impPath, path+"/") {
+			// match all subpaths as well, i.e:
+			//   impPath = golang.org/x/net/context
+			//      path = golang.org/x/net
+			// We add the "/" so we don't match packages with dashes, such as
+			// `golang.org/x/net-
+			imports = append(imports, s)
+		}
+	}
+	return imports
+}
+
+// importPath returns the unquoted import path of s,
+// or "" if the path is not properly quoted.
+func importPath(s *ast.ImportSpec) string {
+	t, err := strconv.Unquote(s.Path.Value)
+	if err == nil {
+		return t
+	}
+	return ""
+}
+
+// isTopName returns true if n is a top-level unresolved identifier with the given name.
+func isTopName(n ast.Expr, name string) bool {
+	id, ok := n.(*ast.Ident)
+	return ok && id.Name == name && id.Obj == nil
+}
+
+func parseDirective(pass *analysis.Pass, c *ast.Comment) (option string) {
+	s := c.Text
+	if !strings.HasPrefix(s, "//lint:") {
+		return ""
+	}
+	s = strings.TrimPrefix(s, "//lint:")
+	fields := strings.SplitN(s, " ", 3)
+
+	if len(fields) < 2 {
+		return ""
+	}
+
+	if fields[1] != "faillint" {
+		return ""
+	}
+
+	if fields[0] != ignoreKey && fields[0] != fileIgnoreKey {
+		pass.Reportf(c.Pos(), unrecognizedOptionTemplate, fields[0])
+		return ""
+	}
+
+	if len(fields) < 3 {
+		pass.Reportf(c.Pos(), missingReasonTemplate, fields[0])
+		return ""
+	}
+
+	return fields[0]
+}
+
+func anyHasDirective(pass *analysis.Pass, cgs []*ast.CommentGroup, option string) bool {
+	for _, cg := range cgs {
+		if hasDirective(pass, cg, option) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDirective(pass *analysis.Pass, cg *ast.CommentGroup, option string) bool {
+	if cg == nil {
+		return false
+	}
+	for _, c := range cg.List {
+		if parseDirective(pass, c) == option {
+			return true
+		}
+	}
+	return false
+}
+
+func usageHasDirective(pass *analysis.Pass, cm ast.CommentMap, n ast.Node, p token.Pos, option string) bool {
+	for _, cg := range cm[n] {
+		if hasDirective(pass, cg, ignoreKey) {
+			return true
+		}
+	}
+	// Try to find an "enclosing" node which the ast.CommentMap will
+	// thus have associated comments to this field selector.
+	for node := range cm {
+		if p >= node.Pos() && p <= node.End() {
+			for _, cg := range cm[node] {
+				if hasDirective(pass, cg, option) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func parsePaths(paths string) []path {
+	pathGroups := pathsRegexp.FindAllStringSubmatch(trimAllWhitespaces(paths), -1)
+
+	parsed := make([]path, 0, len(pathGroups))
+	for _, group := range pathGroups {
+		p := path{}
+		for i, name := range pathsRegexp.SubexpNames() {
+			switch name {
+			case "import":
+				p.imp = group[i]
+			case "recursive":
+				p.recursive = group[i] != ""
+			case "suggestion":
+				p.sugg = group[i]
+			case "declarations":
+				if group[i] == "" {
+					break
+				}
+				p.decls = strings.Split(group[i], ",")
+			}
+		}
+		parsed = append(parsed, p)
+	}
+	return parsed
+}

--- a/vendor/github.com/fatih/faillint/go.mod
+++ b/vendor/github.com/fatih/faillint/go.mod
@@ -1,0 +1,8 @@
+module github.com/fatih/faillint
+
+go 1.13
+
+require (
+	dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363
+	golang.org/x/tools v0.0.0-20200207224406-61798d64f025
+)

--- a/vendor/github.com/fatih/faillint/go.sum
+++ b/vendor/github.com/fatih/faillint/go.sum
@@ -1,0 +1,17 @@
+dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363 h1:o4lAkfETerCnr1kF9/qwkwjICnU+YLHNDCM8h2xj7as=
+dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363/go.mod h1:WG7q7swWsS2f9PYpt5DoEP/EBYWx8We5UoRltn9vJl8=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee h1:WG0RUwxtNT4qqaXX3DPA8zHFNm/D9xaBpxzHt1WcA/E=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20200207224406-61798d64f025 h1:i84/3szN87uN9jFX/jRqUbszQto2oAsFlqPf6lbR8H4=
+golang.org/x/tools v0.0.0-20200207224406-61798d64f025/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/vendor/github.com/fatih/faillint/main.go
+++ b/vendor/github.com/fatih/faillint/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/fatih/faillint/faillint"
+	"golang.org/x/tools/go/analysis/singlechecker"
+)
+
+func main() {
+	singlechecker.Main(faillint.NewAnalyzer())
+}

--- a/vendor/golang.org/x/tools/go/analysis/analysis.go
+++ b/vendor/golang.org/x/tools/go/analysis/analysis.go
@@ -1,0 +1,237 @@
+package analysis
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"reflect"
+
+	"golang.org/x/tools/internal/analysisinternal"
+)
+
+// An Analyzer describes an analysis function and its options.
+type Analyzer struct {
+	// The Name of the analyzer must be a valid Go identifier
+	// as it may appear in command-line flags, URLs, and so on.
+	Name string
+
+	// Doc is the documentation for the analyzer.
+	// The part before the first "\n\n" is the title
+	// (no capital or period, max ~60 letters).
+	Doc string
+
+	// Flags defines any flags accepted by the analyzer.
+	// The manner in which these flags are exposed to the user
+	// depends on the driver which runs the analyzer.
+	Flags flag.FlagSet
+
+	// Run applies the analyzer to a package.
+	// It returns an error if the analyzer failed.
+	//
+	// On success, the Run function may return a result
+	// computed by the Analyzer; its type must match ResultType.
+	// The driver makes this result available as an input to
+	// another Analyzer that depends directly on this one (see
+	// Requires) when it analyzes the same package.
+	//
+	// To pass analysis results between packages (and thus
+	// potentially between address spaces), use Facts, which are
+	// serializable.
+	Run func(*Pass) (interface{}, error)
+
+	// RunDespiteErrors allows the driver to invoke
+	// the Run method of this analyzer even on a
+	// package that contains parse or type errors.
+	RunDespiteErrors bool
+
+	// Requires is a set of analyzers that must run successfully
+	// before this one on a given package. This analyzer may inspect
+	// the outputs produced by each analyzer in Requires.
+	// The graph over analyzers implied by Requires edges must be acyclic.
+	//
+	// Requires establishes a "horizontal" dependency between
+	// analysis passes (different analyzers, same package).
+	Requires []*Analyzer
+
+	// ResultType is the type of the optional result of the Run function.
+	ResultType reflect.Type
+
+	// FactTypes indicates that this analyzer imports and exports
+	// Facts of the specified concrete types.
+	// An analyzer that uses facts may assume that its import
+	// dependencies have been similarly analyzed before it runs.
+	// Facts must be pointers.
+	//
+	// FactTypes establishes a "vertical" dependency between
+	// analysis passes (same analyzer, different packages).
+	FactTypes []Fact
+}
+
+func (a *Analyzer) String() string { return a.Name }
+
+func init() {
+	// Set the analysisinternal functions to be able to pass type errors
+	// to the Pass type without modifying the go/analysis API.
+	analysisinternal.SetTypeErrors = func(p interface{}, errors []types.Error) {
+		p.(*Pass).typeErrors = errors
+	}
+	analysisinternal.GetTypeErrors = func(p interface{}) []types.Error {
+		return p.(*Pass).typeErrors
+	}
+}
+
+// A Pass provides information to the Run function that
+// applies a specific analyzer to a single Go package.
+//
+// It forms the interface between the analysis logic and the driver
+// program, and has both input and an output components.
+//
+// As in a compiler, one pass may depend on the result computed by another.
+//
+// The Run function should not call any of the Pass functions concurrently.
+type Pass struct {
+	Analyzer *Analyzer // the identity of the current analyzer
+
+	// syntax and type information
+	Fset       *token.FileSet // file position information
+	Files      []*ast.File    // the abstract syntax tree of each file
+	OtherFiles []string       // names of non-Go files of this package
+	Pkg        *types.Package // type information about the package
+	TypesInfo  *types.Info    // type information about the syntax trees
+	TypesSizes types.Sizes    // function for computing sizes of types
+
+	// Report reports a Diagnostic, a finding about a specific location
+	// in the analyzed source code such as a potential mistake.
+	// It may be called by the Run function.
+	Report func(Diagnostic)
+
+	// ResultOf provides the inputs to this analysis pass, which are
+	// the corresponding results of its prerequisite analyzers.
+	// The map keys are the elements of Analysis.Required,
+	// and the type of each corresponding value is the required
+	// analysis's ResultType.
+	ResultOf map[*Analyzer]interface{}
+
+	// -- facts --
+
+	// ImportObjectFact retrieves a fact associated with obj.
+	// Given a value ptr of type *T, where *T satisfies Fact,
+	// ImportObjectFact copies the value to *ptr.
+	//
+	// ImportObjectFact panics if called after the pass is complete.
+	// ImportObjectFact is not concurrency-safe.
+	ImportObjectFact func(obj types.Object, fact Fact) bool
+
+	// ImportPackageFact retrieves a fact associated with package pkg,
+	// which must be this package or one of its dependencies.
+	// See comments for ImportObjectFact.
+	ImportPackageFact func(pkg *types.Package, fact Fact) bool
+
+	// ExportObjectFact associates a fact of type *T with the obj,
+	// replacing any previous fact of that type.
+	//
+	// ExportObjectFact panics if it is called after the pass is
+	// complete, or if obj does not belong to the package being analyzed.
+	// ExportObjectFact is not concurrency-safe.
+	ExportObjectFact func(obj types.Object, fact Fact)
+
+	// ExportPackageFact associates a fact with the current package.
+	// See comments for ExportObjectFact.
+	ExportPackageFact func(fact Fact)
+
+	// AllPackageFacts returns a new slice containing all package facts of the analysis's FactTypes
+	// in unspecified order.
+	// WARNING: This is an experimental API and may change in the future.
+	AllPackageFacts func() []PackageFact
+
+	// AllObjectFacts returns a new slice containing all object facts of the analysis's FactTypes
+	// in unspecified order.
+	// WARNING: This is an experimental API and may change in the future.
+	AllObjectFacts func() []ObjectFact
+
+	// typeErrors contains types.Errors that are associated with the pkg.
+	typeErrors []types.Error
+
+	/* Further fields may be added in future. */
+	// For example, suggested or applied refactorings.
+}
+
+// PackageFact is a package together with an associated fact.
+// WARNING: This is an experimental API and may change in the future.
+type PackageFact struct {
+	Package *types.Package
+	Fact    Fact
+}
+
+// ObjectFact is an object together with an associated fact.
+// WARNING: This is an experimental API and may change in the future.
+type ObjectFact struct {
+	Object types.Object
+	Fact   Fact
+}
+
+// Reportf is a helper function that reports a Diagnostic using the
+// specified position and formatted error message.
+func (pass *Pass) Reportf(pos token.Pos, format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	pass.Report(Diagnostic{Pos: pos, Message: msg})
+}
+
+// The Range interface provides a range. It's equivalent to and satisfied by
+// ast.Node.
+type Range interface {
+	Pos() token.Pos // position of first character belonging to the node
+	End() token.Pos // position of first character immediately after the node
+}
+
+// ReportRangef is a helper function that reports a Diagnostic using the
+// range provided. ast.Node values can be passed in as the range because
+// they satisfy the Range interface.
+func (pass *Pass) ReportRangef(rng Range, format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	pass.Report(Diagnostic{Pos: rng.Pos(), End: rng.End(), Message: msg})
+}
+
+func (pass *Pass) String() string {
+	return fmt.Sprintf("%s@%s", pass.Analyzer.Name, pass.Pkg.Path())
+}
+
+// A Fact is an intermediate fact produced during analysis.
+//
+// Each fact is associated with a named declaration (a types.Object) or
+// with a package as a whole. A single object or package may have
+// multiple associated facts, but only one of any particular fact type.
+//
+// A Fact represents a predicate such as "never returns", but does not
+// represent the subject of the predicate such as "function F" or "package P".
+//
+// Facts may be produced in one analysis pass and consumed by another
+// analysis pass even if these are in different address spaces.
+// If package P imports Q, all facts about Q produced during
+// analysis of that package will be available during later analysis of P.
+// Facts are analogous to type export data in a build system:
+// just as export data enables separate compilation of several passes,
+// facts enable "separate analysis".
+//
+// Each pass (a, p) starts with the set of facts produced by the
+// same analyzer a applied to the packages directly imported by p.
+// The analysis may add facts to the set, and they may be exported in turn.
+// An analysis's Run function may retrieve facts by calling
+// Pass.Import{Object,Package}Fact and update them using
+// Pass.Export{Object,Package}Fact.
+//
+// A fact is logically private to its Analysis. To pass values
+// between different analyzers, use the results mechanism;
+// see Analyzer.Requires, Analyzer.ResultType, and Pass.ResultOf.
+//
+// A Fact type must be a pointer.
+// Facts are encoded and decoded using encoding/gob.
+// A Fact may implement the GobEncoder/GobDecoder interfaces
+// to customize its encoding. Fact encoding should not fail.
+//
+// A Fact should not be modified once exported.
+type Fact interface {
+	AFact() // dummy method to avoid type errors
+}

--- a/vendor/golang.org/x/tools/go/analysis/diagnostic.go
+++ b/vendor/golang.org/x/tools/go/analysis/diagnostic.go
@@ -1,0 +1,61 @@
+package analysis
+
+import "go/token"
+
+// A Diagnostic is a message associated with a source location or range.
+//
+// An Analyzer may return a variety of diagnostics; the optional Category,
+// which should be a constant, may be used to classify them.
+// It is primarily intended to make it easy to look up documentation.
+//
+// If End is provided, the diagnostic is specified to apply to the range between
+// Pos and End.
+type Diagnostic struct {
+	Pos      token.Pos
+	End      token.Pos // optional
+	Category string    // optional
+	Message  string
+
+	// SuggestedFixes contains suggested fixes for a diagnostic which can be used to perform
+	// edits to a file that address the diagnostic.
+	// TODO(matloob): Should multiple SuggestedFixes be allowed for a diagnostic?
+	// Diagnostics should not contain SuggestedFixes that overlap.
+	// Experimental: This API is experimental and may change in the future.
+	SuggestedFixes []SuggestedFix // optional
+
+	// Experimental: This API is experimental and may change in the future.
+	Related []RelatedInformation // optional
+}
+
+// RelatedInformation contains information related to a diagnostic.
+// For example, a diagnostic that flags duplicated declarations of a
+// variable may include one RelatedInformation per existing
+// declaration.
+type RelatedInformation struct {
+	Pos     token.Pos
+	End     token.Pos
+	Message string
+}
+
+// A SuggestedFix is a code change associated with a Diagnostic that a user can choose
+// to apply to their code. Usually the SuggestedFix is meant to fix the issue flagged
+// by the diagnostic.
+// TextEdits for a SuggestedFix should not overlap. TextEdits for a SuggestedFix
+// should not contain edits for other packages.
+// Experimental: This API is experimental and may change in the future.
+type SuggestedFix struct {
+	// A description for this suggested fix to be shown to a user deciding
+	// whether to accept it.
+	Message   string
+	TextEdits []TextEdit
+}
+
+// A TextEdit represents the replacement of the code between Pos and End with the new text.
+// Each TextEdit should apply to a single file. End should not be earlier in the file than Pos.
+// Experimental: This API is experimental and may change in the future.
+type TextEdit struct {
+	// For a pure insertion, End can either be set to Pos or token.NoPos.
+	Pos     token.Pos
+	End     token.Pos
+	NewText []byte
+}

--- a/vendor/golang.org/x/tools/go/analysis/doc.go
+++ b/vendor/golang.org/x/tools/go/analysis/doc.go
@@ -1,0 +1,310 @@
+/*
+
+Package analysis defines the interface between a modular static
+analysis and an analysis driver program.
+
+
+Background
+
+A static analysis is a function that inspects a package of Go code and
+reports a set of diagnostics (typically mistakes in the code), and
+perhaps produces other results as well, such as suggested refactorings
+or other facts. An analysis that reports mistakes is informally called a
+"checker". For example, the printf checker reports mistakes in
+fmt.Printf format strings.
+
+A "modular" analysis is one that inspects one package at a time but can
+save information from a lower-level package and use it when inspecting a
+higher-level package, analogous to separate compilation in a toolchain.
+The printf checker is modular: when it discovers that a function such as
+log.Fatalf delegates to fmt.Printf, it records this fact, and checks
+calls to that function too, including calls made from another package.
+
+By implementing a common interface, checkers from a variety of sources
+can be easily selected, incorporated, and reused in a wide range of
+driver programs including command-line tools (such as vet), text editors and
+IDEs, build and test systems (such as go build, Bazel, or Buck), test
+frameworks, code review tools, code-base indexers (such as SourceGraph),
+documentation viewers (such as godoc), batch pipelines for large code
+bases, and so on.
+
+
+Analyzer
+
+The primary type in the API is Analyzer. An Analyzer statically
+describes an analysis function: its name, documentation, flags,
+relationship to other analyzers, and of course, its logic.
+
+To define an analysis, a user declares a (logically constant) variable
+of type Analyzer. Here is a typical example from one of the analyzers in
+the go/analysis/passes/ subdirectory:
+
+	package unusedresult
+
+	var Analyzer = &analysis.Analyzer{
+		Name: "unusedresult",
+		Doc:  "check for unused results of calls to some functions",
+		Run:  run,
+		...
+	}
+
+	func run(pass *analysis.Pass) (interface{}, error) {
+		...
+	}
+
+An analysis driver is a program such as vet that runs a set of
+analyses and prints the diagnostics that they report.
+The driver program must import the list of Analyzers it needs.
+Typically each Analyzer resides in a separate package.
+To add a new Analyzer to an existing driver, add another item to the list:
+
+	import ( "unusedresult"; "nilness"; "printf" )
+
+	var analyses = []*analysis.Analyzer{
+		unusedresult.Analyzer,
+		nilness.Analyzer,
+		printf.Analyzer,
+	}
+
+A driver may use the name, flags, and documentation to provide on-line
+help that describes the analyses it performs.
+The doc comment contains a brief one-line summary,
+optionally followed by paragraphs of explanation.
+
+The Analyzer type has more fields besides those shown above:
+
+	type Analyzer struct {
+		Name             string
+		Doc              string
+		Flags            flag.FlagSet
+		Run              func(*Pass) (interface{}, error)
+		RunDespiteErrors bool
+		ResultType       reflect.Type
+		Requires         []*Analyzer
+		FactTypes        []Fact
+	}
+
+The Flags field declares a set of named (global) flag variables that
+control analysis behavior. Unlike vet, analysis flags are not declared
+directly in the command line FlagSet; it is up to the driver to set the
+flag variables. A driver for a single analysis, a, might expose its flag
+f directly on the command line as -f, whereas a driver for multiple
+analyses might prefix the flag name by the analysis name (-a.f) to avoid
+ambiguity. An IDE might expose the flags through a graphical interface,
+and a batch pipeline might configure them from a config file.
+See the "findcall" analyzer for an example of flags in action.
+
+The RunDespiteErrors flag indicates whether the analysis is equipped to
+handle ill-typed code. If not, the driver will skip the analysis if
+there were parse or type errors.
+The optional ResultType field specifies the type of the result value
+computed by this analysis and made available to other analyses.
+The Requires field specifies a list of analyses upon which
+this one depends and whose results it may access, and it constrains the
+order in which a driver may run analyses.
+The FactTypes field is discussed in the section on Modularity.
+The analysis package provides a Validate function to perform basic
+sanity checks on an Analyzer, such as that its Requires graph is
+acyclic, its fact and result types are unique, and so on.
+
+Finally, the Run field contains a function to be called by the driver to
+execute the analysis on a single package. The driver passes it an
+instance of the Pass type.
+
+
+Pass
+
+A Pass describes a single unit of work: the application of a particular
+Analyzer to a particular package of Go code.
+The Pass provides information to the Analyzer's Run function about the
+package being analyzed, and provides operations to the Run function for
+reporting diagnostics and other information back to the driver.
+
+	type Pass struct {
+		Fset       *token.FileSet
+		Files      []*ast.File
+		OtherFiles []string
+		Pkg        *types.Package
+		TypesInfo  *types.Info
+		ResultOf   map[*Analyzer]interface{}
+		Report     func(Diagnostic)
+		...
+	}
+
+The Fset, Files, Pkg, and TypesInfo fields provide the syntax trees,
+type information, and source positions for a single package of Go code.
+
+The OtherFiles field provides the names, but not the contents, of non-Go
+files such as assembly that are part of this package. See the "asmdecl"
+or "buildtags" analyzers for examples of loading non-Go files and reporting
+diagnostics against them.
+
+The ResultOf field provides the results computed by the analyzers
+required by this one, as expressed in its Analyzer.Requires field. The
+driver runs the required analyzers first and makes their results
+available in this map. Each Analyzer must return a value of the type
+described in its Analyzer.ResultType field.
+For example, the "ctrlflow" analyzer returns a *ctrlflow.CFGs, which
+provides a control-flow graph for each function in the package (see
+golang.org/x/tools/go/cfg); the "inspect" analyzer returns a value that
+enables other Analyzers to traverse the syntax trees of the package more
+efficiently; and the "buildssa" analyzer constructs an SSA-form
+intermediate representation.
+Each of these Analyzers extends the capabilities of later Analyzers
+without adding a dependency to the core API, so an analysis tool pays
+only for the extensions it needs.
+
+The Report function emits a diagnostic, a message associated with a
+source position. For most analyses, diagnostics are their primary
+result.
+For convenience, Pass provides a helper method, Reportf, to report a new
+diagnostic by formatting a string.
+Diagnostic is defined as:
+
+	type Diagnostic struct {
+		Pos      token.Pos
+		Category string // optional
+		Message  string
+	}
+
+The optional Category field is a short identifier that classifies the
+kind of message when an analysis produces several kinds of diagnostic.
+
+Many analyses want to associate diagnostics with a severity level.
+Because Diagnostic does not have a severity level field, an Analyzer's
+diagnostics effectively all have the same severity level. To separate which
+diagnostics are high severity and which are low severity, expose multiple
+Analyzers instead. Analyzers should also be separated when their
+diagnostics belong in different groups, or could be tagged differently
+before being shown to the end user. Analyzers should document their severity
+level to help downstream tools surface diagnostics properly.
+
+Most Analyzers inspect typed Go syntax trees, but a few, such as asmdecl
+and buildtag, inspect the raw text of Go source files or even non-Go
+files such as assembly. To report a diagnostic against a line of a
+raw text file, use the following sequence:
+
+	content, err := ioutil.ReadFile(filename)
+	if err != nil { ... }
+	tf := fset.AddFile(filename, -1, len(content))
+	tf.SetLinesForContent(content)
+	...
+	pass.Reportf(tf.LineStart(line), "oops")
+
+
+Modular analysis with Facts
+
+To improve efficiency and scalability, large programs are routinely
+built using separate compilation: units of the program are compiled
+separately, and recompiled only when one of their dependencies changes;
+independent modules may be compiled in parallel. The same technique may
+be applied to static analyses, for the same benefits. Such analyses are
+described as "modular".
+
+A compiler’s type checker is an example of a modular static analysis.
+Many other checkers we would like to apply to Go programs can be
+understood as alternative or non-standard type systems. For example,
+vet's printf checker infers whether a function has the "printf wrapper"
+type, and it applies stricter checks to calls of such functions. In
+addition, it records which functions are printf wrappers for use by
+later analysis passes to identify other printf wrappers by induction.
+A result such as “f is a printf wrapper” that is not interesting by
+itself but serves as a stepping stone to an interesting result (such as
+a diagnostic) is called a "fact".
+
+The analysis API allows an analysis to define new types of facts, to
+associate facts of these types with objects (named entities) declared
+within the current package, or with the package as a whole, and to query
+for an existing fact of a given type associated with an object or
+package.
+
+An Analyzer that uses facts must declare their types:
+
+	var Analyzer = &analysis.Analyzer{
+		Name:      "printf",
+		FactTypes: []analysis.Fact{new(isWrapper)},
+		...
+	}
+
+	type isWrapper struct{} // => *types.Func f “is a printf wrapper”
+
+The driver program ensures that facts for a pass’s dependencies are
+generated before analyzing the package and is responsible for propagating
+facts from one package to another, possibly across address spaces.
+Consequently, Facts must be serializable. The API requires that drivers
+use the gob encoding, an efficient, robust, self-describing binary
+protocol. A fact type may implement the GobEncoder/GobDecoder interfaces
+if the default encoding is unsuitable. Facts should be stateless.
+
+The Pass type has functions to import and export facts,
+associated either with an object or with a package:
+
+	type Pass struct {
+		...
+		ExportObjectFact func(types.Object, Fact)
+		ImportObjectFact func(types.Object, Fact) bool
+
+		ExportPackageFact func(fact Fact)
+		ImportPackageFact func(*types.Package, Fact) bool
+	}
+
+An Analyzer may only export facts associated with the current package or
+its objects, though it may import facts from any package or object that
+is an import dependency of the current package.
+
+Conceptually, ExportObjectFact(obj, fact) inserts fact into a hidden map keyed by
+the pair (obj, TypeOf(fact)), and the ImportObjectFact function
+retrieves the entry from this map and copies its value into the variable
+pointed to by fact. This scheme assumes that the concrete type of fact
+is a pointer; this assumption is checked by the Validate function.
+See the "printf" analyzer for an example of object facts in action.
+
+Some driver implementations (such as those based on Bazel and Blaze) do
+not currently apply analyzers to packages of the standard library.
+Therefore, for best results, analyzer authors should not rely on
+analysis facts being available for standard packages.
+For example, although the printf checker is capable of deducing during
+analysis of the log package that log.Printf is a printf wrapper,
+this fact is built in to the analyzer so that it correctly checks
+calls to log.Printf even when run in a driver that does not apply
+it to standard packages. We would like to remove this limitation in future.
+
+
+Testing an Analyzer
+
+The analysistest subpackage provides utilities for testing an Analyzer.
+In a few lines of code, it is possible to run an analyzer on a package
+of testdata files and check that it reported all the expected
+diagnostics and facts (and no more). Expectations are expressed using
+"// want ..." comments in the input code.
+
+
+Standalone commands
+
+Analyzers are provided in the form of packages that a driver program is
+expected to import. The vet command imports a set of several analyzers,
+but users may wish to define their own analysis commands that perform
+additional checks. To simplify the task of creating an analysis command,
+either for a single analyzer or for a whole suite, we provide the
+singlechecker and multichecker subpackages.
+
+The singlechecker package provides the main function for a command that
+runs one analyzer. By convention, each analyzer such as
+go/passes/findcall should be accompanied by a singlechecker-based
+command such as go/analysis/passes/findcall/cmd/findcall, defined in its
+entirety as:
+
+	package main
+
+	import (
+		"golang.org/x/tools/go/analysis/passes/findcall"
+		"golang.org/x/tools/go/analysis/singlechecker"
+	)
+
+	func main() { singlechecker.Main(findcall.Analyzer) }
+
+A tool that provides multiple analyzers can use multichecker in a
+similar way, giving it the list of Analyzers.
+
+*/
+package analysis

--- a/vendor/golang.org/x/tools/go/analysis/internal/analysisflags/flags.go
+++ b/vendor/golang.org/x/tools/go/analysis/internal/analysisflags/flags.go
@@ -1,0 +1,388 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package analysisflags defines helpers for processing flags of
+// analysis driver tools.
+package analysisflags
+
+import (
+	"crypto/sha256"
+	"encoding/gob"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/token"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// flags common to all {single,multi,unit}checkers.
+var (
+	JSON    = false // -json
+	Context = -1    // -c=N: if N>0, display offending line plus N lines of context
+)
+
+// Parse creates a flag for each of the analyzer's flags,
+// including (in multi mode) a flag named after the analyzer,
+// parses the flags, then filters and returns the list of
+// analyzers enabled by flags.
+//
+// The result is intended to be passed to unitchecker.Run or checker.Run.
+// Use in unitchecker.Run will gob.Register all fact types for the returned
+// graph of analyzers but of course not the ones only reachable from
+// dropped analyzers. To avoid inconsistency about which gob types are
+// registered from run to run, Parse itself gob.Registers all the facts
+// only reachable from dropped analyzers.
+// This is not a particularly elegant API, but this is an internal package.
+func Parse(analyzers []*analysis.Analyzer, multi bool) []*analysis.Analyzer {
+	// Connect each analysis flag to the command line as -analysis.flag.
+	enabled := make(map[*analysis.Analyzer]*triState)
+	for _, a := range analyzers {
+		var prefix string
+
+		// Add -NAME flag to enable it.
+		if multi {
+			prefix = a.Name + "."
+
+			enable := new(triState)
+			enableUsage := "enable " + a.Name + " analysis"
+			flag.Var(enable, a.Name, enableUsage)
+			enabled[a] = enable
+		}
+
+		a.Flags.VisitAll(func(f *flag.Flag) {
+			if !multi && flag.Lookup(f.Name) != nil {
+				log.Printf("%s flag -%s would conflict with driver; skipping", a.Name, f.Name)
+				return
+			}
+
+			name := prefix + f.Name
+			flag.Var(f.Value, name, f.Usage)
+		})
+	}
+
+	// standard flags: -flags, -V.
+	printflags := flag.Bool("flags", false, "print analyzer flags in JSON")
+	addVersionFlag()
+
+	// flags common to all checkers
+	flag.BoolVar(&JSON, "json", JSON, "emit JSON output")
+	flag.IntVar(&Context, "c", Context, `display offending line with this many lines of context`)
+
+	// Add shims for legacy vet flags to enable existing
+	// scripts that run vet to continue to work.
+	_ = flag.Bool("source", false, "no effect (deprecated)")
+	_ = flag.Bool("v", false, "no effect (deprecated)")
+	_ = flag.Bool("all", false, "no effect (deprecated)")
+	_ = flag.String("tags", "", "no effect (deprecated)")
+	for old, new := range vetLegacyFlags {
+		newFlag := flag.Lookup(new)
+		if newFlag != nil && flag.Lookup(old) == nil {
+			flag.Var(newFlag.Value, old, "deprecated alias for -"+new)
+		}
+	}
+
+	flag.Parse() // (ExitOnError)
+
+	// -flags: print flags so that go vet knows which ones are legitimate.
+	if *printflags {
+		printFlags()
+		os.Exit(0)
+	}
+
+	everything := expand(analyzers)
+
+	// If any -NAME flag is true,  run only those analyzers. Otherwise,
+	// if any -NAME flag is false, run all but those analyzers.
+	if multi {
+		var hasTrue, hasFalse bool
+		for _, ts := range enabled {
+			switch *ts {
+			case setTrue:
+				hasTrue = true
+			case setFalse:
+				hasFalse = true
+			}
+		}
+
+		var keep []*analysis.Analyzer
+		if hasTrue {
+			for _, a := range analyzers {
+				if *enabled[a] == setTrue {
+					keep = append(keep, a)
+				}
+			}
+			analyzers = keep
+		} else if hasFalse {
+			for _, a := range analyzers {
+				if *enabled[a] != setFalse {
+					keep = append(keep, a)
+				}
+			}
+			analyzers = keep
+		}
+	}
+
+	// Register fact types of skipped analyzers
+	// in case we encounter them in imported files.
+	kept := expand(analyzers)
+	for a := range everything {
+		if !kept[a] {
+			for _, f := range a.FactTypes {
+				gob.Register(f)
+			}
+		}
+	}
+
+	return analyzers
+}
+
+func expand(analyzers []*analysis.Analyzer) map[*analysis.Analyzer]bool {
+	seen := make(map[*analysis.Analyzer]bool)
+	var visitAll func([]*analysis.Analyzer)
+	visitAll = func(analyzers []*analysis.Analyzer) {
+		for _, a := range analyzers {
+			if !seen[a] {
+				seen[a] = true
+				visitAll(a.Requires)
+			}
+		}
+	}
+	visitAll(analyzers)
+	return seen
+}
+
+func printFlags() {
+	type jsonFlag struct {
+		Name  string
+		Bool  bool
+		Usage string
+	}
+	var flags []jsonFlag = nil
+	flag.VisitAll(func(f *flag.Flag) {
+		// Don't report {single,multi}checker debugging
+		// flags or fix as these have no effect on unitchecker
+		// (as invoked by 'go vet').
+		switch f.Name {
+		case "debug", "cpuprofile", "memprofile", "trace", "fix":
+			return
+		}
+
+		b, ok := f.Value.(interface{ IsBoolFlag() bool })
+		isBool := ok && b.IsBoolFlag()
+		flags = append(flags, jsonFlag{f.Name, isBool, f.Usage})
+	})
+	data, err := json.MarshalIndent(flags, "", "\t")
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Stdout.Write(data)
+}
+
+// addVersionFlag registers a -V flag that, if set,
+// prints the executable version and exits 0.
+//
+// If the -V flag already exists — for example, because it was already
+// registered by a call to cmd/internal/objabi.AddVersionFlag — then
+// addVersionFlag does nothing.
+func addVersionFlag() {
+	if flag.Lookup("V") == nil {
+		flag.Var(versionFlag{}, "V", "print version and exit")
+	}
+}
+
+// versionFlag minimally complies with the -V protocol required by "go vet".
+type versionFlag struct{}
+
+func (versionFlag) IsBoolFlag() bool { return true }
+func (versionFlag) Get() interface{} { return nil }
+func (versionFlag) String() string   { return "" }
+func (versionFlag) Set(s string) error {
+	if s != "full" {
+		log.Fatalf("unsupported flag value: -V=%s", s)
+	}
+
+	// This replicates the minimal subset of
+	// cmd/internal/objabi.AddVersionFlag, which is private to the
+	// go tool yet forms part of our command-line interface.
+	// TODO(adonovan): clarify the contract.
+
+	// Print the tool version so the build system can track changes.
+	// Formats:
+	//   $progname version devel ... buildID=...
+	//   $progname version go1.9.1
+	progname := os.Args[0]
+	f, err := os.Open(progname)
+	if err != nil {
+		log.Fatal(err)
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		log.Fatal(err)
+	}
+	f.Close()
+	fmt.Printf("%s version devel comments-go-here buildID=%02x\n",
+		progname, string(h.Sum(nil)))
+	os.Exit(0)
+	return nil
+}
+
+// A triState is a boolean that knows whether
+// it has been set to either true or false.
+// It is used to identify whether a flag appears;
+// the standard boolean flag cannot
+// distinguish missing from unset.
+// It also satisfies flag.Value.
+type triState int
+
+const (
+	unset triState = iota
+	setTrue
+	setFalse
+)
+
+func triStateFlag(name string, value triState, usage string) *triState {
+	flag.Var(&value, name, usage)
+	return &value
+}
+
+// triState implements flag.Value, flag.Getter, and flag.boolFlag.
+// They work like boolean flags: we can say vet -printf as well as vet -printf=true
+func (ts *triState) Get() interface{} {
+	return *ts == setTrue
+}
+
+func (ts triState) isTrue() bool {
+	return ts == setTrue
+}
+
+func (ts *triState) Set(value string) error {
+	b, err := strconv.ParseBool(value)
+	if err != nil {
+		// This error message looks poor but package "flag" adds
+		// "invalid boolean value %q for -NAME: %s"
+		return fmt.Errorf("want true or false")
+	}
+	if b {
+		*ts = setTrue
+	} else {
+		*ts = setFalse
+	}
+	return nil
+}
+
+func (ts *triState) String() string {
+	switch *ts {
+	case unset:
+		return "true"
+	case setTrue:
+		return "true"
+	case setFalse:
+		return "false"
+	}
+	panic("not reached")
+}
+
+func (ts triState) IsBoolFlag() bool {
+	return true
+}
+
+// Legacy flag support
+
+// vetLegacyFlags maps flags used by legacy vet to their corresponding
+// new names. The old names will continue to work.
+var vetLegacyFlags = map[string]string{
+	// Analyzer name changes
+	"bool":       "bools",
+	"buildtags":  "buildtag",
+	"methods":    "stdmethods",
+	"rangeloops": "loopclosure",
+
+	// Analyzer flags
+	"compositewhitelist":  "composites.whitelist",
+	"printfuncs":          "printf.funcs",
+	"shadowstrict":        "shadow.strict",
+	"unusedfuncs":         "unusedresult.funcs",
+	"unusedstringmethods": "unusedresult.stringmethods",
+}
+
+// ---- output helpers common to all drivers ----
+
+// PrintPlain prints a diagnostic in plain text form,
+// with context specified by the -c flag.
+func PrintPlain(fset *token.FileSet, diag analysis.Diagnostic) {
+	posn := fset.Position(diag.Pos)
+	fmt.Fprintf(os.Stderr, "%s: %s\n", posn, diag.Message)
+
+	// -c=N: show offending line plus N lines of context.
+	if Context >= 0 {
+		posn := fset.Position(diag.Pos)
+		end := fset.Position(diag.End)
+		if !end.IsValid() {
+			end = posn
+		}
+		data, _ := ioutil.ReadFile(posn.Filename)
+		lines := strings.Split(string(data), "\n")
+		for i := posn.Line - Context; i <= end.Line+Context; i++ {
+			if 1 <= i && i <= len(lines) {
+				fmt.Fprintf(os.Stderr, "%d\t%s\n", i, lines[i-1])
+			}
+		}
+	}
+}
+
+// A JSONTree is a mapping from package ID to analysis name to result.
+// Each result is either a jsonError or a list of jsonDiagnostic.
+type JSONTree map[string]map[string]interface{}
+
+// Add adds the result of analysis 'name' on package 'id'.
+// The result is either a list of diagnostics or an error.
+func (tree JSONTree) Add(fset *token.FileSet, id, name string, diags []analysis.Diagnostic, err error) {
+	var v interface{}
+	if err != nil {
+		type jsonError struct {
+			Err string `json:"error"`
+		}
+		v = jsonError{err.Error()}
+	} else if len(diags) > 0 {
+		type jsonDiagnostic struct {
+			Category string `json:"category,omitempty"`
+			Posn     string `json:"posn"`
+			Message  string `json:"message"`
+		}
+		var diagnostics []jsonDiagnostic
+		// TODO(matloob): Should the JSON diagnostics contain ranges?
+		// If so, how should they be formatted?
+		for _, f := range diags {
+			diagnostics = append(diagnostics, jsonDiagnostic{
+				Category: f.Category,
+				Posn:     fset.Position(f.Pos).String(),
+				Message:  f.Message,
+			})
+		}
+		v = diagnostics
+	}
+	if v != nil {
+		m, ok := tree[id]
+		if !ok {
+			m = make(map[string]interface{})
+			tree[id] = m
+		}
+		m[name] = v
+	}
+}
+
+func (tree JSONTree) Print() {
+	data, err := json.MarshalIndent(tree, "", "\t")
+	if err != nil {
+		log.Panicf("internal error: JSON marshaling failed: %v", err)
+	}
+	fmt.Printf("%s\n", data)
+}

--- a/vendor/golang.org/x/tools/go/analysis/internal/analysisflags/help.go
+++ b/vendor/golang.org/x/tools/go/analysis/internal/analysisflags/help.go
@@ -1,0 +1,92 @@
+package analysisflags
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const help = `PROGNAME is a tool for static analysis of Go programs.
+
+PROGNAME examines Go source code and reports suspicious constructs,
+such as Printf calls whose arguments do not align with the format
+string. It uses heuristics that do not guarantee all reports are
+genuine problems, but it can find errors not caught by the compilers.
+`
+
+// Help implements the help subcommand for a multichecker or unitchecker
+// style command. The optional args specify the analyzers to describe.
+// Help calls log.Fatal if no such analyzer exists.
+func Help(progname string, analyzers []*analysis.Analyzer, args []string) {
+	// No args: show summary of all analyzers.
+	if len(args) == 0 {
+		fmt.Println(strings.Replace(help, "PROGNAME", progname, -1))
+		fmt.Println("Registered analyzers:")
+		fmt.Println()
+		sort.Slice(analyzers, func(i, j int) bool {
+			return analyzers[i].Name < analyzers[j].Name
+		})
+		for _, a := range analyzers {
+			title := strings.Split(a.Doc, "\n\n")[0]
+			fmt.Printf("    %-12s %s\n", a.Name, title)
+		}
+		fmt.Println("\nBy default all analyzers are run.")
+		fmt.Println("To select specific analyzers, use the -NAME flag for each one,")
+		fmt.Println(" or -NAME=false to run all analyzers not explicitly disabled.")
+
+		// Show only the core command-line flags.
+		fmt.Println("\nCore flags:")
+		fmt.Println()
+		fs := flag.NewFlagSet("", flag.ExitOnError)
+		flag.VisitAll(func(f *flag.Flag) {
+			if !strings.Contains(f.Name, ".") {
+				fs.Var(f.Value, f.Name, f.Usage)
+			}
+		})
+		fs.SetOutput(os.Stdout)
+		fs.PrintDefaults()
+
+		fmt.Printf("\nTo see details and flags of a specific analyzer, run '%s help name'.\n", progname)
+
+		return
+	}
+
+	// Show help on specific analyzer(s).
+outer:
+	for _, arg := range args {
+		for _, a := range analyzers {
+			if a.Name == arg {
+				paras := strings.Split(a.Doc, "\n\n")
+				title := paras[0]
+				fmt.Printf("%s: %s\n", a.Name, title)
+
+				// Show only the flags relating to this analysis,
+				// properly prefixed.
+				first := true
+				fs := flag.NewFlagSet(a.Name, flag.ExitOnError)
+				a.Flags.VisitAll(func(f *flag.Flag) {
+					if first {
+						first = false
+						fmt.Println("\nAnalyzer flags:")
+						fmt.Println()
+					}
+					fs.Var(f.Value, a.Name+"."+f.Name, f.Usage)
+				})
+				fs.SetOutput(os.Stdout)
+				fs.PrintDefaults()
+
+				if len(paras) > 1 {
+					fmt.Printf("\n%s\n", strings.Join(paras[1:], "\n\n"))
+				}
+
+				continue outer
+			}
+		}
+		log.Fatalf("Analyzer %q not registered", arg)
+	}
+}

--- a/vendor/golang.org/x/tools/go/analysis/internal/checker/checker.go
+++ b/vendor/golang.org/x/tools/go/analysis/internal/checker/checker.go
@@ -1,0 +1,906 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package checker defines the implementation of the checker commands.
+// The same code drives the multi-analysis driver, the single-analysis
+// driver that is conventionally provided for convenience along with
+// each analysis package, and the test driver.
+package checker
+
+import (
+	"bytes"
+	"encoding/gob"
+	"flag"
+	"fmt"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"io/ioutil"
+	"log"
+	"os"
+	"reflect"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/internal/analysisflags"
+	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/internal/analysisinternal"
+	"golang.org/x/tools/internal/span"
+)
+
+var (
+	// Debug is a set of single-letter flags:
+	//
+	//	f	show [f]acts as they are created
+	// 	p	disable [p]arallel execution of analyzers
+	//	s	do additional [s]anity checks on fact types and serialization
+	//	t	show [t]iming info (NB: use 'p' flag to avoid GC/scheduler noise)
+	//	v	show [v]erbose logging
+	//
+	Debug = ""
+
+	// Log files for optional performance tracing.
+	CPUProfile, MemProfile, Trace string
+
+	// Fix determines whether to apply all suggested fixes.
+	Fix bool
+)
+
+// RegisterFlags registers command-line flags used by the analysis driver.
+func RegisterFlags() {
+	// When adding flags here, remember to update
+	// the list of suppressed flags in analysisflags.
+
+	flag.StringVar(&Debug, "debug", Debug, `debug flags, any subset of "fpstv"`)
+
+	flag.StringVar(&CPUProfile, "cpuprofile", "", "write CPU profile to this file")
+	flag.StringVar(&MemProfile, "memprofile", "", "write memory profile to this file")
+	flag.StringVar(&Trace, "trace", "", "write trace log to this file")
+
+	flag.BoolVar(&Fix, "fix", false, "apply all suggested fixes")
+}
+
+// Run loads the packages specified by args using go/packages,
+// then applies the specified analyzers to them.
+// Analysis flags must already have been set.
+// It provides most of the logic for the main functions of both the
+// singlechecker and the multi-analysis commands.
+// It returns the appropriate exit code.
+func Run(args []string, analyzers []*analysis.Analyzer) (exitcode int) {
+	if CPUProfile != "" {
+		f, err := os.Create(CPUProfile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			log.Fatal(err)
+		}
+		// NB: profile won't be written in case of error.
+		defer pprof.StopCPUProfile()
+	}
+
+	if Trace != "" {
+		f, err := os.Create(Trace)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := trace.Start(f); err != nil {
+			log.Fatal(err)
+		}
+		// NB: trace log won't be written in case of error.
+		defer func() {
+			trace.Stop()
+			log.Printf("To view the trace, run:\n$ go tool trace view %s", Trace)
+		}()
+	}
+
+	if MemProfile != "" {
+		f, err := os.Create(MemProfile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		// NB: memprofile won't be written in case of error.
+		defer func() {
+			runtime.GC() // get up-to-date statistics
+			if err := pprof.WriteHeapProfile(f); err != nil {
+				log.Fatalf("Writing memory profile: %v", err)
+			}
+			f.Close()
+		}()
+	}
+
+	// Load the packages.
+	if dbg('v') {
+		log.SetPrefix("")
+		log.SetFlags(log.Lmicroseconds) // display timing
+		log.Printf("load %s", args)
+	}
+
+	// Optimization: if the selected analyzers don't produce/consume
+	// facts, we need source only for the initial packages.
+	allSyntax := needFacts(analyzers)
+	initial, err := load(args, allSyntax)
+	if err != nil {
+		log.Print(err)
+		return 1 // load errors
+	}
+
+	// Print the results.
+	roots := analyze(initial, analyzers)
+
+	if Fix {
+		applyFixes(roots)
+	}
+
+	return printDiagnostics(roots)
+}
+
+// load loads the initial packages.
+func load(patterns []string, allSyntax bool) ([]*packages.Package, error) {
+	mode := packages.LoadSyntax
+	if allSyntax {
+		mode = packages.LoadAllSyntax
+	}
+	conf := packages.Config{
+		Mode:  mode,
+		Tests: true,
+	}
+	initial, err := packages.Load(&conf, patterns...)
+	if err == nil {
+		if n := packages.PrintErrors(initial); n > 1 {
+			err = fmt.Errorf("%d errors during loading", n)
+		} else if n == 1 {
+			err = fmt.Errorf("error during loading")
+		} else if len(initial) == 0 {
+			err = fmt.Errorf("%s matched no packages", strings.Join(patterns, " "))
+		}
+	}
+
+	return initial, err
+}
+
+// TestAnalyzer applies an analysis to a set of packages (and their
+// dependencies if necessary) and returns the results.
+//
+// Facts about pkg are returned in a map keyed by object; package facts
+// have a nil key.
+//
+// This entry point is used only by analysistest.
+func TestAnalyzer(a *analysis.Analyzer, pkgs []*packages.Package) []*TestAnalyzerResult {
+	var results []*TestAnalyzerResult
+	for _, act := range analyze(pkgs, []*analysis.Analyzer{a}) {
+		facts := make(map[types.Object][]analysis.Fact)
+		for key, fact := range act.objectFacts {
+			if key.obj.Pkg() == act.pass.Pkg {
+				facts[key.obj] = append(facts[key.obj], fact)
+			}
+		}
+		for key, fact := range act.packageFacts {
+			if key.pkg == act.pass.Pkg {
+				facts[nil] = append(facts[nil], fact)
+			}
+		}
+
+		results = append(results, &TestAnalyzerResult{act.pass, act.diagnostics, facts, act.result, act.err})
+	}
+	return results
+}
+
+type TestAnalyzerResult struct {
+	Pass        *analysis.Pass
+	Diagnostics []analysis.Diagnostic
+	Facts       map[types.Object][]analysis.Fact
+	Result      interface{}
+	Err         error
+}
+
+func analyze(pkgs []*packages.Package, analyzers []*analysis.Analyzer) []*action {
+	// Construct the action graph.
+	if dbg('v') {
+		log.Printf("building graph of analysis passes")
+	}
+
+	// Each graph node (action) is one unit of analysis.
+	// Edges express package-to-package (vertical) dependencies,
+	// and analysis-to-analysis (horizontal) dependencies.
+	type key struct {
+		*analysis.Analyzer
+		*packages.Package
+	}
+	actions := make(map[key]*action)
+
+	var mkAction func(a *analysis.Analyzer, pkg *packages.Package) *action
+	mkAction = func(a *analysis.Analyzer, pkg *packages.Package) *action {
+		k := key{a, pkg}
+		act, ok := actions[k]
+		if !ok {
+			act = &action{a: a, pkg: pkg}
+
+			// Add a dependency on each required analyzers.
+			for _, req := range a.Requires {
+				act.deps = append(act.deps, mkAction(req, pkg))
+			}
+
+			// An analysis that consumes/produces facts
+			// must run on the package's dependencies too.
+			if len(a.FactTypes) > 0 {
+				paths := make([]string, 0, len(pkg.Imports))
+				for path := range pkg.Imports {
+					paths = append(paths, path)
+				}
+				sort.Strings(paths) // for determinism
+				for _, path := range paths {
+					dep := mkAction(a, pkg.Imports[path])
+					act.deps = append(act.deps, dep)
+				}
+			}
+
+			actions[k] = act
+		}
+		return act
+	}
+
+	// Build nodes for initial packages.
+	var roots []*action
+	for _, a := range analyzers {
+		for _, pkg := range pkgs {
+			root := mkAction(a, pkg)
+			root.isroot = true
+			roots = append(roots, root)
+		}
+	}
+
+	// Execute the graph in parallel.
+	execAll(roots)
+
+	return roots
+}
+
+func applyFixes(roots []*action) {
+	visited := make(map[*action]bool)
+	var apply func(*action) error
+	var visitAll func(actions []*action) error
+	visitAll = func(actions []*action) error {
+		for _, act := range actions {
+			if !visited[act] {
+				visited[act] = true
+				visitAll(act.deps)
+				if err := apply(act); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	// TODO(matloob): Is this tree business too complicated? (After all this is Go!)
+	// Just create a set (map) of edits, sort by pos and call it a day?
+	type offsetedit struct {
+		start, end int
+		newText    []byte
+	} // TextEdit using byteOffsets instead of pos
+	type node struct {
+		edit        offsetedit
+		left, right *node
+	}
+
+	var insert func(tree **node, edit offsetedit) error
+	insert = func(treeptr **node, edit offsetedit) error {
+		if *treeptr == nil {
+			*treeptr = &node{edit, nil, nil}
+			return nil
+		}
+		tree := *treeptr
+		if edit.end <= tree.edit.start {
+			return insert(&tree.left, edit)
+		} else if edit.start >= tree.edit.end {
+			return insert(&tree.right, edit)
+		}
+
+		// Overlapping text edit.
+		return fmt.Errorf("analyses applying overlapping text edits affecting pos range (%v, %v) and (%v, %v)",
+			edit.start, edit.end, tree.edit.start, tree.edit.end)
+
+	}
+
+	editsForFile := make(map[*token.File]*node)
+
+	apply = func(act *action) error {
+		for _, diag := range act.diagnostics {
+			for _, sf := range diag.SuggestedFixes {
+				for _, edit := range sf.TextEdits {
+					// Validate the edit.
+					if edit.Pos > edit.End {
+						return fmt.Errorf(
+							"diagnostic for analysis %v contains Suggested Fix with malformed edit: pos (%v) > end (%v)",
+							act.a.Name, edit.Pos, edit.End)
+					}
+					file, endfile := act.pkg.Fset.File(edit.Pos), act.pkg.Fset.File(edit.End)
+					if file == nil || endfile == nil || file != endfile {
+						return (fmt.Errorf(
+							"diagnostic for analysis %v contains Suggested Fix with malformed spanning files %v and %v",
+							act.a.Name, file.Name(), endfile.Name()))
+					}
+					start, end := file.Offset(edit.Pos), file.Offset(edit.End)
+
+					// TODO(matloob): Validate that edits do not affect other packages.
+					root := editsForFile[file]
+					if err := insert(&root, offsetedit{start, end, edit.NewText}); err != nil {
+						return err
+					}
+					editsForFile[file] = root // In case the root changed
+				}
+			}
+		}
+		return nil
+	}
+
+	visitAll(roots)
+
+	fset := token.NewFileSet() // Shared by parse calls below
+	// Now we've got a set of valid edits for each file. Get the new file contents.
+	for f, tree := range editsForFile {
+		contents, err := ioutil.ReadFile(f.Name())
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		cur := 0 // current position in the file
+
+		var out bytes.Buffer
+
+		var recurse func(*node)
+		recurse = func(node *node) {
+			if node.left != nil {
+				recurse(node.left)
+			}
+
+			edit := node.edit
+			if edit.start > cur {
+				out.Write(contents[cur:edit.start])
+				out.Write(edit.newText)
+			}
+			cur = edit.end
+
+			if node.right != nil {
+				recurse(node.right)
+			}
+		}
+		recurse(tree)
+		// Write out the rest of the file.
+		if cur < len(contents) {
+			out.Write(contents[cur:])
+		}
+
+		// Try to format the file.
+		ff, err := parser.ParseFile(fset, f.Name(), out.Bytes(), parser.ParseComments)
+		if err == nil {
+			var buf bytes.Buffer
+			if err = format.Node(&buf, fset, ff); err == nil {
+				out = buf
+			}
+		}
+
+		ioutil.WriteFile(f.Name(), out.Bytes(), 0644)
+	}
+}
+
+// printDiagnostics prints the diagnostics for the root packages in either
+// plain text or JSON format. JSON format also includes errors for any
+// dependencies.
+//
+// It returns the exitcode: in plain mode, 0 for success, 1 for analysis
+// errors, and 3 for diagnostics. We avoid 2 since the flag package uses
+// it. JSON mode always succeeds at printing errors and diagnostics in a
+// structured form to stdout.
+func printDiagnostics(roots []*action) (exitcode int) {
+	// Print the output.
+	//
+	// Print diagnostics only for root packages,
+	// but errors for all packages.
+	printed := make(map[*action]bool)
+	var print func(*action)
+	var visitAll func(actions []*action)
+	visitAll = func(actions []*action) {
+		for _, act := range actions {
+			if !printed[act] {
+				printed[act] = true
+				visitAll(act.deps)
+				print(act)
+			}
+		}
+	}
+
+	if analysisflags.JSON {
+		// JSON output
+		tree := make(analysisflags.JSONTree)
+		print = func(act *action) {
+			var diags []analysis.Diagnostic
+			if act.isroot {
+				diags = act.diagnostics
+			}
+			tree.Add(act.pkg.Fset, act.pkg.ID, act.a.Name, diags, act.err)
+		}
+		visitAll(roots)
+		tree.Print()
+	} else {
+		// plain text output
+
+		// De-duplicate diagnostics by position (not token.Pos) to
+		// avoid double-reporting in source files that belong to
+		// multiple packages, such as foo and foo.test.
+		type key struct {
+			pos token.Position
+			end token.Position
+			*analysis.Analyzer
+			message string
+		}
+		seen := make(map[key]bool)
+
+		print = func(act *action) {
+			if act.err != nil {
+				fmt.Fprintf(os.Stderr, "%s: %v\n", act.a.Name, act.err)
+				exitcode = 1 // analysis failed, at least partially
+				return
+			}
+			if act.isroot {
+				for _, diag := range act.diagnostics {
+					// We don't display a.Name/f.Category
+					// as most users don't care.
+
+					posn := act.pkg.Fset.Position(diag.Pos)
+					end := act.pkg.Fset.Position(diag.End)
+					k := key{posn, end, act.a, diag.Message}
+					if seen[k] {
+						continue // duplicate
+					}
+					seen[k] = true
+
+					analysisflags.PrintPlain(act.pkg.Fset, diag)
+				}
+			}
+		}
+		visitAll(roots)
+
+		if exitcode == 0 && len(seen) > 0 {
+			exitcode = 3 // successfully produced diagnostics
+		}
+	}
+
+	// Print timing info.
+	if dbg('t') {
+		if !dbg('p') {
+			log.Println("Warning: times are mostly GC/scheduler noise; use -debug=tp to disable parallelism")
+		}
+		var all []*action
+		var total time.Duration
+		for act := range printed {
+			all = append(all, act)
+			total += act.duration
+		}
+		sort.Slice(all, func(i, j int) bool {
+			return all[i].duration > all[j].duration
+		})
+
+		// Print actions accounting for 90% of the total.
+		var sum time.Duration
+		for _, act := range all {
+			fmt.Fprintf(os.Stderr, "%s\t%s\n", act.duration, act)
+			sum += act.duration
+			if sum >= total*9/10 {
+				break
+			}
+		}
+	}
+
+	return exitcode
+}
+
+// needFacts reports whether any analysis required by the specified set
+// needs facts.  If so, we must load the entire program from source.
+func needFacts(analyzers []*analysis.Analyzer) bool {
+	seen := make(map[*analysis.Analyzer]bool)
+	var q []*analysis.Analyzer // for BFS
+	q = append(q, analyzers...)
+	for len(q) > 0 {
+		a := q[0]
+		q = q[1:]
+		if !seen[a] {
+			seen[a] = true
+			if len(a.FactTypes) > 0 {
+				return true
+			}
+			q = append(q, a.Requires...)
+		}
+	}
+	return false
+}
+
+// An action represents one unit of analysis work: the application of
+// one analysis to one package. Actions form a DAG, both within a
+// package (as different analyzers are applied, either in sequence or
+// parallel), and across packages (as dependencies are analyzed).
+type action struct {
+	once         sync.Once
+	a            *analysis.Analyzer
+	pkg          *packages.Package
+	pass         *analysis.Pass
+	isroot       bool
+	deps         []*action
+	objectFacts  map[objectFactKey]analysis.Fact
+	packageFacts map[packageFactKey]analysis.Fact
+	inputs       map[*analysis.Analyzer]interface{}
+	result       interface{}
+	diagnostics  []analysis.Diagnostic
+	err          error
+	duration     time.Duration
+}
+
+type objectFactKey struct {
+	obj types.Object
+	typ reflect.Type
+}
+
+type packageFactKey struct {
+	pkg *types.Package
+	typ reflect.Type
+}
+
+func (act *action) String() string {
+	return fmt.Sprintf("%s@%s", act.a, act.pkg)
+}
+
+func execAll(actions []*action) {
+	sequential := dbg('p')
+	var wg sync.WaitGroup
+	for _, act := range actions {
+		wg.Add(1)
+		work := func(act *action) {
+			act.exec()
+			wg.Done()
+		}
+		if sequential {
+			work(act)
+		} else {
+			go work(act)
+		}
+	}
+	wg.Wait()
+}
+
+func (act *action) exec() { act.once.Do(act.execOnce) }
+
+func (act *action) execOnce() {
+	// Analyze dependencies.
+	execAll(act.deps)
+
+	// TODO(adonovan): uncomment this during profiling.
+	// It won't build pre-go1.11 but conditional compilation
+	// using build tags isn't warranted.
+	//
+	// ctx, task := trace.NewTask(context.Background(), "exec")
+	// trace.Log(ctx, "pass", act.String())
+	// defer task.End()
+
+	// Record time spent in this node but not its dependencies.
+	// In parallel mode, due to GC/scheduler contention, the
+	// time is 5x higher than in sequential mode, even with a
+	// semaphore limiting the number of threads here.
+	// So use -debug=tp.
+	if dbg('t') {
+		t0 := time.Now()
+		defer func() { act.duration = time.Since(t0) }()
+	}
+
+	// Report an error if any dependency failed.
+	var failed []string
+	for _, dep := range act.deps {
+		if dep.err != nil {
+			failed = append(failed, dep.String())
+		}
+	}
+	if failed != nil {
+		sort.Strings(failed)
+		act.err = fmt.Errorf("failed prerequisites: %s", strings.Join(failed, ", "))
+		return
+	}
+
+	// Plumb the output values of the dependencies
+	// into the inputs of this action.  Also facts.
+	inputs := make(map[*analysis.Analyzer]interface{})
+	act.objectFacts = make(map[objectFactKey]analysis.Fact)
+	act.packageFacts = make(map[packageFactKey]analysis.Fact)
+	for _, dep := range act.deps {
+		if dep.pkg == act.pkg {
+			// Same package, different analysis (horizontal edge):
+			// in-memory outputs of prerequisite analyzers
+			// become inputs to this analysis pass.
+			inputs[dep.a] = dep.result
+
+		} else if dep.a == act.a { // (always true)
+			// Same analysis, different package (vertical edge):
+			// serialized facts produced by prerequisite analysis
+			// become available to this analysis pass.
+			inheritFacts(act, dep)
+		}
+	}
+
+	// Run the analysis.
+	pass := &analysis.Pass{
+		Analyzer:          act.a,
+		Fset:              act.pkg.Fset,
+		Files:             act.pkg.Syntax,
+		OtherFiles:        act.pkg.OtherFiles,
+		Pkg:               act.pkg.Types,
+		TypesInfo:         act.pkg.TypesInfo,
+		TypesSizes:        act.pkg.TypesSizes,
+		ResultOf:          inputs,
+		Report:            func(d analysis.Diagnostic) { act.diagnostics = append(act.diagnostics, d) },
+		ImportObjectFact:  act.importObjectFact,
+		ExportObjectFact:  act.exportObjectFact,
+		ImportPackageFact: act.importPackageFact,
+		ExportPackageFact: act.exportPackageFact,
+		AllObjectFacts:    act.allObjectFacts,
+		AllPackageFacts:   act.allPackageFacts,
+	}
+	act.pass = pass
+
+	var errors []types.Error
+	// Get any type errors that are attributed to the pkg.
+	// This is necessary to test analyzers that provide
+	// suggested fixes for compiler/type errors.
+	for _, err := range act.pkg.Errors {
+		if err.Kind != packages.TypeError {
+			continue
+		}
+		// err.Pos is a string of form: "file:line:col" or "file:line" or "" or "-"
+		spn := span.Parse(err.Pos)
+		// Extract the token positions from the error string.
+		line, col, offset := spn.Start().Line(), spn.Start().Column(), -1
+		act.pkg.Fset.Iterate(func(f *token.File) bool {
+			if f.Name() != spn.URI().Filename() {
+				return true
+			}
+			offset = int(f.LineStart(line)) + col - 1
+			return false
+		})
+		if offset == -1 {
+			continue
+		}
+		errors = append(errors, types.Error{
+			Fset: act.pkg.Fset,
+			Msg:  err.Msg,
+			Pos:  token.Pos(offset),
+		})
+	}
+	analysisinternal.SetTypeErrors(pass, errors)
+
+	var err error
+	if act.pkg.IllTyped && !pass.Analyzer.RunDespiteErrors {
+		err = fmt.Errorf("analysis skipped due to errors in package")
+	} else {
+		act.result, err = pass.Analyzer.Run(pass)
+		if err == nil {
+			if got, want := reflect.TypeOf(act.result), pass.Analyzer.ResultType; got != want {
+				err = fmt.Errorf(
+					"internal error: on package %s, analyzer %s returned a result of type %v, but declared ResultType %v",
+					pass.Pkg.Path(), pass.Analyzer, got, want)
+			}
+		}
+	}
+	act.err = err
+
+	// disallow calls after Run
+	pass.ExportObjectFact = nil
+	pass.ExportPackageFact = nil
+}
+
+// inheritFacts populates act.facts with
+// those it obtains from its dependency, dep.
+func inheritFacts(act, dep *action) {
+	serialize := dbg('s')
+
+	for key, fact := range dep.objectFacts {
+		// Filter out facts related to objects
+		// that are irrelevant downstream
+		// (equivalently: not in the compiler export data).
+		if !exportedFrom(key.obj, dep.pkg.Types) {
+			if false {
+				log.Printf("%v: discarding %T fact from %s for %s: %s", act, fact, dep, key.obj, fact)
+			}
+			continue
+		}
+
+		// Optionally serialize/deserialize fact
+		// to verify that it works across address spaces.
+		if serialize {
+			encodedFact, err := codeFact(fact)
+			if err != nil {
+				log.Panicf("internal error: encoding of %T fact failed in %v", fact, act)
+			}
+			fact = encodedFact
+		}
+
+		if false {
+			log.Printf("%v: inherited %T fact for %s: %s", act, fact, key.obj, fact)
+		}
+		act.objectFacts[key] = fact
+	}
+
+	for key, fact := range dep.packageFacts {
+		// TODO: filter out facts that belong to
+		// packages not mentioned in the export data
+		// to prevent side channels.
+
+		// Optionally serialize/deserialize fact
+		// to verify that it works across address spaces
+		// and is deterministic.
+		if serialize {
+			encodedFact, err := codeFact(fact)
+			if err != nil {
+				log.Panicf("internal error: encoding of %T fact failed in %v", fact, act)
+			}
+			fact = encodedFact
+		}
+
+		if false {
+			log.Printf("%v: inherited %T fact for %s: %s", act, fact, key.pkg.Path(), fact)
+		}
+		act.packageFacts[key] = fact
+	}
+}
+
+// codeFact encodes then decodes a fact,
+// just to exercise that logic.
+func codeFact(fact analysis.Fact) (analysis.Fact, error) {
+	// We encode facts one at a time.
+	// A real modular driver would emit all facts
+	// into one encoder to improve gob efficiency.
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(fact); err != nil {
+		return nil, err
+	}
+
+	// Encode it twice and assert that we get the same bits.
+	// This helps detect nondeterministic Gob encoding (e.g. of maps).
+	var buf2 bytes.Buffer
+	if err := gob.NewEncoder(&buf2).Encode(fact); err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(buf.Bytes(), buf2.Bytes()) {
+		return nil, fmt.Errorf("encoding of %T fact is nondeterministic", fact)
+	}
+
+	new := reflect.New(reflect.TypeOf(fact).Elem()).Interface().(analysis.Fact)
+	if err := gob.NewDecoder(&buf).Decode(new); err != nil {
+		return nil, err
+	}
+	return new, nil
+}
+
+// exportedFrom reports whether obj may be visible to a package that imports pkg.
+// This includes not just the exported members of pkg, but also unexported
+// constants, types, fields, and methods, perhaps belonging to oether packages,
+// that find there way into the API.
+// This is an overapproximation of the more accurate approach used by
+// gc export data, which walks the type graph, but it's much simpler.
+//
+// TODO(adonovan): do more accurate filtering by walking the type graph.
+func exportedFrom(obj types.Object, pkg *types.Package) bool {
+	switch obj := obj.(type) {
+	case *types.Func:
+		return obj.Exported() && obj.Pkg() == pkg ||
+			obj.Type().(*types.Signature).Recv() != nil
+	case *types.Var:
+		if obj.IsField() {
+			return true
+		}
+		// we can't filter more aggressively than this because we need
+		// to consider function parameters exported, but have no way
+		// of telling apart function parameters from local variables.
+		return obj.Pkg() == pkg
+	case *types.TypeName, *types.Const:
+		return true
+	}
+	return false // Nil, Builtin, Label, or PkgName
+}
+
+// importObjectFact implements Pass.ImportObjectFact.
+// Given a non-nil pointer ptr of type *T, where *T satisfies Fact,
+// importObjectFact copies the fact value to *ptr.
+func (act *action) importObjectFact(obj types.Object, ptr analysis.Fact) bool {
+	if obj == nil {
+		panic("nil object")
+	}
+	key := objectFactKey{obj, factType(ptr)}
+	if v, ok := act.objectFacts[key]; ok {
+		reflect.ValueOf(ptr).Elem().Set(reflect.ValueOf(v).Elem())
+		return true
+	}
+	return false
+}
+
+// exportObjectFact implements Pass.ExportObjectFact.
+func (act *action) exportObjectFact(obj types.Object, fact analysis.Fact) {
+	if act.pass.ExportObjectFact == nil {
+		log.Panicf("%s: Pass.ExportObjectFact(%s, %T) called after Run", act, obj, fact)
+	}
+
+	if obj.Pkg() != act.pkg.Types {
+		log.Panicf("internal error: in analysis %s of package %s: Fact.Set(%s, %T): can't set facts on objects belonging another package",
+			act.a, act.pkg, obj, fact)
+	}
+
+	key := objectFactKey{obj, factType(fact)}
+	act.objectFacts[key] = fact // clobber any existing entry
+	if dbg('f') {
+		objstr := types.ObjectString(obj, (*types.Package).Name)
+		fmt.Fprintf(os.Stderr, "%s: object %s has fact %s\n",
+			act.pkg.Fset.Position(obj.Pos()), objstr, fact)
+	}
+}
+
+// allObjectFacts implements Pass.AllObjectFacts.
+func (act *action) allObjectFacts() []analysis.ObjectFact {
+	facts := make([]analysis.ObjectFact, 0, len(act.objectFacts))
+	for k := range act.objectFacts {
+		facts = append(facts, analysis.ObjectFact{k.obj, act.objectFacts[k]})
+	}
+	return facts
+}
+
+// importPackageFact implements Pass.ImportPackageFact.
+// Given a non-nil pointer ptr of type *T, where *T satisfies Fact,
+// fact copies the fact value to *ptr.
+func (act *action) importPackageFact(pkg *types.Package, ptr analysis.Fact) bool {
+	if pkg == nil {
+		panic("nil package")
+	}
+	key := packageFactKey{pkg, factType(ptr)}
+	if v, ok := act.packageFacts[key]; ok {
+		reflect.ValueOf(ptr).Elem().Set(reflect.ValueOf(v).Elem())
+		return true
+	}
+	return false
+}
+
+// exportPackageFact implements Pass.ExportPackageFact.
+func (act *action) exportPackageFact(fact analysis.Fact) {
+	if act.pass.ExportPackageFact == nil {
+		log.Panicf("%s: Pass.ExportPackageFact(%T) called after Run", act, fact)
+	}
+
+	key := packageFactKey{act.pass.Pkg, factType(fact)}
+	act.packageFacts[key] = fact // clobber any existing entry
+	if dbg('f') {
+		fmt.Fprintf(os.Stderr, "%s: package %s has fact %s\n",
+			act.pkg.Fset.Position(act.pass.Files[0].Pos()), act.pass.Pkg.Path(), fact)
+	}
+}
+
+func factType(fact analysis.Fact) reflect.Type {
+	t := reflect.TypeOf(fact)
+	if t.Kind() != reflect.Ptr {
+		log.Fatalf("invalid Fact type: got %T, want pointer", t)
+	}
+	return t
+}
+
+// allObjectFacts implements Pass.AllObjectFacts.
+func (act *action) allPackageFacts() []analysis.PackageFact {
+	facts := make([]analysis.PackageFact, 0, len(act.packageFacts))
+	for k := range act.packageFacts {
+		facts = append(facts, analysis.PackageFact{k.pkg, act.packageFacts[k]})
+	}
+	return facts
+}
+
+func dbg(b byte) bool { return strings.IndexByte(Debug, b) >= 0 }

--- a/vendor/golang.org/x/tools/go/analysis/internal/facts/facts.go
+++ b/vendor/golang.org/x/tools/go/analysis/internal/facts/facts.go
@@ -1,0 +1,323 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package facts defines a serializable set of analysis.Fact.
+//
+// It provides a partial implementation of the Fact-related parts of the
+// analysis.Pass interface for use in analysis drivers such as "go vet"
+// and other build systems.
+//
+// The serial format is unspecified and may change, so the same version
+// of this package must be used for reading and writing serialized facts.
+//
+// The handling of facts in the analysis system parallels the handling
+// of type information in the compiler: during compilation of package P,
+// the compiler emits an export data file that describes the type of
+// every object (named thing) defined in package P, plus every object
+// indirectly reachable from one of those objects. Thus the downstream
+// compiler of package Q need only load one export data file per direct
+// import of Q, and it will learn everything about the API of package P
+// and everything it needs to know about the API of P's dependencies.
+//
+// Similarly, analysis of package P emits a fact set containing facts
+// about all objects exported from P, plus additional facts about only
+// those objects of P's dependencies that are reachable from the API of
+// package P; the downstream analysis of Q need only load one fact set
+// per direct import of Q.
+//
+// The notion of "exportedness" that matters here is that of the
+// compiler. According to the language spec, a method pkg.T.f is
+// unexported simply because its name starts with lowercase. But the
+// compiler must nonetheless export f so that downstream compilations can
+// accurately ascertain whether pkg.T implements an interface pkg.I
+// defined as interface{f()}. Exported thus means "described in export
+// data".
+//
+package facts
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"go/types"
+	"io/ioutil"
+	"log"
+	"reflect"
+	"sort"
+	"sync"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/types/objectpath"
+)
+
+const debug = false
+
+// A Set is a set of analysis.Facts.
+//
+// Decode creates a Set of facts by reading from the imports of a given
+// package, and Encode writes out the set. Between these operation,
+// the Import and Export methods will query and update the set.
+//
+// All of Set's methods except String are safe to call concurrently.
+type Set struct {
+	pkg *types.Package
+	mu  sync.Mutex
+	m   map[key]analysis.Fact
+}
+
+type key struct {
+	pkg *types.Package
+	obj types.Object // (object facts only)
+	t   reflect.Type
+}
+
+// ImportObjectFact implements analysis.Pass.ImportObjectFact.
+func (s *Set) ImportObjectFact(obj types.Object, ptr analysis.Fact) bool {
+	if obj == nil {
+		panic("nil object")
+	}
+	key := key{pkg: obj.Pkg(), obj: obj, t: reflect.TypeOf(ptr)}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if v, ok := s.m[key]; ok {
+		reflect.ValueOf(ptr).Elem().Set(reflect.ValueOf(v).Elem())
+		return true
+	}
+	return false
+}
+
+// ExportObjectFact implements analysis.Pass.ExportObjectFact.
+func (s *Set) ExportObjectFact(obj types.Object, fact analysis.Fact) {
+	if obj.Pkg() != s.pkg {
+		log.Panicf("in package %s: ExportObjectFact(%s, %T): can't set fact on object belonging another package",
+			s.pkg, obj, fact)
+	}
+	key := key{pkg: obj.Pkg(), obj: obj, t: reflect.TypeOf(fact)}
+	s.mu.Lock()
+	s.m[key] = fact // clobber any existing entry
+	s.mu.Unlock()
+}
+
+func (s *Set) AllObjectFacts(filter map[reflect.Type]bool) []analysis.ObjectFact {
+	var facts []analysis.ObjectFact
+	s.mu.Lock()
+	for k, v := range s.m {
+		if k.obj != nil && filter[k.t] {
+			facts = append(facts, analysis.ObjectFact{Object: k.obj, Fact: v})
+		}
+	}
+	s.mu.Unlock()
+	return facts
+}
+
+// ImportPackageFact implements analysis.Pass.ImportPackageFact.
+func (s *Set) ImportPackageFact(pkg *types.Package, ptr analysis.Fact) bool {
+	if pkg == nil {
+		panic("nil package")
+	}
+	key := key{pkg: pkg, t: reflect.TypeOf(ptr)}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if v, ok := s.m[key]; ok {
+		reflect.ValueOf(ptr).Elem().Set(reflect.ValueOf(v).Elem())
+		return true
+	}
+	return false
+}
+
+// ExportPackageFact implements analysis.Pass.ExportPackageFact.
+func (s *Set) ExportPackageFact(fact analysis.Fact) {
+	key := key{pkg: s.pkg, t: reflect.TypeOf(fact)}
+	s.mu.Lock()
+	s.m[key] = fact // clobber any existing entry
+	s.mu.Unlock()
+}
+
+func (s *Set) AllPackageFacts(filter map[reflect.Type]bool) []analysis.PackageFact {
+	var facts []analysis.PackageFact
+	s.mu.Lock()
+	for k, v := range s.m {
+		if k.obj == nil && filter[k.t] {
+			facts = append(facts, analysis.PackageFact{Package: k.pkg, Fact: v})
+		}
+	}
+	s.mu.Unlock()
+	return facts
+}
+
+// gobFact is the Gob declaration of a serialized fact.
+type gobFact struct {
+	PkgPath string          // path of package
+	Object  objectpath.Path // optional path of object relative to package itself
+	Fact    analysis.Fact   // type and value of user-defined Fact
+}
+
+// Decode decodes all the facts relevant to the analysis of package pkg.
+// The read function reads serialized fact data from an external source
+// for one of of pkg's direct imports. The empty file is a valid
+// encoding of an empty fact set.
+//
+// It is the caller's responsibility to call gob.Register on all
+// necessary fact types.
+func Decode(pkg *types.Package, read func(packagePath string) ([]byte, error)) (*Set, error) {
+	// Compute the import map for this package.
+	// See the package doc comment.
+	packages := importMap(pkg.Imports())
+
+	// Read facts from imported packages.
+	// Facts may describe indirectly imported packages, or their objects.
+	m := make(map[key]analysis.Fact) // one big bucket
+	for _, imp := range pkg.Imports() {
+		logf := func(format string, args ...interface{}) {
+			if debug {
+				prefix := fmt.Sprintf("in %s, importing %s: ",
+					pkg.Path(), imp.Path())
+				log.Print(prefix, fmt.Sprintf(format, args...))
+			}
+		}
+
+		// Read the gob-encoded facts.
+		data, err := read(imp.Path())
+		if err != nil {
+			return nil, fmt.Errorf("in %s, can't import facts for package %q: %v",
+				pkg.Path(), imp.Path(), err)
+		}
+		if len(data) == 0 {
+			continue // no facts
+		}
+		var gobFacts []gobFact
+		if err := gob.NewDecoder(bytes.NewReader(data)).Decode(&gobFacts); err != nil {
+			return nil, fmt.Errorf("decoding facts for %q: %v", imp.Path(), err)
+		}
+		if debug {
+			logf("decoded %d facts: %v", len(gobFacts), gobFacts)
+		}
+
+		// Parse each one into a key and a Fact.
+		for _, f := range gobFacts {
+			factPkg := packages[f.PkgPath]
+			if factPkg == nil {
+				// Fact relates to a dependency that was
+				// unused in this translation unit. Skip.
+				logf("no package %q; discarding %v", f.PkgPath, f.Fact)
+				continue
+			}
+			key := key{pkg: factPkg, t: reflect.TypeOf(f.Fact)}
+			if f.Object != "" {
+				// object fact
+				obj, err := objectpath.Object(factPkg, f.Object)
+				if err != nil {
+					// (most likely due to unexported object)
+					// TODO(adonovan): audit for other possibilities.
+					logf("no object for path: %v; discarding %s", err, f.Fact)
+					continue
+				}
+				key.obj = obj
+				logf("read %T fact %s for %v", f.Fact, f.Fact, key.obj)
+			} else {
+				// package fact
+				logf("read %T fact %s for %v", f.Fact, f.Fact, factPkg)
+			}
+			m[key] = f.Fact
+		}
+	}
+
+	return &Set{pkg: pkg, m: m}, nil
+}
+
+// Encode encodes a set of facts to a memory buffer.
+//
+// It may fail if one of the Facts could not be gob-encoded, but this is
+// a sign of a bug in an Analyzer.
+func (s *Set) Encode() []byte {
+
+	// TODO(adonovan): opt: use a more efficient encoding
+	// that avoids repeating PkgPath for each fact.
+
+	// Gather all facts, including those from imported packages.
+	var gobFacts []gobFact
+
+	s.mu.Lock()
+	for k, fact := range s.m {
+		if debug {
+			log.Printf("%v => %s\n", k, fact)
+		}
+		var object objectpath.Path
+		if k.obj != nil {
+			path, err := objectpath.For(k.obj)
+			if err != nil {
+				if debug {
+					log.Printf("discarding fact %s about %s\n", fact, k.obj)
+				}
+				continue // object not accessible from package API; discard fact
+			}
+			object = path
+		}
+		gobFacts = append(gobFacts, gobFact{
+			PkgPath: k.pkg.Path(),
+			Object:  object,
+			Fact:    fact,
+		})
+	}
+	s.mu.Unlock()
+
+	// Sort facts by (package, object, type) for determinism.
+	sort.Slice(gobFacts, func(i, j int) bool {
+		x, y := gobFacts[i], gobFacts[j]
+		if x.PkgPath != y.PkgPath {
+			return x.PkgPath < y.PkgPath
+		}
+		if x.Object != y.Object {
+			return x.Object < y.Object
+		}
+		tx := reflect.TypeOf(x.Fact)
+		ty := reflect.TypeOf(y.Fact)
+		if tx != ty {
+			return tx.String() < ty.String()
+		}
+		return false // equal
+	})
+
+	var buf bytes.Buffer
+	if len(gobFacts) > 0 {
+		if err := gob.NewEncoder(&buf).Encode(gobFacts); err != nil {
+			// Fact encoding should never fail. Identify the culprit.
+			for _, gf := range gobFacts {
+				if err := gob.NewEncoder(ioutil.Discard).Encode(gf); err != nil {
+					fact := gf.Fact
+					pkgpath := reflect.TypeOf(fact).Elem().PkgPath()
+					log.Panicf("internal error: gob encoding of analysis fact %s failed: %v; please report a bug against fact %T in package %q",
+						fact, err, fact, pkgpath)
+				}
+			}
+		}
+	}
+
+	if debug {
+		log.Printf("package %q: encode %d facts, %d bytes\n",
+			s.pkg.Path(), len(gobFacts), buf.Len())
+	}
+
+	return buf.Bytes()
+}
+
+// String is provided only for debugging, and must not be called
+// concurrent with any Import/Export method.
+func (s *Set) String() string {
+	var buf bytes.Buffer
+	buf.WriteString("{")
+	for k, f := range s.m {
+		if buf.Len() > 1 {
+			buf.WriteString(", ")
+		}
+		if k.obj != nil {
+			buf.WriteString(k.obj.String())
+		} else {
+			buf.WriteString(k.pkg.Path())
+		}
+		fmt.Fprintf(&buf, ": %v", f)
+	}
+	buf.WriteString("}")
+	return buf.String()
+}

--- a/vendor/golang.org/x/tools/go/analysis/internal/facts/imports.go
+++ b/vendor/golang.org/x/tools/go/analysis/internal/facts/imports.go
@@ -1,0 +1,88 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package facts
+
+import "go/types"
+
+// importMap computes the import map for a package by traversing the
+// entire exported API each of its imports.
+//
+// This is a workaround for the fact that we cannot access the map used
+// internally by the types.Importer returned by go/importer. The entries
+// in this map are the packages and objects that may be relevant to the
+// current analysis unit.
+//
+// Packages in the map that are only indirectly imported may be
+// incomplete (!pkg.Complete()).
+//
+func importMap(imports []*types.Package) map[string]*types.Package {
+	objects := make(map[types.Object]bool)
+	packages := make(map[string]*types.Package)
+
+	var addObj func(obj types.Object) bool
+	var addType func(T types.Type)
+
+	addObj = func(obj types.Object) bool {
+		if !objects[obj] {
+			objects[obj] = true
+			addType(obj.Type())
+			if pkg := obj.Pkg(); pkg != nil {
+				packages[pkg.Path()] = pkg
+			}
+			return true
+		}
+		return false
+	}
+
+	addType = func(T types.Type) {
+		switch T := T.(type) {
+		case *types.Basic:
+			// nop
+		case *types.Named:
+			if addObj(T.Obj()) {
+				for i := 0; i < T.NumMethods(); i++ {
+					addObj(T.Method(i))
+				}
+			}
+		case *types.Pointer:
+			addType(T.Elem())
+		case *types.Slice:
+			addType(T.Elem())
+		case *types.Array:
+			addType(T.Elem())
+		case *types.Chan:
+			addType(T.Elem())
+		case *types.Map:
+			addType(T.Key())
+			addType(T.Elem())
+		case *types.Signature:
+			addType(T.Params())
+			addType(T.Results())
+		case *types.Struct:
+			for i := 0; i < T.NumFields(); i++ {
+				addObj(T.Field(i))
+			}
+		case *types.Tuple:
+			for i := 0; i < T.Len(); i++ {
+				addObj(T.At(i))
+			}
+		case *types.Interface:
+			for i := 0; i < T.NumMethods(); i++ {
+				addObj(T.Method(i))
+			}
+		}
+	}
+
+	for _, imp := range imports {
+		packages[imp.Path()] = imp
+
+		scope := imp.Scope()
+		for _, name := range scope.Names() {
+			addObj(scope.Lookup(name))
+		}
+	}
+
+	return packages
+}

--- a/vendor/golang.org/x/tools/go/analysis/singlechecker/singlechecker.go
+++ b/vendor/golang.org/x/tools/go/analysis/singlechecker/singlechecker.go
@@ -1,0 +1,77 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singlechecker defines the main function for an analysis
+// driver with only a single analysis.
+// This package makes it easy for a provider of an analysis package to
+// also provide a standalone tool that runs just that analysis.
+//
+// For example, if example.org/findbadness is an analysis package,
+// all that is needed to define a standalone tool is a file,
+// example.org/findbadness/cmd/findbadness/main.go, containing:
+//
+//      // The findbadness command runs an analysis.
+// 	package main
+//
+// 	import (
+// 		"example.org/findbadness"
+// 		"golang.org/x/tools/go/analysis/singlechecker"
+// 	)
+//
+// 	func main() { singlechecker.Main(findbadness.Analyzer) }
+//
+package singlechecker
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/internal/analysisflags"
+	"golang.org/x/tools/go/analysis/internal/checker"
+	"golang.org/x/tools/go/analysis/unitchecker"
+)
+
+// Main is the main function for a checker command for a single analysis.
+func Main(a *analysis.Analyzer) {
+	log.SetFlags(0)
+	log.SetPrefix(a.Name + ": ")
+
+	analyzers := []*analysis.Analyzer{a}
+
+	if err := analysis.Validate(analyzers); err != nil {
+		log.Fatal(err)
+	}
+
+	checker.RegisterFlags()
+
+	flag.Usage = func() {
+		paras := strings.Split(a.Doc, "\n\n")
+		fmt.Fprintf(os.Stderr, "%s: %s\n\n", a.Name, paras[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s [-flag] [package]\n\n", a.Name)
+		if len(paras) > 1 {
+			fmt.Fprintln(os.Stderr, strings.Join(paras[1:], "\n\n"))
+		}
+		fmt.Fprintln(os.Stderr, "\nFlags:")
+		flag.PrintDefaults()
+	}
+
+	analyzers = analysisflags.Parse(analyzers, false)
+
+	args := flag.Args()
+	if len(args) == 0 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if len(args) == 1 && strings.HasSuffix(args[0], ".cfg") {
+		unitchecker.Run(args[0], analyzers)
+		panic("unreachable")
+	}
+
+	os.Exit(checker.Run(args, analyzers))
+}

--- a/vendor/golang.org/x/tools/go/analysis/unitchecker/unitchecker.go
+++ b/vendor/golang.org/x/tools/go/analysis/unitchecker/unitchecker.go
@@ -1,0 +1,396 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The unitchecker package defines the main function for an analysis
+// driver that analyzes a single compilation unit during a build.
+// It is invoked by a build system such as "go vet":
+//
+//   $ go vet -vettool=$(which vet)
+//
+// It supports the following command-line protocol:
+//
+//      -V=full         describe executable               (to the build tool)
+//      -flags          describe flags                    (to the build tool)
+//      foo.cfg         description of compilation unit (from the build tool)
+//
+// This package does not depend on go/packages.
+// If you need a standalone tool, use multichecker,
+// which supports this mode but can also load packages
+// from source using go/packages.
+package unitchecker
+
+// TODO(adonovan):
+// - with gccgo, go build does not build standard library,
+//   so we will not get to analyze it. Yet we must in order
+//   to create base facts for, say, the fmt package for the
+//   printf checker.
+
+import (
+	"encoding/gob"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/internal/analysisflags"
+	"golang.org/x/tools/go/analysis/internal/facts"
+)
+
+// A Config describes a compilation unit to be analyzed.
+// It is provided to the tool in a JSON-encoded file
+// whose name ends with ".cfg".
+type Config struct {
+	ID                        string // e.g. "fmt [fmt.test]"
+	Compiler                  string
+	Dir                       string
+	ImportPath                string
+	GoFiles                   []string
+	NonGoFiles                []string
+	ImportMap                 map[string]string
+	PackageFile               map[string]string
+	Standard                  map[string]bool
+	PackageVetx               map[string]string
+	VetxOnly                  bool
+	VetxOutput                string
+	SucceedOnTypecheckFailure bool
+}
+
+// Main is the main function of a vet-like analysis tool that must be
+// invoked by a build system to analyze a single package.
+//
+// The protocol required by 'go vet -vettool=...' is that the tool must support:
+//
+//      -flags          describe flags in JSON
+//      -V=full         describe executable for build caching
+//      foo.cfg         perform separate modular analyze on the single
+//                      unit described by a JSON config file foo.cfg.
+//
+func Main(analyzers ...*analysis.Analyzer) {
+	progname := filepath.Base(os.Args[0])
+	log.SetFlags(0)
+	log.SetPrefix(progname + ": ")
+
+	if err := analysis.Validate(analyzers); err != nil {
+		log.Fatal(err)
+	}
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, `%[1]s is a tool for static analysis of Go programs.
+
+Usage of %[1]s:
+	%.16[1]s unit.cfg	# execute analysis specified by config file
+	%.16[1]s help    	# general help
+	%.16[1]s help name	# help on specific analyzer and its flags
+`, progname)
+		os.Exit(1)
+	}
+
+	analyzers = analysisflags.Parse(analyzers, true)
+
+	args := flag.Args()
+	if len(args) == 0 {
+		flag.Usage()
+	}
+	if args[0] == "help" {
+		analysisflags.Help(progname, analyzers, args[1:])
+		os.Exit(0)
+	}
+	if len(args) != 1 || !strings.HasSuffix(args[0], ".cfg") {
+		log.Fatalf(`invoking "go tool vet" directly is unsupported; use "go vet"`)
+	}
+	Run(args[0], analyzers)
+}
+
+// Run reads the *.cfg file, runs the analysis,
+// and calls os.Exit with an appropriate error code.
+// It assumes flags have already been set.
+func Run(configFile string, analyzers []*analysis.Analyzer) {
+	cfg, err := readConfig(configFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fset := token.NewFileSet()
+	results, err := run(fset, cfg, analyzers)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// In VetxOnly mode, the analysis is run only for facts.
+	if !cfg.VetxOnly {
+		if analysisflags.JSON {
+			// JSON output
+			tree := make(analysisflags.JSONTree)
+			for _, res := range results {
+				tree.Add(fset, cfg.ID, res.a.Name, res.diagnostics, res.err)
+			}
+			tree.Print()
+		} else {
+			// plain text
+			exit := 0
+			for _, res := range results {
+				if res.err != nil {
+					log.Println(res.err)
+					exit = 1
+				}
+			}
+			for _, res := range results {
+				for _, diag := range res.diagnostics {
+					analysisflags.PrintPlain(fset, diag)
+					exit = 1
+				}
+			}
+			os.Exit(exit)
+		}
+	}
+
+	os.Exit(0)
+}
+
+func readConfig(filename string) (*Config, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	cfg := new(Config)
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("cannot decode JSON config file %s: %v", filename, err)
+	}
+	if len(cfg.GoFiles) == 0 {
+		// The go command disallows packages with no files.
+		// The only exception is unsafe, but the go command
+		// doesn't call vet on it.
+		return nil, fmt.Errorf("package has no files: %s", cfg.ImportPath)
+	}
+	return cfg, nil
+}
+
+var importerForCompiler = func(_ *token.FileSet, compiler string, lookup importer.Lookup) types.Importer {
+	// broken legacy implementation (https://golang.org/issue/28995)
+	return importer.For(compiler, lookup)
+}
+
+func run(fset *token.FileSet, cfg *Config, analyzers []*analysis.Analyzer) ([]result, error) {
+	// Load, parse, typecheck.
+	var files []*ast.File
+	for _, name := range cfg.GoFiles {
+		f, err := parser.ParseFile(fset, name, nil, parser.ParseComments)
+		if err != nil {
+			if cfg.SucceedOnTypecheckFailure {
+				// Silently succeed; let the compiler
+				// report parse errors.
+				err = nil
+			}
+			return nil, err
+		}
+		files = append(files, f)
+	}
+	compilerImporter := importerForCompiler(fset, cfg.Compiler, func(path string) (io.ReadCloser, error) {
+		// path is a resolved package path, not an import path.
+		file, ok := cfg.PackageFile[path]
+		if !ok {
+			if cfg.Compiler == "gccgo" && cfg.Standard[path] {
+				return nil, nil // fall back to default gccgo lookup
+			}
+			return nil, fmt.Errorf("no package file for %q", path)
+		}
+		return os.Open(file)
+	})
+	importer := importerFunc(func(importPath string) (*types.Package, error) {
+		path, ok := cfg.ImportMap[importPath] // resolve vendoring, etc
+		if !ok {
+			return nil, fmt.Errorf("can't resolve import %q", path)
+		}
+		return compilerImporter.Import(path)
+	})
+	tc := &types.Config{
+		Importer: importer,
+		Sizes:    types.SizesFor("gc", build.Default.GOARCH), // assume gccgo ≡ gc?
+	}
+	info := &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Implicits:  make(map[ast.Node]types.Object),
+		Scopes:     make(map[ast.Node]*types.Scope),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+	}
+	pkg, err := tc.Check(cfg.ImportPath, fset, files, info)
+	if err != nil {
+		if cfg.SucceedOnTypecheckFailure {
+			// Silently succeed; let the compiler
+			// report type errors.
+			err = nil
+		}
+		return nil, err
+	}
+
+	// Register fact types with gob.
+	// In VetxOnly mode, analyzers are only for their facts,
+	// so we can skip any analysis that neither produces facts
+	// nor depends on any analysis that produces facts.
+	// Also build a map to hold working state and result.
+	type action struct {
+		once        sync.Once
+		result      interface{}
+		err         error
+		usesFacts   bool // (transitively uses)
+		diagnostics []analysis.Diagnostic
+	}
+	actions := make(map[*analysis.Analyzer]*action)
+	var registerFacts func(a *analysis.Analyzer) bool
+	registerFacts = func(a *analysis.Analyzer) bool {
+		act, ok := actions[a]
+		if !ok {
+			act = new(action)
+			var usesFacts bool
+			for _, f := range a.FactTypes {
+				usesFacts = true
+				gob.Register(f)
+			}
+			for _, req := range a.Requires {
+				if registerFacts(req) {
+					usesFacts = true
+				}
+			}
+			act.usesFacts = usesFacts
+			actions[a] = act
+		}
+		return act.usesFacts
+	}
+	var filtered []*analysis.Analyzer
+	for _, a := range analyzers {
+		if registerFacts(a) || !cfg.VetxOnly {
+			filtered = append(filtered, a)
+		}
+	}
+	analyzers = filtered
+
+	// Read facts from imported packages.
+	read := func(path string) ([]byte, error) {
+		if vetx, ok := cfg.PackageVetx[path]; ok {
+			return ioutil.ReadFile(vetx)
+		}
+		return nil, nil // no .vetx file, no facts
+	}
+	facts, err := facts.Decode(pkg, read)
+	if err != nil {
+		return nil, err
+	}
+
+	// In parallel, execute the DAG of analyzers.
+	var exec func(a *analysis.Analyzer) *action
+	var execAll func(analyzers []*analysis.Analyzer)
+	exec = func(a *analysis.Analyzer) *action {
+		act := actions[a]
+		act.once.Do(func() {
+			execAll(a.Requires) // prefetch dependencies in parallel
+
+			// The inputs to this analysis are the
+			// results of its prerequisites.
+			inputs := make(map[*analysis.Analyzer]interface{})
+			var failed []string
+			for _, req := range a.Requires {
+				reqact := exec(req)
+				if reqact.err != nil {
+					failed = append(failed, req.String())
+					continue
+				}
+				inputs[req] = reqact.result
+			}
+
+			// Report an error if any dependency failed.
+			if failed != nil {
+				sort.Strings(failed)
+				act.err = fmt.Errorf("failed prerequisites: %s", strings.Join(failed, ", "))
+				return
+			}
+
+			factFilter := make(map[reflect.Type]bool)
+			for _, f := range a.FactTypes {
+				factFilter[reflect.TypeOf(f)] = true
+			}
+
+			pass := &analysis.Pass{
+				Analyzer:          a,
+				Fset:              fset,
+				Files:             files,
+				OtherFiles:        cfg.NonGoFiles,
+				Pkg:               pkg,
+				TypesInfo:         info,
+				TypesSizes:        tc.Sizes,
+				ResultOf:          inputs,
+				Report:            func(d analysis.Diagnostic) { act.diagnostics = append(act.diagnostics, d) },
+				ImportObjectFact:  facts.ImportObjectFact,
+				ExportObjectFact:  facts.ExportObjectFact,
+				AllObjectFacts:    func() []analysis.ObjectFact { return facts.AllObjectFacts(factFilter) },
+				ImportPackageFact: facts.ImportPackageFact,
+				ExportPackageFact: facts.ExportPackageFact,
+				AllPackageFacts:   func() []analysis.PackageFact { return facts.AllPackageFacts(factFilter) },
+			}
+
+			t0 := time.Now()
+			act.result, act.err = a.Run(pass)
+			if false {
+				log.Printf("analysis %s = %s", pass, time.Since(t0))
+			}
+		})
+		return act
+	}
+	execAll = func(analyzers []*analysis.Analyzer) {
+		var wg sync.WaitGroup
+		for _, a := range analyzers {
+			wg.Add(1)
+			go func(a *analysis.Analyzer) {
+				_ = exec(a)
+				wg.Done()
+			}(a)
+		}
+		wg.Wait()
+	}
+
+	execAll(analyzers)
+
+	// Return diagnostics and errors from root analyzers.
+	results := make([]result, len(analyzers))
+	for i, a := range analyzers {
+		act := actions[a]
+		results[i].a = a
+		results[i].err = act.err
+		results[i].diagnostics = act.diagnostics
+	}
+
+	data := facts.Encode()
+	if err := ioutil.WriteFile(cfg.VetxOutput, data, 0666); err != nil {
+		return nil, fmt.Errorf("failed to write analysis facts: %v", err)
+	}
+
+	return results, nil
+}
+
+type result struct {
+	a           *analysis.Analyzer
+	diagnostics []analysis.Diagnostic
+	err         error
+}
+
+type importerFunc func(path string) (*types.Package, error)
+
+func (f importerFunc) Import(path string) (*types.Package, error) { return f(path) }

--- a/vendor/golang.org/x/tools/go/analysis/unitchecker/unitchecker112.go
+++ b/vendor/golang.org/x/tools/go/analysis/unitchecker/unitchecker112.go
@@ -1,0 +1,9 @@
+// +build go1.12
+
+package unitchecker
+
+import "go/importer"
+
+func init() {
+	importerForCompiler = importer.ForCompiler
+}

--- a/vendor/golang.org/x/tools/go/analysis/validate.go
+++ b/vendor/golang.org/x/tools/go/analysis/validate.go
@@ -1,0 +1,97 @@
+package analysis
+
+import (
+	"fmt"
+	"reflect"
+	"unicode"
+)
+
+// Validate reports an error if any of the analyzers are misconfigured.
+// Checks include:
+// that the name is a valid identifier;
+// that the Requires graph is acyclic;
+// that analyzer fact types are unique;
+// that each fact type is a pointer.
+func Validate(analyzers []*Analyzer) error {
+	// Map each fact type to its sole generating analyzer.
+	factTypes := make(map[reflect.Type]*Analyzer)
+
+	// Traverse the Requires graph, depth first.
+	const (
+		white = iota
+		grey
+		black
+		finished
+	)
+	color := make(map[*Analyzer]uint8)
+	var visit func(a *Analyzer) error
+	visit = func(a *Analyzer) error {
+		if a == nil {
+			return fmt.Errorf("nil *Analyzer")
+		}
+		if color[a] == white {
+			color[a] = grey
+
+			// names
+			if !validIdent(a.Name) {
+				return fmt.Errorf("invalid analyzer name %q", a)
+			}
+
+			if a.Doc == "" {
+				return fmt.Errorf("analyzer %q is undocumented", a)
+			}
+
+			// fact types
+			for _, f := range a.FactTypes {
+				if f == nil {
+					return fmt.Errorf("analyzer %s has nil FactType", a)
+				}
+				t := reflect.TypeOf(f)
+				if prev := factTypes[t]; prev != nil {
+					return fmt.Errorf("fact type %s registered by two analyzers: %v, %v",
+						t, a, prev)
+				}
+				if t.Kind() != reflect.Ptr {
+					return fmt.Errorf("%s: fact type %s is not a pointer", a, t)
+				}
+				factTypes[t] = a
+			}
+
+			// recursion
+			for i, req := range a.Requires {
+				if err := visit(req); err != nil {
+					return fmt.Errorf("%s.Requires[%d]: %v", a.Name, i, err)
+				}
+			}
+			color[a] = black
+		}
+
+		return nil
+	}
+	for _, a := range analyzers {
+		if err := visit(a); err != nil {
+			return err
+		}
+	}
+
+	// Reject duplicates among analyzers.
+	// Precondition:  color[a] == black.
+	// Postcondition: color[a] == finished.
+	for _, a := range analyzers {
+		if color[a] == finished {
+			return fmt.Errorf("duplicate analyzer: %s", a.Name)
+		}
+		color[a] = finished
+	}
+
+	return nil
+}
+
+func validIdent(name string) bool {
+	for i, r := range name {
+		if !(r == '_' || unicode.IsLetter(r) || i > 0 && unicode.IsDigit(r)) {
+			return false
+		}
+	}
+	return name != ""
+}

--- a/vendor/golang.org/x/tools/go/internal/packagesdriver/sizes.go
+++ b/vendor/golang.org/x/tools/go/internal/packagesdriver/sizes.go
@@ -1,0 +1,117 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package packagesdriver fetches type sizes for go/packages and go/analysis.
+package packagesdriver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"go/types"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/tools/internal/gocommand"
+)
+
+var debug = false
+
+func GetSizes(ctx context.Context, buildFlags, env []string, gocmdRunner *gocommand.Runner, dir string) (types.Sizes, error) {
+	// TODO(matloob): Clean this up. This code is mostly a copy of packages.findExternalDriver.
+	const toolPrefix = "GOPACKAGESDRIVER="
+	tool := ""
+	for _, env := range env {
+		if val := strings.TrimPrefix(env, toolPrefix); val != env {
+			tool = val
+		}
+	}
+
+	if tool == "" {
+		var err error
+		tool, err = exec.LookPath("gopackagesdriver")
+		if err != nil {
+			// We did not find the driver, so use "go list".
+			tool = "off"
+		}
+	}
+
+	if tool == "off" {
+		return GetSizesGolist(ctx, buildFlags, env, gocmdRunner, dir)
+	}
+
+	req, err := json.Marshal(struct {
+		Command    string   `json:"command"`
+		Env        []string `json:"env"`
+		BuildFlags []string `json:"build_flags"`
+	}{
+		Command:    "sizes",
+		Env:        env,
+		BuildFlags: buildFlags,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode message to driver tool: %v", err)
+	}
+
+	buf := new(bytes.Buffer)
+	cmd := exec.CommandContext(ctx, tool)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.Stdin = bytes.NewReader(req)
+	cmd.Stdout = buf
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%v: %v: %s", tool, err, cmd.Stderr)
+	}
+	var response struct {
+		// Sizes, if not nil, is the types.Sizes to use when type checking.
+		Sizes *types.StdSizes
+	}
+	if err := json.Unmarshal(buf.Bytes(), &response); err != nil {
+		return nil, err
+	}
+	return response.Sizes, nil
+}
+
+func GetSizesGolist(ctx context.Context, buildFlags, env []string, gocmdRunner *gocommand.Runner, dir string) (types.Sizes, error) {
+	inv := gocommand.Invocation{
+		Verb:       "list",
+		Args:       []string{"-f", "{{context.GOARCH}} {{context.Compiler}}", "--", "unsafe"},
+		Env:        env,
+		BuildFlags: buildFlags,
+		WorkingDir: dir,
+	}
+	stdout, stderr, friendlyErr, rawErr := gocmdRunner.RunRaw(ctx, inv)
+	var goarch, compiler string
+	if rawErr != nil {
+		if strings.Contains(rawErr.Error(), "cannot find main module") {
+			// User's running outside of a module. All bets are off. Get GOARCH and guess compiler is gc.
+			// TODO(matloob): Is this a problem in practice?
+			inv := gocommand.Invocation{
+				Verb:       "env",
+				Args:       []string{"GOARCH"},
+				Env:        env,
+				WorkingDir: dir,
+			}
+			envout, enverr := gocmdRunner.Run(ctx, inv)
+			if enverr != nil {
+				return nil, enverr
+			}
+			goarch = strings.TrimSpace(envout.String())
+			compiler = "gc"
+		} else {
+			return nil, friendlyErr
+		}
+	} else {
+		fields := strings.Fields(stdout.String())
+		if len(fields) < 2 {
+			return nil, fmt.Errorf("could not parse GOARCH and Go compiler in format \"<GOARCH> <compiler>\":\nstdout: <<%s>>\nstderr: <<%s>>",
+				stdout.String(), stderr.String())
+		}
+		goarch = fields[0]
+		compiler = fields[1]
+	}
+	return types.SizesFor(compiler, goarch), nil
+}

--- a/vendor/golang.org/x/tools/go/packages/doc.go
+++ b/vendor/golang.org/x/tools/go/packages/doc.go
@@ -1,0 +1,221 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package packages loads Go packages for inspection and analysis.
+
+The Load function takes as input a list of patterns and return a list of Package
+structs describing individual packages matched by those patterns.
+The LoadMode controls the amount of detail in the loaded packages.
+
+Load passes most patterns directly to the underlying build tool,
+but all patterns with the prefix "query=", where query is a
+non-empty string of letters from [a-z], are reserved and may be
+interpreted as query operators.
+
+Two query operators are currently supported: "file" and "pattern".
+
+The query "file=path/to/file.go" matches the package or packages enclosing
+the Go source file path/to/file.go.  For example "file=~/go/src/fmt/print.go"
+might return the packages "fmt" and "fmt [fmt.test]".
+
+The query "pattern=string" causes "string" to be passed directly to
+the underlying build tool. In most cases this is unnecessary,
+but an application can use Load("pattern=" + x) as an escaping mechanism
+to ensure that x is not interpreted as a query operator if it contains '='.
+
+All other query operators are reserved for future use and currently
+cause Load to report an error.
+
+The Package struct provides basic information about the package, including
+
+  - ID, a unique identifier for the package in the returned set;
+  - GoFiles, the names of the package's Go source files;
+  - Imports, a map from source import strings to the Packages they name;
+  - Types, the type information for the package's exported symbols;
+  - Syntax, the parsed syntax trees for the package's source code; and
+  - TypeInfo, the result of a complete type-check of the package syntax trees.
+
+(See the documentation for type Package for the complete list of fields
+and more detailed descriptions.)
+
+For example,
+
+	Load(nil, "bytes", "unicode...")
+
+returns four Package structs describing the standard library packages
+bytes, unicode, unicode/utf16, and unicode/utf8. Note that one pattern
+can match multiple packages and that a package might be matched by
+multiple patterns: in general it is not possible to determine which
+packages correspond to which patterns.
+
+Note that the list returned by Load contains only the packages matched
+by the patterns. Their dependencies can be found by walking the import
+graph using the Imports fields.
+
+The Load function can be configured by passing a pointer to a Config as
+the first argument. A nil Config is equivalent to the zero Config, which
+causes Load to run in LoadFiles mode, collecting minimal information.
+See the documentation for type Config for details.
+
+As noted earlier, the Config.Mode controls the amount of detail
+reported about the loaded packages. See the documentation for type LoadMode
+for details.
+
+Most tools should pass their command-line arguments (after any flags)
+uninterpreted to the loader, so that the loader can interpret them
+according to the conventions of the underlying build system.
+See the Example function for typical usage.
+
+*/
+package packages // import "golang.org/x/tools/go/packages"
+
+/*
+
+Motivation and design considerations
+
+The new package's design solves problems addressed by two existing
+packages: go/build, which locates and describes packages, and
+golang.org/x/tools/go/loader, which loads, parses and type-checks them.
+The go/build.Package structure encodes too much of the 'go build' way
+of organizing projects, leaving us in need of a data type that describes a
+package of Go source code independent of the underlying build system.
+We wanted something that works equally well with go build and vgo, and
+also other build systems such as Bazel and Blaze, making it possible to
+construct analysis tools that work in all these environments.
+Tools such as errcheck and staticcheck were essentially unavailable to
+the Go community at Google, and some of Google's internal tools for Go
+are unavailable externally.
+This new package provides a uniform way to obtain package metadata by
+querying each of these build systems, optionally supporting their
+preferred command-line notations for packages, so that tools integrate
+neatly with users' build environments. The Metadata query function
+executes an external query tool appropriate to the current workspace.
+
+Loading packages always returns the complete import graph "all the way down",
+even if all you want is information about a single package, because the query
+mechanisms of all the build systems we currently support ({go,vgo} list, and
+blaze/bazel aspect-based query) cannot provide detailed information
+about one package without visiting all its dependencies too, so there is
+no additional asymptotic cost to providing transitive information.
+(This property might not be true of a hypothetical 5th build system.)
+
+In calls to TypeCheck, all initial packages, and any package that
+transitively depends on one of them, must be loaded from source.
+Consider A->B->C->D->E: if A,C are initial, A,B,C must be loaded from
+source; D may be loaded from export data, and E may not be loaded at all
+(though it's possible that D's export data mentions it, so a
+types.Package may be created for it and exposed.)
+
+The old loader had a feature to suppress type-checking of function
+bodies on a per-package basis, primarily intended to reduce the work of
+obtaining type information for imported packages. Now that imports are
+satisfied by export data, the optimization no longer seems necessary.
+
+Despite some early attempts, the old loader did not exploit export data,
+instead always using the equivalent of WholeProgram mode. This was due
+to the complexity of mixing source and export data packages (now
+resolved by the upward traversal mentioned above), and because export data
+files were nearly always missing or stale. Now that 'go build' supports
+caching, all the underlying build systems can guarantee to produce
+export data in a reasonable (amortized) time.
+
+Test "main" packages synthesized by the build system are now reported as
+first-class packages, avoiding the need for clients (such as go/ssa) to
+reinvent this generation logic.
+
+One way in which go/packages is simpler than the old loader is in its
+treatment of in-package tests. In-package tests are packages that
+consist of all the files of the library under test, plus the test files.
+The old loader constructed in-package tests by a two-phase process of
+mutation called "augmentation": first it would construct and type check
+all the ordinary library packages and type-check the packages that
+depend on them; then it would add more (test) files to the package and
+type-check again. This two-phase approach had four major problems:
+1) in processing the tests, the loader modified the library package,
+   leaving no way for a client application to see both the test
+   package and the library package; one would mutate into the other.
+2) because test files can declare additional methods on types defined in
+   the library portion of the package, the dispatch of method calls in
+   the library portion was affected by the presence of the test files.
+   This should have been a clue that the packages were logically
+   different.
+3) this model of "augmentation" assumed at most one in-package test
+   per library package, which is true of projects using 'go build',
+   but not other build systems.
+4) because of the two-phase nature of test processing, all packages that
+   import the library package had to be processed before augmentation,
+   forcing a "one-shot" API and preventing the client from calling Load
+   in several times in sequence as is now possible in WholeProgram mode.
+   (TypeCheck mode has a similar one-shot restriction for a different reason.)
+
+Early drafts of this package supported "multi-shot" operation.
+Although it allowed clients to make a sequence of calls (or concurrent
+calls) to Load, building up the graph of Packages incrementally,
+it was of marginal value: it complicated the API
+(since it allowed some options to vary across calls but not others),
+it complicated the implementation,
+it cannot be made to work in Types mode, as explained above,
+and it was less efficient than making one combined call (when this is possible).
+Among the clients we have inspected, none made multiple calls to load
+but could not be easily and satisfactorily modified to make only a single call.
+However, applications changes may be required.
+For example, the ssadump command loads the user-specified packages
+and in addition the runtime package.  It is tempting to simply append
+"runtime" to the user-provided list, but that does not work if the user
+specified an ad-hoc package such as [a.go b.go].
+Instead, ssadump no longer requests the runtime package,
+but seeks it among the dependencies of the user-specified packages,
+and emits an error if it is not found.
+
+Overlays: The Overlay field in the Config allows providing alternate contents
+for Go source files, by providing a mapping from file path to contents.
+go/packages will pull in new imports added in overlay files when go/packages
+is run in LoadImports mode or greater.
+Overlay support for the go list driver isn't complete yet: if the file doesn't
+exist on disk, it will only be recognized in an overlay if it is a non-test file
+and the package would be reported even without the overlay.
+
+Questions & Tasks
+
+- Add GOARCH/GOOS?
+  They are not portable concepts, but could be made portable.
+  Our goal has been to allow users to express themselves using the conventions
+  of the underlying build system: if the build system honors GOARCH
+  during a build and during a metadata query, then so should
+  applications built atop that query mechanism.
+  Conversely, if the target architecture of the build is determined by
+  command-line flags, the application can pass the relevant
+  flags through to the build system using a command such as:
+    myapp -query_flag="--cpu=amd64" -query_flag="--os=darwin"
+  However, this approach is low-level, unwieldy, and non-portable.
+  GOOS and GOARCH seem important enough to warrant a dedicated option.
+
+- How should we handle partial failures such as a mixture of good and
+  malformed patterns, existing and non-existent packages, successful and
+  failed builds, import failures, import cycles, and so on, in a call to
+  Load?
+
+- Support bazel, blaze, and go1.10 list, not just go1.11 list.
+
+- Handle (and test) various partial success cases, e.g.
+  a mixture of good packages and:
+  invalid patterns
+  nonexistent packages
+  empty packages
+  packages with malformed package or import declarations
+  unreadable files
+  import cycles
+  other parse errors
+  type errors
+  Make sure we record errors at the correct place in the graph.
+
+- Missing packages among initial arguments are not reported.
+  Return bogus packages for them, like golist does.
+
+- "undeclared name" errors (for example) are reported out of source file
+  order. I suspect this is due to the breadth-first resolution now used
+  by go/types. Is that a bug? Discuss with gri.
+
+*/

--- a/vendor/golang.org/x/tools/go/packages/external.go
+++ b/vendor/golang.org/x/tools/go/packages/external.go
@@ -1,0 +1,101 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This file enables an external tool to intercept package requests.
+// If the tool is present then its results are used in preference to
+// the go list command.
+
+package packages
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// The Driver Protocol
+//
+// The driver, given the inputs to a call to Load, returns metadata about the packages specified.
+// This allows for different build systems to support go/packages by telling go/packages how the
+// packages' source is organized.
+// The driver is a binary, either specified by the GOPACKAGESDRIVER environment variable or in
+// the path as gopackagesdriver. It's given the inputs to load in its argv. See the package
+// documentation in doc.go for the full description of the patterns that need to be supported.
+// A driver receives as a JSON-serialized driverRequest struct in standard input and will
+// produce a JSON-serialized driverResponse (see definition in packages.go) in its standard output.
+
+// driverRequest is used to provide the portion of Load's Config that is needed by a driver.
+type driverRequest struct {
+	Mode LoadMode `json:"mode"`
+	// Env specifies the environment the underlying build system should be run in.
+	Env []string `json:"env"`
+	// BuildFlags are flags that should be passed to the underlying build system.
+	BuildFlags []string `json:"build_flags"`
+	// Tests specifies whether the patterns should also return test packages.
+	Tests bool `json:"tests"`
+	// Overlay maps file paths (relative to the driver's working directory) to the byte contents
+	// of overlay files.
+	Overlay map[string][]byte `json:"overlay"`
+}
+
+// findExternalDriver returns the file path of a tool that supplies
+// the build system package structure, or "" if not found."
+// If GOPACKAGESDRIVER is set in the environment findExternalTool returns its
+// value, otherwise it searches for a binary named gopackagesdriver on the PATH.
+func findExternalDriver(cfg *Config) driver {
+	const toolPrefix = "GOPACKAGESDRIVER="
+	tool := ""
+	for _, env := range cfg.Env {
+		if val := strings.TrimPrefix(env, toolPrefix); val != env {
+			tool = val
+		}
+	}
+	if tool != "" && tool == "off" {
+		return nil
+	}
+	if tool == "" {
+		var err error
+		tool, err = exec.LookPath("gopackagesdriver")
+		if err != nil {
+			return nil
+		}
+	}
+	return func(cfg *Config, words ...string) (*driverResponse, error) {
+		req, err := json.Marshal(driverRequest{
+			Mode:       cfg.Mode,
+			Env:        cfg.Env,
+			BuildFlags: cfg.BuildFlags,
+			Tests:      cfg.Tests,
+			Overlay:    cfg.Overlay,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode message to driver tool: %v", err)
+		}
+
+		buf := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd := exec.CommandContext(cfg.Context, tool, words...)
+		cmd.Dir = cfg.Dir
+		cmd.Env = cfg.Env
+		cmd.Stdin = bytes.NewReader(req)
+		cmd.Stdout = buf
+		cmd.Stderr = stderr
+
+		if err := cmd.Run(); err != nil {
+			return nil, fmt.Errorf("%v: %v: %s", tool, err, cmd.Stderr)
+		}
+		if len(stderr.Bytes()) != 0 && os.Getenv("GOPACKAGESPRINTDRIVERERRORS") != "" {
+			fmt.Fprintf(os.Stderr, "%s stderr: <<%s>>\n", cmdDebugStr(cmd, words...), stderr)
+		}
+
+		var response driverResponse
+		if err := json.Unmarshal(buf.Bytes(), &response); err != nil {
+			return nil, err
+		}
+		return &response, nil
+	}
+}

--- a/vendor/golang.org/x/tools/go/packages/golist.go
+++ b/vendor/golang.org/x/tools/go/packages/golist.go
@@ -1,0 +1,940 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package packages
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"go/types"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"unicode"
+
+	"golang.org/x/tools/go/internal/packagesdriver"
+	"golang.org/x/tools/internal/gocommand"
+	"golang.org/x/xerrors"
+)
+
+// debug controls verbose logging.
+var debug, _ = strconv.ParseBool(os.Getenv("GOPACKAGESDEBUG"))
+
+// A goTooOldError reports that the go command
+// found by exec.LookPath is too old to use the new go list behavior.
+type goTooOldError struct {
+	error
+}
+
+// responseDeduper wraps a driverResponse, deduplicating its contents.
+type responseDeduper struct {
+	seenRoots    map[string]bool
+	seenPackages map[string]*Package
+	dr           *driverResponse
+}
+
+func newDeduper() *responseDeduper {
+	return &responseDeduper{
+		dr:           &driverResponse{},
+		seenRoots:    map[string]bool{},
+		seenPackages: map[string]*Package{},
+	}
+}
+
+// addAll fills in r with a driverResponse.
+func (r *responseDeduper) addAll(dr *driverResponse) {
+	for _, pkg := range dr.Packages {
+		r.addPackage(pkg)
+	}
+	for _, root := range dr.Roots {
+		r.addRoot(root)
+	}
+}
+
+func (r *responseDeduper) addPackage(p *Package) {
+	if r.seenPackages[p.ID] != nil {
+		return
+	}
+	r.seenPackages[p.ID] = p
+	r.dr.Packages = append(r.dr.Packages, p)
+}
+
+func (r *responseDeduper) addRoot(id string) {
+	if r.seenRoots[id] {
+		return
+	}
+	r.seenRoots[id] = true
+	r.dr.Roots = append(r.dr.Roots, id)
+}
+
+type golistState struct {
+	cfg *Config
+	ctx context.Context
+
+	envOnce    sync.Once
+	goEnvError error
+	goEnv      map[string]string
+
+	rootsOnce     sync.Once
+	rootDirsError error
+	rootDirs      map[string]string
+
+	// vendorDirs caches the (non)existence of vendor directories.
+	vendorDirs map[string]bool
+}
+
+// getEnv returns Go environment variables. Only specific variables are
+// populated -- computing all of them is slow.
+func (state *golistState) getEnv() (map[string]string, error) {
+	state.envOnce.Do(func() {
+		var b *bytes.Buffer
+		b, state.goEnvError = state.invokeGo("env", "-json", "GOMOD", "GOPATH")
+		if state.goEnvError != nil {
+			return
+		}
+
+		state.goEnv = make(map[string]string)
+		decoder := json.NewDecoder(b)
+		if state.goEnvError = decoder.Decode(&state.goEnv); state.goEnvError != nil {
+			return
+		}
+	})
+	return state.goEnv, state.goEnvError
+}
+
+// mustGetEnv is a convenience function that can be used if getEnv has already succeeded.
+func (state *golistState) mustGetEnv() map[string]string {
+	env, err := state.getEnv()
+	if err != nil {
+		panic(fmt.Sprintf("mustGetEnv: %v", err))
+	}
+	return env
+}
+
+// goListDriver uses the go list command to interpret the patterns and produce
+// the build system package structure.
+// See driver for more details.
+func goListDriver(cfg *Config, patterns ...string) (*driverResponse, error) {
+	// Make sure that any asynchronous go commands are killed when we return.
+	parentCtx := cfg.Context
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
+	response := newDeduper()
+
+	// Fill in response.Sizes asynchronously if necessary.
+	var sizeserr error
+	var sizeswg sync.WaitGroup
+	if cfg.Mode&NeedTypesSizes != 0 || cfg.Mode&NeedTypes != 0 {
+		sizeswg.Add(1)
+		go func() {
+			var sizes types.Sizes
+			sizes, sizeserr = packagesdriver.GetSizesGolist(ctx, cfg.BuildFlags, cfg.Env, cfg.gocmdRunner, cfg.Dir)
+			// types.SizesFor always returns nil or a *types.StdSizes.
+			response.dr.Sizes, _ = sizes.(*types.StdSizes)
+			sizeswg.Done()
+		}()
+	}
+
+	state := &golistState{
+		cfg:        cfg,
+		ctx:        ctx,
+		vendorDirs: map[string]bool{},
+	}
+
+	// Determine files requested in contains patterns
+	var containFiles []string
+	restPatterns := make([]string, 0, len(patterns))
+	// Extract file= and other [querytype]= patterns. Report an error if querytype
+	// doesn't exist.
+extractQueries:
+	for _, pattern := range patterns {
+		eqidx := strings.Index(pattern, "=")
+		if eqidx < 0 {
+			restPatterns = append(restPatterns, pattern)
+		} else {
+			query, value := pattern[:eqidx], pattern[eqidx+len("="):]
+			switch query {
+			case "file":
+				containFiles = append(containFiles, value)
+			case "pattern":
+				restPatterns = append(restPatterns, value)
+			case "": // not a reserved query
+				restPatterns = append(restPatterns, pattern)
+			default:
+				for _, rune := range query {
+					if rune < 'a' || rune > 'z' { // not a reserved query
+						restPatterns = append(restPatterns, pattern)
+						continue extractQueries
+					}
+				}
+				// Reject all other patterns containing "="
+				return nil, fmt.Errorf("invalid query type %q in query pattern %q", query, pattern)
+			}
+		}
+	}
+
+	// See if we have any patterns to pass through to go list. Zero initial
+	// patterns also requires a go list call, since it's the equivalent of
+	// ".".
+	if len(restPatterns) > 0 || len(patterns) == 0 {
+		dr, err := state.createDriverResponse(restPatterns...)
+		if err != nil {
+			return nil, err
+		}
+		response.addAll(dr)
+	}
+
+	if len(containFiles) != 0 {
+		if err := state.runContainsQueries(response, containFiles); err != nil {
+			return nil, err
+		}
+	}
+
+	modifiedPkgs, needPkgs, err := state.processGolistOverlay(response)
+	if err != nil {
+		return nil, err
+	}
+
+	var containsCandidates []string
+	if len(containFiles) > 0 {
+		containsCandidates = append(containsCandidates, modifiedPkgs...)
+		containsCandidates = append(containsCandidates, needPkgs...)
+	}
+	if err := state.addNeededOverlayPackages(response, needPkgs); err != nil {
+		return nil, err
+	}
+	// Check candidate packages for containFiles.
+	if len(containFiles) > 0 {
+		for _, id := range containsCandidates {
+			pkg, ok := response.seenPackages[id]
+			if !ok {
+				response.addPackage(&Package{
+					ID: id,
+					Errors: []Error{
+						{
+							Kind: ListError,
+							Msg:  fmt.Sprintf("package %s expected but not seen", id),
+						},
+					},
+				})
+				continue
+			}
+			for _, f := range containFiles {
+				for _, g := range pkg.GoFiles {
+					if sameFile(f, g) {
+						response.addRoot(id)
+					}
+				}
+			}
+		}
+	}
+
+	sizeswg.Wait()
+	if sizeserr != nil {
+		return nil, sizeserr
+	}
+	return response.dr, nil
+}
+
+func (state *golistState) addNeededOverlayPackages(response *responseDeduper, pkgs []string) error {
+	if len(pkgs) == 0 {
+		return nil
+	}
+	dr, err := state.createDriverResponse(pkgs...)
+	if err != nil {
+		return err
+	}
+	for _, pkg := range dr.Packages {
+		response.addPackage(pkg)
+	}
+	_, needPkgs, err := state.processGolistOverlay(response)
+	if err != nil {
+		return err
+	}
+	return state.addNeededOverlayPackages(response, needPkgs)
+}
+
+func (state *golistState) runContainsQueries(response *responseDeduper, queries []string) error {
+	for _, query := range queries {
+		// TODO(matloob): Do only one query per directory.
+		fdir := filepath.Dir(query)
+		// Pass absolute path of directory to go list so that it knows to treat it as a directory,
+		// not a package path.
+		pattern, err := filepath.Abs(fdir)
+		if err != nil {
+			return fmt.Errorf("could not determine absolute path of file= query path %q: %v", query, err)
+		}
+		dirResponse, err := state.createDriverResponse(pattern)
+
+		// If there was an error loading the package, or the package is returned
+		// with errors, try to load the file as an ad-hoc package.
+		// Usually the error will appear in a returned package, but may not if we're
+		// in module mode and the ad-hoc is located outside a module.
+		if err != nil || len(dirResponse.Packages) == 1 && len(dirResponse.Packages[0].GoFiles) == 0 &&
+			len(dirResponse.Packages[0].Errors) == 1 {
+			var queryErr error
+			if dirResponse, queryErr = state.adhocPackage(pattern, query); queryErr != nil {
+				return err // return the original error
+			}
+		}
+		isRoot := make(map[string]bool, len(dirResponse.Roots))
+		for _, root := range dirResponse.Roots {
+			isRoot[root] = true
+		}
+		for _, pkg := range dirResponse.Packages {
+			// Add any new packages to the main set
+			// We don't bother to filter packages that will be dropped by the changes of roots,
+			// that will happen anyway during graph construction outside this function.
+			// Over-reporting packages is not a problem.
+			response.addPackage(pkg)
+			// if the package was not a root one, it cannot have the file
+			if !isRoot[pkg.ID] {
+				continue
+			}
+			for _, pkgFile := range pkg.GoFiles {
+				if filepath.Base(query) == filepath.Base(pkgFile) {
+					response.addRoot(pkg.ID)
+					break
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// adhocPackage attempts to load or construct an ad-hoc package for a given
+// query, if the original call to the driver produced inadequate results.
+func (state *golistState) adhocPackage(pattern, query string) (*driverResponse, error) {
+	response, err := state.createDriverResponse(query)
+	if err != nil {
+		return nil, err
+	}
+	// If we get nothing back from `go list`,
+	// try to make this file into its own ad-hoc package.
+	// TODO(rstambler): Should this check against the original response?
+	if len(response.Packages) == 0 {
+		response.Packages = append(response.Packages, &Package{
+			ID:              "command-line-arguments",
+			PkgPath:         query,
+			GoFiles:         []string{query},
+			CompiledGoFiles: []string{query},
+			Imports:         make(map[string]*Package),
+		})
+		response.Roots = append(response.Roots, "command-line-arguments")
+	}
+	// Handle special cases.
+	if len(response.Packages) == 1 {
+		// golang/go#33482: If this is a file= query for ad-hoc packages where
+		// the file only exists on an overlay, and exists outside of a module,
+		// add the file to the package and remove the errors.
+		if response.Packages[0].ID == "command-line-arguments" ||
+			filepath.ToSlash(response.Packages[0].PkgPath) == filepath.ToSlash(query) {
+			if len(response.Packages[0].GoFiles) == 0 {
+				filename := filepath.Join(pattern, filepath.Base(query)) // avoid recomputing abspath
+				// TODO(matloob): check if the file is outside of a root dir?
+				for path := range state.cfg.Overlay {
+					if path == filename {
+						response.Packages[0].Errors = nil
+						response.Packages[0].GoFiles = []string{path}
+						response.Packages[0].CompiledGoFiles = []string{path}
+					}
+				}
+			}
+		}
+	}
+	return response, nil
+}
+
+// Fields must match go list;
+// see $GOROOT/src/cmd/go/internal/load/pkg.go.
+type jsonPackage struct {
+	ImportPath      string
+	Dir             string
+	Name            string
+	Export          string
+	GoFiles         []string
+	CompiledGoFiles []string
+	CFiles          []string
+	CgoFiles        []string
+	CXXFiles        []string
+	MFiles          []string
+	HFiles          []string
+	FFiles          []string
+	SFiles          []string
+	SwigFiles       []string
+	SwigCXXFiles    []string
+	SysoFiles       []string
+	Imports         []string
+	ImportMap       map[string]string
+	Deps            []string
+	Module          *Module
+	TestGoFiles     []string
+	TestImports     []string
+	XTestGoFiles    []string
+	XTestImports    []string
+	ForTest         string // q in a "p [q.test]" package, else ""
+	DepOnly         bool
+
+	Error *jsonPackageError
+}
+
+type jsonPackageError struct {
+	ImportStack []string
+	Pos         string
+	Err         string
+}
+
+func otherFiles(p *jsonPackage) [][]string {
+	return [][]string{p.CFiles, p.CXXFiles, p.MFiles, p.HFiles, p.FFiles, p.SFiles, p.SwigFiles, p.SwigCXXFiles, p.SysoFiles}
+}
+
+// createDriverResponse uses the "go list" command to expand the pattern
+// words and return a response for the specified packages.
+func (state *golistState) createDriverResponse(words ...string) (*driverResponse, error) {
+	// go list uses the following identifiers in ImportPath and Imports:
+	//
+	// 	"p"			-- importable package or main (command)
+	// 	"q.test"		-- q's test executable
+	// 	"p [q.test]"		-- variant of p as built for q's test executable
+	// 	"q_test [q.test]"	-- q's external test package
+	//
+	// The packages p that are built differently for a test q.test
+	// are q itself, plus any helpers used by the external test q_test,
+	// typically including "testing" and all its dependencies.
+
+	// Run "go list" for complete
+	// information on the specified packages.
+	buf, err := state.invokeGo("list", golistargs(state.cfg, words)...)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]*jsonPackage)
+	pkgs := make(map[string]*Package)
+	additionalErrors := make(map[string][]Error)
+	// Decode the JSON and convert it to Package form.
+	var response driverResponse
+	for dec := json.NewDecoder(buf); dec.More(); {
+		p := new(jsonPackage)
+		if err := dec.Decode(p); err != nil {
+			return nil, fmt.Errorf("JSON decoding failed: %v", err)
+		}
+
+		if p.ImportPath == "" {
+			// The documentation for go list says that “[e]rroneous packages will have
+			// a non-empty ImportPath”. If for some reason it comes back empty, we
+			// prefer to error out rather than silently discarding data or handing
+			// back a package without any way to refer to it.
+			if p.Error != nil {
+				return nil, Error{
+					Pos: p.Error.Pos,
+					Msg: p.Error.Err,
+				}
+			}
+			return nil, fmt.Errorf("package missing import path: %+v", p)
+		}
+
+		// Work around https://golang.org/issue/33157:
+		// go list -e, when given an absolute path, will find the package contained at
+		// that directory. But when no package exists there, it will return a fake package
+		// with an error and the ImportPath set to the absolute path provided to go list.
+		// Try to convert that absolute path to what its package path would be if it's
+		// contained in a known module or GOPATH entry. This will allow the package to be
+		// properly "reclaimed" when overlays are processed.
+		if filepath.IsAbs(p.ImportPath) && p.Error != nil {
+			pkgPath, ok, err := state.getPkgPath(p.ImportPath)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				p.ImportPath = pkgPath
+			}
+		}
+
+		if old, found := seen[p.ImportPath]; found {
+			// If one version of the package has an error, and the other doesn't, assume
+			// that this is a case where go list is reporting a fake dependency variant
+			// of the imported package: When a package tries to invalidly import another
+			// package, go list emits a variant of the imported package (with the same
+			// import path, but with an error on it, and the package will have a
+			// DepError set on it). An example of when this can happen is for imports of
+			// main packages: main packages can not be imported, but they may be
+			// separately matched and listed by another pattern.
+			// See golang.org/issue/36188 for more details.
+
+			// The plan is that eventually, hopefully in Go 1.15, the error will be
+			// reported on the importing package rather than the duplicate "fake"
+			// version of the imported package. Once all supported versions of Go
+			// have the new behavior this logic can be deleted.
+			// TODO(matloob): delete the workaround logic once all supported versions of
+			// Go return the errors on the proper package.
+
+			// There should be exactly one version of a package that doesn't have an
+			// error.
+			if old.Error == nil && p.Error == nil {
+				if !reflect.DeepEqual(p, old) {
+					return nil, fmt.Errorf("internal error: go list gives conflicting information for package %v", p.ImportPath)
+				}
+				continue
+			}
+
+			// Determine if this package's error needs to be bubbled up.
+			// This is a hack, and we expect for go list to eventually set the error
+			// on the package.
+			if old.Error != nil {
+				var errkind string
+				if strings.Contains(old.Error.Err, "not an importable package") {
+					errkind = "not an importable package"
+				} else if strings.Contains(old.Error.Err, "use of internal package") && strings.Contains(old.Error.Err, "not allowed") {
+					errkind = "use of internal package not allowed"
+				}
+				if errkind != "" {
+					if len(old.Error.ImportStack) < 1 {
+						return nil, fmt.Errorf(`internal error: go list gave a %q error with empty import stack`, errkind)
+					}
+					importingPkg := old.Error.ImportStack[len(old.Error.ImportStack)-1]
+					if importingPkg == old.ImportPath {
+						// Using an older version of Go which put this package itself on top of import
+						// stack, instead of the importer. Look for importer in second from top
+						// position.
+						if len(old.Error.ImportStack) < 2 {
+							return nil, fmt.Errorf(`internal error: go list gave a %q error with an import stack without importing package`, errkind)
+						}
+						importingPkg = old.Error.ImportStack[len(old.Error.ImportStack)-2]
+					}
+					additionalErrors[importingPkg] = append(additionalErrors[importingPkg], Error{
+						Pos:  old.Error.Pos,
+						Msg:  old.Error.Err,
+						Kind: ListError,
+					})
+				}
+			}
+
+			// Make sure that if there's a version of the package without an error,
+			// that's the one reported to the user.
+			if old.Error == nil {
+				continue
+			}
+
+			// This package will replace the old one at the end of the loop.
+		}
+		seen[p.ImportPath] = p
+
+		pkg := &Package{
+			Name:            p.Name,
+			ID:              p.ImportPath,
+			GoFiles:         absJoin(p.Dir, p.GoFiles, p.CgoFiles),
+			CompiledGoFiles: absJoin(p.Dir, p.CompiledGoFiles),
+			OtherFiles:      absJoin(p.Dir, otherFiles(p)...),
+			forTest:         p.ForTest,
+			Module:          p.Module,
+		}
+
+		if (state.cfg.Mode&typecheckCgo) != 0 && len(p.CgoFiles) != 0 {
+			if len(p.CompiledGoFiles) > len(p.GoFiles) {
+				// We need the cgo definitions, which are in the first
+				// CompiledGoFile after the non-cgo ones. This is a hack but there
+				// isn't currently a better way to find it. We also need the pure
+				// Go files and unprocessed cgo files, all of which are already
+				// in pkg.GoFiles.
+				cgoTypes := p.CompiledGoFiles[len(p.GoFiles)]
+				pkg.CompiledGoFiles = append([]string{cgoTypes}, pkg.GoFiles...)
+			} else {
+				// golang/go#38990: go list silently fails to do cgo processing
+				pkg.CompiledGoFiles = nil
+				pkg.Errors = append(pkg.Errors, Error{
+					Msg:  "go list failed to return CompiledGoFiles; https://golang.org/issue/38990?",
+					Kind: ListError,
+				})
+			}
+		}
+
+		// Work around https://golang.org/issue/28749:
+		// cmd/go puts assembly, C, and C++ files in CompiledGoFiles.
+		// Filter out any elements of CompiledGoFiles that are also in OtherFiles.
+		// We have to keep this workaround in place until go1.12 is a distant memory.
+		if len(pkg.OtherFiles) > 0 {
+			other := make(map[string]bool, len(pkg.OtherFiles))
+			for _, f := range pkg.OtherFiles {
+				other[f] = true
+			}
+
+			out := pkg.CompiledGoFiles[:0]
+			for _, f := range pkg.CompiledGoFiles {
+				if other[f] {
+					continue
+				}
+				out = append(out, f)
+			}
+			pkg.CompiledGoFiles = out
+		}
+
+		// Extract the PkgPath from the package's ID.
+		if i := strings.IndexByte(pkg.ID, ' '); i >= 0 {
+			pkg.PkgPath = pkg.ID[:i]
+		} else {
+			pkg.PkgPath = pkg.ID
+		}
+
+		if pkg.PkgPath == "unsafe" {
+			pkg.GoFiles = nil // ignore fake unsafe.go file
+		}
+
+		// Assume go list emits only absolute paths for Dir.
+		if p.Dir != "" && !filepath.IsAbs(p.Dir) {
+			log.Fatalf("internal error: go list returned non-absolute Package.Dir: %s", p.Dir)
+		}
+
+		if p.Export != "" && !filepath.IsAbs(p.Export) {
+			pkg.ExportFile = filepath.Join(p.Dir, p.Export)
+		} else {
+			pkg.ExportFile = p.Export
+		}
+
+		// imports
+		//
+		// Imports contains the IDs of all imported packages.
+		// ImportsMap records (path, ID) only where they differ.
+		ids := make(map[string]bool)
+		for _, id := range p.Imports {
+			ids[id] = true
+		}
+		pkg.Imports = make(map[string]*Package)
+		for path, id := range p.ImportMap {
+			pkg.Imports[path] = &Package{ID: id} // non-identity import
+			delete(ids, id)
+		}
+		for id := range ids {
+			if id == "C" {
+				continue
+			}
+
+			pkg.Imports[id] = &Package{ID: id} // identity import
+		}
+		if !p.DepOnly {
+			response.Roots = append(response.Roots, pkg.ID)
+		}
+
+		// Work around for pre-go.1.11 versions of go list.
+		// TODO(matloob): they should be handled by the fallback.
+		// Can we delete this?
+		if len(pkg.CompiledGoFiles) == 0 {
+			pkg.CompiledGoFiles = pkg.GoFiles
+		}
+
+		// Temporary work-around for golang/go#39986. Parse filenames out of
+		// error messages. This happens if there are unrecoverable syntax
+		// errors in the source, so we can't match on a specific error message.
+		if err := p.Error; err != nil && len(err.ImportStack) == 0 && len(pkg.CompiledGoFiles) == 0 {
+			addFilenameFromPos := func(pos string) bool {
+				split := strings.Split(pos, ":")
+				if len(split) < 1 {
+					return false
+				}
+				filename := strings.TrimSpace(split[0])
+				if filename == "" {
+					return false
+				}
+				if !filepath.IsAbs(filename) {
+					filename = filepath.Join(state.cfg.Dir, filename)
+				}
+				info, _ := os.Stat(filename)
+				if info == nil {
+					return false
+				}
+				pkg.CompiledGoFiles = append(pkg.CompiledGoFiles, filename)
+				pkg.GoFiles = append(pkg.GoFiles, filename)
+				return true
+			}
+			found := addFilenameFromPos(err.Pos)
+			// In some cases, go list only reports the error position in the
+			// error text, not the error position. One such case is when the
+			// file's package name is a keyword (see golang.org/issue/39763).
+			if !found {
+				addFilenameFromPos(err.Err)
+			}
+		}
+
+		if p.Error != nil {
+			msg := strings.TrimSpace(p.Error.Err) // Trim to work around golang.org/issue/32363.
+			// Address golang.org/issue/35964 by appending import stack to error message.
+			if msg == "import cycle not allowed" && len(p.Error.ImportStack) != 0 {
+				msg += fmt.Sprintf(": import stack: %v", p.Error.ImportStack)
+			}
+			pkg.Errors = append(pkg.Errors, Error{
+				Pos:  p.Error.Pos,
+				Msg:  msg,
+				Kind: ListError,
+			})
+		}
+
+		pkgs[pkg.ID] = pkg
+	}
+
+	for id, errs := range additionalErrors {
+		if p, ok := pkgs[id]; ok {
+			p.Errors = append(p.Errors, errs...)
+		}
+	}
+	for _, pkg := range pkgs {
+		response.Packages = append(response.Packages, pkg)
+	}
+	sort.Slice(response.Packages, func(i, j int) bool { return response.Packages[i].ID < response.Packages[j].ID })
+
+	return &response, nil
+}
+
+// getPkgPath finds the package path of a directory if it's relative to a root directory.
+func (state *golistState) getPkgPath(dir string) (string, bool, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", false, err
+	}
+	roots, err := state.determineRootDirs()
+	if err != nil {
+		return "", false, err
+	}
+
+	for rdir, rpath := range roots {
+		// Make sure that the directory is in the module,
+		// to avoid creating a path relative to another module.
+		if !strings.HasPrefix(absDir, rdir) {
+			continue
+		}
+		// TODO(matloob): This doesn't properly handle symlinks.
+		r, err := filepath.Rel(rdir, dir)
+		if err != nil {
+			continue
+		}
+		if rpath != "" {
+			// We choose only one root even though the directory even it can belong in multiple modules
+			// or GOPATH entries. This is okay because we only need to work with absolute dirs when a
+			// file is missing from disk, for instance when gopls calls go/packages in an overlay.
+			// Once the file is saved, gopls, or the next invocation of the tool will get the correct
+			// result straight from golist.
+			// TODO(matloob): Implement module tiebreaking?
+			return path.Join(rpath, filepath.ToSlash(r)), true, nil
+		}
+		return filepath.ToSlash(r), true, nil
+	}
+	return "", false, nil
+}
+
+// absJoin absolutizes and flattens the lists of files.
+func absJoin(dir string, fileses ...[]string) (res []string) {
+	for _, files := range fileses {
+		for _, file := range files {
+			if !filepath.IsAbs(file) {
+				file = filepath.Join(dir, file)
+			}
+			res = append(res, file)
+		}
+	}
+	return res
+}
+
+func golistargs(cfg *Config, words []string) []string {
+	const findFlags = NeedImports | NeedTypes | NeedSyntax | NeedTypesInfo
+	fullargs := []string{
+		"-e", "-json",
+		fmt.Sprintf("-compiled=%t", cfg.Mode&(NeedCompiledGoFiles|NeedSyntax|NeedTypes|NeedTypesInfo|NeedTypesSizes) != 0),
+		fmt.Sprintf("-test=%t", cfg.Tests),
+		fmt.Sprintf("-export=%t", usesExportData(cfg)),
+		fmt.Sprintf("-deps=%t", cfg.Mode&NeedImports != 0),
+		// go list doesn't let you pass -test and -find together,
+		// probably because you'd just get the TestMain.
+		fmt.Sprintf("-find=%t", !cfg.Tests && cfg.Mode&findFlags == 0),
+	}
+	fullargs = append(fullargs, cfg.BuildFlags...)
+	fullargs = append(fullargs, "--")
+	fullargs = append(fullargs, words...)
+	return fullargs
+}
+
+// invokeGo returns the stdout of a go command invocation.
+func (state *golistState) invokeGo(verb string, args ...string) (*bytes.Buffer, error) {
+	cfg := state.cfg
+
+	inv := gocommand.Invocation{
+		Verb:       verb,
+		Args:       args,
+		BuildFlags: cfg.BuildFlags,
+		Env:        cfg.Env,
+		Logf:       cfg.Logf,
+		WorkingDir: cfg.Dir,
+	}
+	gocmdRunner := cfg.gocmdRunner
+	if gocmdRunner == nil {
+		gocmdRunner = &gocommand.Runner{}
+	}
+	stdout, stderr, _, err := gocmdRunner.RunRaw(cfg.Context, inv)
+	if err != nil {
+		// Check for 'go' executable not being found.
+		if ee, ok := err.(*exec.Error); ok && ee.Err == exec.ErrNotFound {
+			return nil, fmt.Errorf("'go list' driver requires 'go', but %s", exec.ErrNotFound)
+		}
+
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			// Catastrophic error:
+			// - context cancellation
+			return nil, xerrors.Errorf("couldn't run 'go': %w", err)
+		}
+
+		// Old go version?
+		if strings.Contains(stderr.String(), "flag provided but not defined") {
+			return nil, goTooOldError{fmt.Errorf("unsupported version of go: %s: %s", exitErr, stderr)}
+		}
+
+		// Related to #24854
+		if len(stderr.String()) > 0 && strings.Contains(stderr.String(), "unexpected directory layout") {
+			return nil, fmt.Errorf("%s", stderr.String())
+		}
+
+		// Is there an error running the C compiler in cgo? This will be reported in the "Error" field
+		// and should be suppressed by go list -e.
+		//
+		// This condition is not perfect yet because the error message can include other error messages than runtime/cgo.
+		isPkgPathRune := func(r rune) bool {
+			// From https://golang.org/ref/spec#Import_declarations:
+			//    Implementation restriction: A compiler may restrict ImportPaths to non-empty strings
+			//    using only characters belonging to Unicode's L, M, N, P, and S general categories
+			//    (the Graphic characters without spaces) and may also exclude the
+			//    characters !"#$%&'()*,:;<=>?[\]^`{|} and the Unicode replacement character U+FFFD.
+			return unicode.IsOneOf([]*unicode.RangeTable{unicode.L, unicode.M, unicode.N, unicode.P, unicode.S}, r) &&
+				!strings.ContainsRune("!\"#$%&'()*,:;<=>?[\\]^`{|}\uFFFD", r)
+		}
+		if len(stderr.String()) > 0 && strings.HasPrefix(stderr.String(), "# ") {
+			msg := stderr.String()[len("# "):]
+			if strings.HasPrefix(strings.TrimLeftFunc(msg, isPkgPathRune), "\n") {
+				return stdout, nil
+			}
+			// Treat pkg-config errors as a special case (golang.org/issue/36770).
+			if strings.HasPrefix(msg, "pkg-config") {
+				return stdout, nil
+			}
+		}
+
+		// This error only appears in stderr. See golang.org/cl/166398 for a fix in go list to show
+		// the error in the Err section of stdout in case -e option is provided.
+		// This fix is provided for backwards compatibility.
+		if len(stderr.String()) > 0 && strings.Contains(stderr.String(), "named files must be .go files") {
+			output := fmt.Sprintf(`{"ImportPath": "command-line-arguments","Incomplete": true,"Error": {"Pos": "","Err": %q}}`,
+				strings.Trim(stderr.String(), "\n"))
+			return bytes.NewBufferString(output), nil
+		}
+
+		// Similar to the previous error, but currently lacks a fix in Go.
+		if len(stderr.String()) > 0 && strings.Contains(stderr.String(), "named files must all be in one directory") {
+			output := fmt.Sprintf(`{"ImportPath": "command-line-arguments","Incomplete": true,"Error": {"Pos": "","Err": %q}}`,
+				strings.Trim(stderr.String(), "\n"))
+			return bytes.NewBufferString(output), nil
+		}
+
+		// Backwards compatibility for Go 1.11 because 1.12 and 1.13 put the directory in the ImportPath.
+		// If the package doesn't exist, put the absolute path of the directory into the error message,
+		// as Go 1.13 list does.
+		const noSuchDirectory = "no such directory"
+		if len(stderr.String()) > 0 && strings.Contains(stderr.String(), noSuchDirectory) {
+			errstr := stderr.String()
+			abspath := strings.TrimSpace(errstr[strings.Index(errstr, noSuchDirectory)+len(noSuchDirectory):])
+			output := fmt.Sprintf(`{"ImportPath": %q,"Incomplete": true,"Error": {"Pos": "","Err": %q}}`,
+				abspath, strings.Trim(stderr.String(), "\n"))
+			return bytes.NewBufferString(output), nil
+		}
+
+		// Workaround for #29280: go list -e has incorrect behavior when an ad-hoc package doesn't exist.
+		// Note that the error message we look for in this case is different that the one looked for above.
+		if len(stderr.String()) > 0 && strings.Contains(stderr.String(), "no such file or directory") {
+			output := fmt.Sprintf(`{"ImportPath": "command-line-arguments","Incomplete": true,"Error": {"Pos": "","Err": %q}}`,
+				strings.Trim(stderr.String(), "\n"))
+			return bytes.NewBufferString(output), nil
+		}
+
+		// Workaround for #34273. go list -e with GO111MODULE=on has incorrect behavior when listing a
+		// directory outside any module.
+		if len(stderr.String()) > 0 && strings.Contains(stderr.String(), "outside available modules") {
+			output := fmt.Sprintf(`{"ImportPath": %q,"Incomplete": true,"Error": {"Pos": "","Err": %q}}`,
+				// TODO(matloob): command-line-arguments isn't correct here.
+				"command-line-arguments", strings.Trim(stderr.String(), "\n"))
+			return bytes.NewBufferString(output), nil
+		}
+
+		// Another variation of the previous error
+		if len(stderr.String()) > 0 && strings.Contains(stderr.String(), "outside module root") {
+			output := fmt.Sprintf(`{"ImportPath": %q,"Incomplete": true,"Error": {"Pos": "","Err": %q}}`,
+				// TODO(matloob): command-line-arguments isn't correct here.
+				"command-line-arguments", strings.Trim(stderr.String(), "\n"))
+			return bytes.NewBufferString(output), nil
+		}
+
+		// Workaround for an instance of golang.org/issue/26755: go list -e  will return a non-zero exit
+		// status if there's a dependency on a package that doesn't exist. But it should return
+		// a zero exit status and set an error on that package.
+		if len(stderr.String()) > 0 && strings.Contains(stderr.String(), "no Go files in") {
+			// Don't clobber stdout if `go list` actually returned something.
+			if len(stdout.String()) > 0 {
+				return stdout, nil
+			}
+			// try to extract package name from string
+			stderrStr := stderr.String()
+			var importPath string
+			colon := strings.Index(stderrStr, ":")
+			if colon > 0 && strings.HasPrefix(stderrStr, "go build ") {
+				importPath = stderrStr[len("go build "):colon]
+			}
+			output := fmt.Sprintf(`{"ImportPath": %q,"Incomplete": true,"Error": {"Pos": "","Err": %q}}`,
+				importPath, strings.Trim(stderrStr, "\n"))
+			return bytes.NewBufferString(output), nil
+		}
+
+		// Export mode entails a build.
+		// If that build fails, errors appear on stderr
+		// (despite the -e flag) and the Export field is blank.
+		// Do not fail in that case.
+		// The same is true if an ad-hoc package given to go list doesn't exist.
+		// TODO(matloob): Remove these once we can depend on go list to exit with a zero status with -e even when
+		// packages don't exist or a build fails.
+		if !usesExportData(cfg) && !containsGoFile(args) {
+			return nil, fmt.Errorf("go %v: %s: %s", args, exitErr, stderr)
+		}
+	}
+	return stdout, nil
+}
+
+func containsGoFile(s []string) bool {
+	for _, f := range s {
+		if strings.HasSuffix(f, ".go") {
+			return true
+		}
+	}
+	return false
+}
+
+func cmdDebugStr(cmd *exec.Cmd, args ...string) string {
+	env := make(map[string]string)
+	for _, kv := range cmd.Env {
+		split := strings.Split(kv, "=")
+		k, v := split[0], split[1]
+		env[k] = v
+	}
+	var quotedArgs []string
+	for _, arg := range args {
+		quotedArgs = append(quotedArgs, strconv.Quote(arg))
+	}
+
+	return fmt.Sprintf("GOROOT=%v GOPATH=%v GO111MODULE=%v PWD=%v go %s", env["GOROOT"], env["GOPATH"], env["GO111MODULE"], env["PWD"], strings.Join(quotedArgs, " "))
+}

--- a/vendor/golang.org/x/tools/go/packages/golist_overlay.go
+++ b/vendor/golang.org/x/tools/go/packages/golist_overlay.go
@@ -1,0 +1,473 @@
+package packages
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// processGolistOverlay provides rudimentary support for adding
+// files that don't exist on disk to an overlay. The results can be
+// sometimes incorrect.
+// TODO(matloob): Handle unsupported cases, including the following:
+// - determining the correct package to add given a new import path
+func (state *golistState) processGolistOverlay(response *responseDeduper) (modifiedPkgs, needPkgs []string, err error) {
+	havePkgs := make(map[string]string) // importPath -> non-test package ID
+	needPkgsSet := make(map[string]bool)
+	modifiedPkgsSet := make(map[string]bool)
+
+	pkgOfDir := make(map[string][]*Package)
+	for _, pkg := range response.dr.Packages {
+		// This is an approximation of import path to id. This can be
+		// wrong for tests, vendored packages, and a number of other cases.
+		havePkgs[pkg.PkgPath] = pkg.ID
+		x := commonDir(pkg.GoFiles)
+		if x != "" {
+			pkgOfDir[x] = append(pkgOfDir[x], pkg)
+		}
+	}
+
+	// If no new imports are added, it is safe to avoid loading any needPkgs.
+	// Otherwise, it's hard to tell which package is actually being loaded
+	// (due to vendoring) and whether any modified package will show up
+	// in the transitive set of dependencies (because new imports are added,
+	// potentially modifying the transitive set of dependencies).
+	var overlayAddsImports bool
+
+	// If both a package and its test package are created by the overlay, we
+	// need the real package first. Process all non-test files before test
+	// files, and make the whole process deterministic while we're at it.
+	var overlayFiles []string
+	for opath := range state.cfg.Overlay {
+		overlayFiles = append(overlayFiles, opath)
+	}
+	sort.Slice(overlayFiles, func(i, j int) bool {
+		iTest := strings.HasSuffix(overlayFiles[i], "_test.go")
+		jTest := strings.HasSuffix(overlayFiles[j], "_test.go")
+		if iTest != jTest {
+			return !iTest // non-tests are before tests.
+		}
+		return overlayFiles[i] < overlayFiles[j]
+	})
+	for _, opath := range overlayFiles {
+		contents := state.cfg.Overlay[opath]
+		base := filepath.Base(opath)
+		dir := filepath.Dir(opath)
+		var pkg *Package           // if opath belongs to both a package and its test variant, this will be the test variant
+		var testVariantOf *Package // if opath is a test file, this is the package it is testing
+		var fileExists bool
+		isTestFile := strings.HasSuffix(opath, "_test.go")
+		pkgName, ok := extractPackageName(opath, contents)
+		if !ok {
+			// Don't bother adding a file that doesn't even have a parsable package statement
+			// to the overlay.
+			continue
+		}
+		// If all the overlay files belong to a different package, change the
+		// package name to that package.
+		maybeFixPackageName(pkgName, isTestFile, pkgOfDir[dir])
+	nextPackage:
+		for _, p := range response.dr.Packages {
+			if pkgName != p.Name && p.ID != "command-line-arguments" {
+				continue
+			}
+			for _, f := range p.GoFiles {
+				if !sameFile(filepath.Dir(f), dir) {
+					continue
+				}
+				// Make sure to capture information on the package's test variant, if needed.
+				if isTestFile && !hasTestFiles(p) {
+					// TODO(matloob): Are there packages other than the 'production' variant
+					// of a package that this can match? This shouldn't match the test main package
+					// because the file is generated in another directory.
+					testVariantOf = p
+					continue nextPackage
+				}
+				// We must have already seen the package of which this is a test variant.
+				if pkg != nil && p != pkg && pkg.PkgPath == p.PkgPath {
+					if hasTestFiles(p) {
+						testVariantOf = pkg
+					}
+				}
+				pkg = p
+				if filepath.Base(f) == base {
+					fileExists = true
+				}
+			}
+		}
+		// The overlay could have included an entirely new package or an
+		// ad-hoc package. An ad-hoc package is one that we have manually
+		// constructed from inadequate `go list` results for a file= query.
+		// It will have the ID command-line-arguments.
+		if pkg == nil || pkg.ID == "command-line-arguments" {
+			// Try to find the module or gopath dir the file is contained in.
+			// Then for modules, add the module opath to the beginning.
+			pkgPath, ok, err := state.getPkgPath(dir)
+			if err != nil {
+				return nil, nil, err
+			}
+			if !ok {
+				break
+			}
+			var forTest string // only set for x tests
+			isXTest := strings.HasSuffix(pkgName, "_test")
+			if isXTest {
+				forTest = pkgPath
+				pkgPath += "_test"
+			}
+			id := pkgPath
+			if isTestFile {
+				if isXTest {
+					id = fmt.Sprintf("%s [%s.test]", pkgPath, forTest)
+				} else {
+					id = fmt.Sprintf("%s [%s.test]", pkgPath, pkgPath)
+				}
+			}
+			if pkg != nil {
+				// TODO(rstambler): We should change the package's path and ID
+				// here. The only issue is that this messes with the roots.
+			} else {
+				// Try to reclaim a package with the same ID, if it exists in the response.
+				for _, p := range response.dr.Packages {
+					if reclaimPackage(p, id, opath, contents) {
+						pkg = p
+						break
+					}
+				}
+				// Otherwise, create a new package.
+				if pkg == nil {
+					pkg = &Package{
+						PkgPath: pkgPath,
+						ID:      id,
+						Name:    pkgName,
+						Imports: make(map[string]*Package),
+					}
+					response.addPackage(pkg)
+					havePkgs[pkg.PkgPath] = id
+					// Add the production package's sources for a test variant.
+					if isTestFile && !isXTest && testVariantOf != nil {
+						pkg.GoFiles = append(pkg.GoFiles, testVariantOf.GoFiles...)
+						pkg.CompiledGoFiles = append(pkg.CompiledGoFiles, testVariantOf.CompiledGoFiles...)
+						// Add the package under test and its imports to the test variant.
+						pkg.forTest = testVariantOf.PkgPath
+						for k, v := range testVariantOf.Imports {
+							pkg.Imports[k] = &Package{ID: v.ID}
+						}
+					}
+					if isXTest {
+						pkg.forTest = forTest
+					}
+				}
+			}
+		}
+		if !fileExists {
+			pkg.GoFiles = append(pkg.GoFiles, opath)
+			// TODO(matloob): Adding the file to CompiledGoFiles can exhibit the wrong behavior
+			// if the file will be ignored due to its build tags.
+			pkg.CompiledGoFiles = append(pkg.CompiledGoFiles, opath)
+			modifiedPkgsSet[pkg.ID] = true
+		}
+		imports, err := extractImports(opath, contents)
+		if err != nil {
+			// Let the parser or type checker report errors later.
+			continue
+		}
+		for _, imp := range imports {
+			// TODO(rstambler): If the package is an x test and the import has
+			// a test variant, make sure to replace it.
+			if _, found := pkg.Imports[imp]; found {
+				continue
+			}
+			overlayAddsImports = true
+			id, ok := havePkgs[imp]
+			if !ok {
+				var err error
+				id, err = state.resolveImport(dir, imp)
+				if err != nil {
+					return nil, nil, err
+				}
+			}
+			pkg.Imports[imp] = &Package{ID: id}
+			// Add dependencies to the non-test variant version of this package as well.
+			if testVariantOf != nil {
+				testVariantOf.Imports[imp] = &Package{ID: id}
+			}
+		}
+	}
+
+	// toPkgPath guesses the package path given the id.
+	toPkgPath := func(sourceDir, id string) (string, error) {
+		if i := strings.IndexByte(id, ' '); i >= 0 {
+			return state.resolveImport(sourceDir, id[:i])
+		}
+		return state.resolveImport(sourceDir, id)
+	}
+
+	// Now that new packages have been created, do another pass to determine
+	// the new set of missing packages.
+	for _, pkg := range response.dr.Packages {
+		for _, imp := range pkg.Imports {
+			if len(pkg.GoFiles) == 0 {
+				return nil, nil, fmt.Errorf("cannot resolve imports for package %q with no Go files", pkg.PkgPath)
+			}
+			pkgPath, err := toPkgPath(filepath.Dir(pkg.GoFiles[0]), imp.ID)
+			if err != nil {
+				return nil, nil, err
+			}
+			if _, ok := havePkgs[pkgPath]; !ok {
+				needPkgsSet[pkgPath] = true
+			}
+		}
+	}
+
+	if overlayAddsImports {
+		needPkgs = make([]string, 0, len(needPkgsSet))
+		for pkg := range needPkgsSet {
+			needPkgs = append(needPkgs, pkg)
+		}
+	}
+	modifiedPkgs = make([]string, 0, len(modifiedPkgsSet))
+	for pkg := range modifiedPkgsSet {
+		modifiedPkgs = append(modifiedPkgs, pkg)
+	}
+	return modifiedPkgs, needPkgs, err
+}
+
+// resolveImport finds the the ID of a package given its import path.
+// In particular, it will find the right vendored copy when in GOPATH mode.
+func (state *golistState) resolveImport(sourceDir, importPath string) (string, error) {
+	env, err := state.getEnv()
+	if err != nil {
+		return "", err
+	}
+	if env["GOMOD"] != "" {
+		return importPath, nil
+	}
+
+	searchDir := sourceDir
+	for {
+		vendorDir := filepath.Join(searchDir, "vendor")
+		exists, ok := state.vendorDirs[vendorDir]
+		if !ok {
+			info, err := os.Stat(vendorDir)
+			exists = err == nil && info.IsDir()
+			state.vendorDirs[vendorDir] = exists
+		}
+
+		if exists {
+			vendoredPath := filepath.Join(vendorDir, importPath)
+			if info, err := os.Stat(vendoredPath); err == nil && info.IsDir() {
+				// We should probably check for .go files here, but shame on anyone who fools us.
+				path, ok, err := state.getPkgPath(vendoredPath)
+				if err != nil {
+					return "", err
+				}
+				if ok {
+					return path, nil
+				}
+			}
+		}
+
+		// We know we've hit the top of the filesystem when we Dir / and get /,
+		// or C:\ and get C:\, etc.
+		next := filepath.Dir(searchDir)
+		if next == searchDir {
+			break
+		}
+		searchDir = next
+	}
+	return importPath, nil
+}
+
+func hasTestFiles(p *Package) bool {
+	for _, f := range p.GoFiles {
+		if strings.HasSuffix(f, "_test.go") {
+			return true
+		}
+	}
+	return false
+}
+
+// determineRootDirs returns a mapping from absolute directories that could
+// contain code to their corresponding import path prefixes.
+func (state *golistState) determineRootDirs() (map[string]string, error) {
+	env, err := state.getEnv()
+	if err != nil {
+		return nil, err
+	}
+	if env["GOMOD"] != "" {
+		state.rootsOnce.Do(func() {
+			state.rootDirs, state.rootDirsError = state.determineRootDirsModules()
+		})
+	} else {
+		state.rootsOnce.Do(func() {
+			state.rootDirs, state.rootDirsError = state.determineRootDirsGOPATH()
+		})
+	}
+	return state.rootDirs, state.rootDirsError
+}
+
+func (state *golistState) determineRootDirsModules() (map[string]string, error) {
+	// This will only return the root directory for the main module.
+	// For now we only support overlays in main modules.
+	// Editing files in the module cache isn't a great idea, so we don't
+	// plan to ever support that, but editing files in replaced modules
+	// is something we may want to support. To do that, we'll want to
+	// do a go list -m to determine the replaced module's module path and
+	// directory, and then a go list -m {{with .Replace}}{{.Dir}}{{end}} <replaced module's path>
+	// from the main module to determine if that module is actually a replacement.
+	// See bcmills's comment here: https://github.com/golang/go/issues/37629#issuecomment-594179751
+	// for more information.
+	out, err := state.invokeGo("list", "-m", "-json")
+	if err != nil {
+		return nil, err
+	}
+	m := map[string]string{}
+	type jsonMod struct{ Path, Dir string }
+	for dec := json.NewDecoder(out); dec.More(); {
+		mod := new(jsonMod)
+		if err := dec.Decode(mod); err != nil {
+			return nil, err
+		}
+		if mod.Dir != "" && mod.Path != "" {
+			// This is a valid module; add it to the map.
+			absDir, err := filepath.Abs(mod.Dir)
+			if err != nil {
+				return nil, err
+			}
+			m[absDir] = mod.Path
+		}
+	}
+	return m, nil
+}
+
+func (state *golistState) determineRootDirsGOPATH() (map[string]string, error) {
+	m := map[string]string{}
+	for _, dir := range filepath.SplitList(state.mustGetEnv()["GOPATH"]) {
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			return nil, err
+		}
+		m[filepath.Join(absDir, "src")] = ""
+	}
+	return m, nil
+}
+
+func extractImports(filename string, contents []byte) ([]string, error) {
+	f, err := parser.ParseFile(token.NewFileSet(), filename, contents, parser.ImportsOnly) // TODO(matloob): reuse fileset?
+	if err != nil {
+		return nil, err
+	}
+	var res []string
+	for _, imp := range f.Imports {
+		quotedPath := imp.Path.Value
+		path, err := strconv.Unquote(quotedPath)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, path)
+	}
+	return res, nil
+}
+
+// reclaimPackage attempts to reuse a package that failed to load in an overlay.
+//
+// If the package has errors and has no Name, GoFiles, or Imports,
+// then it's possible that it doesn't yet exist on disk.
+func reclaimPackage(pkg *Package, id string, filename string, contents []byte) bool {
+	// TODO(rstambler): Check the message of the actual error?
+	// It differs between $GOPATH and module mode.
+	if pkg.ID != id {
+		return false
+	}
+	if len(pkg.Errors) != 1 {
+		return false
+	}
+	if pkg.Name != "" || pkg.ExportFile != "" {
+		return false
+	}
+	if len(pkg.GoFiles) > 0 || len(pkg.CompiledGoFiles) > 0 || len(pkg.OtherFiles) > 0 {
+		return false
+	}
+	if len(pkg.Imports) > 0 {
+		return false
+	}
+	pkgName, ok := extractPackageName(filename, contents)
+	if !ok {
+		return false
+	}
+	pkg.Name = pkgName
+	pkg.Errors = nil
+	return true
+}
+
+func extractPackageName(filename string, contents []byte) (string, bool) {
+	// TODO(rstambler): Check the message of the actual error?
+	// It differs between $GOPATH and module mode.
+	f, err := parser.ParseFile(token.NewFileSet(), filename, contents, parser.PackageClauseOnly) // TODO(matloob): reuse fileset?
+	if err != nil {
+		return "", false
+	}
+	return f.Name.Name, true
+}
+
+func commonDir(a []string) string {
+	seen := make(map[string]bool)
+	x := append([]string{}, a...)
+	for _, f := range x {
+		seen[filepath.Dir(f)] = true
+	}
+	if len(seen) > 1 {
+		log.Fatalf("commonDir saw %v for %v", seen, x)
+	}
+	for k := range seen {
+		// len(seen) == 1
+		return k
+	}
+	return "" // no files
+}
+
+// It is possible that the files in the disk directory dir have a different package
+// name from newName, which is deduced from the overlays. If they all have a different
+// package name, and they all have the same package name, then that name becomes
+// the package name.
+// It returns true if it changes the package name, false otherwise.
+func maybeFixPackageName(newName string, isTestFile bool, pkgsOfDir []*Package) {
+	names := make(map[string]int)
+	for _, p := range pkgsOfDir {
+		names[p.Name]++
+	}
+	if len(names) != 1 {
+		// some files are in different packages
+		return
+	}
+	var oldName string
+	for k := range names {
+		oldName = k
+	}
+	if newName == oldName {
+		return
+	}
+	// We might have a case where all of the package names in the directory are
+	// the same, but the overlay file is for an x test, which belongs to its
+	// own package. If the x test does not yet exist on disk, we may not yet
+	// have its package name on disk, but we should not rename the packages.
+	//
+	// We use a heuristic to determine if this file belongs to an x test:
+	// The test file should have a package name whose package name has a _test
+	// suffix or looks like "newName_test".
+	maybeXTest := strings.HasPrefix(oldName+"_test", newName) || strings.HasSuffix(newName, "_test")
+	if isTestFile && maybeXTest {
+		return
+	}
+	for _, p := range pkgsOfDir {
+		p.Name = newName
+	}
+}

--- a/vendor/golang.org/x/tools/go/packages/loadmode_string.go
+++ b/vendor/golang.org/x/tools/go/packages/loadmode_string.go
@@ -1,0 +1,57 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package packages
+
+import (
+	"fmt"
+	"strings"
+)
+
+var allModes = []LoadMode{
+	NeedName,
+	NeedFiles,
+	NeedCompiledGoFiles,
+	NeedImports,
+	NeedDeps,
+	NeedExportsFile,
+	NeedTypes,
+	NeedSyntax,
+	NeedTypesInfo,
+	NeedTypesSizes,
+}
+
+var modeStrings = []string{
+	"NeedName",
+	"NeedFiles",
+	"NeedCompiledGoFiles",
+	"NeedImports",
+	"NeedDeps",
+	"NeedExportsFile",
+	"NeedTypes",
+	"NeedSyntax",
+	"NeedTypesInfo",
+	"NeedTypesSizes",
+}
+
+func (mod LoadMode) String() string {
+	m := mod
+	if m == 0 {
+		return "LoadMode(0)"
+	}
+	var out []string
+	for i, x := range allModes {
+		if x > m {
+			break
+		}
+		if (m & x) != 0 {
+			out = append(out, modeStrings[i])
+			m = m ^ x
+		}
+	}
+	if m != 0 {
+		out = append(out, "Unknown")
+	}
+	return fmt.Sprintf("LoadMode(%s)", strings.Join(out, "|"))
+}

--- a/vendor/golang.org/x/tools/go/packages/packages.go
+++ b/vendor/golang.org/x/tools/go/packages/packages.go
@@ -1,0 +1,1212 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package packages
+
+// See doc.go for package documentation and implementation notes.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/scanner"
+	"go/token"
+	"go/types"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/tools/go/gcexportdata"
+	"golang.org/x/tools/internal/gocommand"
+	"golang.org/x/tools/internal/packagesinternal"
+	"golang.org/x/tools/internal/typesinternal"
+)
+
+// A LoadMode controls the amount of detail to return when loading.
+// The bits below can be combined to specify which fields should be
+// filled in the result packages.
+// The zero value is a special case, equivalent to combining
+// the NeedName, NeedFiles, and NeedCompiledGoFiles bits.
+// ID and Errors (if present) will always be filled.
+// Load may return more information than requested.
+type LoadMode int
+
+// TODO(matloob): When a V2 of go/packages is released, rename NeedExportsFile to
+// NeedExportFile to make it consistent with the Package field it's adding.
+
+const (
+	// NeedName adds Name and PkgPath.
+	NeedName LoadMode = 1 << iota
+
+	// NeedFiles adds GoFiles and OtherFiles.
+	NeedFiles
+
+	// NeedCompiledGoFiles adds CompiledGoFiles.
+	NeedCompiledGoFiles
+
+	// NeedImports adds Imports. If NeedDeps is not set, the Imports field will contain
+	// "placeholder" Packages with only the ID set.
+	NeedImports
+
+	// NeedDeps adds the fields requested by the LoadMode in the packages in Imports.
+	NeedDeps
+
+	// NeedExportsFile adds ExportFile.
+	NeedExportsFile
+
+	// NeedTypes adds Types, Fset, and IllTyped.
+	NeedTypes
+
+	// NeedSyntax adds Syntax.
+	NeedSyntax
+
+	// NeedTypesInfo adds TypesInfo.
+	NeedTypesInfo
+
+	// NeedTypesSizes adds TypesSizes.
+	NeedTypesSizes
+
+	// typecheckCgo enables full support for type checking cgo. Requires Go 1.15+.
+	// Modifies CompiledGoFiles and Types, and has no effect on its own.
+	typecheckCgo
+
+	// NeedModule adds Module.
+	NeedModule
+)
+
+const (
+	// Deprecated: LoadFiles exists for historical compatibility
+	// and should not be used. Please directly specify the needed fields using the Need values.
+	LoadFiles = NeedName | NeedFiles | NeedCompiledGoFiles
+
+	// Deprecated: LoadImports exists for historical compatibility
+	// and should not be used. Please directly specify the needed fields using the Need values.
+	LoadImports = LoadFiles | NeedImports
+
+	// Deprecated: LoadTypes exists for historical compatibility
+	// and should not be used. Please directly specify the needed fields using the Need values.
+	LoadTypes = LoadImports | NeedTypes | NeedTypesSizes
+
+	// Deprecated: LoadSyntax exists for historical compatibility
+	// and should not be used. Please directly specify the needed fields using the Need values.
+	LoadSyntax = LoadTypes | NeedSyntax | NeedTypesInfo
+
+	// Deprecated: LoadAllSyntax exists for historical compatibility
+	// and should not be used. Please directly specify the needed fields using the Need values.
+	LoadAllSyntax = LoadSyntax | NeedDeps
+)
+
+// A Config specifies details about how packages should be loaded.
+// The zero value is a valid configuration.
+// Calls to Load do not modify this struct.
+type Config struct {
+	// Mode controls the level of information returned for each package.
+	Mode LoadMode
+
+	// Context specifies the context for the load operation.
+	// If the context is cancelled, the loader may stop early
+	// and return an ErrCancelled error.
+	// If Context is nil, the load cannot be cancelled.
+	Context context.Context
+
+	// Logf is the logger for the config.
+	// If the user provides a logger, debug logging is enabled.
+	// If the GOPACKAGESDEBUG environment variable is set to true,
+	// but the logger is nil, default to log.Printf.
+	Logf func(format string, args ...interface{})
+
+	// Dir is the directory in which to run the build system's query tool
+	// that provides information about the packages.
+	// If Dir is empty, the tool is run in the current directory.
+	Dir string
+
+	// Env is the environment to use when invoking the build system's query tool.
+	// If Env is nil, the current environment is used.
+	// As in os/exec's Cmd, only the last value in the slice for
+	// each environment key is used. To specify the setting of only
+	// a few variables, append to the current environment, as in:
+	//
+	//	opt.Env = append(os.Environ(), "GOOS=plan9", "GOARCH=386")
+	//
+	Env []string
+
+	// gocmdRunner guards go command calls from concurrency errors.
+	gocmdRunner *gocommand.Runner
+
+	// BuildFlags is a list of command-line flags to be passed through to
+	// the build system's query tool.
+	BuildFlags []string
+
+	// Fset provides source position information for syntax trees and types.
+	// If Fset is nil, Load will use a new fileset, but preserve Fset's value.
+	Fset *token.FileSet
+
+	// ParseFile is called to read and parse each file
+	// when preparing a package's type-checked syntax tree.
+	// It must be safe to call ParseFile simultaneously from multiple goroutines.
+	// If ParseFile is nil, the loader will uses parser.ParseFile.
+	//
+	// ParseFile should parse the source from src and use filename only for
+	// recording position information.
+	//
+	// An application may supply a custom implementation of ParseFile
+	// to change the effective file contents or the behavior of the parser,
+	// or to modify the syntax tree. For example, selectively eliminating
+	// unwanted function bodies can significantly accelerate type checking.
+	ParseFile func(fset *token.FileSet, filename string, src []byte) (*ast.File, error)
+
+	// If Tests is set, the loader includes not just the packages
+	// matching a particular pattern but also any related test packages,
+	// including test-only variants of the package and the test executable.
+	//
+	// For example, when using the go command, loading "fmt" with Tests=true
+	// returns four packages, with IDs "fmt" (the standard package),
+	// "fmt [fmt.test]" (the package as compiled for the test),
+	// "fmt_test" (the test functions from source files in package fmt_test),
+	// and "fmt.test" (the test binary).
+	//
+	// In build systems with explicit names for tests,
+	// setting Tests may have no effect.
+	Tests bool
+
+	// Overlay provides a mapping of absolute file paths to file contents.
+	// If the file with the given path already exists, the parser will use the
+	// alternative file contents provided by the map.
+	//
+	// Overlays provide incomplete support for when a given file doesn't
+	// already exist on disk. See the package doc above for more details.
+	Overlay map[string][]byte
+}
+
+// driver is the type for functions that query the build system for the
+// packages named by the patterns.
+type driver func(cfg *Config, patterns ...string) (*driverResponse, error)
+
+// driverResponse contains the results for a driver query.
+type driverResponse struct {
+	// NotHandled is returned if the request can't be handled by the current
+	// driver. If an external driver returns a response with NotHandled, the
+	// rest of the driverResponse is ignored, and go/packages will fallback
+	// to the next driver. If go/packages is extended in the future to support
+	// lists of multiple drivers, go/packages will fall back to the next driver.
+	NotHandled bool
+
+	// Sizes, if not nil, is the types.Sizes to use when type checking.
+	Sizes *types.StdSizes
+
+	// Roots is the set of package IDs that make up the root packages.
+	// We have to encode this separately because when we encode a single package
+	// we cannot know if it is one of the roots as that requires knowledge of the
+	// graph it is part of.
+	Roots []string `json:",omitempty"`
+
+	// Packages is the full set of packages in the graph.
+	// The packages are not connected into a graph.
+	// The Imports if populated will be stubs that only have their ID set.
+	// Imports will be connected and then type and syntax information added in a
+	// later pass (see refine).
+	Packages []*Package
+}
+
+// Load loads and returns the Go packages named by the given patterns.
+//
+// Config specifies loading options;
+// nil behaves the same as an empty Config.
+//
+// Load returns an error if any of the patterns was invalid
+// as defined by the underlying build system.
+// It may return an empty list of packages without an error,
+// for instance for an empty expansion of a valid wildcard.
+// Errors associated with a particular package are recorded in the
+// corresponding Package's Errors list, and do not cause Load to
+// return an error. Clients may need to handle such errors before
+// proceeding with further analysis. The PrintErrors function is
+// provided for convenient display of all errors.
+func Load(cfg *Config, patterns ...string) ([]*Package, error) {
+	l := newLoader(cfg)
+	response, err := defaultDriver(&l.Config, patterns...)
+	if err != nil {
+		return nil, err
+	}
+	l.sizes = response.Sizes
+	return l.refine(response.Roots, response.Packages...)
+}
+
+// defaultDriver is a driver that implements go/packages' fallback behavior.
+// It will try to request to an external driver, if one exists. If there's
+// no external driver, or the driver returns a response with NotHandled set,
+// defaultDriver will fall back to the go list driver.
+func defaultDriver(cfg *Config, patterns ...string) (*driverResponse, error) {
+	driver := findExternalDriver(cfg)
+	if driver == nil {
+		driver = goListDriver
+	}
+	response, err := driver(cfg, patterns...)
+	if err != nil {
+		return response, err
+	} else if response.NotHandled {
+		return goListDriver(cfg, patterns...)
+	}
+	return response, nil
+}
+
+// A Package describes a loaded Go package.
+type Package struct {
+	// ID is a unique identifier for a package,
+	// in a syntax provided by the underlying build system.
+	//
+	// Because the syntax varies based on the build system,
+	// clients should treat IDs as opaque and not attempt to
+	// interpret them.
+	ID string
+
+	// Name is the package name as it appears in the package source code.
+	Name string
+
+	// PkgPath is the package path as used by the go/types package.
+	PkgPath string
+
+	// Errors contains any errors encountered querying the metadata
+	// of the package, or while parsing or type-checking its files.
+	Errors []Error
+
+	// GoFiles lists the absolute file paths of the package's Go source files.
+	GoFiles []string
+
+	// CompiledGoFiles lists the absolute file paths of the package's source
+	// files that are suitable for type checking.
+	// This may differ from GoFiles if files are processed before compilation.
+	CompiledGoFiles []string
+
+	// OtherFiles lists the absolute file paths of the package's non-Go source files,
+	// including assembly, C, C++, Fortran, Objective-C, SWIG, and so on.
+	OtherFiles []string
+
+	// ExportFile is the absolute path to a file containing type
+	// information for the package as provided by the build system.
+	ExportFile string
+
+	// Imports maps import paths appearing in the package's Go source files
+	// to corresponding loaded Packages.
+	Imports map[string]*Package
+
+	// Types provides type information for the package.
+	// The NeedTypes LoadMode bit sets this field for packages matching the
+	// patterns; type information for dependencies may be missing or incomplete,
+	// unless NeedDeps and NeedImports are also set.
+	Types *types.Package
+
+	// Fset provides position information for Types, TypesInfo, and Syntax.
+	// It is set only when Types is set.
+	Fset *token.FileSet
+
+	// IllTyped indicates whether the package or any dependency contains errors.
+	// It is set only when Types is set.
+	IllTyped bool
+
+	// Syntax is the package's syntax trees, for the files listed in CompiledGoFiles.
+	//
+	// The NeedSyntax LoadMode bit populates this field for packages matching the patterns.
+	// If NeedDeps and NeedImports are also set, this field will also be populated
+	// for dependencies.
+	Syntax []*ast.File
+
+	// TypesInfo provides type information about the package's syntax trees.
+	// It is set only when Syntax is set.
+	TypesInfo *types.Info
+
+	// TypesSizes provides the effective size function for types in TypesInfo.
+	TypesSizes types.Sizes
+
+	// forTest is the package under test, if any.
+	forTest string
+
+	// module is the module information for the package if it exists.
+	Module *Module
+}
+
+// Module provides module information for a package.
+type Module struct {
+	Path      string       // module path
+	Version   string       // module version
+	Replace   *Module      // replaced by this module
+	Time      *time.Time   // time version was created
+	Main      bool         // is this the main module?
+	Indirect  bool         // is this module only an indirect dependency of main module?
+	Dir       string       // directory holding files for this module, if any
+	GoMod     string       // path to go.mod file used when loading this module, if any
+	GoVersion string       // go version used in module
+	Error     *ModuleError // error loading module
+}
+
+// ModuleError holds errors loading a module.
+type ModuleError struct {
+	Err string // the error itself
+}
+
+func init() {
+	packagesinternal.GetForTest = func(p interface{}) string {
+		return p.(*Package).forTest
+	}
+	packagesinternal.GetGoCmdRunner = func(config interface{}) *gocommand.Runner {
+		return config.(*Config).gocmdRunner
+	}
+	packagesinternal.SetGoCmdRunner = func(config interface{}, runner *gocommand.Runner) {
+		config.(*Config).gocmdRunner = runner
+	}
+	packagesinternal.TypecheckCgo = int(typecheckCgo)
+}
+
+// An Error describes a problem with a package's metadata, syntax, or types.
+type Error struct {
+	Pos  string // "file:line:col" or "file:line" or "" or "-"
+	Msg  string
+	Kind ErrorKind
+}
+
+// ErrorKind describes the source of the error, allowing the user to
+// differentiate between errors generated by the driver, the parser, or the
+// type-checker.
+type ErrorKind int
+
+const (
+	UnknownError ErrorKind = iota
+	ListError
+	ParseError
+	TypeError
+)
+
+func (err Error) Error() string {
+	pos := err.Pos
+	if pos == "" {
+		pos = "-" // like token.Position{}.String()
+	}
+	return pos + ": " + err.Msg
+}
+
+// flatPackage is the JSON form of Package
+// It drops all the type and syntax fields, and transforms the Imports
+//
+// TODO(adonovan): identify this struct with Package, effectively
+// publishing the JSON protocol.
+type flatPackage struct {
+	ID              string
+	Name            string            `json:",omitempty"`
+	PkgPath         string            `json:",omitempty"`
+	Errors          []Error           `json:",omitempty"`
+	GoFiles         []string          `json:",omitempty"`
+	CompiledGoFiles []string          `json:",omitempty"`
+	OtherFiles      []string          `json:",omitempty"`
+	ExportFile      string            `json:",omitempty"`
+	Imports         map[string]string `json:",omitempty"`
+}
+
+// MarshalJSON returns the Package in its JSON form.
+// For the most part, the structure fields are written out unmodified, and
+// the type and syntax fields are skipped.
+// The imports are written out as just a map of path to package id.
+// The errors are written using a custom type that tries to preserve the
+// structure of error types we know about.
+//
+// This method exists to enable support for additional build systems.  It is
+// not intended for use by clients of the API and we may change the format.
+func (p *Package) MarshalJSON() ([]byte, error) {
+	flat := &flatPackage{
+		ID:              p.ID,
+		Name:            p.Name,
+		PkgPath:         p.PkgPath,
+		Errors:          p.Errors,
+		GoFiles:         p.GoFiles,
+		CompiledGoFiles: p.CompiledGoFiles,
+		OtherFiles:      p.OtherFiles,
+		ExportFile:      p.ExportFile,
+	}
+	if len(p.Imports) > 0 {
+		flat.Imports = make(map[string]string, len(p.Imports))
+		for path, ipkg := range p.Imports {
+			flat.Imports[path] = ipkg.ID
+		}
+	}
+	return json.Marshal(flat)
+}
+
+// UnmarshalJSON reads in a Package from its JSON format.
+// See MarshalJSON for details about the format accepted.
+func (p *Package) UnmarshalJSON(b []byte) error {
+	flat := &flatPackage{}
+	if err := json.Unmarshal(b, &flat); err != nil {
+		return err
+	}
+	*p = Package{
+		ID:              flat.ID,
+		Name:            flat.Name,
+		PkgPath:         flat.PkgPath,
+		Errors:          flat.Errors,
+		GoFiles:         flat.GoFiles,
+		CompiledGoFiles: flat.CompiledGoFiles,
+		OtherFiles:      flat.OtherFiles,
+		ExportFile:      flat.ExportFile,
+	}
+	if len(flat.Imports) > 0 {
+		p.Imports = make(map[string]*Package, len(flat.Imports))
+		for path, id := range flat.Imports {
+			p.Imports[path] = &Package{ID: id}
+		}
+	}
+	return nil
+}
+
+func (p *Package) String() string { return p.ID }
+
+// loaderPackage augments Package with state used during the loading phase
+type loaderPackage struct {
+	*Package
+	importErrors map[string]error // maps each bad import to its error
+	loadOnce     sync.Once
+	color        uint8 // for cycle detection
+	needsrc      bool  // load from source (Mode >= LoadTypes)
+	needtypes    bool  // type information is either requested or depended on
+	initial      bool  // package was matched by a pattern
+}
+
+// loader holds the working state of a single call to load.
+type loader struct {
+	pkgs map[string]*loaderPackage
+	Config
+	sizes        types.Sizes
+	parseCache   map[string]*parseValue
+	parseCacheMu sync.Mutex
+	exportMu     sync.Mutex // enforces mutual exclusion of exportdata operations
+
+	// Config.Mode contains the implied mode (see impliedLoadMode).
+	// Implied mode contains all the fields we need the data for.
+	// In requestedMode there are the actually requested fields.
+	// We'll zero them out before returning packages to the user.
+	// This makes it easier for us to get the conditions where
+	// we need certain modes right.
+	requestedMode LoadMode
+}
+
+type parseValue struct {
+	f     *ast.File
+	err   error
+	ready chan struct{}
+}
+
+func newLoader(cfg *Config) *loader {
+	ld := &loader{
+		parseCache: map[string]*parseValue{},
+	}
+	if cfg != nil {
+		ld.Config = *cfg
+		// If the user has provided a logger, use it.
+		ld.Config.Logf = cfg.Logf
+	}
+	if ld.Config.Logf == nil {
+		// If the GOPACKAGESDEBUG environment variable is set to true,
+		// but the user has not provided a logger, default to log.Printf.
+		if debug {
+			ld.Config.Logf = log.Printf
+		} else {
+			ld.Config.Logf = func(format string, args ...interface{}) {}
+		}
+	}
+	if ld.Config.Mode == 0 {
+		ld.Config.Mode = NeedName | NeedFiles | NeedCompiledGoFiles // Preserve zero behavior of Mode for backwards compatibility.
+	}
+	if ld.Config.Env == nil {
+		ld.Config.Env = os.Environ()
+	}
+	if ld.Config.gocmdRunner == nil {
+		ld.Config.gocmdRunner = &gocommand.Runner{}
+	}
+	if ld.Context == nil {
+		ld.Context = context.Background()
+	}
+	if ld.Dir == "" {
+		if dir, err := os.Getwd(); err == nil {
+			ld.Dir = dir
+		}
+	}
+
+	// Save the actually requested fields. We'll zero them out before returning packages to the user.
+	ld.requestedMode = ld.Mode
+	ld.Mode = impliedLoadMode(ld.Mode)
+
+	if ld.Mode&NeedTypes != 0 || ld.Mode&NeedSyntax != 0 {
+		if ld.Fset == nil {
+			ld.Fset = token.NewFileSet()
+		}
+
+		// ParseFile is required even in LoadTypes mode
+		// because we load source if export data is missing.
+		if ld.ParseFile == nil {
+			ld.ParseFile = func(fset *token.FileSet, filename string, src []byte) (*ast.File, error) {
+				const mode = parser.AllErrors | parser.ParseComments
+				return parser.ParseFile(fset, filename, src, mode)
+			}
+		}
+	}
+
+	return ld
+}
+
+// refine connects the supplied packages into a graph and then adds type and
+// and syntax information as requested by the LoadMode.
+func (ld *loader) refine(roots []string, list ...*Package) ([]*Package, error) {
+	rootMap := make(map[string]int, len(roots))
+	for i, root := range roots {
+		rootMap[root] = i
+	}
+	ld.pkgs = make(map[string]*loaderPackage)
+	// first pass, fixup and build the map and roots
+	var initial = make([]*loaderPackage, len(roots))
+	for _, pkg := range list {
+		rootIndex := -1
+		if i, found := rootMap[pkg.ID]; found {
+			rootIndex = i
+		}
+
+		// Overlays can invalidate export data.
+		// TODO(matloob): make this check fine-grained based on dependencies on overlaid files
+		exportDataInvalid := len(ld.Overlay) > 0 || pkg.ExportFile == "" && pkg.PkgPath != "unsafe"
+		// This package needs type information if the caller requested types and the package is
+		// either a root, or it's a non-root and the user requested dependencies ...
+		needtypes := (ld.Mode&NeedTypes|NeedTypesInfo != 0 && (rootIndex >= 0 || ld.Mode&NeedDeps != 0))
+		// This package needs source if the call requested source (or types info, which implies source)
+		// and the package is either a root, or itas a non- root and the user requested dependencies...
+		needsrc := ((ld.Mode&(NeedSyntax|NeedTypesInfo) != 0 && (rootIndex >= 0 || ld.Mode&NeedDeps != 0)) ||
+			// ... or if we need types and the exportData is invalid. We fall back to (incompletely)
+			// typechecking packages from source if they fail to compile.
+			(ld.Mode&NeedTypes|NeedTypesInfo != 0 && exportDataInvalid)) && pkg.PkgPath != "unsafe"
+		lpkg := &loaderPackage{
+			Package:   pkg,
+			needtypes: needtypes,
+			needsrc:   needsrc,
+		}
+		ld.pkgs[lpkg.ID] = lpkg
+		if rootIndex >= 0 {
+			initial[rootIndex] = lpkg
+			lpkg.initial = true
+		}
+	}
+	for i, root := range roots {
+		if initial[i] == nil {
+			return nil, fmt.Errorf("root package %v is missing", root)
+		}
+	}
+
+	// Materialize the import graph.
+
+	const (
+		white = 0 // new
+		grey  = 1 // in progress
+		black = 2 // complete
+	)
+
+	// visit traverses the import graph, depth-first,
+	// and materializes the graph as Packages.Imports.
+	//
+	// Valid imports are saved in the Packages.Import map.
+	// Invalid imports (cycles and missing nodes) are saved in the importErrors map.
+	// Thus, even in the presence of both kinds of errors, the Import graph remains a DAG.
+	//
+	// visit returns whether the package needs src or has a transitive
+	// dependency on a package that does. These are the only packages
+	// for which we load source code.
+	var stack []*loaderPackage
+	var visit func(lpkg *loaderPackage) bool
+	var srcPkgs []*loaderPackage
+	visit = func(lpkg *loaderPackage) bool {
+		switch lpkg.color {
+		case black:
+			return lpkg.needsrc
+		case grey:
+			panic("internal error: grey node")
+		}
+		lpkg.color = grey
+		stack = append(stack, lpkg) // push
+		stubs := lpkg.Imports       // the structure form has only stubs with the ID in the Imports
+		// If NeedImports isn't set, the imports fields will all be zeroed out.
+		if ld.Mode&NeedImports != 0 {
+			lpkg.Imports = make(map[string]*Package, len(stubs))
+			for importPath, ipkg := range stubs {
+				var importErr error
+				imp := ld.pkgs[ipkg.ID]
+				if imp == nil {
+					// (includes package "C" when DisableCgo)
+					importErr = fmt.Errorf("missing package: %q", ipkg.ID)
+				} else if imp.color == grey {
+					importErr = fmt.Errorf("import cycle: %s", stack)
+				}
+				if importErr != nil {
+					if lpkg.importErrors == nil {
+						lpkg.importErrors = make(map[string]error)
+					}
+					lpkg.importErrors[importPath] = importErr
+					continue
+				}
+
+				if visit(imp) {
+					lpkg.needsrc = true
+				}
+				lpkg.Imports[importPath] = imp.Package
+			}
+		}
+		if lpkg.needsrc {
+			srcPkgs = append(srcPkgs, lpkg)
+		}
+		if ld.Mode&NeedTypesSizes != 0 {
+			lpkg.TypesSizes = ld.sizes
+		}
+		stack = stack[:len(stack)-1] // pop
+		lpkg.color = black
+
+		return lpkg.needsrc
+	}
+
+	if ld.Mode&NeedImports == 0 {
+		// We do this to drop the stub import packages that we are not even going to try to resolve.
+		for _, lpkg := range initial {
+			lpkg.Imports = nil
+		}
+	} else {
+		// For each initial package, create its import DAG.
+		for _, lpkg := range initial {
+			visit(lpkg)
+		}
+	}
+	if ld.Mode&NeedImports != 0 && ld.Mode&NeedTypes != 0 {
+		for _, lpkg := range srcPkgs {
+			// Complete type information is required for the
+			// immediate dependencies of each source package.
+			for _, ipkg := range lpkg.Imports {
+				imp := ld.pkgs[ipkg.ID]
+				imp.needtypes = true
+			}
+		}
+	}
+	// Load type data and syntax if needed, starting at
+	// the initial packages (roots of the import DAG).
+	if ld.Mode&NeedTypes != 0 || ld.Mode&NeedSyntax != 0 {
+		var wg sync.WaitGroup
+		for _, lpkg := range initial {
+			wg.Add(1)
+			go func(lpkg *loaderPackage) {
+				ld.loadRecursive(lpkg)
+				wg.Done()
+			}(lpkg)
+		}
+		wg.Wait()
+	}
+
+	result := make([]*Package, len(initial))
+	for i, lpkg := range initial {
+		result[i] = lpkg.Package
+	}
+	for i := range ld.pkgs {
+		// Clear all unrequested fields, for extra de-Hyrum-ization.
+		if ld.requestedMode&NeedName == 0 {
+			ld.pkgs[i].Name = ""
+			ld.pkgs[i].PkgPath = ""
+		}
+		if ld.requestedMode&NeedFiles == 0 {
+			ld.pkgs[i].GoFiles = nil
+			ld.pkgs[i].OtherFiles = nil
+		}
+		if ld.requestedMode&NeedCompiledGoFiles == 0 {
+			ld.pkgs[i].CompiledGoFiles = nil
+		}
+		if ld.requestedMode&NeedImports == 0 {
+			ld.pkgs[i].Imports = nil
+		}
+		if ld.requestedMode&NeedExportsFile == 0 {
+			ld.pkgs[i].ExportFile = ""
+		}
+		if ld.requestedMode&NeedTypes == 0 {
+			ld.pkgs[i].Types = nil
+			ld.pkgs[i].Fset = nil
+			ld.pkgs[i].IllTyped = false
+		}
+		if ld.requestedMode&NeedSyntax == 0 {
+			ld.pkgs[i].Syntax = nil
+		}
+		if ld.requestedMode&NeedTypesInfo == 0 {
+			ld.pkgs[i].TypesInfo = nil
+		}
+		if ld.requestedMode&NeedTypesSizes == 0 {
+			ld.pkgs[i].TypesSizes = nil
+		}
+		if ld.requestedMode&NeedModule == 0 {
+			ld.pkgs[i].Module = nil
+		}
+	}
+
+	return result, nil
+}
+
+// loadRecursive loads the specified package and its dependencies,
+// recursively, in parallel, in topological order.
+// It is atomic and idempotent.
+// Precondition: ld.Mode&NeedTypes.
+func (ld *loader) loadRecursive(lpkg *loaderPackage) {
+	lpkg.loadOnce.Do(func() {
+		// Load the direct dependencies, in parallel.
+		var wg sync.WaitGroup
+		for _, ipkg := range lpkg.Imports {
+			imp := ld.pkgs[ipkg.ID]
+			wg.Add(1)
+			go func(imp *loaderPackage) {
+				ld.loadRecursive(imp)
+				wg.Done()
+			}(imp)
+		}
+		wg.Wait()
+		ld.loadPackage(lpkg)
+	})
+}
+
+// loadPackage loads the specified package.
+// It must be called only once per Package,
+// after immediate dependencies are loaded.
+// Precondition: ld.Mode & NeedTypes.
+func (ld *loader) loadPackage(lpkg *loaderPackage) {
+	if lpkg.PkgPath == "unsafe" {
+		// Fill in the blanks to avoid surprises.
+		lpkg.Types = types.Unsafe
+		lpkg.Fset = ld.Fset
+		lpkg.Syntax = []*ast.File{}
+		lpkg.TypesInfo = new(types.Info)
+		lpkg.TypesSizes = ld.sizes
+		return
+	}
+
+	// Call NewPackage directly with explicit name.
+	// This avoids skew between golist and go/types when the files'
+	// package declarations are inconsistent.
+	lpkg.Types = types.NewPackage(lpkg.PkgPath, lpkg.Name)
+	lpkg.Fset = ld.Fset
+
+	// Subtle: we populate all Types fields with an empty Package
+	// before loading export data so that export data processing
+	// never has to create a types.Package for an indirect dependency,
+	// which would then require that such created packages be explicitly
+	// inserted back into the Import graph as a final step after export data loading.
+	// The Diamond test exercises this case.
+	if !lpkg.needtypes && !lpkg.needsrc {
+		return
+	}
+	if !lpkg.needsrc {
+		ld.loadFromExportData(lpkg)
+		return // not a source package, don't get syntax trees
+	}
+
+	appendError := func(err error) {
+		// Convert various error types into the one true Error.
+		var errs []Error
+		switch err := err.(type) {
+		case Error:
+			// from driver
+			errs = append(errs, err)
+
+		case *os.PathError:
+			// from parser
+			errs = append(errs, Error{
+				Pos:  err.Path + ":1",
+				Msg:  err.Err.Error(),
+				Kind: ParseError,
+			})
+
+		case scanner.ErrorList:
+			// from parser
+			for _, err := range err {
+				errs = append(errs, Error{
+					Pos:  err.Pos.String(),
+					Msg:  err.Msg,
+					Kind: ParseError,
+				})
+			}
+
+		case types.Error:
+			// from type checker
+			errs = append(errs, Error{
+				Pos:  err.Fset.Position(err.Pos).String(),
+				Msg:  err.Msg,
+				Kind: TypeError,
+			})
+
+		default:
+			// unexpected impoverished error from parser?
+			errs = append(errs, Error{
+				Pos:  "-",
+				Msg:  err.Error(),
+				Kind: UnknownError,
+			})
+
+			// If you see this error message, please file a bug.
+			log.Printf("internal error: error %q (%T) without position", err, err)
+		}
+
+		lpkg.Errors = append(lpkg.Errors, errs...)
+	}
+
+	if ld.Config.Mode&NeedTypes != 0 && len(lpkg.CompiledGoFiles) == 0 && lpkg.ExportFile != "" {
+		// The config requested loading sources and types, but sources are missing.
+		// Add an error to the package and fall back to loading from export data.
+		appendError(Error{"-", fmt.Sprintf("sources missing for package %s", lpkg.ID), ParseError})
+		ld.loadFromExportData(lpkg)
+		return // can't get syntax trees for this package
+	}
+
+	files, errs := ld.parseFiles(lpkg.CompiledGoFiles)
+	for _, err := range errs {
+		appendError(err)
+	}
+
+	lpkg.Syntax = files
+	if ld.Config.Mode&NeedTypes == 0 {
+		return
+	}
+
+	lpkg.TypesInfo = &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Implicits:  make(map[ast.Node]types.Object),
+		Scopes:     make(map[ast.Node]*types.Scope),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+	}
+	lpkg.TypesSizes = ld.sizes
+
+	importer := importerFunc(func(path string) (*types.Package, error) {
+		if path == "unsafe" {
+			return types.Unsafe, nil
+		}
+
+		// The imports map is keyed by import path.
+		ipkg := lpkg.Imports[path]
+		if ipkg == nil {
+			if err := lpkg.importErrors[path]; err != nil {
+				return nil, err
+			}
+			// There was skew between the metadata and the
+			// import declarations, likely due to an edit
+			// race, or because the ParseFile feature was
+			// used to supply alternative file contents.
+			return nil, fmt.Errorf("no metadata for %s", path)
+		}
+
+		if ipkg.Types != nil && ipkg.Types.Complete() {
+			return ipkg.Types, nil
+		}
+		log.Fatalf("internal error: package %q without types was imported from %q", path, lpkg)
+		panic("unreachable")
+	})
+
+	// type-check
+	tc := &types.Config{
+		Importer: importer,
+
+		// Type-check bodies of functions only in non-initial packages.
+		// Example: for import graph A->B->C and initial packages {A,C},
+		// we can ignore function bodies in B.
+		IgnoreFuncBodies: ld.Mode&NeedDeps == 0 && !lpkg.initial,
+
+		Error: appendError,
+		Sizes: ld.sizes,
+	}
+	if (ld.Mode & typecheckCgo) != 0 {
+		if !typesinternal.SetUsesCgo(tc) {
+			appendError(Error{
+				Msg:  "typecheckCgo requires Go 1.15+",
+				Kind: ListError,
+			})
+			return
+		}
+	}
+	types.NewChecker(tc, ld.Fset, lpkg.Types, lpkg.TypesInfo).Files(lpkg.Syntax)
+
+	lpkg.importErrors = nil // no longer needed
+
+	// If !Cgo, the type-checker uses FakeImportC mode, so
+	// it doesn't invoke the importer for import "C",
+	// nor report an error for the import,
+	// or for any undefined C.f reference.
+	// We must detect this explicitly and correctly
+	// mark the package as IllTyped (by reporting an error).
+	// TODO(adonovan): if these errors are annoying,
+	// we could just set IllTyped quietly.
+	if tc.FakeImportC {
+	outer:
+		for _, f := range lpkg.Syntax {
+			for _, imp := range f.Imports {
+				if imp.Path.Value == `"C"` {
+					err := types.Error{Fset: ld.Fset, Pos: imp.Pos(), Msg: `import "C" ignored`}
+					appendError(err)
+					break outer
+				}
+			}
+		}
+	}
+
+	// Record accumulated errors.
+	illTyped := len(lpkg.Errors) > 0
+	if !illTyped {
+		for _, imp := range lpkg.Imports {
+			if imp.IllTyped {
+				illTyped = true
+				break
+			}
+		}
+	}
+	lpkg.IllTyped = illTyped
+}
+
+// An importFunc is an implementation of the single-method
+// types.Importer interface based on a function value.
+type importerFunc func(path string) (*types.Package, error)
+
+func (f importerFunc) Import(path string) (*types.Package, error) { return f(path) }
+
+// We use a counting semaphore to limit
+// the number of parallel I/O calls per process.
+var ioLimit = make(chan bool, 20)
+
+func (ld *loader) parseFile(filename string) (*ast.File, error) {
+	ld.parseCacheMu.Lock()
+	v, ok := ld.parseCache[filename]
+	if ok {
+		// cache hit
+		ld.parseCacheMu.Unlock()
+		<-v.ready
+	} else {
+		// cache miss
+		v = &parseValue{ready: make(chan struct{})}
+		ld.parseCache[filename] = v
+		ld.parseCacheMu.Unlock()
+
+		var src []byte
+		for f, contents := range ld.Config.Overlay {
+			if sameFile(f, filename) {
+				src = contents
+			}
+		}
+		var err error
+		if src == nil {
+			ioLimit <- true // wait
+			src, err = ioutil.ReadFile(filename)
+			<-ioLimit // signal
+		}
+		if err != nil {
+			v.err = err
+		} else {
+			v.f, v.err = ld.ParseFile(ld.Fset, filename, src)
+		}
+
+		close(v.ready)
+	}
+	return v.f, v.err
+}
+
+// parseFiles reads and parses the Go source files and returns the ASTs
+// of the ones that could be at least partially parsed, along with a
+// list of I/O and parse errors encountered.
+//
+// Because files are scanned in parallel, the token.Pos
+// positions of the resulting ast.Files are not ordered.
+//
+func (ld *loader) parseFiles(filenames []string) ([]*ast.File, []error) {
+	var wg sync.WaitGroup
+	n := len(filenames)
+	parsed := make([]*ast.File, n)
+	errors := make([]error, n)
+	for i, file := range filenames {
+		if ld.Config.Context.Err() != nil {
+			parsed[i] = nil
+			errors[i] = ld.Config.Context.Err()
+			continue
+		}
+		wg.Add(1)
+		go func(i int, filename string) {
+			parsed[i], errors[i] = ld.parseFile(filename)
+			wg.Done()
+		}(i, file)
+	}
+	wg.Wait()
+
+	// Eliminate nils, preserving order.
+	var o int
+	for _, f := range parsed {
+		if f != nil {
+			parsed[o] = f
+			o++
+		}
+	}
+	parsed = parsed[:o]
+
+	o = 0
+	for _, err := range errors {
+		if err != nil {
+			errors[o] = err
+			o++
+		}
+	}
+	errors = errors[:o]
+
+	return parsed, errors
+}
+
+// sameFile returns true if x and y have the same basename and denote
+// the same file.
+//
+func sameFile(x, y string) bool {
+	if x == y {
+		// It could be the case that y doesn't exist.
+		// For instance, it may be an overlay file that
+		// hasn't been written to disk. To handle that case
+		// let x == y through. (We added the exact absolute path
+		// string to the CompiledGoFiles list, so the unwritten
+		// overlay case implies x==y.)
+		return true
+	}
+	if strings.EqualFold(filepath.Base(x), filepath.Base(y)) { // (optimisation)
+		if xi, err := os.Stat(x); err == nil {
+			if yi, err := os.Stat(y); err == nil {
+				return os.SameFile(xi, yi)
+			}
+		}
+	}
+	return false
+}
+
+// loadFromExportData returns type information for the specified
+// package, loading it from an export data file on the first request.
+func (ld *loader) loadFromExportData(lpkg *loaderPackage) (*types.Package, error) {
+	if lpkg.PkgPath == "" {
+		log.Fatalf("internal error: Package %s has no PkgPath", lpkg)
+	}
+
+	// Because gcexportdata.Read has the potential to create or
+	// modify the types.Package for each node in the transitive
+	// closure of dependencies of lpkg, all exportdata operations
+	// must be sequential. (Finer-grained locking would require
+	// changes to the gcexportdata API.)
+	//
+	// The exportMu lock guards the Package.Pkg field and the
+	// types.Package it points to, for each Package in the graph.
+	//
+	// Not all accesses to Package.Pkg need to be protected by exportMu:
+	// graph ordering ensures that direct dependencies of source
+	// packages are fully loaded before the importer reads their Pkg field.
+	ld.exportMu.Lock()
+	defer ld.exportMu.Unlock()
+
+	if tpkg := lpkg.Types; tpkg != nil && tpkg.Complete() {
+		return tpkg, nil // cache hit
+	}
+
+	lpkg.IllTyped = true // fail safe
+
+	if lpkg.ExportFile == "" {
+		// Errors while building export data will have been printed to stderr.
+		return nil, fmt.Errorf("no export data file")
+	}
+	f, err := os.Open(lpkg.ExportFile)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// Read gc export data.
+	//
+	// We don't currently support gccgo export data because all
+	// underlying workspaces use the gc toolchain. (Even build
+	// systems that support gccgo don't use it for workspace
+	// queries.)
+	r, err := gcexportdata.NewReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %v", lpkg.ExportFile, err)
+	}
+
+	// Build the view.
+	//
+	// The gcexportdata machinery has no concept of package ID.
+	// It identifies packages by their PkgPath, which although not
+	// globally unique is unique within the scope of one invocation
+	// of the linker, type-checker, or gcexportdata.
+	//
+	// So, we must build a PkgPath-keyed view of the global
+	// (conceptually ID-keyed) cache of packages and pass it to
+	// gcexportdata. The view must contain every existing
+	// package that might possibly be mentioned by the
+	// current package---its transitive closure.
+	//
+	// In loadPackage, we unconditionally create a types.Package for
+	// each dependency so that export data loading does not
+	// create new ones.
+	//
+	// TODO(adonovan): it would be simpler and more efficient
+	// if the export data machinery invoked a callback to
+	// get-or-create a package instead of a map.
+	//
+	view := make(map[string]*types.Package) // view seen by gcexportdata
+	seen := make(map[*loaderPackage]bool)   // all visited packages
+	var visit func(pkgs map[string]*Package)
+	visit = func(pkgs map[string]*Package) {
+		for _, p := range pkgs {
+			lpkg := ld.pkgs[p.ID]
+			if !seen[lpkg] {
+				seen[lpkg] = true
+				view[lpkg.PkgPath] = lpkg.Types
+				visit(lpkg.Imports)
+			}
+		}
+	}
+	visit(lpkg.Imports)
+
+	viewLen := len(view) + 1 // adding the self package
+	// Parse the export data.
+	// (May modify incomplete packages in view but not create new ones.)
+	tpkg, err := gcexportdata.Read(r, ld.Fset, view, lpkg.PkgPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %v", lpkg.ExportFile, err)
+	}
+	if viewLen != len(view) {
+		log.Fatalf("Unexpected package creation during export data loading")
+	}
+
+	lpkg.Types = tpkg
+	lpkg.IllTyped = false
+
+	return tpkg, nil
+}
+
+// impliedLoadMode returns loadMode with its dependencies.
+func impliedLoadMode(loadMode LoadMode) LoadMode {
+	if loadMode&NeedTypesInfo != 0 && loadMode&NeedImports == 0 {
+		// If NeedTypesInfo, go/packages needs to do typechecking itself so it can
+		// associate type info with the AST. To do so, we need the export data
+		// for dependencies, which means we need to ask for the direct dependencies.
+		// NeedImports is used to ask for the direct dependencies.
+		loadMode |= NeedImports
+	}
+
+	if loadMode&NeedDeps != 0 && loadMode&NeedImports == 0 {
+		// With NeedDeps we need to load at least direct dependencies.
+		// NeedImports is used to ask for the direct dependencies.
+		loadMode |= NeedImports
+	}
+
+	return loadMode
+}
+
+func usesExportData(cfg *Config) bool {
+	return cfg.Mode&NeedExportsFile != 0 || cfg.Mode&NeedTypes != 0 && cfg.Mode&NeedDeps == 0
+}

--- a/vendor/golang.org/x/tools/go/packages/visit.go
+++ b/vendor/golang.org/x/tools/go/packages/visit.go
@@ -1,0 +1,55 @@
+package packages
+
+import (
+	"fmt"
+	"os"
+	"sort"
+)
+
+// Visit visits all the packages in the import graph whose roots are
+// pkgs, calling the optional pre function the first time each package
+// is encountered (preorder), and the optional post function after a
+// package's dependencies have been visited (postorder).
+// The boolean result of pre(pkg) determines whether
+// the imports of package pkg are visited.
+func Visit(pkgs []*Package, pre func(*Package) bool, post func(*Package)) {
+	seen := make(map[*Package]bool)
+	var visit func(*Package)
+	visit = func(pkg *Package) {
+		if !seen[pkg] {
+			seen[pkg] = true
+
+			if pre == nil || pre(pkg) {
+				paths := make([]string, 0, len(pkg.Imports))
+				for path := range pkg.Imports {
+					paths = append(paths, path)
+				}
+				sort.Strings(paths) // Imports is a map, this makes visit stable
+				for _, path := range paths {
+					visit(pkg.Imports[path])
+				}
+			}
+
+			if post != nil {
+				post(pkg)
+			}
+		}
+	}
+	for _, pkg := range pkgs {
+		visit(pkg)
+	}
+}
+
+// PrintErrors prints to os.Stderr the accumulated errors of all
+// packages in the import graph rooted at pkgs, dependencies first.
+// PrintErrors returns the number of errors printed.
+func PrintErrors(pkgs []*Package) int {
+	var n int
+	Visit(pkgs, nil, func(pkg *Package) {
+		for _, err := range pkg.Errors {
+			fmt.Fprintln(os.Stderr, err)
+			n++
+		}
+	})
+	return n
+}

--- a/vendor/golang.org/x/tools/go/types/objectpath/objectpath.go
+++ b/vendor/golang.org/x/tools/go/types/objectpath/objectpath.go
@@ -1,0 +1,524 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package objectpath defines a naming scheme for types.Objects
+// (that is, named entities in Go programs) relative to their enclosing
+// package.
+//
+// Type-checker objects are canonical, so they are usually identified by
+// their address in memory (a pointer), but a pointer has meaning only
+// within one address space. By contrast, objectpath names allow the
+// identity of an object to be sent from one program to another,
+// establishing a correspondence between types.Object variables that are
+// distinct but logically equivalent.
+//
+// A single object may have multiple paths. In this example,
+//     type A struct{ X int }
+//     type B A
+// the field X has two paths due to its membership of both A and B.
+// The For(obj) function always returns one of these paths, arbitrarily
+// but consistently.
+package objectpath
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go/types"
+)
+
+// A Path is an opaque name that identifies a types.Object
+// relative to its package. Conceptually, the name consists of a
+// sequence of destructuring operations applied to the package scope
+// to obtain the original object.
+// The name does not include the package itself.
+type Path string
+
+// Encoding
+//
+// An object path is a textual and (with training) human-readable encoding
+// of a sequence of destructuring operators, starting from a types.Package.
+// The sequences represent a path through the package/object/type graph.
+// We classify these operators by their type:
+//
+//   PO package->object	Package.Scope.Lookup
+//   OT  object->type 	Object.Type
+//   TT    type->type 	Type.{Elem,Key,Params,Results,Underlying} [EKPRU]
+//   TO   type->object	Type.{At,Field,Method,Obj} [AFMO]
+//
+// All valid paths start with a package and end at an object
+// and thus may be defined by the regular language:
+//
+//   objectpath = PO (OT TT* TO)*
+//
+// The concrete encoding follows directly:
+// - The only PO operator is Package.Scope.Lookup, which requires an identifier.
+// - The only OT operator is Object.Type,
+//   which we encode as '.' because dot cannot appear in an identifier.
+// - The TT operators are encoded as [EKPRU].
+// - The OT operators are encoded as [AFMO];
+//   three of these (At,Field,Method) require an integer operand,
+//   which is encoded as a string of decimal digits.
+//   These indices are stable across different representations
+//   of the same package, even source and export data.
+//
+// In the example below,
+//
+//	package p
+//
+//	type T interface {
+//		f() (a string, b struct{ X int })
+//	}
+//
+// field X has the path "T.UM0.RA1.F0",
+// representing the following sequence of operations:
+//
+//    p.Lookup("T")					T
+//    .Type().Underlying().Method(0).			f
+//    .Type().Results().At(1)				b
+//    .Type().Field(0)					X
+//
+// The encoding is not maximally compact---every R or P is
+// followed by an A, for example---but this simplifies the
+// encoder and decoder.
+//
+const (
+	// object->type operators
+	opType = '.' // .Type()		  (Object)
+
+	// type->type operators
+	opElem       = 'E' // .Elem()		(Pointer, Slice, Array, Chan, Map)
+	opKey        = 'K' // .Key()		(Map)
+	opParams     = 'P' // .Params()		(Signature)
+	opResults    = 'R' // .Results()	(Signature)
+	opUnderlying = 'U' // .Underlying()	(Named)
+
+	// type->object operators
+	opAt     = 'A' // .At(i)		(Tuple)
+	opField  = 'F' // .Field(i)		(Struct)
+	opMethod = 'M' // .Method(i)		(Named or Interface; not Struct: "promoted" names are ignored)
+	opObj    = 'O' // .Obj()		(Named)
+)
+
+// The For function returns the path to an object relative to its package,
+// or an error if the object is not accessible from the package's Scope.
+//
+// The For function guarantees to return a path only for the following objects:
+// - package-level types
+// - exported package-level non-types
+// - methods
+// - parameter and result variables
+// - struct fields
+// These objects are sufficient to define the API of their package.
+// The objects described by a package's export data are drawn from this set.
+//
+// For does not return a path for predeclared names, imported package
+// names, local names, and unexported package-level names (except
+// types).
+//
+// Example: given this definition,
+//
+//	package p
+//
+//	type T interface {
+//		f() (a string, b struct{ X int })
+//	}
+//
+// For(X) would return a path that denotes the following sequence of operations:
+//
+//    p.Scope().Lookup("T")				(TypeName T)
+//    .Type().Underlying().Method(0).			(method Func f)
+//    .Type().Results().At(1)				(field Var b)
+//    .Type().Field(0)					(field Var X)
+//
+// where p is the package (*types.Package) to which X belongs.
+func For(obj types.Object) (Path, error) {
+	pkg := obj.Pkg()
+
+	// This table lists the cases of interest.
+	//
+	// Object				Action
+	// ------                               ------
+	// nil					reject
+	// builtin				reject
+	// pkgname				reject
+	// label				reject
+	// var
+	//    package-level			accept
+	//    func param/result			accept
+	//    local				reject
+	//    struct field			accept
+	// const
+	//    package-level			accept
+	//    local				reject
+	// func
+	//    package-level			accept
+	//    init functions			reject
+	//    concrete method			accept
+	//    interface method			accept
+	// type
+	//    package-level			accept
+	//    local				reject
+	//
+	// The only accessible package-level objects are members of pkg itself.
+	//
+	// The cases are handled in four steps:
+	//
+	// 1. reject nil and builtin
+	// 2. accept package-level objects
+	// 3. reject obviously invalid objects
+	// 4. search the API for the path to the param/result/field/method.
+
+	// 1. reference to nil or builtin?
+	if pkg == nil {
+		return "", fmt.Errorf("predeclared %s has no path", obj)
+	}
+	scope := pkg.Scope()
+
+	// 2. package-level object?
+	if scope.Lookup(obj.Name()) == obj {
+		// Only exported objects (and non-exported types) have a path.
+		// Non-exported types may be referenced by other objects.
+		if _, ok := obj.(*types.TypeName); !ok && !obj.Exported() {
+			return "", fmt.Errorf("no path for non-exported %v", obj)
+		}
+		return Path(obj.Name()), nil
+	}
+
+	// 3. Not a package-level object.
+	//    Reject obviously non-viable cases.
+	switch obj := obj.(type) {
+	case *types.Const, // Only package-level constants have a path.
+		*types.TypeName, // Only package-level types have a path.
+		*types.Label,    // Labels are function-local.
+		*types.PkgName:  // PkgNames are file-local.
+		return "", fmt.Errorf("no path for %v", obj)
+
+	case *types.Var:
+		// Could be:
+		// - a field (obj.IsField())
+		// - a func parameter or result
+		// - a local var.
+		// Sadly there is no way to distinguish
+		// a param/result from a local
+		// so we must proceed to the find.
+
+	case *types.Func:
+		// A func, if not package-level, must be a method.
+		if recv := obj.Type().(*types.Signature).Recv(); recv == nil {
+			return "", fmt.Errorf("func is not a method: %v", obj)
+		}
+		// TODO(adonovan): opt: if the method is concrete,
+		// do a specialized version of the rest of this function so
+		// that it's O(1) not O(|scope|).  Basically 'find' is needed
+		// only for struct fields and interface methods.
+
+	default:
+		panic(obj)
+	}
+
+	// 4. Search the API for the path to the var (field/param/result) or method.
+
+	// First inspect package-level named types.
+	// In the presence of path aliases, these give
+	// the best paths because non-types may
+	// refer to types, but not the reverse.
+	empty := make([]byte, 0, 48) // initial space
+	names := scope.Names()
+	for _, name := range names {
+		o := scope.Lookup(name)
+		tname, ok := o.(*types.TypeName)
+		if !ok {
+			continue // handle non-types in second pass
+		}
+
+		path := append(empty, name...)
+		path = append(path, opType)
+
+		T := o.Type()
+
+		if tname.IsAlias() {
+			// type alias
+			if r := find(obj, T, path); r != nil {
+				return Path(r), nil
+			}
+		} else {
+			// defined (named) type
+			if r := find(obj, T.Underlying(), append(path, opUnderlying)); r != nil {
+				return Path(r), nil
+			}
+		}
+	}
+
+	// Then inspect everything else:
+	// non-types, and declared methods of defined types.
+	for _, name := range names {
+		o := scope.Lookup(name)
+		path := append(empty, name...)
+		if _, ok := o.(*types.TypeName); !ok {
+			if o.Exported() {
+				// exported non-type (const, var, func)
+				if r := find(obj, o.Type(), append(path, opType)); r != nil {
+					return Path(r), nil
+				}
+			}
+			continue
+		}
+
+		// Inspect declared methods of defined types.
+		if T, ok := o.Type().(*types.Named); ok {
+			path = append(path, opType)
+			for i := 0; i < T.NumMethods(); i++ {
+				m := T.Method(i)
+				path2 := appendOpArg(path, opMethod, i)
+				if m == obj {
+					return Path(path2), nil // found declared method
+				}
+				if r := find(obj, m.Type(), append(path2, opType)); r != nil {
+					return Path(r), nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("can't find path for %v in %s", obj, pkg.Path())
+}
+
+func appendOpArg(path []byte, op byte, arg int) []byte {
+	path = append(path, op)
+	path = strconv.AppendInt(path, int64(arg), 10)
+	return path
+}
+
+// find finds obj within type T, returning the path to it, or nil if not found.
+func find(obj types.Object, T types.Type, path []byte) []byte {
+	switch T := T.(type) {
+	case *types.Basic, *types.Named:
+		// Named types belonging to pkg were handled already,
+		// so T must belong to another package. No path.
+		return nil
+	case *types.Pointer:
+		return find(obj, T.Elem(), append(path, opElem))
+	case *types.Slice:
+		return find(obj, T.Elem(), append(path, opElem))
+	case *types.Array:
+		return find(obj, T.Elem(), append(path, opElem))
+	case *types.Chan:
+		return find(obj, T.Elem(), append(path, opElem))
+	case *types.Map:
+		if r := find(obj, T.Key(), append(path, opKey)); r != nil {
+			return r
+		}
+		return find(obj, T.Elem(), append(path, opElem))
+	case *types.Signature:
+		if r := find(obj, T.Params(), append(path, opParams)); r != nil {
+			return r
+		}
+		return find(obj, T.Results(), append(path, opResults))
+	case *types.Struct:
+		for i := 0; i < T.NumFields(); i++ {
+			f := T.Field(i)
+			path2 := appendOpArg(path, opField, i)
+			if f == obj {
+				return path2 // found field var
+			}
+			if r := find(obj, f.Type(), append(path2, opType)); r != nil {
+				return r
+			}
+		}
+		return nil
+	case *types.Tuple:
+		for i := 0; i < T.Len(); i++ {
+			v := T.At(i)
+			path2 := appendOpArg(path, opAt, i)
+			if v == obj {
+				return path2 // found param/result var
+			}
+			if r := find(obj, v.Type(), append(path2, opType)); r != nil {
+				return r
+			}
+		}
+		return nil
+	case *types.Interface:
+		for i := 0; i < T.NumMethods(); i++ {
+			m := T.Method(i)
+			path2 := appendOpArg(path, opMethod, i)
+			if m == obj {
+				return path2 // found interface method
+			}
+			if r := find(obj, m.Type(), append(path2, opType)); r != nil {
+				return r
+			}
+		}
+		return nil
+	}
+	panic(T)
+}
+
+// Object returns the object denoted by path p within the package pkg.
+func Object(pkg *types.Package, p Path) (types.Object, error) {
+	if p == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+
+	pathstr := string(p)
+	var pkgobj, suffix string
+	if dot := strings.IndexByte(pathstr, opType); dot < 0 {
+		pkgobj = pathstr
+	} else {
+		pkgobj = pathstr[:dot]
+		suffix = pathstr[dot:] // suffix starts with "."
+	}
+
+	obj := pkg.Scope().Lookup(pkgobj)
+	if obj == nil {
+		return nil, fmt.Errorf("package %s does not contain %q", pkg.Path(), pkgobj)
+	}
+
+	// abstraction of *types.{Pointer,Slice,Array,Chan,Map}
+	type hasElem interface {
+		Elem() types.Type
+	}
+	// abstraction of *types.{Interface,Named}
+	type hasMethods interface {
+		Method(int) *types.Func
+		NumMethods() int
+	}
+
+	// The loop state is the pair (t, obj),
+	// exactly one of which is non-nil, initially obj.
+	// All suffixes start with '.' (the only object->type operation),
+	// followed by optional type->type operations,
+	// then a type->object operation.
+	// The cycle then repeats.
+	var t types.Type
+	for suffix != "" {
+		code := suffix[0]
+		suffix = suffix[1:]
+
+		// Codes [AFM] have an integer operand.
+		var index int
+		switch code {
+		case opAt, opField, opMethod:
+			rest := strings.TrimLeft(suffix, "0123456789")
+			numerals := suffix[:len(suffix)-len(rest)]
+			suffix = rest
+			i, err := strconv.Atoi(numerals)
+			if err != nil {
+				return nil, fmt.Errorf("invalid path: bad numeric operand %q for code %q", numerals, code)
+			}
+			index = int(i)
+		case opObj:
+			// no operand
+		default:
+			// The suffix must end with a type->object operation.
+			if suffix == "" {
+				return nil, fmt.Errorf("invalid path: ends with %q, want [AFMO]", code)
+			}
+		}
+
+		if code == opType {
+			if t != nil {
+				return nil, fmt.Errorf("invalid path: unexpected %q in type context", opType)
+			}
+			t = obj.Type()
+			obj = nil
+			continue
+		}
+
+		if t == nil {
+			return nil, fmt.Errorf("invalid path: code %q in object context", code)
+		}
+
+		// Inv: t != nil, obj == nil
+
+		switch code {
+		case opElem:
+			hasElem, ok := t.(hasElem) // Pointer, Slice, Array, Chan, Map
+			if !ok {
+				return nil, fmt.Errorf("cannot apply %q to %s (got %T, want pointer, slice, array, chan or map)", code, t, t)
+			}
+			t = hasElem.Elem()
+
+		case opKey:
+			mapType, ok := t.(*types.Map)
+			if !ok {
+				return nil, fmt.Errorf("cannot apply %q to %s (got %T, want map)", code, t, t)
+			}
+			t = mapType.Key()
+
+		case opParams:
+			sig, ok := t.(*types.Signature)
+			if !ok {
+				return nil, fmt.Errorf("cannot apply %q to %s (got %T, want signature)", code, t, t)
+			}
+			t = sig.Params()
+
+		case opResults:
+			sig, ok := t.(*types.Signature)
+			if !ok {
+				return nil, fmt.Errorf("cannot apply %q to %s (got %T, want signature)", code, t, t)
+			}
+			t = sig.Results()
+
+		case opUnderlying:
+			named, ok := t.(*types.Named)
+			if !ok {
+				return nil, fmt.Errorf("cannot apply %q to %s (got %s, want named)", code, t, t)
+			}
+			t = named.Underlying()
+
+		case opAt:
+			tuple, ok := t.(*types.Tuple)
+			if !ok {
+				return nil, fmt.Errorf("cannot apply %q to %s (got %s, want tuple)", code, t, t)
+			}
+			if n := tuple.Len(); index >= n {
+				return nil, fmt.Errorf("tuple index %d out of range [0-%d)", index, n)
+			}
+			obj = tuple.At(index)
+			t = nil
+
+		case opField:
+			structType, ok := t.(*types.Struct)
+			if !ok {
+				return nil, fmt.Errorf("cannot apply %q to %s (got %T, want struct)", code, t, t)
+			}
+			if n := structType.NumFields(); index >= n {
+				return nil, fmt.Errorf("field index %d out of range [0-%d)", index, n)
+			}
+			obj = structType.Field(index)
+			t = nil
+
+		case opMethod:
+			hasMethods, ok := t.(hasMethods) // Interface or Named
+			if !ok {
+				return nil, fmt.Errorf("cannot apply %q to %s (got %s, want interface or named)", code, t, t)
+			}
+			if n := hasMethods.NumMethods(); index >= n {
+				return nil, fmt.Errorf("method index %d out of range [0-%d)", index, n)
+			}
+			obj = hasMethods.Method(index)
+			t = nil
+
+		case opObj:
+			named, ok := t.(*types.Named)
+			if !ok {
+				return nil, fmt.Errorf("cannot apply %q to %s (got %s, want named)", code, t, t)
+			}
+			obj = named.Obj()
+			t = nil
+
+		default:
+			return nil, fmt.Errorf("invalid path: unknown code %q", code)
+		}
+	}
+
+	if obj.Pkg() != pkg {
+		return nil, fmt.Errorf("path denotes %s, which belongs to a different package", obj)
+	}
+
+	return obj, nil // success
+}

--- a/vendor/golang.org/x/tools/internal/analysisinternal/analysis.go
+++ b/vendor/golang.org/x/tools/internal/analysisinternal/analysis.go
@@ -1,0 +1,283 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package analysisinternal exposes internal-only fields from go/analysis.
+package analysisinternal
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+var (
+	GetTypeErrors func(p interface{}) []types.Error
+	SetTypeErrors func(p interface{}, errors []types.Error)
+)
+
+func TypeErrorEndPos(fset *token.FileSet, src []byte, start token.Pos) token.Pos {
+	// Get the end position for the type error.
+	offset, end := fset.PositionFor(start, false).Offset, start
+	if offset >= len(src) {
+		return end
+	}
+	if width := bytes.IndexAny(src[offset:], " \n,():;[]+-*"); width > 0 {
+		end = start + token.Pos(width)
+	}
+	return end
+}
+
+func ZeroValue(fset *token.FileSet, f *ast.File, pkg *types.Package, typ types.Type) ast.Expr {
+	under := typ
+	if n, ok := typ.(*types.Named); ok {
+		under = n.Underlying()
+	}
+	switch u := under.(type) {
+	case *types.Basic:
+		switch {
+		case u.Info()&types.IsNumeric != 0:
+			return &ast.BasicLit{Kind: token.INT, Value: "0"}
+		case u.Info()&types.IsBoolean != 0:
+			return &ast.Ident{Name: "false"}
+		case u.Info()&types.IsString != 0:
+			return &ast.BasicLit{Kind: token.STRING, Value: `""`}
+		default:
+			panic("unknown basic type")
+		}
+	case *types.Chan, *types.Interface, *types.Map, *types.Pointer, *types.Signature, *types.Slice:
+		return ast.NewIdent("nil")
+	case *types.Struct:
+		texpr := TypeExpr(fset, f, pkg, typ) // typ because we want the name here.
+		if texpr == nil {
+			return nil
+		}
+		return &ast.CompositeLit{
+			Type: texpr,
+		}
+	case *types.Array:
+		texpr := TypeExpr(fset, f, pkg, u.Elem())
+		if texpr == nil {
+			return nil
+		}
+		return &ast.CompositeLit{
+			Type: &ast.ArrayType{
+				Elt: texpr,
+				Len: &ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%v", u.Len())},
+			},
+		}
+	}
+	return nil
+}
+
+func TypeExpr(fset *token.FileSet, f *ast.File, pkg *types.Package, typ types.Type) ast.Expr {
+	switch t := typ.(type) {
+	case *types.Basic:
+		switch t.Kind() {
+		case types.UnsafePointer:
+			return &ast.SelectorExpr{X: ast.NewIdent("unsafe"), Sel: ast.NewIdent("Pointer")}
+		default:
+			return ast.NewIdent(t.Name())
+		}
+	case *types.Pointer:
+		x := TypeExpr(fset, f, pkg, t.Elem())
+		if x == nil {
+			return nil
+		}
+		return &ast.UnaryExpr{
+			Op: token.MUL,
+			X:  x,
+		}
+	case *types.Array:
+		elt := TypeExpr(fset, f, pkg, t.Elem())
+		if elt == nil {
+			return nil
+		}
+		return &ast.ArrayType{
+			Len: &ast.BasicLit{
+				Kind:  token.INT,
+				Value: fmt.Sprintf("%d", t.Len()),
+			},
+			Elt: elt,
+		}
+	case *types.Slice:
+		elt := TypeExpr(fset, f, pkg, t.Elem())
+		if elt == nil {
+			return nil
+		}
+		return &ast.ArrayType{
+			Elt: elt,
+		}
+	case *types.Map:
+		key := TypeExpr(fset, f, pkg, t.Key())
+		value := TypeExpr(fset, f, pkg, t.Elem())
+		if key == nil || value == nil {
+			return nil
+		}
+		return &ast.MapType{
+			Key:   key,
+			Value: value,
+		}
+	case *types.Chan:
+		dir := ast.ChanDir(t.Dir())
+		if t.Dir() == types.SendRecv {
+			dir = ast.SEND | ast.RECV
+		}
+		value := TypeExpr(fset, f, pkg, t.Elem())
+		if value == nil {
+			return nil
+		}
+		return &ast.ChanType{
+			Dir:   dir,
+			Value: value,
+		}
+	case *types.Signature:
+		var params []*ast.Field
+		for i := 0; i < t.Params().Len(); i++ {
+			p := TypeExpr(fset, f, pkg, t.Params().At(i).Type())
+			if p == nil {
+				return nil
+			}
+			params = append(params, &ast.Field{
+				Type: p,
+				Names: []*ast.Ident{
+					{
+						Name: t.Params().At(i).Name(),
+					},
+				},
+			})
+		}
+		var returns []*ast.Field
+		for i := 0; i < t.Results().Len(); i++ {
+			r := TypeExpr(fset, f, pkg, t.Results().At(i).Type())
+			if r == nil {
+				return nil
+			}
+			returns = append(returns, &ast.Field{
+				Type: r,
+			})
+		}
+		return &ast.FuncType{
+			Params: &ast.FieldList{
+				List: params,
+			},
+			Results: &ast.FieldList{
+				List: returns,
+			},
+		}
+	case *types.Named:
+		if t.Obj().Pkg() == nil {
+			return ast.NewIdent(t.Obj().Name())
+		}
+		if t.Obj().Pkg() == pkg {
+			return ast.NewIdent(t.Obj().Name())
+		}
+		pkgName := t.Obj().Pkg().Name()
+		// If the file already imports the package under another name, use that.
+		for _, group := range astutil.Imports(fset, f) {
+			for _, cand := range group {
+				if strings.Trim(cand.Path.Value, `"`) == t.Obj().Pkg().Path() {
+					if cand.Name != nil && cand.Name.Name != "" {
+						pkgName = cand.Name.Name
+					}
+				}
+			}
+		}
+		if pkgName == "." {
+			return ast.NewIdent(t.Obj().Name())
+		}
+		return &ast.SelectorExpr{
+			X:   ast.NewIdent(pkgName),
+			Sel: ast.NewIdent(t.Obj().Name()),
+		}
+	default:
+		return nil // TODO: anonymous structs, but who does that
+	}
+}
+
+type TypeErrorPass string
+
+const (
+	NoNewVars      TypeErrorPass = "nonewvars"
+	NoResultValues TypeErrorPass = "noresultvalues"
+	UndeclaredName TypeErrorPass = "undeclaredname"
+)
+
+// StmtToInsertVarBefore returns the ast.Stmt before which we can safely insert a new variable.
+// Some examples:
+//
+// Basic Example:
+// z := 1
+// y := z + x
+// If x is undeclared, then this function would return `y := z + x`, so that we
+// can insert `x := ` on the line before `y := z + x`.
+//
+// If stmt example:
+// if z == 1 {
+// } else if z == y {}
+// If y is undeclared, then this function would return `if z == 1 {`, because we cannot
+// insert a statement between an if and an else if statement. As a result, we need to find
+// the top of the if chain to insert `y := ` before.
+func StmtToInsertVarBefore(path []ast.Node) ast.Stmt {
+	enclosingIndex := -1
+	for i, p := range path {
+		if _, ok := p.(ast.Stmt); ok {
+			enclosingIndex = i
+			break
+		}
+	}
+	if enclosingIndex == -1 {
+		return nil
+	}
+	enclosingStmt := path[enclosingIndex]
+	switch enclosingStmt.(type) {
+	case *ast.IfStmt:
+		// The enclosingStmt is inside of the if declaration,
+		// We need to check if we are in an else-if stmt and
+		// get the base if statement.
+		return baseIfStmt(path, enclosingIndex)
+	case *ast.CaseClause:
+		// Get the enclosing switch stmt if the enclosingStmt is
+		// inside of the case statement.
+		for i := enclosingIndex + 1; i < len(path); i++ {
+			if node, ok := path[i].(*ast.SwitchStmt); ok {
+				return node
+			} else if node, ok := path[i].(*ast.TypeSwitchStmt); ok {
+				return node
+			}
+		}
+	}
+	if len(path) <= enclosingIndex+1 {
+		return enclosingStmt.(ast.Stmt)
+	}
+	// Check if the enclosing statement is inside another node.
+	switch expr := path[enclosingIndex+1].(type) {
+	case *ast.IfStmt:
+		// Get the base if statement.
+		return baseIfStmt(path, enclosingIndex+1)
+	case *ast.ForStmt:
+		if expr.Init == enclosingStmt || expr.Post == enclosingStmt {
+			return expr
+		}
+	}
+	return enclosingStmt.(ast.Stmt)
+}
+
+// baseIfStmt walks up the if/else-if chain until we get to
+// the top of the current if chain.
+func baseIfStmt(path []ast.Node, index int) ast.Stmt {
+	stmt := path[index]
+	for i := index + 1; i < len(path); i++ {
+		if node, ok := path[i].(*ast.IfStmt); ok && node.Else == stmt {
+			stmt = node
+			continue
+		}
+		break
+	}
+	return stmt.(ast.Stmt)
+}

--- a/vendor/golang.org/x/tools/internal/packagesinternal/packages.go
+++ b/vendor/golang.org/x/tools/internal/packagesinternal/packages.go
@@ -1,0 +1,14 @@
+// Package packagesinternal exposes internal-only fields from go/packages.
+package packagesinternal
+
+import (
+	"golang.org/x/tools/internal/gocommand"
+)
+
+var GetForTest = func(p interface{}) string { return "" }
+
+var GetGoCmdRunner = func(config interface{}) *gocommand.Runner { return nil }
+
+var SetGoCmdRunner = func(config interface{}, runner *gocommand.Runner) {}
+
+var TypecheckCgo int

--- a/vendor/golang.org/x/tools/internal/span/parse.go
+++ b/vendor/golang.org/x/tools/internal/span/parse.go
@@ -1,0 +1,100 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package span
+
+import (
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// Parse returns the location represented by the input.
+// Only file paths are accepted, not URIs.
+// The returned span will be normalized, and thus if printed may produce a
+// different string.
+func Parse(input string) Span {
+	// :0:0#0-0:0#0
+	valid := input
+	var hold, offset int
+	hadCol := false
+	suf := rstripSuffix(input)
+	if suf.sep == "#" {
+		offset = suf.num
+		suf = rstripSuffix(suf.remains)
+	}
+	if suf.sep == ":" {
+		valid = suf.remains
+		hold = suf.num
+		hadCol = true
+		suf = rstripSuffix(suf.remains)
+	}
+	switch {
+	case suf.sep == ":":
+		return New(URIFromPath(suf.remains), NewPoint(suf.num, hold, offset), Point{})
+	case suf.sep == "-":
+		// we have a span, fall out of the case to continue
+	default:
+		// separator not valid, rewind to either the : or the start
+		return New(URIFromPath(valid), NewPoint(hold, 0, offset), Point{})
+	}
+	// only the span form can get here
+	// at this point we still don't know what the numbers we have mean
+	// if have not yet seen a : then we might have either a line or a column depending
+	// on whether start has a column or not
+	// we build an end point and will fix it later if needed
+	end := NewPoint(suf.num, hold, offset)
+	hold, offset = 0, 0
+	suf = rstripSuffix(suf.remains)
+	if suf.sep == "#" {
+		offset = suf.num
+		suf = rstripSuffix(suf.remains)
+	}
+	if suf.sep != ":" {
+		// turns out we don't have a span after all, rewind
+		return New(URIFromPath(valid), end, Point{})
+	}
+	valid = suf.remains
+	hold = suf.num
+	suf = rstripSuffix(suf.remains)
+	if suf.sep != ":" {
+		// line#offset only
+		return New(URIFromPath(valid), NewPoint(hold, 0, offset), end)
+	}
+	// we have a column, so if end only had one number, it is also the column
+	if !hadCol {
+		end = NewPoint(suf.num, end.v.Line, end.v.Offset)
+	}
+	return New(URIFromPath(suf.remains), NewPoint(suf.num, hold, offset), end)
+}
+
+type suffix struct {
+	remains string
+	sep     string
+	num     int
+}
+
+func rstripSuffix(input string) suffix {
+	if len(input) == 0 {
+		return suffix{"", "", -1}
+	}
+	remains := input
+	num := -1
+	// first see if we have a number at the end
+	last := strings.LastIndexFunc(remains, func(r rune) bool { return r < '0' || r > '9' })
+	if last >= 0 && last < len(remains)-1 {
+		number, err := strconv.ParseInt(remains[last+1:], 10, 64)
+		if err == nil {
+			num = int(number)
+			remains = remains[:last+1]
+		}
+	}
+	// now see if we have a trailing separator
+	r, w := utf8.DecodeLastRuneInString(remains)
+	if r != ':' && r != '#' && r == '#' {
+		return suffix{input, "", -1}
+	}
+	remains = remains[:len(remains)-w]
+	return suffix{remains, string(r), num}
+}

--- a/vendor/golang.org/x/tools/internal/span/span.go
+++ b/vendor/golang.org/x/tools/internal/span/span.go
@@ -1,0 +1,285 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package span contains support for representing with positions and ranges in
+// text files.
+package span
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+)
+
+// Span represents a source code range in standardized form.
+type Span struct {
+	v span
+}
+
+// Point represents a single point within a file.
+// In general this should only be used as part of a Span, as on its own it
+// does not carry enough information.
+type Point struct {
+	v point
+}
+
+type span struct {
+	URI   URI   `json:"uri"`
+	Start point `json:"start"`
+	End   point `json:"end"`
+}
+
+type point struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+	Offset int `json:"offset"`
+}
+
+// Invalid is a span that reports false from IsValid
+var Invalid = Span{v: span{Start: invalidPoint.v, End: invalidPoint.v}}
+
+var invalidPoint = Point{v: point{Line: 0, Column: 0, Offset: -1}}
+
+// Converter is the interface to an object that can convert between line:column
+// and offset forms for a single file.
+type Converter interface {
+	//ToPosition converts from an offset to a line:column pair.
+	ToPosition(offset int) (int, int, error)
+	//ToOffset converts from a line:column pair to an offset.
+	ToOffset(line, col int) (int, error)
+}
+
+func New(uri URI, start Point, end Point) Span {
+	s := Span{v: span{URI: uri, Start: start.v, End: end.v}}
+	s.v.clean()
+	return s
+}
+
+func NewPoint(line, col, offset int) Point {
+	p := Point{v: point{Line: line, Column: col, Offset: offset}}
+	p.v.clean()
+	return p
+}
+
+func Compare(a, b Span) int {
+	if r := CompareURI(a.URI(), b.URI()); r != 0 {
+		return r
+	}
+	if r := comparePoint(a.v.Start, b.v.Start); r != 0 {
+		return r
+	}
+	return comparePoint(a.v.End, b.v.End)
+}
+
+func ComparePoint(a, b Point) int {
+	return comparePoint(a.v, b.v)
+}
+
+func comparePoint(a, b point) int {
+	if !a.hasPosition() {
+		if a.Offset < b.Offset {
+			return -1
+		}
+		if a.Offset > b.Offset {
+			return 1
+		}
+		return 0
+	}
+	if a.Line < b.Line {
+		return -1
+	}
+	if a.Line > b.Line {
+		return 1
+	}
+	if a.Column < b.Column {
+		return -1
+	}
+	if a.Column > b.Column {
+		return 1
+	}
+	return 0
+}
+
+func (s Span) HasPosition() bool             { return s.v.Start.hasPosition() }
+func (s Span) HasOffset() bool               { return s.v.Start.hasOffset() }
+func (s Span) IsValid() bool                 { return s.v.Start.isValid() }
+func (s Span) IsPoint() bool                 { return s.v.Start == s.v.End }
+func (s Span) URI() URI                      { return s.v.URI }
+func (s Span) Start() Point                  { return Point{s.v.Start} }
+func (s Span) End() Point                    { return Point{s.v.End} }
+func (s *Span) MarshalJSON() ([]byte, error) { return json.Marshal(&s.v) }
+func (s *Span) UnmarshalJSON(b []byte) error { return json.Unmarshal(b, &s.v) }
+
+func (p Point) HasPosition() bool             { return p.v.hasPosition() }
+func (p Point) HasOffset() bool               { return p.v.hasOffset() }
+func (p Point) IsValid() bool                 { return p.v.isValid() }
+func (p *Point) MarshalJSON() ([]byte, error) { return json.Marshal(&p.v) }
+func (p *Point) UnmarshalJSON(b []byte) error { return json.Unmarshal(b, &p.v) }
+func (p Point) Line() int {
+	if !p.v.hasPosition() {
+		panic(fmt.Errorf("position not set in %v", p.v))
+	}
+	return p.v.Line
+}
+func (p Point) Column() int {
+	if !p.v.hasPosition() {
+		panic(fmt.Errorf("position not set in %v", p.v))
+	}
+	return p.v.Column
+}
+func (p Point) Offset() int {
+	if !p.v.hasOffset() {
+		panic(fmt.Errorf("offset not set in %v", p.v))
+	}
+	return p.v.Offset
+}
+
+func (p point) hasPosition() bool { return p.Line > 0 }
+func (p point) hasOffset() bool   { return p.Offset >= 0 }
+func (p point) isValid() bool     { return p.hasPosition() || p.hasOffset() }
+func (p point) isZero() bool {
+	return (p.Line == 1 && p.Column == 1) || (!p.hasPosition() && p.Offset == 0)
+}
+
+func (s *span) clean() {
+	//this presumes the points are already clean
+	if !s.End.isValid() || (s.End == point{}) {
+		s.End = s.Start
+	}
+}
+
+func (p *point) clean() {
+	if p.Line < 0 {
+		p.Line = 0
+	}
+	if p.Column <= 0 {
+		if p.Line > 0 {
+			p.Column = 1
+		} else {
+			p.Column = 0
+		}
+	}
+	if p.Offset == 0 && (p.Line > 1 || p.Column > 1) {
+		p.Offset = -1
+	}
+}
+
+// Format implements fmt.Formatter to print the Location in a standard form.
+// The format produced is one that can be read back in using Parse.
+func (s Span) Format(f fmt.State, c rune) {
+	fullForm := f.Flag('+')
+	preferOffset := f.Flag('#')
+	// we should always have a uri, simplify if it is file format
+	//TODO: make sure the end of the uri is unambiguous
+	uri := string(s.v.URI)
+	if c == 'f' {
+		uri = path.Base(uri)
+	} else if !fullForm {
+		uri = s.v.URI.Filename()
+	}
+	fmt.Fprint(f, uri)
+	if !s.IsValid() || (!fullForm && s.v.Start.isZero() && s.v.End.isZero()) {
+		return
+	}
+	// see which bits of start to write
+	printOffset := s.HasOffset() && (fullForm || preferOffset || !s.HasPosition())
+	printLine := s.HasPosition() && (fullForm || !printOffset)
+	printColumn := printLine && (fullForm || (s.v.Start.Column > 1 || s.v.End.Column > 1))
+	fmt.Fprint(f, ":")
+	if printLine {
+		fmt.Fprintf(f, "%d", s.v.Start.Line)
+	}
+	if printColumn {
+		fmt.Fprintf(f, ":%d", s.v.Start.Column)
+	}
+	if printOffset {
+		fmt.Fprintf(f, "#%d", s.v.Start.Offset)
+	}
+	// start is written, do we need end?
+	if s.IsPoint() {
+		return
+	}
+	// we don't print the line if it did not change
+	printLine = fullForm || (printLine && s.v.End.Line > s.v.Start.Line)
+	fmt.Fprint(f, "-")
+	if printLine {
+		fmt.Fprintf(f, "%d", s.v.End.Line)
+	}
+	if printColumn {
+		if printLine {
+			fmt.Fprint(f, ":")
+		}
+		fmt.Fprintf(f, "%d", s.v.End.Column)
+	}
+	if printOffset {
+		fmt.Fprintf(f, "#%d", s.v.End.Offset)
+	}
+}
+
+func (s Span) WithPosition(c Converter) (Span, error) {
+	if err := s.update(c, true, false); err != nil {
+		return Span{}, err
+	}
+	return s, nil
+}
+
+func (s Span) WithOffset(c Converter) (Span, error) {
+	if err := s.update(c, false, true); err != nil {
+		return Span{}, err
+	}
+	return s, nil
+}
+
+func (s Span) WithAll(c Converter) (Span, error) {
+	if err := s.update(c, true, true); err != nil {
+		return Span{}, err
+	}
+	return s, nil
+}
+
+func (s *Span) update(c Converter, withPos, withOffset bool) error {
+	if !s.IsValid() {
+		return fmt.Errorf("cannot add information to an invalid span")
+	}
+	if withPos && !s.HasPosition() {
+		if err := s.v.Start.updatePosition(c); err != nil {
+			return err
+		}
+		if s.v.End.Offset == s.v.Start.Offset {
+			s.v.End = s.v.Start
+		} else if err := s.v.End.updatePosition(c); err != nil {
+			return err
+		}
+	}
+	if withOffset && (!s.HasOffset() || (s.v.End.hasPosition() && !s.v.End.hasOffset())) {
+		if err := s.v.Start.updateOffset(c); err != nil {
+			return err
+		}
+		if s.v.End.Line == s.v.Start.Line && s.v.End.Column == s.v.Start.Column {
+			s.v.End.Offset = s.v.Start.Offset
+		} else if err := s.v.End.updateOffset(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *point) updatePosition(c Converter) error {
+	line, col, err := c.ToPosition(p.Offset)
+	if err != nil {
+		return err
+	}
+	p.Line = line
+	p.Column = col
+	return nil
+}
+
+func (p *point) updateOffset(c Converter) error {
+	offset, err := c.ToOffset(p.Line, p.Column)
+	if err != nil {
+		return err
+	}
+	p.Offset = offset
+	return nil
+}

--- a/vendor/golang.org/x/tools/internal/span/token.go
+++ b/vendor/golang.org/x/tools/internal/span/token.go
@@ -1,0 +1,182 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package span
+
+import (
+	"fmt"
+	"go/token"
+)
+
+// Range represents a source code range in token.Pos form.
+// It also carries the FileSet that produced the positions, so that it is
+// self contained.
+type Range struct {
+	FileSet   *token.FileSet
+	Start     token.Pos
+	End       token.Pos
+	Converter Converter
+}
+
+// TokenConverter is a Converter backed by a token file set and file.
+// It uses the file set methods to work out the conversions, which
+// makes it fast and does not require the file contents.
+type TokenConverter struct {
+	fset *token.FileSet
+	file *token.File
+}
+
+// NewRange creates a new Range from a FileSet and two positions.
+// To represent a point pass a 0 as the end pos.
+func NewRange(fset *token.FileSet, start, end token.Pos) Range {
+	return Range{
+		FileSet: fset,
+		Start:   start,
+		End:     end,
+	}
+}
+
+// NewTokenConverter returns an implementation of Converter backed by a
+// token.File.
+func NewTokenConverter(fset *token.FileSet, f *token.File) *TokenConverter {
+	return &TokenConverter{fset: fset, file: f}
+}
+
+// NewContentConverter returns an implementation of Converter for the
+// given file content.
+func NewContentConverter(filename string, content []byte) *TokenConverter {
+	fset := token.NewFileSet()
+	f := fset.AddFile(filename, -1, len(content))
+	f.SetLinesForContent(content)
+	return &TokenConverter{fset: fset, file: f}
+}
+
+// IsPoint returns true if the range represents a single point.
+func (r Range) IsPoint() bool {
+	return r.Start == r.End
+}
+
+// Span converts a Range to a Span that represents the Range.
+// It will fill in all the members of the Span, calculating the line and column
+// information.
+func (r Range) Span() (Span, error) {
+	if !r.Start.IsValid() {
+		return Span{}, fmt.Errorf("start pos is not valid")
+	}
+	f := r.FileSet.File(r.Start)
+	if f == nil {
+		return Span{}, fmt.Errorf("file not found in FileSet")
+	}
+	var s Span
+	var err error
+	var startFilename string
+	startFilename, s.v.Start.Line, s.v.Start.Column, err = position(f, r.Start)
+	if err != nil {
+		return Span{}, err
+	}
+	s.v.URI = URIFromPath(startFilename)
+	if r.End.IsValid() {
+		var endFilename string
+		endFilename, s.v.End.Line, s.v.End.Column, err = position(f, r.End)
+		if err != nil {
+			return Span{}, err
+		}
+		// In the presence of line directives, a single File can have sections from
+		// multiple file names.
+		if endFilename != startFilename {
+			return Span{}, fmt.Errorf("span begins in file %q but ends in %q", startFilename, endFilename)
+		}
+	}
+	s.v.Start.clean()
+	s.v.End.clean()
+	s.v.clean()
+	if r.Converter != nil {
+		return s.WithOffset(r.Converter)
+	}
+	if startFilename != f.Name() {
+		return Span{}, fmt.Errorf("must supply Converter for file %q containing lines from %q", f.Name(), startFilename)
+	}
+	return s.WithOffset(NewTokenConverter(r.FileSet, f))
+}
+
+func position(f *token.File, pos token.Pos) (string, int, int, error) {
+	off, err := offset(f, pos)
+	if err != nil {
+		return "", 0, 0, err
+	}
+	return positionFromOffset(f, off)
+}
+
+func positionFromOffset(f *token.File, offset int) (string, int, int, error) {
+	if offset > f.Size() {
+		return "", 0, 0, fmt.Errorf("offset %v is past the end of the file %v", offset, f.Size())
+	}
+	pos := f.Pos(offset)
+	p := f.Position(pos)
+	if offset == f.Size() {
+		return p.Filename, p.Line + 1, 1, nil
+	}
+	return p.Filename, p.Line, p.Column, nil
+}
+
+// offset is a copy of the Offset function in go/token, but with the adjustment
+// that it does not panic on invalid positions.
+func offset(f *token.File, pos token.Pos) (int, error) {
+	if int(pos) < f.Base() || int(pos) > f.Base()+f.Size() {
+		return 0, fmt.Errorf("invalid pos")
+	}
+	return int(pos) - f.Base(), nil
+}
+
+// Range converts a Span to a Range that represents the Span for the supplied
+// File.
+func (s Span) Range(converter *TokenConverter) (Range, error) {
+	s, err := s.WithOffset(converter)
+	if err != nil {
+		return Range{}, err
+	}
+	// go/token will panic if the offset is larger than the file's size,
+	// so check here to avoid panicking.
+	if s.Start().Offset() > converter.file.Size() {
+		return Range{}, fmt.Errorf("start offset %v is past the end of the file %v", s.Start(), converter.file.Size())
+	}
+	if s.End().Offset() > converter.file.Size() {
+		return Range{}, fmt.Errorf("end offset %v is past the end of the file %v", s.End(), converter.file.Size())
+	}
+	return Range{
+		FileSet:   converter.fset,
+		Start:     converter.file.Pos(s.Start().Offset()),
+		End:       converter.file.Pos(s.End().Offset()),
+		Converter: converter,
+	}, nil
+}
+
+func (l *TokenConverter) ToPosition(offset int) (int, int, error) {
+	_, line, col, err := positionFromOffset(l.file, offset)
+	return line, col, err
+}
+
+func (l *TokenConverter) ToOffset(line, col int) (int, error) {
+	if line < 0 {
+		return -1, fmt.Errorf("line is not valid")
+	}
+	lineMax := l.file.LineCount() + 1
+	if line > lineMax {
+		return -1, fmt.Errorf("line is beyond end of file %v", lineMax)
+	} else if line == lineMax {
+		if col > 1 {
+			return -1, fmt.Errorf("column is beyond end of file")
+		}
+		// at the end of the file, allowing for a trailing eol
+		return l.file.Size(), nil
+	}
+	pos := lineStart(l.file, line)
+	if !pos.IsValid() {
+		return -1, fmt.Errorf("line is not in file")
+	}
+	// we assume that column is in bytes here, and that the first byte of a
+	// line is at column 1
+	pos += token.Pos(col - 1)
+	return offset(l.file, pos)
+}

--- a/vendor/golang.org/x/tools/internal/span/token111.go
+++ b/vendor/golang.org/x/tools/internal/span/token111.go
@@ -1,0 +1,39 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.12
+
+package span
+
+import (
+	"go/token"
+)
+
+// lineStart is the pre-Go 1.12 version of (*token.File).LineStart. For Go
+// versions <= 1.11, we borrow logic from the analysisutil package.
+// TODO(rstambler): Delete this file when we no longer support Go 1.11.
+func lineStart(f *token.File, line int) token.Pos {
+	// Use binary search to find the start offset of this line.
+
+	min := 0        // inclusive
+	max := f.Size() // exclusive
+	for {
+		offset := (min + max) / 2
+		pos := f.Pos(offset)
+		posn := f.Position(pos)
+		if posn.Line == line {
+			return pos - (token.Pos(posn.Column) - 1)
+		}
+
+		if min+1 >= max {
+			return token.NoPos
+		}
+
+		if posn.Line < line {
+			min = offset
+		} else {
+			max = offset
+		}
+	}
+}

--- a/vendor/golang.org/x/tools/internal/span/token112.go
+++ b/vendor/golang.org/x/tools/internal/span/token112.go
@@ -1,0 +1,16 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.12
+
+package span
+
+import (
+	"go/token"
+)
+
+// TODO(rstambler): Delete this file when we no longer support Go 1.11.
+func lineStart(f *token.File, line int) token.Pos {
+	return f.LineStart(line)
+}

--- a/vendor/golang.org/x/tools/internal/span/uri.go
+++ b/vendor/golang.org/x/tools/internal/span/uri.go
@@ -1,0 +1,169 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package span
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"unicode"
+)
+
+const fileScheme = "file"
+
+// URI represents the full URI for a file.
+type URI string
+
+func (uri URI) IsFile() bool {
+	return strings.HasPrefix(string(uri), "file://")
+}
+
+// Filename returns the file path for the given URI.
+// It is an error to call this on a URI that is not a valid filename.
+func (uri URI) Filename() string {
+	filename, err := filename(uri)
+	if err != nil {
+		panic(err)
+	}
+	return filepath.FromSlash(filename)
+}
+
+func filename(uri URI) (string, error) {
+	if uri == "" {
+		return "", nil
+	}
+	u, err := url.ParseRequestURI(string(uri))
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != fileScheme {
+		return "", fmt.Errorf("only file URIs are supported, got %q from %q", u.Scheme, uri)
+	}
+	// If the URI is a Windows URI, we trim the leading "/" and lowercase
+	// the drive letter, which will never be case sensitive.
+	if isWindowsDriveURIPath(u.Path) {
+		u.Path = strings.ToUpper(string(u.Path[1])) + u.Path[2:]
+	}
+	return u.Path, nil
+}
+
+func URIFromURI(s string) URI {
+	if !strings.HasPrefix(s, "file://") {
+		return URI(s)
+	}
+
+	if !strings.HasPrefix(s, "file:///") {
+		// VS Code sends URLs with only two slashes, which are invalid. golang/go#39789.
+		s = "file:///" + s[len("file://"):]
+	}
+	// Even though the input is a URI, it may not be in canonical form. VS Code
+	// in particular over-escapes :, @, etc. Unescape and re-encode to canonicalize.
+	path, err := url.PathUnescape(s[len("file://"):])
+	if err != nil {
+		panic(err)
+	}
+
+	// File URIs from Windows may have lowercase drive letters.
+	// Since drive letters are guaranteed to be case insensitive,
+	// we change them to uppercase to remain consistent.
+	// For example, file:///c:/x/y/z becomes file:///C:/x/y/z.
+	if isWindowsDriveURIPath(path) {
+		path = path[:1] + strings.ToUpper(string(path[1])) + path[2:]
+	}
+	u := url.URL{Scheme: fileScheme, Path: path}
+	return URI(u.String())
+}
+
+func CompareURI(a, b URI) int {
+	if equalURI(a, b) {
+		return 0
+	}
+	if a < b {
+		return -1
+	}
+	return 1
+}
+
+func equalURI(a, b URI) bool {
+	if a == b {
+		return true
+	}
+	// If we have the same URI basename, we may still have the same file URIs.
+	if !strings.EqualFold(path.Base(string(a)), path.Base(string(b))) {
+		return false
+	}
+	fa, err := filename(a)
+	if err != nil {
+		return false
+	}
+	fb, err := filename(b)
+	if err != nil {
+		return false
+	}
+	// Stat the files to check if they are equal.
+	infoa, err := os.Stat(filepath.FromSlash(fa))
+	if err != nil {
+		return false
+	}
+	infob, err := os.Stat(filepath.FromSlash(fb))
+	if err != nil {
+		return false
+	}
+	return os.SameFile(infoa, infob)
+}
+
+// URIFromPath returns a span URI for the supplied file path.
+// It will always have the file scheme.
+func URIFromPath(path string) URI {
+	if path == "" {
+		return ""
+	}
+	// Handle standard library paths that contain the literal "$GOROOT".
+	// TODO(rstambler): The go/packages API should allow one to determine a user's $GOROOT.
+	const prefix = "$GOROOT"
+	if len(path) >= len(prefix) && strings.EqualFold(prefix, path[:len(prefix)]) {
+		suffix := path[len(prefix):]
+		path = runtime.GOROOT() + suffix
+	}
+	if !isWindowsDrivePath(path) {
+		if abs, err := filepath.Abs(path); err == nil {
+			path = abs
+		}
+	}
+	// Check the file path again, in case it became absolute.
+	if isWindowsDrivePath(path) {
+		path = "/" + strings.ToUpper(string(path[0])) + path[1:]
+	}
+	path = filepath.ToSlash(path)
+	u := url.URL{
+		Scheme: fileScheme,
+		Path:   path,
+	}
+	return URI(u.String())
+}
+
+// isWindowsDrivePath returns true if the file path is of the form used by
+// Windows. We check if the path begins with a drive letter, followed by a ":".
+// For example: C:/x/y/z.
+func isWindowsDrivePath(path string) bool {
+	if len(path) < 3 {
+		return false
+	}
+	return unicode.IsLetter(rune(path[0])) && path[1] == ':'
+}
+
+// isWindowsDriveURI returns true if the file URI is of the format used by
+// Windows URIs. The url.Parse package does not specially handle Windows paths
+// (see golang/go#6027). We check if the URI path has a drive prefix (e.g. "/C:").
+func isWindowsDriveURIPath(uri string) bool {
+	if len(uri) < 4 {
+		return false
+	}
+	return uri[0] == '/' && unicode.IsLetter(rune(uri[1])) && uri[2] == ':'
+}

--- a/vendor/golang.org/x/tools/internal/span/utf16.go
+++ b/vendor/golang.org/x/tools/internal/span/utf16.go
@@ -1,0 +1,94 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package span
+
+import (
+	"fmt"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// ToUTF16Column calculates the utf16 column expressed by the point given the
+// supplied file contents.
+// This is used to convert from the native (always in bytes) column
+// representation and the utf16 counts used by some editors.
+func ToUTF16Column(p Point, content []byte) (int, error) {
+	if content == nil {
+		return -1, fmt.Errorf("ToUTF16Column: missing content")
+	}
+	if !p.HasPosition() {
+		return -1, fmt.Errorf("ToUTF16Column: point is missing position")
+	}
+	if !p.HasOffset() {
+		return -1, fmt.Errorf("ToUTF16Column: point is missing offset")
+	}
+	offset := p.Offset()      // 0-based
+	colZero := p.Column() - 1 // 0-based
+	if colZero == 0 {
+		// 0-based column 0, so it must be chr 1
+		return 1, nil
+	} else if colZero < 0 {
+		return -1, fmt.Errorf("ToUTF16Column: column is invalid (%v)", colZero)
+	}
+	// work out the offset at the start of the line using the column
+	lineOffset := offset - colZero
+	if lineOffset < 0 || offset > len(content) {
+		return -1, fmt.Errorf("ToUTF16Column: offsets %v-%v outside file contents (%v)", lineOffset, offset, len(content))
+	}
+	// Use the offset to pick out the line start.
+	// This cannot panic: offset > len(content) and lineOffset < offset.
+	start := content[lineOffset:]
+
+	// Now, truncate down to the supplied column.
+	start = start[:colZero]
+
+	// and count the number of utf16 characters
+	// in theory we could do this by hand more efficiently...
+	return len(utf16.Encode([]rune(string(start)))) + 1, nil
+}
+
+// FromUTF16Column advances the point by the utf16 character offset given the
+// supplied line contents.
+// This is used to convert from the utf16 counts used by some editors to the
+// native (always in bytes) column representation.
+func FromUTF16Column(p Point, chr int, content []byte) (Point, error) {
+	if !p.HasOffset() {
+		return Point{}, fmt.Errorf("FromUTF16Column: point is missing offset")
+	}
+	// if chr is 1 then no adjustment needed
+	if chr <= 1 {
+		return p, nil
+	}
+	if p.Offset() >= len(content) {
+		return p, fmt.Errorf("FromUTF16Column: offset (%v) greater than length of content (%v)", p.Offset(), len(content))
+	}
+	remains := content[p.Offset():]
+	// scan forward the specified number of characters
+	for count := 1; count < chr; count++ {
+		if len(remains) <= 0 {
+			return Point{}, fmt.Errorf("FromUTF16Column: chr goes beyond the content")
+		}
+		r, w := utf8.DecodeRune(remains)
+		if r == '\n' {
+			// Per the LSP spec:
+			//
+			// > If the character value is greater than the line length it
+			// > defaults back to the line length.
+			break
+		}
+		remains = remains[w:]
+		if r >= 0x10000 {
+			// a two point rune
+			count++
+			// if we finished in a two point rune, do not advance past the first
+			if count >= chr {
+				break
+			}
+		}
+		p.v.Column += w
+		p.v.Offset += w
+	}
+	return p, nil
+}

--- a/vendor/golang.org/x/tools/internal/typesinternal/types.go
+++ b/vendor/golang.org/x/tools/internal/typesinternal/types.go
@@ -1,0 +1,28 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package typesinternal
+
+import (
+	"go/types"
+	"reflect"
+	"unsafe"
+)
+
+func SetUsesCgo(conf *types.Config) bool {
+	v := reflect.ValueOf(conf).Elem()
+
+	f := v.FieldByName("go115UsesCgo")
+	if !f.IsValid() {
+		f = v.FieldByName("UsesCgo")
+		if !f.IsValid() {
+			return false
+		}
+	}
+
+	addr := unsafe.Pointer(f.UnsafeAddr())
+	*(*bool)(addr) = true
+
+	return true
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,7 @@
 # cloud.google.com/go v0.56.0
 cloud.google.com/go/compute/metadata
+# dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363
+dmitri.shuralyov.com/go/generated
 # github.com/Azure/azure-sdk-for-go v44.2.0+incompatible
 ## explicit
 github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute
@@ -146,6 +148,10 @@ github.com/edsrzf/mmap-go
 github.com/evanphx/json-patch
 # github.com/fatih/color v1.9.0
 github.com/fatih/color
+# github.com/fatih/faillint v1.5.0
+## explicit
+github.com/fatih/faillint
+github.com/fatih/faillint/faillint
 # github.com/ghodss/yaml v1.0.0
 github.com/ghodss/yaml
 # github.com/go-kit/kit v0.10.0
@@ -528,9 +534,19 @@ golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20200725200936-102e7d357031
 ## explicit
 golang.org/x/tools/cmd/goimports
+golang.org/x/tools/go/analysis
+golang.org/x/tools/go/analysis/internal/analysisflags
+golang.org/x/tools/go/analysis/internal/checker
+golang.org/x/tools/go/analysis/internal/facts
+golang.org/x/tools/go/analysis/singlechecker
+golang.org/x/tools/go/analysis/unitchecker
 golang.org/x/tools/go/ast/astutil
 golang.org/x/tools/go/gcexportdata
 golang.org/x/tools/go/internal/gcimporter
+golang.org/x/tools/go/internal/packagesdriver
+golang.org/x/tools/go/packages
+golang.org/x/tools/go/types/objectpath
+golang.org/x/tools/internal/analysisinternal
 golang.org/x/tools/internal/event
 golang.org/x/tools/internal/event/core
 golang.org/x/tools/internal/event/keys
@@ -539,6 +555,9 @@ golang.org/x/tools/internal/fastwalk
 golang.org/x/tools/internal/gocommand
 golang.org/x/tools/internal/gopathwalk
 golang.org/x/tools/internal/imports
+golang.org/x/tools/internal/packagesinternal
+golang.org/x/tools/internal/span
+golang.org/x/tools/internal/typesinternal
 # golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 golang.org/x/xerrors
 golang.org/x/xerrors/internal


### PR DESCRIPTION
This PR introduces the usage of `faillint` to ensure that no restricted imports are being used, this should be the last bit for https://github.com/prometheus/prometheus/issues/7647

I had to add `faillint` as a dependency for the project even though is only used for the dev toolchain and for Prometheus itself. 