### PR TITLE
Fix Blank TSDB Status Page

### DIFF
--- a/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.test.tsx
+++ b/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.test.tsx
@@ -150,6 +150,16 @@ describe('TSDB Stats', () => {
     });
 
     expect(page.find('h2').text()).toEqual('TSDB Status');
-    expect(page.find('div.text-center')).not.toBeUndefined();
+
+    const headStats = page
+      .find(Table)
+      .at(0)
+      .find('tbody')
+      .find('td');
+    ['0', '0', '0', 'Error parsing time (9223372036854776000)', 'Error parsing time (-9223372036854776000)'].forEach(
+      (value, i) => {
+        expect(headStats.at(i).text()).toEqual(value);
+      }
+    );
   });
 });

--- a/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.test.tsx
+++ b/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.test.tsx
@@ -51,6 +51,26 @@ const fakeTSDBStatusResponse: {
   },
 };
 
+const fakeEmptyTSDBStatusResponse: {
+  status: string;
+  data: TSDBMap;
+} = {
+  status: 'success',
+  data: {
+    headStats: {
+      numSeries: 0,
+      numLabelPairs: 0,
+      chunkCount: 0,
+      minTime: 9223372036854776000,
+      maxTime: -9223372036854776000,
+    },
+    labelValueCountByLabelName: [],
+    seriesCountByMetricName: [],
+    memoryInBytesByLabelName: [],
+    seriesCountByLabelValuePair: [],
+  },
+};
+
 describe('TSDB Stats', () => {
   beforeEach(() => {
     fetchMock.resetMocks();
@@ -110,5 +130,26 @@ describe('TSDB Stats', () => {
         }
       }
     });
+  });
+
+  it('No Data', async () => {
+    const mock = fetchMock.mockResponse(JSON.stringify(fakeEmptyTSDBStatusResponse));
+    let page: any;
+    await act(async () => {
+      page = mount(
+        <PathPrefixContext.Provider value="/path/prefix">
+          <TSDBStatus />
+        </PathPrefixContext.Provider>
+      );
+    });
+    page.update();
+
+    expect(mock).toHaveBeenCalledWith('/path/prefix/api/v1/status/tsdb', {
+      cache: 'no-store',
+      credentials: 'same-origin',
+    });
+
+    expect(page.find('h2').text()).toEqual('TSDB Status');
+    expect(page.find('div.text-center')).not.toBeUndefined();
   });
 });

--- a/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.tsx
+++ b/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.tsx
@@ -37,6 +37,19 @@ export const TSDBStatusContent: FC<TSDBMap> = ({
 }) => {
   const unixToTime = (unix: number): string => new Date(unix).toISOString();
   const { chunkCount, numSeries, numLabelPairs, minTime, maxTime } = headStats;
+  if (numSeries < 1) {
+    return (
+      <div>
+        <h2>TSDB Status</h2>
+        <div className="text-center">
+          <h1>No TSDB statistics available yet</h1>
+          <h4>
+            If this is prolonged, try updating your <a href="/config">config</a>
+          </h4>
+        </div>
+      </div>
+    );
+  }
   const stats = [
     { header: 'Number of Series', value: numSeries },
     { header: 'Number of Chunks', value: chunkCount },

--- a/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.tsx
+++ b/web/ui/react-app/src/pages/tsdbStatus/TSDBStatus.tsx
@@ -35,21 +35,14 @@ export const TSDBStatusContent: FC<TSDBMap> = ({
   memoryInBytesByLabelName,
   seriesCountByLabelValuePair,
 }) => {
-  const unixToTime = (unix: number): string => new Date(unix).toISOString();
+  const unixToTime = (unix: number): string => {
+    try {
+      return new Date(unix).toISOString();
+    } catch {
+      return 'Error parsing time';
+    }
+  };
   const { chunkCount, numSeries, numLabelPairs, minTime, maxTime } = headStats;
-  if (numSeries < 1) {
-    return (
-      <div>
-        <h2>TSDB Status</h2>
-        <div className="text-center">
-          <h1>No TSDB statistics available yet</h1>
-          <h4>
-            If this is prolonged, try updating your <a href="/config">config</a>
-          </h4>
-        </div>
-      </div>
-    );
-  }
   const stats = [
     { header: 'Number of Series', value: numSeries },
     { header: 'Number of Chunks', value: chunkCount },


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR produces a message for the user when the API request on `tsdb-status` returns no data. Previously, there was just a blank page because `unixToTime` can't parse the default timestamps.

Fixes #8596