### PR TITLE
Fixed Svace warning loop-var-in-closure (#8554).

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -507,7 +507,9 @@ func (sp *scrapePool) sync(targets []*Target) {
 	}
 	for _, l := range uniqueLoops {
 		if l != nil {
-			go l.run(interval, timeout, nil)
+			go func(lp loop) {
+				lp.run(interval, timeout, nil)
+			}(l)
 		}
 	}
 	// Wait for all potentially stopped scrapers to terminate.


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
 Close #8554 