### PR TITLE
Remove query hacks in the API and fix metrics

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -564,6 +564,21 @@ func (h *Head) Init(minValidTime int64) error {
 		h.updateWALReplayStatusRead(i)
 	}
 
+	{
+		// Set the sparseHistogramSeries metric once replay is done.
+		// This is a temporary hack.
+		// TODO: remove this hack and do it while replaying WAL if we keep this metric around.
+		sparseHistogramSeries := 0
+		for _, m := range h.series.series {
+			for _, ms := range m {
+				if ms.sparseHistogramSeries {
+					sparseHistogramSeries++
+				}
+			}
+		}
+		h.metrics.sparseHistogramSeries.Set(float64(sparseHistogramSeries))
+	}
+
 	walReplayDuration := time.Since(start)
 	h.metrics.walTotalReplayDuration.Set(walReplayDuration.Seconds())
 	level.Info(h.logger).Log(

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -629,6 +629,7 @@ func (s *memSeries) appendHistogram(t int64, sh histogram.SparseHistogram, appen
 	}
 
 	s.app.AppendHistogram(t, sh)
+	s.sparseHistogramSeries = true
 
 	c.maxTime = t
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2770,3 +2770,39 @@ func TestChunkSnapshot(t *testing.T) {
 		require.Equal(t, expTombstones, actTombstones)
 	}
 }
+
+func TestSparseHistogramMetrics(t *testing.T) {
+	head, _ := newTestHead(t, 1000, false)
+	t.Cleanup(func() {
+		require.NoError(t, head.Close())
+	})
+	require.NoError(t, head.Init(0))
+
+	expHistSeries, expHistSamples := 0, 0
+
+	for x := 0; x < 5; x++ {
+		expHistSeries++
+		l := labels.Labels{{Name: "a", Value: fmt.Sprintf("b%d", x)}}
+		for i, h := range generateHistograms(10) {
+			app := head.Appender(context.Background())
+			_, err := app.AppendHistogram(0, l, int64(i), h)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			expHistSamples++
+		}
+	}
+
+	require.Equal(t, float64(expHistSeries), prom_testutil.ToFloat64(head.metrics.sparseHistogramSeries))
+	require.Equal(t, float64(expHistSamples), prom_testutil.ToFloat64(head.metrics.sparseHistogramSamplesTotal))
+
+	require.NoError(t, head.Close())
+	w, err := wal.NewSize(nil, nil, head.wal.Dir(), 32768, false)
+	require.NoError(t, err)
+	head, err = NewHead(nil, nil, w, head.opts, nil)
+	require.NoError(t, err)
+	require.NoError(t, head.Init(0))
+
+	require.Equal(t, float64(expHistSeries), prom_testutil.ToFloat64(head.metrics.sparseHistogramSeries))
+	require.Equal(t, float64(expHistSamples), prom_testutil.ToFloat64(head.metrics.sparseHistogramSamplesTotal))
+
+}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2803,6 +2803,5 @@ func TestSparseHistogramMetrics(t *testing.T) {
 	require.NoError(t, head.Init(0))
 
 	require.Equal(t, float64(expHistSeries), prom_testutil.ToFloat64(head.metrics.sparseHistogramSeries))
-	require.Equal(t, float64(expHistSamples), prom_testutil.ToFloat64(head.metrics.sparseHistogramSamplesTotal))
-
+	require.Equal(t, float64(0), prom_testutil.ToFloat64(head.metrics.sparseHistogramSamplesTotal)) // Counter reset.
 }

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -161,6 +161,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[uint64]uint64, mmappedChunks 
 			if ms.head() == nil {
 				// First histogram for the series. Count this in metrics.
 				h.metrics.sparseHistogramSeries.Inc()
+				ms.sparseHistogramSeries = true
 			}
 
 			// At the moment the only possible error here is out of order exemplars, which we shouldn't see when


### PR DESCRIPTION
NOTE: pointing to sparsehistogram branch

Removing the hack so that we can see the added histogram tracking metrics. And, metrics get broken when we restart, fixing that here.

cc @beorn7 