### PR TITLE
fix empty am when reload

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -266,7 +266,10 @@ func (n *Manager) ApplyConfig(conf *config.Config) error {
 		if err != nil {
 			return err
 		}
-
+		// If old ams exist, use old ams to avoid empty ams when reload.
+		if oldAms, ok := n.alertmanagers[k]; ok {
+			ams.ams = oldAms.ams
+		}
 		amSets[k] = ams
 	}
 


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
When reload prometheus server, alertmanager of notify would be empty  for some seconds or miniutes before completed (see `prometheus_notifications_alertmanagers_discovered`), notification of alert would be dropped during that time(see `prometheus_notifications_dropped_total`), this would case false recolved alarm for alertmanager.

I think we can use last alertmanagers when applyConfig rather than set alertmanagers to empty.

before:
![image](https://user-images.githubusercontent.com/47807658/112301634-1bf69680-8cd5-11eb-86ea-87eae1917f88.png)
after fix:
![image](https://user-images.githubusercontent.com/47807658/112301794-45172700-8cd5-11eb-9df5-aa903fd6d48f.png)


