### PR TITLE
Replace calls to strings.Compare

### DIFF
--- a/storage/merge.go
+++ b/storage/merge.go
@@ -18,7 +18,6 @@ import (
 	"container/heap"
 	"math"
 	"sort"
-	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -197,15 +196,13 @@ func mergeStrings(a, b []string) []string {
 	res := make([]string, 0, maxl*10/9)
 
 	for len(a) > 0 && len(b) > 0 {
-		d := strings.Compare(a[0], b[0])
-
-		if d == 0 {
+		if a[0] == b[0] {
 			res = append(res, a[0])
 			a, b = a[1:], b[1:]
-		} else if d < 0 {
+		} else if a[0] < b[0] {
 			res = append(res, a[0])
 			a = a[1:]
-		} else if d > 0 {
+		} else {
 			res = append(res, b[0])
 			b = b[1:]
 		}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -18,7 +18,6 @@ import (
 	"encoding/binary"
 	"runtime"
 	"sort"
-	"strings"
 	"sync"
 
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -94,8 +93,8 @@ func (p *MemPostings) SortedKeys() []labels.Label {
 	p.mtx.RUnlock()
 
 	sort.Slice(keys, func(i, j int) bool {
-		if d := strings.Compare(keys[i].Name, keys[j].Name); d != 0 {
-			return d < 0
+		if keys[i].Name != keys[j].Name {
+			return keys[i].Name < keys[j].Name
 		}
 		return keys[i].Value < keys[j].Value
 	})


### PR DESCRIPTION
`<` is clearer and a tiny bit faster. As the documentation says, "Basically no one should use strings.Compare."

I left the one in Promtool, because the code got a bit more complicated without it.