### PR TITLE
docker_sd: Support host network mode

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -738,6 +738,7 @@ var expectedConf = &Config{
 					Filters:          []moby.Filter{},
 					Host:             "unix:///var/run/docker.sock",
 					Port:             80,
+					HostNetworkHost:  "localhost",
 					RefreshInterval:  model.Duration(60 * time.Second),
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
 				},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -735,12 +735,12 @@ var expectedConf = &Config{
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&moby.DockerSDConfig{
-					Filters:          []moby.Filter{},
-					Host:             "unix:///var/run/docker.sock",
-					Port:             80,
-					HostNetworkHost:  "localhost",
-					RefreshInterval:  model.Duration(60 * time.Second),
-					HTTPClientConfig: config.DefaultHTTPClientConfig,
+					Filters:            []moby.Filter{},
+					Host:               "unix:///var/run/docker.sock",
+					Port:               80,
+					HostNetworkingHost: "localhost",
+					RefreshInterval:    model.Duration(60 * time.Second),
+					HTTPClientConfig:   config.DefaultHTTPClientConfig,
 				},
 			},
 		},

--- a/discovery/moby/docker.go
+++ b/discovery/moby/docker.go
@@ -54,6 +54,7 @@ var DefaultDockerSDConfig = DockerSDConfig{
 	RefreshInterval:  model.Duration(60 * time.Second),
 	Port:             80,
 	Filters:          []Filter{},
+	HostNetworkHost:  "localhost",
 	HTTPClientConfig: config.DefaultHTTPClientConfig,
 }
 
