### PR TITLE
mixin: Scope grafana config

### DIFF
--- a/documentation/prometheus-mixin/config.libsonnet
+++ b/documentation/prometheus-mixin/config.libsonnet
@@ -38,7 +38,7 @@
     // Example: @'http://test-alertmanager\..*'
     nonNotifyingAlertmanagerRegEx: @'',
 
-    grafana: {
+    grafanaPrometheus: {
       prefix: 'Prometheus / ',
       tags: ['prometheus-mixin'],
       // The default refresh time for all dashboards, default to 60s

--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -11,7 +11,7 @@ local template = grafana.template;
   grafanaDashboards+:: {
     'prometheus.json':
       g.dashboard(
-        '%(prefix)sOverview' % $._config.grafana
+        '%(prefix)sOverview' % $._config.grafanaPrometheus
       )
       .addMultiTemplate('job', 'prometheus_build_info', 'job')
       .addMultiTemplate('instance', 'prometheus_build_info', 'instance')
@@ -99,8 +99,8 @@ local template = grafana.template;
           g.stack,
         )
       ) + {
-        tags: $._config.grafana.tags,
-        refresh: $._config.grafana.refresh,
+        tags: $._config.grafanaPrometheus.tags,
+        refresh: $._config.grafanaPrometheus.refresh,
       },
     // Remote write specific dashboard.
     'prometheus-remote-write.json':
@@ -293,7 +293,7 @@ local template = grafana.template;
         ));
 
       dashboard.new(
-        title='%(prefix)sRemote Write' % $._config.grafana,
+        title='%(prefix)sRemote Write' % $._config.grafanaPrometheus,
         editable=true
       )
       .addTemplate(
@@ -380,8 +380,8 @@ local template = grafana.template;
         .addPanel(retriedSamples)
         .addPanel(enqueueRetries)
       ) + {
-        tags: $._config.grafana.tags,
-        refresh: $._config.grafana.refresh,
+        tags: $._config.grafanaPrometheus.tags,
+        refresh: $._config.grafanaPrometheus.refresh,
       },
   },
 }


### PR DESCRIPTION
This PR fixes what was reported in comments in https://github.com/prometheus/prometheus/pull/8287

In its current form this configuration clashes in one of the most widely
used configurations (kube-prometheus). This patch scopes the
configuration to prevent this.

An alternative could be to revert https://github.com/prometheus/prometheus/pull/8287 until kube-prometheus can refactor the use of this mixin to not be affected. See: https://github.com/prometheus/prometheus/pull/8333

@beorn7 @paulfantom @metalmatze @roidelapluie 

cc @elisiano 