### PR TITLE
some fixies for consul sd.

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -441,18 +441,19 @@ func (d *Discovery) watchService(ctx context.Context, ch chan<- []*targetgroup.G
 
 	go func() {
 		ticker := time.NewTicker(d.refreshInterval)
+		defer ticker.Stop()
 		var lastIndex uint64
 		health := srv.client.Health()
 		for {
 			select {
 			case <-ctx.Done():
-				ticker.Stop()
 				return
 			default:
 				srv.watch(ctx, ch, health, &lastIndex)
 				select {
 				case <-ticker.C:
 				case <-ctx.Done():
+					return
 				}
 			}
 		}

--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -348,13 +348,13 @@ func (d *Discovery) watchServices(ctx context.Context, ch chan<- []*targetgroup.
 	catalog := d.client.Catalog()
 	level.Debug(d.logger).Log("msg", "Watching services", "tags", strings.Join(d.watchedTags, ","))
 
-	t0 := time.Now()
 	opts := &consul.QueryOptions{
 		WaitIndex:  *lastIndex,
 		WaitTime:   watchTimeout,
 		AllowStale: d.allowStale,
 		NodeMeta:   d.watchedNodeMeta,
 	}
+	t0 := time.Now()
 	srvs, meta, err := catalog.Services(opts.WithContext(ctx))
 	elapsed := time.Since(t0)
 	servicesRPCDuration.Observe(elapsed.Seconds())
@@ -463,7 +463,6 @@ func (d *Discovery) watchService(ctx context.Context, ch chan<- []*targetgroup.G
 func (srv *consulService) watch(ctx context.Context, ch chan<- []*targetgroup.Group, health *consul.Health, lastIndex *uint64) {
 	level.Debug(srv.logger).Log("msg", "Watching service", "service", srv.name, "tags", strings.Join(srv.tags, ","))
 
-	t0 := time.Now()
 	opts := &consul.QueryOptions{
 		WaitIndex:  *lastIndex,
 		WaitTime:   watchTimeout,
@@ -471,6 +470,7 @@ func (srv *consulService) watch(ctx context.Context, ch chan<- []*targetgroup.Gr
 		NodeMeta:   srv.discovery.watchedNodeMeta,
 	}
 
+	t0 := time.Now()
 	serviceNodes, meta, err := health.ServiceMultipleTags(srv.name, srv.tags, false, opts.WithContext(ctx))
 	elapsed := time.Since(t0)
 	serviceRPCDuration.Observe(elapsed.Seconds())


### PR DESCRIPTION
1. Make the rpc duration more accurate.
2. Returns immediately  after the context has expired, rather than waiting for a for cycle