### PR TITLE
Hold lock less when creating series

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1201,13 +1201,14 @@ func (h *Head) getOrCreateWithID(id, hash uint64, lset labels.Labels) (*memSerie
 	h.metrics.seriesCreated.Inc()
 	h.numSeries.Inc()
 
+	// Symbol entry must be created before postings entry.
 	h.symMtx.Lock()
-	defer h.symMtx.Unlock()
-
 	for _, l := range lset {
 		h.symbols[l.Name] = struct{}{}
 		h.symbols[l.Value] = struct{}{}
 	}
+	// Postings has its own lock so we unlock symbols here.
+	h.symMtx.Unlock()
 
 	h.postings.Add(id, lset)
 	return s, true, nil


### PR DESCRIPTION
`symMtx` protects only the `symbols` map: `MemPostings` has another lock protecting its structures. 
By releasing the symbols lock earlier we allow more work to proceed.

Inspired by https://github.com/cortexproject/cortex/issues/3349