### PR TITLE
Fix CI (Windows Testing)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,20 +52,25 @@ jobs:
         path: test-results
 
   test_windows:
-    executor: win/default
+    executor: 
+      name: win/default
+      shell: powershell
     working_directory: /go/src/github.com/prometheus/prometheus
     steps:
     - checkout
     - run:
         # Temporary workaround until circleci updates go.
-        shell: bash
         command: |
           choco upgrade -y golang
     - run:
-        shell: bash
+        command:
+          refreshenv
+    - run:
         command: |
-          (cd web/ui && GOOS= GOARCH= go generate -mod=vendor)
-          go test -mod=vendor -vet=off -test.v `go list ./...|grep -Exv "(github.com/prometheus/prometheus/discovery.*|github.com/prometheus/prometheus/config|github.com/prometheus/prometheus/web)"`
+          $env:GOARCH=""; $env:GOOS=""; cd web/ui; go generate -mod=vendor
+          cd ../..
+          $TestTargets = go list ./... | Where-Object { $_ -NotMatch "(github.com/prometheus/prometheus/discovery.*|github.com/prometheus/prometheus/config|github.com/prometheus/prometheus/web)"}
+          go test $TestTargets -mod=vendor -vet=off -v
         environment:
           GOGC: "20"
           GOOPTS: "-p 2 -mod=vendor"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
         # Temporary workaround until circleci updates go.
         shell: bash
         command: |
-          choco install golang --version 1.15.7
+          choco upgrade -y golang
     - run:
         shell: bash
         command: |


### PR DESCRIPTION
This converts the Bash scripts to PowerShell in order to rectify the environment issues suffered when chocolatey updates the version of Go (which at the moment changes the path from the C:\ root dir to a folder in Program Files as of v.1.15.8).

A little bit of a hacky fix as I'm not too familiar with PS to skip adding a temporary variable `$TestTargets` to store the test targets passed to `go test`

Fixes #8454 