### PR TITLE
documentation/prometheus-mixin: improve PrometheusNotIngestingSamples

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -127,7 +127,15 @@
           {
             alert: 'PrometheusNotIngestingSamples',
             expr: |||
-              rate(prometheus_tsdb_head_samples_appended_total{%(prometheusSelector)s}[5m]) <= 0
+              (
+                rate(prometheus_tsdb_head_samples_appended_total{%(prometheusSelector)s}[5m]) <= 0
+              and
+                (
+                  sum without(scrape_job) (prometheus_target_metadata_cache_entries{%(prometheusSelector)s}) > 0
+                or
+                  sum without(rule_group) (prometheus_rule_group_rules{%(prometheusSelector)s}) > 0
+                )
+              )
             ||| % $._config,
             'for': '10m',
             labels: {


### PR DESCRIPTION
The alert shouldn't fire when there's no target and no rule configured.

Closes #7293