### PR TITLE
Fix a data race in the loadWAL function caused by reusing the same error var in multiple go routines.

### DIFF
--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -113,6 +113,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64, mmappedChunks 
 	wg.Add(1)
 	exemplarsInput = make(chan record.RefExemplar, 300)
 	go func(input <-chan record.RefExemplar) {
+		var err error
 		defer wg.Done()
 		for e := range input {
 			ms := h.series.getByID(e.Ref)


### PR DESCRIPTION
Both go routines started by `loadWAL` were using the same `error` var (the named return parameter), which could cause a data race. The easy fix is to use a different `error` var in one or both of the go routines. 

@codesome feel free to cherry pick my commit into your branch so we can keep that test as well. If you want to backport this to 2.29 the loadWAL function is in a different file.

Signed-off-by: Callum Styan <callumstyan@gmail.com>
