### PR TITLE
Add testutil helpers in tsdb

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1994,8 +1994,7 @@ func TestBlockRanges(t *testing.T) {
 	app := db.Appender(ctx)
 	lbl := labels.Labels{{Name: "a", Value: "b"}}
 	_, err = app.Add(lbl, firstBlockMaxT-1, rand.Float64())
-	testutil.Assert(t, err != nil,
-		"appending a sample with a timestamp covered by a previous block shouldn't be possible")
+	testutil.NotOk(t, err)
 	_, err = app.Add(lbl, firstBlockMaxT+1, rand.Float64())
 	testutil.Ok(t, err)
 	_, err = app.Add(lbl, firstBlockMaxT+2, rand.Float64())
@@ -2813,7 +2812,7 @@ func TestOpen_VariousBlockStates(t *testing.T) {
 	var loaded int
 	for _, l := range loadedBlocks {
 		_, ok := expectedLoadedDirs[filepath.Join(tmpDir, l.meta.ULID.String())]
-		testutil.Assert(t, ok, "unexpected block", l.meta.ULID, "was loaded")
+		testutil.Assert(t, ok, "unexpected block %s was loaded", l.meta.ULID.String())
 		loaded++
 	}
 	testutil.Equals(t, len(expectedLoadedDirs), loaded)

--- a/tsdb/fileutil/flock_test.go
+++ b/tsdb/fileutil/flock_test.go
@@ -42,9 +42,7 @@ func TestLocking(t *testing.T) {
 	testutil.Assert(t, err != nil, "File %q locked twice.", fileName)
 	testutil.Assert(t, lockedAgain == nil, "Unsuccessful locking did not return nil.")
 	testutil.Assert(t, existed, "Existing file %q not recognized.", fileName)
-
-	err = lock.Release()
-	testutil.Ok(t, err)
+	testutil.Ok(t, lock.Release())
 
 	// File must still exist.
 	_, err = os.Stat(fileName)
@@ -54,7 +52,5 @@ func TestLocking(t *testing.T) {
 	lock, existed, err = Flock(fileName)
 	testutil.Ok(t, err)
 	testutil.Assert(t, existed, "Existing file %q not recognized.", fileName)
-
-	err = lock.Release()
-	testutil.Ok(t, err)
+	testutil.Ok(t, lock.Release())
 }

--- a/tsdb/fileutil/flock_test.go
+++ b/tsdb/fileutil/flock_test.go
@@ -27,7 +27,7 @@ func TestLocking(t *testing.T) {
 
 	fileName := filepath.Join(dir.Path(), "LOCK")
 	_, err := os.Stat(fileName)
-	testutil.Assert(t, err != nil, "File %q unexpectedly exists.", fileName)
+	testutil.NotOk(t, err)
 
 	lock, existed, err := Flock(fileName)
 	testutil.Ok(t, err)
@@ -39,7 +39,7 @@ func TestLocking(t *testing.T) {
 
 	// Try to lock again.
 	lockedAgain, existed, err := Flock(fileName)
-	testutil.Assert(t, err != nil, "File %q locked twice.", fileName)
+	testutil.NotOk(t, err)
 	testutil.Assert(t, lockedAgain == nil, "Unsuccessful locking did not return nil.")
 	testutil.Assert(t, existed, "Existing file %q not recognized.", fileName)
 	testutil.Ok(t, lock.Release())

--- a/tsdb/fileutil/flock_test.go
+++ b/tsdb/fileutil/flock_test.go
@@ -26,55 +26,35 @@ func TestLocking(t *testing.T) {
 	defer dir.Close()
 
 	fileName := filepath.Join(dir.Path(), "LOCK")
-
-	if _, err := os.Stat(fileName); err == nil {
-		t.Fatalf("File %q unexpectedly exists.", fileName)
-	}
+	_, err := os.Stat(fileName)
+	testutil.Assert(t, err != nil, "File %q unexpectedly exists.", fileName)
 
 	lock, existed, err := Flock(fileName)
-	if err != nil {
-		t.Fatalf("Error locking file %q: %s", fileName, err)
-	}
-	if existed {
-		t.Errorf("File %q reported as existing during locking.", fileName)
-	}
+	testutil.Ok(t, err)
+	testutil.Assert(t, !existed, "File %q reported as existing during locking.", fileName)
 
 	// File must now exist.
-	if _, err = os.Stat(fileName); err != nil {
-		t.Errorf("Could not stat file %q expected to exist: %s", fileName, err)
-	}
+	_, err = os.Stat(fileName)
+	testutil.Ok(t, err)
 
 	// Try to lock again.
 	lockedAgain, existed, err := Flock(fileName)
-	if err == nil {
-		t.Fatalf("File %q locked twice.", fileName)
-	}
-	if lockedAgain != nil {
-		t.Error("Unsuccessful locking did not return nil.")
-	}
-	if !existed {
-		t.Errorf("Existing file %q not recognized.", fileName)
-	}
+	testutil.Assert(t, err != nil, "File %q locked twice.", fileName)
+	testutil.Assert(t, lockedAgain == nil, "Unsuccessful locking did not return nil.")
+	testutil.Assert(t, existed, "Existing file %q not recognized.", fileName)
 
-	if err := lock.Release(); err != nil {
-		t.Errorf("Error releasing lock for file %q: %s", fileName, err)
-	}
+	err = lock.Release()
+	testutil.Ok(t, err)
 
 	// File must still exist.
-	if _, err = os.Stat(fileName); err != nil {
-		t.Errorf("Could not stat file %q expected to exist: %s", fileName, err)
-	}
+	_, err = os.Stat(fileName)
+	testutil.Ok(t, err)
 
 	// Lock existing file.
 	lock, existed, err = Flock(fileName)
-	if err != nil {
-		t.Fatalf("Error locking file %q: %s", fileName, err)
-	}
-	if !existed {
-		t.Errorf("Existing file %q not recognized.", fileName)
-	}
+	testutil.Ok(t, err)
+	testutil.Assert(t, existed, "Existing file %q not recognized.", fileName)
 
-	if err := lock.Release(); err != nil {
-		t.Errorf("Error releasing lock for file %q: %s", fileName, err)
-	}
+	err = lock.Release()
+	testutil.Ok(t, err)
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -949,9 +949,7 @@ func TestComputeChunkEndTime(t *testing.T) {
 
 	for _, c := range cases {
 		got := computeChunkEndTime(c.start, c.cur, c.max)
-		if got != c.res {
-			t.Errorf("expected %d for (start: %d, cur: %d, max: %d), got %d", c.res, c.start, c.cur, c.max, got)
-		}
+		testutil.Equals(t, got, c.res)
 	}
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -949,7 +949,7 @@ func TestComputeChunkEndTime(t *testing.T) {
 
 	for _, c := range cases {
 		got := computeChunkEndTime(c.start, c.cur, c.max)
-		testutil.Equals(t, got, c.res)
+		testutil.Equals(t, c.res, got)
 	}
 }
 

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -55,9 +55,7 @@ func TestMemPostings_ensureOrder(t *testing.T) {
 			ok := sort.SliceIsSorted(l, func(i, j int) bool {
 				return l[i] < l[j]
 			})
-			if !ok {
-				t.Fatalf("postings list %v is not sorted", l)
-			}
+			testutil.Assert(t, ok, "postings list %v is not sorted", l)
 		}
 	}
 }
@@ -155,9 +153,7 @@ func TestIntersect(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			if c.res == nil {
-				t.Fatal("intersect result expectancy cannot be nil")
-			}
+			testutil.Assert(t, c.res != nil, "intersect result expectancy cannot be nil")
 
 			expected, err := ExpandPostings(c.res)
 			testutil.Ok(t, err)
@@ -168,10 +164,7 @@ func TestIntersect(t *testing.T) {
 				testutil.Equals(t, EmptyPostings(), i)
 				return
 			}
-
-			if i == EmptyPostings() {
-				t.Fatal("intersect unexpected result: EmptyPostings sentinel")
-			}
+			testutil.Assert(t, i != EmptyPostings(), "intersect unexpected result: EmptyPostings sentinel")
 
 			res, err := ExpandPostings(i)
 			testutil.Ok(t, err)
@@ -397,9 +390,7 @@ func TestMergedPostings(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			if c.res == nil {
-				t.Fatal("merge result expectancy cannot be nil")
-			}
+			testutil.Assert(t, c.res != nil, "merge result expectancy cannot be nil")
 
 			expected, err := ExpandPostings(c.res)
 			testutil.Ok(t, err)
@@ -410,10 +401,7 @@ func TestMergedPostings(t *testing.T) {
 				testutil.Equals(t, EmptyPostings(), m)
 				return
 			}
-
-			if m == EmptyPostings() {
-				t.Fatal("merge unexpected result: EmptyPostings sentinel")
-			}
+			testutil.Assert(t, m != EmptyPostings(), "merge unexpected result: EmptyPostings sentinel")
 
 			res, err := ExpandPostings(m)
 			testutil.Ok(t, err)
@@ -789,9 +777,7 @@ func TestWithoutPostings(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			if c.res == nil {
-				t.Fatal("without result expectancy cannot be nil")
-			}
+			testutil.Assert(t, c.res != nil, "without result expectancy cannot be nil")
 
 			expected, err := ExpandPostings(c.res)
 			testutil.Ok(t, err)
@@ -802,10 +788,7 @@ func TestWithoutPostings(t *testing.T) {
 				testutil.Equals(t, EmptyPostings(), w)
 				return
 			}
-
-			if w == EmptyPostings() {
-				t.Fatal("without unexpected result: EmptyPostings sentinel")
-			}
+			testutil.Assert(t, w != EmptyPostings(), "without unexpected result: EmptyPostings sentinel")
 
 			res, err := ExpandPostings(w)
 			testutil.Ok(t, err)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1526,19 +1526,9 @@ func TestFindSetMatches(t *testing.T) {
 	for _, c := range cases {
 		matches := findSetMatches(c.pattern)
 		if len(c.exp) == 0 {
-			if len(matches) != 0 {
-				t.Errorf("Evaluating %s, unexpected result %v", c.pattern, matches)
-			}
+			testutil.Assert(t, len(matches) == 0, "Evaluating %s, unexpected result %v", c.pattern, matches)
 		} else {
-			if len(matches) != len(c.exp) {
-				t.Errorf("Evaluating %s, length of result not equal to exp", c.pattern)
-			} else {
-				for i := 0; i < len(c.exp); i++ {
-					if c.exp[i] != matches[i] {
-						t.Errorf("Evaluating %s, unexpected result %s", c.pattern, matches[i])
-					}
-				}
-			}
+			testutil.Equals(t, c.exp, matches)
 		}
 	}
 }
@@ -1787,16 +1777,12 @@ func TestPostingsForMatchers(t *testing.T) {
 		for p.Next() {
 			lbls := labels.Labels{}
 			testutil.Ok(t, ir.Series(p.At(), &lbls, &[]chunks.Meta{}))
-			if _, ok := exp[lbls.String()]; !ok {
-				t.Errorf("Evaluating %v, unexpected result %s", c.matchers, lbls.String())
-			} else {
-				delete(exp, lbls.String())
-			}
+			_, ok := exp[lbls.String()]
+			testutil.Assert(t, ok, "Evaluating %v, unexpected result %s", c.matchers, lbls.String())
+			delete(exp, lbls.String())
 		}
 		testutil.Ok(t, p.Err())
-		if len(exp) != 0 {
-			t.Errorf("Evaluating %v, missing results %+v", c.matchers, exp)
-		}
+		testutil.Assert(t, len(exp) == 0, "Evaluating %v, missing results %+v", c.matchers, exp)
 	}
 
 }
@@ -1804,9 +1790,7 @@ func TestPostingsForMatchers(t *testing.T) {
 // TestClose ensures that calling Close more than once doesn't block and doesn't panic.
 func TestClose(t *testing.T) {
 	dir, err := ioutil.TempDir("", "test_storage")
-	if err != nil {
-		t.Fatalf("Opening test dir failed: %s", err)
-	}
+	testutil.Ok(t, err)
 	defer func() {
 		testutil.Ok(t, os.RemoveAll(dir))
 	}()
@@ -1815,9 +1799,7 @@ func TestClose(t *testing.T) {
 	createBlock(t, dir, genSeries(1, 1, 10, 20))
 
 	db, err := Open(dir, nil, nil, DefaultOptions())
-	if err != nil {
-		t.Fatalf("Opening test storage failed: %s", err)
-	}
+	testutil.Ok(t, err)
 	defer func() {
 		testutil.Ok(t, db.Close())
 	}()

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1525,11 +1525,7 @@ func TestFindSetMatches(t *testing.T) {
 
 	for _, c := range cases {
 		matches := findSetMatches(c.pattern)
-		if len(c.exp) == 0 {
-			testutil.Assert(t, len(matches) == 0, "Evaluating %s, unexpected result %v", c.pattern, matches)
-		} else {
-			testutil.Equals(t, c.exp, matches)
-		}
+		testutil.Equals(t, c.exp, matches)
 	}
 }
 

--- a/tsdb/tsdbutil/buffer_test.go
+++ b/tsdb/tsdbutil/buffer_test.go
@@ -72,10 +72,10 @@ func TestSampleRing(t *testing.T) {
 					}
 				}
 
-				if sold.t >= s.t-c.delta {
-					testutil.Assert(t, found, "%d: expected sample %d to be in buffer but was not; buffer %v", i, sold.t, buffered)
+				if found {
+					testutil.Assert(t, sold.t >= s.t-c.delta, "%d: unexpected sample %d in buffer; buffer %v", i, sold.t, buffered)
 				} else {
-					testutil.Assert(t, !found, "%d: unexpected sample %d in buffer; buffer %v", i, sold.t, buffered)
+					testutil.Assert(t, sold.t < s.t-c.delta, "%d: expected sample %d to be in buffer but was not; buffer %v", i, sold.t, buffered)
 				}
 			}
 		}

--- a/tsdb/tsdbutil/buffer_test.go
+++ b/tsdb/tsdbutil/buffer_test.go
@@ -71,11 +71,11 @@ func TestSampleRing(t *testing.T) {
 						break
 					}
 				}
-				if sold.t >= s.t-c.delta && !found {
-					t.Fatalf("%d: expected sample %d to be in buffer but was not; buffer %v", i, sold.t, buffered)
-				}
-				if sold.t < s.t-c.delta && found {
-					t.Fatalf("%d: unexpected sample %d in buffer; buffer %v", i, sold.t, buffered)
+
+				if sold.t >= s.t-c.delta {
+					testutil.Assert(t, found, "%d: expected sample %d to be in buffer but was not; buffer %v", i, sold.t, buffered)
+				} else {
+					testutil.Assert(t, !found, "%d: unexpected sample %d in buffer; buffer %v", i, sold.t, buffered)
 				}
 			}
 		}

--- a/tsdb/wal/reader_test.go
+++ b/tsdb/wal/reader_test.go
@@ -180,10 +180,10 @@ func TestReader(t *testing.T) {
 					testutil.Assert(t, j < len(c.exp), "received more records than expected")
 					testutil.Equals(t, c.exp[j], rec, "Bytes within record did not match expected Bytes")
 				}
-				if !c.fail {
-					testutil.Ok(t, r.Err())
-				} else {
+				if c.fail {
 					testutil.NotOk(t, r.Err())
+				} else {
+					testutil.Ok(t, r.Err())
 				}
 			})
 		}

--- a/tsdb/wal/reader_test.go
+++ b/tsdb/wal/reader_test.go
@@ -177,17 +177,13 @@ func TestReader(t *testing.T) {
 				for j := 0; r.Next(); j++ {
 					t.Logf("record %d", j)
 					rec := r.Record()
-
-					if j >= len(c.exp) {
-						t.Fatal("received more records than expected")
-					}
+					testutil.Assert(t, j < len(c.exp), "received more records than expected")
 					testutil.Equals(t, c.exp[j], rec, "Bytes within record did not match expected Bytes")
 				}
-				if !c.fail && r.Err() != nil {
-					t.Fatalf("unexpected error: %s", r.Err())
-				}
-				if c.fail && r.Err() == nil {
-					t.Fatalf("expected error but got none")
+				if !c.fail {
+					testutil.Ok(t, r.Err())
+				} else {
+					testutil.NotOk(t, r.Err())
 				}
 			})
 		}

--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -15,7 +15,6 @@
 package wal
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -195,9 +194,7 @@ func TestWALRepair_ReadingError(t *testing.T) {
 			testutil.Equals(t, test.intactRecs, len(result), "Wrong number of intact records")
 
 			for i, r := range result {
-				if !bytes.Equal(records[i], r) {
-					t.Fatalf("record %d diverges: want %x, got %x", i, records[i][:10], r[:10])
-				}
+				testutil.Equals(t, records[i], r)
 			}
 
 			// Make sure there is a new 0 size Segment after the corrupted Segment.


### PR DESCRIPTION
In this PR, I modified the tsdb tests by replacing **t.Error, t.Fail** and **t.Fatal** with testutil helpers like **Ok, Assert** and **Equals**.

Solves issue #8063 
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->