### PR TITLE
Fix subqueries with default resolution in promql unit tests

### DIFF
--- a/cmd/promtool/testdata/rules.yml
+++ b/cmd/promtool/testdata/rules.yml
@@ -22,3 +22,7 @@ groups:
       # A recording rule that doesn't depend on input series.
       - record: fixed_data
         expr: 1
+
+      # Subquery with default resolution test.
+      - record: suquery_interval_test
+        expr: count_over_time(up[5m:])

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -157,6 +157,7 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 		return []error{err}
 	}
 	defer suite.Close()
+	suite.SubqueryInterval = evalInterval
 
 	// Load the rule files.
 	opts := &rules.ManagerOptions{

--- a/docs/configuration/unit_testing_rules.md
+++ b/docs/configuration/unit_testing_rules.md
@@ -22,8 +22,7 @@ You can use `promtool` to test your rules.
 rule_files:
   [ - <file_name> ]
 
-# optional, default = 1m
-evaluation_interval: <duration>
+[ evaluation_interval: <duration> | default = 1m ]
 
 # The order in which group names are listed below will be the order of evaluation of
 # rule groups (at a given evaluation time). The order is guaranteed only for the groups mentioned below.

--- a/promql/test.go
+++ b/promql/test.go
@@ -657,7 +657,8 @@ type LazyLoader struct {
 
 	loadCmd *loadCmd
 
-	storage storage.Storage
+	storage          storage.Storage
+	SubqueryInterval time.Duration
 
 	queryEngine *Engine
 	context     context.Context
@@ -710,11 +711,12 @@ func (ll *LazyLoader) clear() {
 	ll.storage = teststorage.New(ll)
 
 	opts := EngineOpts{
-		Logger:           nil,
-		Reg:              nil,
-		MaxSamples:       10000,
-		Timeout:          100 * time.Second,
-		EnableAtModifier: true,
+		Logger:                   nil,
+		Reg:                      nil,
+		MaxSamples:               10000,
+		Timeout:                  100 * time.Second,
+		NoStepSubqueryIntervalFn: func(int64) int64 { return durationMilliseconds(ll.SubqueryInterval) },
+		EnableAtModifier:         true,
 	}
 
 	ll.queryEngine = NewEngine(opts)


### PR DESCRIPTION
cc @dgl can you please review this?

Fix #8568 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->