### PR TITLE
HTTP SD: Allow charset in content type

### DIFF
--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -154,7 +155,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		return nil, errors.Errorf("server returned HTTP status %s", resp.Status)
 	}
 
-	if !matchContentType.MatchString(resp.Header.Get("Content-Type")) {
+	if !matchContentType.MatchString(strings.TrimSpace(resp.Header.Get("Content-Type"))) {
 		return nil, errors.Errorf("unsupported content type %q", resp.Header.Get("Content-Type"))
 	}
 

--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -41,7 +42,8 @@ var (
 		RefreshInterval:  model.Duration(60 * time.Second),
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
-	userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+	userAgent        = fmt.Sprintf("Prometheus/%s", version.Version)
+	matchContentType = regexp.MustCompile(`^(?i:application\/json(;\s*charset=("utf-8"|utf-8))?)$`)
 )
 
 func init() {
@@ -152,7 +154,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		return nil, errors.Errorf("server returned HTTP status %s", resp.Status)
 	}
 
-	if resp.Header.Get("Content-Type") != "application/json" {
+	if !matchContentType.MatchString(resp.Header.Get("Content-Type")) {
 		return nil, errors.Errorf("unsupported content type %q", resp.Header.Get("Content-Type"))
 	}
 

--- a/discovery/http/http_test.go
+++ b/discovery/http/http_test.go
@@ -104,3 +104,61 @@ func TestHTTPInvalidFormat(t *testing.T) {
 	_, err = d.refresh(ctx)
 	require.EqualError(t, err, `unsupported content type "text/plain; charset=utf-8"`)
 }
+
+func TestContentTypeRegex(t *testing.T) {
+	cases := []struct {
+		header string
+		match  bool
+	}{
+		{
+			header: "application/json;charset=utf-8",
+			match:  true,
+		},
+		{
+			header: "application/json;charset=UTF-8",
+			match:  true,
+		},
+		{
+			header: "Application/JSON;Charset=\"utf-8\"",
+			match:  true,
+		},
+		{
+			header: "application/json; charset=\"utf-8\"",
+			match:  true,
+		},
+		{
+			header: "application/json",
+			match:  true,
+		},
+		{
+			header: "application/jsonl; charset=\"utf-8\"",
+			match:  false,
+		},
+		{
+			header: "application/json;charset=UTF-9",
+			match:  false,
+		},
+		{
+			header: "application /json;charset=UTF-8",
+			match:  false,
+		},
+		{
+			header: "application/ json;charset=UTF-8",
+			match:  false,
+		},
+		{
+			header: "application/json;",
+			match:  false,
+		},
+		{
+			header: "charset=UTF-8",
+			match:  false,
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.header, func(t *testing.T) {
+			require.Equal(t, test.match, matchContentType.MatchString(test.header))
+		})
+	}
+}


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR replaces the `Content-Type` header check, which only allows `application/json`, with a regex that allows multiple (valid) combinations and formats of `application/json; charset=utf-8`.

(credit to @roidelapluie for the regex)

Fixes #8971