### PR TITLE
Kubernetes SD: Support networking.k8s.io/v1 Ingress

### DIFF
--- a/discovery/kubernetes/ingress_adaptor.go
+++ b/discovery/kubernetes/ingress_adaptor.go
@@ -1,0 +1,145 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/api/networking/v1beta1"
+)
+
+// ingressAdaptor is an adaptor for the different Ingress versions
+type ingressAdaptor interface {
+	name() string
+	namespace() string
+	labels() map[string]string
+	annotations() map[string]string
+	tlsHosts() []string
+	ingressClassName() *string
+	rules() []ingressRuleAdaptor
+}
+
+type ingressRuleAdaptor interface {
+	paths() []string
+	host() string
+}
+
+// Adaptor for networking.k8s.io/v1
+type ingressAdaptorV1 struct {
+	ingress *v1.Ingress
+}
+
+func newIngressAdaptorFromV1(ingress *v1.Ingress) ingressAdaptor {
+	return &ingressAdaptorV1{ingress: ingress}
+}
+
+func (i *ingressAdaptorV1) name() string                   { return i.ingress.Name }
+func (i *ingressAdaptorV1) namespace() string              { return i.ingress.Namespace }
+func (i *ingressAdaptorV1) labels() map[string]string      { return i.ingress.Labels }
+func (i *ingressAdaptorV1) annotations() map[string]string { return i.ingress.Annotations }
+func (i *ingressAdaptorV1) ingressClassName() *string      { return i.ingress.Spec.IngressClassName }
+
+func (i *ingressAdaptorV1) tlsHosts() []string {
+	var hosts []string
+	for _, tls := range i.ingress.Spec.TLS {
+		for _, host := range tls.Hosts {
+			hosts = append(hosts, host)
+		}
+	}
+	return hosts
+}
+
+func (i *ingressAdaptorV1) rules() []ingressRuleAdaptor {
+	var rules []ingressRuleAdaptor
+	for _, rule := range i.ingress.Spec.Rules {
+		rules = append(rules, newIngressRuleAdaptorFromV1(rule))
+	}
+	return rules
+}
+
+type ingressRuleAdaptorV1 struct {
+	rule v1.IngressRule
+}
+
+func newIngressRuleAdaptorFromV1(rule v1.IngressRule) ingressRuleAdaptor {
+	return &ingressRuleAdaptorV1{rule: rule}
+}
+
+func (i *ingressRuleAdaptorV1) paths() []string {
+	rv := i.rule.IngressRuleValue
+	if rv.HTTP == nil {
+		return nil
+	}
+	paths := make([]string, len(rv.HTTP.Paths))
+	for n, p := range rv.HTTP.Paths {
+		paths[n] = p.Path
+	}
+	return paths
+}
+
+func (i *ingressRuleAdaptorV1) host() string { return i.rule.Host }
+
+// Adaptor for networking.k8s.io/v1beta1
+type ingressAdaptorV1Beta1 struct {
+	ingress *v1beta1.Ingress
+}
+
+func newIngressAdaptorFromV1beta1(ingress *v1beta1.Ingress) ingressAdaptor {
+	return &ingressAdaptorV1Beta1{ingress: ingress}
+}
+
+func (i *ingressAdaptorV1Beta1) name() string                   { return i.ingress.Name }
+func (i *ingressAdaptorV1Beta1) namespace() string              { return i.ingress.Namespace }
+func (i *ingressAdaptorV1Beta1) labels() map[string]string      { return i.ingress.Labels }
+func (i *ingressAdaptorV1Beta1) annotations() map[string]string { return i.ingress.Annotations }
+func (i *ingressAdaptorV1Beta1) ingressClassName() *string      { return i.ingress.Spec.IngressClassName }
+
+func (i *ingressAdaptorV1Beta1) tlsHosts() []string {
+	var hosts []string
+	for _, tls := range i.ingress.Spec.TLS {
+		for _, host := range tls.Hosts {
+			hosts = append(hosts, host)
+		}
+	}
+	return hosts
+}
+
+func (i *ingressAdaptorV1Beta1) rules() []ingressRuleAdaptor {
+	var rules []ingressRuleAdaptor
+	for _, rule := range i.ingress.Spec.Rules {
+		rules = append(rules, newIngressRuleAdaptorFromV1Beta1(rule))
+	}
+	return rules
+}
+
+type ingressRuleAdaptorV1Beta1 struct {
+	rule v1beta1.IngressRule
+}
+
+func newIngressRuleAdaptorFromV1Beta1(rule v1beta1.IngressRule) ingressRuleAdaptor {
+	return &ingressRuleAdaptorV1Beta1{rule: rule}
+}
+
+func (i *ingressRuleAdaptorV1Beta1) paths() []string {
+	rv := i.rule.IngressRuleValue
+	if rv.HTTP == nil {
+		return nil
+	}
+	paths := make([]string, len(rv.HTTP.Paths))
+	for n, p := range rv.HTTP.Paths {
+		paths[n] = p.Path
+	}
+	return paths
+}
+
+func (i *ingressRuleAdaptorV1Beta1) host() string { return i.rule.Host }

