### PR TITLE
Speed up PR builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  prometheus: prometheus/prometheus@0.9.0
+  prometheus: prometheus/prometheus@0.10.0
   go: circleci/go@0.2.0
   win: circleci/windows@2.3.0
 
@@ -132,16 +132,44 @@ workflows:
         filters:
           tags:
             only: /.*/
-    - prometheus/build:
+    # Build pipeline for PRs.
+    - prometheus/build_platform:
         name: build
         filters:
           tags:
             only: /.*/
+            ignore: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
+        matrix:
+          parameters:
+            platform:
+            # - aix # Currently doesn't build.
+            - darwin
+            - dragonfly
+            - freebsd
+            - illumos
+            - linux
+            - netbsd
+            - openbsd
+            - windows
+    # Build pipeline for main releases.
+    - prometheus/build:
+        name: build-main
+        filters:
+          branches:
+            only: main
+    # Build pipeline for versioned releases.
+    - prometheus/build:
+        name: build-release
+        filters:
+          tags:
+            only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
+          branches:
+            ignore: /.*/
     - prometheus/publish_main:
         context: org-context
         requires:
         - test
-        - build
+        - build-main
         filters:
           branches:
             only: main
@@ -150,7 +178,7 @@ workflows:
         context: org-context
         requires:
         - test
-        - build
+        - build-release
         filters:
           tags:
             only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/

--- a/Makefile.common
+++ b/Makefile.common
@@ -78,7 +78,7 @@ ifneq ($(shell which gotestsum),)
 endif
 endif
 
-PROMU_VERSION ?= 0.7.0
+PROMU_VERSION ?= 0.10.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 GOLANGCI_LINT :=


### PR DESCRIPTION
* Update to latest promu.
* Split up builds for PRs into a build matrix.
* Keep non-matrix build pipeline for releases.

Signed-off-by: Ben Kochie <superq@gmail.com>
