### PR TITLE
Optimise topk where k==1

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -71,7 +71,7 @@ func BenchmarkRangeQuery(b *testing.B) {
 		a := storage.Appender(context.Background())
 		ts := int64(s * 10000) // 10s interval.
 		for i, metric := range metrics {
-			ref, _ := a.Append(refs[i], metric, ts, float64(s))
+			ref, _ := a.Append(refs[i], metric, ts, float64(s)+float64(i)/float64(len(metrics)))
 			refs[i] = ref
 		}
 		if err := a.Commit(); err != nil {
@@ -158,6 +158,9 @@ func BenchmarkRangeQuery(b *testing.B) {
 		},
 		{
 			expr: "count_values('value', h_X)",
+		},
+		{
+			expr: "topk(1, a_X)",
 		},
 		// Combinations.
 		{

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2210,6 +2210,8 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 			resultSize := k
 			if k > inputVecLen {
 				resultSize = inputVecLen
+			} else if k == 0 {
+				resultSize = 1
 			}
 			switch op {
 			case parser.STDVAR, parser.STDDEV:

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2215,17 +2215,17 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 			case parser.STDVAR, parser.STDDEV:
 				result[groupingKey].value = 0
 			case parser.TOPK, parser.QUANTILE:
-				result[groupingKey].heap = make(vectorByValueHeap, 0, resultSize)
-				heap.Push(&result[groupingKey].heap, &Sample{
+				result[groupingKey].heap = make(vectorByValueHeap, 1, resultSize)
+				result[groupingKey].heap[0] = Sample{
 					Point:  Point{V: s.V},
 					Metric: s.Metric,
-				})
+				}
 			case parser.BOTTOMK:
-				result[groupingKey].reverseHeap = make(vectorByReverseValueHeap, 0, resultSize)
-				heap.Push(&result[groupingKey].reverseHeap, &Sample{
+				result[groupingKey].reverseHeap = make(vectorByReverseValueHeap, 1, resultSize)
+				result[groupingKey].reverseHeap[0] = Sample{
 					Point:  Point{V: s.V},
 					Metric: s.Metric,
-				})
+				}
 			case parser.GROUP:
 				result[groupingKey].value = 1
 			}
@@ -2283,6 +2283,13 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		case parser.TOPK:
 			if int64(len(group.heap)) < k || group.heap[0].V < s.V || math.IsNaN(group.heap[0].V) {
 				if int64(len(group.heap)) == k {
+					if k == 1 { // For k==1 we can replace in-situ.
+						group.heap[0] = Sample{
+							Point:  Point{V: s.V},
+							Metric: s.Metric,
+						}
+						break
+					}
 					heap.Pop(&group.heap)
 				}
 				heap.Push(&group.heap, &Sample{
@@ -2294,6 +2301,13 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		case parser.BOTTOMK:
 			if int64(len(group.reverseHeap)) < k || group.reverseHeap[0].V > s.V || math.IsNaN(group.reverseHeap[0].V) {
 				if int64(len(group.reverseHeap)) == k {
+					if k == 1 { // For k==1 we can replace in-situ.
+						group.reverseHeap[0] = Sample{
+							Point:  Point{V: s.V},
+							Metric: s.Metric,
+						}
+						break
+					}
 					heap.Pop(&group.reverseHeap)
 				}
 				heap.Push(&group.reverseHeap, &Sample{
@@ -2327,7 +2341,9 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 
 		case parser.TOPK:
 			// The heap keeps the lowest value on top, so reverse it.
-			sort.Sort(sort.Reverse(aggr.heap))
+			if len(aggr.heap) > 1 {
+				sort.Sort(sort.Reverse(aggr.heap))
+			}
 			for _, v := range aggr.heap {
 				enh.Out = append(enh.Out, Sample{
 					Metric: v.Metric,
@@ -2338,7 +2354,9 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 
 		case parser.BOTTOMK:
 			// The heap keeps the highest value on top, so reverse it.
-			sort.Sort(sort.Reverse(aggr.reverseHeap))
+			if len(aggr.reverseHeap) > 1 {
+				sort.Sort(sort.Reverse(aggr.reverseHeap))
+			}
 			for _, v := range aggr.reverseHeap {
 				enh.Out = append(enh.Out, Sample{
 					Metric: v.Metric,


### PR DESCRIPTION
In this case we don't need a heap to keep track of values; just a single slot is fine.

Simplify the initialization of the heap: since all cases start off as a single-item heap we can just assign the value directly.

Added a benchmark for `query_range` with `topk`; had to modify sample data so values within a metric differ.

```
name                                             old time/op    new time/op    delta
RangeQuery/expr=topk(1,_a_one),steps=1-4           33.8µs ± 2%    33.5µs ± 2%     ~     (p=0.548 n=5+5)
RangeQuery/expr=topk(1,_a_one),steps=10-4          49.2µs ± 9%    44.8µs ± 1%   -9.01%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_one),steps=100-4          184µs ± 2%     172µs ± 6%   -6.57%  (p=0.016 n=5+5)
RangeQuery/expr=topk(1,_a_one),steps=1000-4        1.48ms ± 3%    1.35ms ±22%     ~     (p=0.190 n=4+5)
RangeQuery/expr=topk(1,_a_ten),steps=1-4            138µs ± 4%     132µs ± 4%   -4.23%  (p=0.032 n=5+5)
RangeQuery/expr=topk(1,_a_ten),steps=10-4           181µs ± 2%     163µs ± 4%  -10.11%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_ten),steps=100-4          688µs ± 3%     489µs ± 3%  -28.92%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_ten),steps=1000-4        5.09ms ±18%    2.96ms ± 4%  -41.92%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1-4       1.18ms ± 4%    1.14ms ± 8%     ~     (p=0.310 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=10-4      1.58ms ± 4%    1.33ms ± 3%  -16.09%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4     5.85ms ± 8%    3.76ms ± 6%  -35.66%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4    39.5ms ± 6%    20.2ms ± 3%  -48.88%  (p=0.008 n=5+5)

name                                             old alloc/op   new alloc/op   delta
RangeQuery/expr=topk(1,_a_one),steps=1-4           8.03kB ± 0%    7.86kB ± 0%   -2.19%  (p=0.029 n=4+4)
RangeQuery/expr=topk(1,_a_one),steps=10-4          13.0kB ± 0%    12.0kB ± 0%   -7.45%  (p=0.016 n=4+5)
RangeQuery/expr=topk(1,_a_one),steps=100-4         63.0kB ± 0%    54.1kB ± 0%  -14.11%  (p=0.029 n=4+4)
RangeQuery/expr=topk(1,_a_one),steps=1000-4         563kB ± 0%     475kB ± 0%  -15.65%  (p=0.016 n=5+4)
RangeQuery/expr=topk(1,_a_ten),steps=1-4           20.8kB ± 0%    18.9kB ± 0%   -9.15%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_ten),steps=10-4          33.8kB ± 0%    23.4kB ± 0%  -30.94%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_ten),steps=100-4          166kB ± 0%      70kB ± 0%  -57.81%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_ten),steps=1000-4        1.49MB ± 0%    0.54MB ± 0%  -63.98%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1-4        144kB ± 0%     125kB ± 0%  -13.35%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=10-4       235kB ± 0%     129kB ± 0%  -45.00%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4     1.16MB ± 0%    0.19MB ± 0%  -83.28%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4    10.4MB ± 0%     0.8MB ± 0%  -92.05%  (p=0.016 n=5+4)

name                                             old allocs/op  new allocs/op  delta
RangeQuery/expr=topk(1,_a_one),steps=1-4              188 ± 0%       182 ± 0%   -3.19%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_one),steps=10-4             278 ± 0%       245 ± 0%  -11.87%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_one),steps=100-4          1.18k ± 0%     0.88k ± 0%  -25.61%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_one),steps=1000-4         10.2k ± 0%      7.2k ± 0%  -29.39%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_ten),steps=1-4              382 ± 0%       340 ± 0%  -10.99%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_ten),steps=10-4             634 ± 0%       403 ± 0%  -36.44%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_ten),steps=100-4          3.19k ± 0%     1.07k ± 0%  -66.38%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_ten),steps=1000-4         28.7k ± 0%      7.7k ± 0%  -73.20%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1-4        2.28k ± 0%     1.87k ± 0%  -17.66%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=10-4       4.15k ± 0%     1.94k ± 0%  -53.30%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4      23.3k ± 0%      3.0k ± 0%     ~     (p=0.079 n=4+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4      214k ± 0%       12k ± 0%  -94.16%  (p=0.008 n=5+5)
```

I come across `topk(1, ...)` in the wild reasonably often. A few moments searching on GitHub gave these examples:
https://github.com/prometheus-operator/kube-prometheus/blob/44466ff434a4a12b4e940891a123080bbff11585/manifests/kubernetes-prometheusRule.yaml#L572
https://github.com/openshift/telemeter/blob/1e97dddbde49e13867733cbf3219f6505d3b083a/jsonnet/telemeter/rules.libsonnet#L30
https://github.com/monitoring-mixins/website/blob/f71ee2699726ad10498915d95dad9041988edd7b/assets/ceph/rules.yaml#L8
https://github.com/istio/installer/blob/16d1d1bf192f447bba752d2e6df725177183cbbf/istio-telemetry/grafana/dashboards/mixer-dashboard.json#L1215