### PR TITLE
Label rule_group_iterations metric with group name

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -269,6 +269,8 @@ func NewGroup(o GroupOptions) *Group {
 	}
 
 	key := groupKey(o.File, o.Name)
+	metrics.iterationsMissed.WithLabelValues(key)
+	metrics.iterationsScheduled.WithLabelValues(key)
 	metrics.evalTotal.WithLabelValues(key)
 	metrics.evalFailures.WithLabelValues(key)
 	metrics.groupLastEvalTime.WithLabelValues(key)

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -970,6 +970,8 @@ func (m *Manager) Update(interval time.Duration, files []string, externalLabels 
 			g.markStale = true
 			g.stop()
 			if m := g.metrics; m != nil {
+				m.iterationsMissed.DeleteLabelValues(n)
+				m.iterationsScheduled.DeleteLabelValues(n)
 				m.evalTotal.DeleteLabelValues(n)
 				m.evalFailures.DeleteLabelValues(n)
 				m.groupInterval.DeleteLabelValues(n)


### PR DESCRIPTION
evalTotal and evalFailures having the label but `iterations_total` not having it
is an odd mismatch.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>