### PR TITLE
Apply gofmt -s on storage/remote/write_test.go

### DIFF
--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -306,7 +306,7 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 		RemoteTimeout: model.Duration(10 * time.Second),
 		QueueConfig:   config.DefaultQueueConfig,
 		WriteRelabelConfigs: []*relabel.Config{
-			&relabel.Config{
+			{
 				Regex: relabel.MustNewRegexp(".+"),
 			},
 		},


### PR DESCRIPTION
Noticed in
https://goreportcard.com/report/github.com/prometheus/prometheus

This is the only file.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->