### PR TITLE
Prevent lexer from seeking to next rune after lexing escape sequence.

### DIFF
--- a/promql/parser/lex.go
+++ b/promql/parser/lex.go
@@ -585,7 +585,7 @@ func lexEscape(l *Lexer) stateFn {
 		x = x*base + d
 		n--
 
-		// don't seek after last rune
+		// Don't seek after last rune.
 		if n > 0 {
 			ch = l.next()
 		}

--- a/promql/parser/lex.go
+++ b/promql/parser/lex.go
@@ -583,8 +583,12 @@ func lexEscape(l *Lexer) stateFn {
 			return lexString
 		}
 		x = x*base + d
-		ch = l.next()
 		n--
+
+		// don't seek after last rune
+		if n > 0 {
+			ch = l.next()
+		}
 	}
 
 	if x > max || 0xD800 <= x && x < 0xE000 {

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -3275,12 +3275,12 @@ var testSeries = []struct {
 		expectedMetric: labels.FromStrings(labels.MetricName, "my_metric", "a", "b"),
 		expectedValues: newSeq(1, 2, 3),
 	}, {
-		// Handle escaped unicode characters as whole label values
+		// Handle escaped unicode characters as whole label values.
 		input:          `my_metric{a="\u70ac"} 1 2 3`,
 		expectedMetric: labels.FromStrings(labels.MetricName, "my_metric", "a", `炬`),
 		expectedValues: newSeq(1, 2, 3),
 	}, {
-		// Handle escaped unicode characters as partial label values
+		// Handle escaped unicode characters as partial label values.
 		input:          `my_metric{a="\u70ac = torch"} 1 2 3`,
 		expectedMetric: labels.FromStrings(labels.MetricName, "my_metric", "a", `炬 = torch`),
 		expectedValues: newSeq(1, 2, 3),

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -3275,6 +3275,16 @@ var testSeries = []struct {
 		expectedMetric: labels.FromStrings(labels.MetricName, "my_metric", "a", "b"),
 		expectedValues: newSeq(1, 2, 3),
 	}, {
+		// Handle escaped unicode characters as whole label values
+		input:          `my_metric{a="\u70ac"} 1 2 3`,
+		expectedMetric: labels.FromStrings(labels.MetricName, "my_metric", "a", `炬`),
+		expectedValues: newSeq(1, 2, 3),
+	}, {
+		// Handle escaped unicode characters as partial label values
+		input:          `my_metric{a="\u70ac = torch"} 1 2 3`,
+		expectedMetric: labels.FromStrings(labels.MetricName, "my_metric", "a", `炬 = torch`),
+		expectedValues: newSeq(1, 2, 3),
+	}, {
 		input: `my_metric{a="b"} -3-3 -3`,
 		fail:  true,
 	}, {


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Fixes #8515