### PR TITLE
Recommend to get promtool from a binary distribution.

### DIFF
--- a/docs/configuration/recording_rules.md
+++ b/docs/configuration/recording_rules.md
@@ -20,13 +20,15 @@ process. The changes are only applied if all rule files are well-formatted.
 ## Syntax-checking rules
 
 To quickly check whether a rule file is syntactically correct without starting
-a Prometheus server, install and run Prometheus's `promtool` command-line
-utility tool:
+a Prometheus server, you can use Prometheus's `promtool` command-line utility
+tool:
 
 ```bash
-go get github.com/prometheus/prometheus/cmd/promtool
 promtool check rules /path/to/example.rules.yml
 ```
+
+The `promtool` binary is part of the `prometheus` archive offered on the
+project's [download page](https://prometheus.io/download/).
 
 When the file is syntactically valid, the checker prints a textual
 representation of the parsed rules to standard output and then exits with


### PR DESCRIPTION
Rather than compile it yourself, which doesn't work as shown anymore
because of Go Modules.

Signed-off-by: beorn7 <beorn@grafana.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->