### PR TITLE
promql: Implement `avg_angle_over_time` function

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -410,6 +410,7 @@ for each of the given times in UTC.
 The following functions allow aggregating each series of a given range vector
 over time and return an instant vector with per-series aggregation results:
 
+* `avg_angle_over_time(range-vector)`: the average angle of all angles in the specified interval.
 * `avg_over_time(range-vector)`: the average value of all points in the specified interval.
 * `min_over_time(range-vector)`: the minimum value of all points in the specified interval.
 * `max_over_time(range-vector)`: the maximum value of all points in the specified interval.

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -377,6 +377,27 @@ func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 	})
 }
 
+// === avg_angle_over_time(Matrix parser.ValueTypeMatrix) Vector ===
+func funcAvgAngleOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	// https://en.wikipedia.org/wiki/Mean_of_circular_quantities#Mean_of_angles
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		var mean, sinSum, cosSum float64
+
+		sinSum = 0
+		cosSum = 0
+		for _, v := range values {
+
+			sinSum += math.Sin(v.V * math.Pi / 180)
+			cosSum += math.Cos(v.V * math.Pi / 180)
+		}
+		mean = (180 / math.Pi) * math.Atan2(sinSum, cosSum)
+		if mean < 0 {
+			mean += 360
+		}
+		return mean
+	})
+}
+
 // === count_over_time(Matrix parser.ValueTypeMatrix) Vector ===
 func funcCountOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	return aggrOverTime(vals, enh, func(values []Point) float64 {
@@ -889,53 +910,54 @@ func funcYear(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper)
 
 // FunctionCalls is a list of all functions supported by PromQL, including their types.
 var FunctionCalls = map[string]FunctionCall{
-	"abs":                funcAbs,
-	"absent":             funcAbsent,
-	"absent_over_time":   funcAbsentOverTime,
-	"avg_over_time":      funcAvgOverTime,
-	"ceil":               funcCeil,
-	"changes":            funcChanges,
-	"clamp_max":          funcClampMax,
-	"clamp_min":          funcClampMin,
-	"count_over_time":    funcCountOverTime,
-	"days_in_month":      funcDaysInMonth,
-	"day_of_month":       funcDayOfMonth,
-	"day_of_week":        funcDayOfWeek,
-	"delta":              funcDelta,
-	"deriv":              funcDeriv,
-	"exp":                funcExp,
-	"floor":              funcFloor,
-	"histogram_quantile": funcHistogramQuantile,
-	"holt_winters":       funcHoltWinters,
-	"hour":               funcHour,
-	"idelta":             funcIdelta,
-	"increase":           funcIncrease,
-	"irate":              funcIrate,
-	"label_replace":      funcLabelReplace,
-	"label_join":         funcLabelJoin,
-	"ln":                 funcLn,
-	"log10":              funcLog10,
-	"log2":               funcLog2,
-	"max_over_time":      funcMaxOverTime,
-	"min_over_time":      funcMinOverTime,
-	"minute":             funcMinute,
-	"month":              funcMonth,
-	"predict_linear":     funcPredictLinear,
-	"quantile_over_time": funcQuantileOverTime,
-	"rate":               funcRate,
-	"resets":             funcResets,
-	"round":              funcRound,
-	"scalar":             funcScalar,
-	"sort":               funcSort,
-	"sort_desc":          funcSortDesc,
-	"sqrt":               funcSqrt,
-	"stddev_over_time":   funcStddevOverTime,
-	"stdvar_over_time":   funcStdvarOverTime,
-	"sum_over_time":      funcSumOverTime,
-	"time":               funcTime,
-	"timestamp":          funcTimestamp,
-	"vector":             funcVector,
-	"year":               funcYear,
+	"abs":                 funcAbs,
+	"absent":              funcAbsent,
+	"absent_over_time":    funcAbsentOverTime,
+	"avg_angle_over_time": funcAvgAngleOverTime,
+	"avg_over_time":       funcAvgOverTime,
+	"ceil":                funcCeil,
+	"changes":             funcChanges,
+	"clamp_max":           funcClampMax,
+	"clamp_min":           funcClampMin,
+	"count_over_time":     funcCountOverTime,
+	"days_in_month":       funcDaysInMonth,
+	"day_of_month":        funcDayOfMonth,
+	"day_of_week":         funcDayOfWeek,
+	"delta":               funcDelta,
+	"deriv":               funcDeriv,
+	"exp":                 funcExp,
+	"floor":               funcFloor,
+	"histogram_quantile":  funcHistogramQuantile,
+	"holt_winters":        funcHoltWinters,
+	"hour":                funcHour,
+	"idelta":              funcIdelta,
+	"increase":            funcIncrease,
+	"irate":               funcIrate,
+	"label_replace":       funcLabelReplace,
+	"label_join":          funcLabelJoin,
+	"ln":                  funcLn,
+	"log10":               funcLog10,
+	"log2":                funcLog2,
+	"max_over_time":       funcMaxOverTime,
+	"min_over_time":       funcMinOverTime,
+	"minute":              funcMinute,
+	"month":               funcMonth,
+	"predict_linear":      funcPredictLinear,
+	"quantile_over_time":  funcQuantileOverTime,
+	"rate":                funcRate,
+	"resets":              funcResets,
+	"round":               funcRound,
+	"scalar":              funcScalar,
+	"sort":                funcSort,
+	"sort_desc":           funcSortDesc,
+	"sqrt":                funcSqrt,
+	"stddev_over_time":    funcStddevOverTime,
+	"stdvar_over_time":    funcStdvarOverTime,
+	"sum_over_time":       funcSumOverTime,
+	"time":                funcTime,
+	"timestamp":           funcTimestamp,
+	"vector":              funcVector,
+	"year":                funcYear,
 }
 
 type vectorByValueHeap Vector

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -44,6 +44,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeMatrix},
 		ReturnType: ValueTypeVector,
 	},
+	"avg_angle_over_time": {
+		Name:       "avg_angle_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+	},
 	"ceil": {
 		Name:       "ceil",
 		ArgTypes:   []ValueType{ValueTypeVector},

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -557,6 +557,27 @@ eval instant at 1m avg_over_time(metric10[1m])
 eval instant at 1m sum_over_time(metric10[1m])/count_over_time(metric10[1m])
   {} 0
 
+# Tests for avg_angle_over_time
+clear
+load 10s
+  metric1 340 358 7 25 5
+  metric2 -20 -2 7 25 5
+  metric3 0 180 0 -180 90
+  metric4 0 180 0 -180 -90
+
+eval instant at 1m avg_angle_over_time(metric1[1m])
+  {} 3.016282588803491
+
+eval instant at 1m avg_angle_over_time(metric2[1m])
+  {} 3.016282588803491
+
+eval instant at 1m avg_angle_over_time(metric3[1m])
+  {} 90
+
+eval instant at 1m avg_angle_over_time(metric4[1m])
+  {} 270
+
+
 # Tests for stddev_over_time and stdvar_over_time.
 clear
 load 10s


### PR DESCRIPTION
As avg_over_time does not work for angles (worst example: avg of 0, 360
would be 180, which is completely wrong), I've implemented an
avg_angle_over_time function to handle this..

Implemented as described in
https://en.wikipedia.org/wiki/Mean_of_circular_quantities#Mean_of_angles

