### PR TITLE
Fix missing remote read spans

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -109,6 +109,11 @@ func NewReadClient(name string, conf *ClientConfig) (ReadClient, error) {
 		return nil, err
 	}
 
+	t := httpClient.Transport
+	httpClient.Transport = &nethttp.Transport{
+		RoundTripper: t,
+	}
+
 	return &Client{
 		remoteName:          name,
 		url:                 conf.URL,


### PR DESCRIPTION
The remote read client needs to use the nethttp.Transport wrapper in
order for spans to be instrumented properly.

Fixes: #7888 

cc: @roidelapluie and @bwplotka (who I think is on vacation)