### PR TITLE
Lowered 'Found overlapping blocks during compaction' log level

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -683,7 +683,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 			if i > 0 && b.Meta().MinTime < globalMaxt {
 				c.metrics.overlappingBlocks.Inc()
 				overlapping = true
-				level.Warn(c.logger).Log("msg", "Found overlapping blocks during compaction", "ulid", meta.ULID)
+				level.Info(c.logger).Log("msg", "Found overlapping blocks during compaction", "ulid", meta.ULID)
 			}
 			if b.Meta().MaxTime > globalMaxt {
 				globalMaxt = b.Meta().MaxTime


### PR DESCRIPTION
In Cortex (and Thanos) having overlapping blocks is expected. Our users get frequently confused by this warning log message, which make them think it's an unexpected condition.

What's the sentiment to lower the log level? Or should I introduce an option to `NewLeveledCompactor()` to specify whether overlapping blocks are expected?