### PR TITLE
Fix Hetzner Robot SD decoding with non HTTP 2xx

### DIFF
--- a/discovery/hetzner/mock_test.go
+++ b/discovery/hetzner/mock_test.go
@@ -550,17 +550,3 @@ func (m *SDMock) HandleRobotServers() {
 		)
 	})
 }
-
-// HandleRobotServers mocks the robot servers list endpoint.
-func (m *SDMock) HandleRobotServersWithError() {
-	m.Mux.HandleFunc("/server", func(w http.ResponseWriter, r *http.Request) {
-		username, password, ok := r.BasicAuth()
-		if username != robotTestUsername && password != robotTestPassword && !ok {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-
-		w.Header().Add("content-type", "application/json; charset=utf-8")
-		w.WriteHeader(http.StatusUnauthorized)
-	})
-}

--- a/discovery/hetzner/mock_test.go
+++ b/discovery/hetzner/mock_test.go
@@ -550,3 +550,17 @@ func (m *SDMock) HandleRobotServers() {
 		)
 	})
 }
+
+// HandleRobotServers mocks the robot servers list endpoint.
+func (m *SDMock) HandleRobotServersWithError() {
+	m.Mux.HandleFunc("/server", func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if username != robotTestUsername && password != robotTestPassword && !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Add("content-type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+}

--- a/discovery/hetzner/robot.go
+++ b/discovery/hetzner/robot.go
@@ -77,8 +77,8 @@ func (d *robotDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, err
 		resp.Body.Close()
 	}()
 
-	if (resp.StatusCode < 200) || (resp.StatusCode >= 300) {
-		return nil, errors.Errorf("non 2xx status '%v' response during hetzner service discovery with role robot", resp.StatusCode)
+	if resp.StatusCode/100 != 2 {
+		return nil, errors.Errorf("non 2xx status '%d' response during hetzner service discovery with role robot", resp.StatusCode)
 	}
 
 	var servers serversList


### PR DESCRIPTION
Fix Hetzner Robot SD trying to decode response when a non 2xx HTTP code was returned.
Closes #7870
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->