### PR TITLE
add option to produce TAP output from tests

### DIFF
--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -44,6 +44,7 @@ func RulesUnitTest(queryOpts promql.LazyLoaderOpts, files ...string) int {
 	return RulesUnitTestTap(io.Discard, queryOpts, files...)
 }
 
+// RulesUnitTestTap does the same as RulesUnitTest and writes results to a TAP file.
 func RulesUnitTestTap(tapout io.Writer, queryOpts promql.LazyLoaderOpts, files ...string) int {
 	failed := false
 

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -109,13 +109,13 @@ func TestRulesUnitTest(t *testing.T) {
 		},
 	}
 
-	tap_files := []string{}
-	tap_count := [2]int{}
+	tapFiles := []string{}
+	tapCount := [2]int{}
 	for _, tt := range tests {
 		// Reuse these tests for the tap output testing, but only ones with default opts.
 		if (tt.queryOpts == promql.LazyLoaderOpts{}) {
-			tap_files = append(tap_files, tt.args.files...)
-			tap_count[tt.want] += len(tt.args.files)
+			tapFiles = append(tapFiles, tt.args.files...)
+			tapCount[tt.want] += len(tt.args.files)
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			if got := RulesUnitTest(tt.queryOpts, tt.args.files...); got != tt.want {
@@ -124,27 +124,27 @@ func TestRulesUnitTest(t *testing.T) {
 		})
 	}
 
-	re_plan := regexp.MustCompile(fmt.Sprintf("^1..%d", len(tap_files)))
-	re_pass := regexp.MustCompile(`(?m)^ok \d+ -`)
-	re_fail := regexp.MustCompile(`(?m)^not ok \d+ -`)
+	rePlan := regexp.MustCompile(fmt.Sprintf("^1..%d", len(tapFiles)))
+	rePass := regexp.MustCompile(`(?m)^ok \d+ -`)
+	reFail := regexp.MustCompile(`(?m)^not ok \d+ -`)
 
 	t.Run("TAP output", func(t *testing.T) {
 		var tapout bytes.Buffer
-		if got := RulesUnitTestTap(&tapout, promql.LazyLoaderOpts{}, tap_files...); got != 1 {
+		if got := RulesUnitTestTap(&tapout, promql.LazyLoaderOpts{}, tapFiles...); got != 1 {
 			t.Errorf("RulesUnitTestTap() = %v, want 1", got)
 		}
 
 		text := tapout.Bytes()
-		if !re_plan.Match(text) {
+		if !rePlan.Match(text) {
 			t.Errorf("TAP output has no plan\n")
 		}
-		passes := re_pass.FindAll(text, -1)
-		if len(passes) != tap_count[0] {
-			t.Errorf("TAP output had %d ok; expected %d\n", len(passes), tap_count[0])
+		passes := rePass.FindAll(text, -1)
+		if len(passes) != tapCount[0] {
+			t.Errorf("TAP output had %d ok; expected %d\n", len(passes), tapCount[0])
 		}
-		fails := re_fail.FindAll(text, -1)
-		if len(fails) != tap_count[1] {
-			t.Errorf("TAP output had %d not ok; expected %d\n", len(fails), tap_count[1])
+		fails := reFail.FindAll(text, -1)
+		if len(fails) != tapCount[1] {
+			t.Errorf("TAP output had %d not ok; expected %d\n", len(fails), tapCount[1])
 		}
 	})
 }


### PR DESCRIPTION
@dgl, I would like to add a "--tap=<file>" option to promtool's "test" subcommand to generate a Test Anything Protocol file with the test results, because we need to record evidence of testing in some standard machine-parseable format, and TAP is much simpler than JUnit XML.

Signed-off-by: Marty Pauley <marty@martian.org>
