### PR TITLE
Add OAuth 2.0 Config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -663,10 +663,10 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 	}
 
 	httpClientConfigAuthEnabled := c.HTTPClientConfig.BasicAuth != nil ||
-		c.HTTPClientConfig.Authorization != nil
+		c.HTTPClientConfig.Authorization != nil || c.HTTPClientConfig.OAuth2 != nil
 
 	if httpClientConfigAuthEnabled && c.SigV4Config != nil {
-		return fmt.Errorf("at most one of basic_auth, authorization, & sigv4 must be configured")
+		return fmt.Errorf("at most one of basic_auth, authorization, oauth2 & sigv4 must be configured")
 	}
 
 	return nil
@@ -675,7 +675,7 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 func validateHeaders(headers map[string]string) error {
 	for header := range headers {
 		if strings.ToLower(header) == "authorization" {
-			return errors.New("authorization header must be changed via the basic_auth or authorization parameter")
+			return errors.New("authorization header must be changed via the basic_auth, authorization, sigv4, or oauth2 parameter")
 		}
 		if _, ok := reservedHeaders[strings.ToLower(header)]; ok {
 			return errors.Errorf("%s is a reserved header. It must not be changed", header)

--- a/config/config.go
+++ b/config/config.go
@@ -666,7 +666,7 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 		c.HTTPClientConfig.Authorization != nil || c.HTTPClientConfig.OAuth2 != nil
 
 	if httpClientConfigAuthEnabled && c.SigV4Config != nil {
-		return fmt.Errorf("at most one of basic_auth, authorization, oauth2 & sigv4 must be configured")
+		return fmt.Errorf("at most one of basic_auth, authorization, oauth2, & sigv4 must be configured")
 	}
 
 	return nil
@@ -675,7 +675,7 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 func validateHeaders(headers map[string]string) error {
 	for header := range headers {
 		if strings.ToLower(header) == "authorization" {
-			return errors.New("authorization header must be changed via the basic_auth, authorization, sigv4, or oauth2 parameter")
+			return errors.New("authorization header must be changed via the basic_auth, authorization, oauth2, or sigv4 parameter")
 		}
 		if _, ok := reservedHeaders[strings.ToLower(header)]; ok {
 			return errors.Errorf("%s is a reserved header. It must not be changed", header)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -93,11 +93,12 @@ var expectedConf = &Config{
 			QueueConfig:    DefaultQueueConfig,
 			MetadataConfig: DefaultMetadataConfig,
 			HTTPClientConfig: config.HTTPClientConfig{
-				OAuth2: config.OAuth2{
+				OAuth2: &config.OAuth2{
 					ClientID:     "123",
 					ClientSecret: "456",
 					TokenURL:     "http://remote1/auth",
 				},
+				FollowRedirects: true,
 			},
 		},
 		{
@@ -892,7 +893,7 @@ func TestElideSecrets(t *testing.T) {
 	yamlConfig := string(config)
 
 	matches := secretRe.FindAllStringIndex(yamlConfig, -1)
-	require.Equal(t, 12, len(matches), "wrong number of secret matches found")
+	require.Equal(t, 13, len(matches), "wrong number of secret matches found")
 	require.NotContains(t, yamlConfig, "mysecret",
 		"yaml marshal reveals authentication credentials.")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -995,7 +995,7 @@ var expectedErrors = []struct {
 		errMsg:   "at most one of bearer_token & bearer_token_file must be configured",
 	}, {
 		filename: "bearertoken_basicauth.bad.yml",
-		errMsg:   "at most one of basic_auth, bearer_token & bearer_token_file must be configured",
+		errMsg:   "at most one of basic_auth, oauth2, bearer_token & bearer_token_file must be configured",
 	}, {
 		filename: "kubernetes_http_config_without_api_server.bad.yml",
 		errMsg:   "to use custom HTTP client configuration please provide the 'api_server' URL explicitly",
@@ -1031,10 +1031,10 @@ var expectedErrors = []struct {
 		errMsg:   "invalid selector: 'metadata.status-Running'; can't understand 'metadata.status-Running'",
 	}, {
 		filename: "kubernetes_bearertoken_basicauth.bad.yml",
-		errMsg:   "at most one of basic_auth, bearer_token & bearer_token_file must be configured",
+		errMsg:   "at most one of basic_auth, oauth2, bearer_token & bearer_token_file must be configured",
 	}, {
 		filename: "kubernetes_authorization_basicauth.bad.yml",
-		errMsg:   "at most one of basic_auth & authorization must be configured",
+		errMsg:   "at most one of basic_auth, oauth2 & authorization must be configured",
 	}, {
 		filename: "marathon_no_servers.bad.yml",
 		errMsg:   "marathon_sd: must contain at least one Marathon server",
@@ -1079,7 +1079,7 @@ var expectedErrors = []struct {
 		errMsg:   `x-prometheus-remote-write-version is a reserved header. It must not be changed`,
 	}, {
 		filename: "remote_write_authorization_header.bad.yml",
-		errMsg:   `authorization header must be changed via the basic_auth or authorization parameter`,
+		errMsg:   `authorization header must be changed via the basic_auth, authorization, oauth2, or sigv4 parameter`,
 	}, {
 		filename: "remote_write_url_missing.bad.yml",
 		errMsg:   `url for remote_write is empty`,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -90,9 +90,15 @@ var expectedConf = &Config{
 					Action:       relabel.Drop,
 				},
 			},
-			QueueConfig:      DefaultQueueConfig,
-			MetadataConfig:   DefaultMetadataConfig,
-			HTTPClientConfig: config.DefaultHTTPClientConfig,
+			QueueConfig:    DefaultQueueConfig,
+			MetadataConfig: DefaultMetadataConfig,
+			HTTPClientConfig: config.HTTPClientConfig{
+				OAuth2: config.OAuth2{
+					ClientID:     "123",
+					ClientSecret: "456",
+					TokenURL:     "http://remote1/auth",
+				},
+			},
 		},
 		{
 			URL:            mustParseURL("http://remote2/push"),

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -19,6 +19,11 @@ remote_write:
     - source_labels: [__name__]
       regex:         expensive.*
       action:        drop
+    oauth2:
+      client_id: "123"
+      client_secret: "456"
+      token_url: "http://remote1/auth"
+        
   - url: http://remote2/push
     name: rw_tls
     tls_config:

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -23,7 +23,7 @@ remote_write:
       client_id: "123"
       client_secret: "456"
       token_url: "http://remote1/auth"
-        
+
   - url: http://remote2/push
     name: rw_tls
     tls_config:

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -473,6 +473,30 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
+# Optionally configures OAuth 2.0 authentication using the
+# client credentials grant type. Fetches the token from the
+# specified endpoint using the client access and secret keys.
+# Cannot be used at the same time as basic_auth, authorization, or sigv4.
+oauth2:
+  [ client_id: <string> ]
+  [ client_secret: <secret> ]
+	
+  # Read the client secret from a file instead of specifying the value
+  # in `client_secret`.
+  [ client_secret_file: <string> ]
+	
+  # Optionally specify scopes for the token.
+  scopes:
+    [ - <string> ... ]
+	
+  # The URL to fetch the token from.
+  [ token_url: <string> ]
+	
+  # Optional parameters to append to the token URL.
+  # Takes the form of `- name: value`.
+  endpoint_params:
+    [ <string>: <string> ... ]
+
 # Optional proxy URL.
 [ proxy_url: <string> ]
 
@@ -564,6 +588,30 @@ authorization:
   # Sets the credentials with the credentials read from the configured file.
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
+
+# Optionally configures OAuth 2.0 authentication using the
+# client credentials grant type. Fetches the token from the
+# specified endpoint using the client access and secret keys.
+# Cannot be used at the same time as basic_auth, authorization, or sigv4.
+oauth2:
+  [ client_id: <string> ]
+  [ client_secret: <secret> ]
+	
+  # Read the client secret from a file instead of specifying the value
+  # in `client_secret`.
+  [ client_secret_file: <string> ]
+	
+  # Optionally specify scopes for the token.
+  scopes:
+    [ - <string> ... ]
+	
+  # The URL to fetch the token from.
+  [ token_url: <string> ]
+	
+  # Optional parameters to append to the token URL.
+  # Takes the form of `- name: value`.
+  endpoint_params:
+    [ <string>: <string> ... ]
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
 [ follow_redirects: <bool> | default = true ]
@@ -722,6 +770,30 @@ authorization:
   # Sets the credentials with the credentials read from the configured file.
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
+
+# Optionally configures OAuth 2.0 authentication using the
+# client credentials grant type. Fetches the token from the
+# specified endpoint using the client access and secret keys.
+# Cannot be used at the same time as basic_auth, authorization, or sigv4.
+oauth2:
+  [ client_id: <string> ]
+  [ client_secret: <secret> ]
+	
+  # Read the client secret from a file instead of specifying the value
+  # in `client_secret`.
+  [ client_secret_file: <string> ]
+	
+  # Optionally specify scopes for the token.
+  scopes:
+    [ - <string> ... ]
+	
+  # The URL to fetch the token from.
+  [ token_url: <string> ]
+	
+  # Optional parameters to append to the token URL.
+  # Takes the form of `- name: value`.
+  endpoint_params:
+    [ <string>: <string> ... ]
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
 [ follow_redirects: <bool> | default = true ]
@@ -1131,6 +1203,30 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
+# Optionally configures OAuth 2.0 authentication using the
+# client credentials grant type. Fetches the token from the
+# specified endpoint using the client access and secret keys.
+# Cannot be used at the same time as basic_auth, authorization, or sigv4.
+oauth2:
+  [ client_id: <string> ]
+  [ client_secret: <secret> ]
+	
+  # Read the client secret from a file instead of specifying the value
+  # in `client_secret`.
+  [ client_secret_file: <string> ]
+	
+  # Optionally specify scopes for the token.
+  scopes:
+    [ - <string> ... ]
+	
+  # The URL to fetch the token from.
+  [ token_url: <string> ]
+	
+  # Optional parameters to append to the token URL.
+  # Takes the form of `- name: value`.
+  endpoint_params:
+    [ <string>: <string> ... ]
+
 # Optional proxy URL.
 [ proxy_url: <string> ]
 
@@ -1302,6 +1398,30 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
+# Optionally configures OAuth 2.0 authentication using the
+# client credentials grant type. Fetches the token from the
+# specified endpoint using the client access and secret keys.
+# Cannot be used at the same time as basic_auth, authorization, or sigv4.
+oauth2:
+  [ client_id: <string> ]
+  [ client_secret: <secret> ]
+	
+  # Read the client secret from a file instead of specifying the value
+  # in `client_secret`.
+  [ client_secret_file: <string> ]
+	
+  # Optionally specify scopes for the token.
+  scopes:
+    [ - <string> ... ]
+	
+  # The URL to fetch the token from.
+  [ token_url: <string> ]
+	
+  # Optional parameters to append to the token URL.
+  # Takes the form of `- name: value`.
+  endpoint_params:
+    [ <string>: <string> ... ]
+
 # Optional proxy URL.
 [ proxy_url: <string> ]
 
@@ -1401,6 +1521,30 @@ authorization:
   # Sets the credentials with the credentials read from the configured file.
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
+
+# Optionally configures OAuth 2.0 authentication using the
+# client credentials grant type. Fetches the token from the
+# specified endpoint using the client access and secret keys.
+# Cannot be used at the same time as basic_auth, authorization, or sigv4.
+oauth2:
+  [ client_id: <string> ]
+  [ client_secret: <secret> ]
+	
+  # Read the client secret from a file instead of specifying the value
+  # in `client_secret`.
+  [ client_secret_file: <string> ]
+	
+  # Optionally specify scopes for the token.
+  scopes:
+    [ - <string> ... ]
+	
+  # The URL to fetch the token from.
+  [ token_url: <string> ]
+	
+  # Optional parameters to append to the token URL.
+  # Takes the form of `- name: value`.
+  endpoint_params:
+    [ <string>: <string> ... ]
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
 [ follow_redirects: <bool> | default = true ]
@@ -1599,6 +1743,30 @@ authorization:
   # Sets the credentials with the credentials read from the configured file.
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
+
+# Optionally configures OAuth 2.0 authentication using the
+# client credentials grant type. Fetches the token from the
+# specified endpoint using the client access and secret keys.
+# Cannot be used at the same time as basic_auth, authorization, or sigv4.
+oauth2:
+  [ client_id: <string> ]
+  [ client_secret: <secret> ]
+	
+  # Read the client secret from a file instead of specifying the value
+  # in `client_secret`.
+  [ client_secret_file: <string> ]
+	
+  # Optionally specify scopes for the token.
+  scopes:
+    [ - <string> ... ]
+	
+  # The URL to fetch the token from.
+  [ token_url: <string> ]
+	
+  # Optional parameters to append to the token URL.
+  # Takes the form of `- name: value`.
+  endpoint_params:
+    [ <string>: <string> ... ]
 
 # Configures the scrape request's TLS settings.
 tls_config:
@@ -1878,6 +2046,30 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
+# Optionally configures OAuth 2.0 authentication using the
+# client credentials grant type. Fetches the token from the
+# specified endpoint using the client access and secret keys.
+# Cannot be used at the same time as basic_auth, authorization, or sigv4.
+oauth2:
+  [ client_id: <string> ]
+  [ client_secret: <secret> ]
+	
+  # Read the client secret from a file instead of specifying the value
+  # in `client_secret`.
+  [ client_secret_file: <string> ]
+	
+  # Optionally specify scopes for the token.
+  scopes:
+    [ - <string> ... ]
+	
+  # The URL to fetch the token from.
+  [ token_url: <string> ]
+	
+  # Optional parameters to append to the token URL.
+  # Takes the form of `- name: value`.
+  endpoint_params:
+    [ <string>: <string> ... ]
+
 # Configures the scrape request's TLS settings.
 tls_config:
   [ <tls_config> ]
@@ -2019,7 +2211,7 @@ authorization:
   [ credentials_file: <filename> ]
 
 # Optionally configures AWS's Signature Verification 4 signing process to
-# sign requests. Cannot be set at the same time as basic_auth or authorization.
+# sign requests. Cannot be set at the same time as basic_auth, authorization or oauth2.
 # To use the default credentials from the AWS SDK, use `sigv4: {}`.
 sigv4:
   # The AWS region. If blank, the region from the default credentials chain
@@ -2036,6 +2228,31 @@ sigv4:
 
   # AWS Role ARN, an alternative to using AWS API keys.
   [ role_arn: <string> ]
+
+# Optionally configures OAuth 2.0 authentication using the
+# client credentials grant type. Fetches the token from the
+# specified endpoint using the client access and secret keys.
+# Cannot be used at the same time as basic_auth, authorization, or sigv4.
+oauth2:
+  [ client_id: <string> ]
+  [ client_secret: <secret> ]
+	
+  # Read the client secret from a file instead of specifying the value
+  # in `client_secret`.
+  [ client_secret_file: <string> ]
+	
+  # Optionally specify scopes for the token.
+  scopes:
+    [ - <string> ... ]
+	
+  # The URL to fetch the token from.
+  [ token_url: <string> ]
+	
+  # Optional parameters to append to the token URL.
+  # Takes the form of `- name: value`.
+  endpoint_params:
+    [ <string>: <string> ... ]
+	
 
 # Configures the remote write request's TLS settings.
 tls_config:
@@ -2130,6 +2347,30 @@ authorization:
   # Sets the credentials with the credentials read from the configured file.
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
+
+# Optionally configures OAuth 2.0 authentication using the
+# client credentials grant type. Fetches the token from the
+# specified endpoint using the client access and secret keys.
+# Cannot be used at the same time as basic_auth, authorization, or sigv4.
+oauth2:
+  [ client_id: <string> ]
+  [ client_secret: <secret> ]
+	
+  # Read the client secret from a file instead of specifying the value
+  # in `client_secret`.
+  [ client_secret_file: <string> ]
+	
+  # Optionally specify scopes for the token.
+  scopes:
+    [ - <string> ... ]
+	
+  # The URL to fetch the token from.
+  [ token_url: <string> ]
+	
+  # Optional parameters to append to the token URL.
+  # Takes the form of `- name: value`.
+  endpoint_params:
+    [ <string>: <string> ... ]
 
 # Configures the remote read request's TLS settings.
 tls_config:

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -475,7 +475,8 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: [ <oauth2> ]
+oauth2: 
+  [ <oauth2> ]
 
 # Optional proxy URL.
 [ proxy_url: <string> ]
@@ -571,7 +572,8 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: [ <oauth2> ]
+oauth2: 
+  [ <oauth2> ]
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
 [ follow_redirects: <bool> | default = true ]
@@ -733,7 +735,8 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: [ <oauth2> ]
+oauth2: 
+  [ <oauth2> ]
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
 [ follow_redirects: <bool> | default = true ]
@@ -1145,7 +1148,8 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: [ <oauth2> ]
+oauth2: 
+  [ <oauth2> ]
 
 # Optional proxy URL.
 [ proxy_url: <string> ]
@@ -1320,7 +1324,8 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: [ <oauth2> ]
+oauth2: 
+  [ <oauth2> ]
 
 # Optional proxy URL.
 [ proxy_url: <string> ]
@@ -1424,7 +1429,8 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: [ <oauth2> ]
+oauth2: 
+  [ <oauth2> ]
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
 [ follow_redirects: <bool> | default = true ]
@@ -1626,7 +1632,8 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: [ <oauth2> ]
+oauth2: 
+  [ <oauth2> ]
 
 # Configures the scrape request's TLS settings.
 tls_config:
@@ -1908,7 +1915,8 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: [ <oauth2> ]
+oauth2: 
+  [ <oauth2> ]
 
 # Configures the scrape request's TLS settings.
 tls_config:
@@ -2071,7 +2079,8 @@ sigv4:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth, authorization, or sigv4.
-oauth2: [ <oauth2> ]
+oauth2: 
+  [ <oauth2> ]
 
 # Configures the remote write request's TLS settings.
 tls_config:
@@ -2169,7 +2178,8 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: [ <oauth2> ]
+oauth2: 
+  [ <oauth2> ]
 
 # Configures the remote read request's TLS settings.
 tls_config:
@@ -2200,7 +2210,7 @@ client_id: <string>
 # It is mutually exclusive with `client_secret`.
 [ client_secret_file: <filename> ]
 
-# Specify scopes for the token request.
+# Scopes for the token request.
 scopes:
   [ - <string> ... ]
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2073,7 +2073,6 @@ sigv4:
 # Cannot be used at the same time as basic_auth, authorization, or sigv4.
 oauth2: [ <oauth2> ]
 
-
 # Configures the remote write request's TLS settings.
 tls_config:
   [ <tls_config> ]
@@ -2194,11 +2193,11 @@ Prometheus fetches an access token from the specified endpoint with
 the given client access and secret keys.
 
 ```yaml
-[ client_id: <string> ]
+client_id: <string>
 [ client_secret: <secret> ]
 
-# Read the client secret from a file instead of specifying the value
-# in `client_secret`.
+# Read the client secret from a file.
+# It is mutually exclusive with `client_secret`.
 [ client_secret_file: <filename> ]
 
 # Specify scopes for the token request.
@@ -2206,7 +2205,7 @@ scopes:
   [ - <string> ... ]
 
 # The URL to fetch the token from.
-[ token_url: <string> ]
+token_url: <string>
 
 # Optional parameters to append to the token URL.
 endpoint_params:

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -180,6 +180,11 @@ authorization:
   # configured file. It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
+# Optional OAuth 2.0 configuration.
+# Cannot be used at the same time as basic_auth or authorization.
+oauth2:
+  [ <oauth2> ]
+
 # Configure whether scrape requests follow HTTP 3xx redirects.
 [ follow_redirects: <bool> | default = true ]
 
@@ -307,6 +312,32 @@ A `tls_config` allows configuring TLS connections.
 
 # Disable validation of the server certificate.
 [ insecure_skip_verify: <boolean> ]
+```
+
+### `oauth2`
+
+OAuth 2.0 authentication using the client credentials grant type.
+Prometheus fetches an access token from the specified endpoint with
+the given client access and secret keys.
+
+```yaml
+client_id: <string>
+[ client_secret: <secret> ]
+
+# Read the client secret from a file.
+# It is mutually exclusive with `client_secret`.
+[ client_secret_file: <filename> ]
+
+# Scopes for the token request.
+scopes:
+  [ - <string> ... ]
+
+# The URL to fetch the token from.
+token_url: <string>
+
+# Optional parameters to append to the token URL.
+endpoint_params:
+  [ <string>: <string> ... ]
 ```
 
 ### `<azure_sd_config>`
@@ -475,7 +506,7 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: 
+oauth2:
   [ <oauth2> ]
 
 # Optional proxy URL.
@@ -572,7 +603,7 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: 
+oauth2:
   [ <oauth2> ]
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
@@ -735,7 +766,7 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: 
+oauth2:
   [ <oauth2> ]
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
@@ -1148,7 +1179,7 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: 
+oauth2:
   [ <oauth2> ]
 
 # Optional proxy URL.
@@ -1324,7 +1355,7 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: 
+oauth2:
   [ <oauth2> ]
 
 # Optional proxy URL.
@@ -1429,7 +1460,7 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: 
+oauth2:
   [ <oauth2> ]
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
@@ -1632,7 +1663,7 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: 
+oauth2:
   [ <oauth2> ]
 
 # Configures the scrape request's TLS settings.
@@ -1915,7 +1946,7 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: 
+oauth2:
   [ <oauth2> ]
 
 # Configures the scrape request's TLS settings.
@@ -2079,7 +2110,7 @@ sigv4:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth, authorization, or sigv4.
-oauth2: 
+oauth2:
   [ <oauth2> ]
 
 # Configures the remote write request's TLS settings.
@@ -2178,7 +2209,7 @@ authorization:
 
 # Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
-oauth2: 
+oauth2:
   [ <oauth2> ]
 
 # Configures the remote read request's TLS settings.
@@ -2195,29 +2226,3 @@ tls_config:
 There is a list of
 [integrations](https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage)
 with this feature.
-
-### `oauth2`
-
-OAuth 2.0 authentication using the client credentials grant type.
-Prometheus fetches an access token from the specified endpoint with 
-the given client access and secret keys.
-
-```yaml
-client_id: <string>
-[ client_secret: <secret> ]
-
-# Read the client secret from a file.
-# It is mutually exclusive with `client_secret`.
-[ client_secret_file: <filename> ]
-
-# Scopes for the token request.
-scopes:
-  [ - <string> ... ]
-
-# The URL to fetch the token from.
-token_url: <string>
-
-# Optional parameters to append to the token URL.
-endpoint_params:
-  [ <string>: <string> ... ]
-```

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -473,7 +473,7 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication.
+# Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
 oauth2: [ <oauth2> ]
 
@@ -569,7 +569,7 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication.
+# Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
 oauth2: [ <oauth2> ]
 
@@ -731,7 +731,7 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication.
+# Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
 oauth2: [ <oauth2> ]
 
@@ -1143,7 +1143,7 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication.
+# Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
 oauth2: [ <oauth2> ]
 
@@ -1318,7 +1318,7 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication.
+# Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
 oauth2: [ <oauth2> ]
 
@@ -1422,7 +1422,7 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication.
+# Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
 oauth2: [ <oauth2> ]
 
@@ -1624,7 +1624,7 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication.
+# Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
 oauth2: [ <oauth2> ]
 
@@ -1906,7 +1906,7 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication.
+# Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth or authorization.
 oauth2: [ <oauth2> ]
 
@@ -2051,7 +2051,7 @@ authorization:
   [ credentials_file: <filename> ]
 
 # Optionally configures AWS's Signature Verification 4 signing process to
-# sign requests. Cannot be set at the same time as basic_auth, authorization or oauth2.
+# sign requests. Cannot be set at the same time as basic_auth, authorization, or oauth2.
 # To use the default credentials from the AWS SDK, use `sigv4: {}`.
 sigv4:
   # The AWS region. If blank, the region from the default credentials chain
@@ -2069,7 +2069,7 @@ sigv4:
   # AWS Role ARN, an alternative to using AWS API keys.
   [ role_arn: <string> ]
 
-# Optionally configures OAuth 2.0 authentication.
+# Optional OAuth 2.0 configuration.
 # Cannot be used at the same time as basic_auth, authorization, or sigv4.
 oauth2: [ <oauth2> ]
 
@@ -2168,10 +2168,9 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication.
-# Cannot be used at the same time as basic_auth, or authorization.
+# Optional OAuth 2.0 configuration.
+# Cannot be used at the same time as basic_auth or authorization.
 oauth2: [ <oauth2> ]
-
 
 # Configures the remote read request's TLS settings.
 tls_config:
@@ -2191,7 +2190,8 @@ with this feature.
 ### `oauth2`
 
 OAuth 2.0 authentication using the client credentials grant type.
-Fetches the token from the specified endpoint with the client access and secret keys.
+Prometheus fetches an access token from the specified endpoint with 
+the given client access and secret keys.
 
 ```yaml
 [ client_id: <string> ]
@@ -2201,7 +2201,7 @@ Fetches the token from the specified endpoint with the client access and secret 
 # in `client_secret`.
 [ client_secret_file: <filename> ]
 
-# Optionally specify scopes for the token.
+# Specify scopes for the token request.
 scopes:
   [ - <string> ... ]
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -473,29 +473,9 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication using the
-# client credentials grant type. Fetches the token from the
-# specified endpoint using the client access and secret keys.
-# Cannot be used at the same time as basic_auth, authorization, or sigv4.
-oauth2:
-  [ client_id: <string> ]
-  [ client_secret: <secret> ]
-
-  # Read the client secret from a file instead of specifying the value
-  # in `client_secret`.
-  [ client_secret_file: <string> ]
-
-  # Optionally specify scopes for the token.
-  scopes:
-    [ - <string> ... ]
-
-  # The URL to fetch the token from.
-  [ token_url: <string> ]
-
-  # Optional parameters to append to the token URL.
-  # Takes the form of `- name: value`.
-  endpoint_params:
-    [ <string>: <string> ... ]
+# Optionally configures OAuth 2.0 authentication.
+# Cannot be used at the same time as basic_auth or authorization.
+oauth2: [ <oauth2> ]
 
 # Optional proxy URL.
 [ proxy_url: <string> ]
@@ -589,29 +569,9 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication using the
-# client credentials grant type. Fetches the token from the
-# specified endpoint using the client access and secret keys.
-# Cannot be used at the same time as basic_auth, authorization, or sigv4.
-oauth2:
-  [ client_id: <string> ]
-  [ client_secret: <secret> ]
-
-  # Read the client secret from a file instead of specifying the value
-  # in `client_secret`.
-  [ client_secret_file: <string> ]
-
-  # Optionally specify scopes for the token.
-  scopes:
-    [ - <string> ... ]
-
-  # The URL to fetch the token from.
-  [ token_url: <string> ]
-
-  # Optional parameters to append to the token URL.
-  # Takes the form of `- name: value`.
-  endpoint_params:
-    [ <string>: <string> ... ]
+# Optionally configures OAuth 2.0 authentication.
+# Cannot be used at the same time as basic_auth or authorization.
+oauth2: [ <oauth2> ]
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
 [ follow_redirects: <bool> | default = true ]
@@ -771,29 +731,9 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication using the
-# client credentials grant type. Fetches the token from the
-# specified endpoint using the client access and secret keys.
-# Cannot be used at the same time as basic_auth, authorization, or sigv4.
-oauth2:
-  [ client_id: <string> ]
-  [ client_secret: <secret> ]
-
-  # Read the client secret from a file instead of specifying the value
-  # in `client_secret`.
-  [ client_secret_file: <string> ]
-
-  # Optionally specify scopes for the token.
-  scopes:
-    [ - <string> ... ]
-
-  # The URL to fetch the token from.
-  [ token_url: <string> ]
-
-  # Optional parameters to append to the token URL.
-  # Takes the form of `- name: value`.
-  endpoint_params:
-    [ <string>: <string> ... ]
+# Optionally configures OAuth 2.0 authentication.
+# Cannot be used at the same time as basic_auth or authorization.
+oauth2: [ <oauth2> ]
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
 [ follow_redirects: <bool> | default = true ]
@@ -1203,29 +1143,9 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication using the
-# client credentials grant type. Fetches the token from the
-# specified endpoint using the client access and secret keys.
-# Cannot be used at the same time as basic_auth, authorization, or sigv4.
-oauth2:
-  [ client_id: <string> ]
-  [ client_secret: <secret> ]
-
-  # Read the client secret from a file instead of specifying the value
-  # in `client_secret`.
-  [ client_secret_file: <string> ]
-
-  # Optionally specify scopes for the token.
-  scopes:
-    [ - <string> ... ]
-
-  # The URL to fetch the token from.
-  [ token_url: <string> ]
-
-  # Optional parameters to append to the token URL.
-  # Takes the form of `- name: value`.
-  endpoint_params:
-    [ <string>: <string> ... ]
+# Optionally configures OAuth 2.0 authentication.
+# Cannot be used at the same time as basic_auth or authorization.
+oauth2: [ <oauth2> ]
 
 # Optional proxy URL.
 [ proxy_url: <string> ]
@@ -1398,29 +1318,9 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication using the
-# client credentials grant type. Fetches the token from the
-# specified endpoint using the client access and secret keys.
-# Cannot be used at the same time as basic_auth, authorization, or sigv4.
-oauth2:
-  [ client_id: <string> ]
-  [ client_secret: <secret> ]
-
-  # Read the client secret from a file instead of specifying the value
-  # in `client_secret`.
-  [ client_secret_file: <string> ]
-
-  # Optionally specify scopes for the token.
-  scopes:
-    [ - <string> ... ]
-
-  # The URL to fetch the token from.
-  [ token_url: <string> ]
-
-  # Optional parameters to append to the token URL.
-  # Takes the form of `- name: value`.
-  endpoint_params:
-    [ <string>: <string> ... ]
+# Optionally configures OAuth 2.0 authentication.
+# Cannot be used at the same time as basic_auth or authorization.
+oauth2: [ <oauth2> ]
 
 # Optional proxy URL.
 [ proxy_url: <string> ]
@@ -1522,29 +1422,9 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication using the
-# client credentials grant type. Fetches the token from the
-# specified endpoint using the client access and secret keys.
-# Cannot be used at the same time as basic_auth, authorization, or sigv4.
-oauth2:
-  [ client_id: <string> ]
-  [ client_secret: <secret> ]
-
-  # Read the client secret from a file instead of specifying the value
-  # in `client_secret`.
-  [ client_secret_file: <string> ]
-
-  # Optionally specify scopes for the token.
-  scopes:
-    [ - <string> ... ]
-
-  # The URL to fetch the token from.
-  [ token_url: <string> ]
-
-  # Optional parameters to append to the token URL.
-  # Takes the form of `- name: value`.
-  endpoint_params:
-    [ <string>: <string> ... ]
+# Optionally configures OAuth 2.0 authentication.
+# Cannot be used at the same time as basic_auth or authorization.
+oauth2: [ <oauth2> ]
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
 [ follow_redirects: <bool> | default = true ]
@@ -1744,29 +1624,9 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication using the
-# client credentials grant type. Fetches the token from the
-# specified endpoint using the client access and secret keys.
-# Cannot be used at the same time as basic_auth, authorization, or sigv4.
-oauth2:
-  [ client_id: <string> ]
-  [ client_secret: <secret> ]
-
-  # Read the client secret from a file instead of specifying the value
-  # in `client_secret`.
-  [ client_secret_file: <string> ]
-
-  # Optionally specify scopes for the token.
-  scopes:
-    [ - <string> ... ]
-
-  # The URL to fetch the token from.
-  [ token_url: <string> ]
-
-  # Optional parameters to append to the token URL.
-  # Takes the form of `- name: value`.
-  endpoint_params:
-    [ <string>: <string> ... ]
+# Optionally configures OAuth 2.0 authentication.
+# Cannot be used at the same time as basic_auth or authorization.
+oauth2: [ <oauth2> ]
 
 # Configures the scrape request's TLS settings.
 tls_config:
@@ -2046,29 +1906,9 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication using the
-# client credentials grant type. Fetches the token from the
-# specified endpoint using the client access and secret keys.
-# Cannot be used at the same time as basic_auth, authorization, or sigv4.
-oauth2:
-  [ client_id: <string> ]
-  [ client_secret: <secret> ]
-
-  # Read the client secret from a file instead of specifying the value
-  # in `client_secret`.
-  [ client_secret_file: <string> ]
-
-  # Optionally specify scopes for the token.
-  scopes:
-    [ - <string> ... ]
-
-  # The URL to fetch the token from.
-  [ token_url: <string> ]
-
-  # Optional parameters to append to the token URL.
-  # Takes the form of `- name: value`.
-  endpoint_params:
-    [ <string>: <string> ... ]
+# Optionally configures OAuth 2.0 authentication.
+# Cannot be used at the same time as basic_auth or authorization.
+oauth2: [ <oauth2> ]
 
 # Configures the scrape request's TLS settings.
 tls_config:
@@ -2229,29 +2069,9 @@ sigv4:
   # AWS Role ARN, an alternative to using AWS API keys.
   [ role_arn: <string> ]
 
-# Optionally configures OAuth 2.0 authentication using the
-# client credentials grant type. Fetches the token from the
-# specified endpoint using the client access and secret keys.
+# Optionally configures OAuth 2.0 authentication.
 # Cannot be used at the same time as basic_auth, authorization, or sigv4.
-oauth2:
-  [ client_id: <string> ]
-  [ client_secret: <secret> ]
-
-  # Read the client secret from a file instead of specifying the value
-  # in `client_secret`.
-  [ client_secret_file: <string> ]
-
-  # Optionally specify scopes for the token.
-  scopes:
-    [ - <string> ... ]
-
-  # The URL to fetch the token from.
-  [ token_url: <string> ]
-
-  # Optional parameters to append to the token URL.
-  # Takes the form of `- name: value`.
-  endpoint_params:
-    [ <string>: <string> ... ]
+oauth2: [ <oauth2> ]
 
 
 # Configures the remote write request's TLS settings.
@@ -2348,29 +2168,10 @@ authorization:
   # It is mutually exclusive with `credentials`.
   [ credentials_file: <filename> ]
 
-# Optionally configures OAuth 2.0 authentication using the
-# client credentials grant type. Fetches the token from the
-# specified endpoint using the client access and secret keys.
-# Cannot be used at the same time as basic_auth, authorization, or sigv4.
-oauth2:
-  [ client_id: <string> ]
-  [ client_secret: <secret> ]
+# Optionally configures OAuth 2.0 authentication.
+# Cannot be used at the same time as basic_auth, or authorization.
+oauth2: [ <oauth2> ]
 
-  # Read the client secret from a file instead of specifying the value
-  # in `client_secret`.
-  [ client_secret_file: <string> ]
-
-  # Optionally specify scopes for the token.
-  scopes:
-    [ - <string> ... ]
-
-  # The URL to fetch the token from.
-  [ token_url: <string> ]
-
-  # Optional parameters to append to the token URL.
-  # Takes the form of `- name: value`.
-  endpoint_params:
-    [ <string>: <string> ... ]
 
 # Configures the remote read request's TLS settings.
 tls_config:
@@ -2386,3 +2187,28 @@ tls_config:
 There is a list of
 [integrations](https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage)
 with this feature.
+
+### `oauth2`
+
+OAuth 2.0 authentication using the client credentials grant type.
+Fetches the token from the specified endpoint with the client access and secret keys.
+
+```yaml
+[ client_id: <string> ]
+[ client_secret: <secret> ]
+
+# Read the client secret from a file instead of specifying the value
+# in `client_secret`.
+[ client_secret_file: <filename> ]
+
+# Optionally specify scopes for the token.
+scopes:
+  [ - <string> ... ]
+
+# The URL to fetch the token from.
+  [ token_url: <string> ]
+
+# Optional parameters to append to the token URL.
+endpoint_params:
+  [ <string>: <string> ... ]
+```

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -480,18 +480,18 @@ authorization:
 oauth2:
   [ client_id: <string> ]
   [ client_secret: <secret> ]
-	
+
   # Read the client secret from a file instead of specifying the value
   # in `client_secret`.
   [ client_secret_file: <string> ]
-	
+
   # Optionally specify scopes for the token.
   scopes:
     [ - <string> ... ]
-	
+
   # The URL to fetch the token from.
   [ token_url: <string> ]
-	
+
   # Optional parameters to append to the token URL.
   # Takes the form of `- name: value`.
   endpoint_params:
@@ -596,18 +596,18 @@ authorization:
 oauth2:
   [ client_id: <string> ]
   [ client_secret: <secret> ]
-	
+
   # Read the client secret from a file instead of specifying the value
   # in `client_secret`.
   [ client_secret_file: <string> ]
-	
+
   # Optionally specify scopes for the token.
   scopes:
     [ - <string> ... ]
-	
+
   # The URL to fetch the token from.
   [ token_url: <string> ]
-	
+
   # Optional parameters to append to the token URL.
   # Takes the form of `- name: value`.
   endpoint_params:
@@ -778,18 +778,18 @@ authorization:
 oauth2:
   [ client_id: <string> ]
   [ client_secret: <secret> ]
-	
+
   # Read the client secret from a file instead of specifying the value
   # in `client_secret`.
   [ client_secret_file: <string> ]
-	
+
   # Optionally specify scopes for the token.
   scopes:
     [ - <string> ... ]
-	
+
   # The URL to fetch the token from.
   [ token_url: <string> ]
-	
+
   # Optional parameters to append to the token URL.
   # Takes the form of `- name: value`.
   endpoint_params:
@@ -1210,18 +1210,18 @@ authorization:
 oauth2:
   [ client_id: <string> ]
   [ client_secret: <secret> ]
-	
+
   # Read the client secret from a file instead of specifying the value
   # in `client_secret`.
   [ client_secret_file: <string> ]
-	
+
   # Optionally specify scopes for the token.
   scopes:
     [ - <string> ... ]
-	
+
   # The URL to fetch the token from.
   [ token_url: <string> ]
-	
+
   # Optional parameters to append to the token URL.
   # Takes the form of `- name: value`.
   endpoint_params:
@@ -1405,18 +1405,18 @@ authorization:
 oauth2:
   [ client_id: <string> ]
   [ client_secret: <secret> ]
-	
+
   # Read the client secret from a file instead of specifying the value
   # in `client_secret`.
   [ client_secret_file: <string> ]
-	
+
   # Optionally specify scopes for the token.
   scopes:
     [ - <string> ... ]
-	
+
   # The URL to fetch the token from.
   [ token_url: <string> ]
-	
+
   # Optional parameters to append to the token URL.
   # Takes the form of `- name: value`.
   endpoint_params:
@@ -1529,18 +1529,18 @@ authorization:
 oauth2:
   [ client_id: <string> ]
   [ client_secret: <secret> ]
-	
+
   # Read the client secret from a file instead of specifying the value
   # in `client_secret`.
   [ client_secret_file: <string> ]
-	
+
   # Optionally specify scopes for the token.
   scopes:
     [ - <string> ... ]
-	
+
   # The URL to fetch the token from.
   [ token_url: <string> ]
-	
+
   # Optional parameters to append to the token URL.
   # Takes the form of `- name: value`.
   endpoint_params:
@@ -1751,18 +1751,18 @@ authorization:
 oauth2:
   [ client_id: <string> ]
   [ client_secret: <secret> ]
-	
+
   # Read the client secret from a file instead of specifying the value
   # in `client_secret`.
   [ client_secret_file: <string> ]
-	
+
   # Optionally specify scopes for the token.
   scopes:
     [ - <string> ... ]
-	
+
   # The URL to fetch the token from.
   [ token_url: <string> ]
-	
+
   # Optional parameters to append to the token URL.
   # Takes the form of `- name: value`.
   endpoint_params:
@@ -2053,18 +2053,18 @@ authorization:
 oauth2:
   [ client_id: <string> ]
   [ client_secret: <secret> ]
-	
+
   # Read the client secret from a file instead of specifying the value
   # in `client_secret`.
   [ client_secret_file: <string> ]
-	
+
   # Optionally specify scopes for the token.
   scopes:
     [ - <string> ... ]
-	
+
   # The URL to fetch the token from.
   [ token_url: <string> ]
-	
+
   # Optional parameters to append to the token URL.
   # Takes the form of `- name: value`.
   endpoint_params:
@@ -2236,23 +2236,23 @@ sigv4:
 oauth2:
   [ client_id: <string> ]
   [ client_secret: <secret> ]
-	
+
   # Read the client secret from a file instead of specifying the value
   # in `client_secret`.
   [ client_secret_file: <string> ]
-	
+
   # Optionally specify scopes for the token.
   scopes:
     [ - <string> ... ]
-	
+
   # The URL to fetch the token from.
   [ token_url: <string> ]
-	
+
   # Optional parameters to append to the token URL.
   # Takes the form of `- name: value`.
   endpoint_params:
     [ <string>: <string> ... ]
-	
+
 
 # Configures the remote write request's TLS settings.
 tls_config:
@@ -2355,18 +2355,18 @@ authorization:
 oauth2:
   [ client_id: <string> ]
   [ client_secret: <secret> ]
-	
+
   # Read the client secret from a file instead of specifying the value
   # in `client_secret`.
   [ client_secret_file: <string> ]
-	
+
   # Optionally specify scopes for the token.
   scopes:
     [ - <string> ... ]
-	
+
   # The URL to fetch the token from.
   [ token_url: <string> ]
-	
+
   # Optional parameters to append to the token URL.
   # Takes the form of `- name: value`.
   endpoint_params:

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2206,7 +2206,7 @@ scopes:
   [ - <string> ... ]
 
 # The URL to fetch the token from.
-  [ token_url: <string> ]
+[ token_url: <string> ]
 
 # Optional parameters to append to the token URL.
 endpoint_params:

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/prometheus/alertmanager v0.21.0
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/client_model v0.2.0
-	github.com/prometheus/common v0.22.0
+	github.com/prometheus/common v0.23.0
 	github.com/prometheus/exporter-toolkit v0.5.1
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210223165440-c65ae3540d44
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/prometheus/alertmanager v0.21.0
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/client_model v0.2.0
-	github.com/prometheus/common v0.21.0
+	github.com/prometheus/common v0.22.0
 	github.com/prometheus/exporter-toolkit v0.5.1
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210223165440-c65ae3540d44
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749

--- a/go.sum
+++ b/go.sum
@@ -724,6 +724,8 @@ github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16
 github.com/prometheus/common v0.18.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/common v0.21.0 h1:SMvI2JVldvfUvRVlP64jkIJEC6WiGHJcN2e5tB+ztF8=
 github.com/prometheus/common v0.21.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
+github.com/prometheus/common v0.22.0 h1:iHzF+cGb5DVDhkBll8ud/7sU75S7ZeJi79tiVj60eR4=
+github.com/prometheus/common v0.22.0/go.mod h1:H6QK/N6XVT42whUeIdI3dp36w49c+/iMDk7UAI2qm7Q=
 github.com/prometheus/exporter-toolkit v0.5.1 h1:9eqgis5er9xN613ZSADjypCJaDGj9ZlcWBvsIHa8/3c=
 github.com/prometheus/exporter-toolkit v0.5.1/go.mod h1:OCkM4805mmisBhLmVFw858QYi3v0wKdY6/UxrT0pZVg=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=

--- a/go.sum
+++ b/go.sum
@@ -722,8 +722,8 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/common v0.18.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
-github.com/prometheus/common v0.22.0 h1:iHzF+cGb5DVDhkBll8ud/7sU75S7ZeJi79tiVj60eR4=
-github.com/prometheus/common v0.22.0/go.mod h1:H6QK/N6XVT42whUeIdI3dp36w49c+/iMDk7UAI2qm7Q=
+github.com/prometheus/common v0.23.0 h1:GXWvPYuTUenIa+BhOq/x+L/QZzCqASkVRny5KTlPDGM=
+github.com/prometheus/common v0.23.0/go.mod h1:H6QK/N6XVT42whUeIdI3dp36w49c+/iMDk7UAI2qm7Q=
 github.com/prometheus/exporter-toolkit v0.5.1 h1:9eqgis5er9xN613ZSADjypCJaDGj9ZlcWBvsIHa8/3c=
 github.com/prometheus/exporter-toolkit v0.5.1/go.mod h1:OCkM4805mmisBhLmVFw858QYi3v0wKdY6/UxrT0pZVg=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=

--- a/go.sum
+++ b/go.sum
@@ -722,8 +722,6 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/common v0.18.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
-github.com/prometheus/common v0.21.0 h1:SMvI2JVldvfUvRVlP64jkIJEC6WiGHJcN2e5tB+ztF8=
-github.com/prometheus/common v0.21.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/common v0.22.0 h1:iHzF+cGb5DVDhkBll8ud/7sU75S7ZeJi79tiVj60eR4=
 github.com/prometheus/common v0.22.0/go.mod h1:H6QK/N6XVT42whUeIdI3dp36w49c+/iMDk7UAI2qm7Q=
 github.com/prometheus/exporter-toolkit v0.5.1 h1:9eqgis5er9xN613ZSADjypCJaDGj9ZlcWBvsIHa8/3c=


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Add the new OAuth 2.0 config from common (prometheus/common#287, prometheus/common#293).

Note: Tests will fail until a new release of common is tagged.

cc @roidelapluie