### PR TITLE
add relabeling link to be consistent with other section

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -294,7 +294,7 @@ A `tls_config` allows configuring TLS connections.
 
 Azure SD configurations allow retrieving scrape targets from Azure VMs.
 
-The following meta labels are available on targets during relabeling:
+The following meta labels are available on targets during [relabeling](#relabel_config):
 
 * `__meta_azure_machine_id`: the machine ID
 * `__meta_azure_machine_location`: the location the machine runs in
@@ -1288,7 +1288,7 @@ stored in [Zookeeper](https://zookeeper.apache.org/). Serversets are commonly
 used by [Finagle](https://twitter.github.io/finagle/) and
 [Aurora](https://aurora.apache.org/).
 
-The following meta labels are available on targets during relabeling:
+The following meta labels are available on targets during [relabeling](#relabel_config):
 
 * `__meta_serverset_path`: the full path to the serverset member node in Zookeeper
 * `__meta_serverset_endpoint_host`: the host of the default endpoint


### PR DESCRIPTION
In the configuration page, we mentioned `relabeling` a lot, and most of them are linking to the relabeling section because the relabeling section is at the bottom part of the page. I added 2 missing link in the page.

![image](https://user-images.githubusercontent.com/43372967/91250764-6427f780-e78c-11ea-8135-9fb8c9b515f6.png)

Signed-off-by: Luke Chen <showuon@gmail.com>
