### PR TITLE
React UI: Add  Exemplar Support to Graph

### DIFF
--- a/web/ui/react-app/src/pages/graph/Graph.test.tsx
+++ b/web/ui/react-app/src/pages/graph/Graph.test.tsx
@@ -74,10 +74,11 @@ describe('Graph', () => {
           },
         ],
       },
+      id: 'test',
     };
     it('renders a graph with props', () => {
       const graph = shallow(<Graph {...props} />);
-      const div = graph.find('div').filterWhere(elem => elem.prop('className') === 'graph');
+      const div = graph.find('div').filterWhere(elem => elem.prop('className') === 'graph-test');
       const resize = div.find(ReactResizeDetector);
       const innerdiv = div.find('div').filterWhere(elem => elem.prop('className') === 'graph-chart');
       expect(resize.prop('handleWidth')).toBe(true);

--- a/web/ui/react-app/src/pages/graph/Graph.test.tsx
+++ b/web/ui/react-app/src/pages/graph/Graph.test.tsx
@@ -54,6 +54,25 @@ describe('Graph', () => {
             ],
           },
         ],
+        exemplars: [
+          {
+            seriesLabels: {
+              code: '200',
+              handler: '/graph',
+              instance: 'localhost:9090',
+              job: 'prometheus',
+            },
+            exemplars: [
+              {
+                labels: {
+                  traceID: '12345',
+                },
+                timestamp: 1572130580,
+                value: '9',
+              },
+            ],
+          },
+        ],
       },
     };
     it('renders a graph with props', () => {
@@ -101,14 +120,18 @@ describe('Graph', () => {
       graph.setProps({ data: { result: [{ values: [{}], metric: {} }] } });
       expect(spyState).toHaveBeenCalledWith(
         {
-          chartData: [
-            {
-              color: 'rgb(237,194,64)',
-              data: [[1572128592000, null]],
-              index: 0,
-              labels: {},
-            },
-          ],
+          chartData: {
+            exemplars: [],
+            series: [
+              {
+                color: 'rgb(237,194,64)',
+                data: [[1572128592000, null]],
+                index: 0,
+                labels: {},
+                stack: true,
+              },
+            ],
+          },
         },
         expect.anything()
       );
@@ -117,14 +140,18 @@ describe('Graph', () => {
       graph.setProps({ stacked: false });
       expect(spyState).toHaveBeenCalledWith(
         {
-          chartData: [
-            {
-              color: 'rgb(237,194,64)',
-              data: [[1572128592000, null]],
-              index: 0,
-              labels: {},
-            },
-          ],
+          chartData: {
+            exemplars: [],
+            series: [
+              {
+                color: 'rgb(237,194,64)',
+                data: [[1572128592000, null]],
+                index: 0,
+                labels: {},
+                stack: false,
+              },
+            ],
+          },
         },
         expect.anything()
       );
@@ -267,7 +294,7 @@ describe('Graph', () => {
       );
       (graph.instance() as any).plot(); // create chart
       graph.find('.graph-legend').simulate('mouseout');
-      expect(mockSetData).toHaveBeenCalledWith(graph.state().chartData);
+      expect(mockSetData).toHaveBeenCalledWith(graph.state().chartData.series);
       spyPlot.mockReset();
     });
   });

--- a/web/ui/react-app/src/pages/graph/Graph.tsx
+++ b/web/ui/react-app/src/pages/graph/Graph.tsx
@@ -46,7 +46,7 @@ export interface GraphData {
 
 interface GraphState {
   chartData: GraphData;
-  selectedExemplarLabels: { [key: string]: string };
+  selectedExemplarLabels: { exemplar: { [key: string]: string }; series: { [key: string]: string } };
 }
 
 class Graph extends PureComponent<GraphProps, GraphState> {
@@ -57,7 +57,7 @@ class Graph extends PureComponent<GraphProps, GraphState> {
 
   state = {
     chartData: normalizeData(this.props),
-    selectedExemplarLabels: {},
+    selectedExemplarLabels: { exemplar: {}, series: {} },
   };
 
   componentDidUpdate(prevProps: GraphProps) {
@@ -86,7 +86,7 @@ class Graph extends PureComponent<GraphProps, GraphState> {
       this.setState(
         {
           chartData: { series: this.state.chartData.series, exemplars: [] },
-          selectedExemplarLabels: {},
+          selectedExemplarLabels: { exemplar: {}, series: {} },
           ...this.state.selectedExemplarLabels,
         },
         () => {
@@ -103,13 +103,13 @@ class Graph extends PureComponent<GraphProps, GraphState> {
       // If an item has the series label property that means it's an exemplar.
       if (item && 'seriesLabels' in item.series) {
         this.setState({
-          selectedExemplarLabels: item.series.labels,
+          selectedExemplarLabels: { exemplar: item.series.labels, series: item.series.seriesLabels },
           chartData: this.state.chartData,
         });
       } else {
         this.setState({
           chartData: this.state.chartData,
-          selectedExemplarLabels: {},
+          selectedExemplarLabels: { exemplar: {}, series: {} },
         });
       }
     });
@@ -191,18 +191,29 @@ class Graph extends PureComponent<GraphProps, GraphState> {
 
   render() {
     const { chartData, selectedExemplarLabels } = this.state;
-    const selectedLabels = selectedExemplarLabels as { [key: string]: string };
+    const selectedLabels = selectedExemplarLabels as {
+      exemplar: { [key: string]: string };
+      series: { [key: string]: string };
+    };
     return (
       <div className="graph">
         <ReactResizeDetector handleWidth onResize={this.handleResize} skipOnMount />
         <div className="graph-chart" ref={this.chartRef} />
-        {Object.keys(selectedLabels).length > 0 ? (
+        {Object.keys(selectedLabels.exemplar).length > 0 ? (
           <div className="float-right">
             <span style={{ fontSize: '17px' }}>Selected exemplar:</span>
             <div className="labels mt-1">
-              {Object.keys(selectedLabels).map((k, i) => (
+              {Object.keys(selectedLabels.exemplar).map((k, i) => (
                 <div key={i} style={{ fontSize: '15px' }}>
-                  <strong>{k}</strong>: {selectedLabels[k]}
+                  <strong>{k}</strong>: {selectedLabels.exemplar[k]}
+                </div>
+              ))}
+            </div>
+            <span style={{ fontSize: '16px' }}>Series labels:</span>
+            <div className="labels mt-1">
+              {Object.keys(selectedLabels.series).map((k, i) => (
+                <div key={i} style={{ fontSize: '15px' }}>
+                  <strong>{k}</strong>: {selectedLabels.series[k]}
                 </div>
               ))}
             </div>
@@ -215,6 +226,8 @@ class Graph extends PureComponent<GraphProps, GraphState> {
           onLegendMouseOut={this.handleLegendMouseOut}
           onSeriesToggle={this.handleSeriesSelect}
         />
+        {/* This is to make sure the graph box expands when the selected exemplar info pops up. */}
+        <br style={{ clear: 'both' }} />
       </div>
     );
   }

--- a/web/ui/react-app/src/pages/graph/Graph.tsx
+++ b/web/ui/react-app/src/pages/graph/Graph.tsx
@@ -89,7 +89,6 @@ class Graph extends PureComponent<GraphProps, GraphState> {
         {
           chartData: { series: this.state.chartData.series, exemplars: [] },
           selectedExemplarLabels: { exemplar: {}, series: {} },
-          ...this.state.selectedExemplarLabels,
         },
         () => {
           this.plot();

--- a/web/ui/react-app/src/pages/graph/Graph.tsx
+++ b/web/ui/react-app/src/pages/graph/Graph.tsx
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import ReactResizeDetector from 'react-resize-detector';
 
 import { Legend } from './Legend';
-import { Metric, Exemplar, QueryParams, SeriesLabels } from '../../types/types';
+import { Metric, Exemplar, QueryParams } from '../../types/types';
 import { isPresent } from '../../utils';
 import { normalizeData, getOptions, toHoverColor } from './GraphHelpers';
 
@@ -17,7 +17,7 @@ export interface GraphProps {
   data: {
     resultType: string;
     result: Array<{ metric: Metric; values: [number, string][] }>;
-    exemplars: Array<{ seriesLabels: SeriesLabels; exemplars: Exemplar[] }> | undefined;
+    exemplars: Array<{ seriesLabels: Metric; exemplars: Exemplar[] }> | undefined;
   };
   stacked: boolean;
   useLocalTime: boolean;
@@ -130,8 +130,8 @@ class Graph extends PureComponent<GraphProps, GraphState> {
         : [
             ...chartData.series.filter((_, i) => selected.includes(i)),
             ...chartData.exemplars.filter(exemplar => {
-              series: for (let i in selected) {
-                for (let name in chartData.series[selected[i]].labels) {
+              series: for (const i in selected) {
+                for (const name in chartData.series[selected[i]].labels) {
                   if (exemplar.labels[`Series: ${name}`] !== chartData.series[selected[i]].labels[name]) {
                     continue series;
                   }

--- a/web/ui/react-app/src/pages/graph/Graph.tsx
+++ b/web/ui/react-app/src/pages/graph/Graph.tsx
@@ -86,6 +86,7 @@ class Graph extends PureComponent<GraphProps, GraphState> {
       this.setState(
         {
           chartData: { series: this.state.chartData.series, exemplars: [] },
+          selectedExemplarLabels: {},
           ...this.state.selectedExemplarLabels,
         },
         () => {

--- a/web/ui/react-app/src/pages/graph/Graph.tsx
+++ b/web/ui/react-app/src/pages/graph/Graph.tsx
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import ReactResizeDetector from 'react-resize-detector';
 
 import { Legend } from './Legend';
-import { Metric, Exemplar, QueryParams } from '../../types/types';
+import { Metric, ExemplarData, QueryParams } from '../../types/types';
 import { isPresent } from '../../utils';
 import { normalizeData, getOptions, toHoverColor } from './GraphHelpers';
 
@@ -17,8 +17,8 @@ export interface GraphProps {
   data: {
     resultType: string;
     result: Array<{ metric: Metric; values: [number, string][] }>;
-    exemplars: Array<{ seriesLabels: Metric; exemplars: Exemplar[] }> | undefined;
   };
+  exemplars: ExemplarData;
   stacked: boolean;
   useLocalTime: boolean;
   showExemplars: boolean;
@@ -33,6 +33,7 @@ export interface GraphSeries {
 }
 
 export interface GraphExemplar {
+  seriesLabels: { [key: string]: string };
   labels: { [key: string]: string };
   data: (number | null)[][];
 }
@@ -132,7 +133,7 @@ class Graph extends PureComponent<GraphProps, GraphState> {
             ...chartData.exemplars.filter(exemplar => {
               series: for (const i in selected) {
                 for (const name in chartData.series[selected[i]].labels) {
-                  if (exemplar.labels[`Series: ${name}`] !== chartData.series[selected[i]].labels[name]) {
+                  if (exemplar.seriesLabels[name] !== chartData.series[selected[i]].labels[name]) {
                     continue series;
                   }
                 }

--- a/web/ui/react-app/src/pages/graph/Graph.tsx
+++ b/web/ui/react-app/src/pages/graph/Graph.tsx
@@ -36,6 +36,7 @@ export interface GraphExemplar {
   seriesLabels: { [key: string]: string };
   labels: { [key: string]: string };
   data: (number | null)[][];
+  color: string;
 }
 
 export interface GraphData {

--- a/web/ui/react-app/src/pages/graph/Graph.tsx
+++ b/web/ui/react-app/src/pages/graph/Graph.tsx
@@ -35,7 +35,8 @@ export interface GraphSeries {
 export interface GraphExemplar {
   seriesLabels: { [key: string]: string };
   labels: { [key: string]: string };
-  data: (number | null)[][];
+  data: number[][];
+  points: any; // This is used to specify the symbol.
   color: string;
 }
 

--- a/web/ui/react-app/src/pages/graph/Graph.tsx
+++ b/web/ui/react-app/src/pages/graph/Graph.tsx
@@ -23,6 +23,7 @@ export interface GraphProps {
   useLocalTime: boolean;
   showExemplars: boolean;
   queryParams: QueryParams | null;
+  id: string;
 }
 
 export interface GraphSeries {
@@ -100,7 +101,7 @@ class Graph extends PureComponent<GraphProps, GraphState> {
   componentDidMount() {
     this.plot();
 
-    $('.graph').bind('plotclick', (event, pos, item) => {
+    $(`.graph-${this.props.id}`).bind('plotclick', (event, pos, item) => {
       // If an item has the series label property that means it's an exemplar.
       if (item && 'seriesLabels' in item.series) {
         this.setState({
@@ -197,7 +198,7 @@ class Graph extends PureComponent<GraphProps, GraphState> {
       series: { [key: string]: string };
     };
     return (
-      <div className="graph">
+      <div className={`graph-${this.props.id}`}>
         <ReactResizeDetector handleWidth onResize={this.handleResize} skipOnMount />
         <div className="graph-chart" ref={this.chartRef} />
         {Object.keys(selectedLabels.exemplar).length > 0 ? (

--- a/web/ui/react-app/src/pages/graph/GraphControls.test.tsx
+++ b/web/ui/react-app/src/pages/graph/GraphControls.test.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import GraphControls from './GraphControls';
 import { Button, ButtonGroup, Form, InputGroup, InputGroupAddon, Input } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlus, faMinus, faChartArea, faChartLine } from '@fortawesome/free-solid-svg-icons';
+import { faSquare, faPlus, faMinus, faChartArea, faChartLine } from '@fortawesome/free-solid-svg-icons';
 import TimeInput from './TimeInput';
 
 const defaultGraphControlProps = {
@@ -11,6 +11,7 @@ const defaultGraphControlProps = {
   endTime: 1572100217898,
   resolution: 10,
   stacked: false,
+  showExemplars: false,
 
   onChangeRange: (): void => {
     // Do nothing.
@@ -22,6 +23,9 @@ const defaultGraphControlProps = {
     // Do nothing.
   },
   onChangeStacking: (): void => {
+    // Do nothing.
+  },
+  onChangeShowExemplars: (): void => {
     // Do nothing.
   },
 };
@@ -112,11 +116,16 @@ describe('GraphControls', () => {
     expect(input.prop('bsSize')).toEqual('sm');
   });
 
-  it('renders a button group', () => {
-    const controls = shallow(<GraphControls {...defaultGraphControlProps} />);
-    const group = controls.find(ButtonGroup);
-    expect(group.prop('className')).toEqual('stacked-input');
-    expect(group.prop('size')).toEqual('sm');
+  it('renders button groups', () => {
+    [
+      { className: 'stacked-input', size: 'sm' },
+      { className: 'show-exemplars', size: 'sm' },
+    ].forEach((testCase, i) => {
+      const controls = shallow(<GraphControls {...defaultGraphControlProps} />);
+      const groups = controls.find(ButtonGroup);
+      expect(groups.get(i).props['className']).toEqual(testCase.className);
+      expect(groups.get(i).props['size']).toEqual(testCase.size);
+    });
   });
 
   it('renders buttons inside the button group', () => {
@@ -129,6 +138,11 @@ describe('GraphControls', () => {
       {
         title: 'Show stacked graph',
         icon: faChartArea,
+        active: false,
+      },
+      {
+        title: 'Show exemplars',
+        icon: faSquare,
         active: false,
       },
     ].forEach(testCase => {

--- a/web/ui/react-app/src/pages/graph/GraphControls.test.tsx
+++ b/web/ui/react-app/src/pages/graph/GraphControls.test.tsx
@@ -140,11 +140,6 @@ describe('GraphControls', () => {
         icon: faChartArea,
         active: false,
       },
-      {
-        title: 'Show exemplars',
-        icon: faSquare,
-        active: false,
-      },
     ].forEach(testCase => {
       const controls = shallow(<GraphControls {...defaultGraphControlProps} />);
       const group = controls.find(ButtonGroup);

--- a/web/ui/react-app/src/pages/graph/GraphControls.tsx
+++ b/web/ui/react-app/src/pages/graph/GraphControls.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Button, ButtonGroup, Form, InputGroup, InputGroupAddon, Input } from 'reactstrap';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlus, faMinus, faChartArea, faChartLine, faSquare } from '@fortawesome/free-solid-svg-icons';
+import { faPlus, faMinus, faChartArea, faChartLine } from '@fortawesome/free-solid-svg-icons';
 import TimeInput from './TimeInput';
 import { parseDuration, formatDuration } from '../../utils';
 
@@ -152,11 +152,11 @@ class GraphControls extends Component<GraphControlsProps> {
         <ButtonGroup className="show-exemplars" size="sm">
           {this.props.showExemplars ? (
             <Button title="Hide exemplars" onClick={() => this.props.onChangeShowExemplars(false)} active={true}>
-              <FontAwesomeIcon icon={faSquare} fixedWidth />
+              Hide Exemplars
             </Button>
           ) : (
             <Button title="Show exemplars" onClick={() => this.props.onChangeShowExemplars(true)} active={false}>
-              <FontAwesomeIcon icon={faSquare} fixedWidth />
+              Show Exemplars
             </Button>
           )}
         </ButtonGroup>

--- a/web/ui/react-app/src/pages/graph/GraphControls.tsx
+++ b/web/ui/react-app/src/pages/graph/GraphControls.tsx
@@ -2,8 +2,7 @@ import React, { Component } from 'react';
 import { Button, ButtonGroup, Form, InputGroup, InputGroupAddon, Input } from 'reactstrap';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlus, faMinus, faChartArea, faChartLine } from '@fortawesome/free-solid-svg-icons';
-
+import { faPlus, faMinus, faChartArea, faChartLine, faSquare } from '@fortawesome/free-solid-svg-icons';
 import TimeInput from './TimeInput';
 import { parseDuration, formatDuration } from '../../utils';
 
@@ -13,11 +12,13 @@ interface GraphControlsProps {
   useLocalTime: boolean;
   resolution: number | null;
   stacked: boolean;
+  showExemplars: boolean;
 
   onChangeRange: (range: number) => void;
   onChangeEndTime: (endTime: number | null) => void;
   onChangeResolution: (resolution: number | null) => void;
   onChangeStacking: (stacked: boolean) => void;
+  onChangeShowExemplars: (show: boolean) => void;
 }
 
 class GraphControls extends Component<GraphControlsProps> {
@@ -146,6 +147,18 @@ class GraphControls extends Component<GraphControlsProps> {
           <Button title="Show stacked graph" onClick={() => this.props.onChangeStacking(true)} active={this.props.stacked}>
             <FontAwesomeIcon icon={faChartArea} fixedWidth />
           </Button>
+        </ButtonGroup>
+
+        <ButtonGroup className="show-exemplars" size="sm">
+          {this.props.showExemplars ? (
+            <Button title="Hide exemplars" onClick={() => this.props.onChangeShowExemplars(false)} active={true}>
+              <FontAwesomeIcon icon={faSquare} fixedWidth />
+            </Button>
+          ) : (
+            <Button title="Show exemplars" onClick={() => this.props.onChangeShowExemplars(true)} active={false}>
+              <FontAwesomeIcon icon={faSquare} fixedWidth />
+            </Button>
+          )}
         </ButtonGroup>
       </Form>
     );

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.test.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.test.ts
@@ -151,8 +151,7 @@ describe('GraphHelpers', () => {
             <div>
             <div class="labels mt-1">
               <div class="mb-1"><strong>foo</strong>: 1</div><div class="mb-1"><strong>bar</strong>: 2</div>
-            </div>
-          `);
+            </div>`);
     });
     it('should return proper tooltip html from options with local time', () => {
       moment.tz.setDefault('America/New_York');
@@ -168,8 +167,27 @@ describe('GraphHelpers', () => {
             <div>
             <div class="labels mt-1">
               <div class="mb-1"><strong>foo</strong>: 1</div><div class="mb-1"><strong>bar</strong>: 2</div>
+            </div>`);
+    });
+    it('should return proper tooltip for exemplar', () => {
+      expect(
+        getOptions(true, false).tooltip.content('', 1572128592, 1572128592, {
+          series: { labels: { foo: '1', bar: '2' }, seriesLabels: { foo: '2', bar: '3' }, color: '' },
+        } as any)
+      ).toEqual(`
+            <div class="date">1970-01-19 04:42:08 +00:00</div>
+            <div>
+              <span class="detail-swatch" style="background-color: "></span>
+              <span>value: <strong>1572128592</strong></span>
+            <div>
+            <div class="labels mt-1">
+              <div class="mb-1"><strong>foo</strong>: 1</div><div class="mb-1"><strong>bar</strong>: 2</div>
             </div>
-          `);
+            
+            <span>Series labels:</span>
+            <div class="labels mt-1">
+              <div class="mb-1"><strong>foo</strong>: 2</div><div class="mb-1"><strong>bar</strong>: 3</div>
+            </div>`);
     });
     it('should render Plot with proper options', () => {
       expect(getOptions(true, false)).toEqual({

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.test.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.test.ts
@@ -102,7 +102,7 @@ describe('GraphHelpers', () => {
     it('should configure options properly if stacked prop is true', () => {
       expect(getOptions(true, false)).toMatchObject({
         series: {
-          stack: true,
+          stack: false,
           lines: { lineWidth: 1, steps: false, fill: true },
           shadowSize: 0,
         },
@@ -196,7 +196,7 @@ describe('GraphHelpers', () => {
           lines: true,
         },
         series: {
-          stack: true,
+          stack: false,
           lines: { lineWidth: 1, steps: false, fill: true },
           shadowSize: 0,
         },

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -161,7 +161,7 @@ export const getColors = (data: { resultType: string; result: Array<{ metric: Me
   });
 };
 
-export const normalizeData = ({ queryParams, data, stacked }: GraphProps): GraphData => {
+export const normalizeData = ({ queryParams, data, exemplars, stacked }: GraphProps): GraphData => {
   const colors = getColors(data);
   const { startTime, endTime, resolution } = queryParams!;
   return {
@@ -189,8 +189,8 @@ export const normalizeData = ({ queryParams, data, stacked }: GraphProps): Graph
         index,
       };
     }),
-    exemplars: data.exemplars
-      ? data.exemplars
+    exemplars: exemplars
+      ? exemplars
           .map(({ seriesLabels, exemplars }) => {
             const newLabels: { [key: string]: string } = {};
             for (const label in seriesLabels) {
@@ -198,6 +198,7 @@ export const normalizeData = ({ queryParams, data, stacked }: GraphProps): Graph
             }
             return exemplars.map(({ labels, value, timestamp }) => {
               return {
+                seriesLabels: seriesLabels,
                 labels: Object.assign(labels, newLabels),
                 data: [[timestamp * 1000, parseValue(value)]],
                 points: { symbol: exemplarSymbol },

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -188,7 +188,7 @@ export const normalizeData = ({ queryParams, data, exemplars, stacked }: GraphPr
   const buckets: { [time: number]: GraphExemplar[] } = {};
   for (const exemplar of exemplars || []) {
     for (const { labels, value, timestamp } of exemplar.exemplars) {
-      let parsed = parseValue(value) || 0;
+      const parsed = parseValue(value) || 0;
       sum += parsed;
       values.push(parsed);
 

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -120,11 +120,11 @@ export const getOptions = (stacked: boolean, useLocalTime: boolean): jquery.flot
                 )
                 .join('')}
             </div>
-						${
+            ${
               'seriesLabels' in both
-                ? `
-						<span>Series Labels:</span>
-						<div class="labels mt-1">
+            ? `
+            <span>Series Labels:</span>
+            <div class="labels mt-1">
               ${Object.keys(both.seriesLabels)
                 .map(k =>
                   k !== '__name__'
@@ -133,7 +133,7 @@ export const getOptions = (stacked: boolean, useLocalTime: boolean): jquery.flot
                 )
                 .join('')}
             </div>
-						`
+            `
                 : ''
             }
           `;

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -122,8 +122,8 @@ export const getOptions = (stacked: boolean, useLocalTime: boolean): jquery.flot
             </div>
             ${
               'seriesLabels' in both
-            ? `
-            <span>Series Labels:</span>
+                ? `
+            <span>Series labels:</span>
             <div class="labels mt-1">
               ${Object.keys(both.seriesLabels)
                 .map(k =>
@@ -136,7 +136,7 @@ export const getOptions = (stacked: boolean, useLocalTime: boolean): jquery.flot
             `
                 : ''
             }
-          `;
+          `.trimEnd();
       },
       defaultTheme: false,
       lines: true,

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -239,10 +239,18 @@ const exemplarSymbol = (ctx: CanvasRenderingContext2D, x: number, y: number) => 
   if (x > ctx.canvas.clientWidth - 59) {
     x = ctx.canvas.clientWidth - 59;
   }
-  if (y > ctx.canvas.clientHeight - 37) {
-    y = ctx.canvas.clientHeight - 37;
+  if (y > ctx.canvas.clientHeight - 40) {
+    y = ctx.canvas.clientHeight - 40;
   }
 
-  ctx.fillStyle = '#0275d8';
+  ctx.translate(x, y);
+  ctx.rotate(Math.PI / 4);
+  ctx.translate(-x, -y);
+
+  ctx.fillStyle = '#92bce1';
   ctx.fillRect(x, y, 7, 7);
+
+  ctx.strokeStyle = '#0275d8';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(x, y, 7, 7);
 };

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -182,7 +182,7 @@ export const normalizeData = ({ queryParams, data, exemplars, stacked }: GraphPr
   const colors = getColors(data);
   const { startTime, endTime, resolution } = queryParams!;
 
-  let sum: number = 0;
+  let sum = 0;
   const values: number[] = [];
   // Exemplars are grouped into buckets by time to use for de-densifying.
   const buckets: { [time: number]: GraphExemplar[] } = {};
@@ -289,7 +289,7 @@ const exemplarSymbol = (ctx: CanvasRenderingContext2D, x: number, y: number) => 
 };
 
 const stdDeviation = (sum: number, values: number[]): number => {
-  let avg = sum / values.length;
+  const avg = sum / values.length;
   let squaredAvg = 0;
   values.map(value => (squaredAvg += (value - avg) ** 2));
   squaredAvg = squaredAvg / values.length;

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -192,8 +192,8 @@ export const normalizeData = ({ queryParams, data, stacked }: GraphProps): Graph
     exemplars: data.exemplars
       ? data.exemplars
           .map(({ seriesLabels, exemplars }) => {
-            let newLabels: { [key: string]: string } = {};
-            for (let label in seriesLabels) {
+            const newLabels: { [key: string]: string } = {};
+            for (const label in seriesLabels) {
               newLabels[`Series: ${label}`] = seriesLabels[label];
             }
             return exemplars.map(({ labels, value, timestamp }) => {

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -186,10 +186,9 @@ export const normalizeData = ({ queryParams, data, exemplars, stacked }: GraphPr
   const values: number[] = [];
   // Exemplars are grouped into buckets by time to use for de-densifying.
   const buckets: { [time: number]: GraphExemplar[] } = {};
-  for (const exemplar of exemplars ? exemplars : []) {
+  for (const exemplar of exemplars || []) {
     for (const { labels, value, timestamp } of exemplar.exemplars) {
-      let parsed = parseValue(value);
-      parsed = parsed ? parsed : 0;
+      let parsed = parseValue(value) || 0;
       sum += parsed;
       values.push(parsed);
 
@@ -245,7 +244,7 @@ export const normalizeData = ({ queryParams, data, exemplars, stacked }: GraphPr
             exemplars.push(exemplar);
           } else {
             const prev = exemplars[exemplars.length - 1];
-            // Don't plot this exemplar if it's less the two times the standard
+            // Don't plot this exemplar if it's less than two times the standard
             // deviation spaced from the last.
             if (exValue(prev) - exValue(exemplar) >= 2 * deviation) {
               exemplars.push(exemplar);

--- a/web/ui/react-app/src/pages/graph/GraphTabContent.tsx
+++ b/web/ui/react-app/src/pages/graph/GraphTabContent.tsx
@@ -11,6 +11,7 @@ interface GraphTabContentProps {
   useLocalTime: boolean;
   showExemplars: boolean;
   lastQueryParams: QueryParams | null;
+  id: string;
 }
 
 export const GraphTabContent: FC<GraphTabContentProps> = ({
@@ -20,6 +21,7 @@ export const GraphTabContent: FC<GraphTabContentProps> = ({
   useLocalTime,
   lastQueryParams,
   showExemplars,
+  id,
 }) => {
   if (!isPresent(data)) {
     return <Alert color="light">No data queried yet</Alert>;
@@ -40,6 +42,7 @@ export const GraphTabContent: FC<GraphTabContentProps> = ({
       useLocalTime={useLocalTime}
       showExemplars={showExemplars}
       queryParams={lastQueryParams}
+      id={id}
     />
   );
 };

--- a/web/ui/react-app/src/pages/graph/GraphTabContent.tsx
+++ b/web/ui/react-app/src/pages/graph/GraphTabContent.tsx
@@ -8,10 +8,17 @@ interface GraphTabContentProps {
   data: any;
   stacked: boolean;
   useLocalTime: boolean;
+  showExemplars: boolean;
   lastQueryParams: QueryParams | null;
 }
 
-export const GraphTabContent: FC<GraphTabContentProps> = ({ data, stacked, useLocalTime, lastQueryParams }) => {
+export const GraphTabContent: FC<GraphTabContentProps> = ({
+  data,
+  stacked,
+  useLocalTime,
+  lastQueryParams,
+  showExemplars,
+}) => {
   if (!isPresent(data)) {
     return <Alert color="light">No data queried yet</Alert>;
   }
@@ -23,5 +30,13 @@ export const GraphTabContent: FC<GraphTabContentProps> = ({ data, stacked, useLo
       <Alert color="danger">Query result is of wrong type '{data.resultType}', should be 'matrix' (range vector).</Alert>
     );
   }
-  return <Graph data={data} stacked={stacked} useLocalTime={useLocalTime} queryParams={lastQueryParams} />;
+  return (
+    <Graph
+      data={data}
+      stacked={stacked}
+      useLocalTime={useLocalTime}
+      showExemplars={showExemplars}
+      queryParams={lastQueryParams}
+    />
+  );
 };

--- a/web/ui/react-app/src/pages/graph/GraphTabContent.tsx
+++ b/web/ui/react-app/src/pages/graph/GraphTabContent.tsx
@@ -1,11 +1,12 @@
 import React, { FC } from 'react';
 import { Alert } from 'reactstrap';
 import Graph from './Graph';
-import { QueryParams } from '../../types/types';
+import { QueryParams, ExemplarData } from '../../types/types';
 import { isPresent } from '../../utils';
 
 interface GraphTabContentProps {
   data: any;
+  exemplars: ExemplarData;
   stacked: boolean;
   useLocalTime: boolean;
   showExemplars: boolean;
@@ -14,6 +15,7 @@ interface GraphTabContentProps {
 
 export const GraphTabContent: FC<GraphTabContentProps> = ({
   data,
+  exemplars,
   stacked,
   useLocalTime,
   lastQueryParams,
@@ -33,6 +35,7 @@ export const GraphTabContent: FC<GraphTabContentProps> = ({
   return (
     <Graph
       data={data}
+      exemplars={exemplars}
       stacked={stacked}
       useLocalTime={useLocalTime}
       showExemplars={showExemplars}

--- a/web/ui/react-app/src/pages/graph/Panel.tsx
+++ b/web/ui/react-app/src/pages/graph/Panel.tsx
@@ -27,6 +27,7 @@ interface PanelProps {
   enableAutocomplete: boolean;
   enableHighlighting: boolean;
   enableLinter: boolean;
+  id: string;
 }
 
 interface PanelState {
@@ -354,6 +355,7 @@ class Panel extends Component<PanelProps, PanelState> {
                       useLocalTime={this.props.useLocalTime}
                       showExemplars={options.showExemplars}
                       lastQueryParams={this.state.lastQueryParams}
+                      id={this.props.id}
                     />
                   </>
                 )}

--- a/web/ui/react-app/src/pages/graph/Panel.tsx
+++ b/web/ui/react-app/src/pages/graph/Panel.tsx
@@ -181,7 +181,7 @@ class Panel extends Component<PanelProps, PanelState> {
       this.setState({
         error: null,
         data: query.data,
-        exemplars: exemplars.data,
+        exemplars: exemplars?.data,
         warnings: query.warnings,
         lastQueryParams: {
           startTime,

--- a/web/ui/react-app/src/pages/graph/Panel.tsx
+++ b/web/ui/react-app/src/pages/graph/Panel.tsx
@@ -27,7 +27,6 @@ interface PanelProps {
   enableAutocomplete: boolean;
   enableHighlighting: boolean;
   enableLinter: boolean;
-  showExemplars: boolean;
 }
 
 interface PanelState {
@@ -48,6 +47,7 @@ export interface PanelOptions {
   endTime: number | null; // Timestamp in milliseconds.
   resolution: number | null; // Resolution in seconds.
   stacked: boolean;
+  showExemplars: boolean;
 }
 
 export enum PanelType {
@@ -62,6 +62,7 @@ export const PanelDefaultOptions: PanelOptions = {
   endTime: null,
   resolution: null,
   stacked: false,
+  showExemplars: false,
 };
 
 class Panel extends Component<PanelProps, PanelState> {
@@ -82,14 +83,14 @@ class Panel extends Component<PanelProps, PanelState> {
     };
   }
 
-  componentDidUpdate({ options: prevOpts, showExemplars }: PanelProps) {
-    const { endTime, range, resolution, type } = this.props.options;
+  componentDidUpdate({ options: prevOpts }: PanelProps) {
+    const { endTime, range, resolution, showExemplars, type } = this.props.options;
     if (
       prevOpts.endTime !== endTime ||
       prevOpts.range !== range ||
       prevOpts.resolution !== resolution ||
       prevOpts.type !== type ||
-      (showExemplars !== this.props.showExemplars && this.props.showExemplars)
+      showExemplars !== prevOpts.showExemplars
     ) {
       this.executeQuery();
     }
@@ -155,7 +156,7 @@ class Panel extends Component<PanelProps, PanelState> {
         throw new Error(query.error || 'invalid response JSON');
       }
 
-      if (this.props.options.type === 'graph' && this.props.showExemplars) {
+      if (this.props.options.type === 'graph' && this.props.options.showExemplars) {
         params.delete('step'); // Not needed for this request.
         exemplars = await fetch(`${this.props.pathPrefix}/${API_PATH}/query_exemplars?${params}`, {
           cache: 'no-store',
@@ -249,6 +250,10 @@ class Panel extends Component<PanelProps, PanelState> {
     this.setOptions({ stacked: stacked });
   };
 
+  handleChangeShowExemplars = (show: boolean) => {
+    this.setOptions({ showExemplars: show });
+  };
+
   render() {
     const { pastQueries, metricNames, options } = this.props;
     return (
@@ -335,17 +340,19 @@ class Panel extends Component<PanelProps, PanelState> {
                       useLocalTime={this.props.useLocalTime}
                       resolution={options.resolution}
                       stacked={options.stacked}
+                      showExemplars={options.showExemplars}
                       onChangeRange={this.handleChangeRange}
                       onChangeEndTime={this.handleChangeEndTime}
                       onChangeResolution={this.handleChangeResolution}
                       onChangeStacking={this.handleChangeStacking}
+                      onChangeShowExemplars={this.handleChangeShowExemplars}
                     />
                     <GraphTabContent
                       data={this.state.data}
                       exemplars={this.state.exemplars}
                       stacked={options.stacked}
                       useLocalTime={this.props.useLocalTime}
-                      showExemplars={this.props.showExemplars}
+                      showExemplars={options.showExemplars}
                       lastQueryParams={this.state.lastQueryParams}
                     />
                   </>

--- a/web/ui/react-app/src/pages/graph/Panel.tsx
+++ b/web/ui/react-app/src/pages/graph/Panel.tsx
@@ -125,7 +125,7 @@ class Panel extends Component<PanelProps, PanelState> {
     });
 
     let path: string;
-    let showExemplars: boolean = false;
+    let showExemplars = false;
     switch (this.props.options.type) {
       case 'graph':
         path = 'query_range';

--- a/web/ui/react-app/src/pages/graph/PanelList.test.tsx
+++ b/web/ui/react-app/src/pages/graph/PanelList.test.tsx
@@ -9,7 +9,6 @@ describe('PanelList', () => {
   it('renders configuration checkboxes', () => {
     [
       { id: 'use-local-time-checkbox', label: 'Use local time', default: false },
-      { id: 'show-exemplars-checkbox', label: 'Show exemplars', default: false },
       { id: 'query-history-checkbox', label: 'Enable query history', default: false },
       { id: 'autocomplete-checkbox', label: 'Enable autocomplete', default: true },
       { id: 'use-experimental-editor-checkbox', label: 'Use experimental editor', default: false },

--- a/web/ui/react-app/src/pages/graph/PanelList.test.tsx
+++ b/web/ui/react-app/src/pages/graph/PanelList.test.tsx
@@ -9,6 +9,7 @@ describe('PanelList', () => {
   it('renders configuration checkboxes', () => {
     [
       { id: 'use-local-time-checkbox', label: 'Use local time', default: false },
+      { id: 'show-exemplars-checkbox', label: 'Show exemplars', default: false },
       { id: 'query-history-checkbox', label: 'Enable query history', default: false },
       { id: 'autocomplete-checkbox', label: 'Enable autocomplete', default: true },
       { id: 'use-experimental-editor-checkbox', label: 'Use experimental editor', default: false },

--- a/web/ui/react-app/src/pages/graph/PanelList.tsx
+++ b/web/ui/react-app/src/pages/graph/PanelList.tsx
@@ -90,6 +90,7 @@ export const PanelListContent: FC<PanelListContentProps> = ({
           pathPrefix={pathPrefix}
           onExecuteQuery={handleExecuteQuery}
           key={id}
+          id={id}
           options={options}
           onOptionsChanged={opts =>
             callAll(setPanels, updateURL)(panels.map(p => (id === p.id ? { ...p, options: opts } : p)))

--- a/web/ui/react-app/src/pages/graph/PanelList.tsx
+++ b/web/ui/react-app/src/pages/graph/PanelList.tsx
@@ -26,6 +26,7 @@ interface PanelListContentProps extends RouteComponentProps {
   enableAutocomplete: boolean;
   enableHighlighting: boolean;
   enableLinter: boolean;
+  showExemplars: boolean;
 }
 
 export const PanelListContent: FC<PanelListContentProps> = ({
@@ -36,6 +37,7 @@ export const PanelListContent: FC<PanelListContentProps> = ({
   enableAutocomplete,
   enableHighlighting,
   enableLinter,
+  showExemplars,
   ...rest
 }) => {
   const [panels, setPanels] = useState(rest.panels);
@@ -112,6 +114,7 @@ export const PanelListContent: FC<PanelListContentProps> = ({
           enableAutocomplete={enableAutocomplete}
           enableHighlighting={enableHighlighting}
           enableLinter={enableLinter}
+          showExemplars={showExemplars}
         />
       ))}
       <Button className="d-block mb-3" color="primary" onClick={addPanel}>
@@ -129,6 +132,7 @@ const PanelList: FC<RouteComponentProps> = () => {
   const [enableAutocomplete, setEnableAutocomplete] = useLocalStorage('enable-metric-autocomplete', true);
   const [enableHighlighting, setEnableHighlighting] = useLocalStorage('enable-syntax-highlighting', true);
   const [enableLinter, setEnableLinter] = useLocalStorage('enable-linter', true);
+  const [showExemplars, setShowExemplars] = useLocalStorage('show-exemplars', false);
 
   const pathPrefix = usePathPrefix();
   const { response: metricsRes, error: metricsErr } = useFetch<string[]>(`${pathPrefix}/${API_PATH}/label/__name__/values`);
@@ -162,6 +166,14 @@ const PanelList: FC<RouteComponentProps> = () => {
             defaultChecked={useLocalTime}
           >
             Use local time
+          </Checkbox>
+          <Checkbox
+            wrapperStyles={{ marginLeft: 20, display: 'inline-block' }}
+            id="show-exemplars-checkbox"
+            onChange={({ target }) => setShowExemplars(target.checked)}
+            defaultChecked={showExemplars}
+          >
+            Show exemplars
           </Checkbox>
           <Checkbox
             wrapperStyles={{ marginLeft: 20, display: 'inline-block' }}
@@ -232,6 +244,7 @@ const PanelList: FC<RouteComponentProps> = () => {
         enableAutocomplete={enableAutocomplete}
         enableHighlighting={enableHighlighting}
         enableLinter={enableLinter}
+        showExemplars={showExemplars}
       />
     </>
   );

--- a/web/ui/react-app/src/pages/graph/PanelList.tsx
+++ b/web/ui/react-app/src/pages/graph/PanelList.tsx
@@ -26,7 +26,6 @@ interface PanelListContentProps extends RouteComponentProps {
   enableAutocomplete: boolean;
   enableHighlighting: boolean;
   enableLinter: boolean;
-  showExemplars: boolean;
 }
 
 export const PanelListContent: FC<PanelListContentProps> = ({
@@ -37,7 +36,6 @@ export const PanelListContent: FC<PanelListContentProps> = ({
   enableAutocomplete,
   enableHighlighting,
   enableLinter,
-  showExemplars,
   ...rest
 }) => {
   const [panels, setPanels] = useState(rest.panels);
@@ -114,7 +112,6 @@ export const PanelListContent: FC<PanelListContentProps> = ({
           enableAutocomplete={enableAutocomplete}
           enableHighlighting={enableHighlighting}
           enableLinter={enableLinter}
-          showExemplars={showExemplars}
         />
       ))}
       <Button className="d-block mb-3" color="primary" onClick={addPanel}>
@@ -132,7 +129,6 @@ const PanelList: FC<RouteComponentProps> = () => {
   const [enableAutocomplete, setEnableAutocomplete] = useLocalStorage('enable-metric-autocomplete', true);
   const [enableHighlighting, setEnableHighlighting] = useLocalStorage('enable-syntax-highlighting', true);
   const [enableLinter, setEnableLinter] = useLocalStorage('enable-linter', true);
-  const [showExemplars, setShowExemplars] = useLocalStorage('show-exemplars', false);
 
   const pathPrefix = usePathPrefix();
   const { response: metricsRes, error: metricsErr } = useFetch<string[]>(`${pathPrefix}/${API_PATH}/label/__name__/values`);
@@ -166,14 +162,6 @@ const PanelList: FC<RouteComponentProps> = () => {
             defaultChecked={useLocalTime}
           >
             Use local time
-          </Checkbox>
-          <Checkbox
-            wrapperStyles={{ marginLeft: 20, display: 'inline-block' }}
-            id="show-exemplars-checkbox"
-            onChange={({ target }) => setShowExemplars(target.checked)}
-            defaultChecked={showExemplars}
-          >
-            Show exemplars
           </Checkbox>
           <Checkbox
             wrapperStyles={{ marginLeft: 20, display: 'inline-block' }}
@@ -244,7 +232,6 @@ const PanelList: FC<RouteComponentProps> = () => {
         enableAutocomplete={enableAutocomplete}
         enableHighlighting={enableHighlighting}
         enableLinter={enableLinter}
-        showExemplars={showExemplars}
       />
     </>
   );

--- a/web/ui/react-app/src/types/types.ts
+++ b/web/ui/react-app/src/types/types.ts
@@ -4,6 +4,14 @@ export interface Metric {
   [key: string]: string;
 }
 
+export interface SeriesLabels extends Metric {}
+
+export interface Exemplar {
+  labels: { [key: string]: string };
+  value: string;
+  timestamp: number;
+}
+
 export interface QueryParams {
   startTime: number;
   endTime: number;

--- a/web/ui/react-app/src/types/types.ts
+++ b/web/ui/react-app/src/types/types.ts
@@ -4,8 +4,6 @@ export interface Metric {
   [key: string]: string;
 }
 
-export interface SeriesLabels extends Metric {}
-
 export interface Exemplar {
   labels: { [key: string]: string };
   value: string;

--- a/web/ui/react-app/src/types/types.ts
+++ b/web/ui/react-app/src/types/types.ts
@@ -40,3 +40,5 @@ export interface WALReplayData {
 export interface WALReplayStatus {
   data?: WALReplayData;
 }
+
+export type ExemplarData = Array<{ seriesLabels: Metric; exemplars: Exemplar[] }> | undefined;

--- a/web/ui/react-app/src/utils/index.ts
+++ b/web/ui/react-app/src/utils/index.ts
@@ -201,6 +201,9 @@ export const parseOption = (param: string): Partial<PanelOptions> => {
     case 'stacked':
       return { stacked: decodedValue === '1' };
 
+    case 'show_exemplars':
+      return { showExemplars: decodedValue === '1' };
+
     case 'range_input':
       const range = parseDuration(decodedValue);
       return isPresent(range) ? { range } : {};
@@ -222,12 +225,13 @@ export const formatParam = (key: string) => (paramName: string, value: number | 
 
 export const toQueryString = ({ key, options }: PanelMeta) => {
   const formatWithKey = formatParam(key);
-  const { expr, type, stacked, range, endTime, resolution } = options;
+  const { expr, type, stacked, range, endTime, resolution, showExemplars } = options;
   const time = isPresent(endTime) ? formatTime(endTime) : false;
   const urlParams = [
     formatWithKey('expr', expr),
     formatWithKey('tab', type === PanelType.Graph ? 0 : 1),
     formatWithKey('stacked', stacked ? 1 : 0),
+    formatWithKey('show_exemplars', showExemplars ? 1 : 0),
     formatWithKey('range_input', formatDuration(range)),
     time ? `${formatWithKey('end_input', time)}&${formatWithKey('moment_input', time)}` : '',
     isPresent(resolution) ? formatWithKey('step_input', resolution) : '',
@@ -240,7 +244,7 @@ export const encodePanelOptionsToQueryString = (panels: PanelMeta[]) => {
 };
 
 export const createExpressionLink = (expr: string) => {
-  return `../graph?g0.expr=${encodeURIComponent(expr)}&g0.tab=1&g0.stacked=0&g0.range_input=1h`;
+  return `../graph?g0.expr=${encodeURIComponent(expr)}&g0.tab=1&g0.stacked=0&g0.show_exemplars=0.g0.range_input=1h.`;
 };
 export const mapObjEntries = <T, key extends keyof T, Z>(
   o: T,

--- a/web/ui/react-app/src/utils/utils.test.ts
+++ b/web/ui/react-app/src/utils/utils.test.ts
@@ -227,7 +227,7 @@ describe('Utils', () => {
       },
     ];
     const query =
-      '?g0.expr=rate(node_cpu_seconds_total%7Bmode%3D%22system%22%7D%5B1m%5D)&g0.tab=0&g0.stacked=0&g0.range_input=1h&g0.end_input=2019-10-25%2023%3A37%3A00&g0.moment_input=2019-10-25%2023%3A37%3A00&g1.expr=node_filesystem_avail_bytes&g1.tab=1&g1.stacked=0&g1.range_input=1h';
+      '?g0.expr=rate(node_cpu_seconds_total%7Bmode%3D%22system%22%7D%5B1m%5D)&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h&g0.end_input=2019-10-25%2023%3A37%3A00&g0.moment_input=2019-10-25%2023%3A37%3A00&g1.expr=node_filesystem_avail_bytes&g1.tab=1&g1.stacked=0&g1.show_exemplars=0&g1.range_input=1h';
 
     describe('decodePanelOptionsFromQueryString', () => {
       it('returns [] when query is empty', () => {
@@ -291,9 +291,17 @@ describe('Utils', () => {
           toQueryString({
             id: 'asdf',
             key: '0',
-            options: { expr: 'foo', type: PanelType.Graph, stacked: true, range: 0, endTime: null, resolution: 1 },
+            options: {
+              expr: 'foo',
+              type: PanelType.Graph,
+              stacked: true,
+              showExemplars: true,
+              range: 0,
+              endTime: null,
+              resolution: 1,
+            },
           })
-        ).toEqual('g0.expr=foo&g0.tab=0&g0.stacked=1&g0.range_input=0s&g0.step_input=1');
+        ).toEqual('g0.expr=foo&g0.tab=0&g0.stacked=1&g0.show_exemplars=1&g0.range_input=0s&g0.step_input=1');
       });
     });
 


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR adds exemplar support to the React UI graph. Exemplars can be:

- Optionally queried using a checkbox
- Hovered over and display their labels and their series' labels
- Filtered out through the regular series selection mechanism

(Partially) implements #8797

One thing that I still can't figure out is this error: `Uncaught TypeError: Cannot read property 'save' of null at drawOverlay (:3000/static/js/main.chunk.js:12297)` when resizing the graph substantially and other big shifts. It has to do with the exemplar symbol, and as far as I can see it doesn't seem to have any effect. I suppose we could just leave it in, but it may be nice to check for undefined in that section of flot to avoid the message.

### Demo

I've found that the fastest way to get exemplars is through Grafana's [Observability Demo App Docker Compose Demo](https://github.com/grafana/tns/tree/main/production/docker-compose). After cloning the repo and following the docker compose setup instructions, go to `production/docker-compose` and run `docker-compose up tempo db app loadgen prometheus`. Then start the react dev server in Prometheus. The two queries used in the video are `histogram_quantile(.99, sum(rate(tns_request_duration_seconds_bucket{}[1m])) by (le))` ([from this article](https://grafana.com/blog/2020/11/09/trace-discovery-in-grafana-tempo-using-prometheus-exemplars-loki-2.0-queries-and-more/)) and `tns_request_duration_seconds_bucket`.

---

https://user-images.githubusercontent.com/54278938/118383973-b1751f00-b5d0-11eb-9b68-7c522aa2847a.mp4