### PR TITLE
tsdb: move exemplar series labels to index entry

### DIFF
--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -304,11 +304,11 @@ func TestIndexOverwrite(t *testing.T) {
 	// index entry for series l1 since we just wrote two exemplars for series l2.
 	_, ok := es.index[l1.String()]
 	require.False(t, ok)
-	require.Equal(t, &indexEntry{1, 0}, es.index[l2.String()])
+	require.Equal(t, &indexEntry{1, 0, l2}, es.index[l2.String()])
 
 	err = es.AddExemplar(l1, exemplar.Exemplar{Value: 4, Ts: 4})
 	require.NoError(t, err)
 
 	i := es.index[l2.String()]
-	require.Equal(t, &indexEntry{0, 0}, i)
+	require.Equal(t, &indexEntry{0, 0, l2}, i)
 }


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This pr moves per-exemplar series labels to the index entry struct. As mentioned in https://github.com/prometheus/prometheus/pull/6635/files#r578162563, it is unnecessary to store series labels multiple times for the same series.