### PR TITLE
Remove symbols map from TSDB head

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -54,16 +54,7 @@ func (h *headIndexReader) Close() error {
 }
 
 func (h *headIndexReader) Symbols() index.StringIter {
-	h.head.symMtx.RLock()
-	res := make([]string, 0, len(h.head.symbols))
-
-	for s := range h.head.symbols {
-		res = append(res, s)
-	}
-	h.head.symMtx.RUnlock()
-
-	sort.Strings(res)
-	return index.NewStringListIter(res)
+	return h.head.postings.Symbols()
 }
 
 // SortedLabelValues returns label values present in the head for the
@@ -88,8 +79,6 @@ func (h *headIndexReader) LabelValues(name string, matchers ...*labels.Matcher) 
 	}
 
 	if len(matchers) == 0 {
-		h.head.symMtx.RLock()
-		defer h.head.symMtx.RUnlock()
 		return h.head.postings.LabelValues(name), nil
 	}
 
@@ -104,10 +93,7 @@ func (h *headIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, err
 	}
 
 	if len(matchers) == 0 {
-		h.head.symMtx.RLock()
 		labelNames := h.head.postings.LabelNames()
-		h.head.symMtx.RUnlock()
-
 		sort.Strings(labelNames)
 		return labelNames, nil
 	}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -469,13 +469,14 @@ func TestHead_Truncate(t *testing.T) {
 	require.Nil(t, postingsB2)
 	require.Nil(t, postingsC1)
 
-	require.Equal(t, map[string]struct{}{
-		"":  {}, // from 'all' postings list
-		"a": {},
-		"b": {},
-		"1": {},
-		"2": {},
-	}, h.symbols)
+	iter := h.postings.Symbols()
+	symbols := []string{}
+	for iter.Next() {
+		symbols = append(symbols, iter.At())
+	}
+	require.Equal(t,
+		[]string{"" /* from 'all' postings list */, "1", "2", "a", "b"},
+		symbols)
 
 	values := map[string]map[string]struct{}{}
 	for _, name := range h.postings.LabelNames() {

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -58,6 +58,29 @@ func NewUnorderedMemPostings() *MemPostings {
 	}
 }
 
+// Symbols returns an iterator over all unique name and value strings, in order.
+func (p *MemPostings) Symbols() StringIter {
+	p.mtx.RLock()
+
+	// Add all the strings to a map to de-duplicate.
+	symbols := make(map[string]struct{}, 512)
+	for n, e := range p.m {
+		symbols[n] = struct{}{}
+		for v := range e {
+			symbols[v] = struct{}{}
+		}
+	}
+	p.mtx.RUnlock()
+
+	res := make([]string, 0, len(symbols))
+	for k := range symbols {
+		res = append(res, k)
+	}
+
+	sort.Strings(res)
+	return NewStringListIter(res)
+}
+
 // SortedKeys returns a list of sorted label keys of the postings.
 func (p *MemPostings) SortedKeys() []labels.Label {
 	p.mtx.RLock()


### PR DESCRIPTION
This saves memory, effort and locking.

Since every symbol is also added to postings, `Symbols()` can be implemented there instead.

This now has to build a map for deduplication, but `Symbols()` is only called for compaction, and `gc()` used to rebuild the symbols map after every compaction so not an additional cost.

Benchmark:
```
name            old time/op    new time/op    delta
CreateSeries-8    2.02µs ± 8%    1.50µs ± 1%  -25.78%  (p=0.016 n=5+4)

name            old alloc/op   new alloc/op   delta
CreateSeries-8    1.19kB ± 5%    1.08kB ± 5%   -8.85%  (p=0.008 n=5+5)

name            old allocs/op  new allocs/op  delta
CreateSeries-8      5.00 ± 0%      5.00 ± 0%     ~     (all equal)
```