### PR TITLE
Support follow_redirect

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -101,24 +101,27 @@ var (
 	DefaultScrapeConfig = ScrapeConfig{
 		// ScrapeTimeout and ScrapeInterval default to the
 		// configured globals.
-		MetricsPath:     "/metrics",
-		Scheme:          "http",
-		HonorLabels:     false,
-		HonorTimestamps: true,
+		MetricsPath:      "/metrics",
+		Scheme:           "http",
+		HonorLabels:      false,
+		HonorTimestamps:  true,
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 
 	// DefaultAlertmanagerConfig is the default alertmanager configuration.
 	DefaultAlertmanagerConfig = AlertmanagerConfig{
-		Scheme:     "http",
-		Timeout:    model.Duration(10 * time.Second),
-		APIVersion: AlertmanagerAPIVersionV1,
+		Scheme:           "http",
+		Timeout:          model.Duration(10 * time.Second),
+		APIVersion:       AlertmanagerAPIVersionV1,
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 
 	// DefaultRemoteWriteConfig is the default remote write configuration.
 	DefaultRemoteWriteConfig = RemoteWriteConfig{
-		RemoteTimeout:  model.Duration(30 * time.Second),
-		QueueConfig:    DefaultQueueConfig,
-		MetadataConfig: DefaultMetadataConfig,
+		RemoteTimeout:    model.Duration(30 * time.Second),
+		QueueConfig:      DefaultQueueConfig,
+		MetadataConfig:   DefaultMetadataConfig,
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 
 	// DefaultQueueConfig is the default remote queue configuration.
@@ -148,7 +151,8 @@ var (
 
 	// DefaultRemoteReadConfig is the default remote read configuration.
 	DefaultRemoteReadConfig = RemoteReadConfig{
-		RemoteTimeout: model.Duration(1 * time.Minute),
+		RemoteTimeout:    model.Duration(1 * time.Minute),
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 )
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -87,8 +87,9 @@ var expectedConf = &Config{
 					Action:       relabel.Drop,
 				},
 			},
-			QueueConfig:    DefaultQueueConfig,
-			MetadataConfig: DefaultMetadataConfig,
+			QueueConfig:      DefaultQueueConfig,
+			MetadataConfig:   DefaultMetadataConfig,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 		},
 		{
 			URL:            mustParseURL("http://remote2/push"),
@@ -101,6 +102,7 @@ var expectedConf = &Config{
 					CertFile: filepath.FromSlash("testdata/valid_cert_file"),
 					KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 				},
+				FollowRedirects: true,
 			},
 			Headers: map[string]string{"name": "value"},
 		},
@@ -108,10 +110,11 @@ var expectedConf = &Config{
 
 	RemoteReadConfigs: []*RemoteReadConfig{
 		{
-			URL:           mustParseURL("http://remote1/read"),
-			RemoteTimeout: model.Duration(1 * time.Minute),
-			ReadRecent:    true,
-			Name:          "default",
+			URL:              mustParseURL("http://remote1/read"),
+			RemoteTimeout:    model.Duration(1 * time.Minute),
+			ReadRecent:       true,
+			Name:             "default",
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 		},
 		{
 			URL:              mustParseURL("http://remote3/read"),
@@ -124,6 +127,7 @@ var expectedConf = &Config{
 					CertFile: filepath.FromSlash("testdata/valid_cert_file"),
 					KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 				},
+				FollowRedirects: true,
 			},
 		},
 	},
@@ -145,6 +149,7 @@ var expectedConf = &Config{
 					Type:            "Bearer",
 					CredentialsFile: filepath.FromSlash("testdata/valid_token_file"),
 				},
+				FollowRedirects: true,
 			},
 
 			ServiceDiscoveryConfigs: discovery.Configs{
@@ -215,6 +220,7 @@ var expectedConf = &Config{
 					Username: "admin_name",
 					Password: "multiline\nmysecret\ntest",
 				},
+				FollowRedirects: true,
 			},
 			MetricsPath: "/my_path",
 			Scheme:      "https",
@@ -297,8 +303,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&consul.SDConfig{
@@ -351,6 +358,8 @@ var expectedConf = &Config{
 					Type:        "Bearer",
 					Credentials: "mysecret",
 				},
+
+				FollowRedirects: true,
 			},
 		},
 		{
@@ -360,8 +369,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&kubernetes.SDConfig{
@@ -376,6 +386,7 @@ var expectedConf = &Config{
 							CertFile: filepath.FromSlash("testdata/valid_cert_file"),
 							KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 						},
+						FollowRedirects: true,
 					},
 					NamespaceDiscovery: kubernetes.NamespaceDiscovery{},
 				},
