### PR TITLE
Added tracing span to evaluator.eval()

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"reflect"
 	"regexp"
 	"runtime"
 	"sort"
@@ -1124,6 +1125,10 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 		ev.error(err)
 	}
 	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
+
+	// Create a new span to help investigate inner evaluation performances.
+	span, _ := opentracing.StartSpanFromContext(ev.ctx, stats.InnerEvalTime.SpanOperation()+" eval "+reflect.TypeOf(expr).String())
+	defer span.Finish()
 
 	switch e := expr.(type) {
 	case *parser.AggregateExpr:


### PR DESCRIPTION
When profiling some slow queries (which originated the PRs https://github.com/prometheus/prometheus/pull/8585 and https://github.com/prometheus/prometheus/pull/8594) I found out that PromQL tracing spans don't allow to see where the actual time is spent because there's no visibility inside `promqlInnerEval`.

With the code in `main` we see something like this:
![Screenshot 2021-03-15 at 15 09 27](https://user-images.githubusercontent.com/1701904/111166528-78083f00-85a0-11eb-8279-40a33df23434.png)

But we can't know why we spent 42s in the `promqlInnerEval`. In this PR I'm proposing to add a tracing span inside `evaluator.eval()` with a reference to the evaluated expression. You would get something like this:

![Screenshot 2021-03-15 at 15 08 51](https://user-images.githubusercontent.com/1701904/111166659-9837fe00-85a0-11eb-9fb2-72cb36c23be3.png)
