### PR TITLE
Add a testcase for #8040

### DIFF
--- a/pkg/labels/regexp_test.go
+++ b/pkg/labels/regexp_test.go
@@ -83,6 +83,7 @@ func TestOptimizeConcatRegex(t *testing.T) {
 		{regex: ".*(?i:abc)def.*", prefix: "", suffix: "", contains: "def"},
 		{regex: "(?i).*(?-i:abc)def", prefix: "", suffix: "", contains: "abc"},
 		{regex: ".*(?msU:abc).*", prefix: "", suffix: "", contains: "abc"},
+		{regex: "[aA]bc.*", prefix: "", suffix: "", contains: "bc"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
This was already fixed by #8013, but add a test case anyway
in case the regexp engine changes in future.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>