### PR TITLE
Fix TSDB race while reading histograms

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2889,7 +2889,7 @@ func (it *memSafeIterator) Next() bool {
 		return false
 	}
 	it.i++
-	if it.Iterator.ChunkEncoding() == chunkenc.EncSHS || it.total-it.i > 4 {
+	if it.total-it.i > 4 {
 		return it.Iterator.Next()
 	}
 	return true


### PR DESCRIPTION
NOTE: this is for sparsehistogram experimental branch

I missed this small change in https://github.com/prometheus/prometheus/pull/9051, this should hopefully finally fix the race