### PR TITLE
golangci: Use depguard to prevent using restricted packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
 
 linters:
   enable:
+  - depguard
   - golint
 
 issues:
@@ -13,5 +14,12 @@ issues:
     - errcheck
 
 linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    packages:
+      - sync/atomic
+    packages-with-error-message:
+      - sync/atomic: "Use go.uber.org/atomic instead of sync/atomic"
   errcheck:
     exclude: scripts/errcheck_excludes.txt


### PR DESCRIPTION
Enabling this linter in golangci will check that we are not using
restricted packages, and when a match is found, it will provide a
message suggesting the alternative package.

In this particular case, we enable it for `sync/atomic`.

---

Closes https://github.com/prometheus/prometheus/issues/7647 and supersedes https://github.com/prometheus/prometheus/pull/7743

---

How I tested this to ensure that it works as expected:

I checked out a previous commit in which we still have occurrences of `sync/atomic` (348ff42), and run `golangci-lint`:

```
➜  prometheus git:(master) ✗ git checkout 348ff42
M	.golangci.yml
Note: switching to '348ff42'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 348ff4285 tsdb: Replace sync/atomic with uber-go/atomic in tsdb (#7659)
➜  prometheus git:(348ff4285) ✗ golangci-lint run --disable-all --enable=depguard -v
INFO [config_reader] Config search paths: [./ /Users/javier/Projects/observability/prometheus/prometheus /Users/javier/Projects/observability/prometheus /Users/javier/Projects/observability /Users/javier/Projects /Users/javier /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 2 linters: [depguard golint]
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|files|name|imports|types_sizes) took 1.566581906s
INFO [runner/filename_unadjuster] Pre-built 1 adjustments in 105.651984ms
INFO [linters context/goanalysis] analyzers took 1.056761662s with top 10 stages: golint: 1.043250665s, depguard: 13.510997ms
INFO [runner/filename_unadjuster] Unadjusted from /Users/javier/Projects/observability/prometheus/prometheus/promql/parser/generated_parser.y:43 to /Users/javier/Projects/observability/prometheus/prometheus/promql/parser/generated_parser.y.go:36:7
INFO [runner/max_same_issues] 7/10 issues with text "`sync/atomic` is in the blacklist: Use go.uber.org/atomic instead of sync/atomic" were hidden, use --max-same-issues
INFO [runner] Issues before processing: 865, after processing: 3
INFO [runner] Processors filtering stat (out/in): max_from_linter: 3/3, cgo: 865/865, skip_files: 865/865, autogenerated_exclude: 202/865, exclude-rules: 11/11, filename_unadjuster: 865/865, diff: 10/10, max_same_issues: 3/10, path_shortener: 3/3, severity-rules: 3/3, sort_results: 3/3, path_prettifier: 865/865, nolint: 10/11, uniq_by_line: 10/10, source_code: 3/3, path_prefixer: 3/3, skip_dirs: 865/865, identifier_marker: 202/202, exclude: 11/202, max_per_file_from_linter: 10/10
INFO [runner] processing took 29.947821ms with stages: nolint: 12.772189ms, exclude: 5.971977ms, identifier_marker: 4.183374ms, path_prettifier: 3.345743ms, autogenerated_exclude: 2.399239ms, skip_dirs: 429.585µs, source_code: 411.487µs, filename_unadjuster: 228.129µs, cgo: 98.145µs, max_same_issues: 76.505µs, exclude-rules: 12.089µs, uniq_by_line: 7.847µs, max_from_linter: 4.679µs, path_shortener: 3.669µs, max_per_file_from_linter: 1.142µs, skip_files: 569ns, severity-rules: 477ns, sort_results: 445ns, diff: 352ns, path_prefixer: 179ns
INFO [runner] linters took 1.719782118s with stages: goanalysis_metalinter: 1.689653629s
tsdb/head_bench_test.go:20:2: `sync/atomic` is in the blacklist: Use go.uber.org/atomic instead of sync/atomic (depguard)
	"sync/atomic"
	^
notifier/notifier.go:29:2: `sync/atomic` is in the blacklist: Use go.uber.org/atomic instead of sync/atomic (depguard)
	"sync/atomic"
	^
notifier/notifier_test.go:25:2: `sync/atomic` is in the blacklist: Use go.uber.org/atomic instead of sync/atomic (depguard)
	"sync/atomic"
	^
INFO File cache stats: 3 entries of total size 35.1KiB
INFO Memory: 36 samples, avg is 193.7MB, max is 536.0MB
INFO Execution took 3.414709461s
```

When running this on `master`, which has no occurrences of `sync/master`, the linter passes:

```
➜  prometheus git:(master) ✗ golangci-lint run --disable-all --enable=depguard -v
INFO [config_reader] Config search paths: [./ /Users/javier/Projects/observability/prometheus/prometheus /Users/javier/Projects/observability/prometheus /Users/javier/Projects/observability /Users/javier/Projects /Users/javier /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 2 linters: [depguard golint]
INFO [loader] Go packages loading at mode 575 (compiled_files|exports_file|files|imports|deps|name|types_sizes) took 1.576922884s
INFO [runner/filename_unadjuster] Pre-built 1 adjustments in 111.914537ms
INFO [linters context/goanalysis] analyzers took 0s with no stages
INFO [runner/filename_unadjuster] Unadjusted from /Users/javier/Projects/observability/prometheus/prometheus/promql/parser/generated_parser.y:43 to /Users/javier/Projects/observability/prometheus/prometheus/promql/parser/generated_parser.y.go:36:7
INFO [runner] Issues before processing: 863, after processing: 0
INFO [runner] Processors filtering stat (out/in): nolint: 0/1, exclude-rules: 1/1, filename_unadjuster: 863/863, path_prettifier: 863/863, skip_dirs: 863/863, identifier_marker: 200/200, exclude: 1/200, skip_files: 863/863, autogenerated_exclude: 200/863, cgo: 863/863
INFO [runner] processing took 20.668772ms with stages: identifier_marker: 6.469908ms, exclude: 5.460288ms, autogenerated_exclude: 3.289079ms, path_prettifier: 2.765864ms, nolint: 1.955973ms, skip_dirs: 426.006µs, filename_unadjuster: 187.172µs, cgo: 108.027µs, exclude-rules: 2.178µs, max_same_issues: 1.021µs, uniq_by_line: 511ns, diff: 383ns, skip_files: 382ns, path_shortener: 356ns, max_from_linter: 337ns, sort_results: 314ns, source_code: 279ns, max_per_file_from_linter: 255ns, severity-rules: 231ns, path_prefixer: 208ns
INFO [runner] linters took 402.232202ms with stages: goanalysis_metalinter: 381.456245ms
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 23 samples, avg is 70.1MB, max is 70.6MB
INFO Execution took 2.113110956s
➜  prometheus git:(master) ✗
```