### PR TITLE
Added test to reproduce panic on TSDB head chunks truncated while querying

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3125,12 +3125,131 @@ func TestNoPanicOnTSDBOpenError(t *testing.T) {
 	require.NoError(t, lockf.Release())
 }
 
+func TestQuerier_ShouldNotPanicIfHeadChunkIsTruncatedWhileReadingQueriedChunks(t *testing.T) {
+	const (
+		numSeries                = 1000
+		numStressIterations      = 10000
+		minStressAllocationBytes = 1 * 1024 * 1024
+		maxStressAllocationBytes = 2 * 1024 * 1024
+	)
+
+	db := openTestDB(t, nil, nil)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	// Disable compactions so we can control it.
+	db.DisableCompactions()
+
+	// Generate the metrics we're going to append.
+	metrics := make([]labels.Labels, 0, numSeries)
+	for i := 0; i < numSeries; i++ {
+		metrics = append(metrics, labels.Labels{{Name: labels.MetricName, Value: fmt.Sprintf("test_%d", i)}})
+	}
+
+	// Push 1 sample every 15s for 2x the block duration period.
+	ctx := context.Background()
+	interval := int64(15 * time.Second / time.Millisecond)
+	ts := int64(0)
+
+	for ; ts < 2*DefaultBlockDuration; ts += interval {
+		app := db.Appender(ctx)
+
+		for _, metric := range metrics {
+			_, err := app.Append(0, metric, ts, float64(ts))
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, app.Commit())
+	}
+
+	// Compact the TSDB head for the first time. We expect the head chunks file has been cut.
+	require.NoError(t, db.Compact())
+	require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.headTruncateTotal))
+
+	// Push more samples for another 1x block duration period.
+	for ; ts < 3*DefaultBlockDuration; ts += interval {
+		app := db.Appender(ctx)
+
+		for _, metric := range metrics {
+			_, err := app.Append(0, metric, ts, float64(ts))
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, app.Commit())
+	}
+
+	// At this point we expect 2 mmap-ed head chunks.
+
+	// Get a querier and make sure it's closed only once the test is over.
+	querier, err := db.Querier(ctx, 0, math.MaxInt64)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, querier.Close())
+	}()
+
+	// Query back all series.
+	hints := &storage.SelectHints{Start: 0, End: math.MaxInt64, Step: interval}
+	seriesSet := querier.Select(true, hints, labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, ".+"))
+
+	// Fetch samples iterators from all series.
+	var iterators []chunkenc.Iterator
+	actualSeries := 0
+	for seriesSet.Next() {
+		actualSeries++
+
+		// Get the iterator and call Next() so that we're sure the chunk is loaded.
+		it := seriesSet.At().Iterator()
+		it.Next()
+		it.At()
+
+		iterators = append(iterators, it)
+	}
+	require.NoError(t, seriesSet.Err())
+	require.Equal(t, actualSeries, numSeries)
+
+	// Compact the TSDB head again.
+	require.NoError(t, db.Compact())
+	require.Equal(t, float64(2), prom_testutil.ToFloat64(db.Head().metrics.headTruncateTotal))
+
+	// At this point we expect 1 head chunk has been deleted.
+
+	// Stress the memory and call GC. This is required to increase the chances
+	// the chunk memory area is released to the kernel.
+	var buf []byte
+	for i := 0; i < numStressIterations; i++ {
+		buf = append(buf, make([]byte, minStressAllocationBytes+rand.Int31n(maxStressAllocationBytes-minStressAllocationBytes))...)
+		if i%1000 == 0 {
+			buf = nil
+		}
+	}
+	runtime.GC()
+
+	// Iterate samples. Here we're summing it just to make sure no golang compiler
+	// optimization triggers in case we discard the result of it.At().
+	var sum float64
+	var firstErr error
+	for _, it := range iterators {
+		for it.Next() {
+			_, v := it.At()
+			sum += v
+		}
+
+		if err := it.Err(); err != nil {
+			firstErr = err
+		}
+	}
+
+	// After having iterated all samples we also want to be sure no error occurred.
+	require.NoError(t, firstErr)
+}
+
 func TestChunkQuerier_ShouldNotPanicIfHeadChunkIsTruncatedWhileReadingQueriedChunks(t *testing.T) {
 	const (
-		numSeries                = 100
+		numSeries                = 1000
 		numStressIterations      = 10000
-		minStressAllocationBytes = 100 * 1024
-		maxStressAllocationBytes = 1024 * 1024
+		minStressAllocationBytes = 1 * 1024 * 1024
+		maxStressAllocationBytes = 2 * 1024 * 1024
 	)
 
 	db := openTestDB(t, nil, nil)
@@ -3184,9 +3303,9 @@ func TestChunkQuerier_ShouldNotPanicIfHeadChunkIsTruncatedWhileReadingQueriedChu
 	// Get a querier and make sure it's closed only once the test is over.
 	querier, err := db.ChunkQuerier(ctx, 0, math.MaxInt64)
 	require.NoError(t, err)
-	t.Cleanup(func() {
+	defer func() {
 		require.NoError(t, querier.Close())
-	})
+	}()
 
 	// Query back all series.
 	hints := &storage.SelectHints{Start: 0, End: math.MaxInt64, Step: interval}
@@ -3215,7 +3334,7 @@ func TestChunkQuerier_ShouldNotPanicIfHeadChunkIsTruncatedWhileReadingQueriedChu
 	var buf []byte
 	for i := 0; i < numStressIterations; i++ {
 		buf = append(buf, make([]byte, minStressAllocationBytes+rand.Int31n(maxStressAllocationBytes-minStressAllocationBytes))...)
-		if i%100 == 0 {
+		if i%1000 == 0 {
 			buf = nil
 		}
 	}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"sync"
@@ -41,6 +42,7 @@ import (
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/index"
@@ -3121,4 +3123,112 @@ func TestNoPanicOnTSDBOpenError(t *testing.T) {
 	require.Error(t, err)
 
 	require.NoError(t, lockf.Release())
+}
+
+func TestChunkQuerier_ShouldNotPanicIfHeadChunkIsTruncatedWhileReadingQueriedChunks(t *testing.T) {
+	const (
+		numSeries                = 100
+		numStressIterations      = 10000
+		minStressAllocationBytes = 100 * 1024
+		maxStressAllocationBytes = 1024 * 1024
+	)
+
+	db := openTestDB(t, nil, nil)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	// Disable compactions so we can control it.
+	db.DisableCompactions()
+
+	// Generate the metrics we're going to append.
+	metrics := make([]labels.Labels, 0, numSeries)
+	for i := 0; i < numSeries; i++ {
+		metrics = append(metrics, labels.Labels{{Name: labels.MetricName, Value: fmt.Sprintf("test_%d", i)}})
+	}
+
+	// Push 1 sample every 15s for 2x the block duration period.
+	ctx := context.Background()
+	interval := int64(15 * time.Second / time.Millisecond)
+	ts := int64(0)
+
+	for ; ts < 2*DefaultBlockDuration; ts += interval {
+		app := db.Appender(ctx)
+
+		for _, metric := range metrics {
+			_, err := app.Append(0, metric, ts, float64(ts))
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, app.Commit())
+	}
+
+	// Compact the TSDB head for the first time. We expect the head chunks file has been cut.
+	require.NoError(t, db.Compact())
+	require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.headTruncateTotal))
+
+	// Push more samples for another 1x block duration period.
+	for ; ts < 3*DefaultBlockDuration; ts += interval {
+		app := db.Appender(ctx)
+
+		for _, metric := range metrics {
+			_, err := app.Append(0, metric, ts, float64(ts))
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, app.Commit())
+	}
+
+	// At this point we expect 2 mmap-ed head chunks.
+
+	// Get a querier and make sure it's closed only once the test is over.
+	querier, err := db.ChunkQuerier(ctx, 0, math.MaxInt64)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, querier.Close())
+	})
+
+	// Query back all series.
+	hints := &storage.SelectHints{Start: 0, End: math.MaxInt64, Step: interval}
+	seriesSet := querier.Select(true, hints, labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, ".+"))
+
+	// Iterate all series and get their chunks.
+	var chunks []chunkenc.Chunk
+	actualSeries := 0
+	for seriesSet.Next() {
+		actualSeries++
+		for it := seriesSet.At().Iterator(); it.Next(); {
+			chunks = append(chunks, it.At().Chunk)
+		}
+	}
+	require.NoError(t, seriesSet.Err())
+	require.Equal(t, actualSeries, numSeries)
+
+	// Compact the TSDB head again.
+	require.NoError(t, db.Compact())
+	require.Equal(t, float64(2), prom_testutil.ToFloat64(db.Head().metrics.headTruncateTotal))
+
+	// At this point we expect 1 head chunk has been deleted.
+
+	// Stress the memory and call GC. This is required to increase the chances
+	// the chunk memory area is released to the kernel.
+	var buf []byte
+	for i := 0; i < numStressIterations; i++ {
+		buf = append(buf, make([]byte, minStressAllocationBytes+rand.Int31n(maxStressAllocationBytes-minStressAllocationBytes))...)
+		if i%100 == 0 {
+			buf = nil
+		}
+	}
+	runtime.GC()
+
+	// Iterate chunks and read their bytes slice. Here we're computing the CRC32
+	// just to iterate through the bytes slice. We don't really care the reason why
+	// we read this data, we just need to read it to make sure the memory address
+	// of the []byte is still valid.
+	chkCRC32 := newCRC32()
+	for _, chunk := range chunks {
+		chkCRC32.Reset()
+		_, err := chkCRC32.Write(chunk.Bytes())
+		require.NoError(t, err)
+	}
 }


