### PR TITLE
Update Makefile.common

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -78,12 +78,12 @@ ifneq ($(shell which gotestsum),)
 endif
 endif
 
-PROMU_VERSION ?= 0.11.1
+PROMU_VERSION ?= 0.12.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.36.0
+GOLANGCI_LINT_VERSION ?= v1.39.0
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -387,7 +387,7 @@ func TestLabels_FromStrings(t *testing.T) {
 
 	require.Equal(t, expected, labels, "unexpected labelset")
 
-	require.Panics(t, func() { FromStrings("aaa", "111", "bbb") })
+	require.Panics(t, func() { FromStrings("aaa", "111", "bbb") }) //nolint:staticcheck // Ignore SA5012, error is intentional test.
 }
 
 func TestLabels_Compare(t *testing.T) {


### PR DESCRIPTION
* Bump promu to latest release.
* Bump golangci-lint to latest release.
* Add nolint to intentional error.

Signed-off-by: Ben Kochie <superq@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->