### PR TITLE
tsdb: Delete blocks atomically; Remove tmp blocks on start; Added test.

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -524,7 +524,7 @@ func (w *instrumentedChunkWriter) WriteChunks(chunks ...chunks.Meta) error {
 // It cleans up all files of the old blocks after completing successfully.
 func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockReader) (err error) {
 	dir := filepath.Join(dest, meta.ULID.String())
-	tmp := dir + ".tmp"
+	tmp := dir + tmpForCreationBlockDirSuffix
 	var closers []io.Closer
 	defer func(t time.Time) {
 		var merr tsdb_errors.MultiError

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -440,7 +440,7 @@ func TestCompactionFailWillCleanUpTempDir(t *testing.T) {
 	}()
 
 	testutil.NotOk(t, compactor.write(tmpdir, &BlockMeta{}, erringBReader{}))
-	_, err = os.Stat(filepath.Join(tmpdir, BlockMeta{}.ULID.String()) + ".tmp")
+	_, err = os.Stat(filepath.Join(tmpdir, BlockMeta{}.ULID.String()) + tmpForCreationBlockDirSuffix)
 	testutil.Assert(t, os.IsNotExist(err), "directory is not cleaned up")
 }
 

--- a/tsdb/repair_test.go
+++ b/tsdb/repair_test.go
@@ -14,6 +14,7 @@
 package tsdb
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,6 +27,12 @@ import (
 )
 
 func TestRepairBadIndexVersion(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "test")
+	testutil.Ok(t, err)
+	t.Cleanup(func() {
+		testutil.Ok(t, os.RemoveAll(tmpDir))
+	})
+
 	// The broken index used in this test was written by the following script
 	// at a broken revision.
 	//
@@ -59,22 +66,21 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	// 		panic(err)
 	// 	}
 	// }
-	dbDir := filepath.Join("testdata", "repair_index_version", "01BZJ9WJQPWHGNC2W4J9TA62KC")
-	tmpDir := filepath.Join("testdata", "repair_index_version", "copy")
-	tmpDbDir := filepath.Join(tmpDir, "3MCNSQ8S31EHGJYWK5E1GPJWJZ")
+	tmpDbDir := filepath.Join(tmpDir, "01BZJ9WJQPWHGNC2W4J9TA62KC")
+
+	// Create a copy DB to run test against.
+	testutil.Ok(t, fileutil.CopyDirs(filepath.Join("testdata", "repair_index_version", "01BZJ9WJQPWHGNC2W4J9TA62KC"), tmpDbDir))
 
 	// Check the current db.
 	// In its current state, lookups should fail with the fixed code.
-	_, _, err := readMetaFile(dbDir)
+	_, _, err = readMetaFile(tmpDbDir)
 	testutil.NotOk(t, err)
 
-	// Touch chunks dir in block.
-	testutil.Ok(t, os.MkdirAll(filepath.Join(dbDir, "chunks"), 0777))
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(filepath.Join(dbDir, "chunks")))
-	}()
+	// Touch chunks dir in block to imitate them.
+	testutil.Ok(t, os.MkdirAll(filepath.Join(tmpDbDir, "chunks"), 0777))
 
-	r, err := index.NewFileReader(filepath.Join(dbDir, indexFilename))
+	// Read current index to check integrity.
+	r, err := index.NewFileReader(filepath.Join(tmpDbDir, indexFilename))
 	testutil.Ok(t, err)
 	p, err := r.Postings("b", "1")
 	testutil.Ok(t, err)
@@ -87,13 +93,6 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	testutil.Ok(t, p.Err())
 	testutil.Ok(t, r.Close())
 
-	// Create a copy DB to run test against.
-	if err = fileutil.CopyDirs(dbDir, tmpDbDir); err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		testutil.Ok(t, os.RemoveAll(tmpDir))
-	}()
 	// On DB opening all blocks in the base dir should be repaired.
 	db, err := Open(tmpDir, nil, nil, nil)
 	testutil.Ok(t, err)

--- a/tsdb/testdata/repair_index_version/01BZJ9WJQPWHGNC2W4J9TA62KC/meta.json
+++ b/tsdb/testdata/repair_index_version/01BZJ9WJQPWHGNC2W4J9TA62KC/meta.json
@@ -1,6 +1,6 @@
 {
 	"version": 2,
-	"ulid": "01BZJ9WJR6Z192734YNMD62F6M",
+	"ulid": "01BZJ9WJQPWHGNC2W4J9TA62KC",
 	"minTime": 1511366400000,
 	"maxTime": 1511368200000,
 	"stats": {
@@ -11,7 +11,7 @@
 	"compaction": {
 		"level": 1,
 		"sources": [
-			"01BZJ9WJR6Z192734YNMD62F6M"
+			"01BZJ9WJQPWHGNC2W4J9TA62KC"
 		]
 	}
 }


### PR DESCRIPTION
Reason: When panic / `SEGFault` happens during deletion TSDB, can't start gracefully ): 

## Changes:

* Rename dir when deleting
* Ignoring blocks with broken meta.json on start (we do that on reload)
* Compactor writes <ulid>.tmp-for-creation blocks instead of just .tmp
* Delete tmp-for-creation and tmp-for-deletion blocks during DB open.

cc @brian-brazil @brancz @metalmatze @codesome 

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>

