### PR TITLE
Improve grouping label match logic

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2191,16 +2191,7 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 				lb.Del(labels.MetricName)
 				m = lb.Labels()
 			} else {
-				m = make(labels.Labels, 0, len(grouping))
-				for _, l := range metric {
-					for _, n := range grouping {
-						if l.Name == n {
-							m = append(m, l)
-							break
-						}
-					}
-				}
-				sort.Sort(m)
+				m = metric.WithLabels(grouping...)
 			}
 			result[groupingKey] = &groupedAggregation{
 				labels:     m,
@@ -2339,7 +2330,7 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 			continue // Bypass default append.
 
 		case parser.BOTTOMK:
-			// The heap keeps the lowest value on top, so reverse it.
+			// The heap keeps the highest value on top, so reverse it.
 			sort.Sort(sort.Reverse(aggr.reverseHeap))
 			for _, v := range aggr.reverseHeap {
 				enh.Out = append(enh.Out, Sample{


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

`Grouping` and `metric` are already sorted so we can use two pointer way to match them.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->