### PR TITLE
Promtool tsdb list now prints block sizes

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -124,6 +124,9 @@ type BlockReader interface {
 
 	// Meta provides meta information about the block reader.
 	Meta() BlockMeta
+
+	// Size returns the number of bytes that the block takes up on disk.
+	Size() int64
 }
 
 // BlockMeta provides meta information about a block.

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -461,6 +461,7 @@ func (erringBReader) Index() (IndexReader, error)            { return nil, error
 func (erringBReader) Chunks() (ChunkReader, error)           { return nil, errors.New("chunks") }
 func (erringBReader) Tombstones() (tombstones.Reader, error) { return nil, errors.New("tombstones") }
 func (erringBReader) Meta() BlockMeta                        { return BlockMeta{} }
+func (erringBReader) Size() int64                            { return 0 }
 
 type nopChunkWriter struct{}
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1103,11 +1103,9 @@ func BeyondSizeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struc
 
 	deletable = make(map[ulid.ULID]struct{})
 
-	walSize, _ := db.Head().wal.Size()
-	headChunksSize := db.Head().chunkDiskMapper.Size()
 	// Initializing size counter with WAL size and Head chunks
 	// written to disk, as that is part of the retention strategy.
-	blocksSize := walSize + headChunksSize
+	blocksSize := db.Head().Size()
 	for i, block := range blocks {
 		blocksSize += block.Size()
 		if blocksSize > int64(db.opts.MaxBytes) {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2345,3 +2345,15 @@ type noopSeriesLifecycleCallback struct{}
 func (noopSeriesLifecycleCallback) PreCreation(labels.Labels) error { return nil }
 func (noopSeriesLifecycleCallback) PostCreation(labels.Labels)      {}
 func (noopSeriesLifecycleCallback) PostDeletion(...labels.Labels)   {}
+
+func (h *Head) Size() int64 {
+	var walSize int64
+	if h.wal != nil {
+		walSize, _ = h.wal.Size()
+	}
+	return walSize + h.chunkDiskMapper.Size()
+}
+
+func (h *RangeHead) Size() int64 {
+	return h.head.Size()
+}

--- a/tsdb/mocks_test.go
+++ b/tsdb/mocks_test.go
@@ -65,3 +65,4 @@ func (r *mockBReader) Tombstones() (tombstones.Reader, error) {
 	return tombstones.NewMemTombstones(), nil
 }
 func (r *mockBReader) Meta() BlockMeta { return BlockMeta{MinTime: r.mint, MaxTime: r.maxt} }
+func (r *mockBReader) Size() int64     { return 0 }


### PR DESCRIPTION
Promtool tsdb list now prints block sizes

Fixes #7972 
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->