### PR TITLE
use consistent margin-bottom for all alert kinds

### DIFF
--- a/web/ui/react-app/src/themes/_shared.scss
+++ b/web/ui/react-app/src/themes/_shared.scss
@@ -135,8 +135,9 @@ input[type='checkbox']:checked + label {
   flex-wrap: nowrap;
 }
 
-.alert.alert-danger {
-  margin-bottom: 10px;
+.alert {
+  padding: 10px;
+  margin-bottom: .2rem;
 }
 
 .nav-tabs .nav-link {

--- a/web/ui/react-app/src/themes/_shared.scss
+++ b/web/ui/react-app/src/themes/_shared.scss
@@ -321,6 +321,7 @@ input[type='checkbox']:checked + label {
   display: flex;
   justify-content: space-between;
   margin-bottom: 10px;
+  margin-top: 10px;
   padding: 10px;
 }
 


### PR DESCRIPTION
`.alert-danger` looks like the odd one out having `margin-bottom: 10px` for some reason (something from pre-react?). The rest has bootstrap default (16px). 

Updated all `.alert` to have the same and a bit less than `.alert-danger` at `.2rem`, to fit some more rows above the fold, as there are quite alot of whitespace as-is. If thats undesirable, I can keep all at `10px` as well.

Visual change

old | 
-----|
![am-old](https://user-images.githubusercontent.com/1887628/132575357-0b26218b-8847-4e79-8fef-eadab5a14e86.png)| 

new |
-----|
![am-new](https://user-images.githubusercontent.com/1887628/132575382-6cfc9ac7-4e0a-4178-a9f3-5002591c24ed.png)|
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
