### PR TITLE
Dockerfile: Consolidate steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,13 @@ COPY LICENSE                                /LICENSE
 COPY NOTICE                                 /NOTICE
 COPY npm_licenses.tar.bz2                   /npm_licenses.tar.bz2
 
-RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
-RUN mkdir -p /prometheus && \
-    chown -R nobody:nobody etc/prometheus /prometheus
+WORKDIR /prometheus
+RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/ && \
+    chown -R nobody:nobody /etc/prometheus /prometheus
 
 USER       nobody
 EXPOSE     9090
 VOLUME     [ "/prometheus" ]
-WORKDIR    /prometheus
 ENTRYPOINT [ "/bin/prometheus" ]
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
              "--storage.tsdb.path=/prometheus", \


### PR DESCRIPTION
* Moving up workdir will make mkdir call redundant
* Consolidate into a single RUN instruction
* Prefix etc/prometheus with a slash (it only worked because WORKDIR was
  / )

