### PR TITLE
Take snapshot only after closing the WAL

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1168,11 +1168,11 @@ func (h *Head) Close() error {
 	defer h.closedMtx.Unlock()
 	h.closed = true
 	errs := tsdb_errors.NewMulti(h.chunkDiskMapper.Close())
-	if errs.Err() == nil && h.opts.EnableMemorySnapshotOnShutdown {
-		errs.Add(h.performChunkSnapshot())
-	}
 	if h.wal != nil {
 		errs.Add(h.wal.Close())
+	}
+	if errs.Err() == nil && h.opts.EnableMemorySnapshotOnShutdown {
+		errs.Add(h.performChunkSnapshot())
 	}
 	return errs.Err()
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2659,6 +2659,10 @@ func TestChunkSnapshot(t *testing.T) {
 	// These references should be the ones used for the snapshot.
 	wlast, woffset, err = head.wal.LastSegmentAndOffset()
 	require.NoError(t, err)
+	if woffset != 0 && woffset < 32*1024 {
+		// The page is always filled before taking the snapshot.
+		woffset = 32 * 1024
+	}
 
 	{
 		// Creating snapshot and verifying it.
@@ -2725,6 +2729,10 @@ func TestChunkSnapshot(t *testing.T) {
 	// Creating another snapshot should delete the older snapshot and replay still works fine.
 	wlast, woffset, err = head.wal.LastSegmentAndOffset()
 	require.NoError(t, err)
+	if woffset != 0 && woffset < 32*1024 {
+		// The page is always filled before taking the snapshot.
+		woffset = 32 * 1024
+	}
 
 	{
 		// Close Head and verify that new snapshot was created.


### PR DESCRIPTION
This small patch ensures that snapshot is taken only after closing WAL so that we are sure not WAL write happened after that. This is an enhancement and not a bugfix but I would like this to be in the release. rc1 would not be required for this patch.