### PR TITLE
remote-write: retain interned labels

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -652,15 +652,13 @@ func (t *QueueManager) StoreSeries(series []record.RefSeries, index int) {
 			t.droppedSeries[s.Ref] = struct{}{}
 			continue
 		}
-		t.internLabels(lbls)
 
-		// We should not ever be replacing a series labels in the map, but just
-		// in case we do we need to ensure we do not leak the replaced interned
-		// strings.
-		if orig, ok := t.seriesLabels[s.Ref]; ok {
-			t.releaseLabels(orig)
+		// Check if we already have labels before interning - active series
+		// will be re-added periodically by garbageCollectSeries().
+		if _, ok := t.seriesLabels[s.Ref]; !ok {
+			t.internLabels(lbls)
+			t.seriesLabels[s.Ref] = lbls
 		}
-		t.seriesLabels[s.Ref] = lbls
 	}
 }
 


### PR DESCRIPTION
For series that already exist, the code was wastefully interning then releasing all its label names and values.

In fact this happens each time a checkpoint is created - `StoreSeries()` is called by `garbageCollectSeries()` for every series in the checkpoint.

Some background at #9082