### PR TITLE
Expose seriesToChunkEncoder

### DIFF
--- a/storage/merge.go
+++ b/storage/merge.go
@@ -667,7 +667,7 @@ func (c *compactChunkIterator) Next() bool {
 	}
 
 	// Add last as it's not yet included in overlap. We operate on same series, so labels does not matter here.
-	iter = (&seriesToChunkEncoder{Series: c.mergeFunc(append(overlapping, newChunkToSeriesDecoder(nil, c.curr))...)}).Iterator()
+	iter = NewSeriesToChunkEncoder(c.mergeFunc(append(overlapping, newChunkToSeriesDecoder(nil, c.curr))...)).Iterator()
 	if !iter.Next() {
 		if c.err = iter.Err(); c.err != nil {
 			return false

--- a/storage/series.go
+++ b/storage/series.go
@@ -204,9 +204,7 @@ func (c *seriesSetToChunkSet) Next() bool {
 }
 
 func (c *seriesSetToChunkSet) At() ChunkSeries {
-	return &seriesToChunkEncoder{
-		Series: c.SeriesSet.At(),
-	}
+	return NewSeriesToChunkEncoder(c.SeriesSet.At())
 }
 
 func (c *seriesSetToChunkSet) Err() error {
@@ -218,6 +216,11 @@ type seriesToChunkEncoder struct {
 }
 
 const seriesToChunkEncoderSplit = 120
+
+// NewSeriesToChunkEncoder encodes samples to chunks with 120 samples limit.
+func NewSeriesToChunkEncoder(series Series) ChunkSeries {
+	return &seriesToChunkEncoder{series}
+}
 
 func (s *seriesToChunkEncoder) Iterator() chunks.Iterator {
 	chk := chunkenc.NewXORChunk()


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

seriesToChunkEncoder is very handy to encode samples to XOR chunks with 120 samples limit. It would be very useful to expose it publicly for reuse. 

Please let me know if this pr makes sense. ~~I am also thinking about making `seriesToChunkEncoderSplit` configurable as a parameter. Now it is a const value 120 so we can only create maximum 120 samples chunks.  But sometimes we want to create a very large chunk for testing purposes.~~