### PR TITLE
fix bug of discovery/refresh

### DIFF
--- a/discovery/refresh/refresh.go
+++ b/discovery/refresh/refresh.go
@@ -74,10 +74,8 @@ func NewDiscovery(l log.Logger, mech string, interval time.Duration, refreshf fu
 func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	// Get an initial set right away.
 	tgs, err := d.refresh(ctx)
-	if err != nil {
-		if ctx.Err() != context.Canceled {
-			level.Error(d.logger).Log("msg", "Unable to refresh target groups", "err", err.Error())
-		}
+	if err != nil && err != context.Canceled {
+		level.Error(d.logger).Log("msg", "Unable to refresh target groups", "err", err)
 	} else {
 		select {
 		case ch <- tgs:
@@ -97,10 +95,8 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 		select {
 		case <-ticker.C:
 			tgs, err := d.refresh(ctx)
-			if err != nil {
-				if ctx.Err() != context.Canceled {
-					level.Error(d.logger).Log("msg", "Unable to refresh target groups", "err", err.Error())
-				}
+			if err != nil && err != context.Canceled {
+				level.Error(d.logger).Log("msg", "Unable to refresh target groups", "err", err)
 				continue
 			}
 

--- a/discovery/refresh/refresh.go
+++ b/discovery/refresh/refresh.go
@@ -81,8 +81,12 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	} else {
 		select {
 		case ch <- tgs:
-		case <-ctx.Done():
-			return
+		default:
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 		}
 	}
 
@@ -102,8 +106,12 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 
 			select {
 			case ch <- tgs:
-			case <-ctx.Done():
-				return
+			default:
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
 			}
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
## bug 1

https://github.com/prometheus/prometheus/blob/8ec6f028541531755bb53a52bd8ea863a45530dd/discovery/refresh/refresh.go#L76-L84

The order in which the SELECT statement is executed determines the possibility of losing the `tgs` just obtained. A more explicit order would solve the bug.

## bug 2

https://github.com/prometheus/prometheus/blob/8ec6f028541531755bb53a52bd8ea863a45530dd/discovery/refresh/refresh.go#L76-L80

1. Comparing `ctx.Err()` and `err` at the same time may cause error loss. For example, no-nil `err` return from `refresh()` but `ctx` has not finished until comparing the two just equal.
2. `ctx.Err()` is passed through via `err` in the subclass implementation.