### PR TITLE
tsdb: align atomically accessed int64

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -117,6 +117,10 @@ type Head struct {
 
 // HeadOptions are parameters for the Head block.
 type HeadOptions struct {
+	// Runtime reloadable option. At the top of the struct for 32 bit OS:
+	// https://pkg.go.dev/sync/atomic#pkg-note-BUG
+	MaxExemplars atomic.Int64
+
 	ChunkRange int64
 	// ChunkDirRoot is the parent directory of the chunks directory.
 	ChunkDirRoot         string
@@ -128,9 +132,6 @@ type HeadOptions struct {
 	StripeSize            int
 	SeriesCallback        SeriesLifecycleCallback
 	EnableExemplarStorage bool
-
-	// Runtime reloadable options.
-	MaxExemplars atomic.Int64
 }
 
 func DefaultHeadOptions() *HeadOptions {


### PR DESCRIPTION
This prevents a panic in 32-bit archs:
https://pkg.go.dev/sync/atomic#pkg-note-BUG

Fixed #9190

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
