### PR TITLE
remote_write: allow passing along custom HTTP headers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,8 +35,10 @@ import (
 var (
 	patRulePath         = regexp.MustCompile(`^[^*]*(\*[^/]*)?$`)
 	unchangeableHeaders = map[string]struct{}{
+		// NOTE: authorization is checked specially,
+		// see RemoteWriteConfig.UnmarshalYAML.
+		// "authorization":                  {},
 		"host":                              {},
-		"authorization":                     {},
 		"content-encoding":                  {},
 		"content-type":                      {},
 		"x-prometheus-remote-write-version": {},

--- a/config/config.go
+++ b/config/config.go
@@ -570,6 +570,7 @@ func CheckTargetAddress(address model.LabelValue) error {
 type RemoteWriteConfig struct {
 	URL                 *config.URL       `yaml:"url"`
 	RemoteTimeout       model.Duration    `yaml:"remote_timeout,omitempty"`
+	Headers             map[string]string `yaml:"headers,omitempty"`
 	WriteRelabelConfigs []*relabel.Config `yaml:"write_relabel_configs,omitempty"`
 	Name                string            `yaml:"name,omitempty"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,7 @@ var (
 		"authorization":                     {},
 		"content-encoding":                  {},
 		"content-type":                      {},
-		"c-prometheus-remote-write-version": {},
+		"x-prometheus-remote-write-version": {},
 		"user-agent":                        {},
 		"connection":                        {},
 		"keep-alive":                        {},
@@ -615,6 +615,9 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 		}
 	}
 	for header := range c.Headers {
+		if strings.ToLower(header) == "authorization" {
+			return errors.New("authorization header must be changed via the basic_auth, bearer_token, or bearer_token_file parameter")
+		}
 		if _, ok := unchangeableHeaders[strings.ToLower(header)]; ok {
 			return errors.Errorf("%s is an unchangeable header", header)
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -939,6 +939,12 @@ var expectedErrors = []struct {
 		filename: "remote_read_url_missing.bad.yml",
 		errMsg:   `url for remote_read is empty`,
 	}, {
+		filename: "remote_write_header.bad.yml",
+		errMsg:   `x-prometheus-remote-write-version is an unchangeable header`,
+	}, {
+		filename: "remote_write_authorization_header.bad.yml",
+		errMsg:   `authorization header must be changed via the basic_auth, bearer_token, or bearer_token_file parameter`,
+	}, {
 		filename: "remote_write_url_missing.bad.yml",
 		errMsg:   `url for remote_write is empty`,
 	}, {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -102,6 +102,7 @@ var expectedConf = &Config{
 					KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 				},
 			},
+			Headers: map[string]string{"name": "value"},
 		},
 	},
 

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -24,6 +24,8 @@ remote_write:
     tls_config:
       cert_file: valid_cert_file
       key_file: valid_key_file
+    headers:
+      name: value
 
 remote_read:
   - url: http://remote1/read

--- a/config/testdata/remote_write_authorization_header.bad.yml
+++ b/config/testdata/remote_write_authorization_header.bad.yml
@@ -1,0 +1,5 @@
+remote_write:
+  - url: localhost:9090
+    name: queue1
+    headers:
+      "authorization": "Basic YWxhZGRpbjpvcGVuc2VzYW1l"

--- a/config/testdata/remote_write_header.bad.yml
+++ b/config/testdata/remote_write_header.bad.yml
@@ -1,0 +1,5 @@
+remote_write:
+  - url: localhost:9090
+    name: queue1
+    headers:
+      "x-prometheus-remote-write-version": "somehack"

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1719,6 +1719,10 @@ url: <string>
 # Timeout for requests to the remote write endpoint.
 [ remote_timeout: <duration> | default = 30s ]
 
+# Custom HTTP headers to be sent along with each remote write request.
+headers:
+  [ <string>: <string> ... ]
+
 # List of remote write relabel configurations.
 write_relabel_configs:
   [ - <relabel_config> ... ]

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1720,6 +1720,7 @@ url: <string>
 [ remote_timeout: <duration> | default = 30s ]
 
 # Custom HTTP headers to be sent along with each remote write request.
+# Be aware that headers that are set by Prometheus itself can't be overwritten.
 headers:
   [ <string>: <string> ... ]
 

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -83,6 +83,7 @@ type Client struct {
 	url        *config_util.URL
 	Client     *http.Client
 	timeout    time.Duration
+	headers    map[string]string
 
 	readQueries         prometheus.Gauge
 	readQueriesTotal    *prometheus.CounterVec
@@ -94,6 +95,7 @@ type ClientConfig struct {
 	URL              *config_util.URL
 	Timeout          model.Duration
 	HTTPClientConfig config_util.HTTPClientConfig
+	Headers          map[string]string
 }
 
 // ReadClient uses the SAMPLES method of remote read to read series samples from remote server.
@@ -142,6 +144,7 @@ func NewWriteClient(name string, conf *ClientConfig) (WriteClient, error) {
 		url:        conf.URL,
 		Client:     httpClient,
 		timeout:    time.Duration(conf.Timeout),
+		headers:    conf.Headers,
 	}, nil
 }
 
@@ -157,6 +160,9 @@ func (c *Client) Store(ctx context.Context, req []byte) error {
 		// Errors from NewRequest are from unparsable URLs, so are not
 		// recoverable.
 		return err
+	}
+	for k, v := range c.headers {
+		httpReq.Header.Set(k, v)
 	}
 	httpReq.Header.Add("Content-Encoding", "snappy")
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -134,6 +134,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			URL:              rwConf.URL,
 			Timeout:          rwConf.RemoteTimeout,
 			HTTPClientConfig: rwConf.HTTPClientConfig,
+			Headers:          rwConf.Headers,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
This change adds the ability to send custom HTTP headers in remote write requests, which makes the configuration of a proxy in between optional and helps the receiver side recognize the given source better.

For example, when using a Thanos receiver a `THANOS-TENANT` header can help Thanos to distribute the data of separate tenants, but some examples need to use a reverse-proxy (like NGINX) for this like in this tutorial: https://www.infracloud.io/blogs/multi-tenancy-monitoring-thanos-receiver/ which is somewhat a larger ceremony for adding just an HTTP header to each request.
