### PR TITLE
web:Fix a potential goroutine leak by channel

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -589,7 +589,7 @@ func (h *Handler) Run(ctx context.Context, listener net.Listener, webConfig stri
 		ReadTimeout: h.options.ReadTimeout,
 	}
 
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
 		errCh <- toolkit_web.Serve(listener, httpSrv, webConfig, h.logger)
 	}()


### PR DESCRIPTION
***What this PR does***
Fix a potential goroutine blocking problem caused by channel `errch`.

***Description***
https://github.com/prometheus/prometheus/blob/eda5f8ca5f2223620cae36627919bab58c78634f/web/web.go#L592-L603
`errch` is a channel with no buffer.
It has a send operation in a child goroutine, and a receive operation in a select in the parent goroutine.
If the select chooses `case <-ctx.Done()`, then no one can receive from the channel, leaving the child goroutine blocked forever.

***How this problem is fixed***
With 1 buffer given to `errch`, the child goroutine won't be blocked, no matter which case the parent goroutine chooses.
This fix won't change the semantics of the parent goroutine, since the behavior of the receive operation is not changed.