### PR TITLE
promtool: Allow "x-*" fields in unittest definitions

### DIFF
--- a/cmd/promtool/testdata/unittest.yml
+++ b/cmd/promtool/testdata/unittest.yml
@@ -3,6 +3,13 @@ rule_files:
 
 evaluation_interval: 1m
 
+# User data, not interpreted by test.
+x-test_merge: &test_merge
+  interval: 1m
+  input_series:
+    - series: test
+      values: 0+1x10
+
 tests:
   # Basic tests for promql_expr_test, not dependent on rules.
   - interval: 1m
@@ -49,6 +56,16 @@ tests:
       - expr: timestamp(test_missing)
         eval_time: 5m1s
         exp_samples: []
+
+  # Test that YAML anchors and merges are applied.
+  - <<: *test_merge
+
+    promql_expr_test:
+      - expr: test
+        eval_time: 10m
+        exp_samples:
+          - value: 10
+            labels: test
 
   # Minimal test case to check edge case of a single sample.
   - input_series:


### PR DESCRIPTION
This makes it possible to use YAML merging, reducing the size of
repeated items in tests, without needing to template the test files.

While in most cases Prometheus encourages users to template the
files using their configuration management tool of choice, it is useful
to not need to template tests, as then they become valuable way to
sanity check other templating.

This allows defining an additional section starting `x-` in a test YAML file,
that is up to the user to use as they see fit. The main usage is defining a
partial set of labels for a test, which can then be used with YAML merging.

Currently it is possible to use YAML anchors to avoid some level of repetition, e.g.:

```yaml
alert_rule_test:
  - eval_time: 5m
     alertname: JobDown
     exp_alerts: &jobdown_alert
        - exp_labels:
             job: test-example
             cluster: test-west-1
           exp_annotations:
             summary: "test-example is down in test-west-1"
   - eval_time: 10m
      alertname: JobDown
      exp_alerts: []
  # alert comes back, can re-use the anchor defined in previous exp_alerts
   - eval_time: 20m
      alertname: JobDown
      exp_alerts: *jobdown_alert
```

This is useful to avoid repetition when an alert should fire over several windows or such.

However often an annotation ends up differing. Currently this means the entire set of
expected annotations has to be redefined.

By providing a section in the file for a user to put partially defined pieces of a test it
becomes possible to use YAML merging like so:

```yaml

x-jobdown-annotations: &jobdown-annotations
    description: Job is down
    url: http://go/alert/JobDown?cluster=test-west-1

[..snip..]

alert_rule_test:
  - eval_time: 5m
     alertname: JobDown
     exp_alerts:
        - exp_labels: &jobdown-labels
             job: test-example
             cluster: test-west-1
           exp_annotations:
             <<: *jobdown-annotations
             summary: "test-example is down in test-west-1 (0/2 healthy)"
   - eval_time: 10m
      alertname: JobDown
      exp_alerts: []
   - eval_time: 20m
      alertname: JobDown
      exp_alerts:
        - exp_labels: *jobdown-labels
           exp_annotations:
             <<: *jobdown-annotations
             summary: "test-example is down in test-west-1 (absent)"
```

(I recreated that rather than base the example on a real alert -- imagine with a few more annotations this gets quite verbose.)

Signed-off-by: David Leadbeater <dgl@dgl.cx>