### PR TITLE
Unnecessary go routine spawn.

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -435,7 +435,6 @@ func (sp *scrapePool) sync(targets []*Target) {
 	)
 
 	for _, t := range targets {
-		t := t
 		hash := t.hash()
 
 		if _, ok := sp.activeTargets[hash]; !ok {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -373,7 +373,7 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 			wg.Done()
 
 			newLoop.setForcedError(forcedErr)
-			go newLoop.run(interval, timeout, nil)
+			newLoop.run(interval, timeout, nil)
 		}(oldLoop, newLoop)
 
 		sp.loops[fp] = newLoop


### PR DESCRIPTION
I've been studying `prometheus` code base, and have noticed that there is no need to create a new `go routine` in this piece of code. This PR removes it. 

Though this doesn't really have much of an impact, I hope to make this my first contribution to `prometheus` repository :)