### PR TITLE
tsdb: coalesce lock/unlock operations for append

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1232,8 +1232,7 @@ func (h *Head) Appender(_ context.Context) storage.Appender {
 }
 
 func (h *Head) appender() *headAppender {
-	appendID := h.iso.newAppendID()
-	cleanupAppendIDsBelow := h.iso.lowWatermark()
+	appendID, cleanupAppendIDsBelow := h.iso.newAppendID()
 
 	// Allocate the exemplars buffer only if exemplars are enabled.
 	var exemplarsBuf []exemplarWithSeriesRef

--- a/tsdb/isolation_test.go
+++ b/tsdb/isolation_test.go
@@ -35,8 +35,7 @@ func BenchmarkIsolation(b *testing.B) {
 					<-start
 
 					for i := 0; i < b.N; i++ {
-						appendID := iso.newAppendID()
-						_ = iso.lowWatermark()
+						appendID, _ := iso.newAppendID()
 
 						iso.closeAppend(appendID)
 					}
@@ -66,8 +65,7 @@ func BenchmarkIsolationWithState(b *testing.B) {
 					<-start
 
 					for i := 0; i < b.N; i++ {
-						appendID := iso.newAppendID()
-						_ = iso.lowWatermark()
+						appendID, _ := iso.newAppendID()
 
 						iso.closeAppend(appendID)
 					}


### PR DESCRIPTION
Fetch the low watermark value under the same lock as we need for the appender, rather than releasing then re-aquiring a lock on the same Mutex.

Fixes #9059 