### PR TITLE
[WIP] Optimise label values API when used with matchers.

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -95,8 +95,7 @@ type ChunkQuerier interface {
 type LabelQuerier interface {
 	// LabelValues returns all potential values for a label name.
 	// It is not safe to use the strings beyond the lifefime of the querier.
-	// TODO(yeya24): support matchers or hints.
-	LabelValues(name string) ([]string, Warnings, error)
+	LabelValues(name string, matchers ...*labels.Matcher) ([]string, Warnings, error)
 
 	// LabelNames returns all the unique label names present in the block in sorted order.
 	// TODO(yeya24): support matchers or hints.

--- a/storage/merge.go
+++ b/storage/merge.go
@@ -155,7 +155,7 @@ func (l labelGenericQueriers) SplitByHalf() (labelGenericQueriers, labelGenericQ
 }
 
 // LabelValues returns all potential values for a label name.
-func (q *mergeGenericQuerier) LabelValues(name string) ([]string, Warnings, error) {
+func (q *mergeGenericQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, Warnings, error) {
 	res, ws, err := q.lvals(q.queriers, name)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "LabelValues() from merge generic querier for label %s", name)

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -28,7 +28,7 @@ func (noopQuerier) Select(bool, *SelectHints, ...*labels.Matcher) SeriesSet {
 	return NoopSeriesSet()
 }
 
-func (noopQuerier) LabelValues(string) ([]string, Warnings, error) {
+func (noopQuerier) LabelValues(string, ...*labels.Matcher) ([]string, Warnings, error) {
 	return nil, nil, nil
 }
 
@@ -51,7 +51,7 @@ func (noopChunkQuerier) Select(bool, *SelectHints, ...*labels.Matcher) ChunkSeri
 	return NoopChunkedSeriesSet()
 }
 
-func (noopChunkQuerier) LabelValues(string) ([]string, Warnings, error) {
+func (noopChunkQuerier) LabelValues(string, ...*labels.Matcher) ([]string, Warnings, error) {
 	return nil, nil, nil
 }
 

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -206,7 +206,7 @@ func (q querier) addExternalLabels(ms []*labels.Matcher) ([]*labels.Matcher, lab
 }
 
 // LabelValues implements storage.Querier and is a noop.
-func (q *querier) LabelValues(string) ([]string, storage.Warnings, error) {
+func (q *querier) LabelValues(string, ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	// TODO: Implement: https://github.com/prometheus/prometheus/issues/3351
 	return nil, nil, errors.New("not implemented")
 }

--- a/storage/secondary.go
+++ b/storage/secondary.go
@@ -47,8 +47,8 @@ func newSecondaryQuerierFromChunk(cq ChunkQuerier) genericQuerier {
 	return &secondaryQuerier{genericQuerier: newGenericQuerierFromChunk(cq)}
 }
 
-func (s *secondaryQuerier) LabelValues(name string) ([]string, Warnings, error) {
-	vals, w, err := s.genericQuerier.LabelValues(name)
+func (s *secondaryQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, Warnings, error) {
+	vals, w, err := s.genericQuerier.LabelValues(name, matchers...)
 	if err != nil {
 		return nil, append([]error{err}, w...), nil
 	}

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -63,10 +63,10 @@ type IndexReader interface {
 	Symbols() index.StringIter
 
 	// SortedLabelValues returns sorted possible label values.
-	SortedLabelValues(name string) ([]string, error)
+	SortedLabelValues(name string, matchers ...*labels.Matcher) ([]string, error)
 
 	// LabelValues returns possible label values which may not be sorted.
-	LabelValues(name string) ([]string, error)
+	LabelValues(name string, matchers ...*labels.Matcher) ([]string, error)
 
 	// Postings returns the postings list iterator for the label pairs.
 	// The Postings here contain the offsets to the series inside the index.
@@ -415,13 +415,13 @@ func (r blockIndexReader) Symbols() index.StringIter {
 	return r.ir.Symbols()
 }
 
-func (r blockIndexReader) SortedLabelValues(name string) ([]string, error) {
-	st, err := r.ir.SortedLabelValues(name)
+func (r blockIndexReader) SortedLabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
+	st, err := r.ir.SortedLabelValues(name, matchers...)
 	return st, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
 }
 
-func (r blockIndexReader) LabelValues(name string) ([]string, error) {
-	st, err := r.ir.LabelValues(name)
+func (r blockIndexReader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
+	st, err := r.ir.LabelValues(name, matchers...)
 	return st, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
 }
 

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -98,7 +98,7 @@ func (p *MemPostings) LabelNames() []string {
 }
 
 // LabelValues returns label values for the given name.
-func (p *MemPostings) LabelValues(name string) []string {
+func (p *MemPostings) LabelValues(name string, matchers ...*labels.Matcher) []string {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -83,8 +83,8 @@ func newBlockBaseQuerier(b BlockReader, mint, maxt int64) (*blockBaseQuerier, er
 	}, nil
 }
 
-func (q *blockBaseQuerier) LabelValues(name string) ([]string, storage.Warnings, error) {
-	res, err := q.index.SortedLabelValues(name)
+func (q *blockBaseQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+	res, err := q.index.SortedLabelValues(name, matchers...)
 	return res, nil, err
 }
 


### PR DESCRIPTION
Signed-off-by: Tom Wilkie <tom@grafana.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->