### PR TITLE
Fix `kuma_sd` targetgroup reporting

### DIFF
--- a/discovery/xds/kuma_test.go
+++ b/discovery/xds/kuma_test.go
@@ -138,65 +138,47 @@ func TestKumaMadsV1ResourceParserValidResources(t *testing.T) {
 	res, err := getKumaMadsV1DiscoveryResponse(testKumaMadsV1Resources...)
 	require.NoError(t, err)
 
-	groups, err := kumaMadsV1ResourceParser(res.Resources, KumaMadsV1ResourceTypeURL)
+	targets, err := kumaMadsV1ResourceParser(res.Resources, KumaMadsV1ResourceTypeURL)
 	require.NoError(t, err)
-	require.Len(t, groups, 3)
+	require.Len(t, targets, 3)
 
-	expectedGroup1 := &targetgroup.Group{
-		Targets: []model.LabelSet{
-			{
-				"__address__":                   "10.1.4.32:9090",
-				"__meta_kuma_label_commit_hash": "620506a88",
-				"__meta_kuma_dataplane":         "prometheus-01",
-				"__metrics_path__":              "/custom-metrics",
-				"__scheme__":                    "http",
-				"instance":                      "prometheus-01",
-			},
-			{
-				"__address__":                   "10.1.4.33:9090",
-				"__meta_kuma_label_commit_hash": "3513bba00",
-				"__meta_kuma_dataplane":         "prometheus-02",
-				"__metrics_path__":              "",
-				"__scheme__":                    "http",
-				"instance":                      "prometheus-02",
-			},
-		},
-		Labels: model.LabelSet{
+	expectedTargets := []model.LabelSet{
+		{
+			"__address__":                    "10.1.4.32:9090",
+			"__metrics_path__":               "/custom-metrics",
+			"__scheme__":                     "http",
+			"instance":                       "prometheus-01",
 			"__meta_kuma_mesh":               "metrics",
 			"__meta_kuma_service":            "prometheus",
 			"__meta_kuma_label_team":         "infra",
 			"__meta_kuma_label_kuma_io_zone": "us-east-1",
+			"__meta_kuma_label_commit_hash":  "620506a88",
+			"__meta_kuma_dataplane":          "prometheus-01",
 		},
-	}
-	require.Equal(t, expectedGroup1, groups[0])
-
-	expectedGroup2 := &targetgroup.Group{
-		Labels: model.LabelSet{
+		{
+			"__address__":                    "10.1.4.33:9090",
+			"__metrics_path__":               "",
+			"__scheme__":                     "http",
+			"instance":                       "prometheus-02",
 			"__meta_kuma_mesh":               "metrics",
-			"__meta_kuma_service":            "grafana",
+			"__meta_kuma_service":            "prometheus",
 			"__meta_kuma_label_team":         "infra",
 			"__meta_kuma_label_kuma_io_zone": "us-east-1",
+			"__meta_kuma_label_commit_hash":  "3513bba00",
+			"__meta_kuma_dataplane":          "prometheus-02",
+		},
+		{
+			"__address__":            "10.1.1.1",
+			"__metrics_path__":       "",
+			"__scheme__":             "http",
+			"instance":               "elasticsearch-01",
+			"__meta_kuma_mesh":       "data",
+			"__meta_kuma_service":    "elasticsearch",
+			"__meta_kuma_label_role": "ml",
+			"__meta_kuma_dataplane":  "elasticsearch-01",
 		},
 	}
-	require.Equal(t, expectedGroup2, groups[1])
-
-	expectedGroup3 := &targetgroup.Group{
-		Targets: []model.LabelSet{
-			{
-				"__address__":            "10.1.1.1",
-				"__meta_kuma_label_role": "ml",
-				"__meta_kuma_dataplane":  "elasticsearch-01",
-				"__metrics_path__":       "",
-				"__scheme__":             "http",
-				"instance":               "elasticsearch-01",
-			},
-		},
-		Labels: model.LabelSet{
-			"__meta_kuma_mesh":    "data",
-			"__meta_kuma_service": "elasticsearch",
-		},
-	}
-	require.Equal(t, expectedGroup3, groups[2])
+	require.Equal(t, expectedTargets, targets)
 }
 
 func TestKumaMadsV1ResourceParserInvalidResources(t *testing.T) {
@@ -262,66 +244,48 @@ tls_config:
 	kd.poll(context.Background(), ch)
 
 	groups := <-ch
-	require.Len(t, groups, 3)
+	require.Len(t, groups, 1)
 
-	expectedGroup1 := &targetgroup.Group{
-		Source: "kuma",
-		Targets: []model.LabelSet{
-			{
-				"__address__":                   "10.1.4.32:9090",
-				"__meta_kuma_label_commit_hash": "620506a88",
-				"__meta_kuma_dataplane":         "prometheus-01",
-				"__metrics_path__":              "/custom-metrics",
-				"__scheme__":                    "http",
-				"instance":                      "prometheus-01",
-			},
-			{
-				"__address__":                   "10.1.4.33:9090",
-				"__meta_kuma_label_commit_hash": "3513bba00",
-				"__meta_kuma_dataplane":         "prometheus-02",
-				"__metrics_path__":              "",
-				"__scheme__":                    "http",
-				"instance":                      "prometheus-02",
-			},
-		},
-		Labels: model.LabelSet{
+	targets := groups[0].Targets
+	require.Len(t, targets, 3)
+
+	expectedTargets := []model.LabelSet{
+		{
+			"__address__":                    "10.1.4.32:9090",
+			"__metrics_path__":               "/custom-metrics",
+			"__scheme__":                     "http",
+			"instance":                       "prometheus-01",
 			"__meta_kuma_mesh":               "metrics",
 			"__meta_kuma_service":            "prometheus",
 			"__meta_kuma_label_team":         "infra",
 			"__meta_kuma_label_kuma_io_zone": "us-east-1",
+			"__meta_kuma_label_commit_hash":  "620506a88",
+			"__meta_kuma_dataplane":          "prometheus-01",
 		},
-	}
-	require.Equal(t, expectedGroup1, groups[0])
-
-	expectedGroup2 := &targetgroup.Group{
-		Source: "kuma",
-		Labels: model.LabelSet{
+		{
+			"__address__":                    "10.1.4.33:9090",
+			"__metrics_path__":               "",
+			"__scheme__":                     "http",
+			"instance":                       "prometheus-02",
 			"__meta_kuma_mesh":               "metrics",
-			"__meta_kuma_service":            "grafana",
+			"__meta_kuma_service":            "prometheus",
 			"__meta_kuma_label_team":         "infra",
 			"__meta_kuma_label_kuma_io_zone": "us-east-1",
+			"__meta_kuma_label_commit_hash":  "3513bba00",
+			"__meta_kuma_dataplane":          "prometheus-02",
+		},
+		{
+			"__address__":            "10.1.1.1",
+			"__metrics_path__":       "",
+			"__scheme__":             "http",
+			"instance":               "elasticsearch-01",
+			"__meta_kuma_mesh":       "data",
+			"__meta_kuma_service":    "elasticsearch",
+			"__meta_kuma_label_role": "ml",
+			"__meta_kuma_dataplane":  "elasticsearch-01",
 		},
 	}
-	require.Equal(t, expectedGroup2, groups[1])
-
-	expectedGroup3 := &targetgroup.Group{
-		Source: "kuma",
-		Targets: []model.LabelSet{
-			{
-				"__address__":            "10.1.1.1",
-				"__meta_kuma_label_role": "ml",
-				"__meta_kuma_dataplane":  "elasticsearch-01",
-				"__metrics_path__":       "",
-				"__scheme__":             "http",
-				"instance":               "elasticsearch-01",
-			},
-		},
-		Labels: model.LabelSet{
-			"__meta_kuma_mesh":    "data",
-			"__meta_kuma_service": "elasticsearch",
-		},
-	}
-	require.Equal(t, expectedGroup3, groups[2])
+	require.Equal(t, expectedTargets, targets)
 
 	// Should skip the next update.
 	ctx, cancel := context.WithCancel(context.Background())

--- a/discovery/xds/xds.go
+++ b/discovery/xds/xds.go
@@ -15,7 +15,6 @@ package xds
 
 import (
 	"context"
-	"github.com/prometheus/common/model"
 	"time"
 
 	v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -23,6 +22,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"

--- a/discovery/xds/xds.go
+++ b/discovery/xds/xds.go
@@ -95,7 +95,9 @@ var (
 	}
 )
 
-type resourceParser func(resources []*anypb.Any, typeUrl string) ([]*targetgroup.Group, error)
+// resourceParser is a function that takes raw discovered objects and translates them into
+// targetgroup.Group Targets. On error, no updates are sent to the scrape manager and the failure count is incremented.
+type resourceParser func(resources []*anypb.Any, typeUrl string) ([]model.LabelSet, error)
 
 // fetchDiscovery implements long-polling via xDS Fetch REST-JSON.
 type fetchDiscovery struct {
@@ -154,23 +156,18 @@ func (d *fetchDiscovery) poll(ctx context.Context, ch chan<- []*targetgroup.Grou
 		return
 	}
 
-	parsedGroups, err := d.parseResources(response.Resources, response.TypeUrl)
+	parsedTargets, err := d.parseResources(response.Resources, response.TypeUrl)
 	if err != nil {
 		level.Error(d.logger).Log("msg", "error parsing resources", "err", err)
 		d.fetchFailuresCount.Inc()
 		return
 	}
 
-	for _, group := range parsedGroups {
-		group.Source = d.source
-	}
+	level.Debug(d.logger).Log("msg", "Updated to version", "version", response.VersionInfo, "targets", len(parsedTargets))
 
-	level.Debug(d.logger).Log("msg", "updated to version", "version", response.VersionInfo, "groups", len(parsedGroups))
-
-	// Check the context before sending an update on the channel.
 	select {
 	case <-ctx.Done():
 		return
-	case ch <- parsedGroups:
+	case ch <- []*targetgroup.Group{{Source: d.source, Targets: parsedTargets}}:
 	}
 }


### PR DESCRIPTION
There are currently a few related issues this PR addresses:
* xDS targetgroups are currently all given the same source name, so each job can only have max 1 group
* xDS targetgroups are not tracked between polling, so it is impossible to remove a target
* The Kuma MADS API's `MonitoringAssignment` is mapped directly into a `targetgroup.Group`, but does not contain a unique identifier.

This PR bundles all discovered targets into a single `targetgroup.Group` by changing the `resourceParser` func to return a set of targets instead of groups.

I've built an image with these patches from `2.29-rc.0` and pushed it to `austince/prometheus:2.29-rc.0-fix2`. I've also tested both adding multiple targets in a single job and removing targets. Testing repo here: https://github.com/austince/kuma-sd-playground

Fixes #9155