### PR TITLE
promtool: Add more negative alert tests

### DIFF
--- a/cmd/promtool/testdata/failing.yml
+++ b/cmd/promtool/testdata/failing.yml
@@ -1,5 +1,8 @@
+rule_files:
+  - rules.yml
+
 tests:
-  # Simple failing test.
+  # Simple failing test, depends on no rules.
   - interval: 1m
     name: "Failing test"
     input_series:
@@ -18,3 +21,18 @@ tests:
         alertname: Test
         exp_alerts:
           - exp_labels: {}
+
+  # Alerts firing, but no alert expected by the test.
+  - interval: 1m
+    name: Failing alert test
+    input_series:
+      - series: 'up{job="test"}'
+        values: 0x10
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: InstanceDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: AlwaysFiring
+        exp_alerts: []

--- a/cmd/promtool/testdata/rules.yml
+++ b/cmd/promtool/testdata/rules.yml
@@ -11,6 +11,8 @@ groups:
         annotations:
           summary: "Instance {{ $labels.instance }} down"
           description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes."
+      - alert: AlwaysFiring
+        expr: 1
 
   - name: rules
     rules:

--- a/cmd/promtool/testdata/unittest.yml
+++ b/cmd/promtool/testdata/unittest.yml
@@ -83,10 +83,17 @@ tests:
       - expr: count(ALERTS) by (alertname, alertstate)
         eval_time: 4m
         exp_samples:
+        - labels: '{alertname="AlwaysFiring",alertstate="firing"}'
+          value: 1
         - labels: '{alertname="InstanceDown",alertstate="pending"}'
           value: 1
 
     alert_rule_test:
+      - eval_time: 1d
+        alertname: AlwaysFiring
+        exp_alerts:
+          - {}
+
       - eval_time: 1d
         alertname: InstanceDown
         exp_alerts:
@@ -97,6 +104,15 @@ tests:
             exp_annotations:
               summary: "Instance localhost:9090 down"
               description: "localhost:9090 of job prometheus has been down for more than 5 minutes."
+
+      - eval_time: 0
+        alertname: AlwaysFiring
+        exp_alerts:
+          - {}
+
+      - eval_time: 0
+        alertname: InstanceDown
+        exp_alerts: []
 
   # Tests for interval vs evaluation_interval.
   - interval: 1s


### PR DESCRIPTION
This makes #8462 actually fail some tests, as existing behaviour is needed to handle multiple alerts firing, but the tests didn't have multiple alerts before.

Signed-off-by: David Leadbeater <dgl@dgl.cx>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->