### PR TITLE
Introduce timestamp tolerance in scrapes

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -239,8 +239,8 @@ func main() {
 	a.Flag("rules.alert.resend-delay", "Minimum amount of time to wait before resending an alert to Alertmanager.").
 		Default("1m").SetValue(&cfg.resendDelay)
 
-	a.Flag("scrape.timestamp-tolerance", "Adjust scrape timestamps by up to this amount to align them to the intended schedule. Experimental.").
-		Hidden().Default("2ms").DurationVar(&scrape.ScrapeTimestampTolerance)
+	a.Flag("scrape.adjust-timestamps", "Adjust scrape timestamps by up to 2ms to align them to the intended schedule. Experimental.").
+		Hidden().Default("true").BoolVar(&scrape.AlignScrapeTimestamps)
 
 	a.Flag("alertmanager.notification-queue-capacity", "The capacity of the queue for pending Alertmanager notifications.").
 		Default("10000").IntVar(&cfg.notifier.QueueCapacity)

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -239,7 +239,7 @@ func main() {
 	a.Flag("rules.alert.resend-delay", "Minimum amount of time to wait before resending an alert to Alertmanager.").
 		Default("1m").SetValue(&cfg.resendDelay)
 
-	a.Flag("scrape.adjust-timestamps", "Adjust scrape timestamps by up to 2ms to align them to the intended schedule. Introduced due to a regression in Go 2.14. See https://github.com/prometheus/prometheus/issues/7846 for more context. Experimental.").
+	a.Flag("scrape.adjust-timestamps", "Adjust scrape timestamps by up to 2ms to align them to the intended schedule. See https://github.com/prometheus/prometheus/issues/7846 for more context. Experimental. This flag will be removed in the future.").
 		Hidden().Default("true").BoolVar(&scrape.AlignScrapeTimestamps)
 
 	a.Flag("alertmanager.notification-queue-capacity", "The capacity of the queue for pending Alertmanager notifications.").

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -239,6 +239,9 @@ func main() {
 	a.Flag("rules.alert.resend-delay", "Minimum amount of time to wait before resending an alert to Alertmanager.").
 		Default("1m").SetValue(&cfg.resendDelay)
 
+	a.Flag("scrape.timestamp-tolerance", "Tolerance applied to scrapes timestamp to improve timestamp compression. Experimental.").
+		Hidden().Default("2ms").DurationVar(&scrape.ScrapeTimestampTolerance)
+
 	a.Flag("alertmanager.notification-queue-capacity", "The capacity of the queue for pending Alertmanager notifications.").
 		Default("10000").IntVar(&cfg.notifier.QueueCapacity)
 

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -239,7 +239,7 @@ func main() {
 	a.Flag("rules.alert.resend-delay", "Minimum amount of time to wait before resending an alert to Alertmanager.").
 		Default("1m").SetValue(&cfg.resendDelay)
 
-	a.Flag("scrape.timestamp-tolerance", "Tolerance applied to scrapes timestamp to improve timestamp compression. Experimental.").
+	a.Flag("scrape.timestamp-tolerance", "Adjust scrape timestamps by up to this amount to align them to the intended schedule. Experimental.").
 		Hidden().Default("2ms").DurationVar(&scrape.ScrapeTimestampTolerance)
 
 	a.Flag("alertmanager.notification-queue-capacity", "The capacity of the queue for pending Alertmanager notifications.").

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -239,7 +239,7 @@ func main() {
 	a.Flag("rules.alert.resend-delay", "Minimum amount of time to wait before resending an alert to Alertmanager.").
 		Default("1m").SetValue(&cfg.resendDelay)
 
-	a.Flag("scrape.adjust-timestamps", "Adjust scrape timestamps by up to 2ms to align them to the intended schedule. See https://github.com/prometheus/prometheus/issues/7846 for more context. Experimental. This flag will be removed in the future.").
+	a.Flag("scrape.adjust-timestamps", "Adjust scrape timestamps by up to 2ms to align them to the intended schedule. See https://github.com/prometheus/prometheus/issues/7846 for more context. Experimental. This flag will be removed in a future release.").
 		Hidden().Default("true").BoolVar(&scrape.AlignScrapeTimestamps)
 
 	a.Flag("alertmanager.notification-queue-capacity", "The capacity of the queue for pending Alertmanager notifications.").

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -239,7 +239,7 @@ func main() {
 	a.Flag("rules.alert.resend-delay", "Minimum amount of time to wait before resending an alert to Alertmanager.").
 		Default("1m").SetValue(&cfg.resendDelay)
 
-	a.Flag("scrape.adjust-timestamps", "Adjust scrape timestamps by up to 2ms to align them to the intended schedule. Experimental.").
+	a.Flag("scrape.adjust-timestamps", "Adjust scrape timestamps by up to 2ms to align them to the intended schedule. Introduced due to a regression in Go 2.14. See https://github.com/prometheus/prometheus/issues/7846 for more context. Experimental.").
 		Hidden().Default("true").BoolVar(&scrape.AlignScrapeTimestamps)
 
 	a.Flag("alertmanager.notification-queue-capacity", "The capacity of the queue for pending Alertmanager notifications.").

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -50,7 +50,10 @@ import (
 // Temporary tolerance for scrape appends timestamps alignment, to enable better
 // compression at the TSDB level.
 // See https://github.com/prometheus/prometheus/issues/7846
-var ScrapeTimestampTolerance = 2 * time.Millisecond
+const scrapeTimestampTolerance = 2 * time.Millisecond
+
+// Enable or disable the tolerance for scrape described above.
+var AlignScrapeTimestamps = true
 
 var errNameLabelMandatory = fmt.Errorf("missing metric name (%s label)", labels.MetricName)
 
@@ -1009,14 +1012,14 @@ mainLoop:
 		// increase in TSDB.
 		// See https://github.com/prometheus/prometheus/issues/7846
 		scrapeTime := time.Now()
-		if interval > 100*ScrapeTimestampTolerance {
+		if AlignScrapeTimestamps && interval > 100*scrapeTimestampTolerance {
 			// For some reason, a tick might have been skipped, in which case we
 			// would call alignedScrapeTime.Add(interval) multiple times.
 			for scrapeTime.Sub(alignedScrapeTime) >= interval {
 				alignedScrapeTime = alignedScrapeTime.Add(interval)
 			}
 			// Align the scrape time if we are in the tolerance boundaries.
-			if scrapeTime.Sub(alignedScrapeTime) <= ScrapeTimestampTolerance {
+			if scrapeTime.Sub(alignedScrapeTime) <= scrapeTimestampTolerance {
 				scrapeTime = alignedScrapeTime
 			}
 		}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -990,8 +990,8 @@ func (sl *scrapeLoop) run(interval, timeout time.Duration, errc chan<- error) {
 
 	var last time.Time
 
-	ticker := time.NewTicker(interval)
 	alignedScrapeTime := time.Now()
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 mainLoop:
@@ -1016,7 +1016,7 @@ mainLoop:
 				alignedScrapeTime = alignedScrapeTime.Add(interval)
 			}
 			// Align the scrape time if we are in the tolerance boundaries.
-			if t := scrapeTime.Sub(alignedScrapeTime); t >= -scrapeTimestampTolerance && t <= scrapeTimestampTolerance {
+			if scrapeTime.Sub(alignedScrapeTime) <= scrapeTimestampTolerance {
 				scrapeTime = alignedScrapeTime
 			}
 		}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -52,7 +52,7 @@ import (
 // See https://github.com/prometheus/prometheus/issues/7846
 const scrapeTimestampTolerance = 2 * time.Millisecond
 
-// Enable or disable the tolerance for scrape appends timestamps described above.
+// AlignScrapeTimestamps enables the tolerance for scrape appends timestamps described above.
 var AlignScrapeTimestamps = true
 
 var errNameLabelMandatory = fmt.Errorf("missing metric name (%s label)", labels.MetricName)

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1010,7 +1010,7 @@ mainLoop:
 		// See https://github.com/prometheus/prometheus/issues/7846
 		scrapeTime := time.Now()
 		if interval > 100*scrapeTimestampTolerance {
-			// For some reason, a ticker might have been skipped, in which case we
+			// For some reason, a tick might have been skipped, in which case we
 			// would call alignedScrapeTime.Add(interval) multiple times.
 			for scrapeTime.Sub(alignedScrapeTime) >= interval {
 				alignedScrapeTime = alignedScrapeTime.Add(interval)

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -52,7 +52,7 @@ import (
 // See https://github.com/prometheus/prometheus/issues/7846
 const scrapeTimestampTolerance = 2 * time.Millisecond
 
-// Enable or disable the tolerance for scrape described above.
+// Enable or disable the tolerance for scrape appends timestamps described above.
 var AlignScrapeTimestamps = true
 
 var errNameLabelMandatory = fmt.Errorf("missing metric name (%s label)", labels.MetricName)

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -50,7 +50,7 @@ import (
 // Temporary tolerance for scrape appends timestamps alignment, to enable better
 // compression at the TSDB level.
 // See https://github.com/prometheus/prometheus/issues/7846
-const scrapeTimestampTolerance = 2 * time.Millisecond
+var ScrapeTimestampTolerance = 2 * time.Millisecond
 
 var errNameLabelMandatory = fmt.Errorf("missing metric name (%s label)", labels.MetricName)
 
@@ -1009,14 +1009,14 @@ mainLoop:
 		// increase in TSDB.
 		// See https://github.com/prometheus/prometheus/issues/7846
 		scrapeTime := time.Now()
-		if interval > 100*scrapeTimestampTolerance {
+		if interval > 100*ScrapeTimestampTolerance {
 			// For some reason, a tick might have been skipped, in which case we
 			// would call alignedScrapeTime.Add(interval) multiple times.
 			for scrapeTime.Sub(alignedScrapeTime) >= interval {
 				alignedScrapeTime = alignedScrapeTime.Add(interval)
 			}
 			// Align the scrape time if we are in the tolerance boundaries.
-			if scrapeTime.Sub(alignedScrapeTime) <= scrapeTimestampTolerance {
+			if scrapeTime.Sub(alignedScrapeTime) <= ScrapeTimestampTolerance {
 				scrapeTime = alignedScrapeTime
 			}
 		}


### PR DESCRIPTION
It appears that Ticker is not always precise up to the millisecond.

I am proposing here to introduce a tolerance in the scrape timestamps. That should prevent bugs like #7973 and #7846.

It turns out that on my machine, with go1.15, a simple script like:
```go
package main

import (
        "fmt"
        "time"
)

func main() {
        c := time.Tick(1 * time.Second)
        for t := range c {
                fmt.Printf("%v / %v\n", t.UnixNano()/int64(time.Millisecond), time.Now().UnixNano()/int64(time.Millisecond))
        }
}
```

is not stable:

```shell
$ go run test.go
1601037886576 / 1601037886576     
1601037887576 / 1601037887576     
1601037888576 / 1601037888576     
1601037889576 / 1601037889576     
1601037890576 / 1601037890576     
1601037891576 / 1601037891576     
1601037892576 / 1601037892576     
1601037893575 / 1601037893576     
1601037894576 / 1601037894576     
1601037895575 / 1601037895575
1601037896575 / 1601037896576     
1601037897575 / 1601037897575    
```

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>