### PR DESCRIPTION
I'm investigating a panic we've seen in Cortex https://github.com/cortexproject/cortex/issues/3907, which looks related to https://github.com/prometheus/prometheus/issues/8318 and https://github.com/prometheus/prometheus/issues/8217.

In this PR I'm adding a unit test to reproduce it (clearly we can't merge this PR, but it's just to show it).

## Theory

My theory, which looks confirmed by this unit test, is that `bstream.stream` is invalid because it was a slice from mmap-ed chunks which has been unmmap-ed.

This about this use case:

1. A query run tsdb.Querier().Select() in the ingester
2. The Select() returns a SeriesSet with a series referencing an mmap-ed chunk
3. TSDB `Compact()` un-mmaps the head chunk
4. The SeriesSet gets iterated and when it's the time to read the chunk []byte it's invalid because unmmap-ed

## Unit test

When I run the unit test, it panics with this stack trace:

```
unexpected fault address 0x2d56cad3
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x2d56cad3 pc=0x113f95c]

goroutine 20 [running]:
runtime.throw(0x16c6fae, 0x5)
	/usr/local/Cellar/go@1.14/1.14.9/libexec/src/runtime/panic.go:1116 +0x72 fp=0xc0001c1308 sp=0xc0001c12d8 pc=0x10362f2
runtime.sigpanic()
	/usr/local/Cellar/go@1.14/1.14.9/libexec/src/runtime/signal_unix.go:702 +0x3cc fp=0xc0001c1338 sp=0xc0001c1308 pc=0x104cb7c
hash/crc32.castagnoliSSE42(0xb6000000ffffffff, 0x2d56cad3, 0x146, 0x7fdd52d, 0x162bbe0, 0x16b4000, 0x2d1da68, 0xc0001c13c8, 0x1105519, 0xc0001eafc0, ...)
	/usr/local/Cellar/go@1.14/1.14.9/libexec/src/hash/crc32/crc32_amd64.s:32 +0x2c fp=0xc0001c1340 sp=0xc0001c1338 pc=0x113f95c
hash/crc32.archUpdateCastagnoli(0x0, 0x2d56cad3, 0x146, 0x7fdd52d, 0x146)
	/usr/local/Cellar/go@1.14/1.14.9/libexec/src/hash/crc32/crc32_amd64.go:189 +0x3d1 fp=0xc0001c13e8 sp=0xc0001c1340 pc=0x113f331
hash/crc32.(*digest).Write(0xc000116010, 0x2d56cad3, 0x146, 0x7fdd52d, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go@1.14/1.14.9/libexec/src/hash/crc32/crc32.go:227 +0xff fp=0xc0001c1428 sp=0xc0001c13e8 pc=0x113eadf
github.com/prometheus/prometheus/tsdb.TestChunkQuerier_ShouldNotPanicIfHeadChunkIsTruncatedWhileReadingQueriedChunks(0xc0001eafc0)
	/Users/marco/workspace/src/github.com/prometheus/prometheus/tsdb/db_test.go:3231 +0x106a fp=0xc0001c1f80 sp=0xc0001c1428 pc=0x152b1fa
testing.tRunner(0xc0001eafc0, 0x16ee7e0)
	/usr/local/Cellar/go@1.14/1.14.9/libexec/src/testing/testing.go:1054 +0xdc fp=0xc0001c1fd0 sp=0xc0001c1f80 pc=0x1105e2c
runtime.goexit()
	/usr/local/Cellar/go@1.14/1.14.9/libexec/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc0001c1fd8 sp=0xc0001c1fd0 pc=0x1068321
created by testing.(*T).Run
	/usr/local/Cellar/go@1.14/1.14.9/libexec/src/testing/testing.go:1105 +0x372
```