### PR TITLE
Promtool: add evaluation time to instant query

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -436,10 +436,8 @@ func QueryInstant(url, query, evalTime string, p printer) int {
 		return 1
 	}
 
-	var eTime time.Time
-	if evalTime == "" {
-		eTime = time.Now()
-	} else {
+	eTime := time.Now()
+	if evalTime != "" {
 		eTime, err = parseTime(evalTime)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "error parsing evaluation time:", err)

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -66,9 +66,11 @@ func main() {
 
 	queryCmd := app.Command("query", "Run query against a Prometheus server.")
 	queryCmdFmt := queryCmd.Flag("format", "Output format of the query.").Short('o').Default("promql").Enum("promql", "json")
+
 	queryInstantCmd := queryCmd.Command("instant", "Run instant query.")
-	queryServer := queryInstantCmd.Arg("server", "Prometheus server to query.").Required().String()
-	queryExpr := queryInstantCmd.Arg("expr", "PromQL query expression.").Required().String()
+	queryInstantServer := queryInstantCmd.Arg("server", "Prometheus server to query.").Required().String()
+	queryInstantExpr := queryInstantCmd.Arg("expr", "PromQL query expression.").Required().String()
+	queryInstantTime := queryInstantCmd.Flag("time", "Query evaluation time (RFC3339 or Unix timestamp).").String()
 
 	queryRangeCmd := queryCmd.Command("range", "Run range query.")
 	queryRangeServer := queryRangeCmd.Arg("server", "Prometheus server to query.").Required().String()
@@ -149,7 +151,7 @@ func main() {
 		os.Exit(CheckMetrics())
 
 	case queryInstantCmd.FullCommand():
-		os.Exit(QueryInstant(*queryServer, *queryExpr, p))
+		os.Exit(QueryInstant(*queryInstantServer, *queryInstantExpr, *queryInstantTime, p))
 
 	case queryRangeCmd.FullCommand():
 		os.Exit(QueryRange(*queryRangeServer, *queryRangeHeaders, *queryRangeExpr, *queryRangeBegin, *queryRangeEnd, *queryRangeStep, p))
@@ -422,7 +424,7 @@ func CheckMetrics() int {
 }
 
 // QueryInstant performs an instant query against a Prometheus server.
-func QueryInstant(url, query string, p printer) int {
+func QueryInstant(url, query, evalTime string, p printer) int {
 	config := api.Config{
 		Address: url,
 	}
@@ -434,11 +436,22 @@ func QueryInstant(url, query string, p printer) int {
 		return 1
 	}
 
+	var eTime time.Time
+	if evalTime == "" {
+		eTime = time.Now()
+	} else {
+		eTime, err = parseTime(evalTime)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error parsing evaluation time:", err)
+			return 1
+		}
+	}
+
 	// Run query against client.
 	api := v1.NewAPI(c)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	val, _, err := api.Query(ctx, query, time.Now()) // Ignoring warnings for now.
+	val, _, err := api.Query(ctx, query, eTime) // Ignoring warnings for now.
 	cancel()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "query error:", err)


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->