### PR TITLE
fix: possible race on shared variables in test

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -663,6 +663,7 @@ func TestDB_SnapshotWithDelete(t *testing.T) {
 	numSamples := int64(10)
 
 	db := openTestDB(t, nil, nil)
+	defer func() { require.NoError(t, db.Close()) }()
 
 	ctx := context.Background()
 	app := db.Appender(ctx)
@@ -700,15 +701,14 @@ Outer:
 			require.NoError(t, os.RemoveAll(snap))
 		}()
 		require.NoError(t, db.Snapshot(snap, true))
-		require.NoError(t, db.Close())
 
 		// reopen DB from snapshot
-		db, err = Open(snap, nil, nil, nil, nil)
+		newDB, err := Open(snap, nil, nil, nil, nil)
 		require.NoError(t, err)
-		defer func() { require.NoError(t, db.Close()) }()
+		defer func() { require.NoError(t, newDB.Close()) }()
 
 		// Compare the result.
-		q, err := db.Querier(context.TODO(), 0, numSamples)
+		q, err := newDB.Querier(context.TODO(), 0, numSamples)
 		require.NoError(t, err)
 		defer func() { require.NoError(t, q.Close()) }()
 


### PR DESCRIPTION
Fixes #9433

Signed-off-by: Furkan <furkan.turkal@trendyol.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
