### PR TITLE
storage: Split chunks if more than 120 samples

### DIFF
--- a/storage/merge_test.go
+++ b/storage/merge_test.go
@@ -465,6 +465,27 @@ func TestCompactingChunkSeriesMerger(t *testing.T) {
 				[]tsdbutil.Sample{sample{31, 31}, sample{35, 35}},
 			),
 		},
+		{
+			name: "110 overlapping",
+			input: []ChunkSeries{
+				NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"), tsdbutil.GenerateSamples(0, 110)), // 0 - 110
+				NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"), tsdbutil.GenerateSamples(60, 50)), // 60 - 110
+			},
+			expected: NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"),
+				tsdbutil.GenerateSamples(0, 110),
+			),
+		},
+		{
+			name: "150 overlapping split chunk",
+			input: []ChunkSeries{
+				NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"), tsdbutil.GenerateSamples(0, 90)),  // 0 - 90
+				NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"), tsdbutil.GenerateSamples(60, 90)), // 90 - 150
+			},
+			expected: NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"),
+				tsdbutil.GenerateSamples(0, 120),
+				tsdbutil.GenerateSamples(120, 30),
+			),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			merged := m(tc.input...)

--- a/storage/merge_test.go
+++ b/storage/merge_test.go
@@ -468,18 +468,18 @@ func TestCompactingChunkSeriesMerger(t *testing.T) {
 		{
 			name: "110 overlapping",
 			input: []ChunkSeries{
-				NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"), tsdbutil.GenerateSamples(0, 110)), // 0 - 110
-				NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"), tsdbutil.GenerateSamples(60, 50)), // 60 - 110
+				NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"), tsdbutil.GenerateSamples(0, 110)), // [0 - 110)
+				NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"), tsdbutil.GenerateSamples(60, 50)), // [60 - 110)
 			},
 			expected: NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"),
 				tsdbutil.GenerateSamples(0, 110),
 			),
 		},
 		{
-			name: "150 overlapping split chunk",
+			name: "150 overlapping samples, split chunk",
 			input: []ChunkSeries{
-				NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"), tsdbutil.GenerateSamples(0, 90)),  // 0 - 90
-				NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"), tsdbutil.GenerateSamples(60, 90)), // 90 - 150
+				NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"), tsdbutil.GenerateSamples(0, 90)),  // [0 - 90)
+				NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"), tsdbutil.GenerateSamples(60, 90)), // [90 - 150)
 			},
 			expected: NewListChunkSeriesFromSamples(labels.FromStrings("bar", "baz"),
 				tsdbutil.GenerateSamples(0, 120),

--- a/storage/series.go
+++ b/storage/series.go
@@ -220,8 +220,6 @@ type seriesToChunkEncoder struct {
 const seriesToChunkEncoderSplit = 120
 
 func (s *seriesToChunkEncoder) Iterator() chunks.Iterator {
-	chks := []chunks.Meta{}
-
 	chk := chunkenc.NewXORChunk()
 	app, err := chk.Appender()
 	if err != nil {
@@ -230,24 +228,25 @@ func (s *seriesToChunkEncoder) Iterator() chunks.Iterator {
 	mint := int64(math.MaxInt64)
 	maxt := int64(math.MinInt64)
 
+	chks := []chunks.Meta{}
+
 	i := 0
 	seriesIter := s.Series.Iterator()
 	for seriesIter.Next() {
-		// Create a new chunk if too many samples in the current one
+		// Create a new chunk if too many samples in the current one.
 		if i >= seriesToChunkEncoderSplit {
 			chks = append(chks, chunks.Meta{
 				MinTime: mint,
 				MaxTime: maxt,
 				Chunk:   chk,
 			})
-			// TODO: There's probably a nicer way than doing this here.
 			chk = chunkenc.NewXORChunk()
 			app, err = chk.Appender()
 			if err != nil {
 				return errChunksIterator{err: err}
 			}
 			mint = int64(math.MaxInt64)
-			// maxt is immediately overwritten below
+			// maxt is immediately overwritten below which is why setting it here won't make a difference.
 			i = 0
 		}
 

--- a/storage/series.go
+++ b/storage/series.go
@@ -247,7 +247,7 @@ func (s *seriesToChunkEncoder) Iterator() chunks.Iterator {
 				return errChunksIterator{err: err}
 			}
 			mint = int64(math.MaxInt64)
-			maxt = int64(math.MinInt64)
+			// maxt is immediately overwritten below
 			i = 0
 		}
 

--- a/tsdb/tsdbutil/chunks.go
+++ b/tsdb/tsdbutil/chunks.go
@@ -65,3 +65,14 @@ func PopulatedChunk(numSamples int, minTime int64) chunks.Meta {
 	}
 	return ChunkFromSamples(samples)
 }
+
+func GenerateSamples(start int, numSamples int) []Sample {
+	samples := make([]Sample, 0, numSamples)
+	for i := start; i < start+numSamples; i++ {
+		samples = append(samples, sample{
+			t: int64(i),
+			v: float64(i),
+		})
+	}
+	return samples
+}

--- a/tsdb/tsdbutil/chunks.go
+++ b/tsdb/tsdbutil/chunks.go
@@ -66,6 +66,7 @@ func PopulatedChunk(numSamples int, minTime int64) chunks.Meta {
 	return ChunkFromSamples(samples)
 }
 
+// GenerateSamples starting at start and counting up numSamples.
 func GenerateSamples(start int, numSamples int) []Sample {
 	samples := make([]Sample, 0, numSamples)
 	for i := start; i < start+numSamples; i++ {


### PR DESCRIPTION
This is my attempt at fixing #5862.

It's based on the work that @bwplotka recently did and uses the `NewSeriesSetToChunkSet`. 
While iterating over the samples we keep track of how many we've appened and if that's more than 120 we append the current chunk to the chunk slice creating a new one to keep appending to.

It's probably not perfect yet but I'd rather get feedback early.

/cc @codesome @hdost 