### PR TITLE
storage/remote: split httpclient name.

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -104,7 +104,7 @@ type ReadClient interface {
 
 // newReadClient creates a new client for remote read.
 func newReadClient(name string, conf *ClientConfig) (ReadClient, error) {
-	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage", false)
+	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client", false)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func newReadClient(name string, conf *ClientConfig) (ReadClient, error) {
 
 // NewWriteClient creates a new client for remote write.
 func NewWriteClient(name string, conf *ClientConfig) (WriteClient, error) {
-	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage", false)
+	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_write_client", false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Split the origin name `remote_storage ` to two parts.

## Modification 

The `remote_storage_read_client` for remote read http client and the `remote_storage_write_client ` for remote write http client.

## Benefit

Two split names are better tracking for metrics `net_contrack_dialer_conn_attempted_total`.
https://github.com/prometheus/prometheus/blob/6a633eece19a782cfeddac435b60c1a7abc2488a/vendor/github.com/mwitkow/go-conntrack/dialer_reporter.go#L25-L31

  

