### PR TITLE
Create less garbage when parsing metrics

### DIFF
--- a/pkg/textparse/openmetricsparse.go
+++ b/pkg/textparse/openmetricsparse.go
@@ -306,11 +306,10 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 
 		t2 := p.nextToken()
 		if t2 == tBraceOpen {
-			offsets, err := p.parseLVals()
+			p.offsets, err = p.parseLVals(p.offsets)
 			if err != nil {
 				return EntryInvalid, err
 			}
-			p.offsets = append(p.offsets, offsets...)
 			p.series = p.l.b[p.start:p.l.i]
 			t2 = p.nextToken()
 		}
@@ -367,12 +366,12 @@ func (p *OpenMetricsParser) parseComment() error {
 		return err
 	}
 
+	var err error
 	// Parse the labels.
-	offsets, err := p.parseLVals()
+	p.eOffsets, err = p.parseLVals(p.eOffsets)
 	if err != nil {
 		return err
 	}
-	p.eOffsets = append(p.eOffsets, offsets...)
 	p.exemplar = p.l.b[p.start:p.l.i]
 
 	// Get the value.
@@ -410,8 +409,7 @@ func (p *OpenMetricsParser) parseComment() error {
 	return nil
 }
 
-func (p *OpenMetricsParser) parseLVals() ([]int, error) {
-	var offsets []int
+func (p *OpenMetricsParser) parseLVals(offsets []int) ([]int, error) {
 	first := true
 	for {
 		t := p.nextToken()

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1390,6 +1390,7 @@ func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string,
 		defTime        = timestamp.FromTime(ts)
 		appErrs        = appendErrors{}
 		sampleLimitErr error
+		e              exemplar.Exemplar // escapes to heap so hoisted out of loop
 	)
 
 	defer func() {
@@ -1406,7 +1407,6 @@ loop:
 		var (
 			et          textparse.Entry
 			sampleAdded bool
-			e           exemplar.Exemplar
 		)
 		if et, err = p.Next(); err != nil {
 			if err == io.EOF {
@@ -1513,6 +1513,7 @@ loop:
 				// Since exemplar storage is still experimental, we don't fail the scrape on ingestion errors.
 				level.Debug(sl.l).Log("msg", "Error while adding exemplar in AddExemplar", "exemplar", fmt.Sprintf("%+v", e), "err", exemplarErr)
 			}
+			e = exemplar.Exemplar{} // reset for next time round loop
 		}
 
 	}

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -929,10 +929,10 @@ test_metric 1
 	require.Equal(t, "", md.Unit)
 }
 
-func TestScrapeLoopSeriesAdded(t *testing.T) {
+func simpleTestScrapeLoop(t testing.TB) (context.Context, *scrapeLoop) {
 	// Need a full storage for correct Add/AddFast semantics.
 	s := teststorage.New(t)
-	defer s.Close()
+	t.Cleanup(func() { s.Close() })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sl := newScrapeLoop(ctx,
@@ -950,7 +950,13 @@ func TestScrapeLoopSeriesAdded(t *testing.T) {
 		0,
 		false,
 	)
-	defer cancel()
+	t.Cleanup(func() { cancel() })
+
+	return ctx, sl
+}
+
+func TestScrapeLoopSeriesAdded(t *testing.T) {
+	ctx, sl := simpleTestScrapeLoop(t)
 
 	slApp := sl.appender(ctx)
 	total, added, seriesAdded, err := sl.append(slApp, []byte("test_metric 1\n"), "", time.Time{})


### PR DESCRIPTION
I noticed that the profile for #9253 had 94% of all allocations in `scrapeLoop.append()`:
```
140179748.80MB 94.40% 94.40% 141080447.83MB 95.01%  github.com/prometheus/prometheus/scrape.(*scrapeLoop).append
```

so added benchmarks and found the cause - Exemplar variable escapes to heap due to being passed through text-parser
interface.  (Note the cost was paid on every line even when exemplars were disabled)

In a different Prometheus I checked this line contributes only 6%, but there is another in the OpenMetrics parser which costs about the same, so I optimised that too.
After calling `parseLVals()` we always append the return value, so pass in what we want to append it to and save garbage.

Benchmark comparison:
```
name                  old time/op    new time/op    delta
ScrapeLoopAppend-8      54.6µs ± 1%    49.3µs ± 2%   -9.60%  (p=0.008 n=5+5)
ScrapeLoopAppendOM-8    58.8µs ± 2%    46.0µs ± 3%  -21.75%  (p=0.008 n=5+5)

name                  old alloc/op   new alloc/op   delta
ScrapeLoopAppend-8      34.5kB ± 2%    21.3kB ± 8%  -38.40%  (p=0.008 n=5+5)
ScrapeLoopAppendOM-8    46.5kB ± 0%    20.3kB ±10%  -56.30%  (p=0.008 n=5+5)

name                  old allocs/op  new allocs/op  delta
ScrapeLoopAppend-8         409 ± 0%       109 ± 0%  -73.35%  (p=0.008 n=5+5)
ScrapeLoopAppendOM-8       709 ± 0%       111 ± 0%  -84.34%  (p=0.008 n=5+5)
```