### PR TITLE
Adds support for reusing allocated timeseries for exemplar and samples.

### DIFF
--- a/storage/remote/cache.go
+++ b/storage/remote/cache.go
@@ -1,0 +1,55 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"sync"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+type labelsString string
+
+// seriesCache stores the position of a series entry in the shard's queue.
+type seriesCache struct {
+	mux   sync.RWMutex
+	size  int
+	cache map[labelsString]int
+}
+
+func newSeriesCache(size int) *seriesCache {
+	return &seriesCache{
+		size:  size,
+		cache: make(map[labelsString]int, size),
+	}
+}
+
+func (s *seriesCache) refresh() {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.cache = make(map[labelsString]int, s.size)
+}
+
+func (s *seriesCache) getSeriesPosition(l labels.Labels) (index int, present bool) {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+	index, present = s.cache[labelsString(l.String())]
+	return index, present
+}
+
+func (s *seriesCache) ackSeriesPosition(l labels.Labels, position int) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.cache[labelsString(l.String())] = position
+}

--- a/storage/remote/cache_test.go
+++ b/storage/remote/cache_test.go
@@ -1,0 +1,44 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeriesCache(t *testing.T) {
+	cache := newSeriesCache(10)
+
+	lset1 := []labels.Label{{Name: "__name__", Value: "test_metric_1"}, {Name: "job", Value: "test"}, {Name: "instance", Value: "localhost:9091"}}
+	lset2 := []labels.Label{{Name: "__name__", Value: "test_metric_2"}, {Name: "job", Value: "test"}, {Name: "instance", Value: "localhost:9092"}}
+	lset3 := []labels.Label{{Name: "__name__", Value: "test_metric_3"}, {Name: "job", Value: "test"}, {Name: "instance", Value: "localhost:9093"}}
+
+	_, exists := cache.getSeriesPosition(lset1)
+	require.False(t, exists)
+
+	cache.ackSeriesPosition(lset1, 1)
+	cache.ackSeriesPosition(lset2, 2)
+	cache.ackSeriesPosition(lset3, 3)
+
+	index, exists := cache.getSeriesPosition(lset2)
+	require.True(t, exists)
+	require.Equal(t, 2, index)
+
+	cache.refresh()
+	_, exists = cache.getSeriesPosition(lset1)
+	require.False(t, exists)
+}


### PR DESCRIPTION
Signed-off-by: Harkishen Singh <harkishensingh@hotmail.com>

Fixes: #8787 

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

This PR allows shards to re-use pre-allocated `prompb.Timeseries` for incoming exemplars and buffer samples if they are already present in the queue, instead of creating another alloc of `prompb.Timeseries`.