### PR TITLE
fixed disappeared target groups in http_sd #9019

### DIFF
--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -104,6 +104,7 @@ type Discovery struct {
 	url             string
 	client          *http.Client
 	refreshInterval time.Duration
+	tgLastLength    int
 }
 
 // NewDiscovery returns a new HTTP discovery for the given config.
@@ -182,6 +183,15 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		}
 		tg.Labels[httpSDURLLabel] = model.LabelValue(d.url)
 	}
+
+	// Generate empty updates for sources that disappeared.
+	l := len(targetGroups)
+	if d.tgLastLength > l {
+		for i := l; i < d.tgLastLength; i++ {
+			targetGroups = append(targetGroups, &targetgroup.Group{Source: urlSource(d.url, i)})
+		}
+	}
+	d.tgLastLength = l
 
 	return targetGroups, nil
 }

--- a/discovery/http/http_test.go
+++ b/discovery/http/http_test.go
@@ -162,3 +162,241 @@ func TestContentTypeRegex(t *testing.T) {
 		})
 	}
 }
+
+func TestSourceDisappeared(t *testing.T) {
+	var stubResponse string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, stubResponse)
+	}))
+	t.Cleanup(ts.Close)
+
+	cases := []struct {
+		responses       []string
+		expectedTargets [][]*targetgroup.Group
+	}{
+		{
+			responses: []string{
+				`[]`,
+				`[]`,
+			},
+			expectedTargets: [][]*targetgroup.Group{{}, {}},
+		},
+		{
+			responses: []string{
+				`[{"labels": {"k": "1"}, "targets": ["127.0.0.1"]}]`,
+				`[{"labels": {"k": "1"}, "targets": ["127.0.0.1"]}, {"labels": {"k": "2"}, "targets": ["127.0.0.1"]}]`,
+			},
+			expectedTargets: [][]*targetgroup.Group{
+				{
+					{
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: model.LabelValue("127.0.0.1"),
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("k"):          model.LabelValue("1"),
+							model.LabelName("__meta_url"): model.LabelValue(ts.URL + "/http_disappeared.json"),
+						},
+						Source: urlSource(ts.URL+"/http_disappeared.json", 0),
+					},
+				},
+				{
+					{
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: model.LabelValue("127.0.0.1"),
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("k"):          model.LabelValue("1"),
+							model.LabelName("__meta_url"): model.LabelValue(ts.URL + "/http_disappeared.json"),
+						},
+						Source: urlSource(ts.URL+"/http_disappeared.json", 0),
+					},
+					{
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: model.LabelValue("127.0.0.1"),
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("k"):          model.LabelValue("2"),
+							model.LabelName("__meta_url"): model.LabelValue(ts.URL + "/http_disappeared.json"),
+						},
+						Source: urlSource(ts.URL+"/http_disappeared.json", 1),
+					},
+				},
+			},
+		},
+		{
+			responses: []string{
+				`[{"labels": {"k": "1"}, "targets": ["127.0.0.1"]}, {"labels": {"k": "2"}, "targets": ["127.0.0.1"]}]`,
+				`[{"labels": {"k": "1"}, "targets": ["127.0.0.1"]}]`,
+			},
+			expectedTargets: [][]*targetgroup.Group{
+				{
+					{
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: model.LabelValue("127.0.0.1"),
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("k"):          model.LabelValue("1"),
+							model.LabelName("__meta_url"): model.LabelValue(ts.URL + "/http_disappeared.json"),
+						},
+						Source: urlSource(ts.URL+"/http_disappeared.json", 0),
+					},
+					{
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: model.LabelValue("127.0.0.1"),
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("k"):          model.LabelValue("2"),
+							model.LabelName("__meta_url"): model.LabelValue(ts.URL + "/http_disappeared.json"),
+						},
+						Source: urlSource(ts.URL+"/http_disappeared.json", 1),
+					},
+				},
+				{
+					{
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: model.LabelValue("127.0.0.1"),
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("k"):          model.LabelValue("1"),
+							model.LabelName("__meta_url"): model.LabelValue(ts.URL + "/http_disappeared.json"),
+						},
+						Source: urlSource(ts.URL+"/http_disappeared.json", 0),
+					},
+					{
+						Targets: nil,
+						Labels:  nil,
+						Source:  urlSource(ts.URL+"/http_disappeared.json", 1),
+					},
+				},
+			},
+		},
+		{
+			responses: []string{
+				`[{"labels": {"k": "1"}, "targets": ["127.0.0.1"]}, {"labels": {"k": "2"}, "targets": ["127.0.0.1"]}, {"labels": {"k": "3"}, "targets": ["127.0.0.1"]}]`,
+				`[{"labels": {"k": "1"}, "targets": ["127.0.0.1"]}]`,
+				`[{"labels": {"k": "v"}, "targets": ["127.0.0.2"]}, {"labels": {"k": "vv"}, "targets": ["127.0.0.3"]}]`,
+			},
+			expectedTargets: [][]*targetgroup.Group{
+				{
+					{
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: model.LabelValue("127.0.0.1"),
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("k"):          model.LabelValue("1"),
+							model.LabelName("__meta_url"): model.LabelValue(ts.URL + "/http_disappeared.json"),
+						},
+						Source: urlSource(ts.URL+"/http_disappeared.json", 0),
+					},
+					{
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: model.LabelValue("127.0.0.1"),
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("k"):          model.LabelValue("2"),
+							model.LabelName("__meta_url"): model.LabelValue(ts.URL + "/http_disappeared.json"),
+						},
+						Source: urlSource(ts.URL+"/http_disappeared.json", 1),
+					},
+					{
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: model.LabelValue("127.0.0.1"),
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("k"):          model.LabelValue("3"),
+							model.LabelName("__meta_url"): model.LabelValue(ts.URL + "/http_disappeared.json"),
+						},
+						Source: urlSource(ts.URL+"/http_disappeared.json", 2),
+					},
+				},
+				{
+					{
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: model.LabelValue("127.0.0.1"),
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("k"):          model.LabelValue("1"),
+							model.LabelName("__meta_url"): model.LabelValue(ts.URL + "/http_disappeared.json"),
+						},
+						Source: urlSource(ts.URL+"/http_disappeared.json", 0),
+					},
+					{
+						Targets: nil,
+						Labels:  nil,
+						Source:  urlSource(ts.URL+"/http_disappeared.json", 1),
+					},
+					{
+						Targets: nil,
+						Labels:  nil,
+						Source:  urlSource(ts.URL+"/http_disappeared.json", 2),
+					},
+				},
+				{
+					{
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: model.LabelValue("127.0.0.2"),
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("k"):          model.LabelValue("v"),
+							model.LabelName("__meta_url"): model.LabelValue(ts.URL + "/http_disappeared.json"),
+						},
+						Source: urlSource(ts.URL+"/http_disappeared.json", 0),
+					},
+					{
+						Targets: []model.LabelSet{
+							{
+								model.AddressLabel: model.LabelValue("127.0.0.3"),
+							},
+						},
+						Labels: model.LabelSet{
+							model.LabelName("k"):          model.LabelValue("vv"),
+							model.LabelName("__meta_url"): model.LabelValue(ts.URL + "/http_disappeared.json"),
+						},
+						Source: urlSource(ts.URL+"/http_disappeared.json", 1),
+					},
+				},
+			},
+		},
+	}
+
+	cfg := SDConfig{
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
+		URL:              ts.URL + "/http_disappeared.json",
+		RefreshInterval:  model.Duration(1 * time.Second),
+	}
+	d, err := NewDiscovery(&cfg, log.NewNopLogger())
+	require.NoError(t, err)
+	for _, test := range cases {
+		ctx := context.Background()
+		for i, res := range test.responses {
+			stubResponse = res
+			tgs, err := d.refresh(ctx)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedTargets[i], tgs)
+		}
+	}
+
+}


### PR DESCRIPTION
This PR insert an empty source when a source is lost in HTTP_SD, and to update the target group appropriately.
Fixes #9019 