### PR TITLE
Experiment to optimize aggregations

### DIFF
--- a/promql/testdata/selectors.test
+++ b/promql/testdata/selectors.test
@@ -205,3 +205,11 @@ eval instant at 0h testmetric
 	testmetric{a="abb"} 2
 
 clear
+
+# Tests for NaN.
+clear
+load 5m
+  http_requests     NaN
+
+eval instant at 0m sum(http_requests)
+  {} NaN


### PR DESCRIPTION
This PR shows an experiment to optimize aggregations.

In https://github.com/prometheus/prometheus/pull/8594 I've proposed some changes to speed up the aggregation function. While working on it I was wondering if there may be a more optimized way to run the `rangeEval()` with an aggregation.

As an experiment, I've implemented a simplified `rangeEvalAggregations()` which is the `rangeEval()` for few (but common) aggregations. In the comments below you can find the benchmark results.
