### PR TITLE
TSDB: optimize series creation on PreCreation() failure

### DIFF
--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
@@ -67,3 +68,32 @@ func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkHeadStripeSeriesCreate_PreCreationFailure(b *testing.B) {
+	chunkDir, err := ioutil.TempDir("", "chunk_dir")
+	require.NoError(b, err)
+	defer func() {
+		require.NoError(b, os.RemoveAll(chunkDir))
+	}()
+	// Put a series, select it. GC it and then access it.
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	opts.ChunkDirRoot = chunkDir
+
+	// Mock the PreCreation() callback to fail on each series.
+	opts.SeriesCallback = failingSeriesLifecycleCallback{}
+
+	h, err := NewHead(nil, nil, nil, opts)
+	require.NoError(b, err)
+	defer h.Close()
+
+	for i := 0; i < b.N; i++ {
+		h.getOrCreate(uint64(i), labels.FromStrings("a", strconv.Itoa(i)))
+	}
+}
+
+type failingSeriesLifecycleCallback struct{}
+
+func (failingSeriesLifecycleCallback) PreCreation(labels.Labels) error { return errors.New("failed") }
+func (failingSeriesLifecycleCallback) PostCreation(labels.Labels)      {}
+func (failingSeriesLifecycleCallback) PostDeletion(...labels.Labels)   {}


### PR DESCRIPTION
In Cortex we use `SeriesCallback` and we have edge cases where the number of series failing the `PreCreation()` is very high. When this happens, we see an higher CPU utilization and memory allocation caused by `*memSeries` being created before checking if the `PreCreation()` callback passes.

This PR proposed a fix for that.

## Benchmark

```
name                                          old time/op    new time/op    delta
HeadStripeSeriesCreate-12                       1.79µs ±17%    1.84µs ±16%     ~     (p=0.421 n=5+5)
HeadStripeSeriesCreateParallel-12               1.60µs ± 2%    1.76µs ±11%     ~     (p=0.286 n=4+5)
HeadStripeSeriesCreate_PreCreationFailure-12    1.48µs ± 2%    1.27µs ± 0%  -14.50%  (p=0.008 n=5+5)

name                                          old alloc/op   new alloc/op   delta
HeadStripeSeriesCreate-12                         783B ± 2%      813B ±13%     ~     (p=0.246 n=5+5)
HeadStripeSeriesCreateParallel-12                 841B ±23%      890B ±16%     ~     (p=0.730 n=5+5)
HeadStripeSeriesCreate_PreCreationFailure-12      699B ± 0%      395B ± 0%  -43.49%  (p=0.000 n=5+4)

name                                          old allocs/op  new allocs/op  delta
HeadStripeSeriesCreate-12                         8.00 ± 0%      8.00 ± 0%     ~     (all equal)
HeadStripeSeriesCreateParallel-12                 8.00 ± 0%      8.00 ± 0%     ~     (all equal)
HeadStripeSeriesCreate_PreCreationFailure-12      9.00 ± 0%      6.00 ± 0%  -33.33%  (p=0.008 n=5+5)
```