### PR TITLE
Sync CircleCI Orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,8 @@ jobs:
     executor: golang
     steps:
     - checkout
+    - run: curl -sL https://github.com/mikefarah/yq/releases/download/v4.6.3/yq_linux_amd64 -O "${PATH%%:*}/yq" && chmod -v +x "${PATH%%:*}/yq"
+    - run: sha256sum -c <(echo "c4343783c3361495c0d6d1eb742bba7432aa65e13e9fb8d7e201d544bcf14247 ${PATH%%:*}/yq")
     - run: ./scripts/sync_repo_files.sh
 
 workflows:


### PR DESCRIPTION
Add sync of the Prometheus CircleCI Orb version to the sync script.
* Add `yq` to the repo sync CI job.

NOTE: This will re-format the down-stream yaml config, it does not
preserve whitespace and enforces some indenting rules. It does preserve
comments.

Signed-off-by: Ben Kochie <superq@gmail.com>