### PR TITLE
discovery/kubernetes: Warn user in case of endpoint over-capacity

### DIFF
--- a/discovery/kubernetes/endpoints.go
+++ b/discovery/kubernetes/endpoints.go
@@ -308,6 +308,14 @@ func (e *Endpoints) buildEndpoints(eps *apiv1.Endpoints) *targetgroup.Group {
 		}
 	}
 
+	v := eps.Labels[apiv1.EndpointsOverCapacity]
+	if v == "truncated" {
+		level.Warn(e.logger).Log("msg", "Number of endpoints in one Endpoints object exceeds 1000 and has been truncated, please use \"role: endpointslice\" instead", "endpoint", eps.Name)
+	}
+	if v == "warning" {
+		level.Warn(e.logger).Log("msg", "Number of endpoints in one Endpoints object exceeds 1000, please use \"role: endpointslice\" instead", "endpoint", eps.Name)
+	}
+
 	// For all seen pods, check all container ports. If they were not covered
 	// by one of the service endpoints, generate targets for them.
 	for _, pe := range seenPods {

--- a/discovery/kubernetes/endpointslice.go
+++ b/discovery/kubernetes/endpointslice.go
@@ -322,14 +322,6 @@ func (e *EndpointSlice) buildEndpointSlice(eps *disv1beta1.EndpointSlice) *targe
 		}
 	}
 
-	v := eps.Labels[apiv1.EndpointsOverCapacity]
-	if v == "truncated" {
-		level.Warn(e.logger).Log("msg", "Number of endpoints in one Endpoints object truncated to 1000", "endpoint", eps.Name)
-	}
-	if v == "warning" {
-		level.Warn(e.logger).Log("msg", "Number of endpoints in one Endpoints object exceeds 1000", "endpoint", eps.Name)
-	}
-
 	// For all seen pods, check all container ports. If they were not covered
 	// by one of the service endpoints, generate targets for them.
 	for _, pe := range seenPods {


### PR DESCRIPTION
After the introduction of Kubernetes EndpointSlice as part of https://github.com/prometheus/prometheus/pull/6838, there was a need to warn the user in case overcapacity labels are present, as stated in https://github.com/prometheus/prometheus/issues/7572#issuecomment-689995810.

Could you please review this PR @roidelapluie?