### PR TITLE
Added option to add custom HTTP-Header for scraping

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -413,6 +413,8 @@ type ScrapeConfig struct {
 	RelabelConfigs []*relabel.Config `yaml:"relabel_configs,omitempty"`
 	// List of metric relabel configurations.
 	MetricRelabelConfigs []*relabel.Config `yaml:"metric_relabel_configs,omitempty"`
+
+	CustomHeaders map[string]string `yaml:"custom_header,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.


### PR DESCRIPTION
Hi together,

I and apparently a few others would like to have the ability to add our own custom HTTP headers for scraping.
For example, if additional headers are needed when authorizing on the API.

So far I have only read that this was possible via proxies (e.g.: https://github.com/prometheus/prometheus/issues/1724 ).
This is a bit inconvenient, which is why I added the possibility to add the custom headers to the scrape config.

With my customizations, the optional entry to add new HTTP headers could look like this:
```
global:
  scrape_interval:     15s 
  evaluation_interval: 15s 

scrape_configs:
  - job_name: 'my_job'
    scrape_interval: 2m
    scrape_timeout: 1m
    scheme: https
    metrics_path: '/foo/metrics'
    proxy_url: 'any-proxy'
    oauth2:
      client_id: 123456
      client_secret: 123456
      scopes:
      - openid
      token_url: https://foobar/as/token.oauth2 
    custom_header: #<- this and the next two lines are new
        My_new_custom_Header: 'foobar'
        My_new_custom_Header2: 'foobar'
    static_configs:
    - targets: ['any-api']
```

This is my first pull request, so please forgive potential mistakes