### PR TITLE
Optimize aggregations in PromQL engine

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -156,6 +156,9 @@ func BenchmarkRangeQuery(b *testing.B) {
 		{
 			expr: "sum by (le)(h_X)",
 		},
+		{
+			expr: "count_values('value', h_X)",
+		},
 		// Combinations.
 		{
 			expr: "rate(a_X[1m]) + rate(b_X[1m])",

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -902,6 +902,12 @@ func (ev *evaluator) Eval(expr parser.Expr) (v parser.Value, ws storage.Warnings
 	return v, ws, nil
 }
 
+// EvalSeriesHelper stores extra information about a series.
+type EvalSeriesHelper struct {
+	// The grouping key used by aggregation.
+	groupingKey uint64
+}
+
 // EvalNodeHelper stores extra information and caches for evaluating a single node across steps.
 type EvalNodeHelper struct {
 	// Evaluation timestamp.
@@ -962,10 +968,12 @@ func (enh *EvalNodeHelper) signatureFunc(on bool, names ...string) func(labels.L
 }
 
 // rangeEval evaluates the given expressions, and then for each step calls
-// the given function with the values computed for each expression at that
-// step.  The return value is the combination into time series of all the
+// the given funcCall with the values computed for each expression at that
+// step. The return value is the combination into time series of all the
 // function call results.
-func (ev *evaluator) rangeEval(funcCall func([]parser.Value, *EvalNodeHelper) (Vector, storage.Warnings), exprs ...parser.Expr) (Matrix, storage.Warnings) {
+// The prepSeries function (if provided) can be used to prepare the helper
+// for each series, then passed to each call funcCall.
+func (ev *evaluator) rangeEval(prepSeries func(labels.Labels, *EvalSeriesHelper), funcCall func([]parser.Value, [][]EvalSeriesHelper, *EvalNodeHelper) (Vector, storage.Warnings), exprs ...parser.Expr) (Matrix, storage.Warnings) {
 	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
 	matrixes := make([]Matrix, len(exprs))
 	origMatrixes := make([]Matrix, len(exprs))
@@ -1001,6 +1009,30 @@ func (ev *evaluator) rangeEval(funcCall func([]parser.Value, *EvalNodeHelper) (V
 	enh := &EvalNodeHelper{Out: make(Vector, 0, biggestLen)}
 	seriess := make(map[uint64]Series, biggestLen) // Output series by series hash.
 	tempNumSamples := ev.currentSamples
+
+	var (
+		seriesHelpers [][]EvalSeriesHelper
+		bufHelpers    [][]EvalSeriesHelper // Buffer updated on each step
+	)
+
+	// If the series preparation function is provided, we should run it for
+	// every single series in the matrix.
+	if prepSeries != nil {
+		seriesHelpers = make([][]EvalSeriesHelper, len(exprs))
+		bufHelpers = make([][]EvalSeriesHelper, len(exprs))
+
+		for i := range exprs {
+			seriesHelpers[i] = make([]EvalSeriesHelper, len(matrixes[i]))
+			bufHelpers[i] = make([]EvalSeriesHelper, len(matrixes[i]))
+
+			for si, series := range matrixes[i] {
+				h := seriesHelpers[i][si]
+				prepSeries(series.Metric, &h)
+				seriesHelpers[i][si] = h
+			}
+		}
+	}
+
 	for ts := ev.startTimestamp; ts <= ev.endTimestamp; ts += ev.interval {
 		if err := contextDone(ev.ctx, "expression evaluation"); err != nil {
 			ev.error(err)
@@ -1010,11 +1042,20 @@ func (ev *evaluator) rangeEval(funcCall func([]parser.Value, *EvalNodeHelper) (V
 		// Gather input vectors for this timestamp.
 		for i := range exprs {
 			vectors[i] = vectors[i][:0]
+
+			if prepSeries != nil {
+				bufHelpers[i] = bufHelpers[i][:0]
+			}
+
 			for si, series := range matrixes[i] {
 				for _, point := range series.Points {
 					if point.T == ts {
 						if ev.currentSamples < ev.maxSamples {
 							vectors[i] = append(vectors[i], Sample{Metric: series.Metric, Point: point})
+							if prepSeries != nil {
+								bufHelpers[i] = append(bufHelpers[i], seriesHelpers[i][si])
+							}
+
 							// Move input vectors forward so we don't have to re-scan the same
 							// past points at the next step.
 							matrixes[i][si].Points = series.Points[1:]
@@ -1028,9 +1069,10 @@ func (ev *evaluator) rangeEval(funcCall func([]parser.Value, *EvalNodeHelper) (V
 			}
 			args[i] = vectors[i]
 		}
+
 		// Make the function call.
 		enh.Ts = ts
-		result, ws := funcCall(args, enh)
+		result, ws := funcCall(args, bufHelpers, enh)
 		if result.ContainsSameLabelset() {
 			ev.errorf("vector cannot contain metrics with the same labelset")
 		}
@@ -1132,18 +1174,29 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 
 	switch e := expr.(type) {
 	case *parser.AggregateExpr:
+		// Grouping labels must be sorted (expected both by generateGroupingKey() and aggregation()).
+		sortedGrouping := e.Grouping
+		sort.Strings(sortedGrouping)
+
+		// Prepare a function to initialise series helpers with the grouping key.
+		buf := make([]byte, 0, 1024)
+		initSeries := func(series labels.Labels, h *EvalSeriesHelper) {
+			h.groupingKey, buf = generateGroupingKey(series, sortedGrouping, e.Without, buf)
+		}
+
 		unwrapParenExpr(&e.Param)
 		if s, ok := unwrapStepInvariantExpr(e.Param).(*parser.StringLiteral); ok {
-			return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) (Vector, storage.Warnings) {
-				return ev.aggregation(e.Op, e.Grouping, e.Without, s.Val, v[0].(Vector), enh), nil
+			return ev.rangeEval(initSeries, func(v []parser.Value, sh [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+				return ev.aggregation(e.Op, sortedGrouping, e.Without, s.Val, v[0].(Vector), sh[0], enh), nil
 			}, e.Expr)
 		}
-		return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+
+		return ev.rangeEval(initSeries, func(v []parser.Value, sh [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 			var param float64
 			if e.Param != nil {
 				param = v[0].(Vector)[0].V
 			}
-			return ev.aggregation(e.Op, e.Grouping, e.Without, param, v[1].(Vector), enh), nil
+			return ev.aggregation(e.Op, sortedGrouping, e.Without, param, v[1].(Vector), sh[1], enh), nil
 		}, e.Param, e.Expr)
 
 	case *parser.Call:
@@ -1156,7 +1209,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 			arg := unwrapStepInvariantExpr(e.Args[0])
 			vs, ok := arg.(*parser.VectorSelector)
 			if ok {
-				return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+				return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 					if vs.Timestamp != nil {
 						// This is a special case only for "timestamp" since the offset
 						// needs to be adjusted for every point.
@@ -1200,7 +1253,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 		}
 		if !matrixArg {
 			// Does not have a matrix argument.
-			return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+			return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 				return call(v, e.Args, enh), warnings
 			}, e.Args...)
 		}
@@ -1367,43 +1420,43 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 	case *parser.BinaryExpr:
 		switch lt, rt := e.LHS.Type(), e.RHS.Type(); {
 		case lt == parser.ValueTypeScalar && rt == parser.ValueTypeScalar:
-			return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+			return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 				val := scalarBinop(e.Op, v[0].(Vector)[0].Point.V, v[1].(Vector)[0].Point.V)
 				return append(enh.Out, Sample{Point: Point{V: val}}), nil
 			}, e.LHS, e.RHS)
 		case lt == parser.ValueTypeVector && rt == parser.ValueTypeVector:
 			switch e.Op {
 			case parser.LAND:
-				return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+				return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 					return ev.VectorAnd(v[0].(Vector), v[1].(Vector), e.VectorMatching, enh), nil
 				}, e.LHS, e.RHS)
 			case parser.LOR:
-				return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+				return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 					return ev.VectorOr(v[0].(Vector), v[1].(Vector), e.VectorMatching, enh), nil
 				}, e.LHS, e.RHS)
 			case parser.LUNLESS:
-				return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+				return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 					return ev.VectorUnless(v[0].(Vector), v[1].(Vector), e.VectorMatching, enh), nil
 				}, e.LHS, e.RHS)
 			default:
-				return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+				return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 					return ev.VectorBinop(e.Op, v[0].(Vector), v[1].(Vector), e.VectorMatching, e.ReturnBool, enh), nil
 				}, e.LHS, e.RHS)
 			}
 
 		case lt == parser.ValueTypeVector && rt == parser.ValueTypeScalar:
-			return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+			return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 				return ev.VectorscalarBinop(e.Op, v[0].(Vector), Scalar{V: v[1].(Vector)[0].Point.V}, false, e.ReturnBool, enh), nil
 			}, e.LHS, e.RHS)
 
 		case lt == parser.ValueTypeScalar && rt == parser.ValueTypeVector:
-			return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+			return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 				return ev.VectorscalarBinop(e.Op, v[1].(Vector), Scalar{V: v[0].(Vector)[0].Point.V}, true, e.ReturnBool, enh), nil
 			}, e.LHS, e.RHS)
 		}
 
 	case *parser.NumberLiteral:
-		return ev.rangeEval(func(v []parser.Value, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+		return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 			return append(enh.Out, Sample{Point: Point{V: e.Val}}), nil
 		})
 
@@ -2067,8 +2120,9 @@ type groupedAggregation struct {
 	reverseHeap vectorByReverseValueHeap
 }
 
-// aggregation evaluates an aggregation operation on a Vector.
-func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without bool, param interface{}, vec Vector, enh *EvalNodeHelper) Vector {
+// aggregation evaluates an aggregation operation on a Vector. The provided grouping labels
+// must be sorted.
+func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without bool, param interface{}, vec Vector, seriesHelper []EvalSeriesHelper, enh *EvalNodeHelper) Vector {
 
 	result := map[uint64]*groupedAggregation{}
 	var k int64
@@ -2087,35 +2141,43 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		q = param.(float64)
 	}
 	var valueLabel string
+	var recomputeGroupingKey bool
 	if op == parser.COUNT_VALUES {
 		valueLabel = param.(string)
 		if !model.LabelName(valueLabel).IsValid() {
 			ev.errorf("invalid label name %q", valueLabel)
 		}
 		if !without {
+			// We're changing the grouping labels so we have to ensure they're still sorted
+			// and we have to flag to recompute the grouping key. Considering the count_values()
+			// operator is less frequently used than other aggregations, we're fine having to
+			// re-compute the grouping key on each step for this case.
 			grouping = append(grouping, valueLabel)
+			sort.Strings(grouping)
+			recomputeGroupingKey = true
 		}
 	}
 
-	sort.Strings(grouping)
 	lb := labels.NewBuilder(nil)
-	buf := make([]byte, 0, 1024)
-	for _, s := range vec {
+	var buf []byte
+	for si, s := range vec {
 		metric := s.Metric
 
 		if op == parser.COUNT_VALUES {
 			lb.Reset(metric)
 			lb.Set(valueLabel, strconv.FormatFloat(s.V, 'f', -1, 64))
 			metric = lb.Labels()
+
+			// We've changed the metric so we have to recompute the grouping key.
+			recomputeGroupingKey = true
 		}
 
-		var (
-			groupingKey uint64
-		)
-		if without {
-			groupingKey, buf = metric.HashWithoutLabels(buf, grouping...)
+		// We can use the pre-computed grouping key unless grouping labels have changed.
+		var groupingKey uint64
+		if !recomputeGroupingKey {
+			groupingKey = seriesHelper[si].groupingKey
 		} else {
-			groupingKey, buf = metric.HashForLabels(buf, grouping...)
+			groupingKey, buf = generateGroupingKey(metric, grouping, without, buf)
 		}
 
 		group, ok := result[groupingKey]
@@ -2300,6 +2362,21 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		})
 	}
 	return enh.Out
+}
+
+// groupingKey builds and returns the grouping key for the given metric and
+// grouping labels.
+func generateGroupingKey(metric labels.Labels, grouping []string, without bool, buf []byte) (uint64, []byte) {
+	if without {
+		return metric.HashWithoutLabels(buf, grouping...)
+	} else {
+		if len(grouping) == 0 {
+			// No need to generate any hash if there are no grouping labels.
+			return 0, buf
+		}
+
+		return metric.HashForLabels(buf, grouping...)
+	}
 }
 
 // btos returns 1 if b is true, 0 otherwise.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2369,14 +2369,14 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 func generateGroupingKey(metric labels.Labels, grouping []string, without bool, buf []byte) (uint64, []byte) {
 	if without {
 		return metric.HashWithoutLabels(buf, grouping...)
-	} else {
-		if len(grouping) == 0 {
-			// No need to generate any hash if there are no grouping labels.
-			return 0, buf
-		}
-
-		return metric.HashForLabels(buf, grouping...)
 	}
+
+	if len(grouping) == 0 {
+		// No need to generate any hash if there are no grouping labels.
+		return 0, buf
+	}
+
+	return metric.HashForLabels(buf, grouping...)
 }
 
 // btos returns 1 if b is true, 0 otherwise.


### PR DESCRIPTION
I'm investigating some slow queries in Cortex (running the vanilla PromQL engine). In particular, I'm investigating some high cardinality queries (50k+ series) with many steps (5000) in the form of `sum by(...) (metric{...})`.

Profiling such queries I've noticed that (in my specific case) 60% of CPU is spent by `Labels.HashForLabels()`:

![Screenshot 2021-03-13 at 07 21 54](https://user-images.githubusercontent.com/1701904/111021513-3b381e80-83cd-11eb-853f-f1e755aa157a.png)

I believe there's a significant inefficiency regarding that. The `HashForLabels()` is called for every series **and** every step in order to generate the grouping key but the grouping key doesn't change on each step. In this PR I'm proposing to compute the grouping key for each series upfront and then pass it to each `aggregation()` call.

_In this PR I've intentionally not optimized `count_values()` because would be more complicated and, in my experience, unfrequently used compared to other aggregation operators._

## Benchmarks TL;DR

The focus in the benchmark should be on queries running aggregations, in particular the case "many steps". Queries are fast on 1 single step, but significantly slower on many steps. As you can see, the CPU reduction (and so execution time) is significant at the cost of a slight increase of allocated memory and allocations.

```
name                                                                                                       old time/op    new time/op    delta
RangeQuery/expr=sum(a_one),steps=1000-12                                                                      593µs ± 0%     584µs ± 0%   -1.53%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1000-12                                                                     1.38ms ± 3%    1.32ms ± 0%   -4.75%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-12                                                                 9.00ms ± 1%    8.66ms ± 0%   -3.82%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                         6.10ms ± 0%    5.75ms ± 0%   -5.70%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                         19.7ms ± 0%    15.0ms ± 1%  -24.00%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                      159ms ± 1%     119ms ± 2%  -24.79%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                        1.78ms ± 1%    1.49ms ± 1%  -16.43%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                        18.1ms ± 1%    14.1ms ± 0%  -22.35%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                     191ms ± 0%     159ms ± 2%  -17.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                              1.73ms ± 0%    1.43ms ± 1%  -17.21%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                              17.1ms ± 0%    13.5ms ± 0%  -21.40%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                           186ms ± 1%     151ms ± 2%  -18.87%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                             5.60ms ± 0%    5.25ms ± 2%   -6.20%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                             19.7ms ± 0%    14.3ms ± 3%  -27.21%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                          165ms ± 1%     118ms ± 1%  -28.43%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                726µs ± 1%     688µs ± 2%   -5.23%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                               2.35ms ± 0%    2.12ms ± 0%   -9.49%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                           17.9ms ± 1%    16.4ms ± 0%   -8.36%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12            1.93ms ± 2%    1.85ms ± 0%   -4.11%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12            5.15ms ± 0%    4.76ms ± 0%   -7.49%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12    36.4ms ± 2%    33.8ms ± 0%   -7.24%  (p=0.008 n=5+5)

name                                                                                                       old alloc/op   new alloc/op   delta
RangeQuery/expr=sum(a_one),steps=1000-12                                                                      442kB ± 0%     443kB ± 0%   +0.10%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1000-12                                                                      472kB ± 0%     476kB ± 0%   +0.76%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-12                                                                  764kB ± 0%     798kB ± 0%   +4.41%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                         2.96MB ± 0%    2.93MB ± 0%   -0.94%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                         3.65MB ± 0%    3.65MB ± 0%   +0.16%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                     6.97MB ± 0%    7.31MB ± 0%   +4.86%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                         571kB ± 0%     543kB ± 0%   -4.92%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                        3.41MB ± 0%    3.42MB ± 0%   +0.17%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                    33.4MB ± 0%    33.7MB ± 0%   +1.00%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                               539kB ± 0%     511kB ± 0%   -5.21%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                              2.77MB ± 0%    2.78MB ± 0%   +0.22%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                          27.0MB ± 0%    27.3MB ± 0%   +1.26%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                             2.61MB ± 0%    2.58MB ± 0%   -1.07%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                             2.94MB ± 0%    2.95MB ± 0%   +0.20%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                         6.26MB ± 0%    6.60MB ± 0%   +5.42%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                476kB ± 0%     444kB ± 0%   -6.65%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                                539kB ± 0%     510kB ± 0%   -5.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                            845kB ± 0%     838kB ± 0%   -0.81%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12            1.11MB ± 0%    1.05MB ± 0%   -5.71%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12            1.24MB ± 0%    1.18MB ± 0%   -4.72%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12    1.85MB ± 0%    1.84MB ± 0%   -0.68%  (p=0.008 n=5+5)

name                                                                                                       old allocs/op  new allocs/op  delta
RangeQuery/expr=sum(a_one),steps=1000-12                                                                      6.18k ± 0%     6.20k ± 0%   +0.34%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1000-12                                                                      6.66k ± 0%     6.83k ± 0%   +2.61%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-12                                                                  11.3k ± 0%     13.0k ± 0%  +14.64%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                          41.1k ± 0%     40.3k ± 0%   -1.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                          46.2k ± 0%     47.1k ± 0%   +1.89%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                      97.7k ± 0%    114.9k ± 0%  +17.60%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                         8.71k ± 0%     7.90k ± 0%   -9.29%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                         43.0k ± 0%     43.9k ± 0%   +2.03%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                      379k ± 0%      396k ± 0%   +4.54%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                               8.71k ± 0%     7.90k ± 0%   -9.29%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                               43.0k ± 0%     43.9k ± 0%   +2.03%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                            379k ± 0%      396k ± 0%   +4.55%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                              41.1k ± 0%     40.3k ± 0%   -1.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                              46.2k ± 0%     47.1k ± 0%   +1.89%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                          97.7k ± 0%    114.9k ± 0%  +17.61%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                7.21k ± 0%     6.23k ± 0%  -13.63%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                                8.69k ± 0%     7.82k ± 0%   -9.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                            13.4k ± 0%     13.6k ± 0%   +1.94%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12             18.4k ± 0%     16.4k ± 0%  -10.69%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12             21.3k ± 0%     19.6k ± 0%   -8.11%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12     30.7k ± 0%     31.2k ± 0%   +1.69%  (p=0.016 n=4+5)
```

## Full benchmarks

```
name                                                                                                       old time/op    new time/op    delta
RangeQuery/expr=a_one,steps=1-12                                                                             12.3µs ± 0%    12.3µs ± 1%     ~     (p=0.214 n=5+5)
RangeQuery/expr=a_one,steps=10-12                                                                            12.8µs ± 2%    13.0µs ± 3%     ~     (p=0.310 n=5+5)
RangeQuery/expr=a_one,steps=100-12                                                                           19.3µs ± 1%    20.0µs ± 8%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_one,steps=1000-12                                                                          65.6µs ± 1%    68.9µs ± 2%   +4.92%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten,steps=1-12                                                                             49.7µs ± 0%    49.7µs ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_ten,steps=10-12                                                                            53.8µs ± 0%    54.0µs ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_ten,steps=100-12                                                                            119µs ± 0%     119µs ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=a_ten,steps=1000-12                                                                           575µs ± 0%     602µs ± 2%   +4.59%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=1-12                                                                          439µs ± 0%     438µs ± 0%     ~     (p=0.286 n=4+5)
RangeQuery/expr=a_hundred,steps=10-12                                                                         506µs ±17%     481µs ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred,steps=100-12                                                                       1.13ms ± 2%    1.13ms ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred,steps=1000-12                                                                      5.68ms ± 2%    5.87ms ± 1%   +3.20%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1-12                                                                   16.9µs ± 0%    16.8µs ± 0%   -0.97%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=10-12                                                                  18.0µs ± 0%    17.8µs ± 0%   -0.70%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=100-12                                                                 31.9µs ± 0%    31.7µs ± 0%     ~     (p=0.057 n=4+4)
RangeQuery/expr=rate(a_one[1m]),steps=1000-12                                                                 146µs ± 0%     149µs ± 2%   +1.99%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=1-12                                                                   54.1µs ± 0%    53.6µs ± 0%   -0.88%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_ten[1m]),steps=10-12                                                                  65.4µs ± 2%    64.6µs ± 1%   -1.25%  (p=0.032 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=100-12                                                                  204µs ± 2%     203µs ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=1000-12                                                                1.34ms ± 0%    1.37ms ± 1%   +1.77%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-12                                                                433µs ± 1%     430µs ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-12                                                               543µs ± 1%     542µs ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-12                                                             1.94ms ± 2%    1.92ms ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-12                                                            13.4ms ± 1%    13.6ms ± 0%   +1.15%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=10000-12                                                               1.47ms ± 0%    1.48ms ± 0%   +0.41%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_ten[1m]),steps=10000-12                                                               14.6ms ± 0%    14.6ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-12                                                            147ms ± 2%     146ms ± 1%     ~     (p=1.000 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12                                                  764µs ± 2%     763µs ± 1%     ~     (p=0.841 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12                                                1.24ms ± 0%    1.25ms ± 0%   +0.64%  (p=0.016 n=4+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12                                               6.11ms ± 0%    6.12ms ± 0%     ~     (p=0.111 n=5+4)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12                                              55.3ms ± 0%    55.4ms ± 1%     ~     (p=0.548 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12                                                 6.03ms ± 0%    6.12ms ± 0%   +1.42%  (p=0.016 n=4+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12                                                10.9ms ± 0%    11.0ms ± 0%   +0.60%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12                                               60.1ms ± 0%    60.6ms ± 2%     ~     (p=0.056 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12                                               542ms ± 2%     554ms ± 7%     ~     (p=0.095 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12                                             60.7ms ± 2%    60.5ms ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12                                             110ms ± 0%     111ms ± 3%     ~     (p=0.151 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12                                            592ms ± 2%     595ms ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12                                           5.40s ± 0%     5.42s ± 0%   +0.37%  (p=0.016 n=4+5)
RangeQuery/expr=changes(a_one[1d]),steps=1-12                                                                 604µs ± 0%     608µs ± 0%   +0.73%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=10-12                                                                766µs ± 0%     768µs ± 0%     ~     (p=0.063 n=4+5)
RangeQuery/expr=changes(a_one[1d]),steps=100-12                                                              2.42ms ± 2%    2.36ms ± 0%   -2.44%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=1000-12                                                             19.0ms ± 1%    18.5ms ± 0%   -2.16%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=1-12                                                                5.29ms ± 0%    5.29ms ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=10-12                                                               6.93ms ± 0%    6.90ms ± 0%     ~     (p=0.111 n=4+5)
RangeQuery/expr=changes(a_ten[1d]),steps=100-12                                                              23.8ms ± 2%    23.2ms ± 0%   -2.73%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=1000-12                                                              187ms ± 1%     183ms ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-12                                                            53.1ms ± 1%    53.8ms ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-12                                                           70.1ms ± 2%    70.2ms ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-12                                                           235ms ± 2%     229ms ± 2%   -2.61%  (p=0.016 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                                                          1.84s ± 1%     1.83s ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=1-12                                                                    586µs ± 0%     591µs ± 0%   +0.92%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=10-12                                                                   667µs ± 0%     675µs ± 0%   +1.19%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_one[1d]),steps=100-12                                                                 1.53ms ± 2%    1.56ms ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=1000-12                                                                10.3ms ± 0%    10.4ms ± 1%     ~     (p=0.111 n=5+4)
RangeQuery/expr=rate(a_ten[1d]),steps=1-12                                                                   5.09ms ± 0%    5.21ms ± 5%   +2.47%  (p=0.016 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=10-12                                                                  5.93ms ± 0%    5.92ms ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=100-12                                                                 14.6ms ± 0%    15.0ms ± 1%   +2.67%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=1000-12                                                                 101ms ± 2%     103ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-12                                                               51.6ms ± 2%    51.7ms ± 1%     ~     (p=0.548 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-12                                                              59.9ms ± 0%    60.0ms ± 0%     ~     (p=0.286 n=5+4)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-12                                                              147ms ± 1%     150ms ± 1%   +2.34%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                                                             1.02s ± 3%     1.02s ± 1%     ~     (p=1.000 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12                                                        571µs ± 0%     577µs ± 0%   +0.98%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12                                                       597µs ± 4%     596µs ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12                                                      777µs ± 2%     788µs ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12                                                    2.56ms ± 4%    2.68ms ± 1%   +4.72%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12                                                       4.95ms ± 0%    4.97ms ± 0%   +0.37%  (p=0.032 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12                                                      5.13ms ± 1%    5.16ms ± 0%   +0.56%  (p=0.032 n=5+4)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12                                                     6.93ms ± 1%    7.06ms ± 0%   +1.88%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12                                                    25.1ms ± 1%    26.7ms ± 7%   +6.67%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12                                                   49.9ms ± 0%    50.3ms ± 1%   +0.91%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12                                                  51.8ms ± 1%    52.2ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12                                                 70.5ms ± 1%    71.8ms ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12                                                 253ms ± 4%     260ms ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=-a_one,steps=1-12                                                                            13.7µs ± 0%    13.5µs ± 0%   -1.02%  (p=0.008 n=5+5)
RangeQuery/expr=-a_one,steps=10-12                                                                           14.2µs ± 2%    14.0µs ± 0%   -1.12%  (p=0.008 n=5+5)
RangeQuery/expr=-a_one,steps=100-12                                                                          20.8µs ± 0%    20.7µs ± 0%   -0.40%  (p=0.048 n=5+5)
RangeQuery/expr=-a_one,steps=1000-12                                                                         67.1µs ± 0%    69.8µs ± 0%   +4.04%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=1-12                                                                            54.3µs ± 1%    54.3µs ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=-a_ten,steps=10-12                                                                           58.5µs ± 0%    58.7µs ± 0%     ~     (p=0.063 n=4+5)
RangeQuery/expr=-a_ten,steps=100-12                                                                           124µs ± 2%     124µs ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=-a_ten,steps=1000-12                                                                          586µs ± 0%     611µs ± 1%   +4.27%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1-12                                                                         474µs ± 2%     470µs ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=-a_hundred,steps=10-12                                                                        518µs ± 3%     514µs ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-12                                                                      1.17ms ± 0%    1.17ms ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-12                                                                     5.75ms ± 1%    5.96ms ± 0%   +3.59%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1-12                                                                     23.9µs ± 0%    24.1µs ± 0%   +0.54%  (p=0.032 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10-12                                                                    29.7µs ± 0%    30.1µs ± 0%   +1.37%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=100-12                                                                   93.5µs ± 2%    95.0µs ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1000-12                                                                   685µs ± 2%     699µs ± 0%     ~     (p=0.063 n=5+4)
RangeQuery/expr=a_ten_-_b_ten,steps=1-12                                                                      121µs ± 0%     121µs ± 0%   +0.43%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10-12                                                                     182µs ± 1%     182µs ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=100-12                                                                    807µs ± 0%     828µs ± 2%   +2.59%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1000-12                                                                  6.65ms ± 1%    6.89ms ± 0%   +3.61%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                                                             1.10ms ± 0%    1.11ms ± 0%     ~     (p=0.413 n=4+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                                                            1.76ms ± 1%    1.77ms ± 0%   +0.65%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                                                           8.75ms ± 0%    8.93ms ± 3%   +2.07%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                                                          75.9ms ± 2%    77.8ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-12                                                                 6.91ms ± 0%    7.07ms ± 1%   +2.41%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10000-12                                                                 69.4ms ± 1%    71.1ms ± 1%   +2.38%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                                                          782ms ± 2%     796ms ± 1%   +1.77%  (p=0.032 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12                                                    53.0µs ± 1%    53.5µs ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12                                                   55.0µs ± 0%    55.6µs ± 1%   +1.03%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12                                                  85.0µs ± 2%    85.5µs ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12                                                  350µs ± 3%     357µs ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12                                                     125µs ± 0%     130µs ± 8%   +3.48%  (p=0.016 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12                                                    154µs ± 0%     154µs ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12                                                   467µs ± 0%     470µs ± 0%   +0.65%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                 3.30ms ± 0%    3.38ms ± 1%   +2.58%  (p=0.016 n=4+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12                                             820µs ± 1%     820µs ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12                                           1.16ms ± 2%    1.15ms ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12                                          4.81ms ± 1%    4.83ms ± 0%   +0.60%  (p=0.016 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                         39.4ms ± 2%    40.0ms ± 2%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12                                                     52.8µs ± 1%    53.2µs ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12                                                    56.8µs ± 0%    57.3µs ± 0%   +0.94%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12                                                   98.6µs ± 0%   101.2µs ± 3%   +2.66%  (p=0.016 n=4+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12                                                   486µs ± 2%     501µs ± 2%   +3.10%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12                                                      129µs ± 0%     129µs ± 0%   +0.55%  (p=0.016 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12                                                     169µs ± 0%     171µs ± 0%   +0.81%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12                                                    594µs ± 0%     604µs ± 0%   +1.63%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                  4.54ms ± 2%    4.63ms ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12                                              855µs ± 0%     857µs ± 0%   +0.18%  (p=0.032 n=5+4)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12                                            1.28ms ± 0%    1.30ms ± 0%   +0.84%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12                                           5.89ms ± 0%    5.97ms ± 0%   +1.37%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                          49.6ms ± 0%    50.9ms ± 1%   +2.80%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12                                                 52.7µs ± 0%    53.6µs ± 2%   +1.67%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12                                                56.6µs ± 0%    57.4µs ± 0%   +1.50%  (p=0.016 n=4+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12                                               97.3µs ± 0%    98.6µs ± 0%   +1.36%  (p=0.016 n=4+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12                                               474µs ± 2%     486µs ± 2%     ~     (p=0.056 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12                                                  125µs ± 0%     126µs ± 0%   +0.40%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12                                                 154µs ± 0%     154µs ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12                                                468µs ± 1%     470µs ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12                                              3.30ms ± 1%    3.36ms ± 0%   +1.85%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12                                          822µs ± 2%     822µs ± 2%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12                                        1.15ms ± 0%    1.16ms ± 0%   +0.55%  (p=0.016 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12                                       4.79ms ± 0%    4.84ms ± 0%   +1.00%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                      38.9ms ± 1%    39.7ms ± 1%   +2.03%  (p=0.016 n=5+5)
RangeQuery/expr=abs(a_one),steps=1-12                                                                        16.2µs ± 2%    16.1µs ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=abs(a_one),steps=10-12                                                                       18.6µs ± 0%    18.6µs ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=abs(a_one),steps=100-12                                                                      45.0µs ± 0%    46.6µs ± 0%   +3.46%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=1000-12                                                                      287µs ± 1%     308µs ± 1%   +7.28%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=1-12                                                                        63.7µs ± 1%    64.4µs ± 2%   +1.15%  (p=0.032 n=5+5)
RangeQuery/expr=abs(a_ten),steps=10-12                                                                       89.5µs ± 0%    91.1µs ± 0%   +1.72%  (p=0.016 n=5+4)
RangeQuery/expr=abs(a_ten),steps=100-12                                                                       364µs ± 0%     378µs ± 0%   +3.82%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=1000-12                                                                     2.93ms ± 3%    3.07ms ± 0%   +4.78%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1-12                                                                     552µs ± 2%     549µs ± 2%     ~     (p=0.841 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=10-12                                                                    810µs ± 0%     826µs ± 0%   +1.93%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-12                                                                  3.67ms ± 0%    3.82ms ± 0%   +3.85%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-12                                                                 31.1ms ± 1%    32.9ms ± 0%   +5.54%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                     29.1µs ± 0%    28.8µs ± 0%   -1.10%  (p=0.016 n=5+4)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                    33.2µs ± 0%    32.9µs ± 0%   -0.78%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                   77.2µs ± 8%    75.9µs ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   468µs ± 0%     482µs ± 1%   +3.04%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                     81.8µs ± 0%    81.8µs ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                     111µs ± 0%     112µs ± 0%   +0.62%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    426µs ± 0%     433µs ± 0%   +1.69%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                  3.36ms ± 1%    3.43ms ± 0%   +2.22%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                  608µs ± 0%     611µs ± 2%     ~     (p=0.905 n=4+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                 903µs ± 0%     907µs ± 0%   +0.46%  (p=0.032 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                               4.04ms ± 0%    4.09ms ± 0%   +1.22%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                              34.5ms ± 0%    35.1ms ± 0%   +1.98%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                                            23.4µs ± 0%    23.4µs ± 0%   -0.38%  (p=0.032 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                                           28.6µs ± 1%    28.7µs ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                                          81.5µs ± 0%    83.0µs ± 0%   +1.76%  (p=0.016 n=5+4)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                                          583µs ± 0%     603µs ± 0%   +3.47%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                                            73.7µs ± 2%    74.2µs ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                                            105µs ± 2%     106µs ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                                           434µs ± 0%     448µs ± 0%   +3.15%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                                         3.51ms ± 0%    3.69ms ± 1%   +5.00%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                                         579µs ± 0%     584µs ± 1%   +0.89%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                                        885µs ± 0%     896µs ± 0%   +1.17%  (p=0.029 n=4+4)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                                      4.12ms ± 0%    4.25ms ± 1%   +3.07%  (p=0.016 n=4+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12                                     35.7ms ± 2%    36.9ms ± 0%   +3.20%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1-12                                                                        16.2µs ± 0%    16.5µs ± 0%   +2.17%  (p=0.016 n=4+5)
RangeQuery/expr=sum(a_one),steps=10-12                                                                       21.6µs ± 2%    21.9µs ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum(a_one),steps=100-12                                                                      76.1µs ± 0%    75.4µs ± 0%   -0.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1000-12                                                                      593µs ± 0%     584µs ± 0%   -1.53%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1-12                                                                        54.4µs ± 1%    55.3µs ± 0%   +1.67%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=10-12                                                                       66.4µs ± 2%    66.4µs ± 2%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum(a_ten),steps=100-12                                                                       203µs ± 0%     196µs ± 1%   -3.20%  (p=0.016 n=5+4)
RangeQuery/expr=sum(a_ten),steps=1000-12                                                                     1.38ms ± 3%    1.32ms ± 0%   -4.75%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1-12                                                                     442µs ± 2%     438µs ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=10-12                                                                    510µs ± 2%     504µs ± 0%   -1.28%  (p=0.016 n=5+4)
RangeQuery/expr=sum(a_hundred),steps=100-12                                                                  1.45ms ± 0%    1.39ms ± 1%   -3.81%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-12                                                                 9.00ms ± 1%    8.66ms ± 0%   -3.82%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                                            70.2µs ± 0%    70.8µs ± 0%   +0.88%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                                            125µs ± 2%     123µs ± 2%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                                           688µs ± 0%     652µs ± 0%   -5.23%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                         6.10ms ± 0%    5.75ms ± 0%   -5.70%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                                             483µs ± 0%     478µs ± 0%   -0.98%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                                            649µs ± 1%     606µs ± 3%   -6.66%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                                          2.55ms ± 0%    2.05ms ± 0%  -19.79%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                         19.7ms ± 0%    15.0ms ± 1%  -24.00%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                                        5.03ms ± 5%    4.94ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                                       6.39ms ± 5%    5.84ms ± 3%   -8.55%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                                      22.3ms ± 1%    17.9ms ± 2%  -19.99%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                      159ms ± 1%     119ms ± 2%  -24.79%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                                           59.1µs ± 1%    60.0µs ± 3%   +1.60%  (p=0.032 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                                          74.1µs ± 0%    71.4µs ± 0%   -3.59%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                                          249µs ± 0%     218µs ± 0%  -12.46%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                        1.78ms ± 1%    1.49ms ± 1%  -16.43%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                                            479µs ± 0%     476µs ± 0%   -0.48%  (p=0.032 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                                           630µs ± 0%     590µs ± 0%   -6.32%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                                         2.39ms ± 0%    1.97ms ± 2%  -17.23%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                        18.1ms ± 1%    14.1ms ± 0%  -22.35%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                                       5.24ms ± 5%    5.07ms ± 2%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                                      7.07ms ± 4%    6.41ms ± 1%   -9.31%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                                                     26.9ms ±12%    22.6ms ± 1%  -15.93%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                     191ms ± 0%     159ms ± 2%  -17.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                                                 59.1µs ± 1%    59.4µs ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                                                74.0µs ± 2%    70.7µs ± 0%   -4.46%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                                                243µs ± 0%     211µs ± 0%  -13.14%  (p=0.016 n=5+4)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                              1.73ms ± 0%    1.43ms ± 1%  -17.21%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                                                  480µs ± 1%     478µs ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                                                 622µs ± 0%     583µs ± 0%   -6.31%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                                               2.32ms ± 3%    1.91ms ± 3%  -17.69%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                              17.1ms ± 0%    13.5ms ± 0%  -21.40%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                                             5.13ms ± 3%    5.20ms ± 9%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                                            6.77ms ± 4%    6.35ms ± 0%   -6.14%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                                           25.9ms ± 7%    22.0ms ± 3%  -14.88%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                           186ms ± 1%     151ms ± 2%  -18.87%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                                                69.6µs ± 1%    69.9µs ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                                                120µs ± 0%     117µs ± 1%   -2.32%  (p=0.016 n=4+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                                               642µs ± 1%     601µs ± 0%   -6.30%  (p=0.016 n=5+4)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                             5.60ms ± 0%    5.25ms ± 2%   -6.20%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                                                 499µs ± 8%     479µs ± 0%   -3.98%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                                                651µs ± 0%     593µs ± 0%   -8.85%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                                              2.56ms ± 2%    1.99ms ± 0%  -22.26%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                             19.7ms ± 0%    14.3ms ± 3%  -27.21%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                                            5.05ms ± 2%    4.93ms ± 1%   -2.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                                           6.48ms ± 3%    5.78ms ± 2%  -10.93%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                                          23.1ms ± 1%    17.7ms ± 1%  -23.39%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                          165ms ± 1%     118ms ± 1%  -28.43%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                                                 30.8µs ± 0%    31.0µs ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                                                37.5µs ± 0%    37.6µs ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                                                110µs ± 1%     110µs ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                                               766µs ± 0%     782µs ± 0%   +2.12%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                                                  124µs ± 3%     122µs ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                                                 186µs ± 0%     189µs ± 0%   +1.44%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                                                880µs ± 0%     893µs ± 0%   +1.41%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                                              7.26ms ± 2%    7.50ms ± 0%   +3.35%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                                         1.04ms ± 0%    1.05ms ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                                        1.76ms ± 0%    1.77ms ± 0%   +0.81%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                                       9.43ms ± 2%    9.56ms ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                                      82.1ms ± 0%    84.6ms ± 1%   +2.97%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                                                  21.0µs ± 0%    21.4µs ± 0%   +1.71%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                                                 27.6µs ± 0%    27.6µs ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                                                95.3µs ± 2%    90.5µs ± 1%   -5.03%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                726µs ± 1%     688µs ± 2%   -5.23%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                                                  59.5µs ± 0%    60.1µs ± 0%   +1.08%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                                                 80.0µs ± 1%    78.4µs ± 0%   -2.01%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                                                 309µs ± 2%     286µs ± 0%   -7.40%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                               2.35ms ± 0%    2.12ms ± 0%   -9.49%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                                               436µs ± 0%     436µs ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                                              585µs ± 1%     572µs ± 0%   -2.20%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                                            2.37ms ± 2%    2.19ms ± 0%   -7.52%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                           17.9ms ± 1%    16.4ms ± 0%   -8.36%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12               39.0µs ± 0%    39.5µs ± 0%   +1.31%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12              56.6µs ± 1%    56.4µs ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12              236µs ± 2%     226µs ± 0%   -3.89%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12            1.93ms ± 2%    1.85ms ± 0%   -4.11%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12                116µs ± 2%     117µs ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12               161µs ± 0%     158µs ± 0%   -2.18%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12              661µs ± 0%     622µs ± 0%   -5.87%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12            5.15ms ± 0%    4.76ms ± 0%   -7.49%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12        871µs ± 0%     881µs ± 2%     ~     (p=0.730 n=4+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12      1.18ms ± 1%    1.15ms ± 0%   -2.02%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12     4.76ms ± 1%    4.50ms ± 0%   -5.56%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12    36.4ms ± 2%    33.8ms ± 0%   -7.24%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                          81.4µs ± 1%    81.6µs ± 2%     ~     (p=1.000 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                          117µs ± 0%     117µs ± 0%   -0.31%  (p=0.016 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                         488µs ± 0%     487µs ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                       3.98ms ± 2%    3.97ms ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                           646µs ± 0%     643µs ± 0%   -0.50%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                         1.06ms ± 0%    1.06ms ± 2%     ~     (p=0.190 n=4+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                        5.38ms ± 0%    5.38ms ± 0%     ~     (p=0.905 n=5+4)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                       46.5ms ± 0%    46.8ms ± 0%   +0.62%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                      7.06ms ± 1%    6.99ms ± 4%     ~     (p=0.421 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                     11.4ms ± 1%    11.6ms ± 4%     ~     (p=0.310 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                    55.4ms ± 0%    55.5ms ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                    473ms ± 2%     473ms ± 0%     ~     (p=0.286 n=5+4)

name                                                                                                       old alloc/op   new alloc/op   delta
RangeQuery/expr=a_one,steps=1-12                                                                             5.72kB ± 0%    5.72kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_one,steps=10-12                                                                            5.72kB ± 0%    5.72kB ± 0%   +0.02%  (p=0.029 n=4+4)
RangeQuery/expr=a_one,steps=100-12                                                                           6.01kB ± 0%    6.01kB ± 0%     ~     (all equal)
RangeQuery/expr=a_one,steps=1000-12                                                                          9.01kB ± 0%    9.33kB ± 0%   +3.54%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten,steps=1-12                                                                             14.4kB ± 0%    14.4kB ± 0%     ~     (p=0.365 n=5+5)
RangeQuery/expr=a_ten,steps=10-12                                                                            14.4kB ± 0%    14.4kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_ten,steps=100-12                                                                           16.6kB ± 0%    16.6kB ± 0%     ~     (p=0.571 n=5+5)
RangeQuery/expr=a_ten,steps=1000-12                                                                          36.5kB ± 0%    39.7kB ± 0%   +8.77%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=1-12                                                                          100kB ± 0%     100kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred,steps=10-12                                                                         100kB ± 0%     100kB ± 0%     ~     (p=0.794 n=5+4)
RangeQuery/expr=a_hundred,steps=100-12                                                                        121kB ± 0%     121kB ± 0%     ~     (p=0.397 n=5+5)
RangeQuery/expr=a_hundred,steps=1000-12                                                                       310kB ± 0%     341kB ± 0%  +10.05%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1-12                                                                   7.08kB ± 0%    7.08kB ± 0%     ~     (p=0.611 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=10-12                                                                  7.08kB ± 0%    7.08kB ± 0%     ~     (p=0.206 n=4+5)
RangeQuery/expr=rate(a_one[1m]),steps=100-12                                                                 7.37kB ± 0%    7.37kB ± 0%     ~     (p=0.968 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1000-12                                                                10.2kB ± 0%    10.4kB ± 0%   +2.42%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=1-12                                                                   19.0kB ± 0%    19.0kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=10-12                                                                  19.0kB ± 0%    19.0kB ± 0%     ~     (p=0.762 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=100-12                                                                 21.2kB ± 0%    21.2kB ± 0%     ~     (p=0.087 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=1000-12                                                                39.0kB ± 0%    41.4kB ± 0%   +6.20%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-12                                                                137kB ± 0%     137kB ± 0%     ~     (p=0.571 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-12                                                               137kB ± 0%     137kB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-12                                                              158kB ± 0%     158kB ± 0%     ~     (p=0.667 n=5+4)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-12                                                             325kB ± 0%     349kB ± 0%   +7.11%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=10000-12                                                               60.3kB ± 0%    61.0kB ± 0%   +1.18%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=10000-12                                                                341kB ± 1%     348kB ± 0%   +2.18%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-12                                                           3.14MB ± 1%    3.20MB ± 1%   +2.03%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12                                                 1.19MB ± 0%    1.20MB ± 0%   +0.09%  (p=0.016 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12                                                1.20MB ± 0%    1.20MB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12                                               1.20MB ± 0%    1.20MB ± 0%   +0.06%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12                                              1.22MB ± 0%    1.22MB ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12                                                 1.40MB ± 0%    1.41MB ± 0%   +0.53%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12                                                1.41MB ± 0%    1.41MB ± 0%   +0.47%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12                                               1.39MB ± 0%    1.40MB ± 0%   +0.60%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12                                              1.45MB ± 0%    1.43MB ± 2%     ~     (p=0.159 n=4+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12                                             3.49MB ± 0%    3.55MB ± 0%   +1.86%  (p=0.016 n=4+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12                                            3.50MB ± 0%    3.56MB ± 0%   +1.79%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12                                           3.53MB ± 0%    3.59MB ± 0%   +1.83%  (p=0.029 n=4+4)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12                                          3.79MB ± 1%    3.83MB ± 1%     ~     (p=0.114 n=4+4)
RangeQuery/expr=changes(a_one[1d]),steps=1-12                                                                 565kB ± 0%     565kB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=10-12                                                                566kB ± 0%     565kB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=100-12                                                               564kB ± 0%     565kB ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=1000-12                                                              577kB ± 0%     578kB ± 0%   +0.15%  (p=0.032 n=4+5)
RangeQuery/expr=changes(a_ten[1d]),steps=1-12                                                                 774kB ± 0%     780kB ± 0%   +0.74%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=10-12                                                                776kB ± 0%     782kB ± 0%   +0.82%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=100-12                                                               784kB ± 1%     796kB ± 2%     ~     (p=0.056 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=1000-12                                                              891kB ±10%     891kB ±10%     ~     (p=0.841 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-12                                                            2.89MB ± 1%    2.95MB ± 1%   +1.91%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-12                                                           2.90MB ± 2%    2.97MB ± 0%   +2.37%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-12                                                          3.01MB ± 0%    3.08MB ± 0%   +2.12%  (p=0.016 n=5+4)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                                                         4.09MB ±63%    3.83MB ± 1%     ~     (p=0.190 n=5+4)
RangeQuery/expr=rate(a_one[1d]),steps=1-12                                                                    565kB ± 0%     565kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=10-12                                                                   565kB ± 0%     566kB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=100-12                                                                  566kB ± 0%     566kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=1000-12                                                                 574kB ± 1%     574kB ± 0%     ~     (p=0.556 n=5+4)
RangeQuery/expr=rate(a_ten[1d]),steps=1-12                                                                    774kB ± 0%     781kB ± 0%   +0.92%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=10-12                                                                   775kB ± 0%     778kB ± 0%   +0.45%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=100-12                                                                  784kB ± 0%     789kB ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=1000-12                                                                 863kB ± 1%     852kB ± 5%     ~     (p=0.651 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-12                                                               2.88MB ± 1%    2.94MB ± 1%   +2.13%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-12                                                              2.93MB ± 0%    2.94MB ± 1%     ~     (p=0.730 n=4+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-12                                                             2.97MB ± 3%    3.01MB ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                                                            3.44MB ± 1%    4.00MB ±66%     ~     (p=0.683 n=4+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12                                                        565kB ± 0%     566kB ± 0%   +0.18%  (p=0.016 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12                                                       565kB ± 0%     566kB ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12                                                      567kB ± 0%     567kB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12                                                     583kB ± 0%     584kB ± 0%   +0.25%  (p=0.032 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12                                                        775kB ± 1%     779kB ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12                                                       776kB ± 0%     783kB ± 0%   +0.83%  (p=0.016 n=5+4)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12                                                      795kB ± 0%     801kB ± 0%   +0.84%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12                                                     975kB ± 1%     985kB ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12                                                   2.88MB ± 1%    2.93MB ± 1%   +1.82%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12                                                  2.90MB ± 1%    2.97MB ± 0%   +2.46%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12                                                 3.10MB ± 0%    3.17MB ± 0%   +2.18%  (p=0.016 n=5+4)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12                                                4.92MB ± 1%    4.97MB ± 0%   +1.08%  (p=0.008 n=5+5)
RangeQuery/expr=-a_one,steps=1-12                                                                            6.28kB ± 0%    6.28kB ± 0%     ~     (all equal)
RangeQuery/expr=-a_one,steps=10-12                                                                           6.28kB ± 0%    6.28kB ± 0%     ~     (all equal)
RangeQuery/expr=-a_one,steps=100-12                                                                          6.57kB ± 0%    6.57kB ± 0%     ~     (p=0.556 n=5+4)
RangeQuery/expr=-a_one,steps=1000-12                                                                         9.57kB ± 0%    9.89kB ± 0%   +3.37%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=1-12                                                                            18.2kB ± 0%    18.2kB ± 0%   +0.01%  (p=0.029 n=4+4)
RangeQuery/expr=-a_ten,steps=10-12                                                                           18.2kB ± 0%    18.2kB ± 0%     ~     (p=0.365 n=5+5)
RangeQuery/expr=-a_ten,steps=100-12                                                                          20.4kB ± 0%    20.4kB ± 0%     ~     (p=0.563 n=5+5)
RangeQuery/expr=-a_ten,steps=1000-12                                                                         40.2kB ± 0%    43.4kB ± 0%   +7.96%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1-12                                                                         136kB ± 0%     136kB ± 0%   +0.01%  (p=0.024 n=5+5)
RangeQuery/expr=-a_hundred,steps=10-12                                                                        136kB ± 0%     136kB ± 0%     ~     (p=0.175 n=4+5)
RangeQuery/expr=-a_hundred,steps=100-12                                                                       157kB ± 0%     157kB ± 0%     ~     (p=0.889 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-12                                                                      345kB ± 0%     376kB ± 0%   +9.03%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1-12                                                                     12.3kB ± 0%    12.3kB ± 0%     ~     (p=0.238 n=4+5)
RangeQuery/expr=a_one_-_b_one,steps=10-12                                                                    13.7kB ± 0%    13.7kB ± 0%   +0.01%  (p=0.029 n=4+4)
RangeQuery/expr=a_one_-_b_one,steps=100-12                                                                   28.7kB ± 0%    28.7kB ± 0%     ~     (p=0.238 n=5+4)
RangeQuery/expr=a_one_-_b_one,steps=1000-12                                                                   179kB ± 0%     179kB ± 0%   +0.37%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1-12                                                                     42.0kB ± 0%    42.0kB ± 0%     ~     (p=0.373 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10-12                                                                    45.0kB ± 0%    45.0kB ± 0%     ~     (p=0.254 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=100-12                                                                   79.7kB ± 0%    80.0kB ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1000-12                                                                   425kB ± 2%     430kB ± 2%     ~     (p=0.310 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                                                              346kB ± 0%     346kB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                                                             371kB ± 0%     371kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                                                            658kB ± 1%     661kB ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                                                          3.55MB ± 2%    3.73MB ± 3%   +5.09%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-12                                                                 1.72MB ± 0%    1.72MB ± 0%   +0.07%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10000-12                                                                 4.06MB ± 4%    4.08MB ± 8%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                                                         33.0MB ± 8%    32.4MB ± 9%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12                                                    20.5kB ± 0%    20.5kB ± 0%     ~     (p=0.651 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12                                                   21.9kB ± 0%    21.9kB ± 0%     ~     (p=0.730 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12                                                  36.6kB ± 0%    36.6kB ± 0%     ~     (p=0.794 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12                                                  184kB ± 0%     184kB ± 0%   +0.19%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12                                                    41.7kB ± 0%    41.8kB ± 0%     ~     (p=0.452 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12                                                   43.2kB ± 0%    43.2kB ± 0%     ~     (p=0.143 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12                                                  60.9kB ± 0%    60.9kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                  236kB ± 0%     240kB ± 0%   +2.07%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12                                             245kB ± 0%     245kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12                                            275kB ± 0%     275kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12                                           606kB ± 0%     606kB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                         3.89MB ± 0%    3.94MB ± 0%   +1.21%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12                                                     20.5kB ± 0%    20.5kB ± 0%     ~     (p=0.968 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12                                                    22.0kB ± 0%    22.0kB ± 0%     ~     (p=0.413 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12                                                   36.7kB ± 0%    36.7kB ± 0%     ~     (p=0.571 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12                                                   184kB ± 0%     184kB ± 0%   +0.22%  (p=0.016 n=4+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12                                                     43.1kB ± 0%    43.1kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12                                                    48.6kB ± 0%    48.6kB ± 0%     ~     (p=0.063 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12                                                    107kB ± 0%     107kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                   691kB ± 0%     696kB ± 0%   +0.68%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12                                              257kB ± 0%     257kB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12                                             320kB ± 0%     320kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12                                            987kB ± 0%     987kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                          7.63MB ± 0%    7.67MB ± 0%   +0.56%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12                                                 20.5kB ± 0%    20.5kB ± 0%     ~     (p=0.651 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12                                                22.0kB ± 0%    22.0kB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12                                               36.7kB ± 0%    36.7kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12                                               184kB ± 0%     184kB ± 0%   +0.20%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12                                                 41.8kB ± 0%    41.8kB ± 0%     ~     (p=0.468 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12                                                43.2kB ± 0%    43.2kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12                                               60.9kB ± 0%    60.9kB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12                                               235kB ± 0%     241kB ± 0%   +2.16%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12                                          245kB ± 0%     245kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12                                         275kB ± 0%     275kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12                                        606kB ± 0%     606kB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                      3.89MB ± 0%    3.94MB ± 0%   +1.19%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=1-12                                                                        7.28kB ± 0%    7.28kB ± 0%     ~     (all equal)
RangeQuery/expr=abs(a_one),steps=10-12                                                                       7.57kB ± 0%    7.57kB ± 0%     ~     (all equal)
RangeQuery/expr=abs(a_one),steps=100-12                                                                      10.7kB ± 0%    10.7kB ± 0%     ~     (p=0.683 n=5+5)
RangeQuery/expr=abs(a_one),steps=1000-12                                                                     42.6kB ± 0%    42.9kB ± 0%   +0.75%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=1-12                                                                        22.9kB ± 0%    22.9kB ± 0%     ~     (p=0.095 n=4+5)
RangeQuery/expr=abs(a_ten),steps=10-12                                                                       24.7kB ± 0%    24.7kB ± 0%     ~     (p=0.881 n=5+5)
RangeQuery/expr=abs(a_ten),steps=100-12                                                                      44.4kB ± 0%    44.4kB ± 0%     ~     (p=0.516 n=5+5)
RangeQuery/expr=abs(a_ten),steps=1000-12                                                                      240kB ± 0%     243kB ± 0%   +1.33%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1-12                                                                     179kB ± 0%     179kB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=10-12                                                                    194kB ± 0%     194kB ± 0%     ~     (p=0.651 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-12                                                                   367kB ± 0%     367kB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-12                                                                 2.08MB ± 0%    2.11MB ± 0%   +1.51%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                     13.3kB ± 0%    13.3kB ± 0%     ~     (p=0.556 n=5+4)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                    14.7kB ± 0%    14.7kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                   29.4kB ± 0%    29.4kB ± 0%     ~     (p=0.492 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   176kB ± 0%     177kB ± 0%   +0.19%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                     30.6kB ± 0%    30.6kB ± 0%     ~     (p=0.484 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                    33.5kB ± 0%    33.5kB ± 0%   +0.01%  (p=0.032 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                   64.7kB ± 0%    64.7kB ± 0%   +0.01%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   376kB ± 0%     379kB ± 0%   +0.87%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                  202kB ± 0%     202kB ± 0%     ~     (p=0.198 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                 218kB ± 0%     218kB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                403kB ± 0%     403kB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                              2.23MB ± 0%    2.26MB ± 0%   +1.39%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                                            10.5kB ± 0%    10.5kB ± 0%   +0.01%  (p=0.029 n=4+4)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                                           12.6kB ± 0%    12.6kB ± 0%     ~     (all equal)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                                          33.0kB ± 0%    33.0kB ± 0%     ~     (p=0.905 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                                          238kB ± 0%     238kB ± 0%   +0.14%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                                            27.4kB ± 0%    27.4kB ± 0%     ~     (p=0.397 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                                           30.9kB ± 0%    30.9kB ± 0%     ~     (p=0.397 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                                          67.9kB ± 0%    67.9kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                                          436kB ± 0%     440kB ± 0%   +0.73%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                                         195kB ± 0%     195kB ± 0%     ~     (p=0.333 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                                        212kB ± 0%     212kB ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                                       403kB ± 0%     403kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12                                     2.29MB ± 0%    2.32MB ± 0%   +1.37%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1-12                                                                        7.50kB ± 0%    7.62kB ± 0%   +1.60%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=10-12                                                                       11.4kB ± 0%    11.5kB ± 0%   +1.06%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=100-12                                                                      50.6kB ± 0%    50.7kB ± 0%   +0.24%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1000-12                                                                      442kB ± 0%     443kB ± 0%   +0.10%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1-12                                                                        18.4kB ± 0%    18.7kB ± 0%   +1.83%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=10-12                                                                       22.3kB ± 0%    22.6kB ± 0%   +1.51%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=100-12                                                                      63.4kB ± 0%    63.7kB ± 0%   +0.53%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1000-12                                                                      472kB ± 0%     476kB ± 0%   +0.76%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1-12                                                                     123kB ± 0%     126kB ± 0%   +2.18%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=10-12                                                                    127kB ± 0%     130kB ± 0%   +2.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-12                                                                   187kB ± 0%     189kB ± 0%   +1.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-12                                                                  764kB ± 0%     798kB ± 0%   +4.41%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                                            25.4kB ± 0%    25.7kB ± 0%   +1.35%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                                           51.6kB ± 0%    51.7kB ± 0%   +0.11%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                                           316kB ± 0%     314kB ± 0%   -0.89%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                         2.96MB ± 0%    2.93MB ± 0%   -0.94%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                                             153kB ± 0%     155kB ± 0%   +1.79%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                                            182kB ± 0%     184kB ± 0%   +1.35%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                                           499kB ± 0%     499kB ± 0%   -0.09%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                         3.65MB ± 0%    3.65MB ± 0%   +0.16%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                                        1.40MB ± 0%    1.43MB ± 0%   +2.00%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                                       1.43MB ± 0%    1.46MB ± 0%   +1.95%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                                      1.95MB ± 0%    1.98MB ± 0%   +1.24%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                     6.97MB ± 0%    7.31MB ± 0%   +4.86%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                                           19.7kB ± 0%    20.1kB ± 0%   +1.74%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                                          24.5kB ± 0%    24.6kB ± 0%   +0.23%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                                         74.4kB ± 0%    71.6kB ± 0%   -3.80%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                         571kB ± 0%     543kB ± 0%   -4.92%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                                            152kB ± 0%     155kB ± 0%   +1.80%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                                           179kB ± 0%     182kB ± 0%   +1.36%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                                          475kB ± 0%     475kB ± 0%   -0.09%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                        3.41MB ± 0%    3.42MB ± 0%   +0.17%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                                       1.46MB ± 0%    1.49MB ± 0%   +1.92%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                                      1.73MB ± 0%    1.75MB ± 0%   +1.61%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                                                     4.63MB ± 0%    4.65MB ± 0%   +0.57%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                    33.4MB ± 0%    33.7MB ± 0%   +1.00%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                                                 19.7kB ± 0%    20.0kB ± 0%   +1.75%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                                                24.1kB ± 0%    24.2kB ± 0%   +0.23%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                                               71.2kB ± 0%    68.3kB ± 0%   -3.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                               539kB ± 0%     511kB ± 0%   -5.21%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                                                  151kB ± 0%     153kB ± 0%   +1.81%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                                                 172kB ± 0%     175kB ± 0%   +1.43%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                                                410kB ± 0%     410kB ± 0%   -0.10%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                              2.77MB ± 0%    2.78MB ± 0%   +0.22%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                                             1.45MB ± 0%    1.47MB ± 0%   +1.96%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                                            1.66MB ± 0%    1.68MB ± 0%   +1.67%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                                           3.98MB ± 0%    4.00MB ± 0%   +0.58%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                          27.0MB ± 0%    27.3MB ± 0%   +1.26%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                                                24.7kB ± 0%    25.0kB ± 0%   +1.40%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                                               47.8kB ± 0%    47.8kB ± 0%   +0.11%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                                               281kB ± 0%     278kB ± 0%   -1.00%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                             2.61MB ± 0%    2.58MB ± 0%   -1.07%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                                                 151kB ± 0%     154kB ± 0%   +1.81%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                                                174kB ± 0%     177kB ± 0%   +1.41%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                                               428kB ± 0%     428kB ± 0%   -0.09%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                             2.94MB ± 0%    2.95MB ± 0%   +0.20%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                                            1.40MB ± 0%    1.42MB ± 0%   +1.99%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                                           1.42MB ± 0%    1.45MB ± 0%   +1.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                                          1.88MB ± 0%    1.91MB ± 0%   +1.32%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                         6.26MB ± 0%    6.60MB ± 0%   +5.42%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                                                 14.5kB ± 0%    14.5kB ± 0%     ~     (p=0.738 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                                                16.0kB ± 0%    16.0kB ± 0%     ~     (p=0.325 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                                               30.9kB ± 0%    30.9kB ± 0%     ~     (p=0.595 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                                               181kB ± 0%     181kB ± 0%   +0.30%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                                                 46.7kB ± 0%    46.7kB ± 0%     ~     (p=0.968 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                                                49.7kB ± 0%    49.7kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                                               84.6kB ± 0%    84.4kB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                                               425kB ± 1%     429kB ± 2%     ~     (p=0.548 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                                          379kB ± 0%     379kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                                         404kB ± 0%     404kB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                                        694kB ± 1%     693kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                                      3.67MB ± 4%    3.56MB ± 4%     ~     (p=0.310 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                                                  8.82kB ± 0%    8.90kB ± 0%   +0.99%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                                                 13.0kB ± 0%    12.8kB ± 0%   -1.53%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                                                55.1kB ± 0%    52.0kB ± 0%   -5.62%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                476kB ± 0%     444kB ± 0%   -6.65%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                                                  23.0kB ± 0%    23.3kB ± 0%   +1.35%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                                                 27.5kB ± 0%    27.5kB ± 0%   +0.11%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                                                74.4kB ± 0%    71.5kB ± 0%   -3.91%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                                539kB ± 0%     510kB ± 0%   -5.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                                               160kB ± 0%     162kB ± 0%   +1.67%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                                              164kB ± 0%     166kB ± 0%   +1.43%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                                             230kB ± 0%     229kB ± 0%   -0.20%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                            845kB ± 0%     838kB ± 0%   -0.81%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12               19.0kB ± 0%    19.2kB ± 0%   +0.92%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12              28.8kB ± 0%    28.4kB ± 0%   -1.41%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12              127kB ± 0%     121kB ± 0%   -4.83%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12            1.11MB ± 0%    1.05MB ± 0%   -5.71%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12               47.4kB ± 0%    48.0kB ± 0%   +1.28%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12              57.8kB ± 0%    57.8kB ± 0%   +0.08%  (p=0.016 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12              166kB ± 0%     160kB ± 0%   -3.47%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12            1.24MB ± 0%    1.18MB ± 0%   -4.72%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12        321kB ± 0%     326kB ± 0%   +1.64%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12       331kB ± 0%     336kB ± 0%   +1.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12      477kB ± 0%     475kB ± 0%   -0.26%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12    1.85MB ± 0%    1.84MB ± 0%   -0.68%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                          28.7kB ± 0%    28.7kB ± 0%   +0.06%  (p=0.016 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                         39.9kB ± 0%    39.9kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                         155kB ± 0%     155kB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                       1.30MB ± 0%    1.30MB ± 0%   +0.28%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                           232kB ± 0%     232kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                          369kB ± 0%     369kB ± 0%     ~     (p=0.278 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                        1.76MB ± 0%    1.76MB ± 0%   +0.04%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                       15.6MB ± 0%    15.7MB ± 0%   +0.25%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                      2.23MB ± 0%    2.23MB ± 0%   +0.03%  (p=0.032 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                     3.60MB ± 0%    3.60MB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                    17.5MB ± 0%    17.5MB ± 0%   +0.05%  (p=0.032 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                    156MB ± 0%     156MB ± 0%   +0.22%  (p=0.008 n=5+5)

name                                                                                                       old allocs/op  new allocs/op  delta
RangeQuery/expr=a_one,steps=1-12                                                                                114 ± 0%       114 ± 0%     ~     (all equal)
RangeQuery/expr=a_one,steps=10-12                                                                               114 ± 0%       114 ± 0%     ~     (all equal)
RangeQuery/expr=a_one,steps=100-12                                                                              119 ± 0%       119 ± 0%     ~     (all equal)
RangeQuery/expr=a_one,steps=1000-12                                                                             154 ± 0%       170 ± 0%  +10.39%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten,steps=1-12                                                                                262 ± 0%       262 ± 0%     ~     (all equal)
RangeQuery/expr=a_ten,steps=10-12                                                                               262 ± 0%       262 ± 0%     ~     (all equal)
RangeQuery/expr=a_ten,steps=100-12                                                                              303 ± 0%       303 ± 0%     ~     (all equal)
RangeQuery/expr=a_ten,steps=1000-12                                                                             626 ± 0%       786 ± 0%  +25.56%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=1-12                                                                          1.71k ± 0%     1.71k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred,steps=10-12                                                                         1.71k ± 0%     1.71k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred,steps=100-12                                                                        2.11k ± 0%     2.11k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred,steps=1000-12                                                                       5.31k ± 0%     6.87k ± 0%  +29.31%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1-12                                                                      150 ± 0%       150 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m]),steps=10-12                                                                     150 ± 0%       150 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m]),steps=100-12                                                                    155 ± 0%       155 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m]),steps=1000-12                                                                   186 ± 0%       198 ± 0%   +6.45%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=1-12                                                                      335 ± 0%       335 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_ten[1m]),steps=10-12                                                                     335 ± 0%       335 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_ten[1m]),steps=100-12                                                                    376 ± 0%       376 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_ten[1m]),steps=1000-12                                                                   659 ± 0%       779 ± 0%  +18.21%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-12                                                                2.14k ± 0%     2.14k ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-12                                                               2.14k ± 0%     2.14k ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-12                                                              2.54k ± 0%     2.54k ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-12                                                             5.35k ± 0%     6.50k ± 0%  +21.60%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=10000-12                                                                  845 ± 0%       877 ± 0%   +3.79%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m]),steps=10000-12                                                                6.92k ± 0%     7.24k ± 0%   +4.63%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-12                                                            67.6k ± 0%     70.8k ± 0%   +4.76%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1-12                                                    761 ± 0%       793 ± 0%   +4.20%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=10-12                                                   761 ± 0%       793 ± 0%   +4.20%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-12                                                  769 ± 0%       801 ± 0%   +4.16%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-12                                                 826 ± 0%       859 ± 0%   +3.95%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1-12                                                  5.74k ± 0%     6.06k ± 0%   +5.58%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=10-12                                                 5.73k ± 0%     6.05k ± 0%   +5.59%  (p=0.016 n=5+4)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=100-12                                                5.81k ± 0%     6.13k ± 0%   +5.49%  (p=0.016 n=5+4)
RangeQuery/expr=holt_winters(a_ten[1d],_0.3,_0.3),steps=1000-12                                               6.38k ± 0%     6.70k ± 0%   +4.97%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-12                                              55.4k ± 0%     58.6k ± 0%   +5.81%  (p=0.016 n=4+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-12                                             55.4k ± 0%     58.6k ± 0%   +5.81%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-12                                            56.2k ± 0%     59.4k ± 0%   +5.73%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-12                                           61.8k ± 0%     65.0k ± 0%   +5.21%  (p=0.029 n=4+4)
RangeQuery/expr=changes(a_one[1d]),steps=1-12                                                                   699 ± 0%       731 ± 0%   +4.58%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=10-12                                                                  699 ± 0%       731 ± 0%   +4.58%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=100-12                                                                 707 ± 0%       739 ± 0%   +4.53%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=1000-12                                                                763 ± 0%       796 ± 0%   +4.27%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=1-12                                                                 5.67k ± 0%     5.99k ± 0%   +5.64%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=10-12                                                                5.67k ± 0%     5.99k ± 0%   +5.64%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=100-12                                                               5.75k ± 0%     6.07k ± 0%   +5.57%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_ten[1d]),steps=1000-12                                                              6.32k ± 0%     6.64k ± 0%   +5.06%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-12                                                             55.3k ± 0%     58.5k ± 0%   +5.82%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-12                                                            55.3k ± 0%     58.5k ± 0%   +5.83%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-12                                                           56.1k ± 0%     59.3k ± 0%   +5.74%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-12                                                          61.7k ± 0%     65.0k ± 0%   +5.23%  (p=0.029 n=4+4)
RangeQuery/expr=rate(a_one[1d]),steps=1-12                                                                      699 ± 0%       731 ± 0%   +4.58%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=10-12                                                                     699 ± 0%       731 ± 0%   +4.58%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=100-12                                                                    707 ± 0%       739 ± 0%   +4.53%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=1000-12                                                                   763 ± 0%       795 ± 0%   +4.19%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=1-12                                                                    5.67k ± 0%     5.99k ± 0%   +5.64%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1d]),steps=10-12                                                                   5.67k ± 0%     5.99k ± 0%   +5.64%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_ten[1d]),steps=100-12                                                                  5.75k ± 0%     6.07k ± 0%   +5.57%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_ten[1d]),steps=1000-12                                                                 6.32k ± 0%     6.64k ± 0%   +5.08%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-12                                                                55.3k ± 0%     58.5k ± 0%   +5.82%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-12                                                               55.3k ± 0%     58.5k ± 0%   +5.82%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-12                                                              56.1k ± 0%     59.3k ± 0%   +5.74%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-12                                                             61.7k ± 0%     64.9k ± 0%   +5.23%  (p=0.016 n=5+4)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1-12                                                          699 ± 0%       731 ± 0%   +4.58%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=10-12                                                         699 ± 0%       731 ± 0%   +4.58%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-12                                                        707 ± 0%       739 ± 0%   +4.53%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-12                                                       763 ± 0%       795 ± 0%   +4.19%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1-12                                                        5.67k ± 0%     5.99k ± 0%   +5.64%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=10-12                                                       5.67k ± 0%     5.99k ± 0%   +5.64%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=100-12                                                      5.75k ± 0%     6.07k ± 0%   +5.56%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_ten[1d]),steps=1000-12                                                     6.31k ± 0%     6.63k ± 0%   +5.07%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-12                                                    55.3k ± 0%     58.5k ± 0%   +5.82%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-12                                                   55.3k ± 0%     58.5k ± 0%   +5.82%  (p=0.016 n=5+4)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-12                                                  56.1k ± 0%     59.3k ± 0%   +5.74%  (p=0.016 n=4+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-12                                                 61.7k ± 0%     64.9k ± 0%   +5.21%  (p=0.016 n=5+4)
RangeQuery/expr=-a_one,steps=1-12                                                                               128 ± 0%       128 ± 0%     ~     (all equal)
RangeQuery/expr=-a_one,steps=10-12                                                                              128 ± 0%       128 ± 0%     ~     (all equal)
RangeQuery/expr=-a_one,steps=100-12                                                                             133 ± 0%       133 ± 0%     ~     (all equal)
RangeQuery/expr=-a_one,steps=1000-12                                                                            168 ± 0%       184 ± 0%   +9.52%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=1-12                                                                               313 ± 0%       313 ± 0%     ~     (all equal)
RangeQuery/expr=-a_ten,steps=10-12                                                                              313 ± 0%       313 ± 0%     ~     (all equal)
RangeQuery/expr=-a_ten,steps=100-12                                                                             354 ± 0%       354 ± 0%     ~     (all equal)
RangeQuery/expr=-a_ten,steps=1000-12                                                                            677 ± 0%       837 ± 0%  +23.63%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1-12                                                                         2.12k ± 0%     2.12k ± 0%     ~     (all equal)
RangeQuery/expr=-a_hundred,steps=10-12                                                                        2.12k ± 0%     2.12k ± 0%     ~     (all equal)
RangeQuery/expr=-a_hundred,steps=100-12                                                                       2.52k ± 0%     2.52k ± 0%     ~     (all equal)
RangeQuery/expr=-a_hundred,steps=1000-12                                                                      5.73k ± 0%     7.28k ± 0%  +27.17%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1-12                                                                        209 ± 0%       209 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_-_b_one,steps=10-12                                                                       245 ± 0%       245 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_-_b_one,steps=100-12                                                                      615 ± 0%       615 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_-_b_one,steps=1000-12                                                                   4.29k ± 0%     4.32k ± 0%   +0.75%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1-12                                                                        622 ± 0%       622 ± 0%     ~     (all equal)
RangeQuery/expr=a_ten_-_b_ten,steps=10-12                                                                       668 ± 0%       668 ± 0%     ~     (p=0.444 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=100-12                                                                    1.21k ± 0%     1.21k ± 0%     ~     (p=0.643 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1000-12                                                                   6.47k ± 0%     6.79k ± 0%   +4.94%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-12                                                              4.63k ± 0%     4.63k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-12                                                             4.75k ± 0%     4.75k ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-12                                                            6.76k ± 0%     6.77k ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-12                                                           25.4k ± 1%     28.8k ± 1%  +13.44%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-12                                                                  41.6k ± 0%     41.7k ± 0%   +0.15%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10000-12                                                                  65.1k ± 1%     65.8k ± 1%   +1.01%  (p=0.040 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-12                                                           269k ± 2%      271k ± 2%     ~     (p=0.310 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-12                                                       292 ± 0%       292 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-12                                                      328 ± 0%       328 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-12                                                     693 ± 0%       693 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-12                                                  4.33k ± 0%     4.34k ± 0%   +0.37%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-12                                                       595 ± 0%       595 ± 0%     ~     (all equal)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-12                                                      631 ± 0%       631 ± 0%     ~     (all equal)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-12                                                   1.05k ± 0%     1.05k ± 0%     ~     (all equal)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                  5.14k ± 0%     5.38k ± 0%   +4.67%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-12                                             3.38k ± 0%     3.38k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-12                                            3.51k ± 0%     3.51k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-12                                           5.44k ± 0%     5.44k ± 0%     ~     (p=0.214 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                          23.5k ± 0%     25.8k ± 0%   +9.94%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-12                                                        294 ± 0%       294 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-12                                                       330 ± 0%       330 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-12                                                      695 ± 0%       695 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-12                                                   4.33k ± 0%     4.35k ± 0%   +0.37%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-12                                                        604 ± 0%       604 ± 0%     ~     (all equal)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-12                                                       659 ± 0%       659 ± 0%     ~     (all equal)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-12                                                    1.27k ± 0%     1.27k ± 0%     ~     (all equal)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-12                                                   7.25k ± 0%     7.49k ± 0%   +3.31%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-12                                              3.44k ± 0%     3.44k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-12                                             3.62k ± 0%     3.62k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-12                                            6.00k ± 0%     6.00k ± 0%     ~     (p=0.302 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                           28.6k ± 0%     30.9k ± 0%   +8.22%  (p=0.016 n=4+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-12                                                    294 ± 0%       294 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-12                                                   330 ± 0%       330 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-12                                                  695 ± 0%       695 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-12                                               4.33k ± 0%     4.35k ± 0%   +0.37%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-12                                                    595 ± 0%       595 ± 0%     ~     (all equal)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-12                                                   631 ± 0%       631 ± 0%     ~     (all equal)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-12                                                1.05k ± 0%     1.05k ± 0%     ~     (all equal)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-12                                               5.14k ± 0%     5.38k ± 0%   +4.67%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-12                                          3.38k ± 0%     3.38k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-12                                         3.51k ± 0%     3.51k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-12                                        5.44k ± 0%     5.44k ± 0%   -0.05%  (p=0.032 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-12                                       23.5k ± 0%     25.8k ± 0%   +9.93%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=1-12                                                                           147 ± 0%       147 ± 0%     ~     (all equal)
RangeQuery/expr=abs(a_one),steps=10-12                                                                          156 ± 0%       156 ± 0%     ~     (all equal)
RangeQuery/expr=abs(a_one),steps=100-12                                                                         251 ± 0%       251 ± 0%     ~     (all equal)
RangeQuery/expr=abs(a_one),steps=1000-12                                                                      1.19k ± 0%     1.20k ± 0%   +1.35%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_ten),steps=1-12                                                                           344 ± 0%       344 ± 0%     ~     (all equal)
RangeQuery/expr=abs(a_ten),steps=10-12                                                                          363 ± 0%       363 ± 0%     ~     (all equal)
RangeQuery/expr=abs(a_ten),steps=100-12                                                                         591 ± 0%       591 ± 0%     ~     (all equal)
RangeQuery/expr=abs(a_ten),steps=1000-12                                                                      2.79k ± 0%     2.95k ± 0%   +5.72%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1-12                                                                     2.26k ± 0%     2.26k ± 0%     ~     (all equal)
RangeQuery/expr=abs(a_hundred),steps=10-12                                                                    2.33k ± 0%     2.33k ± 0%     ~     (all equal)
RangeQuery/expr=abs(a_hundred),steps=100-12                                                                   3.48k ± 0%     3.48k ± 0%     ~     (p=0.556 n=5+4)
RangeQuery/expr=abs(a_hundred),steps=1000-12                                                                  14.2k ± 0%     15.7k ± 0%  +10.99%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                        264 ± 0%       264 ± 0%     ~     (all equal)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                       309 ± 0%       309 ± 0%     ~     (all equal)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                      764 ± 0%       764 ± 0%     ~     (all equal)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   5.30k ± 0%     5.32k ± 0%   +0.30%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                        490 ± 0%       490 ± 0%     ~     (all equal)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                       545 ± 0%       545 ± 0%     ~     (all equal)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                    1.13k ± 0%     1.13k ± 0%     ~     (all equal)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                                   6.93k ± 0%     7.09k ± 0%   +2.30%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-12                                  2.77k ± 0%     2.77k ± 0%     ~     (all equal)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-12                                 2.88k ± 0%     2.88k ± 0%     ~     (all equal)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-12                                4.39k ± 0%     4.39k ± 0%     ~     (p=0.460 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-12                               18.7k ± 0%     20.2k ± 0%   +8.33%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-12                                               224 ± 0%       224 ± 0%     ~     (all equal)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=10-12                                              287 ± 0%       287 ± 0%     ~     (all equal)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-12                                             922 ± 0%       922 ± 0%     ~     (all equal)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-12                                          7.26k ± 0%     7.27k ± 0%   +0.22%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-12                                               439 ± 0%       439 ± 0%     ~     (all equal)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=10-12                                              512 ± 0%       512 ± 0%     ~     (all equal)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-12                                           1.28k ± 0%     1.28k ± 0%     ~     (all equal)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-12                                          8.88k ± 0%     9.04k ± 0%   +1.80%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-12                                         2.54k ± 0%     2.54k ± 0%     ~     (all equal)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-12                                        2.66k ± 0%     2.66k ± 0%     ~     (all equal)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-12                                       4.35k ± 0%     4.35k ± 0%     ~     (p=0.683 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-12                                      20.4k ± 0%     22.0k ± 0%   +7.63%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1-12                                                                           148 ± 0%       153 ± 0%   +3.38%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=10-12                                                                          202 ± 0%       207 ± 0%   +2.48%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=100-12                                                                         747 ± 0%       752 ± 0%   +0.67%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1000-12                                                                      6.18k ± 0%     6.20k ± 0%   +0.34%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1-12                                                                           297 ± 0%       311 ± 0%   +4.71%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=10-12                                                                          351 ± 0%       365 ± 0%   +3.99%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=100-12                                                                         932 ± 0%       946 ± 0%   +1.50%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_ten),steps=1000-12                                                                      6.66k ± 0%     6.83k ± 0%   +2.61%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1-12                                                                     1.74k ± 0%     1.84k ± 0%   +5.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=10-12                                                                    1.79k ± 0%     1.90k ± 0%   +5.79%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-12                                                                   2.74k ± 0%     2.84k ± 0%   +3.80%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-12                                                                  11.3k ± 0%     13.0k ± 0%  +14.64%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1-12                                                               392 ± 0%       406 ± 0%   +3.57%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=10-12                                                              755 ± 0%       760 ± 0%   +0.66%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-12                                                           4.43k ± 0%     4.34k ± 0%     ~     (p=0.079 n=4+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-12                                                          41.1k ± 0%     40.3k ± 0%   -1.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1-12                                                             1.98k ± 0%     2.09k ± 0%   +5.71%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=10-12                                                            2.34k ± 0%     2.45k ± 0%   +4.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=100-12                                                           6.41k ± 0%     6.43k ± 0%   +0.22%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(l)(h_ten),steps=1000-12                                                          46.2k ± 0%     47.1k ± 0%   +1.89%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-12                                                         17.8k ± 0%     18.9k ± 0%   +6.19%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-12                                                        18.2k ± 0%     19.3k ± 0%   +6.01%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-12                                                       26.2k ± 0%     27.2k ± 0%   +3.83%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-12                                                      97.7k ± 0%    114.9k ± 0%  +17.60%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1-12                                                              318 ± 0%       332 ± 0%   +4.40%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=10-12                                                             390 ± 0%       395 ± 0%   +1.28%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-12                                                          1.16k ± 0%     1.07k ± 0%   -7.36%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-12                                                         8.71k ± 0%     7.90k ± 0%   -9.29%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1-12                                                            1.97k ± 0%     2.09k ± 0%   +5.73%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=10-12                                                           2.31k ± 0%     2.41k ± 0%   +4.51%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=100-12                                                          6.09k ± 0%     6.10k ± 0%   +0.24%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_ten),steps=1000-12                                                         43.0k ± 0%     43.9k ± 0%   +2.03%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-12                                                        18.5k ± 0%     19.6k ± 0%   +5.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-12                                                       21.4k ± 0%     22.5k ± 0%   +5.12%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-12                                                      54.6k ± 0%     55.6k ± 0%   +1.84%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-12                                                      379k ± 0%      396k ± 0%   +4.54%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1-12                                                                    318 ± 0%       332 ± 0%   +4.40%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=10-12                                                                   390 ± 0%       395 ± 0%   +1.28%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-12                                                                1.16k ± 0%     1.07k ± 0%   -7.36%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-12                                                               8.71k ± 0%     7.90k ± 0%   -9.29%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1-12                                                                  1.97k ± 0%     2.09k ± 0%   +5.73%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=10-12                                                                 2.31k ± 0%     2.41k ± 0%   +4.51%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_ten),steps=100-12                                                                6.09k ± 0%     6.10k ± 0%   +0.25%  (p=0.029 n=4+4)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1000-12                                                               43.0k ± 0%     43.9k ± 0%   +2.03%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-12                                                              18.5k ± 0%     19.6k ± 0%   +5.97%  (p=0.016 n=4+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-12                                                             21.4k ± 0%     22.5k ± 0%   +5.12%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-12                                                            54.6k ± 0%     55.6k ± 0%   +1.84%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-12                                                            379k ± 0%      396k ± 0%   +4.55%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1-12                                                                   392 ± 0%       406 ± 0%   +3.57%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=10-12                                                                  755 ± 0%       760 ± 0%   +0.66%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-12                                                               4.43k ± 0%     4.34k ± 0%   -1.91%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-12                                                              41.1k ± 0%     40.3k ± 0%   -1.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1-12                                                                 1.98k ± 0%     2.09k ± 0%   +5.71%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=10-12                                                                2.34k ± 0%     2.45k ± 0%   +4.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=100-12                                                               6.41k ± 0%     6.43k ± 0%   +0.22%  (p=0.016 n=4+5)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1000-12                                                              46.2k ± 0%     47.1k ± 0%   +1.89%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-12                                                             17.8k ± 0%     18.9k ± 0%   +6.19%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-12                                                            18.2k ± 0%     19.3k ± 0%   +6.01%  (p=0.016 n=4+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-12                                                           26.2k ± 0%     27.2k ± 0%   +3.83%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-12                                                          97.7k ± 0%    114.9k ± 0%  +17.61%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1-12                                                    267 ± 0%       267 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=10-12                                                   303 ± 0%       303 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-12                                                  673 ± 0%       673 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-12                                               4.33k ± 0%     4.36k ± 0%   +0.55%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1-12                                                    719 ± 0%       719 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=10-12                                                   765 ± 0%       765 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=100-12                                                1.31k ± 0%     1.31k ± 0%     ~     (p=0.095 n=4+5)
RangeQuery/expr=rate(a_ten[1m])_+_rate(b_ten[1m]),steps=1000-12                                               6.49k ± 0%     6.73k ± 0%   +3.66%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-12                                          5.10k ± 0%     5.10k ± 0%     ~     (p=0.444 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-12                                         5.22k ± 0%     5.22k ± 0%     ~     (p=0.095 n=5+4)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-12                                        7.23k ± 0%     7.23k ± 0%     ~     (p=0.849 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-12                                       25.2k ± 1%     27.3k ± 2%   +8.18%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1-12                                                     183 ± 0%       187 ± 0%   +2.19%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=10-12                                                    246 ± 0%       241 ± 0%   -2.03%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-12                                                   881 ± 0%       786 ± 0%  -10.78%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-12                                                7.21k ± 0%     6.23k ± 0%  -13.63%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1-12                                                     371 ± 0%       384 ± 0%   +3.50%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=10-12                                                    443 ± 0%       447 ± 0%   +0.90%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=100-12                                                 1.20k ± 0%     1.12k ± 0%   -7.14%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m])),steps=1000-12                                                8.69k ± 0%     7.82k ± 0%   -9.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-12                                               2.18k ± 0%     2.28k ± 0%   +4.72%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-12                                              2.25k ± 0%     2.35k ± 0%   +4.17%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-12                                             3.37k ± 0%     3.38k ± 0%   +0.12%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-12                                            13.4k ± 0%     13.6k ± 0%   +1.94%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1-12                  341 ± 0%       349 ± 0%   +2.35%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=10-12                 503 ± 0%       493 ± 0%   -1.99%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=100-12              2.13k ± 0%     1.94k ± 0%   -8.91%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m]))_/_sum_without_(l)(rate(b_one[1m])),steps=1000-12             18.4k ± 0%     16.4k ± 0%  -10.69%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1-12                  717 ± 0%       743 ± 0%   +3.63%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=10-12                 897 ± 0%       905 ± 0%   +0.89%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=100-12              2.78k ± 0%     2.61k ± 0%   -6.19%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_ten[1m]))_/_sum_without_(l)(rate(b_ten[1m])),steps=1000-12             21.3k ± 0%     19.6k ± 0%   -8.11%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-12        4.34k ± 0%     4.54k ± 0%   +4.75%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-12       4.52k ± 0%     4.71k ± 0%   +4.16%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-12      7.12k ± 0%     7.13k ± 0%   +0.11%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-12     30.7k ± 0%     31.2k ± 0%   +1.69%  (p=0.016 n=4+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1-12                                             468 ± 0%       468 ± 0%     ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=10-12                                            711 ± 0%       711 ± 0%     ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-12                                         3.19k ± 0%     3.19k ± 0%     ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-12                                        27.8k ± 0%     28.0k ± 0%   +0.63%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1-12                                           3.19k ± 0%     3.19k ± 0%     ~     (p=0.556 n=4+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=10-12                                          6.29k ± 0%     6.29k ± 0%     ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=100-12                                         37.8k ± 0%     37.8k ± 0%     ~     (p=1.000 n=4+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_ten[5m])),steps=1000-12                                         352k ± 0%      354k ± 0%   +0.50%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-12                                       30.1k ± 0%     30.1k ± 0%     ~     (p=0.714 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-12                                      60.8k ± 0%     60.8k ± 0%     ~     (p=0.206 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-12                                      372k ± 0%      372k ± 0%     ~     (p=0.524 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-12                                    3.48M ± 0%     3.49M ± 0%   +0.49%  (p=0.008 n=5+5)
```