### PR TITLE
promql/parser: use pos instead of origin.

### DIFF
--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -72,7 +72,7 @@ func (e *ParseErr) Error() string {
 		positionStr = "invalid position:"
 	} else {
 
-		for i, c := range e.Query[:e.PositionRange.Start] {
+		for i, c := range e.Query[:pos] {
 			if c == '\n' {
 				lastLineBreak = i
 				line++


### PR DESCRIPTION
As `pos` has defined, so use it better.