### PR TITLE
Return error on NaN and Inf timestamps for OpenMetrics parser

### DIFF
--- a/pkg/textparse/openmetricsparse.go
+++ b/pkg/textparse/openmetricsparse.go
@@ -336,6 +336,9 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 			if ts, err = parseFloat(yoloString(p.l.buf()[1:])); err != nil {
 				return EntryInvalid, err
 			}
+			if math.IsNaN(ts) || math.IsInf(ts, 0) {
+				return EntryInvalid, errors.New("invalid timestamp")
+			}
 			p.ts = int64(ts * 1000)
 			switch t3 := p.nextToken(); t3 {
 			case tLinebreak:
@@ -391,6 +394,9 @@ func (p *OpenMetricsParser) parseComment() error {
 		// A float is enough to hold what we need for millisecond resolution.
 		if ts, err = parseFloat(yoloString(p.l.buf()[1:])); err != nil {
 			return err
+		}
+		if math.IsNaN(ts) || math.IsInf(ts, 0) {
+			return errors.New("invalid exemplar timestamp")
 		}
 		p.exemplarTs = int64(ts * 1000)
 		switch t3 := p.nextToken(); t3 {

--- a/pkg/textparse/openmetricsparse_test.go
+++ b/pkg/textparse/openmetricsparse_test.go
@@ -504,6 +504,30 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 			input: `{b="c",} 1`,
 			err:   `"INVALID" "{" is not a valid start token`,
 		},
+		{
+			input: `a 1 NaN`,
+			err:   `invalid timestamp`,
+		},
+		{
+			input: `a 1 -Inf`,
+			err:   `invalid timestamp`,
+		},
+		{
+			input: `a 1 Inf`,
+			err:   `invalid timestamp`,
+		},
+		{
+			input: "# TYPE hhh histogram\nhhh_bucket{le=\"+Inf\"} 1 # {aa=\"bb\"} 4 NaN",
+			err:   `invalid exemplar timestamp`,
+		},
+		{
+			input: "# TYPE hhh histogram\nhhh_bucket{le=\"+Inf\"} 1 # {aa=\"bb\"} 4 -Inf",
+			err:   `invalid exemplar timestamp`,
+		},
+		{
+			input: "# TYPE hhh histogram\nhhh_bucket{le=\"+Inf\"} 1 # {aa=\"bb\"} 4 Inf",
+			err:   `invalid exemplar timestamp`,
+		},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
Currently OpenMetricsParser returns 0 as timestamp for NaN or Inf timestamps, this diff changes the behavior to return error on them instead