### PR TITLE
feat: Add timezone_offset function

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -33,6 +33,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/alecthomas/units"
 	"github.com/go-kit/kit/log"

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -409,6 +409,17 @@ the given vector as the number of seconds since January 1, 1970 UTC.
 
 *This function was added in Prometheus 2.0*
 
+## `timezone_offset()`
+
+`timezone_offset(v string)` returns the offset to the given timezone.
+A list of all supported Timezones is available at en.wikipedia.org/wiki/List_of_tz_database_time_zones .
+ 
+```
+hour(timestamp(up{job="api-server"}) + timezone_offset("Europe/Berlin"))
+```
+
+*This function was added in Prometheus 2.28*
+
 ## `vector()`
 
 `vector(s scalar)` returns the scalar `s` as a vector with no labels.

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -272,6 +272,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeVector},
 		ReturnType: ValueTypeVector,
 	},
+	"timezone_offset": {
+		Name:       "timezone_offset",
+		ArgTypes:   []ValueType{ValueTypeString},
+		ReturnType: ValueTypeScalar,
+	},
 	"vector": {
 		Name:       "vector",
 		ArgTypes:   []ValueType{ValueTypeScalar},

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -747,6 +747,17 @@ eval instant at 0m days_in_month(vector(1454284800))
 eval instant at 0m days_in_month(vector(1485907200))
   {} 28
 
+eval instant at 0m timezone_offset("UTC")
+  0
+
+# With DST
+eval instant at 1622213973s timezone_offset("Europe/Berlin")
+  7200
+
+# Without DST
+eval instant at 0s timezone_offset("Europe/Berlin")
+  3600
+
 clear
 
 # Test duplicate labelset in promql output.


### PR DESCRIPTION
Implemeting the timezone_offset function, thanks to VictoriaMetrics for this very nice approach to the problem. With this function you can combine a timestamp with the offset to calculate correct values for the given timezone 

This was also discussed at https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1306 

Fixes #4160