### PR TITLE
Add MatchesBytes to label matcher.

### DIFF
--- a/pkg/labels/matcher.go
+++ b/pkg/labels/matcher.go
@@ -14,6 +14,7 @@
 package labels
 
 import (
+	"bytes"
 	"fmt"
 )
 
@@ -91,6 +92,20 @@ func (m *Matcher) Matches(s string) bool {
 		return m.re.MatchString(s)
 	case MatchNotRegexp:
 		return !m.re.MatchString(s)
+	}
+	panic("labels.Matcher.Matches: invalid match type")
+}
+
+func (m *Matcher) MatchesBytes(s []byte) bool {
+	switch m.Type {
+	case MatchEqual:
+		return bytes.Equal(s, []byte(m.Value))
+	case MatchNotEqual:
+		return !bytes.Equal(s, []byte(m.Value))
+	case MatchRegexp:
+		return m.re.MatchBytes(s)
+	case MatchNotRegexp:
+		return !m.re.MatchBytes(s)
 	}
 	panic("labels.Matcher.Matches: invalid match type")
 }

--- a/pkg/labels/matcher_test.go
+++ b/pkg/labels/matcher_test.go
@@ -85,6 +85,8 @@ func TestMatcher(t *testing.T) {
 
 	for _, test := range tests {
 		require.Equal(t, test.matcher.Matches(test.value), test.match)
+		require.Equal(t, test.matcher.MatchesBytes([]byte(test.value)), test.match)
+
 	}
 }
 

--- a/pkg/labels/regexp.go
+++ b/pkg/labels/regexp.go
@@ -14,6 +14,7 @@
 package labels
 
 import (
+	"bytes"
 	"regexp"
 	"regexp/syntax"
 	"strings"
@@ -59,6 +60,19 @@ func (m *FastRegexMatcher) MatchString(s string) bool {
 		return false
 	}
 	return m.re.MatchString(s)
+}
+
+func (m *FastRegexMatcher) MatchBytes(s []byte) bool {
+	if m.prefix != "" && !bytes.HasPrefix(s, []byte(m.prefix)) {
+		return false
+	}
+	if m.suffix != "" && !bytes.HasSuffix(s, []byte(m.suffix)) {
+		return false
+	}
+	if m.contains != "" && !bytes.Contains(s, []byte(m.contains)) {
+		return false
+	}
+	return m.re.Match(s)
 }
 
 func (m *FastRegexMatcher) GetRegexString() string {

--- a/pkg/labels/regexp_test.go
+++ b/pkg/labels/regexp_test.go
@@ -56,6 +56,8 @@ func TestNewFastRegexMatcher(t *testing.T) {
 		m, err := NewFastRegexMatcher(c.regex)
 		require.NoError(t, err)
 		require.Equal(t, c.expected, m.MatchString(c.value))
+		require.Equal(t, c.expected, m.MatchBytes([]byte(c.value)))
+
 	}
 }
 


### PR DESCRIPTION
While one can use a yolo string to bypass allocations, I found it cleaner to provide a []byte alternative to the match function.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>