### PR TITLE
Fix tests in histo_test.go

### DIFF
--- a/tsdb/chunkenc/histo_test.go
+++ b/tsdb/chunkenc/histo_test.go
@@ -21,17 +21,15 @@ import (
 )
 
 func TestHistoChunkSameBuckets(t *testing.T) {
-
 	c := NewHistoChunk()
+	var exp []res
 
-	// create fresh appender and add the first histogram
-
+	// Create fresh appender and add the first histogram
 	app, err := c.Appender()
 	require.NoError(t, err)
 	require.Equal(t, 0, c.NumSamples())
 
 	ts := int64(1234567890)
-
 	h := histogram.SparseHistogram{
 		Count:     5,
 		ZeroCount: 2,
@@ -46,54 +44,43 @@ func TestHistoChunkSameBuckets(t *testing.T) {
 		NegativeSpans:   nil,
 		NegativeBuckets: []int64{},
 	}
-
 	app.AppendHistogram(ts, h)
+	exp = append(exp, res{t: ts, h: h})
 	require.Equal(t, 1, c.NumSamples())
 
-	exp := []res{
-		{t: ts, h: h},
-	}
-
-	// add an updated histogram
-
+	// Add an updated histogram.
 	ts += 16
 	h.Count += 9
 	h.ZeroCount++
 	h.Sum = 24.4
 	h.PositiveBuckets = []int64{5, -2, 1, -2} // counts: 5, 3, 4, 2 (total 14)
-
 	app.AppendHistogram(ts, h)
 	exp = append(exp, res{t: ts, h: h})
-
 	require.Equal(t, 2, c.NumSamples())
 
-	// add update with new appender
-
+	// Add update with new appender
 	app, err = c.Appender()
 	require.NoError(t, err)
-	require.Equal(t, 2, c.NumSamples())
 
 	ts += 14
 	h.Count += 13
 	h.ZeroCount += 2
 	h.Sum = 24.4
 	h.PositiveBuckets = []int64{6, 1, -3, 6} // counts: 6, 7, 4, 10 (total 27)
-
 	app.AppendHistogram(ts, h)
 	exp = append(exp, res{t: ts, h: h})
-
 	require.Equal(t, 3, c.NumSamples())
 
 	// 1. Expand iterator in simple case.
-	it1 := c.iterator(nil)
-	require.NoError(t, it1.Err())
-	var res1 []res
-	for it1.Next() {
-		ts, h := it1.AtHistogram()
-		res1 = append(res1, res{t: ts, h: h.Copy()})
+	it := c.iterator(nil)
+	require.NoError(t, it.Err())
+	var act []res
+	for it.Next() {
+		ts, h := it.AtHistogram()
+		act = append(act, res{t: ts, h: h.Copy()})
 	}
-	require.NoError(t, it1.Err())
-	require.Equal(t, exp, res1)
+	require.NoError(t, it.Err())
+	require.Equal(t, exp, act)
 
 	// 2. Expand second iterator while reusing first one.
 	//it2 := c.Iterator(it1)
@@ -133,17 +120,14 @@ type res struct {
 
 // mimics the scenario described for compareSpans()
 func TestHistoChunkBucketChanges(t *testing.T) {
-	t.SkipNow()
-	c := NewHistoChunk()
+	c := Chunk(NewHistoChunk())
 
-	// create fresh appender and add the first histogram
-
+	// Create fresh appender and add the first histogram.
 	app, err := c.Appender()
 	require.NoError(t, err)
 	require.Equal(t, 0, c.NumSamples())
 
 	ts1 := int64(1234567890)
-
 	h1 := histogram.SparseHistogram{
 		Count:     5,
 		ZeroCount: 2,
@@ -165,8 +149,7 @@ func TestHistoChunkBucketChanges(t *testing.T) {
 	app.AppendHistogram(ts1, h1)
 	require.Equal(t, 1, c.NumSamples())
 
-	// add an new histogram that has expanded buckets
-
+	// Add a new histogram that has expanded buckets.
 	ts2 := ts1 + 16
 	h2 := h1
 	h2.PositiveSpans = []histogram.Span{
@@ -178,32 +161,35 @@ func TestHistoChunkBucketChanges(t *testing.T) {
 	h2.Count += 9
 	h2.ZeroCount++
 	h2.Sum = 30
-	// existing histogram should get values converted from the above to: 6 3 0 3 0 0 2 4 5 0 1 (previous values with some new empty buckets in between)
+	// Existing histogram should get values converted from the above to: 6 3 0 3 0 0 2 4 5 0 1 (previous values with some new empty buckets in between)
 	// so the new histogram should have new counts >= these per-bucket counts, e.g.:
 	h2.PositiveBuckets = []int64{7, -2, -4, 2, -2, -1, 2, 3, 0, -5, 1} // 7 5 1 3 1 0 2 5 5 0 1 (total 30)
 
+	// This is how span changes will be handled.
+	histoApp, _ := app.(*HistoAppender)
+	posInterjections, negInterjections, ok := histoApp.Appendable(h2)
+	require.Greater(t, len(posInterjections), 0)
+	require.Equal(t, 0, len(negInterjections))
+	require.True(t, ok) // Only new buckets came in.
+	c, app = histoApp.Recode(posInterjections, negInterjections, h2.PositiveSpans, h2.NegativeSpans)
 	app.AppendHistogram(ts2, h2)
 
-	// TODO is this okay?
-	// the appender can rewrite its own bytes slice but it is not able to update the HistoChunk, so our histochunk is outdated until we update it manually
-	c.b = *(app.(*HistoAppender).b)
 	require.Equal(t, 2, c.NumSamples())
 
-	// because the 2nd histogram has expanded buckets, we should expect all histograms (in particular the first)
-	// to come back using the new spans metadata as well as the expanded buckets
+	// Because the 2nd histogram has expanded buckets, we should expect all histograms (in particular the first)
+	// to come back using the new spans metadata as well as the expanded buckets.
 	h1.PositiveSpans = h2.PositiveSpans
 	h1.PositiveBuckets = []int64{6, -3, -3, 3, -3, 0, 2, 2, 1, -5, 1}
 	exp := []res{
 		{t: ts1, h: h1},
 		{t: ts2, h: h2},
 	}
-	it1 := c.iterator(nil)
-	require.NoError(t, it1.Err())
-	var res1 []res
-	for it1.Next() {
-		ts, h := it1.AtHistogram()
-		res1 = append(res1, res{t: ts, h: h.Copy()})
+	it := c.Iterator(nil)
+	var act []res
+	for it.Next() {
+		ts, h := it.AtHistogram()
+		act = append(act, res{t: ts, h: h.Copy()})
 	}
-	require.NoError(t, it1.Err())
-	require.Equal(t, exp, res1)
+	require.NoError(t, it.Err())
+	require.Equal(t, exp, act)
 }


### PR DESCRIPTION
NOTE: This is pointing to the experimental sparsehistogram branch

This PR fixes the sparse histogram chunk test `TestHistoChunkBucketChanges` which was made to skip before.

cc @beorn7 