### PR TITLE
Deduplicate containers attached to multiple networks

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -737,12 +737,13 @@ var expectedConf = &Config{
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&moby.DockerSDConfig{
-					Filters:            []moby.Filter{},
-					Host:               "unix:///var/run/docker.sock",
-					Port:               80,
-					HostNetworkingHost: "localhost",
-					RefreshInterval:    model.Duration(60 * time.Second),
-					HTTPClientConfig:   config.DefaultHTTPClientConfig,
+					Filters:               []moby.Filter{},
+					Host:                  "unix:///var/run/docker.sock",
+					Port:                  80,
+					RefreshInterval:       model.Duration(60 * time.Second),
+					HTTPClientConfig:      config.DefaultHTTPClientConfig,
+					HostNetworkingHost:    "localhost",
+					DeduplicateContainers: true,
 				},
 			},
 		},

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -290,6 +290,7 @@ scrape_configs:
   - job_name: docker
     docker_sd_configs:
       - host: unix:///var/run/docker.sock
+        deduplicate_containers: true
 
   - job_name: dockerswarm
     dockerswarm_sd_configs:

--- a/discovery/moby/docker.go
+++ b/discovery/moby/docker.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -289,9 +290,16 @@ func (d *DockerDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 	if d.deduplicateContainers {
 		dedupedTargets := []model.LabelSet{}
 		var firstTg model.LabelSet
+		var otherNetworksString string
+
 		for _, otherNetworks := range idPortMap {
-			otherNetworksString := ""
+			sort.Slice(otherNetworks, func(i, j int) bool {
+				return otherNetworks[i].ipAddr < otherNetworks[j].ipAddr
+			})
+
+			otherNetworksString = ""
 			firstTg = otherNetworks[0].target
+
 			for _, otherNetwork := range otherNetworks {
 				if firstTg[dockerLabelNetworkIP] != model.LabelValue(otherNetwork.ipAddr) {
 					otherNetworksString += fmt.Sprintf("%s:%s,", otherNetwork.name, otherNetwork.ipAddr)

--- a/discovery/moby/docker_test.go
+++ b/discovery/moby/docker_test.go
@@ -106,6 +106,7 @@ host: %s
 			"__meta_docker_container_name":                             "/dockersd_host_networking_1",
 			"__meta_docker_container_network_mode":                     "host",
 			"__meta_docker_network_ip":                                 "",
+			"__meta_docker_network_other_networks":                     "",
 		},
 	} {
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {

--- a/discovery/moby/docker_test.go
+++ b/discovery/moby/docker_test.go
@@ -36,9 +36,11 @@ host: %s
 `, url)
 	var cfg DockerSDConfig
 	require.NoError(t, yaml.Unmarshal([]byte(cfgString), &cfg))
+	cfg.DeduplicateContainers = true
 
 	d, err := NewDockerDiscovery(&cfg, log.NewNopLogger())
 	require.NoError(t, err)
+	require.True(t, d.deduplicateContainers)
 
 	ctx := context.Background()
 	tgs, err := d.refresh(ctx)
@@ -70,6 +72,7 @@ host: %s
 			"__meta_docker_network_label_com_docker_compose_project":   "dockersd",
 			"__meta_docker_network_label_com_docker_compose_version":   "1.25.0",
 			"__meta_docker_network_name":                               "dockersd_default",
+			"__meta_docker_network_other_networks":                     "dockersd_bridge:172.19.0.4",
 			"__meta_docker_network_scope":                              "local",
 			"__meta_docker_port_private":                               "9100",
 		},
@@ -92,6 +95,7 @@ host: %s
 			"__meta_docker_network_label_com_docker_compose_version":   "1.25.0",
 			"__meta_docker_network_name":                               "dockersd_default",
 			"__meta_docker_network_scope":                              "local",
+			"__meta_docker_network_other_networks":                     "",
 		},
 		{
 			"__address__":                "localhost",

--- a/discovery/moby/testdata/dockerprom/containers/json_limit_0.json
+++ b/discovery/moby/testdata/dockerprom/containers/json_limit_0.json
@@ -42,6 +42,21 @@
           "GlobalIPv6PrefixLen": 0,
           "MacAddress": "02:42:ac:13:00:02",
           "DriverOpts": null
+        },
+        "dockersd_bridge": {
+          "IPAMConfig": null,
+          "Links": null,
+          "Aliases": null,
+          "NetworkID": "7189986ab399e144e52a71b7451b4e04e2158c044b4cd2f3ae26fc3a285d3798",
+          "EndpointID": "423198ed568efa36699c5f13289c46230580a0ad6453d9e726f5e3cf1a911f77",
+          "Gateway": "172.19.0.1",
+          "IPAddress": "172.19.0.4",
+          "IPPrefixLen": 16,
+          "IPv6Gateway": "",
+          "GlobalIPv6Address": "",
+          "GlobalIPv6PrefixLen": 0,
+          "MacAddress": "02:42:ac:13:00:03",
+          "DriverOpts": null
         }
       }
     },

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -627,6 +627,7 @@ Available meta labels:
 * `__meta_docker_network_label_<labelname>`: each label of the network
 * `__meta_docker_network_scope`: the scope of the network
 * `__meta_docker_network_ip`: the IP of the container in this network
+* `__meta_docker_network_other_networks`: comma separated list of other `networkName:ipAddr` the container is attached to, only set if `deduplicate_containers` is `true`
 * `__meta_docker_port_private`: the port on the container
 * `__meta_docker_port_public`: the external port if a port-mapping exists
 * `__meta_docker_port_public_ip`: the public IP if a port-mapping exists
@@ -639,6 +640,9 @@ host: <string>
 
 # Optional proxy URL.
 [ proxy_url: <string> ]
+
+# Optional deduplicate containers.
+[ deduplicate_containers: <bool> | default = false ]
 
 # TLS configuration.
 tls_config:


### PR DESCRIPTION
closes https://github.com/prometheus/prometheus/issues/8831

Signed-off-by: darshanime <deathbullet@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->