### PR TITLE
Calculate head chunk size based on actual disk usage

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -105,10 +105,6 @@ type ChunkDiskMapper struct {
 	// from which chunks are served till they are flushed and are ready for m-mapping.
 	chunkBuffer *chunkBuffer
 
-	// The total size of bytes in the closed files.
-	// Needed to calculate the total size of all segments on disk.
-	size atomic.Int64
-
 	// If 'true', it indicated that the maxt of all the on-disk files were set
 	// after iterating through all the chunks in those files.
 	fileMaxtSet bool
@@ -181,8 +177,6 @@ func (cdm *ChunkDiskMapper) openMMapFiles() (returnErr error) {
 		chkFileIndices = append(chkFileIndices, seq)
 	}
 
-	cdm.size.Store(int64(0))
-
 	// Check for gaps in the files.
 	sort.Ints(chkFileIndices)
 	if len(chkFileIndices) == 0 {
@@ -209,8 +203,6 @@ func (cdm *ChunkDiskMapper) openMMapFiles() (returnErr error) {
 		if v := int(b.byteSlice.Range(MagicChunksSize, MagicChunksSize+ChunksFormatVersionSize)[0]); v != chunksFormatV1 {
 			return errors.Errorf("%s: invalid chunk format version %d", files[i], v)
 		}
-
-		cdm.size.Add(int64(b.byteSlice.Len()))
 	}
 
 	return nil
@@ -371,7 +363,6 @@ func (cdm *ChunkDiskMapper) cut() (returnErr error) {
 		}
 	}()
 
-	cdm.size.Add(cdm.curFileSize())
 	cdm.curFileNumBytes.Store(int64(n))
 
 	if cdm.curFile != nil {
@@ -727,7 +718,6 @@ func (cdm *ChunkDiskMapper) deleteFiles(removedFiles []int) error {
 			cdm.readPathMtx.Unlock()
 			return err
 		}
-		cdm.size.Sub(int64(cdm.mmappedChunkFiles[seq].byteSlice.Len()))
 		delete(cdm.mmappedChunkFiles, seq)
 		delete(cdm.closers, seq)
 	}
@@ -766,8 +756,8 @@ func (cdm *ChunkDiskMapper) DeleteCorrupted(originalErr error) error {
 }
 
 // Size returns the size of the chunk files.
-func (cdm *ChunkDiskMapper) Size() int64 {
-	return cdm.size.Load() + cdm.curFileSize()
+func (cdm *ChunkDiskMapper) Size() (int64, error) {
+	return fileutil.DirSize(cdm.dir.Name())
 }
 
 func (cdm *ChunkDiskMapper) curFileSize() int64 {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2373,7 +2373,8 @@ func (h *Head) Size() int64 {
 	if h.wal != nil {
 		walSize, _ = h.wal.Size()
 	}
-	return walSize + h.chunkDiskMapper.Size()
+	cdmSize, _ := h.chunkDiskMapper.Size()
+	return walSize + cdmSize
 }
 
 func (h *RangeHead) Size() int64 {


### PR DESCRIPTION
By using fileutil, we take the exact size of the folder, as we do for
the wal.

My understanding of the original issue is that the ByteSlice of the MMAped file is always the max file size, even if it is not allocated.

This is always removing MaxHeadChunkFileSize: 
https://github.com/prometheus/prometheus/blob/7558e9d3c374b00fbb20c119cd0bca98db83efb3/tsdb/chunks/head_chunks.go#L730

Therefore we always remove MaxHeadChunkFileSize from the size of the chunks head, even if on disk space was not used, causing the "calculated" head chunks size to be < 0, therefore breaking size based retention.

This is correct, but when the segment will be deleted, we would remove  MaxHeadChunkFileSize, which can be greater than this.
https://github.com/prometheus/prometheus/blob/7558e9d3c374b00fbb20c119cd0bca98db83efb3/tsdb/chunks/head_chunks.go#L374

It also means that we can then further optimize memory consumption of those head chunks, once we have cut them, we should cut the size of the byteslice in memory, but I'll let that for the tsdb experts.

cc @codesome, TSDB maintainer
cc @brancz While not introduced in 2.22, this bugfix might make it in a 2.22.1 release.

Thanks @ArthurSens for the inspiration and the initial research!


Fixes #8005 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->