### PR TITLE
Expose a metric with the current value of sample_limit per scrape pool

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1328,7 +1328,7 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 
 	// Get the value of the Counter before performing the append.
 	beforeMetric := dto.Metric{}
-	err := targetScrapeSampleLimit.Write(&beforeMetric)
+	err := targetScrapeExceededSampleLimit.Write(&beforeMetric)
 	assert.NoError(t, err)
 
 	beforeMetricValue := beforeMetric.GetCounter().GetValue()
@@ -1347,7 +1347,7 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 	// Check that the Counter has been incremented a single time for the scrape,
 	// not multiple times for each sample.
 	metric := dto.Metric{}
-	err = targetScrapeSampleLimit.Write(&metric)
+	err = targetScrapeExceededSampleLimit.Write(&metric)
 	assert.NoError(t, err)
 
 	value := metric.GetCounter().GetValue()


### PR DESCRIPTION
For target limit there is a metric prometheus_target_scrape_pool_target_limit that can be used to check how close given pool is to the limit. There is no such metric for sample limit, which makes it hard to query for scrape pools close to configured sample limit.
Add prometheus_target_scrape_pool_sample_limit exposing the value of sample_limit scrape config option.

Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->