### PR TITLE
Document gtar use case for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,14 @@ You can build a docker image locally with the following commands:
     $ make npm_licenses
     $ make common-docker-amd64
 
-*NB* if you are on a Mac, you will need [gnu-tar](https://formulae.brew.sh/formula/gnu-tar).
+*NB* if you are on a Mac, you will need [gnu-tar](https://formulae.brew.sh/formula/gnu-tar) and update to use `gtar` instead of `tar` in your Makefile's `npm_licenses` target like so:
+```
+.PHONY: npm_licenses
+npm_licenses: $(REACT_APP_NODE_MODULES_PATH)
+	@echo ">> bundling npm licenses"
+	rm -f $(REACT_APP_NPM_LICENSES_TARBALL)
+	find $(REACT_APP_NODE_MODULES_PATH) -iname "license*" | gtar cfj $(REACT_APP_NPM_LICENSES_TARBALL) --transform 's/^/npm_licenses\//' --files-from=-
+```
 
 ## React UI Development
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You can build a docker image locally with the following commands:
     $ make npm_licenses
     $ make common-docker-amd64
 
-*NB* if you are on a Mac, you will need [gnu-tar](https://formulae.brew.sh/formula/gnu-tar) and update to use `gtar` instead of `tar` in your Makefile's `npm_licenses` target like so:
+*NB* if you are on a Mac, you will first need to install [gnu-tar](https://formulae.brew.sh/formula/gnu-tar) and then update to use `gtar` instead of `tar` in your Makefile's `npm_licenses` target like so:
 ```
 .PHONY: npm_licenses
 npm_licenses: $(REACT_APP_NODE_MODULES_PATH)


### PR DESCRIPTION
In order to build a docker image locally, Mac users need to take another extra step to update to use `gtar` instead of `tar` in their Makefile's target after installing [gnu-tar](https://formulae.brew.sh/formula/gnu-tar). This PR documents that behavior in the project's README.