### PR TITLE
Docs: Fix example in exemplars query

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -361,7 +361,7 @@ URL query parameters:
 - `end=<rfc3339 | unix_timestamp>`: End timestamp.
 
 ```json
-$ curl -g 'http://localhost:9090/api/v1/query_exemplars?query=test_exemplar_metric_total&start=2020-09-14T15:22:25.479Z&end=020-09-14T15:23:25.479Z'
+$ curl -g 'http://localhost:9090/api/v1/query_exemplars?query=test_exemplar_metric_total&start=2020-09-14T15:22:25.479Z&end=2020-09-14T15:23:25.479Z'
 {
     "status": "success",
     "data": [


### PR DESCRIPTION
Fix timestamp in example in exemplars query. The year was `020` instead of `2020`.
