### PR TITLE
Adds support for considering checkpoint dir size in retention policy.

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -1122,18 +1121,6 @@ func BeyondSizeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struc
 		}
 	}
 	return deletable
-}
-
-func getDirsSizeMatchingRegex(re *regexp.Regexp, dir string) (sizes int64, err error) {
-	walk := func(fn string, fi os.FileInfo, err error) error {
-		if fi.IsDir() && re.MatchString(fn) {
-			size, _ := fileutil.DirSize(fn)
-			sizes += size
-		}
-		return nil
-	}
-	err = filepath.Walk(dir, walk)
-	return
 }
 
 // deleteBlocks closes the block if loaded and deletes blocks from the disk if exists.

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1105,7 +1105,7 @@ func BeyondSizeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struc
 	deletable = make(map[ulid.ULID]struct{})
 
 	walSize, _ := db.Head().wal.Size()
-	checkpointsSize := getDirsSizeMatchingRegex(regexp.MustCompile("checkpoint..*"), db.Head().wal.Dir())
+	checkpointsSize, _ := getDirsSizeMatchingRegex(regexp.MustCompile("checkpoint..*"), db.Head().wal.Dir())
 	headChunksSize := db.Head().chunkDiskMapper.Size()
 	// Initializing size counter with WAL size and Head chunks
 	// written to disk, as that is part of the retention strategy.
@@ -1124,7 +1124,7 @@ func BeyondSizeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struc
 	return deletable
 }
 
