### PR TITLE
Hardcoded sorting of query results

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -378,7 +378,6 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 			panic("Error converting to vector")
 		}
 		sort.Slice(vec, func(i, j int) bool {
-			// return labels.Compare((vec)[i].Metric, (vec)[j].Metric) > 0
 			return vec[i].V > vec[j].V
 		})
 	} else if res.Value.Type() == "matrix" {
@@ -386,11 +385,9 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 		if !ok {
 			panic("Error converting to matrix")
 		}
-		if mat != nil {
-			sort.Slice(mat, func(i, j int) bool {
-				return (sum(mat[i]) > sum(mat[j]))
-			})
-		}
+		sort.Slice(mat, func(i, j int) bool {
+			return (sum(mat[i]) > sum(mat[j]))
+		})
 	}
 
 	// Optional stats field in response if parameter "stats" is not empty.
@@ -486,11 +483,9 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 		if !ok {
 			panic("Error converting to matrix")
 		}
-		if mat != nil {
-			sort.Slice(mat, func(i, j int) bool {
-				return (sum(mat[i]) > sum(mat[j]))
-			})
-		}
+		sort.Slice(mat, func(i, j int) bool {
+			return (sum(mat[i]) > sum(mat[j]))
+		})
 	}
 
 	// Optional stats field in response if parameter "stats" is not empty.

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -487,13 +487,13 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 	}()
 
 	ctx = httputil.ContextFromRequest(ctx, r)
-	var rank RankingFunction = Rank{}
 
 	res := qry.Exec(ctx)
 	if res.Err != nil {
 		return apiFuncResult{nil, returnAPIError(res.Err), res.Warnings, qry.Close}
 	}
 
