### PR TITLE
Add unit test case to improve test coverage for tsdb/index/index.go

### DIFF
--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -558,3 +558,33 @@ func TestSymbols(t *testing.T) {
 	}
 	testutil.Ok(t, iter.Err())
 }
+
+func TestIndexWriterStageString(t *testing.T) {
+	for _, tc := range []struct {
+		s        indexWriterStage
+		expected string
+	}{
+		{
+			s:        idxStageNone,
+			expected: "none",
+		},
+		{
+			s:        idxStageSymbols,
+			expected: "symbols",
+		},
+		{
+			s:        idxStageSeries,
+			expected: "series",
+		},
+		{
+			s:        idxStageDone,
+			expected: "done",
+		},
+		{
+			s:        4,
+			expected: "<unknown>",
+		},
+	} {
+		testutil.Equals(t, tc.expected, tc.s.String())
+	}
+}


### PR DESCRIPTION
Signed-off-by: Hu Shuai <hus.fnst@cn.fujitsu.com>
This PR is about adding a unit test for tsdb/index/index.go to improve test coverage.
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->