### PR TITLE
Don't sync if no orb is used

### DIFF
--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -104,7 +104,7 @@ check_circleci_orb() {
     return 1
   fi
 
-  if [[ "${orb_version}" != "${prometheus_orb_version}" ]]; then
+  if [[ "${orb_version}" != "null" && "${orb_version}" != "${prometheus_orb_version}" ]]; then
     echo "CircleCI-orb"
   fi
 }


### PR DESCRIPTION
Don't sync the Prometheus CircleCI orb version if it's not used by the
repo's config.

Signed-off-by: Ben Kochie <superq@gmail.com>