### PR TITLE
Optimise WAL loading by removing extra map and caching min-time

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1437,7 +1437,7 @@ type memSeries struct {
 	ref           uint64
 	lset          labels.Labels
 	mmappedChunks []*mmappedChunk
-	mmMaxTime     int64
+	mmMaxTime     int64 // max time of any mmapped chunk, only used during WAL replay
 	headChunk     *memChunk
 	chunkRange    int64
 	firstChunkID  int

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1437,6 +1437,7 @@ type memSeries struct {
 	ref           uint64
 	lset          labels.Labels
 	mmappedChunks []*mmappedChunk
+	mmMaxTime     int64
 	headChunk     *memChunk
 	chunkRange    int64
 	firstChunkID  int

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1437,7 +1437,7 @@ type memSeries struct {
 	ref           uint64
 	lset          labels.Labels
 	mmappedChunks []*mmappedChunk
-	mmMaxTime     int64 // max time of any mmapped chunk, only used during WAL replay
+	mmMaxTime     int64 // Max time of any mmapped chunk, only used during WAL replay.
 	headChunk     *memChunk
 	chunkRange    int64
 	firstChunkID  int

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -190,7 +190,7 @@ func BenchmarkLoadWAL(b *testing.B) {
 							for j := 1; len(lbls) < labelsPerSeries; j++ {
 								lbls[defaultLabelName+strconv.Itoa(j)] = defaultLabelValue + strconv.Itoa(j)
 							}
-							refSeries = append(refSeries, record.RefSeries{Ref: uint64(i) * 100, Labels: labels.FromMap(lbls)})
+							refSeries = append(refSeries, record.RefSeries{Ref: uint64(i) * 101, Labels: labels.FromMap(lbls)})
 						}
 						populateTestWAL(b, w, []interface{}{refSeries})
 					}
@@ -202,7 +202,7 @@ func BenchmarkLoadWAL(b *testing.B) {
 							refSamples = refSamples[:0]
 							for k := j * c.seriesPerBatch; k < (j+1)*c.seriesPerBatch; k++ {
 								refSamples = append(refSamples, record.RefSample{
-									Ref: uint64(k) * 100,
+									Ref: uint64(k) * 101,
 									T:   int64(i) * 10,
 									V:   float64(i) * 100,
 								})
@@ -218,7 +218,7 @@ func BenchmarkLoadWAL(b *testing.B) {
 							refExemplars = refExemplars[:0]
 							for k := j * c.seriesPerBatch; k < (j+1)*c.seriesPerBatch; k++ {
 								refExemplars = append(refExemplars, record.RefExemplar{
-									Ref:    uint64(k) * 100,
+									Ref:    uint64(k) * 101,
 									T:      int64(i) * 10,
 									V:      float64(i) * 100,
 									Labels: labels.FromStrings("traceID", fmt.Sprintf("trace-%d", i)),

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -239,6 +239,8 @@ func BenchmarkLoadWAL(b *testing.B) {
 						require.NoError(b, err)
 						h.Init(0)
 					}
+					b.StopTimer()
+					w.Close()
 				})
 		}
 	}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -231,7 +231,7 @@ func BenchmarkLoadWAL(b *testing.B) {
 						require.NoError(b, chunkDiskMapper.Close())
 					}
 
-					// Write samples.
+					// Write exemplars.
 					refExemplars := make([]record.RefExemplar, 0, c.seriesPerBatch)
 					for i := 0; i < exemplarsPerSeries; i++ {
 						for j := 0; j < c.batches; j++ {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -218,12 +218,12 @@ func BenchmarkLoadWAL(b *testing.B) {
 						}
 					}
 
-					// Write mmapped chunks
+					// Write mmapped chunks.
 					if c.mmappedChunkT != 0 {
 						chunkDiskMapper, err := chunks.NewChunkDiskMapper(mmappedChunksDir(dir), chunkenc.NewPool(), chunks.DefaultWriteBufferSize)
 						require.NoError(b, err)
 						for k := 0; k < c.batches*c.seriesPerBatch; k++ {
-							// Create one mmapped chunk per series, with one sample at the given time
+							// Create one mmapped chunk per series, with one sample at the given time.
 							s := newMemSeries(labels.Labels{}, uint64(k)*101, c.mmappedChunkT, nil)
 							s.append(c.mmappedChunkT, 42, 0, chunkDiskMapper)
 							s.mmapCurrentHeadChunk(chunkDiskMapper)

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -386,7 +386,7 @@ func (h *Head) processWALSamples(
 				unknownRefs++
 				continue
 			}
-			if s.T < ms.mmMaxTime {
+			if s.T <= ms.mmMaxTime {
 				continue
 			}
 			if _, chunkCreated := ms.append(s.T, s.V, 0, h.chunkDiskMapper); chunkCreated {

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -262,7 +262,6 @@ Outer:
 				mSeries.nextAt = 0
 				mSeries.headChunk = nil
 				mSeries.app = nil
-				h.updateMinMaxTime(mSeries.minTime(), mSeries.maxTime())
 			}
 			//nolint:staticcheck // Ignore SA6002 relax staticcheck verification.
 			seriesPool.Put(v)
@@ -364,6 +363,7 @@ func (h *Head) setMMappedChunks(mSeries *memSeries, mmc []*mmappedChunk) {
 		mSeries.mmMaxTime = math.MinInt64
 	} else {
 		mSeries.mmMaxTime = mmc[len(mmc)-1].maxTime
+		h.updateMinMaxTime(mmc[0].minTime, mSeries.mmMaxTime)
 	}
 }
 


### PR DESCRIPTION
This PR replaces #8645; it includes the first four commits which address benchmark issues at #9101.
Fixes #8638.

Two code changes:
 * A: Remove the additional `refSeries` cache built in `processWALSamples()`. "Mitigate lock contention in getByID", it said, but the locks are sharded so with any likely number of workers there is no contention.
 * B: Cache the highest timestamp of any mmapped chunk for a series, so that we avoid re-looking this up for every sample. We cache it in the main `memSeries` struct.

I spent a lot of time exploring different options, and concluded this is a good combination.
Benchmarking them both separately:

Just A: memory is reduced when we have a lot of series, but it runs a little slower.

```
name                                                                                                    old time/op    new time/op    delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-8         345ms ± 2%     345ms ± 1%     ~     (p=0.730 n=5+4)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-8         523ms ± 2%     549ms ± 3%   +5.03%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-8         214ms ±16%     208ms ± 0%     ~     (p=0.730 n=5+4)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-8     2.19s ± 1%     2.22s ± 1%   +1.54%  (p=0.008 n=5+5)

name                                                                                                    old alloc/op   new alloc/op   delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-8        45.7MB ± 0%    45.6MB ± 0%     ~     (p=0.056 n=5+5)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-8         239MB ± 1%     241MB ± 1%     ~     (p=0.690 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-8        50.9MB ± 2%    52.2MB ± 1%   +2.50%  (p=0.032 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-8     333MB ± 1%     302MB ± 1%   -9.11%  (p=0.008 n=5+5)

name                                                                                                    old allocs/op  new allocs/op  delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-8          545k ± 0%      545k ± 0%     ~     (p=1.000 n=5+5)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-8         2.49M ± 0%     2.49M ± 0%   -0.10%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-8          477k ± 0%      486k ± 1%   +1.90%  (p=0.008 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-8     3.73M ± 0%     3.71M ± 0%   -0.48%  (p=0.008 n=5+5)
```

Just B: a bit faster, slightly higher memory use.

```
name                                                                                                    old time/op    new time/op    delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-8         345ms ± 2%     337ms ± 1%   -2.45%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-8         523ms ± 2%     529ms ± 2%     ~     (p=0.222 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-8         214ms ±16%     193ms ± 1%   -9.90%  (p=0.016 n=5+4)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-8     2.19s ± 1%     2.11s ± 1%   -3.57%  (p=0.008 n=5+5)

name                                                                                                    old alloc/op   new alloc/op   delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-8        45.7MB ± 0%    45.7MB ± 0%     ~     (p=0.690 n=5+5)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-8         239MB ± 1%     247MB ± 2%   +3.32%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-8        50.9MB ± 2%    51.7MB ± 3%     ~     (p=0.421 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-8     333MB ± 1%     333MB ± 1%     ~     (p=0.690 n=5+5)

name                                                                                                    old allocs/op  new allocs/op  delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-8          545k ± 0%      545k ± 0%     ~     (p=1.000 n=5+5)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-8         2.49M ± 0%     2.49M ± 0%   +0.06%  (p=0.016 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-8          477k ± 0%      478k ± 0%     ~     (p=0.310 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-8     3.73M ± 0%     3.73M ± 0%     ~     (p=0.690 n=5+5)
```

A+B: faster and lower memory.
```
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-8         345ms ± 2%     344ms ± 1%     ~     (p=0.690 n=5+5)LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-8         523ms ± 2%     546ms ± 2%   +4.42%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-8         214ms ±16%     206ms ± 1%     ~     (p=0.690 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-8     2.19s ± 1%     2.11s ± 1%   -3.41%  (p=0.008 n=5+5)

name                                                                                                    old alloc/op   new alloc/op   delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-8        45.7MB ± 0%    45.6MB ± 0%   -0.21%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-8         239MB ± 1%     241MB ± 1%     ~     (p=0.421 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-8        50.9MB ± 2%    52.2MB ± 4%     ~     (p=0.222 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-8     333MB ± 1%     300MB ± 0%   -9.81%  (p=0.008 n=5+5)

name                                                                                                    old allocs/op  new allocs/op  delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-8          545k ± 0%      545k ± 0%     ~     (p=0.690 n=5+5)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-8         2.49M ± 0%     2.49M ± 0%   -0.10%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-8          477k ± 0%      485k ± 1%   +1.57%  (p=0.008 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-8     3.73M ± 0%     3.71M ± 0%   -0.55%  (p=0.008 n=5+5)
```

However the benefit is much clearer when we load a real 5GB WAL - it needs 19% less CPU and 24% less RAM:
```
/bin/time before: 172.56user 3.05system 0:27.96elapsed 628%CPU (0avgtext+0avgdata 3840124maxresident)k
           after: 139.75user 2.27system 0:24.07elapsed 590%CPU (0avgtext+0avgdata 2914504maxresident)k

LoadFileWAL-8        27.5s ± 2%     23.7s ± 1%  -13.62%  (p=0.008 n=5+5)
LoadFileWAL-8       5.05GB ± 0%    3.18GB ± 0%  -37.05%  (p=0.008 n=5+5)
LoadFileWAL-8        50.5M ± 0%     49.1M ± 0%   -2.82%  (p=0.008 n=5+5)
```

All benchmarks run on:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Xeon(R) CPU E3-1240 v6 @ 3.70GHz
```


(It is disappointing that we end up carrying the max timestamp around for the life of the program even though we only use it at startup, but I couldn't see an easy way around that.)
