### PR TITLE
Split Go and React Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,6 @@ executors:
   golang_115:
     docker:
       - image: circleci/golang:1.15-node
-  node:
-    docker:
-      - image: circleci/node:14.17
 
 jobs:
   test_go:
@@ -30,7 +27,7 @@ jobs:
       - run:
           command: sudo apt-get install -y yamllint
       - run:
-          command: make go-ci
+          command: make go-only
           environment:
             # Run garbage collection more aggressively to avoid getting OOMed during the lint phase.
             GOGC: "20"
@@ -53,7 +50,7 @@ jobs:
           path: test-results
 
   test_react:
-    executor: node
+    executor: golang
 
     steps:
       - checkout
@@ -62,7 +59,7 @@ jobs:
             - v3-npm-deps-{{ checksum "web/ui/react-app/yarn.lock" }}
             - v3-npm-deps-
       - run:
-          command: make react-ci
+          command: make react-app-test
       - save_cache:
           key: v3-npm-deps-{{ checksum "web/ui/react-app/yarn.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,23 +15,22 @@ executors:
   golang_115:
     docker:
       - image: circleci/golang:1.15-node
+  node:
+    docker:
+      - image: circleci/node:14.17
 
 jobs:
-  test:
+  test_go:
     executor: golang
 
     steps:
       - prometheus/setup_environment
       - go/load-cache:
           key: v1
-      - restore_cache:
-          keys:
-            - v3-npm-deps-{{ checksum "web/ui/react-app/yarn.lock" }}
-            - v3-npm-deps-
       - run:
           command: sudo apt-get install -y yamllint
       - run:
-          command: make
+          command: make go-ci
           environment:
             # Run garbage collection more aggressively to avoid getting OOMed during the lint phase.
             GOGC: "20"
@@ -50,12 +49,24 @@ jobs:
           file: promtool
       - go/save-cache:
           key: v1
+      - store_test_results:
+          path: test-results
+
+  test_react:
+    executor: node
+
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v3-npm-deps-{{ checksum "web/ui/react-app/yarn.lock" }}
+            - v3-npm-deps-
+      - run:
+          command: make react-ci
       - save_cache:
           key: v3-npm-deps-{{ checksum "web/ui/react-app/yarn.lock" }}
           paths:
             - /home/circleci/.cache/yarn
-      - store_test_results:
-          path: test-results
 
   test_windows:
     executor:
@@ -121,7 +132,11 @@ workflows:
   version: 2
   prometheus:
     jobs:
-      - test:
+      - test_go:
+          filters:
+            tags:
+              only: /.*/
+      - test_react:
           filters:
             tags:
               only: /.*/
@@ -155,7 +170,8 @@ workflows:
       - prometheus/publish_release:
           context: org-context
           requires:
-            - test
+            - test_go
+            - test_react
             - build
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,8 @@ workflows:
       - prometheus/publish_main:
           context: org-context
           requires:
-            - test
+            - test_go
+            - test_react
             - build
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run:
           command: sudo apt-get install -y yamllint
       - run:
-          command: make go-only
+          command: make GO_ONLY=1
           environment:
             # Run garbage collection more aggressively to avoid getting OOMed during the lint phase.
             GOGC: "20"

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,21 @@ react-app-test: | $(REACT_APP_NODE_MODULES_PATH) react-app-lint
 	cd $(REACT_APP_PATH) && yarn test --no-watch --coverage
 
 .PHONY: test
+test:
+
+# If we only want to only test go code we have to change the test target
+# which is called by all.
+ifeq ($(MAKECMDGOALS),go-ci)
+test: common-test
+else
 test: common-test react-app-test
+endif
+
+.PHONY: go-ci
+go-ci: all
+
+.PHONY: react-ci
+react-ci: react-app-test
 
 .PHONY: npm_licenses
 npm_licenses: $(REACT_APP_NODE_MODULES_PATH)

--- a/Makefile
+++ b/Makefile
@@ -64,18 +64,14 @@ react-app-test: | $(REACT_APP_NODE_MODULES_PATH) react-app-lint
 	cd $(REACT_APP_PATH) && yarn test --no-watch --coverage
 
 .PHONY: test
-test:
-
 # If we only want to only test go code we have to change the test target
 # which is called by all.
-ifeq ($(MAKECMDGOALS),go-only)
+ifeq ($(GO_ONLY),1)
 test: common-test
 else
 test: common-test react-app-test
 endif
 
-.PHONY: go-only
-go-only: all
 
 .PHONY: npm_licenses
 npm_licenses: $(REACT_APP_NODE_MODULES_PATH)

--- a/Makefile
+++ b/Makefile
@@ -68,17 +68,14 @@ test:
 
 # If we only want to only test go code we have to change the test target
 # which is called by all.
-ifeq ($(MAKECMDGOALS),go-ci)
+ifeq ($(MAKECMDGOALS),go-only)
 test: common-test
 else
 test: common-test react-app-test
 endif
 
-.PHONY: go-ci
-go-ci: all
-
-.PHONY: react-ci
-react-ci: react-app-test
+.PHONY: go-only
+go-only: all
 
 .PHONY: npm_licenses
 npm_licenses: $(REACT_APP_NODE_MODULES_PATH)


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR splits the go and react tests by adding two new Makefile targets: `go-ci` and `react-ci`, and running separate CircleCI jobs for them. I've used a node image for the react tests, although it could be golang too. The node image does trigger these irrelevant errors, and I'm not sure why:
```
make: go: Command not found
make: go: Command not found
make: go: Command not found
make: go: Command not found
make: go: Command not found
make: go: Command not found
make: go: Command not found
make: go: Command not found
make: go: Command not found
make: go: Command not found
```

Fixes: #8849