### PR TITLE
Fully Adopt Prometheus/common HTTPClient in Consul SD

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -332,11 +332,14 @@ var expectedConf = &Config{
 					Scheme:          "https",
 					RefreshInterval: consul.DefaultSDConfig.RefreshInterval,
 					AllowStale:      true,
-					TLSConfig: config.TLSConfig{
-						CertFile:           filepath.FromSlash("testdata/valid_cert_file"),
-						KeyFile:            filepath.FromSlash("testdata/valid_key_file"),
-						CAFile:             filepath.FromSlash("testdata/valid_ca_file"),
-						InsecureSkipVerify: false,
+					HTTPClientConfig: config.HTTPClientConfig{
+						TLSConfig: config.TLSConfig{
+							CertFile:           filepath.FromSlash("testdata/valid_cert_file"),
+							KeyFile:            filepath.FromSlash("testdata/valid_key_file"),
+							CAFile:             filepath.FromSlash("testdata/valid_ca_file"),
+							InsecureSkipVerify: false,
+						},
+						FollowRedirects: true,
 					},
 				},
 			},

--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -92,11 +92,12 @@ var (
 
 	// DefaultSDConfig is the default Consul SD configuration.
 	DefaultSDConfig = SDConfig{
-		TagSeparator:    ",",
-		Scheme:          "http",
-		Server:          "localhost:8500",
-		AllowStale:      true,
-		RefreshInterval: model.Duration(30 * time.Second),
+		TagSeparator:     ",",
+		Scheme:           "http",
+		Server:           "localhost:8500",
+		AllowStale:       true,
+		RefreshInterval:  model.Duration(30 * time.Second),
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 )
 
@@ -134,7 +135,7 @@ type SDConfig struct {
 	// Desired node metadata.
 	NodeMeta map[string]string `yaml:"node_meta,omitempty"`
 
-	TLSConfig config.TLSConfig `yaml:"tls_config,omitempty"`
+	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 }
 
 // Name returns the name of the Config.
@@ -147,7 +148,7 @@ func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Di
 
 // SetDirectory joins any relative file paths with dir.
 func (c *SDConfig) SetDirectory(dir string) {
-	c.TLSConfig.SetDirectory(dir)
+	c.HTTPClientConfig.TLSConfig.SetDirectory(dir)
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -160,6 +161,18 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	if strings.TrimSpace(c.Server) == "" {
 		return errors.New("consul SD configuration requires a server address")
+	}
+	if c.Username != "" || c.Password != "" {
+		if c.HTTPClientConfig.BasicAuth != nil {
+			return errors.New("at most one of consul SD configuration username and password and basic auth can be configured")
+		}
+		c.HTTPClientConfig.BasicAuth = &config.BasicAuth{
+			Username: c.Username,
+			Password: c.Password,
+		}
+	}
+	if c.Token != "" && c.HTTPClientConfig.Authorization != nil {
+		return errors.New("at most one of consul SD configuration token and authorization can be configured")
 	}
 	return nil
 }
@@ -186,13 +199,7 @@ func NewDiscovery(conf *SDConfig, logger log.Logger) (*Discovery, error) {
 		logger = log.NewNopLogger()
 	}
 
-	httpConfig := config.HTTPClientConfig{
-		TLSConfig:       conf.TLSConfig,
-		FollowRedirects: true,
-	}
-
-	wrapper, err := config.NewClientFromConfig(httpConfig, "consul_sd", config.WithHTTP2Disabled(), config.WithIdleConnTimeout(2*time.Duration(watchTimeout)))
-
+	wrapper, err := config.NewClientFromConfig(conf.HTTPClientConfig, "consul_sd", config.WithHTTP2Disabled(), config.WithIdleConnTimeout(2*time.Duration(watchTimeout)))
 	if err != nil {
 		return nil, err
 	}
@@ -204,10 +211,6 @@ func NewDiscovery(conf *SDConfig, logger log.Logger) (*Discovery, error) {
 		Datacenter: conf.Datacenter,
 		Namespace:  conf.Namespace,
 		Token:      string(conf.Token),
-		HttpAuth: &consul.HttpBasicAuth{
-			Username: conf.Username,
-			Password: string(conf.Password),
-		},
 		HttpClient: wrapper,
 	}
 	client, err := consul.NewClient(clientConf)

--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -148,7 +148,7 @@ func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Di
 
 // SetDirectory joins any relative file paths with dir.
 func (c *SDConfig) SetDirectory(dir string) {
-	c.HTTPClientConfig.TLSConfig.SetDirectory(dir)
+	c.HTTPClientConfig.SetDirectory(dir)
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -171,10 +171,10 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			Password: c.Password,
 		}
 	}
