### PR TITLE
tsdb: use dennwc/varint to speed up WAL decoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go v1.38.60
 	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/containerd/containerd v1.5.3 // indirect
+	github.com/dennwc/varint v1.0.0
 	github.com/dgryski/go-sip13 v0.0.0-20200911182023-62edffca9245
 	github.com/digitalocean/godo v1.62.0
 	github.com/docker/docker v20.10.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
+github.com/dennwc/varint v1.0.0 h1:kGNFFSSw8ToIy3obO/kKr8U9GZYUAxQEVuix4zfDWzE=
+github.com/dennwc/varint v1.0.0/go.mod h1:hnItb35rvZvJrbTALZtY/iQfDs48JKRG1RPpgziApxA=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=

--- a/tsdb/encoding/encoding.go
+++ b/tsdb/encoding/encoding.go
@@ -19,6 +19,7 @@ import (
 	"hash/crc32"
 	"unsafe"
 
+	"github.com/dennwc/varint"
 	"github.com/pkg/errors"
 )
 
@@ -139,7 +140,7 @@ func NewDecbufUvarintAt(bs ByteSlice, off int, castagnoliTable *crc32.Table) Dec
 	}
 	b := bs.Range(off, off+binary.MaxVarintLen32)
 
-	l, n := binary.Uvarint(b)
+	l, n := varint.Uvarint(b)
 	if n <= 0 || n > binary.MaxVarintLen32 {
 		return Decbuf{E: errors.Errorf("invalid uvarint %d", n)}
 	}
@@ -207,10 +208,14 @@ func (d *Decbuf) Varint64() int64 {
 	if d.E != nil {
 		return 0
 	}
-	x, n := binary.Varint(d.B)
+	ux, n := varint.Uvarint(d.B)
 	if n < 1 {
 		d.E = ErrInvalidSize
 		return 0
+	}
+	x := int64(ux >> 1)
+	if ux&1 != 0 {
+		x = ^x
 	}
 	d.B = d.B[n:]
 	return x
@@ -220,7 +225,7 @@ func (d *Decbuf) Uvarint64() uint64 {
 	if d.E != nil {
 		return 0
 	}
-	x, n := binary.Uvarint(d.B)
+	x, n := varint.Uvarint(d.B)
 	if n < 1 {
 		d.E = ErrInvalidSize
 		return 0

--- a/tsdb/encoding/encoding.go
+++ b/tsdb/encoding/encoding.go
@@ -208,11 +208,13 @@ func (d *Decbuf) Varint64() int64 {
 	if d.E != nil {
 		return 0
 	}
+	// Decode as unsigned first, since that's what the varint library implements.
 	ux, n := varint.Uvarint(d.B)
 	if n < 1 {
 		d.E = ErrInvalidSize
 		return 0
 	}
+	// Now decode "ZigZag encoding" https://developers.google.com/protocol-buffers/docs/encoding#signed_integers.
 	x := int64(ux >> 1)
 	if ux&1 != 0 {
 		x = ^x


### PR DESCRIPTION
This is a tiny library, MIT-licensed, which unrolls the loop to go about twice as fast.

Needed to copy the unsigned-to-signed ("ZigZag") logic inline, previously provided by the `binary` package.

Benchmarks ("before" is including the benchmark fixes from #8645, at commit 7816674f420bc5c7505bc1eb80b54939424851d2; "after" is cherry-picking the commit from this PR onto that.):
```
name                                                                                old time/op    new time/op    delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0-4     552ms ± 5%     490ms ± 4%  -11.16%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0-4     860ms ±21%     852ms ± 3%     ~     (p=0.548 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0-4     330ms ± 4%     278ms ± 6%  -15.53%  (p=0.008 n=5+5)

name                                                                                old alloc/op   new alloc/op   delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0-4    52.1MB ± 0%    45.6MB ± 0%  -12.47%  (p=0.016 n=5+4)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0-4     262MB ± 3%     280MB ± 4%   +6.95%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0-4    52.1MB ± 6%    52.3MB ± 5%     ~     (p=0.548 n=5+5)

name                                                                                old allocs/op  new allocs/op  delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0-4      586k ± 0%      540k ± 0%   -7.81%  (p=0.016 n=5+4)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0-4     2.49M ± 0%     2.49M ± 0%   +0.11%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0-4      490k ± 3%      488k ± 0%     ~     (p=0.548 n=5+5)
```

(there's no reason for allocs to change; just put that down to randomness in scheduling)

Looks like this should also speed up TSDB index, but I couldn't find any benchmarks relevant to that.

Timings of loading a real 5GB WAL:
```
before: 115.16user 16.00system 0:49.22elapsed 266%CPU (0avgtext+0avgdata 3670632maxresident)k
after:  109.99user 16.72system 0:47.00elapsed 269%CPU (0avgtext+0avgdata 3846304maxresident)k
```