### PR TITLE
Fix memSafeIterator.Seek()

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -2327,3 +2327,111 @@ func TestEngineOptsValidation(t *testing.T) {
 		}
 	}
 }
+
+func TestRangeQuery(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Load     string
+		Query    string
+		Result   parser.Value
+		Start    time.Time
+		End      time.Time
+		Interval time.Duration
+	}{
+		{
+			Name: "sum_over_time with all values",
+			Load: `load 30s
+              bar 0 1 10 100 1000`,
+			Query: "sum_over_time(bar[30s])",
+			Result: Matrix{Series{
+				Points: []Point{{V: 0, T: 0}, {V: 11, T: 60000}, {V: 1100, T: 120000}},
+				Metric: labels.Labels{}},
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(120, 0),
+			Interval: 60 * time.Second,
+		},
+		{
+			Name: "sum_over_time with trailing values",
+			Load: `load 30s
+              bar 0 1 10 100 1000 0 0 0 0`,
+			Query: "sum_over_time(bar[30s])",
+			Result: Matrix{Series{
+				Points: []Point{{V: 0, T: 0}, {V: 11, T: 60000}, {V: 1100, T: 120000}},
+				Metric: labels.Labels{}},
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(120, 0),
+			Interval: 60 * time.Second,
+		},
+		{
+			Name: "sum_over_time with all values long",
+			Load: `load 30s
+              bar 0 1 10 100 1000 10000 100000 1000000 10000000`,
+			Query: "sum_over_time(bar[30s])",
+			Result: Matrix{Series{
+				Points: []Point{{V: 0, T: 0}, {V: 11, T: 60000}, {V: 1100, T: 120000}, {V: 110000, T: 180000}, {V: 11000000, T: 240000}},
+				Metric: labels.Labels{}},
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(240, 0),
+			Interval: 60 * time.Second,
+		},
+		{
+			Name: "sum_over_time with all values random",
+			Load: `load 30s
+              bar 5 17 42 2 7 905 51`,
+			Query: "sum_over_time(bar[30s])",
+			Result: Matrix{Series{
+				Points: []Point{{V: 5, T: 0}, {V: 59, T: 60000}, {V: 9, T: 120000}, {V: 956, T: 180000}},
+				Metric: labels.Labels{}},
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(180, 0),
+			Interval: 60 * time.Second,
+		},
+		{
+			Name: "metric query",
+			Load: `load 30s
+              metric 1+1x4`,
+			Query: "metric",
+			Result: Matrix{Series{
+				Points: []Point{{V: 1, T: 0}, {V: 3, T: 60000}, {V: 5, T: 120000}},
+				Metric: labels.Labels{labels.Label{Name: "__name__", Value: "metric"}}},
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(120, 0),
+			Interval: 1 * time.Minute,
+		},
+		{
+			Name: "metric query with trailing values",
+			Load: `load 30s
+              metric 1+1x8`,
+			Query: "metric",
+			Result: Matrix{Series{
+				Points: []Point{{V: 1, T: 0}, {V: 3, T: 60000}, {V: 5, T: 120000}},
+				Metric: labels.Labels{labels.Label{Name: "__name__", Value: "metric"}}},
+			},
+			Start:    time.Unix(0, 0),
+			End:      time.Unix(120, 0),
+			Interval: 1 * time.Minute,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			test, err := NewTest(t, c.Load)
+			require.NoError(t, err)
+			defer test.Close()
+
+			err = test.Run()
+			require.NoError(t, err)
+
+			qry, err := test.QueryEngine().NewRangeQuery(test.Queryable(), c.Query, c.Start, c.End, c.Interval)
+			require.NoError(t, err)
+
+			res := qry.Exec(test.Context())
+			require.NoError(t, res.Err)
+			require.Equal(t, c.Result, res.Value)
+		})
+	}
+}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2538,6 +2538,23 @@ type memSafeIterator struct {
 	buf   [4]sample
 }
 
+func (it *memSafeIterator) Seek(t int64) bool {
+	if it.Err() != nil {
+		return false
+	}
+
+	ts, _ := it.At()
+
+	for t > ts || it.i == -1 {
+		if !it.Next() {
+			return false
+		}
+		ts, _ = it.At()
+	}
+
+	return true
+}
+
 func (it *memSafeIterator) Next() bool {
 	if it.i+1 >= it.stopAfter {
 		return false


### PR DESCRIPTION
Previously, calling `memSafeIterator.Seek()` would call the `Seek()` method on its embedded iterator (`stopIterator`):
https://github.com/prometheus/prometheus/blob/bcb70dc4630350d28ed175a0ea90e9ea189a0f39/tsdb/head.go#L2534-L2539

This was causing the embedded iterator and the `memSafeIterator` to get out of sync, because when the embedded `Seek()` moved to the next element of the embedded iterator, `memSafeIterator` didn't "know" about it. 

`memSafeIterator` has to "know" when the embedded iterator has moved to be able to work out when it should be reading from its buffer rather than the embedded iterator:
 https://github.com/prometheus/prometheus/blob/bcb70dc4630350d28ed175a0ea90e9ea189a0f39/tsdb/head.go#L2569-L2575

If you checkout the initial commit of this PR (https://github.com/prometheus/prometheus/commit/702d0c5dba30867bef756e2f065987a8669f5cc4), a couple of the added query range tests fail due to this bug, as they double count a point.

---

New `memSafeIterator.Seek()` method copies  `xorIterator.Seek()` behaviour (which in runtime is used as the embedded iterator).  `xorIterator.Seek()` implementation:
https://github.com/prometheus/prometheus/blob/bcb70dc4630350d28ed175a0ea90e9ea189a0f39/tsdb/chunkenc/xor.go#L257-L268

Behaviour: return false if the iterator has an error; try to move to next element if the required time hasn't been reached or if no elements have been read yet. 

The new method calls `memSafeIterator.Next()` so `memSafeIterator.i`, which keeps track of the current element, is always accurate.

cc @colega

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->