### PR TITLE
Add AZ ID label to discovered EC2 targets

### DIFF
--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -158,7 +158,7 @@ func NewEC2Discovery(conf *EC2SDConfig, logger log.Logger) *EC2Discovery {
 	return d
 }
 
-func (d *EC2Discovery) ec2Client() (*ec2.EC2, error) {
+func (d *EC2Discovery) ec2Client(ctx context.Context) (*ec2.EC2, error) {
 	if d.ec2 != nil {
 		return d.ec2, nil
 	}
@@ -188,7 +188,7 @@ func (d *EC2Discovery) ec2Client() (*ec2.EC2, error) {
 	}
 
 	// Region is fixed when client is created, so this is safe to do once.
-	azs, err := d.ec2.DescribeAvailabilityZones(&ec2.DescribeAvailabilityZonesInput{})
+	azs, err := d.ec2.DescribeAvailabilityZonesWithContext(ctx, &ec2.DescribeAvailabilityZonesInput{})
 	if err != nil {
 		return nil, errors.Wrap(err, "could not describe availability zones")
 	}
@@ -201,7 +201,7 @@ func (d *EC2Discovery) ec2Client() (*ec2.EC2, error) {
 }
 
 func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
-	ec2Client, err := d.ec2Client()
+	ec2Client, err := d.ec2Client(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -136,9 +136,9 @@ type EC2Discovery struct {
 	cfg *EC2SDConfig
 	ec2 *ec2.EC2
 
-	// azToID maps this account's availability zones to their underlying AZ ID,
-	// e.g. eu-west-2a -> euw2-az2.
-	azToID map[string]string
+	// azToAZID maps this account's availability zones to their underlying AZ
+	// ID, e.g. eu-west-2a -> euw2-az2.
+	azToAZID map[string]string
 }
 
 // NewEC2Discovery returns a new EC2Discovery which periodically refreshes its targets.
@@ -192,9 +192,9 @@ func (d *EC2Discovery) ec2Client(ctx context.Context) (*ec2.EC2, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not describe availability zones")
 	}
-	d.azToID = make(map[string]string, len(azs.AvailabilityZones))
+	d.azToAZID = make(map[string]string, len(azs.AvailabilityZones))
 	for _, az := range azs.AvailabilityZones {
-		d.azToID[*az.ZoneName] = *az.ZoneId
+		d.azToAZID[*az.ZoneName] = *az.ZoneId
 	}
 
 	return d.ec2, nil
@@ -226,7 +226,7 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 				if inst.PrivateIpAddress == nil {
 					continue
 				}
-				azID, ok := d.azToID[*inst.Placement.AvailabilityZone]
+				azID, ok := d.azToAZID[*inst.Placement.AvailabilityZone]
 				if !ok {
 					continue
 				}

--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -242,7 +242,10 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 				}
 				azID, err := d.azID(ctx, *inst.Placement.AvailabilityZone)
 				if err != nil {
-					level.Warn(d.logger).Log("msg", "Unable to retrieve availability zone ID", "err", err.Error())
+					level.Warn(d.logger).Log(
+						"msg", "Unable to determine availability zone ID",
+						"az", *inst.Placement.AvailabilityZone,
+						"err", err.Error())
 				}
 
 				labels := model.LabelSet{

--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -211,7 +211,7 @@ func (d *EC2Discovery) azID(ctx context.Context, az string) (string, error) {
 	if azID, ok := d.azToAZID[az]; ok {
 		return azID, nil
 	}
-	return "", fmt.Errorf("no availability zone ID mapping found for %v", az)
+	return "", fmt.Errorf("no availability zone ID mapping found for %s", az)
 }
 
 func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
@@ -245,7 +245,7 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 					level.Warn(d.logger).Log(
 						"msg", "Unable to determine availability zone ID",
 						"az", *inst.Placement.AvailabilityZone,
-						"err", err.Error())
+						"err", err)
 				}
 
 				labels := model.LabelSet{

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -893,6 +893,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_ec2_ami`: the EC2 Amazon Machine Image
 * `__meta_ec2_architecture`: the architecture of the instance
 * `__meta_ec2_availability_zone`: the availability zone in which the instance is running
+* `__meta_ec2_availability_zone_id`: the underlying availability zone in which the instance is running
 * `__meta_ec2_instance_id`: the EC2 instance ID
 * `__meta_ec2_instance_lifecycle`: the lifecycle of the EC2 instance, set only for 'spot' or 'scheduled' instances, absent otherwise
 * `__meta_ec2_instance_state`: the state of the EC2 instance

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -893,7 +893,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_ec2_ami`: the EC2 Amazon Machine Image
 * `__meta_ec2_architecture`: the architecture of the instance
 * `__meta_ec2_availability_zone`: the availability zone in which the instance is running
-* `__meta_ec2_availability_zone_id`: the underlying availability zone in which the instance is running
+* `__meta_ec2_availability_zone_id`: the [availability zone ID](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html) in which the instance is running
 * `__meta_ec2_instance_id`: the EC2 instance ID
 * `__meta_ec2_instance_lifecycle`: the lifecycle of the EC2 instance, set only for 'spot' or 'scheduled' instances, absent otherwise
 * `__meta_ec2_instance_state`: the state of the EC2 instance


### PR DESCRIPTION
This PR adds a new `__meta_ec2_availability_zone_id` label to discovered EC2 targets, containing the [underlying AZ](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html) of the instance (e.g. `euw2-az1`). AZ to AZ ID mappings are set when an AWS account is created, so it is safe (and most efficient) to retrieve them once during initialisation.

Important notes:

 - It looks like the EC2 client will never change region, even if the `region` directive changes in the config. I'm not sure whether this is a bug.
 - On start-up, there is a very slim chance the account does not have access to the describe AZs API, in which case this will break EC2 SD.
 - If AWS launch a new AZ, or the account opts into a new AZ while Prometheus is running, targets in that AZ will not show up until Prometheus is restarted. The docs advise scraping within the AZ, so this will only be a problem for those who are both very unlucky and not following best practice.