### PR TITLE
Fix the duplicated results issue from /api/v1/series

### DIFF
--- a/storage/merge.go
+++ b/storage/merge.go
@@ -331,7 +331,7 @@ func (c *genericMergeSeriesSet) Next() bool {
 	// If, for the current label set, all the next series sets come from
 	// failed remote storage sources, we want to keep trying with the next label set.
 	for {
-		// Firstly advance all the current series sets. If any of them have run out
+		// Firstly advance all the current series sets. If any of them have run out,
 		// we can drop them, otherwise they should be inserted back into the heap.
 		for _, set := range c.currentSets {
 			if set.Next() {

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -603,7 +603,8 @@ func (api *API) series(r *http.Request) (result apiFuncResult) {
 
 	var sets []storage.SeriesSet
 	for _, mset := range matcherSets {
-		s := q.Select(false, nil, mset...)
+		// We need to sort this select results to merge(deduplicate) the series sets later.
+		s := q.Select(true, nil, mset...)
 		sets = append(sets, s)
 	}
 

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -603,7 +603,7 @@ func (api *API) series(r *http.Request) (result apiFuncResult) {
 
 	var sets []storage.SeriesSet
 	for _, mset := range matcherSets {
-		// We need to sort this select results to merge(deduplicate) the series sets later.
+		// We need to sort this select results to merge (deduplicate) the series sets later.
 		s := q.Select(true, nil, mset...)
 		sets = append(sets, s)
 	}


### PR DESCRIPTION
Fix #7801 . Sort the Select returned series sets for later merge to de-duplicate results. And add test to try to overlap the select returned series sets and make sure it'll return expected results. I tested if I reverted my change (not sort the select results), the test result will fail sometimes due to the duplicated results returned. (About 20%~30% possibility to reproduce it since the result set is still not large enough. But it somehow can protect the behavior since it'll fail sometimes if behavior changed.)

Signed-off-by: Luke Chen <showuon@gmail.com>
