### PR TITLE
Make queryOrigin context key type in promql public

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -137,7 +137,7 @@ type query struct {
 	ng *Engine
 }
 
-type queryOrigin struct{}
+type QueryOrigin struct{}
 
 // Statement implements the Query interface.
 func (q *query) Statement() parser.Statement {
@@ -414,7 +414,7 @@ func (ng *Engine) exec(ctx context.Context, q *query) (v parser.Value, ws storag
 					f = append(f, "spanID", spanCtx.SpanID())
 				}
 			}
-			if origin := ctx.Value(queryOrigin{}); origin != nil {
+			if origin := ctx.Value(QueryOrigin{}); origin != nil {
 				for k, v := range origin.(map[string]interface{}) {
 					f = append(f, k, v)
 				}
@@ -2116,7 +2116,7 @@ func shouldDropMetricName(op parser.ItemType) bool {
 
 // NewOriginContext returns a new context with data about the origin attached.
 func NewOriginContext(ctx context.Context, data map[string]interface{}) context.Context {
-	return context.WithValue(ctx, queryOrigin{}, data)
+	return context.WithValue(ctx, QueryOrigin{}, data)
 }
 
 func formatDate(t time.Time) string {


### PR DESCRIPTION
Hi Prometheus team,

This PR is an alternate to #7731 and makes the `queryOrigin` context key type in promql public, thereby allowing the reuse of valuable group information by other packages, as well as avoiding redundant information in the context.

Signed-off-by: Annanay <annanayagarwal@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->