### PR TITLE
Add ability to set minValidTime in TSDB

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -681,11 +681,9 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	}
 	// Set the min valid time for the ingested samples
 	// to be no lower than the maxt of the last block.
-	// But if we can overlap blocks, we don't need
-	// this limit.
 	blocks := db.Blocks()
 	minValidTime := int64(math.MinInt64)
-	if !db.opts.AllowOverlappingBlocks && len(blocks) > 0 {
+	if len(blocks) > 0 {
 		minValidTime = blocks[len(blocks)-1].Meta().MaxTime
 	}
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -681,9 +681,11 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	}
 	// Set the min valid time for the ingested samples
 	// to be no lower than the maxt of the last block.
+	// But if we can overlap blocks, we don't need
+	// this limit.
 	blocks := db.Blocks()
 	minValidTime := int64(math.MinInt64)
-	if len(blocks) > 0 {
+	if !db.opts.AllowOverlappingBlocks && len(blocks) > 0 {
 		minValidTime = blocks[len(blocks)-1].Meta().MaxTime
 	}
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -752,6 +752,11 @@ func (h *Head) Init(minValidTime int64) error {
 	return nil
 }
 
+// SetMinValidTime sets the minimum timestamp the head can ingest.
+func (h *Head) SetMinValidTime(minValidTime int64) {
+	h.minValidTime.Store(minValidTime)
+}
+
 func (h *Head) loadMmappedChunks() (map[uint64][]*mmappedChunk, error) {
 	mmappedChunks := map[uint64][]*mmappedChunk{}
 	if err := h.chunkDiskMapper.IterateAllChunks(func(seriesRef, chunkRef uint64, mint, maxt int64, numSamples uint16) error {


### PR DESCRIPTION
I haven't fully thought this through and this is admittedly a shower
thought. But we now limit the data you can ingest only older than the
last block on disk, and for a good reason, to avoid overlapping blocks.

This in particular is not very helpful if the users want to preempt
compaction for some reason. For example, in Cortex, on rollouts we just
shutdown and replay the WAL. This can take quite sometime and our
rollouts are now longer than 6hrs. One way to speed this up is to
compact and load only compacted blocks. But we cannot ingest data older
than the last block so we don't do this.

I feel like this would be common for non-Prometheus use-cases and given
we don't set this option by default in Prometheus, I think we should let
let slight overlaps if the overlapping blocks option is set.

/cc @codesome @bwplotka