### PR TITLE
Support matchers for Labels API

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -272,7 +272,7 @@ URL query parameters:
 - `start=<rfc3339 | unix_timestamp>`: Start timestamp. Optional.
 - `end=<rfc3339 | unix_timestamp>`: End timestamp. Optional.
 - `match[]=<series_selector>`: Repeated series selector argument that selects the
-  series from which to read the label names.
+  series from which to read the label names. Optional.
 
 
 The `data` section of the JSON response is a list of string label names.
@@ -322,7 +322,7 @@ URL query parameters:
 - `start=<rfc3339 | unix_timestamp>`: Start timestamp. Optional.
 - `end=<rfc3339 | unix_timestamp>`: End timestamp. Optional.
 - `match[]=<series_selector>`: Repeated series selector argument that selects the
-  series from which to read the label values.
+  series from which to read the label values. Optional.
 
 
 The `data` section of the JSON response is a list of string label values.

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -319,6 +319,8 @@ URL query parameters:
 
 - `start=<rfc3339 | unix_timestamp>`: Start timestamp. Optional.
 - `end=<rfc3339 | unix_timestamp>`: End timestamp. Optional.
+- `match[]=<series_selector>`: Repeated series selector argument that selects the
+  series from which to read the label's values 
 
 
 The `data` section of the JSON response is a list of string label values.

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -320,7 +320,7 @@ URL query parameters:
 - `start=<rfc3339 | unix_timestamp>`: Start timestamp. Optional.
 - `end=<rfc3339 | unix_timestamp>`: End timestamp. Optional.
 - `match[]=<series_selector>`: Repeated series selector argument that selects the
-  series from which to read the label's values 
+  series from which to read the label values 
 
 
 The `data` section of the JSON response is a list of string label values.

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -271,6 +271,8 @@ URL query parameters:
 
 - `start=<rfc3339 | unix_timestamp>`: Start timestamp. Optional.
 - `end=<rfc3339 | unix_timestamp>`: End timestamp. Optional.
+- `match[]=<series_selector>`: Repeated series selector argument that selects the
+  series from which to read the label names.
 
 
 The `data` section of the JSON response is a list of string label names.
@@ -320,7 +322,7 @@ URL query parameters:
 - `start=<rfc3339 | unix_timestamp>`: Start timestamp. Optional.
 - `end=<rfc3339 | unix_timestamp>`: End timestamp. Optional.
 - `match[]=<series_selector>`: Repeated series selector argument that selects the
