### PR TITLE
Selector functions for data science

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -78,6 +78,10 @@ vector.
 `clamp(v instant-vector, min scalar, max scalar)`
 clamps the sample values of all elements in `v` to have a lower limit of `min` and an upper limit of `max`.
 
+Special cases:
+- Return an empty vector if `min > max`
+- Return `NaN` if `min` or `max` is `NaN`
+
 ## `clamp_max()`
 
 `clamp_max(v instant-vector, max scalar)` clamps the sample values of all

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -377,7 +377,7 @@ have exactly one element, `scalar` will return `NaN`.
 
 ## `sgn()`
 
-`sgn(v instant-vector)` returns vector with the value: 1 if v > 0, -1 if v < 0, and leaves others untouched.
+`sgn(v instant-vector)` returns a vector with all sample values converted to their sign, defined as this: 1 if v is positive, -1 if v is negative and 0 if v is equal to zero.
 
 ## `sort()`
 

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -73,6 +73,11 @@ For each input time series, `changes(v range-vector)` returns the number of
 times its value has changed within the provided time range as an instant
 vector.
 
+## `clamp()`
+
+`clamp(v instant-vector, min max, max scalar)`
+clamps the sample values of all elements in `v` to have a lower limit of `min` and an upper limit of `max`.
+
 ## `clamp_max()`
 
 `clamp_max(v instant-vector, max scalar)` clamps the sample values of all
@@ -370,6 +375,11 @@ Given a single-element input vector, `scalar(v instant-vector)` returns the
 sample value of that single element as a scalar. If the input vector does not
 have exactly one element, `scalar` will return `NaN`.
 
+## `sgn()`
+
+`sgn(v instant-vector)` returns vector with the value: 1 if v > 0, -1 if v < 0,
+and leaves the values of 0 or NaN the same as the input.
+
 ## `sort()`
 
 `sort(v instant-vector)` returns vector elements sorted by their sample values,
@@ -418,6 +428,7 @@ over time and return an instant vector with per-series aggregation results:
 * `quantile_over_time(scalar, range-vector)`: the φ-quantile (0 ≤ φ ≤ 1) of the values in the specified interval.
 * `stddev_over_time(range-vector)`: the population standard deviation of the values in the specified interval.
 * `stdvar_over_time(range-vector)`: the population standard variance of the values in the specified interval.
+* `last_over_time(range-vector)`: the most recent point value in specified interval.
 
 Note that all values in the specified interval have the same weight in the
 aggregation even if the values are not equally spaced throughout the interval.

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -75,7 +75,7 @@ vector.
 
 ## `clamp()`
 
-`clamp(v instant-vector, min max, max scalar)`
+`clamp(v instant-vector, min scalar, max scalar)`
 clamps the sample values of all elements in `v` to have a lower limit of `min` and an upper limit of `max`.
 
 ## `clamp_max()`
@@ -377,8 +377,7 @@ have exactly one element, `scalar` will return `NaN`.
 
 ## `sgn()`
 
-`sgn(v instant-vector)` returns vector with the value: 1 if v > 0, -1 if v < 0,
-and leaves the values of 0 or NaN the same as the input.
+`sgn(v instant-vector)` returns vector with the value: 1 if v > 0, -1 if v < 0, and leaves others untouched.
 
 ## `sort()`
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1216,11 +1216,16 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 			ev.currentSamples -= len(points)
 			points = points[:0]
 			it.Reset(s.Iterator())
+			metric := selVS.Series[i].Labels()
+			// The last_over_time function acts like offset; thus, it
+			// should keep the metric name.  For all the other range
+			// vector functions, the only change needed is to drop the
+			// metric name in the output.
+			if e.Func.Name != "last_over_time" {
+				metric = dropMetricName(metric)
+			}
 			ss := Series{
-				// For all range vector functions, the only change to the
-				// output labels is dropping the metric name so just do
-				// it once here.
-				Metric: dropMetricName(selVS.Series[i].Labels()),
+				Metric: metric,
 				Points: getPointSlice(numSteps),
 			}
 			inMatrix[0].Metric = selVS.Series[i].Labels()

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -278,11 +278,14 @@ func funcSortDesc(vals []parser.Value, args parser.Expressions, enh *EvalNodeHel
 	return Vector(byValueSorter)
 }
 
