### PR TITLE
React UI: Implement missing TSDB head stats section

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -840,7 +840,6 @@ $ curl http://localhost:9090/api/v1/status/runtimeinfo
     "CWD": "/",
     "reloadConfigSuccess": true,
     "lastConfigTime": "2019-11-02T17:23:59+01:00",
-    "chunkCount": 873,
     "timeSeriesCount": 873,
     "corruptionCount": 0,
     "goroutineCount": 48,
@@ -892,6 +891,11 @@ The following endpoint returns various cardinality statistics about the Promethe
 ```
 GET /api/v1/status/tsdb
 ```
+- **headStats**: This provides the following data about the head block of the TSDB:
+  - **numSeries**: The number of series.
+  - **chunkCount**: The number of chunks.
+  - **minTime**: The current minimum timestamp in milliseconds.
+  - **maxTime**: The current maximum timestamp in milliseconds.
 - **seriesCountByMetricName:**  This will provide a list of metrics names and their series count.
 - **labelValueCountByLabelName:** This will provide a list of the label names and their value count.
 - **memoryInBytesByLabelName** This will provide a list of the label names and memory used in bytes. Memory usage is calculated by adding the length of all values for a given label name.
@@ -902,6 +906,12 @@ $ curl http://localhost:9090/api/v1/status/tsdb
 {
   "status": "success",
   "data": {
+    "headStats": {
+      "numSeries": 508,
+      "chunkCount": 937,
+      "minTime": 1591516800000,
+      "maxTime": 1598896800143,
+    },
     "seriesCountByMetricName": [
       {
         "name": "net_conntrack_dialer_conn_failed_total",

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1194,6 +1194,7 @@ func (api *API) serveTSDBStatus(*http.Request) apiFuncResult {
 			m := *mF.Metric[0]
 			if m.Gauge != nil {
 				chunkCount = int64(m.Gauge.GetValue())
+				break
 			}
 		}
 	}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2714,7 +2714,7 @@ func TestTSDBStatus(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			api := &API{db: tc.db}
+			api := &API{db: tc.db, gatherer: prometheus.DefaultGatherer}
 			endpoint := tc.endpoint(api)
 			req, err := http.NewRequest(tc.method, fmt.Sprintf("?%s", tc.values.Encode()), nil)
 			if err != nil {

--- a/web/ui/react-app/src/pages/status/Status.test.tsx
+++ b/web/ui/react-app/src/pages/status/Status.test.tsx
@@ -11,8 +11,6 @@ describe('Status', () => {
         CWD: '/home/boyskila/Desktop/prometheus',
         reloadConfigSuccess: true,
         lastConfigTime: '2019-10-30T22:03:23+02:00',
-        chunkCount: 1383,
-        timeSeriesCount: 461,
         corruptionCount: 0,
         goroutineCount: 37,
         GOMAXPROCS: 4,

--- a/web/ui/react-app/src/pages/status/Status.tsx
+++ b/web/ui/react-app/src/pages/status/Status.tsx
@@ -21,8 +21,6 @@ export const statusConfig: Record<
     customizeValue: (v: boolean) => (v ? 'Successful' : 'Unsuccessful'),
   },
   lastConfigTime: { title: 'Last successful configuration reload' },
-  chunkCount: { title: 'Head chunks' },
-  timeSeriesCount: { title: 'Head time series' },
   corruptionCount: { title: 'WAL corruptions' },
   goroutineCount: { title: 'Goroutines' },
   storageRetention: { title: 'Storage retention' },

--- a/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.test.tsx
+++ b/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.test.tsx
@@ -12,6 +12,12 @@ const fakeTSDBStatusResponse: {
 } = {
   status: 'success',
   data: {
+    headStats: {
+      numSeries: 508,
+      chunkCount: 937,
+      minTime: 1591516800000,
+      maxTime: 1598896800143,
+    },
     labelValueCountByLabelName: [
       {
         name: '__name__',
@@ -51,22 +57,10 @@ describe('TSDB Stats', () => {
   describe('Table Data Validation', () => {
     it('Table Test', async () => {
       const tables = [
-        {
-          data: fakeTSDBStatusResponse.data.labelValueCountByLabelName,
-          table_index: 0,
-        },
-        {
-          data: fakeTSDBStatusResponse.data.seriesCountByMetricName,
-          table_index: 1,
-        },
-        {
-          data: fakeTSDBStatusResponse.data.memoryInBytesByLabelName,
-          table_index: 2,
-        },
-        {
-          data: fakeTSDBStatusResponse.data.seriesCountByLabelValuePair,
-          table_index: 3,
-        },
+        fakeTSDBStatusResponse.data.labelValueCountByLabelName,
+        fakeTSDBStatusResponse.data.seriesCountByMetricName,
+        fakeTSDBStatusResponse.data.memoryInBytesByLabelName,
+        fakeTSDBStatusResponse.data.seriesCountByLabelValuePair,
       ];
 
       const mock = fetchMock.mockResponse(JSON.stringify(fakeTSDBStatusResponse));
@@ -81,11 +75,22 @@ describe('TSDB Stats', () => {
         credentials: 'same-origin',
       });
 
+      const headStats = page
+        .find(Table)
+        .at(0)
+        .find('tbody')
+        .find('td');
+      ['508', '937', '2020-06-07T08:00:00.000Z (1591516800000)', '2020-08-31T18:00:00.143Z (1598896800143)'].forEach(
+        (value, i) => {
+          expect(headStats.at(i).text()).toEqual(value);
+        }
+      );
+
       for (let i = 0; i < tables.length; i++) {
-        const data = tables[i].data;
+        const data = tables[i];
         const table = page
           .find(Table)
-          .at(tables[i].table_index)
+          .at(i + 1)
           .find('tbody');
         const rows = table.find('tr');
         for (let i = 0; i < data.length; i++) {

--- a/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.tsx
+++ b/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.tsx
@@ -11,7 +11,15 @@ interface Stats {
   value: number;
 }
 
+interface HeadStats {
+  numSeries: number;
+  chunkCount: number;
+  minTime: number;
+  maxTime: number;
+}
+
 export interface TSDBMap {
+  headStats: HeadStats;
   seriesCountByMetricName: Stats[];
   labelValueCountByLabelName: Stats[];
   memoryInBytesByLabelName: Stats[];
@@ -19,14 +27,42 @@ export interface TSDBMap {
 }
 
 export const TSDBStatusContent: FC<TSDBMap> = ({
+  headStats,
   labelValueCountByLabelName,
   seriesCountByMetricName,
   memoryInBytesByLabelName,
   seriesCountByLabelValuePair,
 }) => {
+  const unixToTime = (unix: number): string => new Date(unix).toISOString();
+  const { chunkCount, numSeries, minTime, maxTime } = headStats;
+  const stats = [
+    { header: 'Number of Series', value: numSeries },
+    { header: 'Number of Chunks', value: chunkCount },
+    { header: 'Current Min Time', value: `${unixToTime(minTime)} (${minTime})` },
+    { header: 'Current Max Time', value: `${unixToTime(maxTime)} (${maxTime})` },
+  ];
   return (
     <div>
       <h2>TSDB Status</h2>
+      <h3 className="p-2">Head Stats</h3>
+      <div className="p-2">
+        <Table bordered size="sm" striped>
+          <thead>
+            <tr>
+              {stats.map(({ header }) => {
+                return <th key={header}>{header}</th>;
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              {stats.map(({ header, value }) => {
+                return <td key={header}>{value}</td>;
+              })}
+            </tr>
+          </tbody>
+        </Table>
+      </div>
       <h3 className="p-2">Head Cardinality Stats</h3>
       {[
         { title: 'Top 10 label names with value count', stats: labelValueCountByLabelName },

--- a/web/web.go
+++ b/web/web.go
@@ -324,6 +324,7 @@ func New(logger log.Logger, o *Options) *Handler {
 		h.options.CORSOrigin,
 		h.runtimeInfo,
 		h.versionInfo,
+		o.Gatherer,
 	)
 
 	if o.RoutePrefix != "/" {
@@ -859,10 +860,6 @@ func (h *Handler) runtimeInfo() (api_v1.RuntimeInfo, error) {
 	}
 	for _, mF := range metrics {
 		switch *mF.Name {
-		case "prometheus_tsdb_head_chunks":
-			status.ChunkCount = int64(toFloat64(mF))
-		case "prometheus_tsdb_head_series":
-			status.TimeSeriesCount = int64(toFloat64(mF))
 		case "prometheus_tsdb_wal_corruptions_total":
 			status.CorruptionCount = int64(toFloat64(mF))
 		case "prometheus_config_last_reload_successful":


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR implements the missing TSDB head stats section in the React UI. 

It exposes the following fields in the `/api/v1/status/tsdb` to make them available in the UI:
- `numSeries`
- `chunkCount`
- `minTime`
- `maxTime`

It provides functionality comparable to that of  #7544 (the string formatting is slightly different).

<img width="1915" alt="Screen Shot 2020-09-01 at 3 34 22 PM" src="https://user-images.githubusercontent.com/6402556/91911429-4ff16800-ec6e-11ea-8aa3-f5b08648af7d.png">


Closes #7546