### PR TITLE
Make GetRef() return the label set

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -183,9 +183,10 @@ type Appender interface {
 // GetRef is an extra interface on Appenders used by downstream projects
 // (e.g. Cortex) to avoid maintaining a parallel set of references.
 type GetRef interface {
-	// Returns reference number that can be used to pass to Appender.Append().
+	// Returns reference number that can be used to pass to Appender.Append(),
+	// and a set of labels that will not cause another copy when passed to Appender.Append().
 	// 0 means the appender does not have a reference to this series.
-	GetRef(lset labels.Labels) uint64
+	GetRef(lset labels.Labels) (uint64, labels.Labels)
 }
 
 // ExemplarAppender provides an interface for adding samples to exemplar storage, which

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -797,11 +797,11 @@ type dbAppender struct {
 
 var _ storage.GetRef = dbAppender{}
 
-func (a dbAppender) GetRef(lset labels.Labels) uint64 {
+func (a dbAppender) GetRef(lset labels.Labels) (uint64, labels.Labels) {
 	if g, ok := a.Appender.(storage.GetRef); ok {
 		return g.GetRef(lset)
 	}
-	return 0
+	return 0, nil
 }
 
 func (a dbAppender) Commit() error {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1109,11 +1109,11 @@ func (a *initAppender) AppendExemplar(ref uint64, l labels.Labels, e exemplar.Ex
 
 var _ storage.GetRef = &initAppender{}
 
-func (a *initAppender) GetRef(lset labels.Labels) uint64 {
+func (a *initAppender) GetRef(lset labels.Labels) (uint64, labels.Labels) {
 	if g, ok := a.app.(storage.GetRef); ok {
 		return g.GetRef(lset)
 	}
-	return 0
+	return 0, nil
 }
 
 func (a *initAppender) Commit() error {
@@ -1342,12 +1342,13 @@ func (a *headAppender) AppendExemplar(ref uint64, _ labels.Labels, e exemplar.Ex
 
 var _ storage.GetRef = &headAppender{}
 
-func (a *headAppender) GetRef(lset labels.Labels) uint64 {
+func (a *headAppender) GetRef(lset labels.Labels) (uint64, labels.Labels) {
 	s := a.head.series.getByHash(lset.Hash(), lset)
 	if s == nil {
-		return 0
+		return 0, nil
 	}
-	return s.ref
+	// returned labels must be suitable to pass to Append()
+	return s.ref, s.lset
 }
 
 func (a *headAppender) log() error {


### PR DESCRIPTION
This is an addition to #8600, which became necessary after #8489 changed the main Appender API.

The purpose of `GetRef()` is to allow `Append()` to be called without the caller needing to copy the labels. To avoid a race where a series is removed from TSDB between the calls to `GetRef()` and `Append()`, `GetRef()` is made to return TSDB's copy of the labels.

Needed for https://github.com/cortexproject/cortex/pull/3951