### PR TITLE
Fix the computation of prometheus_sd_discovered_targets

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -279,15 +279,17 @@ func (m *Manager) allGroups() map[string][]*targetgroup.Group {
 	defer m.mtx.RUnlock()
 
 	tSets := map[string][]*targetgroup.Group{}
+	n := map[string]int{}
 	for pkey, tsets := range m.targets {
-		var n int
 		for _, tg := range tsets {
 			// Even if the target group 'tg' is empty we still need to send it to the 'Scrape manager'
 			// to signal that it needs to stop all scrape loops for this target set.
 			tSets[pkey.setName] = append(tSets[pkey.setName], tg)
-			n += len(tg.Targets)
+			n[pkey.setName] += len(tg.Targets)
 		}
-		discoveredTargets.WithLabelValues(m.name, pkey.setName).Set(float64(n))
+	}
+	for setName, v := range n {
+		discoveredTargets.WithLabelValues(m.name, setName).Set(float64(v))
 	}
 	return tSets
 }


### PR DESCRIPTION
prometheus_sd_discovered_targets is wrongly calculated when there are
multiple SD configurations in place. One discovery manager can have
multiple groups coming from multiple service discoveries.

When multiple service discovery configs are used, we do not compute the
metric correctly, and instead just set the metric to one of the service
discoveries.


Fixes #8812

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->