### PR TITLE
Read repair empty file in chunks_head

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -219,13 +219,39 @@ func listChunkFiles(dir string) (map[int]string, error) {
 		return nil, err
 	}
 	res := map[int]string{}
+	lastFile := uint64(0)
 	for _, fi := range files {
 		seq, err := strconv.ParseUint(fi.Name(), 10, 64)
 		if err != nil {
 			continue
 		}
+		if seq > lastFile {
+			lastFile = seq
+		}
 		res[int(seq)] = filepath.Join(dir, fi.Name())
 	}
+
+	if lastFile != uint64(0) {
+		// Because we don't fsync when creating these file, we could end
+		// up with an empty file at the end during abrupt shutdown.
+		// Hence we do a read repair here and delete the last file if it is empty.
+		f, err := os.Open(res[int(lastFile)])
+		if err != nil {
+			return nil, errors.Wrap(err, "open file during read repair")
+		}
+		info, err := f.Stat()
+		if err != nil {
+			return nil, errors.Wrap(err, "file stat during read repair")
+		}
+		if info.Size() == 0 {
+			// Corrupt file, hence remove it.
+			if err := os.RemoveAll(res[int(lastFile)]); err != nil {
+				return nil, errors.Wrap(err, "delete corrupt file during read repair")
+			}
+			delete(res, int(lastFile))
+		}
+	}
+
 	return res, nil
 }
 

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -252,12 +252,12 @@ func repairLastChunkFile(files map[int]string) (_ map[int]string, returnErr erro
 
 	info, err := os.Stat(files[lastFile])
 	if err != nil {
-		return files, errors.Wrap(err, "file stat during last chunk file repair")
+		return files, errors.Wrap(err, "file stat during last head chunk file repair")
 	}
 	if info.Size() == 0 {
 		// Corrupt file, hence remove it.
 		if err := os.RemoveAll(files[lastFile]); err != nil {
-			return files, errors.Wrap(err, "delete corrupt file during last chunk file repair")
+			return files, errors.Wrap(err, "delete corrupted, empty head chunk file during last file repair")
 		}
 		delete(files, lastFile)
 	}


### PR DESCRIPTION
Even though we first write the segment file to a temporary file and then rename, the `Close()` method does not assure writes to be reflected to disk (TIL). We faced the `mmap: invalid argument` error again with the temp file protection.

~We should be syncing the temporary file before closing, similar to what we do for compaction. While this is on the hotpath, the sync call won't be that often and should not be a problem in most cases.~

Since we don't want stalls on hot path, this PR does a read repair - deletes the last file if it is empty. Any empty file in between the sequence will still lead to error.