@@ -395,6 +406,7 @@ var expectedConf = &Config{
 					Username:     "myusername",
 					PasswordFile: filepath.FromSlash("testdata/valid_password_file"),
 				},
+				FollowRedirects: true,
 			},
 
 			ServiceDiscoveryConfigs: discovery.Configs{
@@ -406,6 +418,7 @@ var expectedConf = &Config{
 							"default",
 						},
 					},
+					HTTPClientConfig: config.DefaultHTTPClientConfig,
 				},
 			},
 		},
@@ -416,8 +429,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&marathon.SDConfig{
@@ -431,6 +445,7 @@ var expectedConf = &Config{
 							CertFile: filepath.FromSlash("testdata/valid_cert_file"),
 							KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 						},
+						FollowRedirects: true,
 					},
 				},
 			},
@@ -442,8 +457,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&ec2.SDConfig{
@@ -473,8 +489,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&azure.SDConfig{
@@ -496,8 +513,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&zookeeper.NerveSDConfig{
@@ -514,8 +532,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				discovery.StaticConfig{
@@ -535,8 +554,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: "/federate",
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      "/federate",
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				discovery.StaticConfig{
@@ -556,8 +576,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				discovery.StaticConfig{
@@ -577,8 +598,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&triton.SDConfig{
@@ -603,8 +625,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&digitalocean.SDConfig{
@@ -613,6 +636,7 @@ var expectedConf = &Config{
 							Type:        "Bearer",
 							Credentials: "abcdef",
 						},
+						FollowRedirects: true,
 					},
 					Port:            80,
 					RefreshInterval: model.Duration(60 * time.Second),
@@ -626,16 +650,18 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&dockerswarm.SDConfig{
-					Filters:         []dockerswarm.Filter{},
-					Host:            "http://127.0.0.1:2375",
-					Role:            "nodes",
-					Port:            80,
-					RefreshInterval: model.Duration(60 * time.Second),
+					Filters:          []dockerswarm.Filter{},
+					Host:             "http://127.0.0.1:2375",
+					Role:             "nodes",
+					Port:             80,
+					RefreshInterval:  model.Duration(60 * time.Second),
+					HTTPClientConfig: config.DefaultHTTPClientConfig,
 				},
 			},
 		},
@@ -646,8 +672,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{&openstack.SDConfig{
 				Role:            "instance",
@@ -668,8 +695,9 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&hetzner.SDConfig{
@@ -678,6 +706,7 @@ var expectedConf = &Config{
 							Type:        "Bearer",
 							Credentials: "abcdef",
 						},
+						FollowRedirects: true,
 					},
 					Port:            80,
 					RefreshInterval: model.Duration(60 * time.Second),
@@ -685,7 +714,8 @@ var expectedConf = &Config{
 				},
 				&hetzner.SDConfig{
 					HTTPClientConfig: config.HTTPClientConfig{
-						BasicAuth: &config.BasicAuth{Username: "abcdef", Password: "abcdef"},
+						BasicAuth:       &config.BasicAuth{Username: "abcdef", Password: "abcdef"},
+						FollowRedirects: true,
 					},
 					Port:            80,
 					RefreshInterval: model.Duration(60 * time.Second),
@@ -700,22 +730,26 @@ var expectedConf = &Config{
 			ScrapeInterval:  model.Duration(15 * time.Second),
 			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
 
-			MetricsPath: DefaultScrapeConfig.MetricsPath,
-			Scheme:      DefaultScrapeConfig.Scheme,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
 
-			ServiceDiscoveryConfigs: discovery.Configs{&eureka.SDConfig{
-				Server:          "http://eureka.example.com:8761/eureka",
-				RefreshInterval: model.Duration(30 * time.Second),
-			},
+			ServiceDiscoveryConfigs: discovery.Configs{
+				&eureka.SDConfig{
+					Server:           "http://eureka.example.com:8761/eureka",
+					RefreshInterval:  model.Duration(30 * time.Second),
+					HTTPClientConfig: config.DefaultHTTPClientConfig,
+				},
 			},
 		},
 	},
 	AlertingConfig: AlertingConfig{
 		AlertmanagerConfigs: []*AlertmanagerConfig{
 			{
-				Scheme:     "https",
-				Timeout:    model.Duration(10 * time.Second),
-				APIVersion: AlertmanagerAPIVersionV1,
+				Scheme:           "https",
+				Timeout:          model.Duration(10 * time.Second),
+				APIVersion:       AlertmanagerAPIVersionV1,
+				HTTPClientConfig: config.DefaultHTTPClientConfig,
 				ServiceDiscoveryConfigs: discovery.Configs{
 					discovery.StaticConfig{
 						{

--- a/discovery/digitalocean/digitalocean.go
+++ b/discovery/digitalocean/digitalocean.go
@@ -52,8 +52,9 @@ const (
 
 // DefaultSDConfig is the default DigitalOcean SD configuration.
 var DefaultSDConfig = SDConfig{
-	Port:            80,
-	RefreshInterval: model.Duration(60 * time.Second),
+	Port:             80,
+	RefreshInterval:  model.Duration(60 * time.Second),
+	HTTPClientConfig: config.DefaultHTTPClientConfig,
 }
 
 func init() {

--- a/discovery/dockerswarm/dockerswarm.go
+++ b/discovery/dockerswarm/dockerswarm.go
@@ -40,9 +40,10 @@ var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 
 // DefaultSDConfig is the default Docker Swarm SD configuration.
 var DefaultSDConfig = SDConfig{
-	RefreshInterval: model.Duration(60 * time.Second),
-	Port:            80,
-	Filters:         []Filter{},
+	RefreshInterval:  model.Duration(60 * time.Second),
+	Port:             80,
+	Filters:          []Filter{},
+	HTTPClientConfig: config.DefaultHTTPClientConfig,
 }
 
 func init() {

--- a/discovery/eureka/eureka.go
+++ b/discovery/eureka/eureka.go
@@ -60,7 +60,8 @@ const (
 
 // DefaultSDConfig is the default Eureka SD configuration.
 var DefaultSDConfig = SDConfig{
-	RefreshInterval: model.Duration(30 * time.Second),
+	RefreshInterval:  model.Duration(30 * time.Second),
+	HTTPClientConfig: config.DefaultHTTPClientConfig,
 }
 
 func init() {

--- a/discovery/hetzner/hetzner.go
+++ b/discovery/hetzner/hetzner.go
@@ -41,8 +41,9 @@ const (
 
 // DefaultSDConfig is the default Hetzner SD configuration.
 var DefaultSDConfig = SDConfig{
-	Port:            80,
-	RefreshInterval: model.Duration(60 * time.Second),
+	Port:             80,
+	RefreshInterval:  model.Duration(60 * time.Second),
+	HTTPClientConfig: config.DefaultHTTPClientConfig,
 }
 
 func init() {

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -66,7 +66,9 @@ var (
 		[]string{"role", "event"},
 	)
 	// DefaultSDConfig is the default Kubernetes SD configuration
-	DefaultSDConfig = SDConfig{}
+	DefaultSDConfig = SDConfig{
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
+	}
 )
 
 func init() {
@@ -152,7 +154,7 @@ type resourceSelector struct {
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	*c = SDConfig{}
+	*c = DefaultSDConfig
 	type plain SDConfig
 	err := unmarshal((*plain)(c))
 	if err != nil {
@@ -165,7 +167,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err != nil {
 		return err
 	}
-	if c.APIServer.URL == nil && !reflect.DeepEqual(c.HTTPClientConfig, config.HTTPClientConfig{}) {
+	if c.APIServer.URL == nil && !reflect.DeepEqual(c.HTTPClientConfig, config.DefaultHTTPClientConfig) {
 		return errors.Errorf("to use custom HTTP client configuration please provide the 'api_server' URL explicitly")
 	}
 

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -61,7 +61,8 @@ const (
 
 // DefaultSDConfig is the default Marathon SD configuration.
 var DefaultSDConfig = SDConfig{
-	RefreshInterval: model.Duration(30 * time.Second),
+	RefreshInterval:  model.Duration(30 * time.Second),
+	HTTPClientConfig: config.DefaultHTTPClientConfig,
 }
 
 func init() {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -180,6 +180,9 @@ authorization:
   # configured file. It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
+# Configure whether scrape requests follow HTTP 3xx redirects.
+[ follow_redirects: <bool> | default = true ]
+
 # Configures the scrape request's TLS settings.
 tls_config:
   [ <tls_config> ]
@@ -464,6 +467,9 @@ authorization:
 # Optional proxy URL.
 [ proxy_url: <string> ]
 
+# Configure whether HTTP requests follow HTTP 3xx redirects.
+[ follow_redirects: <bool> | default = true ]
+
 # TLS configuration.
 tls_config:
   [ <tls_config> ]
@@ -621,6 +627,10 @@ authorization:
   # Sets the credentials with the credentials read from the configured file.
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
+
+# Configure whether HTTP requests follow HTTP 3xx redirects.
+[ follow_redirects: <bool> | default = true ]
+
 ```
 
 The [relabeling phase](#relabel_config) is the preferred and more powerful
@@ -1029,6 +1039,9 @@ authorization:
 # Optional proxy URL.
 [ proxy_url: <string> ]
 
+# Configure whether HTTP requests follow HTTP 3xx redirects.
+[ follow_redirects: <bool> | default = true ]
+
 # TLS configuration.
 tls_config:
   [ <tls_config> ]
@@ -1197,6 +1210,9 @@ authorization:
 # Optional proxy URL.
 [ proxy_url: <string> ]
 
+# Configure whether HTTP requests follow HTTP 3xx redirects.
+[ follow_redirects: <bool> | default = true ]
+
 # TLS configuration.
 tls_config:
   [ <tls_config> ]
@@ -1290,6 +1306,9 @@ authorization:
   # Sets the credentials with the credentials read from the configured file.
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
+
+# Configure whether HTTP requests follow HTTP 3xx redirects.
+[ follow_redirects: <bool> | default = true ]
 
 # TLS configuration for connecting to marathon servers
 tls_config:
@@ -1493,6 +1512,9 @@ tls_config:
 # Optional proxy URL.
 [ proxy_url: <string> ]
 
+# Configure whether HTTP requests follow HTTP 3xx redirects.
+[ follow_redirects: <bool> | default = true ]
+
 # Refresh interval to re-read the app instance list.
 [ refresh_interval: <duration> | default = 30s ]
 ```
@@ -1665,6 +1687,9 @@ tls_config:
 # Optional proxy URL.
 [ proxy_url: <string> ]
 
+# Configure whether HTTP requests follow HTTP 3xx redirects.
+[ follow_redirects: <bool> | default = true ]
+
 # List of Azure service discovery configurations.
 azure_sd_configs:
   [ - <azure_sd_config> ... ]
@@ -1794,6 +1819,9 @@ tls_config:
 # Optional proxy URL.
 [ proxy_url: <string> ]
 
+# Configure whether HTTP requests follow HTTP 3xx redirects.
+[ follow_redirects: <bool> | default = true ]
+
 # Configures the queue used to write to remote storage.
 queue_config:
   # Number of samples to buffer per shard before we block reading of more
@@ -1884,6 +1912,9 @@ tls_config:
 
 # Optional proxy URL.
 [ proxy_url: <string> ]
+
+# Configure whether HTTP requests follow HTTP 3xx redirects.
+[ follow_redirects: <bool> | default = true ]
 ```
 
 There is a list of

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/prometheus/alertmanager v0.21.0
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/client_model v0.2.0
-	github.com/prometheus/common v0.17.0
+	github.com/prometheus/common v0.18.0
 	github.com/prometheus/exporter-toolkit v0.5.1
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546

--- a/go.sum
+++ b/go.sum
@@ -715,8 +715,8 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.15.0 h1:4fgOnadei3EZvgRwxJ7RMpG1k1pOZth5Pc13tyspaKM=
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
-github.com/prometheus/common v0.17.0 h1:kDIZLI74SS+3tedSvEkykgBkD7txMxaJAPj8DtJUKYA=
-github.com/prometheus/common v0.17.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
+github.com/prometheus/common v0.18.0 h1:WCVKW7aL6LEe1uryfI9dnEc2ZqNB1Fn0ok930v0iL1Y=
+github.com/prometheus/common v0.18.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/exporter-toolkit v0.5.1 h1:9eqgis5er9xN613ZSADjypCJaDGj9ZlcWBvsIHa8/3c=
 github.com/prometheus/exporter-toolkit v0.5.1/go.mod h1:OCkM4805mmisBhLmVFw858QYi3v0wKdY6/UxrT0pZVg=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=


### PR DESCRIPTION
This PR introduces support for follow_redirect, to enable users to
disable following HTTP redirects.

Related to https://github.com/prometheus/prometheus/issues/5108

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->