### PR TITLE
MAINTAINERS.md: remove myself from promtool maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,5 @@
 Julien Pivotto (<roidelapluie@prometheus.io> / @roidelapluie) is the main/default maintainer, some parts of the codebase have other maintainers:
 
-* `cmd`
-  * `promtool`: Simon Pasquier (<pasquier.simon@gmail.com> / @simonpasquier)
 * `discovery`
   * `k8s`: Frederic Branczyk (<fbranczyk@gmail.com> / @brancz)
 * `documentation`


### PR DESCRIPTION
I should have done it long time ago but unfortunately I don't have enough time to take care of `promtool` currently.