### PR TITLE
Add sorting and filtering to flags page

### DIFF
--- a/web/ui/react-app/src/pages/flags/Flags.test.tsx
+++ b/web/ui/react-app/src/pages/flags/Flags.test.tsx
@@ -70,8 +70,10 @@ describe('Flags', () => {
     const td = w
       .find('tbody')
       .find('td')
+      .find('code')
+      .find('span')
       .first();
-    expect(td.text()).toBe('--alertmanager.notification-queue-capacity');
+    expect(td.html()).toBe('<span>--alertmanager.notification-queue-capacity</span>');
   });
 
   it('sorts', (): void => {
@@ -84,8 +86,10 @@ describe('Flags', () => {
     const td = w
       .find('tbody')
       .find('td')
+      .find('code')
+      .find('span')
       .first();
-    expect(td.text()).toBe('--web.user-assets');
+    expect(td.html()).toBe('<span>--web.user-assets</span>');
   });
 
   it('filters by flag name', (): void => {

--- a/web/ui/react-app/src/pages/flags/Flags.test.tsx
+++ b/web/ui/react-app/src/pages/flags/Flags.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { FlagsContent } from './Flags';
-import { Table } from 'reactstrap';
+import { Input, Table } from 'reactstrap';
 import toJson from 'enzyme-to-json';
 
 const sampleFlagsResponse = {
@@ -55,11 +55,60 @@ describe('Flags', () => {
       striped: true,
     });
   });
+
   it('should not fail if data is missing', () => {
     expect(shallow(<FlagsContent />)).toHaveLength(1);
   });
+
   it('should match snapshot', () => {
     const w = shallow(<FlagsContent data={sampleFlagsResponse} />);
     expect(toJson(w)).toMatchSnapshot();
+  });
+
+  it('is sorted by flag by default', (): void => {
+    const w = shallow(<FlagsContent data={sampleFlagsResponse} />);
+    const td = w
+      .find('tbody')
+      .find('td')
+      .first();
+    expect(td.text()).toBe('--alertmanager.notification-queue-capacity');
+  });
+
+  it('sorts', (): void => {
+    const w = shallow(<FlagsContent data={sampleFlagsResponse} />);
+    const th = w
+      .find('thead')
+      .find('td')
+      .filterWhere((td): boolean => td.hasClass('Flag'));
+    th.simulate('click');
+    const td = w
+      .find('tbody')
+      .find('td')
+      .first();
+    expect(td.text()).toBe('--web.user-assets');
+  });
+
+  it('filters by flag name', (): void => {
+    const w = shallow(<FlagsContent data={sampleFlagsResponse} />);
+    const input = w.find(Input);
+    input.simulate('change', { target: { value: 'timeout' } });
+    const tds = w
+      .find('tbody')
+      .find('td')
+      .find('code')
+      .filterWhere(code => code.hasClass('flag-item'));
+    expect(tds.length).toEqual(3);
+  });
+
+  it('filters by flag value', (): void => {
+    const w = shallow(<FlagsContent data={sampleFlagsResponse} />);
+    const input = w.find(Input);
+    input.simulate('change', { target: { value: '10s' } });
+    const tds = w
+      .find('tbody')
+      .find('td')
+      .find('code')
+      .filterWhere(code => code.hasClass('value-item'));
+    expect(tds.length).toEqual(1);
   });
 });

--- a/web/ui/react-app/src/pages/flags/Flags.tsx
+++ b/web/ui/react-app/src/pages/flags/Flags.tsx
@@ -107,11 +107,12 @@ export const FlagsContent: FC<FlagsProps> = ({ data = {} }) => {
         <tbody>
           {Object.entries(data)
             .sort(compareAlphaFn(state.sort.name === 'Flag', !state.sort.alpha))
+            .map(([flag, value]) => [`--${flag}`, value])
             .filter(([flag, value]) => flag.includes(state.search) || value.includes(state.search))
             .map(([flag, value]) => (
               <tr key={flag}>
                 <td className="px-4">
-                  <code className="text-dark flag-item">--{boldSubstring(flag, state.search)}</code>
+                  <code className="text-dark flag-item">{boldSubstring(flag, state.search)}</code>
                 </td>
                 <td className="px-4">
                   <code className="text-dark value-item">{boldSubstring(value, state.search)}</code>

--- a/web/ui/react-app/src/pages/flags/Flags.tsx
+++ b/web/ui/react-app/src/pages/flags/Flags.tsx
@@ -44,27 +44,21 @@ const getSortIcon = (b: boolean | undefined): IconDefinition => {
   return faSortUp;
 };
 
-interface ColumnState {
+interface SortState {
   name: string;
   alpha: boolean;
   focused: boolean;
 }
 
-interface FlagState {
-  search: string;
-  sort: ColumnState;
-}
-
 export const FlagsContent: FC<FlagsProps> = ({ data = {} }) => {
-  const initialState: FlagState = {
-    search: '',
-    sort: {
-      name: 'Flag',
-      alpha: true,
-      focused: true,
-    },
+  const initialSearch = '';
+  const [searchState, setSearchState] = useState(initialSearch);
+  const initialSort: SortState = {
+    name: 'Flag',
+    alpha: true,
+    focused: true,
   };
-  const [state, setState] = useState(initialState);
+  const [sortState, setSortState] = useState(initialSort);
   return (
     <>
       <h2>Command-Line Flags</h2>
@@ -73,9 +67,9 @@ export const FlagsContent: FC<FlagsProps> = ({ data = {} }) => {
           autoFocus
           placeholder="Filter by flag name or value..."
           className="my-3"
-          value={state.search}
+          value={searchState}
           onChange={({ target }: ChangeEvent<HTMLInputElement>): void => {
-            setState({ ...state, search: target.value });
+            setSearchState(target.value);
           }}
         />
       </InputGroup>
@@ -88,34 +82,31 @@ export const FlagsContent: FC<FlagsProps> = ({ data = {} }) => {
                 className={`px-4 ${col}`}
                 style={{ width: '50%' }}
                 onClick={(): void =>
-                  setState({
-                    ...state,
-                    sort: {
-                      name: col,
-                      focused: true,
-                      alpha: state.sort.name === col ? !state.sort.alpha : true,
-                    },
+                  setSortState({
+                    name: col,
+                    focused: true,
+                    alpha: sortState.name === col ? !sortState.alpha : true,
                   })
                 }
               >
                 <span className="mr-2">{col}</span>
-                <FontAwesomeIcon icon={getSortIcon(state.sort.name !== col ? undefined : state.sort.alpha)} />
+                <FontAwesomeIcon icon={getSortIcon(sortState.name !== col ? undefined : sortState.alpha)} />
               </td>
             ))}
           </tr>
         </thead>
         <tbody>
           {Object.entries(data)
-            .sort(compareAlphaFn(state.sort.name === 'Flag', !state.sort.alpha))
+            .sort(compareAlphaFn(sortState.name === 'Flag', !sortState.alpha))
             .map(([flag, value]) => [`--${flag}`, value])
-            .filter(([flag, value]) => flag.includes(state.search) || value.includes(state.search))
+            .filter(([flag, value]) => flag.includes(searchState) || value.includes(searchState))
             .map(([flag, value]) => (
               <tr key={flag}>
                 <td className="px-4">
-                  <code className="text-dark flag-item">{boldSubstring(flag, state.search)}</code>
+                  <code className="text-dark flag-item">{boldSubstring(flag, searchState)}</code>
                 </td>
                 <td className="px-4">
-                  <code className="text-dark value-item">{boldSubstring(value, state.search)}</code>
+                  <code className="text-dark value-item">{boldSubstring(value, searchState)}</code>
                 </td>
               </tr>
             ))}

--- a/web/ui/react-app/src/pages/flags/Flags.tsx
+++ b/web/ui/react-app/src/pages/flags/Flags.tsx
@@ -1,10 +1,13 @@
-import React, { FC } from 'react';
+import React, { ChangeEvent, FC, useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
-import { Table } from 'reactstrap';
+import { Input, InputGroup, Table } from 'reactstrap';
 import { withStatusIndicator } from '../../components/withStatusIndicator';
 import { useFetch } from '../../hooks/useFetch';
 import { usePathPrefix } from '../../contexts/PathPrefixContext';
 import { API_PATH } from '../../constants/constants';
+import { faSort, faSortDown, faSortUp } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconDefinition } from '@fortawesome/fontawesome-common-types';
 
 interface FlagMap {
   [key: string]: string;
@@ -14,18 +17,107 @@ interface FlagsProps {
   data?: FlagMap;
 }
 
+const compareAlphaFn = (keys: boolean, reverse: boolean) => (
+  [k1, v1]: [string, string],
+  [k2, v2]: [string, string]
+): number => {
+  const a = keys ? k1 : v1;
+  const b = keys ? k2 : v2;
+  const reverser = reverse ? -1 : 1;
+  return reverser * a.localeCompare(b);
+};
+
+const boldSubstring = (s: string, subs: string) => {
+  if (subs === '' || s.indexOf(subs) < 0) {
+    return <span>{s}</span>;
+  }
+  return <span dangerouslySetInnerHTML={{ __html: s.split(subs).join(subs.bold()) }} />;
+};
+
+const getSortIcon = (b: boolean | undefined): IconDefinition => {
+  if (b === undefined) {
+    return faSort;
+  }
+  if (b) {
+    return faSortDown;
+  }
+  return faSortUp;
+};
+
+interface ColumnState {
+  name: string;
+  alpha: boolean;
+  focused: boolean;
+}
+
+interface FlagState {
+  search: string;
+  sort: ColumnState;
+}
+
 export const FlagsContent: FC<FlagsProps> = ({ data = {} }) => {
+  const initialState: FlagState = {
+    search: '',
+    sort: {
+      name: 'Flag',
+      alpha: true,
+      focused: true,
+    },
+  };
+  const [state, setState] = useState(initialState);
   return (
     <>
       <h2>Command-Line Flags</h2>
-      <Table bordered size="sm" striped>
+      <InputGroup>
+        <Input
+          autoFocus
+          placeholder="Filter by flag name or value..."
+          className="my-3"
+          value={state.search}
+          onChange={({ target }: ChangeEvent<HTMLInputElement>): void => {
+            setState({ ...state, search: target.value });
+          }}
+        />
+      </InputGroup>
+      <Table bordered size="sm" striped hover>
+        <thead>
+          <tr>
+            {['Flag', 'Value'].map((col: string) => (
+              <td
+                key={col}
+                className={`px-4 ${col}`}
+                style={{ width: '50%' }}
+                onClick={(): void =>
+                  setState({
+                    ...state,
+                    sort: {
+                      name: col,
+                      focused: true,
+                      alpha: state.sort.name === col ? !state.sort.alpha : true,
+                    },
+                  })
+                }
+              >
+                <span className="mr-2">{col}</span>
+                <FontAwesomeIcon icon={getSortIcon(state.sort.name !== col ? undefined : state.sort.alpha)} />
+              </td>
+            ))}
+          </tr>
+        </thead>
         <tbody>
-          {Object.keys(data).map(key => (
-            <tr key={key}>
-              <th>{key}</th>
-              <td>{data[key]}</td>
-            </tr>
-          ))}
+          {Object.entries(data)
+            .sort(compareAlphaFn(state.sort.name === 'Flag', !state.sort.alpha))
+            .filter(([flag, value]) => flag.includes(state.search) || value.includes(state.search))
+            .map(([flag, value]) => (
+              <tr key={flag}>
+                <td className="px-4">
+                  <code className="text-dark flag-item">--{boldSubstring(flag, state.search)}</code>
+                </td>
+                <td className="px-4">
+                  <code className="text-dark value-item">{boldSubstring(value, state.search)}</code>
+                </td>
+              </tr>
+            ))}
         </tbody>
       </Table>
     </>

--- a/web/ui/react-app/src/pages/flags/__snapshots__/Flags.test.tsx.snap
+++ b/web/ui/react-app/src/pages/flags/__snapshots__/Flags.test.tsx.snap
@@ -133,9 +133,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --alertmanager.notification-queue-capacity
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--alertmanager.notification-queue-capacity",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -144,9 +148,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              10000
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "10000",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -159,9 +167,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --alertmanager.timeout
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--alertmanager.timeout",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -170,9 +182,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              10s
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "10s",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -185,9 +201,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --config.file
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--config.file",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -196,9 +216,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              ./documentation/examples/prometheus.yml
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "./documentation/examples/prometheus.yml",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -211,9 +235,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --log.format
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--log.format",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -222,9 +250,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              logfmt
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "logfmt",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -237,9 +269,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --log.level
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--log.level",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -248,9 +284,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              info
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "info",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -263,9 +303,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --query.lookback-delta
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--query.lookback-delta",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -274,9 +318,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              5m
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "5m",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -289,9 +337,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --query.max-concurrency
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--query.max-concurrency",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -300,9 +352,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              20
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "20",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -315,9 +371,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --query.max-samples
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--query.max-samples",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -326,9 +386,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              50000000
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "50000000",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -341,9 +405,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --query.timeout
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--query.timeout",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -352,9 +420,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              2m
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "2m",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -367,9 +439,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --rules.alert.for-grace-period
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--rules.alert.for-grace-period",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -378,9 +454,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              10m
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "10m",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -393,9 +473,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --rules.alert.for-outage-tolerance
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--rules.alert.for-outage-tolerance",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -404,9 +488,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              1h
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "1h",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -419,9 +507,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --rules.alert.resend-delay
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--rules.alert.resend-delay",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -430,9 +522,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              1m
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "1m",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -445,9 +541,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.remote.flush-deadline
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.remote.flush-deadline",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -456,9 +556,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              1m
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "1m",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -471,9 +575,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.remote.read-concurrent-limit
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.remote.read-concurrent-limit",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -482,9 +590,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              10
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "10",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -497,9 +609,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.remote.read-max-bytes-in-frame
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.remote.read-max-bytes-in-frame",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -508,9 +624,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              1048576
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "1048576",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -523,9 +643,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.remote.read-sample-limit
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.remote.read-sample-limit",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -534,9 +658,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              50000000
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "50000000",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -549,9 +677,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.tsdb.allow-overlapping-blocks
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.tsdb.allow-overlapping-blocks",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -560,9 +692,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              false
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "false",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -575,9 +711,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.tsdb.max-block-duration
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.tsdb.max-block-duration",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -586,9 +726,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              36h
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "36h",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -601,9 +745,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.tsdb.min-block-duration
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.tsdb.min-block-duration",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -612,9 +760,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              2h
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "2h",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -627,9 +779,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.tsdb.no-lockfile
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.tsdb.no-lockfile",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -638,9 +794,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              false
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "false",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -653,9 +813,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.tsdb.path
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.tsdb.path",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -664,9 +828,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              data/
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "data/",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -679,9 +847,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.tsdb.retention
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.tsdb.retention",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -690,9 +862,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              0s
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "0s",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -705,9 +881,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.tsdb.retention.size
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.tsdb.retention.size",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -716,9 +896,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              0B
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "0B",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -731,9 +915,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.tsdb.retention.time
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.tsdb.retention.time",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -742,9 +930,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              0s
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "0s",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -757,9 +949,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.tsdb.wal-compression
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.tsdb.wal-compression",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -768,9 +964,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              false
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "false",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -783,9 +983,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --storage.tsdb.wal-segment-size
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--storage.tsdb.wal-segment-size",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -794,9 +998,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              0B
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "0B",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -809,9 +1017,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --web.console.libraries
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--web.console.libraries",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -820,9 +1032,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              console_libraries
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "console_libraries",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -835,9 +1051,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --web.console.templates
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--web.console.templates",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -846,9 +1066,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              consoles
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "consoles",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -861,9 +1085,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --web.cors.origin
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--web.cors.origin",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -872,9 +1100,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              .*
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": ".*",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -887,9 +1119,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --web.enable-admin-api
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--web.enable-admin-api",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -898,9 +1134,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              false
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "false",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -913,9 +1153,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --web.enable-lifecycle
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--web.enable-lifecycle",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -924,9 +1168,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              false
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "false",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -939,9 +1187,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --web.external-url
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--web.external-url",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -950,7 +1202,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span />
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -963,9 +1221,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --web.listen-address
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--web.listen-address",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -974,9 +1236,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              0.0.0.0:9090
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "0.0.0.0:9090",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -989,9 +1255,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --web.max-connections
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--web.max-connections",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -1000,9 +1270,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              512
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "512",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -1015,9 +1289,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --web.page-title
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--web.page-title",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -1026,9 +1304,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              Prometheus Time Series Collection and Processing Server
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "Prometheus Time Series Collection and Processing Server",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -1041,9 +1323,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --web.read-timeout
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--web.read-timeout",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -1052,9 +1338,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              5m
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "5m",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -1067,9 +1357,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --web.route-prefix
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--web.route-prefix",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -1078,9 +1372,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span>
-              /
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "/",
+                }
+              }
+            />
           </code>
         </td>
       </tr>
@@ -1093,9 +1391,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            <span>
-              --web.user-assets
-            </span>
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "--web.user-assets",
+                }
+              }
+            />
           </code>
         </td>
         <td
@@ -1104,7 +1406,13 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark value-item"
           >
-            <span />
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "",
+                }
+              }
+            />
           </code>
         </td>
       </tr>

--- a/web/ui/react-app/src/pages/flags/__snapshots__/Flags.test.tsx.snap
+++ b/web/ui/react-app/src/pages/flags/__snapshots__/Flags.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`Flags should match snapshot 1`] = `
     </thead>
     <tbody>
       <tr
-        key="alertmanager.notification-queue-capacity"
+        key="--alertmanager.notification-queue-capacity"
       >
         <td
           className="px-4"
@@ -133,9 +133,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              alertmanager.notification-queue-capacity
+              --alertmanager.notification-queue-capacity
             </span>
           </code>
         </td>
@@ -152,7 +151,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="alertmanager.timeout"
+        key="--alertmanager.timeout"
       >
         <td
           className="px-4"
@@ -160,9 +159,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              alertmanager.timeout
+              --alertmanager.timeout
             </span>
           </code>
         </td>
@@ -179,7 +177,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="config.file"
+        key="--config.file"
       >
         <td
           className="px-4"
@@ -187,9 +185,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              config.file
+              --config.file
             </span>
           </code>
         </td>
@@ -206,7 +203,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="log.format"
+        key="--log.format"
       >
         <td
           className="px-4"
@@ -214,9 +211,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              log.format
+              --log.format
             </span>
           </code>
         </td>
@@ -233,7 +229,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="log.level"
+        key="--log.level"
       >
         <td
           className="px-4"
@@ -241,9 +237,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              log.level
+              --log.level
             </span>
           </code>
         </td>
@@ -260,7 +255,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="query.lookback-delta"
+        key="--query.lookback-delta"
       >
         <td
           className="px-4"
@@ -268,9 +263,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              query.lookback-delta
+              --query.lookback-delta
             </span>
           </code>
         </td>
@@ -287,7 +281,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="query.max-concurrency"
+        key="--query.max-concurrency"
       >
         <td
           className="px-4"
@@ -295,9 +289,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              query.max-concurrency
+              --query.max-concurrency
             </span>
           </code>
         </td>
@@ -314,7 +307,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="query.max-samples"
+        key="--query.max-samples"
       >
         <td
           className="px-4"
@@ -322,9 +315,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              query.max-samples
+              --query.max-samples
             </span>
           </code>
         </td>
@@ -341,7 +333,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="query.timeout"
+        key="--query.timeout"
       >
         <td
           className="px-4"
@@ -349,9 +341,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              query.timeout
+              --query.timeout
             </span>
           </code>
         </td>
@@ -368,7 +359,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="rules.alert.for-grace-period"
+        key="--rules.alert.for-grace-period"
       >
         <td
           className="px-4"
@@ -376,9 +367,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              rules.alert.for-grace-period
+              --rules.alert.for-grace-period
             </span>
           </code>
         </td>
@@ -395,7 +385,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="rules.alert.for-outage-tolerance"
+        key="--rules.alert.for-outage-tolerance"
       >
         <td
           className="px-4"
@@ -403,9 +393,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              rules.alert.for-outage-tolerance
+              --rules.alert.for-outage-tolerance
             </span>
           </code>
         </td>
@@ -422,7 +411,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="rules.alert.resend-delay"
+        key="--rules.alert.resend-delay"
       >
         <td
           className="px-4"
@@ -430,9 +419,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              rules.alert.resend-delay
+              --rules.alert.resend-delay
             </span>
           </code>
         </td>
@@ -449,7 +437,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.remote.flush-deadline"
+        key="--storage.remote.flush-deadline"
       >
         <td
           className="px-4"
@@ -457,9 +445,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.remote.flush-deadline
+              --storage.remote.flush-deadline
             </span>
           </code>
         </td>
@@ -476,7 +463,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.remote.read-concurrent-limit"
+        key="--storage.remote.read-concurrent-limit"
       >
         <td
           className="px-4"
@@ -484,9 +471,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.remote.read-concurrent-limit
+              --storage.remote.read-concurrent-limit
             </span>
           </code>
         </td>
@@ -503,7 +489,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.remote.read-max-bytes-in-frame"
+        key="--storage.remote.read-max-bytes-in-frame"
       >
         <td
           className="px-4"
@@ -511,9 +497,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.remote.read-max-bytes-in-frame
+              --storage.remote.read-max-bytes-in-frame
             </span>
           </code>
         </td>
@@ -530,7 +515,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.remote.read-sample-limit"
+        key="--storage.remote.read-sample-limit"
       >
         <td
           className="px-4"
@@ -538,9 +523,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.remote.read-sample-limit
+              --storage.remote.read-sample-limit
             </span>
           </code>
         </td>
@@ -557,7 +541,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.tsdb.allow-overlapping-blocks"
+        key="--storage.tsdb.allow-overlapping-blocks"
       >
         <td
           className="px-4"
@@ -565,9 +549,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.tsdb.allow-overlapping-blocks
+              --storage.tsdb.allow-overlapping-blocks
             </span>
           </code>
         </td>
@@ -584,7 +567,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.tsdb.max-block-duration"
+        key="--storage.tsdb.max-block-duration"
       >
         <td
           className="px-4"
@@ -592,9 +575,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.tsdb.max-block-duration
+              --storage.tsdb.max-block-duration
             </span>
           </code>
         </td>
@@ -611,7 +593,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.tsdb.min-block-duration"
+        key="--storage.tsdb.min-block-duration"
       >
         <td
           className="px-4"
@@ -619,9 +601,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.tsdb.min-block-duration
+              --storage.tsdb.min-block-duration
             </span>
           </code>
         </td>
@@ -638,7 +619,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.tsdb.no-lockfile"
+        key="--storage.tsdb.no-lockfile"
       >
         <td
           className="px-4"
@@ -646,9 +627,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.tsdb.no-lockfile
+              --storage.tsdb.no-lockfile
             </span>
           </code>
         </td>
@@ -665,7 +645,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.tsdb.path"
+        key="--storage.tsdb.path"
       >
         <td
           className="px-4"
@@ -673,9 +653,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.tsdb.path
+              --storage.tsdb.path
             </span>
           </code>
         </td>
@@ -692,7 +671,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.tsdb.retention"
+        key="--storage.tsdb.retention"
       >
         <td
           className="px-4"
@@ -700,9 +679,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.tsdb.retention
+              --storage.tsdb.retention
             </span>
           </code>
         </td>
@@ -719,7 +697,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.tsdb.retention.size"
+        key="--storage.tsdb.retention.size"
       >
         <td
           className="px-4"
@@ -727,9 +705,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.tsdb.retention.size
+              --storage.tsdb.retention.size
             </span>
           </code>
         </td>
@@ -746,7 +723,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.tsdb.retention.time"
+        key="--storage.tsdb.retention.time"
       >
         <td
           className="px-4"
@@ -754,9 +731,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.tsdb.retention.time
+              --storage.tsdb.retention.time
             </span>
           </code>
         </td>
@@ -773,7 +749,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.tsdb.wal-compression"
+        key="--storage.tsdb.wal-compression"
       >
         <td
           className="px-4"
@@ -781,9 +757,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.tsdb.wal-compression
+              --storage.tsdb.wal-compression
             </span>
           </code>
         </td>
@@ -800,7 +775,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="storage.tsdb.wal-segment-size"
+        key="--storage.tsdb.wal-segment-size"
       >
         <td
           className="px-4"
@@ -808,9 +783,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              storage.tsdb.wal-segment-size
+              --storage.tsdb.wal-segment-size
             </span>
           </code>
         </td>
@@ -827,7 +801,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="web.console.libraries"
+        key="--web.console.libraries"
       >
         <td
           className="px-4"
@@ -835,9 +809,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              web.console.libraries
+              --web.console.libraries
             </span>
           </code>
         </td>
@@ -854,7 +827,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="web.console.templates"
+        key="--web.console.templates"
       >
         <td
           className="px-4"
@@ -862,9 +835,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              web.console.templates
+              --web.console.templates
             </span>
           </code>
         </td>
@@ -881,7 +853,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="web.cors.origin"
+        key="--web.cors.origin"
       >
         <td
           className="px-4"
@@ -889,9 +861,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              web.cors.origin
+              --web.cors.origin
             </span>
           </code>
         </td>
@@ -908,7 +879,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="web.enable-admin-api"
+        key="--web.enable-admin-api"
       >
         <td
           className="px-4"
@@ -916,9 +887,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              web.enable-admin-api
+              --web.enable-admin-api
             </span>
           </code>
         </td>
@@ -935,7 +905,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="web.enable-lifecycle"
+        key="--web.enable-lifecycle"
       >
         <td
           className="px-4"
@@ -943,9 +913,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              web.enable-lifecycle
+              --web.enable-lifecycle
             </span>
           </code>
         </td>
@@ -962,7 +931,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="web.external-url"
+        key="--web.external-url"
       >
         <td
           className="px-4"
@@ -970,9 +939,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              web.external-url
+              --web.external-url
             </span>
           </code>
         </td>
@@ -987,7 +955,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="web.listen-address"
+        key="--web.listen-address"
       >
         <td
           className="px-4"
@@ -995,9 +963,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              web.listen-address
+              --web.listen-address
             </span>
           </code>
         </td>
@@ -1014,7 +981,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="web.max-connections"
+        key="--web.max-connections"
       >
         <td
           className="px-4"
@@ -1022,9 +989,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              web.max-connections
+              --web.max-connections
             </span>
           </code>
         </td>
@@ -1041,7 +1007,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="web.page-title"
+        key="--web.page-title"
       >
         <td
           className="px-4"
@@ -1049,9 +1015,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              web.page-title
+              --web.page-title
             </span>
           </code>
         </td>
@@ -1068,7 +1033,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="web.read-timeout"
+        key="--web.read-timeout"
       >
         <td
           className="px-4"
@@ -1076,9 +1041,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              web.read-timeout
+              --web.read-timeout
             </span>
           </code>
         </td>
@@ -1095,7 +1059,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="web.route-prefix"
+        key="--web.route-prefix"
       >
         <td
           className="px-4"
@@ -1103,9 +1067,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              web.route-prefix
+              --web.route-prefix
             </span>
           </code>
         </td>
@@ -1122,7 +1085,7 @@ exports[`Flags should match snapshot 1`] = `
         </td>
       </tr>
       <tr
-        key="web.user-assets"
+        key="--web.user-assets"
       >
         <td
           className="px-4"
@@ -1130,9 +1093,8 @@ exports[`Flags should match snapshot 1`] = `
           <code
             className="text-dark flag-item"
           >
-            --
             <span>
-              web.user-assets
+              --web.user-assets
             </span>
           </code>
         </td>

--- a/web/ui/react-app/src/pages/flags/__snapshots__/Flags.test.tsx.snap
+++ b/web/ui/react-app/src/pages/flags/__snapshots__/Flags.test.tsx.snap
@@ -5,389 +5,1146 @@ exports[`Flags should match snapshot 1`] = `
   <h2>
     Command-Line Flags
   </h2>
+  <InputGroup
+    tag="div"
+  >
+    <Input
+      autoFocus={true}
+      className="my-3"
+      onChange={[Function]}
+      placeholder="Filter by flag name or value..."
+      type="text"
+      value=""
+    />
+  </InputGroup>
   <Table
     bordered={true}
+    hover={true}
     responsiveTag="div"
     size="sm"
     striped={true}
     tag="table"
   >
+    <thead>
+      <tr>
+        <td
+          className="px-4 Flag"
+          key="Flag"
+          onClick={[Function]}
+          style={
+            Object {
+              "width": "50%",
+            }
+          }
+        >
+          <span
+            className="mr-2"
+          >
+            Flag
+          </span>
+          <FontAwesomeIcon
+            border={false}
+            className=""
+            fixedWidth={false}
+            flip={null}
+            icon={
+              Object {
+                "icon": Array [
+                  320,
+                  512,
+                  Array [],
+                  "f0dd",
+                  "M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41z",
+                ],
+                "iconName": "sort-down",
+                "prefix": "fas",
+              }
+            }
+            inverse={false}
+            listItem={false}
+            mask={null}
+            pull={null}
+            pulse={false}
+            rotation={null}
+            size={null}
+            spin={false}
+            swapOpacity={false}
+            symbol={false}
+            title=""
+            transform={null}
+          />
+        </td>
+        <td
+          className="px-4 Value"
+          key="Value"
+          onClick={[Function]}
+          style={
+            Object {
+              "width": "50%",
+            }
+          }
+        >
+          <span
+            className="mr-2"
+          >
+            Value
+          </span>
+          <FontAwesomeIcon
+            border={false}
+            className=""
+            fixedWidth={false}
+            flip={null}
+            icon={
+              Object {
+                "icon": Array [
+                  320,
+                  512,
+                  Array [],
+                  "f0dc",
+                  "M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z",
+                ],
+                "iconName": "sort",
+                "prefix": "fas",
+              }
+            }
+            inverse={false}
+            listItem={false}
+            mask={null}
+            pull={null}
+            pulse={false}
+            rotation={null}
+            size={null}
+            spin={false}
+            swapOpacity={false}
+            symbol={false}
+            title=""
+            transform={null}
+          />
+        </td>
+      </tr>
+    </thead>
     <tbody>
       <tr
         key="alertmanager.notification-queue-capacity"
       >
-        <th>
-          alertmanager.notification-queue-capacity
-        </th>
-        <td>
-          10000
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              alertmanager.notification-queue-capacity
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              10000
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="alertmanager.timeout"
       >
-        <th>
-          alertmanager.timeout
-        </th>
-        <td>
-          10s
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              alertmanager.timeout
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              10s
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="config.file"
       >
-        <th>
-          config.file
-        </th>
-        <td>
-          ./documentation/examples/prometheus.yml
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              config.file
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              ./documentation/examples/prometheus.yml
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="log.format"
       >
-        <th>
-          log.format
-        </th>
-        <td>
-          logfmt
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              log.format
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              logfmt
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="log.level"
       >
-        <th>
-          log.level
-        </th>
-        <td>
-          info
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              log.level
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              info
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="query.lookback-delta"
       >
-        <th>
-          query.lookback-delta
-        </th>
-        <td>
-          5m
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              query.lookback-delta
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              5m
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="query.max-concurrency"
       >
-        <th>
-          query.max-concurrency
-        </th>
-        <td>
-          20
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              query.max-concurrency
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              20
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="query.max-samples"
       >
-        <th>
-          query.max-samples
-        </th>
-        <td>
-          50000000
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              query.max-samples
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              50000000
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="query.timeout"
       >
-        <th>
-          query.timeout
-        </th>
-        <td>
-          2m
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              query.timeout
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              2m
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="rules.alert.for-grace-period"
       >
-        <th>
-          rules.alert.for-grace-period
-        </th>
-        <td>
-          10m
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              rules.alert.for-grace-period
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              10m
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="rules.alert.for-outage-tolerance"
       >
-        <th>
-          rules.alert.for-outage-tolerance
-        </th>
-        <td>
-          1h
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              rules.alert.for-outage-tolerance
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              1h
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="rules.alert.resend-delay"
       >
-        <th>
-          rules.alert.resend-delay
-        </th>
-        <td>
-          1m
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              rules.alert.resend-delay
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              1m
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.remote.flush-deadline"
       >
-        <th>
-          storage.remote.flush-deadline
-        </th>
-        <td>
-          1m
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.remote.flush-deadline
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              1m
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.remote.read-concurrent-limit"
       >
-        <th>
-          storage.remote.read-concurrent-limit
-        </th>
-        <td>
-          10
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.remote.read-concurrent-limit
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              10
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.remote.read-max-bytes-in-frame"
       >
-        <th>
-          storage.remote.read-max-bytes-in-frame
-        </th>
-        <td>
-          1048576
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.remote.read-max-bytes-in-frame
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              1048576
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.remote.read-sample-limit"
       >
-        <th>
-          storage.remote.read-sample-limit
-        </th>
-        <td>
-          50000000
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.remote.read-sample-limit
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              50000000
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.tsdb.allow-overlapping-blocks"
       >
-        <th>
-          storage.tsdb.allow-overlapping-blocks
-        </th>
-        <td>
-          false
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.tsdb.allow-overlapping-blocks
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              false
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.tsdb.max-block-duration"
       >
-        <th>
-          storage.tsdb.max-block-duration
-        </th>
-        <td>
-          36h
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.tsdb.max-block-duration
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              36h
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.tsdb.min-block-duration"
       >
-        <th>
-          storage.tsdb.min-block-duration
-        </th>
-        <td>
-          2h
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.tsdb.min-block-duration
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              2h
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.tsdb.no-lockfile"
       >
-        <th>
-          storage.tsdb.no-lockfile
-        </th>
-        <td>
-          false
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.tsdb.no-lockfile
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              false
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.tsdb.path"
       >
-        <th>
-          storage.tsdb.path
-        </th>
-        <td>
-          data/
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.tsdb.path
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              data/
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.tsdb.retention"
       >
-        <th>
-          storage.tsdb.retention
-        </th>
-        <td>
-          0s
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.tsdb.retention
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              0s
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.tsdb.retention.size"
       >
-        <th>
-          storage.tsdb.retention.size
-        </th>
-        <td>
-          0B
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.tsdb.retention.size
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              0B
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.tsdb.retention.time"
       >
-        <th>
-          storage.tsdb.retention.time
-        </th>
-        <td>
-          0s
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.tsdb.retention.time
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              0s
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.tsdb.wal-compression"
       >
-        <th>
-          storage.tsdb.wal-compression
-        </th>
-        <td>
-          false
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.tsdb.wal-compression
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              false
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="storage.tsdb.wal-segment-size"
       >
-        <th>
-          storage.tsdb.wal-segment-size
-        </th>
-        <td>
-          0B
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              storage.tsdb.wal-segment-size
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              0B
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="web.console.libraries"
       >
-        <th>
-          web.console.libraries
-        </th>
-        <td>
-          console_libraries
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              web.console.libraries
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              console_libraries
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="web.console.templates"
       >
-        <th>
-          web.console.templates
-        </th>
-        <td>
-          consoles
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              web.console.templates
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              consoles
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="web.cors.origin"
       >
-        <th>
-          web.cors.origin
-        </th>
-        <td>
-          .*
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              web.cors.origin
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              .*
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="web.enable-admin-api"
       >
-        <th>
-          web.enable-admin-api
-        </th>
-        <td>
-          false
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              web.enable-admin-api
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              false
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="web.enable-lifecycle"
       >
-        <th>
-          web.enable-lifecycle
-        </th>
-        <td>
-          false
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              web.enable-lifecycle
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              false
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="web.external-url"
       >
-        <th>
-          web.external-url
-        </th>
-        <td />
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              web.external-url
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span />
+          </code>
+        </td>
       </tr>
       <tr
         key="web.listen-address"
       >
-        <th>
-          web.listen-address
-        </th>
-        <td>
-          0.0.0.0:9090
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              web.listen-address
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              0.0.0.0:9090
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="web.max-connections"
       >
-        <th>
-          web.max-connections
-        </th>
-        <td>
-          512
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              web.max-connections
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              512
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="web.page-title"
       >
-        <th>
-          web.page-title
-        </th>
-        <td>
-          Prometheus Time Series Collection and Processing Server
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              web.page-title
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              Prometheus Time Series Collection and Processing Server
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="web.read-timeout"
       >
-        <th>
-          web.read-timeout
-        </th>
-        <td>
-          5m
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              web.read-timeout
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              5m
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="web.route-prefix"
       >
-        <th>
-          web.route-prefix
-        </th>
-        <td>
-          /
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              web.route-prefix
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span>
+              /
+            </span>
+          </code>
         </td>
       </tr>
       <tr
         key="web.user-assets"
       >
-        <th>
-          web.user-assets
-        </th>
-        <td />
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark flag-item"
+          >
+            --
+            <span>
+              web.user-assets
+            </span>
+          </code>
+        </td>
+        <td
+          className="px-4"
+        >
+          <code
+            className="text-dark value-item"
+          >
+            <span />
+          </code>
+        </td>
       </tr>
     </tbody>
   </Table>

--- a/web/ui/react-app/src/pages/flags/__snapshots__/Flags.test.tsx.snap
+++ b/web/ui/react-app/src/pages/flags/__snapshots__/Flags.test.tsx.snap
@@ -1307,7 +1307,7 @@ exports[`Flags should match snapshot 1`] = `
             <span
               dangerouslySetInnerHTML={
                 Object {
-                  "__html": "Prometheus Time Series Collection and Processing Server",
+                  "__html": "Prometheus",
                 }
               }
             />


### PR DESCRIPTION
Signed-off-by: Dustin Hooten <dustinhooten@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR adds sorting, filtering, and some minor styling to the flags page. When the flags page loads, the filter is auto-focused, so the user can immediately start typing to filter flags. The matching substrings are bolded. Clicking the sort icons on either column sorts it. As a user of this page, I typically just use `cmd+F`, but I thought this would be nicer.


https://user-images.githubusercontent.com/6402556/108126413-0c958500-7067-11eb-8184-b43214012138.mov

