### PR TITLE
Have a Generic placeholders definition section in API.md

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -46,21 +46,20 @@ The JSON response envelope format is as follows:
 }
 ```
 
-Input timestamps may be provided either in
+Generic placeholders are defined as follows:
+
+* `<rfc3339 | unix_timestamp>`: Input timestamps may be provided either in
 [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format or as a Unix timestamp
 in seconds, with optional decimal places for sub-second precision. Output
 timestamps are always represented as Unix timestamps in seconds.
-
-Names of query parameters that may be repeated end with `[]`.
-
-`<series_selector>` placeholders refer to Prometheus [time series
+* `<series_selector>`: Prometheus [time series
 selectors](basics.md#time-series-selectors) like `http_requests_total` or
 `http_requests_total{method=~"(GET|POST)"}` and need to be URL-encoded.
-
-`<duration>` placeholders refer to [Prometheus duration strings](basics.md#time_durations).
+* `<duration>`: [Prometheus duration strings](basics.md#time_durations).
 For example, `5m` refers to a duration of 5 minutes.
+* `<bool>`: boolean values (strings `true` and `false`).
 
-`<bool>` placeholders refer to boolean values (strings `true` and `false`).
+Note: Names of query parameters that may be repeated end with `[]`.
 
 ## Expression queries
 


### PR DESCRIPTION
Fix #5567, Referring to configuration.md, to have a Generic placeholders definition section in API.md, so that users can easily find the definition of `unix_timestamp` or `rfc3399` timestamp.

Before:
![image](https://user-images.githubusercontent.com/43372967/91786951-603c1f80-ec3b-11ea-9091-a83786418eea.png)



After:
![image](https://user-images.githubusercontent.com/43372967/91786826-13584900-ec3b-11ea-83e6-70c3897dfb10.png)



Signed-off-by: Luke Chen <showuon@gmail.com>
