### PR TITLE
promtool: Print block meta-data slightly more nicely

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -359,7 +359,7 @@ func listBlocks(path string, humanReadable bool) error {
 }
 
 func printBlocks(blocks []tsdb.BlockReader, writeHeader, humanReadable bool) {
-	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	tw := tabwriter.NewWriter(os.Stdout, 13, 0, 2, ' ', 0)
 	defer tw.Flush()
 
 	if writeHeader {


### PR DESCRIPTION
I initially thought I could somehow rescue the current column layout
by recycling the tabwriter, but flushing completely blanks
it. However, by setting a minimum width of 13, we get a slightly
broader DURATION column but otherwise nice formatting, unless numbers
get really big, but that's OK, I guess.

Before:

```
BLOCK ULID                  MIN TIME                       MAX TIME                       DURATION  NUM SAMPLES  NUM CHUNKS  NUM SERIES  SIZE
01ETN0KGNP5WWK9T5QMQGBG9F1  2020-11-19 07:39:17 +0000 UTC  2020-11-19 07:44:17 +0000 UTC  5m0.001s  8            2           2           624B
01ETN0KGQSFF0AB2QDZVQG3CWC  2020-11-19 10:25:57 +0000 UTC  2020-11-19 10:30:57 +0000 UTC  5m0.001s  8  2  2  622B
01ETN0KGSW8KYP3YPG4X20P60Z  2020-11-19 13:12:37 +0000 UTC  2020-11-19 13:17:37 +0000 UTC  5m0.001s  8  2  2  625B
```

After:

```
BLOCK ULID                  MIN TIME                       MAX TIME                       DURATION     NUM SAMPLES  NUM CHUNKS   NUM SERIES   SIZE
01ETN0R72SXN9A1FG732P7KFFN  2020-11-19 07:39:17 +0000 UTC  2020-11-19 07:44:17 +0000 UTC  5m0.001s     8            2            2            624B
01ETN0R74Y9AG1A1MKN4MZK7WM  2020-11-19 10:25:57 +0000 UTC  2020-11-19 10:30:57 +0000 UTC  5m0.001s     8            2            2            622B
01ETN0R76KXZ5VQECMDNES49J6  2020-11-19 13:12:37 +0000 UTC  2020-11-19 13:17:37 +0000 UTC  5m0.001s     8            2            2            625B
```

After without the `-r` flag:

```
BLOCK ULID                  MIN TIME       MAX TIME       DURATION     NUM SAMPLES  NUM CHUNKS   NUM SERIES   SIZE
01ETN0RFFJ42274NWR1GH0RTV6  1605771557000  1605771857001  5m0.001s     8            2            2            624
01ETN0RFJ1MZCHHS2SBZS8XC27  1605781557000  1605781857001  5m0.001s     8            2            2            622
01ETN0RFM98N3V4KD2DZXFGHGN  1605791557000  1605791857001  5m0.001s     8            2            2            625
```

@aSquare14 