### PR TITLE
Remote Write: Add max samples per metadata send

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -173,8 +173,9 @@ var (
 
 	// DefaultMetadataConfig is the default metadata configuration for a remote write endpoint.
 	DefaultMetadataConfig = MetadataConfig{
-		Send:         true,
-		SendInterval: model.Duration(1 * time.Minute),
+		Send:              true,
+		SendInterval:      model.Duration(1 * time.Minute),
+		MaxSamplesPerSend: 500,
 	}
 
 	// DefaultRemoteReadConfig is the default remote read configuration.
@@ -731,6 +732,8 @@ type MetadataConfig struct {
 	Send bool `yaml:"send"`
 	// SendInterval controls how frequently we send metric metadata.
 	SendInterval model.Duration `yaml:"send_interval"`
+	// Maximum number of samples per send.
+	MaxSamplesPerSend int `yaml:"max_samples_per_send,omitempty"`
 }
 
 // SigV4Config is the configuration for signing remote write requests with

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2443,6 +2443,8 @@ metadata_config:
   [ send: <boolean> | default = true ]
   # How frequently metric metadata is sent to remote storage.
   [ send_interval: <duration> | default = 1m ]
+  # Maximum number of samples per send.
+  [ max_samples_per_send: <int> | default = 500]
 ```
 
 There is a list of

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -443,11 +443,21 @@ func (t *QueueManager) AppendMetadata(ctx context.Context, metadata []scrape.Met
 		})
 	}
 
-	err := t.sendMetadataWithBackoff(ctx, mm)
-
-	if err != nil {
-		t.metrics.failedMetadataTotal.Add(float64(len(metadata)))
-		level.Error(t.logger).Log("msg", "non-recoverable error while sending metadata", "count", len(metadata), "err", err)
+	var i int
+	for i = 0; i < len(metadata)/t.mcfg.MaxSamplesPerSend; i++ {
+		err := t.sendMetadataWithBackoff(ctx, mm[i*t.mcfg.MaxSamplesPerSend:(i+1)*t.mcfg.MaxSamplesPerSend])
+		if err != nil {
+			t.metrics.failedMetadataTotal.Add(float64(t.mcfg.MaxSamplesPerSend))
+			level.Error(t.logger).Log("msg", "non-recoverable error while sending metadata", "count", t.mcfg.MaxSamplesPerSend, "err", err)
+		}
+	}
+	if len(metadata)%t.mcfg.MaxSamplesPerSend != 0 {
+		// If the metadata samples don't fit evenly into MaxSamplesPerSend, there will be some left over.
+		err := t.sendMetadataWithBackoff(ctx, mm[i*t.mcfg.MaxSamplesPerSend:])
+		if err != nil {
+			t.metrics.failedMetadataTotal.Add(float64(len(metadata) % t.mcfg.MaxSamplesPerSend))
+			level.Error(t.logger).Log("msg", "non-recoverable error while sending metadata", "count", len(metadata)%t.mcfg.MaxSamplesPerSend, "err", err)
+		}
 	}
 }
 

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -167,16 +167,25 @@ func TestMetadataDelivery(t *testing.T) {
 	m.Start()
 	defer m.Stop()
 
-	m.AppendMetadata(context.Background(), []scrape.MetricMetadata{
-		{
-			Metric: "prometheus_remote_storage_sent_metadata_bytes_total",
+	metadata := []scrape.MetricMetadata{}
+	numMetadata := 1532
+	for i := 0; i < numMetadata; i++ {
+		metadata = append(metadata, scrape.MetricMetadata{
+			Metric: "prometheus_remote_storage_sent_metadata_bytes_total_" + strconv.Itoa(i),
 			Type:   textparse.MetricTypeCounter,
 			Help:   "a nice help text",
 			Unit:   "",
-		},
-	})
+		})
+	}
 
-	require.Equal(t, len(c.receivedMetadata), 1)
+	m.AppendMetadata(context.Background(), metadata)
+
+	require.Equal(t, len(c.receivedMetadata), numMetadata)
+	// One more write than the rounded qoutient should be performed in order to get samples that didn't
+	// fit into MaxSamplesPerSend.
+	require.Equal(t, numMetadata/mcfg.MaxSamplesPerSend+1, c.writes)
+	// Make sure the last samples were sent.
+	require.Equal(t, c.receivedMetadata[metadata[len(metadata)-1].Metric][0].MetricFamilyName, metadata[len(metadata)-1].Metric)
 }
 
 func TestSampleDeliveryTimeout(t *testing.T) {
@@ -522,6 +531,7 @@ type TestWriteClient struct {
 	receivedExemplars map[string][]prompb.Exemplar
 	expectedExemplars map[string][]prompb.Exemplar
 	receivedMetadata  map[string][]prompb.MetricMetadata
+	writes            int
 	withWaitGroup     bool
 	wg                sync.WaitGroup
 	mtx               sync.Mutex
@@ -654,6 +664,8 @@ func (c *TestWriteClient) Store(_ context.Context, req []byte) error {
 	for _, m := range reqProto.Metadata {
 		c.receivedMetadata[m.MetricFamilyName] = append(c.receivedMetadata[m.MetricFamilyName], m)
 	}
+
+	c.writes++
 
 	return nil
 }

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -180,7 +180,7 @@ func TestMetadataDelivery(t *testing.T) {
 
 	m.AppendMetadata(context.Background(), metadata)
 
-	require.Equal(t, len(c.receivedMetadata), numMetadata)
+	require.Equal(t, numMetadata, len(c.receivedMetadata))
 	// One more write than the rounded qoutient should be performed in order to get samples that didn't
 	// fit into MaxSamplesPerSend.
 	require.Equal(t, numMetadata/mcfg.MaxSamplesPerSend+1, c.writes)

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -183,7 +183,7 @@ func TestMetadataDelivery(t *testing.T) {
 	require.Equal(t, numMetadata, len(c.receivedMetadata))
 	// One more write than the rounded qoutient should be performed in order to get samples that didn't
 	// fit into MaxSamplesPerSend.
-	require.Equal(t, numMetadata/mcfg.MaxSamplesPerSend+1, c.writes)
+	require.Equal(t, numMetadata/mcfg.MaxSamplesPerSend+1, c.writesReceived)
 	// Make sure the last samples were sent.
 	require.Equal(t, c.receivedMetadata[metadata[len(metadata)-1].Metric][0].MetricFamilyName, metadata[len(metadata)-1].Metric)
 }
@@ -531,7 +531,7 @@ type TestWriteClient struct {
 	receivedExemplars map[string][]prompb.Exemplar
 	expectedExemplars map[string][]prompb.Exemplar
 	receivedMetadata  map[string][]prompb.MetricMetadata
-	writes            int
+	writesReceived    int
 	withWaitGroup     bool
 	wg                sync.WaitGroup
 	mtx               sync.Mutex
@@ -665,7 +665,7 @@ func (c *TestWriteClient) Store(_ context.Context, req []byte) error {
 		c.receivedMetadata[m.MetricFamilyName] = append(c.receivedMetadata[m.MetricFamilyName], m)
 	}
 
-	c.writes++
+	c.writesReceived++
 
 	return nil
 }


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR adds the `max_samples_per_send` option under the `metadata_config`.

Fixes #8870