### PR TITLE
Avoid series prelookup

### DIFF
--- a/promql/test.go
+++ b/promql/test.go
@@ -462,6 +462,7 @@ func (t *Test) exec(tc testCommand) error {
 
 		err = cmd.compareResult(res.Value)
 		if err != nil {
+			fmt.Println(res.Value)
 			return errors.Wrapf(err, "error in %s %s", cmd, cmd.expr)
 		}
 

--- a/promql/test.go
+++ b/promql/test.go
@@ -462,7 +462,6 @@ func (t *Test) exec(tc testCommand) error {
 
 		err = cmd.compareResult(res.Value)
 		if err != nil {
-			fmt.Println(res.Value)
 			return errors.Wrapf(err, "error in %s %s", cmd, cmd.expr)
 		}
 


### PR DESCRIPTION
PR for #7326 
Stop expanding SeriesSet beforehand, rather expand it during the `eval` stage, hence avoiding series prelookup.

Signed-off by: Sanskar Jaiswal jaiswalsanskar078@gmail.com

cc: @brian-brazil @bwplotka 