### PR TITLE
Fix Metric Names that Violate Naming Best Practices

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -83,7 +83,7 @@ var (
 	)
 	targetScrapePoolsFailed = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "prometheus_target_scrape_pools_failed_total",
+			Name: "prometheus_target_failed_scrape_pools_total",
 			Help: "Total number of scrape pool creations that failed.",
 		},
 	)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -222,7 +222,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			Help: "Total number of out of order samples ingestion failed attempts.",
 		}),
 		headTruncateFail: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "prometheus_tsdb_head_truncations_failed_total",
+			Name: "prometheus_tsdb_head_failed_truncations_total",
 			Help: "Total number of head truncations that failed.",
 		}),
 		headTruncateTotal: prometheus.NewCounter(prometheus.CounterOpts{
@@ -230,7 +230,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			Help: "Total number of head truncations attempted.",
 		}),
 		checkpointDeleteFail: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "prometheus_tsdb_checkpoint_deletions_failed_total",
+			Name: "prometheus_tsdb_checkpoint_failed_deletions_total",
 			Help: "Total number of checkpoint deletions that failed.",
 		}),
 		checkpointDeleteTotal: prometheus.NewCounter(prometheus.CounterOpts{
@@ -238,7 +238,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			Help: "Total number of checkpoint deletions attempted.",
 		}),
 		checkpointCreationFail: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "prometheus_tsdb_checkpoint_creations_failed_total",
+			Name: "prometheus_tsdb_checkpoint_failed_creations_total",
 			Help: "Total number of checkpoint creations that failed.",
 		}),
 		checkpointCreationTotal: prometheus.NewCounter(prometheus.CounterOpts{

--- a/tsdb/wal/wal.go
+++ b/tsdb/wal/wal.go
@@ -218,7 +218,7 @@ func newWALMetrics(r prometheus.Registerer) *walMetrics {
 		Help: "Total number of completed pages.",
 	})
 	m.truncateFail = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_wal_truncations_failed_total",
+		Name: "prometheus_tsdb_wal_failed_truncations_total",
 		Help: "Total number of WAL truncations that failed.",
 	})
 	m.truncateTotal = prometheus.NewCounter(prometheus.CounterOpts{
@@ -230,7 +230,7 @@ func newWALMetrics(r prometheus.Registerer) *walMetrics {
 		Help: "WAL segment index that TSDB is currently writing to.",
 	})
 	m.writesFailed = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_wal_writes_failed_total",
+		Name: "prometheus_tsdb_wal_failed_writes_total",
 		Help: "Total number of WAL writes that failed.",
 	})
 


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR fixes as many metrics as I could find that violate the metrics naming best practices, namely having the unit modifier after the metric name. Related to prometheus/docs#1928.

Fixes #8718 