### PR TITLE
optimize Linode SD by polling for event changes during refresh

### DIFF
--- a/discovery/linode/linode.go
+++ b/discovery/linode/linode.go
@@ -159,8 +159,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	needsRefresh := true
 
 	if d.lastResults != nil && d.eventPollingEnabled {
-		// Update the last refresh timestamp - better to have some overlap than miss something.
-		d.lastRefreshTimestamp = time.Now().UTC()
+		ts := time.Now().UTC()
 
 		// Check to see if there have been any events. If so, refresh our data.
 		opts := linodego.NewListOptions(1, fmt.Sprintf(filterTemplate, d.lastRefreshTimestamp.Format("2006-01-02T15:04:05")))
@@ -185,6 +184,8 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 				needsRefresh = false
 			}
 		}
+
+		d.lastRefreshTimestamp = ts
 	}
 
 	if needsRefresh {

--- a/discovery/linode/linode.go
+++ b/discovery/linode/linode.go
@@ -168,7 +168,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		if err != nil {
 			var e *linodego.Error
 			if errors.As(err, &e) && e.Code == http.StatusUnauthorized {
-				// If we get a 401, the token doesn't have `account:read_only` scope.
+				// If we get a 401, the token doesn't have `events:read_only` scope.
 				// Disable event polling and fallback to doing a full refresh every interval.
 				d.eventPollingEnabled = false
 			} else {

--- a/discovery/linode/linode.go
+++ b/discovery/linode/linode.go
@@ -180,15 +180,15 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		}
 
 		return d.lastResults, nil
-	} else {
-		// If polling is disabled, do a full refresh every interval.
-		newData, err := d.refreshData(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		return newData, nil
 	}
+
+	// If polling is disabled, do a full refresh every interval.
+	newData, err := d.refreshData(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return newData, nil
 }
 
 func (d *Discovery) refreshData(ctx context.Context) ([]*targetgroup.Group, error) {

--- a/discovery/linode/linode.go
+++ b/discovery/linode/linode.go
@@ -157,10 +157,9 @@ func NewDiscovery(conf *SDConfig, logger log.Logger) (*Discovery, error) {
 
 func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	needsRefresh := true
+	ts := time.Now().UTC()
 
 	if d.lastResults != nil && d.eventPollingEnabled {
-		ts := time.Now().UTC()
-
 		// Check to see if there have been any events. If so, refresh our data.
 		opts := linodego.NewListOptions(1, fmt.Sprintf(filterTemplate, d.lastRefreshTimestamp.Format("2006-01-02T15:04:05")))
 		events, err := d.client.ListEvents(ctx, opts)
@@ -184,8 +183,6 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 				needsRefresh = false
 			}
 		}
-
-		d.lastRefreshTimestamp = ts
 	}
 
 	if needsRefresh {
@@ -196,6 +193,8 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		d.pollCount = 0
 		d.lastResults = newData
 	}
+
+	d.lastRefreshTimestamp = ts
 
 	return d.lastResults, nil
 }

--- a/discovery/linode/linode_test.go
+++ b/discovery/linode/linode_test.go
@@ -39,6 +39,7 @@ func (s *LinodeSDTestSuite) SetupTest(t *testing.T) {
 
 	s.Mock.HandleLinodeInstancesList()
 	s.Mock.HandleLinodeNeworkingIPs()
+	s.Mock.HandleLinodeAccountEvents()
 }
 
 func TestLinodeSDRefresh(t *testing.T) {

--- a/discovery/linode/mock_test.go
+++ b/discovery/linode/mock_test.go
@@ -413,3 +413,42 @@ func (m *SDMock) HandleLinodeNeworkingIPs() {
 		)
 	})
 }
+
+// HandleLinodeAccountEvents mocks linode the account/events endpoint.
+func (m *SDMock) HandleLinodeAccountEvents() {
+	m.Mux.HandleFunc("/v4/account/events", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != fmt.Sprintf("Bearer %s", tokenID) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		if r.Header.Get("X-Filter") == "" {
+			// This should never happen; if the client sends an events request without
+			// a filter, cause it to fail. The error below is not a real response from
+			// the API, but should aid in debugging failed tests.
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `
+{
+	"errors": [
+		{
+			"reason": "Request missing expected X-Filter headers"
+		}
+	]
+}`,
+			)
+			return
+		}
+
+		w.Header().Set("content-type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `
+{
+	"data": [],
+	"results": 0,
+	"pages": 1,
+	"page": 1
+}`,
+		)
+	})
+}

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1627,7 +1627,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 # Note that `basic_auth` and `authorization` options are
 # mutually exclusive.
 # password and password_file are mutually exclusive.
-# Note: Linode APIv4 Token must be created with scopes: 'linodes:read_only' and 'ips:read_only'
+# Note: Linode APIv4 Token must be created with scopes: 'linodes:read_only', 'ips:read_only', and 'account:read_only'
 
 # Optional HTTP basic authentication information, not currently supported by Linode APIv4.
 basic_auth:

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1627,7 +1627,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 # Note that `basic_auth` and `authorization` options are
 # mutually exclusive.
 # password and password_file are mutually exclusive.
-# Note: Linode APIv4 Token must be created with scopes: 'linodes:read_only', 'ips:read_only', and 'account:read_only'
+# Note: Linode APIv4 Token must be created with scopes: 'linodes:read_only', 'ips:read_only', and 'events:read_only'
 
 # Optional HTTP basic authentication information, not currently supported by Linode APIv4.
 basic_auth:

--- a/documentation/examples/prometheus-linode.yml
+++ b/documentation/examples/prometheus-linode.yml
@@ -11,7 +11,7 @@ scrape_configs:
   - job_name: "node"
     linode_sd_configs:
       - authorization:
-        credentials: "<replace with a Personal Access Token with linodes:read_only + ips:read_only access>"
+        credentials: "<replace with a Personal Access Token with linodes:read_only, ips:read_only, and account:read_only access>"
     relabel_configs:
       # Only scrape targets that have a tag 'monitoring'.
       - source_labels: [__meta_linode_tags]

--- a/documentation/examples/prometheus-linode.yml
+++ b/documentation/examples/prometheus-linode.yml
@@ -11,7 +11,7 @@ scrape_configs:
   - job_name: "node"
     linode_sd_configs:
       - authorization:
-        credentials: "<replace with a Personal Access Token with linodes:read_only, ips:read_only, and account:read_only access>"
+        credentials: "<replace with a Personal Access Token with linodes:read_only, ips:read_only, and events:read_only access>"
     relabel_configs:
       # Only scrape targets that have a tag 'monitoring'.
       - source_labels: [__meta_linode_tags]


### PR DESCRIPTION
Most accounts are fairly "static", in the sense that they're not cycling
through instances constantly. So rather than do a full refresh every
interval and potentially make several behind-the-scenes paginated API
calls, this will now poll the `/account/events/` endpoint every minute
with a list of events that we care about. If a matching event is found,
we then do a full refresh.

Co-authored-by: William Smith <wsmith@linode.com>
Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
Signed-off-by: William Smith <wsmith@linode.com>