### PR TITLE
WIP: Avoid a single recording rule creating many large objects

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1408,6 +1408,16 @@ func getPointSlice(sz int) []Point {
 }
 
 func putPointSlice(p []Point) {
+	// The sync.Pool works best when the Point slices are of similar
+	// capacity. We guarantee this by discarding very large slices
+	// instead of putting them into the pool.
+	//
+	// See: https://github.com/golang/go/issues/23199
+	// See: https://github.com/golang/go/blob/d277a361231485999cc2b7433e3244e559c7d7da/src/fmt/print.go#L147
+	if cap(p) > 12000 {
+		return
+	}
+
 	//lint:ignore SA6002 relax staticcheck verification.
 	pointPool.Put(p[:0])
 }


### PR DESCRIPTION
I ran into a problem with a rule like `count_over_time( some_series[Many d:Small s])` that would end up with the kernel OOM killer sacrificing prometheus (besides overcommit being turned off). Taking a pprof/heap profile quickly pointed me to the Point slices and looking at the implementation shows me numSamples as a possible contributor. It's a WIP PR as I am not that familiar with Go (and Prometheus)

Most interestingly the --query.max-samples  only partially helps. It does fail the query but still does bad things to the heap (it seems unable to return memory to the OS, even with GODEBUG=madvdontneed=1). The closest thing I have to a working theory is:

1. Pooled []Point with a large capacity ends up being used by smaller queries. This would keep the slices alive with a lot of memory unused. It seems a best practice for sync.Pool is to have objects of roughly the same memory cost in it. I peeked into Go's fmt implementation and have a patch that discards large slices (larger than the ones used in the benchmark).

1. Interestingly the above does not apply when --query.max-samples kicks in as many slices are not returned/inserted to the pool but I can still see Prometheus taking up most of the physical RAM and never return it to the OS (and then run at risk to get OOM killed). My hypothesis is that Go's memory allocator will try to directly allocate large slices.. and we fragment the heap because we have many of them.
On a conceptual level I think the capacity requested by getPointSlice calls in a query should not exceed maxSamples but that might be rather difficult to implement. Another observation is that numSteps is the upper bound and in some cases we might get a lower bound (Min(numSteps, len(result)) or even get it precisely?
