### PR TITLE
codemirror_sync: Use reset and checkout instead of restore

### DIFF
--- a/scripts/sync_codemirror.sh
+++ b/scripts/sync_codemirror.sh
@@ -107,13 +107,13 @@ process_repo() {
   git add .
 
   for excluded_dir in ${excluded_dirs}; do
-      git restore --staged "${excluded_dir}/*"
-      git restore "${excluded_dir}/*"
+      git reset -- "${excluded_dir}/*"
+      git checkout -- "${excluded_dir}/*"
   done
 
   for excluded_file in ${excluded_files}; do
-      git restore --staged "${excluded_file}"
-      git restore "${excluded_file}"
+      git reset -- "${excluded_file}"
+      git checkout -- "${excluded_file}"
   done
 
   if [[ -n "$(git status --porcelain)" ]]; then


### PR DESCRIPTION
The git version we are using for CI is too old.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
