### PR TITLE
Add promtool command to check expressions

### DIFF
--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -75,19 +75,20 @@ func TestCheckExpressions(t *testing.T) {
 	tests := []struct {
 		in               string
 		expectedProblems string
+		exprString       string
 		returnCode       int
 	}{
-		{"\n", emptyError, 3},
-		{"rate()", invalidExprError, 3},
-		{"my_counter", "", 0},
-		{"rate(my_counter[5m])", "", 0},
-		{"my_counter1\nmy_counter2", "", 0},
-		{"\nmy_counter\nrate()", emptyError + invalidExprError, 3},
+		{"\n", emptyError, "", 3},
+		{"rate()", invalidExprError, "", 3},
+		{"my_counter", "", "", 0},
+		{"rate(my_counter[5m])", "", "", 0},
+		{"my_counter1\nmy_counter2", "", "", 0},
+		{"\nmy_counter\nrate()", emptyError + invalidExprError, "", 3},
 	}
 
 	for i, tc := range tests {
 		var b bytes.Buffer
-		gotReturnCode := CheckExpressions(strings.NewReader(tc.in), &b)
+		gotReturnCode := CheckExpressions(strings.NewReader(tc.in), &b, tc.exprString)
 		if gotReturnCode != tc.returnCode {
 			t.Errorf("Test %d: Expected return code: %d but got: %d", i, tc.returnCode, gotReturnCode)
 		}


### PR DESCRIPTION
Adds command to check expressions

```
promtool check expressions --help
usage: promtool check expressions

Pass Prometheus expressions over stdin to check if they are valid.

Each line is considered a separate expression.

examples:

$ cat expressions.prom | promtool check expressions

Flags:
  -h, --help     Show context-sensitive help (also try --help-long and --help-man).
      --version  Show application version.
```
Closes https://github.com/prometheus/prometheus/issues/7167

