### PR TITLE
Fix callback function bind with object as parameter

### DIFF
--- a/web/ui/static/js/graph/index.js
+++ b/web/ui/static/js/graph/index.js
@@ -937,9 +937,11 @@ Prometheus.Page.prototype.init = function() {
   if (graphOptions.length === 0) {
     graphOptions.push({});
   }
-
+  var pageInstance = this;
   graphOptions.forEach(this.addGraph, this);
-  $("#add_graph").click(this.addGraph.bind(this, {}));
+  $("#add_graph").click(function() {
+    pageInstance.addGraph({});
+  });
 };
 
 Prometheus.Page.prototype.parseURL = function() {


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
Fixes #7296: Remove the object parameter in the `add_graph` onClick callback function binding which resulted in the graph option object getting referenced by multiple `Prometheus.Graph`