### PR TITLE
Api: Verify that at every matcher in api/v1/series is not empty

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -587,6 +587,19 @@ func (api *API) series(r *http.Request) (result apiFuncResult) {
 		matcherSets = append(matcherSets, matchers)
 	}
 
+	for _, ms := range matcherSets {
+		var nonEmpty bool
+		for _, lm := range ms {
+			if lm != nil && !lm.Matches("") {
+				nonEmpty = true
+				break
+			}
+		}
+		if !nonEmpty {
+			return apiFuncResult{nil, &apiError{errorBadData, errors.New("match[] must contain at least one non-empty matcher")}, nil, nil}
+		}
+	}
+
 	q, err := api.Queryable.Querier(r.Context(), timestamp.FromTime(start), timestamp.FromTime(end))
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorExec, err}, nil, nil}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -730,6 +730,13 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 		{
 			endpoint: api.series,
 			query: url.Values{
+				"match[]": []string{`{foo=""}`},
+			},
+			errType: errorBadData,
+		},
+		{
+			endpoint: api.series,
+			query: url.Values{
 				"match[]": []string{`test_metric1{foo=~".+o"}`},
 			},
 			response: []labels.Labels{


### PR DESCRIPTION
Fixed #8286

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->