### PR TITLE
Allow importers to override remote write HTTP client

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -100,7 +100,7 @@ func TestSampleDelivery(t *testing.T) {
 	require.NoError(t, s.ApplyConfig(conf))
 	hash, err := toHash(writeConfig)
 	require.NoError(t, err)
-	qm := s.rws.queues[hash]
+	qm := s.Write.queues[hash]
 	qm.SetClient(c)
 
 	qm.StoreSeries(series, 0)

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -101,7 +101,7 @@ func TestNoDuplicateReadConfigs(t *testing.T) {
 				RemoteReadConfigs: tc.cfgs,
 			}
 			err := s.ApplyConfig(conf)
-			prometheus.Unregister(s.rws.highestTimestamp)
+			prometheus.Unregister(s.Write.highestTimestamp)
 			gotError := err != nil
 			require.Equal(t, tc.err, gotError)
 			require.NoError(t, s.Close())

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -55,7 +55,7 @@ func TestStorageLifecycle(t *testing.T) {
 	require.NoError(t, s.ApplyConfig(conf))
 
 	// make sure remote write has a queue.
-	require.Equal(t, 1, len(s.rws.queues))
+	require.Equal(t, 1, len(s.Write.queues))
 
 	// make sure remote write has a queue.
 	require.Equal(t, 1, len(s.queryables))


### PR DESCRIPTION
This PR adds a `NewClient` field to `remote.WriteStorage` to define the function used to create a remote write client. This can allow downstream repositories using Prometheus to add extra functionality to the created HTTP clients used in the remote write queues. 

The `rws` field of `remote.Storage` has been exposed as `Write` to give users of `remote.NewStorage` access to the new field.

I'm opening this in draft for now; it's not clear if this is the best approach to being able to modify the underlying HTTP client that are created for the queues.

/cc @cstyan @tomwilkie 

Signed-off-by: Robert Fratto <robertfratto@gmail.com>
