### PR TITLE
fix potential deadlock

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -57,7 +57,7 @@ func TestQueryConcurrency(t *testing.T) {
 	defer cancelCtx()
 
 	block := make(chan struct{})
-	processing := make(chan struct{})
+	processing := make(chan struct{}, 1)
 
 	f := func(context.Context) error {
 		processing <- struct{}{}

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -57,12 +57,11 @@ func TestQueryConcurrency(t *testing.T) {
 	defer cancelCtx()
 
 	block := make(chan struct{})
-	processing := make(chan struct{}, 1)
+	processing := make(chan struct{})
 	done := make(chan int)
 	defer close(done)
 
 	f := func(context.Context) error {
-
 		select {
 		case processing <- struct{}{}:
 		case <-done:
@@ -380,7 +379,6 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 				{Start: -45000, End: 80000, Func: "count_over_time"},
 			},
 		}, {
-
 			query: "foo", start: 10000, end: 20000,
 			expected: []*storage.SelectHints{
 				{Start: 5000, End: 20000, Step: 1000},

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -58,10 +58,20 @@ func TestQueryConcurrency(t *testing.T) {
 
 	block := make(chan struct{})
 	processing := make(chan struct{}, 1)
+	done := make(chan int)
+	defer close(done)
 
 	f := func(context.Context) error {
-		processing <- struct{}{}
-		<-block
+
+		select {
+		case processing <- struct{}{}:
+		case <-done:
+		}
+
+		select {
+		case <-block:
+		case <-done:
+		}
 		return nil
 	}
 


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
Fix a potential deadlock at TestQueryConcurrency:

https://github.com/prometheus/prometheus/blob/664b39157381239c7c5e568ca9dcebc8732beae4/promql/engine_test.go#L59-L75

If promql/engine_test.go line 74 happened first, promql/engine_test.go line 72 will not be executed and leave sender's goroutine blocked forever after promql/engine_test.go line 75 stops .

Similar to #8964