### PR TITLE
Use temporary directory in test to avoid data race

### DIFF
--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -859,11 +859,15 @@ func TestTargetSetRecreatesEmptyStaticConfigs(t *testing.T) {
 }
 
 func TestIdenticalConfigurationsAreCoalesced(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "sd")
+	tmpDir, err := ioutil.TempDir("", "prometheus-cfg-coalesced")
+	if err != nil {
+		t.Fatalf("error creating temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	tmpFile, err := ioutil.TempFile(tmpDir, "sd")
 	if err != nil {
 		t.Fatalf("error creating temporary file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
 	if _, err := tmpFile.Write([]byte(`[{"targets": ["foo:9090"]}]`)); err != nil {
 		t.Fatalf("error writing temporary file: %v", err)
 	}
@@ -874,7 +878,6 @@ func TestIdenticalConfigurationsAreCoalesced(t *testing.T) {
 	if err = os.Link(tmpFile.Name(), tmpFile2); err != nil {
 		t.Fatalf("error linking temporary file: %v", err)
 	}
-	defer os.Remove(tmpFile2)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -860,24 +860,17 @@ func TestTargetSetRecreatesEmptyStaticConfigs(t *testing.T) {
 
 func TestIdenticalConfigurationsAreCoalesced(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "prometheus-cfg-coalesced")
-	if err != nil {
-		t.Fatalf("error creating temporary directory: %v", err)
-	}
+	testutil.Ok(t, err)
 	defer os.RemoveAll(tmpDir)
 	tmpFile, err := ioutil.TempFile(tmpDir, "sd")
-	if err != nil {
-		t.Fatalf("error creating temporary file: %v", err)
-	}
-	if _, err := tmpFile.Write([]byte(`[{"targets": ["foo:9090"]}]`)); err != nil {
-		t.Fatalf("error writing temporary file: %v", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		t.Fatalf("error closing temporary file: %v", err)
-	}
+	testutil.Ok(t, err)
+	_, err = tmpFile.Write([]byte(`[{"targets": ["foo:9090"]}]`))
+	testutil.Ok(t, err)
+	err = tmpFile.Close()
+	testutil.Ok(t, err)
 	tmpFile2 := fmt.Sprintf("%s.json", tmpFile.Name())
-	if err = os.Link(tmpFile.Name(), tmpFile2); err != nil {
-		t.Fatalf("error linking temporary file: %v", err)
-	}
+	err = os.Link(tmpFile.Name(), tmpFile2)
+	testutil.Ok(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Fixes: #7640 

Signed-off-by: Max Neverov <neverov.max@gmail.com>

The race happens because test uses the private manager targets field to [verify pool key presence](https://github.com/prometheus/prometheus/blob/master/discovery/manager_test.go#L910). All operations with this field are guarded [with the mutex](https://github.com/prometheus/prometheus/blob/master/discovery/manager.go#L150) and this invariant is violated in the test: there is no mutexes used.
But, there should not be any concurrent operations with the `targets`.
Because prometheus watches [not files, but a directory](https://github.com/prometheus/prometheus/blob/master/discovery/file/file.go#L205), and the test creates a config file directly in [/tmp](https://github.com/prometheus/prometheus/blob/master/discovery/manager_test.go#L862) it is possible to get events for the other test directories created in `/tmp` in other tests when run with `-race`.
By creating a directory devoted for this test the events from other tests should go away.

The other solution might be is to [watch over config files](https://github.com/prometheus/prometheus/blob/master/discovery/file/file.go#L215), not directories.

@roidelapluie could you please take a look?