### PR TITLE
Increase maxErrMsgLen value remote_write api

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -38,7 +38,7 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 )
 
-const maxErrMsgLen = 256
+const maxErrMsgLen = 512
 
 var UserAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 


### PR DESCRIPTION
Fixes #7982. 

Increase maxErrMsgLen value from 256 to 512 bytes for remote_write api.