### PR TITLE
UI: Clarify alert state toggle by using a switch

### DIFF
--- a/web/ui/static/js/alerts.js
+++ b/web/ui/static/js/alerts.js
@@ -34,21 +34,21 @@ function init() {
   }
 
   if(localStorage.hideInactiveAlerts === "true") {
-      $("#inactiveAlerts").parent().removeClass("active");
+      $("#inactiveAlerts").prop("checked", false);
       displayAlerts("alert-success", false);
   }
   if(localStorage.hidePendingAlerts === "true") {
-      $("#pendingAlerts").parent().removeClass("active");
+      $("#pendingAlerts").prop("checked", false);
       displayAlerts("alert-warning", false);
   }
   if(localStorage.hideFiringAlerts === "true") {
-      $("#firingAlerts").parent().removeClass("active");
+      $("#firingAlerts").prop("checked", false);
       displayAlerts("alert-danger", false);
   }
 
   $("#alertFilters :input").change(function() {
         const target = $(this).attr("id");
-        var shouldHide = $(this).parent().hasClass("active");
+        var shouldHide = !$(this).prop("checked");
         if (target === "inactiveAlerts") {
             localStorage.setItem("hideInactiveAlerts", shouldHide);
             displayAlerts("alert-success", !shouldHide);

--- a/web/ui/templates/alerts.html
+++ b/web/ui/templates/alerts.html
@@ -6,17 +6,19 @@
 {{define "content"}}
 <div class="container-fluid">
   <h1>Alerts</h1>
-    <div id="alertFilters" class="btn-group btn-group-toggle" data-toggle="buttons">
-        <label class="btn btn-primary active">
-            <input type="checkbox" name="alertFilters" id="inactiveAlerts" autocomplete="off"> Inactive ({{ .Counts.Inactive }})
-        </label>
-        <label class="btn btn-primary active">
-            <input type="checkbox" name="alertFilters" id="pendingAlerts" autocomplete="off"> Pending ({{ .Counts.Pending }})
-        </label>
-        <label class="btn btn-primary active">
-            <input type="checkbox" name="alertFilters" id="firingAlerts" autocomplete="off"> Firing ({{ .Counts.Firing }})
-        </label>
-        </br>
+    <div id="alertFilters">
+      <div class="custom-control custom-switch d-inline my-1 mr-3">
+        <input type="checkbox" class="custom-control-input" id="inactiveAlerts" checked>
+        <label class="custom-control-label" for="inactiveAlerts">Inactive ({{ .Counts.Inactive }})</label>
+      </div>
+      <div class="custom-control custom-switch d-inline my-1 mr-3">
+        <input type="checkbox" class="custom-control-input" id="pendingAlerts" checked>
+        <label class="custom-control-label" for="pendingAlerts">Pending ({{ .Counts.Pending }})</label>
+      </div>
+      <div class="custom-control custom-switch d-inline my-1">
+        <input type="checkbox" class="custom-control-input" id="firingAlerts" checked>
+        <label class="custom-control-label" for="firingAlerts">Firing ({{ .Counts.Firing }})</label>
+      </div>
     </div>
   <div class="show-annotations">
      <i class="glyphicon glyphicon-unchecked"></i>


### PR DESCRIPTION
The current meaning of the alert firing/pending/inactive toggle seems ambiguouos as #7460 demonstrates.
This PR changes the current design from buttons to bootstrap switch items which clearly show the on/off state.

Note: This is one of two PRs which try to accomplish the same thing in different flavours. The other PR (#7936) uses icons.

@juliusv What do you think?
cc @gouthamve because of involvement in the referenced ticket.

## Preview
![alert-toggle-switch](https://user-images.githubusercontent.com/762915/93027435-0eb56c80-f60d-11ea-9ed4-a74bdd5a212e.png)

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->