### PR TITLE
Single literal regexp value test case for querier

### DIFF
--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1513,6 +1513,13 @@ func TestFindSetMatches(t *testing.T) {
 		pattern string
 		exp     []string
 	}{
+		// Single value, coming from a `bar=~"foo"` selector.
+		{
+			pattern: "^(?:foo)$",
+			exp: []string{
+				"foo",
+			},
+		},
 		// Simple sets.
 		{
 			pattern: "^(?:foo|bar|baz)$",


### PR DESCRIPTION
It's common to see queries like bar=~"foo" from machine generated queries in the fronted. 
These are not evaluated as regexps, but are a single-value-set, i.e. and equality matchings instead.

This is just a test case for a single-value case.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->