### PR TITLE
storage/remote: Release two goroutines from endless loops

### DIFF
--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -51,7 +51,7 @@ type startTimeCallback func() (int64, error)
 // Storage represents all the remote read and write endpoints.  It implements
 // storage.Storage.
 type Storage struct {
-	logger log.Logger
+	logger *logging.Deduper
 	mtx    sync.Mutex
 
 	rws *WriteStorage
@@ -66,9 +66,10 @@ func NewStorage(l log.Logger, reg prometheus.Registerer, stCallback startTimeCal
 	if l == nil {
 		l = log.NewNopLogger()
 	}
+	logger := logging.Dedupe(l, 1*time.Minute)
 
 	s := &Storage{
-		logger:                 logging.Dedupe(l, 1*time.Minute),
+		logger:                 logger,
 		localStartTimeCallback: stCallback,
 	}
 	s.rws = NewWriteStorage(s.logger, reg, walDir, flushDeadline, sm)
@@ -181,6 +182,7 @@ func (s *Storage) Appender(ctx context.Context) storage.Appender {
 
 // Close the background processing of the storage queues.
 func (s *Storage) Close() error {
+	s.logger.Stop()
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	return s.rws.Close()

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -60,6 +60,7 @@ type WriteStorage struct {
 	flushDeadline     time.Duration
 	interner          *pool
 	scraper           ReadyScrapeManager
+	quit              chan struct{}
 
 	// For timestampTracker.
 	highestTimestamp *maxTimestamp
@@ -81,6 +82,7 @@ func NewWriteStorage(logger log.Logger, reg prometheus.Registerer, walDir string
 		walDir:            walDir,
 		interner:          newPool(),
 		scraper:           sm,
+		quit:              make(chan struct{}),
 		highestTimestamp: &maxTimestamp{
 			Gauge: prometheus.NewGauge(prometheus.GaugeOpts{
 				Namespace: namespace,
@@ -100,8 +102,13 @@ func NewWriteStorage(logger log.Logger, reg prometheus.Registerer, walDir string
 func (rws *WriteStorage) run() {
 	ticker := time.NewTicker(shardUpdateDuration)
 	defer ticker.Stop()
-	for range ticker.C {
-		rws.samplesIn.tick()
+	for {
+		select {
+		case <-ticker.C:
+			rws.samplesIn.tick()
+		case <-rws.quit:
+			return
+		}
 	}
 }
 
@@ -211,6 +218,7 @@ func (rws *WriteStorage) Close() error {
 	for _, q := range rws.queues {
 		q.Stop()
 	}
+	close(rws.quit)
 	return nil
 }
 


### PR DESCRIPTION
***What this PR does***
Change the structure and methods of `storage/remote.Storage` and `storage/remote.WriteStorage`, to release two goroutines from endless loops.
This PR should have no side effects.

***Problem with Storage***
In the following function, a new `*Storage` is created, with a `*logging.Deduper`:
https://github.com/prometheus/prometheus/blob/eda5f8ca5f2223620cae36627919bab58c78634f/storage/remote/storage.go#L64-L76
The problem is that `logging.Dedupe()` creates a goroutine running `logging.Deduper.run()`, and it won't end until `logging.Deduper.Stop()` is called.
However, after we create the `logging.Deduper` in `NewStorage()`, we never call `logging.Deduper.Stop()`

**How is the problem fixed**
Add a new field `loggerStop` to `*=Storage`, which stores the function `logging.Deduper.Stop()`. This function will be called in `Storage.Close()`

***Problem with WriteStorage***
When a new `WriteStorage` is created, a new goroutine will start and run `WriteStorage.run()`
https://github.com/prometheus/prometheus/blob/eda5f8ca5f2223620cae36627919bab58c78634f/storage/remote/write.go#L96-L106
The problem is that `WriteStorage.run()` never ends, because `time.Ticker.Stop()` is never reached.

**How is the problem fixed**
Add a new field `ticker` to `WriteStorage`, and store the `time.Ticker` in it. In `WriteStorage.Close()`, the ticker will be stopped.
