### PR TITLE
Update retention size flag docs with base2 byte units

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -211,7 +211,7 @@ func main() {
 	a.Flag("storage.tsdb.retention.time", "How long to retain samples in storage. When this flag is set it overrides \"storage.tsdb.retention\". If neither this flag nor \"storage.tsdb.retention\" nor \"storage.tsdb.retention.size\" is set, the retention time defaults to "+defaultRetentionString+". Units Supported: y, w, d, h, m, s, ms.").
 		SetValue(&newFlagRetentionDuration)
 
-	a.Flag("storage.tsdb.retention.size", "[EXPERIMENTAL] Maximum number of bytes that can be stored for blocks. A unit is required, supported units: B, KB, MB, GB, TB, PB, EB. Ex: \"512MB\". This flag is experimental and can be changed in future releases.").
+	a.Flag("storage.tsdb.retention.size", "[EXPERIMENTAL] Maximum number of bytes that can be stored for blocks. A unit is required, supported units: B, KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB,PiB, EB, EiB. Ex: \"512MB\". This flag is experimental and can be changed in future releases. Note that KB here means the same as KiB etc., i.e. 1024B = 1KiB = 1KB, 1024KiB = 1024KB = 1MB = 1MiB, etc.").
 		BytesVar(&cfg.tsdb.MaxBytes)
 
 	a.Flag("storage.tsdb.no-lockfile", "Do not create lockfile in data directory.").

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -76,7 +76,7 @@ Prometheus has several flags that configure local storage. The most important ar
 
 * `--storage.tsdb.path`: Where Prometheus writes its database. Defaults to `data/`.
 * `--storage.tsdb.retention.time`: When to remove old data. Defaults to `15d`. Overrides `storage.tsdb.retention` if this flag is set to anything other than default.
-* `--storage.tsdb.retention.size`: [EXPERIMENTAL] The maximum number of bytes of storage blocks to retain. The oldest data will be removed first. Defaults to `0` or disabled. This flag is experimental and may change in future releases. Units supported: B, KB, MB, GB, TB, PB, EB. Ex: "512MB"
+* `--storage.tsdb.retention.size`: [EXPERIMENTAL] The maximum number of bytes of storage blocks to retain. The oldest data will be removed first. Defaults to `0` or disabled. This flag is experimental and may change in future releases. Units supported: B, KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB,PiB, EB, EiB. Ex: "512MB". **Note** that KB here means the same as KiB etc., i.e. 1024B = 1KiB = 1KB, 1024KiB = 1024KB = 1MB = 1MiB, etc.".
 * `--storage.tsdb.retention`: Deprecated in favor of `storage.tsdb.retention.time`.
 * `--storage.tsdb.wal-compression`: Enables compression of the write-ahead log (WAL). Depending on your data, you can expect the WAL size to be halved with little extra cpu load. This flag was introduced in 2.11.0 and enabled by default in 2.20.0. Note that once enabled, downgrading Prometheus to a version below 2.11.0 will require deleting the WAL.
 


### PR DESCRIPTION
A simple addition to the `--storage.tsdb.retention.size` flag, showing users that base 2 byte units can be used as well.
Previously it sounded like base 2 units weren't allowed when they in fact are :)

```
Prometheus Args - base 2:
    ...
    --storage.tsdb.retention.size=2GiB
    ...
    --log.level=debug

Logs:
level=info ts=2021-01-05T11:19:59.977Z caller=main.go:360 msg="Starting Prometheus" version="(version=2.23.0, branch=HEAD, revision=26d89b4b0776fe4cd5a3656dfa520f119a375273)"
level=info ts=2021-01-05T11:19:59.978Z caller=main.go:365 build_context="(go=go1.15.5, user=root@37609b3a0a21, date=20201126-10:56:17)"
...
level=info ts=2021-01-05T11:20:03.717Z caller=main.go:745 msg="TSDB started"
level=debug ts=2021-01-05T11:20:03.717Z caller=main.go:746 msg="TSDB options" MinBlockDuration=2h MaxBlockDuration=7h12m MaxBytes=2GiB NoLockfile=true RetentionDuration=3d WALSegmentSize=0B AllowOverlappingBlocks=false WALCompression=true

---

Prometheus Args - base 10:
    ...
    --storage.tsdb.retention.size=2GB
    ...
    --log.level=debug

Logs:
level=info ts=2021-01-05T11:26:15.831Z caller=main.go:360 msg="Starting Prometheus" version="(version=2.23.0, branch=HEAD, revision=26d89b4b0776fe4cd5a3656dfa520f119a375273)"
level=info ts=2021-01-05T11:26:15.831Z caller=main.go:365 build_context="(go=go1.15.5, user=root@37609b3a0a21, date=20201126-10:56:17)"
...
level=info ts=2021-01-05T11:26:20.172Z caller=main.go:745 msg="TSDB started"
level=debug ts=2021-01-05T11:26:20.172Z caller=main.go:746 msg="TSDB options" MinBlockDuration=2h MaxBlockDuration=7h12m MaxBytes=2GiB NoLockfile=true RetentionDuration=3d WALSegmentSize=0B AllowOverlappingBlocks=false WALCompression=true
```

As you can see, in both cases prometheus reports that the base 2 unit is used in the `MaxByte` setting.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->