### PR TITLE
remote: don't set highestSentTimestamp to 0

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -374,7 +374,7 @@ func (t *QueueManager) Start() {
 
 	t.shards.start(t.numShards)
 	t.watcher.Start()
-	t.metrics.highestSentTimestamp.Set(float64(t.watcher.GetStartTime().UnixNano()) / 1e9)
+	t.metrics.highestSentTimestamp.Set(float64(t.watcher.GetStartTime().Unix()))
 
 	t.metrics.register()
 

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -367,7 +367,6 @@ outer:
 // Does not block.
 func (t *QueueManager) Start() {
 	// Register and initialise some metrics.
-	t.metrics.register()
 	t.metrics.shardCapacity.Set(float64(t.cfg.Capacity))
 	t.metrics.maxNumShards.Set(float64(t.cfg.MaxShards))
 	t.metrics.minNumShards.Set(float64(t.cfg.MinShards))
@@ -375,6 +374,9 @@ func (t *QueueManager) Start() {
 
 	t.shards.start(t.numShards)
 	t.watcher.Start()
+	t.metrics.highestSentTimestamp.Set(float64(t.watcher.GetStartTime().UnixNano()) / 1e9)
+
+	t.metrics.register()
 
 	t.wg.Add(2)
 	go t.updateShardsLoop()

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -516,6 +516,10 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 	return errors.Wrapf(r.Err(), "segment %d: %v", segmentNum, r.Err())
 }
 
+func (w *Watcher) GetStartTime() time.Time {
+	return w.startTime
+}
+
 func (w *Watcher) SetStartTime(t time.Time) {
 	w.startTime = t
 	w.startTimestamp = timestamp.FromTime(t)


### PR DESCRIPTION
Alternative to #8046 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->