### PR TITLE
[rule] Update rule health for append/commit fails

### DIFF
--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -1163,3 +1163,60 @@ func TestGroupHasAlertingRules(t *testing.T) {
 		require.Equal(t, test.want, got, "test case %d failed, expected:%t got:%t", i, test.want, got)
 	}
 }
+
+func TestRuleHealthUpdates(t *testing.T) {
+	st := teststorage.New(t)
+	defer st.Close()
+	engineOpts := promql.EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := promql.NewEngine(engineOpts)
+	opts := &ManagerOptions{
+		QueryFunc:  EngineQueryFunc(engine, st),
+		Appendable: st,
+		Queryable:  st,
+		Context:    context.Background(),
+		Logger:     log.NewNopLogger(),
+	}
+
+	expr, err := parser.ParseExpr("a + 1")
+	require.NoError(t, err)
+	rule := NewRecordingRule("a_plus_one", expr, labels.Labels{})
+	group := NewGroup(GroupOptions{
+		Name:          "default",
+		Interval:      time.Second,
+		Rules:         []Rule{rule},
+		ShouldRestore: true,
+		Opts:          opts,
+	})
+
+	// A time series that has two samples.
+	app := st.Appender(context.Background())
+	app.Append(0, labels.FromStrings(model.MetricNameLabel, "a"), 0, 1)
+	app.Append(0, labels.FromStrings(model.MetricNameLabel, "a"), 1000, 2)
+	err = app.Commit()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	rules := group.Rules()[0]
+	require.NoError(t, rules.LastError())
+	require.Equal(t, HealthUnknown, rules.Health())
+
+	// Execute 2 times, it should be all green.
+	group.Eval(ctx, time.Unix(0, 0))
+	group.Eval(ctx, time.Unix(1, 0))
+
+	rules = group.Rules()[0]
+	require.NoError(t, rules.LastError())
+	require.Equal(t, HealthGood, rules.Health())
+
+	// Now execute the rule in the past again, this should cause append failures.
+	group.Eval(ctx, time.Unix(0, 0))
+	rules = group.Rules()[0]
+	require.EqualError(t, rules.LastError(), storage.ErrOutOfOrderSample.Error())
+	require.Equal(t, HealthBad, rules.Health())
+}

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -76,8 +76,6 @@ func (rule *RecordingRule) Labels() labels.Labels {
 func (rule *RecordingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, _ *url.URL) (promql.Vector, error) {
 	vector, err := query(ctx, rule.vector.String(), ts)
 	if err != nil {
-		rule.SetHealth(HealthBad)
-		rule.SetLastError(err)
 		return nil, err
 	}
 	// Override the metric name and labels.


### PR DESCRIPTION
Similar to https://github.com/prometheus/prometheus/pull/8410. It will help users notice when their rules are broken on Append and Commit, not just on execution.