### PR TITLE
test: add buffer to channel to avoid goroutine leak

### DIFF
--- a/cmd/prometheus/main_unix_test.go
+++ b/cmd/prometheus/main_unix_test.go
@@ -37,7 +37,7 @@ func TestStartupInterrupt(t *testing.T) {
 		return
 	}
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		done <- prom.Wait()
 	}()


### PR DESCRIPTION
**Description**
Channel `done` has one send operation in a created goroutine, and one receive operation in a select. If the select statement at line 55 chooses `case <-time.After(10 * time.Second)`, then the goroutine created at line 42 will be blocked forever.
This commit adds 1 buffer to the channel `done`. So the send operation will never be blocked.
This commit is safe because it doesn't change the semantics of the unit test: the receive will still wait for the send operation.