### PR TITLE
Do not ignore reload errors in compactHead

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -835,10 +835,9 @@ func (db *DB) compactHead(head *RangeHead) (err error) {
 	runtime.GC()
 
 	if err := db.reload(); err != nil {
-		var merr tsdb_errors.MultiError
-		merr.Add(err)
 		if errRemoveAll := os.RemoveAll(filepath.Join(db.dir, uid.String())); errRemoveAll != nil {
-			merr.Add(errRemoveAll)
+			var merr tsdb_errors.MultiError
+			merr.Add(errors.Wrap(err, "reload blocks"))
 			merr.Add(errors.Wrapf(errRemoveAll, "delete persisted head block after failed db reload:%s", uid))
 			return merr.Err()
 		}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -626,7 +626,7 @@ Outer:
 	}
 
 	if unknownRefs.Load() > 0 {
-		level.Warn(h.logger).Log("msg", "Unknown series references", "count", unknownRefs)
+		level.Warn(h.logger).Log("msg", "Unknown series references", "count", unknownRefs.Load())
 	}
 	return nil
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -626,7 +626,7 @@ Outer:
 	}
 
 	if unknownRefs.Load() > 0 {
-		level.Warn(h.logger).Log("msg", "Unknown series references", "count", unknownRefs.Load())
+		level.Warn(h.logger).Log("msg", "Unknown series references", "count", unknownRefs)
 	}
 	return nil
 }


### PR DESCRIPTION
Modified db.go to club errors from os.RemoveAll and db.reload.
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->