### PR TITLE
Add support for label names and values in vector() function.

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -398,7 +398,18 @@ the given vector as the number of seconds since January 1, 1970 UTC.
 
 ## `vector()`
 
-`vector(s scalar)` returns the scalar `s` as a vector with no labels.
+`vector(s scalar, labelname_1, labelvalue_1, labelname_2, labelvalue_2, ...)`
+returns the scalar `s` as a vector:
+
+```
+vector(1)
+```
+
+Label names and values can be passed as optional parameters:
+
+```
+vector(1,"job","prometheus","instance","localhost")
+```
 
 ## `year()`
 

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -753,9 +753,23 @@ func funcLabelReplace(vals []parser.Value, args parser.Expressions, enh *EvalNod
 
 // === Vector(s Scalar) Vector ===
 func funcVector(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	l := labels.NewBuilder(labels.Labels{})
+
+	if len(args)%2 != 1 {
+		panic(errors.Errorf("expected an odd number of arguments"))
+	}
+
+	for i := 2; i <= len(args); i += 2 {
+		ln := args[i-1].(*parser.StringLiteral).Val
+		if !model.LabelName(ln).IsValid() {
+			panic(errors.Errorf("invalid source label name in label_join(): %s", ln))
+		}
+		l.Set(ln, args[i].(*parser.StringLiteral).Val)
+	}
+
 	return append(enh.Out,
 		Sample{
-			Metric: labels.Labels{},
+			Metric: l.Labels(),
 			Point:  Point{V: vals[0].(Vector)[0].V},
 		})
 }

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -259,7 +259,8 @@ var Functions = map[string]*Function{
 	},
 	"vector": {
 		Name:       "vector",
-		ArgTypes:   []ValueType{ValueTypeScalar},
+		ArgTypes:   []ValueType{ValueTypeScalar, ValueTypeString},
+		Variadic:   -1,
 		ReturnType: ValueTypeVector,
 	},
 	"year": {

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -734,3 +734,15 @@ eval instant at 5m absent_over_time({job="ingress"}[4m])
 
 eval instant at 10m absent_over_time({job="ingress"}[4m])
 	{job="ingress"} 1
+
+# Test for vector
+clear
+
+eval instant at 10m vector(6)
+    {} 6
+
+eval instant at 10m vector(6, "job", "prometheus")
+    {job="prometheus"} 6
+
+eval instant at 10m vector(6, "job", "prometheus", "instance", "localhost")
+    {job="prometheus",instance="localhost"} 6


### PR DESCRIPTION
I sometimes need to do (while testing promql expressions in the
browser):

```
label_replace(
    label_replace(
        vector(1), "instance, "localhost", "", ""
    ), "job", "prometheus", "",""
)
```

And I was thinking that providing a function that in one go can do:

```
vector(1, "job", "prometheus", "instance, "localhost")
```

would be super handy.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->