### PR TITLE
Add: Custom tags and prefix in Prometheus Mixin

### DIFF
--- a/documentation/prometheus-mixin/config.libsonnet
+++ b/documentation/prometheus-mixin/config.libsonnet
@@ -37,5 +37,12 @@
     // expression is matched against the `alertmanager` label.
     // Example: @'http://test-alertmanager\..*'
     nonNotifyingAlertmanagerRegEx: @'',
+
+    grafana: {
+      prefix: 'Prometheus / ',
+      tags: ['prometheus-mixin'],
+      // The default refresh time for all dashboards, default to 60s
+      refresh: '60s',
+    },
   },
 }

--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -294,7 +294,8 @@ local template = grafana.template;
 
       dashboard.new(
         title='%(prefix)sRemote Write' % $._config.grafana,
-        editable=true)
+        editable=true
+      )
       .addTemplate(
         {
           hide: 0,
@@ -378,7 +379,7 @@ local template = grafana.template;
         .addPanel(failedSamples)
         .addPanel(retriedSamples)
         .addPanel(enqueueRetries)
-      )  + {
+      ) + {
         tags: $._config.grafana.tags,
         refresh: $._config.grafana.refresh,
       },

--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -10,7 +10,9 @@ local template = grafana.template;
 {
   grafanaDashboards+:: {
     'prometheus.json':
-      g.dashboard('Prometheus Overview')
+      g.dashboard(
+        '%(prefix)sOverview' % $._config.grafana
+      )
       .addMultiTemplate('job', 'prometheus_build_info', 'job')
       .addMultiTemplate('instance', 'prometheus_build_info', 'instance')
       .addRow(
@@ -96,7 +98,10 @@ local template = grafana.template;
           { yaxes: g.yaxes('ms') } +
           g.stack,
         )
-      ),
+      ) + {
+        tags: $._config.grafana.tags,
+        refresh: $._config.grafana.refresh,
+      },
     // Remote write specific dashboard.
     'prometheus-remote-write.json':
       local timestampComparison =
@@ -287,8 +292,9 @@ local template = grafana.template;
           legendFormat='{{cluster}}:{{instance}} {{remote_name}}:{{url}}'
         ));
 
-      dashboard.new('Prometheus Remote Write',
-                    editable=true)
+      dashboard.new(
+        title='%(prefix)sRemote Write' % $._config.grafana,
+        editable=true)
       .addTemplate(
         {
           hide: 0,
@@ -372,6 +378,9 @@ local template = grafana.template;
         .addPanel(failedSamples)
         .addPanel(retriedSamples)
         .addPanel(enqueueRetries)
-      ),
+      )  + {
+        tags: $._config.grafana.tags,
+        refresh: $._config.grafana.refresh,
+      },
   },
 }


### PR DESCRIPTION
Add some customization like in kubernetes-mixin.
We could use a configuration like that :

```jsonnet
{
  _config+:: {
    // prometheusSelector is inserted as part of the label selector in
    // PromQL queries to identify metrics collected from Prometheus
    // servers.
    prometheusSelector: 'job="prometheus"',

    // prometheusHAGroupLabels is a string with comma-separated labels
    // that are common labels of instances belonging to the same
    // high-availability group of Prometheus servers, i.e. identically
    // configured Prometheus servers. Include not only enough labels
    // to identify the members of the HA group, but also all common
    // labels you want to keep for resulting HA-group-level alerts.
    //
    // If this is set to an empty string, no HA-related alerts are applied.
    prometheusHAGroupLabels: '',

    // prometheusName is inserted into annotations to name the Prometheus
    // instance affected by the alert.
    prometheusName: '{{$labels.instance}}',
    // If you run Prometheus on Kubernetes with the Prometheus
    // Operator, you can make use of the configured target labels for
    // nicer naming:
    // prometheusNameTemplate: '{{$labels.namespace}}/{{$labels.pod}}'

    // prometheusHAGroupName is inserted into annotations to name an
    // HA group. All labels used here must also be present in
    // prometheusHAGroupLabels above.
    prometheusHAGroupName: '{{$labels.job}}',

    // nonNotifyingAlertmanagerRegEx can be used to mark Alertmanager
    // instances that are not part of the Alertmanager cluster
    // delivering production notifications. This is important for the
    // PrometheusErrorSendingAlertsToAnyAlertmanager alert. Otherwise,
    // a still working test or auditing instance could mask a full
    // failure of all the production instances. The provided regular
    // expression is matched against the `alertmanager` label.
    // Example: @'http://test-alertmanager\..*'
    nonNotifyingAlertmanagerRegEx: @'',

    grafana: {
      prefix: 'Prometheus / ',
      tags: ['prometheus-mixin'],
      // The default refresh time for all dashboards, default to 60s
      refresh: '60s',
    },
  },
}
```

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->