+	var rank RankingFunction = Rank{}
 	if res.Value.Type() == parser.ValueTypeMatrix {
 		mat, ok := res.Value.(promql.Matrix)
 		if !ok {

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -372,18 +372,20 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 		return apiFuncResult{nil, returnAPIError(res.Err), res.Warnings, qry.Close}
 	}
 
-	if res.Value.Type() == "vector" {
+	if res.Value.Type() == parser.ValueTypeVector {
 		vec, ok := res.Value.(promql.Vector)
 		if !ok {
-			panic("Error converting to vector")
+			err := errors.New("Cannot convert to vector")
+			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 		}
 		sort.Slice(vec, func(i, j int) bool {
 			return vec[i].V > vec[j].V
 		})
-	} else if res.Value.Type() == "matrix" {
+	} else if res.Value.Type() == parser.ValueTypeMatrix {
 		mat, ok := res.Value.(promql.Matrix)
 		if !ok {
-			panic("Error converting to matrix")
+			err := errors.New("Cannot convert to matrix")
+			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 		}
 		sort.Slice(mat, func(i, j int) bool {
 			return (sum(mat[i]) > sum(mat[j]))
@@ -478,10 +480,11 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 		return apiFuncResult{nil, returnAPIError(res.Err), res.Warnings, qry.Close}
 	}
 
-	if res.Value.Type() == "matrix" {
+	if res.Value.Type() == parser.ValueTypeMatrix {
 		mat, ok := res.Value.(promql.Matrix)
 		if !ok {
-			panic("Error converting to matrix")
+			err := errors.New("Cannot convert to matrix")
+			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 		}
 		sort.Slice(mat, func(i, j int) bool {
 			return (sum(mat[i]) > sum(mat[j]))

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -679,6 +679,22 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 						},
 						Metric: nil,
 					},
+					promql.Series{
+						Points: []promql.Point{
+							{V: 3, T: timestamp.FromTime(start)},
+							{V: 1, T: timestamp.FromTime(start.Add(1 * time.Second))},
+							{V: 2, T: timestamp.FromTime(start.Add(2 * time.Second))},
+						},
+						Metric: nil,
+					},
+					promql.Series{
+						Points: []promql.Point{
+							{V: 1, T: timestamp.FromTime(start)},
+							{V: 4, T: timestamp.FromTime(start.Add(1 * time.Second))},
+							{V: 5, T: timestamp.FromTime(start.Add(2 * time.Second))},
+						},
+						Metric: nil,
+					},
 				},
 			},
 		},

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -670,15 +670,15 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 			},
 			response: &queryData{
 				ResultType: parser.ValueTypeMatrix,
-				Result:     promql.Matrix{
-					// promql.Series{
-					// Points: []promql.Point{
-					// 	{V: 0, T: timestamp.FromTime(start)},
-					// 	{V: 1, T: timestamp.FromTime(start.Add(1 * time.Second))},
-					// 	{V: 2, T: timestamp.FromTime(start.Add(2 * time.Second))},
-					// },
-					// Metric: nil,
-					// },
+				Result: promql.Matrix{
+					promql.Series{
+						Points: []promql.Point{
+							{V: 0, T: timestamp.FromTime(start)},
+							{V: 1, T: timestamp.FromTime(start.Add(1 * time.Second))},
+							{V: 2, T: timestamp.FromTime(start.Add(2 * time.Second))},
+						},
+						Metric: nil,
+					},
 				},
 			},
 		},

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -614,6 +614,75 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 			},
 		},
 		{
+			endpoint: api.query,
+			query: url.Values{
+				"query": []string{"prometheus_target_interval_length_seconds"},
+			},
+			response: &queryData{
+				ResultType: parser.ValueTypeVector,
+				Result: promql.Vector{
+
+					{
+						Point: promql.Point{
+							V: 2.000542683,
+							T: timestamp.FromTime(api.now()),
+						},
+						Metric: nil,
+					},
+					{
+						Point: promql.Point{
+							V: 2.000355733,
+							T: timestamp.FromTime(api.now()),
+						},
+						Metric: nil,
+					},
+					{
+						Point: promql.Point{
+							V: 2.00001554,
+							T: timestamp.FromTime(api.now()),
+						},
+						Metric: nil,
+					},
+					{
+						Point: promql.Point{
+							V: 1.999594005,
+							T: timestamp.FromTime(api.now()),
+						},
+						Metric: nil,
+					},
+					{
+						Point: promql.Point{
+							V: 1.9994983290000001,
+							T: timestamp.FromTime(api.now()),
+						},
+						Metric: nil,
+					},
+				},
+			},
+		},
+		{
+			endpoint: api.queryRange,
+			query: url.Values{
+				"query": []string{"prometheus_target_interval_length_seconds"},
+				"start": []string{"0"},
+				"end":   []string{"2"},
+				"step":  []string{"1"},
+			},
+			response: &queryData{
+				ResultType: parser.ValueTypeMatrix,
+				Result:     promql.Matrix{
+					// promql.Series{
+					// Points: []promql.Point{
+					// 	{V: 0, T: timestamp.FromTime(start)},
+					// 	{V: 1, T: timestamp.FromTime(start.Add(1 * time.Second))},
+					// 	{V: 2, T: timestamp.FromTime(start.Add(2 * time.Second))},
+					// },
+					// Metric: nil,
+					// },
+				},
+			},
+		},
+		{
 			endpoint: api.queryRange,
 			query: url.Values{
 				"query": []string{"time()"},

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -673,9 +673,9 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				Result: promql.Matrix{
 					promql.Series{
 						Points: []promql.Point{
-							{V: 0, T: timestamp.FromTime(start)},
-							{V: 1, T: timestamp.FromTime(start.Add(1 * time.Second))},
-							{V: 2, T: timestamp.FromTime(start.Add(2 * time.Second))},
+							{V: 1, T: timestamp.FromTime(start)},
+							{V: 4, T: timestamp.FromTime(start.Add(1 * time.Second))},
+							{V: 5, T: timestamp.FromTime(start.Add(2 * time.Second))},
 						},
 						Metric: nil,
 					},
@@ -689,9 +689,9 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					},
 					promql.Series{
 						Points: []promql.Point{
-							{V: 1, T: timestamp.FromTime(start)},
-							{V: 4, T: timestamp.FromTime(start.Add(1 * time.Second))},
-							{V: 5, T: timestamp.FromTime(start.Add(2 * time.Second))},
+							{V: 0, T: timestamp.FromTime(start)},
+							{V: 1, T: timestamp.FromTime(start.Add(1 * time.Second))},
+							{V: 2, T: timestamp.FromTime(start.Add(2 * time.Second))},
 						},
 						Metric: nil,
 					},


### PR DESCRIPTION
Added sorting for instant query based on values and for range queries based on the ranking sum, both in descending order.
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->