### PR TITLE
Add https to navbar and fix link in it

### DIFF
--- a/docs/configuration/https.md
+++ b/docs/configuration/https.md
@@ -1,3 +1,8 @@
+---
+title: HTTPS and authentication
+sort_rank: 7
+---
+
 # HTTPS and authentication
 
 Prometheus supports basic authentication and TLS.

--- a/docs/configuration/https.md
+++ b/docs/configuration/https.md
@@ -32,7 +32,8 @@ tls_server_config:
   key_file: <filename>
 
   # Server policy for client authentication. Maps to ClientAuth Policies.
-  # For more detail on clientAuth options: [ClientAuthType](https://golang.org/pkg/crypto/tls/#ClientAuthType)
+  # For more detail on clientAuth options:
+  # https://golang.org/pkg/crypto/tls/#ClientAuthType
   [ client_auth_type: <string> | default = "NoClientCert" ]
 
   # CA certificate for client certificate authentication to the server.


### PR DESCRIPTION
@beorn7 

The https page is currently not in the navbar of the documentation, and the link inside a code block (config documentation) is not rendered properly: https://prometheus.io/docs/prometheus/2.24/configuration/https/

