### PR TITLE
Redact remote write URL when used for metric label

### DIFF
--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -158,7 +158,10 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			continue
 		}
 
-		endpoint := rwConf.URL.String()
+		// Redacted to remove any passwords in the URL (that are
+		// technically accepted but not recommended) since this is
+		// only used for metric labels.
+		endpoint := rwConf.URL.Redacted()
 		newQueues[hash] = NewQueueManager(
 			newQueueManagerMetrics(rws.reg, name, endpoint),
 			rws.watcherMetrics,


### PR DESCRIPTION
Redact any basic auth passwords in the remote write URL (which are
technically allowed although not recommended) when used as metric
labels.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

