### PR TITLE
Use strict unmarshalling of rules

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -16,6 +16,7 @@ package rulefmt
 import (
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"strings"
 	"time"
@@ -268,10 +269,11 @@ func Parse(content []byte) (*RuleGroups, []error) {
 		errs   []error
 	)
 
-	dec := yaml.NewDecoder(bytes.NewReader(content))
-	dec.KnownFields(true)
-	err := dec.Decode(&groups)
-	if err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(content))
+	decoder.KnownFields(true)
+	err := decoder.Decode(&groups)
+	// Ignore io.EOF which happends with empty input.
+	if err != nil && err != io.EOF {
 		errs = append(errs, err)
 	}
 	err = yaml.Unmarshal(content, &node)

--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -14,6 +14,7 @@
 package rulefmt
 
 import (
+	"bytes"
 	"context"
 	"io/ioutil"
 	"strings"
@@ -267,7 +268,9 @@ func Parse(content []byte) (*RuleGroups, []error) {
 		errs   []error
 	)
 
-	err := yaml.Unmarshal(content, &groups)
+	dec := yaml.NewDecoder(bytes.NewReader(content))
+	dec.KnownFields(true)
+	err := dec.Decode(&groups)
 	if err != nil {
 		errs = append(errs, err)
 	}

--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -272,7 +272,7 @@ func Parse(content []byte) (*RuleGroups, []error) {
 	decoder := yaml.NewDecoder(bytes.NewReader(content))
 	decoder.KnownFields(true)
 	err := decoder.Decode(&groups)
-	// Ignore io.EOF which happends with empty input.
+	// Ignore io.EOF which happens with empty input.
 	if err != nil && err != io.EOF {
 		errs = append(errs, err)
 	}

--- a/pkg/rulefmt/rulefmt_test.go
+++ b/pkg/rulefmt/rulefmt_test.go
@@ -67,6 +67,10 @@ func TestParseFileFailure(t *testing.T) {
 			filename: "invalid_record_name.bad.yaml",
 			errMsg:   "invalid recording rule name",
 		},
+		{
+			filename: "bad_field.bad.yaml",
+			errMsg:   "field annotation not found",
+		},
 	}
 
 	for _, c := range table {

--- a/pkg/rulefmt/testdata/bad_field.bad.yaml
+++ b/pkg/rulefmt/testdata/bad_field.bad.yaml
@@ -1,0 +1,10 @@
+groups:
+  - name: yolo
+    rules:
+      - alert: hola
+        expr: 1
+        labels:
+          instance: localhost
+        annotation:
+          summary: annonations is written without s above
+


### PR DESCRIPTION
Fix #7042

The problem is not only in promtool. Prometheus successfully load broken files now, which happened to me today. It loaded a rule file with annotation and not annotations.

The previous PR #7142 seems to have a larger scope, let's move on with this one and see what's left in #7142.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->