### PR TITLE
README: Remove direct reference to debian packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ is the recommended way of installing Prometheus.
 See the [Installing](https://prometheus.io/docs/introduction/install/)
 chapter in the documentation for all the details.
 
-Debian packages [are available](https://packages.debian.org/sid/net/prometheus).
-
 ### Docker images
 
 Docker images are available on [Quay.io](https://quay.io/repository/prometheus/prometheus) or [Docker Hub](https://hub.docker.com/r/prom/prometheus/).


### PR DESCRIPTION
We respect and appreciate the work made by the packaging team downstream
in Debian, however it seems that the package is deviating in a way that
I'd like to remove the direct reference from our README:

- The debian package is deviating from upstream in multiple ways:
  - Some Service discoveries are missing (Azure, Kubernetes)
  - The lock file is disabled and the flag has been renamed
  - The libraries are not at the same release
- We have no control over the backports and the quick availability of
  updates
- There are other distributions with different packages and we do not
  include them either
- I expect Debian users to look in their distribution and just see the
  package there 'as usual'

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->