### PR TITLE
backfill: move checkErr before we close the mmaped file

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -207,7 +207,7 @@ func main() {
 		os.Exit(checkErr(dumpSamples(*dumpPath, *dumpMinTime, *dumpMaxTime)))
 	//TODO(aSquare14): Work on adding support for custom block size.
 	case openMetricsImportCmd.FullCommand():
-		os.Exit(checkErr(backfillOpenMetrics(*importFilePath, *importDBPath, *importHumanReadable)))
+		os.Exit(backfillOpenMetrics(*importFilePath, *importDBPath, *importHumanReadable))
 	}
 }
 

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -618,16 +618,16 @@ func checkErr(err error) int {
 	return 0
 }
 
-func backfillOpenMetrics(path string, outputDir string, humanReadable bool) (err error) {
+func backfillOpenMetrics(path string, outputDir string, humanReadable bool) int {
 	inputFile, err := fileutil.OpenMmapFile(path)
 	if err != nil {
-		return err
+		return checkErr(err)
 	}
 	defer inputFile.Close()
 
 	if err := os.MkdirAll(outputDir, 0777); err != nil {
-		return errors.Wrap(err, "create output dir")
+		return checkErr(errors.Wrap(err, "create output dir"))
 	}
 
-	return backfill(5000, inputFile.Bytes(), outputDir, humanReadable)
+	return checkErr(backfill(5000, inputFile.Bytes(), outputDir, humanReadable))
 }


### PR DESCRIPTION
When printing the error, we still need access to the mmapped byte array
of the file. Therefore, we make sure that we run it before closing the
file.

I could have done something more complex like a defer, or not closing
the file, knowing that we would exit the program anyway. However, I
think that in case we extend this in the future, or this is copy/paster
elsewhere, we should continue closing the file. As it is small enough, I
went for the solution to call the function 3 times instead of playing
with a defer.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->