### PR TITLE
add option to promtool to write JUnit-style XML test results

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -197,6 +197,7 @@ func main() {
 	pushMetricsHeaders := pushMetricsCmd.Flag("header", "Prometheus remote write header.").StringMap()
 
 	testCmd := app.Command("test", "Unit testing.")
+	junitOutFile := testCmd.Flag("junit", "The JUnit xml output file.").OpenFile(os.O_CREATE|os.O_WRONLY, 0o644)
 	testRulesCmd := testCmd.Command("rules", "Unit tests for rules.")
 	testRulesFiles := testRulesCmd.Arg(
 		"test-rule-file",
@@ -360,7 +361,11 @@ func main() {
 		os.Exit(QueryLabels(serverURL, httpRoundTripper, *queryLabelsMatch, *queryLabelsName, *queryLabelsBegin, *queryLabelsEnd, p))
 
 	case testRulesCmd.FullCommand():
-		os.Exit(RulesUnitTest(
+		results := io.Discard
+		if junitOutFile != nil {
+			results = *junitOutFile
+		}
+		os.Exit(RulesUnitTestResults(results,
 			promql.LazyLoaderOpts{
 				EnableAtModifier:     true,
 				EnableNegativeOffset: true,

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -423,6 +423,15 @@ Unit testing.
 
 
 
+#### Flags
+
+| Flag | Description |
+| --- | --- |
+| <code class="text-nowrap">--junit</code> | The JUnit xml output file. |
+
+
+
+
 ##### `promtool test rules`
 
 Unit tests for rules.

--- a/util/junitxml/junitxml.go
+++ b/util/junitxml/junitxml.go
@@ -1,0 +1,74 @@
+// Copyright 2021 Marty Pauley
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package junitxml
+
+import (
+	"encoding/xml"
+	"io"
+)
+
+type JUnitXML struct {
+	XMLName xml.Name     `xml:"testsuites"`
+	Suites  []*TestSuite `xml:"testsuite"`
+}
+
+type TestSuite struct {
+	Name         string      `xml:"name,attr"`
+	TestCount    int         `xml:"tests,attr"`
+	FailureCount int         `xml:"failures,attr"`
+	ErrorCount   int         `xml:"errors,attr"`
+	Cases        []*TestCase `xml:"testcase"`
+}
+
+type TestCase struct {
+	Name     string   `xml:"name,attr"`
+	Failures []string `xml:"failure,omitempty"`
+	Error    string   `xml:"error,omitempty"`
+}
+
+func (j *JUnitXML) Suite(name string) *TestSuite {
+	ts := &TestSuite{Name: name}
+	j.Suites = append(j.Suites, ts)
+	return ts
+}
+
+func (j *JUnitXML) WriteXML(h io.Writer) error {
+	return xml.NewEncoder(h).Encode(j)
+}
+
+func (ts *TestSuite) Case(name string) *TestSuite {
+	ts.TestCount++
+	tc := &TestCase{Name: name}
+	ts.Cases = append(ts.Cases, tc)
+	return ts
+}
+
+func (ts *TestSuite) lastCase() *TestCase {
+	if len(ts.Cases) == 0 {
+		ts.Case("unknown")
+	}
+	return ts.Cases[len(ts.Cases)-1]
+}
+
+func (ts *TestSuite) Fail(f string) {
+	ts.FailureCount++ // yes, there can be more failures than test cases
+	curt := ts.lastCase()
+	curt.Failures = append(curt.Failures, f)
+}
+
+func (ts *TestSuite) Abort(e error) {
+	ts.ErrorCount++
+	curt := ts.lastCase()
+	curt.Error = e.Error()
+}

--- a/util/junitxml/junitxml_test.go
+++ b/util/junitxml/junitxml_test.go
@@ -1,0 +1,60 @@
+// Copyright 2021 Marty Pauley
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package junitxml
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/grafana/regexp"
+)
+
+func TestJunitOutput(t *testing.T) {
+	var buf bytes.Buffer
+	FakeTestSuites().WriteXML(&buf)
+	output := buf.Bytes()
+
+	reTop := regexp.MustCompile(`(?s)^<testsuites\W.*</testsuites>$`)
+	reSuites := regexp.MustCompile(`(?s)<testsuite .*?</testsuite>`)
+	reCases := regexp.MustCompile(`(?s)<testcase .*?</testcase>`)
+
+	if !reTop.Match(output) {
+		t.Errorf("JUnit output has no outer <testsuites>\n")
+	}
+	suites := reSuites.FindAll(output, -1)
+	if len(suites) != 3 {
+		t.Errorf("JUnit output had %d testsuite elements; expected 3\n", len(suites))
+	}
+	cases := reCases.FindAll(output, -1)
+	if len(cases) != 7 {
+		t.Errorf("JUnit output had %d testcase; expected 7\n", len(cases))
+	}
+}
+
+func FakeTestSuites() *JUnitXML {
+	ju := &JUnitXML{}
+	good := ju.Suite("all good")
+	good.Case("alpha")
+	good.Case("beta")
+	good.Case("gamma")
+	mixed := ju.Suite("mixed")
+	mixed.Case("good")
+	bad := mixed.Case("bad")
+	bad.Fail("once")
+	bad.Fail("twice")
+	mixed.Case("ugly").Abort(errors.New("buggy"))
+	ju.Suite("fast").Fail("fail early")
+	return ju
+}


### PR DESCRIPTION
Signed-off-by: Marty Pauley <marty@martian.org>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
