### PR TITLE
Clarify: all rules in a group are concomitant

### DIFF
--- a/docs/configuration/recording_rules.md
+++ b/docs/configuration/recording_rules.md
@@ -45,8 +45,9 @@ dashboards, which need to query the same expression repeatedly every time they
 refresh.
 
 Recording and alerting rules exist in a rule group. Rules within a group are
-run sequentially at a regular interval. The names of recording rules
-must be [valid metric names](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
+run sequentially at a regular interval, with the same evaluation time.
+The names of recording rules must be
+[valid metric names](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
 The names of alerting rules must be
 [valid label values](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
 


### PR DESCRIPTION
Improve the documentation to clarify the differences between rules in a
group and outside a group.


As raised in the tweet https://twitter.com/RobustPerceiver/status/1333355596171636737?s=20 the current documentation can be improved to help the reader understand what is the impact of a rule and a rule group.
This pull request reworks the words of the tweet to match the context of the documentation and ease the reader to understand what is the impact of grouping and not grouping rules.