### PR TITLE
web/ui: Hitting enter on range input creates a new query

### DIFF
--- a/web/ui/react-app/src/pages/graph/GraphControls.tsx
+++ b/web/ui/react-app/src/pages/graph/GraphControls.tsx
@@ -101,6 +101,9 @@ class GraphControls extends Component<GraphControlsProps> {
             defaultValue={formatDuration(this.props.range)}
             innerRef={this.rangeRef}
             onBlur={() => this.onChangeRangeInput(this.rangeRef.current!.value)}
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) =>
+              e.key === 'Enter' && this.onChangeRangeInput(this.rangeRef.current!.value)
+            }
           />
 
           <InputGroupAddon addonType="append">


### PR DESCRIPTION
It seems I was often typing the range I was looking for in the old UI and then hitting enter to query again.
This is broken is new React UI.

This change adds a onKeyDown listener to the range input field, so that it'll query after changing `1h` to `2h` and hitting enter, for exmaple.

![localhost_9999_graph_g0 expr=up g0 tab=0 g0 stacked=1 g0 range_input=5m](https://user-images.githubusercontent.com/872251/110651297-9bf00d00-81bb-11eb-9973-a94e37d2a2e1.png)

/cc @juliusv 