### PR TITLE
use buffered channel for Discovery notifications

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -89,7 +89,7 @@ func NewManager(ctx context.Context, logger log.Logger, options ...func(*Manager
 	}
 	mgr := &Manager{
 		logger:         logger,
-		syncCh:         make(chan map[string][]*targetgroup.Group),
+		syncCh:         make(chan map[string][]*targetgroup.Group, 1),
 		targets:        make(map[poolKey]map[string]*targetgroup.Group),
 		discoverCancel: []context.CancelFunc{},
 		ctx:            ctx,


### PR DESCRIPTION
Signed-off-by: Peter Ballok <peter.ballok@logmein.com>

fixes #8768

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->