### PR TITLE
Replace `godoc.org` links with `pkg.go.dev` links

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For more information on building, running, and developing on the new React-based
 
 ## More information
 
-  * The source code is periodically indexed: [Prometheus Core](https://godoc.org/github.com/prometheus/prometheus).
+  * The source code is periodically indexed: [Prometheus Core](https://pkg.go.dev/github.com/prometheus/prometheus).
   * You will find a CircleCI configuration in [`.circleci/config.yml`](.circleci/config.yml).
   * See the [Community page](https://prometheus.io/community) for how to reach the Prometheus developers and users on various communication channels.
 

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -131,7 +131,7 @@ the Prometheus server will be able to see them.
 
 ### The SD interface
 
-A Service Discovery (SD) mechanism has to discover targets and provide them to Prometheus. We expect similar targets to be grouped together, in the form of a [target group](https://godoc.org/github.com/prometheus/prometheus/discovery/targetgroup#Group). The SD mechanism sends the targets down to prometheus as list of target groups.
+A Service Discovery (SD) mechanism has to discover targets and provide them to Prometheus. We expect similar targets to be grouped together, in the form of a [target group](https://pkg.go.dev/github.com/prometheus/prometheus/discovery/targetgroup#Group). The SD mechanism sends the targets down to prometheus as list of target groups.
 
 An SD mechanism has to implement the `Discoverer` Interface:
 ```go

--- a/documentation/internal_architecture.md
+++ b/documentation/internal_architecture.md
@@ -18,7 +18,7 @@ As a first step, `main()` defines and parses the server's command-line flags int
 
 Next, `main()` instantiates all the major run-time components of Prometheus and connects them together using channels, references, or passing in contexts for later coordination and cancellation. These components include service discovery, target scraping, storage, and more (as laid out in the rest of this document).
 
-Finally, the server [runs all components](https://github.com/prometheus/prometheus/blob/v2.3.1/cmd/prometheus/main.go#L366-L598) in an [actor-like model](https://www.brianstorti.com/the-actor-model/), using [`github.com/oklog/oklog/pkg/group`](https://godoc.org/github.com/oklog/run) to coordinate the startup and shutdown of all interconnected actors. Multiple channels are used to enforce ordering constraints, such as not enabling the web interface before the storage is ready and the initial configuration file load has happened.
+Finally, the server [runs all components](https://github.com/prometheus/prometheus/blob/v2.3.1/cmd/prometheus/main.go#L366-L598) in an [actor-like model](https://www.brianstorti.com/the-actor-model/), using [`github.com/oklog/oklog/pkg/group`](https://pkg.go.dev/github.com/oklog/run) to coordinate the startup and shutdown of all interconnected actors. Multiple channels are used to enforce ordering constraints, such as not enabling the web interface before the storage is ready and the initial configuration file load has happened.
 
 ## Configuration
 
@@ -34,7 +34,7 @@ The [configuration reload handler](https://github.com/prometheus/prometheus/blob
 
 ## Termination handler
 
-The [termination handler](https://github.com/prometheus/prometheus/blob/v2.3.1/cmd/prometheus/main.go#L367-L392) is a goroutine that is implemented directly in `main()` and listens for termination requests from either the web interface or a [`TERM` signal](https://en.wikipedia.org/wiki/Signal_(IPC)#SIGTERM). When it receives a termination request, it returns and thus triggers the orderly shutdown of all other Prometheus components via the actor coordination functionality provided by [`github.com/oklog/oklog/pkg/group`](https://godoc.org/github.com/oklog/run).
+The [termination handler](https://github.com/prometheus/prometheus/blob/v2.3.1/cmd/prometheus/main.go#L367-L392) is a goroutine that is implemented directly in `main()` and listens for termination requests from either the web interface or a [`TERM` signal](https://en.wikipedia.org/wiki/Signal_(IPC)#SIGTERM). When it receives a termination request, it returns and thus triggers the orderly shutdown of all other Prometheus components via the actor coordination functionality provided by [`github.com/oklog/oklog/pkg/group`](https://pkg.go.dev/github.com/oklog/run).
 
 ## Scrape discovery manager
 

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -290,7 +290,7 @@ func (p *parser) recover(errp *error) {
 // the generated and non-generated parts to work together with regards to lookahead
 // and error handling.
 //
-// For more information, see https://godoc.org/golang.org/x/tools/cmd/goyacc.
+// For more information, see https://pkg.go.dev/golang.org/x/tools/cmd/goyacc.
 func (p *parser) Lex(lval *yySymType) int {
 	var typ ItemType
 
@@ -331,7 +331,7 @@ func (p *parser) Lex(lval *yySymType) int {
 //
 // It is a no-op since the parsers error routines are triggered
 // by mechanisms that allow more fine-grained control
-// For more information, see https://godoc.org/golang.org/x/tools/cmd/goyacc.
+// For more information, see https://pkg.go.dev/golang.org/x/tools/cmd/goyacc.
 func (p *parser) Error(e string) {
 }
 

--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -1,6 +1,6 @@
 # TSDB 
 
-[![GoDoc](https://godoc.org/github.com/prometheus/prometheus/tsdb?status.svg)](https://godoc.org/github.com/prometheus/prometheus/tsdb)
+[![GoPkg](https://pkg.go.dev/badge/github.com/prometheus/prometheus/tsdb.svg)](https://pkg.go.dev/github.com/prometheus/prometheus/tsdb)
 
 This directory contains the Prometheus storage layer that is used in its 2.x releases.
 

--- a/web/web.go
+++ b/web/web.go
@@ -373,7 +373,7 @@ func New(logger log.Logger, o *Options) *Handler {
 	})
 	// Make sure that "<path-prefix>/classic" is redirected to "<path-prefix>/classic/" and
 	// not just the naked "/classic/", which would be the default behavior of the router
-	// with the "RedirectTrailingSlash" option (https://godoc.org/github.com/julienschmidt/httprouter#Router.RedirectTrailingSlash),
+	// with the "RedirectTrailingSlash" option (https://pkg.go.dev/github.com/julienschmidt/httprouter#Router.RedirectTrailingSlash),
 	// and which breaks users with a --web.route-prefix that deviates from the path derived
 	// from the external URL.
 	// See https://github.com/prometheus/prometheus/issues/6163#issuecomment-553855129.


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Godoc.org has begun to redirect to pkg.go.dev, and it's recommended we use it now.

[Blog post](https://blog.golang.org/godoc.org-redirect#TOC_2.)