### PR TITLE
Promtool: Validate service discovery files

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -402,22 +402,13 @@ func checkSDFile(filename string) error {
 		return errors.Errorf("invalid file extension: %q", ext)
 	}
 
-	_, err = checkSDOutput(targetGroups)
-	return err
-}
-
-func checkSDOutput(targetGroups []*targetgroup.Group) ([]*targetgroup.Group, error) {
 	for i, tg := range targetGroups {
 		if tg == nil {
-			return nil, errors.Errorf("nil target group item found (index %v)", i)
+			return errors.Errorf("nil target group item found (index %v)", i)
 		}
-
-		if tg.Labels == nil {
-			tg.Labels = model.LabelSet{}
-		}
-		tg.Labels["__<filepath or url>"] = "<path or URL of your targets>"
 	}
-	return targetGroups, nil
+
+	return nil
 }
 
 // CheckRules validates rule files.

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -404,7 +404,7 @@ func checkSDFile(filename string) error {
 
 	for i, tg := range targetGroups {
 		if tg == nil {
-			return errors.Errorf("nil target group item found (index %v)", i)
+			return errors.Errorf("nil target group item found (index %d)", i)
 		}
 	}
 

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -409,8 +409,7 @@ func checkSDFile(filename string) error {
 func checkSDOutput(targetGroups []*targetgroup.Group) ([]*targetgroup.Group, error) {
 	for i, tg := range targetGroups {
 		if tg == nil {
-			err := errors.Errorf("nil target group item found (index %v)", i)
-			return nil, err
+			return nil, errors.Errorf("nil target group item found (index %v)", i)
 		}
 
 		if tg.Labels == nil {

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -114,7 +114,7 @@ func TestCheckSDFile(t *testing.T) {
 				require.Equalf(t, test.err, err.Error(), "Expected error %q, got %q", test.err, err.Error())
 				return
 			}
-			require.NoErrorf(t, err, "Got error %q, expected none", err)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -98,8 +98,8 @@ func TestCheckSDFile(t *testing.T) {
 		},
 		{
 			name: "bad file extension",
-			file: "./testdata/bad-sd-file-extension.",
-			err:  "invalid file extension: \".\"",
+			file: "./testdata/bad-sd-file-extension.nonexistant",
+			err:  "invalid file extension: \".nonexistant\"",
 		},
 		{
 			name: "bad format",

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -77,3 +77,44 @@ func mockServer(code int, body string) (*httptest.Server, func() *http.Request) 
 	}
 	return server, f
 }
+
+func TestCheckSDFile(t *testing.T) {
+	cases := []struct {
+		name string
+		file string
+		err  string
+	}{
+		{
+			name: "good .yml",
+			file: "./testdata/good-sd-file.yml",
+		},
+		{
+			name: "good .yaml",
+			file: "./testdata/good-sd-file.yaml",
+		},
+		{
+			name: "good .json",
+			file: "./testdata/good-sd-file.json",
+		},
+		{
+			name: "bad file extension",
+			file: "./testdata/bad-sd-file-extension.",
+			err:  "invalid file extension: \".\"",
+		},
+		{
+			name: "bad format",
+			file: "./testdata/bad-sd-file-format.yml",
+			err:  "yaml: unmarshal errors:\n  line 1: field targats not found in type struct { Targets []string \"yaml:\\\"targets\\\"\"; Labels model.LabelSet \"yaml:\\\"labels\\\"\" }",
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkSDFile(test.file)
+			if test.err != "" {
+				require.Equalf(t, test.err, err.Error(), "Expected error %q, got %q", test.err, err.Error())
+				return
+			}
+			require.NoErrorf(t, err, "Got error %q, expected none", err)
+		})
+	}
+}

--- a/cmd/promtool/testdata/bad-sd-file-format.yml
+++ b/cmd/promtool/testdata/bad-sd-file-format.yml
@@ -1,0 +1,2 @@
+- targats:
+    - localhost:9100

--- a/cmd/promtool/testdata/good-sd-file.json
+++ b/cmd/promtool/testdata/good-sd-file.json
@@ -1,0 +1,8 @@
+[
+  {
+    "labels": {
+      "job": "node"
+    },
+    "targets": ["localhost:9100"]
+  }
+]

--- a/cmd/promtool/testdata/good-sd-file.yaml
+++ b/cmd/promtool/testdata/good-sd-file.yaml
@@ -1,0 +1,4 @@
+- labels:
+    job: node
+- targets:
+    - localhost:9100

--- a/cmd/promtool/testdata/good-sd-file.yml
+++ b/cmd/promtool/testdata/good-sd-file.yml
@@ -1,0 +1,4 @@
+- labels:
+    job: node
+- targets:
+    - localhost:9100


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR adds support to validate service discovery files specified in a config Promtool is checking.

Fixes #8935