### PR TITLE
Update MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,4 @@
-@brian-brazil is the main/default maintainer, some parts of the codebase have other maintainers:
+@roidelapluie is the main/default maintainer, some parts of the codebase have other maintainers:
 
 * `cmd`
   * `promtool`: @simonpasquier

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,9 +13,9 @@
   * `ui`: @juliusv
 * `Makefile` and related build configuration: @simonpasquier, @SuperQ
 
-For the sake of brevity all subtrees are not explicitly listed. Due to the size
-of this repository, the natural changes in focus of maintainers over time, and
-nuances of where particular features live, this list will always be incomplete
-and out of date. However the listed maintainer(s) should be able to direct a
-PR/question to the right person.
+For the sake of brevity, not all subtrees are explicitly listed. Due to the
+size of this repository, the natural changes in focus of maintainers over time,
+and nuances of where particular features live, this list will always be
+incomplete and out of date. However the listed maintainer(s) should be able to
+direct a PR/question to the right person.
 


### PR DESCRIPTION
Yesterday at the dev-summit, the Prometheus team has proposed @roidelapluie as the new main/default maintainer for this repo after @brian-brazil's retirement from the project.

This change will only be merged after an announcement on the prometheus-developers mailing list and is subject to lazy consensus.

Thank you, @brian-brazil, for the incredible amount of work done in this repository and for the project in general.

(This PR also fixes a slight logical ambiguity in the footer.)