### PR TITLE
Update prombench workflows to incorporate new naming convention for eks

### DIFF
--- a/.github/workflows/prombench.yml
+++ b/.github/workflows/prombench.yml
@@ -34,7 +34,7 @@ jobs:
       uses: docker://prominfra/prombench:master
       with:
         args: >-
-          until make all_nodepools_deleted; do echo "waiting for nodepools to be deleted"; sleep 10; done;
+          until make all_nodes_deleted; do echo "waiting for nodepools to be deleted"; sleep 10; done;
           make deploy;
     - name: Update status to failure
       if: failure()
@@ -69,7 +69,7 @@ jobs:
       uses: docker://prominfra/prombench:master
       with:
         args: >-
-          until make all_nodepools_running; do echo "waiting for nodepools to be created"; sleep 10; done;
+          until make all_nodes_running; do echo "waiting for nodepools to be created"; sleep 10; done;
           make clean;
     - name: Update status to failure
       if: failure()
@@ -104,9 +104,9 @@ jobs:
       uses: docker://prominfra/prombench:master
       with:
         args: >-
-          until make all_nodepools_running; do echo "waiting for nodepools to be created"; sleep 10; done;
+          until make all_nodes_running; do echo "waiting for nodepools to be created"; sleep 10; done;
           make clean;
-          until make all_nodepools_deleted; do echo "waiting for nodepools to be deleted"; sleep 10; done;
+          until make all_nodes_deleted; do echo "waiting for nodepools to be deleted"; sleep 10; done;
           make deploy;
     - name: Update status to failure
       if: failure()


### PR DESCRIPTION
Signed-off-by: Drumil Patel <drumilpatel720@gmail.com>

This pr incorporates following changes in `.github/workflows/prombench.yml` in favor of prometheus/test-infra#384 :-
1. `all_nodepools_deleted` => `all_nodes_deleted`
2. `all_nodepools_running` => `all_nodes_running`