### PR TITLE
scrape: fix 'target_limit exceeded error' when reloading conf with 0

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -423,6 +423,10 @@ func TestScrapePoolTargetLimit(t *testing.T) {
 	validateIsRunning()
 	validateErrorMessage(true)
 
+	reloadWithLimit(0)
+	validateIsRunning()
+	validateErrorMessage(false)
+
 	reloadWithLimit(51)
 	validateIsRunning()
 	validateErrorMessage(false)


### PR DESCRIPTION
Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

The problem is observed while changing the value of  `target_limit` to unlimited(0) when 'target_limit exceeded' error is firing.

### Steps to reproduce

1. Start the prometheus with following config,

```
scrape_configs:
  - job_name: 'prometheus-k8s'
    target_limit: 1
    static_configs:
      - targets:
        - 'localhost:9090'
        labels:
          pod: prometheus-k8s-0
          service: prometheus-k8s
      - targets:
        - 'localhost:9090'
        labels:
          pod: prometheus-k8s-1
          service: prometheus-k8s
```
```
$ ./prometheus --config.file=./config.yaml
```

2. Change `target_limit` to 0 and reload prometheus config,
```
$ kill -SIGHUP $(ps | awk -F ' ' '!/awk/ && /prometheus/{print $1}')
```

3. Check targets status, it will show the error `target_limit exceeded (number of targets: 2, limit: 0)`