### PR TITLE
docker: raise ulimits at docker runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,18 @@ COPY consoles/                              /usr/share/prometheus/consoles/
 COPY LICENSE                                /LICENSE
 COPY NOTICE                                 /NOTICE
 COPY npm_licenses.tar.bz2                   /npm_licenses.tar.bz2
+COPY entrypoint.sh                          /entrypoint.sh
 
 RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
 RUN mkdir -p /prometheus && \
-    chown -R nobody:nobody etc/prometheus /prometheus
+    chown -R nobody:nobody etc/prometheus /prometheus && \
+    chmod +x /entrypoint.sh
 
 USER       nobody
 EXPOSE     9090
 VOLUME     [ "/prometheus" ]
 WORKDIR    /prometheus
-ENTRYPOINT [ "/bin/prometheus" ]
+ENTRYPOINT [ "/entrypoint.sh" ]
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
              "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+ulimit -n `ulimit -Hn`
+
+exec /bin/prometheus $*


### PR DESCRIPTION
fixes: https://github.com/prometheus/prometheus/issues/9096

This change wraps the prometheus binary call in a shell script allowing us to set the nfiles soft limits to the maximum allowed.

dockerhub image I used to test my changes:
azulinho/prometheus:v2.28.1.ulimits
