### PR TITLE
Avoid overflow on /targets page

### DIFF
--- a/web/ui/react-app/src/pages/targets/ScrapePoolPanel.tsx
+++ b/web/ui/react-app/src/pages/targets/ScrapePoolPanel.tsx
@@ -70,7 +70,7 @@ const ScrapePoolPanel: FC<PanelProps> = ({ scrapePool, targetGroup }) => {
                   </td>
                   <td className={styles['last-scrape']}>{formatRelative(lastScrape, now())}</td>
                   <td className={styles['scrape-duration']}>{humanizeDuration(lastScrapeDuration * 1000)}</td>
-                  <td className={styles.errors}>{lastError ? <Badge color={color}>{lastError}</Badge> : null}</td>
+                  <td className={styles.errors}>{lastError ? <span className="text-danger">{lastError}</span> : null}</td>
                 </tr>
               );
             })}


### PR DESCRIPTION
Target errors are rendered as badges. If error text is very long it will expand the table since badges are not allowed to wrap.
Replace badge with <code/> which is allowed to wrap around.

Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
 
 Before:
<img width="1354" alt="Screenshot 2021-03-16 at 11 19 28" src="https://user-images.githubusercontent.com/114288/111301352-071d6180-864a-11eb-96bc-603cf1733d42.png">

After:
<img width="1357" alt="Screenshot 2021-03-16 at 15 19 44" src="https://user-images.githubusercontent.com/114288/111334135-36909600-866b-11eb-80b5-e1b0d8064a39.png">


