### PR TITLE
LabelNames API with matchers 

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -184,8 +184,10 @@ func (q *errQuerier) Select(bool, *storage.SelectHints, ...*labels.Matcher) stor
 func (*errQuerier) LabelValues(string, ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, nil
 }
-func (*errQuerier) LabelNames() ([]string, storage.Warnings, error) { return nil, nil, nil }
-func (*errQuerier) Close() error                                    { return nil }
+func (*errQuerier) LabelNames(...*labels.Matcher) ([]string, storage.Warnings, error) {
+	return nil, nil, nil
+}
+func (*errQuerier) Close() error { return nil }
 
 // errSeriesSet implements storage.SeriesSet which always returns error.
 type errSeriesSet struct {

--- a/storage/fanout_test.go
+++ b/storage/fanout_test.go
@@ -234,7 +234,7 @@ func (errQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]strin
 	return nil, nil, errors.New("label values error")
 }
 
-func (errQuerier) LabelNames() ([]string, storage.Warnings, error) {
+func (errQuerier) LabelNames(...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, errors.New("label names error")
 }
 

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -112,8 +112,9 @@ type LabelQuerier interface {
 	LabelValues(name string, matchers ...*labels.Matcher) ([]string, Warnings, error)
 
 	// LabelNames returns all the unique label names present in the block in sorted order.
-	// TODO(yeya24): support matchers or hints.
-	LabelNames() ([]string, Warnings, error)
+	// If matchers are specified the returned result set is reduced
+	// to label values of metrics matching the matchers.
+	LabelNames(matchers ...*labels.Matcher) ([]string, Warnings, error)
 
 	// Close releases the resources of the Querier.
 	Close() error

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -113,7 +113,7 @@ type LabelQuerier interface {
 
 	// LabelNames returns all the unique label names present in the block in sorted order.
 	// If matchers are specified the returned result set is reduced
-	// to label values of metrics matching the matchers.
+	// to label names of metrics matching the matchers.
 	LabelNames(matchers ...*labels.Matcher) ([]string, Warnings, error)
 
 	// Close releases the resources of the Querier.

--- a/storage/merge.go
+++ b/storage/merge.go
@@ -218,13 +218,13 @@ func mergeStrings(a, b []string) []string {
 }
 
 // LabelNames returns all the unique label names present in all queriers in sorted order.
-func (q *mergeGenericQuerier) LabelNames() ([]string, Warnings, error) {
+func (q *mergeGenericQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, Warnings, error) {
 	var (
 		labelNamesMap = make(map[string]struct{})
 		warnings      Warnings
 	)
 	for _, querier := range q.queriers {
-		names, wrn, err := querier.LabelNames()
+		names, wrn, err := querier.LabelNames(matchers...)
 		if wrn != nil {
 			// TODO(bwplotka): We could potentially wrap warnings.
 			warnings = append(warnings, wrn...)

--- a/storage/merge_test.go
+++ b/storage/merge_test.go
@@ -778,7 +778,7 @@ func (m *mockGenericQuerier) LabelValues(name string, matchers ...*labels.Matche
 	return m.resp, m.warnings, m.err
 }
 
-func (m *mockGenericQuerier) LabelNames() ([]string, Warnings, error) {
+func (m *mockGenericQuerier) LabelNames(...*labels.Matcher) ([]string, Warnings, error) {
 	m.mtx.Lock()
 	m.labelNamesCalls++
 	m.mtx.Unlock()

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -32,7 +32,7 @@ func (noopQuerier) LabelValues(string, ...*labels.Matcher) ([]string, Warnings, 
 	return nil, nil, nil
 }
 
-func (noopQuerier) LabelNames() ([]string, Warnings, error) {
+func (noopQuerier) LabelNames(...*labels.Matcher) ([]string, Warnings, error) {
 	return nil, nil, nil
 }
 
@@ -55,7 +55,7 @@ func (noopChunkQuerier) LabelValues(string, ...*labels.Matcher) ([]string, Warni
 	return nil, nil, nil
 }
 
-func (noopChunkQuerier) LabelNames() ([]string, Warnings, error) {
+func (noopChunkQuerier) LabelNames(...*labels.Matcher) ([]string, Warnings, error) {
 	return nil, nil, nil
 }
 

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -212,7 +212,7 @@ func (q *querier) LabelValues(string, ...*labels.Matcher) ([]string, storage.War
 }
 
 // LabelNames implements storage.Querier and is a noop.
-func (q *querier) LabelNames() ([]string, storage.Warnings, error) {
+func (q *querier) LabelNames(...*labels.Matcher) ([]string, storage.Warnings, error) {
 	// TODO: Implement: https://github.com/prometheus/prometheus/issues/3351
 	return nil, nil, errors.New("not implemented")
 }

--- a/storage/secondary.go
+++ b/storage/secondary.go
@@ -55,8 +55,8 @@ func (s *secondaryQuerier) LabelValues(name string, matchers ...*labels.Matcher)
 	return vals, w, nil
 }
 
-func (s *secondaryQuerier) LabelNames() ([]string, Warnings, error) {
-	names, w, err := s.genericQuerier.LabelNames()
+func (s *secondaryQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, Warnings, error) {
+	names, w, err := s.genericQuerier.LabelNames(matchers...)
 	if err != nil {
 		return nil, append([]error{err}, w...), nil
 	}

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -92,6 +92,10 @@ type IndexReader interface {
 	// storage.ErrNotFound is returned as error.
 	LabelValueFor(id uint64, label string) (string, error)
 
+	// LabelNamesFor returns all the label names for the series referred to by IDs.
+	// The names returned are sorted.
+	LabelNamesFor(ids ...uint64) ([]string, error)
+
 	// Close releases the underlying resources of the reader.
 	Close() error
 }
@@ -481,6 +485,12 @@ func (r blockIndexReader) Close() error {
 // LabelValueFor returns label value for the given label name in the series referred to by ID.
 func (r blockIndexReader) LabelValueFor(id uint64, label string) (string, error) {
 	return r.ir.LabelValueFor(id, label)
+}
+
+// LabelNamesFor returns all the label names for the series referred to by IDs.
+// The names returned are sorted.
+func (r blockIndexReader) LabelNamesFor(ids ...uint64) ([]string, error) {
+	return r.ir.LabelNamesFor(ids...)
 }
 
 type blockTombstoneReader struct {

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -85,7 +85,7 @@ type IndexReader interface {
 	Series(ref uint64, lset *labels.Labels, chks *[]chunks.Meta) error
 
 	// LabelNames returns all the unique label names present in the index in sorted order.
-	LabelNames() ([]string, error)
+	LabelNames(matchers ...*labels.Matcher) ([]string, error)
 
 	// LabelValueFor returns label value for the given label name in the series referred to by ID.
 	// If the series couldn't be found or the series doesn't have the requested label a
@@ -465,8 +465,8 @@ func (r blockIndexReader) Series(ref uint64, lset *labels.Labels, chks *[]chunks
 	return nil
 }
 
-func (r blockIndexReader) LabelNames() ([]string, error) {
-	return r.b.LabelNames()
+func (r blockIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
+	return r.b.LabelNames(matchers...)
 }
 
 func (r blockIndexReader) Close() error {
@@ -642,8 +642,8 @@ func (pb *Block) OverlapsClosedInterval(mint, maxt int64) bool {
 }
 
 // LabelNames returns all the unique label names present in the Block in sorted order.
-func (pb *Block) LabelNames() ([]string, error) {
-	return pb.indexr.LabelNames()
+func (pb *Block) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
+	return pb.indexr.LabelNames(matchers...)
 }
 
 func clampInterval(a, b, mint, maxt int64) (int64, int64) {

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -92,8 +92,6 @@ type IndexReader interface {
 	// storage.ErrNotFound is returned as error.
 	LabelValueFor(id uint64, label string) (string, error)
 
-	LabelNamesFor(id uint64) ([]string, error)
-
 	// Close releases the underlying resources of the reader.
 	Close() error
 }
@@ -478,6 +476,11 @@ func (r blockIndexReader) Series(ref uint64, lset *labels.Labels, chks *[]chunks
 func (r blockIndexReader) Close() error {
 	r.b.pendingReaders.Done()
 	return nil
+}
+
+// LabelValueFor returns label value for the given label name in the series referred to by ID.
+func (r blockIndexReader) LabelValueFor(id uint64, label string) (string, error) {
+	return r.ir.LabelValueFor(id, label)
 }
 
 type blockTombstoneReader struct {

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -421,9 +421,7 @@ func BenchmarkLabelValuesWithMatchers(b *testing.B) {
 func TestLabelNamesWithMatchers(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test_block_label_names_with_matchers")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpdir))
-	}()
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(tmpdir)) })
 
 	var seriesEntries []storage.Series
 	for i := 0; i < 100; i++ {
@@ -456,11 +454,11 @@ func TestLabelNamesWithMatchers(t *testing.T) {
 	// Check open err.
 	block, err := OpenBlock(nil, blockDir, nil)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, block.Close()) }()
+	t.Cleanup(func() { require.NoError(t, block.Close()) })
 
 	indexReader, err := block.Index()
 	require.NoError(t, err)
-	defer func() { require.NoError(t, indexReader.Close()) }()
+	t.Cleanup(func() { require.NoError(t, indexReader.Close()) })
 
 	testCases := []struct {
 		name          string

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1904,16 +1904,12 @@ func (h *headIndexReader) SortedLabelValues(name string, matchers ...*labels.Mat
 // If matchers are specified the returned result set is reduced
 // to label values of metrics matching the matchers.
 func (h *headIndexReader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
-	h.head.symMtx.RLock()
 	if h.maxt < h.head.MinTime() || h.mint > h.head.MaxTime() {
-		h.head.symMtx.RUnlock()
 		return []string{}, nil
 	}
 
 	if len(matchers) == 0 {
-		labelValues := h.head.postings.LabelValues(name)
-		h.head.symMtx.RUnlock()
-		return labelValues, nil
+		return h.head.postings.LabelValues(name), nil
 	}
 
 	return labelValuesWithMatchers(h, name, matchers...)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1930,6 +1930,7 @@ func (h *headIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, err
 		sort.Strings(labelNames)
 		return labelNames, nil
 	}
+	h.head.symMtx.RUnlock()
 
 	return labelNamesWithMatchers(h, matchers...)
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1909,6 +1909,8 @@ func (h *headIndexReader) LabelValues(name string, matchers ...*labels.Matcher) 
 	}
 
 	if len(matchers) == 0 {
+		h.head.symMtx.RLock()
+		defer h.head.symMtx.RUnlock()
 		return h.head.postings.LabelValues(name), nil
 	}
 
@@ -1918,19 +1920,18 @@ func (h *headIndexReader) LabelValues(name string, matchers ...*labels.Matcher) 
 // LabelNames returns all the unique label names present in the head
 // that are within the time range mint to maxt.
 func (h *headIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
-	h.head.symMtx.RLock()
 	if h.maxt < h.head.MinTime() || h.mint > h.head.MaxTime() {
-		h.head.symMtx.RUnlock()
 		return []string{}, nil
 	}
 
 	if len(matchers) == 0 {
+		h.head.symMtx.RLock()
 		labelNames := h.head.postings.LabelNames()
 		h.head.symMtx.RUnlock()
+
 		sort.Strings(labelNames)
 		return labelNames, nil
 	}
-	h.head.symMtx.RUnlock()
 
 	return labelNamesWithMatchers(h, matchers...)
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1919,14 +1919,14 @@ func (h *headIndexReader) LabelValues(name string, matchers ...*labels.Matcher) 
 
 // LabelNames returns all the unique label names present in the head
 // that are within the time range mint to maxt.
-func (h *headIndexReader) LabelNames() ([]string, error) {
+func (h *headIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
 	h.head.symMtx.RLock()
 	if h.maxt < h.head.MinTime() || h.mint > h.head.MaxTime() {
 		h.head.symMtx.RUnlock()
 		return []string{}, nil
 	}
 
-	labelNames := h.head.postings.LabelNames()
+	labelNames := h.head.postings.LabelNames(matchers...)
 	h.head.symMtx.RUnlock()
 
 	sort.Strings(labelNames)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2027,21 +2027,21 @@ func (h *headIndexReader) LabelValueFor(id uint64, label string) (string, error)
 // LabelNamesFor returns all the label names for the series referred to by IDs.
 // The names returned are sorted.
 func (h *headIndexReader) LabelNamesFor(ids ...uint64) ([]string, error) {
-	// FIXME(colega): very quick implementation, check if there's something to optimze
-	namesMap := make(map[string]bool)
+	namesMap := make(map[string]struct{})
 	for _, id := range ids {
 		memSeries := h.head.series.getByID(id)
 		if memSeries == nil {
 			return nil, storage.ErrNotFound
 		}
 		for _, lbl := range memSeries.lset {
-			namesMap[lbl.Name] = true
+			namesMap[lbl.Name] = struct{}{}
 		}
 	}
 	names := make([]string, 0, len(namesMap))
 	for name := range namesMap {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return names, nil
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1929,9 +1929,7 @@ func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 
 func TestHeadLabelValuesWithMatchers(t *testing.T) {
 	head, _ := newTestHead(t, 1000, false)
-	defer func() {
-		require.NoError(t, head.Close())
-	}()
+	t.Cleanup(func() { require.NoError(t, head.Close()) })
 
 	app := head.Appender(context.Background())
 	for i := 0; i < 100; i++ {

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1664,7 +1664,12 @@ func (r *Reader) Size() int64 {
 }
 
 // LabelNames returns all the unique label names present in the index.
-func (r *Reader) LabelNames() ([]string, error) {
+// TODO(twilkie) implement support for matchers
+func (r *Reader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
+	if len(matchers) > 0 {
+		return nil, errors.Errorf("matchers parameter is not implemented: %+v", matchers)
+	}
+
 	labelNames := make([]string, 0, len(r.postings))
 	for name := range r.postings {
 		if name == allPostingsKey.Name {

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1532,7 +1532,7 @@ func (r *Reader) LabelNamesFor(ids ...uint64) ([]string, error) {
 
 		offsets, err := r.dec.LabelNamesOffsetsFor(buf)
 		if err != nil {
-			return nil, storage.ErrNotFound
+			return nil, errors.Wrap(err, "get label name offsets")
 		}
 		for _, off := range offsets {
 			offsetsMap[off] = struct{}{}

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1544,7 +1544,7 @@ func (r *Reader) LabelNamesFor(ids ...uint64) ([]string, error) {
 	for off := range offsetsMap {
 		name, err := r.lookupSymbol(off)
 		if err != nil {
-			return nil, errors.Wrap(err, "lookup symbol in label names for")
+			return nil, errors.Wrap(err, "lookup symbol in LabelNamesFor")
 		}
 		names = append(names, name)
 	}

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1527,7 +1527,7 @@ func (r *Reader) LabelNamesFor(ids ...uint64) ([]string, error) {
 		d := encoding.NewDecbufUvarintAt(r.b, int(offset), castagnoliTable)
 		buf := d.Get()
 		if d.Err() != nil {
-			return nil, errors.Wrap(d.Err(), "label names for")
+			return nil, errors.Wrap(d.Err(), "get buffer for series")
 		}
 
 		offsets, err := r.dec.LabelNamesOffsetsFor(buf)

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1549,8 +1549,6 @@ func (r *Reader) LabelNamesFor(ids ...uint64) ([]string, error) {
 		names = append(names, name)
 	}
 
-	// maybe it's more efficient to built the list of offsets first, then sort the uint32 offsets and then map to names?
-	// that could be an optimization if we measure it and makes any difference
 	sort.Strings(names)
 
 	return names, nil

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1539,7 +1539,7 @@ func (r *Reader) LabelNamesFor(ids ...uint64) ([]string, error) {
 		}
 	}
 
-	// lookup the unique symbols
+	// Lookup the unique symbols.
 	names := make([]string, 0, len(offsetsMap))
 	for off := range offsetsMap {
 		name, err := r.lookupSymbol(off)

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -80,7 +80,10 @@ func (p *MemPostings) SortedKeys() []labels.Label {
 }
 
 // LabelNames returns all the unique label names.
-func (p *MemPostings) LabelNames() []string {
+func (p *MemPostings) LabelNames(matchers ...*labels.Matcher) []string {
+
+	// TODO implement this
+
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 	n := len(p.m)

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -80,10 +80,7 @@ func (p *MemPostings) SortedKeys() []labels.Label {
 }
 
 // LabelNames returns all the unique label names.
-func (p *MemPostings) LabelNames(matchers ...*labels.Matcher) []string {
-
-	// TODO implement this
-
+func (p *MemPostings) LabelNames() []string {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 	n := len(p.m)

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -413,29 +413,12 @@ func labelNamesWithMatchers(r IndexReader, matchers ...*labels.Matcher) ([]strin
 		return nil, err
 	}
 
-	dedupe := map[string]interface{}{}
+	var postings []uint64
 	for p.Next() {
-		v, err := r.LabelValueFor(p.At(), name)
-		if err != nil {
-			if err == storage.ErrNotFound {
-				continue
-			}
-
-			return nil, err
-		}
-		dedupe[v] = nil
+		postings = append(postings, p.At())
 	}
 
-	if err = p.Err(); err != nil {
-		return nil, err
-	}
-
-	values := make([]string, 0, len(dedupe))
-	for value := range dedupe {
-		values = append(values, value)
-	}
-
-	return values, nil
+	return r.LabelNamesFor(postings...)
 }
 
 // blockBaseSeriesSet allows to iterate over all series in the single block.

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -88,8 +88,8 @@ func (q *blockBaseQuerier) LabelValues(name string, matchers ...*labels.Matcher)
 	return res, nil, err
 }
 
-func (q *blockBaseQuerier) LabelNames() ([]string, storage.Warnings, error) {
-	res, err := q.index.LabelNames()
+func (q *blockBaseQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+	res, err := q.index.LabelNames(matchers...)
 	return res, nil, err
 }
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -417,6 +417,9 @@ func labelNamesWithMatchers(r IndexReader, matchers ...*labels.Matcher) ([]strin
 	for p.Next() {
 		postings = append(postings, p.At())
 	}
+	if p.Err() != nil {
+		return nil, errors.Wrapf(err, "postings for label names with matchers")
+	}
 
 	return r.LabelNamesFor(postings...)
 }

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -418,7 +418,7 @@ func labelNamesWithMatchers(r IndexReader, matchers ...*labels.Matcher) ([]strin
 		postings = append(postings, p.At())
 	}
 	if p.Err() != nil {
-		return nil, errors.Wrapf(err, "postings for label names with matchers")
+		return nil, errors.Wrapf(p.Err(), "postings for label names with matchers")
 	}
 
 	return r.LabelNamesFor(postings...)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1180,6 +1180,20 @@ func (m mockIndex) LabelValueFor(id uint64, label string) (string, error) {
 	return m.series[id].l.Get(label), nil
 }
 
+func (m mockIndex) LabelNamesFor(ids ...uint64) ([]string, error) {
+	namesMap := make(map[string]bool)
+	for _, id := range ids {
+		for _, lbl := range m.series[id].l {
+			namesMap[lbl.Name] = true
+		}
+	}
+	names := make([]string, 0, len(namesMap))
+	for name := range namesMap {
+		names = append(names, name)
+	}
+	return names, nil
+}
+
 func (m mockIndex) Postings(name string, values ...string) (index.Postings, error) {
 	res := make([]index.Postings, 0, len(values))
 	for _, value := range values {
@@ -2008,6 +2022,10 @@ func (m mockMatcherIndex) LabelValues(name string, matchers ...*labels.Matcher) 
 
 func (m mockMatcherIndex) LabelValueFor(id uint64, label string) (string, error) {
 	return "", errors.New("label value for called")
+}
+
+func (m mockMatcherIndex) LabelNamesFor(ids ...uint64) ([]string, error) {
+	return nil, errors.New("label names for for called")
 }
 
 func (m mockMatcherIndex) Postings(name string, values ...string) (index.Postings, error) {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1212,7 +1212,10 @@ func (m mockIndex) Series(ref uint64, lset *labels.Labels, chks *[]chunks.Meta) 
 	return nil
 }
 
-func (m mockIndex) LabelNames() ([]string, error) {
+func (m mockIndex) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
+
+	// TODO implement matchers?
+
 	names := map[string]struct{}{}
 	for l := range m.postings {
 		names[l.Name] = struct{}{}
@@ -2019,7 +2022,9 @@ func (m mockMatcherIndex) Series(ref uint64, lset *labels.Labels, chks *[]chunks
 	return nil
 }
 
-func (m mockMatcherIndex) LabelNames() ([]string, error) { return []string{}, nil }
+func (m mockMatcherIndex) LabelNames(...*labels.Matcher) ([]string, error) {
+	return []string{}, nil
+}
 
 func TestPostingsForMatcher(t *testing.T) {
 	cases := []struct {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1154,7 +1154,7 @@ func (m mockIndex) SortedLabelValues(name string, matchers ...*labels.Matcher) (
 }
 
 func (m mockIndex) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
-	values := []string{}
+	var values []string
 
 	if len(matchers) == 0 {
 		for l := range m.postings {

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -464,6 +464,7 @@ func TestLabelNames(t *testing.T) {
 			test_metric1{foo2="boo"} 1+0x100
 			test_metric2{foo="boo"} 1+0x100
 			test_metric2{foo="boo", xyz="qwerty"} 1+0x100
+			test_metric2{foo="baz", abc="qwerty"} 1+0x100
 	`)
 	require.NoError(t, err)
 	defer suite.Close()
@@ -472,21 +473,57 @@ func TestLabelNames(t *testing.T) {
 	api := &API{
 		Queryable: suite.Storage(),
 	}
-	request := func(m string) (*http.Request, error) {
-		if m == http.MethodPost {
-			r, err := http.NewRequest(m, "http://example.com", nil)
-			r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			return r, err
-		}
-		return http.NewRequest(m, "http://example.com", nil)
-	}
-	for _, method := range []string{http.MethodGet, http.MethodPost} {
-		ctx := context.Background()
-		req, err := request(method)
+	request := func(method string, matchers ...string) (*http.Request, error) {
+		u, err := url.Parse("http://example.com")
 		require.NoError(t, err)
-		res := api.labelNames(req.WithContext(ctx))
-		assertAPIError(t, res.err, "")
-		assertAPIResponse(t, res.data, []string{"__name__", "baz", "foo", "foo1", "foo2", "xyz"})
+		q := u.Query()
+		for _, matcher := range matchers {
+			q.Add("match[]", matcher)
+		}
+		u.RawQuery = q.Encode()
+
+		r, err := http.NewRequest(method, u.String(), nil)
+		if method == http.MethodPost {
+			r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		}
+		return r, err
+	}
+
+	for _, tc := range []struct {
+		name     string
+		matchers []string
+		expected []string
+	}{
+		{
+			name:     "no matchers",
+			expected: []string{"__name__", "abc", "baz", "foo", "foo1", "foo2", "xyz"},
+		},
+		{
+			name:     "non empty label matcher",
+			matchers: []string{`{foo=~".+"}`},
+			expected: []string{"__name__", "abc", "foo", "xyz"},
+		},
+		{
+			name:     "exact label matcher",
+			matchers: []string{`{foo="boo"}`},
+			expected: []string{"__name__", "foo", "xyz"},
+		},
+		{
+			name:     "two matchers",
+			matchers: []string{`{foo="boo"}`, `{foo="baz"}`},
+			expected: []string{"__name__", "abc", "foo", "xyz"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, method := range []string{http.MethodGet, http.MethodPost} {
+				ctx := context.Background()
+				req, err := request(method, tc.matchers...)
+				require.NoError(t, err)
+				res := api.labelNames(req.WithContext(ctx))
+				assertAPIError(t, res.err, "")
+				assertAPIResponse(t, res.data, tc.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This modifies the `LabelQuerier.LabelNames()` method adding the matchers to it, similar to it's `LabelValues` counterpart.

Previously, the matchers for `LabelNames` were supported only on the HTTP API surface, then the HTTP API implementation made use of the `Select()` call with special hints to tell TSDB to skip the samples. 

This however is _hacky_ and the implementation divergence causes issues in other projects depending on this, like cortex: https://github.com/cortexproject/cortex/issues/3658

This new approach does what one would expect to: call the `LabelMatchers` providing the matchers, and let the TSDB internals decide how to get that data. As a side effect, we're saving lots of resources, especially on deployments where there are tons of series with different label values but same label names (I'd say this is a common scenario in a cloud-native world, isn't it?)

The work was initiated by @tomwilkie and I finished some details.

See more comments on the PR for thoughts.