### PR TITLE
Append sparse histograms into the Head block

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1164,7 +1164,7 @@ func (n notReadyAppender) AppendExemplar(ref uint64, l labels.Labels, e exemplar
 	return 0, tsdb.ErrNotReady
 }
 
-func (n notReadyAppender) AppendHistogram(ref uint64, l labels.Labels, sh histogram.SparseHistogram) (uint64, error) {
+func (n notReadyAppender) AppendHistogram(ref uint64, l labels.Labels, t int64, sh histogram.SparseHistogram) (uint64, error) {
 	return 0, tsdb.ErrNotReady
 }
 

--- a/promql/value.go
+++ b/promql/value.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/prometheus/prometheus/pkg/histogram"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
@@ -293,6 +294,10 @@ func (ssi *storageSeriesIterator) Seek(t int64) bool {
 func (ssi *storageSeriesIterator) At() (t int64, v float64) {
 	p := ssi.points[ssi.curr]
 	return p.T, p.V
+}
+
+func (ssi *storageSeriesIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	return 0, histogram.SparseHistogram{}
 }
 
 func (ssi *storageSeriesIterator) Next() bool {

--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -16,6 +16,7 @@ package storage
 import (
 	"math"
 
+	"github.com/prometheus/prometheus/pkg/histogram"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
 
@@ -195,6 +196,10 @@ func (it *sampleRingIterator) Err() error {
 
 func (it *sampleRingIterator) At() (int64, float64) {
 	return it.r.at(it.i)
+}
+
+func (it *sampleRingIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	return 0, histogram.SparseHistogram{}
 }
 
 func (r *sampleRing) at(i int) (int64, float64) {

--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -17,6 +17,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/prometheus/prometheus/pkg/histogram"
 	"github.com/stretchr/testify/require"
 )
 
@@ -194,8 +195,11 @@ type mockSeriesIterator struct {
 
 func (m *mockSeriesIterator) Seek(t int64) bool    { return m.seek(t) }
 func (m *mockSeriesIterator) At() (int64, float64) { return m.at() }
-func (m *mockSeriesIterator) Next() bool           { return m.next() }
-func (m *mockSeriesIterator) Err() error           { return m.err() }
+func (m *mockSeriesIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	return 0, histogram.SparseHistogram{}
+}
+func (m *mockSeriesIterator) Next() bool { return m.next() }
+func (m *mockSeriesIterator) Err() error { return m.err() }
 
 type fakeSeriesIterator struct {
 	nsamples int64
@@ -209,6 +213,10 @@ func newFakeSeriesIterator(nsamples, step int64) *fakeSeriesIterator {
 
 func (it *fakeSeriesIterator) At() (int64, float64) {
 	return it.idx * it.step, 123 // value doesn't matter
+}
+
+func (it *fakeSeriesIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	return it.idx * it.step, histogram.SparseHistogram{} // value doesn't matter
 }
 
 func (it *fakeSeriesIterator) Next() bool {

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -173,14 +173,14 @@ func (f *fanoutAppender) AppendExemplar(ref uint64, l labels.Labels, e exemplar.
 	return ref, nil
 }
 
-func (f *fanoutAppender) AppendHistogram(ref uint64, l labels.Labels, sh histogram.SparseHistogram) (uint64, error) {
-	ref, err := f.primary.AppendHistogram(ref, l, sh)
+func (f *fanoutAppender) AppendHistogram(ref uint64, l labels.Labels, t int64, sh histogram.SparseHistogram) (uint64, error) {
+	ref, err := f.primary.AppendHistogram(ref, l, t, sh)
 	if err != nil {
 		return ref, err
 	}
 
 	for _, appender := range f.secondaries {
-		if _, err := appender.AppendHistogram(ref, l, sh); err != nil {
+		if _, err := appender.AppendHistogram(ref, l, t, sh); err != nil {
 			return 0, err
 		}
 	}

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -221,7 +221,7 @@ type HistogramAppender interface {
 	// to Append() at any point. Adding the sample via Append() returns a new
 	// reference number.
 	// If the reference is 0 it must not be used for caching.
-	AppendHistogram(ref uint64, l labels.Labels, sh histogram.SparseHistogram) (uint64, error)
+	AppendHistogram(ref uint64, l labels.Labels, t int64, sh histogram.SparseHistogram) (uint64, error)
 }
 
 // SeriesSet contains a set of series.

--- a/storage/merge.go
+++ b/storage/merge.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/prometheus/prometheus/pkg/histogram"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -479,6 +480,13 @@ func (c *chainSampleIterator) At() (t int64, v float64) {
 		panic("chainSampleIterator.At() called before first .Next() or after .Next() returned false.")
 	}
 	return c.curr.At()
+}
+
+func (c *chainSampleIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	if c.curr == nil {
+		panic("chainSampleIterator.AtHistogram() called before first .Next() or after .Next() returned false.")
+	}
+	return c.curr.AtHistogram()
 }
 
 func (c *chainSampleIterator) Next() bool {

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
+	"github.com/prometheus/prometheus/pkg/histogram"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/prometheus/prometheus/prompb"
@@ -366,6 +367,10 @@ func (c *concreteSeriesIterator) Seek(t int64) bool {
 func (c *concreteSeriesIterator) At() (t int64, v float64) {
 	s := c.series.samples[c.cur]
 	return s.Timestamp, s.Value
+}
+
+func (c *concreteSeriesIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	return 0, histogram.SparseHistogram{}
 }
 
 // Next implements storage.SeriesIterator.

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -238,7 +238,7 @@ func (t *timestampTracker) AppendExemplar(_ uint64, _ labels.Labels, _ exemplar.
 	return 0, nil
 }
 
-func (t *timestampTracker) AppendHistogram(_ uint64, _ labels.Labels, _ histogram.SparseHistogram) (uint64, error) {
+func (t *timestampTracker) AppendHistogram(_ uint64, _ labels.Labels, _ int64, _ histogram.SparseHistogram) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -140,7 +140,7 @@ func (*mockAppendable) AppendExemplar(ref uint64, l labels.Labels, e exemplar.Ex
 	return 0, nil
 }
 
-func (*mockAppendable) AppendHistogram(ref uint64, l labels.Labels, sh histogram.SparseHistogram) (uint64, error) {
+func (*mockAppendable) AppendHistogram(ref uint64, l labels.Labels, t int64, sh histogram.SparseHistogram) (uint64, error) {
 	// noop until we implement sparse histograms over remote write
 	return 0, nil
 }

--- a/storage/series.go
+++ b/storage/series.go
@@ -17,6 +17,7 @@ import (
 	"math"
 	"sort"
 
+	"github.com/prometheus/prometheus/pkg/histogram"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -88,6 +89,10 @@ func NewListSeriesIterator(samples Samples) chunkenc.Iterator {
 func (it *listSeriesIterator) At() (int64, float64) {
 	s := it.samples.Get(it.idx)
 	return s.T(), s.V()
+}
+
+func (it *listSeriesIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	return 0, histogram.SparseHistogram{}
 }
 
 func (it *listSeriesIterator) Next() bool {

--- a/tsdb/chunkenc/histo.go
+++ b/tsdb/chunkenc/histo.go
@@ -191,10 +191,9 @@ func (c *HistoChunk) iterator(it Iterator) *histoIterator {
 }
 
 // Iterator implements the Chunk interface.
-// TODO return interface type?
-//func (c *HistoChunk) Iterator(it Iterator) *histoIterator {
-//	return c.iterator(it)
-//}
+func (c *HistoChunk) Iterator(it Iterator) Iterator {
+	return c.iterator(it)
+}
 
 type histoAppender struct {
 	c *HistoChunk // this is such that during the first append we can set the metadata on the chunk. not sure if that's how it should work
@@ -422,7 +421,12 @@ func (it *histoIterator) Seek(t int64) bool {
 	}
 	return true
 }
-func (it *histoIterator) At() (t int64, h histogram.SparseHistogram) {
+
+func (it *histoIterator) At() (int64, float64) {
+	panic("cannot call histoIterator.At().")
+}
+
+func (it *histoIterator) AtHistogram() (int64, histogram.SparseHistogram) {
 	return it.t, histogram.SparseHistogram{
 		Count:           it.cnt,
 		ZeroCount:       it.zcnt,

--- a/tsdb/chunkenc/histo_test.go
+++ b/tsdb/chunkenc/histo_test.go
@@ -76,7 +76,7 @@ func TestHistoChunkSameBuckets(t *testing.T) {
 	require.NoError(t, it1.Err())
 	var res1 []res
 	for it1.Next() {
-		ts, h := it1.At()
+		ts, h := it1.AtHistogram()
 		res1 = append(res1, res{t: ts, h: h})
 	}
 	require.NoError(t, it1.Err())

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -277,6 +277,10 @@ func (it *xorIterator) At() (int64, float64) {
 	return it.t, it.val
 }
 
+func (it *xorIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	panic("cannot call xorIterator.AtHistogram().")
+}
+
 func (it *xorIterator) Err() error {
 	return it.err
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1195,14 +1195,14 @@ func (a *initAppender) AppendExemplar(ref uint64, l labels.Labels, e exemplar.Ex
 	return a.app.AppendExemplar(ref, l, e)
 }
 
-func (a *initAppender) AppendHistogram(ref uint64, l labels.Labels, sh histogram.SparseHistogram) (uint64, error) {
+func (a *initAppender) AppendHistogram(ref uint64, l labels.Labels, t int64, sh histogram.SparseHistogram) (uint64, error) {
 	if a.app != nil {
-		return a.app.AppendHistogram(ref, l, sh)
+		return a.app.AppendHistogram(ref, l, t, sh)
 	}
 	//a.head.initTime(sh.Ts) FIXME(ganesh)
 	a.app = a.head.appender()
 
-	return a.app.AppendHistogram(ref, l, sh)
+	return a.app.AppendHistogram(ref, l, t, sh)
 }
 
 var _ storage.GetRef = &initAppender{}
@@ -1359,10 +1359,12 @@ type headAppender struct {
 	mint, maxt       int64
 	exemplarAppender ExemplarStorage
 
-	series       []record.RefSeries
-	samples      []record.RefSample
-	exemplars    []exemplarWithSeriesRef
-	sampleSeries []*memSeries
+	series          []record.RefSeries
+	samples         []record.RefSample
+	exemplars       []exemplarWithSeriesRef
+	sampleSeries    []*memSeries
+	histograms      []record.RefHistogram
+	histogramSeries []*memSeries
 
 	appendID, cleanupAppendIDsBelow uint64
 	closed                          bool
@@ -1457,9 +1459,63 @@ func (a *headAppender) AppendExemplar(ref uint64, _ labels.Labels, e exemplar.Ex
 	return s.ref, nil
 }
 
-func (a *headAppender) AppendHistogram(ref uint64, _ labels.Labels, sh histogram.SparseHistogram) (uint64, error) {
-	// TODO.
-	return 0, nil
+func (a *headAppender) AppendHistogram(ref uint64, lset labels.Labels, t int64, sh histogram.SparseHistogram) (uint64, error) {
+	if t < a.minValidTime {
+		a.head.metrics.outOfBoundSamples.Inc()
+		return 0, storage.ErrOutOfBounds
+	}
+
+	s := a.head.series.getByID(ref)
+	if s == nil {
+		// Ensure no empty labels have gotten through.
+		lset = lset.WithoutEmpty()
+		if len(lset) == 0 {
+			return 0, errors.Wrap(ErrInvalidSample, "empty labelset")
+		}
+
+		if l, dup := lset.HasDuplicateLabelNames(); dup {
+			return 0, errors.Wrap(ErrInvalidSample, fmt.Sprintf(`label name "%s" is not unique`, l))
+		}
+
+		var created bool
+		var err error
+		s, created, err = a.head.getOrCreate(lset.Hash(), lset)
+		if err != nil {
+			return 0, err
+		}
+		if created {
+			a.series = append(a.series, record.RefSeries{
+				Ref:    s.ref,
+				Labels: lset,
+			})
+		}
+	}
+
+	s.Lock()
+	if err := s.appendableHistogram(t, sh); err != nil {
+		s.Unlock()
+		if err == storage.ErrOutOfOrderSample {
+			a.head.metrics.outOfOrderSamples.Inc()
+		}
+		return 0, err
+	}
+	s.pendingCommit = true
+	s.Unlock()
+
+	if t < a.mint {
+		a.mint = t
+	}
+	if t > a.maxt {
+		a.maxt = t
+	}
+
+	a.histograms = append(a.histograms, record.RefHistogram{
+		Ref: s.ref,
+		T:   t,
+		H:   sh,
+	})
+	a.histogramSeries = append(a.histogramSeries, s)
+	return s.ref, nil
 }
 
 var _ storage.GetRef = &headAppender{}
@@ -1559,6 +1615,24 @@ func (a *headAppender) Commit() (err error) {
 		series = a.sampleSeries[i]
 		series.Lock()
 		ok, chunkCreated := series.append(s.T, s.V, a.appendID, a.head.chunkDiskMapper)
+		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
+		series.pendingCommit = false
+		series.Unlock()
+
+		if !ok {
+			total--
+			a.head.metrics.outOfOrderSamples.Inc()
+		}
+		if chunkCreated {
+			a.head.metrics.chunks.Inc()
+			a.head.metrics.chunksCreated.Inc()
+		}
+	}
+	total += len(a.histograms) // TODO: different metric?
+	for i, s := range a.histograms {
+		series = a.histogramSeries[i]
+		series.Lock()
+		ok, chunkCreated := series.appendHistogram(s.T, s.H, a.appendID, a.head.chunkDiskMapper)
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
 		series.pendingCommit = false
 		series.Unlock()
@@ -2310,7 +2384,8 @@ type memSeries struct {
 	sampleBuf     [4]sample
 	pendingCommit bool // Whether there are samples waiting to be committed to this series.
 
-	app chunkenc.Appender // Current appender for the chunk.
+	app           chunkenc.Appender // Current appender for the chunk.
+	chunkEncoding chunkenc.Encoding
 
 	memChunkPool *sync.Pool
 
@@ -2347,13 +2422,22 @@ func (s *memSeries) maxTime() int64 {
 	return c.maxTime
 }
 
-func (s *memSeries) cutNewHeadChunk(mint int64, chunkDiskMapper *chunks.ChunkDiskMapper) *memChunk {
+func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkDiskMapper *chunks.ChunkDiskMapper) *memChunk {
 	s.mmapCurrentHeadChunk(chunkDiskMapper)
 
 	s.headChunk = &memChunk{
-		chunk:   chunkenc.NewXORChunk(),
 		minTime: mint,
 		maxTime: math.MinInt64,
+	}
+
+	if chunkenc.IsValidEncoding(e) {
+		var err error
+		s.headChunk.chunk, err = chunkenc.NewEmptyChunk(e)
+		if err != nil {
+			panic(err) // This should never happen.
+		}
+	} else {
+		s.headChunk.chunk = chunkenc.NewXORChunk()
 	}
 
 	// Set upper bound on when the next chunk must be started. An earlier timestamp
@@ -2406,6 +2490,28 @@ func (s *memSeries) appendable(t int64, v float64) error {
 	if math.Float64bits(s.sampleBuf[3].v) != math.Float64bits(v) {
 		return storage.ErrDuplicateSampleForTimestamp
 	}
+	return nil
+}
+
+// appendableHistogram checks whether the given sample is valid for appending to the series.
+func (s *memSeries) appendableHistogram(t int64, sh histogram.SparseHistogram) error {
+	c := s.head()
+	if c == nil {
+		return nil
+	}
+
+	if t > c.maxTime {
+		return nil
+	}
+	if t < c.maxTime {
+		return storage.ErrOutOfOrderSample
+	}
+	// TODO: do it for histogram.
+	// We are allowing exact duplicates as we can encounter them in valid cases
+	// like federation and erroring out at that time would be extremely noisy.
+	//if math.Float64bits(s.sampleBuf[3].v) != math.Float64bits(v) {
+	//	return storage.ErrDuplicateSampleForTimestamp
+	//}
 	return nil
 }
 
@@ -2475,38 +2581,11 @@ func (s *memSeries) truncateChunksBefore(mint int64) (removed int) {
 // isolation for this append.)
 // It is unsafe to call this concurrently with s.iterator(...) without holding the series lock.
 func (s *memSeries) append(t int64, v float64, appendID uint64, chunkDiskMapper *chunks.ChunkDiskMapper) (sampleInOrder, chunkCreated bool) {
-	// Based on Gorilla white papers this offers near-optimal compression ratio
-	// so anything bigger that this has diminishing returns and increases
-	// the time range within which we have to decompress all samples.
-	const samplesPerChunk = 120
+	c, sampleInOrder, chunkCreated := s.appendPreprocessor(t, chunkenc.EncXOR, chunkDiskMapper)
+	if !sampleInOrder {
+		return sampleInOrder, chunkCreated
+	}
 
-	c := s.head()
-
-	if c == nil {
-		if len(s.mmappedChunks) > 0 && s.mmappedChunks[len(s.mmappedChunks)-1].maxTime >= t {
-			// Out of order sample. Sample timestamp is already in the mmaped chunks, so ignore it.
-			return false, false
-		}
-		// There is no chunk in this series yet, create the first chunk for the sample.
-		c = s.cutNewHeadChunk(t, chunkDiskMapper)
-		chunkCreated = true
-	}
-	numSamples := c.chunk.NumSamples()
-
-	// Out of order sample.
-	if c.maxTime >= t {
-		return false, chunkCreated
-	}
-	// If we reach 25% of a chunk's desired sample count, set a definitive time
-	// at which to start the next chunk.
-	// At latest it must happen at the timestamp set when the chunk was cut.
-	if numSamples == samplesPerChunk/4 {
-		s.nextAt = computeChunkEndTime(c.minTime, c.maxTime, s.nextAt)
-	}
-	if t >= s.nextAt {
-		c = s.cutNewHeadChunk(t, chunkDiskMapper)
-		chunkCreated = true
-	}
 	s.app.Append(t, v)
 
 	c.maxTime = t
@@ -2521,6 +2600,64 @@ func (s *memSeries) append(t int64, v float64, appendID uint64, chunkDiskMapper 
 	}
 
 	return true, chunkCreated
+}
+
+// appendHistogram adds the sparse histogram.
+// It is unsafe to call this concurrently with s.iterator(...) without holding the series lock.
+func (s *memSeries) appendHistogram(t int64, sh histogram.SparseHistogram, appendID uint64, chunkDiskMapper *chunks.ChunkDiskMapper) (sampleInOrder, chunkCreated bool) {
+	c, sampleInOrder, chunkCreated := s.appendPreprocessor(t, chunkenc.EncSHS, chunkDiskMapper)
+	if !sampleInOrder {
+		return sampleInOrder, chunkCreated
+	}
+
+	s.app.AppendHistogram(sh)
+
+	c.maxTime = t
+
+	if appendID > 0 {
+		s.txs.add(appendID)
+	}
+
+	return true, chunkCreated
+}
+
+// appendPreprocessor takes care of cutting new chunks and m-mapping old chunks.
+// It is unsafe to call this concurrently with s.iterator(...) without holding the series lock.
+// This should be called only when appending data.
+func (s *memSeries) appendPreprocessor(t int64, e chunkenc.Encoding, chunkDiskMapper *chunks.ChunkDiskMapper) (c *memChunk, sampleInOrder, chunkCreated bool) {
+	// Based on Gorilla white papers this offers near-optimal compression ratio
+	// so anything bigger that this has diminishing returns and increases
+	// the time range within which we have to decompress all samples.
+	const samplesPerChunk = 120
+
+	c = s.head()
+
+	if c == nil {
+		if len(s.mmappedChunks) > 0 && s.mmappedChunks[len(s.mmappedChunks)-1].maxTime >= t {
+			// Out of order sample. Sample timestamp is already in the mmaped chunks, so ignore it.
+			return c, false, false
+		}
+		// There is no chunk in this series yet, create the first chunk for the sample.
+		c = s.cutNewHeadChunk(t, e, chunkDiskMapper)
+		chunkCreated = true
+	}
+	numSamples := c.chunk.NumSamples()
+
+	// Out of order sample.
+	if c.maxTime >= t {
+		return c, false, chunkCreated
+	}
+	// If we reach 25% of a chunk's desired sample count, set a definitive time
+	// at which to start the next chunk.
+	// At latest it must happen at the timestamp set when the chunk was cut.
+	if numSamples == samplesPerChunk/4 {
+		s.nextAt = computeChunkEndTime(c.minTime, c.maxTime, s.nextAt)
+	}
+	if t >= s.nextAt {
+		c = s.cutNewHeadChunk(t, e, chunkDiskMapper)
+		chunkCreated = true
+	}
+	return c, true, chunkCreated
 }
 
 // cleanupAppendIDsBelow cleans up older appendIDs. Has to be called after

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1199,7 +1199,7 @@ func (a *initAppender) AppendHistogram(ref uint64, l labels.Labels, t int64, sh 
 	if a.app != nil {
 		return a.app.AppendHistogram(ref, l, t, sh)
 	}
-	//a.head.initTime(sh.Ts) FIXME(ganesh)
+	a.head.initTime(t)
 	a.app = a.head.appender()
 
 	return a.app.AppendHistogram(ref, l, t, sh)
@@ -2384,8 +2384,7 @@ type memSeries struct {
 	sampleBuf     [4]sample
 	pendingCommit bool // Whether there are samples waiting to be committed to this series.
 
-	app           chunkenc.Appender // Current appender for the chunk.
-	chunkEncoding chunkenc.Encoding
+	app chunkenc.Appender // Current appender for the chunk.
 
 	memChunkPool *sync.Pool
 
@@ -2610,7 +2609,7 @@ func (s *memSeries) appendHistogram(t int64, sh histogram.SparseHistogram, appen
 		return sampleInOrder, chunkCreated
 	}
 
-	s.app.AppendHistogram(sh)
+	s.app.AppendHistogram(t, sh)
 
 	c.maxTime = t
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/prometheus/prometheus/pkg/histogram"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -631,6 +632,9 @@ func (p *populateWithDelSeriesIterator) Seek(t int64) bool {
 }
 
 func (p *populateWithDelSeriesIterator) At() (int64, float64) { return p.curr.At() }
+func (p *populateWithDelSeriesIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	return 0, histogram.SparseHistogram{}
+}
 
 func (p *populateWithDelSeriesIterator) Err() error {
 	if err := p.populateWithDelGenericSeriesIterator.Err(); err != nil {
@@ -816,6 +820,10 @@ type DeletedIterator struct {
 
 func (it *DeletedIterator) At() (int64, float64) {
 	return it.Iter.At()
+}
+
+func (it *DeletedIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	return 0, histogram.SparseHistogram{}
 }
 
 func (it *DeletedIterator) Seek(t int64) bool {

--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/prometheus/prometheus/pkg/histogram"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
@@ -65,6 +66,13 @@ type RefExemplar struct {
 	T      int64
 	V      float64
 	Labels labels.Labels
+}
+
+// RefHistogram is a histogram.
+type RefHistogram struct {
+	Ref uint64
+	T   int64
+	H   histogram.SparseHistogram
 }
 
 // Decoder decodes series, sample, and tombstone records.

--- a/tsdb/tsdbutil/buffer.go
+++ b/tsdb/tsdbutil/buffer.go
@@ -16,6 +16,7 @@ package tsdbutil
 import (
 	"math"
 
+	"github.com/prometheus/prometheus/pkg/histogram"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
 
@@ -157,6 +158,10 @@ func (it *sampleRingIterator) Err() error {
 
 func (it *sampleRingIterator) At() (int64, float64) {
 	return it.r.at(it.i)
+}
+
+func (it *sampleRingIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	return 0, histogram.SparseHistogram{}
 }
 
 func (r *sampleRing) at(i int) (int64, float64) {

--- a/tsdb/tsdbutil/buffer_test.go
+++ b/tsdb/tsdbutil/buffer_test.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/prometheus/prometheus/pkg/histogram"
 	"github.com/stretchr/testify/require"
 )
 
@@ -148,6 +149,10 @@ func newListSeriesIterator(list []sample) *listSeriesIterator {
 func (it *listSeriesIterator) At() (int64, float64) {
 	s := it.list[it.idx]
 	return s.t, s.v
+}
+
+func (it *listSeriesIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	return 0, histogram.SparseHistogram{}
 }
 
 func (it *listSeriesIterator) Next() bool {


### PR DESCRIPTION
NOTE: This is pointing to `sparsehistogram` branch and not to be merged into `main` branch. This is part of the sparse histogram experiments.

### What this PR includes

* Ingesting sparse histograms into Head block (only head block, compaction will fail at the moment if there are histograms)
* Includes m-mapping of the histogram chunks
* Isolation seems to be taken care for the append


### What this PR *DOES NOT* include

* Writing these histograms to WAL
* A way to query back these histograms
* To be able to compact these histograms into a block


### Blockers

1. `HistoChunk` does not conform to the `Chunk` interface yet because of the iterator function. This needs to be fixed.
2. (only for query path and compaction, so not a blocker for this PR necessarily) Need a way to create `HistoChunk` from the byte slice of the chunk. I have already added the code for that in appropriate places, the only thing missing is populating the `schema`, `posSpans` and `negSpans` from the byte slice when chunk is created.

cc @Dieterbe 