### PR TITLE
UI: Remove useless else-if

### DIFF
--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -47,8 +47,6 @@ export const formatValue = (y: number | null): string => {
     return (y / 1e-6).toFixed(2) + 'µ';
   } else if (absY < 1e-2) {
     return (y / 1e-3).toFixed(2) + 'm';
-  } else if (absY <= 1) {
-    return y.toFixed(2);
   }
   throw Error("couldn't format a value, this is a bug");
 };


### PR DESCRIPTION
That else-if can never be reached.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->