### PR TITLE
Add wave() function

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -400,6 +400,11 @@ the given vector as the number of seconds since January 1, 1970 UTC.
 
 `vector(s scalar)` returns the scalar `s` as a vector with no labels.
 
+## `wave()`
+
+`wave(a scalar, p scalar, s scalar)` returns the value of a sine wave with amplitude `a`, period
+`p` and horizontal shift of `s` seconds
+
 ## `year()`
 
 `year(v=vector(time()) instant-vector)` returns the year

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -887,6 +887,19 @@ func funcYear(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper)
 	})
 }
 
+// === wave(a scalar, p scalar, s scalar) Vector ===
+func funcWave(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	amplitude := vals[0].(Vector)[0].Point.V
+	period := vals[1].(Vector)[0].Point.V
+	shift := vals[2].(Vector)[0].Point.V
+
+	// y = a * sin((2π/p * x) + s)
+	v := amplitude * math.Sin((2*math.Pi/period)*((float64(enh.Ts)/1000)+shift))
+	return Vector{Sample{Point: Point{
+		V: v,
+	}}}
+}
+
 // FunctionCalls is a list of all functions supported by PromQL, including their types.
 var FunctionCalls = map[string]FunctionCall{
 	"abs":                funcAbs,
@@ -935,6 +948,7 @@ var FunctionCalls = map[string]FunctionCall{
 	"time":               funcTime,
 	"timestamp":          funcTimestamp,
 	"vector":             funcVector,
+	"wave":               funcWave,
 	"year":               funcYear,
 }
 

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -262,6 +262,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeScalar},
 		ReturnType: ValueTypeVector,
 	},
+	"wave": {
+		Name:       "wave",
+		ArgTypes:   []ValueType{ValueTypeScalar, ValueTypeScalar, ValueTypeScalar},
+		ReturnType: ValueTypeVector,
+	},
 	"year": {
 		Name:       "year",
 		ArgTypes:   []ValueType{ValueTypeVector},


### PR DESCRIPTION
## Description

It could be useful to include a `wave()` function that returns the value of a sine wave over time, to work with metrics that oscillate over time. 

The function receives the amplitude, period and shift (in seconds), and returns the value at any given time

![wave](https://user-images.githubusercontent.com/12643415/100373109-27c19d00-3002-11eb-999f-06614eb08a2c.png)

### To verify

Build prometheus from this PR, and graph the query `wave(1, 60, 0)`, it should plot a wave with 1 minute period and values in the range of [-1, 1] (as in the picture)