### PR TITLE
Merge defer function to improve readability

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1066,20 +1066,19 @@ func (sl *scrapeLoop) scrapeAndReport(interval, timeout time.Duration, last, app
 	var err, appErr, scrapeErr error
 
 	app := sl.appender(sl.parentCtx)
+
 	defer func() {
 		if err != nil {
 			app.Rollback()
 			return
 		}
-		err = app.Commit()
-		if err != nil {
-			level.Error(sl.l).Log("msg", "Scrape commit failed", "err", err)
-		}
-	}()
 
-	defer func() {
 		if err = sl.report(app, appendTime, time.Since(start), total, added, seriesAdded, scrapeErr); err != nil {
 			level.Warn(sl.l).Log("msg", "Appending scrape report failed", "err", err)
+		}
+
+		if err = app.Commit(); err != nil {
+			level.Error(sl.l).Log("msg", "Scrape commit failed", "err", err)
 		}
 	}()
 


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
Merge two defer function in `scrapeAndReport` method of `scrape.go` to improve readability