### PR TITLE
Fix a data race in the loadWAL function caused by reusing the same error var in multiple goroutines

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -602,6 +602,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64, mmappedChunks 
 	wg.Add(1)
 	exemplarsInput = make(chan record.RefExemplar, 300)
 	go func(input <-chan record.RefExemplar) {
+		var err error
 		defer wg.Done()
 		for e := range input {
 			ms := h.series.getByID(e.Ref)


### PR DESCRIPTION
This PR cherry-picks https://github.com/prometheus/prometheus/pull/9259 onto the release branch to fix the race described in https://github.com/prometheus/prometheus/pull/9256

cc @brancz, this will require a minor release :)