### PR TITLE
Correct spelling of "iterable"

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -209,7 +209,7 @@ type ExemplarAppender interface {
 // SeriesSet contains a set of series.
 type SeriesSet interface {
 	Next() bool
-	// At returns full series. Returned series should be iteratable even after Next is called.
+	// At returns full series. Returned series should be iterable even after Next is called.
 	At() Series
 	// The error that iteration as failed with.
 	// When an error occurs, set cannot continue to iterate.
@@ -264,13 +264,13 @@ func ErrChunkSeriesSet(err error) ChunkSeriesSet {
 // Series exposes a single time series and allows iterating over samples.
 type Series interface {
 	Labels
-	SampleIteratable
+	SampleIterable
 }
 
 // ChunkSeriesSet contains a set of chunked series.
 type ChunkSeriesSet interface {
 	Next() bool
-	// At returns full chunk series. Returned series should be iteratable even after Next is called.
+	// At returns full chunk series. Returned series should be iterable even after Next is called.
 	At() ChunkSeries
 	// The error that iteration has failed with.
 	// When an error occurs, set cannot continue to iterate.
@@ -283,7 +283,7 @@ type ChunkSeriesSet interface {
 // ChunkSeries exposes a single time series and allows iterating over chunks.
 type ChunkSeries interface {
 	Labels
-	ChunkIteratable
+	ChunkIterable
 }
 
 // Labels represents an item that has labels e.g. time series.
@@ -292,12 +292,12 @@ type Labels interface {
 	Labels() labels.Labels
 }
 
-type SampleIteratable interface {
+type SampleIterable interface {
 	// Iterator returns a new, independent iterator of the data of the series.
 	Iterator() chunkenc.Iterator
 }
 
-type ChunkIteratable interface {
+type ChunkIterable interface {
 	// Iterator returns a new, independent iterator that iterates over potentially overlapping
 	// chunks of the series, sorted by min time.
 	Iterator() chunks.Iterator

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -453,7 +453,7 @@ func (b *blockBaseSeriesSet) Next() bool {
 
 		var trimFront, trimBack bool
 
-		// Copy chunks as iteratables are reusable.
+		// Copy chunks as iterables are reusable.
 		chks := make([]chunks.Meta, 0, len(b.bufChks))
 
 		// Prefilter chunks and pick those which are not entirely deleted or totally outside of the requested range.


### PR DESCRIPTION
This fixes the spelling of `iter(at)able`, not too sure how much those interfaces are refereced and hence how disruptive this could turn out to be. 