### PR TITLE
Add parseDuration to template functions

### DIFF
--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -74,7 +74,7 @@ versions.
 | reReplaceAll  | pattern, replacement, text | string | [Regexp.ReplaceAllString](https://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
 | graphLink  | expr | string | Returns path to graph view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
 | tableLink  | expr | string | Returns path to tabular ("Table") view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
-| parseDuration | string | string | Parses a duration string such as "1h" into the integer number of seconds it represents. |
+| parseDuration | string | float | Parses a duration string such as "1h" into the number of seconds it represents. |
 
 ### Others
 

--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -74,6 +74,7 @@ versions.
 | reReplaceAll  | pattern, replacement, text | string | [Regexp.ReplaceAllString](https://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
 | graphLink  | expr | string | Returns path to graph view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
 | tableLink  | expr | string | Returns path to tabular ("Table") view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
+| parseDuration | string | string | Parses a duration string such as "1h" into the integer number of seconds it represents. |
 
 ### Others
 

--- a/template/template.go
+++ b/template/template.go
@@ -290,13 +290,12 @@ func NewTemplateExpander(
 			"externalURL": func() string {
 				return externalURL.String()
 			},
-			"parseDuration": func(d string) (string, error) {
+			"parseDuration": func(d string) (float64, error) {
 				v, err := model.ParseDuration(d)
 				if err != nil {
-					return "", err
+					return 0, err
 				}
-				dur := int64(time.Duration(v) / time.Second)
-				return fmt.Sprintf("%d", dur), nil
+				return float64(time.Duration(v)) / float64(time.Second), nil
 			},
 		},
 	}

--- a/template/template.go
+++ b/template/template.go
@@ -290,6 +290,14 @@ func NewTemplateExpander(
 			"externalURL": func() string {
 				return externalURL.String()
 			},
+			"parseDuration": func(d string) (string, error) {
+				v, err := model.ParseDuration(d)
+				if err != nil {
+					return "", err
+				}
+				dur := int64(time.Duration(v) / time.Second)
+				return fmt.Sprintf("%d", dur), nil
+			},
 		},
 	}
 }

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -329,9 +329,9 @@ func TestTemplateExpansion(t *testing.T) {
 			output: "http://testhost:9090/path/prefix",
 		},
 		{
-			// parseDuration.
-			text:   "{{ parseDuration \"1h2m10ms\" }}",
-			output: "3720",
+			// parseDuration (using printf to ensure the return is a string).
+			text:   "{{ printf \"%0.2f\" (parseDuration \"1h2m10ms\") }}",
+			output: "3720.01",
 		},
 	}
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -328,6 +328,11 @@ func TestTemplateExpansion(t *testing.T) {
 			text:   "{{ externalURL }}",
 			output: "http://testhost:9090/path/prefix",
 		},
+		{
+			// parseDuration.
+			text:   "{{ parseDuration \"1h2m10ms\" }}",
+			output: "3720",
+		},
 	}
 
 	extURL, err := url.Parse("http://testhost:9090/path/prefix")


### PR DESCRIPTION
This can be useful when generating rules, a query may use a duration,
and it may be useful to template that into a URL parameter. Therefore
this allows interfacing with systems that don't implement Prometheus
style duration parsing.

Signed-off-by: David Leadbeater <dgl@dgl.cx>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->