### PR TITLE
feat: explicit gce interface ipv4 address metadata

### DIFF
--- a/discovery/gce/gce.go
+++ b/discovery/gce/gce.go
@@ -180,7 +180,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 			// Append named interface metadata for all interfaces
 			for _, iface := range inst.NetworkInterfaces {
-				gceLabelNetAddress := model.LabelName(fmt.Sprintf("%sinterface_ipv4_%s", gceLabel, iface.Name))
+				gceLabelNetAddress := model.LabelName(fmt.Sprintf("%sinterface_ipv4_%s", gceLabel, strutil.SanitizeLabelName(iface.Name)))
 				labels[gceLabelNetAddress] = model.LabelValue(iface.NetworkIP)
 			}
 

--- a/discovery/gce/gce.go
+++ b/discovery/gce/gce.go
@@ -178,13 +178,10 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 			addr := fmt.Sprintf("%s:%d", priIface.NetworkIP, d.port)
 			labels[model.AddressLabel] = model.LabelValue(addr)
 
-			// Append additional interface private IP address metadata if multiple interfaces exist.
-			if len(inst.NetworkInterfaces) > 1 {
-				gceLabelEthAddressPrefix := gceLabel + "private_ip_eth"
-				for idx, iface := range inst.NetworkInterfaces {
-					gceLabelEthAddressPrivate := model.LabelName(fmt.Sprintf("%s%d", gceLabelEthAddressPrefix, idx))
-					labels[gceLabelEthAddressPrivate] = model.LabelValue(iface.NetworkIP)
-				}
+			// Append named interface metadata for all interfaces
+			for _, iface := range inst.NetworkInterfaces {
+				gceLabelNetAddress := model.LabelName(fmt.Sprintf("%sinterface_ipv4_%s", gceLabel, iface.Name))
+				labels[gceLabelNetAddress] = model.LabelValue(iface.NetworkIP)
 			}
 
 			// Tags in GCE are usually only used for networking rules.

--- a/discovery/gce/gce.go
+++ b/discovery/gce/gce.go
@@ -178,6 +178,15 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 			addr := fmt.Sprintf("%s:%d", priIface.NetworkIP, d.port)
 			labels[model.AddressLabel] = model.LabelValue(addr)
 
+			// Append additional interface private IP address metadata if multiple interfaces exist.
+			if len(inst.NetworkInterfaces) > 1 {
+				gceLabelEthAddressPrefix := gceLabel + "private_ip_eth"
+				for idx, iface := range inst.NetworkInterfaces {
+					gceLabelEthAddressPrivate := model.LabelName(fmt.Sprintf("%s%d", gceLabelEthAddressPrefix, idx))
+					labels[gceLabelEthAddressPrivate] = model.LabelValue(iface.NetworkIP)
+				}
+			}
+
 			// Tags in GCE are usually only used for networking rules.
 			if inst.Tags != nil && len(inst.Tags.Items) > 0 {
 				// We surround the separated list with the separator as well. This way regular expressions

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1131,7 +1131,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_gce_metadata_<name>`: each metadata item of the instance
 * `__meta_gce_network`: the network URL of the instance
 * `__meta_gce_private_ip`: the private IP address of the instance
-* `__meta_gce_private_ip_eth<int>`: if more than one interface exists
+* `__meta_gce_interface_ipv4_<name>`: IPv4 address of each named interface
 * `__meta_gce_project`: the GCP project in which the instance is running
 * `__meta_gce_public_ip`: the public IP address of the instance, if present
 * `__meta_gce_subnetwork`: the subnetwork URL of the instance

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1131,6 +1131,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_gce_metadata_<name>`: each metadata item of the instance
 * `__meta_gce_network`: the network URL of the instance
 * `__meta_gce_private_ip`: the private IP address of the instance
+* `__meta_gce_private_ip_eth<int>`: if more than one interface exists
 * `__meta_gce_project`: the GCP project in which the instance is running
 * `__meta_gce_public_ip`: the public IP address of the instance, if present
 * `__meta_gce_subnetwork`: the subnetwork URL of the instance


### PR DESCRIPTION
Always add GCE interface IPv4 address metadata for all interfaces.  In cases where you have multiple interfaces, this can then be used, for instance, to rewrite the address label to target metrics on a separate interface.

This utilizes the Google Compute API's instances metadata, https://cloud.google.com/compute/docs/reference/rest/v1/instances, using the `networkInterfaces[].networkIP` field which according to the documentation will return an IPv4 address.

```
networkInterfaces[].networkIP | string | An IPv4 internal IP address to assign to the instance for this network interface. If not specified by the user, an unused internal IP is assigned by the system.
networkInterfaces[].ipv6Address | string | [Output Only] An IPv6 internal network address for this network interface.
```

In GCP a TCP load balancer (_and probably others_) can only forward traffic to `nic0`.  A snippet from https://cloud.google.com/load-balancing/docs/network/setting-up-network-backend-service#configuring_the_load_balancer:
* "If you are using an image provided by Compute Engine, your instances are automatically configured to handle this IP address. If you are using any other image, you must configure this address as an alias on nic0 or as a loopback on each instance."

In some cases this may mean that you need to move functions that historically ran on `nic0` to another interface.  For instance, some network software vendors typically run their management interface, where one scrapes metrics and manages the machine on `nic0`, however in GCP this requires moving the management interface to `nic1` or some other interface.  Take for instance https://github.com/memes/terraform-google-f5-bigip/blob/main/modules/metadata/files/multiNicMgmtSwap.sh.

Testing this requires that you set up 2 instances in GCE:
* a node named `<node_prefix>-N` that has 2 interfaces and is exposing metrics on the relevant IP and port, e.g. `node_exporter --web.listen-address="<management_ip>:9090"`
  * the primary interface, e.g. `nic0`, should be in some network that is not your default network
  * the second interface, e.g. `nic1`, should be in some 'management' subnet
* a prometheus node with an interface in the `management` subnet where you can download, build, and run prometheus from this branch, that (_ideally_) is running with a service account that has access to the GCP metadata service.

I used the following prometheus.conf and this worked as intended.
```
global:
  scrape_interval:     15s
  evaluation_interval: 30s

scrape_configs:
- job_name: prometheus

  honor_labels: true

  gce_sd_configs:
  - project: <my project>
    zone: us-central1-a
    filter: "name:<node_prefix>-*"

  relabel_configs:
    - source_labels: [__meta_gce_interface_ipv4_nic1]
      target_label: __address__
      replacement: "${1}:9090"
```

Related to #7406.