### PR TITLE
UI: Clarify alert state toggle via checkbox icon

### DIFF
--- a/web/ui/static/js/alerts.js
+++ b/web/ui/static/js/alerts.js
@@ -49,6 +49,11 @@ function init() {
   $("#alertFilters :input").change(function() {
         const target = $(this).attr("id");
         var shouldHide = $(this).parent().hasClass("active");
+        var checkClass = shouldHide ? 'unchecked' : 'check';
+        $(this).parent().find('i.glyphicon')
+          .removeClass("glyphicon-check")
+          .removeClass("glyphicon-unchecked")
+          .addClass("glyphicon-" + checkClass);
         if (target === "inactiveAlerts") {
             localStorage.setItem("hideInactiveAlerts", shouldHide);
             displayAlerts("alert-success", !shouldHide);

--- a/web/ui/templates/alerts.html
+++ b/web/ui/templates/alerts.html
@@ -8,13 +8,13 @@
   <h1>Alerts</h1>
     <div id="alertFilters" class="btn-group btn-group-toggle" data-toggle="buttons">
         <label class="btn btn-primary active">
-            <input type="checkbox" name="alertFilters" id="inactiveAlerts" autocomplete="off"> Inactive ({{ .Counts.Inactive }})
+            <input type="checkbox" name="alertFilters" id="inactiveAlerts" autocomplete="off"> <i class="glyphicon glyphicon-check"></i> Inactive ({{ .Counts.Inactive }})
         </label>
         <label class="btn btn-primary active">
-            <input type="checkbox" name="alertFilters" id="pendingAlerts" autocomplete="off"> Pending ({{ .Counts.Pending }})
+            <input type="checkbox" name="alertFilters" id="pendingAlerts" autocomplete="off"> <i class="glyphicon glyphicon-check"></i> Pending ({{ .Counts.Pending }})
         </label>
         <label class="btn btn-primary active">
-            <input type="checkbox" name="alertFilters" id="firingAlerts" autocomplete="off"> Firing ({{ .Counts.Firing }})
+            <input type="checkbox" name="alertFilters" id="firingAlerts" autocomplete="off"> <i class="glyphicon glyphicon-check"></i> Firing ({{ .Counts.Firing }})
         </label>
         </br>
     </div>


### PR DESCRIPTION
The current meaning of the alert firing/pending/inactive toggle seems ambiguouos as #7460 demonstrates.
This PR adds a checkbox icon to clarify the active state of the button.

Note: This is one of two PRs which try to accomplish the same thing in different flavours. The other PR (#7937) uses bootstrap switch items instead of icons.

@juliusv What do you think?
cc @gouthamve because of involvement in the referenced ticket.

## Preview of this variant with checkboxes
![alert-toggle-checkbox](https://user-images.githubusercontent.com/762915/93027353-70c1a200-f60c-11ea-97f3-24e2437a2c5a.png)

## Preview of another alternative which uses the eye-open/close icons
![alert-toggle-eyes](https://user-images.githubusercontent.com/762915/93027355-715a3880-f60c-11ea-81a9-80ac575afa00.png)

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->