### PR TITLE
doc: Add $value variable description

### DIFF
--- a/docs/configuration/alerting_rules.md
+++ b/docs/configuration/alerting_rules.md
@@ -47,6 +47,7 @@ templates](https://prometheus.io/docs/visualization/consoles).  The `$labels`
 variable holds the label key/value pairs of an alert instance. The configured
 external labels can be accessed via the `$externalLabels` variable. The
 `$value` variable holds the evaluated value of an alert instance.
+When the alert is restored, that sample value will no longer be returned.
 
     # To insert a firing element's label values:
     {{ $labels.<labelname> }}


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->