### PR TITLE
Prevent creating Point slices with a cap larger than the remaining samples

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -32,7 +32,7 @@ func BenchmarkRangeQuery(b *testing.B) {
 	opts := EngineOpts{
 		Logger:     nil,
 		Reg:        nil,
-		MaxSamples: 50000000,
+		MaxSamples: 5000000,
 		Timeout:    100 * time.Second,
 	}
 	engine := NewEngine(opts)
@@ -170,6 +170,12 @@ func BenchmarkRangeQuery(b *testing.B) {
 		},
 		{
 			expr: "histogram_quantile(0.9, rate(h_X[5m]))",
+		},
+		// Memory or compute intensive queries.
+		{
+			// Run for a single timeseries over a large amount of potential samples.
+			expr:  "count_over_time(a_one[999d:1s])",
+			steps: 1,
 		},
 	}
 


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Add a testcase with a large subquery and run the benchmark next to each other ten times. Benchstat seems to be happy with slightly less allocations after the change.


```
:~/environment $ ~/go/bin/benchstat  -sort delta ./github.com/prometheus/prometheus.old/before9 ./github.com/prometheus/prometheus/after9
name                                                                                                      old time/op    new time/op    delta
RangeQuery/expr=a_one,steps=1-2                                                                              147µs ±98%    119µs ±147%    ~     (p=0.604 n=9+10)
RangeQuery/expr=a_one,steps=10-2                                                                             162µs ±79%    124µs ±162%    ~     (p=0.218 n=10+10)
RangeQuery/expr=a_one,steps=100-2                                                                            199µs ±80%    152µs ±156%    ~     (p=0.684 n=10+10)
RangeQuery/expr=a_one,steps=1000-2                                                                          506µs ±117%    364µs ±134%    ~     (p=0.579 n=10+10)
RangeQuery/expr=a_ten,steps=1-2                                                                              422µs ±93%    308µs ±143%    ~     (p=0.143 n=10+10)
RangeQuery/expr=a_ten,steps=10-2                                                                             434µs ±76%    346µs ±124%    ~     (p=0.436 n=10+10)
RangeQuery/expr=a_ten,steps=100-2                                                                           858µs ±130%    716µs ±122%    ~     (p=0.912 n=10+10)
RangeQuery/expr=a_ten,steps=1000-2                                                                          3.59ms ±73%   3.16ms ±122%    ~     (p=0.853 n=10+10)
RangeQuery/expr=a_hundred,steps=1-2                                                                        2.53ms ±111%   2.59ms ±113%    ~     (p=0.971 n=10+10)
RangeQuery/expr=a_hundred,steps=10-2                                                                       2.86ms ±109%   2.76ms ±111%    ~     (p=0.579 n=10+10)
RangeQuery/expr=a_hundred,steps=100-2                                                                      7.02ms ±191%   7.05ms ±132%    ~     (p=0.971 n=10+10)
RangeQuery/expr=a_hundred,steps=1000-2                                                                     31.2ms ±101%   31.1ms ±116%    ~     (p=0.796 n=10+10)
RangeQuery/expr=rate(a_one[1m]),steps=1-2                                                                   162µs ±105%    163µs ±111%    ~     (p=0.579 n=10+10)
RangeQuery/expr=rate(a_one[1m]),steps=10-2                                                                  167µs ±100%    167µs ±121%    ~     (p=0.853 n=10+10)
RangeQuery/expr=rate(a_one[1m]),steps=100-2                                                                 242µs ±116%    245µs ±148%    ~     (p=0.912 n=10+10)
RangeQuery/expr=rate(a_one[1m]),steps=1000-2                                                                797µs ±120%    824µs ±140%    ~     (p=0.971 n=10+10)
RangeQuery/expr=rate(a_ten[1m]),steps=1-2                                                                   368µs ±107%    428µs ±148%    ~     (p=0.684 n=10+10)
RangeQuery/expr=rate(a_ten[1m]),steps=10-2                                                                  420µs ±104%    469µs ±111%    ~     (p=0.912 n=10+10)
RangeQuery/expr=rate(a_ten[1m]),steps=100-2                                                                1.16ms ±146%   1.15ms ±118%    ~     (p=0.853 n=10+10)
RangeQuery/expr=rate(a_ten[1m]),steps=1000-2                                                               5.44ms ±143%   5.99ms ±166%    ~     (p=0.971 n=10+10)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-2                                                              2.12ms ±136%   2.49ms ±105%    ~     (p=0.393 n=10+10)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-2                                                             2.65ms ±151%   3.14ms ±112%    ~     (p=0.796 n=10+10)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-2                                                            8.36ms ±137%  10.29ms ±114%    ~     (p=0.912 n=10+10)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-2                                                           56.4ms ±152%   71.2ms ±174%    ~     (p=0.912 n=10+10)
RangeQuery/expr=rate(a_one[1m]),steps=10000-2                                                              5.83ms ±136%   7.52ms ±147%    ~     (p=0.971 n=10+10)
RangeQuery/expr=rate(a_ten[1m]),steps=10000-2                                                              54.8ms ±133%   74.1ms ±136%    ~     (p=0.280 n=10+10)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-2                                                           542ms ±132%    735ms ±161%    ~     (p=0.143 n=10+10)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-2                                                4.34ms ±135%   5.76ms ±163%    ~     (p=0.796 n=10+10)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-2                                               5.77ms ±132%   7.48ms ±171%    ~     (p=1.000 n=10+10)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-2                                              19.8ms ±145%   25.4ms ±171%    ~     (p=0.579 n=10+10)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-2                                              158ms ±124%    198ms ±165%    ~     (p=0.684 n=10+10)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-2                                                26.5ms ±149%   35.8ms ±244%    ~     (p=0.971 n=10+10)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-2                                               40.0ms ±127%   50.4ms ±148%    ~     (p=0.631 n=10+10)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-2                                               209ms ±124%    243ms ±161%    ~     (p=0.739 n=10+10)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-2                                              1.75s ±101%    1.80s ±103%    ~     (p=0.579 n=10+10)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-2                                              260ms ±94%    267ms ±103%    ~     (p=0.796 n=10+10)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-2                                            436ms ±109%    428ms ±100%    ~     (p=0.796 n=10+10)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-2                                           2.01s ±110%    2.00s ±100%    ~     (p=0.912 n=10+10)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-2                                          15.6s ±118%    16.1s ±115%    ~     (p=0.739 n=10+10)
RangeQuery/expr=changes(a_one[1d]),steps=1-2                                                               3.84ms ±108%   3.79ms ±107%    ~     (p=0.315 n=10+10)
RangeQuery/expr=changes(a_one[1d]),steps=10-2                                                              4.66ms ±104%   4.59ms ±133%    ~     (p=0.631 n=10+10)
RangeQuery/expr=changes(a_one[1d]),steps=100-2                                                             11.4ms ±100%   11.6ms ±101%    ~     (p=0.853 n=10+10)
RangeQuery/expr=changes(a_one[1d]),steps=1000-2                                                             78.3ms ±99%   81.7ms ±107%    ~     (p=0.796 n=10+10)
RangeQuery/expr=changes(a_ten[1d]),steps=1-2                                                               27.4ms ±127%   25.6ms ±105%    ~     (p=0.393 n=10+10)
RangeQuery/expr=changes(a_ten[1d]),steps=10-2                                                               31.8ms ±96%   32.8ms ±113%    ~     (p=0.853 n=10+10)
RangeQuery/expr=changes(a_ten[1d]),steps=100-2                                                              104ms ±100%     101ms ±99%    ~     (p=0.481 n=10+10)
RangeQuery/expr=changes(a_ten[1d]),steps=1000-2                                                             793ms ±106%     781ms ±97%    ~     (p=0.912 n=10+10)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-2                                                            246ms ±110%    261ms ±164%    ~     (p=0.971 n=10+10)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-2                                                           321ms ±115%     310ms ±98%    ~     (p=0.853 n=10+10)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-2                                                           1.01s ±99%     0.99s ±96%    ~     (p=0.684 n=10+10)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-2                                                         7.51s ±106%    7.10s ±113%    ~     (p=1.000 n=10+10)
RangeQuery/expr=rate(a_one[1d]),steps=1-2                                                                  3.12ms ±146%   2.87ms ±131%    ~     (p=0.218 n=10+10)
RangeQuery/expr=rate(a_one[1d]),steps=10-2                                                                 3.48ms ±149%   3.25ms ±136%    ~     (p=0.853 n=10+10)
RangeQuery/expr=rate(a_one[1d]),steps=100-2                                                                6.55ms ±147%   6.58ms ±130%    ~     (p=0.853 n=10+10)
RangeQuery/expr=rate(a_one[1d]),steps=1000-2                                                               34.7ms ±135%   34.5ms ±138%    ~     (p=0.739 n=10+10)
RangeQuery/expr=rate(a_ten[1d]),steps=1-2                                                                  22.1ms ±140%   22.2ms ±164%    ~     (p=0.796 n=10+10)
RangeQuery/expr=rate(a_ten[1d]),steps=10-2                                                                 25.0ms ±141%   25.3ms ±151%    ~     (p=0.579 n=10+10)
RangeQuery/expr=rate(a_ten[1d]),steps=100-2                                                                57.3ms ±150%   58.2ms ±119%    ~     (p=0.143 n=10+10)
RangeQuery/expr=rate(a_ten[1d]),steps=1000-2                                                                344ms ±123%    357ms ±131%    ~     (p=0.579 n=10+10)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-2                                                               217ms ±121%    227ms ±127%    ~     (p=0.739 n=10+10)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-2                                                              287ms ±123%     272ms ±98%    ~     (p=0.739 n=10+10)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-2                                                             637ms ±121%    660ms ±113%    ~     (p=0.123 n=10+10)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-2                                                            3.92s ±102%     3.88s ±96%    ~     (p=0.579 n=10+10)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1-2                                                      3.69ms ±109%   3.59ms ±108%    ~     (p=0.912 n=10+10)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=10-2                                                     3.81ms ±102%   3.72ms ±103%    ~     (p=0.315 n=10+10)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-2                                                    5.44ms ±105%   5.27ms ±109%    ~     (p=0.796 n=10+10)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-2                                                   19.4ms ±105%   19.1ms ±100%    ~     (p=0.912 n=10+10)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-2                                                      26.2ms ±127%    24.5ms ±98%    ~     (p=0.481 n=10+10)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-2                                                     26.4ms ±105%   25.4ms ±107%    ~     (p=0.393 n=10+10)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-2                                                    42.3ms ±115%   33.4ms ±128%    ~     (p=0.190 n=10+10)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-2                                                     183ms ±98%    154ms ±133%    ~     (p=1.000 n=10+10)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-2                                                   243ms ±115%    195ms ±132%    ~     (p=0.631 n=10+10)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-2                                                  258ms ±139%    218ms ±157%    ~     (p=0.631 n=10+10)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-2                                                  408ms ±98%    342ms ±126%    ~     (p=0.631 n=10+10)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-2                                                 1.84s ±92%    1.60s ±126%    ~     (p=0.796 n=10+10)
RangeQuery/expr=-a_one,steps=1-2                                                                             158µs ±77%    141µs ±102%    ~     (p=1.000 n=10+10)
RangeQuery/expr=-a_one,steps=10-2                                                                            172µs ±87%     146µs ±99%    ~     (p=0.315 n=10+10)
RangeQuery/expr=-a_one,steps=100-2                                                                           211µs ±75%    177µs ±107%    ~     (p=0.579 n=10+10)
RangeQuery/expr=-a_one,steps=1000-2                                                                         529µs ±145%    420µs ±111%    ~     (p=0.971 n=10+10)
RangeQuery/expr=-a_ten,steps=1-2                                                                             442µs ±94%     358µs ±98%    ~     (p=0.280 n=10+10)
RangeQuery/expr=-a_ten,steps=10-2                                                                            478µs ±86%    389µs ±106%    ~     (p=0.190 n=10+10)
RangeQuery/expr=-a_ten,steps=100-2                                                                          925µs ±126%    719µs ±111%    ~     (p=0.123 n=10+10)
RangeQuery/expr=-a_ten,steps=1000-2                                                                         3.73ms ±81%   3.12ms ±100%    ~     (p=0.739 n=10+10)
RangeQuery/expr=-a_hundred,steps=1-2                                                                        3.17ms ±80%   2.80ms ±115%    ~     (p=0.912 n=10+10)
RangeQuery/expr=-a_hundred,steps=10-2                                                                       3.58ms ±81%    2.93ms ±97%    ~     (p=0.481 n=10+10)
RangeQuery/expr=-a_hundred,steps=100-2                                                                     7.70ms ±104%   6.42ms ±112%    ~     (p=0.481 n=10+10)
RangeQuery/expr=-a_hundred,steps=1000-2                                                                    41.6ms ±135%   32.0ms ±104%    ~     (p=0.353 n=10+10)
RangeQuery/expr=a_one_-_b_one,steps=1-2                                                                      242µs ±79%    205µs ±111%    ~     (p=0.796 n=10+10)
RangeQuery/expr=a_one_-_b_one,steps=10-2                                                                     277µs ±80%     228µs ±98%    ~     (p=0.481 n=10+10)
RangeQuery/expr=a_one_-_b_one,steps=100-2                                                                    697µs ±89%    603µs ±110%    ~     (p=0.353 n=10+10)
RangeQuery/expr=a_one_-_b_one,steps=1000-2                                                                 3.61ms ±106%    3.61ms ±97%    ~     (p=0.684 n=10+10)
RangeQuery/expr=a_ten_-_b_ten,steps=1-2                                                                     776µs ±109%    790µs ±103%    ~     (p=0.631 n=10+10)
RangeQuery/expr=a_ten_-_b_ten,steps=10-2                                                                   1.10ms ±110%   1.13ms ±109%    ~     (p=0.393 n=10+10)
RangeQuery/expr=a_ten_-_b_ten,steps=100-2                                                                  4.65ms ±136%   4.48ms ±112%    ~     (p=0.739 n=10+10)
RangeQuery/expr=a_ten_-_b_ten,steps=1000-2                                                                 35.5ms ±121%   36.0ms ±109%    ~     (p=0.912 n=10+10)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-2                                                            6.76ms ±123%    7.83ms ±84%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-2                                                           10.3ms ±104%    11.6ms ±75%    ~     (p=0.631 n=10+10)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-2                                                          45.8ms ±108%   59.2ms ±155%    ~     (p=0.796 n=10+10)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-2                                                          373ms ±108%     425ms ±84%    ~     (p=0.739 n=10+10)
RangeQuery/expr=a_one_-_b_one,steps=10000-2                                                                35.3ms ±103%    40.9ms ±77%    ~     (p=0.579 n=10+10)
RangeQuery/expr=a_ten_-_b_ten,steps=10000-2                                                                 365ms ±174%     392ms ±77%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-2                                                         3.88s ±107%     4.46s ±79%    ~     (p=0.912 n=10+10)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-2                                                    395µs ±122%     460µs ±81%    ~     (p=0.796 n=10+10)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-2                                                   413µs ±122%     449µs ±73%    ~     (p=0.739 n=10+10)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-2                                                  635µs ±116%     672µs ±82%    ~     (p=0.631 n=10+10)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-2                                                2.15ms ±105%    2.51ms ±79%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-2                                                    811µs ±105%     921µs ±91%    ~     (p=0.631 n=10+10)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-2                                                   968µs ±118%    1090µs ±92%    ~     (p=0.912 n=10+10)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-2                                                 2.75ms ±156%   3.26ms ±132%    ~     (p=0.912 n=10+10)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-2                                                16.8ms ±104%   22.3ms ±100%    ~     (p=0.481 n=10+10)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-2                                           5.17ms ±103%    5.51ms ±74%    ~     (p=0.436 n=10+10)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-2                                          7.08ms ±119%   8.17ms ±111%    ~     (p=0.971 n=10+10)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-2                                         29.7ms ±159%    29.2ms ±77%    ~     (p=0.315 n=10+10)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-2                                         202ms ±105%    235ms ±108%    ~     (p=0.739 n=10+10)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-2                                                     429µs ±108%     469µs ±82%    ~     (p=0.853 n=10+10)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-2                                                    427µs ±109%     476µs ±91%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-2                                                   813µs ±103%     780µs ±89%    ~     (p=0.481 n=10+10)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-2                                                  3.40ms ±93%   2.61ms ±102%    ~     (p=0.105 n=10+10)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-2                                                      964µs ±85%    802µs ±102%    ~     (p=0.190 n=10+10)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-2                                                   1.32ms ±112%   1.05ms ±105%    ~     (p=0.280 n=10+10)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-2                                                   3.97ms ±85%   3.18ms ±111%    ~     (p=0.089 n=10+10)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-2                                                 28.8ms ±104%   23.9ms ±144%    ~     (p=0.393 n=10+10)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-2                                             6.11ms ±81%   5.65ms ±159%    ~     (p=0.912 n=10+10)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-2                                           9.86ms ±107%   7.60ms ±125%    ~     (p=0.353 n=10+10)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-2                                           38.0ms ±88%   31.7ms ±104%    ~     (p=0.579 n=10+10)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-2                                           295ms ±73%    254ms ±116%    ~     (p=0.796 n=10+10)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-2                                                 493µs ±107%    403µs ±118%    ~     (p=0.280 n=10+10)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-2                                                 493µs ±80%    434µs ±135%    ~     (p=0.579 n=10+10)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-2                                                756µs ±81%    618µs ±100%    ~     (p=0.280 n=10+10)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-2                                              3.24ms ±79%   2.74ms ±112%    ~     (p=0.579 n=10+10)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-2                                                1.04ms ±101%   0.82ms ±109%    ~     (p=0.436 n=10+10)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-2                                                973µs ±113%   1011µs ±127%    ~     (p=0.853 n=10+10)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-2                                              2.60ms ±124%   2.73ms ±138%    ~     (p=0.853 n=10+10)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-2                                             17.4ms ±133%   19.9ms ±149%    ~     (p=0.853 n=10+10)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-2                                        5.05ms ±110%   5.04ms ±113%    ~     (p=0.684 n=10+10)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-2                                       7.33ms ±146%   7.23ms ±117%    ~     (p=0.631 n=10+10)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-2                                      26.4ms ±124%   26.6ms ±105%    ~     (p=0.971 n=10+10)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-2                                       196ms ±99%    197ms ±102%    ~     (p=0.631 n=10+10)
RangeQuery/expr=abs(a_one),steps=1-2                                                                        176µs ±125%    172µs ±116%    ~     (p=0.739 n=10+10)
RangeQuery/expr=abs(a_one),steps=10-2                                                                       192µs ±105%    185µs ±109%    ~     (p=0.436 n=10+10)
RangeQuery/expr=abs(a_one),steps=100-2                                                                      325µs ±116%    366µs ±125%    ~     (p=0.436 n=10+10)
RangeQuery/expr=abs(a_one),steps=1000-2                                                                    1.61ms ±117%   2.04ms ±105%    ~     (p=0.481 n=10+10)
RangeQuery/expr=abs(a_ten),steps=1-2                                                                        453µs ±120%     526µs ±84%    ~     (p=0.739 n=10+10)
RangeQuery/expr=abs(a_ten),steps=10-2                                                                       581µs ±113%     675µs ±99%    ~     (p=0.971 n=10+10)
RangeQuery/expr=abs(a_ten),steps=100-2                                                                     1.93ms ±106%   2.51ms ±109%    ~     (p=0.912 n=10+10)
RangeQuery/expr=abs(a_ten),steps=1000-2                                                                    14.6ms ±117%    16.9ms ±93%    ~     (p=0.218 n=10+10)
RangeQuery/expr=abs(a_hundred),steps=1-2                                                                   3.10ms ±106%    3.78ms ±78%    ~     (p=0.436 n=10+10)
RangeQuery/expr=abs(a_hundred),steps=10-2                                                                  4.83ms ±135%   5.50ms ±101%    ~     (p=0.796 n=10+10)
RangeQuery/expr=abs(a_hundred),steps=100-2                                                                 20.0ms ±114%    24.0ms ±97%    ~     (p=0.853 n=10+10)
RangeQuery/expr=abs(a_hundred),steps=1000-2                                                                 153ms ±106%     186ms ±91%    ~     (p=0.393 n=10+10)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-2                                     253µs ±143%     278µs ±78%    ~     (p=0.796 n=10+10)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-2                                    277µs ±120%     316µs ±90%    ~     (p=0.796 n=10+10)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-2                                   511µs ±109%     594µs ±88%    ~     (p=1.000 n=10+10)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-2                                 2.87ms ±127%    3.01ms ±81%    ~     (p=0.393 n=10+10)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-2                                     565µs ±102%     649µs ±84%    ~     (p=0.529 n=10+10)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-2                                    741µs ±121%     823µs ±95%    ~     (p=0.912 n=10+10)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-2                                   2.53ms ±92%   2.63ms ±106%    ~     (p=0.912 n=10+10)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-2                                  19.7ms ±81%    20.3ms ±97%    ~     (p=0.971 n=10+10)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-2                                 4.39ms ±82%   3.63ms ±119%    ~     (p=0.280 n=10+10)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-2                                6.19ms ±90%   5.42ms ±147%    ~     (p=0.529 n=10+10)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-2                               26.8ms ±96%   24.3ms ±158%    ~     (p=0.912 n=10+10)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-2                               206ms ±84%    184ms ±145%    ~     (p=0.481 n=10+10)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-2                                             234µs ±98%    193µs ±110%    ~     (p=0.529 n=10+10)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-2                                           225µs ±117%    231µs ±128%    ~     (p=0.631 n=10+10)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-2                                          519µs ±111%    510µs ±108%    ~     (p=1.000 n=10+10)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-2                                        3.33ms ±108%   3.30ms ±124%    ~     (p=0.739 n=10+10)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-2                                            460µs ±110%    487µs ±112%    ~     (p=0.796 n=10+10)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-2                                           677µs ±128%    651µs ±115%    ~     (p=0.481 n=10+10)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-2                                         2.27ms ±102%   2.55ms ±132%    ~     (p=0.796 n=10+10)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-2                                        19.7ms ±150%   18.5ms ±135%    ~     (p=0.684 n=10+10)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-2                                       3.39ms ±125%   3.38ms ±102%    ~     (p=0.971 n=10+10)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-2                                      5.26ms ±113%   5.34ms ±131%    ~     (p=0.971 n=10+10)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-2                                     23.5ms ±143%   21.9ms ±124%    ~     (p=0.481 n=10+10)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-2                                     186ms ±124%     175ms ±98%    ~     (p=0.631 n=10+10)
RangeQuery/expr=sum(a_one),steps=1-2                                                                        171µs ±130%    166µs ±130%    ~     (p=0.315 n=10+10)
RangeQuery/expr=sum(a_one),steps=10-2                                                                       192µs ±115%    191µs ±109%    ~     (p=1.000 n=10+10)
RangeQuery/expr=sum(a_one),steps=100-2                                                                      558µs ±104%    544µs ±108%    ~     (p=0.393 n=10+10)
RangeQuery/expr=sum(a_one),steps=1000-2                                                                    3.76ms ±106%    3.65ms ±98%    ~     (p=0.631 n=10+10)
RangeQuery/expr=sum(a_ten),steps=1-2                                                                        398µs ±111%    395µs ±122%    ~     (p=0.529 n=10+10)
RangeQuery/expr=sum(a_ten),steps=10-2                                                                       466µs ±123%    464µs ±109%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum(a_ten),steps=100-2                                                                     1.22ms ±123%   1.29ms ±103%    ~     (p=0.684 n=10+10)
RangeQuery/expr=sum(a_ten),steps=1000-2                                                                    7.89ms ±142%   8.57ms ±103%    ~     (p=0.912 n=10+10)
RangeQuery/expr=sum(a_hundred),steps=1-2                                                                   2.64ms ±103%   3.21ms ±103%    ~     (p=0.631 n=10+10)
RangeQuery/expr=sum(a_hundred),steps=10-2                                                                  2.55ms ±142%    3.58ms ±85%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum(a_hundred),steps=100-2                                                                 6.76ms ±146%  10.11ms ±105%    ~     (p=0.853 n=10+10)
RangeQuery/expr=sum(a_hundred),steps=1000-2                                                                45.4ms ±150%   55.4ms ±118%    ~     (p=0.631 n=10+10)
RangeQuery/expr=sum_without_(l)(h_one),steps=1-2                                                            417µs ±132%    468µs ±103%    ~     (p=0.739 n=10+10)
RangeQuery/expr=sum_without_(l)(h_one),steps=10-2                                                           779µs ±138%    800µs ±108%    ~     (p=0.393 n=10+10)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-2                                                          3.92ms ±99%   4.35ms ±126%    ~     (p=0.739 n=10+10)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-2                                                         34.4ms ±98%   35.7ms ±110%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1-2                                                            2.80ms ±99%   2.88ms ±111%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum_without_(l)(h_ten),steps=10-2                                                          3.71ms ±115%   3.89ms ±111%    ~     (p=0.912 n=10+10)
RangeQuery/expr=sum_without_(l)(h_ten),steps=100-2                                                         14.2ms ±108%   14.6ms ±129%    ~     (p=0.529 n=10+10)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1000-2                                                          102ms ±99%    108ms ±135%    ~     (p=0.971 n=10+10)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-2                                                       32.8ms ±111%   33.2ms ±122%    ~     (p=0.481 n=10+10)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-2                                                      40.1ms ±120%   41.8ms ±166%    ~     (p=0.529 n=10+10)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-2                                                      118ms ±115%    106ms ±203%    ~     (p=0.739 n=10+10)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-2                                                     818ms ±107%    714ms ±149%    ~     (p=0.739 n=10+10)
RangeQuery/expr=sum_without_(le)(h_one),steps=1-2                                                           341µs ±142%    339µs ±150%    ~     (p=0.579 n=10+10)
RangeQuery/expr=sum_without_(le)(h_one),steps=10-2                                                          412µs ±142%    402µs ±138%    ~     (p=0.739 n=10+10)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-2                                                        1.24ms ±159%   1.21ms ±147%    ~     (p=0.579 n=10+10)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-2                                                       8.01ms ±133%   8.43ms ±160%    ~     (p=0.739 n=10+10)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1-2                                                          2.34ms ±136%   2.45ms ±160%    ~     (p=0.971 n=10+10)
RangeQuery/expr=sum_without_(le)(h_ten),steps=10-2                                                         3.00ms ±133%   3.10ms ±142%    ~     (p=0.631 n=10+10)
RangeQuery/expr=sum_without_(le)(h_ten),steps=100-2                                                        11.6ms ±147%   11.0ms ±148%    ~     (p=0.912 n=10+10)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1000-2                                                       81.6ms ±142%   85.0ms ±166%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-2                                                      29.0ms ±127%   27.6ms ±143%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-2                                                     37.1ms ±127%   37.1ms ±159%    ~     (p=0.579 n=10+10)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-2                                                     121ms ±125%    121ms ±123%    ~     (p=0.739 n=10+10)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-2                                                    936ms ±123%    892ms ±121%    ~     (p=0.529 n=10+10)
RangeQuery/expr=sum_by_(l)(h_one),steps=1-2                                                                  396µs ±98%    390µs ±103%    ~     (p=0.481 n=10+10)
RangeQuery/expr=sum_by_(l)(h_one),steps=10-2                                                                493µs ±124%    485µs ±117%    ~     (p=0.579 n=10+10)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-2                                                              1.41ms ±100%   1.51ms ±120%    ~     (p=0.481 n=10+10)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-2                                                             9.38ms ±102%   9.66ms ±117%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1-2                                                                 2.74ms ±99%   2.82ms ±110%    ~     (p=0.853 n=10+10)
RangeQuery/expr=sum_by_(l)(h_ten),steps=10-2                                                               3.64ms ±100%   3.46ms ±102%    ~     (p=0.247 n=10+10)
RangeQuery/expr=sum_by_(l)(h_ten),steps=100-2                                                              13.1ms ±108%   13.4ms ±125%    ~     (p=0.912 n=10+10)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1000-2                                                             95.4ms ±148%    89.7ms ±96%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-2                                                            35.0ms ±115%   34.3ms ±136%    ~     (p=0.631 n=10+10)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-2                                                           44.3ms ±106%   42.4ms ±108%    ~     (p=0.529 n=10+10)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-2                                                           139ms ±124%    145ms ±120%    ~     (p=0.971 n=10+10)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-2                                                          1.03s ±102%     1.01s ±92%    ~     (p=0.971 n=10+10)
RangeQuery/expr=sum_by_(le)(h_one),steps=1-2                                                                 472µs ±93%    458µs ±108%    ~     (p=0.739 n=10+10)
RangeQuery/expr=sum_by_(le)(h_one),steps=10-2                                                               827µs ±121%    743µs ±106%    ~     (p=0.393 n=10+10)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-2                                                              4.36ms ±84%    3.68ms ±98%    ~     (p=0.315 n=10+10)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-2                                                             37.7ms ±74%   31.4ms ±107%    ~     (p=0.280 n=10+10)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1-2                                                                3.43ms ±83%   2.93ms ±115%    ~     (p=0.481 n=10+10)
RangeQuery/expr=sum_by_(le)(h_ten),steps=10-2                                                               4.50ms ±86%   3.85ms ±110%    ~     (p=0.579 n=10+10)
RangeQuery/expr=sum_by_(le)(h_ten),steps=100-2                                                              16.7ms ±87%   14.2ms ±119%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1000-2                                                              124ms ±79%    102ms ±102%    ~     (p=0.315 n=10+10)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-2                                                            38.4ms ±83%   31.4ms ±110%    ~     (p=0.190 n=10+10)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-2                                                           47.7ms ±89%   38.8ms ±102%    ~     (p=0.218 n=10+10)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-2                                                           153ms ±82%    121ms ±109%    ~     (p=0.190 n=10+10)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-2                                                          1.00s ±77%    0.85s ±106%    ~     (p=0.529 n=10+10)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-2                                                  286µs ±87%    246µs ±100%    ~     (p=0.529 n=10+10)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-2                                                 347µs ±89%    308µs ±149%    ~     (p=0.436 n=10+10)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-2                                                821µs ±84%    673µs ±117%    ~     (p=0.105 n=10+10)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-2                                             5.10ms ±109%   4.01ms ±103%    ~     (p=0.165 n=10+10)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-2                                                  931µs ±78%    767µs ±107%    ~     (p=0.165 n=10+10)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-2                                                1.39ms ±86%   1.12ms ±101%    ~     (p=0.315 n=10+10)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-2                                              5.54ms ±100%   4.66ms ±105%    ~     (p=0.853 n=10+10)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-2                                              43.3ms ±82%   38.2ms ±120%    ~     (p=0.796 n=10+10)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-2                                         7.32ms ±83%   6.59ms ±132%    ~     (p=0.631 n=10+10)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-2                                        12.1ms ±82%   10.3ms ±101%    ~     (p=0.280 n=10+10)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-2                                       61.8ms ±90%   51.8ms ±126%    ~     (p=0.912 n=10+10)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-2                                       457ms ±72%     431ms ±79%    ~     (p=0.190 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-2                                                   224µs ±76%     220µs ±77%    ~     (p=0.436 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-2                                                  269µs ±80%     270µs ±85%    ~     (p=0.684 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-2                                                 747µs ±76%     709µs ±82%    ~     (p=0.218 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-2                                               5.33ms ±83%    4.84ms ±79%    ~     (p=0.190 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-2                                                  435µs ±113%     488µs ±81%    ~     (p=0.579 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-2                                                 544µs ±107%     627µs ±86%    ~     (p=0.912 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-2                                               1.72ms ±105%    1.95ms ±88%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-2                                              12.2ms ±101%    14.5ms ±88%    ~     (p=0.853 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-2                                             2.67ms ±108%    3.29ms ±95%    ~     (p=0.971 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-2                                            3.36ms ±105%    3.95ms ±83%    ~     (p=0.912 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-2                                           12.6ms ±103%   15.7ms ±106%    ~     (p=0.912 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-2                                          89.8ms ±109%   110.6ms ±81%    ~     (p=0.853 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-2               295µs ±105%     340µs ±70%    ~     (p=0.853 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-2              413µs ±116%     467µs ±79%    ~     (p=0.853 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-2            1.42ms ±101%    1.68ms ±93%    ~     (p=0.853 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-2           11.2ms ±103%    13.4ms ±95%    ~     (p=0.853 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-2                741µs ±98%     901µs ±95%    ~     (p=0.739 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-2              983µs ±107%    1160µs ±90%    ~     (p=0.971 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-2            3.58ms ±106%    4.18ms ±78%    ~     (p=0.631 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-2           27.9ms ±139%    31.8ms ±74%    ~     (p=0.579 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-2      5.62ms ±146%    6.35ms ±81%    ~     (p=0.971 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-2     7.71ms ±142%    8.25ms ±87%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-2    26.4ms ±118%    32.4ms ±81%    ~     (p=0.631 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-2     185ms ±99%    188ms ±115%    ~     (p=1.000 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-2                                          563µs ±116%    533µs ±112%    ~     (p=0.579 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-2                                         729µs ±107%    727µs ±100%    ~     (p=0.971 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-2                                        2.75ms ±87%   2.89ms ±131%    ~     (p=0.971 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-2                                      23.1ms ±122%   21.5ms ±109%    ~     (p=0.315 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-2                                         4.55ms ±136%   3.94ms ±136%    ~     (p=0.280 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-2                                         7.45ms ±88%   6.48ms ±134%    ~     (p=0.684 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-2                                        37.4ms ±84%    29.7ms ±97%    ~     (p=0.631 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-2                                       331ms ±115%    249ms ±101%    ~     (p=0.165 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-2                                     53.0ms ±107%   42.4ms ±107%    ~     (p=0.315 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-2                                     80.1ms ±88%   68.3ms ±118%    ~     (p=0.853 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-2                                     350ms ±97%    291ms ±101%    ~     (p=0.315 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-2                                   2.82s ±100%    2.54s ±101%    ~     (p=0.280 n=10+10)
RangeQuery/expr=count_over_time(a_one[999d:1s]),steps=1-2                                                   4.65s ±114%     4.62s ±98%    ~     (p=0.579 n=10+10)
Parser/a-2                                                                                                 2.74µs ±105%   2.97µs ±119%    ~     (p=0.869 n=10+10)
Parser/metric-2                                                                                            3.10µs ±104%   3.29µs ±113%    ~     (p=0.579 n=10+10)
Parser/1-2                                                                                                 1.97µs ±104%   2.28µs ±126%    ~     (p=0.425 n=10+10)
Parser/1_>=_bool_1-2                                                                                       5.57µs ±114%   5.88µs ±103%    ~     (p=0.516 n=10+10)
Parser/1_+_2/(3*1)-2                                                                                       11.7µs ±107%   12.7µs ±100%    ~     (p=0.631 n=10+10)
Parser/foo_or_bar-2                                                                                        6.88µs ±114%   7.36µs ±105%    ~     (p=0.853 n=10+10)
Parser/foo_and_bar_unless_baz_or_qux-2                                                                     14.7µs ±108%   16.0µs ±103%    ~     (p=0.811 n=10+10)
Parser/bar_+_on(foo)_bla_/_on(baz,_buz)_group_right(test)_blub-2                                           18.8µs ±107%   21.1µs ±104%    ~     (p=1.000 n=10+10)
Parser/foo_/_ignoring(test,blub)_group_left(blub)_bar-2                                                    12.9µs ±114%   14.3µs ±104%    ~     (p=0.670 n=10+10)
Parser/foo_-_ignoring(test,blub)_group_right(bar,foo)_bar-2                                                15.0µs ±113%   16.4µs ±106%    ~     (p=0.853 n=10+10)
Parser/foo{a="b",_foo!="bar",_test=~"test",_bar!~"baz"}-2                                                  57.9µs ±170%   72.1µs ±118%    ~     (p=0.912 n=10+10)
Parser/min_over_time(rate(foo{bar="baz"}[2s])[5m:])[4m:3s]-2                                               46.1µs ±157%    51.3µs ±88%    ~     (p=0.739 n=10+10)
Parser/sum_without(and,_by,_avg,_count,_alert,_annotations)(some_metric)_[30m:10s]-2                       32.7µs ±135%    37.8µs ±70%    ~     (p=0.971 n=10+10)
Parser/(_(should_fail)-2                                                                                   12.2µs ±103%    16.0µs ±78%    ~     (p=0.579 n=10+10)
Parser/}_(should_fail)-2                                                                                   13.3µs ±124%    15.7µs ±95%    ~     (p=0.739 n=10+10)
Parser/1_or_1_(should_fail)-2                                                                              15.7µs ±107%    18.1µs ±84%    ~     (p=0.796 n=10+10)
Parser/1_or_on(bar)_foo_(should_fail)-2                                                                    27.8µs ±121%    32.2µs ±84%    ~     (p=1.000 n=10+10)
Parser/foo_unless_on(bar)_group_left(baz)_bar_(should_fail)-2                                              36.1µs ±143%    38.6µs ±84%    ~     (p=0.912 n=10+10)
Parser/test[5d]_OFFSET_10s_[10m:5s]_(should_fail)-2                                                        65.1µs ±112%    65.4µs ±81%    ~     (p=0.853 n=10+10)

name                                                                                                      old alloc/op   new alloc/op   delta
RangeQuery/expr=a_one,steps=1-2                                                                             5.54kB ± 3%    5.51kB ± 0%    ~     (p=1.000 n=9+8)
RangeQuery/expr=a_one,steps=10-2                                                                            5.51kB ± 0%    5.51kB ± 0%    ~     (p=0.323 n=9+9)
RangeQuery/expr=a_one,steps=100-2                                                                           5.83kB ± 1%    5.83kB ± 1%    ~     (p=0.299 n=10+10)
RangeQuery/expr=a_one,steps=1000-2                                                                          9.48kB ± 1%    9.23kB ± 5%    ~     (p=0.557 n=8+10)
RangeQuery/expr=a_ten,steps=1-2                                                                             14.2kB ± 0%    14.2kB ± 0%    ~     (p=0.537 n=10+10)
RangeQuery/expr=a_ten,steps=10-2                                                                            14.2kB ± 0%    14.2kB ± 0%    ~     (p=0.759 n=10+10)
RangeQuery/expr=a_ten,steps=100-2                                                                           16.6kB ± 4%    16.6kB ± 4%    ~     (p=0.866 n=10+10)
RangeQuery/expr=a_ten,steps=1000-2                                                                          42.9kB ± 2%    40.4kB ±10%    ~     (p=0.146 n=8+10)
RangeQuery/expr=a_hundred,steps=1-2                                                                          100kB ± 0%     100kB ± 0%    ~     (p=0.328 n=9+9)
RangeQuery/expr=a_hundred,steps=10-2                                                                         100kB ± 0%     100kB ± 0%    ~     (p=0.117 n=10+9)
RangeQuery/expr=a_hundred,steps=100-2                                                                        121kB ± 0%     121kB ± 0%    ~     (p=0.981 n=8+9)
RangeQuery/expr=a_hundred,steps=1000-2                                                                       371kB ± 3%     350kB ±12%    ~     (p=0.588 n=8+10)
RangeQuery/expr=rate(a_one[1m]),steps=1-2                                                                   6.60kB ± 0%    6.60kB ± 0%    ~     (p=0.615 n=10+10)
RangeQuery/expr=rate(a_one[1m]),steps=10-2                                                                  6.60kB ± 0%    6.60kB ± 0%    ~     (p=0.585 n=9+10)
RangeQuery/expr=rate(a_one[1m]),steps=100-2                                                                 6.93kB ± 1%    6.93kB ± 1%    ~     (p=0.897 n=10+10)
RangeQuery/expr=rate(a_one[1m]),steps=1000-2                                                                10.3kB ± 1%    10.1kB ± 4%    ~     (p=0.139 n=8+10)
RangeQuery/expr=rate(a_ten[1m]),steps=1-2                                                                   18.6kB ± 0%    18.5kB ± 0%    ~     (p=0.061 n=10+9)
RangeQuery/expr=rate(a_ten[1m]),steps=10-2                                                                  18.6kB ± 0%    18.6kB ± 0%    ~     (p=0.921 n=10+9)
RangeQuery/expr=rate(a_ten[1m]),steps=100-2                                                                 20.9kB ± 3%    20.9kB ± 3%    ~     (p=0.898 n=10+10)
RangeQuery/expr=rate(a_ten[1m]),steps=1000-2                                                                44.5kB ± 2%    42.3kB ± 9%    ~     (p=0.227 n=8+10)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-2                                                                136kB ± 0%     136kB ± 0%    ~     (p=0.243 n=10+9)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-2                                                               136kB ± 0%     136kB ± 0%    ~     (p=0.968 n=9+10)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-2                                                              157kB ± 0%     157kB ± 0%    ~     (p=0.489 n=9+9)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-2                                                             381kB ± 4%     361kB ±10%    ~     (p=0.408 n=8+10)
RangeQuery/expr=rate(a_one[1m]),steps=10000-2                                                               60.5kB ± 1%    60.7kB ± 2%    ~     (p=0.370 n=8+9)
RangeQuery/expr=rate(a_ten[1m]),steps=10000-2                                                                348kB ± 1%     352kB ± 6%    ~     (p=0.965 n=8+10)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-2                                                          7.62MB ±136%    9.10MB ±98%    ~     (p=0.684 n=10+10)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-2                                                 1.19MB ± 0%    1.19MB ± 0%    ~     (p=0.965 n=10+8)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-2                                                1.20MB ± 0%    1.19MB ± 0%    ~     (p=0.297 n=9+9)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-2                                               1.20MB ± 0%    1.20MB ± 0%    ~     (p=1.000 n=9+10)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-2                                              1.22MB ± 0%    1.21MB ± 0%    ~     (p=0.191 n=8+9)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-2                                                 1.41MB ± 0%    1.41MB ± 0%    ~     (p=0.573 n=8+10)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-2                                                1.41MB ± 0%    1.41MB ± 1%    ~     (p=0.633 n=8+10)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-2                                               1.40MB ± 1%    1.39MB ± 1%    ~     (p=0.497 n=10+9)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-2                                              1.62MB ±20%    1.62MB ±18%    ~     (p=0.868 n=10+10)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-2                                             3.57MB ± 2%    3.55MB ± 2%    ~     (p=0.447 n=9+10)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-2                                            3.58MB ± 2%    3.55MB ± 2%    ~     (p=0.278 n=9+10)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-2                                           3.74MB ± 7%    3.72MB ± 7%    ~     (p=0.684 n=10+10)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-2                                          6.71MB ± 2%    6.71MB ± 1%    ~     (p=0.813 n=10+7)
RangeQuery/expr=changes(a_one[1d]),steps=1-2                                                                 565kB ± 1%     566kB ± 1%    ~     (p=0.661 n=9+10)
RangeQuery/expr=changes(a_one[1d]),steps=10-2                                                                565kB ± 1%     566kB ± 1%    ~     (p=0.297 n=9+9)
RangeQuery/expr=changes(a_one[1d]),steps=100-2                                                               565kB ± 0%     564kB ± 0%    ~     (p=0.053 n=9+9)
RangeQuery/expr=changes(a_one[1d]),steps=1000-2                                                              566kB ± 0%     597kB ±11%    ~     (p=0.051 n=8+10)
RangeQuery/expr=changes(a_ten[1d]),steps=1-2                                                                 788kB ± 3%     787kB ± 2%    ~     (p=0.912 n=10+10)
RangeQuery/expr=changes(a_ten[1d]),steps=10-2                                                                782kB ± 2%     784kB ± 3%    ~     (p=0.921 n=9+10)
RangeQuery/expr=changes(a_ten[1d]),steps=100-2                                                               784kB ± 0%     816kB ±10%    ~     (p=0.426 n=6+10)
RangeQuery/expr=changes(a_ten[1d]),steps=1000-2                                                             1.17MB ±50%    0.97MB ±20%    ~     (p=0.740 n=10+8)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-2                                                            2.96MB ± 2%    2.98MB ± 3%    ~     (p=0.604 n=9+10)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-2                                                           2.96MB ± 4%    3.06MB ± 7%    ~     (p=0.173 n=8+10)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-2                                                          3.22MB ± 3%    3.16MB ± 6%    ~     (p=0.536 n=7+8)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-2                                                         6.22MB ± 7%    6.46MB ± 2%    ~     (p=0.278 n=10+9)
RangeQuery/expr=rate(a_one[1d]),steps=1-2                                                                    565kB ± 0%     565kB ± 0%    ~     (p=0.905 n=9+10)
RangeQuery/expr=rate(a_one[1d]),steps=10-2                                                                   565kB ± 0%     565kB ± 0%    ~     (p=0.863 n=9+9)
RangeQuery/expr=rate(a_one[1d]),steps=100-2                                                                  565kB ± 0%     565kB ± 0%    ~     (p=0.604 n=10+9)
RangeQuery/expr=rate(a_one[1d]),steps=1000-2                                                                 569kB ± 2%     569kB ± 1%    ~     (p=0.683 n=9+9)
RangeQuery/expr=rate(a_ten[1d]),steps=1-2                                                                    783kB ± 1%     782kB ± 2%    ~     (p=0.863 n=9+9)
RangeQuery/expr=rate(a_ten[1d]),steps=10-2                                                                   781kB ± 0%     784kB ± 3%    ~     (p=0.474 n=6+9)
RangeQuery/expr=rate(a_ten[1d]),steps=100-2                                                                  787kB ± 2%     783kB ± 2%    ~     (p=0.286 n=10+9)
RangeQuery/expr=rate(a_ten[1d]),steps=1000-2                                                                 806kB ± 1%     803kB ± 1%    ~     (p=0.203 n=8+8)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-2                                                               3.01MB ± 6%    2.95MB ± 0%    ~     (p=0.315 n=10+7)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-2                                                              2.98MB ± 7%    2.96MB ± 7%    ~     (p=0.814 n=9+9)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-2                                                             3.11MB ± 8%    3.09MB ± 7%    ~     (p=0.931 n=9+9)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-2                                                            6.16MB ± 7%    6.06MB ± 7%    ~     (p=0.218 n=10+10)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1-2                                                        565kB ± 1%     564kB ± 0%    ~     (p=0.139 n=9+8)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=10-2                                                       565kB ± 1%     564kB ± 0%    ~     (p=0.815 n=9+8)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-2                                                      568kB ± 1%     568kB ± 1%    ~     (p=0.796 n=10+10)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-2                                                     585kB ± 1%     584kB ± 1%    ~     (p=0.676 n=10+9)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-2                                                       783kB ± 1%     781kB ± 1%    ~     (p=0.284 n=8+10)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-2                                                      803kB ± 2%     801kB ± 1%    ~     (p=0.949 n=9+9)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-2                                                     970kB ± 1%     978kB ± 2%    ~     (p=0.550 n=7+8)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-2                                                   3.02MB ± 9%    2.95MB ± 4%    ~     (p=0.314 n=10+10)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-2                                                  2.96MB ± 3%    2.95MB ± 3%    ~     (p=0.435 n=9+9)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-2                                                 3.15MB ± 3%    3.19MB ± 9%    ~     (p=0.646 n=9+10)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-2                                                4.99MB ±10%    4.81MB ± 2%    ~     (p=0.105 n=10+8)
RangeQuery/expr=-a_one,steps=1-2                                                                            5.97kB ± 0%    5.97kB ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=-a_one,steps=10-2                                                                           5.97kB ± 0%    5.97kB ± 0%    ~     (p=0.900 n=10+10)
RangeQuery/expr=-a_one,steps=100-2                                                                          6.30kB ± 1%    6.30kB ± 1%    ~     (p=0.642 n=10+10)
RangeQuery/expr=-a_one,steps=1000-2                                                                         9.94kB ± 1%    9.69kB ± 5%    ~     (p=0.761 n=8+10)
RangeQuery/expr=-a_ten,steps=1-2                                                                            17.9kB ± 0%    17.9kB ± 0%    ~     (p=0.736 n=10+10)
RangeQuery/expr=-a_ten,steps=10-2                                                                           17.9kB ± 0%    17.9kB ± 0%    ~     (p=0.255 n=10+10)
RangeQuery/expr=-a_ten,steps=100-2                                                                          20.3kB ± 3%    20.3kB ± 3%    ~     (p=0.492 n=10+10)
RangeQuery/expr=-a_ten,steps=1000-2                                                                         46.6kB ± 2%    44.1kB ± 9%    ~     (p=0.180 n=8+10)
RangeQuery/expr=-a_hundred,steps=1-2                                                                         135kB ± 0%     135kB ± 0%    ~     (p=0.782 n=10+10)
RangeQuery/expr=-a_hundred,steps=10-2                                                                        135kB ± 0%     135kB ± 0%    ~     (p=0.325 n=10+10)
RangeQuery/expr=-a_hundred,steps=100-2                                                                       156kB ± 0%     156kB ± 0%    ~     (p=0.715 n=9+9)
RangeQuery/expr=-a_hundred,steps=1000-2                                                                      406kB ± 3%     384kB ±10%    ~     (p=0.325 n=8+10)
RangeQuery/expr=a_one_-_b_one,steps=1-2                                                                     11.8kB ± 0%    11.8kB ± 0%    ~     (p=0.386 n=10+10)
RangeQuery/expr=a_one_-_b_one,steps=100-2                                                                   28.3kB ± 0%    28.3kB ± 0%    ~     (p=0.982 n=10+10)
RangeQuery/expr=a_one_-_b_one,steps=1000-2                                                                   180kB ± 0%     179kB ± 0%    ~     (p=0.055 n=8+10)
RangeQuery/expr=a_ten_-_b_ten,steps=1-2                                                                     41.6kB ± 0%    41.6kB ± 0%    ~     (p=0.955 n=10+10)
RangeQuery/expr=a_ten_-_b_ten,steps=10-2                                                                    44.6kB ± 0%    44.6kB ± 0%    ~     (p=0.617 n=9+10)
RangeQuery/expr=a_ten_-_b_ten,steps=100-2                                                                   79.7kB ± 1%    79.7kB ± 1%    ~     (p=0.971 n=10+10)
RangeQuery/expr=a_ten_-_b_ten,steps=1000-2                                                                   445kB ±12%     426kB ± 4%    ~     (p=0.133 n=10+9)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-2                                                              346kB ± 0%     346kB ± 0%    ~     (p=0.736 n=9+10)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-2                                                             371kB ± 0%     370kB ± 0%    ~     (p=0.280 n=10+10)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-2                                                            658kB ± 1%     655kB ± 4%    ~     (p=0.661 n=9+10)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-2                                                          3.55MB ±11%    3.65MB ±16%    ~     (p=0.579 n=10+10)
RangeQuery/expr=a_one_-_b_one,steps=10000-2                                                                 1.72MB ± 0%    1.72MB ± 0%    ~     (p=0.265 n=8+10)
RangeQuery/expr=a_ten_-_b_ten,steps=10000-2                                                                 3.95MB ± 2%    3.99MB ± 4%    ~     (p=0.139 n=8+9)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-2                                                         76.0MB ±16%    77.6MB ±14%    ~     (p=0.739 n=10+10)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-2                                                    20.1kB ± 0%    20.0kB ± 0%    ~     (p=0.513 n=8+7)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-2                                                   21.4kB ± 0%    21.4kB ± 0%    ~     (p=0.150 n=10+9)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-2                                                  36.2kB ± 0%    36.2kB ± 0%    ~     (p=0.954 n=10+10)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-2                                                  184kB ± 0%     184kB ± 0%    ~     (p=0.274 n=8+10)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-2                                                    41.3kB ± 0%    41.3kB ± 0%    ~     (p=0.669 n=10+10)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-2                                                   42.7kB ± 0%    42.8kB ± 0%    ~     (p=0.459 n=9+10)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-2                                                  60.9kB ± 1%    60.9kB ± 1%    ~     (p=0.796 n=10+10)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-2                                                  245kB ± 0%     242kB ± 3%    ~     (p=0.515 n=8+10)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-2                                             244kB ± 0%     244kB ± 0%    ~     (p=0.315 n=8+10)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-2                                            274kB ± 0%     274kB ± 0%    ~     (p=0.113 n=9+9)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-2                                           606kB ± 0%     606kB ± 0%    ~     (p=0.730 n=9+9)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-2                                         3.98MB ± 1%    3.95MB ± 2%    ~     (p=0.274 n=8+10)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-2                                                     20.1kB ± 0%    20.1kB ± 0%    ~     (p=0.953 n=9+10)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-2                                                    21.5kB ± 0%    21.5kB ± 0%    ~     (p=0.956 n=10+10)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-2                                                   36.3kB ± 0%    36.3kB ± 0%    ~     (p=0.781 n=10+10)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-2                                                   184kB ± 0%     184kB ± 0%    ~     (p=0.684 n=10+10)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-2                                                     42.6kB ± 0%    42.6kB ± 0%    ~     (p=0.853 n=10+10)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-2                                                    48.2kB ± 0%    48.2kB ± 0%    ~     (p=0.255 n=10+10)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-2                                                    107kB ± 1%     107kB ± 1%    ~     (p=0.739 n=10+10)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-2                                                   701kB ± 0%     697kB ± 1%    ~     (p=0.101 n=8+10)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-2                                              256kB ± 0%     256kB ± 0%    ~     (p=0.810 n=10+10)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-2                                             320kB ± 0%     320kB ± 0%    ~     (p=0.353 n=10+10)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-2                                            988kB ± 0%     987kB ± 0%    ~     (p=0.113 n=9+9)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-2                                          7.72MB ± 0%    7.69MB ± 1%    ~     (p=0.460 n=8+10)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-2                                                 20.1kB ± 0%    20.1kB ± 0%    ~     (p=0.853 n=10+10)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-2                                                21.5kB ± 0%    21.5kB ± 0%    ~     (p=0.810 n=10+10)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-2                                               36.3kB ± 0%    36.3kB ± 0%    ~     (p=0.840 n=10+10)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-2                                               184kB ± 0%     184kB ± 0%    ~     (p=0.190 n=10+10)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-2                                                 41.3kB ± 0%    41.3kB ± 0%    ~     (p=0.382 n=10+10)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-2                                                42.8kB ± 0%    42.8kB ± 0%    ~     (p=0.810 n=10+10)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-2                                               60.9kB ± 1%    60.9kB ± 1%    ~     (p=0.684 n=10+10)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-2                                          244kB ± 0%     244kB ± 0%    ~     (p=0.436 n=10+10)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-2                                         274kB ± 0%     274kB ± 0%    ~     (p=0.604 n=9+10)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-2                                        606kB ± 0%     606kB ± 0%    ~     (p=0.931 n=9+9)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-2                                      3.99MB ± 1%    3.95MB ± 2%    ~     (p=0.083 n=8+10)
RangeQuery/expr=abs(a_one),steps=1-2                                                                        6.96kB ± 0%    6.96kB ± 0%    ~     (p=0.964 n=10+10)
RangeQuery/expr=abs(a_one),steps=10-2                                                                       7.25kB ± 0%    7.25kB ± 0%    ~     (p=0.726 n=9+9)
RangeQuery/expr=abs(a_one),steps=100-2                                                                      10.5kB ± 0%    10.5kB ± 0%    ~     (p=0.777 n=10+10)
RangeQuery/expr=abs(a_one),steps=1000-2                                                                     42.9kB ± 0%    42.7kB ± 1%    ~     (p=0.395 n=8+10)
RangeQuery/expr=abs(a_ten),steps=1-2                                                                        22.6kB ± 0%    22.6kB ± 0%    ~     (p=0.488 n=10+9)
RangeQuery/expr=abs(a_ten),steps=10-2                                                                       24.3kB ± 0%    24.3kB ± 0%    ~     (p=0.956 n=10+10)
RangeQuery/expr=abs(a_ten),steps=100-2                                                                      44.3kB ± 1%    44.3kB ± 1%    ~     (p=0.579 n=10+10)
RangeQuery/expr=abs(a_ten),steps=1000-2                                                                      246kB ± 0%     244kB ± 2%    ~     (p=0.515 n=8+10)
RangeQuery/expr=abs(a_hundred),steps=1-2                                                                     178kB ± 0%     178kB ± 0%    ~     (p=0.543 n=10+10)
RangeQuery/expr=abs(a_hundred),steps=1000-2                                                                 2.14MB ± 0%    2.12MB ± 2%    ~     (p=0.633 n=8+10)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-2                                     11.6kB ± 0%    11.6kB ± 0%    ~     (p=0.742 n=9+10)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-2                                    13.0kB ± 0%    13.0kB ± 0%    ~     (p=0.094 n=8+9)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-2                                   27.7kB ± 0%    27.7kB ± 0%    ~     (p=0.955 n=10+10)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-2                                   175kB ± 0%     175kB ± 0%    ~     (p=0.211 n=8+10)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-2                                     28.8kB ± 0%    28.8kB ± 0%    ~     (p=0.225 n=10+10)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-2                                    31.7kB ± 0%    31.7kB ± 0%    ~     (p=0.147 n=10+9)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-2                                   63.2kB ± 1%    63.2kB ± 0%    ~     (p=0.675 n=10+9)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-2                                   381kB ± 0%     378kB ± 1%    ~     (p=0.122 n=8+10)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-2                                  200kB ± 0%     200kB ± 0%    ~     (p=1.000 n=10+9)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-2                                 217kB ± 0%     217kB ± 0%    ~     (p=0.128 n=10+8)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-2                                402kB ± 0%     402kB ± 0%    ~     (p=0.297 n=9+9)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-2                              2.29MB ± 1%    2.27MB ± 2%    ~     (p=0.173 n=8+10)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-2                                            8.83kB ± 0%    8.83kB ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-2                                           10.8kB ± 0%    10.8kB ± 0%    ~     (p=0.437 n=10+8)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-2                                          31.3kB ± 0%    31.3kB ± 0%    ~     (p=0.985 n=10+10)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-2                                          237kB ± 0%     236kB ± 0%    ~     (p=0.127 n=8+10)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-2                                            25.7kB ± 0%    25.7kB ± 0%    ~     (p=0.762 n=9+10)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-2                                           29.2kB ± 0%    29.2kB ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-2                                          66.4kB ± 1%    66.4kB ± 1%    ~     (p=0.839 n=10+10)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-2                                          441kB ± 0%     439kB ± 1%    ~     (p=0.395 n=8+10)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-2                                         193kB ± 0%     193kB ± 0%    ~     (p=0.382 n=10+10)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-2                                        210kB ± 0%     210kB ± 0%    ~     (p=0.869 n=10+10)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-2                                       401kB ± 0%     401kB ± 0%    ~     (p=0.589 n=9+9)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-2                                     2.35MB ± 1%    2.33MB ± 2%    ~     (p=0.146 n=8+10)
RangeQuery/expr=sum(a_one),steps=1-2                                                                        7.19kB ± 0%    7.18kB ± 0%    ~     (p=1.000 n=8+8)
RangeQuery/expr=sum(a_one),steps=10-2                                                                       11.1kB ± 0%    11.1kB ± 0%    ~     (p=0.884 n=10+10)
RangeQuery/expr=sum(a_one),steps=100-2                                                                      50.3kB ± 0%    50.3kB ± 0%    ~     (p=0.781 n=10+10)
RangeQuery/expr=sum(a_one),steps=1000-2                                                                      443kB ± 0%     443kB ± 0%    ~     (p=0.274 n=8+10)
RangeQuery/expr=sum(a_ten),steps=1-2                                                                        18.1kB ± 0%    18.1kB ± 0%    ~     (p=0.185 n=6+9)
RangeQuery/expr=sum(a_ten),steps=10-2                                                                       22.0kB ± 0%    22.0kB ± 0%    ~     (p=0.139 n=10+9)
RangeQuery/expr=sum(a_ten),steps=100-2                                                                      63.2kB ± 1%    63.2kB ± 1%    ~     (p=0.927 n=10+10)
RangeQuery/expr=sum(a_ten),steps=1000-2                                                                      478kB ± 0%     476kB ± 1%    ~     (p=0.360 n=8+10)
RangeQuery/expr=sum(a_hundred),steps=1-2                                                                     123kB ± 0%     123kB ± 0%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum(a_hundred),steps=10-2                                                                    127kB ± 0%     127kB ± 0%    ~     (p=0.435 n=10+9)
RangeQuery/expr=sum(a_hundred),steps=1000-2                                                                  826kB ± 2%     804kB ± 5%    ~     (p=0.326 n=8+10)
RangeQuery/expr=sum_without_(l)(h_one),steps=1-2                                                            25.1kB ± 0%    25.1kB ± 0%    ~     (p=0.418 n=9+9)
RangeQuery/expr=sum_without_(l)(h_one),steps=10-2                                                           51.3kB ± 0%    51.3kB ± 0%    ~     (p=0.838 n=10+10)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-2                                                           317kB ± 0%     317kB ± 0%    ~     (p=0.579 n=10+10)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-2                                                         2.97MB ± 0%    2.97MB ± 0%    ~     (p=0.460 n=8+10)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1-2                                                             152kB ± 0%     152kB ± 0%    ~     (p=0.643 n=10+10)
RangeQuery/expr=sum_without_(l)(h_ten),steps=10-2                                                            182kB ± 0%     182kB ± 0%    ~     (p=0.239 n=10+10)
RangeQuery/expr=sum_without_(l)(h_ten),steps=100-2                                                           501kB ± 1%     501kB ± 1%    ~     (p=0.481 n=10+10)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1000-2                                                         3.72MB ± 0%    3.69MB ± 1%    ~     (p=0.573 n=8+10)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-2                                                       1.43MB ± 0%    1.43MB ± 0%    ~     (p=0.762 n=8+10)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-2                                                      1.96MB ± 0%    1.96MB ± 0%    ~     (p=0.605 n=9+9)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-2                                                     17.8MB ±97%   15.9MB ±134%    ~     (p=1.000 n=10+10)
RangeQuery/expr=sum_without_(le)(h_one),steps=1-2                                                           19.4kB ± 0%    19.4kB ± 0%    ~     (p=0.722 n=10+10)
RangeQuery/expr=sum_without_(le)(h_one),steps=10-2                                                          24.2kB ± 0%    24.2kB ± 0%    ~     (p=0.775 n=10+10)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-2                                                         74.5kB ± 1%    74.5kB ± 1%    ~     (p=0.362 n=10+10)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-2                                                         579kB ± 0%     576kB ± 1%    ~     (p=0.284 n=8+10)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1-2                                                            152kB ± 0%     152kB ± 0%    ~     (p=0.496 n=8+9)
RangeQuery/expr=sum_without_(le)(h_ten),steps=10-2                                                           179kB ± 0%     179kB ± 0%    ~     (p=0.923 n=9+10)
RangeQuery/expr=sum_without_(le)(h_ten),steps=100-2                                                          477kB ± 1%     477kB ± 1%    ~     (p=0.494 n=10+10)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1000-2                                                        3.48MB ± 0%    3.46MB ± 1%    ~     (p=0.696 n=8+10)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-2                                                      1.73MB ± 0%    1.73MB ± 0%    ~     (p=0.079 n=10+9)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-2                                                     4.63MB ± 0%    4.63MB ± 0%    ~     (p=0.863 n=9+9)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-2                                                    44.8MB ±39%    42.2MB ±50%    ~     (p=0.912 n=10+10)
RangeQuery/expr=sum_by_(l)(h_one),steps=1-2                                                                 19.4kB ± 0%    19.4kB ± 0%    ~     (p=0.941 n=10+10)
RangeQuery/expr=sum_by_(l)(h_one),steps=10-2                                                                23.8kB ± 0%    23.8kB ± 0%    ~     (p=0.624 n=10+10)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-2                                                               71.3kB ± 1%    71.3kB ± 1%    ~     (p=0.781 n=10+10)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-2                                                               547kB ± 0%     544kB ± 1%    ~     (p=0.557 n=8+10)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1-2                                                                  150kB ± 0%     150kB ± 0%    ~     (p=0.469 n=10+10)
RangeQuery/expr=sum_by_(l)(h_ten),steps=10-2                                                                 172kB ± 0%     172kB ± 0%    ~     (p=0.984 n=9+10)
RangeQuery/expr=sum_by_(l)(h_ten),steps=100-2                                                                412kB ± 2%     412kB ± 2%    ~     (p=0.870 n=10+10)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1000-2                                                              2.84MB ± 0%    2.82MB ± 2%    ~     (p=0.633 n=8+10)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-2                                                             1.45MB ± 0%    1.45MB ± 0%    ~     (p=0.393 n=10+10)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-2                                                            1.66MB ± 0%    1.66MB ± 0%    ~     (p=0.280 n=10+10)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-2                                                           3.98MB ± 0%    3.98MB ± 0%    ~     (p=0.605 n=9+9)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-2                                                          38.6MB ±47%    38.9MB ±46%    ~     (p=0.631 n=10+10)
RangeQuery/expr=sum_by_(le)(h_one),steps=1-2                                                                24.4kB ± 0%    24.4kB ± 0%    ~     (p=0.452 n=9+10)
RangeQuery/expr=sum_by_(le)(h_one),steps=10-2                                                               47.5kB ± 0%    47.5kB ± 0%    ~     (p=0.402 n=10+10)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-2                                                               281kB ± 0%     281kB ± 0%    ~     (p=0.839 n=10+10)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-2                                                             2.62MB ± 0%    2.61MB ± 0%    ~     (p=0.203 n=8+10)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1-2                                                                 151kB ± 0%     151kB ± 0%    ~     (p=0.643 n=10+10)
RangeQuery/expr=sum_by_(le)(h_ten),steps=10-2                                                                174kB ± 0%     174kB ± 0%    ~     (p=0.240 n=10+10)
RangeQuery/expr=sum_by_(le)(h_ten),steps=100-2                                                               430kB ± 1%     430kB ± 1%    ~     (p=0.739 n=10+10)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1000-2                                                             3.02MB ± 0%    2.99MB ± 2%    ~     (p=0.408 n=8+10)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-2                                                            1.40MB ± 0%    1.40MB ± 0%    ~     (p=0.138 n=10+10)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-2                                                           1.42MB ± 0%    1.42MB ± 0%    ~     (p=0.549 n=9+10)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-2                                                          1.89MB ± 1%    1.89MB ± 0%    ~     (p=0.730 n=9+9)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-2                                                         19.9MB ±73%    17.9MB ±94%    ~     (p=0.796 n=10+10)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-2                                                 13.7kB ± 0%    13.7kB ± 0%    ~     (p=0.847 n=9+10)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-2                                                15.1kB ± 0%    15.1kB ± 0%    ~     (p=0.410 n=9+10)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-2                                               30.2kB ± 0%    30.2kB ± 0%    ~     (p=0.839 n=10+10)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-2                                               181kB ± 0%     181kB ± 1%    ~     (p=0.237 n=8+10)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-2                                                 45.9kB ± 0%    45.9kB ± 0%    ~     (p=0.968 n=9+10)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-2                                                48.9kB ± 0%    48.9kB ± 0%    ~     (p=0.165 n=10+10)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-2                                               84.2kB ± 1%    84.0kB ± 2%    ~     (p=0.912 n=10+10)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-2                                               426kB ± 2%     428kB ± 5%    ~     (p=0.796 n=9+9)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-2                                          379kB ± 0%     379kB ± 0%    ~     (p=0.853 n=10+10)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-2                                        693kB ± 3%     698kB ± 4%    ~     (p=0.549 n=9+10)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-2                                      3.73MB ±15%    3.56MB ±12%    ~     (p=0.481 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-2                                                  8.30kB ± 0%    8.30kB ± 0%    ~     (p=0.732 n=9+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-2                                                 12.5kB ± 0%    12.5kB ± 0%    ~     (p=0.696 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-2                                                54.6kB ± 0%    54.6kB ± 0%    ~     (p=0.781 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-2                                                476kB ± 0%     476kB ± 0%    ~     (p=0.481 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-2                                                  22.5kB ± 0%    22.5kB ± 0%    ~     (p=0.670 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-2                                                 27.0kB ± 0%    27.0kB ± 0%    ~     (p=0.082 n=9+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-2                                                74.1kB ± 1%    74.0kB ± 1%    ~     (p=0.684 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-2                                                545kB ± 0%     543kB ± 1%    ~     (p=0.315 n=8+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-2                                               159kB ± 0%     159kB ± 0%    ~     (p=0.968 n=9+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-2                                              164kB ± 0%     164kB ± 0%    ~     (p=0.497 n=10+9)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-2                                             229kB ± 0%     229kB ± 0%    ~     (p=0.863 n=9+9)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-2                                            900kB ± 2%     882kB ± 4%    ~     (p=0.408 n=8+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-2               17.6kB ± 0%    17.6kB ± 0%    ~     (p=0.388 n=10+9)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-2              27.4kB ± 0%    27.4kB ± 0%    ~     (p=0.782 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-2              126kB ± 0%     126kB ± 0%    ~     (p=0.593 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-2            1.11MB ± 0%    1.11MB ± 0%    ~     (p=0.190 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-2               46.0kB ± 0%    46.0kB ± 0%    ~     (p=0.781 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-2              56.4kB ± 0%    56.4kB ± 0%    ~     (p=0.579 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-2              165kB ± 1%     165kB ± 1%    ~     (p=0.912 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-2            1.25MB ± 0%    1.25MB ± 1%    ~     (p=0.573 n=8+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-2        319kB ± 0%     319kB ± 0%    ~     (p=0.133 n=9+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-2       330kB ± 0%     330kB ± 0%    ~     (p=0.796 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-2      475kB ± 0%     476kB ± 0%    ~     (p=0.136 n=9+9)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-2    1.94MB ± 5%    1.93MB ± 4%    ~     (p=0.739 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-2                                          27.8kB ± 0%    27.8kB ± 0%    ~     (p=0.869 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-2                                         39.0kB ± 0%    39.0kB ± 0%    ~     (p=0.304 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-2                                         154kB ± 0%     154kB ± 0%    ~     (p=0.813 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-2                                       1.31MB ± 1%    1.30MB ± 0%    ~     (p=0.353 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-2                                           231kB ± 0%     231kB ± 0%    ~     (p=0.356 n=10+9)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-2                                          368kB ± 0%     368kB ± 0%    ~     (p=0.156 n=10+9)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-2                                        1.76MB ± 0%    1.76MB ± 0%    ~     (p=0.684 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-2                                      2.23MB ± 0%    2.23MB ± 0%    ~     (p=0.631 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-2                                     3.60MB ± 0%    3.60MB ± 0%    ~     (p=0.095 n=10+9)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-2                                    17.5MB ± 0%    17.5MB ± 0%    ~     (p=0.136 n=9+9)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-2                                    170MB ± 9%     168MB ±11%    ~     (p=0.912 n=10+10)
Parser/a-2                                                                                                    168B ± 0%      168B ± 0%    ~     (all equal)
Parser/metric-2                                                                                               168B ± 0%      168B ± 0%    ~     (all equal)
Parser/1-2                                                                                                   32.0B ± 0%     32.0B ± 0%    ~     (all equal)
Parser/1_>=_bool_1-2                                                                                          192B ± 0%      192B ± 0%    ~     (all equal)
Parser/1_+_2/(3*1)-2                                                                                          544B ± 0%      544B ± 0%    ~     (all equal)
Parser/foo_or_bar-2                                                                                           464B ± 0%      464B ± 0%    ~     (all equal)
Parser/foo_and_bar_unless_baz_or_qux-2                                                                      1.06kB ± 0%    1.06kB ± 0%    ~     (all equal)
Parser/bar_+_on(foo)_bla_/_on(baz,_buz)_group_right(test)_blub-2                                              840B ± 0%      840B ± 0%    ~     (all equal)
Parser/foo_/_ignoring(test,blub)_group_left(blub)_bar-2                                                       528B ± 0%      528B ± 0%    ~     (all equal)
Parser/foo_-_ignoring(test,blub)_group_right(bar,foo)_bar-2                                                   560B ± 0%      560B ± 0%    ~     (all equal)
Parser/foo{a="b",_foo!="bar",_test=~"test",_bar!~"baz"}-2                                                   6.94kB ± 0%    6.94kB ± 0%    ~     (all equal)
Parser/min_over_time(rate(foo{bar="baz"}[2s])[5m:])[4m:3s]-2                                                2.64kB ± 0%    2.64kB ± 0%    ~     (p=0.570 n=9+10)
Parser/sum_without(and,_by,_avg,_count,_alert,_annotations)(some_metric)_[30m:10s]-2                        1.56kB ± 0%    1.56kB ± 0%    ~     (p=0.446 n=10+10)
Parser/(_(should_fail)-2                                                                                      448B ± 0%      448B ± 0%    ~     (all equal)
Parser/}_(should_fail)-2                                                                                      452B ± 0%      452B ± 0%    ~     (all equal)
Parser/1_or_1_(should_fail)-2                                                                                 680B ± 0%      680B ± 0%    ~     (all equal)
Parser/1_or_on(bar)_foo_(should_fail)-2                                                                     1.33kB ± 0%    1.33kB ± 0%    ~     (all equal)
Parser/foo_unless_on(bar)_group_left(baz)_bar_(should_fail)-2                                               1.45kB ± 0%    1.45kB ± 0%    ~     (all equal)
Parser/test[5d]_OFFSET_10s_[10m:5s]_(should_fail)-2                                                         3.04kB ± 0%    3.04kB ± 0%    ~     (p=0.746 n=10+10)
RangeQuery/expr=a_one_-_b_one,steps=10-2                                                                    13.3kB ± 0%    13.3kB ± 0%  -0.01%  (p=0.019 n=10+8)
RangeQuery/expr=sum(a_hundred),steps=100-2                                                                   187kB ± 0%     186kB ± 0%  -0.02%  (p=0.021 n=9+8)
RangeQuery/expr=count_over_time(a_one[999d:1s]),steps=1-2                                                   45.1MB ± 0%    45.0MB ± 0%  -0.03%  (p=0.020 n=10+10)
RangeQuery/expr=abs(a_hundred),steps=100-2                                                                   367kB ± 0%     367kB ± 0%  -0.05%  (p=0.002 n=9+7)
RangeQuery/expr=abs(a_hundred),steps=10-2                                                                    194kB ± 0%     193kB ± 0%  -0.05%  (p=0.041 n=10+9)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-2                                                       1.46MB ± 0%    1.46MB ± 0%  -0.10%  (p=0.022 n=10+9)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-2                                                        1.40MB ± 0%    1.40MB ± 0%  -0.15%  (p=0.043 n=10+9)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-2                                       15.7MB ± 0%    15.7MB ± 0%  -0.20%  (p=0.043 n=8+10)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-2                                         404kB ± 0%     403kB ± 0%  -0.21%  (p=0.008 n=9+9)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-2                                                        793kB ± 3%     780kB ± 1%  -1.56%  (p=0.023 n=10+10)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-2                                               245kB ± 1%     241kB ± 3%  -1.71%  (p=0.034 n=8+10)

name                                                                                                      old allocs/op  new allocs/op  delta
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-2                                  2.72k ± 0%     2.72k ± 0%  +0.03%  (p=0.008 n=8+10)
RangeQuery/expr=a_one,steps=1-2                                                                                108 ± 0%       108 ± 0%    ~     (all equal)
RangeQuery/expr=a_one,steps=10-2                                                                               108 ± 0%       108 ± 0%    ~     (all equal)
RangeQuery/expr=a_one,steps=100-2                                                                              115 ± 2%       115 ± 2%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_one,steps=1000-2                                                                             182 ± 3%       170 ±13%    ~     (p=0.349 n=8+10)
RangeQuery/expr=a_ten,steps=1-2                                                                                256 ± 0%       256 ± 0%    ~     (all equal)
RangeQuery/expr=a_ten,steps=10-2                                                                               256 ± 0%       256 ± 0%    ~     (all equal)
RangeQuery/expr=a_ten,steps=100-2                                                                              307 ±10%       307 ±10%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_ten,steps=1000-2                                                                             948 ± 5%       826 ±25%    ~     (p=0.359 n=8+10)
RangeQuery/expr=a_hundred,steps=1-2                                                                          1.70k ± 0%     1.70k ± 0%    ~     (all equal)
RangeQuery/expr=a_hundred,steps=10-2                                                                         1.70k ± 0%     1.70k ± 0%    ~     (all equal)
RangeQuery/expr=a_hundred,steps=100-2                                                                        2.10k ± 0%     2.10k ± 0%    ~     (all equal)
RangeQuery/expr=a_hundred,steps=1000-2                                                                       8.36k ± 8%     7.26k ±27%    ~     (p=0.526 n=8+10)
RangeQuery/expr=rate(a_one[1m]),steps=1-2                                                                      135 ± 0%       135 ± 0%    ~     (all equal)
RangeQuery/expr=rate(a_one[1m]),steps=10-2                                                                     135 ± 0%       135 ± 0%    ~     (all equal)
RangeQuery/expr=rate(a_one[1m]),steps=100-2                                                                    142 ± 1%       142 ± 1%    ~     (p=1.000 n=10+10)
RangeQuery/expr=rate(a_one[1m]),steps=1000-2                                                                   201 ± 3%       190 ±10%    ~     (p=0.323 n=8+10)
RangeQuery/expr=rate(a_ten[1m]),steps=1-2                                                                      320 ± 0%       320 ± 0%    ~     (all equal)
RangeQuery/expr=rate(a_ten[1m]),steps=10-2                                                                     320 ± 0%       320 ± 0%    ~     (all equal)
RangeQuery/expr=rate(a_ten[1m]),steps=100-2                                                                    371 ± 8%       371 ± 8%    ~     (p=1.000 n=10+10)
RangeQuery/expr=rate(a_ten[1m]),steps=1000-2                                                                   932 ± 5%       822 ±22%    ~     (p=0.327 n=8+10)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-2                                                                2.13k ± 0%     2.13k ± 0%    ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-2                                                               2.13k ± 0%     2.13k ± 0%    ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-2                                                              2.53k ± 0%     2.53k ± 0%    ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-2                                                             7.99k ± 8%     7.02k ±24%    ~     (p=0.369 n=8+10)
RangeQuery/expr=rate(a_one[1m]),steps=10000-2                                                                  880 ± 1%       862 ± 4%    ~     (p=0.322 n=8+10)
RangeQuery/expr=rate(a_ten[1m]),steps=10000-2                                                                7.39k ± 1%     7.22k ± 5%    ~     (p=0.320 n=8+10)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-2                                                            72.4k ± 1%     70.7k ± 5%    ~     (p=0.396 n=8+10)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-2                                                    778 ± 1%       760 ± 5%    ~     (p=0.235 n=8+10)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-2                                                   778 ± 1%       760 ± 5%    ~     (p=0.300 n=8+10)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-2                                                  786 ± 1%       769 ± 5%    ~     (p=0.335 n=8+10)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-2                                                 845 ± 1%       827 ± 4%    ~     (p=0.123 n=8+10)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-2                                                  6.19k ± 1%     6.02k ± 6%    ~     (p=0.406 n=8+10)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-2                                                 6.19k ± 1%     6.02k ± 6%    ~     (p=0.310 n=8+10)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-2                                                6.27k ± 1%     6.10k ± 6%    ~     (p=0.208 n=8+10)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-2                                               6.85k ± 1%     6.67k ± 5%    ~     (p=0.106 n=8+10)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-2                                              60.1k ± 1%     58.4k ± 6%    ~     (p=0.348 n=8+10)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-2                                             60.1k ± 1%     58.4k ± 6%    ~     (p=0.246 n=8+10)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-2                                            61.0k ± 1%     59.4k ± 6%    ~     (p=0.203 n=8+10)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-2                                           66.8k ± 1%     65.2k ± 5%    ~     (p=0.315 n=8+10)
RangeQuery/expr=changes(a_one[1d]),steps=1-2                                                                   734 ± 1%       716 ± 5%    ~     (p=0.322 n=8+10)
RangeQuery/expr=changes(a_one[1d]),steps=10-2                                                                  734 ± 1%       716 ± 5%    ~     (p=0.322 n=8+10)
RangeQuery/expr=changes(a_one[1d]),steps=100-2                                                                 742 ± 1%       724 ± 5%    ~     (p=0.327 n=8+10)
RangeQuery/expr=changes(a_one[1d]),steps=1000-2                                                                799 ± 1%       782 ± 4%    ~     (p=0.544 n=8+10)
RangeQuery/expr=changes(a_ten[1d]),steps=1-2                                                                 6.15k ± 1%     5.97k ± 6%    ~     (p=0.318 n=8+10)
RangeQuery/expr=changes(a_ten[1d]),steps=10-2                                                                6.15k ± 1%     5.97k ± 6%    ~     (p=0.322 n=8+10)
RangeQuery/expr=changes(a_ten[1d]),steps=100-2                                                               6.23k ± 1%     6.05k ± 6%    ~     (p=0.323 n=8+10)
RangeQuery/expr=changes(a_ten[1d]),steps=1000-2                                                              6.82k ± 1%     6.64k ± 5%    ~     (p=0.212 n=8+10)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-2                                                             60.0k ± 1%     58.4k ± 6%    ~     (p=0.371 n=8+10)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-2                                                            60.0k ± 1%     58.4k ± 6%    ~     (p=0.359 n=8+10)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-2                                                           61.0k ± 1%     59.3k ± 6%    ~     (p=0.246 n=8+10)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-2                                                          66.7k ± 1%     65.1k ± 5%    ~     (p=0.573 n=8+10)
RangeQuery/expr=rate(a_one[1d]),steps=1-2                                                                      734 ± 1%       716 ± 5%    ~     (p=0.322 n=8+10)
RangeQuery/expr=rate(a_one[1d]),steps=10-2                                                                     734 ± 1%       716 ± 5%    ~     (p=0.322 n=8+10)
RangeQuery/expr=rate(a_one[1d]),steps=100-2                                                                    742 ± 1%       724 ± 5%    ~     (p=0.322 n=8+10)
RangeQuery/expr=rate(a_one[1d]),steps=1000-2                                                                   798 ± 1%       781 ± 5%    ~     (p=0.373 n=8+10)
RangeQuery/expr=rate(a_ten[1d]),steps=1-2                                                                    6.15k ± 1%     5.97k ± 6%    ~     (p=0.325 n=8+10)
RangeQuery/expr=rate(a_ten[1d]),steps=10-2                                                                   6.15k ± 1%     5.97k ± 6%    ~     (p=0.345 n=8+10)
RangeQuery/expr=rate(a_ten[1d]),steps=100-2                                                                  6.23k ± 1%     6.05k ± 6%    ~     (p=0.188 n=8+10)
RangeQuery/expr=rate(a_ten[1d]),steps=1000-2                                                                 6.79k ± 1%     6.62k ± 5%    ~     (p=0.283 n=8+10)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-2                                                                60.0k ± 1%     58.4k ± 6%    ~     (p=0.195 n=8+10)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-2                                                               60.0k ± 1%     58.4k ± 6%    ~     (p=0.179 n=8+10)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-2                                                              61.0k ± 1%     59.3k ± 6%    ~     (p=0.315 n=8+10)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-2                                                             66.7k ± 1%     65.1k ± 5%    ~     (p=0.274 n=8+10)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1-2                                                          734 ± 1%       716 ± 5%    ~     (p=0.327 n=8+10)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=10-2                                                         734 ± 1%       716 ± 5%    ~     (p=0.322 n=8+10)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-2                                                        742 ± 1%       724 ± 5%    ~     (p=0.322 n=8+10)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-2                                                       798 ± 1%       780 ± 5%    ~     (p=0.428 n=8+10)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-2                                                        6.14k ± 1%     5.97k ± 6%    ~     (p=0.276 n=8+10)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-2                                                       6.14k ± 1%     5.97k ± 6%    ~     (p=0.272 n=8+10)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-2                                                      6.22k ± 1%     6.05k ± 6%    ~     (p=0.269 n=8+10)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-2                                                     6.79k ± 1%     6.61k ± 5%    ~     (p=0.370 n=8+10)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-2                                                    60.0k ± 1%     58.4k ± 6%    ~     (p=0.159 n=8+10)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-2                                                   60.0k ± 1%     58.4k ± 6%    ~     (p=0.194 n=8+10)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-2                                                  60.8k ± 1%     59.2k ± 6%    ~     (p=0.417 n=8+10)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-2                                                 66.4k ± 1%     64.8k ± 5%    ~     (p=0.227 n=8+10)
RangeQuery/expr=-a_one,steps=1-2                                                                               118 ± 0%       118 ± 0%    ~     (all equal)
RangeQuery/expr=-a_one,steps=10-2                                                                              118 ± 0%       118 ± 0%    ~     (all equal)
RangeQuery/expr=-a_one,steps=100-2                                                                             125 ± 2%       125 ± 2%    ~     (p=1.000 n=10+10)
RangeQuery/expr=-a_one,steps=1000-2                                                                            192 ± 3%       180 ±12%    ~     (p=0.349 n=8+10)
RangeQuery/expr=-a_ten,steps=1-2                                                                               303 ± 0%       303 ± 0%    ~     (all equal)
RangeQuery/expr=-a_ten,steps=10-2                                                                              303 ± 0%       303 ± 0%    ~     (all equal)
RangeQuery/expr=-a_ten,steps=100-2                                                                             354 ± 8%       354 ± 8%    ~     (p=1.000 n=10+10)
RangeQuery/expr=-a_ten,steps=1000-2                                                                          0.99k ± 5%     0.87k ±24%    ~     (p=0.359 n=8+10)
RangeQuery/expr=-a_hundred,steps=1-2                                                                         2.11k ± 0%     2.11k ± 0%    ~     (all equal)
RangeQuery/expr=-a_hundred,steps=10-2                                                                        2.11k ± 0%     2.11k ± 0%    ~     (all equal)
RangeQuery/expr=-a_hundred,steps=100-2                                                                       2.51k ± 0%     2.51k ± 0%    ~     (all equal)
RangeQuery/expr=-a_hundred,steps=1000-2                                                                      8.77k ± 7%     7.68k ±26%    ~     (p=0.208 n=8+10)
RangeQuery/expr=a_one_-_b_one,steps=1-2                                                                        195 ± 0%       195 ± 0%    ~     (all equal)
RangeQuery/expr=a_one_-_b_one,steps=10-2                                                                       231 ± 0%       231 ± 0%    ~     (all equal)
RangeQuery/expr=a_one_-_b_one,steps=100-2                                                                      605 ± 1%       605 ± 1%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_one_-_b_one,steps=1000-2                                                                   4.34k ± 0%     4.31k ± 1%    ~     (p=0.349 n=8+10)
RangeQuery/expr=a_ten_-_b_ten,steps=1-2                                                                        608 ± 0%       608 ± 0%    ~     (all equal)
RangeQuery/expr=a_ten_-_b_ten,steps=10-2                                                                       654 ± 0%       654 ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_ten_-_b_ten,steps=100-2                                                                    1.22k ± 5%     1.22k ± 5%    ~     (p=0.807 n=10+10)
RangeQuery/expr=a_ten_-_b_ten,steps=1000-2                                                                   7.16k ± 1%     6.87k ± 7%    ~     (p=0.086 n=8+10)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-2                                                              4.62k ± 0%     4.62k ± 0%    ~     (all equal)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-2                                                             4.74k ± 0%     4.74k ± 0%    ~     (p=0.572 n=10+10)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-2                                                            6.74k ± 0%     6.73k ± 1%    ~     (p=0.496 n=8+9)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-2                                                           29.9k ±17%     29.3k ±18%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_one_-_b_one,steps=10000-2                                                                  41.7k ± 0%     41.6k ± 0%    ~     (p=0.252 n=8+10)
RangeQuery/expr=a_ten_-_b_ten,steps=10000-2                                                                  65.6k ± 0%     65.6k ± 0%    ~     (p=0.193 n=8+6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-2                                                           274k ± 6%      276k ± 9%    ~     (p=0.971 n=10+10)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-2                                                       278 ± 0%       278 ± 0%    ~     (all equal)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-2                                                      314 ± 0%       314 ± 0%    ~     (all equal)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-2                                                     681 ± 0%       681 ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-2                                                  4.35k ± 0%     4.34k ± 0%    ~     (p=0.349 n=8+10)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-2                                                       581 ± 0%       581 ± 0%    ~     (all equal)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-2                                                      617 ± 0%       617 ± 0%    ~     (all equal)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-2                                                   1.06k ± 4%     1.06k ± 4%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-2                                                  5.62k ± 1%     5.44k ± 6%    ~     (p=0.359 n=8+10)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-2                                             3.36k ± 0%     3.36k ± 0%    ~     (all equal)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-2                                            3.50k ± 0%     3.50k ± 0%    ~     (p=0.137 n=8+10)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-2                                           5.42k ± 0%     5.43k ± 0%    ~     (p=0.370 n=9+9)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-2                                          28.1k ± 3%     26.4k ±11%    ~     (p=0.315 n=8+10)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-2                                                        280 ± 0%       280 ± 0%    ~     (all equal)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-2                                                       316 ± 0%       316 ± 0%    ~     (all equal)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-2                                                      683 ± 0%       683 ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-2                                                   4.35k ± 0%     4.34k ± 0%    ~     (p=0.349 n=8+10)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-2                                                        590 ± 0%       590 ± 0%    ~     (all equal)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-2                                                       645 ± 0%       645 ± 0%    ~     (all equal)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-2                                                    1.28k ± 3%     1.28k ± 3%    ~     (p=0.834 n=10+10)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-2                                                   7.74k ± 1%     7.55k ± 4%    ~     (p=0.227 n=8+10)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-2                                              3.42k ± 0%     3.42k ± 0%    ~     (all equal)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-2                                             3.60k ± 0%     3.60k ± 0%    ~     (p=0.092 n=10+7)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-2                                            5.99k ± 0%     5.98k ± 0%    ~     (p=0.068 n=9+9)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-2                                           33.2k ± 3%     31.5k ± 9%    ~     (p=0.360 n=8+10)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-2                                                    280 ± 0%       280 ± 0%    ~     (all equal)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-2                                                   316 ± 0%       316 ± 0%    ~     (all equal)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-2                                                  683 ± 0%       683 ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-2                                               4.35k ± 0%     4.34k ± 0%    ~     (p=0.349 n=8+10)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-2                                                    581 ± 0%       581 ± 0%    ~     (all equal)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-2                                                   617 ± 0%       617 ± 0%    ~     (all equal)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-2                                                1.06k ± 4%     1.06k ± 4%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-2                                               5.62k ± 1%     5.44k ± 6%    ~     (p=0.359 n=8+10)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-2                                          3.36k ± 0%     3.36k ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-2                                         3.50k ± 0%     3.50k ± 0%    ~     (all equal)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-2                                        5.42k ± 0%     5.42k ± 0%    ~     (p=0.237 n=9+9)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-2                                       28.1k ± 3%     26.4k ±11%    ~     (p=0.460 n=8+10)
RangeQuery/expr=abs(a_one),steps=1-2                                                                           136 ± 0%       136 ± 0%    ~     (all equal)
RangeQuery/expr=abs(a_one),steps=10-2                                                                          145 ± 0%       145 ± 0%    ~     (all equal)
RangeQuery/expr=abs(a_one),steps=100-2                                                                         242 ± 1%       242 ± 1%    ~     (p=1.000 n=10+10)
RangeQuery/expr=abs(a_one),steps=1000-2                                                                      1.21k ± 0%     1.20k ± 2%    ~     (p=0.349 n=8+10)
RangeQuery/expr=abs(a_ten),steps=1-2                                                                           333 ± 0%       333 ± 0%    ~     (all equal)
RangeQuery/expr=abs(a_ten),steps=10-2                                                                          352 ± 0%       352 ± 0%    ~     (all equal)
RangeQuery/expr=abs(a_ten),steps=100-2                                                                         591 ± 5%       591 ± 5%    ~     (p=1.000 n=10+10)
RangeQuery/expr=abs(a_ten),steps=1000-2                                                                      3.11k ± 1%     2.99k ± 7%    ~     (p=0.420 n=8+10)
RangeQuery/expr=abs(a_hundred),steps=1-2                                                                     2.25k ± 0%     2.25k ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=abs(a_hundred),steps=10-2                                                                    2.32k ± 0%     2.32k ± 0%    ~     (p=0.065 n=10+9)
RangeQuery/expr=abs(a_hundred),steps=1000-2                                                                  17.2k ± 4%     16.1k ±12%    ~     (p=0.372 n=8+10)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-2                                        217 ± 0%       217 ± 0%    ~     (all equal)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-2                                       262 ± 0%       262 ± 0%    ~     (all equal)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-2                                      719 ± 0%       719 ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-2                                   5.29k ± 0%     5.27k ± 0%    ~     (p=0.349 n=8+10)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-2                                        443 ± 0%       443 ± 0%    ~     (all equal)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-2                                       498 ± 0%       498 ± 0%    ~     (p=0.211 n=10+10)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-2                                    1.10k ± 3%     1.10k ± 3%    ~     (p=0.962 n=10+10)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-2                                   7.21k ± 1%     7.09k ± 3%    ~     (p=0.395 n=8+10)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-2                                4.34k ± 0%     4.34k ± 0%    ~     (p=0.551 n=9+8)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-2                               21.7k ± 3%     20.6k ±10%    ~     (p=0.246 n=8+10)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-2                                               177 ± 0%       177 ± 0%    ~     (all equal)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-2                                              240 ± 0%       240 ± 0%    ~     (all equal)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-2                                             877 ± 0%       877 ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-2                                          7.24k ± 0%     7.23k ± 0%    ~     (p=0.349 n=8+10)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-2                                               392 ± 0%       392 ± 0%    ~     (all equal)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-2                                              465 ± 0%       465 ± 0%    ~     (all equal)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-2                                           1.24k ± 2%     1.24k ± 2%    ~     (p=0.984 n=10+10)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-2                                          9.16k ± 1%     9.04k ± 2%    ~     (p=0.443 n=8+10)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-2                                         2.49k ± 0%     2.49k ± 0%    ~     (p=0.370 n=10+10)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-2                                        2.62k ± 0%     2.62k ± 0%    ~     (p=0.700 n=10+10)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-2                                       4.31k ± 0%     4.31k ± 0%    ~     (p=0.203 n=9+7)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-2                                      23.4k ± 3%     22.4k ± 9%    ~     (p=0.829 n=8+10)
RangeQuery/expr=sum(a_one),steps=1-2                                                                           138 ± 0%       138 ± 0%    ~     (all equal)
RangeQuery/expr=sum(a_one),steps=10-2                                                                          192 ± 0%       192 ± 0%    ~     (all equal)
RangeQuery/expr=sum(a_one),steps=100-2                                                                         739 ± 0%       739 ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=sum(a_one),steps=1000-2                                                                      6.21k ± 0%     6.19k ± 0%    ~     (p=0.349 n=8+10)
RangeQuery/expr=sum(a_ten),steps=1-2                                                                           287 ± 0%       287 ± 0%    ~     (all equal)
RangeQuery/expr=sum(a_ten),steps=10-2                                                                          341 ± 0%       341 ± 0%    ~     (all equal)
RangeQuery/expr=sum(a_ten),steps=100-2                                                                         932 ± 3%       932 ± 3%    ~     (p=1.000 n=10+10)
RangeQuery/expr=sum(a_ten),steps=1000-2                                                                      6.97k ± 1%     6.85k ± 3%    ~     (p=0.271 n=8+10)
RangeQuery/expr=sum(a_hundred),steps=1-2                                                                     1.73k ± 0%     1.73k ± 0%    ~     (all equal)
RangeQuery/expr=sum(a_hundred),steps=10-2                                                                    1.78k ± 0%     1.78k ± 0%    ~     (all equal)
RangeQuery/expr=sum(a_hundred),steps=100-2                                                                   2.73k ± 0%     2.73k ± 0%    ~     (all equal)
RangeQuery/expr=sum(a_hundred),steps=1000-2                                                                  14.4k ± 4%     13.3k ±15%    ~     (p=0.290 n=8+10)
RangeQuery/expr=sum_without_(l)(h_one),steps=1-2                                                               382 ± 0%       382 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(h_one),steps=10-2                                                              745 ± 0%       745 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-2                                                           4.44k ± 1%     4.44k ± 1%    ~     (p=0.925 n=10+10)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-2                                                          41.4k ± 0%     41.3k ± 1%    ~     (p=0.459 n=8+10)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1-2                                                             1.97k ± 0%     1.97k ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(h_ten),steps=10-2                                                            2.33k ± 0%     2.33k ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(h_ten),steps=100-2                                                           6.52k ± 5%     6.52k ± 5%    ~     (p=0.986 n=10+10)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1000-2                                                          49.8k ± 1%     48.5k ± 5%    ~     (p=0.473 n=8+10)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-2                                                        18.2k ± 0%     18.2k ± 0%    ~     (p=0.620 n=9+10)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-2                                                       26.2k ± 0%     26.2k ± 0%    ~     (p=0.348 n=9+9)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-2                                                       133k ± 4%      120k ±19%    ~     (p=0.315 n=8+10)
RangeQuery/expr=sum_without_(le)(h_one),steps=1-2                                                              308 ± 0%       308 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(le)(h_one),steps=10-2                                                             380 ± 0%       380 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-2                                                          1.17k ± 2%     1.17k ± 2%    ~     (p=1.000 n=10+10)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-2                                                         9.07k ± 1%     8.94k ± 3%    ~     (p=0.349 n=8+10)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1-2                                                            1.96k ± 0%     1.96k ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(le)(h_ten),steps=10-2                                                           2.30k ± 0%     2.30k ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(le)(h_ten),steps=100-2                                                          6.19k ± 5%     6.19k ± 5%    ~     (p=0.715 n=10+10)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1000-2                                                         46.6k ± 1%     45.3k ± 5%    ~     (p=0.237 n=8+10)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-2                                                        18.5k ± 0%     18.5k ± 0%    ~     (p=0.585 n=9+9)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-2                                                       21.4k ± 0%     21.4k ± 0%    ~     (p=0.754 n=9+10)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-2                                                      54.6k ± 0%     54.6k ± 0%    ~     (p=0.181 n=9+9)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-2                                                      413k ± 1%      401k ± 6%    ~     (p=0.274 n=8+10)
RangeQuery/expr=sum_by_(l)(h_one),steps=1-2                                                                    308 ± 0%       308 ± 0%    ~     (all equal)
RangeQuery/expr=sum_by_(l)(h_one),steps=10-2                                                                   380 ± 0%       380 ± 0%    ~     (all equal)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-2                                                                1.17k ± 2%     1.17k ± 2%    ~     (p=1.000 n=10+10)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-2                                                               9.07k ± 1%     8.94k ± 3%    ~     (p=0.349 n=8+10)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1-2                                                                  1.96k ± 0%     1.96k ± 0%    ~     (all equal)
RangeQuery/expr=sum_by_(l)(h_ten),steps=10-2                                                                 2.30k ± 0%     2.30k ± 0%    ~     (all equal)
RangeQuery/expr=sum_by_(l)(h_ten),steps=100-2                                                                6.19k ± 5%     6.19k ± 5%    ~     (p=0.505 n=10+10)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1000-2                                                               46.6k ± 1%     45.3k ± 5%    ~     (p=0.264 n=8+10)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-2                                                              18.5k ± 0%     18.5k ± 0%    ~     (p=0.580 n=10+10)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-2                                                             21.4k ± 0%     21.4k ± 0%    ~     (p=0.348 n=10+10)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-2                                                            54.6k ± 0%     54.6k ± 0%    ~     (p=0.619 n=9+9)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-2                                                            413k ± 1%      401k ± 6%    ~     (p=0.360 n=8+10)
RangeQuery/expr=sum_by_(le)(h_one),steps=1-2                                                                   382 ± 0%       382 ± 0%    ~     (all equal)
RangeQuery/expr=sum_by_(le)(h_one),steps=10-2                                                                  745 ± 0%       745 ± 0%    ~     (all equal)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-2                                                               4.44k ± 1%     4.44k ± 1%    ~     (p=0.825 n=10+10)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-2                                                              41.4k ± 0%     41.3k ± 1%    ~     (p=0.285 n=8+10)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1-2                                                                 1.97k ± 0%     1.97k ± 0%    ~     (all equal)
RangeQuery/expr=sum_by_(le)(h_ten),steps=10-2                                                                2.33k ± 0%     2.33k ± 0%    ~     (all equal)
RangeQuery/expr=sum_by_(le)(h_ten),steps=100-2                                                               6.52k ± 5%     6.52k ± 5%    ~     (p=0.867 n=10+10)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1000-2                                                              49.8k ± 1%     48.5k ± 5%    ~     (p=0.617 n=8+10)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-2                                                             17.8k ± 0%     17.8k ± 0%    ~     (p=0.370 n=10+10)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-2                                                            18.2k ± 0%     18.2k ± 0%    ~     (p=0.424 n=9+10)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-2                                                           26.2k ± 0%     26.2k ± 0%    ~     (p=0.652 n=8+9)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-2                                                           133k ± 5%      120k ±19%    ~     (p=0.360 n=8+10)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-2                                                    239 ± 0%       239 ± 0%    ~     (all equal)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-2                                                   275 ± 0%       275 ± 0%    ~     (all equal)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-2                                                  649 ± 1%       649 ± 1%    ~     (p=1.000 n=10+10)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-2                                               4.37k ± 0%     4.34k ± 1%    ~     (p=0.323 n=8+10)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-2                                                    691 ± 0%       691 ± 0%    ~     (all equal)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-2                                                   737 ± 0%       737 ± 0%    ~     (all equal)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-2                                                1.30k ± 5%     1.30k ± 5%    ~     (p=0.811 n=10+10)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-2                                               7.02k ± 2%     6.83k ± 6%    ~     (p=0.965 n=8+10)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-2                                          5.07k ± 0%     5.07k ± 0%    ~     (p=0.900 n=10+10)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-2                                         5.19k ± 0%     5.19k ± 0%    ~     (p=0.734 n=8+10)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-2                                        7.21k ± 1%     7.21k ± 0%    ~     (p=0.226 n=9+8)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-2                                       29.4k ±16%     28.2k ±12%    ~     (p=0.315 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-2                                                     166 ± 0%       166 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-2                                                    229 ± 0%       229 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-2                                                   866 ± 0%       866 ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-2                                                7.22k ± 0%     7.21k ± 0%    ~     (p=0.323 n=8+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-2                                                     354 ± 0%       354 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-2                                                    426 ± 0%       426 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-2                                                 1.20k ± 2%     1.20k ± 2%    ~     (p=1.000 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-2                                                8.96k ± 1%     8.85k ± 2%    ~     (p=0.326 n=8+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-2                                               2.16k ± 0%     2.16k ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-2                                              2.24k ± 0%     2.24k ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-2                                             3.36k ± 0%     3.36k ± 0%    ~     (p=0.529 n=8+9)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-2                                            16.0k ± 4%     15.0k ±11%    ~     (p=0.307 n=8+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-2                  305 ± 0%       305 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-2                 467 ± 0%       467 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-2              2.10k ± 0%     2.10k ± 0%    ~     (p=1.000 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-2             18.4k ± 0%     18.4k ± 0%    ~     (p=0.381 n=8+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-2                  681 ± 0%       681 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-2                 861 ± 0%       861 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-2              2.76k ± 2%     2.76k ± 2%    ~     (p=1.000 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-2             21.9k ± 0%     21.7k ± 2%    ~     (p=0.492 n=8+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-2        4.30k ± 0%     4.30k ± 0%    ~     (p=0.650 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-2       4.48k ± 0%     4.48k ± 0%    ~     (p=0.720 n=10+10)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-2      7.08k ± 0%     7.08k ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-2     36.0k ± 4%     34.1k ±10%    ~     (p=0.421 n=8+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-2                                             441 ± 0%       441 ± 0%    ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-2                                            684 ± 0%       684 ± 0%    ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-2                                         3.18k ± 1%     3.18k ± 1%    ~     (p=1.000 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-2                                        28.2k ± 0%     28.1k ± 1%    ~     (p=0.172 n=8+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-2                                           3.16k ± 0%     3.16k ± 0%    ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-2                                          6.27k ± 0%     6.27k ± 0%    ~     (p=0.650 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-2                                         37.9k ± 1%     37.9k ± 1%    ~     (p=0.990 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-2                                         355k ± 0%      354k ± 1%    ~     (p=0.372 n=8+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-2                                       30.1k ± 0%     30.1k ± 0%    ~     (p=0.741 n=9+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-2                                      60.8k ± 0%     60.8k ± 0%    ~     (p=0.543 n=10+10)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-2                                      372k ± 0%      372k ± 0%    ~     (p=0.559 n=9+9)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-2                                    3.51M ± 0%     3.50M ± 1%    ~     (p=0.237 n=8+10)
RangeQuery/expr=count_over_time(a_one[999d:1s]),steps=1-2                                                    1.26k ± 1%     1.24k ± 3%    ~     (p=0.077 n=8+10)
Parser/a-2                                                                                                    3.00 ± 0%      3.00 ± 0%    ~     (all equal)
Parser/metric-2                                                                                               3.00 ± 0%      3.00 ± 0%    ~     (all equal)
Parser/1-2                                                                                                    1.00 ± 0%      1.00 ± 0%    ~     (all equal)
Parser/1_>=_bool_1-2                                                                                          4.00 ± 0%      4.00 ± 0%    ~     (all equal)
Parser/1_+_2/(3*1)-2                                                                                          11.0 ± 0%      11.0 ± 0%    ~     (all equal)
Parser/foo_or_bar-2                                                                                           8.00 ± 0%      8.00 ± 0%    ~     (all equal)
Parser/foo_and_bar_unless_baz_or_qux-2                                                                        18.0 ± 0%      18.0 ± 0%    ~     (all equal)
Parser/bar_+_on(foo)_bla_/_on(baz,_buz)_group_right(test)_blub-2                                              17.0 ± 0%      17.0 ± 0%    ~     (all equal)
Parser/foo_/_ignoring(test,blub)_group_left(blub)_bar-2                                                       11.0 ± 0%      11.0 ± 0%    ~     (all equal)
Parser/foo_-_ignoring(test,blub)_group_right(bar,foo)_bar-2                                                   12.0 ± 0%      12.0 ± 0%    ~     (all equal)
Parser/foo{a="b",_foo!="bar",_test=~"test",_bar!~"baz"}-2                                                      114 ± 0%       114 ± 0%    ~     (all equal)
Parser/min_over_time(rate(foo{bar="baz"}[2s])[5m:])[4m:3s]-2                                                  28.0 ± 0%      28.0 ± 0%    ~     (all equal)
Parser/sum_without(and,_by,_avg,_count,_alert,_annotations)(some_metric)_[30m:10s]-2                          15.0 ± 0%      15.0 ± 0%    ~     (all equal)
Parser/(_(should_fail)-2                                                                                      6.00 ± 0%      6.00 ± 0%    ~     (all equal)
Parser/}_(should_fail)-2                                                                                      7.00 ± 0%      7.00 ± 0%    ~     (all equal)
Parser/1_or_1_(should_fail)-2                                                                                 11.0 ± 0%      11.0 ± 0%    ~     (all equal)
Parser/1_or_on(bar)_foo_(should_fail)-2                                                                       19.0 ± 0%      19.0 ± 0%    ~     (all equal)
Parser/foo_unless_on(bar)_group_left(baz)_bar_(should_fail)-2                                                 22.0 ± 0%      22.0 ± 0%    ~     (all equal)
Parser/test[5d]_OFFSET_10s_[10m:5s]_(should_fail)-2                                                           46.0 ± 0%      46.0 ± 0%    ~     (all equal)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-2                                                         17.8k ± 0%     17.8k ± 0%  -0.00%  (p=0.029 n=7+10)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-2                                 2.83k ± 0%     2.83k ± 0%  -0.02%  (p=0.013 n=10+8)
RangeQuery/expr=abs(a_hundred),steps=100-2                                                                   3.47k ± 0%     3.47k ± 0%  -0.05%  (p=0.033 n=8+8)
```