### PR TITLE
Exemplar resize

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -345,9 +345,13 @@ func main() {
 	}
 
 	// Throw error for invalid config before starting other components.
-	if _, err := config.LoadFile(cfg.configFile, false, log.NewNopLogger()); err != nil {
+	var cfgFile *config.Config
+	if cfgFile, err = config.LoadFile(cfg.configFile, false, log.NewNopLogger()); err != nil {
 		level.Error(logger).Log("msg", fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "err", err)
 		os.Exit(2)
+	}
+	if cfgFile.StorageConfig.ExemplarsConfig.MaxExemplars > 0 {
+		cfg.tsdb.MaxExemplars = cfgFile.StorageConfig.ExemplarsConfig.MaxExemplars
 	}
 	// Now that the validity of the config is established, set the config
 	// success metrics accordingly, although the config isn't really loaded
@@ -1260,6 +1264,7 @@ type tsdbOptions struct {
 	MinBlockDuration         model.Duration
 	MaxBlockDuration         model.Duration
 	EnableExemplarStorage    bool
+	MaxExemplars             int
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -1275,6 +1280,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		MinBlockDuration:         int64(time.Duration(opts.MinBlockDuration) / time.Millisecond),
 		MaxBlockDuration:         int64(time.Duration(opts.MaxBlockDuration) / time.Millisecond),
 		EnableExemplarStorage:    opts.EnableExemplarStorage,
+		MaxExemplars:             opts.MaxExemplars,
 	}
 }
 

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -350,9 +350,8 @@ func main() {
 		level.Error(logger).Log("msg", fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "err", err)
 		os.Exit(2)
 	}
-	if cfgFile.StorageConfig.ExemplarsConfig.MaxExemplars > 0 {
-		cfg.tsdb.MaxExemplars = cfgFile.StorageConfig.ExemplarsConfig.MaxExemplars
-	}
+	cfg.tsdb.MaxExemplars = cfgFile.StorageConfig.ExemplarsConfig.MaxExemplars
+
 	// Now that the validity of the config is established, set the config
 	// success metrics accordingly, although the config isn't really loaded
 	// yet. This will happen later (including setting these metrics again),
