### PR TITLE
PromQL: short-circuit vector binary ops

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -130,6 +130,9 @@ func BenchmarkRangeQuery(b *testing.B) {
 		{
 			expr: "a_X unless b_X{l=~'.*[0-4]$'}",
 		},
+		{
+			expr: "a_X and b_X{l='notfound'}",
+		},
 		// Simple functions.
 		{
 			expr: "abs(a_X)",

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1767,6 +1767,9 @@ func (ev *evaluator) VectorAnd(lhs, rhs Vector, matching *parser.VectorMatching,
 	if matching.Card != parser.CardManyToMany {
 		panic("set operations must only use many-to-many matching")
 	}
+	if len(lhs) == 0 || len(rhs) == 0 {
+		return nil // Short-circuit: AND with nothing is nothing.
+	}
 
 	// The set of signatures for the right-hand side Vector.
 	rightSigs := map[string]struct{}{}
@@ -1788,6 +1791,11 @@ func (ev *evaluator) VectorOr(lhs, rhs Vector, matching *parser.VectorMatching, 
 	if matching.Card != parser.CardManyToMany {
 		panic("set operations must only use many-to-many matching")
 	}
+	if len(lhs) == 0 { // Short-circuit.
+		return rhs
+	} else if len(rhs) == 0 {
+		return lhs
+	}
 
 	leftSigs := map[string]struct{}{}
 	// Add everything from the left-hand-side Vector.
@@ -1808,6 +1816,11 @@ func (ev *evaluator) VectorUnless(lhs, rhs Vector, matching *parser.VectorMatchi
 	if matching.Card != parser.CardManyToMany {
 		panic("set operations must only use many-to-many matching")
 	}
+	// Short-circuit: empty rhs means we will return everything in lhs;
+	// empty lhs means we will return empty - don't need to build a map.
+	if len(lhs) == 0 || len(rhs) == 0 {
+		return lhs
+	}
 
 	rightSigs := map[string]struct{}{}
 	for _, sh := range rhsh {
@@ -1826,6 +1839,9 @@ func (ev *evaluator) VectorUnless(lhs, rhs Vector, matching *parser.VectorMatchi
 func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *parser.VectorMatching, returnBool bool, lhsh, rhsh []EvalSeriesHelper, enh *EvalNodeHelper) Vector {
 	if matching.Card == parser.CardManyToMany {
 		panic("many-to-many only allowed for set operators")
+	}
+	if len(lhs) == 0 || len(rhs) == 0 {
+		return nil // Short-circuit: nothing is going to match.
 	}
 
 	// The control flow below handles one-to-one or many-to-one matching.


### PR DESCRIPTION
In degenerate cases, where one side of an AND, OR, etc., is empty, we can save the effort of building a map.

I added a benchmark to demonstrate; here is a run with a sample of other cases to show nothing else changes (apart from noise).

```
name                                                                           old time/op    new time/op    delta
RangeQuery/expr=a_hundred,steps=100-8                                             875µs ± 2%     870µs ± 1%     ~     (p=0.548 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                  1.34ms ± 0%    1.41ms ± 5%     ~     (p=0.151 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8                 618ms ± 0%     615ms ± 2%     ~     (p=0.548 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                                139ms ± 1%     139ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                   113ms ± 1%     112ms ± 0%     ~     (p=0.111 n=5+4)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                      57.0ms ± 0%    57.1ms ± 2%     ~     (p=1.000 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-8                                            904µs ± 1%     905µs ± 1%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                                7.71ms ± 2%    7.64ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8               4.22ms ± 6%    4.03ms ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8                5.20ms ± 2%    5.15ms ± 4%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8            4.03ms ± 1%    4.14ms ±10%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8                1.63ms ± 1%    0.96ms ± 1%  -40.88%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-8                                       3.37ms ± 2%    3.34ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8    3.81ms ± 5%    3.76ms ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8           3.71ms ± 0%    3.74ms ± 3%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-8                                       1.07ms ± 2%    1.09ms ± 6%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                           12.9ms ± 2%    12.8ms ± 3%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                          16.3ms ± 4%    16.1ms ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                                15.6ms ± 1%    15.4ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                               12.9ms ± 2%    12.9ms ± 3%     ~     (p=0.690 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                     43.0ms ± 2%    42.6ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8            8.03ms ± 1%    8.06ms ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                 1.58ms ± 4%    1.57ms ± 1%     ~     (p=1.000 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8         39.4ms ± 1%    39.3ms ± 0%     ~     (p=0.095 n=5+5)

name                                                                           old alloc/op   new alloc/op   delta
RangeQuery/expr=a_hundred,steps=100-8                                             119kB ± 0%     119kB ± 0%     ~     (p=0.743 n=4+4)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                   155kB ± 0%     155kB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8                5.95MB ± 0%    5.99MB ± 0%   +0.73%  (p=0.016 n=4+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                               5.40MB ± 0%    5.45MB ± 0%   +0.88%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                  5.36MB ± 1%    5.44MB ± 0%   +1.48%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                      5.51MB ± 0%    5.57MB ± 0%   +0.98%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-8                                            154kB ± 0%     154kB ± 0%     ~     (p=0.452 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                                 641kB ± 0%     641kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8                596kB ± 0%     596kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8                 974kB ± 0%     974kB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8             596kB ± 0%     596kB ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8                 182kB ± 0%     147kB ± 0%  -19.27%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-8                                        361kB ± 0%     361kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8     394kB ± 0%     394kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8            393kB ± 0%     393kB ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-8                                        189kB ± 0%     189kB ± 0%   +0.01%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                           1.95MB ± 0%    1.95MB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                          4.55MB ± 0%    4.55MB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                                4.30MB ± 0%    4.31MB ± 0%   +0.07%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                               1.92MB ± 0%    1.92MB ± 0%   -0.01%  (p=0.024 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                     39.7MB ± 0%    39.6MB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8             676kB ± 0%     676kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                  224kB ± 0%     224kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8         17.4MB ± 0%    17.4MB ± 0%     ~     (p=0.841 n=5+5)

name                                                                           old allocs/op  new allocs/op  delta
RangeQuery/expr=a_hundred,steps=100-8                                             2.11k ± 0%     2.11k ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                   2.55k ± 0%     2.55k ± 0%     ~     (all equal)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8                 71.4k ± 0%     72.1k ± 0%   +0.86%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                                71.4k ± 0%     72.0k ± 0%   +0.87%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                   71.4k ± 0%     72.0k ± 0%   +0.87%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                       71.3k ± 0%     72.0k ± 0%   +0.87%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-8                                            2.53k ± 0%     2.53k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                                 6.75k ± 0%     6.75k ± 0%     ~     (p=0.373 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8                5.44k ± 0%     5.44k ± 0%     ~     (p=0.397 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8                 5.99k ± 0%     5.99k ± 0%     ~     (p=0.683 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8             5.44k ± 0%     5.44k ± 0%     ~     (p=0.190 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8                 2.98k ± 0%     2.37k ± 0%  -20.59%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-8                                        3.49k ± 0%     3.49k ± 0%     ~     (p=0.794 n=5+4)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8     4.39k ± 0%     4.39k ± 0%     ~     (p=0.333 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8            4.36k ± 0%     4.36k ± 0%     ~     (p=0.206 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-8                                        2.85k ± 0%     2.85k ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                            27.2k ± 0%     27.2k ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                           55.6k ± 0%     55.6k ± 0%     ~     (p=0.952 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                                 45.5k ± 0%     45.5k ± 0%     ~     (p=0.881 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                                26.1k ± 0%     26.1k ± 0%     ~     (p=0.429 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                       580k ± 0%      580k ± 0%     ~     (p=0.968 n=5+4)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8             7.22k ± 0%     7.22k ± 0%     ~     (p=0.873 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                  3.39k ± 0%     3.39k ± 0%     ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8           372k ± 0%      372k ± 0%     ~     (p=0.198 n=5+5)
```