### PR TITLE
Add the "assets" make target and change directory note in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The Makefile provides several targets:
   * *format*: format the source code
   * *vet*: check the source code for common errors
   * *docker*: build a docker container for the current `HEAD`
+  * *assets*: build the new experimental React UI
 
 ## React UI Development
 

--- a/web/ui/react-app/README.md
+++ b/web/ui/react-app/README.md
@@ -26,6 +26,8 @@ The React UI depends on a large number of [npm](https://www.npmjs.com/) packages
 
 Yarn consults the `package.json` and `yarn.lock` files for dependencies to install. It creates a `node_modules` directory with all installed dependencies.
 
+**NOTE**: Remember to change directory to `web/ui/react-app` before running this command and the following commands
+
 ## Running a local development server
 
 You can start a development server for the React UI outside of a running Prometheus server by running:

--- a/web/ui/react-app/README.md
+++ b/web/ui/react-app/README.md
@@ -26,7 +26,7 @@ The React UI depends on a large number of [npm](https://www.npmjs.com/) packages
 
 Yarn consults the `package.json` and `yarn.lock` files for dependencies to install. It creates a `node_modules` directory with all installed dependencies.
 
-**NOTE**: Remember to change directory to `web/ui/react-app` before running this command and the following commands
+**NOTE**: Remember to change directory to `web/ui/react-app` before running this command and the following commands.
 
 ## Running a local development server
 


### PR DESCRIPTION
Add the "assets" make target and change directory note in readme

1. We mentioned `make assets` in readme, but we didn't list the _assets_ target. Add it
> Note also that these directories do not include the new experimental React UI unless it has been built explicitly using make assets or make build.

2. In react UI readme, we ask users to run `yarn`, but didn't ask users to change diretory to `web/ui/react-app`, it'll cause the `yarn` command running on the wrong dir and got unexpected error. We only ask users to open `web/ui/react-app` dir in the IDE for lint working well, but forgot to tell user to change dir before running `yarn`

Signed-off-by: Luke Chen <showuon@gmail.com>
