### PR TITLE
Fix bad metrics name

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -186,7 +186,7 @@ func (r *RuleNode) Validate() (nodes []WrappedError) {
 	}
 
 	for k, v := range r.Labels {
-		if !model.LabelName(k).IsValid() {
+		if !model.LabelName(k).IsValid() || k == model.MetricNameLabel {
 			nodes = append(nodes, WrappedError{
 				err: errors.Errorf("invalid label name: %s", k),
 			})

--- a/pkg/rulefmt/rulefmt_test.go
+++ b/pkg/rulefmt/rulefmt_test.go
@@ -71,6 +71,10 @@ func TestParseFileFailure(t *testing.T) {
 			filename: "bad_field.bad.yaml",
 			errMsg:   "field annotation not found",
 		},
+		{
+			filename: "invalid_label_name.bad.yaml",
+			errMsg:   "invalid label name",
+		},
 	}
 
 	for _, c := range table {

--- a/pkg/rulefmt/testdata/invalid_label_name.bad.yaml
+++ b/pkg/rulefmt/testdata/invalid_label_name.bad.yaml
@@ -1,0 +1,7 @@
+groups:
+- name: yolo
+  rules:
+  - record: hola
+    expr: 1
+    labels:
+      __name__: anything


### PR DESCRIPTION
Add new fmt node rule: if a label has a name "__name__" then the value will be checked if it is a valid label name.
Fixes: #7762.

@roidelapluie could you please take a look?

Signed-off-by: Max Neverov <neverov.max@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->