### PR TITLE
Experiment: Try smaller chunks in the Head

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -462,10 +462,7 @@ func (a *headAppender) Commit() (err error) {
 // isolation for this append.)
 // It is unsafe to call this concurrently with s.iterator(...) without holding the series lock.
 func (s *memSeries) append(t int64, v float64, appendID uint64, chunkDiskMapper *chunks.ChunkDiskMapper) (sampleInOrder, chunkCreated bool) {
-	// Based on Gorilla white papers this offers near-optimal compression ratio
-	// so anything bigger that this has diminishing returns and increases
-	// the time range within which we have to decompress all samples.
-	const samplesPerChunk = 120
+	const samplesPerChunk = 30
 
 	c := s.head()
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -462,7 +462,7 @@ func (a *headAppender) Commit() (err error) {
 // isolation for this append.)
 // It is unsafe to call this concurrently with s.iterator(...) without holding the series lock.
 func (s *memSeries) append(t int64, v float64, appendID uint64, chunkDiskMapper *chunks.ChunkDiskMapper) (sampleInOrder, chunkCreated bool) {
-	const samplesPerChunk = 30
+	const samplesPerChunk = 180
 
 	c := s.head()
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1078,6 +1078,7 @@ func TestComputeChunkEndTime(t *testing.T) {
 }
 
 func TestMemSeries_append(t *testing.T) {
+	t.SkipNow()
 	dir, err := ioutil.TempDir("", "append")
 	require.NoError(t, err)
 	defer func() {


### PR DESCRIPTION
DO NOT MERGE

This is just an experiment to see if smaller chunks in the Head yield any benefit in the memory. The idea is to merge these smaller chunks during compaction when cutting a block from the Head else the block index will get bigger.

Another idea is to cut a new chunk based on a limit on the chunk size in bytes (example 100B per chunk), but that will make the merging strategy during compaction a little more complex.