### PR TITLE
added doc for changed metric name in remote write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,8 +116,7 @@ This vulnerability has been reported by Aaron Devaney from MDSec.
 
 ## 2.27.0 / 2021-05-12
 
-* [CHANGE] Remote write: The following metrics were removed/renamed in remote write. #8296
-  - `prometheus_remote_storage_samples_bytes_total` was replaced with `prometheus_remote_storage_bytes_total`.
+* [CHANGE] Remote write: Metric `prometheus_remote_storage_samples_bytes_total` renamed to `prometheus_remote_storage_bytes_total`. #8296
 * [FEATURE] Promtool: Retroactive rule evaluation functionality. #7675
 * [FEATURE] Configuration: Environment variable expansion for external labels. Behind `--enable-feature=expand-external-labels` flag. #8649
 * [FEATURE] TSDB: Add a flag(`--storage.tsdb.max-block-chunk-segment-size`) to control the max chunks file size of the blocks for small Prometheus instances. #8478


### PR DESCRIPTION
Adding `prometheus_remote_storage_bytes_total` in CHANGELOG since I was caught off guard that the metric changed after a recent update. 

Did my best to correlate the change back to the correct version. Found what I believe to be the change here:
https://github.com/prometheus/prometheus/pull/8296/files#diff-1e66d5e658a9d99e1bd9b7be7d626d6b3bf9bbf480e210d2946c562cd746767cL200-R244