### PR TITLE
Add optional name property to testgroup for better test failure output

### DIFF
--- a/cmd/promtool/testdata/failing.yml
+++ b/cmd/promtool/testdata/failing.yml
@@ -1,6 +1,7 @@
 tests:
   # Simple failing test.
   - interval: 1m
+    name: "Failing test"
     input_series:
       - series: test
         values: '0'

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -146,6 +146,7 @@ type testGroup struct {
 	AlertRuleTests  []alertTestCase  `yaml:"alert_rule_test,omitempty"`
 	PromqlExprTests []promqlTestCase `yaml:"promql_expr_test,omitempty"`
 	ExternalLabels  labels.Labels    `yaml:"external_labels,omitempty"`
+	TestGroupName   string           `yaml:"name,omitempty"`
 }
 
 // test performs the unit tests.
@@ -300,15 +301,25 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 				}
 
 				if gotAlerts.Len() != expAlerts.Len() {
-					errs = append(errs, errors.Errorf("    alertname:%s, time:%s, \n        exp:%#v, \n        got:%#v",
-						testcase.Alertname, testcase.EvalTime.String(), expAlerts.String(), gotAlerts.String()))
+					if tg.TestGroupName == "" {
+						errs = append(errs, errors.Errorf("    alertname:%s, time:%s, \n        exp:%#v, \n        got:%#v",
+							testcase.Alertname, testcase.EvalTime.String(), expAlerts.String(), gotAlerts.String()))
+					} else {
+						errs = append(errs, errors.Errorf("    name: %s,\n    alertname:%s, time:%s, \n        exp:%#v, \n        got:%#v",
+							tg.TestGroupName, testcase.Alertname, testcase.EvalTime.String(), expAlerts.String(), gotAlerts.String()))
+					}
 				} else {
 					sort.Sort(gotAlerts)
 					sort.Sort(expAlerts)
 
 					if !reflect.DeepEqual(expAlerts, gotAlerts) {
-						errs = append(errs, errors.Errorf("    alertname:%s, time:%s, \n        exp:%#v, \n        got:%#v",
-							testcase.Alertname, testcase.EvalTime.String(), expAlerts.String(), gotAlerts.String()))
+						if tg.TestGroupName == "" {
+							errs = append(errs, errors.Errorf("    alertname:%s, time:%s, \n        exp:%#v, \n        got:%#v",
+								testcase.Alertname, testcase.EvalTime.String(), expAlerts.String(), gotAlerts.String()))
+						} else {
+							errs = append(errs, errors.Errorf("   name: %s,\n    alertname:%s, time:%s, \n        exp:%#v, \n        got:%#v",
+								tg.TestGroupName, testcase.Alertname, testcase.EvalTime.String(), expAlerts.String(), gotAlerts.String()))
+						}
 					}
 				}
 			}

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -300,26 +300,29 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 					})
 				}
 
+				var sb strings.Builder
 				if gotAlerts.Len() != expAlerts.Len() {
-					if tg.TestGroupName == "" {
-						errs = append(errs, errors.Errorf("    alertname:%s, time:%s, \n        exp:%#v, \n        got:%#v",
-							testcase.Alertname, testcase.EvalTime.String(), expAlerts.String(), gotAlerts.String()))
-					} else {
-						errs = append(errs, errors.Errorf("    name: %s,\n    alertname:%s, time:%s, \n        exp:%#v, \n        got:%#v",
-							tg.TestGroupName, testcase.Alertname, testcase.EvalTime.String(), expAlerts.String(), gotAlerts.String()))
+					if tg.TestGroupName != "" {
+						fmt.Fprintf(&sb, "    name: %s,\n", tg.TestGroupName)
 					}
+					fmt.Fprintf(&sb, "    alertname:%s, time:%s, \n", testcase.Alertname, testcase.EvalTime.String())
+					fmt.Fprintf(&sb, "        exp:%#v, \n", expAlerts.String())
+					fmt.Fprintf(&sb, "        got:%#v", gotAlerts.String())
+
+					errs = append(errs, errors.New(sb.String()))
 				} else {
 					sort.Sort(gotAlerts)
 					sort.Sort(expAlerts)
 
 					if !reflect.DeepEqual(expAlerts, gotAlerts) {
-						if tg.TestGroupName == "" {
-							errs = append(errs, errors.Errorf("    alertname:%s, time:%s, \n        exp:%#v, \n        got:%#v",
-								testcase.Alertname, testcase.EvalTime.String(), expAlerts.String(), gotAlerts.String()))
-						} else {
-							errs = append(errs, errors.Errorf("   name: %s,\n    alertname:%s, time:%s, \n        exp:%#v, \n        got:%#v",
-								tg.TestGroupName, testcase.Alertname, testcase.EvalTime.String(), expAlerts.String(), gotAlerts.String()))
+						if tg.TestGroupName != "" {
+							fmt.Fprintf(&sb, "    name: %s,\n", tg.TestGroupName)
 						}
+						fmt.Fprintf(&sb, "    alertname:%s, time:%s, \n", testcase.Alertname, testcase.EvalTime.String())
+						fmt.Fprintf(&sb, "        exp:%#v, \n", expAlerts.String())
+						fmt.Fprintf(&sb, "        got:%#v", gotAlerts.String())
+
+						errs = append(errs, errors.New(sb.String()))
 					}
 				}
 			}

--- a/docs/configuration/unit_testing_rules.md
+++ b/docs/configuration/unit_testing_rules.md
@@ -44,6 +44,9 @@ interval: <duration>
 input_series:
   [ - <series> ]
 
+# Name of the test group
+[ name: <string> ]
+
 # Unit tests for the above data.
 
 # Unit tests for alerting rules. We consider the alerting rules from the input file.


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
Addresses #8439