### PR TITLE
Give a more explicit error in promtool when number of alerts does not match

### DIFF
--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -303,17 +303,14 @@ func (tg *testGroup) test(mint, maxt time.Time, evalInterval time.Duration, grou
 					})
 				}
 
+				sort.Sort(gotAlerts)
+				sort.Sort(expAlerts)
 				if gotAlerts.Len() != expAlerts.Len() {
+					errs = append(errs, errors.Errorf("    alertname:%s, time:%s, \n        exp:%v alerts %#v, \n        got:%v alerts %#v",
+						testcase.Alertname, testcase.EvalTime.String(), expAlerts.Len(), expAlerts.String(), gotAlerts.Len(), gotAlerts.String()))
+				} else if !reflect.DeepEqual(expAlerts, gotAlerts) {
 					errs = append(errs, errors.Errorf("    alertname:%s, time:%s, \n        exp:%#v, \n        got:%#v",
 						testcase.Alertname, testcase.EvalTime.String(), expAlerts.String(), gotAlerts.String()))
-				} else {
-					sort.Sort(gotAlerts)
-					sort.Sort(expAlerts)
-
-					if !reflect.DeepEqual(expAlerts, gotAlerts) {
-						errs = append(errs, errors.Errorf("    alertname:%s, time:%s, \n        exp:%#v, \n        got:%#v",
-							testcase.Alertname, testcase.EvalTime.String(), expAlerts.String(), gotAlerts.String()))
-					}
 				}
 			}
 


### PR DESCRIPTION
When testing a new alert with promtool I made a silly mistake in the yaml:
```
      - alertname: my_alert
        eval_time: 1m
        exp_alerts:
          - exp_labels:
              team: myteam
              severity: critical
              environment: prod
          -  exp_annotations:       # <= wrong '-' added by mistake! It is rightly understood as 2 distinct alerts
              summary: "My summary..."
              description: "My description..."
```
Since the alertname is appended by the tool to the expected labels, I did not get exactly what went wrong when reading the error dump.  I only realised my mistake after debugging the tool.
This PR is to give a bit more context and explicitly reporting that the length of alerts is not what expected.

Error dump before:
```
  FAILED:
    alertname:myalert, time:1m, 
        exp:"[Labels:{alertname=\"myalert\", environment=\"prod\", severity=\"critical\", team=\"myteam\"} Annotations:{}, Labels:{alertname=\"myalert\"} Annotations:{description=\"My description...\", summary=\"My summary...\"}]", 
        got:"[Labels:{alertname=\"myalert\", environment=\"prod\", severity=\"critical\", team=\"myteam\"} Annotations:{description=\"My description...\", summary=\"My summary...\"}]"
```

Error dump after:
```
  FAILED:
    alertname:myalert, time:1m, 
        exp:2 alerts "[Labels:{alertname=\"myalert\"} Annotations:{description=\"My description...\", summary=\"My summary...\"}, Labels:{alertname=\"myalert\", environment=\"prod\", severity=\"critical\", team=\"myteam\"} Annotations:{}]", 
        got:1 alerts "[Labels:{alertname=\"myalert\", environment=\"prod\", severity=\"critical\", team=\"myteam\"} Annotations:{description=\"My description...\", summary=\"My summary...\"}]"
```
I have also sorted the alerts before outputting the dump for better read. 