### PR TITLE
Drop metric name in bool comparison between two instant vectors

### DIFF
--- a/docs/querying/operators.md
+++ b/docs/querying/operators.md
@@ -31,7 +31,7 @@ scalar that is the result of the operator applied to both scalar operands.
 **Between an instant vector and a scalar**, the operator is applied to the
 value of every data sample in the vector. E.g. if a time series instant vector
 is multiplied by 2, the result is another vector in which every sample value of
-the original vector is multiplied by 2.
+the original vector is multiplied by 2. The metric name is dropped.
 
 **Between two instant vectors**, a binary arithmetic operator is applied to
 each entry in the left-hand side vector and its [matching element](#vector-matching)
@@ -64,7 +64,8 @@ operators result in another scalar that is either `0` (`false`) or `1`
 value of every data sample in the vector, and vector elements between which the
 comparison result is `false` get dropped from the result vector. If the `bool`
 modifier is provided, vector elements that would be dropped instead have the value
-`0` and vector elements that would be kept have the value `1`.
+`0` and vector elements that would be kept have the value `1`. The metric name
+is dropped if the `bool` modifier is provided.
 
 **Between two instant vectors**, these operators behave as a filter by default,
 applied to matching entries. Vector elements for which the expression is not
@@ -74,6 +75,7 @@ with the grouping labels becoming the output label set.
 If the `bool` modifier is provided, vector elements that would have been
 dropped instead have the value `0` and vector elements that would be kept have
 the value `1`, with the grouping labels again becoming the output label set.
+The metric name is dropped if the `bool` modifier is provided.
 
 ### Logical/set binary operators
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1656,6 +1656,9 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 			continue
 		}
 		metric := resultMetric(ls.Metric, rs.Metric, op, matching, enh)
+		if returnBool {
+			metric = enh.dropMetricName(metric)
+		}
 		insertedSigs, exists := matchedSigs[sig]
 		if matching.Card == parser.CardOneToOne {
 			if exists {

--- a/promql/testdata/operators.test
+++ b/promql/testdata/operators.test
@@ -438,3 +438,20 @@ load 5m
   testmetric2{src="a",dst="b"} 1
 
 eval_fail instant at 0m -{__name__=~'testmetric1|testmetric2'}
+
+clear
+
+load 5m
+    test_total{instance="localhost"} 5
+    test_smaller{instance="localhost"} 10
+
+eval instant at 5m test_total < bool test_smaller
+    {instance="localhost"} 1
+
+eval instant at 5m test_total < test_smaller
+    test_total{instance="localhost"} 5
+
+eval instant at 5m test_total > bool test_smaller
+    {instance="localhost"} 0
+
+eval instant at 5m test_total > test_smaller


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->