### PR TITLE
Add exemplar total label length limit check.

### DIFF
--- a/pkg/exemplar/exemplar.go
+++ b/pkg/exemplar/exemplar.go
@@ -15,6 +15,10 @@ package exemplar
 
 import "github.com/prometheus/prometheus/pkg/labels"
 
+// The combined length of the label names and values of an Exemplar's LabelSet MUST NOT exceed 128 UTF-8 characters
+// https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars
+const ExemplarMaxLabelSetLength = 128
+
 // Exemplar is additional information associated with a time series.
 type Exemplar struct {
 	Labels labels.Labels

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -30,6 +30,7 @@ var (
 	ErrDuplicateSampleForTimestamp = errors.New("duplicate sample for timestamp")
 	ErrOutOfBounds                 = errors.New("out of bounds")
 	ErrOutOfOrderExemplar          = errors.New("out of order exemplar")
+	ErrExemplarLabelLength         = errors.New("label length for exemplar exceeds maximum")
 )
 
 // Appendable allows creating appenders.

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -16,6 +16,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -30,7 +31,7 @@ var (
 	ErrDuplicateSampleForTimestamp = errors.New("duplicate sample for timestamp")
 	ErrOutOfBounds                 = errors.New("out of bounds")
 	ErrOutOfOrderExemplar          = errors.New("out of order exemplar")
-	ErrExemplarLabelLength         = errors.New("label length for exemplar exceeds maximum")
+	ErrExemplarLabelLength         = fmt.Errorf("label length for exemplar exceeds maximum of %d UTF-8 characters", exemplar.ExemplarMaxLabelSetLength)
 )
 
 // Appendable allows creating appenders.

--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -17,17 +17,12 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
-)
-
-const (
-	// The combined length of the label names and values of an Exemplar's LabelSet MUST NOT exceed 128 UTF-8 characters
-	// https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars
-	ExemplarMaxLabelSetLength = 128
 )
 
 type CircularExemplarStorage struct {
@@ -179,11 +174,11 @@ func (ce *CircularExemplarStorage) AddExemplar(l labels.Labels, e exemplar.Exemp
 	// equals sign, or commas. See definiton of const ExemplarMaxLabelLength.
 	labelSetLen := 0
 	for _, l := range e.Labels {
-		labelSetLen += len(l.Name)
-		labelSetLen += len(l.Value)
+		labelSetLen += utf8.RuneCountInString(l.Name)
+		labelSetLen += utf8.RuneCountInString(l.Value)
 	}
 
-	if labelSetLen > ExemplarMaxLabelSetLength {
+	if labelSetLen > exemplar.ExemplarMaxLabelSetLength {
 		return storage.ErrExemplarLabelLength
 	}
 

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -16,6 +16,7 @@ package tsdb
 import (
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -76,6 +77,19 @@ func TestAddExemplar(t *testing.T) {
 	e3.Value = 0.3
 	err = es.AddExemplar(l, e3)
 	require.Equal(t, err, storage.ErrOutOfOrderExemplar)
+
+	e4 := exemplar.Exemplar{
+		Labels: labels.Labels{
+			labels.Label{
+				Name:  "a",
+				Value: strings.Repeat("b", ExemplarMaxLabelSetLength),
+			},
+		},
+		Value: 0.1,
+		Ts:    2,
+	}
+	err = es.AddExemplar(l, e4)
+	require.Equal(t, err, storage.ErrExemplarLabelLength)
 }
 
 func TestStorageOverflow(t *testing.T) {

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -60,36 +60,31 @@ func TestAddExemplar(t *testing.T) {
 		Ts:    2,
 	}
 
-	err = es.AddExemplar(l, e2)
-	require.NoError(t, err)
+	require.NoError(t, es.AddExemplar(l, e2))
 	require.Equal(t, es.index[l.String()].newest, 1, "exemplar was not stored correctly, location of newest exemplar for series in index did not update")
 	require.True(t, es.exemplars[es.index[l.String()].newest].exemplar.Equals(e2), "exemplar was not stored correctly, expected %+v got: %+v", e2, es.exemplars[es.index[l.String()].newest].exemplar)
 
-	err = es.AddExemplar(l, e2)
-	require.NoError(t, err, "no error is expected attempting to add duplicate exemplar")
+	require.NoError(t, es.AddExemplar(l, e2), "no error is expected attempting to add duplicate exemplar")
 
 	e3 := e2
 	e3.Ts = 3
-	err = es.AddExemplar(l, e3)
-	require.NoError(t, err, "no error is expected when attempting to add duplicate exemplar, even with different timestamp")
+	require.NoError(t, es.AddExemplar(l, e3), "no error is expected when attempting to add duplicate exemplar, even with different timestamp")
 
 	e3.Ts = 1
 	e3.Value = 0.3
-	err = es.AddExemplar(l, e3)
-	require.Equal(t, err, storage.ErrOutOfOrderExemplar)
+	require.Equal(t, storage.ErrOutOfOrderExemplar, es.AddExemplar(l, e3))
 
 	e4 := exemplar.Exemplar{
 		Labels: labels.Labels{
 			labels.Label{
 				Name:  "a",
-				Value: strings.Repeat("b", ExemplarMaxLabelSetLength),
+				Value: strings.Repeat("b", exemplar.ExemplarMaxLabelSetLength),
 			},
 		},
 		Value: 0.1,
 		Ts:    2,
 	}
-	err = es.AddExemplar(l, e4)
-	require.Equal(t, err, storage.ErrExemplarLabelLength)
+	require.Equal(t, storage.ErrExemplarLabelLength, es.AddExemplar(l, e4))
 }
 
 func TestStorageOverflow(t *testing.T) {


### PR DESCRIPTION
This was missed in the initial storage implementation PR. 

cc @mdisibio 

Signed-off-by: Callum Styan <callumstyan@gmail.com>
