### PR TITLE
declare variable from "var" to "make"

### DIFF
--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -361,11 +361,11 @@ func TestHandlerQueuing(t *testing.T) {
 	go h.Run(nil)
 	defer h.Stop()
 
-	var alerts []*Alert
+	alerts := make([]*Alert, 20*maxBatchSize)
 	for i := range make([]struct{}, 20*maxBatchSize) {
-		alerts = append(alerts, &Alert{
+		alerts[i] = &Alert{
 			Labels: labels.FromStrings("alertname", fmt.Sprintf("%d", i)),
-		})
+		}
 	}
 
 	assertAlerts := func(expected []*Alert) {


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

## Which problem is this PR solving?
- declare variable from "var" to "make"

## Short description of the changes
- Because we have knowed the slice's length. So we can avoid using 'append' to enlarge the extra memory.