### PR TITLE
Bunch of fixes for sparse histograms

### DIFF
--- a/pkg/histogram/sparse_histogram_test.go
+++ b/pkg/histogram/sparse_histogram_test.go
@@ -15,8 +15,9 @@ package histogram
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCumulativeExpandSparseHistogram(t *testing.T) {
@@ -110,28 +111,44 @@ func TestCumulativeExpandSparseHistogram(t *testing.T) {
 				{Le: 1.5422108254079407, Count: 13}, // 4
 			},
 		},
-		//{
-		//	hist: SparseHistogram{
-		//		Schema: -2,
-		//		PositiveSpans: []Span{
-		//			{Offset: -2, Length: 4}, // -2 -1 0 1
-		//			{Offset: 2, Length: 2},  // 4 5
-		//		},
-		//		PositiveBuckets: []int64{1, 2, -2, 1, -1, 0},
-		//	},
-		//	expBuckets: []Bucket{
-		//		{Le: 0.00390625, Count: 1}, // -2
-		//		{Le: 0.0625, Count: 4},     // -1
-		//		{Le: 1, Count: 5},          // 0
-		//		{Le: 16, Count: 7},         // 1
-		//
-		//		{Le: 256, Count: 7},  // 2
-		//		{Le: 4096, Count: 7}, // 3
-		//
-		//		{Le: 65539, Count: 8},   // 4
-		//		{Le: 1048576, Count: 9}, // 5
-		//	},
-		//},
+		{
+			hist: SparseHistogram{
+				Schema: -2,
+				PositiveSpans: []Span{
+					{Offset: -2, Length: 4}, // -2 -1 0 1
+					{Offset: 2, Length: 2},  // 4 5
+				},
+				PositiveBuckets: []int64{1, 2, -2, 1, -1, 0},
+			},
+			expBuckets: []Bucket{
+				{Le: 0.00390625, Count: 1}, // -2
+				{Le: 0.0625, Count: 4},     // -1
+				{Le: 1, Count: 5},          // 0
+				{Le: 16, Count: 7},         // 1
+
+				{Le: 256, Count: 7},  // 2
+				{Le: 4096, Count: 7}, // 3
+
+				{Le: 65536, Count: 8},   // 4
+				{Le: 1048576, Count: 9}, // 5
+			},
+		},
+		{
+			hist: SparseHistogram{
+				Schema: -1,
+				PositiveSpans: []Span{
+					{Offset: -2, Length: 5}, // -2 -1 0 1 2
+				},
+				PositiveBuckets: []int64{1, 2, -2, 1, -1},
+			},
+			expBuckets: []Bucket{
+				{Le: 0.0625, Count: 1}, // -2
+				{Le: 0.25, Count: 4},   // -1
+				{Le: 1, Count: 5},      // 0
+				{Le: 4, Count: 7},      // 1
+				{Le: 16, Count: 8},     // 2
+			},
+		},
 	}
 
 	for i, c := range cases {

--- a/tsdb/chunkenc/histo.go
+++ b/tsdb/chunkenc/histo.go
@@ -230,9 +230,7 @@ func putUvarint(b *bstream, buf []byte, x uint64) {
 	}
 }
 
-func (a *histoAppender) Append(int64, float64) {
-	panic("cannot call histoAppender.Append()")
-}
+func (a *histoAppender) Append(int64, float64) {}
 
 // AppendHistogram appends a SparseHistogram to the chunk. We assume the
 // histogram is properly structured. E.g. that the number of pos/neg buckets


### PR DESCRIPTION
NOTE: this is pointing to sparsehistogram branch. There is nothing to see here if you are not @beorn7 or @Dieterbe.

This fixes a bunch of things:

* Dont panic on trying to append float64 sample to histogram. This is used by the staleness.
* M-map all in-memory chunks on shutdown to not lose the latest histograms since they are not stored in WAL yet
* Support negative schema while querying