### PR TITLE
Add label scrape limits

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -382,11 +382,21 @@ type ScrapeConfig struct {
 	MetricsPath string `yaml:"metrics_path,omitempty"`
 	// The URL scheme with which to fetch metrics from targets.
 	Scheme string `yaml:"scheme,omitempty"`
-	// More than this many samples post metric-relabeling will cause the scrape to fail.
+	// More than this many samples post metric-relabeling will cause the scrape to
+	// fail.
 	SampleLimit uint `yaml:"sample_limit,omitempty"`
 	// More than this many targets after the target relabeling will cause the
 	// scrapes to fail.
 	TargetLimit uint `yaml:"target_limit,omitempty"`
+	// More than this many labels post metric-relabeling will cause the scrape to
+	// fail.
+	LabelLimit uint `yaml:"label_limit,omitempty"`
+	// More than this label name length post metric-relabeling will cause the
+	// scrape to fail.
+	LabelNameLengthLimit uint `yaml:"label_name_length_limit,omitempty"`
+	// More than this label value length post metric-relabeling will cause the
+	// scrape to fail.
+	LabelValueLengthLimit uint `yaml:"label_value_length_limit,omitempty"`
 
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -279,6 +279,21 @@ metric_relabel_configs:
 # the entire scrape will be treated as failed. 0 means no limit.
 [ sample_limit: <int> | default = 0 ]
 
+# Per-scrape limit on number of labels that will be accepted for a sample. If
+# more than this number of labels are present post metric-relabeling, the
+# entire scrape will be treated as failed. 0 means no limit.
+[ label_limit: <int> | default = 0 ]
+
+# Per-scrape limit on length of labels name that will be accepted for a sample.
+# If a label name is longer than this number post metric-relabeling, the entire
+# scrape will be treated as failed. 0 means no limit.
+[ label_name_length_limit: <int> | default = 0 ]
+
+# Per-scrape limit on length of labels value that will be accepted for a sample.
+# If a label value is longer than this number post metric-relabeling, the
+# entire scrape will be treated as failed. 0 means no limit.
+[ label_value_length_limit: <int> | default = 0 ]
+
 # Per-scrape config limit on number of unique targets that will be
 # accepted. If more than this number of targets are present after target
 # relabeling, Prometheus will mark the targets as failed without scraping them.

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -261,6 +261,20 @@
               description: 'Prometheus %(prometheusName)s has dropped {{ printf "%%.0f" $value }} targets because the number of targets exceeded the configured target_limit.' % $._config,
             },
           },
