### PR TITLE
tsdb: remove redundant fields.

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1397,11 +1397,10 @@ func (h *Head) chunksRange(mint, maxt int64, is *isolationState) (*headChunkRead
 		mint = hmin
 	}
 	return &headChunkReader{
-		head:         h,
-		mint:         mint,
-		maxt:         maxt,
-		isoState:     is,
-		memChunkPool: &h.memChunkPool,
+		head:     h,
+		mint:     mint,
+		maxt:     maxt,
+		isoState: is,
 	}, nil
 }
 
@@ -1456,10 +1455,9 @@ func (h *Head) Close() error {
 }
 
 type headChunkReader struct {
-	head         *Head
-	mint, maxt   int64
-	isoState     *isolationState
-	memChunkPool *sync.Pool
+	head       *Head
+	mint, maxt int64
+	isoState   *isolationState
 }
 
 func (h *headChunkReader) Close() error {
@@ -1503,7 +1501,7 @@ func (h *headChunkReader) Chunk(ref uint64) (chunkenc.Chunk, error) {
 		if garbageCollect {
 			// Set this to nil so that Go GC can collect it after it has been used.
 			c.chunk = nil
-			h.memChunkPool.Put(c)
+			s.memChunkPool.Put(c)
 		}
 	}()
 


### PR DESCRIPTION
Remove redundant fields as the `memSeries` already has a reference to the pool.

https://github.com/prometheus/prometheus/blob/c8062622063179bff4eed36df0bf81be3890902b/tsdb/head.go#L1953
