### PR TITLE
Optimized vectorSelectorSingle()

### DIFF
--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -103,6 +103,12 @@ func TestBufferedSeriesIterator(t *testing.T) {
 		require.Equal(t, ets, ts, "timestamp mismatch")
 		require.Equal(t, ev, v, "value mismatch")
 	}
+	prevSampleEq := func(ets int64, ev float64, eok bool) {
+		ts, v, ok := it.PeekBack(1)
+		require.Equal(t, eok, ok, "exist mismatch")
+		require.Equal(t, ets, ts, "timestamp mismatch")
+		require.Equal(t, ev, v, "value mismatch")
+	}
 
 	it = NewBufferIterator(NewListSeriesIterator(samples{
 		sample{t: 1, v: 2},
@@ -117,24 +123,29 @@ func TestBufferedSeriesIterator(t *testing.T) {
 
 	require.True(t, it.Seek(-123), "seek failed")
 	sampleEq(1, 2)
+	prevSampleEq(0, 0, false)
 	bufferEq(nil)
 
 	require.True(t, it.Next(), "next failed")
 	sampleEq(2, 3)
+	prevSampleEq(1, 2, true)
 	bufferEq([]sample{{t: 1, v: 2}})
 
 	require.True(t, it.Next(), "next failed")
 	require.True(t, it.Next(), "next failed")
 	require.True(t, it.Next(), "next failed")
 	sampleEq(5, 6)
+	prevSampleEq(4, 5, true)
 	bufferEq([]sample{{t: 2, v: 3}, {t: 3, v: 4}, {t: 4, v: 5}})
 
 	require.True(t, it.Seek(5), "seek failed")
 	sampleEq(5, 6)
+	prevSampleEq(4, 5, true)
 	bufferEq([]sample{{t: 2, v: 3}, {t: 3, v: 4}, {t: 4, v: 5}})
 
 	require.True(t, it.Seek(101), "seek failed")
 	sampleEq(101, 10)
+	prevSampleEq(100, 9, true)
 	bufferEq([]sample{{t: 99, v: 8}, {t: 100, v: 9}})
 
 	require.False(t, it.Next(), "next succeeded unexpectedly")

--- a/storage/memoized_iterator.go
+++ b/storage/memoized_iterator.go
@@ -19,7 +19,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
 
-// MemoizedSeriesIterator wraps an iterator with a buffer to look-back the previous element.
+// MemoizedSeriesIterator wraps an iterator with a buffer to look back the previous element.
 type MemoizedSeriesIterator struct {
 	it    chunkenc.Iterator
 	delta int64

--- a/storage/memoized_iterator.go
+++ b/storage/memoized_iterator.go
@@ -1,0 +1,123 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"math"
+
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+// MemoizedSeriesIterator wraps an iterator with a buffer to look-back the previous element.
+type MemoizedSeriesIterator struct {
+	it    chunkenc.Iterator
+	delta int64
+
+	lastTime int64
+	ok       bool
+
+	// Keep track of the previously returned value.
+	prevTime  int64
+	prevValue float64
+}
+
+// NewMemoizedEmptyIterator is like NewMemoizedIterator but it's initialised with an empty iterator.
+func NewMemoizedEmptyIterator(delta int64) *MemoizedSeriesIterator {
+	return NewMemoizedIterator(chunkenc.NewNopIterator(), delta)
+}
+
+// NewMemoizedIterator returns a new iterator that buffers the values within the
+// time range of the current element and the duration of delta before.
+func NewMemoizedIterator(it chunkenc.Iterator, delta int64) *MemoizedSeriesIterator {
+	bit := &MemoizedSeriesIterator{
+		delta:    delta,
+		prevTime: math.MinInt64,
+	}
+	bit.Reset(it)
+
+	return bit
+}
+
+// Reset the internal state to reuse the wrapper with the provided iterator.
+func (b *MemoizedSeriesIterator) Reset(it chunkenc.Iterator) {
+	b.it = it
+	b.lastTime = math.MinInt64
+	b.ok = true
+	b.prevTime = math.MinInt64
+	it.Next()
+}
+
+// PeekPrev returns the previous element of the iterator. If there is none buffered,
+// ok is false.
+func (b *MemoizedSeriesIterator) PeekPrev() (t int64, v float64, ok bool) {
+	if b.prevTime == math.MinInt64 {
+		return 0, 0, false
+	}
+	return b.prevTime, b.prevValue, true
+}
+
+// Seek advances the iterator to the element at time t or greater.
+func (b *MemoizedSeriesIterator) Seek(t int64) bool {
+	t0 := t - b.delta
+
+	if t0 > b.lastTime {
+		// Reset the previously stored element because the seek advanced
+		// more than the delta.
+		b.prevTime = math.MinInt64
+
+		b.ok = b.it.Seek(t0)
+		if !b.ok {
+			return false
+		}
+		b.lastTime, _ = b.it.At()
+	}
+
+	if b.lastTime >= t {
+		return true
+	}
+	for b.Next() {
+		if b.lastTime >= t {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Next advances the iterator to the next element.
+func (b *MemoizedSeriesIterator) Next() bool {
+	if !b.ok {
+		return false
+	}
+
+	// Keep track of the previous element.
+	b.prevTime, b.prevValue = b.it.At()
+
+	b.ok = b.it.Next()
+	if b.ok {
+		b.lastTime, _ = b.it.At()
+	}
+
+	return b.ok
+}
+
+// Values returns the current element of the iterator.
+func (b *MemoizedSeriesIterator) Values() (int64, float64) {
+	return b.it.At()
+}
+
+// Err returns the last encountered error.
+func (b *MemoizedSeriesIterator) Err() error {
+	return b.it.Err()
+}

--- a/storage/memoized_iterator_test.go
+++ b/storage/memoized_iterator_test.go
@@ -1,0 +1,85 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoizedSeriesIterator(t *testing.T) {
+	var it *MemoizedSeriesIterator
+
+	sampleEq := func(ets int64, ev float64) {
+		ts, v := it.Values()
+		require.Equal(t, ets, ts, "timestamp mismatch")
+		require.Equal(t, ev, v, "value mismatch")
+	}
+	prevSampleEq := func(ets int64, ev float64, eok bool) {
+		ts, v, ok := it.PeekPrev()
+		require.Equal(t, eok, ok, "exist mismatch")
+		require.Equal(t, ets, ts, "timestamp mismatch")
+		require.Equal(t, ev, v, "value mismatch")
+	}
+
+	it = NewMemoizedIterator(NewListSeriesIterator(samples{
+		sample{t: 1, v: 2},
+		sample{t: 2, v: 3},
+		sample{t: 3, v: 4},
+		sample{t: 4, v: 5},
+		sample{t: 5, v: 6},
+		sample{t: 99, v: 8},
+		sample{t: 100, v: 9},
+		sample{t: 101, v: 10},
+	}), 2)
+
+	require.True(t, it.Seek(-123), "seek failed")
+	sampleEq(1, 2)
+	prevSampleEq(0, 0, false)
+
+	require.True(t, it.Next(), "next failed")
+	sampleEq(2, 3)
+	prevSampleEq(1, 2, true)
+
+	require.True(t, it.Next(), "next failed")
+	require.True(t, it.Next(), "next failed")
+	require.True(t, it.Next(), "next failed")
+	sampleEq(5, 6)
+	prevSampleEq(4, 5, true)
+
+	require.True(t, it.Seek(5), "seek failed")
+	sampleEq(5, 6)
+	prevSampleEq(4, 5, true)
+
+	require.True(t, it.Seek(101), "seek failed")
+	sampleEq(101, 10)
+	prevSampleEq(100, 9, true)
+
+	require.False(t, it.Next(), "next succeeded unexpectedly")
+}
+
+func BenchmarkMemoizedSeriesIterator(b *testing.B) {
+	// Simulate a 5 minute rate.
+	it := NewMemoizedIterator(newFakeSeriesIterator(int64(b.N), 30), 5*60)
+
+	b.SetBytes(int64(b.N * 16))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for it.Next() {
+		// scan everything
+	}
+	require.NoError(b, it.Err())
+}


### PR DESCRIPTION
I'm investigating some slow queries which, according to the profile, looks spending much time in the PromQL and I'm checking if there's any low-hanging fruit. It's difficult to find something to optimise (you've all already done a great job).

I've noticed that for some queries, a significant % of time inside PromQL is spent in `vectorSelectorSingle()`, which iterates the samples using `BufferedSeriesIterator`. This buffered iterator keeps a buffer of the returned buffer but `vectorSelectorSingle()` doesn't actually need the whole buffer but just the previous value.

In this PR I'm proposing some code duplication (sorry) introducing `MemoizedSeriesIterator` which is like `BufferedSeriesIterator` but just keeps track of the previous element. Benchmarks on `MemoizedSeriesIterator.Next()` are about 2x faster than `BufferedSeriesIterator`, but impact on the whole range query is definitely smaller (see below).


## BenchmarkBufferedSeriesIterator

```
BenchmarkBufferedSeriesIterator-12    	87461358	        13.8 ns/op	101247175509.44 MB/s	       0 B/op	       0 allocs/op
BenchmarkBufferedSeriesIterator-12    	91528774	        13.1 ns/op	111380936676.88 MB/s	       0 B/op	       0 allocs/op
BenchmarkBufferedSeriesIterator-12    	86143618	        14.9 ns/op	92586167446.73 MB/s	           0 B/op	       0 allocs/op
BenchmarkBufferedSeriesIterator-12    	90630134	        13.1 ns/op	110779457851.50 MB/s	       0 B/op	       0 allocs/op
BenchmarkBufferedSeriesIterator-12    	90841784	        13.8 ns/op	105544088430.95 MB/s	       0 B/op	       0 allocs/op
```

## BenchmarkMemoizedSeriesIterator

```
BenchmarkMemoizedSeriesIterator-12    	167776471	         7.30 ns/op	367776094718.48 MB/s	       0 B/op	       0 allocs/op
BenchmarkMemoizedSeriesIterator-12    	166226320	         7.26 ns/op	366486550585.07 MB/s	       0 B/op	       0 allocs/op
BenchmarkMemoizedSeriesIterator-12    	167046273	         7.14 ns/op	374182160447.54 MB/s	       0 B/op	       0 allocs/op
BenchmarkMemoizedSeriesIterator-12    	165566178	         7.36 ns/op	359816615878.45 MB/s	       0 B/op	       0 allocs/op
BenchmarkMemoizedSeriesIterator-12    	167822944	         7.18 ns/op	373868150052.88 MB/s	       0 B/op	       0 allocs/op
```

## RangeQuery

```
name                                                                                                       old time/op    new time/op    delta
RangeQuery/expr=a_one,steps=1-12                                                                             12.6µs ± 2%    12.0µs ± 3%   -4.71%  (p=0.008 n=5+5)
RangeQuery/expr=a_one,steps=10-12                                                                            12.9µs ± 1%    12.1µs ± 1%   -5.82%  (p=0.008 n=5+5)
RangeQuery/expr=a_one,steps=100-12                                                                           19.6µs ± 1%    18.0µs ± 0%   -8.21%  (p=0.016 n=5+4)
RangeQuery/expr=a_one,steps=1000-12                                                                          68.5µs ± 2%    61.6µs ± 0%  -10.01%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten,steps=1-12                                                                             50.2µs ± 0%    47.5µs ± 0%   -5.56%  (p=0.016 n=5+4)
RangeQuery/expr=a_ten,steps=10-12                                                                            54.6µs ± 1%    51.4µs ± 1%   -5.88%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten,steps=100-12                                                                            120µs ± 2%     110µs ± 0%   -8.29%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten,steps=1000-12                                                                           600µs ± 2%     537µs ± 1%  -10.52%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=1-12                                                                          441µs ± 0%     423µs ± 2%   -4.20%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=10-12                                                                         484µs ± 1%     459µs ± 1%   -5.04%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=100-12                                                                       1.14ms ± 1%    1.05ms ± 1%   -7.96%  (p=0.016 n=4+5)
RangeQuery/expr=a_hundred,steps=1000-12                                                                      6.13ms ± 9%    5.51ms ±18%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1-12                                                                   17.3µs ± 0%    17.1µs ± 0%   -1.18%  (p=0.016 n=4+5)
RangeQuery/expr=rate(a_one[1m]),steps=10-12                                                                  18.4µs ± 0%    18.2µs ± 2%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=100-12                                                                 32.3µs ± 0%    31.9µs ± 0%   -1.17%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1000-12                                                                 149µs ± 0%     150µs ± 1%   +0.86%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=1-12                                                                   54.6µs ± 2%    54.0µs ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=10-12                                                                  65.2µs ± 0%    64.9µs ± 0%   -0.41%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_ten[1m]),steps=100-12                                                                  207µs ± 2%     203µs ± 0%   -1.59%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=1000-12                                                                1.54ms ±17%    1.37ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-12                                                                458µs ± 7%     433µs ± 0%   -5.40%  (p=0.016 n=4+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-12                                                               555µs ± 1%     543µs ± 0%   -2.27%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-12                                                             1.97ms ± 3%    1.92ms ± 0%   -2.46%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-12                                                            14.8ms ±16%    13.6ms ± 1%   -7.59%  (p=0.032 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=10000-12                                                               1.53ms ±10%    1.48ms ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=10000-12                                                               14.7ms ± 1%    14.6ms ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-12                                                            146ms ± 1%     147ms ± 2%     ~     (p=1.000 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12                                                  766µs ± 1%     765µs ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12                                                1.25ms ± 0%    1.25ms ± 0%     ~     (p=1.000 n=4+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12                                               6.18ms ± 3%    6.12ms ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12                                              55.9ms ± 3%    55.5ms ± 1%     ~     (p=0.841 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12                                                 6.32ms ± 5%    6.13ms ± 0%   -3.00%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12                                                11.8ms ± 5%    11.0ms ± 1%   -6.23%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12                                               62.6ms ±10%    60.2ms ± 0%   -3.75%  (p=0.016 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12                                               545ms ± 1%     545ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12                                             61.0ms ± 0%    61.1ms ± 1%     ~     (p=1.000 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12                                             111ms ± 2%     109ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12                                            598ms ± 2%     594ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12                                           5.44s ± 1%     5.45s ± 2%     ~     (p=1.000 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=1-12                                                                 609µs ± 0%     617µs ± 3%     ~     (p=0.190 n=4+5)
RangeQuery/expr=changes(a_one[1d]),steps=10-12                                                                801µs ± 6%     776µs ± 2%     ~     (p=0.310 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=100-12                                                              2.65ms ±12%    2.35ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=1000-12                                                             19.3ms ± 8%    18.4ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=1-12                                                                5.54ms ±10%    5.33ms ± 1%     ~     (p=0.548 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=10-12                                                               6.90ms ± 1%    6.90ms ± 2%     ~     (p=0.841 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=100-12                                                              23.3ms ± 4%    22.9ms ± 0%   -1.73%  (p=0.016 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=1000-12                                                              183ms ± 3%     182ms ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-12                                                            54.3ms ± 5%    53.6ms ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-12                                                           70.7ms ± 4%    69.6ms ± 0%   -1.53%  (p=0.032 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-12                                                           237ms ± 7%     227ms ± 3%     ~     (p=0.056 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                                                          1.83s ± 2%     1.81s ± 0%   -1.36%  (p=0.032 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=1-12                                                                    614µs ±11%     593µs ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=10-12                                                                   678µs ± 1%     686µs ± 2%     ~     (p=0.056 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=100-12                                                                 1.60ms ± 9%    1.59ms ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=1000-12                                                                10.4ms ± 4%    10.7ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=1-12                                                                   5.25ms ± 5%    5.13ms ± 0%   -2.32%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=10-12                                                                  5.95ms ± 1%    6.01ms ± 0%     ~     (p=0.190 n=5+4)
RangeQuery/expr=rate(a_ten[1d]),steps=100-12                                                                 14.9ms ± 0%    15.2ms ± 1%   +2.02%  (p=0.016 n=4+5)
RangeQuery/expr=rate(a_ten[1d]),steps=1000-12                                                                 103ms ± 8%     106ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-12                                                               51.8ms ± 1%    51.7ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-12                                                              60.1ms ± 1%    60.7ms ± 0%   +0.94%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-12                                                              152ms ± 3%     153ms ± 3%     ~     (p=0.421 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                                                             1.04s ± 3%     1.04s ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12                                                        588µs ± 0%     578µs ± 0%   -1.83%  (p=0.016 n=4+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12                                                       648µs ± 8%     596µs ± 0%   -8.05%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12                                                      849µs ± 9%     780µs ± 1%   -8.08%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12                                                    2.63ms ± 5%    2.63ms ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12                                                       5.12ms ± 4%    4.97ms ± 1%   -2.88%  (p=0.032 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12                                                      5.21ms ± 2%    5.17ms ± 1%     ~     (p=0.548 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12                                                     6.98ms ± 1%    7.01ms ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12                                                    26.3ms ± 5%    26.1ms ± 5%     ~     (p=1.000 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12                                                   52.7ms ± 6%    50.2ms ± 1%   -4.59%  (p=0.016 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12                                                  52.3ms ± 1%    52.2ms ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12                                                 73.3ms ± 6%    71.0ms ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12                                                 265ms ± 7%     263ms ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=-a_one,steps=1-12                                                                            15.0µs ± 8%    13.2µs ± 1%  -11.67%  (p=0.008 n=5+5)
RangeQuery/expr=-a_one,steps=10-12                                                                           14.7µs ± 3%    13.6µs ± 1%   -7.35%  (p=0.029 n=4+4)
RangeQuery/expr=-a_one,steps=100-12                                                                          21.1µs ± 1%    19.7µs ± 1%   -6.72%  (p=0.008 n=5+5)
RangeQuery/expr=-a_one,steps=1000-12                                                                         73.6µs ±13%    63.8µs ± 0%  -13.36%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=1-12                                                                            60.8µs ±34%    52.4µs ± 0%  -13.87%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=10-12                                                                           64.9µs ± 9%    56.2µs ± 0%  -13.37%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=100-12                                                                           129µs ±11%     116µs ± 0%  -10.33%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=1000-12                                                                          617µs ± 5%     550µs ± 1%  -10.86%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1-12                                                                         474µs ± 0%     462µs ± 7%     ~     (p=0.151 n=5+5)
RangeQuery/expr=-a_hundred,steps=10-12                                                                        517µs ± 1%     494µs ± 1%   -4.43%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-12                                                                      1.17ms ± 0%    1.10ms ± 3%   -6.14%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-12                                                                     5.94ms ± 1%    5.39ms ± 1%   -9.22%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1-12                                                                     24.3µs ± 0%    23.1µs ± 2%   -4.78%  (p=0.016 n=4+5)
RangeQuery/expr=a_one_-_b_one,steps=10-12                                                                    31.3µs ± 5%    28.9µs ± 0%   -7.63%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=100-12                                                                   98.5µs ± 6%    91.5µs ± 0%   -7.11%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1000-12                                                                   714µs ± 9%     678µs ± 0%   -4.91%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1-12                                                                      127µs ± 5%     118µs ± 2%   -6.79%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10-12                                                                     183µs ± 1%     177µs ± 0%   -3.30%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=100-12                                                                    812µs ± 1%     798µs ± 0%   -1.78%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1000-12                                                                  6.79ms ± 2%    6.71ms ± 0%   -1.13%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                                                             1.11ms ± 1%    1.10ms ± 9%     ~     (p=0.190 n=4+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                                                            1.76ms ± 1%    1.74ms ± 1%   -1.34%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                                                           8.77ms ± 0%    8.69ms ± 1%   -0.99%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                                                          76.2ms ± 0%    75.6ms ± 0%   -0.80%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-12                                                                 6.91ms ± 0%    6.85ms ± 1%   -0.87%  (p=0.016 n=5+4)
RangeQuery/expr=a_ten_-_b_ten,steps=10000-12                                                                 69.6ms ± 1%    68.8ms ± 1%   -1.12%  (p=0.016 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                                                          785ms ± 1%     772ms ± 2%   -1.69%  (p=0.016 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12                                                    54.4µs ± 3%    52.7µs ± 3%     ~     (p=0.095 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12                                                   55.7µs ± 0%    54.4µs ± 0%   -2.34%  (p=0.016 n=4+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12                                                  85.2µs ± 0%    83.9µs ± 1%   -1.55%  (p=0.016 n=4+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12                                                  389µs ±19%     358µs ± 3%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12                                                     137µs ±13%     123µs ± 1%  -10.19%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12                                                    159µs ± 4%     151µs ± 1%   -5.07%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12                                                   472µs ± 0%     458µs ± 1%   -3.08%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                 3.35ms ± 1%    3.26ms ± 1%   -2.57%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12                                             848µs ± 5%     800µs ± 3%   -5.64%  (p=0.032 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12                                           1.23ms ± 5%    1.13ms ± 1%   -8.39%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12                                          5.15ms ± 9%    4.69ms ± 1%   -8.90%  (p=0.016 n=5+4)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                         39.1ms ± 0%    38.3ms ± 1%   -2.04%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12                                                     55.7µs ±11%    53.1µs ± 3%     ~     (p=0.056 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12                                                    59.0µs ± 3%    56.7µs ± 1%   -4.00%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12                                                    102µs ± 4%      99µs ± 0%   -3.78%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12                                                   503µs ± 5%     490µs ± 0%   -2.63%  (p=0.032 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12                                                      132µs ± 2%     127µs ± 3%     ~     (p=0.056 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12                                                     172µs ± 1%     167µs ± 0%   -3.09%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12                                                    608µs ± 3%     584µs ± 0%   -4.01%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                  4.55ms ± 0%    4.53ms ± 5%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12                                              885µs ± 5%     830µs ± 1%   -6.17%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12                                            1.30ms ± 1%    1.26ms ± 0%   -3.67%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12                                           6.03ms ± 4%    5.81ms ± 1%   -3.64%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                          51.6ms ± 7%    49.2ms ± 1%   -4.56%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12                                                 56.8µs ± 5%    52.8µs ± 0%   -7.08%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12                                                58.0µs ± 1%    56.7µs ± 1%   -2.23%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12                                               98.7µs ± 0%    97.4µs ± 0%   -1.34%  (p=0.016 n=4+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12                                               477µs ± 3%     474µs ± 1%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12                                                  131µs ± 7%     127µs ± 8%     ~     (p=0.095 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12                                                 160µs ± 3%     150µs ± 0%   -5.85%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12                                                485µs ± 4%     454µs ± 1%   -6.35%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12                                              3.45ms ± 4%    3.25ms ± 1%   -5.64%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12                                          867µs ± 4%     790µs ± 0%   -8.87%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12                                        1.17ms ± 1%    1.13ms ± 2%   -3.48%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12                                       4.96ms ± 7%    4.68ms ± 1%   -5.57%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                      39.4ms ± 0%    38.2ms ± 1%   -2.97%  (p=0.016 n=4+5)
RangeQuery/expr=abs(a_one),steps=1-12                                                                        17.3µs ± 4%    15.7µs ± 0%   -9.57%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=10-12                                                                       19.5µs ± 2%    18.2µs ± 0%   -6.68%  (p=0.016 n=5+4)
RangeQuery/expr=abs(a_one),steps=100-12                                                                      47.6µs ± 6%    44.2µs ± 1%   -7.19%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=1000-12                                                                      296µs ± 3%     285µs ± 0%   -3.81%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=1-12                                                                        65.0µs ± 2%    61.7µs ± 0%   -5.05%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=10-12                                                                       90.2µs ± 0%    86.8µs ± 1%   -3.78%  (p=0.016 n=4+5)
RangeQuery/expr=abs(a_ten),steps=100-12                                                                       377µs ± 4%     357µs ± 1%   -5.34%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=1000-12                                                                     2.98ms ± 5%    2.90ms ± 0%   -2.70%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1-12                                                                     547µs ± 0%     527µs ± 0%   -3.57%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=10-12                                                                    881µs ±15%     793µs ± 2%   -9.98%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-12                                                                  3.79ms ± 7%    3.69ms ± 9%     ~     (p=0.095 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-12                                                                 34.2ms ± 8%    30.8ms ± 1%   -9.89%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                     31.6µs ±15%    28.2µs ± 0%  -10.70%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                    34.1µs ± 2%    32.5µs ± 1%   -4.72%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                   75.0µs ± 1%    73.9µs ± 1%   -1.45%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   471µs ± 2%     466µs ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                     91.3µs ±16%    79.2µs ± 0%  -13.29%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                     118µs ± 4%     109µs ± 2%   -7.28%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    429µs ± 1%     418µs ± 0%   -2.36%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                  3.58ms ± 8%    3.32ms ± 0%   -7.19%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                  729µs ±25%     590µs ± 1%  -18.97%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                1.03ms ±13%    0.88ms ± 0%  -15.20%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                               4.26ms ± 8%    3.99ms ± 0%   -6.23%  (p=0.016 n=5+4)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                              35.6ms ± 4%    34.0ms ± 0%   -4.71%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                                            23.9µs ± 0%    23.0µs ± 0%   -3.80%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                                           29.0µs ± 0%    28.1µs ± 1%   -3.24%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                                          81.5µs ± 0%    80.9µs ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                                          595µs ± 7%     586µs ± 1%     ~     (p=1.000 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                                            74.2µs ± 0%    71.6µs ± 1%   -3.46%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                                            105µs ± 0%     103µs ± 0%   -2.45%  (p=0.029 n=4+4)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                                           437µs ± 1%     430µs ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                                         3.56ms ± 1%    3.51ms ± 0%   -1.38%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                                         583µs ± 0%     562µs ± 0%   -3.72%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                                        889µs ± 0%     863µs ± 1%   -2.92%  (p=0.016 n=4+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                                      4.14ms ± 1%    4.10ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12                                     36.3ms ± 2%    35.5ms ± 4%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum(a_one),steps=1-12                                                                        16.4µs ± 0%    15.7µs ± 0%   -4.38%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=10-12                                                                       21.8µs ± 0%    21.2µs ± 0%   -2.80%  (p=0.016 n=5+4)
RangeQuery/expr=sum(a_one),steps=100-12                                                                      76.5µs ± 0%    76.3µs ± 3%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum(a_one),steps=1000-12                                                                      603µs ± 3%     595µs ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1-12                                                                        55.1µs ± 1%    52.8µs ± 1%   -4.26%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=10-12                                                                       66.8µs ± 0%    64.0µs ± 0%   -4.07%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=100-12                                                                       203µs ± 0%     197µs ± 2%   -3.15%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1000-12                                                                     1.39ms ± 2%    1.34ms ± 2%   -3.58%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1-12                                                                     438µs ± 1%     419µs ± 0%   -4.52%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=10-12                                                                    509µs ± 1%     487µs ± 0%   -4.38%  (p=0.016 n=4+5)
RangeQuery/expr=sum(a_hundred),steps=100-12                                                                  1.45ms ± 1%    1.36ms ± 0%   -5.86%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-12                                                                 9.02ms ± 0%    8.75ms ± 8%     ~     (p=0.190 n=4+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                                            70.7µs ± 0%    68.1µs ± 1%   -3.75%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                                            126µs ± 1%     123µs ± 0%   -2.04%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                                           687µs ± 1%     684µs ± 0%     ~     (p=0.063 n=5+4)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                         6.09ms ± 0%    6.09ms ± 0%     ~     (p=0.413 n=4+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                                             482µs ± 1%     462µs ± 0%   -4.10%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                                            652µs ± 0%     626µs ± 1%   -3.99%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                                          2.78ms ±13%    2.47ms ± 1%  -11.27%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                         20.4ms ± 3%    19.5ms ± 3%   -4.47%  (p=0.016 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                                        6.36ms ± 8%    5.10ms ± 2%  -19.83%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                                       7.99ms ± 3%    6.39ms ± 2%  -20.00%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                                      24.2ms ± 7%    21.8ms ± 3%   -9.93%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                      160ms ± 1%     154ms ± 2%   -3.67%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                                           59.3µs ± 2%    57.0µs ± 1%   -3.93%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                                          74.1µs ± 1%    71.5µs ± 0%   -3.53%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                                          249µs ± 1%     241µs ± 0%   -3.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                        1.81ms ± 1%    1.76ms ± 2%   -2.89%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                                            481µs ± 1%     458µs ± 0%   -4.75%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                                           632µs ± 1%     611µs ± 4%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                                         2.39ms ± 1%    2.32ms ± 4%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                        18.3ms ± 3%    18.1ms ± 8%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                                       5.28ms ± 7%    5.23ms ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                                      7.40ms ±18%    7.09ms ± 4%     ~     (p=1.000 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                                                     26.2ms ± 1%    25.2ms ± 1%   -3.49%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                     193ms ± 0%     209ms ±11%     ~     (p=0.730 n=4+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                                                 59.4µs ± 1%    66.6µs ±21%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                                                73.6µs ± 1%    73.7µs ± 5%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                                                244µs ± 1%     244µs ± 4%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                              1.75ms ± 0%    1.72ms ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                                                  477µs ± 1%     492µs ± 6%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                                                 623µs ± 0%     645µs ± 6%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                                               2.29ms ± 0%    2.35ms ± 5%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                              17.3ms ± 1%    18.2ms ± 6%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                                             5.29ms ± 3%    6.51ms ±49%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                                            7.09ms ±10%    9.16ms ±36%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                                           25.4ms ± 1%    28.8ms ± 9%  +13.28%  (p=0.016 n=4+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                           192ms ± 2%     193ms ±10%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                                                72.5µs ± 5%    70.2µs ±10%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                                                123µs ± 4%     124µs ± 4%     ~     (p=1.000 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                                               648µs ± 0%     674µs ± 5%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                             5.73ms ± 2%    6.02ms ± 7%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                                                 489µs ± 0%     478µs ±10%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                                                657µs ± 0%     657µs ± 4%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                                              2.57ms ± 1%    2.64ms ± 6%     ~     (p=0.310 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                             20.1ms ± 0%    20.6ms ± 7%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                                            6.22ms ± 7%    6.06ms ± 9%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                                           7.86ms ±10%    8.38ms ±28%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                                          25.5ms ± 9%    27.3ms ± 7%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                          169ms ± 4%     160ms ± 1%   -5.29%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                                                 32.3µs ± 4%    31.2µs ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                                                38.3µs ± 1%    37.6µs ± 1%   -1.91%  (p=0.016 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                                                110µs ± 0%     110µs ± 3%     ~     (p=1.000 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                                               788µs ± 5%     776µs ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                                                  123µs ± 0%     123µs ± 3%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                                                 187µs ± 1%     187µs ± 1%     ~     (p=1.000 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                                                881µs ± 1%     883µs ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                                              7.32ms ± 0%    7.38ms ± 1%   +0.82%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                                         1.07ms ± 4%    1.04ms ± 1%   -1.92%  (p=0.032 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                                        1.76ms ± 1%    1.77ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                                       9.43ms ± 1%   10.15ms ±13%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                                      82.4ms ± 1%    82.9ms ± 2%     ~     (p=0.413 n=4+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                                                  21.8µs ± 2%    21.3µs ± 1%   -2.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                                                 28.3µs ± 0%    27.9µs ± 1%   -1.36%  (p=0.016 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                                                94.9µs ± 0%    94.7µs ± 0%   -0.26%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                726µs ± 0%     733µs ± 3%     ~     (p=0.556 n=4+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                                                  60.1µs ± 1%    59.7µs ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                                                 80.2µs ± 1%    79.7µs ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                                                 309µs ± 0%     311µs ± 2%     ~     (p=0.548 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                               2.36ms ± 0%    2.37ms ± 1%     ~     (p=0.548 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                                               435µs ± 0%     435µs ± 1%     ~     (p=0.730 n=4+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                                              584µs ± 0%     582µs ± 1%     ~     (p=0.548 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                                            2.36ms ± 0%    2.35ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                           18.1ms ± 0%    18.3ms ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12               39.9µs ± 2%    39.0µs ± 1%   -2.33%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12              57.3µs ± 1%    56.3µs ± 1%   -1.71%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12              235µs ± 1%     233µs ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12            1.93ms ± 1%    1.94ms ± 2%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12                117µs ± 2%     115µs ± 1%   -1.52%  (p=0.032 n=5+4)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12               161µs ± 1%     160µs ± 1%   -0.84%  (p=0.016 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12              662µs ± 1%     658µs ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12            5.17ms ± 1%    5.19ms ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12        870µs ± 0%     875µs ± 2%     ~     (p=0.905 n=4+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12      1.17ms ± 1%    1.17ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12     4.76ms ± 1%    4.75ms ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12    36.6ms ± 1%    36.4ms ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                          81.7µs ± 1%    81.6µs ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                          129µs ±20%     118µs ± 2%     ~     (p=0.310 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                         497µs ± 1%     497µs ± 2%     ~     (p=1.000 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                       4.00ms ± 1%    4.02ms ± 1%     ~     (p=0.111 n=5+4)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                           644µs ± 1%     660µs ± 3%     ~     (p=0.056 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                         1.06ms ± 0%    1.06ms ± 0%     ~     (p=0.190 n=4+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                        5.45ms ± 1%    5.43ms ± 1%     ~     (p=0.548 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                       47.0ms ± 0%    47.1ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                      7.24ms ± 3%    7.34ms ± 4%     ~     (p=0.421 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                     12.2ms ± 3%    12.1ms ± 6%     ~     (p=0.690 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                    55.9ms ± 1%    55.9ms ± 1%     ~     (p=1.000 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                    477ms ± 1%     495ms ± 9%     ~     (p=0.286 n=4+5)

name                                                                                                       old alloc/op   new alloc/op   delta
RangeQuery/expr=a_one,steps=1-12                                                                             5.76kB ± 0%    4.93kB ± 0%  -14.44%  (p=0.008 n=5+5)
RangeQuery/expr=a_one,steps=10-12                                                                            5.76kB ± 0%    4.93kB ± 0%  -14.45%  (p=0.029 n=4+4)
RangeQuery/expr=a_one,steps=100-12                                                                           6.05kB ± 0%    5.22kB ± 0%  -13.75%  (p=0.029 n=4+4)
RangeQuery/expr=a_one,steps=1000-12                                                                          9.29kB ± 0%    8.70kB ± 0%   -6.44%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten,steps=1-12                                                                             14.5kB ± 0%    13.7kB ± 0%   -5.75%  (p=0.016 n=4+5)
RangeQuery/expr=a_ten,steps=10-12                                                                            14.5kB ± 0%    13.7kB ± 0%   -5.74%  (p=0.000 n=5+4)
RangeQuery/expr=a_ten,steps=100-12                                                                           16.6kB ± 0%    15.8kB ± 0%   -5.00%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten,steps=1000-12                                                                          38.9kB ± 0%    40.5kB ± 0%   +4.03%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=1-12                                                                          100kB ± 0%     100kB ± 0%   -0.83%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=10-12                                                                         100kB ± 0%      99kB ± 0%   -0.83%  (p=0.029 n=4+4)
RangeQuery/expr=a_hundred,steps=100-12                                                                        121kB ± 0%     120kB ± 0%   -0.69%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=1000-12                                                                       333kB ± 0%     355kB ± 0%   +6.38%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1-12                                                                   7.12kB ± 0%    7.12kB ± 0%     ~     (p=0.429 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=10-12                                                                  7.12kB ± 0%    7.12kB ± 0%     ~     (p=0.063 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=100-12                                                                 7.40kB ± 0%    7.41kB ± 0%     ~     (p=0.087 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1000-12                                                                10.4kB ± 0%    10.6kB ± 0%   +2.39%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=1-12                                                                   19.1kB ± 0%    19.1kB ± 0%     ~     (p=0.167 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=10-12                                                                  19.1kB ± 0%    19.1kB ± 0%     ~     (p=0.738 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=100-12                                                                 21.3kB ± 0%    21.3kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=1000-12                                                                40.6kB ± 0%    43.0kB ± 0%   +5.81%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-12                                                                137kB ± 0%     137kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-12                                                               137kB ± 0%     137kB ± 0%     ~     (p=0.500 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-12                                                              158kB ± 0%     158kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-12                                                             341kB ± 0%     363kB ± 0%   +6.43%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=10000-12                                                               61.0kB ± 0%    61.2kB ± 0%   +0.40%  (p=0.032 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=10000-12                                                                345kB ± 1%     349kB ± 1%   +1.17%  (p=0.016 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-12                                                           3.19MB ± 1%    3.23MB ± 0%   +1.27%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12                                                 1.20MB ± 0%    1.20MB ± 0%   +0.04%  (p=0.032 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12                                                1.20MB ± 0%    1.20MB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12                                               1.20MB ± 0%    1.20MB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12                                              1.22MB ± 0%    1.22MB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12                                                 1.41MB ± 0%    1.41MB ± 0%   +0.19%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12                                                1.41MB ± 0%    1.41MB ± 0%   +0.22%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12                                               1.39MB ± 0%    1.40MB ± 0%   +0.40%  (p=0.016 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12                                              1.45MB ± 1%    1.44MB ± 1%     ~     (p=0.381 n=5+4)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12                                             3.55MB ± 0%    3.57MB ± 0%   +0.56%  (p=0.016 n=4+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12                                            3.55MB ± 0%    3.57MB ± 0%   +0.47%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12                                           3.57MB ± 0%    3.60MB ± 1%   +0.92%  (p=0.016 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12                                          3.85MB ± 1%    3.82MB ± 1%     ~     (p=0.114 n=4+4)
RangeQuery/expr=changes(a_one[1d]),steps=1-12                                                                 566kB ± 0%     566kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=10-12                                                                565kB ± 0%     565kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=100-12                                                               564kB ± 0%     566kB ± 0%   +0.20%  (p=0.016 n=4+5)
RangeQuery/expr=changes(a_one[1d]),steps=1000-12                                                              578kB ± 0%     578kB ± 2%     ~     (p=0.841 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=1-12                                                                 780kB ± 0%     783kB ± 0%   +0.35%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=10-12                                                                781kB ± 0%     783kB ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=100-12                                                               788kB ± 2%     797kB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=1000-12                                                              916kB ± 1%     897kB ± 9%     ~     (p=0.794 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-12                                                            2.94MB ± 1%    2.96MB ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-12                                                           2.96MB ± 0%    2.98MB ± 0%   +0.64%  (p=0.029 n=4+4)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-12                                                          3.08MB ± 2%    3.04MB ± 3%     ~     (p=1.000 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                                                         4.10MB ±60%    3.82MB ± 1%     ~     (p=0.556 n=5+4)
RangeQuery/expr=rate(a_one[1d]),steps=1-12                                                                    566kB ± 0%     566kB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=10-12                                                                   567kB ± 0%     566kB ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=100-12                                                                  565kB ± 0%     565kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=1000-12                                                                 572kB ± 1%     574kB ± 0%     ~     (p=0.198 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=1-12                                                                    778kB ± 0%     781kB ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=10-12                                                                   781kB ± 0%     782kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=100-12                                                                  790kB ± 0%     789kB ± 1%     ~     (p=0.730 n=4+5)
RangeQuery/expr=rate(a_ten[1d]),steps=1000-12                                                                 859kB ± 6%     849kB ± 4%     ~     (p=0.421 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-12                                                               2.93MB ± 1%    2.96MB ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-12                                                              2.95MB ± 1%    2.97MB ± 0%     ~     (p=0.190 n=5+4)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-12                                                             3.02MB ± 2%    3.03MB ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                                                            3.81MB ± 1%    3.85MB ± 0%   +1.17%  (p=0.029 n=4+4)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12                                                        566kB ± 0%     566kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12                                                       566kB ± 0%     566kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12                                                      567kB ± 0%     567kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12                                                     584kB ± 0%     585kB ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12                                                        779kB ± 0%     782kB ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12                                                       782kB ± 0%     783kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12                                                      802kB ± 0%     803kB ± 0%     ~     (p=0.730 n=4+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12                                                     980kB ± 1%     980kB ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12                                                   2.94MB ± 1%    2.95MB ± 1%     ~     (p=0.841 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12                                                  2.96MB ± 1%    2.97MB ± 1%     ~     (p=0.841 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12                                                 3.14MB ± 1%    3.19MB ± 0%   +1.31%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12                                                4.87MB ± 2%    5.00MB ± 1%   +2.74%  (p=0.032 n=5+5)
RangeQuery/expr=-a_one,steps=1-12                                                                            6.32kB ± 0%    5.49kB ± 0%  -13.16%  (p=0.029 n=4+4)
RangeQuery/expr=-a_one,steps=10-12                                                                           6.32kB ± 0%    5.49kB ± 0%  -13.17%  (p=0.000 n=5+4)
RangeQuery/expr=-a_one,steps=100-12                                                                          6.61kB ± 0%    5.78kB ± 0%  -12.59%  (p=0.008 n=5+5)
RangeQuery/expr=-a_one,steps=1000-12                                                                         9.85kB ± 0%    9.26kB ± 0%   -6.03%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=1-12                                                                            18.3kB ± 0%    17.4kB ± 0%   -4.56%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=10-12                                                                           18.3kB ± 0%    17.4kB ± 0%   -4.55%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=100-12                                                                          20.4kB ± 0%    19.6kB ± 0%   -4.07%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=1000-12                                                                         42.7kB ± 0%    44.3kB ± 0%   +3.67%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1-12                                                                         136kB ± 0%     135kB ± 0%   -0.61%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=10-12                                                                        136kB ± 0%     135kB ± 0%   -0.61%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-12                                                                       157kB ± 0%     156kB ± 0%   -0.53%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-12                                                                      369kB ± 0%     390kB ± 0%   +5.79%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1-12                                                                     12.3kB ± 0%    10.7kB ± 0%  -13.52%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10-12                                                                    13.8kB ± 0%    12.1kB ± 0%  -12.10%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=100-12                                                                   28.7kB ± 0%    27.1kB ± 0%   -5.79%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1000-12                                                                   179kB ± 0%     178kB ± 0%   -0.66%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1-12                                                                     42.0kB ± 0%    40.4kB ± 0%   -3.95%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10-12                                                                    45.1kB ± 0%    43.4kB ± 0%   -3.68%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=100-12                                                                   79.7kB ± 0%    78.3kB ± 0%   -1.79%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1000-12                                                                   431kB ± 2%     431kB ± 3%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                                                              346kB ± 0%     344kB ± 0%   -0.48%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                                                             371kB ± 0%     369kB ± 0%   -0.47%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                                                            663kB ± 1%     658kB ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                                                          3.64MB ± 2%    3.64MB ± 7%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-12                                                                 1.72MB ± 0%    1.72MB ± 0%   -0.09%  (p=0.016 n=5+4)
RangeQuery/expr=a_ten_-_b_ten,steps=10000-12                                                                 4.02MB ± 5%    4.14MB ± 6%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                                                         38.4MB ±11%    32.0MB ±15%  -16.71%  (p=0.032 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12                                                    20.5kB ± 0%    19.3kB ± 0%   -5.62%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12                                                   21.9kB ± 0%    20.8kB ± 0%   -5.25%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12                                                  36.6kB ± 0%    35.5kB ± 0%   -3.16%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12                                                  184kB ± 0%     183kB ± 0%   -0.48%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12                                                    41.8kB ± 0%    40.1kB ± 0%   -4.03%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12                                                   43.2kB ± 0%    41.6kB ± 0%   -3.81%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12                                                  60.9kB ± 0%    59.3kB ± 0%   -2.75%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                  239kB ± 0%     241kB ± 0%   +0.80%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12                                             245kB ± 0%     243kB ± 0%   -0.66%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12                                            275kB ± 0%     273kB ± 0%   -0.64%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12                                           606kB ± 0%     604kB ± 0%   -0.28%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                         3.93MB ± 0%    3.96MB ± 0%   +0.83%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12                                                     20.6kB ± 0%    19.4kB ± 0%   -5.63%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12                                                    22.0kB ± 0%    20.8kB ± 0%   -5.25%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12                                                   36.7kB ± 0%    35.6kB ± 0%   -3.14%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12                                                   184kB ± 0%     183kB ± 0%   -0.49%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12                                                     43.1kB ± 0%    41.4kB ± 0%   -3.85%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12                                                    48.6kB ± 0%    47.0kB ± 0%   -3.42%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12                                                    107kB ± 0%     106kB ± 0%   -1.55%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                   695kB ± 0%     697kB ± 0%   +0.29%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12                                              257kB ± 0%     255kB ± 0%   -0.63%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12                                             320kB ± 0%     319kB ± 0%   -0.48%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12                                            987kB ± 0%     985kB ± 0%   -0.19%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                          7.66MB ± 0%    7.69MB ± 0%   +0.40%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12                                                 20.6kB ± 0%    19.4kB ± 0%   -5.60%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12                                                22.0kB ± 0%    20.8kB ± 0%   -5.25%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12                                               36.7kB ± 0%    35.5kB ± 0%   -3.15%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12                                               184kB ± 0%     183kB ± 0%   -0.47%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12                                                 41.8kB ± 0%    40.1kB ± 0%   -4.00%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12                                                43.2kB ± 0%    41.6kB ± 0%   -3.85%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12                                               60.9kB ± 0%    59.3kB ± 0%   -2.76%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12                                               239kB ± 0%     241kB ± 0%   +0.81%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12                                          245kB ± 0%     243kB ± 0%   -0.67%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12                                         275kB ± 0%     273kB ± 0%   -0.60%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12                                        606kB ± 0%     604kB ± 0%   -0.32%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                      3.93MB ± 0%    3.96MB ± 0%   +0.80%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=1-12                                                                        7.32kB ± 0%    6.48kB ± 0%  -11.37%  (p=0.000 n=5+4)
RangeQuery/expr=abs(a_one),steps=10-12                                                                       7.60kB ± 0%    6.77kB ± 0%  -10.94%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=100-12                                                                      10.8kB ± 0%     9.9kB ± 0%   -7.72%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=1000-12                                                                     42.8kB ± 0%    42.2kB ± 0%   -1.37%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=1-12                                                                        22.9kB ± 0%    22.1kB ± 0%   -3.63%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=10-12                                                                       24.7kB ± 0%    23.9kB ± 0%   -3.37%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=100-12                                                                      44.4kB ± 0%    43.6kB ± 0%   -1.88%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=1000-12                                                                      243kB ± 0%     244kB ± 0%   +0.65%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1-12                                                                     179kB ± 0%     178kB ± 0%   -0.46%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=10-12                                                                    194kB ± 0%     193kB ± 0%   -0.41%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-12                                                                   367kB ± 0%     366kB ± 0%   -0.23%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-12                                                                 2.10MB ± 0%    2.12MB ± 0%   +1.00%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                     13.3kB ± 0%    12.5kB ± 0%   -6.24%  (p=0.000 n=5+4)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                    14.8kB ± 0%    13.9kB ± 0%     ~     (p=0.079 n=4+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                   29.5kB ± 0%    28.6kB ± 0%   -2.83%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   177kB ± 0%     176kB ± 0%   -0.34%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                     30.6kB ± 0%    29.8kB ± 0%   -2.72%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                    33.5kB ± 0%    32.7kB ± 0%   -2.48%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                   64.8kB ± 0%    63.9kB ± 0%   -1.28%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   378kB ± 0%     380kB ± 0%   +0.42%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                  202kB ± 0%     201kB ± 0%   -0.42%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                 219kB ± 0%     218kB ± 0%   -0.39%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                403kB ± 0%     402kB ± 0%   -0.22%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                              2.25MB ± 0%    2.28MB ± 0%   +0.94%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                                            10.6kB ± 0%     9.7kB ± 0%   -7.86%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                                           12.6kB ± 0%    11.8kB ± 0%   -6.61%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                                          33.1kB ± 0%    32.2kB ± 0%   -2.52%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                                          238kB ± 0%     237kB ± 0%   -0.25%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                                            27.4kB ± 0%    26.6kB ± 0%   -3.03%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                                           30.9kB ± 0%    30.1kB ± 0%   -2.69%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                                          68.0kB ± 0%    67.1kB ± 0%   -1.22%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                                          439kB ± 0%     440kB ± 0%   +0.35%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                                         195kB ± 0%     194kB ± 0%   -0.42%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                                        212kB ± 0%     211kB ± 0%   -0.40%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                                       403kB ± 0%     402kB ± 0%   -0.18%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12                                     2.31MB ± 0%    2.33MB ± 0%   +0.91%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1-12                                                                        7.54kB ± 0%    6.71kB ± 0%  -11.04%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=10-12                                                                       11.4kB ± 0%    10.6kB ± 0%   -7.28%  (p=0.000 n=5+4)
RangeQuery/expr=sum(a_one),steps=100-12                                                                      50.6kB ± 0%    49.8kB ± 0%   -1.64%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1000-12                                                                      443kB ± 0%     442kB ± 0%   -0.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1-12                                                                        18.5kB ± 0%    17.6kB ± 0%   -4.51%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=10-12                                                                       22.3kB ± 0%    21.5kB ± 0%   -3.72%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=100-12                                                                      63.4kB ± 0%    62.6kB ± 0%   -1.31%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1000-12                                                                      475kB ± 0%     476kB ± 0%   +0.33%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1-12                                                                     123kB ± 0%     122kB ± 0%   -0.67%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=10-12                                                                    127kB ± 0%     126kB ± 0%   -0.65%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-12                                                                   187kB ± 0%     186kB ± 0%   -0.45%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-12                                                                  788kB ± 0%     809kB ± 0%   +2.71%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                                            25.4kB ± 0%    24.6kB ± 0%   -3.28%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                                           51.7kB ± 0%    50.9kB ± 0%   -1.61%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                                           317kB ± 0%     316kB ± 0%   -0.26%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                         2.97MB ± 0%    2.97MB ± 0%   +0.07%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                                             153kB ± 0%     152kB ± 0%   -0.54%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                                            182kB ± 0%     181kB ± 0%   -0.46%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                                           499kB ± 0%     498kB ± 0%   -0.17%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                         3.67MB ± 0%    3.70MB ± 0%   +0.70%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                                        1.40MB ± 0%    1.40MB ± 0%   -0.07%  (p=0.016 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                                       1.43MB ± 0%    1.43MB ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                                      1.95MB ± 0%    1.95MB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                     7.24MB ± 0%    7.47MB ± 0%   +3.28%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                                           19.8kB ± 0%    18.9kB ± 0%   -4.21%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                                          24.5kB ± 0%    23.7kB ± 0%   -3.39%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                                         74.4kB ± 0%    73.6kB ± 0%   -1.12%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                         574kB ± 0%     576kB ± 0%   +0.32%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                                            152kB ± 0%     151kB ± 0%   -0.54%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                                           179kB ± 0%     178kB ± 0%   -0.46%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                                          475kB ± 0%     474kB ± 0%   -0.18%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                        3.44MB ± 0%    3.46MB ± 0%   +0.75%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                                       1.46MB ± 0%    1.46MB ± 0%   -0.07%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                                      1.73MB ± 0%    1.73MB ± 0%   -0.03%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                                                     4.63MB ± 0%    4.63MB ± 0%   -0.05%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                    33.6MB ± 0%    33.9MB ± 0%   +0.73%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                                                 19.7kB ± 0%    18.9kB ± 0%   -4.22%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                                                24.2kB ± 0%    23.4kB ± 0%   -3.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                                               71.2kB ± 0%    70.4kB ± 0%   -1.17%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                               542kB ± 0%     544kB ± 0%   +0.33%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                                                  151kB ± 0%     150kB ± 0%   -0.55%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                                                 172kB ± 0%     171kB ± 0%   -0.48%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                                                410kB ± 0%     410kB ± 0%   -0.20%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                              2.80MB ± 0%    2.82MB ± 0%   +0.91%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                                             1.45MB ± 0%    1.45MB ± 0%   -0.05%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                                            1.66MB ± 0%    1.65MB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                                           3.98MB ± 0%    3.98MB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                          27.2MB ± 0%    27.5MB ± 0%   +0.88%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                                                24.7kB ± 0%    23.9kB ± 0%   -3.36%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                                               47.8kB ± 0%    47.0kB ± 0%   -1.74%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                                               281kB ± 0%     280kB ± 0%   -0.29%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                             2.61MB ± 0%    2.61MB ± 0%   +0.07%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                                                 151kB ± 0%     150kB ± 0%   -0.55%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                                                174kB ± 0%     173kB ± 0%   -0.48%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                                               428kB ± 0%     427kB ± 0%   -0.19%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                             2.97MB ± 0%    3.00MB ± 0%   +0.86%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                                            1.40MB ± 0%    1.40MB ± 0%   -0.06%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                                           1.42MB ± 0%    1.42MB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                                          1.88MB ± 0%    1.88MB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                         6.53MB ± 0%    6.76MB ± 0%   +3.61%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                                                 14.5kB ± 0%    14.5kB ± 0%     ~     (p=0.738 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                                                16.0kB ± 0%    16.0kB ± 0%     ~     (p=0.714 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                                               31.0kB ± 0%    31.0kB ± 0%     ~     (p=0.175 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                                               181kB ± 0%     181kB ± 0%   +0.10%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                                                 46.7kB ± 0%    46.7kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                                                49.8kB ± 0%    49.8kB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                                               84.6kB ± 0%    84.6kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                                               432kB ± 2%     431kB ± 2%     ~     (p=0.841 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                                          379kB ± 0%     379kB ± 0%     ~     (p=0.333 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                                         404kB ± 0%     404kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                                        693kB ± 1%     693kB ± 1%     ~     (p=1.000 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                                      3.58MB ± 3%    3.55MB ± 5%     ~     (p=1.000 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                                                  8.85kB ± 0%    8.85kB ± 0%     ~     (p=0.524 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                                                 13.0kB ± 0%    13.0kB ± 0%     ~     (p=0.897 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                                                55.1kB ± 0%    55.1kB ± 0%     ~     (p=0.389 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                476kB ± 0%     476kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                                                  23.1kB ± 0%    23.1kB ± 0%     ~     (p=0.476 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                                                 27.5kB ± 0%    27.5kB ± 0%     ~     (p=0.984 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                                                74.4kB ± 0%    74.4kB ± 0%     ~     (p=0.079 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                                540kB ± 0%     541kB ± 0%   +0.16%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                                               160kB ± 0%     160kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                                              164kB ± 0%     164kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                                             230kB ± 0%     230kB ± 0%     ~     (p=0.627 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                            861kB ± 0%     868kB ± 0%   +0.78%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12               19.0kB ± 0%    19.0kB ± 0%     ~     (p=0.373 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12              28.8kB ± 0%    28.8kB ± 0%     ~     (p=0.889 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12              127kB ± 0%     127kB ± 0%     ~     (p=0.516 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12            1.11MB ± 0%    1.11MB ± 0%   +0.03%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12               47.5kB ± 0%    47.5kB ± 0%     ~     (p=0.984 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12              57.8kB ± 0%    57.8kB ± 0%     ~     (p=0.286 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12              166kB ± 0%     166kB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12            1.24MB ± 0%    1.24MB ± 0%   +0.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12        321kB ± 0%     321kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12       331kB ± 0%     331kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12      477kB ± 0%     477kB ± 0%     ~     (p=0.397 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12    1.88MB ± 0%    1.90MB ± 0%   +0.87%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                          28.7kB ± 0%    28.7kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                         39.9kB ± 0%    39.9kB ± 0%     ~     (p=0.730 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                         155kB ± 0%     155kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                       1.30MB ± 0%    1.30MB ± 0%   +0.06%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                           232kB ± 0%     232kB ± 0%     ~     (p=0.135 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                          369kB ± 0%     369kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                        1.76MB ± 0%    1.76MB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                       15.7MB ± 0%    15.7MB ± 0%   +0.05%  (p=0.032 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                      2.23MB ± 0%    2.23MB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                     3.60MB ± 0%    3.60MB ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                    17.5MB ± 0%    17.5MB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                    156MB ± 0%     156MB ± 0%   +0.05%  (p=0.008 n=5+5)

name                                                                                                       old allocs/op  new allocs/op  delta
RangeQuery/expr=a_one,steps=1-12                                                                                116 ± 0%       113 ± 0%   -2.59%  (p=0.008 n=5+5)
RangeQuery/expr=a_one,steps=10-12                                                                               116 ± 0%       113 ± 0%   -2.59%  (p=0.008 n=5+5)
RangeQuery/expr=a_one,steps=100-12                                                                              121 ± 0%       118 ± 0%   -2.48%  (p=0.008 n=5+5)
RangeQuery/expr=a_one,steps=1000-12                                                                             168 ± 0%       177 ± 0%   +5.36%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten,steps=1-12                                                                                264 ± 0%       261 ± 0%   -1.14%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten,steps=10-12                                                                               264 ± 0%       261 ± 0%   -1.14%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten,steps=100-12                                                                              305 ± 0%       302 ± 0%   -0.98%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten,steps=1000-12                                                                             748 ± 0%       865 ± 0%  +15.64%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=1-12                                                                          1.71k ± 0%     1.70k ± 0%   -0.18%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=10-12                                                                         1.71k ± 0%     1.70k ± 0%   -0.18%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=100-12                                                                        2.11k ± 0%     2.10k ± 0%   -0.14%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=1000-12                                                                       6.50k ± 0%     7.60k ± 0%  +17.00%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1-12                                                                      152 ± 0%       152 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m]),steps=10-12                                                                     152 ± 0%       152 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m]),steps=100-12                                                                    157 ± 0%       157 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m]),steps=1000-12                                                                   196 ± 0%       208 ± 0%   +6.12%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=1-12                                                                      337 ± 0%       337 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_ten[1m]),steps=10-12                                                                     337 ± 0%       337 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_ten[1m]),steps=100-12                                                                    378 ± 0%       378 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_ten[1m]),steps=1000-12                                                                   741 ± 0%       861 ± 0%  +16.19%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-12                                                                2.15k ± 0%     2.15k ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-12                                                               2.15k ± 0%     2.15k ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-12                                                              2.55k ± 0%     2.55k ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-12                                                             6.14k ± 0%     7.25k ± 0%  +18.05%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=10000-12                                                                  875 ± 0%       887 ± 0%   +1.37%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=10000-12                                                                7.20k ± 0%     7.32k ± 0%   +1.67%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-12                                                            70.5k ± 0%     71.6k ± 0%   +1.58%  (p=0.029 n=4+4)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12                                                    791 ± 0%       803 ± 0%   +1.52%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12                                                   791 ± 0%       803 ± 0%   +1.52%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12                                                  799 ± 0%       811 ± 0%   +1.50%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12                                                 857 ± 0%       869 ± 0%   +1.45%  (p=0.016 n=5+4)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12                                                  6.02k ± 0%     6.14k ± 0%   +1.99%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12                                                 6.02k ± 0%     6.14k ± 0%   +1.99%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12                                                6.09k ± 0%     6.21k ± 0%   +2.00%  (p=0.016 n=4+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12                                               6.66k ± 0%     6.78k ± 0%   +1.79%  (p=0.016 n=5+4)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12                                              58.2k ± 0%     59.3k ± 0%   +1.90%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12                                             58.2k ± 0%     59.3k ± 0%   +1.90%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12                                            59.0k ± 0%     60.1k ± 0%   +1.88%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12                                           64.7k ± 0%     65.7k ± 0%   +1.57%  (p=0.016 n=5+4)
RangeQuery/expr=changes(a_one[1d]),steps=1-12                                                                   729 ± 0%       741 ± 0%   +1.65%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=10-12                                                                  729 ± 0%       741 ± 0%   +1.65%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=100-12                                                                 737 ± 0%       749 ± 0%   +1.63%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=1000-12                                                                793 ± 0%       806 ± 0%   +1.59%  (p=0.016 n=4+5)
RangeQuery/expr=changes(a_ten[1d]),steps=1-12                                                                 5.95k ± 0%     6.07k ± 0%   +2.02%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=10-12                                                                5.95k ± 0%     6.07k ± 0%   +2.02%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=100-12                                                               6.03k ± 0%     6.16k ± 0%   +2.00%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=1000-12                                                              6.60k ± 0%     6.72k ± 0%   +1.76%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-12                                                             58.2k ± 0%     59.3k ± 0%   +1.91%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-12                                                            58.2k ± 0%     59.3k ± 0%   +1.91%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-12                                                           59.0k ± 0%     60.1k ± 0%   +1.88%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                                                          64.6k ± 0%     65.7k ± 0%   +1.72%  (p=0.029 n=4+4)
RangeQuery/expr=rate(a_one[1d]),steps=1-12                                                                      729 ± 0%       741 ± 0%   +1.65%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=10-12                                                                     729 ± 0%       741 ± 0%   +1.65%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=100-12                                                                    737 ± 0%       749 ± 0%   +1.63%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=1000-12                                                                   793 ± 0%       805 ± 0%   +1.51%  (p=0.016 n=4+5)
RangeQuery/expr=rate(a_ten[1d]),steps=1-12                                                                    5.95k ± 0%     6.07k ± 0%   +2.02%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=10-12                                                                   5.95k ± 0%     6.07k ± 0%   +2.02%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_ten[1d]),steps=100-12                                                                  6.04k ± 0%     6.15k ± 0%   +1.98%  (p=0.016 n=4+5)
RangeQuery/expr=rate(a_ten[1d]),steps=1000-12                                                                 6.60k ± 0%     6.72k ± 0%   +1.82%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-12                                                                58.2k ± 0%     59.3k ± 0%   +1.90%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-12                                                               58.2k ± 0%     59.3k ± 0%   +1.90%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-12                                                              59.0k ± 0%     60.1k ± 0%   +1.88%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                                                             64.6k ± 0%     65.7k ± 0%   +1.72%  (p=0.029 n=4+4)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12                                                          729 ± 0%       741 ± 0%   +1.65%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12                                                         729 ± 0%       741 ± 0%   +1.65%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12                                                        737 ± 0%       749 ± 0%   +1.63%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12                                                       793 ± 0%       805 ± 0%   +1.51%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12                                                        5.95k ± 0%     6.07k ± 0%   +2.02%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12                                                       5.95k ± 0%     6.07k ± 0%   +2.02%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12                                                      6.03k ± 0%     6.15k ± 0%   +1.99%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12                                                     6.59k ± 0%     6.71k ± 0%   +1.82%  (p=0.016 n=5+4)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12                                                    58.1k ± 0%     59.3k ± 0%   +1.90%  (p=0.016 n=4+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12                                                   58.1k ± 0%     59.3k ± 0%   +1.90%  (p=0.016 n=5+4)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12                                                  58.9k ± 0%     60.1k ± 0%   +1.88%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12                                                 64.5k ± 0%     65.7k ± 0%   +1.74%  (p=0.008 n=5+5)
RangeQuery/expr=-a_one,steps=1-12                                                                               130 ± 0%       127 ± 0%   -2.31%  (p=0.008 n=5+5)
RangeQuery/expr=-a_one,steps=10-12                                                                              130 ± 0%       127 ± 0%   -2.31%  (p=0.008 n=5+5)
RangeQuery/expr=-a_one,steps=100-12                                                                             135 ± 0%       132 ± 0%   -2.22%  (p=0.008 n=5+5)
RangeQuery/expr=-a_one,steps=1000-12                                                                            182 ± 0%       191 ± 0%   +4.95%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=1-12                                                                               315 ± 0%       312 ± 0%   -0.95%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=10-12                                                                              315 ± 0%       312 ± 0%   -0.95%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=100-12                                                                             356 ± 0%       353 ± 0%   -0.84%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=1000-12                                                                            799 ± 0%       916 ± 0%  +14.64%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1-12                                                                         2.12k ± 0%     2.12k ± 0%   -0.14%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=10-12                                                                        2.12k ± 0%     2.12k ± 0%   -0.14%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-12                                                                       2.52k ± 0%     2.52k ± 0%   -0.12%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-12                                                                      6.92k ± 0%     8.02k ± 0%  +15.98%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1-12                                                                        211 ± 0%       205 ± 0%   -2.84%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10-12                                                                       247 ± 0%       241 ± 0%   -2.43%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=100-12                                                                      617 ± 0%       611 ± 0%   -0.97%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1000-12                                                                   4.31k ± 0%     4.33k ± 0%   +0.42%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1-12                                                                        624 ± 0%       618 ± 0%   -0.96%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10-12                                                                       670 ± 0%       664 ± 0%   -0.90%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=100-12                                                                    1.21k ± 0%     1.21k ± 0%   -0.46%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1000-12                                                                   6.72k ± 0%     6.95k ± 1%   +3.40%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                                                              4.64k ± 0%     4.63k ± 0%   -0.13%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                                                             4.76k ± 0%     4.75k ± 0%   -0.12%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                                                            6.77k ± 0%     6.76k ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                                                           27.9k ± 1%     30.0k ± 2%   +7.40%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-12                                                                  41.6k ± 0%     41.7k ± 0%   +0.04%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10000-12                                                                  65.5k ± 1%     66.1k ± 1%   +0.93%  (p=0.032 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                                                           286k ± 4%      275k ± 5%     ~     (p=0.056 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12                                                       294 ± 0%       289 ± 0%   -1.70%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12                                                      330 ± 0%       325 ± 0%   -1.52%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12                                                     695 ± 0%       690 ± 0%   -0.72%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12                                                  4.34k ± 0%     4.35k ± 0%   +0.16%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12                                                       597 ± 0%       591 ± 0%   -1.01%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12                                                      633 ± 0%       627 ± 0%   -0.95%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12                                                   1.05k ± 0%     1.05k ± 0%   -0.57%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                  5.32k ± 0%     5.50k ± 0%   +3.27%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12                                             3.38k ± 0%     3.37k ± 0%   -0.18%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12                                            3.51k ± 0%     3.51k ± 0%   -0.15%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12                                           5.44k ± 0%     5.43k ± 0%   -0.11%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                          25.3k ± 0%     27.0k ± 0%   +6.59%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12                                                        296 ± 0%       291 ± 0%   -1.69%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12                                                       332 ± 0%       327 ± 0%   -1.51%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12                                                      697 ± 0%       692 ± 0%   -0.72%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12                                                   4.34k ± 0%     4.35k ± 0%   +0.16%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12                                                        606 ± 0%       600 ± 0%   -0.99%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12                                                       661 ± 0%       655 ± 0%   -0.91%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12                                                    1.27k ± 0%     1.27k ± 0%   -0.47%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                   7.43k ± 0%     7.61k ± 0%   +2.34%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12                                              3.44k ± 0%     3.44k ± 0%   -0.17%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12                                             3.62k ± 0%     3.61k ± 0%   -0.18%  (p=0.000 n=4+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12                                            6.00k ± 0%     5.99k ± 0%   -0.12%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                           30.4k ± 0%     32.0k ± 0%   +5.50%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12                                                    296 ± 0%       291 ± 0%   -1.69%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12                                                   332 ± 0%       327 ± 0%   -1.51%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12                                                  697 ± 0%       692 ± 0%   -0.72%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12                                               4.34k ± 0%     4.35k ± 0%   +0.16%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12                                                    597 ± 0%       591 ± 0%   -1.01%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12                                                   633 ± 0%       627 ± 0%   -0.95%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12                                                1.05k ± 0%     1.05k ± 0%   -0.57%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12                                               5.32k ± 0%     5.50k ± 0%   +3.27%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12                                          3.38k ± 0%     3.37k ± 0%   -0.18%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12                                         3.51k ± 0%     3.51k ± 0%     ~     (p=0.079 n=4+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12                                        5.44k ± 0%     5.43k ± 0%   -0.14%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                       25.3k ± 0%     27.0k ± 0%   +6.57%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=1-12                                                                           149 ± 0%       146 ± 0%   -2.01%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=10-12                                                                          158 ± 0%       155 ± 0%   -1.90%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=100-12                                                                         253 ± 0%       250 ± 0%   -1.19%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=1000-12                                                                      1.20k ± 0%     1.21k ± 0%   +0.75%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=1-12                                                                           346 ± 0%       343 ± 0%   -0.87%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=10-12                                                                          365 ± 0%       362 ± 0%   -0.82%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=100-12                                                                         593 ± 0%       590 ± 0%   -0.51%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=1000-12                                                                      2.91k ± 0%     3.03k ± 0%   +4.04%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1-12                                                                     2.26k ± 0%     2.26k ± 0%   -0.13%  (p=0.000 n=5+4)
RangeQuery/expr=abs(a_hundred),steps=10-12                                                                    2.34k ± 0%     2.33k ± 0%   -0.13%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-12                                                                   3.49k ± 0%     3.48k ± 0%   -0.09%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-12                                                                  15.4k ± 0%     16.5k ± 0%   +7.20%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                        266 ± 0%       263 ± 0%   -1.13%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                       311 ± 0%       308 ± 0%   -0.96%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                      766 ± 0%       763 ± 0%   -0.39%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   5.31k ± 0%     5.32k ± 0%   +0.17%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                        492 ± 0%       489 ± 0%   -0.61%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                       547 ± 0%       544 ± 0%   -0.55%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    1.14k ± 0%     1.13k ± 0%   -0.26%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   7.06k ± 0%     7.17k ± 0%   +1.66%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                  2.77k ± 0%     2.77k ± 0%     ~     (p=0.079 n=4+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                 2.88k ± 0%     2.88k ± 0%     ~     (p=0.079 n=4+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                4.39k ± 0%     4.38k ± 0%   -0.09%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                               19.9k ± 0%     21.0k ± 0%   +5.58%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                                               226 ± 0%       223 ± 0%   -1.33%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                                              289 ± 0%       286 ± 0%   -1.04%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                                             924 ± 0%       921 ± 0%   -0.32%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                                          7.27k ± 0%     7.28k ± 0%   +0.12%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                                               441 ± 0%       438 ± 0%   -0.68%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                                              514 ± 0%       511 ± 0%   -0.58%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                                           1.28k ± 0%     1.28k ± 0%   -0.23%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                                          9.00k ± 0%     9.12k ± 0%   +1.30%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                                         2.54k ± 0%     2.53k ± 0%   -0.12%  (p=0.029 n=4+4)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                                        2.67k ± 0%     2.66k ± 0%   -0.11%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                                       4.35k ± 0%     4.35k ± 0%     ~     (p=0.127 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12                                      21.6k ± 0%     22.7k ± 0%   +5.12%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1-12                                                                           150 ± 0%       147 ± 0%   -2.00%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=10-12                                                                          204 ± 0%       201 ± 0%   -1.47%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=100-12                                                                         749 ± 0%       746 ± 0%   -0.40%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1000-12                                                                      6.20k ± 0%     6.21k ± 0%   +0.15%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1-12                                                                           299 ± 0%       296 ± 0%   -1.00%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=10-12                                                                          353 ± 0%       350 ± 0%   -0.85%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=100-12                                                                         934 ± 0%       931 ± 0%   -0.32%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1000-12                                                                      6.78k ± 0%     6.89k ± 0%   +1.73%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1-12                                                                     1.74k ± 0%     1.74k ± 0%   -0.17%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=10-12                                                                    1.80k ± 0%     1.79k ± 0%   -0.17%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-12                                                                   2.74k ± 0%     2.73k ± 0%   -0.11%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-12                                                                  12.5k ± 0%     13.6k ± 0%   +8.82%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                                               394 ± 0%       391 ± 0%   -0.76%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                                              757 ± 0%       754 ± 0%   -0.40%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                                           4.43k ± 0%     4.43k ± 0%   -0.07%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                          41.2k ± 0%     41.3k ± 0%   +0.32%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                                             1.98k ± 0%     1.98k ± 0%   -0.15%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                                            2.35k ± 0%     2.34k ± 0%   -0.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                                           6.42k ± 0%     6.41k ± 0%   -0.04%  (p=0.000 n=4+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                          47.6k ± 0%     48.9k ± 0%   +2.78%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                                         17.8k ± 0%     17.8k ± 0%   -0.02%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                                        18.2k ± 0%     18.2k ± 0%   -0.02%  (p=0.029 n=4+4)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                                       26.2k ± 0%     26.2k ± 0%     ~     (p=0.071 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                       111k ± 0%      123k ± 0%  +11.00%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                                              320 ± 0%       317 ± 0%   -0.94%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                                             392 ± 0%       389 ± 0%   -0.77%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                                          1.16k ± 0%     1.15k ± 0%   -0.26%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                         8.84k ± 0%     8.97k ± 0%   +1.46%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                                            1.98k ± 0%     1.97k ± 0%   -0.15%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                                           2.31k ± 0%     2.31k ± 0%   -0.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                                          6.09k ± 0%     6.09k ± 0%   -0.04%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                         44.3k ± 0%     45.6k ± 0%   +2.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                                        18.5k ± 0%     18.5k ± 0%   -0.02%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                                       21.4k ± 0%     21.4k ± 0%   -0.01%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                                                      54.6k ± 0%     54.6k ± 0%     ~     (p=0.302 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                      392k ± 0%      404k ± 0%   +3.12%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                                                    320 ± 0%       317 ± 0%   -0.94%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                                                   392 ± 0%       389 ± 0%   -0.77%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                                                1.16k ± 0%     1.15k ± 0%   -0.26%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                               8.84k ± 0%     8.97k ± 0%   +1.46%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                                                  1.98k ± 0%     1.97k ± 0%   -0.15%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                                                 2.31k ± 0%     2.31k ± 0%   -0.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                                                6.09k ± 0%     6.09k ± 0%   -0.03%  (p=0.029 n=4+4)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                               44.3k ± 0%     45.6k ± 0%   +2.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                                              18.5k ± 0%     18.5k ± 0%   -0.02%  (p=0.000 n=5+4)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                                             21.4k ± 0%     21.4k ± 0%   -0.01%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                                            54.6k ± 0%     54.6k ± 0%     ~     (p=0.635 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                            392k ± 0%      404k ± 0%   +3.11%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                                                   394 ± 0%       391 ± 0%   -0.76%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                                                  757 ± 0%       754 ± 0%   -0.40%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                                               4.43k ± 0%     4.43k ± 0%     ~     (p=0.079 n=4+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                              41.2k ± 0%     41.3k ± 0%   +0.31%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                                                 1.98k ± 0%     1.98k ± 0%   -0.15%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                                                2.35k ± 0%     2.34k ± 0%   -0.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                                               6.42k ± 0%     6.41k ± 0%   -0.05%  (p=0.029 n=4+4)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                              47.6k ± 0%     48.9k ± 0%   +2.77%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                                             17.8k ± 0%     17.8k ± 0%   -0.02%  (p=0.000 n=5+4)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                                            18.2k ± 0%     18.2k ± 0%     ~     (p=0.079 n=4+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                                           26.2k ± 0%     26.2k ± 0%   -0.01%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                           111k ± 0%      123k ± 0%  +11.00%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                                                    269 ± 0%       269 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                                                   305 ± 0%       305 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                                                  675 ± 0%       675 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                                               4.35k ± 0%     4.36k ± 0%   +0.18%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                                                    721 ± 0%       721 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                                                   767 ± 0%       767 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                                                1.31k ± 0%     1.31k ± 0%     ~     (p=0.683 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                                               6.66k ± 0%     6.74k ± 0%   +1.15%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                                          5.10k ± 0%     5.10k ± 0%     ~     (p=0.556 n=4+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                                         5.22k ± 0%     5.22k ± 0%     ~     (p=0.556 n=5+4)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                                        7.23k ± 0%     7.23k ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                                       26.6k ± 1%     27.2k ± 1%   +2.17%  (p=0.016 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                                                     185 ± 0%       185 ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                                                    248 ± 0%       248 ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                                                   883 ± 0%       883 ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                7.22k ± 0%     7.23k ± 0%   +0.06%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                                                     373 ± 0%       373 ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                                                    445 ± 0%       445 ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                                                 1.21k ± 0%     1.21k ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                                8.77k ± 0%     8.81k ± 0%   +0.46%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                                               2.18k ± 0%     2.18k ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                                              2.25k ± 0%     2.25k ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                                             3.38k ± 0%     3.38k ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                            14.2k ± 0%     14.5k ± 0%   +2.59%  (p=0.029 n=4+4)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12                  343 ± 0%       343 ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12                 505 ± 0%       505 ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12              2.13k ± 0%     2.13k ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12             18.4k ± 0%     18.4k ± 0%   +0.04%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12                  719 ± 0%       719 ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12                 899 ± 0%       899 ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12              2.78k ± 0%     2.78k ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12             21.5k ± 0%     21.6k ± 0%   +0.37%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12        4.34k ± 0%     4.34k ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12       4.52k ± 0%     4.52k ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12      7.12k ± 0%     7.12k ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12     32.3k ± 0%     33.0k ± 0%   +2.28%  (p=0.016 n=4+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                             470 ± 0%       470 ± 0%     ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                            713 ± 0%       713 ± 0%     ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                         3.19k ± 0%     3.19k ± 0%     ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                        28.0k ± 0%     28.0k ± 0%   +0.16%  (p=0.016 n=4+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                           3.19k ± 0%     3.19k ± 0%     ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                          6.30k ± 0%     6.30k ± 0%     ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                         37.8k ± 0%     37.8k ± 0%     ~     (p=0.444 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                         353k ± 0%      354k ± 0%   +0.12%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                       30.1k ± 0%     30.1k ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                      60.8k ± 0%     60.8k ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                      372k ± 0%      372k ± 0%     ~     (p=0.738 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                    3.49M ± 0%     3.49M ± 0%   +0.12%  (p=0.008 n=5+5)
```
