### PR TITLE
Allow VectorSelector.String() without matchers

### DIFF
--- a/promql/parser/printer.go
+++ b/promql/parser/printer.go
@@ -182,7 +182,10 @@ func (node *UnaryExpr) String() string {
 }
 
 func (node *VectorSelector) String() string {
-	labelStrings := make([]string, 0, len(node.LabelMatchers)-1)
+	var labelStrings []string
+	if len(node.LabelMatchers) > 1 {
+		labelStrings = make([]string, 0, len(node.LabelMatchers)-1)
+	}
 	for _, matcher := range node.LabelMatchers {
 		// Only include the __name__ label if its equality matching and matches the name.
 		if matcher.Name == labels.MetricName && matcher.Type == labels.MatchEqual && matcher.Value == node.Name {

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -16,8 +16,6 @@ package parser
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -142,5 +140,5 @@ func TestExprString(t *testing.T) {
 }
 
 func TestVectorSelector_String_WithZeroMatchers(t *testing.T) {
-	assert.Equal(t, "foobar", (&VectorSelector{Name: "foobar"}).String())
+	require.Equal(t, "foobar", (&VectorSelector{Name: "foobar"}).String())
 }

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -16,6 +16,8 @@ package parser
 import (
 	"testing"
 
+	"github.com/prometheus/prometheus/pkg/labels"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -139,6 +141,75 @@ func TestExprString(t *testing.T) {
 	}
 }
 
-func TestVectorSelector_String_WithZeroMatchers(t *testing.T) {
-	require.Equal(t, "foobar", (&VectorSelector{Name: "foobar"}).String())
+func TestVectorSelector_String(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		vs       VectorSelector
+		expected string
+	}{
+		{
+			name:     "empty value",
+			vs:       VectorSelector{},
+			expected: ``,
+		},
+		{
+			name:     "no matchers with name",
+			vs:       VectorSelector{Name: "foobar"},
+			expected: `foobar`,
+		},
+		{
+			name: "one matcher with name",
+			vs: VectorSelector{
+				Name: "foobar",
+				LabelMatchers: []*labels.Matcher{
+					labels.MustNewMatcher(labels.MatchEqual, "a", "x"),
+				},
+			},
+			expected: `foobar{a="x"}`,
+		},
+		{
+			name: "two matchers with name",
+			vs: VectorSelector{
+				Name: "foobar",
+				LabelMatchers: []*labels.Matcher{
+					labels.MustNewMatcher(labels.MatchEqual, "a", "x"),
+					labels.MustNewMatcher(labels.MatchEqual, "b", "y"),
+				},
+			},
+			expected: `foobar{a="x",b="y"}`,
+		},
+		{
+			name: "two matchers without name",
+			vs: VectorSelector{
+				LabelMatchers: []*labels.Matcher{
+					labels.MustNewMatcher(labels.MatchEqual, "a", "x"),
+					labels.MustNewMatcher(labels.MatchEqual, "b", "y"),
+				},
+			},
+			expected: `{a="x",b="y"}`,
+		},
+		{
+			name: "name matcher and name",
+			vs: VectorSelector{
+				Name: "foobar",
+				LabelMatchers: []*labels.Matcher{
+					labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "foobar"),
+				},
+			},
+			expected: `foobar`,
+		},
+		{
+			name: "name matcher only",
+			vs: VectorSelector{
+				LabelMatchers: []*labels.Matcher{
+					labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "foobar"),
+				},
+			},
+			expected: `{__name__="foobar"}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.vs.String())
+		})
+	}
 }

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -16,6 +16,8 @@ package parser
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -137,4 +139,8 @@ func TestExprString(t *testing.T) {
 
 		require.Equal(t, exp, expr.String())
 	}
+}
+
+func TestVectorSelector_String_WithZeroMatchers(t *testing.T) {
+	assert.Equal(t, "foobar", (&VectorSelector{Name: "foobar"}).String())
 }


### PR DESCRIPTION
Previously this method was panicking because it was trying to allocate a slice with capacity -1. There's nothing saying that VectorSelector should have matchers, and it's actually prepared to have zero matcher strings, so it's worth checking instead of panicking.