### PR TITLE
Build for Apple Silicon

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -30,6 +30,7 @@ crossbuild:
         - linux/amd64
         - linux/386
         - darwin/amd64
+        - darwin/arm64
         - windows/amd64
         - windows/386
         - freebsd/amd64


### PR DESCRIPTION
Quote from https://golang.org/doc/go1.16:

Go 1.16 adds support of 64-bit ARM architecture on macOS (also known as
Apple Silicon) with GOOS=darwin, GOARCH=arm64. Like the darwin/amd64
port, the darwin/arm64 port supports cgo, internal and external linking,
c-archive, c-shared, and pie build modes, and the race detector.

Closes #8577 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->