### PR TITLE
digitalocean_sd: Expose vpc for use in relabeling.

### DIFF
--- a/discovery/digitalocean/digitalocean.go
+++ b/discovery/digitalocean/digitalocean.go
@@ -47,6 +47,7 @@ const (
 	doLabelStatus      = doLabel + "status"
 	doLabelFeatures    = doLabel + "features"
 	doLabelTags        = doLabel + "tags"
+	doLabelVPC         = doLabel + "vpc"
 	separator          = ","
 )
 
@@ -170,6 +171,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 			doLabelRegion:      model.LabelValue(droplet.Region.Slug),
 			doLabelSize:        model.LabelValue(droplet.SizeSlug),
 			doLabelStatus:      model.LabelValue(droplet.Status),
+			doLabelVPC:         model.LabelValue(droplet.VPCUUID),
 		}
 
 		addr := net.JoinHostPort(publicIPv4, strconv.FormatUint(uint64(d.port), 10))

--- a/discovery/digitalocean/digitalocean_test.go
+++ b/discovery/digitalocean/digitalocean_test.go
@@ -76,6 +76,7 @@ func TestDigitalOceanSDRefresh(t *testing.T) {
 			"__meta_digitalocean_region":       model.LabelValue("nyc3"),
 			"__meta_digitalocean_size":         model.LabelValue("s-1vcpu-1gb"),
 			"__meta_digitalocean_status":       model.LabelValue("active"),
+			"__meta_digitalocean_vpc":          model.LabelValue("f9b0769c-e118-42fb-a0c4-fed15ef69662"),
 			"__meta_digitalocean_features":     model.LabelValue(",backups,ipv6,virtio,"),
 		},
 		{
@@ -90,6 +91,7 @@ func TestDigitalOceanSDRefresh(t *testing.T) {
 			"__meta_digitalocean_region":       model.LabelValue("nyc3"),
 			"__meta_digitalocean_size":         model.LabelValue("s-1vcpu-1gb"),
 			"__meta_digitalocean_status":       model.LabelValue("active"),
+			"__meta_digitalocean_vpc":          model.LabelValue("f9b0769c-e118-42fb-a0c4-fed15ef69662"),
 			"__meta_digitalocean_tags":         model.LabelValue(",monitor,"),
 			"__meta_digitalocean_features":     model.LabelValue(",virtio,"),
 		},
@@ -105,6 +107,7 @@ func TestDigitalOceanSDRefresh(t *testing.T) {
 			"__meta_digitalocean_region":       model.LabelValue("fra1"),
 			"__meta_digitalocean_size":         model.LabelValue("s-1vcpu-1gb"),
 			"__meta_digitalocean_status":       model.LabelValue("off"),
+			"__meta_digitalocean_vpc":          model.LabelValue("953d698c-dc84-11e8-80bc-3cfdfea9fba1"),
 			"__meta_digitalocean_features":     model.LabelValue(",ipv6,private_networking,"),
 		},
 		{
@@ -119,6 +122,7 @@ func TestDigitalOceanSDRefresh(t *testing.T) {
 			"__meta_digitalocean_region":       model.LabelValue("fra1"),
 			"__meta_digitalocean_size":         model.LabelValue("s-1vcpu-1gb"),
 			"__meta_digitalocean_status":       model.LabelValue("active"),
+			"__meta_digitalocean_vpc":          model.LabelValue("953d698c-dc84-11e8-80bc-3cfdfea9fba1"),
 			"__meta_digitalocean_features":     model.LabelValue(",ipv6,private_networking,"),
 		},
 	} {

--- a/discovery/digitalocean/mock_test.go
+++ b/discovery/digitalocean/mock_test.go
@@ -445,7 +445,8 @@ func (m *SDMock) HandleDropletsList() {
           "m6-24vcpu-192gb"
         ]
       },
-      "tags": []
+      "tags": [],
+      "vpc_uuid": "953d698c-dc84-11e8-80bc-3cfdfea9fba1"
     },
     {
       "id": 176011507,
@@ -624,7 +625,8 @@ func (m *SDMock) HandleDropletsList() {
           "m6-24vcpu-192gb"
         ]
       },
-      "tags": []
+      "tags": [],
+      "vpc_uuid": "953d698c-dc84-11e8-80bc-3cfdfea9fba1"
     }
   ],
   "links": {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -444,6 +444,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_digitalocean_status`: the status of the droplet
 * `__meta_digitalocean_features`: the comma-separated list of features of the droplet
 * `__meta_digitalocean_tags`: the comma-separated list of tags of the droplet
+* `__meta_digitalocean_vpc`: the id of the droplet's VPC
 
 ```yaml
 # Authentication information used to authenticate to the API server.


### PR DESCRIPTION
This PR exposes a label for the instance's VPC in the DigitalOcean SD. This is useful in relabeling to access targets on their private IPs as the instance must reside in the same VPC to be reachable. 

```
  - job_name:       'node'
    scrape_interval: 5s
    digitalocean_sd_configs:
    - bearer_token: '<DO_TOKEN>'

    relabel_configs:
    - source_labels: [__meta_digitalocean_vpc]
      regex: '<VPC ID>'
      action: keep

    - source_labels: [__meta_digitalocean_private_ipv4]
      target_label: __address__
      replacement: '[$1]:9100'
```