### PR TITLE
update the protoc version to 3.12.3 in readme

### DIFF
--- a/prompb/README.md
+++ b/prompb/README.md
@@ -4,6 +4,6 @@ re-compile them when building Prometheus.
 If however you have modified the defs and do need to re-compile, run
 `make proto` from the parent dir.
 
-In order for the script to run, you'll need `protoc` (version 3.5.1) in your
+In order for the script to run, you'll need `protoc` (version 3.12.3) in your
 PATH.
 


### PR DESCRIPTION
We use `protoc` v3.12.3 now (ref: https://github.com/prometheus/prometheus/blob/master/scripts/genproto.sh#L13). Update the readme content.

Signed-off-by: Luke Chen <showuon@gmail.com>
