### PR TITLE
Fix TSDB head struct dump on querier error

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1010,6 +1010,13 @@ func (h *RangeHead) Meta() BlockMeta {
 	}
 }
 
+// String returns an human readable representation of the range head. It's important to
+// keep this function in order to avoid the struct dump when the head is stringified in
+// errors or logs.
+func (h *RangeHead) String() string {
+	return "range head"
+}
+
 // initAppender is a helper to initialize the time bounds of the head
 // upon the first sample it receives.
 type initAppender struct {
@@ -1490,6 +1497,13 @@ func (h *Head) Close() error {
 		errs.Add(h.wal.Close())
 	}
 	return errs.Err()
+}
+
+// String returns an human readable representation of the TSDB head. It's important to
+// keep this function in order to avoid the struct dump when the head is stringified in
+// errors or logs.
+func (h *Head) String() string {
+	return "head"
 }
 
 type headChunkReader struct {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1014,7 +1014,7 @@ func (h *RangeHead) Meta() BlockMeta {
 // keep this function in order to avoid the struct dump when the head is stringified in
 // errors or logs.
 func (h *RangeHead) String() string {
-	return "range head"
+	return fmt.Sprintf("range head (mint: %d, maxt: %d)", h.MinTime(), h.MaxTime())
 }
 
 // initAppender is a helper to initialize the time bounds of the head


### PR DESCRIPTION
Today, I noticed (in Cortex) that the `open querier for block` include a stringify of the block, but if what failed was the TSDB head it actually dump the struct. Eg.

```
level=warn ts=2021-01-18T10:47:58.080281469Z caller=grpc_logging.go:55 duration=8.779921ms method=/cortex.Ingester/QueryStream err="open querier for block &{%!s(*tsdb.Head=&{{[] 7200000} {[] 6} {[] 1610964898033} {[] 1610966818087} {... REDACTED ...}) %!s(int64=1610966518087) %!s(int64=1610966818087)}: open chunk reader: can't read from a closed head" msg="gRPC\n"
```

This PR should fix it. I'm open to suggestions if you prefer address it differently.