### PR TITLE
Improve graph info tooltip for series and exemplars

### DIFF
--- a/web/ui/react-app/src/pages/graph/GraphHelpers.test.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.test.ts
@@ -143,15 +143,21 @@ describe('GraphHelpers', () => {
         getOptions(true, false).tooltip.content('', 1572128592, 1572128592, {
           series: { labels: { foo: '1', bar: '2' }, color: '' },
         } as any)
-      ).toEqual(`
+      ).toEqual(
+        `
             <div class="date">1970-01-19 04:42:08 +00:00</div>
             <div>
               <span class="detail-swatch" style="background-color: "></span>
               <span>value: <strong>1572128592</strong></span>
-            <div>
-            <div class="labels mt-1">
+            </div>
+            <div class="mt-2 mb-1 font-weight-bold">Series:</div>
+            
+            <div class="labels">
+              
+              
               <div class="mb-1"><strong>foo</strong>: 1</div><div class="mb-1"><strong>bar</strong>: 2</div>
-            </div>`);
+            </div>`
+      );
     });
     it('should return proper tooltip html from options with local time', () => {
       moment.tz.setDefault('America/New_York');
@@ -164,8 +170,12 @@ describe('GraphHelpers', () => {
             <div>
               <span class="detail-swatch" style="background-color: "></span>
               <span>value: <strong>1572128592</strong></span>
-            <div>
-            <div class="labels mt-1">
+            </div>
+            <div class="mt-2 mb-1 font-weight-bold">Series:</div>
+            
+            <div class="labels">
+              
+              
               <div class="mb-1"><strong>foo</strong>: 1</div><div class="mb-1"><strong>bar</strong>: 2</div>
             </div>`);
     });
@@ -179,13 +189,19 @@ describe('GraphHelpers', () => {
             <div>
               <span class="detail-swatch" style="background-color: "></span>
               <span>value: <strong>1572128592</strong></span>
-            <div>
-            <div class="labels mt-1">
+            </div>
+            <div class="mt-2 mb-1 font-weight-bold">Trace exemplar:</div>
+            
+            <div class="labels">
+              
+              
               <div class="mb-1"><strong>foo</strong>: 1</div><div class="mb-1"><strong>bar</strong>: 2</div>
             </div>
             
-            <span>Series labels:</span>
-            <div class="labels mt-1">
+            <div class="mt-2 mb-1 font-weight-bold">Associated series:</div>
+            <div class="labels">
+              
+              
               <div class="mb-1"><strong>foo</strong>: 2</div><div class="mb-1"><strong>bar</strong>: 3</div>
             </div>`);
     });

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -113,7 +113,7 @@ export const getOptions = (stacked: boolean, useLocalTime: boolean): jquery.flot
               <span class="detail-swatch" style="background-color: ${color}"></span>
               <span>${labels.__name__ || 'value'}: <strong>${yval}</strong></span>
             </div>
-            <div class="mt-2 mb-1 font-weight-bold">${'seriesLabels' in both ? 'Trace Exemplar:' : 'Series:'}</div>
+            <div class="mt-2 mb-1 font-weight-bold">${'seriesLabels' in both ? 'Trace exemplar:' : 'Series:'}</div>
             <div class="labels">
               ${labels['__name__'] ? `<div class="mb-1"><strong>${labels['__name__']}</strong></div>` : ''}
               ${Object.keys(labels)

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -108,20 +108,20 @@ export const getOptions = (stacked: boolean, useLocalTime: boolean): jquery.flot
           dateTime = dateTime.utc();
         }
 
-        const formatLabels = (labels: { [key: string]: string }): string =>
-          `<div class="labels">
-            ${Object.keys(labels).length === 0 ? '<div class="mb-1 font-italic">no labels</div>' : ''}
-            ${labels['__name__'] ? `<div class="mb-1"><strong>${labels['__name__']}</strong></div>` : ''}
-            ${Object.keys(labels)
-              .filter(k => k !== '__name__')
-              .map(k => `<div class="mb-1"><strong>${k}</strong>: ${escapeHTML(labels[k])}</div>`)
-              .join('')}
-          </div>`;
+        const formatLabels = (labels: { [key: string]: string }): string => `
+            <div class="labels">
+              ${Object.keys(labels).length === 0 ? '<div class="mb-1 font-italic">no labels</div>' : ''}
+              ${labels['__name__'] ? `<div class="mb-1"><strong>${labels['__name__']}</strong></div>` : ''}
+              ${Object.keys(labels)
+                .filter(k => k !== '__name__')
+                .map(k => `<div class="mb-1"><strong>${k}</strong>: ${escapeHTML(labels[k])}</div>`)
+                .join('')}
+            </div>`;
 
         return `
             <div class="date">${dateTime.format('YYYY-MM-DD HH:mm:ss Z')}</div>
             <div>
-              ${'seriesLabels' in both ? `<span class="detail-swatch" style="background-color: ${color}"></span>` : ''}
+              <span class="detail-swatch" style="background-color: ${color}"></span>
               <span>${labels.__name__ || 'value'}: <strong>${yval}</strong></span>
             </div>
             <div class="mt-2 mb-1 font-weight-bold">${'seriesLabels' in both ? 'Trace exemplar:' : 'Series:'}</div>
@@ -129,9 +129,8 @@ export const getOptions = (stacked: boolean, useLocalTime: boolean): jquery.flot
             ${
               'seriesLabels' in both
                 ? `
-            <div class="mt-2 mb-1 font-weight-bold">Associated series:</div>
-            ${formatLabels(both.seriesLabels)}
-            `
+            <div class="mt-2 mb-1 font-weight-bold">Associated series:</div>${formatLabels(both.seriesLabels)}
+`
                 : ''
             }
           `.trimEnd();

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -112,25 +112,28 @@ export const getOptions = (stacked: boolean, useLocalTime: boolean): jquery.flot
             <div>
               <span class="detail-swatch" style="background-color: ${color}"></span>
               <span>${labels.__name__ || 'value'}: <strong>${yval}</strong></span>
-            <div>
-            <div class="labels mt-1">
+            </div>
+            <div class="mt-2 mb-1 font-weight-bold">${'seriesLabels' in both ? 'Trace Exemplar:' : 'Series:'}</div>
+            <div class="labels">
+              ${labels['__name__'] ? `<div class="mb-1"><strong>${labels['__name__']}</strong></div>` : ''}
               ${Object.keys(labels)
-                .map(k =>
-                  k !== '__name__' ? `<div class="mb-1"><strong>${k}</strong>: ${escapeHTML(labels[k])}</div>` : ''
-                )
+                .filter(k => k !== '__name__')
+                .map(k => `<div class="mb-1"><strong>${k}</strong>: ${escapeHTML(labels[k])}</div>`)
                 .join('')}
             </div>
             ${
               'seriesLabels' in both
                 ? `