@@ -1268,6 +1267,10 @@ type tsdbOptions struct {
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
+	// Ugly hack to get the previous default size.
+	if opts.MaxExemplars == 0 {
+		opts.MaxExemplars = config.DefaultExemplarsConfig.MaxExemplars
+	}
 	return tsdb.Options{
 		WALSegmentSize:           int(opts.WALSegmentSize),
 		MaxBlockChunkSegmentSize: int64(opts.MaxBlockChunkSegmentSize),

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -352,9 +352,7 @@ func main() {
 	}
 	if cfg.tsdb.EnableExemplarStorage {
 		if cfgFile.StorageConfig.ExemplarsConfig == nil {
-			fmt.Println("exemplars config was empty, assigning default")
 			cfgFile.StorageConfig.ExemplarsConfig = &config.DefaultExemplarsConfig
-			fmt.Printf("main.go storage config %+v\n", cfgFile.StorageConfig)
 		}
 		cfg.tsdb.MaxExemplars = int64(cfgFile.StorageConfig.ExemplarsConfig.MaxExemplars)
 	}
@@ -986,9 +984,7 @@ func reloadConfig(filename string, expandExternalLabels bool, enableExemplarStor
 
 	if enableExemplarStorage {
 		if conf.StorageConfig.ExemplarsConfig == nil {
-			// fmt.Println("exemplars config was empty, assigning default")
 			conf.StorageConfig.ExemplarsConfig = &config.DefaultExemplarsConfig
-			// fmt.Printf("main.go storage config %+v\n", conf.StorageConfig)
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -481,7 +481,7 @@ type StorageConfig struct {
 // ExemplarsConfig configures runtime reloadable configuration options.
 type ExemplarsConfig struct {
 	// MaxExemplars sets the size, in # of exemplars stored, of the single circular buffer used to store exemplars in memory.
-	// Explicitly use -1, if the value is 0 we interpret it as the default max exemplars in the tsdb/exemplar.go code.
+	// Use a value of 0 or less than 0 to disable the storage without having to restart Prometheus.
 	MaxExemplars int64 `yaml:"max_exemplars,omitempty"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -185,6 +185,10 @@ var (
 
 	// DefaultStorageConfig is the default TSDB/Exemplar storage configuration.
 	DefaultStorageConfig = StorageConfig{
+		ExemplarsConfig: DefaultExemplarsConfig,
+	}
+
+	DefaultExemplarsConfig = ExemplarsConfig{
 		MaxExemplars: 100000,
 	}
 )
@@ -195,7 +199,7 @@ type Config struct {
 	AlertingConfig AlertingConfig  `yaml:"alerting,omitempty"`
 	RuleFiles      []string        `yaml:"rule_files,omitempty"`
 	ScrapeConfigs  []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
-	StorageConfig  StorageConfig   `yaml:"storage_config,omitempty"`
+	StorageConfig  StorageConfig   `yaml:"storage,omitempty"`
 
 	RemoteWriteConfigs []*RemoteWriteConfig `yaml:"remote_write,omitempty"`
 	RemoteReadConfigs  []*RemoteReadConfig  `yaml:"remote_read,omitempty"`
@@ -471,6 +475,11 @@ func (c *ScrapeConfig) MarshalYAML() (interface{}, error) {
 
 // StorageConfig configures runtime reloadable configuration options.
 type StorageConfig struct {
+	ExemplarsConfig ExemplarsConfig `yaml:"exemplars,omitempty"`
+}
+
+// ExemplarsConfig configures runtime reloadable configuration options.
+type ExemplarsConfig struct {
 	// Explicitly use -1, if the value is 0 we interpret it as the default max exemplars in the tsdb/exemplar.go code.
 	MaxExemplars int `yaml:"max_exemplars,omitempty"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -185,7 +185,7 @@ var (
 
 	// DefaultStorageConfig is the default TSDB/Exemplar storage configuration.
 	DefaultStorageConfig = StorageConfig{
-		ExemplarsConfig: DefaultExemplarsConfig,
+		ExemplarsConfig: &DefaultExemplarsConfig,
 	}
 
 	DefaultExemplarsConfig = ExemplarsConfig{
@@ -475,14 +475,14 @@ func (c *ScrapeConfig) MarshalYAML() (interface{}, error) {
 
 // StorageConfig configures runtime reloadable configuration options.
 type StorageConfig struct {
-	ExemplarsConfig ExemplarsConfig `yaml:"exemplars,omitempty"`
+	ExemplarsConfig *ExemplarsConfig `yaml:"exemplars,omitempty"`
 }
 
 // ExemplarsConfig configures runtime reloadable configuration options.
 type ExemplarsConfig struct {
 	// MaxExemplars sets the size, in # of exemplars stored, of the single circular buffer used to store exemplars in memory.
 	// Explicitly use -1, if the value is 0 we interpret it as the default max exemplars in the tsdb/exemplar.go code.
-	MaxExemplars int `yaml:"max_exemplars,omitempty"`
+	MaxExemplars int64 `yaml:"max_exemplars,omitempty"`
 }
 
 // AlertingConfig configures alerting and alertmanager related configs.

--- a/config/config.go
+++ b/config/config.go
@@ -480,6 +480,7 @@ type StorageConfig struct {
 
 // ExemplarsConfig configures runtime reloadable configuration options.
 type ExemplarsConfig struct {
+	// MaxExemplars sets the size, in # of exemplars stored, of the single circular buffer used to store exemplars in memory.
 	// Explicitly use -1, if the value is 0 we interpret it as the default max exemplars in the tsdb/exemplar.go code.
 	MaxExemplars int `yaml:"max_exemplars,omitempty"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -182,6 +182,11 @@ var (
 		RemoteTimeout:    model.Duration(1 * time.Minute),
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
+
+	// DefaultStorageConfig is the default TSDB/Exemplar storage configuration.
+	DefaultStorageConfig = StorageConfig{
+		MaxExemplars: 100000,
+	}
 )
 
 // Config is the top-level configuration for Prometheus's config files.
@@ -190,6 +195,7 @@ type Config struct {
 	AlertingConfig AlertingConfig  `yaml:"alerting,omitempty"`
 	RuleFiles      []string        `yaml:"rule_files,omitempty"`
 	ScrapeConfigs  []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
+	StorageConfig  StorageConfig   `yaml:"storage_config,omitempty"`
 
 	RemoteWriteConfigs []*RemoteWriteConfig `yaml:"remote_write,omitempty"`
 	RemoteReadConfigs  []*RemoteReadConfig  `yaml:"remote_read,omitempty"`
@@ -461,6 +467,12 @@ func (c *ScrapeConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // MarshalYAML implements the yaml.Marshaler interface.
 func (c *ScrapeConfig) MarshalYAML() (interface{}, error) {
 	return discovery.MarshalYAMLWithInlineConfigs(c)
+}
+
+// StorageConfig configures runtime reloadable configuration options.
+type StorageConfig struct {
+	// Explicitly use -1, if the value is 0 we interpret it as the default max exemplars in the tsdb/exemplar.go code.
+	MaxExemplars int `yaml:"max_exemplars,omitempty"`
 }
 
 // AlertingConfig configures alerting and alertmanager related configs.

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -33,7 +33,7 @@ var (
 	ErrOutOfOrderExemplar          = errors.New("out of order exemplar")
 	ErrDuplicateExemplar           = errors.New("duplicate exemplar")
 	ErrExemplarLabelLength         = fmt.Errorf("label length for exemplar exceeds maximum of %d UTF-8 characters", exemplar.ExemplarMaxLabelSetLength)
-	ErrExemplarsDisabled           = fmt.Errorf("exemplar storage is disabled or max exemplars is less than 1")
+	ErrExemplarsDisabled           = fmt.Errorf("exemplar storage is disabled or max exemplars is less than or equal to 0")
 )
 
 // Appendable allows creating appenders.

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -33,6 +33,7 @@ var (
 	ErrOutOfOrderExemplar          = errors.New("out of order exemplar")
 	ErrDuplicateExemplar           = errors.New("duplicate exemplar")
 	ErrExemplarLabelLength         = fmt.Errorf("label length for exemplar exceeds maximum of %d UTF-8 characters", exemplar.ExemplarMaxLabelSetLength)
+	ErrExemplarsDisabled           = fmt.Errorf("exemplar storage is disabled or max exemplars is less than 1")
 )
 
 // Appendable allows creating appenders.

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -143,9 +144,8 @@ type Options struct {
 	// mainly meant for external users who import TSDB.
 	BlocksToDelete BlocksToDeleteFunc
 
-	// MaxExemplars sets the size, in # of exemplars stored, of the single circular buffer used to store exemplars in memory.
-	// See tsdb/exemplar.go, specifically the CircularExemplarStorage struct and it's constructor NewCircularExemplarStorage.
-	MaxExemplars int
+	// Enables the in memory exemplar storage,.
+	EnableExemplarStorage bool
 }
 
 type BlocksToDeleteFunc func(blocks []*Block) map[ulid.ULID]struct{}
@@ -695,7 +695,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	headOpts.ChunkWriteBufferSize = opts.HeadChunksWriteBufferSize
 	headOpts.StripeSize = opts.StripeSize
 	headOpts.SeriesCallback = opts.SeriesLifecycleCallback
-	headOpts.NumExemplars = opts.MaxExemplars
+	headOpts.EnableExemplarStorage = opts.EnableExemplarStorage
 	db.head, err = NewHead(r, l, wlog, headOpts, stats.Head)
 	if err != nil {
 		return nil, err
@@ -814,6 +814,10 @@ func (db *DB) run() {
 // Appender opens a new appender against the database.
 func (db *DB) Appender(ctx context.Context) storage.Appender {
 	return dbAppender{db: db, Appender: db.head.Appender(ctx)}
+}
+
+func (db *DB) ApplyConfig(conf *config.Config) error {
+	return db.head.ApplyConfig(conf)
 }
 
 // dbAppender wraps the DB's head appender and triggers compactions on commit

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -149,7 +149,7 @@ type Options struct {
 
 	// MaxExemplars sets the size, in # of exemplars stored, of the single circular buffer used to store exemplars in memory.
 	// See tsdb/exemplar.go, specifically the CircularExemplarStorage struct and it's constructor NewCircularExemplarStorage.
-	MaxExemplars int
+	MaxExemplars int64
 }
 
 type BlocksToDeleteFunc func(blocks []*Block) map[ulid.ULID]struct{}
@@ -700,7 +700,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	headOpts.StripeSize = opts.StripeSize
 	headOpts.SeriesCallback = opts.SeriesLifecycleCallback
 	headOpts.EnableExemplarStorage = opts.EnableExemplarStorage
-	headOpts.MaxExemplars = opts.MaxExemplars
+	headOpts.MaxExemplars.Store(opts.MaxExemplars)
 	db.head, err = NewHead(r, l, wlog, headOpts, stats.Head)
 	if err != nil {
 		return nil, err

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -147,6 +147,8 @@ type Options struct {
 	// Enables the in memory exemplar storage,.
 	EnableExemplarStorage bool
 
+	// MaxExemplars sets the size, in # of exemplars stored, of the single circular buffer used to store exemplars in memory.
+	// See tsdb/exemplar.go, specifically the CircularExemplarStorage struct and it's constructor NewCircularExemplarStorage.
 	MaxExemplars int
 }
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -146,6 +146,8 @@ type Options struct {
 
 	// Enables the in memory exemplar storage,.
 	EnableExemplarStorage bool
+
+	MaxExemplars int
 }
 
 type BlocksToDeleteFunc func(blocks []*Block) map[ulid.ULID]struct{}
@@ -696,6 +698,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	headOpts.StripeSize = opts.StripeSize
 	headOpts.SeriesCallback = opts.SeriesLifecycleCallback
 	headOpts.EnableExemplarStorage = opts.EnableExemplarStorage
+	headOpts.MaxExemplars = opts.MaxExemplars
 	db.head, err = NewHead(r, l, wlog, headOpts, stats.Head)
 	if err != nil {
 		return nil, err

--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -26,8 +26,6 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
-const defaultMaxExemplars = 100000
-
 type CircularExemplarStorage struct {
 	exemplarsAppended            prometheus.Counter
 	exemplarsInStorage           prometheus.Gauge
@@ -113,7 +111,7 @@ func NewCircularExemplarStorage(len int, reg prometheus.Registerer) (ExemplarSto
 }
 
 func (ce *CircularExemplarStorage) ApplyConfig(cfg *config.Config) error {
-	ce.Resize(cfg.StorageConfig.MaxExemplars)
+	ce.Resize(cfg.StorageConfig.ExemplarsConfig.MaxExemplars)
 	return nil
 }
 

--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -234,7 +234,7 @@ func (ce *CircularExemplarStorage) Resize(l int) int {
 		count = l
 	}
 
-	// Rewind previous next index by count with wrap-around
+	// Rewind previous next index by count with wrap-around.
 	startIndex := (oldNextIndex - count + len(oldBuffer)) % len(oldBuffer)
 
 	migrated := 0

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -279,7 +279,7 @@ func TestSelectExemplar_MultiSeries(t *testing.T) {
 }
 
 func TestSelectExemplar_TimeRange(t *testing.T) {
-	lenEs := 5
+	var lenEs int64 = 5
 	exs, err := NewCircularExemplarStorage(lenEs, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
@@ -288,7 +288,7 @@ func TestSelectExemplar_TimeRange(t *testing.T) {
 		{Name: "service", Value: "asdf"},
 	}
 
-	for i := 0; i < lenEs; i++ {
+	for i := 0; int64(i) < lenEs; i++ {
 		err := es.AddExemplar(l, exemplar.Exemplar{
 			Labels: labels.Labels{
 				labels.Label{
@@ -390,8 +390,8 @@ func TestIndexOverwrite(t *testing.T) {
 func TestResize(t *testing.T) {
 	testCases := []struct {
 		name              string
-		startSize         int
-		newCount          int
+		startSize         int64
+		newCount          int64
 		expectedSeries    []int
 		notExpectedSeries []int
 		expectedMigrated  int
@@ -421,7 +421,7 @@ func TestResize(t *testing.T) {
 			require.NoError(t, err)
 			es := exs.(*CircularExemplarStorage)
 
-			for i := 0; i < tc.startSize; i++ {
+			for i := 0; int64(i) < tc.startSize; i++ {
 				err = es.AddExemplar(labels.FromStrings("service", strconv.Itoa(i)), exemplar.Exemplar{
 					Value: float64(i),
 					Ts:    int64(i)})
@@ -454,7 +454,7 @@ func TestResize(t *testing.T) {
 }
 
 func BenchmarkAddExemplar(t *testing.B) {
-	exs, err := NewCircularExemplarStorage(t.N, eMetrics)
+	exs, err := NewCircularExemplarStorage(int64(t.N), eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
 
@@ -469,8 +469,8 @@ func BenchmarkAddExemplar(t *testing.B) {
 func BenchmarkResizeExemplars(b *testing.B) {
 	testCases := []struct {
 		name         string
-		startSize    int
-		endSize      int
+		startSize    int64
+		endSize      int64
 		numExemplars int
 	}{
 		{

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -412,6 +412,30 @@ func TestResize(t *testing.T) {
 			notExpectedSeries: []int{49, 1, 0},
 			expectedMigrated:  50,
 		},
+		{
+			name:              "Zero",
+			startSize:         100,
+			newCount:          0,
+			expectedSeries:    []int{},
+			notExpectedSeries: []int{},
+			expectedMigrated:  0,
+		},
+		{
+			name:              "Negative",
+			startSize:         100,
+			newCount:          -1,
+			expectedSeries:    []int{},
+			notExpectedSeries: []int{},
+			expectedMigrated:  0,
+		},
+		{
+			name:              "NegativeToNegative",
+			startSize:         -1,
+			newCount:          -2,
+			expectedSeries:    []int{},
+			notExpectedSeries: []int{},
+			expectedMigrated:  0,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -15,7 +15,6 @@ package tsdb
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"reflect"
 	"strconv"
@@ -450,7 +449,21 @@ func TestResize(t *testing.T) {
 	}
 }
 
-func BenchmarkResize(t *testing.B) {
+func BenchmarkAddExemplar(t *testing.B) {
+
+	exs, err := NewCircularExemplarStorage(t.N, nil)
+	require.NoError(t, err)
+	es := exs.(*CircularExemplarStorage)
+
+	for i := 0; i < t.N; i++ {
+		l := labels.FromStrings("service", strconv.Itoa(i))
+
+		err = es.AddExemplar(l, exemplar.Exemplar{Value: float64(i), Ts: int64(i)})
+		require.NoError(t, err)
+	}
+}
+
+func BenchmarkResizeExemplars(t *testing.B) {
 	var startCount int
 	var endCount int
 
@@ -479,8 +492,6 @@ func BenchmarkResize(t *testing.B) {
 
 			tc.setupfn(t)
 
-			fmt.Println("Creating", startCount)
-
 			exs, err := NewCircularExemplarStorage(startCount, nil)
 			require.NoError(t, err)
 			es := exs.(*CircularExemplarStorage)
@@ -493,7 +504,6 @@ func BenchmarkResize(t *testing.B) {
 			}
 
 			t.ResetTimer()
-			fmt.Println("resizing", endCount)
 			es.Resize(endCount)
 		})
 	}

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -24,14 +24,17 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 )
 
+var eMetrics = NewExemplarMetrics(prometheus.DefaultRegisterer)
+
 // Tests the same exemplar cases as AddExemplar, but specifically the ValidateExemplar function so it can be relied on externally.
 func TestValidateExemplar(t *testing.T) {
-	exs, err := NewCircularExemplarStorage(2, nil)
+	exs, err := NewCircularExemplarStorage(2, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
 
@@ -90,7 +93,7 @@ func TestValidateExemplar(t *testing.T) {
 }
 
 func TestAddExemplar(t *testing.T) {
-	exs, err := NewCircularExemplarStorage(2, nil)
+	exs, err := NewCircularExemplarStorage(2, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
 
@@ -153,7 +156,7 @@ func TestStorageOverflow(t *testing.T) {
 	// Test that circular buffer index and assignment
 	// works properly, adding more exemplars than can
 	// be stored and then querying for them.
-	exs, err := NewCircularExemplarStorage(5, nil)
+	exs, err := NewCircularExemplarStorage(5, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
 
@@ -188,7 +191,7 @@ func TestStorageOverflow(t *testing.T) {
 }
 
 func TestSelectExemplar(t *testing.T) {
-	exs, err := NewCircularExemplarStorage(5, nil)
+	exs, err := NewCircularExemplarStorage(5, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
 
@@ -219,7 +222,7 @@ func TestSelectExemplar(t *testing.T) {
 }
 
 func TestSelectExemplar_MultiSeries(t *testing.T) {
-	exs, err := NewCircularExemplarStorage(5, nil)
+	exs, err := NewCircularExemplarStorage(5, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
 
@@ -277,7 +280,7 @@ func TestSelectExemplar_MultiSeries(t *testing.T) {
 
 func TestSelectExemplar_TimeRange(t *testing.T) {
 	lenEs := 5
-	exs, err := NewCircularExemplarStorage(lenEs, nil)
+	exs, err := NewCircularExemplarStorage(lenEs, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
 
@@ -311,7 +314,7 @@ func TestSelectExemplar_TimeRange(t *testing.T) {
 // Test to ensure that even though a series matches more than one matcher from the
 // query that it's exemplars are only included in the result a single time.
 func TestSelectExemplar_DuplicateSeries(t *testing.T) {
-	exs, err := NewCircularExemplarStorage(4, nil)
+	exs, err := NewCircularExemplarStorage(4, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
 
@@ -352,7 +355,7 @@ func TestSelectExemplar_DuplicateSeries(t *testing.T) {
 }
 
 func TestIndexOverwrite(t *testing.T) {
-	exs, err := NewCircularExemplarStorage(2, nil)
+	exs, err := NewCircularExemplarStorage(2, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
 
@@ -414,7 +417,7 @@ func TestResize(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			exs, err := NewCircularExemplarStorage(tc.startSize, nil)
+			exs, err := NewCircularExemplarStorage(tc.startSize, eMetrics)
 			require.NoError(t, err)
 			es := exs.(*CircularExemplarStorage)
 
@@ -451,7 +454,7 @@ func TestResize(t *testing.T) {
 }
 
 func BenchmarkAddExemplar(t *testing.B) {
-	exs, err := NewCircularExemplarStorage(t.N, nil)
+	exs, err := NewCircularExemplarStorage(t.N, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
 
@@ -497,7 +500,7 @@ func BenchmarkResizeExemplars(b *testing.B) {
 	}
 
 	for _, tc := range testCases {
-		exs, err := NewCircularExemplarStorage(tc.startSize, nil)
+		exs, err := NewCircularExemplarStorage(tc.startSize, eMetrics)
 		require.NoError(b, err)
 		es := exs.(*CircularExemplarStorage)
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -51,7 +51,7 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = chunkRange
 	opts.ChunkDirRoot = dir
-	opts.NumExemplars = 10
+	opts.EnableExemplarStorage = true
 	h, err := NewHead(nil, nil, wlog, opts, nil)
 	require.NoError(t, err)
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -53,7 +53,7 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 	opts.ChunkRange = chunkRange
 	opts.ChunkDirRoot = dir
 	opts.EnableExemplarStorage = true
-	opts.MaxExemplars = config.DefaultExemplarsConfig.MaxExemplars
+	opts.MaxExemplars.Store(config.DefaultExemplarsConfig.MaxExemplars)
 	h, err := NewHead(nil, nil, wlog, opts, nil)
 	require.NoError(t, err)
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -30,6 +30,7 @@ import (
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -52,6 +53,7 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 	opts.ChunkRange = chunkRange
 	opts.ChunkDirRoot = dir
 	opts.EnableExemplarStorage = true
+	opts.MaxExemplars = config.DefaultExemplarsConfig.MaxExemplars
 	h, err := NewHead(nil, nil, wlog, opts, nil)
 	require.NoError(t, err)
 

--- a/util/teststorage/storage.go
+++ b/util/teststorage/storage.go
@@ -26,8 +26,6 @@ import (
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
-var eMetrics = tsdb.NewExemplarMetrics(prometheus.DefaultRegisterer)
-
 // New returns a new TestStorage for testing purposes
 // that removes all associated files on closing.
 func New(t testutil.T) *TestStorage {
@@ -45,6 +43,9 @@ func New(t testutil.T) *TestStorage {
 	if err != nil {
 		t.Fatalf("Opening test storage failed: %s", err)
 	}
+	reg := prometheus.NewRegistry()
+	eMetrics := tsdb.NewExemplarMetrics(reg)
+
 	es, err := tsdb.NewCircularExemplarStorage(10, eMetrics)
 	if err != nil {
 		t.Fatalf("Opening test exemplar storage failed: %s", err)

--- a/util/teststorage/storage.go
+++ b/util/teststorage/storage.go
@@ -38,7 +38,6 @@ func New(t testutil.T) *TestStorage {
 	opts := tsdb.DefaultOptions()
 	opts.MinBlockDuration = int64(24 * time.Hour / time.Millisecond)
 	opts.MaxBlockDuration = int64(24 * time.Hour / time.Millisecond)
-	opts.MaxExemplars = 10
 	db, err := tsdb.Open(dir, nil, nil, opts, tsdb.NewDBStats())
 	if err != nil {
 		t.Fatalf("Opening test storage failed: %s", err)

--- a/util/teststorage/storage.go
+++ b/util/teststorage/storage.go
@@ -18,12 +18,15 @@ import (
 	"os"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/util/testutil"
 )
+
+var eMetrics = tsdb.NewExemplarMetrics(prometheus.DefaultRegisterer)
 
 // New returns a new TestStorage for testing purposes
 // that removes all associated files on closing.
@@ -42,7 +45,7 @@ func New(t testutil.T) *TestStorage {
 	if err != nil {
 		t.Fatalf("Opening test storage failed: %s", err)
 	}
-	es, err := tsdb.NewCircularExemplarStorage(10, nil)
+	es, err := tsdb.NewCircularExemplarStorage(10, eMetrics)
 	if err != nil {
 		t.Fatalf("Opening test exemplar storage failed: %s", err)
 	}


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR adds `Resize` method to CircularExemplarStorage.  The need for this originally stems from Cortex, to support dynamically adjusting exemplar storage at runtime, but it is submitted here as it aligns with Prometheus direction of hot reload for some configuration.  A future PR is expected to complete this functionality and utilize this `Resize` method.  It seemed better to submit separately, but this work can be combined if preferred.

Storage is resized by allocating a new circular buffer and index, and replaying data into it which rebuilds index and entry linking.  There is some optimization to reduce allocs and replay as little as needed (i.e. when shrinking buffer).  Other approaches were considered, but lacked correctness or were less straightforward.  For example, it would be very efficient when growing the ring to simply leave entries in place which preserves all indexes, but loses guarantee that oldest exemplars are overwritten first.  Instead of the current implementation of absolute indexing between exemplars, we could use relative indexing or direct pointers, but this increases complexity for adding or selecting.

Benchmark:
```
$ go test -run=ResizeExemplar -bench=ResizeExemplar
goos: darwin
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkResizeExemplars/grow-12         	 1726984	       619.9 ns/op
BenchmarkResizeExemplars/shrink-12       	 4756222	       358.8 ns/op
PASS
ok  	github.com/prometheus/prometheus/tsdb	15.775s
```