### PR TITLE
test:Fix two potential goroutine leaks

### DIFF
--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -1115,7 +1115,11 @@ func (tp mockdiscoveryProvider) Run(ctx context.Context, upCh chan<- []*targetgr
 		for i := range u.targetGroups {
 			tgs[i] = &u.targetGroups[i]
 		}
-		upCh <- tgs
+		select {
+		case <-ctx.Done():
+			return
+		case upCh <- tgs:
+		}
 	}
 	<-ctx.Done()
 }

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -399,6 +399,7 @@ func TestReleaseNoninternedString(t *testing.T) {
 	c := NewTestWriteClient()
 	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
 	m.Start()
+	defer m.Stop()
 
 	for i := 1; i < 1000; i++ {
 		m.StoreSeries([]record.RefSeries{


### PR DESCRIPTION
***What this PR does***
It fixes two potential goroutine blocking problems in two unit tests.

**1. In discovery/manager_test.go, func `TestTargetUpdatesOrder`**
https://github.com/prometheus/prometheus/blob/eda5f8ca5f2223620cae36627919bab58c78634f/discovery/manager_test.go#L662-L683
`provUpdates` is a channel with no buffer. (Line 670)
It has one send operation (`upCh <- tgs `, Line 1118) in a child goroutine: `go newMockDiscoveryProvider(up...).Run(ctx, provUpdates)` (Line 672).
https://github.com/prometheus/prometheus/blob/eda5f8ca5f2223620cae36627919bab58c78634f/discovery/manager_test.go#L1118
The receive operation is in a select (Line 679) in the parent goroutine: `select {case <-ctx.Done(): t.Fatalf(); case tgs := <-provUpdates: ...;}`
Note that `ctx` has a deadline. If the deadline passes, then `select` may choose the first case and calls `t.Fatalf()`, which will only kill the parent goroutine, leaving the child goroutine blocked forever at `upCh <- tgs`

**How is this problem fixed**
In the child goroutine, put the send operation into a select. The function returns if the select chooses `case <-ctx.Done()`.
So when the parent goroutine is killed after `ctx` is done, the child goroutine will also exit.

**2. In storage/remote/queue_manager_test.go, func `TestReleaseNoninternedString`**
https://github.com/prometheus/prometheus/blob/eda5f8ca5f2223620cae36627919bab58c78634f/storage/remote/queue_manager_test.go#L395-L420
After `m := NewQueueManager(...)` and `m.Start()`, there is no `m.Stop()`.
The absence of `m.Stop()` will result in the blocking of multiple goroutines.
Actually, `m.Start()` is used in 10 unit tests, and 9 of them call `m.Stop()`. This is the only unit test doesn't call `m.Stop()`.

Examples of the other 9 correct unit tests:
https://github.com/prometheus/prometheus/blob/eda5f8ca5f2223620cae36627919bab58c78634f/storage/remote/queue_manager_test.go#L166-L168
https://github.com/prometheus/prometheus/blob/eda5f8ca5f2223620cae36627919bab58c78634f/storage/remote/queue_manager_test.go#L457-L462

**How is this problem fixed**
Add `defer m.Stop()`