### PR TITLE
Create output directory before backfilling

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -621,5 +621,9 @@ func backfillOpenMetrics(path string, outputDir string) (err error) {
 		return err
 	}
 	defer inputFile.Close()
+
+	if err := os.MkdirAll(outputDir, 0777); err != nil {
+		return errors.Wrap(err, "create output dir")
+	}
 	return backfill(5000, inputFile.Bytes(), outputDir)
 }


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Currently, the output directory needs to be created before backfilling. Otherwise we will get the error below. IMO the output directory should be created by `promtool` before doing backfilling

```
block creation: opening the db dir: stat output: no such file or directory
```