### PR TITLE
Improve logging of snapshot start and completion

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1346,6 +1346,8 @@ func (db *DB) Snapshot(dir string, withHead bool) error {
 		return errors.Errorf("dir must not be a valid ULID")
 	}
 
+	level.Info(db.logger).Log("msg", "Starting to snapshot all blocks")
+
 	db.cmtx.Lock()
 	defer db.cmtx.Unlock()
 
@@ -1371,6 +1373,7 @@ func (db *DB) Snapshot(dir string, withHead bool) error {
 	if _, err := db.compactor.Write(dir, head, mint, maxt+1, nil); err != nil {
 		return errors.Wrap(err, "snapshot head block")
 	}
+	level.Info(db.logger).Log("msg", "Snapshot all blocks completed")
 	return nil
 }
 


### PR DESCRIPTION
Fix #7877, add log of snapshot start and completion, to let user know what's going no.

Now, the log is like this:
```
level=info ts=2020-09-04T03:15:26.219Z caller=db.go:1340 component=tsdb msg="Starting to snapshot all blocks"
level=info ts=2020-09-04T03:15:26.219Z caller=db.go:1365 component=tsdb msg="Snapshotting block" block=01EGSPZNKRTXKN8R0RYYKH5KYM
level=info ts=2020-09-04T03:15:26.220Z caller=db.go:1365 component=tsdb msg="Snapshotting block" block=01EHBFNZ8XJ0B9B0FK6ZVFX7VH
level=info ts=2020-09-04T03:15:26.221Z caller=db.go:1365 component=tsdb msg="Snapshotting block" block=01EHBFNTKPS121MC2ZQC3ZHMBS
level=info ts=2020-09-04T03:15:26.722Z caller=compact.go:494 component=tsdb msg="write block" mint=1599184800000 maxt=1599189325776 ulid=01EHBHS6CETP3SHDHH383NJ5MD duration=499.389657ms
level=info ts=2020-09-04T03:15:26.722Z caller=db.go:1342 component=tsdb msg="Snapshot all blocks completed"
```