### PR TITLE
Switch golangci-lint to GitHub Actions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,22 @@
+name: golangci-lint
+on:
+  push:
+  pull_request:
+    paths:
+      - "go.sum"
+      - "go.mod"
+      - "**.go"
+      - "scripts/errcheck_excludes.txt"
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.39.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,12 +1,19 @@
 name: golangci-lint
 on:
   push:
+    paths:
+      - "go.sum"
+      - "go.mod"
+      - "**.go"
+      - "scripts/errcheck_excludes.txt"
+      - ".github/workflows/golangci-lint.yml"
   pull_request:
     paths:
       - "go.sum"
       - "go.mod"
       - "**.go"
       - "scripts/errcheck_excludes.txt"
+      - ".github/workflows/golangci-lint.yml"
 
 jobs:
   golangci:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,3 +25,5 @@ jobs:
 
       - name: Lint
         uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.42.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,5 +25,3 @@ jobs:
 
       - name: Lint
         uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.39.0

--- a/.yamllint
+++ b/.yamllint
@@ -24,3 +24,4 @@ rules:
       .github/workflows/funcbench.yml
       .github/workflows/fuzzing.yml
       .github/workflows/prombench.yml
+      .github/workflows/golangci-lint.yml

--- a/Makefile.common
+++ b/Makefile.common
@@ -84,14 +84,18 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
 GOLANGCI_LINT_VERSION ?= v1.39.0
-ifeq ($(CIRCLE_JOB),)
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))
 	ifeq ($(GOHOSTARCH),$(filter $(GOHOSTARCH),amd64 i386))
-		GOLANGCI_LINT := $(FIRST_GOPATH)/bin/golangci-lint
+		# If we're in CI and there is an Actions file, that means the linter
+		# is being run in Actions, so we don't need to run it here.
+		ifeq (,$(CIRCLE_JOB))
+			GOLANGCI_LINT := $(FIRST_GOPATH)/bin/golangci-lint
+		else ifeq (,$(wildcard .github/workflows/golangci-lint.yml))
+			GOLANGCI_LINT := $(FIRST_GOPATH)/bin/golangci-lint
+		endif
 	endif
-endif
 endif
 
 PREFIX                  ?= $(shell pwd)

--- a/Makefile.common
+++ b/Makefile.common
@@ -83,7 +83,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.39.0
+GOLANGCI_LINT_VERSION ?= v1.42.0
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))

--- a/Makefile.common
+++ b/Makefile.common
@@ -84,12 +84,14 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
 GOLANGCI_LINT_VERSION ?= v1.39.0
+ifeq ($(CIRCLE_JOB),)
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))
 	ifeq ($(GOHOSTARCH),$(filter $(GOHOSTARCH),amd64 i386))
 		GOLANGCI_LINT := $(FIRST_GOPATH)/bin/golangci-lint
 	endif
+endif
 endif
 
 PREFIX                  ?= $(shell pwd)

--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -37,7 +37,7 @@ if [ -z "${GITHUB_TOKEN}" ]; then
 fi
 
 # List of files that should be synced.
-SYNC_FILES="CODE_OF_CONDUCT.md LICENSE Makefile.common SECURITY.md .yamllint"
+SYNC_FILES="CODE_OF_CONDUCT.md LICENSE Makefile.common SECURITY.md .yamllint .github/workflows/golangci-lint.yml"
 
 # Go to the root of the repo
 cd "$(git rev-parse --show-cdup)" || exit 1
@@ -96,6 +96,15 @@ check_license() {
   echo "$1" | grep --quiet --no-messages --ignore-case 'Apache License'
 }
 
+check_go() {
+  local org_repo
+  local default_branch
+  org_repo="$1"
+  default_branch="$2"
+
+  curl -sLf -o /dev/null "https://raw.githubusercontent.com/${org_repo}/${default_branch}/go.mod"
+}
+
 check_circleci_orb() {
   local org_repo
   local default_branch
@@ -136,10 +145,14 @@ process_repo() {
       echo "LICENSE in ${org_repo} is not apache, skipping."
       continue
     fi
+    if [[ "${source_file}" == '.github/workflows/golangci-lint.yml' ]] && ! check_go "${org_repo}" "${default_branch}" ; then
+      echo "${org_repo} is not Go, skipping .github/workflows/golangci-lint.yml."
+      continue
+    fi
     if [[ -z "${target_file}" ]]; then
       echo "${source_file} doesn't exist in ${org_repo}"
       case "${source_file}" in
-        CODE_OF_CONDUCT.md | SECURITY.md)
+        CODE_OF_CONDUCT.md | SECURITY.md | .github/workflows/golangci-lint.yml)
           echo "${source_file} missing in ${org_repo}, force updating."
           needs_update+=("${source_file}")
           ;;


### PR DESCRIPTION
The [official golangci-lint GitHub Action](https://github.com/marketplace/actions/run-golangci-lint) speeds up the linter through caching and adds helpful annotations of errors (example: https://github.com/LeviHarrison/prometheus/commit/1bb34da5a76977710f30b85398ac21708ed7b6f2).

The workflow file is force synced to Go repositories because `Makefile.common` now won't run golangci-lint in CircleCI. Because there isn't any centralized CircleCI config where a variable to skip linting could be specified, this is the cleanest way I could do it. I guess if we wanted to make it optional we could check if the workflow file is present when running the make target, similarly to how we check if `yamllint` is installed (just with the logic reversed).

Ref #8453, #8984

cc @roidelapluie 