### PR TITLE
Adding regex support for hashmod relabel action

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1553,7 +1553,8 @@ anchored on both ends. To un-anchor the regex, use `.*<regex>.*`.
   does not match, no replacement takes place.
 * `keep`: Drop targets for which `regex` does not match the concatenated `source_labels`.
 * `drop`: Drop targets for which `regex` matches the concatenated `source_labels`.
-* `hashmod`: Set `target_label` to the `modulus` of a hash of the concatenated `source_labels`.
+* `hashmod`: Set `target_label` to the `modulus` of a hash of the concatenated `source_labels`
+   if `regex` matches the concatenated `source_labels`.
 * `labelmap`: Match `regex` against all label names. Then copy the values of the matching labels
    to label names given by `replacement` with match group references
   (`${1}`, `${2}`, ...) in `replacement` substituted by their value.

--- a/pkg/relabel/relabel.go
+++ b/pkg/relabel/relabel.go
@@ -226,7 +226,7 @@ func relabel(lset labels.Labels, cfg *Config) labels.Labels {
 		}
 		lb.Set(string(target), string(res))
 	case HashMod:
-		if  cfg.Regex.Regexp != nil && !cfg.Regex.MatchString(val) {
+		if cfg.Regex.Regexp != nil && !cfg.Regex.MatchString(val) {
 			break
 		}
 		mod := sum64(md5.Sum([]byte(val))) % cfg.Modulus

--- a/pkg/relabel/relabel.go
+++ b/pkg/relabel/relabel.go
@@ -226,6 +226,9 @@ func relabel(lset labels.Labels, cfg *Config) labels.Labels {
 		}
 		lb.Set(string(target), string(res))
 	case HashMod:
+		if  cfg.Regex.Regexp != nil && !cfg.Regex.MatchString(val) {
+			break
+		}
 		mod := sum64(md5.Sum([]byte(val))) % cfg.Modulus
 		lb.Set(cfg.TargetLabel, fmt.Sprintf("%d", mod))
 	case LabelMap:

--- a/pkg/relabel/relabel_test.go
+++ b/pkg/relabel/relabel_test.go
@@ -221,6 +221,7 @@ func TestRelabel(t *testing.T) {
 				{
 					SourceLabels: model.LabelNames{"c"},
 					TargetLabel:  "d",
+					Regex:        MustNewRegexp("(?s)(.*)"),
 					Separator:    ";",
 					Action:       HashMod,
 					Modulus:      1000,

--- a/pkg/relabel/relabel_test.go
+++ b/pkg/relabel/relabel_test.go
@@ -235,6 +235,42 @@ func TestRelabel(t *testing.T) {
 		},
 		{
 			input: labels.FromMap(map[string]string{
+				"a": "foo",
+			}),
+			relabel: []*Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					TargetLabel:  "a",
+					Regex: MustNewRegexp(".*-.*"),
+					Separator:    ";",
+					Action:       HashMod,
+					Modulus:      1000,
+				},
+			},
+			output: labels.FromMap(map[string]string{
+				"a": "foo",
+			}),
+		},
+		{
+			input: labels.FromMap(map[string]string{
+				"a": "foo-bar",
+			}),
+			relabel: []*Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					TargetLabel:  "a",
+					Regex: MustNewRegexp(".*-.*"),
+					Separator:    ";",
+					Action:       HashMod,
+					Modulus:      1000,
+				},
+			},
+			output: labels.FromMap(map[string]string{
+				"a": "17",
+			}),
+		},
+		{
+			input: labels.FromMap(map[string]string{
 				"a":  "foo",
 				"b1": "bar",
 				"b2": "baz",

--- a/pkg/relabel/relabel_test.go
+++ b/pkg/relabel/relabel_test.go
@@ -236,12 +236,39 @@ func TestRelabel(t *testing.T) {
 		{
 			input: labels.FromMap(map[string]string{
 				"a": "foo",
+				"b": "foo-bar",
+				"c": "bar",
+				"d": "baz",
 			}),
 			relabel: []*Config{
 				{
 					SourceLabels: model.LabelNames{"a"},
 					TargetLabel:  "a",
 					Regex:        MustNewRegexp(".*-.*"),
+					Separator:    ";",
+					Action:       HashMod,
+					Modulus:      1000,
+				},
+				{
+					SourceLabels: model.LabelNames{"b"},
+					TargetLabel:  "b",
+					Regex:        MustNewRegexp(".*-.*"),
+					Separator:    ";",
+					Action:       HashMod,
+					Modulus:      1000,
+				},
+				{
+					SourceLabels: model.LabelNames{"a", "c"},
+					TargetLabel:  "c",
+					Regex:        MustNewRegexp(".*;baz"),
+					Separator:    ";",
+					Action:       HashMod,
+					Modulus:      1000,
+				},
+				{
+					SourceLabels: model.LabelNames{"a", "d"},
+					TargetLabel:  "d",
+					Regex:        MustNewRegexp(".*;baz"),
 					Separator:    ";",
 					Action:       HashMod,
 					Modulus:      1000,
@@ -249,24 +276,9 @@ func TestRelabel(t *testing.T) {
 			},
 			output: labels.FromMap(map[string]string{
 				"a": "foo",
-			}),
-		},
-		{
-			input: labels.FromMap(map[string]string{
-				"a": "foo-bar",
-			}),
-			relabel: []*Config{
-				{
-					SourceLabels: model.LabelNames{"a"},
-					TargetLabel:  "a",
-					Regex:        MustNewRegexp(".*-.*"),
-					Separator:    ";",
-					Action:       HashMod,
-					Modulus:      1000,
-				},
-			},
-			output: labels.FromMap(map[string]string{
-				"a": "17",
+				"b": "17",
+				"c": "bar",
+				"d": "158",
 			}),
 		},
 		{

--- a/pkg/relabel/relabel_test.go
+++ b/pkg/relabel/relabel_test.go
@@ -241,7 +241,7 @@ func TestRelabel(t *testing.T) {
 				{
 					SourceLabels: model.LabelNames{"a"},
 					TargetLabel:  "a",
-					Regex: MustNewRegexp(".*-.*"),
+					Regex:        MustNewRegexp(".*-.*"),
 					Separator:    ";",
 					Action:       HashMod,
 					Modulus:      1000,
@@ -259,7 +259,7 @@ func TestRelabel(t *testing.T) {
 				{
 					SourceLabels: model.LabelNames{"a"},
 					TargetLabel:  "a",
-					Regex: MustNewRegexp(".*-.*"),
+					Regex:        MustNewRegexp(".*-.*"),
 					Separator:    ";",
 					Action:       HashMod,
 					Modulus:      1000,

--- a/pkg/relabel/relabel_test.go
+++ b/pkg/relabel/relabel_test.go
@@ -237,8 +237,6 @@ func TestRelabel(t *testing.T) {
 			input: labels.FromMap(map[string]string{
 				"a": "foo",
 				"b": "foo-bar",
-				"c": "bar",
-				"d": "baz",
 			}),
 			relabel: []*Config{
 				{
@@ -257,28 +255,10 @@ func TestRelabel(t *testing.T) {
 					Action:       HashMod,
 					Modulus:      1000,
 				},
-				{
-					SourceLabels: model.LabelNames{"a", "c"},
-					TargetLabel:  "c",
-					Regex:        MustNewRegexp(".*;baz"),
-					Separator:    ";",
-					Action:       HashMod,
-					Modulus:      1000,
-				},
-				{
-					SourceLabels: model.LabelNames{"a", "d"},
-					TargetLabel:  "d",
-					Regex:        MustNewRegexp(".*;baz"),
-					Separator:    ";",
-					Action:       HashMod,
-					Modulus:      1000,
-				},
 			},
 			output: labels.FromMap(map[string]string{
 				"a": "foo",
 				"b": "17",
-				"c": "bar",
-				"d": "158",
 			}),
 		},
 		{


### PR DESCRIPTION
**What**
Adding support for regex on the hashmod action in relabel config to apply only if matching a certain pattern. hashmod is currently the only relabel action that doesn't support regex, adding this will add consistency across all actions. 

**Why**
Label with two formats from the same target. One of which has a high cardinality.
example: 
- good format: instance_id within boundaries (for instance 2x instance numbers)
- high cardinality format: instance_id being host:port creating potential hundred of thousands of 

We want to limit the cardinality of the second by applying a modulus on it an limit the effects like this:

```
metric_relabel_configs:
    - source_labels: [instance_id]
      action: hashmod
      modulus: 1000
      target_label: '__tmp_id'
    - source_labels: [instance_id,__tmp_id]
      regex: '[a-z]+:\d+;(\d+)'
      target_label: 'instance_id'
      replacement: '$1'
    - action: labeldrop
      regex: '__tmp_id'
```

This could be written to:

```
 metric_relabel_configs:
      - source_labels: [instance_id]
        regex: '[a-z]+:\d+'
        modulus: 1000
        action: hashmod
        target_label: 'instance_id'
```

This adds simplicity and only hash if its needed 