### PR TITLE
Replace changed metric in alerts.libsonnet

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -163,7 +163,7 @@
                 (
                   (rate(prometheus_remote_storage_failed_samples_total{%(prometheusSelector)s}[5m]) or rate(prometheus_remote_storage_samples_failed_total{%(prometheusSelector)s}[5m]))
                 +
-                  (rate(prometheus_remote_storage_succeeded_samples_total{%(prometheusSelector)s}[5m]) or rate(prometheus_remote_storage_samples_total{%(prometheusSelector)s}[5m]))
+                  (rate(prometheus_remote_storage_samples_total{%(prometheusSelector)s}[5m]) or rate(prometheus_remote_storage_samples_total{%(prometheusSelector)s}[5m]))
                 )
               )
               * 100


### PR DESCRIPTION
Replace `prometheus_remote_storage_succeeded_samples_total` with `prometheus_remote_storage_samples_total`.

According to [2.23.0 changelog](prometheus_remote_storage_succeeded_samples_total).