### PR TITLE
Add `proxy_url` option to Azure SD

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -564,6 +564,7 @@ var expectedConf = &Config{
 					AuthenticationMethod: "OAuth",
 					RefreshInterval:      model.Duration(5 * time.Minute),
 					Port:                 9100,
+					HTTPClientConfig:     config.DefaultHTTPClientConfig,
 				},
 			},
 		},
@@ -1254,6 +1255,10 @@ var expectedErrors = []struct {
 	{
 		filename: "azure_authentication_method.bad.yml",
 		errMsg:   "unknown authentication_type \"invalid\". Supported types are \"OAuth\" or \"ManagedIdentity\"",
+	},
+	{
+		filename: "azure_two_authentication_method.bad.yml",
+		errMsg:   "standard authentication methods cannot be used, only azure OAuth or ManagedIdentity",
 	},
 	{
 		filename: "empty_scrape_config.bad.yml",

--- a/config/testdata/azure_two_authentication_method.bad.yml
+++ b/config/testdata/azure_two_authentication_method.bad.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - azure_sd_configs:
+      - subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
+        authentication_method: ManagedIdentity
+        oauth2:
+          token_url: http://localhost

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -83,7 +83,7 @@ type SDConfig struct {
 	RefreshInterval      model.Duration     `yaml:"refresh_interval,omitempty"`
 	AuthenticationMethod string             `yaml:"authentication_method,omitempty"`
 
-	HTTPClientConfig config.HTTPClientConfig `yaml:",omitempty"`
+	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 }
 
 // Name returns the name of the Config.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -428,6 +428,13 @@ subscription_id: <string>
 
 # Optional proxy URL.
 [ proxy_url: <string> ]
+
+# Configure whether HTTP requests follow HTTP 3xx redirects.
+[ follow_redirects: <bool> | default = true ]
+
+# TLS configuration.
+tls_config:
+  [ <tls_config> ]
 ```
 
 ### `<consul_sd_config>`

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -425,6 +425,9 @@ subscription_id: <string>
 # The port to scrape metrics from. If using the public IP address, this must
 # instead be specified in the relabeling rule.
 [ port: <int> | default = 80 ]
+
+# Optional proxy URL.
+[ proxy_url: <string> ]
 ```
 
 ### `<consul_sd_config>`


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR adds the `proxy_url` option to the Azure SD. I could have added the entire common HTTP client, but because none of the authentication methods would have worked I didn't think it was worth it.

Fixes #9088