### PR TITLE
fix(promql): Add validation to check for negative numbers.

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -75,7 +75,7 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 	if isCounter {
 		var lastValue float64
 		for _, sample := range samples.Points {
-			if sample.V < lastValue {
+			if sample.V < lastValue && sample.V >= 0 {
 				resultValue += lastValue
 			}
 			lastValue = sample.V


### PR DESCRIPTION
Point struct can have negative numbers.
So add validation to check for negative numbers to extrapolated functions.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->