### PR TITLE
[BUGFIX] File SD: Reload may no effect when file list empty

### DIFF
--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -472,11 +472,26 @@ func TestRemoveFile(t *testing.T) {
 	runner.requireUpdate(
 		ref,
 		[]*targetgroup.Group{
+			{},
 			{
 				Source: fileSource(sdFile, 0),
 			},
 			{
 				Source: fileSource(sdFile, 1),
 			}},
+	)
+}
+
+func TestEmptyDir(t *testing.T) {
+	t.Parallel()
+
+	runner := newTestRunner(t)
+	runner.run("*.yml")
+	defer runner.stop()
+
+	ref := runner.lastReceive()
+	runner.requireUpdate(
+		ref,
+		[]*targetgroup.Group{{}},
 	)
 }


### PR DESCRIPTION
### How to recurring problem

prometheus.yml
```
scrape_configs:
  - job_name: test_sd
    scrape_interval: 30s
    scrape_timeout: 10s
    metrics_path: /metrics
    scheme: http
    file_sd_configs:
    - files:
      - /usr/local/prometheus/cfg/test.json
      refresh_interval: 5m
```

test.json
```
[
	{
		"targets": ["localhost:9090"]
	}
]
```

curl localhost:9090/api/v1/targets
```
{"status":"success","data":{"activeTargets":[{"discoveredLabels":{"__address__":"localhost:9090","__meta_filepath":"/usr/local/prometheus/cfg/test.json","__metrics_path__":"/metrics","__scheme__":"http","__scrape_interval__":"30s","__scrape_timeout__":"10s","job":"test_sd"},"labels":{"instance":"localhost:9090","job":"test_sd"},"scrapePool":"test_sd","scrapeUrl":"http://localhost:9090/metrics","globalUrl":"http://vm-gaia-prom-01:9090/metrics","lastError":"","lastScrape":"0001-01-01T00:00:00Z","lastScrapeDuration":0,"health":"unknown","scrapeInterval":"30s","scrapeTimeout":"10s"}],"droppedTargets":[]}}
```

sudo mv /usr/local/prometheus/cfg/test.json /usr/local/prometheus/cfg/test.json2 && curl -XPOST localhost:9090/-/reload. 

now, curl localhost:9090/api/v1/targets, targets still in result:
```
{"status":"success","data":{"activeTargets":[{"discoveredLabels":{"__address__":"localhost:9090","__meta_filepath":"/usr/local/prometheus/cfg/test.json","__metrics_path__":"/metrics","__scheme__":"http","__scrape_interval__":"30s","__scrape_timeout__":"10s","job":"test_sd"},"labels":{"instance":"localhost:9090","job":"test_sd"},"scrapePool":"test_sd","scrapeUrl":"http://localhost:9090/metrics","globalUrl":"http://vm-gaia-prom-01:9090/metrics","lastError":"","lastScrape":"2021-10-12T16:46:38.022650958+08:00","lastScrapeDuration":0.006648387,"health":"up","scrapeInterval":"30s","scrapeTimeout":"10s"}],"droppedTargets":[]}}
```

