### PR TITLE
Align scrapes to the middle of the millisecond

### DIFF
--- a/scrape/target.go
+++ b/scrape/target.go
@@ -162,6 +162,10 @@ func (t *Target) offset(interval time.Duration, jitterSeed uint64) time.Duration
 		next   = base + int64(offset)
 	)
 
+	// We align the timestamp to 1/10 millisecond; to prevent changes in the
+	// scrape timestamp.
+	next = int64(time.Millisecond)*(next/int64(time.Millisecond)) + int64(time.Millisecond/10)
+
 	if next > int64(interval) {
 		next -= int64(interval)
 	}


### PR DESCRIPTION
Align scrapes to the middle of the second to reduce scrape timestamp
variation.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->