### PR TITLE
fix typo in comment for scrape manager

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -119,7 +119,7 @@ func NewManager(logger log.Logger, app storage.Appendable) *Manager {
 }
 
 // Manager maintains a set of scrape pools and manages start/stop cycles
-// when receiving new target groups form the discovery manager.
+// when receiving new target groups from the discovery manager.
 type Manager struct {
 	logger    log.Logger
 	append    storage.Appendable


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

It seems that the proper word is `from` not `form` because the scrape manager receives new target groups from the discover manager via `syncCh` as an argument of `Run()`