### PR TITLE
[RFC] Add method to get reference number for TSDB Appender

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -180,8 +180,8 @@ type Appender interface {
 	ExemplarAppender
 }
 
-// OptionalGetRef is used by downstream projects (e.g. Cortex) to avoid maintaining a parallel set of references.
-type OptionalGetRef interface {
+// GetRef is used by downstream projects (e.g. Cortex) to avoid maintaining a parallel set of references.
+type GetRef interface {
 	// Returns reference number that can be used to pass to Appender.Append()
 	GetRef(lset labels.Labels) (uint64, bool)
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -180,6 +180,12 @@ type Appender interface {
 	ExemplarAppender
 }
 
+// OptionalGetRef is used by downstream projects (e.g. Cortex) to avoid maintaining a parallel set of references.
+type OptionalGetRef interface {
+	// Returns reference number that can be used to pass to Appender.Append()
+	GetRef(lset labels.Labels) (uint64, bool)
+}
+
 // ExemplarAppender provides an interface for adding samples to exemplar storage, which
 // within Prometheus is in-memory only.
 type ExemplarAppender interface {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -180,10 +180,12 @@ type Appender interface {
 	ExemplarAppender
 }
 
-// GetRef is used by downstream projects (e.g. Cortex) to avoid maintaining a parallel set of references.
+// GetRef is an extra interface on Appenders used by downstream projects
+// (e.g. Cortex) to avoid maintaining a parallel set of references.
 type GetRef interface {
-	// Returns reference number that can be used to pass to Appender.Append()
-	GetRef(lset labels.Labels) (uint64, bool)
+	// Returns reference number that can be used to pass to Appender.Append().
+	// 0 means the appender does not have a reference to this series.
+	GetRef(lset labels.Labels) uint64
 }
 
 // ExemplarAppender provides an interface for adding samples to exemplar storage, which

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -795,6 +795,15 @@ type dbAppender struct {
 	db *DB
 }
 
+func (a dbAppender) GetRef(lset labels.Labels) (uint64, bool) {
+	if g, ok := a.Appender.(interface {
+		GetRef(lset labels.Labels) (uint64, bool)
+	}); ok {
+		return g.GetRef(lset)
+	}
+	return 0, false
+}
+
 func (a dbAppender) Commit() error {
 	err := a.Appender.Commit()
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -795,10 +795,10 @@ type dbAppender struct {
 	db *DB
 }
 
+var _ storage.OptionalGetRef = dbAppender{}
+
 func (a dbAppender) GetRef(lset labels.Labels) (uint64, bool) {
-	if g, ok := a.Appender.(interface {
-		GetRef(lset labels.Labels) (uint64, bool)
-	}); ok {
+	if g, ok := a.Appender.(storage.OptionalGetRef); ok {
 		return g.GetRef(lset)
 	}
 	return 0, false

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -797,11 +797,11 @@ type dbAppender struct {
 
 var _ storage.GetRef = dbAppender{}
 
-func (a dbAppender) GetRef(lset labels.Labels) (uint64, bool) {
+func (a dbAppender) GetRef(lset labels.Labels) uint64 {
 	if g, ok := a.Appender.(storage.GetRef); ok {
 		return g.GetRef(lset)
 	}
-	return 0, false
+	return 0
 }
 
 func (a dbAppender) Commit() error {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -795,10 +795,10 @@ type dbAppender struct {
 	db *DB
 }
 
-var _ storage.OptionalGetRef = dbAppender{}
+var _ storage.GetRef = dbAppender{}
 
 func (a dbAppender) GetRef(lset labels.Labels) (uint64, bool) {
-	if g, ok := a.Appender.(storage.OptionalGetRef); ok {
+	if g, ok := a.Appender.(storage.GetRef); ok {
 		return g.GetRef(lset)
 	}
 	return 0, false

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1107,10 +1107,10 @@ func (a *initAppender) AppendExemplar(ref uint64, l labels.Labels, e exemplar.Ex
 	return a.app.AppendExemplar(ref, l, e)
 }
 
-var _ storage.OptionalGetRef = &initAppender{}
+var _ storage.GetRef = &initAppender{}
 
 func (a *initAppender) GetRef(lset labels.Labels) (uint64, bool) {
-	if g, ok := a.app.(storage.OptionalGetRef); ok {
+	if g, ok := a.app.(storage.GetRef); ok {
 		return g.GetRef(lset)
 	}
 	return 0, false
@@ -1340,7 +1340,7 @@ func (a *headAppender) AppendExemplar(ref uint64, _ labels.Labels, e exemplar.Ex
 	return s.ref, nil
 }
 
-var _ storage.OptionalGetRef = &headAppender{}
+var _ storage.GetRef = &headAppender{}
 
 func (a *headAppender) GetRef(lset labels.Labels) (uint64, bool) {
 	s := a.head.series.getByHash(lset.Hash(), lset)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1109,11 +1109,11 @@ func (a *initAppender) AppendExemplar(ref uint64, l labels.Labels, e exemplar.Ex
 
 var _ storage.GetRef = &initAppender{}
 
-func (a *initAppender) GetRef(lset labels.Labels) (uint64, bool) {
+func (a *initAppender) GetRef(lset labels.Labels) uint64 {
 	if g, ok := a.app.(storage.GetRef); ok {
 		return g.GetRef(lset)
 	}
-	return 0, false
+	return 0
 }
 
 func (a *initAppender) Commit() error {
@@ -1342,12 +1342,12 @@ func (a *headAppender) AppendExemplar(ref uint64, _ labels.Labels, e exemplar.Ex
 
 var _ storage.GetRef = &headAppender{}
 
-func (a *headAppender) GetRef(lset labels.Labels) (uint64, bool) {
+func (a *headAppender) GetRef(lset labels.Labels) uint64 {
 	s := a.head.series.getByHash(lset.Hash(), lset)
 	if s == nil {
-		return 0, false
+		return 0
 	}
-	return s.ref, true
+	return s.ref
 }
 
 func (a *headAppender) log() error {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1107,10 +1107,10 @@ func (a *initAppender) AppendExemplar(ref uint64, l labels.Labels, e exemplar.Ex
 	return a.app.AppendExemplar(ref, l, e)
 }
 
+var _ storage.OptionalGetRef = &initAppender{}
+
 func (a *initAppender) GetRef(lset labels.Labels) (uint64, bool) {
-	if g, ok := a.app.(interface {
-		GetRef(lset labels.Labels) (uint64, bool)
-	}); ok {
+	if g, ok := a.app.(storage.OptionalGetRef); ok {
 		return g.GetRef(lset)
 	}
 	return 0, false
@@ -1340,7 +1340,8 @@ func (a *headAppender) AppendExemplar(ref uint64, _ labels.Labels, e exemplar.Ex
 	return s.ref, nil
 }
 
-// GetRef is used by downstream projects (e.g. Cortex) to avoid maintaining a parallel set of references
+var _ storage.OptionalGetRef = &headAppender{}
+
 func (a *headAppender) GetRef(lset labels.Labels) (uint64, bool) {
 	s := a.head.series.getByHash(lset.Hash(), lset)
 	if s == nil {


### PR DESCRIPTION
This is for https://github.com/cortexproject/cortex/pull/3951 which gives a massive reduction in memory usage for Cortex.

In situations where we need to copy labels before calling `Add()`, `GetRef()` allows to check first, then call `AddFast()` in the case that the series is already known.

I deliberately did not add `GetRef()` to `storage.Appender`, to reduce the impact elsewhere, however that might be worth considering.
