### PR TITLE
Further increase max log line in remote write client

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -39,7 +39,7 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 )
 
-const maxErrMsgLen = 512
+const maxErrMsgLen = 1024
 
 var UserAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 


### PR DESCRIPTION
From the UX perspective, a common feedback we hear in Cortex is that Prometheus remote write logs are truncated and so they can't get the full error message. Despite some work we've done in Cortex to put the most valuable information at the beginning of error messages, there're still cases where having the full error (eg. the full series labels) helps for investigating an issue.

The max log line was already increased from 256 to 512 in #8017.  What's the sentiment if we do a step forward and we increase it to 1024?