### PR TITLE
Guard closing quitCh with sync.Once to prevent double close

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -919,14 +919,13 @@ func (h *Handler) version(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) quit(w http.ResponseWriter, r *http.Request) {
-	var stopped bool
+	var closed bool
 	h.quitOnce.Do(func() {
-		stopped = true
+		closed = true
 		close(h.quitCh)
-	})
-	if stopped {
 		fmt.Fprintf(w, "Requesting termination... Goodbye!")
-	} else {
+	})
+	if !closed {
 		fmt.Fprintf(w, "Termination already in progress.")
 	}
 }

--- a/web/web.go
+++ b/web/web.go
@@ -186,6 +186,7 @@ type Handler struct {
 
 	router      *route.Router
 	quitCh      chan struct{}
+	quitOnce    sync.Once
 	reloadCh    chan chan error
 	options     *Options
 	config      *config.Config
@@ -923,7 +924,9 @@ func (h *Handler) quit(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Termination already in progress.")
 	default:
 		fmt.Fprintf(w, "Requesting termination... Goodbye!")
-		close(h.quitCh)
+		h.quitOnce.Do(func() {
+			close(h.quitCh)
+		})
 	}
 }
 

--- a/web/web.go
+++ b/web/web.go
@@ -919,14 +919,15 @@ func (h *Handler) version(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) quit(w http.ResponseWriter, r *http.Request) {
-	select {
-	case <-h.quitCh:
-		fmt.Fprintf(w, "Termination already in progress.")
-	default:
+	var stopped bool
+	h.quitOnce.Do(func() {
+		stopped = true
+		close(h.quitCh)
+	})
+	if stopped {
 		fmt.Fprintf(w, "Requesting termination... Goodbye!")
-		h.quitOnce.Do(func() {
-			close(h.quitCh)
-		})
+	} else {
+		fmt.Fprintf(w, "Termination already in progress.")
 	}
 }
 


### PR DESCRIPTION
related #8144 #8166 

See https://github.com/prometheus/prometheus/issues/8144#issuecomment-735814282

Signed-off-by: Mitsuo Heijo <mitsuo.heijo@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->