### PR TITLE
Fix panic with  double close() of channel on /-/quit/

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -918,8 +918,13 @@ func (h *Handler) version(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) quit(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Requesting termination... Goodbye!")
-	close(h.quitCh)
+	select {
+	case <-h.quitCh:
+		fmt.Fprintf(w, "Termination already in progress.")
+	default:
+		fmt.Fprintf(w, "Requesting termination... Goodbye!")
+		close(h.quitCh)
+	}
 }
 
 func (h *Handler) reload(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fix #8144

```
=== RUN   TestHandleMultipleQuitRequests
    web_test.go:492: 
        	Error Trace:	web_test.go:492
        	            				asm_amd64.s:1374
        	Error:      	Received unexpected error:
        	            	Post "http://localhost:9090/-/quit": EOF
        	Test:       	TestHandleMultipleQuitRequests
    web_test.go:492: 
        	Error Trace:	web_test.go:492
        	            				asm_amd64.s:1374
        	Error:      	Received unexpected error:
        	            	Post "http://localhost:9090/-/quit": EOF
        	Test:       	TestHandleMultipleQuitRequests
--- FAIL: TestHandleMultipleQuitRequests (5.00s)
FAIL
FAIL	github.com/prometheus/prometheus/web	5.026s
FAIL
```

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->