-            <span>Series labels:</span>
-            <div class="labels mt-1">
+            <div class="mt-2 mb-1 font-weight-bold">Associated series:</div>
+            <div class="labels">
+              ${
+                both.seriesLabels['__name__']
+                  ? `<div class="mb-1"><strong>${both.seriesLabels['__name__']}</strong></div>`
+                  : ''
+              }
               ${Object.keys(both.seriesLabels)
-                .map(k =>
-                  k !== '__name__'
-                    ? `<div class="mb-1"><strong>${k}</strong>: ${escapeHTML(both.seriesLabels[k])}</div>`
-                    : ''
-                )
+                .filter(k => k !== '__name__')
+                .map(k => `<div class="mb-1"><strong>${k}</strong>: ${escapeHTML(both.seriesLabels[k])}</div>`)
                 .join('')}
             </div>
             `

--- a/web/ui/react-app/src/pages/graph/GraphHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHelpers.ts
@@ -107,35 +107,30 @@ export const getOptions = (stacked: boolean, useLocalTime: boolean): jquery.flot
         if (!useLocalTime) {
           dateTime = dateTime.utc();
         }
+
+        const formatLabels = (labels: { [key: string]: string }): string =>
+          `<div class="labels">
+            ${Object.keys(labels).length === 0 ? '<div class="mb-1 font-italic">no labels</div>' : ''}
+            ${labels['__name__'] ? `<div class="mb-1"><strong>${labels['__name__']}</strong></div>` : ''}
+            ${Object.keys(labels)
+              .filter(k => k !== '__name__')
+              .map(k => `<div class="mb-1"><strong>${k}</strong>: ${escapeHTML(labels[k])}</div>`)
+              .join('')}
+          </div>`;
+
         return `
             <div class="date">${dateTime.format('YYYY-MM-DD HH:mm:ss Z')}</div>
             <div>
-              <span class="detail-swatch" style="background-color: ${color}"></span>
+              ${'seriesLabels' in both ? `<span class="detail-swatch" style="background-color: ${color}"></span>` : ''}
               <span>${labels.__name__ || 'value'}: <strong>${yval}</strong></span>
             </div>
             <div class="mt-2 mb-1 font-weight-bold">${'seriesLabels' in both ? 'Trace exemplar:' : 'Series:'}</div>
-            <div class="labels">
-              ${labels['__name__'] ? `<div class="mb-1"><strong>${labels['__name__']}</strong></div>` : ''}
-              ${Object.keys(labels)
-                .filter(k => k !== '__name__')
-                .map(k => `<div class="mb-1"><strong>${k}</strong>: ${escapeHTML(labels[k])}</div>`)
-                .join('')}
-            </div>
+            ${formatLabels(labels)}
             ${
               'seriesLabels' in both
                 ? `
             <div class="mt-2 mb-1 font-weight-bold">Associated series:</div>
-            <div class="labels">
-              ${
-                both.seriesLabels['__name__']
-                  ? `<div class="mb-1"><strong>${both.seriesLabels['__name__']}</strong></div>`
-                  : ''
-              }
-              ${Object.keys(both.seriesLabels)
-                .filter(k => k !== '__name__')
-                .map(k => `<div class="mb-1"><strong>${k}</strong>: ${escapeHTML(both.seriesLabels[k])}</div>`)
-                .join('')}
-            </div>
+            ${formatLabels(both.seriesLabels)}
             `
                 : ''
             }


### PR DESCRIPTION
It now shows more clearly what the label sets are about (series vs. exemplar +
associated series) and also shows the metric name for both label sets when it
is present.

**Old exemplar tooltip:**

![exemplar-old](https://user-images.githubusercontent.com/538008/121783763-cbdef000-cbb0-11eb-93c5-6c574cf10d6d.png)

**New exemplar tooltip:**

![exemplar-new](https://user-images.githubusercontent.com/538008/121783765-cc778680-cbb0-11eb-8f35-fe3096c03ff7.png)

**Old series tooltip:**

![series-old](https://user-images.githubusercontent.com/538008/121783615-e9f82080-cbaf-11eb-9d70-5bbd4b487070.png)

**New series tooltip:**

![series-new](https://user-images.githubusercontent.com/538008/121783614-e9f82080-cbaf-11eb-9a8e-6e1117ccbed8.png)

Signed-off-by: Julius Volz <julius.volz@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->