### PR TITLE
Add Support for OAuth 2.0 Authorization for Remote Write Requests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -629,6 +629,7 @@ type RemoteWriteConfig struct {
 	QueueConfig      QueueConfig             `yaml:"queue_config,omitempty"`
 	MetadataConfig   MetadataConfig          `yaml:"metadata_config,omitempty"`
 	SigV4Config      *SigV4Config            `yaml:"sigv4,omitempty"`
+	OAuth2Config     *OAuth2Config           `yaml:"oauth2,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.
@@ -665,8 +666,8 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 	httpClientConfigAuthEnabled := c.HTTPClientConfig.BasicAuth != nil ||
 		c.HTTPClientConfig.Authorization != nil
 
-	if httpClientConfigAuthEnabled && c.SigV4Config != nil {
-		return fmt.Errorf("at most one of basic_auth, authorization, & sigv4 must be configured")
+	if (httpClientConfigAuthEnabled && (c.SigV4Config != nil || c.OAuth2Config != nil)) || (c.SigV4Config != nil && c.OAuth2Config != nil) {
+		return fmt.Errorf("at most one of basic_auth, authorization, sigv4, & oauth2 must be configured")
 	}
 
 	return nil
@@ -727,6 +728,10 @@ type SigV4Config struct {
 	SecretKey config.Secret `yaml:"secret_key,omitempty"`
 	Profile   string        `yaml:"profile,omitempty"`
 	RoleARN   string        `yaml:"role_arn,omitempty"`
+}
+
+type OAuth2Config struct {
+	AccessToken string `yaml:"access_token,omitempty"`
 }
 
 // RemoteReadConfig is the configuration for reading from remote storage.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2037,6 +2037,11 @@ sigv4:
   # AWS Role ARN, an alternative to using AWS API keys.
   [ role_arn: <string> ]
 
+# Optionally configures OAuth 2.0 authorization for requests.
+oauth2:
+    # Your access token with the needed scopes.
+    [ access_token: <string> ]
+
 # Configures the remote write request's TLS settings.
 tls_config:
   [ <tls_config> ]

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -98,6 +98,7 @@ type ClientConfig struct {
 	Timeout          model.Duration
 	HTTPClientConfig config_util.HTTPClientConfig
 	SigV4Config      *config.SigV4Config
+	OAuth2Config     *config.OAuth2Config
 	Headers          map[string]string
 	RetryOnRateLimit bool
 }
@@ -147,6 +148,10 @@ func NewWriteClient(name string, conf *ClientConfig) (WriteClient, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if conf.OAuth2Config != nil {
+		t = newOAuth2RoundTripper(conf.OAuth2Config, httpClient.Transport)
 	}
 
 	if len(conf.Headers) > 0 {

--- a/storage/remote/oauth2.go
+++ b/storage/remote/oauth2.go
@@ -1,0 +1,44 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"net/http"
+
+	"github.com/prometheus/prometheus/config"
+)
+
+type oauth2RoundTripper struct {
+	token string
+	next  http.RoundTripper
+}
+
+// newOAuth2RoundTripper returns a new http.RoundTripper that will
+// authorize requests with a provided OAuth 2.0 access token.
+func newOAuth2RoundTripper(cfg *config.OAuth2Config, next http.RoundTripper) http.RoundTripper {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+
+	return &oauth2RoundTripper{
+		token: cfg.AccessToken,
+		next:  next,
+	}
+}
+
+func (rt *oauth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+
+	return rt.next.RoundTrip(req)
+}

--- a/storage/remote/oauth2_test.go
+++ b/storage/remote/oauth2_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/prometheus/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOAuth2RoundTripper(t *testing.T) {
+	token := "12345"
+	var gotReq *http.Request
+
+	rt := newOAuth2RoundTripper(&config.OAuth2Config{AccessToken: token}, promhttp.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotReq = req
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}))
+
+	client := &http.Client{Transport: rt}
+
+	req, err := http.NewRequest(http.MethodPost, "google.com", strings.NewReader("Hello, world!"))
+	require.NoError(t, err)
+
+	_, err = client.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, gotReq)
+
+	require.Equal(t, req.Header.Get("Authorization"), "Bearer "+token)
+}

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -136,6 +136,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			Timeout:          rwConf.RemoteTimeout,
 			HTTPClientConfig: rwConf.HTTPClientConfig,
 			SigV4Config:      rwConf.SigV4Config,
+			OAuth2Config:     rwConf.OAuth2Config,
 			Headers:          rwConf.Headers,
 			RetryOnRateLimit: rwConf.QueueConfig.RetryOnRateLimit,
 		})


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR adds support for OAuth 2.0 authorization on remote write requests by way of a provided `access_token`.