### PR TITLE
Volunteer for v2.23 release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,7 +27,9 @@ Release cadence of first pre-releases being cut is 6 weeks.
 | v2.20          | 2020-07-15                                 | Björn Rabenstein (GitHub: @beorn7)          |
 | v2.21          | 2020-08-26                                 | Julien Pivotto (GitHub: @roidelapluie)      |
 | v2.22          | 2020-10-07                                 | Frederic Branczyk (GitHub: @brancz)         |
-| v2.23          | 2020-11-18                                 | **searching for volunteer**                 |
+| v2.23          | 2020-11-18                                 | Ganesh Vernekar (GitHub: @codesome)         |
+| v2.24          | 2020-12-30                                 | Björn Rabenstein (GitHub: @beorn7)          |
+| v2.25          | 2021-02-10                                 | **searching for volunteer**                 |
 
 If you are interested in volunteering please create a pull request against the [prometheus/prometheus](https://github.com/prometheus/prometheus) repository and propose yourself for the release series of your choice.
 


### PR DESCRIPTION
Today, I realized we don't have a volunteer for v2.23 yet. After two
releases from non-Grafanistas, perhaps another "Grafana-sponsored"
release is acceptable.

So I'm proposing myself here. @cstyan or @codesome, if any of you (or
anyone else, really) qis also willing to volunteer, I'd happily step
back.
