### PR TITLE
Change starting show screen progress bar condition

### DIFF
--- a/web/ui/react-app/src/components/withStartingIndicator.test.tsx
+++ b/web/ui/react-app/src/components/withStartingIndicator.test.tsx
@@ -17,6 +17,17 @@ describe('Starting', () => {
       expect(progress).toHaveLength(0);
     });
 
+    it('shows progress bar when max is not 0', () => {
+      const status: WALReplayData = {
+        min: 0,
+        max: 1,
+        current: 0,
+      };
+      const starting = shallow(<StartingContent status={status} isUnexpected={false} />);
+      const progress = starting.find(Progress);
+      expect(progress).toHaveLength(1);
+    })
+
     it('renders progress correctly', () => {
       const status: WALReplayData = {
         min: 0,

--- a/web/ui/react-app/src/components/withStartingIndicator.test.tsx
+++ b/web/ui/react-app/src/components/withStartingIndicator.test.tsx
@@ -26,7 +26,7 @@ describe('Starting', () => {
       const starting = shallow(<StartingContent status={status} isUnexpected={false} />);
       const progress = starting.find(Progress);
       expect(progress).toHaveLength(1);
-    })
+    });
 
     it('renders progress correctly', () => {
       const status: WALReplayData = {

--- a/web/ui/react-app/src/components/withStartingIndicator.tsx
+++ b/web/ui/react-app/src/components/withStartingIndicator.tsx
@@ -23,7 +23,7 @@ export const StartingContent: FC<StartingContentProps> = ({ status, isUnexpected
     <div className="text-center m-3">
       <div className="m-4">
         <h2>Starting up...</h2>
-        {status?.current! > status?.min! ? (
+        {status?.max! > 0 ? (
           <div>
             <p>
               Replaying WAL ({status?.current}/{status?.max})


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Currently, we determine if the WAL replay has started by checking if the index of the current segment is greater than the index of the first segment (`min`). But, if we have just read the first segment, the values will be the same and the progress bar will not be shown even though it should. This PR changes the condition so we show the progress bar when the index of the final segment is not `0`, which means that a WAL replay has commenced (`max` is set when the replay starts and the default value is `0`). I realize that this still won’t work for the case when only the segment `0` needs to be loaded, but that requires some more involved changes.