### PR TITLE
Switch to alertmanager api v2

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -117,7 +117,7 @@ var (
 	DefaultAlertmanagerConfig = AlertmanagerConfig{
 		Scheme:           "http",
 		Timeout:          model.Duration(10 * time.Second),
-		APIVersion:       AlertmanagerAPIVersionV1,
+		APIVersion:       AlertmanagerAPIVersionV2,
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -785,7 +785,7 @@ var expectedConf = &Config{
 			{
 				Scheme:           "https",
 				Timeout:          model.Duration(10 * time.Second),
-				APIVersion:       AlertmanagerAPIVersionV1,
+				APIVersion:       AlertmanagerAPIVersionV2,
 				HTTPClientConfig: config.DefaultHTTPClientConfig,
 				ServiceDiscoveryConfigs: discovery.Configs{
 					discovery.StaticConfig{

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1755,7 +1755,7 @@ through the `__alerts_path__` label.
 [ timeout: <duration> | default = 10s ]
 
 # The api version of Alertmanager.
-[ api_version: <string> | default = v1 ]
+[ api_version: <string> | default = v2 ]
 
 # Prefix for the HTTP path alerts are pushed to.
 [ path_prefix: <path> | default = / ]

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -454,7 +454,7 @@ func TestReload(t *testing.T) {
 					},
 				},
 			},
-			out: "http://alertmanager:9093/api/v1/alerts",
+			out: "http://alertmanager:9093/api/v2/alerts",
 		},
 	}
 
@@ -504,7 +504,7 @@ func TestDroppedAlertmanagers(t *testing.T) {
 					},
 				},
 			},
-			out: "http://alertmanager:9093/api/v1/alerts",
+			out: "http://alertmanager:9093/api/v2/alerts",
 		},
 	}
 


### PR DESCRIPTION
According to the 2.25 release notes, 2.26 should switch to alertmanager
api v2 by default.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->