--- a/discovery/kubernetes/ingress_adaptor.go
+++ b/discovery/kubernetes/ingress_adaptor.go
@@ -52,9 +52,7 @@ func (i *ingressAdaptorV1) ingressClassName() *string      { return i.ingress.Sp
 func (i *ingressAdaptorV1) tlsHosts() []string {
 	var hosts []string
 	for _, tls := range i.ingress.Spec.TLS {
-		for _, host := range tls.Hosts {
-			hosts = append(hosts, host)
-		}
+		hosts = append(hosts, tls.Hosts...)
 	}
 	return hosts
 }
@@ -107,9 +105,7 @@ func (i *ingressAdaptorV1Beta1) ingressClassName() *string      { return i.ingre
 func (i *ingressAdaptorV1Beta1) tlsHosts() []string {
 	var hosts []string
 	for _, tls := range i.ingress.Spec.TLS {
-		for _, host := range tls.Hosts {
-			hosts = append(hosts, host)
-		}
+		hosts = append(hosts, tls.Hosts...)
 	}
 	return hosts
 }

--- a/discovery/kubernetes/ingress_test.go
+++ b/discovery/kubernetes/ingress_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
+	v1 "k8s.io/api/networking/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -33,7 +34,59 @@ const (
 	TLSMixed
 )
 
-func makeIngress(tls TLSMode) *v1beta1.Ingress {
+func makeIngress(tls TLSMode) *v1.Ingress {
+	ret := &v1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "testingress",
+			Namespace:   "default",
+			Labels:      map[string]string{"test/label": "testvalue"},
+			Annotations: map[string]string{"test/annotation": "testannotationvalue"},
+		},
+		Spec: v1.IngressSpec{
+			IngressClassName: classString("testclass"),
+			TLS:              nil,
+			Rules: []v1.IngressRule{
+				{
+					Host: "example.com",
+					IngressRuleValue: v1.IngressRuleValue{
+						HTTP: &v1.HTTPIngressRuleValue{
+							Paths: []v1.HTTPIngressPath{
+								{Path: "/"},
+								{Path: "/foo"},
+							},
+						},
+					},
+				},
+				{
+					// No backend config, ignored
+					Host: "nobackend.example.com",
+					IngressRuleValue: v1.IngressRuleValue{
+						HTTP: &v1.HTTPIngressRuleValue{},
+					},
+				},
+				{
+					Host: "test.example.com",
+					IngressRuleValue: v1.IngressRuleValue{
+						HTTP: &v1.HTTPIngressRuleValue{
+							Paths: []v1.HTTPIngressPath{{}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	switch tls {
+	case TLSYes:
+		ret.Spec.TLS = []v1.IngressTLS{{Hosts: []string{"example.com", "test.example.com"}}}
+	case TLSMixed:
+		ret.Spec.TLS = []v1.IngressTLS{{Hosts: []string{"example.com"}}}
+	}
+
+	return ret
+}
+
+func makeIngressV1beta1(tls TLSMode) *v1beta1.Ingress {
 	ret := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "testingress",
@@ -145,6 +198,20 @@ func TestIngressDiscoveryAdd(t *testing.T) {
 		discovery: n,
 		afterStart: func() {
 			obj := makeIngress(TLSNo)
+			c.NetworkingV1().Ingresses("default").Create(context.Background(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes:      expectedTargetGroups("default", TLSNo),
+	}.Run(t)
+}
+
+func TestIngressDiscoveryAddV1beta1(t *testing.T) {
+	n, c := makeDiscoveryWithVersion(RoleIngress, NamespaceDiscovery{Names: []string{"default"}}, "v1.18.0")
+
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := makeIngressV1beta1(TLSNo)
 			c.NetworkingV1beta1().Ingresses("default").Create(context.Background(), obj, metav1.CreateOptions{})
 		},
 		expectedMaxItems: 1,
@@ -159,6 +226,20 @@ func TestIngressDiscoveryAddTLS(t *testing.T) {
 		discovery: n,
 		afterStart: func() {
 			obj := makeIngress(TLSYes)
+			c.NetworkingV1().Ingresses("default").Create(context.Background(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes:      expectedTargetGroups("default", TLSYes),
+	}.Run(t)
+}
+
+func TestIngressDiscoveryAddTLSV1beta1(t *testing.T) {
+	n, c := makeDiscoveryWithVersion(RoleIngress, NamespaceDiscovery{Names: []string{"default"}}, "v1.18.0")
+
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := makeIngressV1beta1(TLSYes)
 			c.NetworkingV1beta1().Ingresses("default").Create(context.Background(), obj, metav1.CreateOptions{})
 		},
 		expectedMaxItems: 1,
@@ -173,6 +254,20 @@ func TestIngressDiscoveryAddMixed(t *testing.T) {
 		discovery: n,
 		afterStart: func() {
 			obj := makeIngress(TLSMixed)
+			c.NetworkingV1().Ingresses("default").Create(context.Background(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes:      expectedTargetGroups("default", TLSMixed),
+	}.Run(t)
+}
+
+func TestIngressDiscoveryAddMixedV1beta1(t *testing.T) {
+	n, c := makeDiscoveryWithVersion(RoleIngress, NamespaceDiscovery{Names: []string{"default"}}, "v1.18.0")
+
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := makeIngressV1beta1(TLSMixed)
 			c.NetworkingV1beta1().Ingresses("default").Create(context.Background(), obj, metav1.CreateOptions{})
 		},
 		expectedMaxItems: 1,
@@ -192,6 +287,27 @@ func TestIngressDiscoveryNamespaces(t *testing.T) {
 		afterStart: func() {
 			for _, ns := range []string{"ns1", "ns2"} {
 				obj := makeIngress(TLSNo)
+				obj.Namespace = ns
+				c.NetworkingV1().Ingresses(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
+			}
+		},
+		expectedMaxItems: 2,
+		expectedRes:      expected,
+	}.Run(t)
+}
+
+func TestIngressDiscoveryNamespacesV1beta1(t *testing.T) {
+	n, c := makeDiscoveryWithVersion(RoleIngress, NamespaceDiscovery{Names: []string{"ns1", "ns2"}}, "v1.18.0")
+
+	expected := expectedTargetGroups("ns1", TLSNo)
+	for k, v := range expectedTargetGroups("ns2", TLSNo) {
+		expected[k] = v
+	}
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			for _, ns := range []string{"ns1", "ns2"} {
+				obj := makeIngressV1beta1(TLSNo)
 				obj.Namespace = ns
 				c.NetworkingV1beta1().Ingresses(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
 			}

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -30,11 +30,13 @@ import (
 	"github.com/prometheus/common/version"
 	apiv1 "k8s.io/api/core/v1"
 	disv1beta1 "k8s.io/api/discovery/v1beta1"
+	networkv1 "k8s.io/api/networking/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -491,23 +493,58 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 			go svc.informer.Run(ctx.Done())
 		}
 	case RoleIngress:
+		// Check "networking.k8s.io/v1" availability with retries.
+		// If "v1" is not avaiable, use "networking.k8s.io/v1beta1" for backward compatibility
+		var v1Supported bool
+		if retryOnError(ctx, 10*time.Second,
+			func() (err error) {
+				v1Supported, err = checkNetworkingV1Supported(d.client)
+				if err != nil {
+					level.Error(d.logger).Log("msg", "Failed to check networking.k8s.io/v1 availability", "err", err)
+				}
+				return err
+			},
+		) {
+			d.Unlock()
+			return
+		}
+
 		for _, namespace := range namespaces {
-			i := d.client.NetworkingV1beta1().Ingresses(namespace)
-			ilw := &cache.ListWatch{
-				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					options.FieldSelector = d.selectors.ingress.field
-					options.LabelSelector = d.selectors.ingress.label
-					return i.List(ctx, options)
-				},
-				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					options.FieldSelector = d.selectors.ingress.field
-					options.LabelSelector = d.selectors.ingress.label
-					return i.Watch(ctx, options)
-				},
+			var informer cache.SharedInformer
+			if v1Supported {
+				i := d.client.NetworkingV1().Ingresses(namespace)
+				ilw := &cache.ListWatch{
+					ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+						options.FieldSelector = d.selectors.ingress.field
+						options.LabelSelector = d.selectors.ingress.label
+						return i.List(ctx, options)
+					},
+					WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+						options.FieldSelector = d.selectors.ingress.field
+						options.LabelSelector = d.selectors.ingress.label
+						return i.Watch(ctx, options)
+					},
+				}
+				informer = cache.NewSharedInformer(ilw, &networkv1.Ingress{}, resyncPeriod)
+			} else {
+				i := d.client.NetworkingV1beta1().Ingresses(namespace)
+				ilw := &cache.ListWatch{
+					ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+						options.FieldSelector = d.selectors.ingress.field
+						options.LabelSelector = d.selectors.ingress.label
+						return i.List(ctx, options)
+					},
+					WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+						options.FieldSelector = d.selectors.ingress.field
+						options.LabelSelector = d.selectors.ingress.label
+						return i.Watch(ctx, options)
+					},
+				}
+				informer = cache.NewSharedInformer(ilw, &v1beta1.Ingress{}, resyncPeriod)
 			}
 			ingress := NewIngress(
 				log.With(d.logger, "role", "ingress"),
-				cache.NewSharedInformer(ilw, &v1beta1.Ingress{}, resyncPeriod),
+				informer,
 			)
 			d.discoverers = append(d.discoverers, ingress)
 			go ingress.informer.Run(ctx.Done())
@@ -562,4 +599,34 @@ func send(ctx context.Context, ch chan<- []*targetgroup.Group, tg *targetgroup.G
 	case <-ctx.Done():
 	case ch <- []*targetgroup.Group{tg}:
 	}
+}
+
+func retryOnError(ctx context.Context, interval time.Duration, f func() error) (canceled bool) {
+	var err error
+	err = f()
+	for {
+		if err == nil {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return true
+		case <-time.After(interval):
+			err = f()
+		}
+	}
+}
+
+func checkNetworkingV1Supported(client kubernetes.Interface) (bool, error) {
+	k8sVer, err := client.Discovery().ServerVersion()
+	if err != nil {
+		return false, err
+	}
+	semVer, err := utilversion.ParseSemantic(k8sVer.String())
+	if err != nil {
+		return false, err
+	}
+	// networking.k8s.io/v1 is available since Kubernetes v1.19
+	// https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md
+	return semVer.Major() >= 1 && semVer.Minor() >= 19, nil
 }


### PR DESCRIPTION
Signed-off-by: Takashi Kusumi <tkusumi@zlab.co.jp>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Fixes: #9199

This PR is to support the `networking.k8s.io/v1` Ingress for Kubernetes v1.22 and later. The `networking.k8s.io/v1beta1` Ingress that Kubernetes SD currently uses was [removed in Kubernetes v1.22](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#removal-of-several-beta-kubernetes-apis).

Since the `networking.k8s.io/v1` Ingress is not available below Kubernetes v1.19, I made it support both `networking.k8s.io/v1` and `networking.k8s.io/v1beta1` for backward compatibility. Which Ingress API Kubernetes SD will use is decided based on the Kubernetes version. If the Kubernetes version >= 1.19, it will use `networking.k8s.io/v1`, otherwise it will use `networking.k8s.io/v1beta1`.

## Notes for reviewers
- `networking.k8s.io/v1` Ingress is [introduced in Kubernetes v1.19](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#ingress-graduates-to-general-availability)
    - `v1` Ingress is GA since v1.19, so I made it check the Kubernetes version for the API availability rather than calling [ServerSupportsVersion()](https://pkg.go.dev/k8s.io/client-go@v0.22.0/discovery#ServerSupportsVersion), which makes many API requests.
- I moved the functions for `v1beta1` to `V1beta1` suffixed functions. We can remove the suffixed functions after we stop support for Kubernetes below v1.19.
    - Conversion between `v1` and `v1beta1` needs the Kubernetes internal package, so I gave up on the conversion.

I confirmed that Ingress discovery with this PR worked in the following Kubernetes versions on minikube.

k8s version | Ingress support | Ingress used
--- | --- | ---
v1.18.20 | `v1beta1` | `v1beta1`
v1.19.14 | `v1beta1`, `v1` | `v1`
v1.22.0 | `v1` | `v1`

Here is my confirmation procedure.

## Confirmation procedure on minikube

### Start minikube
Start minikube with the specific Kubernetes version.

```
minikube start --kubernetes-version v1.22.0
```

### Build the Prometheus image on minikube

```
eval $(minikube -p minikube docker-env)
make common-docker-amd64
```

### Deploy the custom Prometheus with Ingress setting
Here is the manifest for custom Prometheus with [Ingress setting](https://gist.github.com/tksm/2de340ba5b057ce8f099f8541c8cb400#file-prometheus-deploy-yaml-L95-L115). The image name for Prometheus might need to be changed.

https://gist.github.com/tksm/2de340ba5b057ce8f099f8541c8cb400#file-prometheus-deploy-yaml

```
kubectl apply -f https://gist.githubusercontent.com/tksm/2de340ba5b057ce8f099f8541c8cb400/raw/0ca2d976d3a49ff6cdf6af3a044448904755eb48/prometheus-deploy.yaml
```

### Create an Ingress resource for test
For Kubernetes v1.19 and later. create an Ingress resource with v1.

https://gist.github.com/tksm/2de340ba5b057ce8f099f8541c8cb400#file-ingress-v1-yaml

```
kubectl apply -f https://gist.githubusercontent.com/tksm/2de340ba5b057ce8f099f8541c8cb400/raw/0ca2d976d3a49ff6cdf6af3a044448904755eb48/ingress-v1.yaml
```

For below Kubernetes v1.19, create an Ingress resource with v1beta1.

https://gist.github.com/tksm/2de340ba5b057ce8f099f8541c8cb400#file-ingress-v1beta1-yaml

```
kubectl apply -f https://gist.githubusercontent.com/tksm/2de340ba5b057ce8f099f8541c8cb400/raw/0ca2d976d3a49ff6cdf6af3a044448904755eb48/ingress-v1beta1.yaml
```

### Check an Ingress target is added

Open the Prometheus Web UI.

```
minikube service prometheus
```

Check an ingress target is added and its labels are correctly set in Prometheus UI (`/targets`).

![image](https://user-images.githubusercontent.com/9250296/129474054-49fee519-0569-47ed-a892-b61f6d0f5d0e.png)

