### PR TITLE
expose UserAgent to make it changeable by importers

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -40,7 +40,7 @@ import (
 
 const maxErrMsgLen = 256
 
-var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+var UserAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 
 var (
 	remoteReadQueriesTotal = prometheus.NewCounterVec(
@@ -155,7 +155,7 @@ func (c *Client) Store(ctx context.Context, req []byte) error {
 	}
 	httpReq.Header.Add("Content-Encoding", "snappy")
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
-	httpReq.Header.Set("User-Agent", userAgent)
+	httpReq.Header.Set("User-Agent", UserAgent)
 	httpReq.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
@@ -233,7 +233,7 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query) (*prompb.QueryRe
 	httpReq.Header.Add("Content-Encoding", "snappy")
 	httpReq.Header.Add("Accept-Encoding", "snappy")
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
-	httpReq.Header.Set("User-Agent", userAgent)
+	httpReq.Header.Set("User-Agent", UserAgent)
 	httpReq.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
 
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)


### PR DESCRIPTION
This is the PR to make the old `userAgent` global public as a follow up to the discussion in [prometheus/common#252](https://github.com/prometheus/common/pull/252#issuecomment-676780230). 

I would like to modify the User-Agent header sent from `grafana/agent` to track incoming remote_write requests coming from Prometheus vs the Grafana Cloud Agent.