### PR TITLE
Do not stop scrapes in progress during reload

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -559,9 +559,10 @@ func TestScrapeLoopStop(t *testing.T) {
 		numScrapes++
 		if numScrapes == 2 {
 			go sl.stop()
+			<-sl.ctx.Done()
 		}
 		w.Write([]byte("metric_a 42\n"))
-		return nil
+		return ctx.Err()
 	}
 
 	go func() {


### PR DESCRIPTION
See #7097

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->