### PR TITLE
Send empty targetgroup if nothing discovered [consul_sd]

### DIFF
--- a/discovery/README.md
+++ b/discovery/README.md
@@ -262,6 +262,6 @@ Here are some non-obvious parts of adding service discoveries that need to be ve
 
 ### Examples of Service Discovery pull requests
 
-The exemples given might become out of date but should give a good impression about the areas touched by a new service discovery.
+The examples given might become out of date but should give a good impression about the areas touched by a new service discovery.
 
 - [Eureka](https://github.com/prometheus/prometheus/pull/3369)

--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -426,6 +426,15 @@ func (d *Discovery) watchServices(ctx context.Context, ch chan<- []*targetgroup.
 			}
 		}
 	}
+
+	// Send targetgroup with no targets if nothing was discovered.
+	if len(services) == 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- []*targetgroup.Group{{}}:
+		}
+	}
 }
 
 // consulService contains data belonging to the same service.

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -298,6 +298,23 @@ func TestAllServices(t *testing.T) {
 	<-ch
 }
 
+// targetgroup with no targets is emitted if no services were discovered.
+func TestNoTargets(t *testing.T) {
+	stub, config := newServer(t)
+	defer stub.Close()
+	config.ServiceTags = []string{"missing"}
+
+	d := newDiscovery(t, config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan []*targetgroup.Group)
+	go d.Run(ctx, ch)
+
+	targets := (<-ch)[0].Targets
+	require.Equal(t, 0, len(targets))
+	cancel()
+}
+
 // Watch only the test service.
 func TestOneService(t *testing.T) {
 	stub, config := newServer(t)


### PR DESCRIPTION
Fixes #8727.

[discovery/README.md](https://github.com/prometheus/prometheus/blob/main/discovery/README.md) states every discovery implementation must send the complete set of discovered targets initially. However, consul_sd does not emit a targetgroup when no targets are discovered which leads to the behaviour described  in #8727. The bug happens only if:
1. There are targets discovered via consul_sd.
2. The consul_sd configuration is changed such that no targets are discovered.
3. The changed config is reloaded (e. g. SIGHUP).

Bug reproduction script: https://github.com/Nick-Triller/prometheus-bug-repro

Edit: Please note the failing test is also failing in the main branch.