### PR TITLE
Don't error on overlapping m-mapped chunks during WAL replay

### DIFF
--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -241,8 +241,6 @@ Outer:
 				}
 
 				// Checking if the new m-mapped chunks overlap with the already existing ones.
-				// This should never happen, but we have a check anyway to detect any
-				// edge cases that we might have missed.
 				if len(mSeries.mmappedChunks) > 0 && len(mmc) > 0 {
 					if overlapsClosedInterval(
 						mSeries.mmappedChunks[0].minTime,
@@ -250,9 +248,16 @@ Outer:
 						mmc[0].minTime,
 						mmc[len(mmc)-1].maxTime,
 					) {
-						// The m-map chunks for the new series ref overlaps with old m-map chunks.
-						seriesCreationErr = errors.Errorf("overlapping m-mapped chunks for series %s", mSeries.lset.String())
-						break Outer
+						level.Warn(h.logger).Log(
+							"msg", "M-mapped chunks overlap on a duplicate series record",
+							"series", mSeries.lset.String(),
+							"oldref", mSeries.ref,
+							"oldmint", mSeries.mmappedChunks[0].minTime,
+							"oldmaxt", mSeries.mmappedChunks[len(mSeries.mmappedChunks)-1].maxTime,
+							"newref", walSeries.Ref,
+							"newmint", mmc[0].minTime,
+							"newmaxt", mmc[len(mmc)-1].maxTime,
+						)
 					}
 				}
 


### PR DESCRIPTION
Turns out overlaps in m-mapped chunks is possible when you have duplicate series record. Consider this scenario:

1. WAL corruption happened, and the data for series X in last 2-3hr was removed (but the series still exists in the checkpoint and also its m-mapped chunks). 
2. When WAL replay happens, series won't exist in the memory, so next time when series X is created it gets a new reference. Since no sample for X in the Head, some scrape ended up adding some old samples for X in memory. Which eventually goes as m-mapped chunk on disk.
3. Now when Prometheus is restarted for an upgrade, you face this overlap error because old m-map chunks gets attached for the old reference and the old sample added in step 2 overlaps now.

In this case, we should be using the new m-mapped chunks which is a valid in-memory state.

I have replaced the error return with a warning log in this case.

Update: A better explanation here https://github.com/prometheus/prometheus/pull/9381#issuecomment-932052730