### PR TITLE
Log sparse histograms into WAL and replay from it

### DIFF
--- a/pkg/histogram/sparse_histogram.go
+++ b/pkg/histogram/sparse_histogram.go
@@ -30,9 +30,10 @@ import (
 // neg bucket idx             3    2    1         0          -1        ...
 // actively used bucket indices themselves are represented by the spans
 type SparseHistogram struct {
-	Count, ZeroCount                 uint64
-	Sum, ZeroThreshold               float64
 	Schema                           int32
+	ZeroThreshold                    float64
+	ZeroCount, Count                 uint64
+	Sum                              float64
 	PositiveSpans, NegativeSpans     []Span
 	PositiveBuckets, NegativeBuckets []int64
 }

--- a/tsdb/encoding/encoding.go
+++ b/tsdb/encoding/encoding.go
@@ -179,9 +179,10 @@ func NewDecbufRaw(bs ByteSlice, length int) Decbuf {
 	return Decbuf{B: bs.Range(0, length)}
 }
 
-func (d *Decbuf) Uvarint() int     { return int(d.Uvarint64()) }
-func (d *Decbuf) Be32int() int     { return int(d.Be32()) }
-func (d *Decbuf) Be64int64() int64 { return int64(d.Be64()) }
+func (d *Decbuf) Uvarint() int      { return int(d.Uvarint64()) }
+func (d *Decbuf) Uvarint32() uint32 { return uint32(d.Uvarint64()) }
+func (d *Decbuf) Be32int() int      { return int(d.Be32()) }
+func (d *Decbuf) Be64int64() int64  { return int64(d.Be64()) }
 
 // Crc32 returns a CRC32 checksum over the remaining bytes.
 func (d *Decbuf) Crc32(castagnoliTable *crc32.Table) uint32 {


### PR DESCRIPTION
NOTE: This is pointing to the experimental sparsehistogram branch.

This PR adds support for logging histograms into WAL and replaying from it.

M-mapping is already supported. Snapshots not yet supported.

cc @beorn7 