### PR TITLE
hcloud discovery: Add testcase for key only labels

### DIFF
--- a/discovery/hetzner/hcloud.go
+++ b/discovery/hetzner/hcloud.go
@@ -47,6 +47,7 @@ const (
 	hetznerLabelHcloudDiskGB                        = hetznerHcloudLabelPrefix + "disk_size_gb"
 	hetznerLabelHcloudType                          = hetznerHcloudLabelPrefix + "server_type"
 	hetznerLabelHcloudLabel                         = hetznerHcloudLabelPrefix + "label_"
+	hetznerLabelHcloudLabelPresent                  = hetznerHcloudLabelPrefix + "labelpresent_"
 )
 
 // Discovery periodically performs Hetzner Cloud requests. It implements
@@ -126,6 +127,7 @@ func (d *hcloudDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 		for labelKey, labelValue := range server.Labels {
 			label := model.LabelName(hetznerLabelHcloudLabel + strutil.SanitizeLabelName(labelKey))
 			if labelValue == "" {
+				label = model.LabelName(hetznerLabelHcloudLabelPresent + strutil.SanitizeLabelName(labelKey))
 				labelValue = "true"
 			}
 			labels[label] = model.LabelValue(labelValue)

--- a/discovery/hetzner/hcloud.go
+++ b/discovery/hetzner/hcloud.go
@@ -127,10 +127,9 @@ func (d *hcloudDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 		for labelKey, labelValue := range server.Labels {
 			presentLabel := model.LabelName(hetznerLabelHcloudLabelPresent + strutil.SanitizeLabelName(labelKey))
 			labels[presentLabel] = model.LabelValue("true")
-			if labelValue != "" {
-				label := model.LabelName(hetznerLabelHcloudLabel + strutil.SanitizeLabelName(labelKey))
-				labels[label] = model.LabelValue(labelValue)
-			}
+
+			label := model.LabelName(hetznerLabelHcloudLabel + strutil.SanitizeLabelName(labelKey))
+			labels[label] = model.LabelValue(labelValue)
 		}
 		targets[i] = labels
 	}

--- a/discovery/hetzner/hcloud.go
+++ b/discovery/hetzner/hcloud.go
@@ -125,12 +125,12 @@ func (d *hcloudDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 			}
 		}
 		for labelKey, labelValue := range server.Labels {
-			label := model.LabelName(hetznerLabelHcloudLabel + strutil.SanitizeLabelName(labelKey))
-			if labelValue == "" {
-				label = model.LabelName(hetznerLabelHcloudLabelPresent + strutil.SanitizeLabelName(labelKey))
-				labelValue = "true"
+			presentLabel := model.LabelName(hetznerLabelHcloudLabelPresent + strutil.SanitizeLabelName(labelKey))
+			labels[presentLabel] = model.LabelValue("true")
+			if labelValue != "" {
+				label := model.LabelName(hetznerLabelHcloudLabel + strutil.SanitizeLabelName(labelKey))
+				labels[label] = model.LabelValue(labelValue)
 			}
-			labels[label] = model.LabelValue(labelValue)
 		}
 		targets[i] = labels
 	}

--- a/discovery/hetzner/hcloud.go
+++ b/discovery/hetzner/hcloud.go
@@ -125,6 +125,9 @@ func (d *hcloudDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 		}
 		for labelKey, labelValue := range server.Labels {
 			label := model.LabelName(hetznerLabelHcloudLabel + strutil.SanitizeLabelName(labelKey))
+			if labelValue == "" {
+				labelValue = "true"
+			}
 			labels[label] = model.LabelValue(labelValue)
 		}
 		targets[i] = labels

--- a/discovery/hetzner/hcloud_test.go
+++ b/discovery/hetzner/hcloud_test.go
@@ -77,6 +77,7 @@ func TestHCloudSDRefresh(t *testing.T) {
 			"__meta_hetzner_hcloud_disk_size_gb":                     model.LabelValue("25"),
 			"__meta_hetzner_hcloud_server_type":                      model.LabelValue("cx11"),
 			"__meta_hetzner_hcloud_private_ipv4_mynet":               model.LabelValue("10.0.0.2"),
+			"__meta_hetzner_hcloud_labelpresent_my_key":              model.LabelValue("true"),
 			"__meta_hetzner_hcloud_label_my_key":                     model.LabelValue("my-value"),
 		},
 		{

--- a/discovery/hetzner/hcloud_test.go
+++ b/discovery/hetzner/hcloud_test.go
@@ -99,7 +99,7 @@ func TestHCloudSDRefresh(t *testing.T) {
 			"__meta_hetzner_hcloud_memory_size_gb":                   model.LabelValue("1"),
 			"__meta_hetzner_hcloud_disk_size_gb":                     model.LabelValue("50"),
 			"__meta_hetzner_hcloud_server_type":                      model.LabelValue("cpx11"),
-			"__meta_hetzner_hcloud_label_key":                        model.LabelValue(""),
+			"__meta_hetzner_hcloud_label_key":                        model.LabelValue("true"),
 		},
 		{
 			"__address__":                                            model.LabelValue("1.2.3.6:80"),

--- a/discovery/hetzner/hcloud_test.go
+++ b/discovery/hetzner/hcloud_test.go
@@ -101,6 +101,9 @@ func TestHCloudSDRefresh(t *testing.T) {
 			"__meta_hetzner_hcloud_disk_size_gb":                     model.LabelValue("50"),
 			"__meta_hetzner_hcloud_server_type":                      model.LabelValue("cpx11"),
 			"__meta_hetzner_hcloud_labelpresent_key":                 model.LabelValue("true"),
+			"__meta_hetzner_hcloud_labelpresent_other_key":           model.LabelValue("true"),
+			"__meta_hetzner_hcloud_label_key":                        model.LabelValue(""),
+			"__meta_hetzner_hcloud_label_other_key":                  model.LabelValue("value"),
 		},
 		{
 			"__address__":                                            model.LabelValue("1.2.3.6:80"),

--- a/discovery/hetzner/hcloud_test.go
+++ b/discovery/hetzner/hcloud_test.go
@@ -99,7 +99,7 @@ func TestHCloudSDRefresh(t *testing.T) {
 			"__meta_hetzner_hcloud_memory_size_gb":                   model.LabelValue("1"),
 			"__meta_hetzner_hcloud_disk_size_gb":                     model.LabelValue("50"),
 			"__meta_hetzner_hcloud_server_type":                      model.LabelValue("cpx11"),
-			"__meta_hetzner_hcloud_label_key":                        model.LabelValue("true"),
+			"__meta_hetzner_hcloud_labelpresent_key":                 model.LabelValue("true"),
 		},
 		{
 			"__address__":                                            model.LabelValue("1.2.3.6:80"),

--- a/discovery/hetzner/hcloud_test.go
+++ b/discovery/hetzner/hcloud_test.go
@@ -99,6 +99,7 @@ func TestHCloudSDRefresh(t *testing.T) {
 			"__meta_hetzner_hcloud_memory_size_gb":                   model.LabelValue("1"),
 			"__meta_hetzner_hcloud_disk_size_gb":                     model.LabelValue("50"),
 			"__meta_hetzner_hcloud_server_type":                      model.LabelValue("cpx11"),
+			"__meta_hetzner_hcloud_label_key":                        model.LabelValue(""),
 		},
 		{
 			"__address__":                                            model.LabelValue("1.2.3.6:80"),

--- a/discovery/hetzner/mock_test.go
+++ b/discovery/hetzner/mock_test.go
@@ -311,7 +311,8 @@ func (m *SDMock) HandleHcloudServers() {
         "rebuild": false
       },
       "labels": {
-        "key": ""
+        "key": "",
+        "other-key": "value"
       },
       "volumes": [],
       "load_balancers": []

--- a/discovery/hetzner/mock_test.go
+++ b/discovery/hetzner/mock_test.go
@@ -310,7 +310,9 @@ func (m *SDMock) HandleHcloudServers() {
         "delete": false,
         "rebuild": false
       },
-      "labels": {},
+      "labels": {
+        "key": ""
+      },
       "volumes": [],
       "load_balancers": []
     },

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1211,6 +1211,7 @@ The labels below are only available for targets with `role` set to `hcloud`:
 * `__meta_hetzner_hcloud_disk_size_gb`: the disk size of the server (in GB)
 * `__meta_hetzner_hcloud_private_ipv4_<networkname>`: the private ipv4 address of the server within a given network
 * `__meta_hetzner_hcloud_label_<labelname>`: each label of the server
+* `__meta_hetzner_hcloud_labelpresent_<labelname>`: `true` each label of the server that does not contain a value
 
 The labels below are only available for targets with `role` set to `robot`:
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1211,7 +1211,7 @@ The labels below are only available for targets with `role` set to `hcloud`:
 * `__meta_hetzner_hcloud_disk_size_gb`: the disk size of the server (in GB)
 * `__meta_hetzner_hcloud_private_ipv4_<networkname>`: the private ipv4 address of the server within a given network
 * `__meta_hetzner_hcloud_label_<labelname>`: each label of the server
-* `__meta_hetzner_hcloud_labelpresent_<labelname>`: `true` each label of the server that does not contain a value
+* `__meta_hetzner_hcloud_labelpresent_<labelname>`: `true` for each label of the server
 
 The labels below are only available for targets with `role` set to `robot`:
 


### PR DESCRIPTION
This adds a test case for the hcloud discovery with key only labels.

Key Only Labels should already be possible as they are returned from the hcloud API `{"key":""}`

Fixes https://github.com/prometheus/prometheus/issues/9023

