### PR TITLE
Fix yaml indent to make CI happy

### DIFF
--- a/config/testdata/kubernetes_kubeconfig_with_http_config.bad.yml
+++ b/config/testdata/kubernetes_kubeconfig_with_http_config.bad.yml
@@ -6,4 +6,3 @@ scrape_configs:
         basic_auth:
           username: user
           password: password
-

--- a/config/testdata/kubernetes_kubeconfig_without_apiserver.good.yml
+++ b/config/testdata/kubernetes_kubeconfig_without_apiserver.good.yml
@@ -1,5 +1,5 @@
 scrape_configs:
-- job_name: prometheus
-  kubernetes_sd_configs:
-  - role: endpoints
-    kubeconfig_file: /user1/.kube/config
+  - job_name: prometheus
+    kubernetes_sd_configs:
+      - role: endpoints
+        kubeconfig_file: /user1/.kube/config


### PR DESCRIPTION
cc @SuperQ 

my personnal preference would be to set `indent-sequences: false`

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->