### PR TITLE
Use global string map for MatchType.String()

### DIFF
--- a/pkg/labels/matcher.go
+++ b/pkg/labels/matcher.go
@@ -28,7 +28,7 @@ const (
 	MatchNotRegexp
 )
 
-var matchTypeToStr = map[MatchType]string{
+var matchTypeToStr = [...]string{
 	MatchEqual:     "=",
 	MatchNotEqual:  "!=",
 	MatchRegexp:    "=~",
@@ -36,10 +36,10 @@ var matchTypeToStr = map[MatchType]string{
 }
 
 func (m MatchType) String() string {
-	if str, ok := matchTypeToStr[m]; ok {
-		return str
+	if m < 0 || int(m) > len(matchTypeToStr) {
+		panic("unknown match type")
 	}
-	panic("unknown match type")
+	return matchTypeToStr[m]
 }
 
 // Matcher models the matching of a label.

--- a/pkg/labels/matcher.go
+++ b/pkg/labels/matcher.go
@@ -28,14 +28,15 @@ const (
 	MatchNotRegexp
 )
 
+var matchTypeToStr = map[MatchType]string{
+	MatchEqual:     "=",
+	MatchNotEqual:  "!=",
+	MatchRegexp:    "=~",
+	MatchNotRegexp: "!~",
+}
+
 func (m MatchType) String() string {
-	typeToStr := map[MatchType]string{
-		MatchEqual:     "=",
-		MatchNotEqual:  "!=",
-		MatchRegexp:    "=~",
-		MatchNotRegexp: "!~",
-	}
-	if str, ok := typeToStr[m]; ok {
+	if str, ok := matchTypeToStr[m]; ok {
 		return str
 	}
 	panic("unknown match type")

--- a/pkg/labels/matcher.go
+++ b/pkg/labels/matcher.go
@@ -36,7 +36,7 @@ var matchTypeToStr = [...]string{
 }
 
 func (m MatchType) String() string {
-	if m < 0 || int(m) > len(matchTypeToStr) {
+	if m < MatchEqual || m > MatchNotRegexp {
 		panic("unknown match type")
 	}
 	return matchTypeToStr[m]

--- a/pkg/labels/matcher_test.go
+++ b/pkg/labels/matcher_test.go
@@ -120,6 +120,6 @@ func TestInverse(t *testing.T) {
 
 func BenchmarkMatchType_String(b *testing.B) {
 	for i := 0; i <= b.N; i++ {
-		_ = MatchType(i % int(MatchNotRegexp)).String()
+		_ = MatchType(i % int(MatchNotRegexp+1)).String()
 	}
 }

--- a/pkg/labels/matcher_test.go
+++ b/pkg/labels/matcher_test.go
@@ -117,3 +117,9 @@ func TestInverse(t *testing.T) {
 		require.Equal(t, test.expected.Type, result.Type)
 	}
 }
+
+func BenchmarkMatchType_String(b *testing.B) {
+	for i := 0; i <= b.N; i++ {
+		_ = MatchType(i % int(MatchNotRegexp)).String()
+	}
+}


### PR DESCRIPTION
We were unnecessarily creating a new map for each call of `String()`.

This is a 10x improvement in `MatchType.String()` performance in time, from 53ns to 4ns on my i7 laptop, and I guess that this method is being called quite often so why throw out the resources.

I was surprised that benchmark says that there are no allocations made in the old version.

I also tried using `//go:generate stringer` and the result is even better, at about 2.8ns, but having to keep the generated code updated isn't worth the change (at least it's bigger than a small change I was intended to do)

Benchmark comparison:

    name \ time/op    old          global_map  stringer
    MatchType_String  53.6ns ± 1%  4.1ns ± 1%  2.8ns ± 1%

    name \ alloc/op   old          global_map  stringer
    MatchType_String   0.00B       0.00B       0.00B

    name \ allocs/op  old          global_map  stringer
    MatchType_String    0.00        0.00        0.00

Old benchmark:

    goos: darwin
    goarch: amd64
    pkg: github.com/prometheus/prometheus/pkg/labels
    cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
    BenchmarkMatchType_String 	21766578	        54.36 ns/op	       0 B/op	       0 allocs/op
    BenchmarkMatchType_String 	21742339	        53.28 ns/op	       0 B/op	       0 allocs/op
    BenchmarkMatchType_String 	21985470	        53.37 ns/op	       0 B/op	       0 allocs/op
    BenchmarkMatchType_String 	21676282	        53.50 ns/op	       0 B/op	       0 allocs/op
    BenchmarkMatchType_String 	22075573	        53.33 ns/op	       0 B/op	       0 allocs/op
    PASS
    ok  	github.com/prometheus/prometheus/pkg/labels	6.252s

New with global map:

    goos: darwin
    goarch: amd64
    pkg: github.com/prometheus/prometheus/pkg/labels
    cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
    BenchmarkMatchType_String 	283412692	         4.129 ns/op	       0 B/op	       0 allocs/op
    BenchmarkMatchType_String 	294859941	         4.091 ns/op	       0 B/op	       0 allocs/op
    BenchmarkMatchType_String 	295750158	         4.113 ns/op	       0 B/op	       0 allocs/op
    BenchmarkMatchType_String 	282827982	         4.072 ns/op	       0 B/op	       0 allocs/op
    BenchmarkMatchType_String 	292942393	         4.047 ns/op	       0 B/op	       0 allocs/op
    PASS
    ok  	github.com/prometheus/prometheus/pkg/labels	8.238s

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>