### PR TITLE
React UI: Starting Screen Progress Bar Should Start at 0

### DIFF
--- a/web/ui/react-app/src/pages/starting/Starting.test.tsx
+++ b/web/ui/react-app/src/pages/starting/Starting.test.tsx
@@ -26,6 +26,7 @@ describe('Starting', () => {
       const starting = shallow(<StartingContent status={status} isUnexpected={false} />);
       const progress = starting.find(Progress);
       expect(progress.prop('value')).toBe(2);
+      expect(progress.prop('min')).toBe(0);
       expect(progress.prop('max')).toBe(21);
     });
 

--- a/web/ui/react-app/src/pages/starting/Starting.test.tsx
+++ b/web/ui/react-app/src/pages/starting/Starting.test.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { WALReplayData } from '../../types/types';
+import { StartingContent } from './Starting';
+import { Progress } from 'reactstrap';
+
+describe('Starting', () => {
+  describe('progress bar', () => {
+    it('does not show when replay not started', () => {
+      const status: WALReplayData = {
+        min: 0,
+        max: 0,
+        current: 0,
+      };
+      const starting = shallow(<StartingContent status={status} isUnexpected={false} />);
+      const progress = starting.find(Progress);
+      expect(progress).toHaveLength(0);
+    });
+
+    it('renders progress correctly', () => {
+      const status: WALReplayData = {
+        min: 0,
+        max: 20,
+        current: 1,
+      };
+      const starting = shallow(<StartingContent status={status} isUnexpected={false} />);
+      const progress = starting.find(Progress);
+      expect(progress.prop('value')).toBe(2);
+      expect(progress.prop('max')).toBe(21);
+    });
+
+    it('shows done when replay done', () => {
+      const status: WALReplayData = {
+        min: 0,
+        max: 20,
+        current: 20,
+      };
+      const starting = shallow(<StartingContent status={status} isUnexpected={false} />);
+      const progress = starting.find(Progress);
+      expect(progress.prop('value')).toBe(21);
+      expect(progress.prop('color')).toBe('success');
+    });
+  });
+});

--- a/web/ui/react-app/src/pages/starting/Starting.tsx
+++ b/web/ui/react-app/src/pages/starting/Starting.tsx
@@ -32,6 +32,7 @@ export const StartingContent: FC<StartingContentProps> = ({ status, isUnexpected
             <Progress
               animated
               value={status?.current! - status?.min! + 1}
+              min={status?.min}
               max={status?.max! - status?.min! + 1}
               color={status?.max === status?.current ? 'success' : undefined}
               style={{ width: '10%', margin: 'auto' }}

--- a/web/ui/react-app/src/pages/starting/Starting.tsx
+++ b/web/ui/react-app/src/pages/starting/Starting.tsx
@@ -31,9 +31,8 @@ export const StartingContent: FC<StartingContentProps> = ({ status, isUnexpected
             </p>
             <Progress
               animated
-              value={status?.current}
-              min={status?.min}
-              max={status?.max}
+              value={status?.current! - status?.min! + 1}
+              max={status?.max! - status?.min! + 1}
               color={status?.max === status?.current ? 'success' : undefined}
               style={{ width: '10%', margin: 'auto' }}
             />


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Not all WAL replays start at segment 0, so we must set the progress bar's zero value to the start point. As it turns out, the `min` prop of Bootstrap's progress bar doesn't seem to do anything, so this PR implements an alternative way of setting a minimum.

Fixes #8903