### PR TITLE
Ignore k8s' updateUnfinishedWorkLoop go routine in goleak tests

### DIFF
--- a/util/testutil/testing.go
+++ b/util/testutil/testing.go
@@ -36,5 +36,9 @@ func TolerantVerifyLeak(m *testing.M) {
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
 		// https://github.com/kubernetes/klog/blob/c85d02d1c76a9ebafa81eb6d35c980734f2c4727/klog.go#L417
 		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
+		// This go routine uses a ticker to stop, so it can create false
+		// positives.
+		// https://github.com/kubernetes/client-go/blob/f6ce18ae578c8cca64d14ab9687824d9e1305a67/util/workqueue/queue.go#L201
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop"),
 	)
 }


### PR DESCRIPTION
This go routing uses a ticker to stop. This is prompt to create false
positives in tests failures. It is also unexported so let's threat that
as a k8s internal. Therefore, let's ignore it in goleak.

example failure: https://app.circleci.com/pipelines/github/prometheus/prometheus/11256/workflows/56ee22d9-a39c-4bd8-8134-2a8902a2b227/jobs/49326

Fix #7692

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->