@@ -65,9 +66,10 @@ func init() {
 type DockerSDConfig struct {
 	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 
-	Host    string   `yaml:"host"`
-	Port    int      `yaml:"port"`
-	Filters []Filter `yaml:"filters"`
+	Host            string   `yaml:"host"`
+	Port            int      `yaml:"port"`
+	Filters         []Filter `yaml:"filters"`
+	HostNetworkHost string   `yaml:"host_network_host"`
 
 	RefreshInterval model.Duration `yaml:"refresh_interval"`
 }
@@ -104,9 +106,10 @@ func (c *DockerSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 
 type DockerDiscovery struct {
 	*refresh.Discovery
-	client  *client.Client
-	port    int
-	filters filters.Args
+	client          *client.Client
+	port            int
+	hostNetworkHost string
+	filters         filters.Args
 }
 
 // NewDockerDiscovery returns a new DockerDiscovery which periodically refreshes its targets.
@@ -114,7 +117,8 @@ func NewDockerDiscovery(conf *DockerSDConfig, logger log.Logger) (*DockerDiscove
 	var err error
 
 	d := &DockerDiscovery{
-		port: conf.Port,
+		port:            conf.Port,
+		hostNetworkHost: conf.HostNetworkHost,
 	}
 
 	hostURL, err := url.Parse(conf.Host)
@@ -245,7 +249,15 @@ func (d *DockerDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 					labels[model.LabelName(k)] = model.LabelValue(v)
 				}
 
-				addr := net.JoinHostPort(n.IPAddress, strconv.FormatUint(uint64(d.port), 10))
+				// Containers in host networking mode don't have ports,
+				// so they only end up here, not in the previous loop.
+				var addr string
+				if c.HostConfig.NetworkMode != "host" {
+					addr = net.JoinHostPort(n.IPAddress, strconv.FormatUint(uint64(d.port), 10))
+				} else {
+					addr = d.hostNetworkHost
+				}
+
 				labels[model.AddressLabel] = model.LabelValue(addr)
 				tg.Targets = append(tg.Targets, labels)
 			}

--- a/discovery/moby/docker.go
+++ b/discovery/moby/docker.go
@@ -51,11 +51,11 @@ const (
 
 // DefaultDockerSDConfig is the default Docker SD configuration.
 var DefaultDockerSDConfig = DockerSDConfig{
-	RefreshInterval:  model.Duration(60 * time.Second),
-	Port:             80,
-	Filters:          []Filter{},
-	HostNetworkHost:  "localhost",
-	HTTPClientConfig: config.DefaultHTTPClientConfig,
+	RefreshInterval:    model.Duration(60 * time.Second),
+	Port:               80,
+	Filters:            []Filter{},
+	HostNetworkingHost: "localhost",
+	HTTPClientConfig:   config.DefaultHTTPClientConfig,
 }
 
 func init() {
@@ -66,10 +66,10 @@ func init() {
 type DockerSDConfig struct {
 	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 
-	Host            string   `yaml:"host"`
-	Port            int      `yaml:"port"`
-	Filters         []Filter `yaml:"filters"`
-	HostNetworkHost string   `yaml:"host_network_host"`
+	Host               string   `yaml:"host"`
+	Port               int      `yaml:"port"`
+	Filters            []Filter `yaml:"filters"`
+	HostNetworkingHost string   `yaml:"host_networking_host"`
 
 	RefreshInterval model.Duration `yaml:"refresh_interval"`
 }
@@ -106,10 +106,10 @@ func (c *DockerSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 
 type DockerDiscovery struct {
 	*refresh.Discovery
-	client          *client.Client
-	port            int
-	hostNetworkHost string
-	filters         filters.Args
+	client             *client.Client
+	port               int
+	hostNetworkingHost string
+	filters            filters.Args
 }
 
 // NewDockerDiscovery returns a new DockerDiscovery which periodically refreshes its targets.
@@ -117,8 +117,8 @@ func NewDockerDiscovery(conf *DockerSDConfig, logger log.Logger) (*DockerDiscove
 	var err error
 
 	d := &DockerDiscovery{
-		port:            conf.Port,
-		hostNetworkHost: conf.HostNetworkHost,
+		port:               conf.Port,
+		hostNetworkingHost: conf.HostNetworkingHost,
 	}
 
 	hostURL, err := url.Parse(conf.Host)
@@ -255,7 +255,7 @@ func (d *DockerDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 				if c.HostConfig.NetworkMode != "host" {
 					addr = net.JoinHostPort(n.IPAddress, strconv.FormatUint(uint64(d.port), 10))
 				} else {
-					addr = d.hostNetworkHost
+					addr = d.hostNetworkingHost
 				}
 
 				labels[model.AddressLabel] = model.LabelValue(addr)

--- a/discovery/moby/docker_test.go
+++ b/discovery/moby/docker_test.go
@@ -49,7 +49,7 @@ host: %s
 	tg := tgs[0]
 	require.NotNil(t, tg)
 	require.NotNil(t, tg.Targets)
-	require.Equal(t, 2, len(tg.Targets))
+	require.Equal(t, 3, len(tg.Targets))
 
 	for i, lbls := range []model.LabelSet{
 		{
@@ -92,6 +92,16 @@ host: %s
 			"__meta_docker_network_label_com_docker_compose_version":   "1.25.0",
 			"__meta_docker_network_name":                               "dockersd_default",
 			"__meta_docker_network_scope":                              "local",
+		},
+		{
+			"__address__":                "localhost",
+			"__meta_docker_container_id": "54ed6cc5c0988260436cb0e739b7b6c9cad6c439a93b4c4fdbe9753e1c94b189",
+			"__meta_docker_container_label_com_docker_compose_project": "dockersd",
+			"__meta_docker_container_label_com_docker_compose_service": "host_networking",
+			"__meta_docker_container_label_com_docker_compose_version": "1.25.0",
+			"__meta_docker_container_name":                             "/dockersd_host_networking_1",
+			"__meta_docker_container_network_mode":                     "host",
+			"__meta_docker_network_ip":                                 "",
 		},
 	} {
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {

--- a/discovery/moby/testdata/dockerprom/containers/json_limit_0.json
+++ b/discovery/moby/testdata/dockerprom/containers/json_limit_0.json
@@ -89,5 +89,44 @@
       }
     },
     "Mounts": []
+  },
+  {
+    "Id": "54ed6cc5c0988260436cb0e739b7b6c9cad6c439a93b4c4fdbe9753e1c94b189",
+    "Names": [
+      "/dockersd_host_networking_1"
+    ],
+    "Image": "httpd",
+    "ImageID": "sha256:73b8cfec11558fe86f565b4357f6d6c8560f4c49a5f15ae970a24da86c9adc93",
+    "Command": "httpd-foreground",
+    "Created": 1627440494,
+    "Ports": [],
+    "Labels": {
+      "com.docker.compose.project": "dockersd",
+      "com.docker.compose.service": "host_networking",
+      "com.docker.compose.version": "1.25.0"
+    },
+    "State": "running",
+    "Status": "Up 3 minutes",
+    "HostConfig": { "NetworkMode": "host" },
+    "NetworkSettings": {
+      "Networks": {
+        "host": {
+          "IPAMConfig": null,
+          "Links": null,
+          "Aliases": null,
+          "NetworkID": "80c4459fa193c5c8b57e90e117d2f899d1a86708e548738149d62e03df0ec35c",
+          "EndpointID": "e9bea4c499c34bd41609b0e1e9b38f9964c69180c1a22130f28b6af802c156d8",
+          "Gateway": "",
+          "IPAddress": "",
+          "IPPrefixLen": 0,
+          "IPv6Gateway": "",
+          "GlobalIPv6Address": "",
+          "GlobalIPv6PrefixLen": 0,
+          "MacAddress": "",
+          "DriverOpts": null
+        }
+      }
+    },
+    "Mounts": []
   }
 ]

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -640,7 +640,7 @@ tls_config:
 [ port: <int> | default = 80 ]
 
 # The host to use if the container is in host networking mode.
-[ host_network_host: <string> | default = "localhost" ]
+[ host_networking_host: <string> | default = "localhost" ]
 
 # Optional filters to limit the discovery process to a subset of available
 # resources.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -639,6 +639,9 @@ tls_config:
 # tasks and services that don't have published ports.
 [ port: <int> | default = 80 ]
 
+# The host to use if the container is in host networking mode.
+[ host_network_host: <string> | default = "localhost" ]
+
 # Optional filters to limit the discovery process to a subset of available
 # resources.
 # The available filters are listed in the upstream documentation:


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR adds a new configuration option, `host_network_host` (I'm kind of still unsure about this name), that is used as the host when the container is set to host network mode.

Fixes: #9116 