### PR TITLE
tsdb/chunks/head_chunks_test.go: Fix typo

### DIFF
--- a/tsdb/chunks/head_chunks_test.go
+++ b/tsdb/chunks/head_chunks_test.go
@@ -175,7 +175,7 @@ func TestHeadReadWriter_Truncate(t *testing.T) {
 	var timeToTruncate, timeToTruncateAfterRestart int64
 
 	addChunk := func() int {
-		mint := timeRange + 1                // Just after the the new file cut.
+		mint := timeRange + 1                // Just after the new file cut.
 		maxt := timeRange + fileTimeStep - 1 // Just before the next file.
 
 		// Write a chunks to set maxt for the segment.

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -196,7 +196,7 @@ func TestDataAvailableOnlyAfterCommit(t *testing.T) {
 func TestNoPanicAfterWALCorrutpion(t *testing.T) {
 	db := openTestDB(t, &Options{WALSegmentSize: 32 * 1024}, nil)
 
-	// Append until the the first mmaped head chunk.
+	// Append until the first mmaped head chunk.
 	// This is to ensure that all samples can be read from the mmaped chunks when the WAL is corrupted.
 	var expSamples []tsdbutil.Sample
 	var maxt int64


### PR DESCRIPTION
tsdb/db_test.go: Fix typo

Signed-off-by: Jorge Vallecillo <jorgevallecilloc@gmail.com>

@codesome I removed consecutive 'the' occurrences