### PR TITLE
Rules backfill: return 1 if unsuccessful

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -911,20 +911,17 @@ func importRules(url *url.URL, start, end, outputDir string, evalInterval time.D
 	} else {
 		etime, err = parseTime(end)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "error parsing end time:", err)
-			return err
+			return fmt.Errorf("error parsing end time: %v", err)
 		}
 	}
 
 	stime, err = parseTime(start)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "error parsing start time:", err)
-		return err
+		return fmt.Errorf("error parsing start time: %v", err)
 	}
 
 	if !stime.Before(etime) {
-		fmt.Fprintln(os.Stderr, "start time is not before end time")
-		return nil
+		return errors.New("start time is not before end time")
 	}
 
 	cfg := ruleImporterConfig{
@@ -937,25 +934,24 @@ func importRules(url *url.URL, start, end, outputDir string, evalInterval time.D
 		Address: url.String(),
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "new api client error", err)
-		return err
+		return fmt.Errorf("new api client error: %v", err)
 	}
 
 	ruleImporter := newRuleImporter(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), cfg, v1.NewAPI(client))
 	errs := ruleImporter.loadGroups(ctx, files)
 	for _, err := range errs {
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "rule importer parse error", err)
-			return err
+			return fmt.Errorf("rule importer parse error: %v", err)
 		}
 	}
 
 	errs = ruleImporter.importAll(ctx)
 	for _, err := range errs {
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "rule importer error", err)
-		}
+		fmt.Fprintln(os.Stderr, "rule importer error:", err)
+	}
+	if len(errs) > 0 {
+		return errors.New("error importing rules")
 	}
 
-	return err
+	return nil
 }


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

`importRules` is called by `checkError`, which prints any error and handles the return code, therefore the function itself shouldn't be doing any printing. The rule importer can return multiple errors though, so I had to make an exception for that.

Fixes #9292 