### PR TITLE
add discovery for tencentcloud instances

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/prometheus/prometheus/discovery/puppetdb"
 	"github.com/prometheus/prometheus/discovery/scaleway"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/discovery/tencentcloud"
 	"github.com/prometheus/prometheus/discovery/triton"
 	"github.com/prometheus/prometheus/discovery/xds"
 	"github.com/prometheus/prometheus/discovery/zookeeper"
@@ -516,6 +517,38 @@ var expectedConf = &Config{
 						{
 							Name:   "tag:service",
 							Values: []string{"web", "db"},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			JobName: "service-tencentcloud",
+
+			HonorTimestamps: true,
+			ScrapeInterval:  model.Duration(15 * time.Second),
+			ScrapeTimeout:   DefaultGlobalConfig.ScrapeTimeout,
+
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
+
+			ServiceDiscoveryConfigs: discovery.Configs{
+				&tencentcloud.SDConfig{
+					Region:          "ap-guangzhou",
+					AccessKey:       "access",
+					SecretKey:       "mysecret",
+					RefreshInterval: model.Duration(60 * time.Second),
+					Port:            80,
+					Filters: []*tencentcloud.Filter{
+						{
+							Name:   "env",
+							Values: []string{"prod"},
+						},
+						{
+							Name:   "zone",
+							Values: []string{"ap-guangzhou-3"},
 						},
 					},
 				},
@@ -1018,7 +1051,7 @@ func TestElideSecrets(t *testing.T) {
 	yamlConfig := string(config)
 
 	matches := secretRe.FindAllStringIndex(yamlConfig, -1)
-	require.Equal(t, 15, len(matches), "wrong number of secret matches found")
+	require.Equal(t, 16, len(matches), "wrong number of secret matches found")
 	require.NotContains(t, yamlConfig, "mysecret",
 		"yaml marshal reveals authentication credentials.")
 }

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -223,6 +223,20 @@ scrape_configs:
               - web
               - db
 
+  - job_name: service-tencentcloud
+    tencentcloud_sd_configs:
+      - region: ap-guangzhou
+        access_key: access
+        secret_key: mysecret
+        filters:
+          - name: env
+            values:
+              - prod
+
+          - name: zone
+            values:
+              - ap-guangzhou-3
+
   - job_name: service-lightsail
     lightsail_sd_configs:
       - region: us-east-1

--- a/discovery/install/install.go
+++ b/discovery/install/install.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/prometheus/prometheus/discovery/openstack"    // register openstack
 	_ "github.com/prometheus/prometheus/discovery/puppetdb"     // register puppetdb
 	_ "github.com/prometheus/prometheus/discovery/scaleway"     // register scaleway
+	_ "github.com/prometheus/prometheus/discovery/tencentcloud" // register tencentcloud
 	_ "github.com/prometheus/prometheus/discovery/triton"       // register triton
 	_ "github.com/prometheus/prometheus/discovery/xds"          // register xds
 	_ "github.com/prometheus/prometheus/discovery/zookeeper"    // register zookeeper

--- a/discovery/tencentcloud/tencentcloud.go
+++ b/discovery/tencentcloud/tencentcloud.go
@@ -1,0 +1,204 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tencentcloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/refresh"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
+	tencenterr "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
+	cvm "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312"
+)
+
+const (
+	cvmLabel              = model.MetaLabelPrefix + "tencentcloud_"
+	cvmLabelRegion        = cvmLabel + "region"
+	cvmLabelZone          = cvmLabel + "zone"
+	cvmLabelPublicIP      = cvmLabel + "public_ip"
+	cvmLabelPrivateIP     = cvmLabel + "private_ip"
+	cvmLabelInstanceID    = cvmLabel + "instance_id"
+	cvmLabelInstanceName  = cvmLabel + "instance_name"
+	cvmLabelInstanceState = cvmLabel + "instance_state"
+)
+
+var (
+	// DefaultSDConfig is the default EC2 SD configuration.
+	DefaultSDConfig = SDConfig{
+		Port:            80,
+		RefreshInterval: model.Duration(60 * time.Second),
+	}
+)
+
+func init() {
+	discovery.RegisterConfig(&SDConfig{})
+}
+
+// SDConfig is the configuration for tencentcloud based service discovery.
+type SDConfig struct {
+	Region          string         `yaml:"region"`
+	AccessKey       string         `yaml:"access_key"`
+	SecretKey       config.Secret  `yaml:"secret_key"`
+	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
+	Port            int            `yaml:"port"`
+	Filters         []*Filter      `yaml:"filters,omitempty"`
+}
+
+// Filter is the configuration for filtering tencentcloud instances.
+type Filter struct {
+	Name   string   `yaml:"name"`
+	Values []string `yaml:"values"`
+}
+
+// Name returns the name of the tencentcloud Config.
+func (*SDConfig) Name() string { return "tencentcloud" }
+
+// NewDiscoverer returns a Discoverer for the tencentcloud Config.
+func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Discoverer, error) {
+	return NewDiscovery(c, opts.Logger)
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for the tencentcloud Config.
+func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultSDConfig
+	type plain SDConfig
+	err := unmarshal((*plain)(c))
+	if err != nil {
+		return err
+	}
+	if c.Region == "" {
+		return errors.New("TencentCloud SD configuration requires a region")
+	}
+
+	if c.AccessKey == "" {
+		return errors.New("TencentCloud SD configuration requires a access_key")
+	}
+	if c.SecretKey == "" {
+		return errors.New("TencentCloud SD configuration requires a secret_key")
+	}
+	return nil
+}
+
+// Discovery periodically performs tencentcloud-SD requests. It implements
+// the Discoverer interface.
+type Discovery struct {
+	*refresh.Discovery
+	cfg    *SDConfig
+	client *cvm.Client
+	logger log.Logger
+}
+
+// NewDiscovery returns a new Discovery which periodically refreshes its targets.
+func NewDiscovery(conf *SDConfig, logger log.Logger) (*Discovery, error) {
+	d := &Discovery{
+		cfg:    conf,
+		logger: logger,
+	}
+
+	credential := common.NewCredential(d.cfg.AccessKey, string(d.cfg.SecretKey))
+	d.client, _ = cvm.NewClient(credential, d.cfg.Region, profile.NewClientProfile())
+	d.Discovery = refresh.NewDiscovery(
+		logger,
+		"tencentcloud",
+		time.Duration(d.cfg.RefreshInterval),
+		d.refresh,
+	)
+
+	return d, nil
+}
+
+func (d *Discovery) getNodes() ([]*cvm.Instance, error) {
+	var filters []*cvm.Filter
+	for _, f := range d.cfg.Filters {
+		filters = append(filters, &cvm.Filter{
+			Name:   common.StringPtr(f.Name),
+			Values: common.StringPtrs(f.Values),
+		})
+	}
+
+	var instances []*cvm.Instance
+
+	for {
+		request := cvm.NewDescribeInstancesRequest()
+		offset := len(instances)
+		request.Offset = common.Int64Ptr(int64(offset))
+		request.Filters = filters
+		response, err := d.client.DescribeInstances(request)
+		if _, ok := err.(*tencenterr.TencentCloudSDKError); ok {
+			return nil, fmt.Errorf("tencentcloud api error has returned: %s", err)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		instances = append(instances, response.Response.InstanceSet...)
+		if int64(len(instances)) == *response.Response.TotalCount {
+			break
+		}
+	}
+
+	return instances, nil
+}
+
+func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	tg := &targetgroup.Group{
+		Source: d.cfg.Region,
+	}
+
+	instances, err := d.getNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, instance := range instances {
+		labels := model.LabelSet{
+			cvmLabelInstanceID:    model.LabelValue(*instance.InstanceId),
+			cvmLabelInstanceName:  model.LabelValue(*instance.InstanceName),
+			cvmLabelInstanceState: model.LabelValue(*instance.InstanceState),
+			cvmLabelRegion:        model.LabelValue(d.cfg.Region),
+			cvmLabelZone:          model.LabelValue(*instance.Placement.Zone),
+		}
+
+		// private IPs
+		var privateIPs []string
+		for _, privateIP := range instance.PrivateIpAddresses {
+			privateIPs = append(privateIPs, *privateIP)
+		}
+		labels[cvmLabelPrivateIP] = model.LabelValue(strings.Join(privateIPs, ","))
+
+		addr := fmt.Sprintf("%s:%d", privateIPs[0], d.cfg.Port)
+		labels[model.AddressLabel] = model.LabelValue(addr)
+
+		// public IPs
+		var publicIPs []string
+		for _, publicIP := range instance.PublicIpAddresses {
+			publicIPs = append(publicIPs, *publicIP)
+		}
+		labels[cvmLabelPublicIP] = model.LabelValue(strings.Join(publicIPs, ","))
+
+		tg.Targets = append(tg.Targets, labels)
+	}
+
+	return []*targetgroup.Group{tg}, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,8 @@ require (
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546
 	github.com/stretchr/testify v1.7.0
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.205
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.205
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible
 	go.uber.org/atomic v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1253,6 +1253,10 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.205 h1:dBzee5hHuE6T+mfje5KmPabs1pxslu4sgncuXb+ZCQk=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.205/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.205 h1:Ktt/5NS2cl/7X5f6x48tkQWr2NqGYVNnfKS/oleKI2w=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.205/go.mod h1:AqyM/ZZMD7q5mHBqNY9YImbSpEpoEe7E/vrTbUWX+po=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=


### PR DESCRIPTION
Signed-off-by: yiyang5055 <yiyang5055@gmail.com>

This enables discovery for tencentcloud Scraping targets

Simple example scrape config:

```
scrape_configs:
  - job_name: service-tencentcloud
    tencentcloud_sd_configs:
      - region: ap-guangzhou
        access_key: access
        secret_key: mysecret
```
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
