### PR TITLE
Avoid overflow on /rules page

### DIFF
--- a/web/ui/react-app/src/pages/rules/RulesContent.tsx
+++ b/web/ui/react-app/src/pages/rules/RulesContent.tsx
@@ -61,14 +61,16 @@ export const RulesContent: FC<RouteComponentProps & RulesContentProps> = ({ resp
                 <tr>
                   <td colSpan={3}>
                     <a href={'#' + g.name}>
-                      <h2 id={g.name}>{g.name}</h2>
+                      <h4 id={g.name} className="text-break">
+                        {g.name}
+                      </h4>
                     </a>
                   </td>
                   <td>
-                    <h2>{formatRelative(g.lastEvaluation, now())}</h2>
+                    <h4>{formatRelative(g.lastEvaluation, now())}</h4>
                   </td>
                   <td>
-                    <h2>{humanizeDuration(parseFloat(g.evaluationTime) * 1000)}</h2>
+                    <h4>{humanizeDuration(parseFloat(g.evaluationTime) * 1000)}</h4>
                   </td>
                 </tr>
               </thead>


### PR DESCRIPTION
If I have a rule with a very long name it will force the table to be wider then the viewport.
This forces the browser to wrap long rule names and uses smaller font, to avoid having overflow.

Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
 
 Before:
<img width="1364" alt="Screenshot 2021-03-16 at 11 11 37" src="https://user-images.githubusercontent.com/114288/111300408-f4eef380-8648-11eb-9788-4eb2d752966f.png">

After:
<img width="1363" alt="Screenshot 2021-03-16 at 11 12 21" src="https://user-images.githubusercontent.com/114288/111300417-f7514d80-8648-11eb-9c42-194eb9444117.png">

