### PR TITLE
Adds support for WAL truncation on start-up

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -657,6 +657,10 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		minValidTime = blocks[len(blocks)-1].Meta().MaxTime
 	}
 
+	if err := truncateWAL(db.head, minValidTime, nil); err != nil {
+		return nil, errors.Wrap(err, "wal-truncate")
+	}
+
 	if initErr := db.head.Init(minValidTime); initErr != nil {
 		db.head.metrics.walCorruptionsTotal.Inc()
 		level.Warn(db.logger).Log("msg", "Encountered WAL read error, attempting repair", "err", initErr)

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -661,6 +661,14 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		return nil, err
 	}
 
+	// Set the min valid time for the ingested samples
+	// to be no lower than the maxt of the last block.
+	blocks := db.Blocks()
+	minValidTime := int64(math.MinInt64)
+	if len(blocks) > 0 {
+		minValidTime = blocks[len(blocks)-1].Meta().MaxTime
+	}
+	go truncateWAL(db.head, minValidTime)
 	// Register metrics after assigning the head block.
 	db.metrics = newDBMetrics(db, r)
 	maxBytes := opts.MaxBytes
@@ -671,13 +679,6 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 
 	if err := db.reload(); err != nil {
 		return nil, err
-	}
-	// Set the min valid time for the ingested samples
-	// to be no lower than the maxt of the last block.
-	blocks := db.Blocks()
-	minValidTime := int64(math.MinInt64)
-	if len(blocks) > 0 {
-		minValidTime = blocks[len(blocks)-1].Meta().MaxTime
 	}
 
 	if initErr := db.head.Init(minValidTime); initErr != nil {

--- a/tsdb/wal/checkpoint.go
+++ b/tsdb/wal/checkpoint.go
@@ -170,11 +170,9 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id uint64) bo
 			}
 			// Drop irrelevant series in place.
 			repl := series[:0]
-			if keep != nil {
-				for _, s := range series {
-					if keep(s.Ref) {
-						repl = append(repl, s)
-					}
+			for _, s := range series {
+				if keep(s.Ref) {
+					repl = append(repl, s)
 				}
 			}
 			if len(repl) > 0 {

--- a/tsdb/wal/checkpoint.go
+++ b/tsdb/wal/checkpoint.go
@@ -170,9 +170,11 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id uint64) bo
 			}
 			// Drop irrelevant series in place.
 			repl := series[:0]
-			for _, s := range series {
-				if keep(s.Ref) {
-					repl = append(repl, s)
+			if keep != nil {
+				for _, s := range series {
+					if keep(s.Ref) {
+						repl = append(repl, s)
+					}
 				}
 			}
 			if len(repl) > 0 {


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
Fixes: #7575 

cc @codesome 