### PR TITLE
Check relabel action at yaml unmarshal stage

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1302,6 +1302,10 @@ var expectedErrors = []struct {
 		filename: "http_url_bad_scheme.bad.yml",
 		errMsg:   "URL scheme must be 'http' or 'https'",
 	},
+	{
+		filename: "empty_scrape_config_action.bad.yml",
+		errMsg:   "relabel action cannot be empty",
+	},
 }
 
 func TestBadConfigs(t *testing.T) {

--- a/config/testdata/empty_scrape_config_action.bad.yml
+++ b/config/testdata/empty_scrape_config_action.bad.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - job_name: prometheus
+    relabel_configs:
+      - action: null

--- a/pkg/relabel/relabel.go
+++ b/pkg/relabel/relabel.go
@@ -130,7 +130,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // Reset Default RelabelConfig
-func (c *Config) ResetDefaultRelabelConfigIfNecessary() error{
+func (c *Config) ResetDefaultRelabelConfigIfNecessary() error {
 	if c.Action == "" {
 		c.Action = DefaultRelabelConfig.Action
 	}

--- a/pkg/relabel/relabel.go
+++ b/pkg/relabel/relabel.go
@@ -139,14 +139,6 @@ func (c *Config) ResetDefaultRelabelConfigIfNecessary() error {
 		c.Regex = MustNewRegexp("")
 	}
 
-	if c.Replacement == "" {
-		c.Replacement = DefaultRelabelConfig.Replacement
-	}
-
-	if c.Separator == "" {
-		c.Separator = DefaultRelabelConfig.Separator
-	}
-
 	return nil
 }
 

--- a/pkg/relabel/relabel.go
+++ b/pkg/relabel/relabel.go
@@ -97,8 +97,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if err := c.ResetDefaultRelabelConfigIfNecessary(); err != nil {
-		return err
+	if c.Regex.Regexp == nil {
+		c.Regex = MustNewRegexp("")
+	}
+	if c.Action == "" {
+		return errors.Errorf("relabel action cannot be empty")
 	}
 	if c.Modulus == 0 && c.Action == HashMod {
 		return errors.Errorf("relabel configuration for hashmod requires non-zero modulus")
@@ -124,19 +127,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			c.Replacement != DefaultRelabelConfig.Replacement {
 			return errors.Errorf("%s action requires only 'regex', and no other fields", c.Action)
 		}
-	}
-
-	return nil
-}
-
-// Reset Default RelabelConfig
-func (c *Config) ResetDefaultRelabelConfigIfNecessary() error {
-	if c.Action == "" {
-		c.Action = DefaultRelabelConfig.Action
-	}
-
-	if c.Regex.Regexp == nil {
-		c.Regex = MustNewRegexp("")
 	}
 
 	return nil

--- a/pkg/relabel/relabel.go
+++ b/pkg/relabel/relabel.go
@@ -136,7 +136,7 @@ func (c *Config) ResetDefaultRelabelConfigIfNecessary() error {
 	}
 
 	if c.Regex.Regexp == nil {
-		c.Regex = DefaultRelabelConfig.Regex
+		c.Regex = MustNewRegexp("")
 	}
 
 	if c.Replacement == "" {

--- a/pkg/relabel/relabel.go
+++ b/pkg/relabel/relabel.go
@@ -97,8 +97,8 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if c.Regex.Regexp == nil {
-		c.Regex = MustNewRegexp("")
+	if err := c.ResetDefaultRelabelConfigIfNecessary(); err != nil {
+		return err
 	}
 	if c.Modulus == 0 && c.Action == HashMod {
 		return errors.Errorf("relabel configuration for hashmod requires non-zero modulus")
@@ -124,6 +124,27 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			c.Replacement != DefaultRelabelConfig.Replacement {
 			return errors.Errorf("%s action requires only 'regex', and no other fields", c.Action)
 		}
+	}
+
+	return nil
+}
+
+// Reset Default RelabelConfig
+func (c *Config) ResetDefaultRelabelConfigIfNecessary() error{
+	if c.Action == "" {
+		c.Action = DefaultRelabelConfig.Action
+	}
+
+	if c.Regex.Regexp == nil {
+		c.Regex = DefaultRelabelConfig.Regex
+	}
+
+	if c.Replacement == "" {
+		c.Replacement = DefaultRelabelConfig.Replacement
+	}
+
+	if c.Separator == "" {
+		c.Separator = DefaultRelabelConfig.Separator
 	}
 
 	return nil


### PR DESCRIPTION
When action set null value, something  like this:
- job_name: actuator
  metrics_path: /actuator/prometheus
  scrape_interval: null
  relabel_configs:
  - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
    separator: ;
    regex: null
    replacement: null
    target_label: __param_target
    action: null

Case panic as blow:
panic: relabel: unknown relabel action type ""

goroutine 348 [running]:
github.com/prometheus/prometheus/pkg/relabel.relabel(0xc000868280, 0x4, 0x4, 0xc0004ee600, 0xc0002fc0a0, 0xc000805300, 0x3233011)
	/root/go/src/github.com/DrAuYueng/prometheus/pkg/relabel/relabel.go:272 +0xde6
github.com/prometheus/prometheus/pkg/relabel.Process(0xc000868280, 0x4, 0x4, 0xc000286378, 0x1, 0x1, 0x0, 0x0, 0x0)
	/root/go/src/github.com/DrAuYueng/prometheus/pkg/relabel/relabel.go:206 +0x72
github.com/prometheus/prometheus/scrape.populateLabels(0xc000c874c0, 0x1, 0x1, 0xc00080e840, 0x1, 0x1, 0xc, 0x60, 0xc0004d95c0, 0x60, ...)
	/root/go/src/github.com/DrAuYueng/prometheus/scrape/target.go:350 +0x41b
github.com/prometheus/prometheus/scrape.targetsFromGroup(0xc000ffd1d0, 0xc00080e840, 0x5025a60, 0x2a497a0, 0xc000c8c370, 0xc0002fe9a8, 0xc0002fea28, 0x2c53ec0)
	/root/go/src/github.com/DrAuYueng/prometheus/scrape/target.go:435 +0x487
github.com/prometheus/prometheus/scrape.(*scrapePool).Sync(0xc000868180, 0xc00013e320, 0x1, 0x1)
	/root/go/src/github.com/DrAuYueng/prometheus/scrape/scrape.go:465 +0x5e5
github.com/prometheus/prometheus/scrape.(*Manager).reload.func1(0xc00067d890, 0xc000868180, 0xc00013e320, 0x1, 0x1)
	/root/go/src/github.com/DrAuYueng/prometheus/scrape/manager.go:195 +0x49
created by github.com/prometheus/prometheus/scrape.(*Manager).reload
	/root/go/src/github.com/DrAuYueng/prometheus/scrape/manager.go:194 +0x210

In this case, the code in func UnmarshalYAML of receiver Action can not be reached which work well when action set to "foo" or something else.
This meaning check will be ignore(same as promtool check config) and the panic occurs in relabel func.
It's useful to reset default relabel config when action (etc.) overwrite with null, for example, set scrape_interval: null, still set correctly with default value 15s.
