### PR TITLE
fix: Wrap text in CodeMirror expression editor

### DIFF
--- a/web/ui/react-app/src/App.css
+++ b/web/ui/react-app/src/App.css
@@ -32,8 +32,11 @@ input[type='checkbox']:checked + label {
   text-transform: capitalize;
 }
 
-.expression-input {
+/* Using a more specific selector here to be able to override Bootstrap's default input group styles. */
+.input-group.expression-input {
   margin-bottom: 10px;
+  /* Prevent the input group from wrapping around when the editor content is too long for a line. */
+  flex-wrap: nowrap;
 }
 
 .expression-input .cm-expression-input {

--- a/web/ui/react-app/src/pages/graph/CMExpressionInput.tsx
+++ b/web/ui/react-app/src/pages/graph/CMExpressionInput.tsx
@@ -128,6 +128,7 @@ const CMExpressionInput: FC<CMExpressionInputProps> = ({
           closeBrackets(),
           autocompletion(),
           highlightSelectionMatches(),
+          EditorView.lineWrapping,
           keymap.of([
             ...closeBracketsKeymap,
             ...defaultKeymap,


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/8663

Signed-off-by: Julius Volz <julius.volz@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->