### PR TITLE
Avoid deadlock when processing duplicate series record

### DIFF
--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -359,9 +359,9 @@ Outer:
 	return nil
 }
 
-// processWALSamples adds a partition of samples it receives to the head and passes
-// them on to other workers.
-// Samples before the mint timestamp are discarded.
+// processWALSamples adds the samples it receives to the head and passes
+// the buffer received to an output channel for reuse.
+// Samples before the minValidTime timestamp are discarded.
 func (h *Head) processWALSamples(
 	minValidTime int64,
 	input <-chan []record.RefSample, output chan<- []record.RefSample,


### PR DESCRIPTION
fixes #9169, plus another deadlock on the line before which I didn't experience but seems plausible.

`processWALSamples()` needs to be able to send on its output channel before it can read the input channel, so read to allow this in case the output channel is full.

Also update the comment describing `processWALSamples()`   - previous text seems to relate to an earlier implementation.