### PR TITLE
promtool: add extended flag for tsdb analysis

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -137,6 +137,7 @@ func main() {
 	analyzePath := tsdbAnalyzeCmd.Arg("db path", "Database path (default is "+defaultDBPath+").").Default(defaultDBPath).String()
 	analyzeBlockID := tsdbAnalyzeCmd.Arg("block id", "Block to analyze (default is the last block).").String()
 	analyzeLimit := tsdbAnalyzeCmd.Flag("limit", "How many items to show in each list.").Default("20").Int()
+	analyzeRunExtended := tsdbAnalyzeCmd.Flag("extended", "Run extended analysis.").Bool()
 
 	tsdbListCmd := tsdbCmd.Command("list", "List tsdb blocks.")
 	listHumanReadable := tsdbListCmd.Flag("human-readable", "Print human readable values.").Short('r').Bool()
@@ -237,7 +238,7 @@ func main() {
 		os.Exit(checkErr(benchmarkWrite(*benchWriteOutPath, *benchSamplesFile, *benchWriteNumMetrics, *benchWriteNumScrapes)))
 
 	case tsdbAnalyzeCmd.FullCommand():
-		os.Exit(checkErr(analyzeBlock(*analyzePath, *analyzeBlockID, *analyzeLimit)))
+		os.Exit(checkErr(analyzeBlock(*analyzePath, *analyzeBlockID, *analyzeLimit, *analyzeRunExtended)))
 
 	case tsdbListCmd.FullCommand():
 		os.Exit(checkErr(listBlocks(*listPath, *listHumanReadable)))

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -418,7 +418,7 @@ func openBlock(path, blockID string) (*tsdb.DBReadOnly, tsdb.BlockReader, error)
 	return db, block, nil
 }
 
-func analyzeBlock(path, blockID string, limit int) error {
+func analyzeBlock(path, blockID string, limit int, runExtended bool) error {
 	db, block, err := openBlock(path, blockID)
 	if err != nil {
 		return err
@@ -564,7 +564,11 @@ func analyzeBlock(path, blockID string, limit int) error {
 	fmt.Printf("\nHighest cardinality metric names:\n")
 	printInfo(postingInfos)
 
-	return analyzeCompaction(block, ir)
+	if runExtended {
+		return analyzeCompaction(block, ir)
+	}
+
+	return nil
 }
 
 func analyzeCompaction(block tsdb.BlockReader, indexr tsdb.IndexReader) (err error) {


### PR DESCRIPTION
The compaction analysis which runs under promtool tsdb analyze can be an
intensive process which slows down the entire command.

This commit adds an --extended flag to tsdb analyze which can be toggled
for running long running tasks, such as compaction analysis.

Signed-off-by: fpetkovski <filip.petkovsky@gmail.com>

Follows up on: https://github.com/prometheus/prometheus/pull/8940

cc @bwplotka @roidelapluie 

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
