### PR TITLE
Disable time based retention in tests

### DIFF
--- a/cmd/promtool/testdata/long-period.yml
+++ b/cmd/promtool/testdata/long-period.yml
@@ -1,0 +1,34 @@
+# Evaluate once every 100d to avoid this taking too long.
+evaluation_interval: 100d
+
+rule_files:
+  - rules.yml
+
+tests:
+  - interval: 100d
+    input_series:
+      - series: test
+        # Max time in time.Duration is 106751d from 1970 (2^63/10^9), i.e. 2262.
+        # We use the nearest 100 days to that to ensure the unit tests can fully
+        # cover the expected range.
+        values: '0+1x1067'
+
+    promql_expr_test:
+      - expr: timestamp(test)
+        eval_time: 0m
+        exp_samples:
+          - value: 0
+      - expr: test
+        eval_time: 100d # one evaluation_interval.
+        exp_samples:
+          - labels: test
+            value: 1
+      - expr: timestamp(test)
+        eval_time: 106700d
+        exp_samples:
+          - value: 9218880000 # 106700d -> seconds.
+      - expr: fixed_data
+        eval_time: 106700d
+        exp_samples:
+          - labels: fixed_data
+            value: 1

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -37,6 +37,13 @@ func TestRulesUnitTest(t *testing.T) {
 			want: 0,
 		},
 		{
+			name: "Long evaluation interval",
+			args: args{
+				files: []string{"./testdata/long-period.yml"},
+			},
+			want: 0,
+		},
+		{
 			name: "Bad input series",
 			args: args{
 				files: []string{"./testdata/bad-input-series.yml"},

--- a/util/teststorage/storage.go
+++ b/util/teststorage/storage.go
@@ -39,6 +39,7 @@ func New(t testutil.T) *TestStorage {
 	opts := tsdb.DefaultOptions()
 	opts.MinBlockDuration = int64(24 * time.Hour / time.Millisecond)
 	opts.MaxBlockDuration = int64(24 * time.Hour / time.Millisecond)
+	opts.RetentionDuration = 0
 	db, err := tsdb.Open(dir, nil, nil, opts, tsdb.NewDBStats())
 	require.NoError(t, err, "unexpected error while opening test storage")
 	reg := prometheus.NewRegistry()


### PR DESCRIPTION
Fixes #7699.

Signed-off-by: David Leadbeater <dgl@dgl.cx>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->