### PR TITLE
tsdb: reduce time on closing segment file

### DIFF
--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -180,15 +180,17 @@ func (w *Writer) finalizeTail() error {
 	if err := w.wbuf.Flush(); err != nil {
 		return err
 	}
-	if err := tf.Sync(); err != nil {
-		return err
-	}
+
 	// As the file was pre-allocated, we truncate any superfluous zero bytes.
 	off, err := tf.Seek(0, io.SeekCurrent)
 	if err != nil {
 		return err
 	}
 	if err := tf.Truncate(off); err != nil {
+		return err
+	}
+
+	if err := tf.Sync(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Since 500M disk space has been pre-allocated for the new segment file, if we call `ftruncate()` after `fsync()`, closing the segment file will take too much time when the actual size of the file is much smaller than `defaultSegmentSize`. @bwplotka @robey @mpalmer @bernerdschaefer 