### PR TITLE
Backport: Fix missing remote read spans (#7914)

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -109,6 +109,11 @@ func newReadClient(name string, conf *ClientConfig) (ReadClient, error) {
 		return nil, err
 	}
 
+	t := httpClient.Transport
+	httpClient.Transport = &nethttp.Transport{
+		RoundTripper: t,
+	}
+
 	return &Client{
 		remoteName:          name,
 		url:                 conf.URL,


### PR DESCRIPTION
The remote read client needs to use the nethttp.Transport wrapper in
order for spans to be instrumented properly.

Signed-off-by: Chris Marchbanks <csmarchbanks@gmail.com>

*I will add this to the changelog when crafting the release*.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->