### PR TITLE
Added Content-Length HTTP header to remote write requests.

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -160,6 +160,7 @@ func (c *Client) Store(ctx context.Context, req []byte) error {
 	}
 	httpReq.Header.Add("Content-Encoding", "snappy")
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
+	httpReq.Header.Set("Content-Length", fmt.Sprintf("%v", len(req)))
 	httpReq.Header.Set("User-Agent", UserAgent)
 	httpReq.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)


### PR DESCRIPTION
Tiny change, but as well improve a little bit allocating memory for reading the body (potentially large remote write) on the receiving side.

![image](https://user-images.githubusercontent.com/6950331/95347890-57cbaa00-08b5-11eb-9e69-43174ff620aa.png)

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>