+          {
+            alert: 'PrometheusLabelLimitHit',
+            expr: |||
+              increase(prometheus_target_scrape_pool_exceeded_label_limits_total{%(prometheusSelector)s}[5m]) > 0
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Prometheus has dropped targets because some scrape configs have exceeded the labels limit.',
+              description: 'Prometheus %(prometheusName)s has dropped {{ printf "%%.0f" $value }} targets because some samples exceeded the configured label_limit, label_name_length_limit or label_value_length_limit.' % $._config,
+            },
+          },
         ] + if $._config.prometheusHAGroupLabels == '' then self.rulesWithoutHA else self.rulesWithHA,
         rulesWithoutHA:: [
           {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -602,31 +602,27 @@ func (sp *scrapePool) refreshTargetLimitErr() error {
 }
 
 func verifyLabelLimits(lset labels.Labels, limits labelLimits) error {
+	met := lset.Get(labels.MetricName)
+
 	if limits.labelLimit != 0 {
-		// Skip metric name in the count.
-		nbLabels := len(lset) - 1
+		nbLabels := len(lset)
 		if nbLabels > int(limits.labelLimit) {
-			return fmt.Errorf("label_limit exceeded (metric: %v, number of label: %d, limit: %d)", lset, nbLabels, limits.labelLimit)
+			return fmt.Errorf("label_limit exceeded (metric: %.50s, number of label: %d, limit: %d)", met, nbLabels, limits.labelLimit)
 		}
 	}
 
 	for _, l := range lset {
-		// Skip metric name since we don't need to apply constraints to it.
-		if l.Name == labels.MetricName {
-			continue
-		}
-
 		if limits.labelNameLengthLimit != 0 {
 			nameLength := len(l.Name)
 			if nameLength > int(limits.labelNameLengthLimit) {
-				return fmt.Errorf("label_name_length_limit exceeded (metric: %v, name length: %d, limit: %d)", lset, nameLength, limits.labelNameLengthLimit)
+				return fmt.Errorf("label_name_length_limit exceeded (metric: %.50s, label: %.50v, name length: %d, limit: %d)", met, l, nameLength, limits.labelNameLengthLimit)
 			}
 		}
 
 		if limits.labelValueLengthLimit != 0 {
 			valueLength := len(l.Value)
 			if valueLength > int(limits.labelValueLengthLimit) {
-				return fmt.Errorf("label_name_length_limit exceeded (metric: %v, value length: %d, limit: %d)", lset, valueLength, limits.labelValueLengthLimit)
+				return fmt.Errorf("label_name_length_limit exceeded (metric: %.50s, label: %.50v, value length: %d, limit: %d)", met, l, valueLength, limits.labelValueLengthLimit)
 			}
 		}
 	}

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -577,7 +577,7 @@ func TestScrapeLoopStopBeforeRun(t *testing.T) {
 		nopMutator,
 		nil, nil, 0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	// The scrape pool synchronizes on stopping scrape loops. However, new scrape
@@ -642,7 +642,7 @@ func TestScrapeLoopStop(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	// Terminate loop after 2 scrapes.
@@ -710,7 +710,7 @@ func TestScrapeLoopRun(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	// The loop must terminate during the initial offset if the context
@@ -758,7 +758,7 @@ func TestScrapeLoopRun(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	go func() {
@@ -810,7 +810,7 @@ func TestScrapeLoopForcedErr(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	forcedErr := fmt.Errorf("forced err")
@@ -861,7 +861,7 @@ func TestScrapeLoopMetadata(t *testing.T) {
 		cache,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 	defer cancel()
 
@@ -911,7 +911,7 @@ func TestScrapeLoopSeriesAdded(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 	defer cancel()
 
@@ -950,7 +950,7 @@ func TestScrapeLoopRunCreatesStaleMarkersOnFailedScrape(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 	// Succeed once, several failures, then stop.
 	numScrapes := 0
@@ -1005,7 +1005,7 @@ func TestScrapeLoopRunCreatesStaleMarkersOnParseFailure(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	// Succeed once, several failures, then stop.
@@ -1064,7 +1064,7 @@ func TestScrapeLoopCache(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	numScrapes := 0
@@ -1139,7 +1139,7 @@ func TestScrapeLoopCacheMemoryExhaustionProtection(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	numScrapes := 0
@@ -1246,7 +1246,7 @@ func TestScrapeLoopAppend(t *testing.T) {
 			nil,
 			0,
 			true,
-			labelLimits{},
+			nil,
 		)
 
 		now := time.Now()
@@ -1288,7 +1288,7 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	fakeRef := uint64(1)
@@ -1338,7 +1338,7 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	// Get the value of the Counter before performing the append.
@@ -1408,7 +1408,7 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	now := time.Now()
@@ -1449,7 +1449,7 @@ func TestScrapeLoopAppendStaleness(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	now := time.Now()
@@ -1493,7 +1493,7 @@ func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	now := time.Now()
@@ -1595,7 +1595,7 @@ metric_total{n="2"} 2 # {t="2"} 2.0 20000
 				nil,
 				0,
 				true,
-				labelLimits{},
+				nil,
 			)
 
 			now := time.Now()
@@ -1653,7 +1653,7 @@ func TestScrapeLoopAppendExemplarSeries(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	now := time.Now()
@@ -1698,7 +1698,7 @@ func TestScrapeLoopRunReportsTargetDownOnScrapeError(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	scraper.scrapeFunc = func(ctx context.Context, w io.Writer) error {
@@ -1727,7 +1727,7 @@ func TestScrapeLoopRunReportsTargetDownOnInvalidUTF8(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	scraper.scrapeFunc = func(ctx context.Context, w io.Writer) error {
@@ -1769,7 +1769,7 @@ func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	now := time.Unix(1, 0)
@@ -1807,7 +1807,7 @@ func TestScrapeLoopOutOfBoundsTimeError(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	now := time.Now().Add(20 * time.Minute)
@@ -1995,7 +1995,7 @@ func TestScrapeLoop_RespectTimestamps(t *testing.T) {
 		func(ctx context.Context) storage.Appender { return capp },
 		nil, 0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	now := time.Now()
@@ -2029,7 +2029,7 @@ func TestScrapeLoop_DiscardTimestamps(t *testing.T) {
 		func(ctx context.Context) storage.Appender { return capp },
 		nil, 0,
 		false,
-		labelLimits{},
+		nil,
 	)
 
 	now := time.Now()
@@ -2062,7 +2062,7 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 	defer cancel()
 
@@ -2113,7 +2113,7 @@ func TestScrapeLoopDiscardUnnamedMetrics(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 	defer cancel()
 
@@ -2331,7 +2331,7 @@ func TestScrapeAddFast(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 	defer cancel()
 
@@ -2415,7 +2415,7 @@ func TestScrapeReportSingleAppender(t *testing.T) {
 		nil,
 		0,
 		true,
-		labelLimits{},
+		nil,
 	)
 
 	numScrapes := 0
@@ -2544,7 +2544,7 @@ func TestScrapeLoopLabelLimit(t *testing.T) {
 			nil,
 			0,
 			true,
-			test.labelLimits,
+			&test.labelLimits,
 		)
 
 		slApp := sl.appender(context.Background())

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -464,8 +464,8 @@ func TestScrapePoolAppender(t *testing.T) {
 	require.True(t, ok, "Expected base appender but got %T", tl.Appender)
 
 	loop = sp.newLoop(scrapeLoopOptions{
-		target: &Target{},
-		limit:  100,
+		target:      &Target{},
+		sampleLimit: 100,
 	})
 	appl, ok = loop.(*scrapeLoop)
 	require.True(t, ok, "Expected scrapeLoop but got %T", loop)
@@ -577,6 +577,7 @@ func TestScrapeLoopStopBeforeRun(t *testing.T) {
 		nopMutator,
 		nil, nil, 0,
 		true,
+		labelLimits{},
 	)
 
 	// The scrape pool synchronizes on stopping scrape loops. However, new scrape
@@ -641,6 +642,7 @@ func TestScrapeLoopStop(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	// Terminate loop after 2 scrapes.
@@ -708,6 +710,7 @@ func TestScrapeLoopRun(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	// The loop must terminate during the initial offset if the context
@@ -755,6 +758,7 @@ func TestScrapeLoopRun(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	go func() {
@@ -806,6 +810,7 @@ func TestScrapeLoopForcedErr(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	forcedErr := fmt.Errorf("forced err")
@@ -856,6 +861,7 @@ func TestScrapeLoopMetadata(t *testing.T) {
 		cache,
 		0,
 		true,
+		labelLimits{},
 	)
 	defer cancel()
 
@@ -905,6 +911,7 @@ func TestScrapeLoopSeriesAdded(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 	defer cancel()
 
@@ -943,6 +950,7 @@ func TestScrapeLoopRunCreatesStaleMarkersOnFailedScrape(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 	// Succeed once, several failures, then stop.
 	numScrapes := 0
@@ -997,6 +1005,7 @@ func TestScrapeLoopRunCreatesStaleMarkersOnParseFailure(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	// Succeed once, several failures, then stop.
@@ -1055,6 +1064,7 @@ func TestScrapeLoopCache(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	numScrapes := 0
@@ -1129,6 +1139,7 @@ func TestScrapeLoopCacheMemoryExhaustionProtection(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	numScrapes := 0
@@ -1235,6 +1246,7 @@ func TestScrapeLoopAppend(t *testing.T) {
 			nil,
 			0,
 			true,
+			labelLimits{},
 		)
 
 		now := time.Now()
@@ -1276,6 +1288,7 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	fakeRef := uint64(1)
@@ -1325,6 +1338,7 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	// Get the value of the Counter before performing the append.
@@ -1394,6 +1408,7 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	now := time.Now()
@@ -1434,6 +1449,7 @@ func TestScrapeLoopAppendStaleness(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	now := time.Now()
@@ -1477,6 +1493,7 @@ func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	now := time.Now()
@@ -1578,6 +1595,7 @@ metric_total{n="2"} 2 # {t="2"} 2.0 20000
 				nil,
 				0,
 				true,
+				labelLimits{},
 			)
 
 			now := time.Now()
@@ -1635,6 +1653,7 @@ func TestScrapeLoopAppendExemplarSeries(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	now := time.Now()
@@ -1679,6 +1698,7 @@ func TestScrapeLoopRunReportsTargetDownOnScrapeError(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	scraper.scrapeFunc = func(ctx context.Context, w io.Writer) error {
@@ -1707,6 +1727,7 @@ func TestScrapeLoopRunReportsTargetDownOnInvalidUTF8(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	scraper.scrapeFunc = func(ctx context.Context, w io.Writer) error {
@@ -1748,6 +1769,7 @@ func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	now := time.Unix(1, 0)
@@ -1785,6 +1807,7 @@ func TestScrapeLoopOutOfBoundsTimeError(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	now := time.Now().Add(20 * time.Minute)
@@ -1972,6 +1995,7 @@ func TestScrapeLoop_RespectTimestamps(t *testing.T) {
 		func(ctx context.Context) storage.Appender { return capp },
 		nil, 0,
 		true,
+		labelLimits{},
 	)
 
 	now := time.Now()
@@ -2005,6 +2029,7 @@ func TestScrapeLoop_DiscardTimestamps(t *testing.T) {
 		func(ctx context.Context) storage.Appender { return capp },
 		nil, 0,
 		false,
+		labelLimits{},
 	)
 
 	now := time.Now()
@@ -2037,6 +2062,7 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 	defer cancel()
 
@@ -2087,6 +2113,7 @@ func TestScrapeLoopDiscardUnnamedMetrics(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 	defer cancel()
 
@@ -2304,6 +2331,7 @@ func TestScrapeAddFast(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 	defer cancel()
 
@@ -2387,6 +2415,7 @@ func TestScrapeReportSingleAppender(t *testing.T) {
 		nil,
 		0,
 		true,
+		labelLimits{},
 	)
 
 	numScrapes := 0
@@ -2428,5 +2457,105 @@ func TestScrapeReportSingleAppender(t *testing.T) {
 	case <-signal:
 	case <-time.After(5 * time.Second):
 		t.Fatalf("Scrape wasn't stopped.")
+	}
+}
+
+func TestScrapeLoopLabelLimit(t *testing.T) {
+	tests := []struct {
+		title           string
+		scrapeLabels    string
+		discoveryLabels []string
+		labelLimits     labelLimits
+		expectErr       bool
+	}{
+		{
+			title:           "Valid number of labels",
+			scrapeLabels:    `metric{l1="1", l2="2"} 0`,
+			discoveryLabels: nil,
+			labelLimits:     labelLimits{labelLimit: 5},
+			expectErr:       false,
+		}, {
+			title:           "Too many labels",
+			scrapeLabels:    `metric{l1="1", l2="2", l3="3", l4="4", l5="5", l6="6"} 0`,
+			discoveryLabels: nil,
+			labelLimits:     labelLimits{labelLimit: 5},
+			expectErr:       true,
+		}, {
+			title:           "Too many labels including discovery labels",
+			scrapeLabels:    `metric{l1="1", l2="2", l3="3", l4="4"} 0`,
+			discoveryLabels: []string{"l5", "5", "l6", "6"},
+			labelLimits:     labelLimits{labelLimit: 5},
+			expectErr:       true,
+		}, {
+			title:           "Valid labels name length",
+			scrapeLabels:    `metric{l1="1", l2="2"} 0`,
+			discoveryLabels: nil,
+			labelLimits:     labelLimits{labelNameLengthLimit: 10},
+			expectErr:       false,
+		}, {
+			title:           "Label name too long",
+			scrapeLabels:    `metric{label_name_too_long="0"} 0`,
+			discoveryLabels: nil,
+			labelLimits:     labelLimits{labelNameLengthLimit: 10},
+			expectErr:       true,
+		}, {
+			title:           "Discovery label name too long",
+			scrapeLabels:    `metric{l1="1", l2="2"} 0`,
+			discoveryLabels: []string{"label_name_too_long", "0"},
+			labelLimits:     labelLimits{labelNameLengthLimit: 10},
+			expectErr:       true,
+		}, {
+			title:           "Valid labels value length",
+			scrapeLabels:    `metric{l1="1", l2="2"} 0`,
+			discoveryLabels: nil,
+			labelLimits:     labelLimits{labelValueLengthLimit: 10},
+			expectErr:       false,
+		}, {
+			title:           "Label value too long",
+			scrapeLabels:    `metric{l1="label_value_too_long"} 0`,
+			discoveryLabels: nil,
+			labelLimits:     labelLimits{labelValueLengthLimit: 10},
+			expectErr:       true,
+		}, {
+			title:           "Discovery label value too long",
+			scrapeLabels:    `metric{l1="1", l2="2"} 0`,
+			discoveryLabels: []string{"l1", "label_value_too_long"},
+			labelLimits:     labelLimits{labelValueLengthLimit: 10},
+			expectErr:       true,
+		},
+	}
+
+	for _, test := range tests {
+		app := &collectResultAppender{}
+
+		discoveryLabels := &Target{
+			labels: labels.FromStrings(test.discoveryLabels...),
+		}
+
+		sl := newScrapeLoop(context.Background(),
+			nil, nil, nil,
+			func(l labels.Labels) labels.Labels {
+				return mutateSampleLabels(l, discoveryLabels, false, nil)
+			},
+			func(l labels.Labels) labels.Labels {
+				return mutateReportSampleLabels(l, discoveryLabels)
+			},
+			func(ctx context.Context) storage.Appender { return app },
+			nil,
+			0,
+			true,
+			test.labelLimits,
+		)
+
+		slApp := sl.appender(context.Background())
+		_, _, _, err := sl.append(slApp, []byte(test.scrapeLabels), "", time.Now())
+
+		t.Logf("Test:%s", test.title)
+		if test.expectErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.NoError(t, slApp.Commit())
+		}
 	}
 }


### PR DESCRIPTION
Add three new limits to the scrape configuration to provide some
mechanism to defend against unbound number of labels and excessive
label lengths. If any of these limits are broken by a sample from a
scrape, the whole scrape will fail. For all of these configuration
options, a zero value means no limit.

The `label_limit` configuration will provide a mechanism to bound the
number of labels per-scrape of a certain sample to a user defined limit.
This limit will be tested against the sample labels plus the discovery
labels.

The `label_name_length_limit` and `label_value_length_limit` will
prevent having labels of excessive lengths. These limits will
also make the scrape fail if any sample has a label name/value length
that exceed the predefined limits.

Fixes #8291 

