### PR TITLE
rules: add evaluationTimestamp when copy state.

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -500,6 +500,7 @@ func nameAndLabels(rule Rule) string {
 // first is matched with the first, second with the second etc.
 func (g *Group) CopyState(from *Group) {
 	g.evaluationDuration = from.evaluationDuration
+	g.evaluationTimestamp = from.evaluationTimestamp
 
 	ruleMap := make(map[string][]int, len(from.rules))
 

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -657,6 +657,7 @@ func TestCopyState(t *testing.T) {
 	testutil.Equals(t, want, newGroup.seriesInPreviousEval)
 	testutil.Equals(t, oldGroup.rules[0], newGroup.rules[3])
 	testutil.Equals(t, oldGroup.evaluationDuration, newGroup.evaluationDuration)
+	testutil.Equals(t, oldGroup.evaluationTimestamp, newGroup.evaluationTimestamp)
 	testutil.Equals(t, []labels.Labels{{{Name: "l1", Value: "v3"}}}, newGroup.staleSeries)
 }
 


### PR DESCRIPTION
## Bug

`LastEvaluation` in web API may be missing in the interval between `CopyState` and `newg.run(m.opts.Context)`

## Detail


two properties used in web API
https://github.com/prometheus/prometheus/blob/e6d7cc5fa43716281bdf5d1cf40415f99a0e9623/web/api/v1/api.go#L1066-L1067

https://github.com/prometheus/prometheus/blob/c7a17f649168ef47caa683cf9c6e243f27379a92/rules/manager.go#L501-L503

the property `evaluationTimestamp` was not copied before a new group running.
https://github.com/prometheus/prometheus/blob/c7a17f649168ef47caa683cf9c6e243f27379a92/rules/manager.go#L947-L954

