### PR TITLE
Gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,18 @@
+tasks:
+  - init: 
+      make build
+    command: |
+      gp sync-done build
+      ./prometheus --config.file=documentation/examples/prometheus.yml
+  - command: |
+      cd web/ui/react-app
+      gp sync-await build
+      unset BROWSER
+      export DANGEROUSLY_DISABLE_HOST_CHECK=true
+      yarn start
+    openMode: split-right
+ports:
+  - port: 3000
+    onOpen: open-preview
+  - port: 9090
+    onOpen: ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,8 @@ Should you wish to work on an issue, please claim it first by commenting on the 
 
 Please check the [`low-hanging-fruit`](https://github.com/prometheus/prometheus/issues?q=is%3Aissue+is%3Aopen+label%3A%22low+hanging+fruit%22) label to find issues that are good for getting started. If you have questions about one of the issues, with or without the tag, please comment on them and one of the maintainers will clarify it. For a quicker response, contact us over [IRC](https://prometheus.io/community).
 
+You can [spin up a prebuilt dev environment](https://gitpod.io/#https://github.com/prometheus/prometheus) using Gitpod.io.
+
 For complete instructions on how to compile see: [Building From Source](https://github.com/prometheus/prometheus#building-from-source)
 
 For quickly compiling and testing your changes do:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/prometheus/prometheus)](https://goreportcard.com/report/github.com/prometheus/prometheus)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/486/badge)](https://bestpractices.coreinfrastructure.org/projects/486)
 [![fuzzit](https://app.fuzzit.dev/badge?org_id=prometheus&branch=master)](https://fuzzit.dev)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/prometheus/prometheus)
 
 Visit [prometheus.io](https://prometheus.io) for the full documentation,
 examples and guides.


### PR DESCRIPTION
This PR adds configuration for Gitpod to this repo. 
It allows anyone to quickly spin up fresh prebuilt dev environment in a browser for any branches, issues and pull requests.
I have configured it to prebuild your branches using (i.e. the init task in .gitpod.yml)
```
make build
```
On start it launches prometheus with the example config 
```
./prometheus --config.file=documentation/examples/prometheus.yml
```
in one terminal and the web UI in a separate one:

```
cd web/ui/react-app
yarn start
```

I hope the config is a good start. Please propose any changes to align better with your daily routines and use cases.

To get the prebuilds, you also need to install the [GitHub app](https://github.com/apps/gitpod-io) on this project. Without the app the config works, but users will have to wait for the init task (`make build`). 

You can try the experience on my fork https://gitpod.io/#https://github.com/svenefftinge/prometheus
Or even review this PR using gitpod by prefixing the URL of this page with `gitpod.io#`.

<img width="1526" alt="Screenshot 2020-07-26 at 11 42 40" src="https://user-images.githubusercontent.com/372735/88476040-571dab80-cf35-11ea-8c98-ce61635d894d.png">
