### PR TITLE
Speed up BenchmarkPostings_Stats

### DIFF
--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -818,10 +818,13 @@ func TestWithoutPostings(t *testing.T) {
 func BenchmarkPostings_Stats(b *testing.B) {
 	p := NewMemPostings()
 
+	var seriesID uint64
+
 	createPostingsLabelValues := func(name, valuePrefix string, count int) {
 		for n := 1; n < count; n++ {
 			value := fmt.Sprintf("%s-%d", valuePrefix, n)
-			p.Add(uint64(n), labels.FromStrings(name, value))
+			p.Add(seriesID, labels.FromStrings(name, value))
+			seriesID++
 		}
 
 	}


### PR DESCRIPTION
The previous code re-used series IDs 1-1000 many times over, so a lot of time was spent ensuring the lists of series were in ascending order.
The intended use of `MemPostings.Add()` is that all series IDs are unique, and changing the benchmark to do this lets it finish ten times faster.

(It doesn't affect the benchmark result, just the setup code)

Before:
```
$ go test -run xxx -bench Postings_Stats ./tsdb/index/ 
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb/index
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
BenchmarkPostings_Stats-4             56          22650463 ns/op
PASS
ok      github.com/prometheus/prometheus/tsdb/index     26.927s
```

After:
```
$ go test -run xxx -bench Postings_Stats ./tsdb/index/ 
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb/index
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
BenchmarkPostings_Stats-4             51          22821872 ns/op
PASS
ok      github.com/prometheus/prometheus/tsdb/index     1.560s
```