### PR TITLE
head_chunks: include filesize into mmapedChunkFile to avoid file read

### DIFF
--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -409,14 +409,24 @@ type ByteSlice interface {
 	Range(start, end int) []byte
 }
 
-type realByteSlice []byte
+type realByteSlice struct {
+	b []byte
+	s int
+}
+
+func newRealByteSlice(b []byte, size int) ByteSlice {
+	return realByteSlice{
+		b: b,
+		s: size,
+	}
+}
 
 func (b realByteSlice) Len() int {
-	return len(b)
+	return b.s
 }
 
 func (b realByteSlice) Range(start, end int) []byte {
-	return b[start:end]
+	return b.b[start:end]
 }
 
 // Reader implements a ChunkReader for a serialized byte stream
@@ -474,7 +484,7 @@ func NewDirReader(dir string, pool chunkenc.Pool) (*Reader, error) {
 			).Err()
 		}
 		cs = append(cs, f)
-		bs = append(bs, realByteSlice(f.Bytes()))
+		bs = append(bs, newRealByteSlice(f.Bytes(), f.Size()))
 	}
 
 	reader, err := newReader(bs, cs, pool)

--- a/tsdb/chunks/chunks_test.go
+++ b/tsdb/chunks/chunks_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestReaderWithInvalidBuffer(t *testing.T) {
-	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
+	b := newRealByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81}, 6)
 	r := &Reader{bs: []ByteSlice{b}}
 
 	_, err := r.Chunk(0)

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -188,7 +188,7 @@ func (cdm *ChunkDiskMapper) openMMapFiles() (returnErr error) {
 			return errors.Wrapf(err, "mmap files, file: %s", fn)
 		}
 		cdm.closers[seq] = f
-		cdm.mmappedChunkFiles[seq] = &mmappedChunkFile{byteSlice: realByteSlice(f.Bytes())}
+		cdm.mmappedChunkFiles[seq] = &mmappedChunkFile{byteSlice: newRealByteSlice(f.Bytes(), f.Size())}
 		chkFileIndices = append(chkFileIndices, seq)
 	}
 
@@ -401,7 +401,7 @@ func (cdm *ChunkDiskMapper) cut() (returnErr error) {
 	}
 
 	cdm.closers[cdm.curFileSequence] = mmapFile
-	cdm.mmappedChunkFiles[cdm.curFileSequence] = &mmappedChunkFile{byteSlice: realByteSlice(mmapFile.Bytes())}
+	cdm.mmappedChunkFiles[cdm.curFileSequence] = &mmappedChunkFile{byteSlice: newRealByteSlice(mmapFile.Bytes(), mmapFile.Size())}
 	cdm.readPathMtx.Unlock()
 
 	cdm.curFileMaxt = 0

--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -22,6 +22,7 @@ import (
 type MmapFile struct {
 	f *os.File
 	b []byte
+	s int
 }
 
 func OpenMmapFile(path string) (*MmapFile, error) {
@@ -51,7 +52,7 @@ func OpenMmapFileWithSize(path string, size int) (mf *MmapFile, retErr error) {
 		return nil, errors.Wrapf(err, "mmap, size %d", size)
 	}
 
-	return &MmapFile{f: f, b: b}, nil
+	return &MmapFile{f: f, b: b, s: size}, nil
 }
 
 func (f *MmapFile) Close() error {
@@ -70,4 +71,8 @@ func (f *MmapFile) File() *os.File {
 
 func (f *MmapFile) Bytes() []byte {
 	return f.b
+}
+
+func (f *MmapFile) Size() int {
+	return f.s
 }

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -486,14 +486,14 @@ func TestPersistence_index_e2e(t *testing.T) {
 }
 
 func TestDecbufUvarintWithInvalidBuffer(t *testing.T) {
-	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
+	b := newRealByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81}, 6)
 
 	db := encoding.NewDecbufUvarintAt(b, 0, castagnoliTable)
 	require.Error(t, db.Err())
 }
 
 func TestReaderWithInvalidBuffer(t *testing.T) {
-	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
+	b := newRealByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81}, 6)
 
 	_, err := NewReader(b)
 	require.Error(t, err)
@@ -530,7 +530,7 @@ func TestSymbols(t *testing.T) {
 	checksum := crc32.Checksum(buf.Get()[symbolsStart+4:], castagnoliTable)
 	buf.PutBE32(checksum) // Check sum at the end.
 
-	s, err := NewSymbols(realByteSlice(buf.Get()), FormatV2, symbolsStart)
+	s, err := NewSymbols(newRealByteSlice(buf.Get(), buf.Len()), FormatV2, symbolsStart)
 	require.NoError(t, err)
 
 	// We store only 4 offsets to symbols.


### PR DESCRIPTION
b.byteSlice.Len() reads the entire mmaped file into memory to find out
the file size. Avoid this by passing the size to realByteSlice to use for the length.