### PR TITLE
change module path of current version (v2) to ...prometheus/v2 #8852

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/prometheus/prometheus
+module github.com/prometheus/prometheus/v2
 
 go 1.14
 


### PR DESCRIPTION
Change the first line of go.mod to:
module github.com/prometheus/prometheus/v2

Use case. Why is this important?
it's [the recommended way ](https://blog.golang.org/v2-go-modules) of releasing V2 and beyond
We have multiple projects using both v1 and v2 Prometheus in our monorepo. sharing the same import path for the incompatible versions is causing the problem