### PR TITLE
Support stale samples for sparse histograms

### DIFF
--- a/tsdb/chunkenc/histo.go
+++ b/tsdb/chunkenc/histo.go
@@ -625,10 +625,14 @@ func (it *histoIterator) Next() bool {
 		it.zeroThreshold = zeroThreshold
 		it.posSpans, it.negSpans = posSpans, negSpans
 		numPosBuckets, numNegBuckets := countSpans(posSpans), countSpans(negSpans)
-		it.posbuckets = make([]int64, numPosBuckets)
-		it.negbuckets = make([]int64, numNegBuckets)
-		it.posbucketsDelta = make([]int64, numPosBuckets)
-		it.negbucketsDelta = make([]int64, numNegBuckets)
+		if numPosBuckets > 0 {
+			it.posbuckets = make([]int64, numPosBuckets)
+			it.posbucketsDelta = make([]int64, numPosBuckets)
+		}
+		if numNegBuckets > 0 {
+			it.negbuckets = make([]int64, numNegBuckets)
+			it.negbucketsDelta = make([]int64, numNegBuckets)
+		}
 
 		// now read actual data
 

--- a/tsdb/chunkenc/histo.go
+++ b/tsdb/chunkenc/histo.go
@@ -49,6 +49,7 @@ import (
 	"math/bits"
 
 	"github.com/prometheus/prometheus/pkg/histogram"
+	"github.com/prometheus/prometheus/pkg/value"
 )
 
 const ()
@@ -248,6 +249,15 @@ func (a *HistoAppender) Append(int64, float64) {}
 // * any buckets disappeared
 // * there was a counter reset in the count of observations or in any bucket, including the zero bucket
 func (a *HistoAppender) Appendable(h histogram.SparseHistogram) ([]Interjection, []Interjection, bool) {
+	if value.IsStaleNaN(h.Sum) {
+		// This is a stale sample whose buckets and spans don't matter.
+		return nil, nil, true
+	}
+	if value.IsStaleNaN(a.sum) {
+		// If the last sample was stale, then we can only accept stale samples in this chunk.
+		return nil, nil, false
+	}
+
 	if h.Schema != a.schema || h.ZeroThreshold != a.zeroThreshold {
 		return nil, nil, false
 	}
@@ -350,6 +360,12 @@ func (a *HistoAppender) AppendHistogram(t int64, h histogram.SparseHistogram) {
 	var tDelta, cntDelta, zcntDelta int64
 	num := binary.BigEndian.Uint16(a.b.bytes())
 
+	if value.IsStaleNaN(h.Sum) {
+		// Emptying out other fields to write empty meta in case of
+		// first histogram in the chunk.
+		h = histogram.SparseHistogram{Sum: h.Sum}
+	}
+
 	switch num {
 	case 0:
 		// the first append gets the privilege to dictate the metadata
@@ -377,10 +393,13 @@ func (a *HistoAppender) AppendHistogram(t int64, h histogram.SparseHistogram) {
 			putVarint(a.b, a.buf64, buck)
 		}
 	case 1:
-
 		tDelta = t - a.t
 		cntDelta = int64(h.Count) - int64(a.cnt)
 		zcntDelta = int64(h.ZeroCount) - int64(a.zcnt)
+
+		if value.IsStaleNaN(h.Sum) {
+			tDelta, cntDelta, zcntDelta = 0, 0, 0
+		}
 
 		putVarint(a.b, a.buf64, tDelta)
 		putVarint(a.b, a.buf64, cntDelta)
@@ -398,6 +417,7 @@ func (a *HistoAppender) AppendHistogram(t int64, h histogram.SparseHistogram) {
 			putVarint(a.b, a.buf64, delta)
 			a.negbucketsDelta[i] = delta
 		}
+
 	default:
 		tDelta = t - a.t
 		cntDelta = int64(h.Count) - int64(a.cnt)
@@ -406,6 +426,10 @@ func (a *HistoAppender) AppendHistogram(t int64, h histogram.SparseHistogram) {
 		tDod := tDelta - a.tDelta
 		cntDod := cntDelta - a.cntDelta
 		zcntDod := zcntDelta - a.zcntDelta
+
+		if value.IsStaleNaN(h.Sum) {
+			tDod, cntDod, zcntDod = 0, 0, 0
+		}
 
 		putInt64VBBucket(a.b, tDod)
 		putInt64VBBucket(a.b, cntDod)
@@ -438,9 +462,7 @@ func (a *HistoAppender) AppendHistogram(t int64, h histogram.SparseHistogram) {
 
 	a.posbuckets, a.negbuckets = h.PositiveBuckets, h.NegativeBuckets
 	// note that the bucket deltas were already updated above
-
 	a.sum = h.Sum
-
 }
 
 // Recode converts the current chunk to accommodate an expansion of the set of
@@ -566,6 +588,10 @@ func (it *histoIterator) ChunkEncoding() Encoding {
 }
 
 func (it *histoIterator) AtHistogram() (int64, histogram.SparseHistogram) {
+	if value.IsStaleNaN(it.sum) {
+		it.numRead++
+		return it.t, histogram.SparseHistogram{Sum: it.sum}
+	}
 	return it.t, histogram.SparseHistogram{
 		Count:           it.cnt,
 		ZeroCount:       it.zcnt,
@@ -715,6 +741,11 @@ func (it *histoIterator) Next() bool {
 			return false
 		}
 
+		if value.IsStaleNaN(it.sum) {
+			it.numRead++
+			return true
+		}
+
 		for i := range it.posbuckets {
 			delta, err := binary.ReadVarint(&it.br)
 			if err != nil {
@@ -766,6 +797,11 @@ func (it *histoIterator) Next() bool {
 	ok := it.readSum()
 	if !ok {
 		return false
+	}
+
+	if value.IsStaleNaN(it.sum) {
+		it.numRead++
+		return true
 	}
 
 	for i := range it.posbuckets {

--- a/tsdb/chunkenc/histo.go
+++ b/tsdb/chunkenc/histo.go
@@ -248,6 +248,7 @@ func (a *HistoAppender) Append(int64, float64) {}
 // * the zerobucket threshold has changed
 // * any buckets disappeared
 // * there was a counter reset in the count of observations or in any bucket, including the zero bucket
+// * the last sample in the chunk was stale while the current sample is not stale
 func (a *HistoAppender) Appendable(h histogram.SparseHistogram) ([]Interjection, []Interjection, bool) {
 	if value.IsStaleNaN(h.Sum) {
 		// This is a stale sample whose buckets and spans don't matter.

--- a/tsdb/chunkenc/histo_test.go
+++ b/tsdb/chunkenc/histo_test.go
@@ -41,8 +41,6 @@ func TestHistoChunkSameBuckets(t *testing.T) {
 			{Offset: 1, Length: 2},
 		},
 		PositiveBuckets: []int64{1, 1, -1, 0}, // counts: 1, 2, 1, 1 (total 5)
-		NegativeSpans:   nil,
-		NegativeBuckets: []int64{},
 	}
 	app.AppendHistogram(ts, h)
 	exp = append(exp, res{t: ts, h: h})
@@ -142,8 +140,6 @@ func TestHistoChunkBucketChanges(t *testing.T) {
 			{Offset: 1, Length: 1},
 		},
 		PositiveBuckets: []int64{6, -3, 0, -1, 2, 1, -4}, // counts: 6, 3, 3, 2, 4, 5, 1 (total 24)
-		NegativeSpans:   nil,
-		NegativeBuckets: []int64{},
 	}
 
 	app.AppendHistogram(ts1, h1)
@@ -217,8 +213,6 @@ func TestHistoChunkAppendable(t *testing.T) {
 			{Offset: 1, Length: 1},
 		},
 		PositiveBuckets: []int64{6, -3, 0, -1, 2, 1, -4}, // counts: 6, 3, 3, 2, 4, 5, 1 (total 24)
-		NegativeSpans:   nil,
-		NegativeBuckets: []int64{},
 	}
 
 	app.AppendHistogram(ts, h1)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -610,12 +610,12 @@ func (s *memSeries) appendHistogram(t int64, sh histogram.SparseHistogram, appen
 		return sampleInOrder, chunkCreated
 	}
 
-	if !chunkCreated && value.IsStaleNaN(sh.Sum) {
+	if value.IsStaleNaN(sh.Sum) {
 		// Deliberately empty other fields so that any future histogram will result in a new chunk.
 		sh = histogram.SparseHistogram{Sum: sh.Sum}
-		c = s.cutNewHeadChunk(t, chunkenc.EncSHS, chunkDiskMapper)
-		chunkCreated = true
-	} else if !chunkCreated {
+	}
+
+	if !chunkCreated {
 		// Head controls the execution of recoding, so that we own the proper chunk reference afterwards
 		app, _ := s.app.(*chunkenc.HistoAppender)
 		posInterjections, negInterjections, ok := app.Appendable(sh)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -610,11 +610,6 @@ func (s *memSeries) appendHistogram(t int64, sh histogram.SparseHistogram, appen
 		return sampleInOrder, chunkCreated
 	}
 
-	if value.IsStaleNaN(sh.Sum) {
-		// Deliberately empty other fields so that any future histogram will result in a new chunk.
-		sh = histogram.SparseHistogram{Sum: sh.Sum}
-	}
-
 	if !chunkCreated {
 		// Head controls the execution of recoding, so that we own the proper chunk reference afterwards
 		app, _ := s.app.(*chunkenc.HistoAppender)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2870,10 +2870,10 @@ func TestSparseHistogramStaleSample(t *testing.T) {
 	expHists = append(expHists, timedHist{int64(len(expHists)), histogram.SparseHistogram{Sum: math.Float64frombits(value.StaleNaN)}})
 	require.NoError(t, app.Commit())
 
-	// Total 2 chunks, 1 m-mapped.
+	// Only 1 chunk in the memory, no m-mapped chunk.
 	s := head.series.getByHash(l.Hash(), l)
 	require.NotNil(t, s)
-	require.Equal(t, 1, len(s.mmappedChunks))
+	require.Equal(t, 0, len(s.mmappedChunks))
 	testQuery(1)
 
 	// Adding stale in different appender and continuing series after a stale sample.
@@ -2891,9 +2891,9 @@ func TestSparseHistogramStaleSample(t *testing.T) {
 	expHists = append(expHists, timedHist{int64(len(expHists)), histogram.SparseHistogram{Sum: math.Float64frombits(value.StaleNaN)}})
 	require.NoError(t, app.Commit())
 
-	// Total 4 chunks, 3 m-mapped.
+	// Total 2 chunks, 1 m-mapped.
 	s = head.series.getByHash(l.Hash(), l)
 	require.NotNil(t, s)
-	require.Equal(t, 3, len(s.mmappedChunks))
+	require.Equal(t, 1, len(s.mmappedChunks))
 	testQuery(2)
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/exemplar"
 	"github.com/prometheus/prometheus/pkg/histogram"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -2605,7 +2606,6 @@ func generateHistograms(n int) (r []histogram.SparseHistogram) {
 				{Offset: 1, Length: 2},
 			},
 			PositiveBuckets: []int64{int64(i + 1), 1, -1, 0},
-			NegativeBuckets: []int64{},
 		})
 	}
 
@@ -2804,4 +2804,96 @@ func TestSparseHistogramMetrics(t *testing.T) {
 
 	require.Equal(t, float64(expHistSeries), prom_testutil.ToFloat64(head.metrics.sparseHistogramSeries))
 	require.Equal(t, float64(0), prom_testutil.ToFloat64(head.metrics.sparseHistogramSamplesTotal)) // Counter reset.
+}
+
+func TestSparseHistogramStaleSample(t *testing.T) {
+	l := labels.Labels{{Name: "a", Value: "b"}}
+	numHistograms := 20
+	head, _ := newTestHead(t, 1000, false)
+	t.Cleanup(func() {
+		require.NoError(t, head.Close())
+	})
+	require.NoError(t, head.Init(0))
+
+	type timedHist struct {
+		t int64
+		h histogram.SparseHistogram
+	}
+	expHists := make([]timedHist, 0, numHistograms)
+
+	testQuery := func(numStale int) {
+		q, err := NewBlockQuerier(head, head.MinTime(), head.MaxTime())
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, q.Close())
+		})
+
+		ss := q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
+
+		require.True(t, ss.Next())
+		s := ss.At()
+		require.False(t, ss.Next())
+
+		it := s.Iterator()
+		actHists := make([]timedHist, 0, len(expHists))
+		for it.Next() {
+			t, h := it.AtHistogram()
+			actHists = append(actHists, timedHist{t, h.Copy()})
+		}
+
+		// We cannot compare StaleNAN with require.Equal, hence checking each histogram manually.
+		require.Equal(t, len(expHists), len(actHists))
+		actNumStale := 0
+		for i, eh := range expHists {
+			ah := actHists[i]
+			if value.IsStaleNaN(eh.h.Sum) {
+				actNumStale++
+				require.True(t, value.IsStaleNaN(ah.h.Sum))
+				// To make require.Equal work.
+				ah.h.Sum = 0
+				eh.h.Sum = 0
+			}
+			require.Equal(t, eh, ah)
+		}
+		require.Equal(t, numStale, actNumStale)
+	}
+
+	// Adding stale in the same appender.
+	app := head.Appender(context.Background())
+	for _, h := range generateHistograms(numHistograms) {
+		_, err := app.AppendHistogram(0, l, int64(len(expHists)), h)
+		require.NoError(t, err)
+		expHists = append(expHists, timedHist{int64(len(expHists)), h})
+	}
+	_, err := app.Append(0, l, int64(len(expHists)), math.Float64frombits(value.StaleNaN))
+	require.NoError(t, err)
+	expHists = append(expHists, timedHist{int64(len(expHists)), histogram.SparseHistogram{Sum: math.Float64frombits(value.StaleNaN)}})
+	require.NoError(t, app.Commit())
+
+	// Total 2 chunks, 1 m-mapped.
+	s := head.series.getByHash(l.Hash(), l)
+	require.NotNil(t, s)
+	require.Equal(t, 1, len(s.mmappedChunks))
+	testQuery(1)
+
+	// Adding stale in different appender and continuing series after a stale sample.
+	app = head.Appender(context.Background())
+	for _, h := range generateHistograms(2 * numHistograms)[numHistograms:] {
+		_, err := app.AppendHistogram(0, l, int64(len(expHists)), h)
+		require.NoError(t, err)
+		expHists = append(expHists, timedHist{int64(len(expHists)), h})
+	}
+	require.NoError(t, app.Commit())
+
+	app = head.Appender(context.Background())
+	_, err = app.Append(0, l, int64(len(expHists)), math.Float64frombits(value.StaleNaN))
+	require.NoError(t, err)
+	expHists = append(expHists, timedHist{int64(len(expHists)), histogram.SparseHistogram{Sum: math.Float64frombits(value.StaleNaN)}})
+	require.NoError(t, app.Commit())
+
+	// Total 4 chunks, 3 m-mapped.
+	s = head.series.getByHash(l.Hash(), l)
+	require.NotNil(t, s)
+	require.Equal(t, 3, len(s.mmappedChunks))
+	testQuery(2)
 }


### PR DESCRIPTION
NOTE: this is pointing to sparsehistogram branch

This PR adds support for handling StaleNaN for sparse histograms. We accept stale samples via `Append()` too, so we do not require any special handling in scraping code.

cc @beorn7 