### PR TITLE
API: Fix global URL when external address has no port

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -750,14 +750,26 @@ type GlobalURLOptions struct {
 	Scheme        string
 }
 
-func getGlobalURL(u *url.URL, opts GlobalURLOptions) (*url.URL, error) {
-	host, port, err := net.SplitHostPort(u.Host)
-	if err != nil {
-		if strings.HasSuffix(err.Error(), "missing port in address") {
-			host = u.Host
-		} else {
-			return u, err
+// sanitizeSplitHostPort acts like net.SplitHostPort.
+// Additionally, if there is no port in the host passed as input, we return the
+// original host, making sure that IPv6 addresses are not surrounded by square
+// brackets.
+func sanitizeSplitHostPort(input string) (string, string, error) {
+	host, port, err := net.SplitHostPort(input)
+	if err != nil && strings.HasSuffix(err.Error(), "missing port in address") {
+		var errWithPort error
+		host, _, errWithPort = net.SplitHostPort(input + ":80")
+		if errWithPort == nil {
+			err = nil
 		}
+	}
+	return host, port, err
+}
+
+func getGlobalURL(u *url.URL, opts GlobalURLOptions) (*url.URL, error) {
+	host, port, err := sanitizeSplitHostPort(u.Host)
+	if err != nil {
+		return u, err
 	}
 
 	for _, lhr := range LocalhostRepresentations {
@@ -782,17 +794,13 @@ func getGlobalURL(u *url.URL, opts GlobalURLOptions) (*url.URL, error) {
 				// externally, so we replace only the hostname by the one in the
 				// external URL. It could be the wrong hostname for the service on
 				// this port, but it's still the best possible guess.
-				host, _, err := net.SplitHostPort(opts.Host)
+				host, _, err := sanitizeSplitHostPort(opts.Host)
 				if err != nil {
-					if strings.HasSuffix(err.Error(), "missing port in address") {
-						host = opts.Host
-					} else {
-						return u, err
-					}
+					return u, err
 				}
 				u.Host = host
 				if port != "" {
-					u.Host += ":" + port
+					u.Host = net.JoinHostPort(u.Host, port)
 				}
 			}
 			break

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -3000,6 +3000,16 @@ func TestGetGlobalURL(t *testing.T) {
 			mustParseURL(t, "http://prometheus.io"),
 			false,
 		},
+		{
+			mustParseURL(t, "http://localhost:9091"),
+			GlobalURLOptions{
+				ListenAddress: "[::1]:9090",
+				Host:          "[::1]",
+				Scheme:        "https",
+			},
+			mustParseURL(t, "http://[::1]:9091"),
+			false,
+		},
 	}
 
 	for i, tc := range testcases {
@@ -3009,6 +3019,7 @@ func TestGetGlobalURL(t *testing.T) {
 				require.Error(t, err)
 				return
 			}
+			require.NoError(t, err)
 			require.Equal(t, tc.expected, output)
 		})
 	}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -3010,6 +3010,16 @@ func TestGetGlobalURL(t *testing.T) {
 			mustParseURL(t, "http://[::1]:9091"),
 			false,
 		},
+		{
+			mustParseURL(t, "http://localhost:9091"),
+			GlobalURLOptions{
+				ListenAddress: "[::1]:9090",
+				Host:          "[::1]:9090",
+				Scheme:        "https",
+			},
+			mustParseURL(t, "http://[::1]:9091"),
+			false,
+		},
 	}
 
 	for i, tc := range testcases {


### PR DESCRIPTION
fix #8358 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->