### PR TITLE
[Improvement] Code quality.

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -704,8 +704,7 @@ func alertmanagerFromGroup(tg *targetgroup.Group, cfg *config.AlertmanagerConfig
 			lbls = append(lbls, labels.Label{Name: string(ln), Value: string(lv)})
 		}
 		// Set configured scheme as the initial scheme label for overwrite.
-		lbls = append(lbls, labels.Label{Name: model.SchemeLabel, Value: cfg.Scheme})
-		lbls = append(lbls, labels.Label{Name: pathLabel, Value: postPath(cfg.PathPrefix, cfg.APIVersion)})
+        lbls = append(lbls, labels.Label{Name: model.SchemeLabel, Value: cfg.Scheme}, labels.Label{Name: pathLabel, Value: postPath(cfg.PathPrefix, cfg.APIVersion)})
 
 		// Combine target labels with target group labels.
 		for ln, lv := range tg.Labels {

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -704,7 +704,7 @@ func alertmanagerFromGroup(tg *targetgroup.Group, cfg *config.AlertmanagerConfig
 			lbls = append(lbls, labels.Label{Name: string(ln), Value: string(lv)})
 		}
 		// Set configured scheme as the initial scheme label for overwrite.
-        lbls = append(lbls, labels.Label{Name: model.SchemeLabel, Value: cfg.Scheme}, labels.Label{Name: pathLabel, Value: postPath(cfg.PathPrefix, cfg.APIVersion)})
+		lbls = append(lbls, labels.Label{Name: model.SchemeLabel, Value: cfg.Scheme}, labels.Label{Name: pathLabel, Value: postPath(cfg.PathPrefix, cfg.APIVersion)})
 
 		// Combine target labels with target group labels.
 		for ln, lv := range tg.Labels {

--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -38,26 +38,23 @@ func BenchmarkRangeQuery(b *testing.B) {
 	engine := NewEngine(opts)
 
 	metrics := []labels.Labels{}
-	metrics = append(metrics, labels.FromStrings("__name__", "a_one"))
-	metrics = append(metrics, labels.FromStrings("__name__", "b_one"))
-	for j := 0; j < 10; j++ {
+	metrics = append(metrics, labels.FromStrings("__name__", "a_one"), labels.FromStrings("__name__", "b_one"))
+    for j := 0; j < 10; j++ {
 		metrics = append(metrics, labels.FromStrings("__name__", "h_one", "le", strconv.Itoa(j)))
 	}
 	metrics = append(metrics, labels.FromStrings("__name__", "h_one", "le", "+Inf"))
 
 	for i := 0; i < 10; i++ {
-		metrics = append(metrics, labels.FromStrings("__name__", "a_ten", "l", strconv.Itoa(i)))
-		metrics = append(metrics, labels.FromStrings("__name__", "b_ten", "l", strconv.Itoa(i)))
-		for j := 0; j < 10; j++ {
+		metrics = append(metrics, labels.FromStrings("__name__", "a_ten", "l", strconv.Itoa(i)), labels.FromStrings("__name__", "b_ten", "l", strconv.Itoa(i)))
+        for j := 0; j < 10; j++ {
 			metrics = append(metrics, labels.FromStrings("__name__", "h_ten", "l", strconv.Itoa(i), "le", strconv.Itoa(j)))
 		}
 		metrics = append(metrics, labels.FromStrings("__name__", "h_ten", "l", strconv.Itoa(i), "le", "+Inf"))
 	}
 
 	for i := 0; i < 100; i++ {
-		metrics = append(metrics, labels.FromStrings("__name__", "a_hundred", "l", strconv.Itoa(i)))
-		metrics = append(metrics, labels.FromStrings("__name__", "b_hundred", "l", strconv.Itoa(i)))
-		for j := 0; j < 10; j++ {
+		metrics = append(metrics, labels.FromStrings("__name__", "a_hundred", "l", strconv.Itoa(i)), labels.FromStrings("__name__", "b_hundred", "l", strconv.Itoa(i)))
+        for j := 0; j < 10; j++ {
 			metrics = append(metrics, labels.FromStrings("__name__", "h_hundred", "l", strconv.Itoa(i), "le", strconv.Itoa(j)))
 		}
 		metrics = append(metrics, labels.FromStrings("__name__", "h_hundred", "l", strconv.Itoa(i), "le", "+Inf"))
@@ -179,9 +176,7 @@ func BenchmarkRangeQuery(b *testing.B) {
 		if !strings.Contains(c.expr, "X") {
 			tmp = append(tmp, c)
 		} else {
-			tmp = append(tmp, benchCase{expr: strings.Replace(c.expr, "X", "one", -1), steps: c.steps})
-			tmp = append(tmp, benchCase{expr: strings.Replace(c.expr, "X", "ten", -1), steps: c.steps})
-			tmp = append(tmp, benchCase{expr: strings.Replace(c.expr, "X", "hundred", -1), steps: c.steps})
+            tmp = append(tmp, benchCase{expr: strings.Replace(c.expr, "X", "one", -1), steps: c.steps}, benchCase{expr: strings.Replace(c.expr, "X", "ten", -1), steps: c.steps}, benchCase{expr: strings.Replace(c.expr, "X", "hundred", -1), steps: c.steps})
 		}
 	}
 	cases = tmp
@@ -192,10 +187,7 @@ func BenchmarkRangeQuery(b *testing.B) {
 		if c.steps != 0 {
 			tmp = append(tmp, c)
 		} else {
-			tmp = append(tmp, benchCase{expr: c.expr, steps: 1})
-			tmp = append(tmp, benchCase{expr: c.expr, steps: 10})
-			tmp = append(tmp, benchCase{expr: c.expr, steps: 100})
-			tmp = append(tmp, benchCase{expr: c.expr, steps: 1000})
+            tmp = append(tmp, benchCase{expr: c.expr, steps: 1}, benchCase{expr: c.expr, steps: 10}, benchCase{expr: c.expr, steps: 100}, benchCase{expr: c.expr, steps: 1000})
 		}
 	}
 	cases = tmp

--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -39,14 +39,14 @@ func BenchmarkRangeQuery(b *testing.B) {
 
 	metrics := []labels.Labels{}
 	metrics = append(metrics, labels.FromStrings("__name__", "a_one"), labels.FromStrings("__name__", "b_one"))
-    for j := 0; j < 10; j++ {
+	for j := 0; j < 10; j++ {
 		metrics = append(metrics, labels.FromStrings("__name__", "h_one", "le", strconv.Itoa(j)))
 	}
 	metrics = append(metrics, labels.FromStrings("__name__", "h_one", "le", "+Inf"))
 
 	for i := 0; i < 10; i++ {
 		metrics = append(metrics, labels.FromStrings("__name__", "a_ten", "l", strconv.Itoa(i)), labels.FromStrings("__name__", "b_ten", "l", strconv.Itoa(i)))
-        for j := 0; j < 10; j++ {
+		for j := 0; j < 10; j++ {
 			metrics = append(metrics, labels.FromStrings("__name__", "h_ten", "l", strconv.Itoa(i), "le", strconv.Itoa(j)))
 		}
 		metrics = append(metrics, labels.FromStrings("__name__", "h_ten", "l", strconv.Itoa(i), "le", "+Inf"))
@@ -54,7 +54,7 @@ func BenchmarkRangeQuery(b *testing.B) {
 
 	for i := 0; i < 100; i++ {
 		metrics = append(metrics, labels.FromStrings("__name__", "a_hundred", "l", strconv.Itoa(i)), labels.FromStrings("__name__", "b_hundred", "l", strconv.Itoa(i)))
-        for j := 0; j < 10; j++ {
+		for j := 0; j < 10; j++ {
 			metrics = append(metrics, labels.FromStrings("__name__", "h_hundred", "l", strconv.Itoa(i), "le", strconv.Itoa(j)))
 		}
 		metrics = append(metrics, labels.FromStrings("__name__", "h_hundred", "l", strconv.Itoa(i), "le", "+Inf"))
@@ -176,7 +176,7 @@ func BenchmarkRangeQuery(b *testing.B) {
 		if !strings.Contains(c.expr, "X") {
 			tmp = append(tmp, c)
 		} else {
-            tmp = append(tmp, benchCase{expr: strings.Replace(c.expr, "X", "one", -1), steps: c.steps}, benchCase{expr: strings.Replace(c.expr, "X", "ten", -1), steps: c.steps}, benchCase{expr: strings.Replace(c.expr, "X", "hundred", -1), steps: c.steps})
+			tmp = append(tmp, benchCase{expr: strings.Replace(c.expr, "X", "one", -1), steps: c.steps}, benchCase{expr: strings.Replace(c.expr, "X", "ten", -1), steps: c.steps}, benchCase{expr: strings.Replace(c.expr, "X", "hundred", -1), steps: c.steps})
 		}
 	}
 	cases = tmp
@@ -187,7 +187,7 @@ func BenchmarkRangeQuery(b *testing.B) {
 		if c.steps != 0 {
 			tmp = append(tmp, c)
 		} else {
-            tmp = append(tmp, benchCase{expr: c.expr, steps: 1}, benchCase{expr: c.expr, steps: 10}, benchCase{expr: c.expr, steps: 100}, benchCase{expr: c.expr, steps: 1000})
+			tmp = append(tmp, benchCase{expr: c.expr, steps: 1}, benchCase{expr: c.expr, steps: 10}, benchCase{expr: c.expr, steps: 100}, benchCase{expr: c.expr, steps: 1000})
 		}
 	}
 	cases = tmp

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -412,7 +412,7 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 		}
 
 		if r.restored {
-            vec = append(vec, r.sample(a, ts), r.forStateSample(a, ts, float64(a.ActiveAt.Unix())))
+			vec = append(vec, r.sample(a, ts), r.forStateSample(a, ts, float64(a.ActiveAt.Unix())))
 		}
 	}
 

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -412,8 +412,7 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 		}
 
 		if r.restored {
-			vec = append(vec, r.sample(a, ts))
-			vec = append(vec, r.forStateSample(a, ts, float64(a.ActiveAt.Unix())))
+            vec = append(vec, r.sample(a, ts), r.forStateSample(a, ts, float64(a.ActiveAt.Unix())))
 		}
 	}
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -201,7 +201,7 @@ func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
 		Help: "Size of symbol table in memory for loaded blocks",
 	}, func() float64 {
 		db.mtx.RLock()
-		blocks := db.blocks[:]
+		blocks := db.blocks
 		db.mtx.RUnlock()
 		symTblSize := uint64(0)
 		for _, b := range blocks {
@@ -1519,7 +1519,7 @@ func (db *DB) CleanTombstones() (err error) {
 	}()
 
 	db.mtx.RLock()
-	blocks := db.blocks[:]
+	blocks := db.blocks
 	db.mtx.RUnlock()
 
 	for _, b := range blocks {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1512,7 +1512,7 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 	// Additional case.
 	var nc1 []BlockMeta
 	nc1 = append(nc1, BlockMeta{MinTime: 1, MaxTime: 5}, BlockMeta{MinTime: 2, MaxTime: 3}, BlockMeta{MinTime: 2, MaxTime: 3}, BlockMeta{MinTime: 2, MaxTime: 3}, BlockMeta{MinTime: 2, MaxTime: 3}, BlockMeta{MinTime: 2, MaxTime: 6}, BlockMeta{MinTime: 3, MaxTime: 5}, BlockMeta{MinTime: 5, MaxTime: 7}, BlockMeta{MinTime: 7, MaxTime: 10}, BlockMeta{MinTime: 8, MaxTime: 9})
-    require.Equal(t, Overlaps{
+	require.Equal(t, Overlaps{
 		{Min: 2, Max: 3}: {nc1[0], nc1[1], nc1[2], nc1[3], nc1[4], nc1[5]}, // 1-5, 2-3, 2-3, 2-3, 2-3, 2,6
 		{Min: 3, Max: 5}: {nc1[0], nc1[5], nc1[6]},                         // 1-5, 2-6, 3-5
 		{Min: 5, Max: 6}: {nc1[5], nc1[7]},                                 // 2-6, 5-7

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1511,17 +1511,8 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 
 	// Additional case.
 	var nc1 []BlockMeta
-	nc1 = append(nc1, BlockMeta{MinTime: 1, MaxTime: 5})
-	nc1 = append(nc1, BlockMeta{MinTime: 2, MaxTime: 3})
-	nc1 = append(nc1, BlockMeta{MinTime: 2, MaxTime: 3})
-	nc1 = append(nc1, BlockMeta{MinTime: 2, MaxTime: 3})
-	nc1 = append(nc1, BlockMeta{MinTime: 2, MaxTime: 3})
-	nc1 = append(nc1, BlockMeta{MinTime: 2, MaxTime: 6})
-	nc1 = append(nc1, BlockMeta{MinTime: 3, MaxTime: 5})
-	nc1 = append(nc1, BlockMeta{MinTime: 5, MaxTime: 7})
-	nc1 = append(nc1, BlockMeta{MinTime: 7, MaxTime: 10})
-	nc1 = append(nc1, BlockMeta{MinTime: 8, MaxTime: 9})
-	require.Equal(t, Overlaps{
+	nc1 = append(nc1, BlockMeta{MinTime: 1, MaxTime: 5}, BlockMeta{MinTime: 2, MaxTime: 3}, BlockMeta{MinTime: 2, MaxTime: 3}, BlockMeta{MinTime: 2, MaxTime: 3}, BlockMeta{MinTime: 2, MaxTime: 3}, BlockMeta{MinTime: 2, MaxTime: 6}, BlockMeta{MinTime: 3, MaxTime: 5}, BlockMeta{MinTime: 5, MaxTime: 7}, BlockMeta{MinTime: 7, MaxTime: 10}, BlockMeta{MinTime: 8, MaxTime: 9})
+    require.Equal(t, Overlaps{
 		{Min: 2, Max: 3}: {nc1[0], nc1[1], nc1[2], nc1[3], nc1[4], nc1[5]}, // 1-5, 2-3, 2-3, 2-3, 2-3, 2,6
 		{Min: 3, Max: 5}: {nc1[0], nc1[5], nc1[6]},                         // 1-5, 2-6, 3-5
 		{Min: 5, Max: 6}: {nc1[5], nc1[7]},                                 // 2-6, 5-7

--- a/tsdb/isolation.go
+++ b/tsdb/isolation.go
@@ -182,7 +182,7 @@ func (txr *txRing) add(appendID uint64) {
 	if txr.txIDCount == len(txr.txIDs) {
 		// Ring buffer is full, expand by doubling.
 		newRing := make([]uint64, txr.txIDCount*2)
-		idx := copy(newRing[:], txr.txIDs[txr.txIDFirst:])
+		idx := copy(newRing, txr.txIDs[txr.txIDFirst:])
 		copy(newRing[idx:], txr.txIDs[:txr.txIDFirst])
 		txr.txIDs = newRing
 		txr.txIDFirst = 0

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -229,9 +229,8 @@ func (m rulesRetrieverMock) AlertingRules() []*rules.AlertingRule {
 		log.NewNopLogger(),
 	)
 	var r []*rules.AlertingRule
-	r = append(r, rule1)
-	r = append(r, rule2)
-	return r
+	r = append(r, rule1, rule2)
+    return r
 }
 
 func (m rulesRetrieverMock) RuleGroups() []*rules.Group {

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -230,7 +230,7 @@ func (m rulesRetrieverMock) AlertingRules() []*rules.AlertingRule {
 	)
 	var r []*rules.AlertingRule
 	r = append(r, rule1, rule2)
-    return r
+	return r
 }
 
 func (m rulesRetrieverMock) RuleGroups() []*rules.Group {


### PR DESCRIPTION
This PR improves few code qualities. 
**Commit 1**: If a value is of type slice already, it need not be converted to slice again.
Example:
```
f(s[:])               // s is string
copy(b[:], values...) // b is []byte
```
should be written as:
```
f(s)
copy(b, values...)
```
**Commit 2**: appends can be clubbed into a single call. 
Example:
```
x = append(x, 1)
x = append(x, 2)
```
should be written as:
```
x = append(x, 1, 2)
```
