### PR TITLE
Update support link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,14 +7,16 @@ assignees: ''
 
 <!--
 
-    Please do *NOT* ask usage questions in Github issues.
+    Please do *NOT* ask support questions in Github issues.
 
-    If your issue is not a feature request or bug report use:
-    https://groups.google.com/forum/#!forum/prometheus-users. If
-    you are unsure whether you hit a bug, search and ask in the
-    mailing list first.
+    If your issue is not a feature request or bug report use our
+    community support.
 
-    You can find more information at: https://prometheus.io/community/
+    https://prometheus.io/community/
+
+    There is also commercial support available.
+
+    https://prometheus.io/support-training/
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Users mailing list
-    url: https://groups.google.com/forum/#!forum/prometheus-users
-    about: Please ask and answer usage questions here.
-  - name: Prometheus community
+  - name: Prometheus Community Support
     url: https://prometheus.io/community/
-    about: List of communication channels for the Prometheus community.
+    about: If you need help or support, please request help here.
+  - name: Commercial Support & Training
+    url: https://prometheus.io/support-training/
+    about: If you want commercial support or training, vendors are listed here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,14 +8,16 @@ assignees: ''
 
 <!--
 
-    Please do *NOT* ask usage questions in Github issues.
+    Please do *NOT* ask support questions in Github issues.
 
-    If your issue is not a feature request or bug report use:
-    https://groups.google.com/forum/#!forum/prometheus-users. If
-    you are unsure whether you hit a bug, search and ask in the
-    mailing list first.
+    If your issue is not a feature request or bug report use our
+    community support.
 
-    You can find more information at: https://prometheus.io/community/
+    https://prometheus.io/community/
+
+    There is also commercial support available.
+
+    https://prometheus.io/support-training/
 
 -->
 ## Proposal


### PR DESCRIPTION
Simplify "I need help" wording and links
* Point directly prometheus.io/community.
* Add link to commercial support page.

Signed-off-by: Ben Kochie <superq@gmail.com>