### PR TITLE
Encode and Decode method for tombstones

### DIFF
--- a/tsdb/tombstones/tombstones.go
+++ b/tsdb/tombstones/tombstones.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"hash"
 	"hash/crc32"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -98,33 +97,27 @@ func WriteFile(logger log.Logger, dir string, tr Reader) (int64, error) {
 	buf.Reset()
 	// Write the meta.
 	buf.PutBE32(MagicTombstone)
-	buf.PutByte(tombstoneFormatV1)
 	n, err := f.Write(buf.Get())
 	if err != nil {
 		return 0, err
 	}
 	size += n
 
-	mw := io.MultiWriter(f, hash)
-
-	if err := tr.Iter(func(ref uint64, ivs Intervals) error {
-		for _, iv := range ivs {
-			buf.Reset()
-
-			buf.PutUvarint64(ref)
-			buf.PutVarint64(iv.Mint)
-			buf.PutVarint64(iv.Maxt)
-
-			n, err = mw.Write(buf.Get())
-			if err != nil {
-				return err
-			}
-			size += n
-		}
-		return nil
-	}); err != nil {
+	bytes, err := Encode(tr)
+	if err != nil {
 		return 0, fmt.Errorf("error writing tombstones: %v", err)
 	}
+
+	// Ignore first byte which is the format type.
+	if _, err := hash.Write(bytes[1:]); err != nil {
+		return 0, fmt.Errorf("error writing tombstones: %v", err)
+	}
+
+	n, err = f.Write(bytes)
+	if err != nil {
+		return 0, fmt.Errorf("error writing tombstones: %v", err)
+	}
+	size += n
 
 	n, err = f.Write(hash.Sum(nil))
 	if err != nil {
@@ -143,6 +136,44 @@ func WriteFile(logger log.Logger, dir string, tr Reader) (int64, error) {
 	}
 	f = nil
 	return int64(size), fileutil.Replace(tmp, path)
+}
+
+func Encode(tr Reader) ([]byte, error) {
+	buf := encoding.Encbuf{}
+	buf.PutByte(tombstoneFormatV1)
+	err := tr.Iter(func(ref uint64, ivs Intervals) error {
+		for _, iv := range ivs {
+			buf.PutUvarint64(ref)
+			buf.PutVarint64(iv.Mint)
+			buf.PutVarint64(iv.Maxt)
+		}
+		return nil
+	})
+	return buf.Get(), errors.Wrap(err, "encoding tombstones")
+}
+
+func Decode(b []byte) (Reader, error) {
+	d := &encoding.Decbuf{B: b}
+	if flag := d.Byte(); flag != tombstoneFormatV1 {
+		return nil, errors.Errorf("invalid tombstone format %x", flag)
+	}
+
+	if d.Err() != nil {
+		return nil, d.Err()
+	}
+
+	stonesMap := NewMemTombstones()
+	for d.Len() > 0 {
+		k := d.Uvarint64()
+		mint := d.Varint64()
+		maxt := d.Varint64()
+		if d.Err() != nil {
+			return nil, d.Err()
+		}
+
+		stonesMap.AddInterval(k, Interval{mint, maxt})
+	}
+	return stonesMap, nil
 }
 
 // Stone holds the information on the posting and time-range
@@ -168,34 +199,24 @@ func ReadTombstones(dir string) (Reader, int64, error) {
 	if mg := d.Be32(); mg != MagicTombstone {
 		return nil, 0, fmt.Errorf("invalid magic number %x", mg)
 	}
-	if flag := d.Byte(); flag != tombstoneFormatV1 {
-		return nil, 0, fmt.Errorf("invalid tombstone format %x", flag)
-	}
-
-	if d.Err() != nil {
-		return nil, 0, d.Err()
-	}
 
 	// Verify checksum.
 	hash := newCRC32()
-	if _, err := hash.Write(d.Get()); err != nil {
+	// Ignore first byte which is the format type.
+	if _, err := hash.Write(d.Get()[1:]); err != nil {
 		return nil, 0, errors.Wrap(err, "write to hash")
 	}
 	if binary.BigEndian.Uint32(b[len(b)-4:]) != hash.Sum32() {
 		return nil, 0, errors.New("checksum did not match")
 	}
 
-	stonesMap := NewMemTombstones()
+	if d.Err() != nil {
+		return nil, 0, d.Err()
+	}
 
-	for d.Len() > 0 {
-		k := d.Uvarint64()
-		mint := d.Varint64()
-		maxt := d.Varint64()
-		if d.Err() != nil {
-			return nil, 0, d.Err()
-		}
-
-		stonesMap.AddInterval(k, Interval{mint, maxt})
+	stonesMap, err := Decode(d.Get())
+	if err != nil {
+		return nil, 0, err
 	}
 
 	return stonesMap, int64(len(b)), nil


### PR DESCRIPTION
This is a part of https://github.com/prometheus/prometheus/pull/7229. Opened a separate PR for easier review. 

With the Encode method, we wont be streaming tombstone writes to disk, but that should be fine as tombstones are usually small files.