### PR TITLE
Azure: Fix panic when no computername is set

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -464,7 +464,9 @@ func mapFromVM(vm compute.VirtualMachine) virtualMachine {
 		}
 	}
 
-	if vm.VirtualMachineProperties != nil && vm.VirtualMachineProperties.OsProfile != nil {
+	if vm.VirtualMachineProperties != nil &&
+		vm.VirtualMachineProperties.OsProfile != nil &&
+		vm.VirtualMachineProperties.OsProfile.ComputerName != nil {
 		computerName = *(vm.VirtualMachineProperties.OsProfile.ComputerName)
 	}
 


### PR DESCRIPTION
Fix #9382

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
