### PR TITLE
promtool: Don't end alert tests early, in some failure situations

### DIFF
--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -234,6 +234,7 @@ func (tg *testGroup) test(mint, maxt time.Time, evalInterval time.Duration, grou
 	var errs []error
 	for ts := mint; ts.Before(maxt); ts = ts.Add(evalInterval) {
 		// Collects the alerts asked for unit testing.
+		var evalErrs []error
 		suite.WithSamplesTill(ts, func(err error) {
 			if err != nil {
 				errs = append(errs, err)
@@ -243,13 +244,16 @@ func (tg *testGroup) test(mint, maxt time.Time, evalInterval time.Duration, grou
 				g.Eval(suite.Context(), ts)
 				for _, r := range g.Rules() {
 					if r.LastError() != nil {
-						errs = append(errs, errors.Errorf("    rule: %s, time: %s, err: %v",
+						evalErrs = append(evalErrs, errors.Errorf("    rule: %s, time: %s, err: %v",
 							r.Name(), ts.Sub(time.Unix(0, 0).UTC()), r.LastError()))
 					}
 				}
 			}
 		})
-		if len(errs) > 0 {
+		errs = append(errs, evalErrs...)
+		// Only end testing at this point if errors occurred evaluating above,
+		// rather than any test failures already collected in errs.
+		if len(evalErrs) > 0 {
 			return errs
 		}
 


### PR DESCRIPTION
If an alert test had a failing test, then any other alert test interval
specified after that point would result in the test exiting early.
This made debugging some tests more difficult than needed.

Now only exit early for evaluation failures.

Example of test with different output before and after:
https://gist.github.com/dgl/d5f3ae0b32ae419a11afe2b017aa7650

It's a bit hard to fit this into the current unit testing, it's tempting to add a way to use `ruleUnitTest` (rather than `RulesUnitTest`) as then it could easily look at the errors returned, but then it's using an internal function. Seems to make sense in this particular case, but suggestions welcome...

Signed-off-by: David Leadbeater <dgl@dgl.cx>