### PR TITLE
Fix query results floating point rounding stability

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -557,20 +557,20 @@ load 1s
 	testutil.Ok(t, err)
 
 	cases := []struct {
-		Query       string
-		Start       time.Time
-		End         time.Time
-		Interval    time.Duration
+		Query    string
+		Start    time.Time
+		End      time.Time
+		Interval time.Duration
 	}{
 		// Range queries.
 		{
-			Query: `sum by (status) (label_replace(rate(metric[5s]), "status", "${1}xx", "status_code", "([0-9]).."))`,
+			Query:    `sum by (status) (label_replace(rate(metric[5s]), "status", "${1}xx", "status_code", "([0-9]).."))`,
 			Start:    time.Unix(0, 0),
 			End:      time.Unix(10, 0),
 			Interval: time.Second,
 		},
 		{
-			Query: `sum(sum by(status_code) (rate(metric[5s])))`,
+			Query:    `sum(sum by(status_code) (rate(metric[5s])))`,
 			Start:    time.Unix(0, 0),
 			End:      time.Unix(10, 0),
 			Interval: time.Second,


### PR DESCRIPTION
I opened this PR to have a conversation whether Prometheus should guarantee or not query results stability (floating point rounding) for the same exact query executed multiple times.

## The problem

While comparing query results differences between Cortex and Prometheus for the same exact data and query, I've noticed differences in floating point rounding for some queries. I digged deeper and I've noticed that, for some queries, the same exact query (eg. `curl` command) executed twice on Prometheus returns different results with regards to floating point precision.

This is caused by the (known) fact that PromQL engine internally doesn't guarantee stability in the series order. However, when you sum up a list of floating point values in an order and then you sum up the same exact values but in a different order, the result is not guaranteed to be the exact same.

## Do we wanna solve it?

Should Prometheus guarantee the same exact result for the same exact query run twice on the same exact set of data or no?

_I don't know the answer._

## The fix in this PR

It's very likely that the fix in this PR is incomplete (not every case where series are shuffled has been spotted) but first of all I would like to understand if we should fix it or not.

The main problem I see is having to call `Select()` with `sorted = true` which may cause a significant performance penalty. I believe that within PromQL engine we could fix it without significant performance penalties (eg. issues caused by the usage of `map` could be fixed using `slice` + `map` as done in the couple of places fixed in this PR).

## Benchmarks

### BenchmarkRangeQuery

```
benchmark                                                                                                              old ns/op      new ns/op      delta
BenchmarkRangeQuery/expr=a_one,steps=1-12                                                                              11825          12343          +4.38%
BenchmarkRangeQuery/expr=a_one,steps=10-12                                                                             12154          12708          +4.56%
BenchmarkRangeQuery/expr=a_one,steps=100-12                                                                            19120          19427          +1.61%
BenchmarkRangeQuery/expr=a_one,steps=1000-12                                                                           67936          68148          +0.31%
BenchmarkRangeQuery/expr=a_ten,steps=1-12                                                                              51189          50091          -2.14%
BenchmarkRangeQuery/expr=a_ten,steps=10-12                                                                             54475          54528          +0.10%
BenchmarkRangeQuery/expr=a_ten,steps=100-12                                                                            120777         119286         -1.23%
BenchmarkRangeQuery/expr=a_ten,steps=1000-12                                                                           603249         603562         +0.05%
BenchmarkRangeQuery/expr=a_hundred,steps=1-12                                                                          439457         453718         +3.25%
BenchmarkRangeQuery/expr=a_hundred,steps=10-12                                                                         489319         496974         +1.56%
BenchmarkRangeQuery/expr=a_hundred,steps=100-12                                                                        1202771        1148530        -4.51%
BenchmarkRangeQuery/expr=a_hundred,steps=1000-12                                                                       6055289        5974496        -1.33%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1-12                                                                    15817          16481          +4.20%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10-12                                                                   17315          17638          +1.87%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=100-12                                                                  31558          31418          -0.44%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1000-12                                                                 149990         151303         +0.88%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1-12                                                                    53600          53855          +0.48%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10-12                                                                   64499          65088          +0.91%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=100-12                                                                  205321         200970         -2.12%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1000-12                                                                 1416149        1359696        -3.99%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1-12                                                                437021         445626         +1.97%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10-12                                                               551180         552156         +0.18%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=100-12                                                              1970910        1927958        -2.18%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1000-12                                                             13974374       13576775       -2.85%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10000-12                                                                1934558        1905669        -1.49%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10000-12                                                                19365799       19027998       -1.74%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10000-12                                                            193137059      189064898      -2.11%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12                                                  767917         765364         -0.33%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12                                                 1251542        1284709        +2.65%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12                                                6155303        6095555        -0.97%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12                                               54993088       54783934       -0.38%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12                                                  6414718        6131718        -4.41%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12                                                 11162729       10993835       -1.51%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12                                                59285826       59767332       +0.81%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12                                               553900232      542487606      -2.06%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12                                              60816774       60593971       -0.37%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12                                             110285389      109445776      -0.76%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12                                            604520050      594681479      -1.63%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12                                           5487069073     5411334051     -1.38%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1-12                                                                 601080         601767         +0.11%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=10-12                                                                718083         734314         +2.26%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=100-12                                                               1842892        2020893        +9.66%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1000-12                                                              13467301       15159101       +12.56%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1-12                                                                 5282199        5243473        -0.73%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=10-12                                                                6514000        6524001        +0.15%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=100-12                                                               18021299       19676355       +9.18%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1000-12                                                              138126770      149724644      +8.40%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1-12                                                             53935120       52375731       -2.89%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=10-12                                                            65356349       66618276       +1.93%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=100-12                                                           183120378      194577137      +6.26%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                                                          1361457725     1482127359     +8.86%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1-12                                                                    600363         590172         -1.70%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=10-12                                                                   711596         688125         -3.30%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=100-12                                                                  1785140        1561803        -12.51%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1000-12                                                                 11193175       10460653       -6.54%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1-12                                                                    5097101        5292417        +3.83%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=10-12                                                                   6080097        6010138        -1.15%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=100-12                                                                  16507799       15119997       -8.41%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1000-12                                                                 114402070      103671889      -9.38%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1-12                                                                53139702       51773327       -2.57%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=10-12                                                               63932660       60676021       -5.09%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=100-12                                                              216789120      149601935      -30.99%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                                                             1167845312     1035256641     -11.35%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12                                                        579003         577194         -0.31%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12                                                       595453         596583         +0.19%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12                                                      857851         770980         -10.13%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12                                                     2686190        2666445        -0.74%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12                                                        4941977        4975842        +0.69%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12                                                       5144968        5186001        +0.80%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12                                                      6918800        7038313        +1.73%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12                                                     25832776       24513948       -5.11%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12                                                    49183748       50497067       +2.67%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12                                                   51854039       51659027       -0.38%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12                                                  69834460       70375529       +0.77%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12                                                 268388306      240288165      -10.47%
BenchmarkRangeQuery/expr=-a_one,steps=1-12                                                                             12953          13649          +5.37%
BenchmarkRangeQuery/expr=-a_one,steps=10-12                                                                            13897          14069          +1.24%
BenchmarkRangeQuery/expr=-a_one,steps=100-12                                                                           20315          21285          +4.77%
BenchmarkRangeQuery/expr=-a_one,steps=1000-12                                                                          69924          70737          +1.16%
BenchmarkRangeQuery/expr=-a_ten,steps=1-12                                                                             59919          54578          -8.91%
BenchmarkRangeQuery/expr=-a_ten,steps=10-12                                                                            59159          59017          -0.24%
BenchmarkRangeQuery/expr=-a_ten,steps=100-12                                                                           126156         124311         -1.46%
BenchmarkRangeQuery/expr=-a_ten,steps=1000-12                                                                          633184         617758         -2.44%
BenchmarkRangeQuery/expr=-a_hundred,steps=1-12                                                                         545885         481803         -11.74%
BenchmarkRangeQuery/expr=-a_hundred,steps=10-12                                                                        567643         527454         -7.08%
BenchmarkRangeQuery/expr=-a_hundred,steps=100-12                                                                       1333134        1182570        -11.29%
BenchmarkRangeQuery/expr=-a_hundred,steps=1000-12                                                                      6336028        6133039        -3.20%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1-12                                                                      23856          24092          +0.99%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10-12                                                                     30421          29925          -1.63%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=100-12                                                                    92023          92706          +0.74%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1000-12                                                                   722390         675572         -6.48%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1-12                                                                      120449         122128         +1.39%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10-12                                                                     182339         179979         -1.29%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=100-12                                                                    844090         794621         -5.86%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1000-12                                                                   6676400        6618672        -0.86%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                                                              1100793        1146179        +4.12%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                                                             1726708        1782044        +3.20%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                                                            8525946        8825535        +3.51%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                                                           79698200       73335379       -7.98%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10000-12                                                                  8131451        7710610        -5.18%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10000-12                                                                  78205511       77308814       -1.15%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                                                          875727182      844345110      -3.58%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12                                                     53588          54467          +1.64%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12                                                    56075          57400          +2.36%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12                                                   88628          87390          -1.40%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12                                                  362451         362044         -0.11%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12                                                     126205         128295         +1.66%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12                                                    163179         155280         -4.84%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12                                                   483894         465706         -3.76%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                  3380560        3307605        -2.16%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12                                             828654         840453         +1.42%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12                                            1173744        1175346        +0.14%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12                                           5377992        4764257        -11.41%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                          44327746       38920191       -12.20%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12                                                      54449          54395          -0.10%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12                                                     57208          59739          +4.42%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12                                                    99108          100631         +1.54%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12                                                   484847         480515         -0.89%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12                                                      128458         131694         +2.52%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12                                                     171414         171767         +0.21%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12                                                    602928         594416         -1.41%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                   4495866        4400591        -2.12%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12                                              861707         881474         +2.29%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12                                             1268658        1288158        +1.54%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12                                            5883038        5760295        -2.09%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                           49540589       48711432       -1.67%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12                                                  53201          54452          +2.35%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12                                                 58536          58942          +0.69%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12                                                97350          98838          +1.53%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12                                               474766         466767         -1.68%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12                                                  123463         127818         +3.53%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12                                                 153360         156374         +1.97%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12                                                463818         466139         +0.50%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12                                               3328969        3332017        +0.09%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12                                          806077         861107         +6.83%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12                                         1132889        1173594        +3.59%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12                                        4754576        4893763        +2.93%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                       38523531       38517266       -0.02%
BenchmarkRangeQuery/expr=abs(a_one),steps=1-12                                                                         15260          15770          +3.34%
BenchmarkRangeQuery/expr=abs(a_one),steps=10-12                                                                        17600          18149          +3.12%
BenchmarkRangeQuery/expr=abs(a_one),steps=100-12                                                                       44752          43538          -2.71%
BenchmarkRangeQuery/expr=abs(a_one),steps=1000-12                                                                      290692         278054         -4.35%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1-12                                                                         62089          63204          +1.80%
BenchmarkRangeQuery/expr=abs(a_ten),steps=10-12                                                                        87639          87007          -0.72%
BenchmarkRangeQuery/expr=abs(a_ten),steps=100-12                                                                       356602         346036         -2.96%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1000-12                                                                      2918935        2767776        -5.18%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1-12                                                                     539353         557428         +3.35%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=10-12                                                                    806217         802222         -0.50%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=100-12                                                                   3719584        3532762        -5.02%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1000-12                                                                  30781638       29920852       -2.80%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                      25249          26014          +3.03%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                     29250          29687          +1.49%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    71658          70882          -1.08%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   469463         465908         -0.76%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                      77233          78255          +1.32%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                     106815         106326         -0.46%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    414702         402076         -3.04%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   3330109        3287962        -1.27%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                  598138         619399         +3.55%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                 888761         901317         +1.41%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                4070029        3913889        -3.84%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                               34422351       32994227       -4.15%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                                             20171          21002          +4.12%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                                            25543          26171          +2.46%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                                           84029          78824          -6.19%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                                          592839         578878         -2.35%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                                             70345          71178          +1.18%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                                            101872         100148         -1.69%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                                           443762         411323         -7.31%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                                          3536719        3366540        -4.81%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                                         573393         592280         +3.29%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                                        874119         875461         +0.15%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                                       4061614        3957697        -2.56%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12                                      34964745       33924844       -2.97%
BenchmarkRangeQuery/expr=sum(a_one),steps=1-12                                                                         15160          15736          +3.80%
BenchmarkRangeQuery/expr=sum(a_one),steps=10-12                                                                        20786          21476          +3.32%
BenchmarkRangeQuery/expr=sum(a_one),steps=100-12                                                                       76137          74657          -1.94%
BenchmarkRangeQuery/expr=sum(a_one),steps=1000-12                                                                      600040         603812         +0.63%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1-12                                                                         53041          54810          +3.34%
BenchmarkRangeQuery/expr=sum(a_ten),steps=10-12                                                                        65018          66033          +1.56%
BenchmarkRangeQuery/expr=sum(a_ten),steps=100-12                                                                       201438         202058         +0.31%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1000-12                                                                      1394614        1384619        -0.72%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1-12                                                                     434515         459199         +5.68%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=10-12                                                                    501735         525501         +4.74%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=100-12                                                                   1421430        1473849        +3.69%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1000-12                                                                  8975142        9303337        +3.66%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                                             69682          70118          +0.63%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                                            123717         123892         +0.14%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                                           687532         672192         -2.23%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                          6033455        5999307        -0.57%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                                             474319         498740         +5.15%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                                            635784         666354         +4.81%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                                           2497840        2548708        +2.04%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                          19634432       20135736       +2.55%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                                         5080499        6310700        +24.21%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                                        6669771        8192026        +22.82%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                                       22997773       25842786       +12.37%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                      156340124      165073791      +5.59%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                                            58049          60200          +3.71%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                                           72688          74671          +2.73%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                                          244097         246593         +1.02%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                         1776367        1782633        +0.35%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                                            470649         499033         +6.03%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                                           615825         646308         +4.95%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                                          2330965        2398689        +2.91%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                         17650815       18260520       +3.45%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                                        5007588        6453893        +28.88%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                                       6923554        8615654        +24.44%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                                                      25741244       28275355       +9.84%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                     197236712      198509612      +0.65%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                                                  57705          59718          +3.49%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                                                 72496          74938          +3.37%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                                                239312         251810         +5.22%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                               1712565        1783337        +4.13%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                                                  469957         496694         +5.69%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                                                 606685         640881         +5.64%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                                                2256730        2326627        +3.10%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                               16930791       18140812       +7.15%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                                              4943245        6539608        +32.29%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                                             6644353        8523769        +28.29%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                                            25635414       27219092       +6.18%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                           182913829      187999599      +2.78%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                                                 68941          70440          +2.17%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                                                120072         119994         -0.06%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                                               638562         643674         +0.80%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                              5597984        5604017        +0.11%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                                                 473986         500855         +5.67%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                                                646440         665491         +2.95%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                                               2509421        2561102        +2.06%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                              19634141       20031859       +2.03%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                                             5168634        6238018        +20.69%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                                            6709043        7883005        +17.50%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                                           23467311       24890448       +6.06%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                          163246590      164300781      +0.65%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                                                  29999          30381          +1.27%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                                                 35908          37128          +3.40%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                                                106648         110452         +3.57%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                                               774912         762988         -1.54%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                                                  118784         123211         +3.73%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                                                 180863         185173         +2.38%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                                                859744         863056         +0.39%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                                               7190756        7127663        -0.88%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                                          1022734        1084944        +6.08%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                                         1714861        1769427        +3.18%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                                        9046770        9087592        +0.45%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                                       78866922       78809943       -0.07%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                                                   19752          20436          +3.46%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                                                  26284          27144          +3.27%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                                                 92294          93039          +0.81%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                725290         714412         -1.50%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                                                   57334          59698          +4.12%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                                                  77240          79160          +2.49%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                                                 303863         306290         +0.80%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                                2324341        2342201        +0.77%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                                               428038         453470         +5.94%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                                              573178         607810         +6.04%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                                             2317846        2433725        +5.00%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                            17802142       18094379       +1.64%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12                35871          38029          +6.02%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12               53536          55321          +3.33%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12              231104         229924         -0.51%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12             1936326        1918450        -0.92%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12                110787         115023         +3.82%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12               155653         161868         +3.99%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12              649632         682753         +5.10%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12             5157564        5449450        +5.66%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12        848543         911782         +7.45%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12       1145877        1233943        +7.69%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12      4708863        5131198        +8.97%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12     36455540       40925046       +12.26%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                           78158          81147          +3.82%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                          116256         116244         -0.01%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                         480905         487652         +1.40%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                        3979479        3975231        -0.11%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                           630405         662396         +5.07%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                          1037615        1074975        +3.60%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                         5310296        5384708        +1.40%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                        46295817       47657004       +2.94%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                       7376319        8610090        +16.73%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                      12449469       13812880       +10.95%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                     54861073       55431986       +1.04%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                    467475756      470063636      +0.55%

benchmark                                                                                                              old allocs     new allocs     delta
BenchmarkRangeQuery/expr=a_one,steps=1-12                                                                              108            112            +3.70%
BenchmarkRangeQuery/expr=a_one,steps=10-12                                                                             108            112            +3.70%
BenchmarkRangeQuery/expr=a_one,steps=100-12                                                                            113            117            +3.54%
BenchmarkRangeQuery/expr=a_one,steps=1000-12                                                                           164            172            +4.88%
BenchmarkRangeQuery/expr=a_ten,steps=1-12                                                                              256            261            +1.95%
BenchmarkRangeQuery/expr=a_ten,steps=10-12                                                                             256            261            +1.95%
BenchmarkRangeQuery/expr=a_ten,steps=100-12                                                                            297            302            +1.68%
BenchmarkRangeQuery/expr=a_ten,steps=1000-12                                                                           780            825            +5.77%
BenchmarkRangeQuery/expr=a_hundred,steps=1-12                                                                          1699           1704           +0.29%
BenchmarkRangeQuery/expr=a_hundred,steps=10-12                                                                         1699           1704           +0.29%
BenchmarkRangeQuery/expr=a_hundred,steps=100-12                                                                        2100           2105           +0.24%
BenchmarkRangeQuery/expr=a_hundred,steps=1000-12                                                                       6859           7236           +5.50%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1-12                                                                    135            139            +2.96%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10-12                                                                   135            139            +2.96%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=100-12                                                                  140            144            +2.86%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1000-12                                                                 183            191            +4.37%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1-12                                                                    320            325            +1.56%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10-12                                                                   320            325            +1.56%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=100-12                                                                  361            366            +1.39%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1000-12                                                                 764            809            +5.89%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1-12                                                                2129           2134           +0.23%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10-12                                                               2129           2134           +0.23%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=100-12                                                              2530           2535           +0.20%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1000-12                                                             6489           6867           +5.83%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10000-12                                                                863            867            +0.46%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10000-12                                                                7232           7272           +0.55%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10000-12                                                            70921          71295          +0.53%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12                                                  760            772            +1.58%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12                                                 760            772            +1.58%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12                                                768            780            +1.56%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12                                               825            838            +1.58%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12                                                  6024           6073           +0.81%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12                                                 6021           6071           +0.83%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12                                                6098           6147           +0.80%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12                                               6669           6715           +0.69%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12                                              58552          58932          +0.65%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12                                             58548          58932          +0.66%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12                                            59356          59743          +0.65%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12                                           65327          65695          +0.56%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1-12                                                                 716            724            +1.12%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=10-12                                                                716            724            +1.12%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=100-12                                                               724            732            +1.10%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1000-12                                                              780            788            +1.03%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1-12                                                                 5977           6022           +0.75%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=10-12                                                                5977           6022           +0.75%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=100-12                                                               6058           6103           +0.74%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1000-12                                                              6623           6670           +0.71%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1-12                                                             58505          58882          +0.64%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=10-12                                                            58507          58883          +0.64%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=100-12                                                           59309          59683          +0.63%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                                                          65209          65593          +0.59%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1-12                                                                    716            724            +1.12%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=10-12                                                                   716            724            +1.12%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=100-12                                                                  724            732            +1.10%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1000-12                                                                 780            788            +1.03%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1-12                                                                    5977           6022           +0.75%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=10-12                                                                   5977           6022           +0.75%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=100-12                                                                  6058           6103           +0.74%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1000-12                                                                 6623           6665           +0.63%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1-12                                                                58506          58881          +0.64%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=10-12                                                               58506          58882          +0.64%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=100-12                                                              59308          59685          +0.64%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                                                             65214          65569          +0.54%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12                                                        716            724            +1.12%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12                                                       716            724            +1.12%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12                                                      724            732            +1.10%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12                                                     780            788            +1.03%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12                                                        5976           6021           +0.75%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12                                                       5976           6021           +0.75%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12                                                      6056           6101           +0.74%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12                                                     6616           6662           +0.70%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12                                                    58496          58872          +0.64%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12                                                   58497          58874          +0.64%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12                                                  59296          59675          +0.64%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12                                                 64906          65279          +0.57%
BenchmarkRangeQuery/expr=-a_one,steps=1-12                                                                             118            122            +3.39%
BenchmarkRangeQuery/expr=-a_one,steps=10-12                                                                            118            122            +3.39%
BenchmarkRangeQuery/expr=-a_one,steps=100-12                                                                           123            127            +3.25%
BenchmarkRangeQuery/expr=-a_one,steps=1000-12                                                                          174            182            +4.60%
BenchmarkRangeQuery/expr=-a_ten,steps=1-12                                                                             303            308            +1.65%
BenchmarkRangeQuery/expr=-a_ten,steps=10-12                                                                            303            308            +1.65%
BenchmarkRangeQuery/expr=-a_ten,steps=100-12                                                                           344            349            +1.45%
BenchmarkRangeQuery/expr=-a_ten,steps=1000-12                                                                          827            872            +5.44%
BenchmarkRangeQuery/expr=-a_hundred,steps=1-12                                                                         2112           2117           +0.24%
BenchmarkRangeQuery/expr=-a_hundred,steps=10-12                                                                        2112           2117           +0.24%
BenchmarkRangeQuery/expr=-a_hundred,steps=100-12                                                                       2513           2518           +0.20%
BenchmarkRangeQuery/expr=-a_hundred,steps=1000-12                                                                      7272           7649           +5.18%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1-12                                                                      195            205            +5.13%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10-12                                                                     231            241            +4.33%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=100-12                                                                    601            611            +1.66%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1000-12                                                                   4303           4321           +0.42%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1-12                                                                      608            629            +3.45%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10-12                                                                     654            675            +3.21%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=100-12                                                                    1198           1219           +1.75%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1000-12                                                                   6775           6872           +1.43%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                                                              4621           4731           +2.38%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                                                             4740           4851           +2.34%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                                                            6734           6881           +2.18%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                                                           28511          29165          +2.29%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10000-12                                                                  41640          41650          +0.02%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10000-12                                                                  66018          65388          -0.95%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                                                          295041         281246         -4.68%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12                                                     278            286            +2.88%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12                                                    314            322            +2.55%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12                                                   679            687            +1.18%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12                                                  4330           4342           +0.28%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12                                                     581            597            +2.75%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12                                                    617            633            +2.59%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12                                                   1039           1055           +1.54%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                  5365           5441           +1.42%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12                                             3363           3424           +1.81%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12                                            3496           3557           +1.74%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12                                           5424           5485           +1.12%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                          25824          26444          +2.40%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12                                                      280            289            +3.21%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12                                                     316            325            +2.85%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12                                                    681            690            +1.32%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12                                                   4332           4345           +0.30%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12                                                      590            611            +3.56%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12                                                     645            666            +3.26%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12                                                    1257           1278           +1.67%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                   7479           7560           +1.08%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12                                              3425           3535           +3.21%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12                                             3603           3713           +3.05%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12                                            5984           6092           +1.80%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                           30902          31610          +2.29%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12                                                  280            289            +3.21%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12                                                 316            325            +2.85%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12                                                681            690            +1.32%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12                                               4332           4345           +0.30%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12                                                  581            597            +2.75%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12                                                 617            633            +2.59%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12                                                1039           1055           +1.54%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12                                               5365           5441           +1.42%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12                                          3363           3424           +1.81%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12                                         3496           3557           +1.74%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12                                        5424           5483           +1.09%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                       25822          26455          +2.45%
BenchmarkRangeQuery/expr=abs(a_one),steps=1-12                                                                         136            142            +4.41%
BenchmarkRangeQuery/expr=abs(a_one),steps=10-12                                                                        145            151            +4.14%
BenchmarkRangeQuery/expr=abs(a_one),steps=100-12                                                                       240            246            +2.50%
BenchmarkRangeQuery/expr=abs(a_one),steps=1000-12                                                                      1191           1201           +0.84%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1-12                                                                         333            349            +4.80%
BenchmarkRangeQuery/expr=abs(a_ten),steps=10-12                                                                        352            368            +4.55%
BenchmarkRangeQuery/expr=abs(a_ten),steps=100-12                                                                       580            596            +2.76%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1000-12                                                                      2942           2997           +1.87%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1-12                                                                     2250           2354           +4.62%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=10-12                                                                    2324           2429           +4.52%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=100-12                                                                   3472           3577           +3.02%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1000-12                                                                  15717          16187          +2.99%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                      217            223            +2.76%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                     262            268            +2.29%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    717            723            +0.84%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   5268           5278           +0.19%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                      443            459            +3.61%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                     498            514            +3.21%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    1087           1102           +1.38%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   7046           7104           +0.82%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                  2719           2824           +3.86%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                 2830           2935           +3.71%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                4339           4443           +2.40%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                               20194          20656          +2.29%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                                             177            183            +3.39%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                                            240            246            +2.50%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                                           875            881            +0.69%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                                          7226           7236           +0.14%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                                             392            408            +4.08%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                                            465            481            +3.44%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                                           1233           1250           +1.38%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                                          8995           9049           +0.60%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                                         2488           2594           +4.26%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                                        2617           2722           +4.01%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                                       4306           4410           +2.42%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12                                      21949          22427          +2.18%
BenchmarkRangeQuery/expr=sum(a_one),steps=1-12                                                                         138            146            +5.80%
BenchmarkRangeQuery/expr=sum(a_one),steps=10-12                                                                        192            209            +8.85%
BenchmarkRangeQuery/expr=sum(a_one),steps=100-12                                                                       737            844            +14.52%
BenchmarkRangeQuery/expr=sum(a_one),steps=1000-12                                                                      6188           7199           +16.34%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1-12                                                                         287            296            +3.14%
BenchmarkRangeQuery/expr=sum(a_ten),steps=10-12                                                                        341            359            +5.28%
BenchmarkRangeQuery/expr=sum(a_ten),steps=100-12                                                                       922            1030           +11.71%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1000-12                                                                      6805           7853           +15.40%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1-12                                                                     1731           1740           +0.52%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=10-12                                                                    1785           1803           +1.01%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=100-12                                                                   2726           2834           +3.96%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1000-12                                                                  12885          14265          +10.71%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                                             382            409            +7.07%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                                            745            817            +9.66%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                                           4420           4942           +11.81%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                          41244          46315          +12.30%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                                             1970           1997           +1.37%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                                            2333           2405           +3.09%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                                           6404           6926           +8.15%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                          47982          53443          +11.38%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                                         17815          17846          +0.17%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                                        18178          18254          +0.42%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                                       26209          26733          +2.00%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                      114791         123929         +7.96%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                                            308            317            +2.92%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                                           380            398            +4.74%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                                          1145           1253           +9.43%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                         8876           9928           +11.85%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                                            1963           1989           +1.32%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                                           2297           2368           +3.09%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                                          6078           6599           +8.57%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                         44757          50219          +12.20%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                                        18465          18591          +0.68%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                                       21352          21549          +0.92%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                                                      54627          55543          +1.68%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                     395603         407891         +3.11%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                                                  308            317            +2.92%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                                                 380            398            +4.74%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                                                1145           1253           +9.43%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                               8876           9928           +11.85%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                                                  1963           1989           +1.32%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                                                 2297           2368           +3.09%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                                                6078           6599           +8.57%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                               44760          50215          +12.19%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                                              18466          18591          +0.68%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                                             21352          21550          +0.93%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                                            54622          55539          +1.68%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                           395653         407820         +3.08%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                                                 382            409            +7.07%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                                                745            817            +9.66%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                                               4420           4942           +11.81%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                              41248          46311          +12.27%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                                                 1970           1997           +1.37%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                                                2333           2405           +3.09%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                                               6404           6926           +8.15%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                              47981          53440          +11.38%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                                             17815          17846          +0.17%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                                            18178          18254          +0.42%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                                           26206          26734          +2.01%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                          114786         123902         +7.94%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                                                  239            249            +4.18%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                                                 275            285            +3.64%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                                                645            655            +1.55%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                                               4331           4349           +0.42%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                                                  691            712            +3.04%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                                                 737            758            +2.85%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                                                1280           1301           +1.64%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                                               6697           6797           +1.49%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                                          5073           5183           +2.17%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                                         5192           5303           +2.14%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                                        7184           7315           +1.82%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                                       27319          28022          +2.57%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                                                   166            174            +4.82%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                                                  229            246            +7.42%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                                                 864            971            +12.38%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                7207           8218           +14.03%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                                                   354            363            +2.54%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                                                  426            444            +4.23%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                                                 1187           1295           +9.10%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                                8790           9838           +11.92%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                                               2164           2173           +0.42%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                                              2236           2254           +0.81%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                                             3357           3465           +3.22%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                            14517          15897          +9.51%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12                305            323            +5.90%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12               467            503            +7.71%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12              2097           2313           +10.30%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12             18383          20407          +11.01%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12                681            701            +2.94%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12               861            899            +4.41%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12              2743           2961           +7.95%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12             21549          23647          +9.74%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12        4301           4321           +0.47%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12       4481           4519           +0.85%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12      7084           7301           +3.06%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12     33004          35764          +8.36%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                           441            450            +2.04%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                          684            693            +1.32%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                         3159           3168           +0.28%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                        27990          28044          +0.19%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                           3163           3181           +0.57%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                          6268           6286           +0.29%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                         37768          37786          +0.05%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                        353635         354098         +0.13%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                       30105          30217          +0.37%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                      60805          60917          +0.18%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                     372235         372350         +0.03%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                    3494764        3498910        +0.12%

benchmark                                                                                                              old bytes     new bytes     delta
BenchmarkRangeQuery/expr=a_one,steps=1-12                                                                              5524          6620          +19.84%
BenchmarkRangeQuery/expr=a_one,steps=10-12                                                                             5523          6620          +19.86%
BenchmarkRangeQuery/expr=a_one,steps=100-12                                                                            5811          6907          +18.86%
BenchmarkRangeQuery/expr=a_one,steps=1000-12                                                                           9132          10306         +12.86%
BenchmarkRangeQuery/expr=a_ten,steps=1-12                                                                              14244         15445         +8.43%
BenchmarkRangeQuery/expr=a_ten,steps=10-12                                                                             14243         15444         +8.43%
BenchmarkRangeQuery/expr=a_ten,steps=100-12                                                                            16407         17606         +7.31%
BenchmarkRangeQuery/expr=a_ten,steps=1000-12                                                                           39462         41464         +5.07%
BenchmarkRangeQuery/expr=a_hundred,steps=1-12                                                                          100242        102519        +2.27%
BenchmarkRangeQuery/expr=a_hundred,steps=10-12                                                                         99995         102030        +2.04%
BenchmarkRangeQuery/expr=a_hundred,steps=100-12                                                                        120890        122923        +1.68%
BenchmarkRangeQuery/expr=a_hundred,steps=1000-12                                                                       340523        349976        +2.78%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1-12                                                                    6621          7715          +16.52%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10-12                                                                   6621          7718          +16.57%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=100-12                                                                  6907          8013          +16.01%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=1000-12                                                                 9952          11127         +11.81%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1-12                                                                    18580         19775         +6.43%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10-12                                                                   18563         19781         +6.56%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=100-12                                                                  20727         21964         +5.97%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=1000-12                                                                 41223         43155         +4.69%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1-12                                                                136226        138167        +1.42%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10-12                                                               136170        138241        +1.52%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=100-12                                                              157026        159093        +1.32%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=1000-12                                                             351021        359449        +2.40%
BenchmarkRangeQuery/expr=rate(a_one[1m]),steps=10000-12                                                                60450         60192         -0.43%
BenchmarkRangeQuery/expr=rate(a_ten[1m]),steps=10000-12                                                                343708        343827        +0.03%
BenchmarkRangeQuery/expr=rate(a_hundred[1m]),steps=10000-12                                                            3170625       3212340       +1.32%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12                                                  1194366       1196341       +0.17%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12                                                 1194885       1196387       +0.13%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12                                                1196307       1198032       +0.14%
BenchmarkRangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12                                               1216124       1221418       +0.44%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12                                                  1409113       1411229       +0.15%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12                                                 1410700       1412814       +0.15%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12                                                1393712       1393426       -0.02%
BenchmarkRangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12                                               1453276       1455100       +0.13%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12                                              3552486       3557831       +0.15%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12                                             3553172       3567451       +0.40%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12                                            3590364       3600116       +0.27%
BenchmarkRangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12                                           6781440       6783504       +0.03%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1-12                                                                 566018        566642        +0.11%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=10-12                                                                564293        565135        +0.15%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=100-12                                                               564873        566296        +0.25%
BenchmarkRangeQuery/expr=changes(a_one[1d]),steps=1000-12                                                              574023        576532        +0.44%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1-12                                                                 777722        779909        +0.28%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=10-12                                                                777954        780196        +0.29%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=100-12                                                               781862        795774        +1.78%
BenchmarkRangeQuery/expr=changes(a_ten[1d]),steps=1000-12                                                              889638        912166        +2.53%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1-12                                                             2953087       2959000       +0.20%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=10-12                                                            2957192       2966412       +0.31%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=100-12                                                           3056809       2954788       -3.34%
BenchmarkRangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                                                          6487864       6514248       +0.41%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1-12                                                                    566169        566079        -0.02%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=10-12                                                                   565419        565624        +0.04%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=100-12                                                                  565025        565954        +0.16%
BenchmarkRangeQuery/expr=rate(a_one[1d]),steps=1000-12                                                                 572639        574564        +0.34%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1-12                                                                    781174        780091        -0.14%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=10-12                                                                   781521        783309        +0.23%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=100-12                                                                  790243        792674        +0.31%
BenchmarkRangeQuery/expr=rate(a_ten[1d]),steps=1000-12                                                                 886375        814473        -8.11%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1-12                                                                2951373       2930318       -0.71%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=10-12                                                               2922045       2929173       +0.24%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=100-12                                                              3056750       3050033       -0.22%
BenchmarkRangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                                                             6481672       5865480       -9.51%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12                                                        565640        566431        +0.14%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12                                                       565357        565877        +0.09%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12                                                      566448        567512        +0.19%
BenchmarkRangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12                                                     582851        585132        +0.39%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12                                                        780401        782703        +0.29%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12                                                       782076        786946        +0.62%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12                                                      798433        804286        +0.73%
BenchmarkRangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12                                                     968759        984268        +1.60%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12                                                    2916964       2924514       +0.26%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12                                                   2959970       2969418       +0.32%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12                                                  3121199       3175651       +1.74%
BenchmarkRangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12                                                 4985998       4950947       -0.70%
BenchmarkRangeQuery/expr=-a_one,steps=1-12                                                                             5986          7083          +18.33%
BenchmarkRangeQuery/expr=-a_one,steps=10-12                                                                            5986          7082          +18.31%
BenchmarkRangeQuery/expr=-a_one,steps=100-12                                                                           6275          7372          +17.48%
BenchmarkRangeQuery/expr=-a_one,steps=1000-12                                                                          9593          10768         +12.25%
BenchmarkRangeQuery/expr=-a_ten,steps=1-12                                                                             17927         19129         +6.70%
BenchmarkRangeQuery/expr=-a_ten,steps=10-12                                                                            17928         19128         +6.69%
BenchmarkRangeQuery/expr=-a_ten,steps=100-12                                                                           20091         21293         +5.98%
BenchmarkRangeQuery/expr=-a_ten,steps=1000-12                                                                          43145         45147         +4.64%
BenchmarkRangeQuery/expr=-a_hundred,steps=1-12                                                                         135429        137447        +1.49%
BenchmarkRangeQuery/expr=-a_hundred,steps=10-12                                                                        135431        137447        +1.49%
BenchmarkRangeQuery/expr=-a_hundred,steps=100-12                                                                       156333        158332        +1.28%
BenchmarkRangeQuery/expr=-a_hundred,steps=1000-12                                                                      375975        385379        +2.50%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1-12                                                                      11851         14100         +18.98%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10-12                                                                     13291         15541         +16.93%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=100-12                                                                    28273         30519         +7.94%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=1000-12                                                                   178963        181351        +1.33%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1-12                                                                      41575         43789         +5.33%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10-12                                                                     44614         46836         +4.98%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=100-12                                                                    79430         81470         +2.57%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=1000-12                                                                   426385        433414        +1.65%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                                                              345548        349279        +1.08%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                                                             370078        373897        +1.03%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                                                            652388        673752        +3.27%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                                                           3665616       3657784       -0.21%
BenchmarkRangeQuery/expr=a_one_-_b_one,steps=10000-12                                                                  1718719       1720055       +0.08%
BenchmarkRangeQuery/expr=a_ten_-_b_ten,steps=10000-12                                                                  4084848       3925520       -3.90%
BenchmarkRangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                                                          39717716      35271568      -11.19%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12                                                     20023         22224         +10.99%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12                                                    21460         23654         +10.22%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12                                                   36149         38369         +6.14%
BenchmarkRangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12                                                  183705        185957        +1.23%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12                                                     41312         43259         +4.71%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12                                                    42766         44718         +4.56%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12                                                   60478         62430         +3.23%
BenchmarkRangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                  239706        243022        +1.38%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12                                             244266        245553        +0.53%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12                                            274046        275622        +0.58%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12                                           605707        606671        +0.16%
BenchmarkRangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                          3935123       3947790       +0.32%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12                                                      20100         22354         +11.21%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12                                                     21539         23797         +10.48%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12                                                    36250         38502         +6.21%
BenchmarkRangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12                                                   183700        185975        +1.24%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12                                                      42661         44843         +5.11%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12                                                     48186         50407         +4.61%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12                                                    106805        108988        +2.04%
BenchmarkRangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                   695144        698632        +0.50%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12                                              256246        259434        +1.24%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12                                             319913        322927        +0.94%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12                                            986500        989259        +0.28%
BenchmarkRangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                           7671153       7689443       +0.24%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12                                                  20102         22335         +11.11%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12                                                 21538         23798         +10.49%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12                                                36235         38492         +6.23%
BenchmarkRangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12                                               183746        186101        +1.28%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12                                                  41310         43293         +4.80%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12                                                 42770         44711         +4.54%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12                                                60471         62444         +3.26%
BenchmarkRangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12                                               239881        243115        +1.35%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12                                          244193        245456        +0.52%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12                                         274125        275631        +0.55%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12                                        605703        606529        +0.14%
BenchmarkRangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                       3929910       3945813       +0.40%
BenchmarkRangeQuery/expr=abs(a_one),steps=1-12                                                                         6979          8131          +16.51%
BenchmarkRangeQuery/expr=abs(a_one),steps=10-12                                                                        7267          8419          +15.85%
BenchmarkRangeQuery/expr=abs(a_one),steps=100-12                                                                       10436         11589         +11.05%
BenchmarkRangeQuery/expr=abs(a_one),steps=1000-12                                                                      42567         43789         +2.87%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1-12                                                                         22591         23608         +4.50%
BenchmarkRangeQuery/expr=abs(a_ten),steps=10-12                                                                        24350         25365         +4.17%
BenchmarkRangeQuery/expr=abs(a_ten),steps=100-12                                                                       44092         45108         +2.30%
BenchmarkRangeQuery/expr=abs(a_ten),steps=1000-12                                                                      243024        244822        +0.74%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1-12                                                                     178314        179763        +0.81%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=10-12                                                                    193497        195009        +0.78%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=100-12                                                                   366598        368144        +0.42%
BenchmarkRangeQuery/expr=abs(a_hundred),steps=1000-12                                                                  2110249       2118236       +0.38%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                      11588         12741         +9.95%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                     13028         14181         +8.85%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    27725         28877         +4.16%
BenchmarkRangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   175102        176332        +0.70%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                      28850         29865         +3.52%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                     31761         32774         +3.19%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    63047         64040         +1.58%
BenchmarkRangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   377178        379042        +0.49%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                  200386        201840        +0.73%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                 216736        218192        +0.67%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                401425        402898        +0.37%
BenchmarkRangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                               2260733       2268944       +0.36%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                                             8843          9996          +13.04%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                                            10859         12013         +10.63%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                                           31315         32469         +3.69%
BenchmarkRangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                                          236298        237525        +0.52%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                                             25703         26722         +3.96%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                                            29188         30209         +3.50%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                                           66225         67241         +1.53%
BenchmarkRangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                                          438005        439755        +0.40%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                                         193418        194906        +0.77%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                                        210341        211849        +0.72%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                                       400816        402176        +0.34%
BenchmarkRangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12                                      2317228       2325909       +0.37%
BenchmarkRangeQuery/expr=sum(a_one),steps=1-12                                                                         7203          8370          +16.20%
BenchmarkRangeQuery/expr=sum(a_one),steps=10-12                                                                        11092         12332         +11.18%
BenchmarkRangeQuery/expr=sum(a_one),steps=100-12                                                                       50270         52227         +3.89%
BenchmarkRangeQuery/expr=sum(a_one),steps=1000-12                                                                      442501        451738        +2.09%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1-12                                                                         18116         18726         +3.37%
BenchmarkRangeQuery/expr=sum(a_ten),steps=10-12                                                                        22007         22685         +3.08%
BenchmarkRangeQuery/expr=sum(a_ten),steps=100-12                                                                       63059         64460         +2.22%
BenchmarkRangeQuery/expr=sum(a_ten),steps=1000-12                                                                      475015        484472        +1.99%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1-12                                                                     122819        120305        -2.05%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=10-12                                                                    126715        124260        -1.94%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=100-12                                                                   186476        184786        -0.91%
BenchmarkRangeQuery/expr=sum(a_hundred),steps=1000-12                                                                  795134        807889        +1.60%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                                             25101         26680         +6.29%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                                            51337         55161         +7.45%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                                           316159        342266        +8.26%
BenchmarkRangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                          2965859       3216434       +8.45%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                                             152272        145210        -4.64%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                                            181686        176843        -2.67%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                                           498812        516340        +3.51%
BenchmarkRangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                          3683248       3932673       +6.77%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                                         1398502       1354498       -3.15%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                                        1427690       1385686       -2.94%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                                       1952073       1931574       -1.05%
BenchmarkRangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                      7301131       7586934       +3.91%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                                            19445         20086         +3.30%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                                           24198         24909         +2.94%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                                          74099         75538         +1.94%
BenchmarkRangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                         574709        584224        +1.66%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                                            151676        144562        -4.69%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                                           178969        174073        -2.74%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                                          474751        492176        +3.67%
BenchmarkRangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                         3445491       3694950       +7.24%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                                        1458338       1422385       -2.47%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                                       1725274       1706844       -1.07%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                                                      4627067       4791974       +3.56%
BenchmarkRangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                     33722334      35816702      +6.21%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                                                  19380         20022         +3.31%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                                                 23846         24559         +2.99%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                                                70866         72304         +2.03%
BenchmarkRangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                               542629        552222        +1.77%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                                                  150412        143267        -4.75%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                                                 171918        167027        -2.84%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                                                410137        427557        +4.25%
BenchmarkRangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                               2804849       3054060       +8.89%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                                              1445456       1408912       -2.53%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                                             1654632       1636895       -1.07%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                                            3978040       4144652       +4.19%
BenchmarkRangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                           27317670      29391496      +7.59%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                                                 24399         25975         +6.46%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                                                47472         51281         +8.02%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                                               280612        306728        +9.31%
BenchmarkRangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                              2613498       2863729       +9.57%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                                                 150867        143798        -4.69%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                                                173948        169116        -2.78%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                                               427674        445211        +4.10%
BenchmarkRangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                              2978250       3227487       +8.37%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                                             1397195       1352064       -3.23%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                                            1419632       1377467       -2.97%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                                           1880228       1860532       -1.05%
BenchmarkRangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                          6598152       6883614       +4.33%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                                                  13697         15959         +16.51%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                                                 15148         17395         +14.83%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                                                30133         32386         +7.48%
BenchmarkRangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                                               180286        182766        +1.38%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                                                  45883         48094         +4.82%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                                                 48936         51160         +4.54%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                                                83677         85689         +2.40%
BenchmarkRangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                                               425266        427696        +0.57%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                                          378263        381843        +0.95%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                                         402579        406444        +0.96%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                                        684311        699049        +2.15%
BenchmarkRangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                                       3621076       3609929       -0.31%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                                                   8313          9483          +14.07%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                                                  12501         13746         +9.96%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                                                 54574         56566         +3.65%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                475652        484941        +1.95%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                                                   22530         23143         +2.72%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                                                  26999         27671         +2.49%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                                                 73868         75288         +1.92%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                                540984        550403        +1.74%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                                               159113        156559        -1.61%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                                              163457        161213        -1.37%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                                             229215        227575        -0.72%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                            870339        882366        +1.38%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12                17604         20016         +13.70%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12               27411         29958         +9.29%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12              126046        130003        +3.14%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12             1111894       1130677       +1.69%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12                46017         47301         +2.79%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12               56425         57857         +2.54%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12              164476        167449        +1.81%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12             1242907       1261733       +1.51%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12        319284        314147        -1.61%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12       329333        324479        -1.47%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12      475114        471688        -0.72%
BenchmarkRangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12     1900270       1925815       +1.34%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                           27822         28515         +2.49%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                          39060         39781         +1.85%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                         153852        154585        +0.48%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                        1302470       1305109       +0.20%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                           231224        223545        -3.32%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                          367777        360196        -2.06%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                         1756695       1748796       -0.45%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                        15655912      15661313      +0.03%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                       2230003       2189879       -1.80%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                      3596334       3556113       -1.12%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                     17491635      17458530      -0.19%
BenchmarkRangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                    156337792     156403208     +0.04%
```
