### PR TITLE
add networking.k8s.io for ingress

### DIFF
--- a/documentation/examples/rbac-setup.yml
+++ b/documentation/examples/rbac-setup.yml
@@ -22,6 +22,7 @@ rules:
   - extensions
   resources:
   - ingresses
+  - networking.k8s.io
   verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
   verbs: ["get"]

--- a/documentation/examples/rbac-setup.yml
+++ b/documentation/examples/rbac-setup.yml
@@ -20,9 +20,9 @@ rules:
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - extensions
+  - networking.k8s.io
   resources:
   - ingresses
-  - networking.k8s.io
   verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
   verbs: ["get"]


### PR DESCRIPTION
When I start prometheus on kubernetes and config blackbox-exporter for ingress monitor, found error like below and ingress can't be collecterd by prometheus:
level=error ts=2020-10-19T08:32:30.544Z caller=klog.go:96 component=k8s_client_runtime func=ErrorDepth msg="github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:494: Failed to watch *v1beta1.Ingress: failed to list *v1beta1.Ingress: ingresses.networking.k8s.io is forbidden: User \"system:serviceaccount:monitoring:prometheus\" cannot list resource \"ingresses\" in API group \"networking.k8s.io\" at the cluster scope"