### PR TITLE
Remove Individual Data Type Caps in Per-shard Buffering for Remote Write

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1034,7 +1034,9 @@ func (s *shards) runShard(ctx context.Context, shardID int, queue chan interface
 	var pendingData = make([]prompb.TimeSeries, max)
 	for i := range pendingData {
 		pendingData[i].Samples = []prompb.Sample{{}}
-		pendingData[i].Exemplars = []prompb.Exemplar{{}}
+		if s.qm.sendExemplars {
+			pendingData[i].Exemplars = []prompb.Exemplar{{}}
+		}
 	}
 
 	timer := time.NewTimer(time.Duration(s.qm.cfg.BatchSendDeadline))
@@ -1076,8 +1078,9 @@ func (s *shards) runShard(ctx context.Context, shardID int, queue chan interface
 			}
 
 			pendingData[nPending].Samples = pendingData[nPending].Samples[:0]
-			pendingData[nPending].Exemplars = pendingData[nPending].Exemplars[:0]
-
+			if s.qm.sendExemplars {
+				pendingData[nPending].Exemplars = pendingData[nPending].Exemplars[:0]
+			}
 			// Number of pending samples is limited by the fact that sendSamples (via sendSamplesWithBackoff)
 			// retries endlessly, so once we reach max samples, if we can never send to the endpoint we'll
 			// stop reading from the queue. This makes it safe to reference pendingSamples by index.

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1022,17 +1022,14 @@ func (s *shards) runShard(ctx context.Context, shardID int, queue chan interface
 	// Send batches of at most MaxSamplesPerSend samples to the remote storage.
 	// If we have fewer samples than that, flush them out after a deadline anyways.
 	var (
-		max = s.qm.cfg.MaxSamplesPerSend
-		// Rough estimate, 1% of active series will contain an exemplar on each scrape.
-		// TODO(cstyan): Casting this many times smells, also we could get index out of bounds issues here.
-		maxExemplars                                 = int(math.Max(1, float64(max/10)))
+		max                                          = s.qm.cfg.MaxSamplesPerSend
 		nPending, nPendingSamples, nPendingExemplars = 0, 0, 0
 
 		buf         []byte
 		pendingData []prompb.TimeSeries
 	)
 	if s.qm.sendExemplars {
-		max += maxExemplars
+		max += int(float64(max) * 0.1)
 	}
 
 	pendingData = make([]prompb.TimeSeries, max)


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR consolidates the `sampleBuffer` and `exemplarBuffer` buffers into the `pendingData` buffer, removing the individual cap for each respective data type in favor of having a cap for all data points combined.

Fixes #8788