### PR TITLE
Query histograms from TSDB and unit test for append+query

### DIFF
--- a/promql/value.go
+++ b/promql/value.go
@@ -300,6 +300,10 @@ func (ssi *storageSeriesIterator) AtHistogram() (int64, histogram.SparseHistogra
 	return 0, histogram.SparseHistogram{}
 }
 
+func (ssi *storageSeriesIterator) ChunkEncoding() chunkenc.Encoding {
+	return chunkenc.EncXOR
+}
+
 func (ssi *storageSeriesIterator) Next() bool {
 	ssi.curr++
 	return ssi.curr < len(ssi.points)

--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -202,6 +202,10 @@ func (it *sampleRingIterator) AtHistogram() (int64, histogram.SparseHistogram) {
 	return 0, histogram.SparseHistogram{}
 }
 
+func (it *sampleRingIterator) ChunkEncoding() chunkenc.Encoding {
+	return chunkenc.EncXOR
+}
+
 func (r *sampleRing) at(i int) (int64, float64) {
 	j := (r.f + i) % len(r.buf)
 	s := r.buf[j]

--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/prometheus/pkg/histogram"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -198,6 +199,9 @@ func (m *mockSeriesIterator) At() (int64, float64) { return m.at() }
 func (m *mockSeriesIterator) AtHistogram() (int64, histogram.SparseHistogram) {
 	return 0, histogram.SparseHistogram{}
 }
+func (m *mockSeriesIterator) ChunkEncoding() chunkenc.Encoding {
+	return chunkenc.EncXOR
+}
 func (m *mockSeriesIterator) Next() bool { return m.next() }
 func (m *mockSeriesIterator) Err() error { return m.err() }
 
@@ -217,6 +221,10 @@ func (it *fakeSeriesIterator) At() (int64, float64) {
 
 func (it *fakeSeriesIterator) AtHistogram() (int64, histogram.SparseHistogram) {
 	return it.idx * it.step, histogram.SparseHistogram{} // value doesn't matter
+}
+
+func (it *fakeSeriesIterator) ChunkEncoding() chunkenc.Encoding {
+	return chunkenc.EncXOR
 }
 
 func (it *fakeSeriesIterator) Next() bool {

--- a/storage/merge.go
+++ b/storage/merge.go
@@ -489,6 +489,13 @@ func (c *chainSampleIterator) AtHistogram() (int64, histogram.SparseHistogram) {
 	return c.curr.AtHistogram()
 }
 
+func (c *chainSampleIterator) ChunkEncoding() chunkenc.Encoding {
+	if c.curr == nil {
+		panic("chainSampleIterator.ChunkEncoding() called before first .Next() or after .Next() returned false.")
+	}
+	return c.curr.ChunkEncoding()
+}
+
 func (c *chainSampleIterator) Next() bool {
 	if c.h == nil {
 		c.h = samplesIteratorHeap{}

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -373,6 +373,10 @@ func (c *concreteSeriesIterator) AtHistogram() (int64, histogram.SparseHistogram
 	return 0, histogram.SparseHistogram{}
 }
 
+func (c *concreteSeriesIterator) ChunkEncoding() chunkenc.Encoding {
+	return chunkenc.EncXOR
+}
+
 // Next implements storage.SeriesIterator.
 func (c *concreteSeriesIterator) Next() bool {
 	c.cur++

--- a/storage/series.go
+++ b/storage/series.go
@@ -95,6 +95,10 @@ func (it *listSeriesIterator) AtHistogram() (int64, histogram.SparseHistogram) {
 	return 0, histogram.SparseHistogram{}
 }
 
+func (it *listSeriesIterator) ChunkEncoding() chunkenc.Encoding {
+	return chunkenc.EncXOR
+}
+
 func (it *listSeriesIterator) Next() bool {
 	it.idx++
 	return it.idx < it.samples.Len()

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -103,6 +103,8 @@ type Iterator interface {
 	// Err returns the current error. It should be used only after iterator is
 	// exhausted, that is `Next` or `Seek` returns false.
 	Err() error
+	// ChunkEncoding returns the encoding of the chunk that it is iterating.
+	ChunkEncoding() Encoding
 }
 
 // NewNopIterator returns a new chunk iterator that does not hold any data.
@@ -117,8 +119,9 @@ func (nopIterator) At() (int64, float64) { return math.MinInt64, 0 }
 func (nopIterator) AtHistogram() (int64, histogram.SparseHistogram) {
 	return math.MinInt64, histogram.SparseHistogram{}
 }
-func (nopIterator) Next() bool { return false }
-func (nopIterator) Err() error { return nil }
+func (nopIterator) Next() bool              { return false }
+func (nopIterator) Err() error              { return nil }
+func (nopIterator) ChunkEncoding() Encoding { return EncNone }
 
 // Pool is used to create and reuse chunk references to avoid allocations.
 type Pool interface {

--- a/tsdb/chunkenc/histo.go
+++ b/tsdb/chunkenc/histo.go
@@ -403,6 +403,10 @@ func (it *histoIterator) At() (int64, float64) {
 	panic("cannot call histoIterator.At().")
 }
 
+func (it *histoIterator) ChunkEncoding() Encoding {
+	return EncSHS
+}
+
 func (it *histoIterator) AtHistogram() (int64, histogram.SparseHistogram) {
 	return it.t, histogram.SparseHistogram{
 		Count:           it.cnt,

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -281,6 +281,10 @@ func (it *xorIterator) AtHistogram() (int64, histogram.SparseHistogram) {
 	panic("cannot call xorIterator.AtHistogram().")
 }
 
+func (it *xorIterator) ChunkEncoding() Encoding {
+	return EncXOR
+}
+
 func (it *xorIterator) Err() error {
 	return it.err
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2678,7 +2678,7 @@ func computeChunkEndTime(start, cur, max int64) int64 {
 
 // iterator returns a chunk iterator.
 // It is unsafe to call this concurrently with s.append(...) without holding the series lock.
-func (s *memSeries) iterator(id int, isoState *isolationState, chunkDiskMapper *chunks.ChunkDiskMapper, it chunkenc.Iterator) chunkenc.Iterator {
+func (s *memSeries) iterator(id int, isoState *isolationState, chunkDiskMapper *chunks.ChunkDiskMapper, it chunkenc.Iterator) (ttt chunkenc.Iterator) {
 	c, garbageCollect, err := s.chunk(id, chunkDiskMapper)
 	// TODO(fabxc): Work around! An error will be returns when a querier have retrieved a pointer to a
 	// series's chunk, which got then garbage collected before it got
@@ -2837,7 +2837,7 @@ func (it *memSafeIterator) Next() bool {
 		return false
 	}
 	it.i++
-	if it.total-it.i > 4 {
+	if it.Iterator.ChunkEncoding() == chunkenc.EncSHS || it.total-it.i > 4 {
 		return it.Iterator.Next()
 	}
 	return true

--- a/tsdb/tsdbutil/buffer.go
+++ b/tsdb/tsdbutil/buffer.go
@@ -164,6 +164,10 @@ func (it *sampleRingIterator) AtHistogram() (int64, histogram.SparseHistogram) {
 	return 0, histogram.SparseHistogram{}
 }
 
+func (it *sampleRingIterator) ChunkEncoding() chunkenc.Encoding {
+	return chunkenc.EncXOR
+}
+
 func (r *sampleRing) at(i int) (int64, float64) {
 	j := (r.f + i) % len(r.buf)
 	s := r.buf[j]

--- a/tsdb/tsdbutil/buffer_test.go
+++ b/tsdb/tsdbutil/buffer_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/prometheus/pkg/histogram"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -153,6 +154,10 @@ func (it *listSeriesIterator) At() (int64, float64) {
 
 func (it *listSeriesIterator) AtHistogram() (int64, histogram.SparseHistogram) {
 	return 0, histogram.SparseHistogram{}
+}
+
+func (it *listSeriesIterator) ChunkEncoding() chunkenc.Encoding {
+	return chunkenc.EncXOR
 }
 
 func (it *listSeriesIterator) Next() bool {


### PR DESCRIPTION
NOTE: this PR is pointing to `sparsehistogram` and part of histogram experiments

This PR fixes few small stuff here and there to make querying work for the Head block (including from the m-mapped chunks). This is not tested for blocks since compaction does not work for histograms yet.

Adds `ChunkEncoding()` method to the chunk iterator since based on the encoding we have different methods to call and different things to consider while querying.

Also has a unit test testing all of this.