### PR TITLE
Eureka: Fix service discovery when compiled in 32-bit

### DIFF
--- a/discovery/eureka/client.go
+++ b/discovery/eureka/client.go
@@ -55,8 +55,6 @@ type Instance struct {
 	DataCenterInfo                *DataCenterInfo `xml:"dataCenterInfo"`
 	Metadata                      *MetaData       `xml:"metadata"`
 	IsCoordinatingDiscoveryServer bool            `xml:"isCoordinatingDiscoveryServer"`
-	LastUpdatedTimestamp          int             `xml:"lastUpdatedTimestamp"`
-	LastDirtyTimestamp            int             `xml:"lastDirtyTimestamp"`
 	ActionType                    string          `xml:"actionType"`
 	CountryID                     int             `xml:"countryId"`
 	InstanceID                    string          `xml:"instanceId"`


### PR DESCRIPTION
Java timestamps are causing issues when unmarshalling with a 32 bit
prometheus. It appears that we do not use those fields, so let's remove
them.

Fix #7960

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->