### PR TITLE
Fix protobuf parsing of quantile-less summaries

### DIFF
--- a/pkg/textparse/protobufparse.go
+++ b/pkg/textparse/protobufparse.go
@@ -96,6 +96,10 @@ func (p *ProtobufParser) Series() ([]byte, *int64, float64) {
 			v = float64(s.GetSampleCount())
 		case -1:
 			v = s.GetSampleSum()
+			// Need to detect a summaries without quantile here.
+			if len(s.GetQuantile()) == 0 {
+				p.fieldsDone = true
+			}
 		default:
 			v = s.GetQuantile()[p.fieldPos].GetValue()
 		}

--- a/pkg/textparse/protobufparse_test.go
+++ b/pkg/textparse/protobufparse_test.go
@@ -228,6 +228,16 @@ metric: <
   >
 >
 `,
+		`name: "without_quantiles"
+help: "A summary without quantiles."
+type: SUMMARY
+metric: <
+  summary: <
+    sample_count: 42
+    sample_sum: 1.234
+  >
+>
+`,
 	}
 
 	varintBuf := make([]byte, binary.MaxVarintLen32)
@@ -456,6 +466,28 @@ metric: <
 				"__name__", "rpc_durations_seconds",
 				"quantile", "0.99",
 				"service", "exponential",
+			),
+		},
+		{
+			m:    "without_quantiles",
+			help: "A summary without quantiles.",
+		},
+		{
+			m:   "without_quantiles",
+			typ: MetricTypeSummary,
+		},
+		{
+			m: "without_quantiles_count",
+			v: 42,
+			lset: labels.FromStrings(
+				"__name__", "without_quantiles_count",
+			),
+		},
+		{
+			m: "without_quantiles_sum",
+			v: 1.234,
+			lset: labels.FromStrings(
+				"__name__", "without_quantiles_sum",
 			),
 		},
 	}


### PR DESCRIPTION
__This is just against the sparsehistogram branch. Nothing to see here unless you are @codesome or @Dieterbe .__