### PR TITLE
Fix the alerting rules name description (#7083)

### DIFF
--- a/docs/configuration/recording_rules.md
+++ b/docs/configuration/recording_rules.md
@@ -45,8 +45,10 @@ dashboards, which need to query the same expression repeatedly every time they
 refresh.
 
 Recording and alerting rules exist in a rule group. Rules within a group are
-run sequentially at a regular interval. The names of recording and alerting rules
+run sequentially at a regular interval. The names of recording rules
 must be [valid metric names](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
+The names of alerting rules must be
+[valid label values](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
 
 The syntax of a rule file is:
 


### PR DESCRIPTION
commit 9875afc491983cc7462fef336ab1c6b67da45020 changed the type from
metric names to label values, we might as well adjust the description.
The alternative is to revert that commit and restrict names of alerting
rules again even if that was not really enforced.
___
CC @roidelapluie @brian-brazil who worked on https://github.com/prometheus/prometheus/pull/7523.