### PR TITLE
cmd/prometheus: Issue a warning on 32 bit archs

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/bits"
 	"net"
 	"net/http"
 	_ "net/http/pprof" // Comment this line to disable pprof endpoint.
@@ -344,6 +345,10 @@ func main() {
 	klog.SetLogger(log.With(logger, "component", "k8s_client_runtime"))
 
 	level.Info(logger).Log("msg", "Starting Prometheus", "version", version.Info())
+	if bits.UintSize < 64 {
+		level.Warn(logger).Log("msg", "This Prometheus binary hasn't been compiled for a 64-bit architecture. Due to memory mapping constraints of 32-bit systems, it is highly recommended to switch to a 64-bit build of Prometheus.", "GOARCH", runtime.GOARCH)
+	}
+
 	level.Info(logger).Log("build_context", version.BuildContext())
 	level.Info(logger).Log("host_details", prom_runtime.Uname())
 	level.Info(logger).Log("fd_limits", prom_runtime.FdLimits())

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -346,7 +346,7 @@ func main() {
 
 	level.Info(logger).Log("msg", "Starting Prometheus", "version", version.Info())
 	if bits.UintSize < 64 {
-		level.Warn(logger).Log("msg", "This Prometheus binary hasn't been compiled for a 64-bit architecture. Due to virtual memory constraints of 32-bit systems, it is highly recommended to switch to a 64-bit binary of Prometheus.", "GOARCH", runtime.GOARCH)
+		level.Warn(logger).Log("msg", "This Prometheus binary has not been compiled for a 64-bit architecture. Due to virtual memory constraints of 32-bit systems, it is highly recommended to switch to a 64-bit binary of Prometheus.", "GOARCH", runtime.GOARCH)
 	}
 
 	level.Info(logger).Log("build_context", version.BuildContext())

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -346,7 +346,7 @@ func main() {
 
 	level.Info(logger).Log("msg", "Starting Prometheus", "version", version.Info())
 	if bits.UintSize < 64 {
-		level.Warn(logger).Log("msg", "This Prometheus binary hasn't been compiled for a 64-bit architecture. Due to memory mapping constraints of 32-bit systems, it is highly recommended to switch to a 64-bit build of Prometheus.", "GOARCH", runtime.GOARCH)
+		level.Warn(logger).Log("msg", "This Prometheus binary hasn't been compiled for a 64-bit architecture. Due to virtual memory constraints of 32-bit systems, it is highly recommended to switch to a 64-bit build of Prometheus.", "GOARCH", runtime.GOARCH)
 	}
 
 	level.Info(logger).Log("build_context", version.BuildContext())

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -346,7 +346,7 @@ func main() {
 
 	level.Info(logger).Log("msg", "Starting Prometheus", "version", version.Info())
 	if bits.UintSize < 64 {
-		level.Warn(logger).Log("msg", "This Prometheus binary hasn't been compiled for a 64-bit architecture. Due to virtual memory constraints of 32-bit systems, it is highly recommended to switch to a 64-bit build of Prometheus.", "GOARCH", runtime.GOARCH)
+		level.Warn(logger).Log("msg", "This Prometheus binary hasn't been compiled for a 64-bit architecture. Due to virtual memory constraints of 32-bit systems, it is highly recommended to switch to a 64-bit binary of Prometheus.", "GOARCH", runtime.GOARCH)
 	}
 
 	level.Info(logger).Log("build_context", version.BuildContext())


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->