### PR TITLE
Check exemplar timestamp before matching

### DIFF
--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -121,6 +121,9 @@ func (ce *CircularExemplarStorage) Select(start, end int64, matchers ...[]*label
 	for _, idx := range ce.index {
 		var se exemplar.QueryResult
 		e := ce.exemplars[idx.oldest]
+		if e.exemplar.Ts > end || ce.exemplars[idx.newest].exemplar.Ts < start {
+			continue
+		}
 		if !matchesSomeMatcherSet(e.seriesLabels, matchers) {
 			continue
 		}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This pr adds a timestamp check for exemplars Select API.

If the newest exemplar's timestamp in one series is smaller than the select start time, we can skip this series before label matching. Same for the oldest exemplar.