### PR TITLE
Custom headers on remote-read and refactor implementation to roundtripper

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,21 +33,24 @@ import (
 )
 
 var (
-	patRulePath         = regexp.MustCompile(`^[^*]*(\*[^/]*)?$`)
-	unchangeableHeaders = map[string]struct{}{
+	patRulePath     = regexp.MustCompile(`^[^*]*(\*[^/]*)?$`)
+	reservedHeaders = map[string]struct{}{
 		// NOTE: authorization is checked specially,
 		// see RemoteWriteConfig.UnmarshalYAML.
 		// "authorization":                  {},
 		"host":                              {},
 		"content-encoding":                  {},
+		"content-length":                    {},
 		"content-type":                      {},
-		"x-prometheus-remote-write-version": {},
 		"user-agent":                        {},
 		"connection":                        {},
 		"keep-alive":                        {},
 		"proxy-authenticate":                {},
 		"proxy-authorization":               {},
 		"www-authenticate":                  {},
+		"accept-encoding":                   {},
+		"x-prometheus-remote-write-version": {},
+		"x-prometheus-remote-read-version":  {},
 	}
 )
 
@@ -616,19 +619,26 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 			return errors.New("empty or null relabeling rule in remote write config")
 		}
 	}
-	for header := range c.Headers {
-		if strings.ToLower(header) == "authorization" {
-			return errors.New("authorization header must be changed via the basic_auth or authorization parameter")
-		}
-		if _, ok := unchangeableHeaders[strings.ToLower(header)]; ok {
-			return errors.Errorf("%s is an unchangeable header", header)
-		}
+	if err := validateHeaders(c.Headers); err != nil {
+		return err
 	}
 
 	// The UnmarshalYAML method of HTTPClientConfig is not being called because it's not a pointer.
 	// We cannot make it a pointer as the parser panics for inlined pointer structs.
 	// Thus we just do its validation here.
 	return c.HTTPClientConfig.Validate()
+}
+
+func validateHeaders(headers map[string]string) error {
+	for header := range headers {
+		if strings.ToLower(header) == "authorization" {
+			return errors.New("authorization header must be changed via the basic_auth or authorization parameter")
+		}
+		if _, ok := reservedHeaders[strings.ToLower(header)]; ok {
+			return errors.Errorf("%s is a reserved header. It must not be changed", header)
+		}
+	}
+	return nil
 }
 
 // QueueConfig is the configuration for the queue used to write to remote
@@ -667,10 +677,11 @@ type MetadataConfig struct {
 
 // RemoteReadConfig is the configuration for reading from remote storage.
 type RemoteReadConfig struct {
-	URL           *config.URL    `yaml:"url"`
-	RemoteTimeout model.Duration `yaml:"remote_timeout,omitempty"`
-	ReadRecent    bool           `yaml:"read_recent,omitempty"`
-	Name          string         `yaml:"name,omitempty"`
+	URL           *config.URL       `yaml:"url"`
+	RemoteTimeout model.Duration    `yaml:"remote_timeout,omitempty"`
+	Headers       map[string]string `yaml:"headers,omitempty"`
+	ReadRecent    bool              `yaml:"read_recent,omitempty"`
+	Name          string            `yaml:"name,omitempty"`
 
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.
@@ -695,6 +706,9 @@ func (c *RemoteReadConfig) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	}
 	if c.URL == nil {
 		return errors.New("url for remote_read is empty")
+	}
+	if err := validateHeaders(c.Headers); err != nil {
+		return err
 	}
 	// The UnmarshalYAML method of HTTPClientConfig is not being called because it's not a pointer.
 	// We cannot make it a pointer as the parser panics for inlined pointer structs.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -972,7 +972,10 @@ var expectedErrors = []struct {
 		errMsg:   `url for remote_read is empty`,
 	}, {
 		filename: "remote_write_header.bad.yml",
-		errMsg:   `x-prometheus-remote-write-version is an unchangeable header`,
+		errMsg:   `x-prometheus-remote-write-version is a reserved header. It must not be changed`,
+	}, {
+		filename: "remote_read_header.bad.yml",
+		errMsg:   `x-prometheus-remote-write-version is a reserved header. It must not be changed`,
 	}, {
 		filename: "remote_write_authorization_header.bad.yml",
 		errMsg:   `authorization header must be changed via the basic_auth or authorization parameter`,

--- a/config/testdata/remote_read_header.bad.yml
+++ b/config/testdata/remote_read_header.bad.yml
@@ -1,0 +1,5 @@
+remote_read:
+  - url: localhost:9090
+    name: queue1
+    headers:
+      "x-prometheus-remote-write-version": "somehack"

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1850,6 +1850,11 @@ required_matchers:
 # Timeout for requests to the remote read endpoint.
 [ remote_timeout: <duration> | default = 1m ]
 
+# Custom HTTP headers to be sent along with each remote read request.
+# Be aware that headers that are set by Prometheus itself can't be overwritten.
+headers:
+  [ <string>: <string> ... ]
+
 # Whether reads should be made for queries for time ranges that
 # the local storage should have complete data for.
 [ read_recent: <boolean> | default = false ]

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -111,6 +111,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 			URL:              rrConf.URL,
 			Timeout:          rrConf.RemoteTimeout,
 			HTTPClientConfig: rrConf.HTTPClientConfig,
+			Headers:          rrConf.Headers,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Fixes: #8503 

TODO:

- [x] Update config for remote-read
- [x] Implement config tests for remote-read headers