### PR TITLE
segments sequential validate

### DIFF
--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -304,20 +304,19 @@ func (w *Watcher) segments(dir string) ([]int, error) {
 	}
 
 	var refs []int
-	var last int
 	for _, f := range files {
 		k, err := strconv.Atoi(f.Name())
 		if err != nil {
 			continue
 		}
-		if len(refs) > 0 && k > last+1 {
-			return nil, errors.New("segments are not sequential")
-		}
 		refs = append(refs, k)
-		last = k
 	}
 	sort.Ints(refs)
-
+	for i := 0; i < len(refs)-1; i++ {
+		if refs[i]+1 != refs[i+1] {
+			return nil, errors.New("segments are not sequential")
+		}
+	}
 	return refs, nil
 }
 


### PR DESCRIPTION
More strictly validate if segment files  are sequential.
Signed-off-by: XiaoYu Zhang <ideoutrea@163.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->