### PR TITLE
Add info about counter resets in chunk meta

### DIFF
--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -82,7 +82,7 @@ type Chunk interface {
 // Appender adds sample pairs to a chunk.
 type Appender interface {
 	Append(int64, float64)
-	AppendHistogram(t int64, h histogram.SparseHistogram)
+	AppendHistogram(t int64, h histogram.SparseHistogram, counterReset bool)
 }
 
 // Iterator is a simple iterator that can only get the next value.

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -150,7 +150,7 @@ type xorAppender struct {
 	trailing uint8
 }
 
-func (a *xorAppender) AppendHistogram(t int64, h histogram.SparseHistogram) {
+func (a *xorAppender) AppendHistogram(t int64, h histogram.SparseHistogram, counterReset bool) {
 	//panic("cannot call xorAppender.AppendHistogram().")
 }
 


### PR DESCRIPTION
NOTE: this is pointing to sparsehistogram branch.

I have also introduced a 8 bit header to store upto 8 boolean info about the chunk. Using the first bit to know if it was a counter reset.

I will follow up with unit tests in the same PR.