### PR TITLE
Windows CI: downgrade golang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
         # Temporary workaround until circleci updates go.
         shell: bash
         command: |
-          choco upgrade -y golang
+          choco install golang --version 1.15.7
     - run:
         shell: bash
         command: |


### PR DESCRIPTION
Latest releases has a change in behaviour or a bug:

bash: go: command not found
bash: line 1: go: command not found
bash: line 1: go: command not found

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->