### PR TITLE
Optimise query_range by computing join signatures just once

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -172,6 +172,10 @@ func BenchmarkRangeQuery(b *testing.B) {
 		{
 			expr: "histogram_quantile(0.9, rate(h_X[5m]))",
 		},
+		// Many-to-one join.
+		{
+			expr: "a_X + on(l) group_right a_one",
+		},
 	}
 
 	// X in an expr will be replaced by different metric sizes.


### PR DESCRIPTION
For an expression like `a + on(p,q) b`, extract the `p,q` part from each series once, instead of re-computing at every step of the range.

Although there was a cache, computing the key by concatenating all labels was expensive.

I added a benchmark case for many-to-one join; the speed-up is much greater with more labels in the benchmark but I left them as-is; it's pretty good already.

```
name                                                                     old time/op    new time/op    delta
RangeQuery/expr=-a_one,steps=1-8                                           9.23µs ± 0%    9.15µs ± 0%   -0.90%  (p=0.008 n=5+5)
RangeQuery/expr=-a_one,steps=10-8                                          9.63µs ± 0%    9.60µs ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=-a_one,steps=100-8                                         14.7µs ± 0%    14.7µs ± 0%     ~     (p=0.341 n=5+5)
RangeQuery/expr=-a_one,steps=1000-8                                        47.3µs ± 2%    47.6µs ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=-a_ten,steps=1-8                                           38.9µs ± 0%    38.8µs ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=-a_ten,steps=10-8                                          43.3µs ± 1%    43.1µs ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=-a_ten,steps=100-8                                         94.5µs ± 0%    94.7µs ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=-a_ten,steps=1000-8                                         420µs ± 2%     423µs ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=-a_hundred,steps=1-8                                        341µs ± 0%     340µs ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=-a_hundred,steps=10-8                                       382µs ± 0%     385µs ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-8                                      899µs ± 1%     898µs ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-8                                    4.11ms ± 1%    4.17ms ± 1%   +1.69%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1-8                                    16.3µs ± 5%    15.8µs ± 1%   -2.97%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10-8                                   21.1µs ± 0%    19.9µs ± 1%   -5.33%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=100-8                                  73.7µs ± 3%    62.4µs ± 1%  -15.34%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1000-8                                  549µs ± 1%     447µs ± 3%  -18.56%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1-8                                    88.0µs ± 0%    83.3µs ± 0%   -5.35%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10-8                                    146µs ± 0%     131µs ± 2%  -10.58%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=100-8                                   740µs ± 0%     608µs ± 0%  -17.86%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1000-8                                 6.28ms ± 1%    4.97ms ± 0%  -20.85%  (p=0.016 n=5+4)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-8                             814µs ± 0%     772µs ± 1%   -5.18%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-8                           1.42ms ± 1%    1.26ms ± 0%  -11.18%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                          7.66ms ± 1%    6.30ms ± 0%  -17.78%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                         66.8ms ± 1%    53.5ms ± 0%  -19.92%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-8                                5.67ms ± 3%    4.61ms ± 2%  -18.58%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10000-8                                65.5ms ± 0%    52.7ms ± 0%  -19.62%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-8                         692ms ± 1%     561ms ± 0%  -18.92%  (p=0.016 n=5+4)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-8                   36.7µs ± 1%    37.2µs ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-8                  39.2µs ± 2%    38.5µs ± 1%   -1.63%  (p=0.016 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-8                 60.8µs ± 0%    51.9µs ± 0%  -14.66%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-8                 257µs ± 0%     165µs ± 1%  -35.72%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-8                   89.4µs ± 0%    85.9µs ± 0%   -3.91%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-8                   117µs ± 1%     104µs ± 0%  -10.80%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-8                  394µs ± 1%     298µs ± 0%  -24.42%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-8                2.83ms ± 1%    1.95ms ± 1%  -31.24%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-8            603µs ± 2%     564µs ± 1%   -6.38%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-8           894µs ± 0%     777µs ± 1%  -13.05%  (p=0.016 n=4+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8         4.00ms ± 1%    3.04ms ± 1%  -23.96%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8        32.5ms ± 1%    23.0ms ± 1%  -29.26%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-8                    37.4µs ± 0%    37.9µs ± 5%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-8                   40.6µs ± 0%    39.8µs ± 0%   -1.99%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-8                  74.8µs ± 1%    65.3µs ± 1%  -12.71%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-8                  391µs ± 0%     294µs ± 0%  -24.94%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-8                    94.6µs ± 6%    89.7µs ± 1%   -5.19%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-8                    132µs ± 1%     119µs ± 0%   -9.70%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-8                   528µs ± 0%     427µs ± 0%  -19.15%  (p=0.016 n=4+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-8                 4.20ms ± 0%    3.21ms ± 1%  -23.62%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-8             632µs ± 1%     600µs ± 1%   -5.15%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-8           1.03ms ± 0%    0.91ms ± 0%  -11.71%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8          5.12ms ± 1%    4.12ms ± 0%  -19.55%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8         43.2ms ± 1%    33.9ms ± 1%  -21.52%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-8                37.4µs ± 0%    37.4µs ± 0%     ~     (p=0.111 n=5+4)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-8               40.5µs ± 1%    39.7µs ± 0%   -1.81%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-8              73.5µs ± 1%    64.7µs ± 0%  -11.99%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-8              376µs ± 1%     290µs ± 1%  -22.98%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-8                89.5µs ± 0%    86.6µs ± 1%   -3.30%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-8                116µs ± 1%     104µs ± 0%  -10.61%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-8               389µs ± 0%     297µs ± 0%  -23.59%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-8             2.82ms ± 1%    1.94ms ± 0%  -31.27%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-8         601µs ± 1%     566µs ± 1%   -5.83%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-8        895µs ± 1%     781µs ± 1%  -12.74%  (p=0.016 n=4+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8      4.01ms ± 0%    3.05ms ± 1%  -23.88%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8     32.6ms ± 2%    23.0ms ± 1%  -29.42%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=1-8                  16.7µs ± 1%    16.6µs ± 2%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=10-8                 22.7µs ± 1%    21.6µs ± 0%   -4.77%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=100-8                81.7µs ± 0%    70.1µs ± 1%  -14.23%  (p=0.016 n=4+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=1000-8                628µs ± 2%     516µs ± 1%  -17.93%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=1-8                  48.1µs ± 0%    46.2µs ± 0%   -3.90%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=10-8                 65.8µs ± 0%    56.7µs ± 0%  -13.78%  (p=0.016 n=4+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=100-8                 249µs ± 0%     174µs ± 2%  -29.87%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=1000-8               1.86ms ± 0%    1.11ms ± 0%  -40.09%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1-8               370µs ± 0%     352µs ± 1%   -4.92%  (p=0.016 n=4+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=10-8              536µs ± 2%     458µs ± 1%  -14.56%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8            2.28ms ± 1%    1.65ms ± 0%  -27.86%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8           17.9ms ± 0%    11.7ms ± 1%  -34.66%  (p=0.008 n=5+5)

name                                                                     old alloc/op   new alloc/op   delta
RangeQuery/expr=-a_one,steps=1-8                                           5.65kB ± 0%    5.65kB ± 0%     ~     (all equal)
RangeQuery/expr=-a_one,steps=10-8                                          5.65kB ± 0%    5.65kB ± 0%     ~     (all equal)
RangeQuery/expr=-a_one,steps=100-8                                         5.94kB ± 0%    5.94kB ± 0%     ~     (p=0.238 n=5+4)
RangeQuery/expr=-a_one,steps=1000-8                                        9.37kB ± 0%    9.83kB ± 0%   +4.95%  (p=0.029 n=4+4)
RangeQuery/expr=-a_ten,steps=1-8                                           17.4kB ± 0%    17.4kB ± 0%     ~     (p=0.444 n=5+5)
RangeQuery/expr=-a_ten,steps=10-8                                          17.4kB ± 0%    17.4kB ± 0%     ~     (p=0.532 n=5+5)
RangeQuery/expr=-a_ten,steps=100-8                                         19.5kB ± 0%    19.5kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=-a_ten,steps=1000-8                                        43.7kB ± 0%    48.4kB ± 0%  +10.64%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1-8                                        133kB ± 0%     133kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=-a_hundred,steps=10-8                                       133kB ± 0%     133kB ± 0%     ~     (p=0.286 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-8                                      154kB ± 0%     154kB ± 0%     ~     (p=0.524 n=5+4)
RangeQuery/expr=-a_hundred,steps=1000-8                                     384kB ± 0%     432kB ± 0%  +12.41%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1-8                                    10.9kB ± 0%    11.5kB ± 0%   +6.04%  (p=0.016 n=5+4)
RangeQuery/expr=a_one_-_b_one,steps=10-8                                   12.1kB ± 0%    12.0kB ± 0%   -1.12%  (p=0.029 n=4+4)
RangeQuery/expr=a_one_-_b_one,steps=100-8                                  24.9kB ± 0%    16.9kB ± 0%  -32.35%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1000-8                                  154kB ± 0%      68kB ± 0%  -55.99%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1-8                                    40.0kB ± 0%    38.5kB ± 0%   -3.74%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10-8                                   42.8kB ± 0%    40.5kB ± 0%   -5.34%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=100-8                                  75.2kB ± 0%    65.0kB ± 0%  -13.59%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1000-8                                  405kB ± 0%     324kB ± 0%  -19.84%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-8                             338kB ± 0%     316kB ± 0%   -6.51%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-8                            362kB ± 0%     339kB ± 0%   -6.31%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                           641kB ± 0%     610kB ± 0%   -4.82%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                         3.48MB ± 0%    3.46MB ± 0%   -0.40%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-8                                1.53MB ± 0%    0.65MB ± 0%  -57.32%  (p=0.016 n=4+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10000-8                                4.37MB ± 0%    3.49MB ± 0%  -20.00%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-8                        38.3MB ± 0%    37.5MB ± 0%   -2.13%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-8                   19.6kB ± 0%    20.2kB ± 0%   +3.03%  (p=0.029 n=4+4)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-8                  20.8kB ± 0%    20.6kB ± 0%   -0.93%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-8                 33.3kB ± 0%    25.2kB ± 0%  -24.37%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-8                 159kB ± 0%      72kB ± 0%  -54.58%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-8                   40.0kB ± 0%    38.6kB ± 0%   -3.59%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-8                  41.2kB ± 0%    39.0kB ± 0%   -5.40%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-8                 56.8kB ± 0%    46.6kB ± 0%  -17.90%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-8                 216kB ± 0%     134kB ± 0%  -38.17%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-8            239kB ± 0%     218kB ± 0%   -8.73%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-8           269kB ± 0%     247kB ± 0%   -8.06%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8          596kB ± 0%     566kB ± 0%   -4.98%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8        3.90MB ± 0%    3.86MB ± 0%   -0.96%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-8                    19.6kB ± 0%    20.2kB ± 0%   +3.03%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-8                   20.9kB ± 0%    20.7kB ± 0%   -0.94%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-8                  33.4kB ± 0%    25.3kB ± 0%  -24.33%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-8                  159kB ± 0%      72kB ± 0%  -54.57%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-8                    41.3kB ± 0%    39.8kB ± 0%   -3.48%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-8                   46.6kB ± 0%    44.4kB ± 0%   -4.80%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-8                   103kB ± 0%      93kB ± 0%   -9.88%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-8                  671kB ± 0%     589kB ± 0%  -12.28%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-8             251kB ± 0%     230kB ± 0%   -8.33%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-8            314kB ± 0%     292kB ± 0%   -6.93%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8           974kB ± 0%     944kB ± 0%   -3.05%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8         7.61MB ± 0%    7.57MB ± 0%   -0.51%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-8                19.6kB ± 0%    20.2kB ± 0%   +3.03%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-8               20.9kB ± 0%    20.7kB ± 0%   -0.90%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-8              33.4kB ± 0%    25.3kB ± 0%  -24.32%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-8              159kB ± 0%      72kB ± 0%  -54.57%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-8                40.0kB ± 0%    38.6kB ± 0%   -3.56%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-8               41.2kB ± 0%    39.0kB ± 0%   -5.40%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-8              56.7kB ± 0%    46.6kB ± 0%  -17.84%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-8              216kB ± 0%     134kB ± 0%  -38.18%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-8         239kB ± 0%     218kB ± 0%   -8.73%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-8        269kB ± 0%     247kB ± 0%   -8.05%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8       596kB ± 0%     566kB ± 0%   -4.94%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8     3.90MB ± 0%    3.86MB ± 0%   -0.99%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=1-8                  11.1kB ± 0%    11.8kB ± 0%   +6.72%  (p=0.016 n=5+4)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=10-8                 13.7kB ± 0%    13.4kB ± 0%   -1.93%  (p=0.029 n=4+4)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=100-8                40.2kB ± 0%    29.8kB ± 0%  -25.75%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=1000-8                306kB ± 0%     196kB ± 0%  -35.99%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=1-8                  24.1kB ± 0%    23.9kB ± 0%   -0.74%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=10-8                 25.6kB ± 0%    24.4kB ± 0%   -4.63%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=100-8                43.3kB ± 0%    32.0kB ± 0%  -26.05%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=1000-8                223kB ± 0%     116kB ± 0%  -47.93%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1-8               172kB ± 0%     161kB ± 0%   -6.17%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=10-8              181kB ± 0%     169kB ± 0%   -6.41%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8             289kB ± 0%     267kB ± 0%   -7.58%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8           1.39MB ± 0%    1.32MB ± 0%   -5.40%  (p=0.008 n=5+5)

name                                                                     old allocs/op  new allocs/op  delta
RangeQuery/expr=-a_one,steps=1-8                                              134 ± 0%       134 ± 0%     ~     (all equal)
RangeQuery/expr=-a_one,steps=10-8                                             134 ± 0%       134 ± 0%     ~     (all equal)
RangeQuery/expr=-a_one,steps=100-8                                            139 ± 0%       139 ± 0%     ~     (all equal)
RangeQuery/expr=-a_one,steps=1000-8                                           180 ± 0%       186 ± 0%   +3.33%  (p=0.008 n=5+5)
RangeQuery/expr=-a_ten,steps=1-8                                              319 ± 0%       319 ± 0%     ~     (all equal)
RangeQuery/expr=-a_ten,steps=10-8                                             319 ± 0%       319 ± 0%     ~     (all equal)
RangeQuery/expr=-a_ten,steps=100-8                                            360 ± 0%       360 ± 0%     ~     (all equal)
RangeQuery/expr=-a_ten,steps=1000-8                                           743 ± 0%       803 ± 0%   +8.08%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1-8                                        2.13k ± 0%     2.13k ± 0%     ~     (all equal)
RangeQuery/expr=-a_hundred,steps=10-8                                       2.13k ± 0%     2.13k ± 0%     ~     (all equal)
RangeQuery/expr=-a_hundred,steps=100-8                                      2.53k ± 0%     2.53k ± 0%     ~     (all equal)
RangeQuery/expr=-a_hundred,steps=1000-8                                     6.31k ± 0%     6.93k ± 0%   +9.79%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1-8                                       216 ± 0%       216 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_-_b_one,steps=10-8                                      252 ± 0%       234 ± 0%   -7.14%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=100-8                                     622 ± 0%       424 ± 0%  -31.83%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1000-8                                  4.30k ± 0%     2.32k ± 0%  -46.14%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1-8                                       629 ± 0%       609 ± 0%   -3.18%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10-8                                      675 ± 0%       637 ± 0%   -5.63%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=100-8                                   1.22k ± 0%     1.00k ± 0%     ~     (p=0.079 n=4+5)
RangeQuery/expr=a_ten_-_b_ten,steps=1000-8                                  6.60k ± 0%     4.70k ± 0%  -28.79%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-8                             4.64k ± 0%     4.43k ± 0%   -4.57%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-8                            4.76k ± 0%     4.53k ± 0%   -4.83%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                           6.75k ± 0%     6.34k ± 0%   -6.06%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                          26.2k ± 0%     25.3k ± 0%   -3.70%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-8                                 41.9k ± 0%     22.0k ± 0%  -47.65%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_-_b_ten,steps=10000-8                                 68.5k ± 0%     48.6k ± 0%  -29.06%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-8                          302k ± 0%      283k ± 0%   -6.28%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1-8                      300 ± 0%       298 ± 0%   -0.67%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=10-8                     336 ± 0%       316 ± 0%   -5.95%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-8                    701 ± 0%       501 ± 0%  -28.53%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-8                 4.34k ± 0%     2.35k ± 0%  -45.92%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1-8                      602 ± 0%       586 ± 0%   -2.66%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=10-8                     638 ± 0%       604 ± 0%   -5.33%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=100-8                  1.06k ± 0%     0.85k ± 0%  -20.19%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_and_b_ten{l=~'.*[0-4]$'},steps=1000-8                 5.24k ± 0%     3.31k ± 0%  -36.75%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-8            3.38k ± 0%     3.22k ± 0%   -4.73%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-8           3.52k ± 0%     3.34k ± 0%   -5.06%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8          5.44k ± 0%     5.08k ± 0%   -6.56%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8         24.3k ± 0%     23.1k ± 0%   -5.06%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1-8                       302 ± 0%       300 ± 0%   -0.66%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=10-8                      338 ± 0%       318 ± 0%   -5.92%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-8                     703 ± 0%       503 ± 0%  -28.45%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-8                  4.34k ± 0%     2.35k ± 0%  -45.90%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1-8                       611 ± 0%       595 ± 0%   -2.62%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=10-8                      666 ± 0%       632 ± 0%   -5.11%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=100-8                   1.28k ± 0%     1.06k ± 0%  -16.80%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_or_b_ten{l=~'.*[0-4]$'},steps=1000-8                  7.35k ± 0%     5.42k ± 0%  -26.20%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-8             3.45k ± 0%     3.29k ± 0%   -4.63%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-8            3.62k ± 0%     3.44k ± 0%   -4.91%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8           5.99k ± 0%     5.63k ± 0%   -5.98%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8          29.3k ± 0%     28.1k ± 0%   -4.26%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1-8                   302 ± 0%       300 ± 0%   -0.66%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=10-8                  338 ± 0%       318 ± 0%   -5.92%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-8                 703 ± 0%       503 ± 0%  -28.45%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-8              4.34k ± 0%     2.35k ± 0%  -45.90%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1-8                   602 ± 0%       586 ± 0%   -2.66%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=10-8                  638 ± 0%       604 ± 0%   -5.33%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=100-8               1.06k ± 0%     0.85k ± 0%  -20.19%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_unless_b_ten{l=~'.*[0-4]$'},steps=1000-8              5.24k ± 0%     3.31k ± 0%  -36.75%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-8         3.38k ± 0%     3.22k ± 0%   -4.73%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-8        3.52k ± 0%     3.34k ± 0%   -5.06%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8       5.44k ± 0%     5.08k ± 0%   -6.55%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8      24.3k ± 0%     23.1k ± 0%   -5.12%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=1-8                     220 ± 0%       222 ± 0%   +0.91%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=10-8                    283 ± 0%       258 ± 0%   -8.83%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=100-8                   923 ± 0%       628 ± 0%  -31.96%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=1000-8                7.30k ± 0%     4.32k ± 0%  -40.84%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=1-8                     396 ± 0%       384 ± 0%   -3.03%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=10-8                    441 ± 0%       402 ± 0%   -8.84%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=100-8                   939 ± 0%       629 ± 0%  -32.97%  (p=0.008 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=1000-8                5.88k ± 0%     2.94k ± 0%  -50.05%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1-8               2.22k ± 0%     2.11k ± 0%   -4.98%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=10-8              2.28k ± 0%     2.14k ± 0%   -6.01%  (p=0.000 n=5+4)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8             3.29k ± 0%     2.88k ± 0%  -12.41%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8            13.1k ± 0%     10.6k ± 0%  -18.94%  (p=0.008 n=5+5)
```