### PR TITLE
Add num scrapes as tsdb write benchmark command flag

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -124,6 +124,7 @@ func main() {
 	tsdbBenchWriteCmd := tsdbBenchCmd.Command("write", "Run a write performance benchmark.")
 	benchWriteOutPath := tsdbBenchWriteCmd.Flag("out", "Set the output path.").Default("benchout").String()
 	benchWriteNumMetrics := tsdbBenchWriteCmd.Flag("metrics", "Number of metrics to read.").Default("10000").Int()
+	benchWriteNumScrapes := tsdbBenchWriteCmd.Flag("scrapes", "Number of scrapes to simulate.").Default("3000").Int()
 	benchSamplesFile := tsdbBenchWriteCmd.Arg("file", "Input file with samples data, default is ("+filepath.Join("..", "..", "tsdb", "testdata", "20kseries.json")+").").Default(filepath.Join("..", "..", "tsdb", "testdata", "20kseries.json")).String()
 
 	tsdbAnalyzeCmd := tsdbCmd.Command("analyze", "Analyze churn, label pair cardinality.")
@@ -195,7 +196,7 @@ func main() {
 		os.Exit(RulesUnitTest(*testRulesFiles...))
 
 	case tsdbBenchWriteCmd.FullCommand():
-		os.Exit(checkErr(benchmarkWrite(*benchWriteOutPath, *benchSamplesFile, *benchWriteNumMetrics)))
+		os.Exit(checkErr(benchmarkWrite(*benchWriteOutPath, *benchSamplesFile, *benchWriteNumMetrics, *benchWriteNumScrapes)))
 
 	case tsdbAnalyzeCmd.FullCommand():
 		os.Exit(checkErr(analyzeBlock(*analyzePath, *analyzeBlockID, *analyzeLimit)))

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -58,7 +58,7 @@ type writeBenchmark struct {
 	logger    log.Logger
 }
 
-func benchmarkWrite(outPath, samplesFile string, numMetrics int) error {
+func benchmarkWrite(outPath, samplesFile string, numMetrics, numScrapes int) error {
 	b := &writeBenchmark{
 		outPath:     outPath,
 		samplesFile: samplesFile,
@@ -118,7 +118,7 @@ func benchmarkWrite(outPath, samplesFile string, numMetrics int) error {
 		if err := b.startProfiling(); err != nil {
 			return err
 		}
-		total, err = b.ingestScrapes(lbs, 3000)
+		total, err = b.ingestScrapes(lbs, numScrapes)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
By default, the same value that was hardcoded is used, but with the
new flag added the number of scrapes can be increased to any value.