### PR TITLE
WIP: Improved latency of refactored iterators.

### DIFF
--- a/storage/merge.go
+++ b/storage/merge.go
@@ -478,15 +478,14 @@ func (c *chainSampleIterator) Next() bool {
 			c.curr = heap.Pop(&c.h).(chunkenc.Iterator)
 			return true
 		}
-		return false
+	}
+
+	if len(c.h) == 0 {
+		return c.curr != nil && c.curr.Next()
 	}
 
 	for {
 		if c.curr.Next() {
-			if len(c.h) == 0 {
-				return true
-			}
-
 			currt, _ := c.curr.At()
 			nextt, _ := c.h[0].At()
 			if currt < nextt {
@@ -494,10 +493,6 @@ func (c *chainSampleIterator) Next() bool {
 			}
 			if currt == nextt {
 				// Ignoring sample.
-				iter := heap.Pop(&c.h).(chunkenc.Iterator)
-				if iter.Next() {
-					heap.Push(&c.h, iter)
-				}
 				continue
 			}
 			heap.Push(&c.h, c.curr)
@@ -505,9 +500,6 @@ func (c *chainSampleIterator) Next() bool {
 			return true
 		}
 
-		if len(c.h) == 0 {
-			return false
-		}
 		c.curr = heap.Pop(&c.h).(chunkenc.Iterator)
 		return true
 	}

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -141,6 +141,8 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 	}
 }
 
+var StubForBenchmark int64
+
 func BenchmarkQuerierSelect(b *testing.B) {
 	tmpDir, err := ioutil.TempDir("", "test_querier_select_dir")
 	testutil.Ok(b, err)
@@ -199,6 +201,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 						testutil.Ok(b, err)
 						defer q.Close()
 
+						var t int64
 						b.ResetTimer()
 						for i := 0; i < b.N; i++ {
 							counter := 0
@@ -208,7 +211,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 								counter++
 								it := at.Iterator()
 								for it.Next() {
-									_, _ = it.At()
+									t, _ = it.At()
 								}
 								testutil.Ok(b, it.Err())
 							}
@@ -216,6 +219,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 							testutil.Equals(b, 0, len(ss.Warnings()))
 							testutil.Equals(b, s, counter)
 						}
+						StubForBenchmark = t
 
 					})
 				}


### PR DESCRIPTION
Reduced latency 4x for problematic case we had: 

```
BenchmarkDBBlocksQuerierSelect/[__name__="up"]
85.466431ms
99.624186ms
104.738759ms
94.795444ms
98.706406ms
96.335081ms
100.298595ms
94.806766ms
```
(was ~450ms).

Still some gap to ~60ms we had before this iterator change. I will keep looking but also I would merge this improvement straight away, to unblock release, will do next improvements in next PR.

Fixes https://github.com/prometheus/prometheus/issues/7873

Previously vs prior iterator:
```
name                                   old time/op    new time/op    delta
DBBlocksQuerierSelect/[__name__="up"]    53.0ms ± 0%   489.5ms ± 0%  +823.32%

name                                   old alloc/op   new alloc/op   delta
DBBlocksQuerierSelect/[__name__="up"]    1.86MB ± 0%    3.71MB ± 0%   +98.80%

name                                   old allocs/op  new allocs/op  delta
DBBlocksQuerierSelect/[__name__="up"]     49.5k ± 0%     67.9k ± 0%   +37.18%
```

Now:
```
name                                   old time/op    new time/op    delta
DBBlocksQuerierSelect/[__name__="up"]    52.7ms ± 0%    81.1ms ± 0%  +53.97%

name                                   old alloc/op   new alloc/op   delta
DBBlocksQuerierSelect/[__name__="up"]    1.86MB ± 0%    1.96MB ± 0%   +5.18%

name                                   old allocs/op  new allocs/op  delta
DBBlocksQuerierSelect/[__name__="up"]     49.5k ± 0%     52.4k ± 0%   +5.80%
```

Also: enhanced benchmarks.