### PR TITLE
Remove unneeded rule state modifications

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -604,6 +604,8 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 				}
 				return
 			}
+			rule.SetHealth(HealthGood)
+			rule.SetLastError(nil)
 			samplesTotal += float64(len(vector))
 
 			if ar, ok := rule.(*AlertingRule); ok {

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -96,14 +96,9 @@ func (rule *RecordingRule) Eval(ctx context.Context, ts time.Time, query QueryFu
 	// Check that the rule does not produce identical metrics after applying
 	// labels.
 	if vector.ContainsSameLabelset() {
-		err = fmt.Errorf("vector contains metrics with the same labelset after applying rule labels")
-		rule.SetHealth(HealthBad)
-		rule.SetLastError(err)
-		return nil, err
+		return nil, fmt.Errorf("vector contains metrics with the same labelset after applying rule labels")
 	}
 
-	rule.SetHealth(HealthGood)
-	rule.SetLastError(err)
 	return vector, nil
 }
 


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

The health and last error are set in the parent when an evaluation returns an error, so they don't need to be in the evaluation function. In addition, we can set the health and last error when the evaluation returns no error, so those don't need to be in the evaluation function either.