### PR TITLE
Use 1.0.0 in the accept header for application/openmetrics-text

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -748,7 +748,7 @@ type targetScraper struct {
 
 var errBodySizeLimit = errors.New("body size limit exceeded")
 
-const acceptHeader = `application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
+const acceptHeader = `application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1;q=0.75,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
 
 var UserAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 


### PR DESCRIPTION
Related: https://github.com/prometheus/client_java/issues/702
Fixes gh-9430

Please let me know if you want me to add a test for this change, `scrape_test.go` checks the Accept header but it ignores the version, I'm not sure you want to tie the tests for it.