### PR TITLE
promql: Exposed parsing and using test commands, so Thanos/Cortex can reuse the same language.

### DIFF
--- a/promql/promql_test.go
+++ b/promql/promql_test.go
@@ -23,6 +23,7 @@ import (
 func TestEvaluations(t *testing.T) {
 	files, err := filepath.Glob("testdata/*.test")
 	require.NoError(t, err)
+	require.Equal(t, 9, len(files))
 
 	for _, fn := range files {
 		t.Run(fn, func(t *testing.T) {


### PR DESCRIPTION
This is the extremely nice framework I would love to leverage for future query pushdown tests on Thanos 🤗 

Related to https://github.com/thanos-io/thanos/pull/3631

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>