-	if c.Token != "" && c.HTTPClientConfig.Authorization != nil {
-		return errors.New("at most one of consul SD configuration token and authorization can be configured")
+	if c.Token != "" && (c.HTTPClientConfig.Authorization != nil || c.HTTPClientConfig.OAuth2 != nil) {
+		return errors.New("at most one of consul SD configuration token, authorization or oauth2 can be configured")
 	}
-	return nil
+	return c.HTTPClientConfig.Validate()
 }
 
 // Discovery retrieves target information from a Consul server

--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -172,7 +172,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if c.Token != "" && (c.HTTPClientConfig.Authorization != nil || c.HTTPClientConfig.OAuth2 != nil) {
-		return errors.New("at most one of consul SD configuration token, authorization or oauth2 can be configured")
+		return errors.New("at most one of consul SD token, authorization, or oauth2 can be configured")
 	}
 	return c.HTTPClientConfig.Validate()
 }

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -453,7 +453,7 @@ token: 1234567
 authorization:
   credentials: 12345678
 `,
-			errMessage: "at most one of consul SD configuration token, authorization or oauth2 can be configured",
+			errMessage: "at most one of consul SD token, authorization, or oauth2 can be configured",
 		},
 		{
 			name: "token and oauth2 configured",
@@ -465,7 +465,7 @@ oauth2:
   client_secret: 11
   token_url: http://example.com
 `,
-			errMessage: "at most one of consul SD configuration token, authorization or oauth2 can be configured",
+			errMessage: "at most one of consul SD token, authorization, or oauth2 can be configured",
 		},
 	}
 
@@ -474,7 +474,7 @@ oauth2:
 			var config SDConfig
 			err := config.UnmarshalYAML(unmarshal([]byte(test.config)))
 			if err != nil {
-				require.Equalf(t, err.Error(), test.errMessage, "Expected error %s, got %v", test.errMessage, err)
+				require.Equalf(t, err.Error(), test.errMessage, "Expected error '%s', got '%v'", test.errMessage, err)
 				return
 			}
 			if test.errMessage != "" {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -450,9 +450,6 @@ The following meta labels are available on targets during [relabeling](#relabel_
 [ username: <string> ]
 [ password: <secret> ]
 
-tls_config:
-  [ <tls_config> ]
-
 # A list of services for which targets are retrieved. If omitted, all services
 # are scraped.
 services:
@@ -478,6 +475,42 @@ tags:
 # The time after which the provided names are refreshed.
 # On large setup it might be a good idea to increase this value because the catalog will change all the time.
 [ refresh_interval: <duration> | default = 30s ]
+
+# Authentication information used to authenticate to the API server.
+# Note that `basic_auth`, `authorization` and `oauth2` options are
+# mutually exclusive.
+# `password` and `password_file` are mutually exclusive.
+
+# Optional HTTP basic authentication information.
+basic_auth:
+  [ username: <string> ]
+  [ password: <secret> ]
+  [ password_file: <string> ]
+
+# Optional `Authorization` header configuration.
+authorization:
+  # Sets the authentication type.
+  [ type: <string> | default: Bearer ]
+  # Sets the credentials. It is mutually exclusive with
+  # `credentials_file`.
+  [ credentials: <secret> ]
+  # Sets the credentials to the credentials read from the configured file.
+  # It is mutually exclusive with `credentials`.
+  [ credentials_file: <filename> ]
+
+# Optional OAuth 2.0 configuration.
+oauth2:
+  [ <oauth2> ]
+
+# Optional proxy URL.
+[ proxy_url: <string> ]
+
+# Configure whether HTTP requests follow HTTP 3xx redirects.
+[ follow_redirects: <bool> | default = true ]
+
+# TLS configuration.
+tls_config:
+  [ <tls_config> ]
 ```
 
 Note that the IP number and port used to scrape the targets is assembled as

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -447,6 +447,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 # Namespaces are only supported in Consul Enterprise.
 [ namespace: <string> ]
 [ scheme: <string> | default = "http" ]
+# The username and password fields are deprecated in favor of the basic_auth configuration.
 [ username: <string> ]
 [ password: <secret> ]
 
@@ -476,7 +477,7 @@ tags:
 # On large setup it might be a good idea to increase this value because the catalog will change all the time.
 [ refresh_interval: <duration> | default = 30s ]
 
-# Authentication information used to authenticate to the API server.
+# Authentication information used to authenticate to the consul server.
 # Note that `basic_auth`, `authorization` and `oauth2` options are
 # mutually exclusive.
 # `password` and `password_file` are mutually exclusive.


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR fully adopts common's HTTPClient into the Consul SD.

Fixes #8924