### PR TITLE
API: Make snapshot length always the same size

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1478,9 +1478,9 @@ func (api *API) snapshot(r *http.Request) apiFuncResult {
 
 	var (
 		snapdir = filepath.Join(api.dbDir, "snapshots")
-		name    = fmt.Sprintf("%s-%x",
+		name    = fmt.Sprintf("%s-%016x",
 			time.Now().UTC().Format("20060102T150405Z0700"),
-			rand.Int())
+			rand.Int63())
 		dir = filepath.Join(snapdir, name)
 	)
 	if err := os.MkdirAll(dir, 0777); err != nil {


### PR DESCRIPTION
Fixes #8135

Minor improvement, also we now use Int64 even on 32 bit systems.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->