### PR TITLE
Pin go version for windows to go1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
     - run:
         # Temporary workaround until circleci updates go.
         command: |
-          choco upgrade -y golang
+          choco upgrade -y golang --version=1.15.8
     - run:
         command:
           refreshenv


### PR DESCRIPTION
Tests are failing with go 1.16 at the moment, and by default we test
with latest go version.

https://github.com/prometheus/prometheus/issues/8403

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->