### PR TITLE
Add more verbose error message for many to one matching

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1937,7 +1937,8 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 				insertedSigs = map[uint64]struct{}{}
 				matchedSigs[sig] = insertedSigs
 			} else if _, duplicate := insertedSigs[insertSig]; duplicate {
-				ev.errorf("multiple matches for labels: grouping labels must ensure unique matches")
+				ev.errorf(`multiple matches for labels: grouping labels must ensure unique matches: duplicate output series found: %s`,
+					metric.String())
 			}
 			insertedSigs[insertSig] = struct{}{}
 		}

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
@@ -2434,7 +2433,7 @@ func TestRangeQuery(t *testing.T) {
 func TestVectorBinopReturnsVerboseErrorForManyToOneMatching(t *testing.T) {
 	ev := &evaluator{}
 
-	assert.PanicsWithError(t, `multiple matches for labels: grouping labels must ensure unique matches: duplicate output series found: {job="1"}`,
+	require.PanicsWithError(t, `multiple matches for labels: grouping labels must ensure unique matches: duplicate output series found: {job="1"}`,
 		func() {
 			ev.VectorBinop(
 				parser.ADD,


### PR DESCRIPTION
Signed-off-by: Shirley Leu <shirley.w.leu@gmail.com>

Resolves #5616 

@brian-brazil @roidelapluie 
Can you please let me know if you think it would be helpful to have more added to the error message? For example I wasn't sure what corresponds to the "group" exactly. In #8355 I also see that the change also includes the `ls.Metric.String(), rs.Metric.String())` -- I thought that might be redundant. Let me know if it is not.
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
