### PR TITLE
Add initial GCP IAP roundtripper

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -667,6 +667,7 @@ type RemoteWriteConfig struct {
 	QueueConfig      QueueConfig             `yaml:"queue_config,omitempty"`
 	MetadataConfig   MetadataConfig          `yaml:"metadata_config,omitempty"`
 	SigV4Config      *SigV4Config            `yaml:"sigv4,omitempty"`
+	IAPConfig        *IAPConfig              `yaml:"iap,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.
@@ -767,6 +768,14 @@ type SigV4Config struct {
 	SecretKey config.Secret `yaml:"secret_key,omitempty"`
 	Profile   string        `yaml:"profile,omitempty"`
 	RoleARN   string        `yaml:"role_arn,omitempty"`
+}
+
+// IAPConfig is the configuration for signing remote write requests with
+// Google's Identity Aware Proxy. Empty values will be retrieved using
+// GCP's default application credentials chain.
+type IAPConfig struct {
+	Audience       string `yaml:"audience,omitempty"`
+	ServiceAccount string `yaml:"service_account,omitempty"`
 }
 
 // RemoteReadConfig is the configuration for reading from remote storage.

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -98,6 +98,7 @@ type ClientConfig struct {
 	Timeout          model.Duration
 	HTTPClientConfig config_util.HTTPClientConfig
 	SigV4Config      *config.SigV4Config
+	IAPConfig        *config.IAPConfig
 	Headers          map[string]string
 	RetryOnRateLimit bool
 }

--- a/storage/remote/iap.go
+++ b/storage/remote/iap.go
@@ -1,0 +1,67 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/prometheus/prometheus/config"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/idtoken"
+)
+
+type iapRoundTripper struct {
+	next http.RoundTripper
+	ts   oauth2.TokenSource
+}
+
+// newIapRoundTripper returns a new http.RoundTripper that will sign requests
+// using GCP's Identity Aware Proxy (IAP) authentication method.
+// The request will be handed off to the next RoundTripper provided by next. If next is nil,
+// http.DefaultTransport will be used.
+//
+// Credentials for IAP are found using the default GCP credential chain. If credentials
+// cannot be found, en error will be returned.
+func newIapRoundTripper(cfg *config.IAPConfig, next http.RoundTripper) (http.RoundTripper, error) {
+	if next == nil {
+		next = http.DefaultClient.Transport
+	}
+
+	ctx := context.Background()
+	// TODO - add reading the service account from prometheus config
+	// using  idtoken.WithCredentialsJSON() as an idtoken.ClientOption
+	ts, err := idtoken.NewTokenSource(ctx, cfg.Audience)
+	if err != nil {
+		return nil, fmt.Errorf("could not create new IAP token source: %w", err)
+	}
+
+	rt := &iapRoundTripper{
+		next: next,
+		ts:   ts,
+	}
+
+	return rt, nil
+}
+
+func (rt *iapRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := rt.ts.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create IAP token: %w", err)
+	}
+	token.SetAuthHeader(req)
+
+	return rt.next.RoundTrip(req)
+}

--- a/storage/remote/iap_test.go
+++ b/storage/remote/iap_test.go
@@ -1,0 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+// TODO - write tests


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
In Progress, WIP

Resolves #9240 