-  series from which to read the label values 
+  series from which to read the label values.
 
 
 The `data` section of the JSON response is a list of string label values.

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -95,9 +95,11 @@ type ChunkQuerier interface {
 type LabelQuerier interface {
 	// LabelValues returns all potential values for a label name.
 	// It is not safe to use the strings beyond the lifefime of the querier.
+	// TODO(yeya24): support matchers or hints.
 	LabelValues(name string) ([]string, Warnings, error)
 
 	// LabelNames returns all the unique label names present in the block in sorted order.
+	// TODO(yeya24): support matchers or hints.
 	LabelNames() ([]string, Warnings, error)
 
 	// Close releases the resources of the Querier.

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -553,7 +553,7 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 	var vals []string
 	var warnings storage.Warnings
 	if len(r.Form["match[]"]) > 0 {
-		// get all series which match
+		// Get all series which match matchers.
 		var sets []storage.SeriesSet
 		for _, mset := range matcherSets {
 			s := q.Select(false, nil, mset...)
@@ -574,16 +574,14 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 	return apiFuncResult{vals, nil, warnings, closer}
 }
 
-// LabelValuesByMatchers uses matchers to filter out the series
-// from which we get the label values
+// LabelValuesByMatchers uses matchers to filter out matching series, then label values are extracted.
 func labelValuesByMatchers(sets []storage.SeriesSet, name string) ([]string, storage.Warnings, error) {
-	// get all the labels in the selected series
 	set := storage.NewMergeSeriesSet(sets, storage.ChainedSeriesMerge)
 	labelValuesMap := make(map[string]string)
 	for set.Next() {
 		series := set.At()
 		labelValue := series.Labels().Get(name)
-		// to avoid duplicates, any better way?
+		// This is to avoid duplicates.
 		_, ok := labelValuesMap[labelValue]
 		if !ok && labelValue != ""  {
 			labelValuesMap[labelValue] = labelValue
@@ -594,7 +592,7 @@ func labelValuesByMatchers(sets []storage.SeriesSet, name string) ([]string, sto
 	if set.Err() != nil {
 		return nil, warnings, set.Err()
 	}
-	// convert map to array
+	// Convert the map to an array.
 	labelValues := []string{}
 	for key := range labelValuesMap {
 		labelValues = append(labelValues, key)

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -577,14 +577,12 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 // LabelValuesByMatchers uses matchers to filter out matching series, then label values are extracted.
 func labelValuesByMatchers(sets []storage.SeriesSet, name string) ([]string, storage.Warnings, error) {
 	set := storage.NewMergeSeriesSet(sets, storage.ChainedSeriesMerge)
-	labelValuesMap := make(map[string]string)
+	labelValuesSet := make(map[string]struct{})
 	for set.Next() {
 		series := set.At()
 		labelValue := series.Labels().Get(name)
-		// This is to avoid duplicates.
-		_, ok := labelValuesMap[labelValue]
-		if !ok && labelValue != ""  {
-			labelValuesMap[labelValue] = labelValue
+		if labelValue != ""  {
+			labelValuesSet[labelValue] = struct{}{}
 		}
 	}
 
@@ -594,7 +592,7 @@ func labelValuesByMatchers(sets []storage.SeriesSet, name string) ([]string, sto
 	}
 	// Convert the map to an array.
 	labelValues := []string{}
-	for key := range labelValuesMap {
+	for key := range labelValuesSet {
 		labelValues = append(labelValues, key)
 	}
 	sort.Strings(labelValues)

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -581,9 +581,7 @@ func labelValuesByMatchers(sets []storage.SeriesSet, name string) ([]string, sto
 	for set.Next() {
 		series := set.At()
 		labelValue := series.Labels().Get(name)
-		if labelValue != ""  {
-			labelValuesSet[labelValue] = struct{}{}
-		}
+		labelValuesSet[labelValue] = struct{}{}
 	}
 
 	warnings := set.Warnings()

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1622,8 +1622,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
-
-			//Should only return label value of matching metric name and label name
+			// Label values with matcher
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{
@@ -1636,8 +1635,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
-
-			// Should only return label value of matching metric name and label name
+			// Label values with matcher
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{
@@ -1651,7 +1649,35 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
-
+			// Label values with matcher using label filter
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"match[]": []string{`test_metric1{foo="bar"}`},
+				},
+				response: []string{
+					"bar",
+				},
+			},
+			// Label values with matcher and time range
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"match[]": []string{`test_metric1`},
+					"start": []string{"1"},
+					"end":   []string{"100000000"},
+				},
+				response: []string{
+					"bar",
+					"boo",
+				},
+			},
 			// Label names.
 			{
 				endpoint: api.labelNames,

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1622,7 +1622,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
-			// Label values with matcher
+			// Label values with matcher.
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{
@@ -1635,7 +1635,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
-			// Label values with matcher
+			// Label values with matcher.
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{
@@ -1649,7 +1649,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
-			// Label values with matcher using label filter
+			// Label values with matcher using label filter.
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{
@@ -1662,7 +1662,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"bar",
 				},
 			},
-			// Label values with matcher and time range
+			// Label values with matcher and time range.
 			{
 				endpoint: api.labelValues,
 				params: map[string]string{

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1622,6 +1622,17 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"boo",
 				},
 			},
+			// Label values with bad matchers.
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"match[]": []string{`{foo=""`, `test_metric2`},
+				},
+				errType: errorBadData,
+			},
 			// Label values with matcher.
 			{
 				endpoint: api.labelValues,
@@ -1670,8 +1681,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				},
 				query: url.Values{
 					"match[]": []string{`test_metric1`},
-					"start": []string{"1"},
-					"end":   []string{"100000000"},
+					"start":   []string{"1"},
+					"end":     []string{"100000000"},
 				},
 				response: []string{
 					"bar",
@@ -1762,6 +1773,49 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 					"end": []string{"20"},
 				},
 				response: []string{"__name__", "dup", "foo"},
+			},
+			// Label names with bad matchers.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"match[]": []string{`{foo=""`, `test_metric2`},
+				},
+				errType: errorBadData,
+			},
+			// Label names with matcher.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"match[]": []string{`test_metric2`},
+				},
+				response: []string{"__name__", "foo"},
+			},
+			// Label names with matcher.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"match[]": []string{`test_metric3`},
+				},
+				response: []string{"__name__", "dup", "foo"},
+			},
+			// Label names with matcher using label filter.
+			// There is no matching series.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"match[]": []string{`test_metric1{foo="test"}`},
+				},
+				response: []string{},
+			},
+			// Label names with matcher and time range.
+			{
+				endpoint: api.labelNames,
+				query: url.Values{
+					"match[]": []string{`test_metric2`},
+					"start":   []string{"1"},
+					"end":     []string{"100000000"},
+				},
+				response: []string{"__name__", "foo"},
 			},
 		}...)
 	}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1623,6 +1623,35 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				},
 			},
 
+			//Should only return label value of matching metric name and label name
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"match[]": []string{`test_metric2`},
+				},
+				response: []string{
+					"boo",
+				},
+			},
+
+			// Should only return label value of matching metric name and label name
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"match[]": []string{`test_metric1`},
+				},
+				response: []string{
+					"bar",
+					"boo",
+				},
+			},
+
 			// Label names.
 			{
 				endpoint: api.labelNames,

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1633,6 +1633,17 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				},
 				errType: errorBadData,
 			},
+			// Label values with empty matchers.
+			{
+				endpoint: api.labelValues,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"match[]": []string{`{foo=""}`},
+				},
+				errType: errorBadData,
+			},
 			// Label values with matcher.
 			{
 				endpoint: api.labelValues,
@@ -1779,6 +1790,17 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 				endpoint: api.labelNames,
 				query: url.Values{
 					"match[]": []string{`{foo=""`, `test_metric2`},
+				},
+				errType: errorBadData,
+			},
+			// Label values with empty matchers.
+			{
+				endpoint: api.labelNames,
+				params: map[string]string{
+					"name": "foo",
+				},
+				query: url.Values{
+					"match[]": []string{`{foo=""}`},
 				},
 				errType: errorBadData,
 			},


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This pr is based on #7496 and it adds label names matchers support using the same way.