### PR TITLE
Fix promtool alert tests for no alert validation

### DIFF
--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -250,7 +250,6 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 			// then we compare alerts with the Eval at `ts`.
 			t := alertEvalTimes[curr]
 
-			presentAlerts := alertsInTest[t]
 			got := make(map[string]labelsAndAnnotations)
 
 			// Same Alert name can be present in multiple groups.
@@ -260,9 +259,6 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 				for _, r := range grules {
 					ar, ok := r.(*rules.AlertingRule)
 					if !ok {
-						continue
-					}
-					if _, ok := presentAlerts[ar.Name()]; !ok {
 						continue
 					}
 
@@ -282,7 +278,10 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 
 			for _, testcase := range alertTests[t] {
 				// Checking alerts.
-				gotAlerts := got[testcase.Alertname]
+				var gotAlerts labelsAndAnnotations
+				for _, m := range got {
+					gotAlerts = append(gotAlerts, m...)
+				}
 
 				var expAlerts labelsAndAnnotations
 				for _, a := range testcase.ExpAlerts {


### PR DESCRIPTION
The documentation of `promtool rules test` states "If you want to test
if an alerting rule should not be firing, then .. leave 'exp_alerts' empty."
This was not working though, as the code always based its checks on the
expected alerts in the test definition and didn't look at the alerts
that effectively fired. With an empty list for the expected alert, no
validation occured!
With this change, the code now looks at the alerts that fired and checks
this is corresponding to the expected alerts found in the test
definition.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->