### PR TITLE
prometheus-mixin: Make PrometheusRemoteWriteBehind more generic

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -185,7 +185,7 @@
               # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
               (
                 max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{%(prometheusSelector)s}[5m])
-              - on(job, instance) group_right
+              - ignoring(remote_name, url) group_right
                 max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{%(prometheusSelector)s}[5m])
               )
               > 120


### PR DESCRIPTION
Currently, it relies on `job, instance` being the labels completely
identifying a Prometheus instance. However, what's intended is to
simply not match on `remote_name, url`.
