### PR TITLE
Add "graph rules" command(s) to promtool

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -46,6 +46,7 @@ import (
 	_ "github.com/prometheus/prometheus/discovery/install" // Register service discovery implementations.
 	"github.com/prometheus/prometheus/discovery/kubernetes"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"github.com/prometheus/prometheus/pkg/rulegraph"
 )
 
 func main() {
@@ -75,6 +76,7 @@ func main() {
 
 	checkMetricsCmd := checkCmd.Command("metrics", checkMetricsUsage)
 
+	graphCmd := app.Command("graph", "Graph resources.")
 	graphRulesCmd := graphCmd.Command("rules", "Check rules, if they are all OK, prepare a graph of how metrics are used.")
 	graphRuleFiles := graphRulesCmd.Arg(
 		"rule-files",

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -476,7 +476,8 @@ func GraphRules(files ...string) int {
 		return 1
 	}
 
-	rulegraph.BuildRuleDiagram(allGroups, os.Stdout)
+	graph := rulegraph.BuildRuleDiagram(allGroups)
+	rulegraph.EmitGraph(graph, os.Stdout)
 	return 0
 }
 

--- a/pkg/rulegraph/rulegraph.go
+++ b/pkg/rulegraph/rulegraph.go
@@ -1,0 +1,137 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rulegraph
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+type ruleType uint8
+
+const (
+	recorded ruleType = 0
+	alert    ruleType = 1
+)
+
+type metricFinder struct {
+	names  []string
+	visits int
+}
+
+func (mf *metricFinder) Visit(node parser.Node, path []parser.Node) (parser.Visitor, error) {
+	if node == nil && path == nil {
+		return nil, nil
+	}
+
+	mf.visits++
+
+	if vs, ok := node.(*parser.VectorSelector); ok {
+		mf.names = append(mf.names, vs.Name)
+		return nil, nil
+	}
+
+	return mf, nil
+}
+
+// Return all dependency edges from a single rule, this is basically
+// "record/alerd name -> <each metric used in the expr>" with all
+// label filters stripped out.
+func diagramEdges(r rulefmt.RuleNode) []string {
+	var acc []string
+
+	name := ruleName(r)
+	parsed, err := parser.ParseExpr(r.Expr.Value)
+	if err != nil {
+		// This should already have been verified
+		return acc
+	}
+
+	var mf metricFinder
+	err = parser.Walk(&mf, parsed, nil)
+	if err != nil {
+		return acc
+	}
+
+	for _, next := range mf.names {
+		acc = append(acc, fmt.Sprintf("%s -> %s", name, next))
+	}
+
+	return acc
+}
+
+func getType(r rulefmt.RuleNode) ruleType {
+	if r.Record.Value == "" {
+		return alert
+	}
+
+	return recorded
+}
+
+func ruleName(r rulefmt.RuleNode) string {
+	name := r.Record.Value
+	if name == "" {
+		name = r.Alert.Value
+	}
+
+	if i := strings.Index(name, "{"); i >= 0 {
+		name = name[0:i]
+	}
+
+	return name
+}
+
+// Build a diagram of the interdependency of all rule files passed
+// in. We expect that these have already been checked for errors and
+// passed that check.
+//
+// When we have processed these, simply serialise the graph as a DOT
+// graph to w.
+func BuildRuleDiagram(groups []rulefmt.RuleGroup, w io.Writer) {
+	nodes := make(map[string]ruleType)
+	edges := make(map[string]bool)
+
+	for _, group := range groups {
+		for _, rule := range group.Rules {
+			nodes[ruleName(rule)] = getType(rule)
+			for _, edge := range diagramEdges(rule) {
+				edges[edge] = true
+			}
+		}
+	}
+
+	fmt.Fprintf(w, "digraph {\n")
+	for name, t := range nodes {
+		switch {
+		case t == recorded:
+			fmt.Fprintf(w, "  %s [shape=oval]\n", name)
+		case t == alert:
+			fmt.Fprintf(w, "  %s [shape=doubleoctagon]", name)
+		default:
+			fmt.Fprintf(w, "  /* Unknown node type %v for %s */\n", t, name)
+		}
+	}
+
+	fmt.Fprintf(w, "\n")
+
+	for edge, _ := range edges {
+		fmt.Fprintf(w, "  %s\n", edge)
+	}
+
+	fmt.Fprintf(w, "}\n")
+}

--- a/pkg/rulegraph/rulegraph_test.go
+++ b/pkg/rulegraph/rulegraph_test.go
@@ -1,0 +1,49 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rulegraph
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+func TestMetricFinder(t *testing.T) {
+	cases := []struct {
+		expr string
+		want []string
+	}{
+		{"a+b", []string{"a", "b"}},
+		{"max_over_time(a[1h]) > 3", []string{"a"}},
+	}
+
+	for ix, c := range cases {
+		var mf metricFinder
+		expr, err := parser.ParseExpr(c.expr)
+		if err != nil {
+			t.Errorf("Case #%d, unexpected error: %v", ix, err)
+			continue
+		}
+
+		parser.Walk(&mf, expr, nil)
+		want := strings.Join(c.want, ",")
+		sort.Strings(mf.names)
+		saw := strings.Join(mf.names, ",")
+		if saw != want {
+			t.Errorf("Case #%d, saw %s want %s", ix, saw, want)
+		}
+	}
+}

--- a/pkg/rulegraph/rulegraph_test.go
+++ b/pkg/rulegraph/rulegraph_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
-func TestMetricFinder(t *testing.T) {
+func TestGraphFinder(t *testing.T) {
 	cases := []struct {
 		expr string
 		want []string
@@ -31,7 +31,7 @@ func TestMetricFinder(t *testing.T) {
 	}
 
 	for ix, c := range cases {
-		var mf metricFinder
+		var mf Graph
 		expr, err := parser.ParseExpr(c.expr)
 		if err != nil {
 			t.Errorf("Case #%d, unexpected error: %v", ix, err)
@@ -40,8 +40,8 @@ func TestMetricFinder(t *testing.T) {
 
 		parser.Walk(&mf, expr, nil)
 		want := strings.Join(c.want, ",")
-		sort.Strings(mf.names)
-		saw := strings.Join(mf.names, ",")
+		sort.Strings(mf.nexts)
+		saw := strings.Join(mf.nexts, ",")
 		if saw != want {
 			t.Errorf("Case #%d, saw %s want %s", ix, saw, want)
 		}


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This adds one (well, technically two) commands to promtool to allow users to generate GraphViz graphs of rule dependencies.