### PR TITLE
Adds support to handle checkpoint corruption errors.

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -172,10 +172,19 @@ func NewChunkDiskMapper(dir string, pool chunkenc.Pool, writeBufferSize int) (*C
 		m.pool = chunkenc.NewPool()
 	}
 
-	return m, m.openMMapFiles()
+	return m, m.OpenMMapFiles()
 }
 
-func (cdm *ChunkDiskMapper) openMMapFiles() (returnErr error) {
+func (cdm *ChunkDiskMapper) Pool() chunkenc.Pool {
+	return cdm.pool
+}
+
+func (cdm *ChunkDiskMapper) WriteBufferSize() int {
+	return cdm.writeBufferSize
+}
+
+// OpenMMapFiles opens head chunks and mmaps them.
+func (cdm *ChunkDiskMapper) OpenMMapFiles() (returnErr error) {
 	cdm.mmappedChunkFiles = map[int]*mmappedChunkFile{}
 	cdm.closers = map[int]io.Closer{}
 	defer func() {
@@ -367,6 +376,14 @@ func (cdm *ChunkDiskMapper) CutNewFile() (returnErr error) {
 	defer cdm.writePathMtx.Unlock()
 
 	return cdm.cut()
+}
+
+func (cdm *ChunkDiskMapper) Dir() (string, error) {
+	path, err := filepath.Abs(cdm.dir.Name())
+	if err != nil {
+		return "", errors.Wrap(err, "absolute path")
+	}
+	return path, nil
 }
 
 // cut creates a new m-mapped file. The write lock should be held before calling this.

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -172,7 +172,7 @@ func NewChunkDiskMapper(dir string, pool chunkenc.Pool, writeBufferSize int) (*C
 		m.pool = chunkenc.NewPool()
 	}
 
-	return m, m.OpenMMapFiles()
+	return m, m.openMMapFiles()
 }
 
 func (cdm *ChunkDiskMapper) Pool() chunkenc.Pool {
@@ -183,8 +183,7 @@ func (cdm *ChunkDiskMapper) WriteBufferSize() int {
 	return cdm.writeBufferSize
 }
 
-// OpenMMapFiles opens head chunks and mmaps them.
-func (cdm *ChunkDiskMapper) OpenMMapFiles() (returnErr error) {
+func (cdm *ChunkDiskMapper) openMMapFiles() (returnErr error) {
 	cdm.mmappedChunkFiles = map[int]*mmappedChunkFile{}
 	cdm.closers = map[int]io.Closer{}
 	defer func() {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -753,6 +753,14 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 
 	if initErr := db.head.Init(minValidTime); initErr != nil {
 		db.head.metrics.walCorruptionsTotal.Inc()
+		if strings.Contains(initErr.Error(), ErrCheckpointCorrupted.Error()) && wlog != nil {
+			level.Warn(db.logger).Log("msg", "Encountered checkpoint corruption error, starting Head fresh", "err", err)
+			if err = db.head.CleanRestart(); err != nil {
+				return nil, errors.Wrap(err, "Head clean restart")
+			}
+			// Initialize new Head. If the error still persists, we continue as a repairable error.
+			initErr = db.head.Init(minValidTime)
+		}
 		level.Warn(db.logger).Log("msg", "Encountered WAL read error, attempting repair", "err", initErr)
 		if err := wlog.Repair(initErr); err != nil {
 			return nil, errors.Wrap(err, "repair corrupted WAL")

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -610,13 +610,13 @@ func (h *Head) Init(minValidTime int64) error {
 // CleanRestart cleans up the WAL and Head chunks dir and restarts the Head.
 // It must not be called after calling head.Init()
 func (h *Head) CleanRestart() error {
-	level.Warn(h.logger).Log("msg", "Restarting Head clean...")
+	level.Warn(h.logger).Log("msg", "Restarting Head clean")
 
 	oldWAL := h.wal
 	oldHeadChunks := h.chunkDiskMapper
 
 	// Clean up on disk data (WAL + head chunks).
-	level.Debug(h.logger).Log("msg", "Cleaning up WAL...")
+	level.Debug(h.logger).Log("msg", "Cleaning up WAL")
 	err := oldWAL.Close()
 	if err != nil {
 		return errors.Wrap(err, "close WAL")
@@ -624,7 +624,7 @@ func (h *Head) CleanRestart() error {
 	if err = os.RemoveAll(oldWAL.Dir()); err != nil {
 		return errors.Wrap(err, "remove WAL")
 	}
-	level.Debug(h.logger).Log("msg", "Cleaning up head chunks...")
+	level.Debug(h.logger).Log("msg", "Cleaning up head chunks")
 	if err = oldHeadChunks.Close(); err != nil {
 		return errors.Wrap(err, "close head chunks")
 	}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -1002,76 +1001,6 @@ func TestDelete_e2e(t *testing.T) {
 			require.Equal(t, 0, len(ss.Warnings()))
 		}
 	}
-}
-
-func TestOnCorruptedCheckpoint(t *testing.T) {
-	dbDir, err := ioutil.TempDir("", "test")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dbDir))
-	}()
-
-	walDir := filepath.Join(dbDir, "wal")
-	wlog, err := wal.NewSize(nil, nil, walDir, 32*1024, true)
-	require.NoError(t, err)
-	head, err := NewHead(nil, nil, wlog, DefaultHeadOptions(), nil)
-	require.NoError(t, err)
-
-	app := head.Appender(context.Background())
-	series := genSeries(100, 3, 0, 100)
-	for _, s := range series {
-		lbls := s.Labels()
-		itr := s.Iterator()
-		for itr.Next() {
-			ts, v := itr.At()
-			_, err = app.Append(0, lbls, ts, v)
-			require.NoError(t, err)
-		}
-	}
-	require.NoError(t, app.Commit())
-
-	// Create a checkpoint.
-	_, _, err = wal.LastCheckpoint(walDir)
-	require.Equal(t, record.ErrNotFound, err)
-
-	first, _, err := wal.Segments(walDir)
-	require.NoError(t, err)
-
-	// We have 2 segments, i.e., 0 & 1. Let's create a checkpoint of 0 segment only.
-	_, err = wal.Checkpoint(log.NewNopLogger(), wlog, first, first, func(_ uint64) bool { return true }, 0)
-	require.NoError(t, err)
-
-	_, checkpointNum, err := wal.LastCheckpoint(walDir)
-	require.NoError(t, err)
-	require.Equal(t, 0, checkpointNum)
-
-	// Stop the head.
-	require.NoError(t, head.Close())
-
-	// Introduce checkpoint corruption.
-	checkpointFile := filepath.Join(walDir, "checkpoint.00000000/00000000")
-
-	contents, err := ioutil.ReadFile(checkpointFile)
-	require.NoError(t, err)
-
-	total := len(contents)
-	newContent := []byte("random_stuff")
-	newContent = append(newContent, contents[total/2:]...)
-	contents = append(contents[:total/2-100], newContent...)
-	require.NoError(t, ioutil.WriteFile(checkpointFile, contents, 0644))
-
-	// Restart Head and initialize it.
-	wlog, err = wal.New(nil, nil, walDir, true)
-	require.NoError(t, err)
-	head, err = NewHead(nil, nil, wlog, DefaultHeadOptions(), nil)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, head.Close())
-	}()
-
-	err = head.Init(math.MinInt64)
-	require.NotNil(t, err)
-	require.True(t, strings.Contains(err.Error(), ErrCheckpointCorrupted.Error()))
 }
 
 func boundedSamples(full []tsdbutil.Sample, mint, maxt int64) []tsdbutil.Sample {

--- a/tsdb/wal/wal.go
+++ b/tsdb/wal/wal.go
@@ -294,7 +294,7 @@ func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSi
 		return nil, err
 	}
 
-	if err := w.setSegment(segment); err != nil {
+	if err := w.SetSegment(segment); err != nil {
 		return nil, err
 	}
 
@@ -404,7 +404,7 @@ func (w *WAL) Repair(origErr error) error {
 	if err != nil {
 		return err
 	}
-	if err := w.setSegment(s); err != nil {
+	if err := w.SetSegment(s); err != nil {
 		return err
 	}
 
@@ -452,7 +452,7 @@ func (w *WAL) Repair(origErr error) error {
 	if err != nil {
 		return err
 	}
-	if err := w.setSegment(s); err != nil {
+	if err := w.SetSegment(s); err != nil {
 		return err
 	}
 	return nil
@@ -461,6 +461,10 @@ func (w *WAL) Repair(origErr error) error {
 // SegmentName builds a segment name for the directory.
 func SegmentName(dir string, i int) string {
 	return filepath.Join(dir, fmt.Sprintf("%08d", i))
+}
+
+func (w *WAL) SegmentSize() int {
+	return w.segmentSize
 }
 
 // NextSegment creates the next segment and closes the previous one.
@@ -483,7 +487,7 @@ func (w *WAL) nextSegment() error {
 		return errors.Wrap(err, "create new segment file")
 	}
 	prev := w.segment
-	if err := w.setSegment(next); err != nil {
+	if err := w.SetSegment(next); err != nil {
 		return err
 	}
 
@@ -499,7 +503,8 @@ func (w *WAL) nextSegment() error {
 	return nil
 }
 
-func (w *WAL) setSegment(segment *Segment) error {
+// SetSegment sets the current segment for writes.
+func (w *WAL) SetSegment(segment *Segment) error {
 	w.segment = segment
 
 	// Correctly initialize donePages.
@@ -782,8 +787,8 @@ func (w *WAL) Close() (err error) {
 	return nil
 }
 
-// Segments returns the range [first, n] of currently existing segments.
-// If no segments are found, first and n are -1.
+// Segments returns the range [first, last] of currently existing segments.
+// If no segments are found, first and last are -1.
 func Segments(walDir string) (first, last int, err error) {
 	refs, err := listSegments(walDir)
 	if err != nil {

--- a/tsdb/wal/wal.go
+++ b/tsdb/wal/wal.go
@@ -294,7 +294,7 @@ func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSi
 		return nil, err
 	}
 
-	if err := w.SetSegment(segment); err != nil {
+	if err := w.setSegment(segment); err != nil {
 		return nil, err
 	}
 
@@ -404,7 +404,7 @@ func (w *WAL) Repair(origErr error) error {
 	if err != nil {
 		return err
 	}
-	if err := w.SetSegment(s); err != nil {
+	if err := w.setSegment(s); err != nil {
 		return err
 	}
 
@@ -452,7 +452,7 @@ func (w *WAL) Repair(origErr error) error {
 	if err != nil {
 		return err
 	}
-	if err := w.SetSegment(s); err != nil {
+	if err := w.setSegment(s); err != nil {
 		return err
 	}
 	return nil
@@ -487,7 +487,7 @@ func (w *WAL) nextSegment() error {
 		return errors.Wrap(err, "create new segment file")
 	}
 	prev := w.segment
-	if err := w.SetSegment(next); err != nil {
+	if err := w.setSegment(next); err != nil {
 		return err
 	}
 
@@ -503,8 +503,7 @@ func (w *WAL) nextSegment() error {
 	return nil
 }
 
-// SetSegment sets the current segment for writes.
-func (w *WAL) SetSegment(segment *Segment) error {
+func (w *WAL) setSegment(segment *Segment) error {
 	w.segment = segment
 
 	// Correctly initialize donePages.


### PR DESCRIPTION
Signed-off-by: Harkishen Singh <harkishensingh@hotmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Fixes: #7530 

We check for `wal.CorruptionErr` while backfilling checkpoint and if found, remove the entire `Head` data (WAL + head_chunks) and start a new `Head`.