### PR TITLE
Fix Experimental UI for cookie based authentication

### DIFF
--- a/web/ui/react-app/public/index.html
+++ b/web/ui/react-app/public/index.html
@@ -27,7 +27,7 @@
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials"/>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
We're using Prometheus behind a reverse proxy which authenticates based on cookies. 
Without this attribute the cookie is not send with the request for the manifest.json

I found this question on [stackoverflow](https://stackoverflow.com/questions/51777346/cookies-not-sent-with-request-for-web-app-manifest-json) which indicates that cookies are only send with this attribute