### PR TITLE
promql/parser: add testcases for lex.

### DIFF
--- a/promql/parser/lex_test.go
+++ b/promql/parser/lex_test.go
@@ -180,6 +180,18 @@ var tests = []struct {
 			}, {
 				input:    "1y",
 				expected: []Item{{DURATION, 0, "1y"}},
+			}, {
+				input:    "1h6ms",
+				expected: []Item{{DURATION, 0, "1h6ms"}},
+			}, {
+				input:    "10m5s",
+				expected: []Item{{DURATION, 0, "10m5s"}},
+			}, {
+				input:    "10m5h",
+				expected: []Item{{DURATION, 0, "10m5h"}},
+			}, {
+				input: "1h6",
+				fail:  true,
 			},
 		},
 	},


### PR DESCRIPTION
Add some test cases for new human-friendly durations(#7713)  in lex level parse.