### PR TITLE
documentation/examples: change ingress apiGroup

### DIFF
--- a/documentation/examples/rbac-setup.yml
+++ b/documentation/examples/rbac-setup.yml
@@ -19,7 +19,7 @@ rules:
   - pods
   verbs: ["get", "list", "watch"]
 - apiGroups:
-  - extensions
+  - networking.k8s.io
   resources:
   - ingresses
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Signed-off-by: paulfantom <pawel@krupa.net.pl>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Since kubernetes 1.19 ingress object lives in a `networking.k8s.io` API Group. Source: https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource

cc @brancz 