### PR TITLE
fix: UI error while compiling on Windows

### DIFF
--- a/web/ui/ui.go
+++ b/web/ui/ui.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/shurcooL/httpfs/filter"
@@ -32,7 +33,7 @@ var Assets = func() http.FileSystem {
 		panic(err)
 	}
 	var assetsPrefix string
-	switch path.Base(wd) {
+	switch filepath.Base(wd) {
 	case "prometheus":
 		// When running Prometheus (without built-in assets) from the repo root.
 		assetsPrefix = "./web/ui"


### PR DESCRIPTION
These few lines of code are used to set the `assetsPrefix`:

```go
var assetsPrefix string
switch path.Base(wd) {
case "prometheus":
	// When running Prometheus (without built-in assets) from the repo root.
	assetsPrefix = "./web/ui"
case "web":
	// When running web tests.
	assetsPrefix = "./ui"
case "ui":
	// When generating statically compiled-in assets.
	assetsPrefix = "./"
}
```

When I am compiling and running project on Windows, variable `wd` is a real path like `D:\source\prometheus`. 

`path.Base` is not able to get the correct result, my expected result is **prometheus**, but the actual result is **D:\source\prometheus**. This error prevents the program from finding the correct UI resource.

We can change the `path.Base` to `filepath.Base` to solve the problem.

The PR may solve issues like #4596.