### PR TITLE
Enforce SECURITY.md updates

### DIFF
--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -73,10 +73,12 @@ process_repo() {
     fi
     if [[ -z "${target_file}" ]]; then
       echo "${source_file} doesn't exist in ${org_repo}"
-      if [[ "${source_file}" == 'CODE_OF_CONDUCT.md' ]] ; then
-        echo "CODE_OF_CONDUCT.md missing in ${org_repo}, force updating."
-        needs_update+=('CODE_OF_CONDUCT.md')
-      fi
+      case "${source_file}" in
+        CODE_OF_CONDUCT.md | SECURITY.md)
+          echo "${source_file} missing in ${org_repo}, force updating."
+          needs_update+=("${source_file}")
+          ;;
+      esac
       continue
     fi
     target_checksum="$(echo "${target_file}" | sha256sum | cut -d' ' -f1)"


### PR DESCRIPTION
Add SECURITY.md to the enforced repo sync updates.

Signed-off-by: Ben Kochie <superq@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->