### PR TITLE
tsdb: Expose total number of label pairs in head

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -115,7 +115,8 @@ type PostingsStats struct {
 	CardinalityLabelStats   []Stat
 	LabelValueStats         []Stat
 	LabelValuePairsStats    []Stat
-	NumLabelPairs           uint64
+	// TODO: Currently this is only counted for Head block. It will need to include persistent blocks in the future.
+	NumLabelPairs int
 }
 
 // Stats calculates the cardinality statistics from postings.
@@ -129,7 +130,7 @@ func (p *MemPostings) Stats(label string) *PostingsStats {
 	labels := &maxHeap{}
 	labelValueLength := &maxHeap{}
 	labelValuePairs := &maxHeap{}
-	numLabelPairs := uint64(0)
+	numLabelPairs := 0
 
 	metrics.init(maxNumOfRecords)
 	labels.init(maxNumOfRecords)
@@ -141,9 +142,9 @@ func (p *MemPostings) Stats(label string) *PostingsStats {
 			continue
 		}
 		labels.push(Stat{Name: n, Count: uint64(len(e))})
+		numLabelPairs += len(e)
 		size = 0
 		for name, values := range e {
-			numLabelPairs++
 			if n == label {
 				metrics.push(Stat{Name: name, Count: uint64(len(values))})
 			}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -115,6 +115,7 @@ type PostingsStats struct {
 	CardinalityLabelStats   []Stat
 	LabelValueStats         []Stat
 	LabelValuePairsStats    []Stat
+	NumLabelPairs           uint64
 }
 
 // Stats calculates the cardinality statistics from postings.
@@ -128,6 +129,7 @@ func (p *MemPostings) Stats(label string) *PostingsStats {
 	labels := &maxHeap{}
 	labelValueLength := &maxHeap{}
 	labelValuePairs := &maxHeap{}
+	numLabelPairs := uint64(0)
 
 	metrics.init(maxNumOfRecords)
 	labels.init(maxNumOfRecords)
@@ -141,6 +143,7 @@ func (p *MemPostings) Stats(label string) *PostingsStats {
 		labels.push(Stat{Name: n, Count: uint64(len(e))})
 		size = 0
 		for name, values := range e {
+			numLabelPairs++
 			if n == label {
 				metrics.push(Stat{Name: name, Count: uint64(len(values))})
 			}
@@ -157,6 +160,7 @@ func (p *MemPostings) Stats(label string) *PostingsStats {
 		CardinalityLabelStats:   labels.get(),
 		LabelValueStats:         labelValueLength.get(),
 		LabelValuePairsStats:    labelValuePairs.get(),
+		NumLabelPairs:           numLabelPairs,
 	}
 }
 

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -115,8 +115,7 @@ type PostingsStats struct {
 	CardinalityLabelStats   []Stat
 	LabelValueStats         []Stat
 	LabelValuePairsStats    []Stat
-	// TODO: Currently this is only counted for Head block. It will need to include persistent blocks in the future.
-	NumLabelPairs int
+	NumLabelPairs           int
 }
 
 // Stats calculates the cardinality statistics from postings.

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1236,10 +1236,11 @@ type stat struct {
 
 // HeadStats has information about the TSDB head.
 type HeadStats struct {
-	NumSeries  uint64 `json:"numSeries"`
-	ChunkCount int64  `json:"chunkCount"`
-	MinTime    int64  `json:"minTime"`
-	MaxTime    int64  `json:"maxTime"`
+	NumSeries     uint64 `json:"numSeries"`
+	NumLabelPairs uint64 `json:"numLabelPairs"`
+	ChunkCount    int64  `json:"chunkCount"`
+	MinTime       int64  `json:"minTime"`
+	MaxTime       int64  `json:"maxTime"`
 }
 
 // tsdbStatus has information of cardinality statistics from postings.
@@ -1281,10 +1282,11 @@ func (api *API) serveTSDBStatus(*http.Request) apiFuncResult {
 	}
 	return apiFuncResult{tsdbStatus{
 		HeadStats: HeadStats{
-			NumSeries:  s.NumSeries,
-			ChunkCount: chunkCount,
-			MinTime:    s.MinTime,
-			MaxTime:    s.MaxTime,
+			NumSeries:     s.NumSeries,
+			ChunkCount:    chunkCount,
+			MinTime:       s.MinTime,
+			MaxTime:       s.MaxTime,
+			NumLabelPairs: s.IndexPostingStats.NumLabelPairs,
 		},
 		SeriesCountByMetricName:     convertStats(s.IndexPostingStats.CardinalityMetricsStats),
 		LabelValueCountByLabelName:  convertStats(s.IndexPostingStats.CardinalityLabelStats),

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1237,7 +1237,7 @@ type stat struct {
 // HeadStats has information about the TSDB head.
 type HeadStats struct {
 	NumSeries     uint64 `json:"numSeries"`
-	NumLabelPairs uint64 `json:"numLabelPairs"`
+	NumLabelPairs int    `json:"numLabelPairs"`
 	ChunkCount    int64  `json:"chunkCount"`
 	MinTime       int64  `json:"minTime"`
 	MaxTime       int64  `json:"maxTime"`

--- a/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.test.tsx
+++ b/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.test.tsx
@@ -15,6 +15,7 @@ const fakeTSDBStatusResponse: {
   data: {
     headStats: {
       numSeries: 508,
+      numLabelPairs: 1234,
       chunkCount: 937,
       minTime: 1591516800000,
       maxTime: 1598896800143,
@@ -85,7 +86,7 @@ describe('TSDB Stats', () => {
         .at(0)
         .find('tbody')
         .find('td');
-      ['508', '937', '2020-06-07T08:00:00.000Z (1591516800000)', '2020-08-31T18:00:00.143Z (1598896800143)'].forEach(
+      ['508', '937', '1234', '2020-06-07T08:00:00.000Z (1591516800000)', '2020-08-31T18:00:00.143Z (1598896800143)'].forEach(
         (value, i) => {
           expect(headStats.at(i).text()).toEqual(value);
         }

--- a/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.tsx
+++ b/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.tsx
@@ -14,6 +14,7 @@ interface Stats {
 
 interface HeadStats {
   numSeries: number;
+  numLabelPairs: number;
   chunkCount: number;
   minTime: number;
   maxTime: number;
@@ -35,10 +36,11 @@ export const TSDBStatusContent: FC<TSDBMap> = ({
   seriesCountByLabelValuePair,
 }) => {
   const unixToTime = (unix: number): string => new Date(unix).toISOString();
-  const { chunkCount, numSeries, minTime, maxTime } = headStats;
+  const { chunkCount, numSeries, numLabelPairs, minTime, maxTime } = headStats;
   const stats = [
     { header: 'Number of Series', value: numSeries },
     { header: 'Number of Chunks', value: chunkCount },
+    { header: 'Number of Label Pairs', value: numLabelPairs },
     { header: 'Current Min Time', value: `${unixToTime(minTime)} (${minTime})` },
     { header: 'Current Max Time', value: `${unixToTime(maxTime)} (${maxTime})` },
   ];


### PR DESCRIPTION
Signed-off-by: Nguyen Le Vu Long <vulongvn98@gmail.com>

Partially solves https://github.com/prometheus/prometheus/issues/7147

The metrics will be shown in the TSDB status page like this:
![image](https://user-images.githubusercontent.com/20140368/103679351-521a5900-4fb7-11eb-8177-f6f0270ba1e9.png)


<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->