### PR TITLE
Rename `remote.newReadClient()` to `remote.NewReadClient()`

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -102,8 +102,8 @@ type ReadClient interface {
 	Read(ctx context.Context, query *prompb.Query) (*prompb.QueryResult, error)
 }
 
-// newReadClient creates a new client for remote read.
-func newReadClient(name string, conf *ClientConfig) (ReadClient, error) {
+// NewReadClient creates a new client for remote read.
+func NewReadClient(name string, conf *ClientConfig) (ReadClient, error) {
 	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client", false, false)
 	if err != nil {
 		return nil, err

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -102,7 +102,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 			name = rrConf.Name
 		}
 
-		c, err := newReadClient(name, &ClientConfig{
+		c, err := NewReadClient(name, &ClientConfig{
 			URL:              rrConf.URL,
 			Timeout:          rrConf.RemoteTimeout,
 			HTTPClientConfig: rrConf.HTTPClientConfig,


### PR DESCRIPTION
This should make the `NewReadClient()` exported outside the `remote` package

Signed-off-by: Anand Sanmukhani <asanmukh@redhat.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->