### PR TITLE
Split queryable and appendable arguments in api_v1.NewAPI.

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -205,7 +205,8 @@ func init() {
 // NewAPI returns an initialized API type.
 func NewAPI(
 	qe *promql.Engine,
-	s storage.Storage,
+	q storage.SampleAndChunkQueryable,
+	ap storage.Appendable,
 	tr func(context.Context) TargetRetriever,
 	ar func(context.Context) AlertmanagerRetriever,
 	configFunc func() config.Config,
@@ -224,11 +225,10 @@ func NewAPI(
 	runtimeInfo func() (RuntimeInfo, error),
 	buildInfo *PrometheusVersion,
 	gatherer prometheus.Gatherer,
-	remoteWriteReceiver bool,
 ) *API {
 	a := &API{
 		QueryEngine: qe,
-		Queryable:   s,
+		Queryable:   q,
 
 		targetRetriever:       tr,
 		alertmanagerRetriever: ar,
@@ -252,8 +252,8 @@ func NewAPI(
 		gatherer:                  gatherer,
 	}
 
-	if remoteWriteReceiver {
-		a.remoteWriteHandler = remote.NewWriteHandler(logger, s)
+	if ap != nil {
+		a.remoteWriteHandler = remote.NewWriteHandler(logger, ap)
 	}
 
 	return a

--- a/web/web.go
+++ b/web/web.go
@@ -298,7 +298,12 @@ func New(logger log.Logger, o *Options) *Handler {
 	factoryAr := func(_ context.Context) api_v1.AlertmanagerRetriever { return h.notifier }
 	FactoryRr := func(_ context.Context) api_v1.RulesRetriever { return h.ruleManager }
 
-	h.apiV1 = api_v1.NewAPI(h.queryEngine, h.storage, factoryTr, factoryAr,
+	var app storage.Appendable
+	if o.RemoteWriteReceiver {
+		app = h.storage
+	}
+
+	h.apiV1 = api_v1.NewAPI(h.queryEngine, h.storage, app, factoryTr, factoryAr,
 		func() config.Config {
 			h.mtx.RLock()
 			defer h.mtx.RUnlock()
@@ -323,7 +328,6 @@ func New(logger log.Logger, o *Options) *Handler {
 		h.runtimeInfo,
 		h.versionInfo,
 		o.Gatherer,
-		o.RemoteWriteReceiver,
 	)
 
 	if o.RoutePrefix != "/" {


### PR DESCRIPTION
This simple PR proposes to split `storage.SampleAndChunkQueryable` and `storage.Appender` parameters sent to `api_v1.NewAPI` function, instead of current `storage.Storage`.

Problem with using `storage.Storage` is that code that it's not clear what should code that is not using remote-write capabilities of API pass as argument. There are extra methods in `Storage`, namely `StartTime()` that we simply cannot implement in our read-only wrapper around Queryable. Furthermore `StartTime` is not even used by API (for now).

To clear that confusion, I propose to send queryable for querying, and appendable for appending separately, and only allow remote-write if appendable is not `nil`.