### PR TITLE
Add `make npm_licenses` command to docker build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ You can build a docker image locally with the following commands:
 
     $ make promu
     $ promu crossbuild -p linux/amd64
+    $ make npm_licenses
     $ make common-docker-amd64
 
 *NB* if you are on a Mac, you will need [gnu-tar](https://formulae.brew.sh/formula/gnu-tar).


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

In order to run `make common-docker-amd64`, the npm licenses must be generated using `make npm_licenses`. I originally came across this when troubleshooting docker builds on macOS (#8912), but after testing I believe this applies to all operating systems.