### PR TITLE
Fix inconsistent display of word 'ago' on rules page

### DIFF
--- a/web/ui/react-app/src/pages/rules/RulesContent.tsx
+++ b/web/ui/react-app/src/pages/rules/RulesContent.tsx
@@ -65,7 +65,10 @@ export const RulesContent: FC<RouteComponentProps & RulesContentProps> = ({ resp
                     </a>
                   </td>
                   <td>
-                    <h2>{formatRelative(g.lastEvaluation, now())} ago</h2>
+                    <h2>
+                      {formatRelative(g.lastEvaluation, now())}{' '}
+                      {formatRelative(g.lastEvaluation, now()) === 'Never' ? '' : 'ago'}
+                    </h2>
                   </td>
                   <td>
                     <h2>{humanizeDuration(parseFloat(g.evaluationTime) * 1000)}</h2>
@@ -120,7 +123,10 @@ export const RulesContent: FC<RouteComponentProps & RulesContentProps> = ({ resp
                         <Badge color={getBadgeColor(r.health)}>{r.health.toUpperCase()}</Badge>
                       </td>
                       <td>{r.lastError ? <Alert color="danger">{r.lastError}</Alert> : null}</td>
-                      <td>{formatRelative(r.lastEvaluation, now())} ago</td>
+                      <td>
+                        {formatRelative(r.lastEvaluation, now())}{' '}
+                        {formatRelative(r.lastEvaluation, now()) === 'Never' ? '' : 'ago'}
+                      </td>
                       <td>{humanizeDuration(parseFloat(r.evaluationTime) * 1000)}</td>
                     </tr>
                   );

--- a/web/ui/react-app/src/pages/rules/RulesContent.tsx
+++ b/web/ui/react-app/src/pages/rules/RulesContent.tsx
@@ -65,10 +65,7 @@ export const RulesContent: FC<RouteComponentProps & RulesContentProps> = ({ resp
                     </a>
                   </td>
                   <td>
-                    <h2>
-                      {formatRelative(g.lastEvaluation, now())}{' '}
-                      {formatRelative(g.lastEvaluation, now()) === 'Never' ? '' : 'ago'}
-                    </h2>
+                    <h2>{formatRelative(g.lastEvaluation, now())}</h2>
                   </td>
                   <td>
                     <h2>{humanizeDuration(parseFloat(g.evaluationTime) * 1000)}</h2>
@@ -123,10 +120,7 @@ export const RulesContent: FC<RouteComponentProps & RulesContentProps> = ({ resp
                         <Badge color={getBadgeColor(r.health)}>{r.health.toUpperCase()}</Badge>
                       </td>
                       <td>{r.lastError ? <Alert color="danger">{r.lastError}</Alert> : null}</td>
-                      <td>
-                        {formatRelative(r.lastEvaluation, now())}{' '}
-                        {formatRelative(r.lastEvaluation, now()) === 'Never' ? '' : 'ago'}
-                      </td>
+                      <td>{formatRelative(r.lastEvaluation, now())}</td>
                       <td>{humanizeDuration(parseFloat(r.evaluationTime) * 1000)}</td>
                     </tr>
                   );

--- a/web/ui/react-app/src/utils/index.ts
+++ b/web/ui/react-app/src/utils/index.ts
@@ -155,7 +155,7 @@ export const formatRelative = (startStr: string, end: number): string => {
   if (start < 0) {
     return 'Never';
   }
-  return humanizeDuration(end - start);
+  return humanizeDuration(end - start) + ' ago';
 };
 
 const paramFormat = /^g\d+\..+=.+$/;

--- a/web/ui/react-app/src/utils/utils.test.ts
+++ b/web/ui/react-app/src/utils/utils.test.ts
@@ -192,10 +192,10 @@ describe('Utils', () => {
       });
       it('renders a humanized duration for sane durations', () => {
         expect(formatRelative('2019-11-04T09:15:29.578701-07:00', parseTime('2019-11-04T09:15:35.8701-07:00'))).toEqual(
-          '6.292s'
+          '6.292s ago'
         );
         expect(formatRelative('2019-11-04T09:15:35.8701-07:00', parseTime('2019-11-04T09:15:29.578701-07:00'))).toEqual(
-          '-6.292s'
+          '-6.292s ago'
         );
       });
     });


### PR DESCRIPTION
Good time of the day,

I removed the word ago from Last Evaluation column on the rule page when the last evaluation time is equal to 'Never' as suggested in #8564. Let me know if you want me to change anything, thanks!