### PR TITLE
Cleanup tempfiles

### DIFF
--- a/tsdb/blockwriter_test.go
+++ b/tsdb/blockwriter_test.go
@@ -32,6 +32,7 @@ func TestBlockWriter(t *testing.T) {
 	ctx := context.Background()
 	outputDir, err := ioutil.TempDir(os.TempDir(), "output")
 	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(outputDir)) }()
 	w, err := NewBlockWriter(log.NewNopLogger(), outputDir, DefaultBlockDuration)
 	require.NoError(t, err)
 
@@ -55,6 +56,7 @@ func TestBlockWriter(t *testing.T) {
 	blockpath := filepath.Join(outputDir, id.String())
 	b, err := OpenBlock(nil, blockpath, nil)
 	require.NoError(t, err)
+	defer func() { require.NoError(t, b.Close()) }()
 	q, err := NewBlockQuerier(b, math.MinInt64, math.MaxInt64)
 	require.NoError(t, err)
 	series := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "", ".*"))

--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -454,8 +454,9 @@ func TestLogPartialWrite(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			dirPath, err := ioutil.TempDir("", "")
+			dirPath, err := ioutil.TempDir("", "logpartialwrite")
 			require.NoError(t, err)
+			defer func() { require.NoError(t, os.RemoveAll(dirPath)) }()
 
 			w, err := NewSize(nil, nil, dirPath, segmentSize, false)
 			require.NoError(t, err)
@@ -480,6 +481,7 @@ func TestLogPartialWrite(t *testing.T) {
 			// Read it back. We expect no corruption.
 			s, err := OpenReadSegment(SegmentName(dirPath, 0))
 			require.NoError(t, err)
+			defer func() { require.NoError(t, s.Close()) }()
 
 			r := NewReader(NewSegmentBufReader(s))
 			for i := 0; i < testData.numRecords; i++ {


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->