### PR TITLE
Support customization of template options

### DIFF
--- a/pkg/rulefmt/rulefmt.go
+++ b/pkg/rulefmt/rulefmt.go
@@ -239,6 +239,7 @@ func testTemplateParsing(rl *RuleNode) (errs []error) {
 			model.Time(timestamp.FromTime(time.Now())),
 			nil,
 			nil,
+			nil,
 		)
 		return tmpl.ParseTest()
 	}

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -338,6 +338,7 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 				model.Time(timestamp.FromTime(ts)),
 				template.QueryFunc(query),
 				externalURL,
+				nil,
 			)
 			result, err := tmpl.Expand()
 			if err != nil {

--- a/template/template.go
+++ b/template/template.go
@@ -115,6 +115,7 @@ type Expander struct {
 	name    string
 	data    interface{}
 	funcMap text_template.FuncMap
+	options []string
 }
 
 // NewTemplateExpander returns a template expander ready to use.
@@ -126,7 +127,11 @@ func NewTemplateExpander(
 	timestamp model.Time,
 	queryFunc QueryFunc,
 	externalURL *url.URL,
+	options []string,
 ) *Expander {
+	if options == nil {
+		options = []string{"missingkey=zero"}
+	}
 	return &Expander{
 		text: text,
 		name: name,
@@ -291,6 +296,7 @@ func NewTemplateExpander(
 				return externalURL.String()
 			},
 		},
+		options: options,
 	}
 }
 
@@ -336,7 +342,9 @@ func (te Expander) Expand() (result string, resultErr error) {
 
 	templateTextExpansionTotal.Inc()
 
-	tmpl, err := text_template.New(te.name).Funcs(te.funcMap).Option("missingkey=zero").Parse(te.text)
+	tmpl := text_template.New(te.name).Funcs(te.funcMap)
+	tmpl.Option(te.options...)
+	tmpl, err := tmpl.Parse(te.text)
 	if err != nil {
 		return "", errors.Wrapf(err, "error parsing template %v", te.name)
 	}
@@ -361,7 +369,7 @@ func (te Expander) ExpandHTML(templateFiles []string) (result string, resultErr 
 	}()
 
 	tmpl := html_template.New(te.name).Funcs(html_template.FuncMap(te.funcMap))
-	tmpl.Option("missingkey=zero")
+	tmpl.Option(te.options...)
 	tmpl.Funcs(html_template.FuncMap{
 		"tmpl": func(name string, data interface{}) (html_template.HTML, error) {
 			var buffer bytes.Buffer

--- a/web/web.go
+++ b/web/web.go
@@ -709,6 +709,7 @@ func (h *Handler) consoles(w http.ResponseWriter, r *http.Request) {
 		h.now(),
 		template.QueryFunc(rules.EngineQueryFunc(h.queryEngine, h.storage)),
 		h.options.ExternalURL,
+		nil,
 	)
 	filenames, err := filepath.Glob(h.options.ConsoleLibrariesPath + "/*.lib")
 	if err != nil {
@@ -1113,6 +1114,7 @@ func (h *Handler) executeTemplate(w http.ResponseWriter, name string, data inter
 		h.now(),
 		template.QueryFunc(rules.EngineQueryFunc(h.queryEngine, h.storage)),
 		h.options.ExternalURL,
+		nil,
 	)
 	tmpl.Funcs(tmplFuncs(h.consolesPath(), h.options))
 


### PR DESCRIPTION
This commit adds supports for customizing the template options in `TemplateExpander` as we want to use it in Grafana but with `missingkey=error`.