### PR TITLE
API: Add limit output modifier

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -83,6 +83,7 @@ URL query parameters:
 - `time=<rfc3339 | unix_timestamp>`: Evaluation timestamp. Optional.
 - `timeout=<duration>`: Evaluation timeout. Optional. Defaults to and
    is capped by the value of the `-query.timeout` flag.
+- `limit=<int>`: limit the size of the returned result.
 
 The current server time is used if the `time` parameter is omitted.
 
@@ -151,6 +152,7 @@ URL query parameters:
 - `step=<duration | float>`: Query resolution step width in `duration` format or float number of seconds.
 - `timeout=<duration>`: Evaluation timeout. Optional. Defaults to and
    is capped by the value of the `-query.timeout` flag.
+- `limit=<int>`: limit the size of the returned result.
 
 You can URL-encode these parameters directly in the request body by using the `POST` method and
 `Content-Type: application/x-www-form-urlencoded` header. This is useful when specifying a large

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -377,6 +377,11 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 		qs = stats.NewQueryStats(qry.Stats())
 	}
 
+	res, err = applyModifiers(r, res)
+	if err != nil {
+		return apiFuncResult{nil, returnAPIError(err), res.Warnings, qry.Close}
+	}
+
 	return apiFuncResult{&queryData{
 		ResultType: res.Value.Type(),
 		Result:     res.Value,
@@ -455,6 +460,11 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 	var qs *stats.QueryStats
 	if r.FormValue("stats") != "" {
 		qs = stats.NewQueryStats(qry.Stats())
+	}
+
+	res, err = applyModifiers(r, res)
+	if err != nil {
+		return apiFuncResult{nil, returnAPIError(err), res.Warnings, qry.Close}
 	}
 
 	return apiFuncResult{&queryData{

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -397,7 +397,7 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 	err := validateModifiers(r)
 	if err != nil {
-		return apiFuncResult{nil, returnAPIError(err), nil, nil}
+		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
 
 	start, err := parseTime(r.FormValue("start"))

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -333,6 +333,11 @@ func (api *API) options(r *http.Request) apiFuncResult {
 }
 
 func (api *API) query(r *http.Request) (result apiFuncResult) {
+	err := validateModifiers(r)
+	if err != nil {
+		return apiFuncResult{nil, returnAPIError(err), nil, nil}
+	}
+
 	ts, err := parseTimeParam(r, "time", api.now())
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
@@ -390,6 +395,11 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 }
 
 func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
+	err := validateModifiers(r)
+	if err != nil {
+		return apiFuncResult{nil, returnAPIError(err), nil, nil}
+	}
+
 	start, err := parseTime(r.FormValue("start"))
 	if err != nil {
 		err = errors.Wrapf(err, "invalid parameter 'start'")

--- a/web/api/v1/output.go
+++ b/web/api/v1/output.go
@@ -35,6 +35,10 @@ func validateModifiers(r *http.Request) error {
 		if l := len(p); l != 1 {
 			return fmt.Errorf("limit only takes 1 argument, got %d", l)
 		}
+		_, err := strconv.ParseUint(p[0], 10, 64)
+		if err != nil {
+			return err
+		}
 	}
 	if p, ok := params[sortParam]; ok {
 		for _, s := range p {
@@ -67,7 +71,9 @@ func applyModifiers(r *http.Request, res *promql.Result) (*promql.Result, error)
 func applyLimit(l string, res *promql.Result) (*promql.Result, error) {
 	outSize, err := strconv.ParseUint(l, 10, 64)
 	if err != nil {
-		return nil, err
+		// This should never happen as the validate function should have been
+		// called first.
+		panic(err)
 	}
 	switch result := res.Value.(type) {
 	case promql.Matrix:

--- a/web/api/v1/output.go
+++ b/web/api/v1/output.go
@@ -1,0 +1,70 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/prometheus/prometheus/promql"
+)
+
+// modifier is a function that alters the value of a query result.
+type modifier struct {
+	name  string
+	apply func([]string, *promql.Result) (*promql.Result, error)
+}
+
+// modifiers is an ordered list of registered modifiers.
+var modifiers = []modifier{
+	{
+		name:  "limit",
+		apply: limitModifier,
+	},
+}
+
+func applyModifiers(r *http.Request, res *promql.Result) (*promql.Result, error) {
+	params := r.URL.Query()
+	var err error
+	for _, f := range modifiers {
+		if v, ok := params[f.name]; ok {
+			res, err = f.apply(v, res)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return res, nil
+}
+
+func limitModifier(limit []string, res *promql.Result) (*promql.Result, error) {
+	if l := len(limit); l != 1 {
+		return res, fmt.Errorf("limit only takes 1 argument, got %d", l)
+	}
+	outSize, err := strconv.ParseUint(limit[0], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	switch result := res.Value.(type) {
+	case promql.Matrix:
+		res.Value = result[:outSize]
+		return res, nil
+	case promql.Vector:
+		res.Value = result[:outSize]
+		return res, nil
+	default:
+		panic("unknown return type")
+	}
+}


### PR DESCRIPTION
This is the beginning of the output modifiers.

This is primitve and has no tests, it is a first POC to validate if that is the general direction we want to go.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->