### PR TITLE
Fixed Decoder.Series() error checking

### DIFF
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1852,7 +1852,7 @@ func (dec *Decoder) Series(b []byte, lbls *labels.Labels, chks *[]chunks.Meta) e
 	k = d.Uvarint()
 
 	if k == 0 {
-		return nil
+		return d.Err()
 	}
 
 	t0 := d.Varint64()


### PR DESCRIPTION
While reading `Decoder.Series()` code we noticed that there's one case where error could happen but it's not checked/returned. This PR should fix it.