### PR TITLE
Improved the output of `promtool test rules`

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -559,9 +559,10 @@ func TestScrapeLoopStop(t *testing.T) {
 		numScrapes++
 		if numScrapes == 2 {
 			go sl.stop()
+			<-sl.ctx.Done()
 		}
 		w.Write([]byte("metric_a 42\n"))
-		return nil
+		return ctx.Err()
 	}
 
 	go func() {


### PR DESCRIPTION
This PR improves the output of the command `promtool test rules`. It adds a human readable summary on the top which provides stats about all the alerts that were identified along with their intervals. The new output looks like the image shown below. cc: @simonpasquier

<img width="468" alt="Promtool_change" src="https://user-images.githubusercontent.com/1458117/89694826-e8026880-d8df-11ea-8bce-21884fa4f812.png">
