### PR TITLE
Add a link to Clean TombStone for better reference

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -980,7 +980,7 @@ The snapshot now exists at `<data-dir>/snapshots/20171210T211224Z-2be650b6d019eb
 *New in v2.1 and supports PUT from v2.9*
 
 ### Delete Series
-DeleteSeries deletes data for a selection of series in a time range. The actual data still exists on disk and is cleaned up in future compactions or can be explicitly cleaned up by hitting the Clean Tombstones endpoint.
+DeleteSeries deletes data for a selection of series in a time range. The actual data still exists on disk and is cleaned up in future compactions or can be explicitly cleaned up by hitting the [Clean Tombstones](#clean-tombstones) endpoint.
 
 If successful, a `204` is returned.
 


### PR DESCRIPTION
We mentioned the `Clean Tombstones` endpoint in `Delete Series` section, and it'll confuse user because the `Clean Tombstones` is still not introduced. Add a link to Clean TombStone for better reference.