### PR TITLE
SD: Add target creation failure counter and change failure handling

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -285,7 +285,7 @@
               severity: 'critical',
             },
             annotations: {
-              summary: 'A target failed to sync.',
+              summary: 'Prometheus has failed to sync targets.',
               description: '{{ printf "%%.of" $value }} targets in Prometheus %(prometheusName)s have failed to sync because invalid configuration was supplied.' % $._config,
             },
           },

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -278,7 +278,7 @@
           {
             alert: 'PrometheusTargetSyncFailure',
             expr: |||
-              increase(prometheus_target_sync_failed_total{%(prometheusSelector)s}[15m]) > 0
+              increase(prometheus_target_sync_failed_total{%(prometheusSelector)s}[30m]) > 0
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -286,7 +286,7 @@
             },
             annotations: {
               summary: 'Prometheus has failed to sync targets.',
-              description: '{{ printf "%%.of" $value }} targets in Prometheus %(prometheusName)s have failed to sync because invalid configuration was supplied.' % $._config,
+              description: '{{ printf "%%.0f" $value }} targets in Prometheus %(prometheusName)s have failed to sync because invalid configuration was supplied.' % $._config,
             },
           },
         ] + if $._config.prometheusHAGroupLabels == '' then self.rulesWithoutHA else self.rulesWithHA,

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -278,7 +278,7 @@
           {
             alert: 'PrometheusTargetSyncFailure',
             expr: |||
-              increase(prometheus_target_sync_failed_total{%(prometheusSelector)s}[5m]) > 0
+              increase(prometheus_target_sync_failed_total{%(prometheusSelector)s}[15m]) > 0
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -275,6 +275,20 @@
               description: 'Prometheus %(prometheusName)s has dropped {{ printf "%%.0f" $value }} targets because some samples exceeded the configured label_limit, label_name_length_limit or label_value_length_limit.' % $._config,
             },
           },
+          {
+            alert: 'PrometheusTargetSyncFailure',
+            expr: |||
+              increase(prometheus_target_sync_failed_total{%(prometheusSelector)s}[5m]) > 0
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'A target failed to sync.',
+              description: '{{ printf "%%.of" $value }} targets in Prometheus %(prometheusName)s have failed to sync because invalid configuration was supplied.' % $._config,
+            },
+          },
         ] + if $._config.prometheusHAGroupLabels == '' then self.rulesWithoutHA else self.rulesWithHA,
         rulesWithoutHA:: [
           {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -176,6 +176,13 @@ var (
 			Help: "Total number of times scrape pools hit the label limits, during sync or config reload.",
 		},
 	)
+	targetSyncFailed = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "prometheus_target_sync_failed_total",
+			Help: "Total number of target sync failures.",
+		},
+		[]string{"scrape_job"},
+	)
 )
 
 func init() {
@@ -199,6 +206,7 @@ func init() {
 		targetMetadataCache,
 		targetScrapeExemplarOutOfOrder,
 		targetScrapePoolExceededLabelLimits,
+		targetSyncFailed,
 	)
 }
 
@@ -346,6 +354,7 @@ func (sp *scrapePool) stop() {
 		targetScrapePoolTargetLimit.DeleteLabelValues(sp.config.JobName)
 		targetScrapePoolTargetsAdded.DeleteLabelValues(sp.config.JobName)
 		targetSyncIntervalLength.DeleteLabelValues(sp.config.JobName)
+		targetSyncFailed.DeleteLabelValues(sp.config.JobName)
 	}
 }
 
@@ -445,11 +454,11 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 	var all []*Target
 	sp.droppedTargets = []*Target{}
 	for _, tg := range tgs {
-		targets, err := targetsFromGroup(tg, sp.config)
-		if err != nil {
+		targets, failures := targetsFromGroup(tg, sp.config)
+		for _, err := range failures {
 			level.Error(sp.logger).Log("msg", "creating targets failed", "err", err)
-			continue
 		}
+		targetSyncFailed.WithLabelValues(sp.config.JobName).Add(float64(len(failures)))
 		for _, t := range targets {
 			if t.Labels().Len() > 0 {
 				all = append(all, t)

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -456,7 +456,7 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 	for _, tg := range tgs {
 		targets, failures := targetsFromGroup(tg, sp.config)
 		for _, err := range failures {
-			level.Error(sp.logger).Log("msg", "creating targets failed", "err", err)
+			level.Error(sp.logger).Log("msg", "Creating target failed", "err", err)
 		}
 		targetSyncFailed.WithLabelValues(sp.config.JobName).Add(float64(len(failures)))
 		for _, t := range targets {

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -414,8 +414,9 @@ func populateLabels(lset labels.Labels, cfg *config.ScrapeConfig) (res, orig lab
 }
 
 // targetsFromGroup builds targets based on the given TargetGroup and config.
-func targetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig) ([]*Target, error) {
+func targetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig) ([]*Target, []error) {
 	targets := make([]*Target, 0, len(tg.Targets))
+	failures := []error{}
 
 	for i, tlset := range tg.Targets {
 		lbls := make([]labels.Label, 0, len(tlset)+len(tg.Labels))
@@ -433,11 +434,11 @@ func targetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig) ([]*Targe
 
 		lbls, origLabels, err := populateLabels(lset, cfg)
 		if err != nil {
-			return nil, errors.Wrapf(err, "instance %d in group %s", i, tg)
+			failures = append(failures, errors.Wrapf(err, "instance %d in group %s", i, tg))
 		}
 		if lbls != nil || origLabels != nil {
 			targets = append(targets, NewTarget(lbls, origLabels, cfg.Params))
 		}
 	}
-	return targets, nil
+	return targets, failures
 }

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
@@ -363,5 +365,20 @@ func TestNewClientWithBadTLSConfig(t *testing.T) {
 	_, err := config_util.NewClientFromConfig(cfg, "test", config_util.WithHTTP2Disabled())
 	if err == nil {
 		t.Fatalf("Expected error, got nil.")
+	}
+}
+
+func TestTargetsFromGroup(t *testing.T) {
+	expectedError := "instance 0 in group : no address"
+
+	targets, failures := targetsFromGroup(&targetgroup.Group{Targets: []model.LabelSet{{}, {model.AddressLabel: "localhost:9090"}}}, &config.ScrapeConfig{})
+	if len(targets) != 1 {
+		t.Fatalf("Expected 1 target, got %v", len(targets))
+	}
+	if len(failures) != 1 {
+		t.Fatalf("Expected 1 failure, got %v", len(failures))
+	}
+	if failures[0].Error() != expectedError {
+		t.Fatalf("Expected error %s, got %s", expectedError, failures[0])
 	}
 }


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR adds an error counter for target creation failures and changes the way failures are handled so that a single invalid target does not pause scraping for the entire group.

Fixes #8438

On a side note, maybe it would be better to change this counter to a gauge and have it represent the current number of failures, not just the accumulated failures over time. That might provide more useful information for remediation.