### PR TITLE
bump the minimum required go version to build to 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Prometheus will now be reachable at http://localhost:9090/.
 ### Building from source
 
 To build Prometheus from source code, first ensure that have a working
-Go environment with [version 1.13 or greater installed](https://golang.org/doc/install).
+Go environment with [version 1.14 or greater installed](https://golang.org/doc/install).
 You also need [Node.js](https://nodejs.org/) and [Yarn](https://yarnpkg.com/)
 installed in order to build the frontend assets.
 


### PR DESCRIPTION
Prometheus panics about accessing a private struct key while parsing the config, if built with go 1.3. So bumping the README reference to 1.4