### PR TITLE
Add tsdb relabel command to relabel a block

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -148,6 +148,12 @@ func main() {
 	dumpMinTime := tsdbDumpCmd.Flag("min-time", "Minimum timestamp to dump.").Default(strconv.FormatInt(math.MinInt64, 10)).Int64()
 	dumpMaxTime := tsdbDumpCmd.Flag("max-time", "Maximum timestamp to dump.").Default(strconv.FormatInt(math.MaxInt64, 10)).Int64()
 
+	tsdbRelabelCmd := tsdbCmd.Command("relabel", "Relabel TSDB block.")
+	relabelPath := tsdbRelabelCmd.Arg("db path", "Database path (default is "+defaultDBPath+").").Default(defaultDBPath).String()
+	relabelBlockID := tsdbRelabelCmd.Arg("block id", "BlockID to relabel.").String()
+	relabelConfig := tsdbRelabelCmd.Arg("file", "Relabel config file to apply.").String()
+	relabelAddChangelog := tsdbRelabelCmd.Flag("add-changelog", "If specified, all modifications are written to db path. Disable if latency is to high.").Default("true").Bool()
+
 	importCmd := tsdbCmd.Command("create-blocks-from", "[Experimental] Import samples from input and produce TSDB blocks. Please refer to the storage docs for more details.")
 	importHumanReadable := importCmd.Flag("human-readable", "Print human readable values.").Short('r').Bool()
 	importQuiet := importCmd.Flag("quiet", "Do not print created blocks.").Short('q').Bool()
@@ -245,6 +251,10 @@ func main() {
 
 	case tsdbDumpCmd.FullCommand():
 		os.Exit(checkErr(dumpSamples(*dumpPath, *dumpMinTime, *dumpMaxTime)))
+
+	case tsdbRelabelCmd.FullCommand():
+		os.Exit(checkErr(relabelBlock(*relabelPath, *relabelBlockID, *relabelConfig, *relabelAddChangelog)))
+
 	//TODO(aSquare14): Work on adding support for custom block size.
 	case openMetricsImportCmd.FullCommand():
 		os.Exit(backfillOpenMetrics(*importFilePath, *importDBPath, *importHumanReadable, *importQuiet, *maxBlockDuration))

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -17,10 +17,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/prometheus/prometheus/pkg/relabel"
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	"github.com/prometheus/prometheus/tsdb/index"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"math"
@@ -38,12 +34,16 @@ import (
 	"github.com/alecthomas/units"
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
+	"github.com/prometheus/prometheus/tsdb/index"
 )
 
 const timeDelta = 30000

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -17,7 +17,10 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"github.com/prometheus/prometheus/pkg/relabel"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/index"
+	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"math"
@@ -416,6 +419,64 @@ func openBlock(path, blockID string) (*tsdb.DBReadOnly, tsdb.BlockReader, error)
 		return nil, nil, fmt.Errorf("block %s not found", blockID)
 	}
 	return db, block, nil
+}
+
+func relabelBlock(path, blockID, file string, addChangelog bool) error {
+	db, block, err := openBlock(path, blockID)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = tsdb_errors.NewMulti(err, db.Close()).Err()
+	}()
+
+	var relabelConfig []*relabel.Config
+	b, err := ioutil.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	if err := yaml.Unmarshal(b, &relabelConfig); err != nil {
+		return errors.Wrap(err, "parsing relabel configuration")
+	}
+
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	meta := block.Meta()
+
+	changeLog := tsdb.NewChangeLog(ioutil.Discard)
+	if addChangelog {
+		changeLogPath := filepath.Join(path, "change.log")
+		f, err := os.OpenFile(changeLogPath, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+		if err != nil {
+			return errors.Wrap(err, "open changelog file")
+		}
+		defer func() {
+			err = tsdb_errors.NewMulti(err, f.Close()).Err()
+		}()
+
+		changeLog = tsdb.NewChangeLog(f)
+		fmt.Printf("changelog will be available at: %s\n", changeLogPath)
+	}
+
+	compactor, err := tsdb.NewLeveledCompactor(
+		context.Background(),
+		nil,
+		logger,
+		tsdb.ExponentialBlockRanges(tsdb.DefaultOptions().MinBlockDuration, 3, 5),
+		chunkenc.NewPool(),
+		nil,
+		tsdb.WithRelabelModifier(changeLog, relabelConfig...),
+	)
+	if err != nil {
+		return errors.Wrap(err, "create leveled compactor")
+	}
+
+	newID, err := compactor.Write(path, block, meta.MinTime, meta.MaxTime, &meta)
+	if err != nil {
+		return errors.Wrap(err, "create new block")
+	}
+
+	fmt.Printf("Create new block %s successfully\n", newID.String())
+	return nil
 }
 
 func analyzeBlock(path, blockID string, limit int, runExtended bool) error {

--- a/storage/series.go
+++ b/storage/series.go
@@ -275,6 +275,25 @@ func (s *seriesToChunkEncoder) Iterator() chunks.Iterator {
 	return NewListChunkSeriesIterator(chks...)
 }
 
+type listChunkSeriesSet struct {
+	css []ChunkSeries
+	idx int
+}
+
+func NewListChunkSeriesSet(css ...ChunkSeries) ChunkSeriesSet {
+	return &listChunkSeriesSet{css: css, idx: -1}
+}
+
+func (s *listChunkSeriesSet) Next() bool {
+	s.idx++
+	return s.idx < len(s.css)
+}
+
+func (s *listChunkSeriesSet) At() ChunkSeries    { return s.css[s.idx] }
+func (s *listChunkSeriesSet) Err() error                 { return nil }
+func (s *listChunkSeriesSet) Warnings() Warnings { return nil }
+
+
 type errChunksIterator struct {
 	err error
 }

--- a/tsdb/changelog.go
+++ b/tsdb/changelog.go
@@ -1,0 +1,45 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
+)
+
+type ChangeLogger interface {
+	DeleteSeries(del labels.Labels, intervals tombstones.Intervals)
+	ModifySeries(old labels.Labels, new labels.Labels)
+}
+
+type changeLog struct {
+	w io.Writer
+}
+
+func NewChangeLog(w io.Writer) *changeLog {
+	return &changeLog{
+		w: w,
+	}
+}
+
+func (l *changeLog) DeleteSeries(del labels.Labels, intervals tombstones.Intervals) {
+	_, _ = fmt.Fprintf(l.w, "Deleted %v %v\n", del.String(), intervals)
+}
+
+func (l *changeLog) ModifySeries(old, new labels.Labels) {
+	_, _ = fmt.Fprintf(l.w, "Relabelled %v %v\n", old.String(), new.String())
+}

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -83,6 +83,7 @@ type LeveledCompactor struct {
 	ctx                      context.Context
 	maxBlockChunkSegmentSize int64
 	mergeFunc                storage.VerticalChunkSeriesMergeFunc
+	modifiers                []Modifier
 }
 
 type compactorMetrics struct {
@@ -146,11 +147,11 @@ func newCompactorMetrics(r prometheus.Registerer) *compactorMetrics {
 }
 
 // NewLeveledCompactor returns a LeveledCompactor.
-func NewLeveledCompactor(ctx context.Context, r prometheus.Registerer, l log.Logger, ranges []int64, pool chunkenc.Pool, mergeFunc storage.VerticalChunkSeriesMergeFunc) (*LeveledCompactor, error) {
-	return NewLeveledCompactorWithChunkSize(ctx, r, l, ranges, pool, chunks.DefaultChunkSegmentSize, mergeFunc)
+func NewLeveledCompactor(ctx context.Context, r prometheus.Registerer, l log.Logger, ranges []int64, pool chunkenc.Pool, mergeFunc storage.VerticalChunkSeriesMergeFunc, modifiers ...Modifier) (*LeveledCompactor, error) {
+	return NewLeveledCompactorWithChunkSize(ctx, r, l, ranges, pool, chunks.DefaultChunkSegmentSize, mergeFunc, modifiers...)
 }
 
-func NewLeveledCompactorWithChunkSize(ctx context.Context, r prometheus.Registerer, l log.Logger, ranges []int64, pool chunkenc.Pool, maxBlockChunkSegmentSize int64, mergeFunc storage.VerticalChunkSeriesMergeFunc) (*LeveledCompactor, error) {
+func NewLeveledCompactorWithChunkSize(ctx context.Context, r prometheus.Registerer, l log.Logger, ranges []int64, pool chunkenc.Pool, maxBlockChunkSegmentSize int64, mergeFunc storage.VerticalChunkSeriesMergeFunc, modifiers ...Modifier) (*LeveledCompactor, error) {
 	if len(ranges) == 0 {
 		return nil, errors.Errorf("at least one range must be provided")
 	}
@@ -171,6 +172,7 @@ func NewLeveledCompactorWithChunkSize(ctx context.Context, r prometheus.Register
 		ctx:                      ctx,
 		maxBlockChunkSegmentSize: maxBlockChunkSegmentSize,
 		mergeFunc:                mergeFunc,
+		modifiers:                modifiers,
 	}, nil
 }
 
@@ -735,6 +737,17 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		symbols = NewMergedStringIter(symbols, syms)
 	}
 
+	set := sets[0]
+	if len(sets) > 1 {
+		// Merge series using specified chunk series merger.
+		// The default one is the compacting series merger.
+		set = storage.NewMergeChunkSeriesSet(sets, c.mergeFunc)
+	}
+
+	for _, modifier := range c.modifiers {
+		symbols, set = modifier.Modify(symbols, set)
+	}
+
 	for symbols.Next() {
 		if err := indexw.AddSymbol(symbols.At()); err != nil {
 			return errors.Wrap(err, "add symbol")
@@ -748,13 +761,6 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		ref  = uint64(0)
 		chks []chunks.Meta
 	)
-
-	set := sets[0]
-	if len(sets) > 1 {
-		// Merge series using specified chunk series merger.
-		// The default one is the compacting series merger.
-		set = storage.NewMergeChunkSeriesSet(sets, c.mergeFunc)
-	}
 
 	// Iterate over all sorted chunk series.
 	for set.Next() {

--- a/tsdb/modifiers.go
+++ b/tsdb/modifiers.go
@@ -1,0 +1,152 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"math"
+	"sort"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/relabel"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
+)
+
+type Modifier interface {
+	Modify(sym index.StringIter, set storage.ChunkSeriesSet) (index.StringIter, storage.ChunkSeriesSet)
+}
+
+type RelabelModifier struct {
+	relabels []*relabel.Config
+	log      ChangeLogger
+}
+
+func WithRelabelModifier(log ChangeLogger, relabels ...*relabel.Config) *RelabelModifier {
+	return &RelabelModifier{relabels: relabels, log: log}
+}
+
+func (d *RelabelModifier) Modify(_ index.StringIter, set storage.ChunkSeriesSet) (index.StringIter, storage.ChunkSeriesSet) {
+	// Gather symbols.
+	symbols := make(map[string]struct{})
+	chunkSeriesMap := make(map[string]*mergeChunkSeries)
+
+	for set.Next() {
+		s := set.At()
+		lbls := s.Labels()
+		chksIter := s.Iterator()
+
+		if processedLabels := relabel.Process(lbls, d.relabels...); len(processedLabels) == 0 {
+			// Special case: Delete whole series if no labels are present.
+			var (
+				minT int64 = math.MaxInt64
+				maxT int64 = math.MinInt64
+			)
+			for chksIter.Next() {
+				c := chksIter.At()
+				if c.MinTime < minT {
+					minT = c.MinTime
+				}
+				if c.MaxTime > maxT {
+					maxT = c.MaxTime
+				}
+			}
+
+			if err := chksIter.Err(); err != nil {
+				return errorOnlyStringIter{err: err}, nil
+			}
+
+			var deleted tombstones.Intervals
+			// If minTime is set then there is at least one chunk.
+			if minT != math.MaxInt64 {
+				deleted = deleted.Add(tombstones.Interval{Mint: minT, Maxt: maxT})
+			}
+			d.log.DeleteSeries(lbls, deleted)
+		} else {
+			for _, lb := range processedLabels {
+				symbols[lb.Name] = struct{}{}
+				symbols[lb.Value] = struct{}{}
+			}
+
+			lbStr := processedLabels.String()
+			if _, ok := chunkSeriesMap[lbStr]; !ok {
+				chunkSeriesMap[lbStr] = newMergeChunkSeries(processedLabels)
+			}
+			cs := chunkSeriesMap[lbStr]
+
+			cs.cs = append(cs.cs, &storage.ChunkSeriesEntry{
+				Lset: nil,
+				ChunkIteratorFn: func() chunks.Iterator {
+					return chksIter
+				},
+			})
+
+			if !labels.Equal(lbls, processedLabels) {
+				d.log.ModifySeries(lbls, processedLabels)
+			}
+		}
+	}
+
+	symbolsSlice := make([]string, 0, len(symbols))
+	for s := range symbols {
+		symbolsSlice = append(symbolsSlice, s)
+	}
+	sort.Strings(symbolsSlice)
+
+	chunkSeriesSet := make([]storage.ChunkSeries, 0, len(chunkSeriesMap))
+	for _, chunkSeries := range chunkSeriesMap {
+		chunkSeriesSet = append(chunkSeriesSet, chunkSeries)
+	}
+	sort.Slice(chunkSeriesSet, func(i, j int) bool {
+		return labels.Compare(chunkSeriesSet[i].Labels(), chunkSeriesSet[j].Labels()) < 0
+	})
+	return index.NewStringListIter(symbolsSlice), storage.NewListChunkSeriesSet(chunkSeriesSet...)
+}
+
+// mergeChunkSeries merges []storage.ChunkSeries to storage.ChunkSeries.
+type mergeChunkSeries struct {
+	lset labels.Labels
+	cs   []storage.ChunkSeries
+}
+
+func newMergeChunkSeries(lset labels.Labels) *mergeChunkSeries {
+	return &mergeChunkSeries{
+		lset: lset,
+		cs:   make([]storage.ChunkSeries, 0),
+	}
+}
+
+func (s *mergeChunkSeries) Labels() labels.Labels {
+	return s.lset
+}
+
+func (s *mergeChunkSeries) Iterator() chunks.Iterator {
+	if len(s.cs) == 0 {
+		return nil
+	}
+	if len(s.cs) == 1 {
+		return s.cs[0].Iterator()
+	}
+
+	return storage.NewCompactingChunkSeriesMerger(storage.ChainedSeriesMerge)(s.cs...).Iterator()
+}
+
+type errorOnlyStringIter struct {
+	err error
+}
+
+func (errorOnlyStringIter) Next() bool   { return false }
+func (errorOnlyStringIter) At() string   { return "" }
+func (s errorOnlyStringIter) Err() error { return s.err }


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

Fixes https://github.com/prometheus/prometheus/issues/8579.

This pr upstreams `thanos tools bucket rewrite relabel` feature to promtool.

Unit tests TBD.

Example usage:

```
promtool tsdb relabel <db path> <block ID> relabel.yaml
```

relabel.yaml

```yaml
- action: drop
  regex: k8s_app_metric37
  source_labels: [__name__]
- action: replace
  source_labels: [__name__]
  regex: k8s_app_metric38
  target_label: __name__
  replacement: old_metric

```

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
