### PR TITLE
Refactor file discovery init function

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -102,8 +102,7 @@ var (
 
 func init() {
 	discovery.RegisterConfig(&SDConfig{})
-	prometheus.MustRegister(rpcFailuresCount)
-	prometheus.MustRegister(rpcDuration)
+	prometheus.MustRegister(rpcFailuresCount, rpcDuration)
 }
 
 // SDConfig is the configuration for Consul service discovery.

--- a/discovery/dns/dns.go
+++ b/discovery/dns/dns.go
@@ -68,8 +68,7 @@ var (
 
 func init() {
 	discovery.RegisterConfig(&SDConfig{})
-	prometheus.MustRegister(dnsSDLookupFailuresCount)
-	prometheus.MustRegister(dnsSDLookupsCount)
+	prometheus.MustRegister(dnsSDLookupFailuresCount, dnsSDLookupsCount)
 }
 
 // SDConfig is the configuration for DNS based service discovery.

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -62,9 +62,7 @@ var (
 
 func init() {
 	discovery.RegisterConfig(&SDConfig{})
-	prometheus.MustRegister(fileSDScanDuration)
-	prometheus.MustRegister(fileSDReadErrorsCount)
-	prometheus.MustRegister(fileSDTimeStamp)
+	prometheus.MustRegister(fileSDScanDuration, fileSDReadErrorsCount, fileSDTimeStamp)
 }
 
 // SDConfig is the configuration for file based discovery.

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -39,6 +39,19 @@ import (
 )
 
 var (
+	fileSDScanDuration = prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Name:       "prometheus_sd_file_scan_duration_seconds",
+			Help:       "The duration of the File-SD scan in seconds.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		})
+	fileSDReadErrorsCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "prometheus_sd_file_read_errors_total",
+			Help: "The number of File-SD read errors.",
+		})
+	fileSDTimeStamp = NewTimestampCollector()
+
 	patFileSDName = regexp.MustCompile(`^[^*]*(\*[^/]*)?\.(json|yml|yaml|JSON|YML|YAML)$`)
 
 	// DefaultSDConfig is the default file SD configuration.
@@ -49,6 +62,9 @@ var (
 
 func init() {
 	discovery.RegisterConfig(&SDConfig{})
+	prometheus.MustRegister(fileSDScanDuration)
+	prometheus.MustRegister(fileSDReadErrorsCount)
+	prometheus.MustRegister(fileSDTimeStamp)
 }
 
 // SDConfig is the configuration for file based discovery.
@@ -151,27 +167,6 @@ func NewTimestampCollector() *TimestampCollector {
 		),
 		discoverers: make(map[*Discovery]struct{}),
 	}
-}
-
-var (
-	fileSDScanDuration = prometheus.NewSummary(
-		prometheus.SummaryOpts{
-			Name:       "prometheus_sd_file_scan_duration_seconds",
-			Help:       "The duration of the File-SD scan in seconds.",
-			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
-		})
-	fileSDReadErrorsCount = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "prometheus_sd_file_read_errors_total",
-			Help: "The number of File-SD read errors.",
-		})
-	fileSDTimeStamp = NewTimestampCollector()
-)
-
-func init() {
-	prometheus.MustRegister(fileSDScanDuration)
-	prometheus.MustRegister(fileSDReadErrorsCount)
-	prometheus.MustRegister(fileSDTimeStamp)
 }
 
 // Discovery provides service discovery functionality based


### PR DESCRIPTION
Combine to one init function like other discovery [discovery/dns/dns.go#L69](https://github.com/prometheus/prometheus/blob/main/discovery/dns/dns.go#L69).

Signed-off-by: songjiayang <songjiayang1@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->