### PR TITLE
provide a way to override the apiPrefix in codemirror prom client and cleanup readme

### DIFF
--- a/web/ui/module/codemirror-promql/README.md
+++ b/web/ui/module/codemirror-promql/README.md
@@ -172,6 +172,16 @@ You can change it to use the HTTP method `GET` if you prefer.
 const promQL = new PromQLExtension().setComplete({ remote: { httpMethod: 'GET' } })
 ```
 
+###### Override the API Prefix
+
+The default Prometheus Client, when building the query to get data from Prometheus, is using an API prefix which is by default `/api/v1`.
+
+You can override this value like this:
+
+```typescript
+const promql = new PromQLExtension().setComplete({ remote: { apiPrefix: '/my/api/prefix' } })
+```
+
 ###### Cache
 
 The default client has an embedded cache that is used to store the different metrics and labels retrieved from a remote
@@ -232,7 +242,6 @@ Note: In case this parameter is provided, then the rest of the configuration is 
 
 ### Example
 
-* The development [app](./src/app) can give you an example of how to use it with no TS Framework.
 * [ReactJS example](https://github.com/prometheus/prometheus/blob/431ea75a11ca165dad9dd5d629b3cf975f4c186b/web/ui/react-app/src/pages/graph/CMExpressionInput.tsx)
 * [Angular example](https://github.com/perses/perses/blob/28b3bdac88b0ed7a4602f9c91106442eafcb6c34/internal/api/front/perses/src/app/project/prometheusrule/promql-editor/promql-editor.component.ts)
 
@@ -241,24 +250,6 @@ Note: In case this parameter is provided, then the rest of the configuration is 
 Any contribution or suggestion would be really appreciated. Feel free
 to [file an issue](https://github.com/prometheus-community/codemirror-promql/issues)
 or [send a pull request](https://github.com/prometheus-community/codemirror-promql/pulls).
-
-## Development
-
-In case you want to contribute and change the code by yourself, run the following commands:
-
-To install all dependencies:
-
-```
-npm install
-```
-
-To start the web server:
-
-```
-npm start
-```
-
-This should create a tab in your browser with the development app that contains CodeMirror Next with the PromQL plugin.
 
 ## License
 


### PR DESCRIPTION
Signed-off-by: Augustin Husson <husson.augustin@gmail.com>

fix https://github.com/prometheus-community/codemirror-promql/issues/148