### PR TITLE
More info in mmap error message

### DIFF
--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -48,7 +48,7 @@ func OpenMmapFileWithSize(path string, size int) (mf *MmapFile, retErr error) {
 
 	b, err := mmap(f, size)
 	if err != nil {
-		return nil, errors.Wrap(err, "mmap")
+		return nil, errors.Wrapf(err, "mmap, size %d", size)
 	}
 
 	return &MmapFile{f: f, b: b}, nil


### PR DESCRIPTION
Useful when investigating "mmap: invalid argument" errors.