### PR TITLE
Describe EC2 availability zone IDs at most once per refresh (#9142)

### DIFF
--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -228,8 +228,8 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 	// Prometheus requires a reload if AWS adds a new AZ to the region.
 	if d.azToAZID == nil {
 		if err := d.refreshAZIDs(ctx); err != nil {
-			level.Warn(d.logger).Log(
-				"msg", "Unable to describe availability zones, ensure Prometheus has ec2:DescribeAvailabilityZones",
+			level.Debug(d.logger).Log(
+				"msg", "Unable to describe availability zones",
 				"err", err)
 		}
 	}
@@ -270,7 +270,7 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 				azID, ok := d.azToAZID[*inst.Placement.AvailabilityZone]
 				if !ok && d.azToAZID != nil {
 					level.Debug(d.logger).Log(
-						"msg", "Availability zone not found, try reloading Prometheus",
+						"msg", "Availability zone not found",
 						"az", *inst.Placement.AvailabilityZone)
 				}
 				labels[ec2LabelAZID] = model.LabelValue(azID)

--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -270,7 +270,7 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 				azID, ok := d.azToAZID[*inst.Placement.AvailabilityZone]
 				if !ok && d.azToAZID != nil {
 					level.Debug(d.logger).Log(
-						"msg", "Availability zone not found",
+						"msg", "Availability zone ID not found",
 						"az", *inst.Placement.AvailabilityZone)
 				}
 				labels[ec2LabelAZID] = model.LabelValue(azID)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -898,7 +898,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_ec2_ami`: the EC2 Amazon Machine Image
 * `__meta_ec2_architecture`: the architecture of the instance
 * `__meta_ec2_availability_zone`: the availability zone in which the instance is running
-* `__meta_ec2_availability_zone_id`: the [availability zone ID](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html) in which the instance is running
+* `__meta_ec2_availability_zone_id`: the [availability zone ID](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html) in which the instance is running (requires `ec2:DescribeAvailabilityZones`)
 * `__meta_ec2_instance_id`: the EC2 instance ID
 * `__meta_ec2_instance_lifecycle`: the lifecycle of the EC2 instance, set only for 'spot' or 'scheduled' instances, absent otherwise
 * `__meta_ec2_instance_state`: the state of the EC2 instance


### PR DESCRIPTION
This was an oversight on my part. If Prometheus is missing `ec2:DescribeAvailabilityZones`, the SD will attempt to refresh for every target, resulting in lots of 403s:

```
level=warn ts=2021-08-02T12:17:48.880Z caller=ec2.go:245 component="discovery manager scrape" discovery=ec2 msg="Unable to determine availability zone ID" az=eu-west-2a err="could not describe availability zones: UnauthorizedOperation: You are not authorized to perform this operation.\n\tstatus code: 403, request id: b9c37a4b-789a-4963-8655-db4671bf8cf4"
level=warn ts=2021-08-02T12:17:48.884Z caller=ec2.go:245 component="discovery manager scrape" discovery=ec2 msg="Unable to determine availability zone ID" az=eu-west-2c err="could not describe availability zones: UnauthorizedOperation: You are not authorized to perform this operation.\n\tstatus code: 403, request id: efc89d50-fbf9-43a2-9b63-c527dcffccf5"
level=warn ts=2021-08-02T12:17:48.889Z caller=ec2.go:245 component="discovery manager scrape" discovery=ec2 msg="Unable to determine availability zone ID" az=eu-west-2a err="could not describe availability zones: UnauthorizedOperation: You are not authorized to perform this operation.\n\tstatus code: 403, request id: 1d55608a-def0-4757-b401-be726630031d"
level=warn ts=2021-08-02T12:17:48.893Z caller=ec2.go:245 component="discovery manager scrape" discovery=ec2 msg="Unable to determine availability zone ID" az=eu-west-2c err="could not describe availability zones: UnauthorizedOperation: You are not authorized to perform this operation.\n\tstatus code: 403, request id: b197e921-af02-4320-b950-c98f43c2d542"
```

This PR caps this to a single request per `refresh()`, turning the above into this:

```
level=warn ts=2021-08-02T12:54:44.102Z caller=ec2.go:256 component="discovery manager scrape" discovery=ec2 msg="Unable to determine availability zone ID" az=eu-west-2a err="could not describe availability zones: UnauthorizedOperation: You are not authorized to perform this operation.\n\tstatus code: 403, request id: e1086f51-d8fd-4383-b1e7-814e167c5caf"                                                                                                                                                         
level=warn ts=2021-08-02T12:54:44.102Z caller=ec2.go:256 component="discovery manager scrape" discovery=ec2 msg="Unable to determine availability zone ID" az=eu-west-2c err="no availability zone ID mapping found for eu-west-2c"        
level=warn ts=2021-08-02T12:54:44.102Z caller=ec2.go:256 component="discovery manager scrape" discovery=ec2 msg="Unable to determine availability zone ID" az=eu-west-2a err="no availability zone ID mapping found for eu-west-2a"
level=warn ts=2021-08-02T12:54:44.102Z caller=ec2.go:256 component="discovery manager scrape" discovery=ec2 msg="Unable to determine availability zone ID" az=eu-west-2c err="no availability zone ID mapping found for eu-west-2c"              
```

It would be good to integrate this before v0.29.0 final.