### PR TITLE
promtool: Add TLSClientConfig to query subcmd

### DIFF
--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/api"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -56,14 +57,15 @@ func TestQueryRange(t *testing.T) {
 	require.Equal(t, nil, err)
 
 	p := &promqlPrinter{}
-	exitCode := QueryRange(urlObject, map[string]string{}, "up", "0", "300", 0, p)
+	rt := api.DefaultRoundTripper
+	exitCode := QueryRange(urlObject, map[string]string{}, "up", "0", "300", 0, p, rt)
 	require.Equal(t, "/api/v1/query_range", getRequest().URL.Path)
 	form := getRequest().Form
 	require.Equal(t, "up", form.Get("query"))
 	require.Equal(t, "1", form.Get("step"))
 	require.Equal(t, 0, exitCode)
 
-	exitCode = QueryRange(urlObject, map[string]string{}, "up", "0", "300", 10*time.Millisecond, p)
+	exitCode = QueryRange(urlObject, map[string]string{}, "up", "0", "300", 10*time.Millisecond, p, rt)
 	require.Equal(t, "/api/v1/query_range", getRequest().URL.Path)
 	form = getRequest().Form
 	require.Equal(t, "up", form.Get("query"))
@@ -79,7 +81,8 @@ func TestQueryInstant(t *testing.T) {
 	require.Equal(t, nil, err)
 
 	p := &promqlPrinter{}
-	exitCode := QueryInstant(urlObject, "up", "300", p)
+	rt := api.DefaultRoundTripper
+	exitCode := QueryInstant(urlObject, "up", "300", p, rt)
 	require.Equal(t, "/api/v1/query", getRequest().URL.Path)
 	form := getRequest().Form
 	require.Equal(t, "up", form.Get("query"))


### PR DESCRIPTION
This adds client cert support to promtool query subcmd, allowing queries against a prometheus server.

Usage:
```
./promtool query --cacert chain.pem --cert client.pem --key key.pem instant $SERVER $QUERY
```

```
usage: promtool query instant [<flags>] <server> <expr>

Run instant query.

Flags:
  -h, --help           Show context-sensitive help (also try --help-long and --help-man).
      --version        Show application version.
      --cacert=CACERT  Path to CA Certificate File
      --cert=CERT      Path to Client Certificate File
      --key=KEY        Path to Client Key File
  -o, --format=promql  Output format of the query.
      --time=TIME      Query evaluation time (RFC3339 or Unix timestamp).

Args:
  <server>  Prometheus server to query.
  <expr>    PromQL query expression.
```


Fixes: https://github.com/prometheus/prometheus/issues/8081