-// === clamp(Vector parser.ValueTypeVector, max Scalar) Vector ===
+// === clamp(Vector parser.ValueTypeVector, min, max Scalar) Vector ===
 func funcClamp(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	vec := vals[0].(Vector)
 	min := vals[1].(Vector)[0].Point.V
 	max := vals[2].(Vector)[0].Point.V
+	if max < min {
+		return enh.Out
+	}
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
 			Metric: enh.DropMetricName(el.Metric),
@@ -560,7 +563,7 @@ func funcLog10(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper
 	return simpleFunc(vals, enh, math.Log10)
 }
 
-// === sgn(Vector parser.ValueTypeVector, min, max) Vector ===
+// === sgn(Vector parser.ValueTypeVector) Vector ===
 func funcSgn(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	return simpleFunc(vals, enh, func(v float64) float64 {
 		if v < 0 {

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -399,8 +399,11 @@ func funcCountOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNo
 
 // === last_over_time(Matrix parser.ValueTypeMatrix) Vector ===
 func funcLastOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
-	return aggrOverTime(vals, enh, func(values []Point) float64 {
-		return values[len(values)-1].V
+	el := vals[0].(Matrix)[0]
+
+	return append(enh.Out, Sample{
+		Metric: el.Metric,
+		Point:  Point{V: el.Points[len(el.Points)-1].V},
 	})
 }
 
@@ -557,7 +560,7 @@ func funcLog10(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper
 	return simpleFunc(vals, enh, math.Log10)
 }
 
-// === sgn(Vector parser.ValueTypeVector) Vector ===
+// === sgn(Vector parser.ValueTypeVector, min, max) Vector ===
 func funcSgn(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	return simpleFunc(vals, enh, func(v float64) float64 {
 		if v < 0 {

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -54,6 +54,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeMatrix},
 		ReturnType: ValueTypeVector,
 	},
+	"clamp": {
+		Name:       "clamp",
+		ArgTypes:   []ValueType{ValueTypeVector, ValueTypeScalar, ValueTypeScalar},
+		ReturnType: ValueTypeVector,
+	},
 	"clamp_max": {
 		Name:       "clamp_max",
 		ArgTypes:   []ValueType{ValueTypeVector, ValueTypeScalar},
@@ -161,6 +166,16 @@ var Functions = map[string]*Function{
 	},
 	"log2": {
 		Name:       "log2",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+	},
+	"last_over_time": {
+		Name:       "last_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+	},
+	"sgn": {
+		Name:       "sgn",
 		ArgTypes:   []ValueType{ValueTypeVector},
 		ReturnType: ValueTypeVector,
 	},

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -154,6 +154,11 @@ var Functions = map[string]*Function{
 		Variadic:   -1,
 		ReturnType: ValueTypeVector,
 	},
+	"last_over_time": {
+		Name:       "last_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+	},
 	"ln": {
 		Name:       "ln",
 		ArgTypes:   []ValueType{ValueTypeVector},
@@ -166,16 +171,6 @@ var Functions = map[string]*Function{
 	},
 	"log2": {
 		Name:       "log2",
-		ArgTypes:   []ValueType{ValueTypeVector},
-		ReturnType: ValueTypeVector,
-	},
-	"last_over_time": {
-		Name:       "last_over_time",
-		ArgTypes:   []ValueType{ValueTypeMatrix},
-		ReturnType: ValueTypeVector,
-	},
-	"sgn": {
-		Name:       "sgn",
 		ArgTypes:   []ValueType{ValueTypeVector},
 		ReturnType: ValueTypeVector,
 	},
@@ -231,6 +226,11 @@ var Functions = map[string]*Function{
 		Name:       "scalar",
 		ArgTypes:   []ValueType{ValueTypeVector},
 		ReturnType: ValueTypeScalar,
+	},
+	"sgn": {
+		Name:       "sgn",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
 	},
 	"sort": {
 		Name:       "sort",

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -372,7 +372,7 @@ eval instant at 60m vector(time())
   {} 3600
 
 
-# Tests for clamp_max, clamp_min(), clamp(0, and sgn().
+# Tests for clamp_max, clamp_min(), clamp(), and sgn().
 load 5m
 	test_clamp{src="clamp-a"}	-50
 	test_clamp{src="clamp-b"}	0

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -781,11 +781,11 @@ eval instant at 1m max_over_time(data[1m])
 	{type="only_nan"} NaN
 
 eval instant at 1m last_over_time(data[1m])
-	{type="numbers"} 3
-	{type="some_nan"} NaN
-	{type="some_nan2"} 1
-	{type="some_nan3"} 1
-	{type="only_nan"} NaN
+	data{type="numbers"} 3
+	data{type="some_nan"} NaN
+	data{type="some_nan2"} 1
+	data{type="some_nan3"} 1
+	data{type="only_nan"} NaN
 
 clear
 

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -372,7 +372,7 @@ eval instant at 60m vector(time())
   {} 3600
 
 
-# Tests for clamp_max and clamp_min().
+# Tests for clamp_max, clamp_min(), clamp(0, and sgn().
 load 5m
 	test_clamp{src="clamp-a"}	-50
 	test_clamp{src="clamp-b"}	0
@@ -388,6 +388,11 @@ eval instant at 0m clamp_min(test_clamp, -25)
 	{src="clamp-b"}	0
 	{src="clamp-c"}	100
 
+eval instant at 0m clamp(test_clamp, -25, 75)
+	{src="clamp-a"}	-25
+	{src="clamp-b"}	0
+	{src="clamp-c"}	75
+
 eval instant at 0m clamp_max(clamp_min(test_clamp, -20), 70)
 	{src="clamp-a"}	-20
 	{src="clamp-b"}	0
@@ -397,6 +402,11 @@ eval instant at 0m clamp_max((clamp_min(test_clamp, (-20))), (70))
 	{src="clamp-a"}	-20
 	{src="clamp-b"}	0
 	{src="clamp-c"}	70
+
+eval instant at 0m sgn(test_clamp)
+	{src="clamp-a"}	-1
+	{src="clamp-b"}	0
+	{src="clamp-c"}	1
 
 
 # Tests for sort/sort_desc.
@@ -742,6 +752,13 @@ eval instant at 1m max_over_time(data[1m])
 	{type="numbers"} 3
 	{type="some_nan"} 2
 	{type="some_nan2"} 2
+	{type="some_nan3"} 1
+	{type="only_nan"} NaN
+
+eval instant at 1m last_over_time(data[1m])
+	{type="numbers"} 3
+	{type="some_nan"} NaN
+	{type="some_nan2"} 1
 	{type="some_nan3"} 1
 	{type="only_nan"} NaN
 

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -372,7 +372,7 @@ eval instant at 60m vector(time())
   {} 3600
 
 
-# Tests for clamp_max, clamp_min(), clamp(), and sgn().
+# Tests for clamp_max, clamp_min(), and clamp().
 load 5m
 	test_clamp{src="clamp-a"}	-50
 	test_clamp{src="clamp-b"}	0
@@ -403,22 +403,35 @@ eval instant at 0m clamp_max((clamp_min(test_clamp, (-20))), (70))
 	{src="clamp-b"}	0
 	{src="clamp-c"}	70
 
-eval instant at 0m sgn(test_clamp)
-	{src="clamp-a"}	-1
-	{src="clamp-b"}	0
-	{src="clamp-c"}	1
+eval instant at 0m clamp(test_clamp, 0, NaN)
+	{src="clamp-a"}	NaN
+	{src="clamp-b"}	NaN
+	{src="clamp-c"}	NaN
 
-# Test special cases of sgn
+eval instant at 0m clamp(test_clamp, NaN, 0)
+	{src="clamp-a"}	NaN
+	{src="clamp-b"}	NaN
+	{src="clamp-c"}	NaN
+
+eval instant at 0m clamp(test_clamp, 5, -5)
+
+# Test cases for sgn.
 clear
 load 5m
 	test_sgn{src="sgn-a"}	-Inf
 	test_sgn{src="sgn-b"}	Inf
 	test_sgn{src="sgn-c"}	NaN
+	test_sgn{src="sgn-d"}	-50
+	test_sgn{src="sgn-e"}	0
+	test_sgn{src="sgn-f"}	100
 
 eval instant at 0m sgn(test_sgn)
 	{src="sgn-a"}	-1
 	{src="sgn-b"}	1
 	{src="sgn-c"}	NaN
+	{src="sgn-d"}	-1
+	{src="sgn-e"}	0
+	{src="sgn-f"}	1
 
 
 # Tests for sort/sort_desc.
@@ -768,11 +781,11 @@ eval instant at 1m max_over_time(data[1m])
 	{type="only_nan"} NaN
 
 eval instant at 1m last_over_time(data[1m])
-	data{type="numbers"} 3
-	data{type="some_nan"} NaN
-	data{type="some_nan2"} 1
-	data{type="some_nan3"} 1
-	data{type="only_nan"} NaN
+	{type="numbers"} 3
+	{type="some_nan"} NaN
+	{type="some_nan2"} 1
+	{type="some_nan3"} 1
+	{type="only_nan"} NaN
 
 clear
 

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -408,6 +408,18 @@ eval instant at 0m sgn(test_clamp)
 	{src="clamp-b"}	0
 	{src="clamp-c"}	1
 
+# Test special cases of sgn
+clear
+load 5m
+	test_sgn{src="sgn-a"}	-Inf
+	test_sgn{src="sgn-b"}	Inf
+	test_sgn{src="sgn-c"}	NaN
+
+eval instant at 0m sgn(test_sgn)
+	{src="sgn-a"}	-1
+	{src="sgn-b"}	1
+	{src="sgn-c"}	NaN
+
 
 # Tests for sort/sort_desc.
 clear
@@ -756,11 +768,11 @@ eval instant at 1m max_over_time(data[1m])
 	{type="only_nan"} NaN
 
 eval instant at 1m last_over_time(data[1m])
-	{type="numbers"} 3
-	{type="some_nan"} NaN
-	{type="some_nan2"} 1
-	{type="some_nan3"} 1
-	{type="only_nan"} NaN
+	data{type="numbers"} 3
+	data{type="some_nan"} NaN
+	data{type="some_nan2"} 1
+	data{type="some_nan3"} 1
+	data{type="only_nan"} NaN
 
 clear
 


### PR DESCRIPTION
Adding selector operator functions to the Prometheus baseline.
step - step function for responding 1 for any values greater than 0
rect - range selecting vector
Timestamp_Range - select dates over time for future / past / linear regression selector

The intent is to multiply this with a vector or be a binary operator.