### PR TITLE
scaleway_sd_config: be more cautious with pointers

### DIFF
--- a/discovery/scaleway/instance.go
+++ b/discovery/scaleway/instance.go
@@ -134,23 +134,32 @@ func (d *instanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 	var targets []model.LabelSet
 	for _, server := range servers.Servers {
 		labels := model.LabelSet{
-			instanceBootTypeLabel:          model.LabelValue(server.BootType),
-			instanceHostnameLabel:          model.LabelValue(server.Hostname),
-			instanceIDLabel:                model.LabelValue(server.ID),
-			instanceImageArchLabel:         model.LabelValue(server.Image.Arch),
-			instanceImageIDLabel:           model.LabelValue(server.Image.ID),
-			instanceImageNameLabel:         model.LabelValue(server.Image.Name),
-			instanceLocationClusterID:      model.LabelValue(server.Location.ClusterID),
-			instanceLocationHypervisorID:   model.LabelValue(server.Location.HypervisorID),
-			instanceLocationNodeID:         model.LabelValue(server.Location.NodeID),
-			instanceNameLabel:              model.LabelValue(server.Name),
-			instanceOrganizationLabel:      model.LabelValue(server.Organization),
-			instanceProjectLabel:           model.LabelValue(server.Project),
-			instanceSecurityGroupIDLabel:   model.LabelValue(server.SecurityGroup.ID),
-			instanceSecurityGroupNameLabel: model.LabelValue(server.SecurityGroup.Name),
-			instanceStateLabel:             model.LabelValue(server.State),
-			instanceTypeLabel:              model.LabelValue(server.CommercialType),
-			instanceZoneLabel:              model.LabelValue(server.Zone.String()),
+			instanceBootTypeLabel:     model.LabelValue(server.BootType),
+			instanceHostnameLabel:     model.LabelValue(server.Hostname),
+			instanceIDLabel:           model.LabelValue(server.ID),
+			instanceNameLabel:         model.LabelValue(server.Name),
+			instanceOrganizationLabel: model.LabelValue(server.Organization),
+			instanceProjectLabel:      model.LabelValue(server.Project),
+			instanceStateLabel:        model.LabelValue(server.State),
+			instanceTypeLabel:         model.LabelValue(server.CommercialType),
+			instanceZoneLabel:         model.LabelValue(server.Zone.String()),
+		}
+
+		if server.Image != nil {
+			labels[instanceImageArchLabel] = model.LabelValue(server.Image.Arch)
+			labels[instanceImageIDLabel] = model.LabelValue(server.Image.ID)
+			labels[instanceImageNameLabel] = model.LabelValue(server.Image.Name)
+		}
+
+		if server.Location != nil {
+			labels[instanceLocationClusterID] = model.LabelValue(server.Location.ClusterID)
+			labels[instanceLocationHypervisorID] = model.LabelValue(server.Location.HypervisorID)
+			labels[instanceLocationNodeID] = model.LabelValue(server.Location.NodeID)
+		}
+
+		if server.SecurityGroup != nil {
+			labels[instanceSecurityGroupIDLabel] = model.LabelValue(server.SecurityGroup.ID)
+			labels[instanceSecurityGroupNameLabel] = model.LabelValue(server.SecurityGroup.Name)
 		}
 
 		if region, err := server.Zone.Region(); err == nil {


### PR DESCRIPTION
cc @remyleone @sdurrheimer 

Fixes #8736 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->