### PR TITLE
Add names and email addresses to MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,17 +1,17 @@
-@roidelapluie is the main/default maintainer, some parts of the codebase have other maintainers:
+Julien Pivotto (<roidelapluie@prometheus.io> / @roidelapluie) is the main/default maintainer, some parts of the codebase have other maintainers:
 
 * `cmd`
-  * `promtool`: @simonpasquier
+  * `promtool`: Simon Pasquier (<pasquier.simon@gmail.com> / @simonpasquier)
 * `discovery`
-  * `k8s`: @brancz
+  * `k8s`: Frederic Branczyk (<fbranczyk@gmail.com> / @brancz)
 * `documentation`
-  * `prometheus-mixin`: @beorn7
+  * `prometheus-mixin`: Björn Rabenstein (<bjoern@rabenste.in> / @beorn7)
 * `storage`
-  * `remote`: @csmarchbanks, @cstyan, @bwplotka
-* `tsdb`: @codesome, @bwplotka
+  * `remote`: Chris Marchbanks (<csmarchbanks@gmail.com> / @csmarchbanks), Callum Styan (<callumstyan@gmail.com> / @cstyan), Bartłomiej Płotka (<bwplotka@gmail.com> / @bwplotka)
+* `tsdb`: Ganesh Vernekar (<ganesh@grafana.com> / @codesome), Bartłomiej Płotka (<bwplotka@gmail.com> / @bwplotka)
 * `web`
-  * `ui`: @juliusv
-* `Makefile` and related build configuration: @simonpasquier, @SuperQ
+  * `ui`: Julius Volz (<julius.volz@gmail.com> / @juliusv)
+* `Makefile` and related build configuration: Simon Pasquier (<pasquier.simon@gmail.com> / @simonpasquier), Ben Kochie (<superq@gmail.com> / @SuperQ)
 
 For the sake of brevity, not all subtrees are explicitly listed. Due to the
 size of this repository, the natural changes in focus of maintainers over time,

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,7 @@ Julien Pivotto (<roidelapluie@prometheus.io> / @roidelapluie) is the main/defaul
 * `discovery`
   * `k8s`: Frederic Branczyk (<fbranczyk@gmail.com> / @brancz)
 * `documentation`
-  * `prometheus-mixin`: Björn Rabenstein (<bjoern@rabenste.in> / @beorn7)
+  * `prometheus-mixin`: Björn Rabenstein (<beorn@grafana.com> / @beorn7)
 * `storage`
   * `remote`: Chris Marchbanks (<csmarchbanks@gmail.com> / @csmarchbanks), Callum Styan (<callumstyan@gmail.com> / @cstyan), Bartłomiej Płotka (<bwplotka@gmail.com> / @bwplotka)
 * `tsdb`: Ganesh Vernekar (<ganesh@grafana.com> / @codesome), Bartłomiej Płotka (<bwplotka@gmail.com> / @bwplotka)


### PR DESCRIPTION
This is so people can more easily reach the right people (e.g. for security
reports), and because we do it like this in other repos.

I did add parentheses to the formatting (different than in other
MAINTAINERS.md) to make it more readable, this this repo is more complex.

Signed-off-by: Julius Volz <julius.volz@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->