### PR TITLE
Log recoverable remote write errors as warnings

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1064,7 +1064,7 @@ func sendWriteRequestWithBackoff(ctx context.Context, cfg config.QueueConfig, s 
 
 		// If we make it this far, we've encountered a recoverable error and will retry.
 		onRetry()
-		level.Debug(l).Log("msg", "failed to send batch, retrying", "err", err)
+		level.Warn(l).Log("msg", "Failed to send batch, retrying", "err", err)
 
 		time.Sleep(time.Duration(backoff))
 		backoff = backoff * 2


### PR DESCRIPTION
This was initially implemented in https://github.com/prometheus/prometheus/pull/7184, but a subsequent PR accidentally reverted the behavior, I assume due to missing the change in a rebase.