### PR TITLE
fix: remove pre-2.21 tmp blocks on start

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -56,7 +56,7 @@ const (
 	// about removing those too on start to save space. Currently only blocks tmp dirs are removed.
 	tmpForDeletionBlockDirSuffix = ".tmp-for-deletion"
 	tmpForCreationBlockDirSuffix = ".tmp-for-creation"
-	// Pre-2.21 suffix for tmp dirs
+	// Pre-2.21 tmp dir suffix, used in clean-up functions.
 	tmpLegacy = ".tmp"
 )
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -56,6 +56,8 @@ const (
 	// about removing those too on start to save space. Currently only blocks tmp dirs are removed.
 	tmpForDeletionBlockDirSuffix = ".tmp-for-deletion"
 	tmpForCreationBlockDirSuffix = ".tmp-for-creation"
+	// Pre-2.21 suffix for tmp dirs
+	tmpLegacy = ".tmp"
 )
 
 var (
@@ -1570,7 +1572,7 @@ func isTmpBlockDir(fi os.FileInfo) bool {
 
 	fn := fi.Name()
 	ext := filepath.Ext(fn)
-	if ext == tmpForDeletionBlockDirSuffix || ext == tmpForCreationBlockDirSuffix {
+	if ext == tmpForDeletionBlockDirSuffix || ext == tmpForCreationBlockDirSuffix || ext == tmpLegacy {
 		if _, err := ulid.ParseStrict(fn[:len(fn)-len(ext)]); err == nil {
 			return true
 		}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -2795,15 +2795,20 @@ func TestOpen_VariousBlockStates(t *testing.T) {
 		require.NoError(t, os.Remove(filepath.Join(dir, metaFilename)))
 	}
 	{
-		// Tmp blocks during creation & deletion; those should be removed on start.
+		// Tmp blocks during creation; those should be removed on start.
 		dir := createBlock(t, tmpDir, genSeries(10, 2, 30, 40))
 		require.NoError(t, fileutil.Replace(dir, dir+tmpForCreationBlockDirSuffix))
 		expectedRemovedDirs[dir+tmpForCreationBlockDirSuffix] = struct{}{}
 
-		// Tmp blocks during creation & deletion; those should be removed on start.
+		// Tmp blocks during deletion; those should be removed on start.
 		dir = createBlock(t, tmpDir, genSeries(10, 2, 40, 50))
 		require.NoError(t, fileutil.Replace(dir, dir+tmpForDeletionBlockDirSuffix))
 		expectedRemovedDirs[dir+tmpForDeletionBlockDirSuffix] = struct{}{}
+
+		// Pre-2.21 tmp blocks; those should be removed on start.
+		dir = createBlock(t, tmpDir, genSeries(10, 2, 50, 60))
+		require.NoError(t, fileutil.Replace(dir, dir+tmpLegacy))
+		expectedRemovedDirs[dir+tmpLegacy] = struct{}{}
 	}
 	{
 		// One ok block; but two should be replaced.


### PR DESCRIPTION
Signed-off-by: Nguyen Le Vu Long <vulongvn98@gmail.com>

Fixes https://github.com/prometheus/prometheus/issues/8180

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->