### PR TITLE
Combine NewHead() args into a HeadOptions struct

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -323,7 +323,7 @@ func createBlockFromHead(tb testing.TB, dir string, head *Head) string {
 
 func createHead(tb testing.TB, w *wal.WAL, series []storage.Series, chunkDir string) *Head {
 	opts := DefaultHeadOptions()
-	opts.ChkDirRoot = chunkDir
+	opts.ChunkDirRoot = chunkDir
 	head, err := NewHead(nil, nil, w, opts)
 	require.NoError(tb, err)
 

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -322,7 +322,8 @@ func createBlockFromHead(tb testing.TB, dir string, head *Head) string {
 }
 
 func createHead(tb testing.TB, w *wal.WAL, series []storage.Series, chunkDir string) *Head {
-	opts := DefaultHeadOptions(&HeadOptions{ChkDirRoot: chunkDir})
+	opts := DefaultHeadOptions()
+	opts.ChkDirRoot = chunkDir
 	head, err := NewHead(nil, nil, w, opts)
 	require.NoError(tb, err)
 

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -322,7 +322,8 @@ func createBlockFromHead(tb testing.TB, dir string, head *Head) string {
 }
 
 func createHead(tb testing.TB, w *wal.WAL, series []storage.Series, chunkDir string) *Head {
-	head, err := NewHead(nil, nil, w, DefaultBlockDuration, chunkDir, nil, chunks.DefaultWriteBufferSize, DefaultStripeSize, nil)
+	opts := DefaultHeadOptions(&HeadOptions{ChkDirRoot: chunkDir})
+	head, err := NewHead(nil, nil, w, opts)
 	require.NoError(tb, err)
 
 	app := head.Appender(context.Background())

--- a/tsdb/blockwriter.go
+++ b/tsdb/blockwriter.go
@@ -69,10 +69,9 @@ func (w *BlockWriter) initHead() error {
 		return errors.Wrap(err, "create temp dir")
 	}
 	w.chunkDir = chunkDir
-	opts := DefaultHeadOptions(&HeadOptions{
-		ChunkRange: w.blockSize,
-		ChkDirRoot: w.chunkDir,
-	})
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = w.blockSize
+	opts.ChkDirRoot = w.chunkDir
 	h, err := NewHead(nil, w.logger, nil, opts)
 	if err != nil {
 		return errors.Wrap(err, "tsdb.NewHead")

--- a/tsdb/blockwriter.go
+++ b/tsdb/blockwriter.go
@@ -27,7 +27,6 @@ import (
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
 // BlockWriter is a block writer that allows appending and flushing series to disk.
@@ -70,8 +69,11 @@ func (w *BlockWriter) initHead() error {
 		return errors.Wrap(err, "create temp dir")
 	}
 	w.chunkDir = chunkDir
-
-	h, err := NewHead(nil, w.logger, nil, w.blockSize, w.chunkDir, nil, chunks.DefaultWriteBufferSize, DefaultStripeSize, nil)
+	opts := DefaultHeadOptions(&HeadOptions{
+		ChunkRange: w.blockSize,
+		ChkDirRoot: w.chunkDir,
+	})
+	h, err := NewHead(nil, w.logger, nil, opts)
 	if err != nil {
 		return errors.Wrap(err, "tsdb.NewHead")
 	}

--- a/tsdb/blockwriter.go
+++ b/tsdb/blockwriter.go
@@ -71,7 +71,7 @@ func (w *BlockWriter) initHead() error {
 	w.chunkDir = chunkDir
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = w.blockSize
-	opts.ChkDirRoot = w.chunkDir
+	opts.ChunkDirRoot = w.chunkDir
 	h, err := NewHead(nil, w.logger, nil, opts)
 	if err != nil {
 		return errors.Wrap(err, "tsdb.NewHead")

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1095,7 +1095,7 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 			}()
 			opts := DefaultHeadOptions()
 			opts.ChunkRange = 1000
-			opts.ChkDirRoot = chunkDir
+			opts.ChunkDirRoot = chunkDir
 			h, err := NewHead(nil, nil, nil, opts)
 			require.NoError(b, err)
 			for ln := 0; ln < labelNames; ln++ {

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1093,7 +1093,11 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 			defer func() {
 				require.NoError(b, os.RemoveAll(chunkDir))
 			}()
-			h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, chunks.DefaultWriteBufferSize, DefaultStripeSize, nil)
+			opts := DefaultHeadOptions(&HeadOptions{
+				ChunkRange: 1000,
+				ChkDirRoot: chunkDir,
+			})
+			h, err := NewHead(nil, nil, nil, opts)
 			require.NoError(b, err)
 			for ln := 0; ln < labelNames; ln++ {
 				app := h.Appender(context.Background())

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1093,10 +1093,9 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 			defer func() {
 				require.NoError(b, os.RemoveAll(chunkDir))
 			}()
-			opts := DefaultHeadOptions(&HeadOptions{
-				ChunkRange: 1000,
-				ChkDirRoot: chunkDir,
-			})
+			opts := DefaultHeadOptions()
+			opts.ChunkRange = 1000
+			opts.ChkDirRoot = chunkDir
 			h, err := NewHead(nil, nil, nil, opts)
 			require.NoError(b, err)
 			for ln := 0; ln < labelNames; ln++ {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -334,7 +334,8 @@ func (db *DBReadOnly) FlushWAL(dir string) (returnErr error) {
 	if err != nil {
 		return err
 	}
-	opts := DefaultHeadOptions(&HeadOptions{ChkDirRoot: db.dir})
+	opts := DefaultHeadOptions()
+	opts.ChkDirRoot = db.dir
 	head, err := NewHead(nil, db.logger, w, opts)
 	if err != nil {
 		return err
@@ -388,7 +389,8 @@ func (db *DBReadOnly) loadDataAsQueryable(maxt int64) (storage.SampleAndChunkQue
 		blocks[i] = b
 	}
 
-	opts := DefaultHeadOptions(&HeadOptions{ChkDirRoot: db.dir})
+	opts := DefaultHeadOptions()
+	opts.ChkDirRoot = db.dir
 	head, err := NewHead(nil, db.logger, nil, opts)
 	if err != nil {
 		return nil, err
@@ -407,6 +409,8 @@ func (db *DBReadOnly) loadDataAsQueryable(maxt int64) (storage.SampleAndChunkQue
 		if err != nil {
 			return nil, err
 		}
+		opts := DefaultHeadOptions()
+		opts.ChkDirRoot = db.dir
 		head, err = NewHead(nil, db.logger, w, opts)
 		if err != nil {
 			return nil, err
@@ -652,14 +656,15 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		}
 	}
 
-	headOpts := DefaultHeadOptions(&HeadOptions{
-		ChunkRange:         rngs[0],
-		ChkDirRoot:         dir,
-		ChkPool:            db.chunkPool,
-		ChkWriteBufferSize: opts.HeadChunksWriteBufferSize,
-		StripeSize:         opts.StripeSize,
-		SeriesCallback:     opts.SeriesLifecycleCallback,
-	})
+	headOpts := DefaultHeadOptions()
+	headOpts.ChunkRange = rngs[0]
+	headOpts.ChkDirRoot = dir
+	headOpts.ChkPool = db.chunkPool
+	headOpts.ChkWriteBufferSize = opts.HeadChunksWriteBufferSize
+	headOpts.StripeSize = opts.StripeSize
+	if opts.SeriesLifecycleCallback != nil {
+		headOpts.SeriesCallback = opts.SeriesLifecycleCallback
+	}
 	db.head, err = NewHead(r, l, wlog, headOpts)
 	if err != nil {
 		return nil, err

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -335,7 +335,7 @@ func (db *DBReadOnly) FlushWAL(dir string) (returnErr error) {
 		return err
 	}
 	opts := DefaultHeadOptions()
-	opts.ChkDirRoot = db.dir
+	opts.ChunkDirRoot = db.dir
 	head, err := NewHead(nil, db.logger, w, opts)
 	if err != nil {
 		return err
@@ -390,7 +390,7 @@ func (db *DBReadOnly) loadDataAsQueryable(maxt int64) (storage.SampleAndChunkQue
 	}
 
 	opts := DefaultHeadOptions()
-	opts.ChkDirRoot = db.dir
+	opts.ChunkDirRoot = db.dir
 	head, err := NewHead(nil, db.logger, nil, opts)
 	if err != nil {
 		return nil, err
@@ -410,7 +410,7 @@ func (db *DBReadOnly) loadDataAsQueryable(maxt int64) (storage.SampleAndChunkQue
 			return nil, err
 		}
 		opts := DefaultHeadOptions()
-		opts.ChkDirRoot = db.dir
+		opts.ChunkDirRoot = db.dir
 		head, err = NewHead(nil, db.logger, w, opts)
 		if err != nil {
 			return nil, err
@@ -658,13 +658,11 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 
 	headOpts := DefaultHeadOptions()
 	headOpts.ChunkRange = rngs[0]
-	headOpts.ChkDirRoot = dir
-	headOpts.ChkPool = db.chunkPool
-	headOpts.ChkWriteBufferSize = opts.HeadChunksWriteBufferSize
+	headOpts.ChunkDirRoot = dir
+	headOpts.ChunkPool = db.chunkPool
+	headOpts.ChunkWriteBufferSize = opts.HeadChunksWriteBufferSize
 	headOpts.StripeSize = opts.StripeSize
-	if opts.SeriesLifecycleCallback != nil {
-		headOpts.SeriesCallback = opts.SeriesLifecycleCallback
-	}
+	headOpts.SeriesCallback = opts.SeriesLifecycleCallback
 	db.head, err = NewHead(r, l, wlog, headOpts)
 	if err != nil {
 		return nil, err

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -334,7 +334,8 @@ func (db *DBReadOnly) FlushWAL(dir string) (returnErr error) {
 	if err != nil {
 		return err
 	}
-	head, err := NewHead(nil, db.logger, w, DefaultBlockDuration, db.dir, nil, chunks.DefaultWriteBufferSize, DefaultStripeSize, nil)
+	opts := DefaultHeadOptions(&HeadOptions{ChkDirRoot: db.dir})
+	head, err := NewHead(nil, db.logger, w, opts)
 	if err != nil {
 		return err
 	}
@@ -387,7 +388,8 @@ func (db *DBReadOnly) loadDataAsQueryable(maxt int64) (storage.SampleAndChunkQue
 		blocks[i] = b
 	}
 
-	head, err := NewHead(nil, db.logger, nil, DefaultBlockDuration, db.dir, nil, chunks.DefaultWriteBufferSize, DefaultStripeSize, nil)
+	opts := DefaultHeadOptions(&HeadOptions{ChkDirRoot: db.dir})
+	head, err := NewHead(nil, db.logger, nil, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +407,7 @@ func (db *DBReadOnly) loadDataAsQueryable(maxt int64) (storage.SampleAndChunkQue
 		if err != nil {
 			return nil, err
 		}
-		head, err = NewHead(nil, db.logger, w, DefaultBlockDuration, db.dir, nil, chunks.DefaultWriteBufferSize, DefaultStripeSize, nil)
+		head, err = NewHead(nil, db.logger, w, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -650,7 +652,15 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		}
 	}
 
-	db.head, err = NewHead(r, l, wlog, rngs[0], dir, db.chunkPool, opts.HeadChunksWriteBufferSize, opts.StripeSize, opts.SeriesLifecycleCallback)
+	headOpts := DefaultHeadOptions(&HeadOptions{
+		ChunkRange:         rngs[0],
+		ChkDirRoot:         dir,
+		ChkPool:            db.chunkPool,
+		ChkWriteBufferSize: opts.HeadChunksWriteBufferSize,
+		StripeSize:         opts.StripeSize,
+		SeriesCallback:     opts.SeriesLifecycleCallback,
+	})
+	db.head, err = NewHead(r, l, wlog, headOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -109,8 +109,8 @@ type HeadOptions struct {
 	SeriesCallback SeriesLifecycleCallback
 }
 
-func DefaultHeadOptions(overrides *HeadOptions) *HeadOptions {
-	base := &HeadOptions{
+func DefaultHeadOptions() *HeadOptions {
+	return &HeadOptions{
 		ChunkRange:         DefaultBlockDuration,
 		ChkDirRoot:         "",
 		ChkPool:            chunkenc.NewPool(),
@@ -118,25 +118,6 @@ func DefaultHeadOptions(overrides *HeadOptions) *HeadOptions {
 		StripeSize:         DefaultStripeSize,
 		SeriesCallback:     &noopSeriesLifecycleCallback{},
 	}
-	if overrides.ChunkRange != 0 {
-		base.ChunkRange = overrides.ChunkRange
-	}
-	if overrides.ChkDirRoot != "" {
-		base.ChkDirRoot = overrides.ChkDirRoot
-	}
-	if overrides.ChkPool != nil {
-		base.ChkPool = overrides.ChkPool
-	}
-	if overrides.ChkWriteBufferSize != 0 {
-		base.ChkWriteBufferSize = overrides.ChkWriteBufferSize
-	}
-	if overrides.StripeSize != 0 {
-		base.StripeSize = overrides.StripeSize
-	}
-	if overrides.SeriesCallback != nil {
-		base.SeriesCallback = overrides.SeriesCallback
-	}
-	return base
 }
 
 type headMetrics struct {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -61,6 +61,7 @@ type Head struct {
 	lastSeriesID          atomic.Uint64
 
 	metrics      *headMetrics
+	opts         *HeadOptions
 	wal          *wal.WAL
 	logger       log.Logger
 	appendPool   sync.Pool
@@ -69,8 +70,7 @@ type Head struct {
 	memChunkPool sync.Pool
 
 	// All series addressable by their ID or hash.
-	series         *stripeSeries
-	seriesCallback SeriesLifecycleCallback
+	series *stripeSeries
 
 	symMtx  sync.RWMutex
 	symbols map[string]struct{}
@@ -90,11 +90,53 @@ type Head struct {
 
 	// chunkDiskMapper is used to write and read Head chunks to/from disk.
 	chunkDiskMapper *chunks.ChunkDiskMapper
-	// chunkDirRoot is the parent directory of the chunks directory.
-	chunkDirRoot string
 
 	closedMtx sync.Mutex
 	closed    bool
+}
+
+// HeadOptions are parameters for Head.
+type HeadOptions struct {
+	ChunkRange int64
+	// chunkDirRoot is the parent directory of the chunks directory.
+	ChkDirRoot         string
+	ChkPool            chunkenc.Pool
+	ChkWriteBufferSize int
+	// StripeSize sets the number of entries in the hash map, it must be a power of 2.
+	// A larger StripeSize will allocate more memory up-front, but will increase performance when handling a large number of series.
+	// A smaller StripeSize reduces the memory allocated, but can decrease performance with large number of series.
+	StripeSize     int
+	SeriesCallback SeriesLifecycleCallback
+}
+
+func DefaultHeadOptions(overrides *HeadOptions) *HeadOptions {
+	base := &HeadOptions{
+		ChunkRange:         DefaultBlockDuration,
+		ChkDirRoot:         "",
+		ChkPool:            chunkenc.NewPool(),
+		ChkWriteBufferSize: chunks.DefaultWriteBufferSize,
+		StripeSize:         DefaultStripeSize,
+		SeriesCallback:     &noopSeriesLifecycleCallback{},
+	}
+	if overrides.ChunkRange != 0 {
+		base.ChunkRange = overrides.ChunkRange
+	}
+	if overrides.ChkDirRoot != "" {
+		base.ChkDirRoot = overrides.ChkDirRoot
+	}
+	if overrides.ChkPool != nil {
+		base.ChkPool = overrides.ChkPool
+	}
+	if overrides.ChkWriteBufferSize != 0 {
+		base.ChkWriteBufferSize = overrides.ChkWriteBufferSize
+	}
+	if overrides.StripeSize != 0 {
+		base.StripeSize = overrides.StripeSize
+	}
+	if overrides.SeriesCallback != nil {
+		base.SeriesCallback = overrides.SeriesCallback
+	}
+	return base
 }
 
 type headMetrics struct {
@@ -292,23 +334,18 @@ func (h *Head) PostingsCardinalityStats(statsByLabelName string) *index.Postings
 }
 
 // NewHead opens the head block in dir.
-// stripeSize sets the number of entries in the hash map, it must be a power of 2.
-// A larger stripeSize will allocate more memory up-front, but will increase performance when handling a large number of series.
-// A smaller stripeSize reduces the memory allocated, but can decrease performance with large number of series.
-func NewHead(r prometheus.Registerer, l log.Logger, wal *wal.WAL, chunkRange int64, chkDirRoot string, chkPool chunkenc.Pool, chkWriteBufferSize, stripeSize int, seriesCallback SeriesLifecycleCallback) (*Head, error) {
+func NewHead(r prometheus.Registerer, l log.Logger, wal *wal.WAL, opts *HeadOptions) (*Head, error) {
 	if l == nil {
 		l = log.NewNopLogger()
 	}
-	if chunkRange < 1 {
-		return nil, errors.Errorf("invalid chunk range %d", chunkRange)
-	}
-	if seriesCallback == nil {
-		seriesCallback = &noopSeriesLifecycleCallback{}
+	if opts.ChunkRange < 1 {
+		return nil, errors.Errorf("invalid chunk range %d", opts.ChunkRange)
 	}
 	h := &Head{
 		wal:        wal,
 		logger:     l,
-		series:     newStripeSeries(stripeSize, seriesCallback),
+		opts:       opts,
+		series:     newStripeSeries(opts.StripeSize, opts.SeriesCallback),
 		symbols:    map[string]struct{}{},
 		postings:   index.NewUnorderedMemPostings(),
 		tombstones: tombstones.NewMemTombstones(),
@@ -319,21 +356,19 @@ func NewHead(r prometheus.Registerer, l log.Logger, wal *wal.WAL, chunkRange int
 				return &memChunk{}
 			},
 		},
-		chunkDirRoot:   chkDirRoot,
-		seriesCallback: seriesCallback,
 	}
-	h.chunkRange.Store(chunkRange)
+	h.chunkRange.Store(opts.ChunkRange)
 	h.minTime.Store(math.MaxInt64)
 	h.maxTime.Store(math.MinInt64)
 	h.lastWALTruncationTime.Store(math.MinInt64)
 	h.metrics = newHeadMetrics(h, r)
 
-	if chkPool == nil {
-		chkPool = chunkenc.NewPool()
-	}
-
 	var err error
-	h.chunkDiskMapper, err = chunks.NewChunkDiskMapper(mmappedChunksDir(chkDirRoot), chkPool, chkWriteBufferSize)
+	h.chunkDiskMapper, err = chunks.NewChunkDiskMapper(
+		mmappedChunksDir(opts.ChkDirRoot),
+		opts.ChkPool,
+		opts.ChkWriteBufferSize,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -23,7 +23,6 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
 func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
@@ -33,7 +32,11 @@ func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 		require.NoError(b, os.RemoveAll(chunkDir))
 	}()
 	// Put a series, select it. GC it and then access it.
-	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, chunks.DefaultWriteBufferSize, DefaultStripeSize, nil)
+	opts := DefaultHeadOptions(&HeadOptions{
+		ChunkRange: 1000,
+		ChkDirRoot: chunkDir,
+	})
+	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(b, err)
 	defer h.Close()
 
@@ -49,7 +52,11 @@ func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 		require.NoError(b, os.RemoveAll(chunkDir))
 	}()
 	// Put a series, select it. GC it and then access it.
-	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, chunks.DefaultWriteBufferSize, DefaultStripeSize, nil)
+	opts := DefaultHeadOptions(&HeadOptions{
+		ChunkRange: 1000,
+		ChkDirRoot: chunkDir,
+	})
+	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(b, err)
 	defer h.Close()
 

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -32,10 +32,9 @@ func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 		require.NoError(b, os.RemoveAll(chunkDir))
 	}()
 	// Put a series, select it. GC it and then access it.
-	opts := DefaultHeadOptions(&HeadOptions{
-		ChunkRange: 1000,
-		ChkDirRoot: chunkDir,
-	})
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	opts.ChkDirRoot = chunkDir
 	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(b, err)
 	defer h.Close()
@@ -52,10 +51,9 @@ func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 		require.NoError(b, os.RemoveAll(chunkDir))
 	}()
 	// Put a series, select it. GC it and then access it.
-	opts := DefaultHeadOptions(&HeadOptions{
-		ChunkRange: 1000,
-		ChkDirRoot: chunkDir,
-	})
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	opts.ChkDirRoot = chunkDir
 	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(b, err)
 	defer h.Close()

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -34,7 +34,7 @@ func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 	// Put a series, select it. GC it and then access it.
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
-	opts.ChkDirRoot = chunkDir
+	opts.ChunkDirRoot = chunkDir
 	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(b, err)
 	defer h.Close()
@@ -53,7 +53,7 @@ func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 	// Put a series, select it. GC it and then access it.
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
-	opts.ChkDirRoot = chunkDir
+	opts.ChunkDirRoot = chunkDir
 	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(b, err)
 	defer h.Close()

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -47,10 +47,9 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 	wlog, err := wal.NewSize(nil, nil, filepath.Join(dir, "wal"), 32768, compressWAL)
 	require.NoError(t, err)
 
-	opts := DefaultHeadOptions(&HeadOptions{
-		ChunkRange: chunkRange,
-		ChkDirRoot: dir,
-	})
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = chunkRange
+	opts.ChkDirRoot = dir
 	h, err := NewHead(nil, nil, wlog, opts)
 	require.NoError(t, err)
 
@@ -195,10 +194,9 @@ func BenchmarkLoadWAL(b *testing.B) {
 
 				// Load the WAL.
 				for i := 0; i < b.N; i++ {
-					opts := DefaultHeadOptions(&HeadOptions{
-						ChunkRange: 1000,
-						ChkDirRoot: w.Dir(),
-					})
+					opts := DefaultHeadOptions()
+					opts.ChunkRange = 1000
+					opts.ChkDirRoot = w.Dir()
 					h, err := NewHead(nil, nil, w, opts)
 					require.NoError(b, err)
 					h.Init(0)
@@ -310,10 +308,9 @@ func TestHead_WALMultiRef(t *testing.T) {
 	w, err = wal.New(nil, nil, w.Dir(), false)
 	require.NoError(t, err)
 
-	opts := DefaultHeadOptions(&HeadOptions{
-		ChunkRange: 1000,
-		ChkDirRoot: w.Dir(),
-	})
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	opts.ChkDirRoot = w.Dir()
 	head, err = NewHead(nil, nil, w, opts)
 	require.NoError(t, err)
 	require.NoError(t, head.Init(0))
@@ -595,10 +592,9 @@ func TestHeadDeleteSimple(t *testing.T) {
 				// Compare the samples for both heads - before and after the reloadBlocks.
 				reloadedW, err := wal.New(nil, nil, w.Dir(), compress) // Use a new wal to ensure deleted samples are gone even after a reloadBlocks.
 				require.NoError(t, err)
-				opts := DefaultHeadOptions(&HeadOptions{
-					ChunkRange: 1000,
-					ChkDirRoot: reloadedW.Dir(),
-				})
+				opts := DefaultHeadOptions()
+				opts.ChunkRange = 1000
+				opts.ChkDirRoot = reloadedW.Dir()
 				reloadedHead, err := NewHead(nil, nil, reloadedW, opts)
 				require.NoError(t, err)
 				require.NoError(t, reloadedHead.Init(0))
@@ -1281,10 +1277,9 @@ func TestWalRepair_DecodingError(t *testing.T) {
 						require.NoError(t, w.Log(test.rec))
 					}
 
-					opts := DefaultHeadOptions(&HeadOptions{
-						ChunkRange: 1,
-						ChkDirRoot: w.Dir(),
-					})
+					opts := DefaultHeadOptions()
+					opts.ChunkRange = 1
+					opts.ChkDirRoot = w.Dir()
 					h, err := NewHead(nil, nil, w, opts)
 					require.NoError(t, err)
 					require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.walCorruptionsTotal))
@@ -1340,10 +1335,9 @@ func TestHeadReadWriterRepair(t *testing.T) {
 		w, err := wal.New(nil, nil, walDir, false)
 		require.NoError(t, err)
 
-		opts := DefaultHeadOptions(&HeadOptions{
-			ChunkRange: chunkRange,
-			ChkDirRoot: dir,
-		})
+		opts := DefaultHeadOptions()
+		opts.ChunkRange = chunkRange
+		opts.ChkDirRoot = dir
 		h, err := NewHead(nil, nil, w, opts)
 		require.NoError(t, err)
 		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.mmapChunkCorruptionTotal))
@@ -1574,10 +1568,9 @@ func TestMemSeriesIsolation(t *testing.T) {
 
 	wlog, err := wal.NewSize(nil, nil, w.Dir(), 32768, false)
 	require.NoError(t, err)
-	opts := DefaultHeadOptions(&HeadOptions{
-		ChunkRange: 1000,
-		ChkDirRoot: wlog.Dir(),
-	})
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	opts.ChkDirRoot = wlog.Dir()
 	hb, err = NewHead(nil, nil, wlog, opts)
 	defer func() { require.NoError(t, hb.Close()) }()
 	require.NoError(t, err)
@@ -1959,86 +1952,3 @@ func TestHeadMintAfterTruncation(t *testing.T) {
 
 	require.NoError(t, head.Close())
 }
-
-func TestDefaultHeadOptions(t *testing.T) {
-	testCases := []struct {
-		overrides *HeadOptions
-		expected  *HeadOptions
-	}{
-		{
-			overrides: &HeadOptions{
-				ChunkRange:         0,
-				ChkDirRoot:         "",
-				ChkPool:            mockPool{},
-				ChkWriteBufferSize: 0,
-				StripeSize:         0,
-				SeriesCallback:     nil,
-			},
-			expected: &HeadOptions{
-				ChunkRange:         DefaultBlockDuration,
-				ChkDirRoot:         "",
-				ChkPool:            mockPool{},
-				ChkWriteBufferSize: chunks.DefaultWriteBufferSize,
-				StripeSize:         DefaultStripeSize,
-				SeriesCallback:     &noopSeriesLifecycleCallback{},
-			},
-		},
-		{
-			overrides: &HeadOptions{
-				ChunkRange: 1000,
-				ChkDirRoot: "tmp/chunk_dir",
-				ChkPool:    mockPool{},
-			},
-			expected: &HeadOptions{
-				ChunkRange:         1000,
-				ChkDirRoot:         "tmp/chunk_dir",
-				ChkPool:            mockPool{},
-				ChkWriteBufferSize: chunks.DefaultWriteBufferSize,
-				StripeSize:         DefaultStripeSize,
-				SeriesCallback:     &noopSeriesLifecycleCallback{},
-			},
-		},
-		{
-			overrides: &HeadOptions{
-				ChunkRange:         2000,
-				ChkDirRoot:         "/etc/chunk_dir",
-				ChkPool:            mockPool{},
-				ChkWriteBufferSize: 1000,
-				StripeSize:         100,
-				SeriesCallback:     mockSeriesLifecycleCallback{},
-			},
-			expected: &HeadOptions{
-				ChunkRange:         2000,
-				ChkDirRoot:         "/etc/chunk_dir",
-				ChkPool:            mockPool{},
-				ChkWriteBufferSize: 1000,
-				StripeSize:         100,
-				SeriesCallback:     mockSeriesLifecycleCallback{},
-			},
-		},
-	}
-	for _, tc := range testCases {
-		actual := DefaultHeadOptions(tc.overrides)
-		require.Equal(t, tc.expected, actual)
-	}
-}
-
-type mockPool struct{}
-
-func (m mockPool) Put(_ chunkenc.Chunk) error {
-	return nil
-}
-
-func (m mockPool) Get(_ chunkenc.Encoding, _ []byte) (chunkenc.Chunk, error) {
-	return nil, nil
-}
-
-type mockSeriesLifecycleCallback struct{}
-
-func (m mockSeriesLifecycleCallback) PreCreation(_ labels.Labels) error {
-	return nil
-}
-
-func (m mockSeriesLifecycleCallback) PostCreation(_ labels.Labels) {}
-
-func (m mockSeriesLifecycleCallback) PostDeletion(_ ...labels.Labels) {}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -49,7 +49,7 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = chunkRange
-	opts.ChkDirRoot = dir
+	opts.ChunkDirRoot = dir
 	h, err := NewHead(nil, nil, wlog, opts)
 	require.NoError(t, err)
 
@@ -196,7 +196,7 @@ func BenchmarkLoadWAL(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					opts := DefaultHeadOptions()
 					opts.ChunkRange = 1000
-					opts.ChkDirRoot = w.Dir()
+					opts.ChunkDirRoot = w.Dir()
 					h, err := NewHead(nil, nil, w, opts)
 					require.NoError(b, err)
 					h.Init(0)
@@ -310,7 +310,7 @@ func TestHead_WALMultiRef(t *testing.T) {
 
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
-	opts.ChkDirRoot = w.Dir()
+	opts.ChunkDirRoot = w.Dir()
 	head, err = NewHead(nil, nil, w, opts)
 	require.NoError(t, err)
 	require.NoError(t, head.Init(0))
@@ -594,7 +594,7 @@ func TestHeadDeleteSimple(t *testing.T) {
 				require.NoError(t, err)
 				opts := DefaultHeadOptions()
 				opts.ChunkRange = 1000
-				opts.ChkDirRoot = reloadedW.Dir()
+				opts.ChunkDirRoot = reloadedW.Dir()
 				reloadedHead, err := NewHead(nil, nil, reloadedW, opts)
 				require.NoError(t, err)
 				require.NoError(t, reloadedHead.Init(0))
@@ -1279,7 +1279,7 @@ func TestWalRepair_DecodingError(t *testing.T) {
 
 					opts := DefaultHeadOptions()
 					opts.ChunkRange = 1
-					opts.ChkDirRoot = w.Dir()
+					opts.ChunkDirRoot = w.Dir()
 					h, err := NewHead(nil, nil, w, opts)
 					require.NoError(t, err)
 					require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.walCorruptionsTotal))
@@ -1337,7 +1337,7 @@ func TestHeadReadWriterRepair(t *testing.T) {
 
 		opts := DefaultHeadOptions()
 		opts.ChunkRange = chunkRange
-		opts.ChkDirRoot = dir
+		opts.ChunkDirRoot = dir
 		h, err := NewHead(nil, nil, w, opts)
 		require.NoError(t, err)
 		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.mmapChunkCorruptionTotal))
@@ -1570,7 +1570,7 @@ func TestMemSeriesIsolation(t *testing.T) {
 	require.NoError(t, err)
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
-	opts.ChkDirRoot = wlog.Dir()
+	opts.ChunkDirRoot = wlog.Dir()
 	hb, err = NewHead(nil, nil, wlog, opts)
 	defer func() { require.NoError(t, hb.Close()) }()
 	require.NoError(t, err)

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -37,10 +37,9 @@ func BenchmarkPostingsForMatchers(b *testing.B) {
 	defer func() {
 		require.NoError(b, os.RemoveAll(chunkDir))
 	}()
-	opts := DefaultHeadOptions(&HeadOptions{
-		ChunkRange: 1000,
-		ChkDirRoot: chunkDir,
-	})
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	opts.ChkDirRoot = chunkDir
 	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(b, err)
 	defer func() {
@@ -150,10 +149,9 @@ func BenchmarkQuerierSelect(b *testing.B) {
 	defer func() {
 		require.NoError(b, os.RemoveAll(chunkDir))
 	}()
-	opts := DefaultHeadOptions(&HeadOptions{
-		ChunkRange: 1000,
-		ChkDirRoot: chunkDir,
-	})
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	opts.ChkDirRoot = chunkDir
 	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(b, err)
 	defer h.Close()

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
 // Make entries ~50B in size, to emulate real-world high cardinality.
@@ -38,7 +37,11 @@ func BenchmarkPostingsForMatchers(b *testing.B) {
 	defer func() {
 		require.NoError(b, os.RemoveAll(chunkDir))
 	}()
-	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, chunks.DefaultWriteBufferSize, DefaultStripeSize, nil)
+	opts := DefaultHeadOptions(&HeadOptions{
+		ChunkRange: 1000,
+		ChkDirRoot: chunkDir,
+	})
+	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(b, err)
 	defer func() {
 		require.NoError(b, h.Close())
@@ -147,7 +150,11 @@ func BenchmarkQuerierSelect(b *testing.B) {
 	defer func() {
 		require.NoError(b, os.RemoveAll(chunkDir))
 	}()
-	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, chunks.DefaultWriteBufferSize, DefaultStripeSize, nil)
+	opts := DefaultHeadOptions(&HeadOptions{
+		ChunkRange: 1000,
+		ChkDirRoot: chunkDir,
+	})
+	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(b, err)
 	defer h.Close()
 	app := h.Appender(context.Background())

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -39,7 +39,7 @@ func BenchmarkPostingsForMatchers(b *testing.B) {
 	}()
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
-	opts.ChkDirRoot = chunkDir
+	opts.ChunkDirRoot = chunkDir
 	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(b, err)
 	defer func() {
@@ -151,7 +151,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 	}()
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
-	opts.ChkDirRoot = chunkDir
+	opts.ChunkDirRoot = chunkDir
 	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(b, err)
 	defer h.Close()

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -407,7 +407,8 @@ func TestBlockQuerier_AgainstHeadWithOpenChunks(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			h, err := NewHead(nil, nil, nil, 2*time.Hour.Milliseconds(), "", nil, chunks.DefaultWriteBufferSize, DefaultStripeSize, nil)
+			opts := DefaultHeadOptions(&HeadOptions{ChunkRange: 2 * time.Hour.Milliseconds()})
+			h, err := NewHead(nil, nil, nil, opts)
 			require.NoError(t, err)
 			defer h.Close()
 
@@ -1550,7 +1551,11 @@ func TestPostingsForMatchers(t *testing.T) {
 	defer func() {
 		require.NoError(t, os.RemoveAll(chunkDir))
 	}()
-	h, err := NewHead(nil, nil, nil, 1000, chunkDir, nil, chunks.DefaultWriteBufferSize, DefaultStripeSize, nil)
+	opts := DefaultHeadOptions(&HeadOptions{
+		ChunkRange: 1000,
+		ChkDirRoot: chunkDir,
+	})
+	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, h.Close())

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1554,7 +1554,7 @@ func TestPostingsForMatchers(t *testing.T) {
 	}()
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
-	opts.ChkDirRoot = chunkDir
+	opts.ChunkDirRoot = chunkDir
 	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(t, err)
 	defer func() {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -407,7 +407,8 @@ func TestBlockQuerier_AgainstHeadWithOpenChunks(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			opts := DefaultHeadOptions(&HeadOptions{ChunkRange: 2 * time.Hour.Milliseconds()})
+			opts := DefaultHeadOptions()
+			opts.ChunkRange = 2 * time.Hour.Milliseconds()
 			h, err := NewHead(nil, nil, nil, opts)
 			require.NoError(t, err)
 			defer h.Close()
@@ -1551,10 +1552,9 @@ func TestPostingsForMatchers(t *testing.T) {
 	defer func() {
 		require.NoError(t, os.RemoveAll(chunkDir))
 	}()
-	opts := DefaultHeadOptions(&HeadOptions{
-		ChunkRange: 1000,
-		ChkDirRoot: chunkDir,
-	})
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	opts.ChkDirRoot = chunkDir
 	h, err := NewHead(nil, nil, nil, opts)
 	require.NoError(t, err)
 	defer func() {

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2266,7 +2266,8 @@ func (f *fakeDB) Stats(statsByLabelName string) (_ *tsdb.Stats, retErr error) {
 			retErr = err
 		}
 	}()
-	opts := tsdb.DefaultHeadOptions(&tsdb.HeadOptions{ChunkRange: 1000})
+	opts := tsdb.DefaultHeadOptions()
+	opts.ChunkRange = 1000
 	h, _ := tsdb.NewHead(nil, nil, nil, opts)
 	return h.Stats(statsByLabelName), nil
 }

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -56,7 +56,6 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb"
-	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/util/teststorage"
 )
 
@@ -2267,7 +2266,8 @@ func (f *fakeDB) Stats(statsByLabelName string) (_ *tsdb.Stats, retErr error) {
 			retErr = err
 		}
 	}()
-	h, _ := tsdb.NewHead(nil, nil, nil, 1000, "", nil, chunks.DefaultWriteBufferSize, tsdb.DefaultStripeSize, nil)
+	opts := tsdb.DefaultHeadOptions(&tsdb.HeadOptions{ChunkRange: 1000})
+	h, _ := tsdb.NewHead(nil, nil, nil, opts)
 	return h.Stats(statsByLabelName), nil
 }
 


### PR DESCRIPTION
Signed-off-by: Dustin Hooten <dustinhooten@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
 
+ Create `HeadOptions` struct for passing parameters to `NewHead()`. 
+ Create a `DefaultHeadOptions(overrides *HeadOptions) *HeadOptions` function for easy defaulting.

Closes #8447