### PR TITLE
Fix: Use json.Unmarshal() instead of json.Decoder

### DIFF
--- a/discovery/hetzner/robot.go
+++ b/discovery/hetzner/robot.go
@@ -92,8 +92,13 @@ func (d *robotDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, err
 		return nil, errors.Errorf("non 2xx status '%d' response during hetzner service discovery with role robot", resp.StatusCode)
 	}
 
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
 	var servers serversList
-	err = json.NewDecoder(resp.Body).Decode(&servers)
+	err = json.Unmarshal(b, &servers)
 	if err != nil {
 		return nil, err
 	}

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -339,8 +339,13 @@ func fetchApps(ctx context.Context, client *http.Client, url string) (*appList, 
 		return nil, errors.Errorf("non 2xx status '%v' response during marathon service discovery", resp.StatusCode)
 	}
 
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
 	var apps appList
-	err = json.NewDecoder(resp.Body).Decode(&apps)
+	err = json.Unmarshal(b, &apps)
 	if err != nil {
 		return nil, errors.Wrapf(err, "%q", url)
 	}

--- a/discovery/targetgroup/targetgroup.go
+++ b/discovery/targetgroup/targetgroup.go
@@ -14,7 +14,6 @@
 package targetgroup
 
 import (
-	"bytes"
 	"encoding/json"
 
 	"github.com/prometheus/common/model"
@@ -77,9 +76,7 @@ func (tg *Group) UnmarshalJSON(b []byte) error {
 		Labels  model.LabelSet `json:"labels"`
 	}{}
 
-	dec := json.NewDecoder(bytes.NewReader(b))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&g); err != nil {
+	if err := json.Unmarshal(b, &g); err != nil {
 		return err
 	}
 	tg.Targets = make([]model.LabelSet, 0, len(g.Targets))

--- a/discovery/targetgroup/targetgroup_test.go
+++ b/discovery/targetgroup/targetgroup_test.go
@@ -14,7 +14,6 @@
 package targetgroup
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -22,7 +21,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TestTargetGroupStrictJsonUnmarshal(t *testing.T) {
+func TestTargetGroupJSONUnmarshal(t *testing.T) {
 	tests := []struct {
 		json          string
 		expectedReply error
@@ -40,14 +39,6 @@ func TestTargetGroupStrictJsonUnmarshal(t *testing.T) {
 				{"__address__": "localhost:9090"},
 				{"__address__": "localhost:9091"}}, Labels: model.LabelSet{"my": "label"}},
 		},
-		{
-			json: `	{"label": {},"targets": []}`,
-			expectedReply: errors.New("json: unknown field \"label\""),
-		},
-		{
-			json: `	{"labels": {},"target": []}`,
-			expectedReply: errors.New("json: unknown field \"target\""),
-		},
 	}
 
 	for _, test := range tests {
@@ -59,7 +50,7 @@ func TestTargetGroupStrictJsonUnmarshal(t *testing.T) {
 
 }
 
-func TestTargetGroupYamlMarshal(t *testing.T) {
+func TestTargetGroupYAMLMarshal(t *testing.T) {
 	marshal := func(g interface{}) []byte {
 		d, err := yaml.Marshal(g)
 		if err != nil {
@@ -97,7 +88,7 @@ func TestTargetGroupYamlMarshal(t *testing.T) {
 	}
 }
 
-func TestTargetGroupYamlUnmarshal(t *testing.T) {
+func TestTargetGroupYAMLUnmarshal(t *testing.T) {
 	unmarshal := func(d []byte) func(interface{}) error {
 		return func(o interface{}) error {
 			return yaml.Unmarshal(d, o)

--- a/documentation/examples/custom-sd/adapter-usage/main.go
+++ b/documentation/examples/custom-sd/adapter-usage/main.go
@@ -100,13 +100,17 @@ func (d *discovery) parseServiceNodes(resp *http.Response, name string) (*target
 		Labels: make(model.LabelSet),
 	}
 
-	dec := json.NewDecoder(resp.Body)
 	defer func() {
 		io.Copy(ioutil.Discard, resp.Body)
 		resp.Body.Close()
 	}()
-	err := dec.Decode(&nodes)
 
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(b, &nodes)
 	if err != nil {
 		return &tgroup, err
 	}
@@ -165,11 +169,19 @@ func (d *discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 			continue
 		}
 
-		dec := json.NewDecoder(resp.Body)
-		err = dec.Decode(&srvs)
+		b, err := ioutil.ReadAll(resp.Body)
+		io.Copy(ioutil.Discard, resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			level.Error(d.logger).Log("msg", "Error reading services list", "err", err)
+			time.Sleep(time.Duration(d.refreshInterval) * time.Second)
+			continue
+		}
+
+		err = json.Unmarshal(b, &srvs)
+		resp.Body.Close()
+		if err != nil {
+			level.Error(d.logger).Log("msg", "Error parsing services list", "err", err)
 			time.Sleep(time.Duration(d.refreshInterval) * time.Second)
 			continue
 		}
@@ -191,6 +203,7 @@ func (d *discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 				level.Error(d.logger).Log("msg", "Error getting services nodes", "service", name, "err", err)
 				break
 			}
+
 			tg, err := d.parseServiceNodes(resp, name)
 			if err != nil {
 				level.Error(d.logger).Log("msg", "Error parsing services nodes", "service", name, "err", err)

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -125,8 +125,16 @@ func TestHandlerSendAll(t *testing.T) {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
+
+			b, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				err = errors.Errorf("error reading body: %v", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
 			var alerts []*Alert
-			err = json.NewDecoder(r.Body).Decode(&alerts)
+			err = json.Unmarshal(b, &alerts)
 			if err == nil {
 				err = alertsEqual(expected, alerts)
 			}
@@ -322,7 +330,13 @@ func TestHandlerQueuing(t *testing.T) {
 		select {
 		case expected := <-expectedc:
 			var alerts []*Alert
-			err := json.NewDecoder(r.Body).Decode(&alerts)
+
+			b, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				panic(err)
+			}
+
+			err = json.Unmarshal(b, &alerts)
 			if err == nil {
 				err = alertsEqual(expected, alerts)
 			}


### PR DESCRIPTION
See https://ahmet.im/blog/golang-json-decoder-pitfalls/

json.Decoder is for JSON streams, not single JSON objects / bodies.

Signed-off-by: Julius Volz <julius.volz@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->