### PR TITLE
discovery/refresh: make metric more accurate.

### DIFF
--- a/discovery/refresh/refresh.go
+++ b/discovery/refresh/refresh.go
@@ -113,8 +113,8 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 
 func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	now := time.Now()
-	defer d.duration.Observe(time.Since(now).Seconds())
 	tgs, err := d.refreshf(ctx)
+	d.duration.Observe(time.Since(now).Seconds())
 	if err != nil {
 		d.failures.Inc()
 	}


### PR DESCRIPTION
Make metric `prometheus_sd_refresh_duration_seconds` more accurate. Because `d.refreshf` is the concrete implementation of the subclasses.