### PR TITLE
Update github workflow for funcbench and prombench to incorporate new test infra related changes for gke

### DIFF
--- a/.github/workflows/funcbench.yml
+++ b/.github/workflows/funcbench.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.action == 'funcbench_start'
     runs-on: ubuntu-latest
     env:
-      AUTH_FILE: ${{ secrets.TEST_INFRA_GKE_AUTH }}
+      AUTH_FILE: ${{ secrets.TEST_INFRA_PROVIDER_AUTH }}
       BRANCH: ${{ github.event.client_payload.BRANCH }}
       BENCH_FUNC_REGEX: ${{ github.event.client_payload.BENCH_FUNC_REGEX }}
       PACKAGE_PATH: ${{ github.event.client_payload.PACKAGE_PATH }}
@@ -17,8 +17,9 @@ jobs:
       GITHUB_REPO: prometheus
       GITHUB_STATUS_TARGET_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
       LAST_COMMIT_SHA: ${{ github.event.client_payload.LAST_COMMIT_SHA }}
-      PROJECT_ID: macro-mile-203600
+      GKE_PROJECT_ID: macro-mile-203600
       PR_NUMBER: ${{ github.event.client_payload.PR_NUMBER }}
+      PROVIDER: gke
       ZONE: europe-west3-a
     steps:
     - name: Update status to pending

--- a/.github/workflows/prombench.yml
+++ b/.github/workflows/prombench.yml
@@ -3,7 +3,7 @@ on:
     types: [prombench_start,prombench_restart,prombench_stop]
 name: Prombench Workflow
 env:
-  AUTH_FILE: ${{ secrets.TEST_INFRA_GKE_AUTH }}
+  AUTH_FILE: ${{ secrets.TEST_INFRA_PROVIDER_AUTH }}
   CLUSTER_NAME: test-infra
   DOMAIN_NAME: prombench.prometheus.io
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -11,8 +11,9 @@ env:
   GITHUB_REPO: prometheus
   GITHUB_STATUS_TARGET_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
   LAST_COMMIT_SHA: ${{ github.event.client_payload.LAST_COMMIT_SHA }}
-  PROJECT_ID: macro-mile-203600
+  GKE_PROJECT_ID: macro-mile-203600
   PR_NUMBER: ${{ github.event.client_payload.PR_NUMBER }}
+  PROVIDER: gke
   RELEASE: ${{ github.event.client_payload.RELEASE }}
   ZONE: europe-west3-a
 jobs:


### PR DESCRIPTION
Signed-off-by: Drumil Patel <drumilpatel720@gmail.com>

This pr incorporates following changes in favour of prometheus/test-infra#425:
- `PROJECT_ID`  =>  `GKE_PROJECT_ID`
- `TEST_INFRA_GKE_AUTH` => `TEST_INFRA_PROVIDER_AUTH`
- Add `PROVIDER` variable