### PR TITLE
Fixed WAL corruption on partial writes

### DIFF
--- a/tsdb/wal/wal.go
+++ b/tsdb/wal/wal.go
@@ -74,9 +74,18 @@ func (p *page) reset() {
 	p.flushed = 0
 }
 
+// SegmentFile represents the underlying file used to store a segment.
+type SegmentFile interface {
+	Stat() (os.FileInfo, error)
+	Sync() error
+	io.Writer
+	io.Reader
+	io.Closer
+}
+
 // Segment represents a segment file.
 type Segment struct {
-	*os.File
+	SegmentFile
 	dir string
 	i   int
 }
@@ -130,7 +139,7 @@ func OpenWriteSegment(logger log.Logger, dir string, k int) (*Segment, error) {
 			return nil, errors.Wrap(err, "zero-pad torn page")
 		}
 	}
-	return &Segment{File: f, i: k, dir: dir}, nil
+	return &Segment{SegmentFile: f, i: k, dir: dir}, nil
 }
 
 // CreateSegment creates a new segment k in dir.
@@ -139,7 +148,7 @@ func CreateSegment(dir string, k int) (*Segment, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Segment{File: f, i: k, dir: dir}, nil
+	return &Segment{SegmentFile: f, i: k, dir: dir}, nil
 }
 
 // OpenReadSegment opens the segment with the given filename.
@@ -152,7 +161,7 @@ func OpenReadSegment(fn string) (*Segment, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Segment{File: f, i: k, dir: filepath.Dir(fn)}, nil
+	return &Segment{SegmentFile: f, i: k, dir: filepath.Dir(fn)}, nil
 }
 
 // WAL is a write ahead log that stores records in segment files.
@@ -517,8 +526,10 @@ func (w *WAL) flushPage(clear bool) error {
 	if clear {
 		p.alloc = pageSize // Write till end of page.
 	}
+
 	n, err := w.segment.Write(p.buf[p.flushed:p.alloc])
 	if err != nil {
+		p.flushed += n
 		return err
 	}
 	p.flushed += n
@@ -664,6 +675,9 @@ func (w *WAL) log(rec []byte, final bool) error {
 
 		if w.page.full() {
 			if err := w.flushPage(true); err != nil {
+				// TODO When the flushing fails at this point and the record has not been
+				// fully written to the buffer, we end up with a corrupted WAL because some part of the
+				// record have been written to the buffer, while the rest of the record will be discarded.
 				return err
 			}
 		}
@@ -705,7 +719,7 @@ func (w *WAL) Truncate(i int) (err error) {
 
 func (w *WAL) fsync(f *Segment) error {
 	start := time.Now()
-	err := f.File.Sync()
+	err := f.Sync()
 	w.metrics.fsyncDuration.Observe(time.Since(start).Seconds())
 	return err
 }

--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -439,7 +439,7 @@ func TestLogPartialWrite(t *testing.T) {
 		},
 		"partial write when logging record in the middle of a page": {
 			numRecords:   10,
-			faultyRecord: 1,
+			faultyRecord: 3,
 		},
 		"partial write when logging last record of a page": {
 			numRecords:   (pageSize / (recordHeaderSize + len(record))) + 10,

--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -494,22 +494,22 @@ func TestLogPartialWrite(t *testing.T) {
 type faultySegmentFile struct {
 	SegmentFile
 
-	writeCount      int
+	written         int
 	writeFailureAt  int
 	writeFailureErr error
 }
 
 func (f *faultySegmentFile) Write(p []byte) (int, error) {
-	if f.writeFailureAt <= f.writeCount || f.writeFailureAt > f.writeCount+len(p) {
+	if f.writeFailureAt <= f.written || f.writeFailureAt > f.written+len(p) {
 		n, err := f.SegmentFile.Write(p)
-		f.writeCount += n
+		f.written += n
 		return n, err
 	}
 
 	// Inject failure.
-	partialLen := f.writeFailureAt - f.writeCount
+	partialLen := f.writeFailureAt - f.written
 	n, _ := f.SegmentFile.Write(p[:partialLen])
-	f.writeCount += n
+	f.written += n
 	return n, f.writeFailureErr
 }
 


### PR DESCRIPTION
This week we got a couple of incidents in our Cortex cluster caused by WAL corruption. Specifically, we got this error:
```
reload blocks: head truncate failed: create checkpoint: read segments: corruption in segment /<redacted>/wal/00028082 at 92762769: unexpected checksum fb8694d0, expected 89d4e21d
```

We noticed that in both incidents, some time before TSDB logged a train of these errors for a short period:
```
write to WAL: log samples: write /<redacted>/wal/00028082: cannot allocate memory
```

The `cannot allocate memory` comes from `WAL.flushPage()`, specifically the call to `w.segment.Write()`. My **theory** is that the WAL corruption happens when a partial write happens, which is when the `os.File.Write()` returns error but some bytes have been written.

Following this theory, I've reproduced the corruption in a unit test and in this PR I'm proposing a fix. Unfortunately, the fix doesn't solve WAL corruption in all scenarios: I can't find an easy way to solve the case the partial write happens while writing the initial part of a record which spans over 2 pages. I left a couple of `TODO` comments to show it. Any idea how to solve it?