### PR TITLE
Bump cm-promql to v0.15.0

### DIFF
--- a/web/ui/react-app/package.json
+++ b/web/ui/react-app/package.json
@@ -20,7 +20,7 @@
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@reach/router": "^1.2.1",
     "bootstrap": "^4.2.1",
-    "codemirror-promql": "^0.14.1",
+    "codemirror-promql": "^0.15.0",
     "css.escape": "^1.5.1",
     "downshift": "^3.4.8",
     "enzyme-to-json": "^3.4.3",

--- a/web/ui/react-app/src/pages/graph/CMExpressionInput.test.tsx
+++ b/web/ui/react-app/src/pages/graph/CMExpressionInput.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import CMExpressionInput from './CMExpressionInput';
-import { Button, InputGroup, InputGroupAddon, Input } from 'reactstrap';
+import { Button, InputGroup, InputGroupAddon } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch, faSpinner } from '@fortawesome/free-solid-svg-icons';
 

--- a/web/ui/react-app/src/pages/graph/CMExpressionInput.tsx
+++ b/web/ui/react-app/src/pages/graph/CMExpressionInput.tsx
@@ -11,15 +11,15 @@ import { closeBrackets, closeBracketsKeymap } from '@codemirror/closebrackets';
 import { searchKeymap, highlightSelectionMatches } from '@codemirror/search';
 import { commentKeymap } from '@codemirror/comment';
 import { lintKeymap } from '@codemirror/lint';
-import { PromQLExtension } from 'codemirror-promql';
+import { PromQLExtension, CompleteStrategy } from 'codemirror-promql';
 import { autocompletion, completionKeymap, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import { theme, promqlHighlighter } from './CMTheme';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch, faSpinner, faGlobeEurope } from '@fortawesome/free-solid-svg-icons';
 import MetricsExplorer from './MetricsExplorer';
-import { CompleteStrategy, newCompleteStrategy } from 'codemirror-promql/complete';
 import { usePathPrefix } from '../../contexts/PathPrefixContext';
+import { newCompleteStrategy } from 'codemirror-promql/cjs/complete';
 
 const promqlExtension = new PromQLExtension();
 
@@ -102,7 +102,7 @@ const CMExpressionInput: FC<CMExpressionInputProps> = ({
       .setComplete({
         completeStrategy: new HistoryCompleteStrategy(
           newCompleteStrategy({
-            remote: { url: pathPrefix },
+            remote: { url: pathPrefix, cache: { initialMetricList: metricNames } },
           }),
           queryHistory
         ),

--- a/web/ui/react-app/yarn.lock
+++ b/web/ui/react-app/yarn.lock
@@ -3418,10 +3418,10 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
-codemirror-promql@^0.14.1:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/codemirror-promql/-/codemirror-promql-0.14.1.tgz#ea927f347effd7f28e4c1f87dcd8898d1681ea40"
-  integrity sha512-zAdvVrvehVToPBlwySVlTXCY3hzOMPgO1B0m7O6PBY5BUOYbNIDk+DSjrc7glUTwySUwkyWt/x7kDabGv4tXNg==
+codemirror-promql@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/codemirror-promql/-/codemirror-promql-0.15.0.tgz#dd6365ea5c2d18421d225cef12b74e64d8cab280"
+  integrity sha512-u5f6Narj8Kx79AHMPlr8vogGUhinZfsZVT00R7wStquDA3kRTvxfEBYK77UtWNNJshxC1B3EZnHzXN2K9RzVXw==
   dependencies:
     lezer-promql "^0.18.0"
     lru-cache "^6.0.0"


### PR DESCRIPTION
* upgrade `codemirror-promql` to [v0.15.0](https://github.com/prometheus-community/codemirror-promql/releases/tag/0.15.0)
* inject the `metricNames` coming from the `MetricExplorer` in the `PromQLExtension` (fix #8686)
* update the import paths accordingly to the changes provided by this new release.