### PR TITLE
Increase golint timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ TSDB_BENCHMARK_NUM_METRICS ?= 1000
 TSDB_BENCHMARK_DATASET ?= ./tsdb/testdata/20kseries.json
 TSDB_BENCHMARK_OUTPUT_DIR ?= ./benchout
 
-GOLANGCI_LINT_OPTS ?= --timeout 2m
+GOLANGCI_LINT_OPTS ?= --timeout 10m
 
 include Makefile.common
 


### PR DESCRIPTION
A timed golint run took 1m42s in CI. I can see how depending on the load
of the underlying machine, it can take longer.

Increasing the timeout to 10m to remove flaky tests.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->