### PR TITLE
mixin: Filter instance by selected job for Prometheus overview dashboard

### DIFF
--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -13,8 +13,8 @@ local template = grafana.template;
       g.dashboard(
         '%(prefix)sOverview' % $._config.grafanaPrometheus
       )
-      .addMultiTemplate('job', 'prometheus_build_info', 'job')
-      .addMultiTemplate('instance', 'prometheus_build_info', 'instance')
+      .addMultiTemplate('job', 'prometheus_build_info{%(prometheusSelector)s}' % $._config, 'job')
+      .addMultiTemplate('instance', 'prometheus_build_info{job=~"$job"}', 'instance')
       .addRow(
         g.row('Prometheus Stats')
         .addPanel(


### PR DESCRIPTION
A bug was created downstream which suggested that the Prometheus/Overview dashboard "instance" dropdown was not filtering correctly when a job was selected.

I was able to replicate it locally using the following config:

```yaml
global:
  scrape_interval:     15s # By default, scrape targets every 15 seconds.
scrape_configs:
  - job_name: 'prometheus-k8s-0'
    static_configs:
      - targets:
        - 'localhost:9090'
        labels:
          pod: prometheus-k8s-00
          service: prometheus-k8s
      - targets:
        - 'localhost:9091'
        labels:
          pod: prometheus-k8s-01
          service: prometheus-k8s
  - job_name: 'prometheus-k8s-1'
    static_configs:
      - targets:
        - 'localhost:9090'
        labels:
          pod: prometheus-k8s-10
          service: prometheus-k8s
      - targets:
        - 'localhost:9091'
        labels:
          pod: prometheus-k8s-11
          service: prometheus-k8s
```

Heres a before and after from this change:

<img width="1628" alt="before" src="https://user-images.githubusercontent.com/5781491/127331200-e4b2f306-f93b-4917-884b-f464b52c2ad6.png">

<img width="1719" alt="after" src="https://user-images.githubusercontent.com/5781491/127331237-44c564fb-b81d-41e0-91b1-79dc09962628.png">


<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git 
    - 
    - commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
