### PR TITLE
kubernetes ingress: adjust comment style

### DIFF
--- a/discovery/kubernetes/ingress.go
+++ b/discovery/kubernetes/ingress.go
@@ -220,9 +220,8 @@ func (i *Ingress) buildIngress(ingress ingressAdaptor) *targetgroup.Group {
 }
 
 // matchesHostnamePattern returns true if the host matches a wildcard DNS
-// pattern or pattern and host are equal
+// pattern or pattern and host are equal.
 func matchesHostnamePattern(pattern, host string) bool {
-	// check for exact match
 	if pattern == host {
 		return true
 	}
@@ -230,13 +229,13 @@ func matchesHostnamePattern(pattern, host string) bool {
 	patternParts := strings.Split(pattern, ".")
 	hostParts := strings.Split(host, ".")
 
-	// if they are not equal, we cna check if we need to match
-	// on a wildcard or else give up
+	// If the first element of the pattern is not a wildcard, give up.
 	if len(patternParts) == 0 || patternParts[0] != "*" {
 		return false
 	}
 
-	// to get a valid wildcard match the parts will need to be the same length
+	// A wildcard match require the pattern to have the same length as the host
+	// path.
 	if len(patternParts) != len(hostParts) {
 		return false
 	}

--- a/discovery/kubernetes/ingress_test.go
+++ b/discovery/kubernetes/ingress_test.go
@@ -19,11 +19,11 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
-
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 type TLSMode int


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
