### PR TITLE
Fix sync of CircleCI orb

### DIFF
--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -15,14 +15,19 @@ orgs="prometheus prometheus-community"
 
 color_red='\e[31m'
 color_green='\e[32m'
+color_yellow='\e[33m'
 color_none='\e[0m'
 
 echo_red() {
-  echo -e "${color_red}$@${color_none}"
+  echo -e "${color_red}$@${color_none}" 1>&2
 }
 
 echo_green() {
-  echo -e "${color_green}$@${color_none}"
+  echo -e "${color_green}$@${color_none}" 1>&2
+}
+
+echo_yellow() {
+  echo -e "${color_yellow}$@${color_none}" 1>&2
 }
 
 GITHUB_TOKEN="${GITHUB_TOKEN:-}"
@@ -100,8 +105,8 @@ check_circleci_orb() {
 
   orb_version="$(curl -sL --fail "${ci_config_url}" | yq eval '.orbs.prometheus' -)"
   if [[ -z "${orb_version}" ]]; then
-    echo_red "ERROR: Failed to fetch CirleCI orb version from '${org_repo}'"
-    return 1
+    echo_yellow "WARNING: Failed to fetch CirleCI orb version from '${org_repo}'"
+    return 0
   fi
 
   if [[ "${orb_version}" != "null" && "${orb_version}" != "${prometheus_orb_version}" ]]; then


### PR DESCRIPTION
Fix the case where there is no circleci config in a repo.
* Add echo_yellow() for warnings.
* Send echo_COLOR output to stderr to not be in function output.
* Make check_circleci_orb curl failure a warning.

Signed-off-by: SuperQ <superq@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->