### PR TITLE
storage/remote: fix concurrent access bug for pool.

### DIFF
--- a/storage/remote/intern.go
+++ b/storage/remote/intern.go
@@ -61,13 +61,6 @@ func (p *pool) intern(s string) string {
 		return ""
 	}
 
-	p.mtx.RLock()
-	interned, ok := p.pool[s]
-	p.mtx.RUnlock()
-	if ok {
-		interned.refs.Inc()
-		return interned.s
-	}
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	if interned, ok := p.pool[s]; ok {


### PR DESCRIPTION
There is a bug about concurrent access.

## Bug detail

The race path of `TestIntern_MultiRef_Concurrent`
```go
	go interner.release(testString)

	interner.intern(testString)
```

Steps to reappear:
```go
// step 1
func (p *pool) intern(s string) string {
	if s == "" {
		return ""
	}

	p.mtx.RLock()
	interned, ok := p.pool[s]
	p.mtx.RUnlock()

// step 2
func (p *pool) release(s string) {
	p.mtx.RLock()
	interned, ok := p.pool[s]
	p.mtx.RUnlock()

	if !ok {
		noReferenceReleases.Inc()
		return
	}

// step3 in `intern`
	if ok {
                 // step 5: not running  until `release` finished.  <-- step 5 is here.
		interned.refs.Inc()
		return interned.s
	}

// step 4 in `release`
if !ok {
		noReferenceReleases.Inc()
		return
	}

	refs := interned.refs.Dec()
	if refs > 0 {
		return
	}

	p.mtx.Lock()
	defer p.mtx.Unlock()
	if interned.refs.Load() != 0 {
		return
	}
	delete(p.pool, s)
```

Then `TestIntern_MultiRef_Concurrent` failed at 
https://github.com/prometheus/prometheus/blob/b58a61344334651f0000f9d467e76066a9ea998f/storage/remote/intern_test.go#L85

## Tests

It's hard to reproduce this.  When I look at the ci result of pr #7745, I find the error https://app.circleci.com/pipelines/github/prometheus/prometheus/8443/workflows/7cf94e94-4776-4762-aabf-4e4c3d2712f3/jobs/36890.

It's not easy to write a test case if not modify `pool` implementation. So I send this pr without updating the  test case. 
Some tool may be useful like 
https://github.com/etcd-io/gofail
https://github.com/pingcap/failpoint

Inject a fail point to trigger a delay operation.