### PR TITLE
Add a metric for tracking max_samples_per_send from the remote write

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -64,6 +64,7 @@ type queueManagerMetrics struct {
 	minNumShards          prometheus.Gauge
 	desiredNumShards      prometheus.Gauge
 	bytesSent             prometheus.Counter
+	maxSamplesPerSend     prometheus.Gauge
 }
 
 func newQueueManagerMetrics(r prometheus.Registerer, rn, e string) *queueManagerMetrics {
@@ -176,6 +177,13 @@ func newQueueManagerMetrics(r prometheus.Registerer, rn, e string) *queueManager
 		Help:        "The total number of bytes sent by the queue.",
 		ConstLabels: constLabels,
 	})
+	m.maxSamplesPerSend = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   namespace,
+		Subsystem:   subsystem,
+		Name:        "max_samples_per_send",
+		Help:        "The maximum number of samples to be sent, in a single request, to the remote storage.",
+		ConstLabels: constLabels,
+	})
 
 	return m
 }
@@ -197,6 +205,7 @@ func (m *queueManagerMetrics) register() {
 			m.minNumShards,
 			m.desiredNumShards,
 			m.bytesSent,
+			m.maxSamplesPerSend,
 		)
 	}
 }
@@ -217,6 +226,7 @@ func (m *queueManagerMetrics) unregister() {
 		m.reg.Unregister(m.minNumShards)
 		m.reg.Unregister(m.desiredNumShards)
 		m.reg.Unregister(m.bytesSent)
+		m.reg.Unregister(m.maxSamplesPerSend)
 	}
 }
 
@@ -372,6 +382,7 @@ func (t *QueueManager) Start() {
 	t.metrics.maxNumShards.Set(float64(t.cfg.MaxShards))
 	t.metrics.minNumShards.Set(float64(t.cfg.MinShards))
 	t.metrics.desiredNumShards.Set(float64(t.cfg.MinShards))
+	t.metrics.maxSamplesPerSend.Set(float64(t.cfg.MaxSamplesPerSend))
 
 	t.shards.start(t.numShards)
 	t.watcher.Start()


### PR DESCRIPTION
Currently, there is no way of tracking the value of the `max_samples_per_send` configuration option, which is sometimes tweaked when integrating with a remote write backend. This PR adds a new `max_samples_per_send` gauge for this purpose.

We could also add/use the metric in the remote write section of the prometheus-mixin.