### PR TITLE
Add the ability to disable tsdb isolation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
     steps:
       - checkout
       - run: go test ./tsdb/...
+      - run: go test ./tsdb/ -test.tsdb-isolation=false
 
   test_mixins:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
             GOOPTS: "-p 2"
             GOMAXPROCS: "2"
             GO111MODULE: "on"
+      - run: go test ./tsdb/ -test.tsdb-isolation=false
       - prometheus/check_proto:
           version: "3.15.8"
       - prometheus/store_artifact:

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1480,6 +1480,7 @@ type tsdbOptions struct {
 	EnableExemplarStorage          bool
 	MaxExemplars                   int64
 	EnableMemorySnapshotOnShutdown bool
+	IsolationDisabled              bool
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -1497,6 +1498,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		EnableExemplarStorage:          opts.EnableExemplarStorage,
 		MaxExemplars:                   opts.MaxExemplars,
 		EnableMemorySnapshotOnShutdown: opts.EnableMemorySnapshotOnShutdown,
+		IsolationDisabled:              opts.IsolationDisabled,
 	}
 }
 

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1480,7 +1480,6 @@ type tsdbOptions struct {
 	EnableExemplarStorage          bool
 	MaxExemplars                   int64
 	EnableMemorySnapshotOnShutdown bool
-	IsolationDisabled              bool
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -1498,7 +1497,6 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		EnableExemplarStorage:          opts.EnableExemplarStorage,
 		MaxExemplars:                   opts.MaxExemplars,
 		EnableMemorySnapshotOnShutdown: opts.EnableMemorySnapshotOnShutdown,
-		IsolationDisabled:              opts.IsolationDisabled,
 	}
 }
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -149,9 +149,6 @@ type Options struct {
 	// Enables the snapshot of in-memory chunks on shutdown. This makes restarts faster.
 	EnableMemorySnapshotOnShutdown bool
 
-	// Disables tsdb isolation.
-	IsolationDisabled bool
-
 	// MaxExemplars sets the size, in # of exemplars stored, of the single circular buffer used to store exemplars in memory.
 	// See tsdb/exemplar.go, specifically the CircularExemplarStorage struct and it's constructor NewCircularExemplarStorage.
 	MaxExemplars int64
@@ -705,7 +702,6 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	headOpts.EnableExemplarStorage = opts.EnableExemplarStorage
 	headOpts.MaxExemplars.Store(opts.MaxExemplars)
 	headOpts.EnableMemorySnapshotOnShutdown = opts.EnableMemorySnapshotOnShutdown
-	headOpts.IsolationEnabled = !opts.IsolationDisabled
 	db.head, err = NewHead(r, l, wlog, headOpts, stats.Head)
 	if err != nil {
 		return nil, err

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -705,7 +705,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	headOpts.EnableExemplarStorage = opts.EnableExemplarStorage
 	headOpts.MaxExemplars.Store(opts.MaxExemplars)
 	headOpts.EnableMemorySnapshotOnShutdown = opts.EnableMemorySnapshotOnShutdown
-	headOpts.IsolationDisabled = opts.IsolationDisabled
+	headOpts.IsolationEnabled = !opts.IsolationDisabled
 	db.head, err = NewHead(r, l, wlog, headOpts, stats.Head)
 	if err != nil {
 		return nil, err

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -143,11 +143,14 @@ type Options struct {
 	// mainly meant for external users who import TSDB.
 	BlocksToDelete BlocksToDeleteFunc
 
-	// Enables the in memory exemplar storage,.
+	// Enables the in memory exemplar storage.
 	EnableExemplarStorage bool
 
 	// Enables the snapshot of in-memory chunks on shutdown. This makes restarts faster.
 	EnableMemorySnapshotOnShutdown bool
+
+	// Disables tsdb isolation.
+	IsolationDisabled bool
 
 	// MaxExemplars sets the size, in # of exemplars stored, of the single circular buffer used to store exemplars in memory.
 	// See tsdb/exemplar.go, specifically the CircularExemplarStorage struct and it's constructor NewCircularExemplarStorage.
@@ -702,6 +705,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	headOpts.EnableExemplarStorage = opts.EnableExemplarStorage
 	headOpts.MaxExemplars.Store(opts.MaxExemplars)
 	headOpts.EnableMemorySnapshotOnShutdown = opts.EnableMemorySnapshotOnShutdown
+	headOpts.IsolationDisabled = opts.IsolationDisabled
 	db.head, err = NewHead(r, l, wlog, headOpts, stats.Head)
 	if err != nil {
 		return nil, err

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"flag"
 	"fmt"
 	"hash/crc32"
 	"io/ioutil"
@@ -54,6 +55,9 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	flag.BoolVar(&DefaultIsolationState, "test.tsdb-isolation", true, "enable isolation")
+	flag.Parse()
+
 	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func1"), goleak.IgnoreTopFunction("github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func2"))
 }
 

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -2413,6 +2413,10 @@ func TestDBReadOnly_FlushWAL(t *testing.T) {
 }
 
 func TestDBCannotSeePartialCommits(t *testing.T) {
+	if defaultIsolationDisabled {
+		t.Skip("skipping test since tsdb isolation is disabled")
+	}
+
 	tmpdir, _ := ioutil.TempDir("", "test")
 	defer func() {
 		require.NoError(t, os.RemoveAll(tmpdir))
@@ -2483,6 +2487,10 @@ func TestDBCannotSeePartialCommits(t *testing.T) {
 }
 
 func TestDBQueryDoesntSeeAppendsAfterCreation(t *testing.T) {
+	if defaultIsolationDisabled {
+		t.Skip("skipping test since tsdb isolation is disabled")
+	}
+
 	tmpdir, _ := ioutil.TempDir("", "test")
 	defer func() {
 		require.NoError(t, os.RemoveAll(tmpdir))

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -55,8 +55,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	flag.BoolVar(&defaultIsolationState, "test.tsdb-isolation", true, "enable isolation")
+	var isolationEnabled bool
+	flag.BoolVar(&isolationEnabled, "test.tsdb-isolation", true, "enable isolation")
 	flag.Parse()
+	defaultIsolationDisabled = !isolationEnabled
 
 	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func1"), goleak.IgnoreTopFunction("github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func2"))
 }

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -55,7 +55,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	flag.BoolVar(&DefaultIsolationState, "test.tsdb-isolation", true, "enable isolation")
+	flag.BoolVar(&defaultIsolationState, "test.tsdb-isolation", true, "enable isolation")
 	flag.Parse()
 
 	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func1"), goleak.IgnoreTopFunction("github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func2"))

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -52,6 +52,9 @@ var (
 	// ErrAppenderClosed is returned if an appender has already be successfully
 	// rolled back or committed.
 	ErrAppenderClosed = errors.New("appender closed")
+
+	// DefaultIsolationState is the default isolation level
+	DefaultIsolationState = true
 )
 
 // Head handles reads and writes of time series data within a time window.
@@ -143,7 +146,7 @@ func DefaultHeadOptions() *HeadOptions {
 		ChunkWriteBufferSize: chunks.DefaultWriteBufferSize,
 		StripeSize:           DefaultStripeSize,
 		SeriesCallback:       &noopSeriesLifecycleCallback{},
-		IsolationDisabled:    false,
+		IsolationDisabled:    !DefaultIsolationState,
 	}
 }
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -53,8 +53,8 @@ var (
 	// rolled back or committed.
 	ErrAppenderClosed = errors.New("appender closed")
 
-	// DefaultIsolationState is the default isolation level
-	DefaultIsolationState = true
+	// defaultIsolationState defines whether isolation is enabled by default.
+	defaultIsolationState = true
 )
 
 // Head handles reads and writes of time series data within a time window.
@@ -135,7 +135,7 @@ type HeadOptions struct {
 	EnableExemplarStorage          bool
 	EnableMemorySnapshotOnShutdown bool
 
-	IsolationDisabled bool
+	IsolationEnabled bool
 }
 
 func DefaultHeadOptions() *HeadOptions {
@@ -146,7 +146,7 @@ func DefaultHeadOptions() *HeadOptions {
 		ChunkWriteBufferSize: chunks.DefaultWriteBufferSize,
 		StripeSize:           DefaultStripeSize,
 		SeriesCallback:       &noopSeriesLifecycleCallback{},
-		IsolationDisabled:    !DefaultIsolationState,
+		IsolationEnabled:     defaultIsolationState,
 	}
 }
 
@@ -237,7 +237,7 @@ func (h *Head) resetInMemoryState() error {
 	}
 
 	h.iso = newIsolation()
-	if h.opts.IsolationDisabled {
+	if !h.opts.IsolationEnabled {
 		h.iso.disabled = true
 	}
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -522,7 +522,7 @@ func (s *memSeries) append(t int64, v float64, appendID uint64, chunkDiskMapper 
 	s.sampleBuf[2] = s.sampleBuf[3]
 	s.sampleBuf[3] = sample{t: t, v: v}
 
-	if appendID > 0 {
+	if appendID > 0 && s.txs != nil {
 		s.txs.add(appendID)
 	}
 

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -360,7 +360,7 @@ func (s *memSeries) iterator(id int, isoState *isolationState, chunkDiskMapper *
 	numSamples := c.chunk.NumSamples()
 	stopAfter := numSamples
 
-	if isoState != nil {
+	if isoState != nil && !isoState.IsolationDisabled() {
 		totalSamples := 0    // Total samples in this series.
 		previousSamples := 0 // Samples before this chunk.
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -60,6 +60,8 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 	opts.ChunkDirRoot = dir
 	opts.EnableExemplarStorage = true
 	opts.MaxExemplars.Store(config.DefaultExemplarsConfig.MaxExemplars)
+	require.False(t, opts.IsolationDisabled)
+
 	h, err := NewHead(nil, nil, wlog, opts, nil)
 	require.NoError(t, err)
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -60,7 +60,7 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 	opts.ChunkDirRoot = dir
 	opts.EnableExemplarStorage = true
 	opts.MaxExemplars.Store(config.DefaultExemplarsConfig.MaxExemplars)
-	require.False(t, opts.IsolationDisabled)
+	require.Equal(t, !DefaultIsolationState, opts.IsolationDisabled)
 
 	h, err := NewHead(nil, nil, wlog, opts, nil)
 	require.NoError(t, err)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2445,7 +2445,6 @@ func TestDataMissingOnQueryDuringCompaction(t *testing.T) {
 }
 
 func TestIsQuerierCollidingWithTruncation(t *testing.T) {
-	defaultIsolationDisabled = true
 	db := newTestDB(t)
 	db.DisableCompactions()
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -60,7 +60,7 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 	opts.ChunkDirRoot = dir
 	opts.EnableExemplarStorage = true
 	opts.MaxExemplars.Store(config.DefaultExemplarsConfig.MaxExemplars)
-	require.Equal(t, !DefaultIsolationState, opts.IsolationDisabled)
+	require.Equal(t, !defaultIsolationState, opts.IsolationEnabled)
 
 	h, err := NewHead(nil, nil, wlog, opts, nil)
 	require.NoError(t, err)
@@ -1549,8 +1549,8 @@ func TestAddDuplicateLabelName(t *testing.T) {
 }
 
 func TestMemSeriesIsolation(t *testing.T) {
-	if !DefaultIsolationState {
-		t.Skip("skipping test since testing with isolation disabled")
+	if !defaultIsolationState {
+		t.Skip("skipping test since tsdb isolation is disabled")
 	}
 
 	// Put a series, select it. GC it and then access it.
@@ -1724,8 +1724,8 @@ func TestMemSeriesIsolation(t *testing.T) {
 }
 
 func TestIsolationRollback(t *testing.T) {
-	if !DefaultIsolationState {
-		t.Skip("skipping test since testing with isolation disabled")
+	if !defaultIsolationState {
+		t.Skip("skipping test since tsdb isolation is disabled")
 	}
 
 	// Rollback after a failed append and test if the low watermark has progressed anyway.
@@ -1756,8 +1756,8 @@ func TestIsolationRollback(t *testing.T) {
 }
 
 func TestIsolationLowWatermarkMonotonous(t *testing.T) {
-	if !DefaultIsolationState {
-		t.Skip("skipping test since testing with isolation disabled")
+	if !defaultIsolationState {
+		t.Skip("skipping test since tsdb isolation is disabled")
 	}
 
 	hb, _ := newTestHead(t, 1000, false)
@@ -1793,8 +1793,8 @@ func TestIsolationLowWatermarkMonotonous(t *testing.T) {
 }
 
 func TestIsolationAppendIDZeroIsNoop(t *testing.T) {
-	if !DefaultIsolationState {
-		t.Skip("skipping test since testing with isolation disabled")
+	if !defaultIsolationState {
+		t.Skip("skipping test since tsdb isolation is disabled")
 	}
 
 	h, _ := newTestHead(t, 1000, false)
@@ -1818,8 +1818,8 @@ func TestHeadSeriesChunkRace(t *testing.T) {
 }
 
 func TestIsolationWithoutAdd(t *testing.T) {
-	if !DefaultIsolationState {
-		t.Skip("skipping test since testing with isolation disabled")
+	if !defaultIsolationState {
+		t.Skip("skipping test since tsdb isolation is disabled")
 	}
 
 	hb, _ := newTestHead(t, 1000, false)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -60,7 +60,7 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 	opts.ChunkDirRoot = dir
 	opts.EnableExemplarStorage = true
 	opts.MaxExemplars.Store(config.DefaultExemplarsConfig.MaxExemplars)
-	require.Equal(t, !defaultIsolationState, opts.IsolationEnabled)
+	require.Equal(t, defaultIsolationState, opts.IsolationEnabled)
 
 	h, err := NewHead(nil, nil, wlog, opts, nil)
 	require.NoError(t, err)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2490,7 +2490,6 @@ func TestIsQuerierCollidingWithTruncation(t *testing.T) {
 }
 
 func TestWaitForPendingReadersInTimeRange(t *testing.T) {
-	defaultIsolationDisabled = true
 	db := newTestDB(t)
 	db.DisableCompactions()
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1549,6 +1549,10 @@ func TestAddDuplicateLabelName(t *testing.T) {
 }
 
 func TestMemSeriesIsolation(t *testing.T) {
+	if !DefaultIsolationState {
+		return
+	}
+
 	// Put a series, select it. GC it and then access it.
 	lastValue := func(h *Head, maxAppendID uint64) int {
 		idx, err := h.Index()
@@ -1720,6 +1724,10 @@ func TestMemSeriesIsolation(t *testing.T) {
 }
 
 func TestIsolationRollback(t *testing.T) {
+	if !DefaultIsolationState {
+		return
+	}
+
 	// Rollback after a failed append and test if the low watermark has progressed anyway.
 	hb, _ := newTestHead(t, 1000, false)
 	defer func() {
@@ -1748,6 +1756,10 @@ func TestIsolationRollback(t *testing.T) {
 }
 
 func TestIsolationLowWatermarkMonotonous(t *testing.T) {
+	if !DefaultIsolationState {
+		return
+	}
+
 	hb, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, hb.Close())
@@ -1781,6 +1793,10 @@ func TestIsolationLowWatermarkMonotonous(t *testing.T) {
 }
 
 func TestIsolationAppendIDZeroIsNoop(t *testing.T) {
+	if !DefaultIsolationState {
+		return
+	}
+
 	h, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, h.Close())
@@ -1802,6 +1818,10 @@ func TestHeadSeriesChunkRace(t *testing.T) {
 }
 
 func TestIsolationWithoutAdd(t *testing.T) {
+	if !DefaultIsolationState {
+		return
+	}
+
 	hb, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, hb.Close())

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1550,7 +1550,7 @@ func TestAddDuplicateLabelName(t *testing.T) {
 
 func TestMemSeriesIsolation(t *testing.T) {
 	if !DefaultIsolationState {
-		return
+		t.Skip("skipping test since testing with isolation disabled")
 	}
 
 	// Put a series, select it. GC it and then access it.
@@ -1725,7 +1725,7 @@ func TestMemSeriesIsolation(t *testing.T) {
 
 func TestIsolationRollback(t *testing.T) {
 	if !DefaultIsolationState {
-		return
+		t.Skip("skipping test since testing with isolation disabled")
 	}
 
 	// Rollback after a failed append and test if the low watermark has progressed anyway.
@@ -1757,7 +1757,7 @@ func TestIsolationRollback(t *testing.T) {
 
 func TestIsolationLowWatermarkMonotonous(t *testing.T) {
 	if !DefaultIsolationState {
-		return
+		t.Skip("skipping test since testing with isolation disabled")
 	}
 
 	hb, _ := newTestHead(t, 1000, false)
@@ -1794,7 +1794,7 @@ func TestIsolationLowWatermarkMonotonous(t *testing.T) {
 
 func TestIsolationAppendIDZeroIsNoop(t *testing.T) {
 	if !DefaultIsolationState {
-		return
+		t.Skip("skipping test since testing with isolation disabled")
 	}
 
 	h, _ := newTestHead(t, 1000, false)
@@ -1819,7 +1819,7 @@ func TestHeadSeriesChunkRace(t *testing.T) {
 
 func TestIsolationWithoutAdd(t *testing.T) {
 	if !DefaultIsolationState {
-		return
+		t.Skip("skipping test since testing with isolation disabled")
 	}
 
 	hb, _ := newTestHead(t, 1000, false)

--- a/tsdb/isolation.go
+++ b/tsdb/isolation.go
@@ -63,8 +63,7 @@ type isolation struct {
 	readMtx sync.RWMutex
 	// All current in use isolationStates. This is a doubly-linked list.
 	readsOpen *isolationState
-	// codesome's suggestion
-	disabled bool
+	disabled  bool
 }
 
 func newIsolation() *isolation {

--- a/tsdb/isolation.go
+++ b/tsdb/isolation.go
@@ -117,10 +117,6 @@ func (i *isolation) lowWatermarkLocked() uint64 {
 // State returns an object used to control isolation
 // between a query and appends. Must be closed when complete.
 func (i *isolation) State(mint, maxt int64) *isolationState {
-	if i.disabled {
-		return &isolationState{}
-	}
-
 	i.appendMtx.RLock() // Take append mutex before read mutex.
 	defer i.appendMtx.RUnlock()
 	isoState := &isolationState{
@@ -148,10 +144,6 @@ func (i *isolation) State(mint, maxt int64) *isolationState {
 // function on those states. The given function MUST NOT mutate the isolationState.
 // The iteration is stopped when the function returns false or once all reads have been iterated.
 func (i *isolation) TraverseOpenReads(f func(s *isolationState) bool) {
-	if i.disabled {
-		return
-	}
-
 	i.readMtx.RLock()
 	defer i.readMtx.RUnlock()
 	s := i.readsOpen.next

--- a/tsdb/isolation.go
+++ b/tsdb/isolation.go
@@ -33,6 +33,10 @@ type isolationState struct {
 
 // Close closes the state.
 func (i *isolationState) Close() {
+	if i.isolation == nil || i.isolation.disabled {
+		return
+	}
+
 	i.isolation.readMtx.Lock()
 	defer i.isolation.readMtx.Unlock()
 	i.next.prev = i.prev

--- a/tsdb/isolation_test.go
+++ b/tsdb/isolation_test.go
@@ -23,7 +23,7 @@ import (
 func BenchmarkIsolation(b *testing.B) {
 	for _, goroutines := range []int{10, 100, 1000, 10000} {
 		b.Run(strconv.Itoa(goroutines), func(b *testing.B) {
-			iso := newIsolation()
+			iso := newIsolation(false)
 
 			wg := sync.WaitGroup{}
 			start := make(chan struct{})
@@ -53,7 +53,7 @@ func BenchmarkIsolation(b *testing.B) {
 func BenchmarkIsolationWithState(b *testing.B) {
 	for _, goroutines := range []int{10, 100, 1000, 10000} {
 		b.Run(strconv.Itoa(goroutines), func(b *testing.B) {
-			iso := newIsolation()
+			iso := newIsolation(false)
 
 			wg := sync.WaitGroup{}
 			start := make(chan struct{})


### PR DESCRIPTION
closes https://github.com/prometheus/prometheus/issues/9265

Signed-off-by: darshanime <deathbullet@gmail.com>
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