-func getDirsSizeMatchingRegex(re *regexp.Regexp, dir string) (sizes int64) {
+func getDirsSizeMatchingRegex(re *regexp.Regexp, dir string) (sizes int64, err error) {
 	walk := func(fn string, fi os.FileInfo, err error) error {
 		if fi.IsDir() && re.MatchString(fn) {
 			size, _ := fileutil.DirSize(fn)
@@ -1132,7 +1132,7 @@ func getDirsSizeMatchingRegex(re *regexp.Regexp, dir string) (sizes int64) {
 		}
 		return nil
 	}
-	filepath.Walk(dir, walk)
+	err = filepath.Walk(dir, walk)
 	return
 }
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1105,7 +1105,7 @@ func BeyondSizeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struc
 	deletable = make(map[ulid.ULID]struct{})
 
 	walSize, _ := db.Head().wal.Size()
-	checkpointsSize, _ := getDirsSizeMatchingRegex(regexp.MustCompile("checkpoint..*"), db.Head().wal.Dir())
+	checkpointsSize := wal.GetCheckpointSize(db.Head().wal.Dir())
 	headChunksSize := db.Head().chunkDiskMapper.Size()
 	// Initializing size counter with WAL size and Head chunks
 	// written to disk, as that is part of the retention strategy.

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1104,10 +1104,11 @@ func BeyondSizeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struc
 	deletable = make(map[ulid.ULID]struct{})
 
 	walSize, _ := db.Head().wal.Size()
+	checkpointSize, _ := wal.CheckpointSize(db.Head().lastCheckpointName)
 	headChunksSize := db.Head().chunkDiskMapper.Size()
 	// Initializing size counter with WAL size and Head chunks
 	// written to disk, as that is part of the retention strategy.
-	blocksSize := walSize + headChunksSize
+	blocksSize := walSize + checkpointSize + headChunksSize
 	for i, block := range blocks {
 		blocksSize += block.Size()
 		if blocksSize > int64(db.opts.MaxBytes) {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1103,8 +1103,14 @@ func BeyondSizeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struc
 
 	deletable = make(map[ulid.ULID]struct{})
 
-	walSize, _ := db.Head().wal.Size()
-	checkpointsSize := wal.GetCheckpointSize(db.Head().wal.Dir())
+	walSize, err := db.Head().wal.Size()
+	if err != nil {
+		level.Error(db.logger).Log("msg", "failed to get wal segments size. Skipping", "err", err)
+	}
+	checkpointsSize, err := wal.GetCheckpointSize(db.Head().wal.Dir())
+	if err != nil {
+		level.Error(db.logger).Log("msg", "failed to get wal checkpoint size. Skipping", "err", err)
+	}
 	headChunksSize := db.Head().chunkDiskMapper.Size()
 	// Initializing size counter with WAL size and Head chunks
 	// written to disk, as that is part of the retention strategy.

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1254,8 +1254,10 @@ func TestSizeRetention(t *testing.T) {
 	blockSize := int64(prom_testutil.ToFloat64(db.metrics.blocksBytes)) // Use the actual internal metrics.
 	walSize, err := db.Head().wal.Size()
 	testutil.Ok(t, err)
-	// Expected size should take into account block size + WAL size
-	expSize := blockSize + walSize
+	checkpointSize, err := wal.GetCheckpointSize(db.Head().wal.Dir())
+	testutil.Ok(t, err)
+	// Expected size should take into account block size + WAL size + checkpoint size
+	expSize := blockSize + walSize + checkpointSize
 	actSize, err := fileutil.DirSize(db.Dir())
 	testutil.Ok(t, err)
 	testutil.Equals(t, expSize, actSize, "registered size doesn't match actual disk size")
@@ -1268,7 +1270,9 @@ func TestSizeRetention(t *testing.T) {
 	blockSize = int64(prom_testutil.ToFloat64(db.metrics.blocksBytes)) // Use the actual internal metrics.
 	walSize, err = db.Head().wal.Size()
 	testutil.Ok(t, err)
-	expSize = blockSize + walSize
+	checkpointSize, err = wal.GetCheckpointSize(db.Head().wal.Dir())
+	testutil.Ok(t, err)
+	expSize = blockSize + walSize + checkpointSize
 	actSize, err = fileutil.DirSize(db.Dir())
 	testutil.Ok(t, err)
 	testutil.Equals(t, expSize, actSize, "registered size doesn't match actual disk size")
@@ -1285,8 +1289,10 @@ func TestSizeRetention(t *testing.T) {
 	blockSize = int64(prom_testutil.ToFloat64(db.metrics.blocksBytes))
 	walSize, err = db.Head().wal.Size()
 	testutil.Ok(t, err)
-	// Expected size should take into account block size + WAL size
-	expSize = blockSize + walSize
+	checkpointSize, err = wal.GetCheckpointSize(db.Head().wal.Dir())
+	testutil.Ok(t, err)
+	// Expected size should take into account block size + WAL size + checkpoint size
+	expSize = blockSize + walSize + checkpointSize
 	actRetentionCount := int(prom_testutil.ToFloat64(db.metrics.sizeRetentionCount))
 	actSize, err = fileutil.DirSize(db.Dir())
 	testutil.Ok(t, err)

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1257,10 +1257,10 @@ func TestSizeRetention(t *testing.T) {
 	checkpointSize, err := wal.GetCheckpointSize(db.Head().wal.Dir())
 	testutil.Ok(t, err)
 	// Expected size should take into account block size + WAL size + checkpoint size
-	expSize := blockSize + walSize + checkpointSize
+	expSize := blockSize + walSize
 	actSize, err := fileutil.DirSize(db.Dir())
 	testutil.Ok(t, err)
-	testutil.Equals(t, expSize, actSize, "registered size doesn't match actual disk size")
+	testutil.Equals(t, expSize, actSize, "tregistered size doesn't match actual disk size")
 
 	// Create a WAL checkpoint, and compare sizes.
 	first, last, err := wal.Segments(db.Head().wal.Dir())
@@ -1272,10 +1272,10 @@ func TestSizeRetention(t *testing.T) {
 	testutil.Ok(t, err)
 	checkpointSize, err = wal.GetCheckpointSize(db.Head().wal.Dir())
 	testutil.Ok(t, err)
-	expSize = blockSize + walSize + checkpointSize
+	expSize = blockSize + walSize
 	actSize, err = fileutil.DirSize(db.Dir())
 	testutil.Ok(t, err)
-	testutil.Equals(t, expSize, actSize, "registered size doesn't match actual disk size")
+	testutil.Equals(t, expSize, actSize, "tregistered size doesn't match actual disk size")
 
 	// Decrease the max bytes limit so that a delete is triggered.
 	// Check total size, total count and check that the oldest block was deleted.
@@ -1298,7 +1298,7 @@ func TestSizeRetention(t *testing.T) {
 	testutil.Ok(t, err)
 
 	testutil.Equals(t, 1, actRetentionCount, "metric retention count mismatch")
-	testutil.Equals(t, actSize, expSize, "metric db size doesn't match actual disk size")
+	testutil.Equals(t, actSize, expSize, "=metric db size doesn't match actual disk size")
 	testutil.Assert(t, expSize <= sizeLimit, "actual size (%v) is expected to be less than or equal to limit (%v)", expSize, sizeLimit)
 	testutil.Equals(t, len(blocks)-1, len(actBlocks), "new block count should be decreased from:%v to:%v", len(blocks), len(blocks)-1)
 	testutil.Equals(t, expBlocks[0].MaxTime, actBlocks[0].meta.MaxTime, "maxT mismatch of the first block")

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -58,14 +58,13 @@ type Head struct {
 	minValidTime     atomic.Int64 // Mint allowed to be added to the head. It shouldn't be lower than the maxt of the last persisted block.
 	lastSeriesID     atomic.Uint64
 
-	metrics            *headMetrics
-	wal                *wal.WAL
-	lastCheckpointName string
-	logger             log.Logger
-	appendPool         sync.Pool
-	seriesPool         sync.Pool
-	bytesPool          sync.Pool
-	memChunkPool       sync.Pool
+	metrics      *headMetrics
+	wal          *wal.WAL
+	logger       log.Logger
+	appendPool   sync.Pool
+	seriesPool   sync.Pool
+	bytesPool    sync.Pool
+	memChunkPool sync.Pool
 
 	// All series addressable by their ID or hash.
 	series         *stripeSeries
@@ -858,15 +857,14 @@ func (h *Head) Truncate(mint int64) (err error) {
 		return ok
 	}
 	h.metrics.checkpointCreationTotal.Inc()
-	cpStats, err := wal.Checkpoint(h.logger, h.wal, first, last, keep, mint)
-	if err != nil {
+	if _, err = wal.Checkpoint(h.logger, h.wal, first, last, keep, mint); err != nil {
 		h.metrics.checkpointCreationFail.Inc()
 		if _, ok := errors.Cause(err).(*wal.CorruptionErr); ok {
 			h.metrics.walCorruptionsTotal.Inc()
 		}
 		return errors.Wrap(err, "create checkpoint")
 	}
-	h.lastCheckpointName = cpStats.Name
+
 	if err := h.wal.Truncate(last + 1); err != nil {
 		// If truncating fails, we'll just try again at the next checkpoint.
 		// Leftover segments will just be ignored in the future if there's a checkpoint

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -864,7 +864,6 @@ func (h *Head) Truncate(mint int64) (err error) {
 		}
 		return errors.Wrap(err, "create checkpoint")
 	}
-
 	if err := h.wal.Truncate(last + 1); err != nil {
 		// If truncating fails, we'll just try again at the next checkpoint.
 		// Leftover segments will just be ignored in the future if there's a checkpoint

--- a/tsdb/wal/checkpoint.go
+++ b/tsdb/wal/checkpoint.go
@@ -122,7 +122,7 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id uint64) bo
 		defer sgmReader.Close()
 	}
 
-	cpdir := CheckpointDir(w.Dir(), to)
+	cpdir := checkpointDir(w.Dir(), to)
 	cpdirtmp := cpdir + ".tmp"
 
 	if err := os.RemoveAll(cpdirtmp); err != nil {
@@ -271,11 +271,7 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id uint64) bo
 	return stats, nil
 }
 
-func CheckpointSize(dir string) (int64, error) {
-	return fileutil.DirSize(dir)
-}
-
-func CheckpointDir(dir string, i int) string {
+func checkpointDir(dir string, i int) string {
 	return filepath.Join(dir, fmt.Sprintf(checkpointPrefix+"%08d", i))
 }
 

--- a/tsdb/wal/checkpoint.go
+++ b/tsdb/wal/checkpoint.go
@@ -36,6 +36,7 @@ import (
 
 // CheckpointStats returns stats about a created checkpoint.
 type CheckpointStats struct {
+	Name              string
 	DroppedSeries     int
 	DroppedSamples    int
 	DroppedTombstones int
@@ -121,7 +122,7 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id uint64) bo
 		defer sgmReader.Close()
 	}
 
-	cpdir := checkpointDir(w.Dir(), to)
+	cpdir := CheckpointDir(w.Dir(), to)
 	cpdirtmp := cpdir + ".tmp"
 
 	if err := os.RemoveAll(cpdirtmp); err != nil {
@@ -270,7 +271,11 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id uint64) bo
 	return stats, nil
 }
 
-func checkpointDir(dir string, i int) string {
+func CheckpointSize(dir string) (int64, error) {
+	return fileutil.DirSize(dir)
+}
+
+func CheckpointDir(dir string, i int) string {
 	return filepath.Join(dir, fmt.Sprintf(checkpointPrefix+"%08d", i))
 }
 

--- a/tsdb/wal/checkpoint.go
+++ b/tsdb/wal/checkpoint.go
@@ -36,7 +36,6 @@ import (
 
 // CheckpointStats returns stats about a created checkpoint.
 type CheckpointStats struct {
-	Name              string
 	DroppedSeries     int
 	DroppedSamples    int
 	DroppedTombstones int


### PR DESCRIPTION
Signed-off-by: Harkishen Singh <harkishensingh@hotmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Fixes: #7954 