### PR TITLE
Added warnings into React Panel on the Graph page

### DIFF
--- a/web/ui/react-app/src/pages/graph/Panel.tsx
+++ b/web/ui/react-app/src/pages/graph/Panel.tsx
@@ -29,6 +29,7 @@ interface PanelState {
   data: any; // TODO: Type data.
   lastQueryParams: QueryParams | null;
   loading: boolean;
+  warnings: string[] | null;
   error: string | null;
   stats: QueryStats | null;
   exprInputValue: string;
@@ -67,6 +68,7 @@ class Panel extends Component<PanelProps, PanelState> {
       data: null,
       lastQueryParams: null,
       loading: false,
+      warnings: null,
       error: null,
       stats: null,
       exprInputValue: props.options.expr,
@@ -156,6 +158,7 @@ class Panel extends Component<PanelProps, PanelState> {
         this.setState({
           error: null,
           data: json.data,
+          warnings: json.warnings,
           lastQueryParams: {
             startTime,
             endTime,
@@ -245,6 +248,11 @@ class Panel extends Component<PanelProps, PanelState> {
         <Row>
           <Col>{this.state.error && <Alert color="danger">{this.state.error}</Alert>}</Col>
         </Row>
+        {this.state.warnings?.map((warning, index) => (
+          <Row key={index}>
+            <Col>{warning && <Alert color="warning">{warning}</Alert>}</Col>
+          </Row>
+        ))}
         <Row>
           <Col>
             <Nav tabs>


### PR DESCRIPTION
Good time of the day,

I added warnings to be displayed in React Graph panel similarly as to how they are displayed in the old UI as suggested in #8030. The change seemed small enough to not require individual test. It's my first time contributing to Prometheus, so please let me know if you want me to change anything.