### PR TITLE
Add a tsdb writer interface

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -302,7 +302,7 @@ func TestReadIndexFormatV1(t *testing.T) {
 
 // createBlock creates a block with given set of series and returns its dir.
 func createBlock(tb testing.TB, dir string, series []storage.Series) string {
-	blockDir, err := CreateBlock(series, dir, 0, 0, log.NewNopLogger())
+	blockDir, err := CreateBlock(series, dir, 0, log.NewNopLogger())
 	testutil.Ok(tb, err)
 	return blockDir
 }

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -302,12 +302,9 @@ func TestReadIndexFormatV1(t *testing.T) {
 
 // createBlock creates a block with given set of series and returns its dir.
 func createBlock(tb testing.TB, dir string, series []storage.Series) string {
-	chunkDir, err := ioutil.TempDir("", "chunk_dir")
+	blockDir, err := CreateBlock(series, dir, 0, 0, log.NewNopLogger())
 	testutil.Ok(tb, err)
-	defer func() { testutil.Ok(tb, os.RemoveAll(chunkDir)) }()
-	head := createHead(tb, nil, series, chunkDir)
-	defer func() { testutil.Ok(tb, head.Close()) }()
-	return createBlockFromHead(tb, dir, head)
+	return blockDir
 }
 
 func createBlockFromHead(tb testing.TB, dir string, head *Head) string {

--- a/tsdb/blockwriter.go
+++ b/tsdb/blockwriter.go
@@ -117,6 +117,10 @@ func (w *BlockWriter) Flush(ctx context.Context) (ulid.ULID, error) {
 }
 
 func (w *BlockWriter) Close() error {
-	defer os.RemoveAll(w.chunkDir)
+	defer func() {
+		if err := os.RemoveAll(w.chunkDir); err != nil {
+			w.logger.Log("err BlockerWriter Close", err.Error())
+		}
+	}()
 	return w.head.Close()
 }

--- a/tsdb/blockwriter.go
+++ b/tsdb/blockwriter.go
@@ -91,7 +91,7 @@ func (w *BlockWriter) Appender(ctx context.Context) storage.Appender {
 func (w *BlockWriter) Flush(ctx context.Context) (ulid.ULID, error) {
 	seriesCount := w.head.NumSeries()
 	if w.head.NumSeries() == 0 {
-		return ulid.ULID{}, errors.New("no series appended; aborting.")
+		return ulid.ULID{}, errors.New("no series appended, aborting")
 	}
 
 	mint := w.head.MinTime()

--- a/tsdb/blockwriter_test.go
+++ b/tsdb/blockwriter_test.go
@@ -41,20 +41,13 @@ func TestBlockWriter(t *testing.T) {
 
 	// Add some series.
 	app := w.Appender(ctx)
-	expectedLabelNames := []string{"a", "c"}
-	expectedValues := []string{"b", "d"}
-	l := labels.Labels{{Name: expectedLabelNames[0], Value: expectedValues[0]}}
-	ts1 := int64(44)
-	v1 := float64(7)
-	_, err = app.Add(l, ts1, v1)
+	ts1, v1 := int64(44), float64(7)
+	_, err = app.Add(labels.Labels{{Name: "a", Value: "b"}}, ts1, v1)
 	testutil.Ok(t, err)
-	l = labels.Labels{{Name: expectedLabelNames[1], Value: expectedValues[1]}}
-	ts2 := int64(55)
-	v2 := float64(12)
-	_, err = app.Add(l, ts2, v2)
+	ts2, v2 := int64(55), float64(12)
+	_, err = app.Add(labels.Labels{{Name: "c", Value: "d"}}, ts2, v2)
 	testutil.Ok(t, err)
-	err = app.Commit()
-	testutil.Ok(t, err)
+	testutil.Ok(t, app.Commit())
 	id, err := w.Flush(ctx)
 	testutil.Ok(t, err)
 

--- a/tsdb/blockwriter_test.go
+++ b/tsdb/blockwriter_test.go
@@ -1,0 +1,63 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestBlockWriter(t *testing.T) {
+	ctx := context.Background()
+	outputDir, err := ioutil.TempDir(os.TempDir(), "output")
+	testutil.Ok(t, err)
+	w := NewBlockWriter(log.NewNopLogger(), outputDir, DefaultBlockDuration)
+	testutil.Ok(t, w.initHead())
+
+	// flush with no series results in error
+	_, err = w.Flush(ctx)
+	testutil.ErrorEqual(t, err, errors.New("no series appended, aborting"))
+
+	// add some series
+	app := w.Appender(ctx)
+	expectedLabelNames := "a"
+	l := labels.Labels{{Name: expectedLabelNames, Value: "b"}}
+	ts := int64(44)
+	_, err = app.Add(l, ts, 7)
+	testutil.Ok(t, err)
+	err = app.Commit()
+	testutil.Ok(t, err)
+	id, err := w.Flush(ctx)
+	testutil.Ok(t, err)
+
+	// confirm block has the correct data
+	blockpath := filepath.Join(outputDir, id.String())
+	b, err := OpenBlock(nil, blockpath, nil)
+	testutil.Ok(t, err)
+	testutil.Equals(t, b.MinTime(), ts)
+	testutil.Equals(t, b.MaxTime(), ts+int64(1))
+	actualNames, err := b.LabelNames()
+	testutil.Ok(t, err)
+	testutil.Equals(t, actualNames, []string{expectedLabelNames})
+
+	testutil.Ok(t, w.Close())
+}

--- a/tsdb/importer/blocks/writer.go
+++ b/tsdb/importer/blocks/writer.go
@@ -1,0 +1,135 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocks
+
+import (
+	"context"
+	"io/ioutil"
+	"math"
+	"os"
+	"time"
+
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+// Writer is interface to write time series into Prometheus blocks.
+type Writer interface {
+	storage.Appendable
+
+	// Flush writes current data to disk.
+	// The block or blocks will contain values accumulated by `Write`.
+	Flush() ([]ulid.ULID, error)
+
+	// Close releases all resources.
+	Close() error
+}
+
+var _ Writer = &TSDBWriter{}
+
+// Writer is a block writer that allows appending and flushing series to disk.
+type TSDBWriter struct {
+	logger log.Logger
+	dir    string
+
+	head   *tsdb.Head
+	tmpDir string
+}
+
+func durationToMillis(t time.Duration) int64 {
+	return int64(t.Seconds() * 1000)
+}
+
+// NewTSDBWriter create a new block writer.
+//
+// The returned writer accumulates all the series in memory until `Flush` is called.
+//
+// Note that the writer will not check if the target directory exists or
+// contains anything at all. It is the caller's responsibility to
+// ensure that the resulting blocks do not overlap etc.
+// Writer ensures the block flush is atomic (via rename).
+func NewTSDBWriter(logger log.Logger, dir string) (*TSDBWriter, error) {
+	res := &TSDBWriter{
+		logger: logger,
+		dir:    dir,
+	}
+	return res, res.initHead()
+}
+
+// initHead creates and initialises a new TSDB head.
+// blockSize should be in milliseconds.
+func (w *TSDBWriter) initHead(blockSize int64) error {
+	logger := w.logger
+
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "head")
+	if err != nil {
+		return errors.Wrap(err, "create temp dir")
+	}
+	w.tmpDir = tmpDir
+
+	h, err := tsdb.NewHead(nil, logger, nil, blockSize, w.tmpDir, nil, tsdb.DefaultStripeSize, nil)
+	if err != nil {
+		return errors.Wrap(err, "tsdb.NewHead")
+	}
+
+	w.head = h
+	return w.head.Init(math.MinInt64)
+}
+
+// Appender returns a new appender on the database.
+// Appender can't be called concurrently. However, the returned Appender can safely be used concurrently.
+func (w *TSDBWriter) Appender() storage.Appender {
+	return w.head.Appender()
+}
+
+// Flush implements the Writer interface. This is where actual block writing
+// happens. After flush completes, no writes can be done.
+func (w *TSDBWriter) Flush() ([]ulid.ULID, error) {
+	seriesCount := w.head.NumSeries()
+	if w.head.NumSeries() == 0 {
+		return nil, errors.New("no series appended; aborting.")
+	}
+
+	mint := w.head.MinTime()
+	maxt := w.head.MaxTime()
+	level.Info(w.logger).Log("msg", "flushing", "series_count", seriesCount, "mint", timestamp.Time(mint), "maxt", timestamp.Time(maxt))
+
+	compactor, err := tsdb.NewLeveledCompactor(
+		context.Background(),
+		nil,
+		w.logger,
+		[]int64{durationToMillis(2 * time.Hour)},
+		chunkenc.NewPool())
+	if err != nil {
+		return nil, errors.Wrap(err, "create leveled compactor")
+	}
+	id, err := compactor.Write(w.dir, w.head, mint, maxt, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "compactor write")
+	}
+
+	return []ulid.ULID{id}, nil
+}
+
+func (w *TSDBWriter) Close() error {
+	_ = os.RemoveAll(w.tmpDir)
+	return w.head.Close()
+}

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -46,7 +46,8 @@ func CreateBlock(samples []*MetricSample, dir string, mint, maxt int64, logger l
 		return "", err
 	}
 
-	app := w.Appender(context.Background())
+	ctx := context.Background()
+	app := w.Appender(ctx)
 
 	for _, sample := range samples {
 		_, err = app.Add(sample.Labels, sample.TimestampMs, sample.Value)
@@ -59,7 +60,7 @@ func CreateBlock(samples []*MetricSample, dir string, mint, maxt int64, logger l
 		return "", err
 	}
 
-	ulid, err := w.Flush()
+	ulid, err := w.Flush(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -35,7 +35,11 @@ func CreateBlock(series []storage.Series, dir string, mint, maxt int64, logger l
 	}
 
 	w := NewBlockWriter(logger, dir, chunkRange)
-	defer w.Close()
+	defer func() {
+		if err := w.Close(); err != nil {
+			logger.Log("err closing blockwriter", err.Error())
+		}
+	}()
 
 	if err := w.initHead(); err != nil {
 		return "", err

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -25,8 +25,7 @@ import (
 var ErrInvalidTimes = fmt.Errorf("max time is lesser than min time")
 
 // CreateBlock creates a chunkrange block from the samples passed to it, and writes it to disk.
-func CreateBlock(series []storage.Series, dir string, mint, maxt int64, logger log.Logger) (_ string, err error) {
-	chunkRange := maxt - mint
+func CreateBlock(series []storage.Series, dir string, chunkRange int64, logger log.Logger) (string, error) {
 	if chunkRange == 0 {
 		chunkRange = DefaultBlockDuration
 	}
@@ -34,16 +33,15 @@ func CreateBlock(series []storage.Series, dir string, mint, maxt int64, logger l
 		return "", ErrInvalidTimes
 	}
 
-	w := NewBlockWriter(logger, dir, chunkRange)
+	w, err := NewBlockWriter(logger, dir, chunkRange)
+	if err != nil {
+		return "", err
+	}
 	defer func() {
 		if err := w.Close(); err != nil {
 			logger.Log("err closing blockwriter", err.Error())
 		}
 	}()
-
-	if err := w.initHead(); err != nil {
-		return "", err
-	}
 
 	ctx := context.Background()
 	app := w.Appender(ctx)


### PR DESCRIPTION
This PR adds one file from #7586 that is copy/pasted into another PR #7675 .

The change in the PR adds a tsdb writer interface and also a tsdbWriter object that implements the interface. This is nice to have so we have a simple wrapper around writing time series to tsdb blocks.


Signed-off-by: jessicagreben <jessicagrebens@gmail.com>
