### PR TITLE
Parallelize tests in packages where test execution takes a long time

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - depguard
     - gofumpt
     - goimports
+    - paralleltest
     - revive
 
 issues:
@@ -19,6 +20,10 @@ issues:
     - path: _test.go
       linters:
         - errcheck
+    # False positive: https://github.com/kunwardeep/paralleltest/issues/8.
+    - linters:
+        - paralleltest
+      text: "does not use range value in test Run"
 
 linters-settings:
   depguard:

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -208,6 +208,8 @@ func TestSendAlerts(t *testing.T) {
 }
 
 func TestWALSegmentSizeBounds(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -366,6 +368,8 @@ func getCurrentGaugeValuesFor(t *testing.T, reg prometheus.Gatherer, metricNames
 }
 
 func TestAgentSuccessfulStartup(t *testing.T) {
+	t.Parallel()
+
 	prom := exec.Command(promPath, "-test.main", "--enable-feature=agent", "--config.file="+agentConfig)
 	require.NoError(t, prom.Start())
 
@@ -384,6 +388,8 @@ func TestAgentSuccessfulStartup(t *testing.T) {
 }
 
 func TestAgentFailedStartupWithServerFlag(t *testing.T) {
+	t.Parallel()
+
 	prom := exec.Command(promPath, "-test.main", "--enable-feature=agent", "--storage.tsdb.path=.", "--config.file="+promConfig)
 
 	output := bytes.Buffer{}
@@ -411,6 +417,8 @@ func TestAgentFailedStartupWithServerFlag(t *testing.T) {
 }
 
 func TestAgentFailedStartupWithInvalidConfig(t *testing.T) {
+	t.Parallel()
+
 	prom := exec.Command(promPath, "-test.main", "--enable-feature=agent", "--config.file="+promConfig)
 	require.NoError(t, prom.Start())
 
@@ -429,6 +437,8 @@ func TestAgentFailedStartupWithInvalidConfig(t *testing.T) {
 }
 
 func TestModeSpecificFlags(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -446,6 +456,8 @@ func TestModeSpecificFlags(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("%s mode with option %s", tc.mode, tc.arg), func(t *testing.T) {
+			t.Parallel()
+
 			args := []string{"-test.main", tc.arg, t.TempDir()}
 
 			if tc.mode == "agent" {

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -60,6 +60,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestComputeExternalURL(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		input string
 		valid bool
@@ -110,6 +112,8 @@ func TestComputeExternalURL(t *testing.T) {
 
 // Let's provide an invalid configuration file and verify the exit status indicates the error.
 func TestFailedStartupExitCode(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -136,6 +140,8 @@ func (s senderFunc) Send(alerts ...*notifier.Alert) {
 }
 
 func TestSendAlerts(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		in  []*rules.Alert
 		exp []*notifier.Alert
@@ -188,6 +194,8 @@ func TestSendAlerts(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+
 			senderFunc := senderFunc(func(alerts ...*notifier.Alert) {
 				if len(tc.in) == 0 {
 					t.Fatalf("sender called with 0 alert")
@@ -288,6 +296,8 @@ func TestMaxBlockChunkSegmentSizeBounds(t *testing.T) {
 }
 
 func TestTimeMetrics(t *testing.T) {
+	t.Parallel()
+
 	tmpDir, err := ioutil.TempDir("", "time_metrics_e2e")
 	require.NoError(t, err)
 

--- a/cmd/prometheus/main_unix_test.go
+++ b/cmd/prometheus/main_unix_test.go
@@ -30,6 +30,8 @@ import (
 // As soon as prometheus starts responding to http request it should be able to
 // accept Interrupt signals for a graceful shutdown.
 func TestStartupInterrupt(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}

--- a/cmd/promtool/backfill_test.go
+++ b/cmd/promtool/backfill_test.go
@@ -86,6 +86,8 @@ func testBlocks(t *testing.T, db *tsdb.DB, expectedMinTime, expectedMaxTime, exp
 }
 
 func TestBackfill(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		ToParse              string
 		IsOk                 bool
@@ -684,7 +686,11 @@ after_eof 1 2
 		},
 	}
 	for _, test := range tests {
+		test := test
+
 		t.Run(test.Description, func(t *testing.T) {
+			t.Parallel()
+
 			t.Logf("Test:%s", test.Description)
 
 			outputDir, err := ioutil.TempDir("", "myDir")

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestQueryRange(t *testing.T) {
+	t.Parallel()
+
 	s, getRequest := mockServer(200, `{"status": "success", "data": {"resultType": "matrix", "result": []}}`)
 	defer s.Close()
 
@@ -51,6 +53,8 @@ func TestQueryRange(t *testing.T) {
 }
 
 func TestQueryInstant(t *testing.T) {
+	t.Parallel()
+
 	s, getRequest := mockServer(200, `{"status": "success", "data": {"resultType": "vector", "result": []}}`)
 	defer s.Close()
 
@@ -82,6 +86,8 @@ func mockServer(code int, body string) (*httptest.Server, func() *http.Request) 
 }
 
 func TestCheckSDFile(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name string
 		file string
@@ -111,7 +117,11 @@ func TestCheckSDFile(t *testing.T) {
 		},
 	}
 	for _, test := range cases {
+		test := test
+
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := checkSDFile(test.file)
 			if test.err != "" {
 				require.Equalf(t, test.err, err.Error(), "Expected error %q, got %q", test.err, err.Error())
@@ -123,6 +133,8 @@ func TestCheckSDFile(t *testing.T) {
 }
 
 func TestCheckDuplicates(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name         string
 		ruleFile     string
@@ -147,6 +159,8 @@ func TestCheckDuplicates(t *testing.T) {
 	for _, test := range cases {
 		c := test
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			rgs, err := rulefmt.ParseFile(c.ruleFile)
 			require.Empty(t, err)
 			dups := checkDuplicates(rgs.Groups)

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -180,6 +180,8 @@ func BenchmarkCheckDuplicates(b *testing.B) {
 }
 
 func TestCheckTargetConfig(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name string
 		file string
@@ -207,7 +209,11 @@ func TestCheckTargetConfig(t *testing.T) {
 		},
 	}
 	for _, test := range cases {
+		test := test
+
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := checkConfig(false, "testdata/"+test.file)
 			if test.err != "" {
 				require.Equalf(t, test.err, err.Error(), "Expected error %q, got %q", test.err, err.Error())

--- a/cmd/promtool/rules_test.go
+++ b/cmd/promtool/rules_test.go
@@ -43,6 +43,8 @@ const defaultBlockDuration = time.Duration(tsdb.DefaultBlockDuration) * time.Mil
 
 // TestBackfillRuleIntegration is an integration test that runs all the rule importer code to confirm the parts work together.
 func TestBackfillRuleIntegration(t *testing.T) {
+	t.Parallel()
+
 	const (
 		testMaxSampleCount = 50
 		testValue          = 123

--- a/cmd/promtool/rules_test.go
+++ b/cmd/promtool/rules_test.go
@@ -73,7 +73,11 @@ func TestBackfillRuleIntegration(t *testing.T) {
 		{"run importer once with larger blocks", 1, twentyFourHourDuration, 4, 4, 4, []*model.SampleStream{{Metric: model.Metric{"name1": "val1"}, Values: []model.SamplePair{{Timestamp: testTime, Value: testValue}}}}},
 	}
 	for _, tt := range testCases {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			tmpDir, err := ioutil.TempDir("", "backfilldata")
 			require.NoError(t, err)
 			defer func() {
@@ -221,6 +225,8 @@ func createMultiRuleTestFiles(path string) error {
 // TestBackfillLabels confirms that the labels in the rule file override the labels from the metrics
 // received from Prometheus Query API, including the __name__ label.
 func TestBackfillLabels(t *testing.T) {
+	t.Parallel()
+
 	tmpDir, err := ioutil.TempDir("", "backfilldata")
 	require.NoError(t, err)
 	defer func() {

--- a/cmd/promtool/sd_test.go
+++ b/cmd/promtool/sd_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestSDCheckResult(t *testing.T) {
+	t.Parallel()
+
 	targetGroups := []*targetgroup.Group{{
 		Targets: []model.LabelSet{
 			map[model.LabelName]model.LabelValue{"__address__": "localhost:8080", "foo": "bar"},

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestRulesUnitTest(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		files []string
 	}
@@ -107,7 +109,11 @@ func TestRulesUnitTest(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			if got := RulesUnitTest(tt.queryOpts, tt.args.files...); got != tt.want {
 				t.Errorf("RulesUnitTest() = %v, want %v", got, tt.want)
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -989,6 +989,8 @@ var expectedConf = &Config{
 }
 
 func TestYAMLRoundtrip(t *testing.T) {
+	t.Parallel()
+
 	want, err := LoadFile("testdata/roundtrip.good.yml", false, false, log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -1002,6 +1004,8 @@ func TestYAMLRoundtrip(t *testing.T) {
 }
 
 func TestRemoteWriteRetryOnRateLimit(t *testing.T) {
+	t.Parallel()
+
 	want, err := LoadFile("testdata/remote_write_retry_on_rate_limit.good.yml", false, false, log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -1016,6 +1020,8 @@ func TestRemoteWriteRetryOnRateLimit(t *testing.T) {
 }
 
 func TestLoadConfig(t *testing.T) {
+	t.Parallel()
+
 	// Parse a valid file that sets a global scrape timeout. This tests whether parsing
 	// an overwritten default field in the global config permanently changes the default.
 	_, err := LoadFile("testdata/global_timeout.good.yml", false, false, log.NewNopLogger())
@@ -1027,6 +1033,8 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestScrapeIntervalLarger(t *testing.T) {
+	t.Parallel()
+
 	c, err := LoadFile("testdata/scrape_interval_larger.good.yml", false, false, log.NewNopLogger())
 	require.NoError(t, err)
 	require.Equal(t, 1, len(c.ScrapeConfigs))
@@ -1037,6 +1045,8 @@ func TestScrapeIntervalLarger(t *testing.T) {
 
 // YAML marshaling must not reveal authentication credentials.
 func TestElideSecrets(t *testing.T) {
+	t.Parallel()
+
 	c, err := LoadFile("testdata/conf.good.yml", false, false, log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -1053,6 +1063,8 @@ func TestElideSecrets(t *testing.T) {
 }
 
 func TestLoadConfigRuleFilesAbsolutePath(t *testing.T) {
+	t.Parallel()
+
 	// Parse a valid file that sets a rule files with an absolute path
 	c, err := LoadFile(ruleFilesConfigFile, false, false, log.NewNopLogger())
 	require.NoError(t, err)
@@ -1060,16 +1072,22 @@ func TestLoadConfigRuleFilesAbsolutePath(t *testing.T) {
 }
 
 func TestKubernetesEmptyAPIServer(t *testing.T) {
+	t.Parallel()
+
 	_, err := LoadFile("testdata/kubernetes_empty_apiserver.good.yml", false, false, log.NewNopLogger())
 	require.NoError(t, err)
 }
 
 func TestKubernetesWithKubeConfig(t *testing.T) {
+	t.Parallel()
+
 	_, err := LoadFile("testdata/kubernetes_kubeconfig_without_apiserver.good.yml", false, false, log.NewNopLogger())
 	require.NoError(t, err)
 }
 
 func TestKubernetesSelectors(t *testing.T) {
+	t.Parallel()
+
 	_, err := LoadFile("testdata/kubernetes_selectors_endpoints.good.yml", false, false, log.NewNopLogger())
 	require.NoError(t, err)
 	_, err = LoadFile("testdata/kubernetes_selectors_node.good.yml", false, false, log.NewNopLogger())
@@ -1437,6 +1455,8 @@ var expectedErrors = []struct {
 }
 
 func TestBadConfigs(t *testing.T) {
+	t.Parallel()
+
 	for _, ee := range expectedErrors {
 		_, err := LoadFile("testdata/"+ee.filename, false, false, log.NewNopLogger())
 		require.Error(t, err, "%s", ee.filename)
@@ -1446,6 +1466,8 @@ func TestBadConfigs(t *testing.T) {
 }
 
 func TestBadStaticConfigsJSON(t *testing.T) {
+	t.Parallel()
+
 	content, err := ioutil.ReadFile("testdata/static_config.bad.json")
 	require.NoError(t, err)
 	var tg targetgroup.Group
@@ -1454,6 +1476,8 @@ func TestBadStaticConfigsJSON(t *testing.T) {
 }
 
 func TestBadStaticConfigsYML(t *testing.T) {
+	t.Parallel()
+
 	content, err := ioutil.ReadFile("testdata/static_config.bad.yml")
 	require.NoError(t, err)
 	var tg targetgroup.Group
@@ -1462,6 +1486,8 @@ func TestBadStaticConfigsYML(t *testing.T) {
 }
 
 func TestEmptyConfig(t *testing.T) {
+	t.Parallel()
+
 	c, err := Load("", false, log.NewNopLogger())
 	require.NoError(t, err)
 	exp := DefaultConfig
@@ -1469,6 +1495,8 @@ func TestEmptyConfig(t *testing.T) {
 }
 
 func TestExpandExternalLabels(t *testing.T) {
+	t.Parallel()
+
 	// Cleanup ant TEST env variable that could exist on the system.
 	os.Setenv("TEST", "")
 
@@ -1493,6 +1521,8 @@ func TestExpandExternalLabels(t *testing.T) {
 }
 
 func TestEmptyGlobalBlock(t *testing.T) {
+	t.Parallel()
+
 	c, err := Load("global:\n", false, log.NewNopLogger())
 	require.NoError(t, err)
 	exp := DefaultConfig

--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -26,6 +26,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestMapFromVMWithEmptyTags(t *testing.T) {
+	t.Parallel()
+
 	id := "test"
 	name := "name"
 	vmType := "type"
@@ -72,6 +74,8 @@ func TestMapFromVMWithEmptyTags(t *testing.T) {
 }
 
 func TestMapFromVMWithTags(t *testing.T) {
+	t.Parallel()
+
 	id := "test"
 	name := "name"
 	vmType := "type"
@@ -121,6 +125,8 @@ func TestMapFromVMWithTags(t *testing.T) {
 }
 
 func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
+	t.Parallel()
+
 	id := "test"
 	name := "name"
 	vmType := "type"
@@ -169,6 +175,8 @@ func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 }
 
 func TestMapFromVMScaleSetVMWithTags(t *testing.T) {
+	t.Parallel()
+
 	id := "test"
 	name := "name"
 	vmType := "type"
@@ -220,6 +228,8 @@ func TestMapFromVMScaleSetVMWithTags(t *testing.T) {
 }
 
 func TestNewAzureResourceFromID(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		id       string
 		expected azureResource

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -36,6 +36,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestConfiguredService(t *testing.T) {
+	t.Parallel()
+
 	conf := &SDConfig{
 		Services: []string{"configuredServiceName"},
 	}
@@ -52,6 +54,8 @@ func TestConfiguredService(t *testing.T) {
 }
 
 func TestConfiguredServiceWithTag(t *testing.T) {
+	t.Parallel()
+
 	conf := &SDConfig{
 		Services:    []string{"configuredServiceName"},
 		ServiceTags: []string{"http"},
@@ -75,6 +79,8 @@ func TestConfiguredServiceWithTag(t *testing.T) {
 }
 
 func TestConfiguredServiceWithTags(t *testing.T) {
+	t.Parallel()
+
 	type testcase struct {
 		// What we've configured to watch.
 		conf *SDConfig
@@ -164,6 +170,8 @@ func TestConfiguredServiceWithTags(t *testing.T) {
 }
 
 func TestNonConfiguredService(t *testing.T) {
+	t.Parallel()
+
 	conf := &SDConfig{}
 	consulDiscovery, err := NewDiscovery(conf, nil)
 	if err != nil {
@@ -280,6 +288,8 @@ func checkOneTarget(t *testing.T, tg []*targetgroup.Group) {
 
 // Watch all the services in the catalog.
 func TestAllServices(t *testing.T) {
+	t.Parallel()
+
 	stub, config := newServer(t)
 	defer stub.Close()
 
@@ -299,6 +309,8 @@ func TestAllServices(t *testing.T) {
 
 // targetgroup with no targets is emitted if no services were discovered.
 func TestNoTargets(t *testing.T) {
+	t.Parallel()
+
 	stub, config := newServer(t)
 	defer stub.Close()
 	config.ServiceTags = []string{"missing"}
@@ -320,6 +332,8 @@ func TestNoTargets(t *testing.T) {
 
 // Watch only the test service.
 func TestOneService(t *testing.T) {
+	t.Parallel()
+
 	stub, config := newServer(t)
 	defer stub.Close()
 
@@ -335,6 +349,8 @@ func TestOneService(t *testing.T) {
 
 // Watch the test service with a specific tag and node-meta.
 func TestAllOptions(t *testing.T) {
+	t.Parallel()
+
 	stub, config := newServer(t)
 	defer stub.Close()
 
@@ -358,6 +374,8 @@ func TestAllOptions(t *testing.T) {
 }
 
 func TestGetDatacenterShouldReturnError(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		handler    func(http.ResponseWriter, *http.Request)
 		errMessage string
@@ -402,6 +420,8 @@ func TestGetDatacenterShouldReturnError(t *testing.T) {
 }
 
 func TestUnmarshalConfig(t *testing.T) {
+	t.Parallel()
+
 	unmarshal := func(d []byte) func(interface{}) error {
 		return func(o interface{}) error {
 			return yaml.Unmarshal(d, o)
@@ -471,7 +491,11 @@ oauth2:
 	}
 
 	for _, test := range cases {
+		test := test
+
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			var config SDConfig
 			err := config.UnmarshalYAML(unmarshal([]byte(test.config)))
 			if err != nil {

--- a/discovery/digitalocean/digitalocean_test.go
+++ b/discovery/digitalocean/digitalocean_test.go
@@ -40,6 +40,8 @@ func (s *DigitalOceanSDTestSuite) SetupTest(t *testing.T) {
 }
 
 func TestDigitalOceanSDRefresh(t *testing.T) {
+	t.Parallel()
+
 	sdmock := &DigitalOceanSDTestSuite{}
 	sdmock.SetupTest(t)
 	t.Cleanup(sdmock.TearDownSuite)
@@ -126,8 +128,13 @@ func TestDigitalOceanSDRefresh(t *testing.T) {
 			"__meta_digitalocean_features":     model.LabelValue(",ipv6,private_networking,"),
 		},
 	} {
+		lbls := lbls
+		targets := tg.Targets[i]
+
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
-			require.Equal(t, lbls, tg.Targets[i])
+			t.Parallel()
+
+			require.Equal(t, lbls, targets)
 		})
 	}
 }

--- a/discovery/dns/dns_test.go
+++ b/discovery/dns/dns_test.go
@@ -35,6 +35,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestDNS(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name   string
 		config SDConfig
@@ -212,6 +214,8 @@ func TestDNS(t *testing.T) {
 }
 
 func TestSDConfigUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
 	marshal := func(c SDConfig) []byte {
 		d, err := yaml.Marshal(c)
 		if err != nil {
@@ -292,7 +296,11 @@ func TestSDConfigUnmarshalYAML(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		c := c
+
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			var config SDConfig
 			d := marshal(c.input)
 			err := config.UnmarshalYAML(unmarshal(d))

--- a/discovery/eureka/client_test.go
+++ b/discovery/eureka/client_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestFetchApps(t *testing.T) {
+	t.Parallel()
+
 	appsXML := `<applications>
   <versions__delta>1</versions__delta>
   <apps__hashcode>UP_4_</apps__hashcode>
@@ -198,6 +200,8 @@ func TestFetchApps(t *testing.T) {
 }
 
 func Test500ErrorHttpResponse(t *testing.T) {
+	t.Parallel()
+
 	// Simulate 500 error.
 	respHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/discovery/eureka/eureka_test.go
+++ b/discovery/eureka/eureka_test.go
@@ -44,6 +44,8 @@ func testUpdateServices(respHandler http.HandlerFunc) ([]*targetgroup.Group, err
 }
 
 func TestEurekaSDHandleError(t *testing.T) {
+	t.Parallel()
+
 	var (
 		errTesting  = "non 2xx status '500' response during eureka service discovery"
 		respHandler = func(w http.ResponseWriter, r *http.Request) {
@@ -59,6 +61,8 @@ func TestEurekaSDHandleError(t *testing.T) {
 }
 
 func TestEurekaSDEmptyList(t *testing.T) {
+	t.Parallel()
+
 	var (
 		appsXML = `<applications>
 <versions__delta>1</versions__delta>
@@ -76,6 +80,8 @@ func TestEurekaSDEmptyList(t *testing.T) {
 }
 
 func TestEurekaSDSendGroup(t *testing.T) {
+	t.Parallel()
+
 	var (
 		appsXML = `<applications>
   <versions__delta>1</versions__delta>

--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -308,6 +308,8 @@ func valid2Tg(file string) []*targetgroup.Group {
 }
 
 func TestInitialUpdate(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []string{
 		"fixtures/valid.yml",
 		"fixtures/valid.json",
@@ -328,6 +330,8 @@ func TestInitialUpdate(t *testing.T) {
 }
 
 func TestInvalidFile(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []string{
 		"fixtures/invalid_nil.yml",
 		"fixtures/invalid_nil.json",

--- a/discovery/hetzner/hcloud_test.go
+++ b/discovery/hetzner/hcloud_test.go
@@ -36,6 +36,8 @@ func (s *hcloudSDTestSuite) SetupTest(t *testing.T) {
 }
 
 func TestHCloudSDRefresh(t *testing.T) {
+	t.Parallel()
+
 	suite := &hcloudSDTestSuite{}
 	suite.SetupTest(t)
 
@@ -123,8 +125,13 @@ func TestHCloudSDRefresh(t *testing.T) {
 			"__meta_hetzner_hcloud_server_type":                      model.LabelValue("cpx11"),
 		},
 	} {
+		labelSet := labelSet
+		targets := targetGroup.Targets[i]
+
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
-			require.Equal(t, labelSet, targetGroup.Targets[i])
+			t.Parallel()
+
+			require.Equal(t, labelSet, targets)
 		})
 	}
 }

--- a/discovery/hetzner/robot_test.go
+++ b/discovery/hetzner/robot_test.go
@@ -36,6 +36,8 @@ func (s *robotSDTestSuite) SetupTest(t *testing.T) {
 }
 
 func TestRobotSDRefresh(t *testing.T) {
+	t.Parallel()
+
 	suite := &robotSDTestSuite{}
 	suite.SetupTest(t)
 	cfg := DefaultSDConfig
@@ -79,13 +81,20 @@ func TestRobotSDRefresh(t *testing.T) {
 			"__meta_hetzner_robot_cancelled": model.LabelValue("true"),
 		},
 	} {
+		labelSet := labelSet
+		targets := targetGroup.Targets[i]
+
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
-			require.Equal(t, labelSet, targetGroup.Targets[i])
+			t.Parallel()
+
+			require.Equal(t, labelSet, targets)
 		})
 	}
 }
 
 func TestRobotSDRefreshHandleError(t *testing.T) {
+	t.Parallel()
+
 	suite := &robotSDTestSuite{}
 	suite.SetupTest(t)
 	cfg := DefaultSDConfig

--- a/discovery/http/http_test.go
+++ b/discovery/http/http_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestHTTPValidRefresh(t *testing.T) {
+	t.Parallel()
+
 	ts := httptest.NewServer(http.FileServer(http.Dir("./fixtures")))
 	t.Cleanup(ts.Close)
 
@@ -64,6 +66,8 @@ func TestHTTPValidRefresh(t *testing.T) {
 }
 
 func TestHTTPInvalidCode(t *testing.T) {
+	t.Parallel()
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	}))
@@ -85,6 +89,8 @@ func TestHTTPInvalidCode(t *testing.T) {
 }
 
 func TestHTTPInvalidFormat(t *testing.T) {
+	t.Parallel()
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "{}")
 	}))
@@ -106,6 +112,8 @@ func TestHTTPInvalidFormat(t *testing.T) {
 }
 
 func TestContentTypeRegex(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		header string
 		match  bool
@@ -157,13 +165,19 @@ func TestContentTypeRegex(t *testing.T) {
 	}
 
 	for _, test := range cases {
+		test := test
+
 		t.Run(test.header, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, test.match, matchContentType.MatchString(test.header))
 		})
 	}
 }
 
 func TestSourceDisappeared(t *testing.T) {
+	t.Parallel()
+
 	var stubResponse string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -74,6 +74,8 @@ func makeEndpoints() *v1.Endpoints {
 }
 
 func TestEndpointsDiscoveryBeforeRun(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -118,6 +120,8 @@ func TestEndpointsDiscoveryBeforeRun(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryAdd(t *testing.T) {
+	t.Parallel()
+
 	obj := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testpod",
@@ -237,6 +241,8 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryDelete(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
@@ -255,6 +261,8 @@ func TestEndpointsDiscoveryDelete(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryUpdate(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
@@ -326,6 +334,8 @@ func TestEndpointsDiscoveryUpdate(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryEmptySubsets(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
@@ -354,6 +364,8 @@ func TestEndpointsDiscoveryEmptySubsets(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryWithService(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
@@ -409,6 +421,8 @@ func TestEndpointsDiscoveryWithService(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryWithServiceUpdate(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
@@ -479,6 +493,8 @@ func TestEndpointsDiscoveryWithServiceUpdate(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryNamespaces(t *testing.T) {
+	t.Parallel()
+
 	epOne := makeEndpoints()
 	epOne.Namespace = "ns1"
 	objs := []runtime.Object{

--- a/discovery/kubernetes/endpointslice_test.go
+++ b/discovery/kubernetes/endpointslice_test.go
@@ -80,6 +80,8 @@ func makeEndpointSlice() *disv1beta1.EndpointSlice {
 }
 
 func TestEndpointSliceDiscoveryBeforeRun(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -126,6 +128,8 @@ func TestEndpointSliceDiscoveryBeforeRun(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryAdd(t *testing.T) {
+	t.Parallel()
+
 	obj := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testpod",
@@ -247,6 +251,8 @@ func TestEndpointSliceDiscoveryAdd(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryDelete(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{}, makeEndpointSlice())
 
 	k8sDiscoveryTest{
@@ -265,6 +271,8 @@ func TestEndpointSliceDiscoveryDelete(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryUpdate(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{}, makeEndpointSlice())
 
 	k8sDiscoveryTest{
@@ -328,6 +336,8 @@ func TestEndpointSliceDiscoveryUpdate(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryEmptyEndpoints(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{}, makeEndpointSlice())
 
 	k8sDiscoveryTest{
@@ -365,6 +375,8 @@ func TestEndpointSliceDiscoveryEmptyEndpoints(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryWithService(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{}, makeEndpointSlice())
 
 	k8sDiscoveryTest{
@@ -422,6 +434,8 @@ func TestEndpointSliceDiscoveryWithService(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryWithServiceUpdate(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{}, makeEndpointSlice())
 
 	k8sDiscoveryTest{
@@ -494,6 +508,8 @@ func TestEndpointSliceDiscoveryWithServiceUpdate(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryNamespaces(t *testing.T) {
+	t.Parallel()
+
 	epOne := makeEndpointSlice()
 	epOne.Namespace = "ns1"
 	objs := []runtime.Object{

--- a/discovery/kubernetes/ingress_test.go
+++ b/discovery/kubernetes/ingress_test.go
@@ -199,6 +199,8 @@ func expectedTargetGroups(ns string, tls TLSMode) map[string]*targetgroup.Group 
 }
 
 func TestIngressDiscoveryAdd(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"default"}})
 
 	k8sDiscoveryTest{
@@ -213,6 +215,8 @@ func TestIngressDiscoveryAdd(t *testing.T) {
 }
 
 func TestIngressDiscoveryAddV1beta1(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscoveryWithVersion(RoleIngress, NamespaceDiscovery{Names: []string{"default"}}, "v1.18.0")
 
 	k8sDiscoveryTest{
@@ -227,6 +231,8 @@ func TestIngressDiscoveryAddV1beta1(t *testing.T) {
 }
 
 func TestIngressDiscoveryAddTLS(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"default"}})
 
 	k8sDiscoveryTest{
@@ -241,6 +247,8 @@ func TestIngressDiscoveryAddTLS(t *testing.T) {
 }
 
 func TestIngressDiscoveryAddTLSV1beta1(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscoveryWithVersion(RoleIngress, NamespaceDiscovery{Names: []string{"default"}}, "v1.18.0")
 
 	k8sDiscoveryTest{
@@ -255,6 +263,8 @@ func TestIngressDiscoveryAddTLSV1beta1(t *testing.T) {
 }
 
 func TestIngressDiscoveryAddMixed(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"default"}})
 
 	k8sDiscoveryTest{
@@ -269,6 +279,8 @@ func TestIngressDiscoveryAddMixed(t *testing.T) {
 }
 
 func TestIngressDiscoveryAddMixedV1beta1(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscoveryWithVersion(RoleIngress, NamespaceDiscovery{Names: []string{"default"}}, "v1.18.0")
 
 	k8sDiscoveryTest{
@@ -283,6 +295,8 @@ func TestIngressDiscoveryAddMixedV1beta1(t *testing.T) {
 }
 
 func TestIngressDiscoveryNamespaces(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"ns1", "ns2"}})
 
 	expected := expectedTargetGroups("ns1", TLSNo)
@@ -304,6 +318,8 @@ func TestIngressDiscoveryNamespaces(t *testing.T) {
 }
 
 func TestIngressDiscoveryNamespacesV1beta1(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscoveryWithVersion(RoleIngress, NamespaceDiscovery{Names: []string{"ns1", "ns2"}}, "v1.18.0")
 
 	expected := expectedTargetGroups("ns1", TLSNo)

--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -222,6 +222,8 @@ func (s *Service) hasSynced() bool {
 }
 
 func TestRetryOnError(t *testing.T) {
+	t.Parallel()
+
 	for _, successAt := range []int{1, 2, 3} {
 		var called int
 		f := func() error {
@@ -237,6 +239,8 @@ func TestRetryOnError(t *testing.T) {
 }
 
 func TestCheckNetworkingV1Supported(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		version       string
 		wantSupported bool
@@ -255,6 +259,8 @@ func TestCheckNetworkingV1Supported(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.version, func(t *testing.T) {
+			t.Parallel()
+
 			clientset := fake.NewSimpleClientset()
 			fakeDiscovery, _ := clientset.Discovery().(*fakediscovery.FakeDiscovery)
 			fakeDiscovery.FakedServerVersion = &version.Info{GitVersion: tc.version}

--- a/discovery/kubernetes/node_test.go
+++ b/discovery/kubernetes/node_test.go
@@ -142,6 +142,8 @@ func TestNodeDiscoveryDelete(t *testing.T) {
 }
 
 func TestNodeDiscoveryUpdate(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleNode, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{

--- a/discovery/kubernetes/node_test.go
+++ b/discovery/kubernetes/node_test.go
@@ -53,6 +53,8 @@ func makeEnumeratedNode(i int) *v1.Node {
 }
 
 func TestNodeDiscoveryBeforeStart(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleNode, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -90,6 +92,8 @@ func TestNodeDiscoveryBeforeStart(t *testing.T) {
 }
 
 func TestNodeDiscoveryAdd(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleNode, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -118,6 +122,8 @@ func TestNodeDiscoveryAdd(t *testing.T) {
 }
 
 func TestNodeDiscoveryDelete(t *testing.T) {
+	t.Parallel()
+
 	obj := makeEnumeratedNode(0)
 	n, c := makeDiscovery(RoleNode, NamespaceDiscovery{}, obj)
 

--- a/discovery/kubernetes/pod_test.go
+++ b/discovery/kubernetes/pod_test.go
@@ -191,6 +191,8 @@ func expectedPodTargetGroups(ns string) map[string]*targetgroup.Group {
 }
 
 func TestPodDiscoveryBeforeRun(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -248,6 +250,8 @@ func TestPodDiscoveryBeforeRun(t *testing.T) {
 }
 
 func TestPodDiscoveryInitContainer(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
 
 	ns := "default"
@@ -273,6 +277,8 @@ func TestPodDiscoveryInitContainer(t *testing.T) {
 }
 
 func TestPodDiscoveryAdd(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -287,6 +293,8 @@ func TestPodDiscoveryAdd(t *testing.T) {
 }
 
 func TestPodDiscoveryDelete(t *testing.T) {
+	t.Parallel()
+
 	obj := makePods()
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{}, obj)
 
@@ -306,6 +314,8 @@ func TestPodDiscoveryDelete(t *testing.T) {
 }
 
 func TestPodDiscoveryUpdate(t *testing.T) {
+	t.Parallel()
+
 	obj := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testpod",
@@ -346,6 +356,8 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 }
 
 func TestPodDiscoveryUpdateEmptyPodIP(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
 	initialPod := makePods()
 
@@ -370,6 +382,8 @@ func TestPodDiscoveryUpdateEmptyPodIP(t *testing.T) {
 }
 
 func TestPodDiscoveryNamespaces(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{Names: []string{"ns1", "ns2"}})
 
 	expected := expectedPodTargetGroups("ns1")

--- a/discovery/kubernetes/service_test.go
+++ b/discovery/kubernetes/service_test.go
@@ -97,6 +97,8 @@ func makeExternalService() *v1.Service {
 }
 
 func TestServiceDiscoveryAdd(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -146,6 +148,8 @@ func TestServiceDiscoveryAdd(t *testing.T) {
 }
 
 func TestServiceDiscoveryDelete(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{}, makeService())
 
 	k8sDiscoveryTest{
@@ -164,6 +168,8 @@ func TestServiceDiscoveryDelete(t *testing.T) {
 }
 
 func TestServiceDiscoveryUpdate(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{}, makeService())
 
 	k8sDiscoveryTest{
@@ -206,6 +212,8 @@ func TestServiceDiscoveryUpdate(t *testing.T) {
 }
 
 func TestServiceDiscoveryNamespaces(t *testing.T) {
+	t.Parallel()
+
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{Names: []string{"ns1", "ns2"}})
 
 	k8sDiscoveryTest{

--- a/discovery/legacymanager/manager_test.go
+++ b/discovery/legacymanager/manager_test.go
@@ -37,6 +37,8 @@ func TestMain(m *testing.M) {
 
 // TestTargetUpdatesOrder checks that the target updates are received in the expected order.
 func TestTargetUpdatesOrder(t *testing.T) {
+	t.Parallel()
+
 	// The order by which the updates are send is determined by the interval passed to the mock discovery adapter
 	// Final targets array is ordered alphabetically by the name of the discoverer.
 	// For example discoverer "A" with targets "t2,t3" and discoverer "B" with targets "t1,t2" will result in "t2,t3,t1,t2" after the merge.
@@ -661,6 +663,8 @@ func TestTargetUpdatesOrder(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
@@ -746,6 +750,8 @@ func verifyPresence(t *testing.T, tSets map[poolKey]map[string]*targetgroup.Grou
 }
 
 func TestTargetSetRecreatesTargetGroupsEveryRun(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, log.NewNopLogger())
@@ -774,6 +780,8 @@ func TestTargetSetRecreatesTargetGroupsEveryRun(t *testing.T) {
 }
 
 func TestDiscovererConfigs(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, log.NewNopLogger())
@@ -798,6 +806,8 @@ func TestDiscovererConfigs(t *testing.T) {
 // removing all targets from the static_configs sends an update with empty targetGroups.
 // This is required to signal the receiver that this target set has no current targets.
 func TestTargetSetRecreatesEmptyStaticConfigs(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, log.NewNopLogger())
@@ -837,6 +847,8 @@ func TestTargetSetRecreatesEmptyStaticConfigs(t *testing.T) {
 }
 
 func TestIdenticalConfigurationsAreCoalesced(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, nil)
@@ -862,6 +874,8 @@ func TestIdenticalConfigurationsAreCoalesced(t *testing.T) {
 }
 
 func TestApplyConfigDoesNotModifyStaticTargets(t *testing.T) {
+	t.Parallel()
+
 	originalConfig := discovery.Configs{
 		staticConfig("foo:9090", "bar:9090", "baz:9090"),
 	}
@@ -892,6 +906,7 @@ func (e errorConfig) NewDiscoverer(discovery.DiscovererOptions) (discovery.Disco
 	return nil, e.err
 }
 
+//nolint:paralleltest // This test currently fails when run in parallel.
 func TestGaugeFailedConfigs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -927,6 +942,8 @@ func TestGaugeFailedConfigs(t *testing.T) {
 }
 
 func TestCoordinationWithReceiver(t *testing.T) {
+	t.Parallel()
+
 	updateDelay := 100 * time.Millisecond
 
 	type expect struct {
@@ -1048,6 +1065,8 @@ func TestCoordinationWithReceiver(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 

--- a/discovery/linode/linode_test.go
+++ b/discovery/linode/linode_test.go
@@ -43,6 +43,8 @@ func (s *LinodeSDTestSuite) SetupTest(t *testing.T) {
 }
 
 func TestLinodeSDRefresh(t *testing.T) {
+	t.Parallel()
+
 	sdmock := &LinodeSDTestSuite{}
 	sdmock.SetupTest(t)
 	t.Cleanup(sdmock.TearDownSuite)
@@ -164,8 +166,12 @@ func TestLinodeSDRefresh(t *testing.T) {
 			"__meta_linode_extra_ips":            model.LabelValue(",172.104.18.104,"),
 		},
 	} {
+		lbls := lbls
+		targets := tg.Targets[i]
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
-			require.Equal(t, lbls, tg.Targets[i])
+			t.Parallel()
+
+			require.Equal(t, lbls, targets)
 		})
 	}
 }

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -37,6 +37,8 @@ func TestMain(m *testing.M) {
 
 // TestTargetUpdatesOrder checks that the target updates are received in the expected order.
 func TestTargetUpdatesOrder(t *testing.T) {
+	t.Parallel()
+
 	// The order by which the updates are send is determined by the interval passed to the mock discovery adapter
 	// Final targets array is ordered alphabetically by the name of the discoverer.
 	// For example discoverer "A" with targets "t2,t3" and discoverer "B" with targets "t1,t2" will result in "t2,t3,t1,t2" after the merge.
@@ -661,6 +663,8 @@ func TestTargetUpdatesOrder(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
@@ -778,6 +782,8 @@ func pk(provider, setName string, n int) poolKey {
 }
 
 func TestTargetSetTargetGroupsPresentOnConfigReload(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, log.NewNopLogger())
@@ -810,6 +816,8 @@ func TestTargetSetTargetGroupsPresentOnConfigReload(t *testing.T) {
 }
 
 func TestTargetSetTargetGroupsPresentOnConfigRename(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, log.NewNopLogger())
@@ -845,6 +853,8 @@ func TestTargetSetTargetGroupsPresentOnConfigRename(t *testing.T) {
 }
 
 func TestTargetSetTargetGroupsPresentOnConfigDuplicateAndDeleteOriginal(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, log.NewNopLogger())
@@ -883,6 +893,8 @@ func TestTargetSetTargetGroupsPresentOnConfigDuplicateAndDeleteOriginal(t *testi
 }
 
 func TestTargetSetTargetGroupsPresentOnConfigChange(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, log.NewNopLogger())
@@ -944,6 +956,8 @@ func TestTargetSetTargetGroupsPresentOnConfigChange(t *testing.T) {
 }
 
 func TestTargetSetRecreatesTargetGroupsOnConfigChange(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, log.NewNopLogger())
@@ -983,6 +997,8 @@ func TestTargetSetRecreatesTargetGroupsOnConfigChange(t *testing.T) {
 }
 
 func TestDiscovererConfigs(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, log.NewNopLogger())
@@ -1015,6 +1031,8 @@ func TestDiscovererConfigs(t *testing.T) {
 // removing all targets from the static_configs sends an update with empty targetGroups.
 // This is required to signal the receiver that this target set has no current targets.
 func TestTargetSetRecreatesEmptyStaticConfigs(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, log.NewNopLogger())
@@ -1062,6 +1080,8 @@ func TestTargetSetRecreatesEmptyStaticConfigs(t *testing.T) {
 }
 
 func TestIdenticalConfigurationsAreCoalesced(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, nil)
@@ -1092,6 +1112,8 @@ func TestIdenticalConfigurationsAreCoalesced(t *testing.T) {
 }
 
 func TestApplyConfigDoesNotModifyStaticTargets(t *testing.T) {
+	t.Parallel()
+
 	originalConfig := Configs{
 		staticConfig("foo:9090", "bar:9090", "baz:9090"),
 	}
@@ -1143,6 +1165,7 @@ func (s lockStaticDiscoverer) Run(ctx context.Context, up chan<- []*targetgroup.
 	}
 }
 
+//nolint:paralleltest // TODO This test use global variable metrics, so it may interfere with other tests.
 func TestGaugeFailedConfigs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1178,6 +1201,8 @@ func TestGaugeFailedConfigs(t *testing.T) {
 }
 
 func TestCoordinationWithReceiver(t *testing.T) {
+	t.Parallel()
+
 	updateDelay := 100 * time.Millisecond
 
 	type expect struct {
@@ -1299,6 +1324,8 @@ func TestCoordinationWithReceiver(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
@@ -1397,6 +1424,8 @@ func (o onceProvider) Run(_ context.Context, ch chan<- []*targetgroup.Group) {
 // TestTargetSetTargetGroupsUpdateDuringApplyConfig is used to detect races when
 // ApplyConfig happens at the same time as targets update.
 func TestTargetSetTargetGroupsUpdateDuringApplyConfig(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	discoveryManager := NewManager(ctx, log.NewNopLogger())

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -47,6 +47,8 @@ func testUpdateServices(client appListClient) ([]*targetgroup.Group, error) {
 }
 
 func TestMarathonSDHandleError(t *testing.T) {
+	t.Parallel()
+
 	var (
 		errTesting = errors.New("testing failure")
 		client     = func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
@@ -63,6 +65,8 @@ func TestMarathonSDHandleError(t *testing.T) {
 }
 
 func TestMarathonSDEmptyList(t *testing.T) {
+	t.Parallel()
+
 	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) { return &appList{}, nil }
 	tgs, err := testUpdateServices(client)
 	if err != nil {
@@ -100,6 +104,8 @@ func marathonTestAppList(labels map[string]string, runningTasks int) *appList {
 }
 
 func TestMarathonSDSendGroup(t *testing.T) {
+	t.Parallel()
+
 	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
 		return marathonTestAppList(marathonValidLabel, 1), nil
 	}
@@ -129,6 +135,8 @@ func TestMarathonSDSendGroup(t *testing.T) {
 }
 
 func TestMarathonSDRemoveApp(t *testing.T) {
+	t.Parallel()
+
 	md, err := NewDiscovery(testConfig(), nil)
 	if err != nil {
 		t.Fatalf("%s", err)
@@ -194,6 +202,8 @@ func marathonTestAppListWithMultiplePorts(labels map[string]string, runningTasks
 }
 
 func TestMarathonSDSendGroupWithMultiplePort(t *testing.T) {
+	t.Parallel()
+
 	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
 		return marathonTestAppListWithMultiplePorts(marathonValidLabel, 1), nil
 	}
@@ -251,6 +261,8 @@ func marathonTestZeroTaskPortAppList(labels map[string]string, runningTasks int)
 }
 
 func TestMarathonZeroTaskPorts(t *testing.T) {
+	t.Parallel()
+
 	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
 		return marathonTestZeroTaskPortAppList(marathonValidLabel, 1), nil
 	}
@@ -272,6 +284,8 @@ func TestMarathonZeroTaskPorts(t *testing.T) {
 }
 
 func Test500ErrorHttpResponseWithValidJSONBody(t *testing.T) {
+	t.Parallel()
+
 	// Simulate 500 error with a valid JSON response.
 	respHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -319,6 +333,8 @@ func marathonTestAppListWithPortDefinitions(labels map[string]string, runningTas
 }
 
 func TestMarathonSDSendGroupWithPortDefinitions(t *testing.T) {
+	t.Parallel()
+
 	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
 		return marathonTestAppListWithPortDefinitions(marathonValidLabel, 1), nil
 	}
@@ -389,6 +405,8 @@ func marathonTestAppListWithPortDefinitionsRequirePorts(labels map[string]string
 }
 
 func TestMarathonSDSendGroupWithPortDefinitionsRequirePorts(t *testing.T) {
+	t.Parallel()
+
 	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
 		return marathonTestAppListWithPortDefinitionsRequirePorts(marathonValidLabel, 1), nil
 	}
@@ -454,6 +472,8 @@ func marathonTestAppListWithPorts(labels map[string]string, runningTasks int) *a
 }
 
 func TestMarathonSDSendGroupWithPorts(t *testing.T) {
+	t.Parallel()
+
 	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
 		return marathonTestAppListWithPorts(marathonValidLabel, 1), nil
 	}
@@ -528,6 +548,8 @@ func marathonTestAppListWithContainerPortMappings(labels map[string]string, runn
 }
 
 func TestMarathonSDSendGroupWithContainerPortMappings(t *testing.T) {
+	t.Parallel()
+
 	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
 		return marathonTestAppListWithContainerPortMappings(marathonValidLabel, 1), nil
 	}
@@ -602,6 +624,8 @@ func marathonTestAppListWithDockerContainerPortMappings(labels map[string]string
 }
 
 func TestMarathonSDSendGroupWithDockerContainerPortMappings(t *testing.T) {
+	t.Parallel()
+
 	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
 		return marathonTestAppListWithDockerContainerPortMappings(marathonValidLabel, 1), nil
 	}
@@ -680,6 +704,8 @@ func marathonTestAppListWithContainerNetworkAndPortMappings(labels map[string]st
 }
 
 func TestMarathonSDSendGroupWithContainerNetworkAndPortMapping(t *testing.T) {
+	t.Parallel()
+
 	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
 		return marathonTestAppListWithContainerNetworkAndPortMappings(marathonValidLabel, 1), nil
 	}

--- a/discovery/moby/docker_test.go
+++ b/discovery/moby/docker_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestDockerSDRefresh(t *testing.T) {
+	t.Parallel()
+
 	sdmock := NewSDMock(t, "dockerprom")
 	sdmock.Setup()
 
@@ -104,8 +106,12 @@ host: %s
 			"__meta_docker_network_ip":                                 "",
 		},
 	} {
+		lbls := lbls
+		targets := tg.Targets[i]
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
-			require.Equal(t, lbls, tg.Targets[i])
+			t.Parallel()
+
+			require.Equal(t, lbls, targets)
 		})
 	}
 }

--- a/discovery/moby/nodes_test.go
+++ b/discovery/moby/nodes_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestDockerSwarmNodesSDRefresh(t *testing.T) {
+	t.Parallel()
+
 	sdmock := NewSDMock(t, "swarmprom")
 	sdmock.Setup()
 
@@ -123,8 +125,13 @@ host: %s
 			"__meta_dockerswarm_node_status":                model.LabelValue("ready"),
 		},
 	} {
+		lbls := lbls
+		targets := tg.Targets[i]
+
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
-			require.Equal(t, lbls, tg.Targets[i])
+			t.Parallel()
+
+			require.Equal(t, lbls, targets)
 		})
 	}
 }

--- a/discovery/moby/services_test.go
+++ b/discovery/moby/services_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestDockerSwarmSDServicesRefresh(t *testing.T) {
+	t.Parallel()
+
 	sdmock := NewSDMock(t, "swarmprom")
 	sdmock.Setup()
 
@@ -309,13 +311,20 @@ host: %s
 			"__meta_dockerswarm_service_task_container_image":             model.LabelValue("stefanprodan/caddy:latest@sha256:44541cfacb66f4799f81f17fcfb3cb757ccc8f327592745549f5930c42d115c9"),
 		},
 	} {
+		lbls := lbls
+		targets := tg.Targets[i]
+
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
-			require.Equal(t, lbls, tg.Targets[i])
+			t.Parallel()
+
+			require.Equal(t, lbls, targets)
 		})
 	}
 }
 
 func TestDockerSwarmSDServicesRefreshWithFilters(t *testing.T) {
+	t.Parallel()
+
 	sdmock := NewSDMock(t, "swarmprom")
 	sdmock.Setup()
 
@@ -418,8 +427,13 @@ filters:
 			"__meta_dockerswarm_service_task_container_image":             model.LabelValue("stefanprodan/swarmprom-grafana:5.3.4@sha256:2aca8aa5716e6e0eed3fcdc88fec256a0a1828c491a8cf240486ae7cc473092d"),
 		},
 	} {
+		lbls := lbls
+		targets := tg.Targets[i]
+
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
-			require.Equal(t, lbls, tg.Targets[i])
+			t.Parallel()
+
+			require.Equal(t, lbls, targets)
 		})
 	}
 }

--- a/discovery/moby/tasks_test.go
+++ b/discovery/moby/tasks_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestDockerSwarmTasksSDRefresh(t *testing.T) {
+	t.Parallel()
+
 	sdmock := NewSDMock(t, "swarmprom")
 	sdmock.Setup()
 
@@ -786,8 +788,13 @@ host: %s
 			"__meta_dockerswarm_task_state":                               model.LabelValue("running"),
 		},
 	} {
+		lbls := lbls
+		targets := tg.Targets[i]
+
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
-			require.Equal(t, lbls, tg.Targets[i])
+			t.Parallel()
+
+			require.Equal(t, lbls, targets)
 		})
 	}
 }

--- a/discovery/openstack/hypervisor_test.go
+++ b/discovery/openstack/hypervisor_test.go
@@ -47,6 +47,8 @@ func (s *OpenstackSDHypervisorTestSuite) openstackAuthSuccess() (refresher, erro
 }
 
 func TestOpenstackSDHypervisorRefresh(t *testing.T) {
+	t.Parallel()
+
 	mock := &OpenstackSDHypervisorTestSuite{}
 	mock.SetupTest(t)
 
@@ -86,6 +88,8 @@ func TestOpenstackSDHypervisorRefresh(t *testing.T) {
 }
 
 func TestOpenstackSDHypervisorRefreshWithDoneContext(t *testing.T) {
+	t.Parallel()
+
 	mock := &OpenstackSDHypervisorTestSuite{}
 	mock.SetupTest(t)
 

--- a/discovery/openstack/instance_test.go
+++ b/discovery/openstack/instance_test.go
@@ -51,6 +51,8 @@ func (s *OpenstackSDInstanceTestSuite) openstackAuthSuccess() (refresher, error)
 }
 
 func TestOpenstackSDInstanceRefresh(t *testing.T) {
+	t.Parallel()
+
 	mock := &OpenstackSDInstanceTestSuite{}
 	mock.SetupTest(t)
 
@@ -118,13 +120,20 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 			"__meta_openstack_user_id":         model.LabelValue("9349aff8be7545ac9d2f1d00999a23cd"),
 		},
 	} {
+		lbls := lbls
+		targets := tg.Targets[i]
+
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
-			require.Equal(t, lbls, tg.Targets[i])
+			t.Parallel()
+
+			require.Equal(t, lbls, targets)
 		})
 	}
 }
 
 func TestOpenstackSDInstanceRefreshWithDoneContext(t *testing.T) {
+	t.Parallel()
+
 	mock := &OpenstackSDHypervisorTestSuite{}
 	mock.SetupTest(t)
 

--- a/discovery/puppetdb/puppetdb_test.go
+++ b/discovery/puppetdb/puppetdb_test.go
@@ -47,6 +47,8 @@ func mockServer(t *testing.T) *httptest.Server {
 }
 
 func TestPuppetSlashInURL(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]string{
 		"https://puppetserver":      "https://puppetserver/pdb/query/v4",
 		"https://puppetserver/":     "https://puppetserver/pdb/query/v4",
@@ -69,6 +71,8 @@ func TestPuppetSlashInURL(t *testing.T) {
 }
 
 func TestPuppetDBRefresh(t *testing.T) {
+	t.Parallel()
+
 	ts := mockServer(t)
 
 	cfg := SDConfig{
@@ -108,6 +112,8 @@ func TestPuppetDBRefresh(t *testing.T) {
 }
 
 func TestPuppetDBRefreshWithParameters(t *testing.T) {
+	t.Parallel()
+
 	ts := mockServer(t)
 
 	cfg := SDConfig{
@@ -154,6 +160,8 @@ func TestPuppetDBRefreshWithParameters(t *testing.T) {
 }
 
 func TestPuppetDBInvalidCode(t *testing.T) {
+	t.Parallel()
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	}))
@@ -175,6 +183,8 @@ func TestPuppetDBInvalidCode(t *testing.T) {
 }
 
 func TestPuppetDBInvalidFormat(t *testing.T) {
+	t.Parallel()
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "{}")
 	}))

--- a/discovery/refresh/refresh_test.go
+++ b/discovery/refresh/refresh_test.go
@@ -31,6 +31,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestRefresh(t *testing.T) {
+	t.Parallel()
+
 	tg1 := []*targetgroup.Group{
 		{
 			Source: "tg",

--- a/discovery/scaleway/instance_test.go
+++ b/discovery/scaleway/instance_test.go
@@ -34,6 +34,8 @@ var (
 )
 
 func TestScalewayInstanceRefresh(t *testing.T) {
+	t.Parallel()
+
 	mock := httptest.NewServer(http.HandlerFunc(mockScalewayInstance))
 	defer mock.Close()
 
@@ -111,8 +113,13 @@ api_url: %s
 			"__meta_scaleway_instance_zone":                   "fr-par-1",
 		},
 	} {
+		lbls := lbls
+		targets := tg.Targets[i]
+
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
-			require.Equal(t, lbls, tg.Targets[i])
+			t.Parallel()
+
+			require.Equal(t, lbls, targets)
 		})
 	}
 }
@@ -140,6 +147,8 @@ func mockScalewayInstance(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestScalewayInstanceAuthToken(t *testing.T) {
+	t.Parallel()
+
 	mock := httptest.NewServer(http.HandlerFunc(mockScalewayInstance))
 	defer mock.Close()
 

--- a/discovery/targetgroup/targetgroup_test.go
+++ b/discovery/targetgroup/targetgroup_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestTargetGroupStrictJsonUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		json          string
 		expectedReply error
@@ -60,6 +62,8 @@ func TestTargetGroupStrictJsonUnmarshal(t *testing.T) {
 }
 
 func TestTargetGroupYamlMarshal(t *testing.T) {
+	t.Parallel()
+
 	marshal := func(g interface{}) []byte {
 		d, err := yaml.Marshal(g)
 		if err != nil {
@@ -101,6 +105,8 @@ func TestTargetGroupYamlMarshal(t *testing.T) {
 }
 
 func TestTargetGroupYamlUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	unmarshal := func(d []byte) func(interface{}) error {
 		return func(o interface{}) error {
 			return yaml.Unmarshal(d, o)
@@ -142,6 +148,8 @@ func TestTargetGroupYamlUnmarshal(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
+	t.Parallel()
+
 	// String() should return only the source, regardless of other attributes.
 	group1 :=
 		Group{

--- a/discovery/triton/triton_test.go
+++ b/discovery/triton/triton_test.go
@@ -83,6 +83,8 @@ func newTritonDiscovery(c SDConfig) (*Discovery, error) {
 }
 
 func TestTritonSDNew(t *testing.T) {
+	t.Parallel()
+
 	td, err := newTritonDiscovery(conf)
 	require.NoError(t, err)
 	require.NotNil(t, td)
@@ -96,12 +98,16 @@ func TestTritonSDNew(t *testing.T) {
 }
 
 func TestTritonSDNewBadConfig(t *testing.T) {
+	t.Parallel()
+
 	td, err := newTritonDiscovery(badconf)
 	require.Error(t, err)
 	require.Nil(t, td)
 }
 
 func TestTritonSDNewGroupsConfig(t *testing.T) {
+	t.Parallel()
+
 	td, err := newTritonDiscovery(groupsconf)
 	require.NoError(t, err)
 	require.NotNil(t, td)
@@ -116,6 +122,8 @@ func TestTritonSDNewGroupsConfig(t *testing.T) {
 }
 
 func TestTritonSDNewCNConfig(t *testing.T) {
+	t.Parallel()
+
 	td, err := newTritonDiscovery(cnconf)
 	require.NoError(t, err)
 	require.NotNil(t, td)
@@ -130,11 +138,15 @@ func TestTritonSDNewCNConfig(t *testing.T) {
 }
 
 func TestTritonSDRefreshNoTargets(t *testing.T) {
+	t.Parallel()
+
 	tgts := testTritonSDRefresh(t, conf, "{\"containers\":[]}")
 	require.Nil(t, tgts)
 }
 
 func TestTritonSDRefreshMultipleTargets(t *testing.T) {
+	t.Parallel()
+
 	dstr := `{"containers":[
 		 	{
                                 "groups":["foo","bar","baz"],
@@ -159,6 +171,8 @@ func TestTritonSDRefreshMultipleTargets(t *testing.T) {
 }
 
 func TestTritonSDRefreshNoServer(t *testing.T) {
+	t.Parallel()
+
 	td, _ := newTritonDiscovery(conf)
 
 	_, err := td.refresh(context.Background())
@@ -167,6 +181,8 @@ func TestTritonSDRefreshNoServer(t *testing.T) {
 }
 
 func TestTritonSDRefreshCancelled(t *testing.T) {
+	t.Parallel()
+
 	td, _ := newTritonDiscovery(conf)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -177,6 +193,8 @@ func TestTritonSDRefreshCancelled(t *testing.T) {
 }
 
 func TestTritonSDRefreshCNsUUIDOnly(t *testing.T) {
+	t.Parallel()
+
 	dstr := `{"cns":[
 		 	{
 				"server_uuid":"44454c4c-5000-104d-8037-b7c04f5a5131"
@@ -192,6 +210,8 @@ func TestTritonSDRefreshCNsUUIDOnly(t *testing.T) {
 }
 
 func TestTritonSDRefreshCNsWithHostname(t *testing.T) {
+	t.Parallel()
+
 	dstr := `{"cns":[
 		 	{
 				"server_uuid":"44454c4c-5000-104d-8037-b7c04f5a5131",

--- a/discovery/xds/client_test.go
+++ b/discovery/xds/client_test.go
@@ -49,6 +49,8 @@ func urlMustParse(str string) *url.URL {
 }
 
 func TestMakeXDSResourceHttpEndpointEmptyServerURLScheme(t *testing.T) {
+	t.Parallel()
+
 	endpointURL, err := makeXDSResourceHTTPEndpointURL(ProtocolV3, urlMustParse("127.0.0.1"), "monitoring")
 
 	require.Empty(t, endpointURL)
@@ -57,6 +59,8 @@ func TestMakeXDSResourceHttpEndpointEmptyServerURLScheme(t *testing.T) {
 }
 
 func TestMakeXDSResourceHttpEndpointEmptyServerURLHost(t *testing.T) {
+	t.Parallel()
+
 	endpointURL, err := makeXDSResourceHTTPEndpointURL(ProtocolV3, urlMustParse("grpc://127.0.0.1"), "monitoring")
 
 	require.Empty(t, endpointURL)
@@ -65,6 +69,8 @@ func TestMakeXDSResourceHttpEndpointEmptyServerURLHost(t *testing.T) {
 }
 
 func TestMakeXDSResourceHttpEndpoint(t *testing.T) {
+	t.Parallel()
+
 	endpointURL, err := makeXDSResourceHTTPEndpointURL(ProtocolV3, urlMustParse("http://127.0.0.1:5000"), "monitoring")
 
 	require.NoError(t, err)
@@ -72,6 +78,8 @@ func TestMakeXDSResourceHttpEndpoint(t *testing.T) {
 }
 
 func TestCreateNewHTTPResourceClient(t *testing.T) {
+	t.Parallel()
+
 	c := &HTTPResourceClientConfig{
 		HTTPClientConfig: sdConf.HTTPClientConfig,
 		Name:             "test",
@@ -108,6 +116,8 @@ func createTestHTTPResourceClient(t *testing.T, conf *HTTPResourceClientConfig, 
 }
 
 func TestHTTPResourceClientFetchEmptyResponse(t *testing.T) {
+	t.Parallel()
+
 	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(request *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		return nil, nil
 	})
@@ -119,6 +129,8 @@ func TestHTTPResourceClientFetchEmptyResponse(t *testing.T) {
 }
 
 func TestHTTPResourceClientFetchFullResponse(t *testing.T) {
+	t.Parallel()
+
 	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(request *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		if request.VersionInfo == "1" {
 			return nil, nil
@@ -148,6 +160,8 @@ func TestHTTPResourceClientFetchFullResponse(t *testing.T) {
 }
 
 func TestHTTPResourceClientServerError(t *testing.T) {
+	t.Parallel()
+
 	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(request *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		return nil, errors.New("server error")
 	})

--- a/discovery/xds/kuma_test.go
+++ b/discovery/xds/kuma_test.go
@@ -120,6 +120,8 @@ func newKumaTestHTTPDiscovery(c KumaSDConfig) (*fetchDiscovery, error) {
 }
 
 func TestKumaMadsV1ResourceParserInvalidTypeURL(t *testing.T) {
+	t.Parallel()
+
 	resources := make([]*anypb.Any, 0)
 	groups, err := kumaMadsV1ResourceParser(resources, "type.googleapis.com/some.api.v1.Monitoring")
 	require.Nil(t, groups)
@@ -127,6 +129,8 @@ func TestKumaMadsV1ResourceParserInvalidTypeURL(t *testing.T) {
 }
 
 func TestKumaMadsV1ResourceParserEmptySlice(t *testing.T) {
+	t.Parallel()
+
 	resources := make([]*anypb.Any, 0)
 	groups, err := kumaMadsV1ResourceParser(resources, KumaMadsV1ResourceTypeURL)
 	require.Len(t, groups, 0)
@@ -134,6 +138,8 @@ func TestKumaMadsV1ResourceParserEmptySlice(t *testing.T) {
 }
 
 func TestKumaMadsV1ResourceParserValidResources(t *testing.T) {
+	t.Parallel()
+
 	res, err := getKumaMadsV1DiscoveryResponse(testKumaMadsV1Resources...)
 	require.NoError(t, err)
 
@@ -181,6 +187,8 @@ func TestKumaMadsV1ResourceParserValidResources(t *testing.T) {
 }
 
 func TestKumaMadsV1ResourceParserInvalidResources(t *testing.T) {
+	t.Parallel()
+
 	data, err := protoJSONMarshalOptions.Marshal(&MonitoringAssignment_Target{})
 	require.NoError(t, err)
 
@@ -196,6 +204,8 @@ func TestKumaMadsV1ResourceParserInvalidResources(t *testing.T) {
 }
 
 func TestNewKumaHTTPDiscovery(t *testing.T) {
+	t.Parallel()
+
 	kd, err := newKumaTestHTTPDiscovery(kumaConf)
 	require.NoError(t, err)
 	require.NotNil(t, kd)
@@ -209,6 +219,8 @@ func TestNewKumaHTTPDiscovery(t *testing.T) {
 }
 
 func TestKumaHTTPDiscoveryRefresh(t *testing.T) {
+	t.Parallel()
+
 	s := createTestHTTPServer(t, func(request *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		if request.VersionInfo == "1" {
 			return nil, nil

--- a/discovery/xds/xds_test.go
+++ b/discovery/xds/xds_test.go
@@ -128,6 +128,8 @@ func (rc testResourceClient) Close() {
 }
 
 func TestPollingRefreshSkipUpdate(t *testing.T) {
+	t.Parallel()
+
 	rc := &testResourceClient{
 		fetch: func(ctx context.Context) (*v3.DiscoveryResponse, error) {
 			return nil, nil
@@ -158,6 +160,8 @@ func TestPollingRefreshSkipUpdate(t *testing.T) {
 }
 
 func TestPollingRefreshAttachesGroupMetadata(t *testing.T) {
+	t.Parallel()
+
 	server := "http://198.161.2.0"
 	source := "test"
 	rc := &testResourceClient{
@@ -205,6 +209,8 @@ func TestPollingRefreshAttachesGroupMetadata(t *testing.T) {
 }
 
 func TestPollingDisappearingTargets(t *testing.T) {
+	t.Parallel()
+
 	server := "http://198.161.2.0"
 	source := "test"
 	rc := &testResourceClient{

--- a/discovery/zookeeper/zookeeper_test.go
+++ b/discovery/zookeeper/zookeeper_test.go
@@ -26,6 +26,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestNewDiscoveryError(t *testing.T) {
+	t.Parallel()
+
 	_, err := NewDiscovery(
 		[]string{"unreachable.test"},
 		time.Second, []string{"/"},

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestLabels_String(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		lables   Labels
 		expected string
@@ -55,6 +57,8 @@ func TestLabels_String(t *testing.T) {
 }
 
 func TestLabels_MatchLabels(t *testing.T) {
+	t.Parallel()
+
 	labels := Labels{
 		{
 			Name:  "__name__",
@@ -186,6 +190,8 @@ func TestLabels_MatchLabels(t *testing.T) {
 }
 
 func TestLabels_HasDuplicateLabelNames(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Input     Labels
 		Duplicate bool
@@ -212,6 +218,8 @@ func TestLabels_HasDuplicateLabelNames(t *testing.T) {
 }
 
 func TestLabels_WithoutEmpty(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct {
 		input    Labels
 		expected Labels
@@ -286,13 +294,19 @@ func TestLabels_WithoutEmpty(t *testing.T) {
 			},
 		},
 	} {
+		test := test
+
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, test.expected, test.input.WithoutEmpty())
 		})
 	}
 }
 
 func TestLabels_Equal(t *testing.T) {
+	t.Parallel()
+
 	labels := Labels{
 		{
 			Name:  "aaa",
@@ -373,6 +387,8 @@ func TestLabels_Equal(t *testing.T) {
 }
 
 func TestLabels_FromStrings(t *testing.T) {
+	t.Parallel()
+
 	labels := FromStrings("aaa", "111", "bbb", "222")
 	expected := Labels{
 		{
@@ -391,6 +407,8 @@ func TestLabels_FromStrings(t *testing.T) {
 }
 
 func TestLabels_Compare(t *testing.T) {
+	t.Parallel()
+
 	labels := Labels{
 		{
 			Name:  "aaa",
@@ -510,6 +528,8 @@ func TestLabels_Compare(t *testing.T) {
 }
 
 func TestLabels_Has(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		input    string
 		expected bool
@@ -542,6 +562,8 @@ func TestLabels_Has(t *testing.T) {
 }
 
 func TestLabels_Get(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, "", Labels{{"aaa", "111"}, {"bbb", "222"}}.Get("foo"))
 	require.Equal(t, "111", Labels{{"aaa", "111"}, {"bbb", "222"}}.Get("aaa"))
 }
@@ -587,23 +609,33 @@ func BenchmarkLabels_Get(b *testing.B) {
 }
 
 func TestLabels_Copy(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, Labels{{"aaa", "111"}, {"bbb", "222"}}, Labels{{"aaa", "111"}, {"bbb", "222"}}.Copy())
 }
 
 func TestLabels_Map(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, map[string]string{"aaa": "111", "bbb": "222"}, Labels{{"aaa", "111"}, {"bbb", "222"}}.Map())
 }
 
 func TestLabels_WithLabels(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, Labels{{"aaa", "111"}, {"bbb", "222"}}, Labels{{"aaa", "111"}, {"bbb", "222"}, {"ccc", "333"}}.WithLabels("aaa", "bbb"))
 }
 
 func TestLabels_WithoutLabels(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, Labels{{"aaa", "111"}}, Labels{{"aaa", "111"}, {"bbb", "222"}, {"ccc", "333"}}.WithoutLabels("bbb", "ccc"))
 	require.Equal(t, Labels{{"aaa", "111"}}, Labels{{"aaa", "111"}, {"bbb", "222"}, {MetricName, "333"}}.WithoutLabels("bbb"))
 }
 
 func TestBulider_NewBulider(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(
 		t,
 		&Builder{
@@ -616,6 +648,8 @@ func TestBulider_NewBulider(t *testing.T) {
 }
 
 func TestBuilder_Del(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(
 		t,
 		&Builder{
@@ -630,6 +664,8 @@ func TestBuilder_Del(t *testing.T) {
 }
 
 func TestBuilder_Set(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(
 		t,
 		&Builder{
@@ -660,6 +696,8 @@ func TestBuilder_Set(t *testing.T) {
 }
 
 func TestBuilder_Labels(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(
 		t,
 		Labels{{"aaa", "111"}, {"ccc", "333"}, {"ddd", "444"}},
@@ -672,6 +710,8 @@ func TestBuilder_Labels(t *testing.T) {
 }
 
 func TestLabels_Hash(t *testing.T) {
+	t.Parallel()
+
 	lbls := Labels{
 		{Name: "foo", Value: "bar"},
 		{Name: "baz", Value: "qux"},

--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -26,6 +26,8 @@ func mustNewMatcher(t *testing.T, mType MatchType, value string) *Matcher {
 }
 
 func TestMatcher(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		matcher *Matcher
 		value   string
@@ -89,6 +91,8 @@ func TestMatcher(t *testing.T) {
 }
 
 func TestInverse(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		matcher  *Matcher
 		expected *Matcher

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestNewFastRegexMatcher(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		regex    string
 		value    string
@@ -60,6 +62,8 @@ func TestNewFastRegexMatcher(t *testing.T) {
 }
 
 func TestOptimizeConcatRegex(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		regex    string
 		prefix   string

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestRelabel(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		input   labels.Labels
 		relabel []*Config
@@ -453,6 +455,8 @@ func TestRelabel(t *testing.T) {
 }
 
 func TestTargetLabelValidity(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		str   string
 		valid bool

--- a/model/rulefmt/rulefmt_test.go
+++ b/model/rulefmt/rulefmt_test.go
@@ -21,11 +21,15 @@ import (
 )
 
 func TestParseFileSuccess(t *testing.T) {
+	t.Parallel()
+
 	_, errs := ParseFile("testdata/test.yaml")
 	require.Empty(t, errs, "unexpected errors parsing file")
 }
 
 func TestParseFileFailure(t *testing.T) {
+	t.Parallel()
+
 	table := []struct {
 		filename string
 		errMsg   string
@@ -80,6 +84,8 @@ func TestParseFileFailure(t *testing.T) {
 }
 
 func TestTemplateParsing(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		ruleString string
 		shouldPass bool
@@ -159,6 +165,8 @@ groups:
 }
 
 func TestUniqueErrorNodes(t *testing.T) {
+	t.Parallel()
+
 	group := `
 groups:
 - name: example

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestOpenMetricsParse(t *testing.T) {
+	t.Parallel()
+
 	input := `# HELP go_gc_duration_seconds A summary of the GC invocation durations.
 # TYPE go_gc_duration_seconds summary
 # UNIT go_gc_duration_seconds seconds
@@ -269,6 +271,8 @@ foo_total 17.0 1520879607.789 # {xx="yy"} 5`
 }
 
 func TestOpenMetricsParseErrors(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		input string
 		err   string
@@ -541,6 +545,8 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 }
 
 func TestOMNullByteHandling(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		input string
 		err   string

--- a/model/textparse/promparse_test.go
+++ b/model/textparse/promparse_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestPromParse(t *testing.T) {
+	t.Parallel()
+
 	input := `# HELP go_gc_duration_seconds A summary of the GC invocation durations.
 # 	TYPE go_gc_duration_seconds summary
 go_gc_duration_seconds{quantile="0"} 4.9351e-05
@@ -214,6 +216,8 @@ testmetric{label="\"bar\""} 1`
 }
 
 func TestPromParseErrors(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		input string
 		err   string
@@ -284,6 +288,8 @@ func TestPromParseErrors(t *testing.T) {
 }
 
 func TestPromNullByteHandling(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		input string
 		err   string

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -40,6 +40,8 @@ import (
 )
 
 func TestPostPath(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		in, out string
 	}{
@@ -70,6 +72,8 @@ func TestPostPath(t *testing.T) {
 }
 
 func TestHandlerNextBatch(t *testing.T) {
+	t.Parallel()
+
 	h := NewManager(&Options{}, nil)
 
 	for i := range make([]struct{}, 2*maxBatchSize+1) {
@@ -99,6 +103,8 @@ func alertsEqual(a, b []*Alert) error {
 }
 
 func TestHandlerSendAll(t *testing.T) {
+	t.Parallel()
+
 	var (
 		errc             = make(chan error, 1)
 		expected         = make([]*Alert, 0, maxBatchSize)
@@ -214,6 +220,8 @@ func TestHandlerSendAll(t *testing.T) {
 }
 
 func TestCustomDo(t *testing.T) {
+	t.Parallel()
+
 	const testURL = "http://testurl.com/"
 	const testBody = "testbody"
 
@@ -241,6 +249,8 @@ func TestCustomDo(t *testing.T) {
 }
 
 func TestExternalLabels(t *testing.T) {
+	t.Parallel()
+
 	h := NewManager(&Options{
 		QueueCapacity:  3 * maxBatchSize,
 		ExternalLabels: labels.Labels{{Name: "a", Value: "b"}},
@@ -275,6 +285,8 @@ func TestExternalLabels(t *testing.T) {
 }
 
 func TestHandlerRelabel(t *testing.T) {
+	t.Parallel()
+
 	h := NewManager(&Options{
 		QueueCapacity: 3 * maxBatchSize,
 		RelabelConfigs: []*relabel.Config{
@@ -311,6 +323,8 @@ func TestHandlerRelabel(t *testing.T) {
 }
 
 func TestHandlerQueuing(t *testing.T) {
+	t.Parallel()
+
 	var (
 		expectedc = make(chan []*Alert)
 		called    = make(chan struct{})
@@ -446,6 +460,8 @@ func (a alertmanagerMock) url() *url.URL {
 }
 
 func TestLabelSetNotReused(t *testing.T) {
+	t.Parallel()
+
 	tg := makeInputTargetGroup()
 	_, _, err := AlertmanagerFromGroup(tg, &config.AlertmanagerConfig{})
 
@@ -456,6 +472,8 @@ func TestLabelSetNotReused(t *testing.T) {
 }
 
 func TestReload(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		in  *targetgroup.Group
 		out string
@@ -503,6 +521,8 @@ alerting:
 }
 
 func TestDroppedAlertmanagers(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		in  *targetgroup.Group
 		out string
@@ -570,5 +590,7 @@ func makeInputTargetGroup() *targetgroup.Group {
 }
 
 func TestLabelsToOpenAPILabelSet(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, models.LabelSet{"aaa": "111", "bbb": "222"}, labelsToOpenAPILabelSet(labels.Labels{{Name: "aaa", Value: "111"}, {Name: "bbb", Value: "222"}}))
 }

--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestDeriv(t *testing.T) {
+	t.Parallel()
+
 	// https://github.com/prometheus/prometheus/issues/2674#issuecomment-315439393
 	// This requires more precision than the usual test system offers,
 	// so we test it by hand.
@@ -61,6 +63,8 @@ func TestDeriv(t *testing.T) {
 }
 
 func TestFunctionList(t *testing.T) {
+	t.Parallel()
+
 	// Test that Functions and parser.Functions list the same functions.
 	for i := range FunctionCalls {
 		_, ok := parser.Functions[i]
@@ -74,6 +78,8 @@ func TestFunctionList(t *testing.T) {
 }
 
 func TestKahanSum(t *testing.T) {
+	t.Parallel()
+
 	vals := []float64{1.0, math.Pow(10, 100), 1.0, -1 * math.Pow(10, 100)}
 	expected := 2.0
 	require.Equal(t, expected, kahanSum(vals))

--- a/promql/parser/lex_test.go
+++ b/promql/parser/lex_test.go
@@ -725,8 +725,14 @@ var tests = []struct {
 // TestLexer tests basic functionality of the lexer. More elaborate tests are implemented
 // for the parser to avoid duplicated effort.
 func TestLexer(t *testing.T) {
+	t.Parallel()
+
 	for _, typ := range tests {
+		typ := typ
+
 		t.Run(typ.name, func(t *testing.T) {
+			t.Parallel()
+
 			for i, test := range typ.tests {
 				l := &Lexer{
 					input:      test.input,

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -3556,8 +3556,14 @@ func makeInt64Pointer(val int64) *int64 {
 }
 
 func TestParseExpressions(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range testExpr {
+		test := test
+
 		t.Run(test.input, func(t *testing.T) {
+			t.Parallel()
+
 			expr, err := ParseExpr(test.input)
 
 			// Unexpected errors are always caused by a bug.
@@ -3586,6 +3592,8 @@ func TestParseExpressions(t *testing.T) {
 
 // NaN has no equality. Thus, we need a separate test for it.
 func TestNaNExpression(t *testing.T) {
+	t.Parallel()
+
 	expr, err := ParseExpr("NaN")
 	require.NoError(t, err)
 
@@ -3696,6 +3704,8 @@ func newSeq(vals ...float64) (res []SequenceValue) {
 }
 
 func TestParseSeries(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range testSeries {
 		metric, vals, err := ParseSeriesDesc(test.input)
 
@@ -3713,6 +3723,8 @@ func TestParseSeries(t *testing.T) {
 }
 
 func TestRecoverParserRuntime(t *testing.T) {
+	t.Parallel()
+
 	p := newParser("foo bar")
 	var err error
 
@@ -3727,6 +3739,8 @@ func TestRecoverParserRuntime(t *testing.T) {
 }
 
 func TestRecoverParserError(t *testing.T) {
+	t.Parallel()
+
 	p := newParser("foo bar")
 	var err error
 
@@ -3741,6 +3755,8 @@ func TestRecoverParserError(t *testing.T) {
 }
 
 func TestExtractSelectors(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range [...]struct {
 		input    string
 		expected []string

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestExprString(t *testing.T) {
+	t.Parallel()
+
 	// A list of valid expressions that are expected to be
 	// returned as out when calling String(). If out is empty the output
 	// is expected to equal the input.
@@ -142,6 +144,8 @@ func TestExprString(t *testing.T) {
 }
 
 func TestVectorSelector_String(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name     string
 		vs       VectorSelector

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -212,7 +212,11 @@ func TestVectorSelector_String(t *testing.T) {
 			expected: `{__name__="foobar"}`,
 		},
 	} {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, tc.expected, tc.vs.String())
 		})
 	}

--- a/promql/promql_test.go
+++ b/promql/promql_test.go
@@ -21,11 +21,16 @@ import (
 )
 
 func TestEvaluations(t *testing.T) {
+	t.Parallel()
+
 	files, err := filepath.Glob("testdata/*.test")
 	require.NoError(t, err)
 
 	for _, fn := range files {
+		fn := fn
 		t.Run(fn, func(t *testing.T) {
+			t.Parallel()
+
 			test, err := newTestFromFile(t, fn)
 			require.NoError(t, err)
 			require.NoError(t, test.Run())

--- a/promql/query_logger_test.go
+++ b/promql/query_logger_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestQueryLogging(t *testing.T) {
+	t.Parallel()
+
 	fileAsBytes := make([]byte, 4096)
 	queryLogger := ActiveQueryTracker{
 		mmapedFile:   fileAsBytes,
@@ -68,6 +70,8 @@ func TestQueryLogging(t *testing.T) {
 }
 
 func TestIndexReuse(t *testing.T) {
+	t.Parallel()
+
 	queryBytes := make([]byte, 1+3*entrySize)
 	queryLogger := ActiveQueryTracker{
 		mmapedFile:   queryBytes,
@@ -105,6 +109,8 @@ func TestIndexReuse(t *testing.T) {
 }
 
 func TestMMapFile(t *testing.T) {
+	t.Parallel()
+
 	file, err := ioutil.TempFile("", "mmapedFile")
 	require.NoError(t, err)
 
@@ -128,6 +134,8 @@ func TestMMapFile(t *testing.T) {
 }
 
 func TestParseBrokenJSON(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		b []byte
 
@@ -154,7 +162,11 @@ func TestParseBrokenJSON(t *testing.T) {
 			out: "[\"up == 0\",\"rate(http_requests[2w]\"]",
 		},
 	} {
+		tc := tc
+
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
 			out, ok := parseBrokenJSON(tc.b)
 			require.Equal(t, tc.ok, ok)
 			if ok {

--- a/promql/test_test.go
+++ b/promql/test_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestLazyLoader_WithSamplesTill(t *testing.T) {
+	t.Parallel()
+
 	type testCase struct {
 		ts             time.Time
 		series         []Series // Each series is checked separately. Need not mention all series here.

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestAlertingRuleHTMLSnippet(t *testing.T) {
+	t.Parallel()
+
 	expr, err := parser.ParseExpr(`foo{html="<b>BOLD<b>"}`)
 	require.NoError(t, err)
 	rule := NewAlertingRule("testrule", expr, 0, labels.FromStrings("html", "<b>BOLD</b>"), labels.FromStrings("html", "<b>BOLD</b>"), nil, "", false, nil)
@@ -47,6 +49,8 @@ annotations:
 }
 
 func TestAlertingRuleState(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		active map[uint64]*Alert
@@ -87,6 +91,8 @@ func TestAlertingRuleState(t *testing.T) {
 }
 
 func TestAlertingRuleLabelsUpdate(t *testing.T) {
+	t.Parallel()
+
 	suite, err := promql.NewTest(t, `
 		load 1m
 			http_requests{job="app-server", instance="0"}	75 85 70 70
@@ -189,6 +195,8 @@ func TestAlertingRuleLabelsUpdate(t *testing.T) {
 }
 
 func TestAlertingRuleExternalLabelsInTemplate(t *testing.T) {
+	t.Parallel()
+
 	suite, err := promql.NewTest(t, `
 		load 1m
 			http_requests{job="app-server", instance="0"}	75 85 70 70
@@ -283,6 +291,8 @@ func TestAlertingRuleExternalLabelsInTemplate(t *testing.T) {
 }
 
 func TestAlertingRuleExternalURLInTemplate(t *testing.T) {
+	t.Parallel()
+
 	suite, err := promql.NewTest(t, `
 		load 1m
 			http_requests{job="app-server", instance="0"}	75 85 70 70
@@ -377,6 +387,8 @@ func TestAlertingRuleExternalURLInTemplate(t *testing.T) {
 }
 
 func TestAlertingRuleEmptyLabelFromTemplate(t *testing.T) {
+	t.Parallel()
+
 	suite, err := promql.NewTest(t, `
 		load 1m
 			http_requests{job="app-server", instance="0"}	75 85 70 70
@@ -433,6 +445,8 @@ func TestAlertingRuleEmptyLabelFromTemplate(t *testing.T) {
 }
 
 func TestAlertingRuleDuplicate(t *testing.T) {
+	t.Parallel()
+
 	storage := teststorage.New(t)
 	defer storage.Close()
 
@@ -466,6 +480,8 @@ func TestAlertingRuleDuplicate(t *testing.T) {
 }
 
 func TestAlertingRuleLimit(t *testing.T) {
+	t.Parallel()
+
 	suite, err := promql.NewTest(t, `
 		load 1m
 			metric{label="1"} 1

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -45,6 +45,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestAlertingRule(t *testing.T) {
+	t.Parallel()
+
 	suite, err := promql.NewTest(t, `
 		load 5m
 			http_requests{job="app-server", instance="0", group="canary", severity="overwrite-me"}	75 85  95 105 105  95  85
@@ -188,6 +190,8 @@ func TestAlertingRule(t *testing.T) {
 }
 
 func TestForStateAddSamples(t *testing.T) {
+	t.Parallel()
+
 	suite, err := promql.NewTest(t, `
 		load 5m
 			http_requests{job="app-server", instance="0", group="canary", severity="overwrite-me"}	75 85  95 105 105  95  85
@@ -349,6 +353,8 @@ func sortAlerts(items []*Alert) {
 }
 
 func TestForStateRestore(t *testing.T) {
+	t.Parallel()
+
 	suite, err := promql.NewTest(t, `
 		load 5m
 		http_requests{job="app-server", instance="0", group="canary", severity="overwrite-me"}	75  85 50 0 0 25 0 0 40 0 120
@@ -519,6 +525,8 @@ func TestForStateRestore(t *testing.T) {
 }
 
 func TestStaleness(t *testing.T) {
+	t.Parallel()
+
 	st := teststorage.New(t)
 	defer st.Close()
 	engineOpts := promql.EngineOpts{
@@ -609,6 +617,8 @@ func readSeriesSet(ss storage.SeriesSet) (map[string][]promql.Point, error) {
 }
 
 func TestCopyState(t *testing.T) {
+	t.Parallel()
+
 	oldGroup := &Group{
 		rules: []Rule{
 			NewAlertingRule("alert", nil, 0, nil, nil, nil, "", true, nil),
@@ -664,6 +674,8 @@ func TestCopyState(t *testing.T) {
 }
 
 func TestDeletedRuleMarkedStale(t *testing.T) {
+	t.Parallel()
+
 	st := teststorage.New(t)
 	defer st.Close()
 	oldGroup := &Group{
@@ -704,6 +716,8 @@ func TestDeletedRuleMarkedStale(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	t.Parallel()
+
 	files := []string{"fixtures/rules.yaml"}
 	expected := map[string]labels.Labels{
 		"test": labels.FromStrings("name", "value"),
@@ -846,6 +860,8 @@ func reloadAndValidate(rgs *rulefmt.RuleGroups, t *testing.T, tmpFile *os.File, 
 }
 
 func TestNotify(t *testing.T) {
+	t.Parallel()
+
 	storage := teststorage.New(t)
 	defer storage.Close()
 	engineOpts := promql.EngineOpts{
@@ -910,6 +926,8 @@ func TestNotify(t *testing.T) {
 }
 
 func TestMetricsUpdate(t *testing.T) {
+	t.Parallel()
+
 	files := []string{"fixtures/rules.yaml", "fixtures/rules2.yaml"}
 	metricNames := []string{
 		"prometheus_rule_evaluations_total",
@@ -988,6 +1006,8 @@ func TestMetricsUpdate(t *testing.T) {
 }
 
 func TestGroupStalenessOnRemoval(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -1066,6 +1086,8 @@ func TestGroupStalenessOnRemoval(t *testing.T) {
 }
 
 func TestMetricsStalenessOnManagerShutdown(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -1135,6 +1157,8 @@ func countStaleNaN(t *testing.T, st storage.Storage) int {
 }
 
 func TestGroupHasAlertingRules(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		group *Group
 		want  bool
@@ -1174,6 +1198,8 @@ func TestGroupHasAlertingRules(t *testing.T) {
 }
 
 func TestRuleHealthUpdates(t *testing.T) {
+	t.Parallel()
+
 	st := teststorage.New(t)
 	defer st.Close()
 	engineOpts := promql.EngineOpts{

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestRuleEval(t *testing.T) {
+	t.Parallel()
+
 	storage := teststorage.New(t)
 	defer storage.Close()
 
@@ -85,6 +87,8 @@ func TestRuleEval(t *testing.T) {
 }
 
 func TestRecordingRuleHTMLSnippet(t *testing.T) {
+	t.Parallel()
+
 	expr, err := parser.ParseExpr(`foo{html="<b>BOLD<b>"}`)
 	require.NoError(t, err)
 	rule := NewRecordingRule("testrule", expr, labels.FromStrings("html", "<b>BOLD</b>"))
@@ -101,6 +105,8 @@ labels:
 
 // TestRuleEvalDuplicate tests for duplicate labels in recorded metrics, see #5529.
 func TestRuleEvalDuplicate(t *testing.T) {
+	t.Parallel()
+
 	storage := teststorage.New(t)
 	defer storage.Close()
 

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -131,6 +131,8 @@ func TestRuleEvalDuplicate(t *testing.T) {
 }
 
 func TestRecordingRuleLimit(t *testing.T) {
+	t.Parallel()
+
 	suite, err := promql.NewTest(t, `
 		load 1m
 			metric{label="1"} 1

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestPopulateLabels(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		in      labels.Labels
 		cfg     *config.ScrapeConfig
@@ -332,18 +334,24 @@ func TestPopulateLabels(t *testing.T) {
 			err:     "scrape timeout cannot be greater than scrape interval (\"2s\" > \"1s\")",
 		},
 	}
-	for _, c := range cases {
+	for i, c := range cases {
+		c := c
+
 		in := c.in.Copy()
 
-		res, orig, err := PopulateLabels(c.in, c.cfg)
-		if c.err != "" {
-			require.EqualError(t, err, c.err)
-		} else {
-			require.NoError(t, err)
-		}
-		require.Equal(t, c.in, in)
-		require.Equal(t, c.res, res)
-		require.Equal(t, c.resOrig, orig)
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			res, orig, err := PopulateLabels(c.in, c.cfg)
+			if c.err != "" {
+				require.EqualError(t, err, c.err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, c.in, in)
+			require.Equal(t, c.res, res)
+			require.Equal(t, c.resOrig, orig)
+		})
 	}
 }
 
@@ -364,6 +372,7 @@ func noopLoop() loop {
 	}
 }
 
+//nolint:paralleltest // TODO: NewManager() is not thread-safe.
 func TestManagerApplyConfig(t *testing.T) {
 	// Valid initial configuration.
 	cfgText1 := `
@@ -460,6 +469,7 @@ scrape_configs:
 	}
 }
 
+//nolint:paralleltest // TODO: NewManager() is not thread-safe.
 func TestManagerTargetsUpdates(t *testing.T) {
 	opts := Options{}
 	m := NewManager(&opts, nil, nil)
@@ -498,6 +508,7 @@ func TestManagerTargetsUpdates(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // TODO: NewManager() is not thread-safe.
 func TestSetJitter(t *testing.T) {
 	getConfig := func(prometheus string) *config.Config {
 		cfgText := `

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -54,6 +55,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestNewScrapePool(t *testing.T) {
+	t.Parallel()
+
 	var (
 		app   = &nopAppendable{}
 		cfg   = &config.ScrapeConfig{}
@@ -72,6 +75,8 @@ func TestNewScrapePool(t *testing.T) {
 }
 
 func TestDroppedTargetsList(t *testing.T) {
+	t.Parallel()
+
 	var (
 		app = &nopAppendable{}
 		cfg = &config.ScrapeConfig{
@@ -109,6 +114,8 @@ func TestDroppedTargetsList(t *testing.T) {
 // TestDiscoveredLabelsUpdate checks that DiscoveredLabels are updated
 // even when new labels don't affect the target `hash`.
 func TestDiscoveredLabelsUpdate(t *testing.T) {
+	t.Parallel()
+
 	sp := &scrapePool{}
 	// These are used when syncing so need this to avoid a panic.
 	sp.config = &config.ScrapeConfig{
@@ -181,6 +188,8 @@ func (l *testLoop) getCache() *scrapeCache {
 }
 
 func TestScrapePoolStop(t *testing.T) {
+	t.Parallel()
+
 	sp := &scrapePool{
 		activeTargets: map[uint64]*Target{},
 		loops:         map[uint64]loop{},
@@ -239,6 +248,8 @@ func TestScrapePoolStop(t *testing.T) {
 }
 
 func TestScrapePoolReload(t *testing.T) {
+	t.Parallel()
+
 	var mtx sync.Mutex
 	numTargets := 20
 
@@ -327,6 +338,8 @@ func TestScrapePoolReload(t *testing.T) {
 }
 
 func TestScrapePoolTargetLimit(t *testing.T) {
+	t.Parallel()
+
 	var wg sync.WaitGroup
 	// On starting to run, new loops created on reload check whether their preceding
 	// equivalents have been stopped.
@@ -453,6 +466,8 @@ func TestScrapePoolTargetLimit(t *testing.T) {
 }
 
 func TestScrapePoolAppender(t *testing.T) {
+	t.Parallel()
+
 	cfg := &config.ScrapeConfig{}
 	app := &nopAppendable{}
 	sp, _ := newScrapePool(cfg, app, 0, nil, false)
@@ -491,6 +506,8 @@ func TestScrapePoolAppender(t *testing.T) {
 }
 
 func TestScrapePoolRaces(t *testing.T) {
+	t.Parallel()
+
 	interval, _ := model.ParseDuration("1s")
 	timeout, _ := model.ParseDuration("500ms")
 	newConfig := func() *config.ScrapeConfig {
@@ -528,6 +545,8 @@ func TestScrapePoolRaces(t *testing.T) {
 }
 
 func TestScrapePoolScrapeLoopsStarted(t *testing.T) {
+	t.Parallel()
+
 	var wg sync.WaitGroup
 	newLoop := func(opts scrapeLoopOptions) loop {
 		wg.Add(1)
@@ -576,6 +595,8 @@ func TestScrapePoolScrapeLoopsStarted(t *testing.T) {
 }
 
 func TestScrapeLoopStopBeforeRun(t *testing.T) {
+	t.Parallel()
+
 	scraper := &testScraper{}
 
 	sl := newScrapeLoop(context.Background(),
@@ -638,6 +659,8 @@ func TestScrapeLoopStopBeforeRun(t *testing.T) {
 func nopMutator(l labels.Labels) labels.Labels { return l }
 
 func TestScrapeLoopStop(t *testing.T) {
+	t.Parallel()
+
 	var (
 		signal   = make(chan struct{}, 1)
 		appender = &collectResultAppender{}
@@ -708,6 +731,8 @@ func TestScrapeLoopStop(t *testing.T) {
 }
 
 func TestScrapeLoopRun(t *testing.T) {
+	t.Parallel()
+
 	var (
 		signal = make(chan struct{}, 1)
 		errc   = make(chan error)
@@ -816,6 +841,8 @@ func TestScrapeLoopRun(t *testing.T) {
 }
 
 func TestScrapeLoopForcedErr(t *testing.T) {
+	t.Parallel()
+
 	var (
 		signal = make(chan struct{}, 1)
 		errc   = make(chan error)
@@ -872,6 +899,8 @@ func TestScrapeLoopForcedErr(t *testing.T) {
 }
 
 func TestScrapeLoopMetadata(t *testing.T) {
+	t.Parallel()
+
 	var (
 		signal  = make(chan struct{})
 		scraper = &testScraper{}
@@ -955,6 +984,8 @@ func simpleTestScrapeLoop(t testing.TB) (context.Context, *scrapeLoop) {
 }
 
 func TestScrapeLoopSeriesAdded(t *testing.T) {
+	t.Parallel()
+
 	ctx, sl := simpleTestScrapeLoop(t)
 
 	slApp := sl.appender(ctx)
@@ -1016,6 +1047,8 @@ func BenchmarkScrapeLoopAppendOM(b *testing.B) {
 }
 
 func TestScrapeLoopRunCreatesStaleMarkersOnFailedScrape(t *testing.T) {
+	t.Parallel()
+
 	appender := &collectResultAppender{}
 	var (
 		signal  = make(chan struct{}, 1)
@@ -1074,6 +1107,8 @@ func TestScrapeLoopRunCreatesStaleMarkersOnFailedScrape(t *testing.T) {
 }
 
 func TestScrapeLoopRunCreatesStaleMarkersOnParseFailure(t *testing.T) {
+	t.Parallel()
+
 	appender := &collectResultAppender{}
 	var (
 		signal     = make(chan struct{}, 1)
@@ -1135,6 +1170,8 @@ func TestScrapeLoopRunCreatesStaleMarkersOnParseFailure(t *testing.T) {
 }
 
 func TestScrapeLoopCache(t *testing.T) {
+	t.Parallel()
+
 	s := teststorage.New(t)
 	defer s.Close()
 
@@ -1212,6 +1249,8 @@ func TestScrapeLoopCache(t *testing.T) {
 }
 
 func TestScrapeLoopCacheMemoryExhaustionProtection(t *testing.T) {
+	t.Parallel()
+
 	s := teststorage.New(t)
 	defer s.Close()
 
@@ -1274,6 +1313,8 @@ func TestScrapeLoopCacheMemoryExhaustionProtection(t *testing.T) {
 }
 
 func TestScrapeLoopAppend(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		title           string
 		honorLabels     bool
@@ -1326,60 +1367,67 @@ func TestScrapeLoopAppend(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		app := &collectResultAppender{}
+	for i, test := range tests {
+		test := test
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 
-		discoveryLabels := &Target{
-			labels: labels.FromStrings(test.discoveryLabels...),
-		}
+			app := &collectResultAppender{}
 
-		sl := newScrapeLoop(context.Background(),
-			nil, nil, nil,
-			func(l labels.Labels) labels.Labels {
-				return mutateSampleLabels(l, discoveryLabels, test.honorLabels, nil)
-			},
-			func(l labels.Labels) labels.Labels {
-				return mutateReportSampleLabels(l, discoveryLabels)
-			},
-			func(ctx context.Context) storage.Appender { return app },
-			nil,
-			0,
-			true,
-			0,
-			nil,
-			0,
-			0,
-			false,
-		)
+			discoveryLabels := &Target{
+				labels: labels.FromStrings(test.discoveryLabels...),
+			}
 
-		now := time.Now()
+			sl := newScrapeLoop(context.Background(),
+				nil, nil, nil,
+				func(l labels.Labels) labels.Labels {
+					return mutateSampleLabels(l, discoveryLabels, test.honorLabels, nil)
+				},
+				func(l labels.Labels) labels.Labels {
+					return mutateReportSampleLabels(l, discoveryLabels)
+				},
+				func(ctx context.Context) storage.Appender { return app },
+				nil,
+				0,
+				true,
+				0,
+				nil,
+				0,
+				0,
+				false,
+			)
 
-		slApp := sl.appender(context.Background())
-		_, _, _, err := sl.append(slApp, []byte(test.scrapeLabels), "", now)
-		require.NoError(t, err)
-		require.NoError(t, slApp.Commit())
+			now := time.Now()
 
-		expected := []sample{
-			{
-				metric: test.expLset,
-				t:      timestamp.FromTime(now),
-				v:      test.expValue,
-			},
-		}
+			slApp := sl.appender(context.Background())
+			_, _, _, err := sl.append(slApp, []byte(test.scrapeLabels), "", now)
+			require.NoError(t, err)
+			require.NoError(t, slApp.Commit())
 
-		// When the expected value is NaN
-		// DeepEqual will report NaNs as being different,
-		// so replace it with the expected one.
-		if test.expValue == float64(value.NormalNaN) {
-			app.result[0].v = expected[0].v
-		}
+			expected := []sample{
+				{
+					metric: test.expLset,
+					t:      timestamp.FromTime(now),
+					v:      test.expValue,
+				},
+			}
 
-		t.Logf("Test:%s", test.title)
-		require.Equal(t, expected, app.result)
+			// When the expected value is NaN
+			// DeepEqual will report NaNs as being different,
+			// so replace it with the expected one.
+			if test.expValue == float64(value.NormalNaN) {
+				app.result[0].v = expected[0].v
+			}
+
+			t.Logf("Test:%s", test.title)
+			require.Equal(t, expected, app.result)
+		})
 	}
 }
 
 func TestScrapeLoopAppendForConflictingPrefixedLabels(t *testing.T) {
+	t.Parallel()
+
 	testcases := map[string]struct {
 		targetLabels  []string
 		exposedLabels string
@@ -1430,7 +1478,11 @@ func TestScrapeLoopAppendForConflictingPrefixedLabels(t *testing.T) {
 	}
 
 	for name, tc := range testcases {
+		tc := tc
+
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			app := &collectResultAppender{}
 			sl := newScrapeLoop(context.Background(), nil, nil, nil,
 				func(l labels.Labels) labels.Labels {
@@ -1457,6 +1509,8 @@ func TestScrapeLoopAppendForConflictingPrefixedLabels(t *testing.T) {
 }
 
 func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
+	t.Parallel()
+
 	// collectResultAppender's AddFast always returns ErrNotFound if we don't give it a next.
 	app := &collectResultAppender{}
 
@@ -1506,6 +1560,8 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 }
 
 func TestScrapeLoopAppendSampleLimit(t *testing.T) {
+	t.Parallel()
+
 	resApp := &collectResultAppender{}
 	app := &limitAppender{Appender: resApp, limit: 1}
 
@@ -1580,6 +1636,8 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 }
 
 func TestScrapeLoop_ChangingMetricString(t *testing.T) {
+	t.Parallel()
+
 	// This is a regression test for the scrape loop cache not properly maintaining
 	// IDs when the string representation of a metric changes across a scrape. Thus
 	// we use a real storage appender here.
@@ -1631,6 +1689,8 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 }
 
 func TestScrapeLoopAppendStaleness(t *testing.T) {
+	t.Parallel()
+
 	app := &collectResultAppender{}
 
 	sl := newScrapeLoop(context.Background(),
@@ -1680,6 +1740,8 @@ func TestScrapeLoopAppendStaleness(t *testing.T) {
 }
 
 func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
+	t.Parallel()
+
 	app := &collectResultAppender{}
 	sl := newScrapeLoop(context.Background(),
 		nil, nil, nil,
@@ -1718,6 +1780,8 @@ func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
 }
 
 func TestScrapeLoopAppendExemplar(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		title           string
 		scrapeText      string
@@ -1778,7 +1842,11 @@ metric_total{n="2"} 2 # {t="2"} 2.0 20000
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(test.title, func(t *testing.T) {
+			t.Parallel()
+
 			app := &collectResultAppender{}
 
 			discoveryLabels := &Target{
@@ -1827,6 +1895,8 @@ metric_total{n="2"} 2 # {t="2"} 2.0 20000
 }
 
 func TestScrapeLoopAppendExemplarSeries(t *testing.T) {
+	t.Parallel()
+
 	scrapeText := []string{`metric_total{n="1"} 1 # {t="1"} 1.0 10000
 # EOF`, `metric_total{n="1"} 2 # {t="2"} 2.0 20000
 # EOF`}
@@ -1892,6 +1962,8 @@ func TestScrapeLoopAppendExemplarSeries(t *testing.T) {
 }
 
 func TestScrapeLoopRunReportsTargetDownOnScrapeError(t *testing.T) {
+	t.Parallel()
+
 	var (
 		scraper  = &testScraper{}
 		appender = &collectResultAppender{}
@@ -1925,6 +1997,8 @@ func TestScrapeLoopRunReportsTargetDownOnScrapeError(t *testing.T) {
 }
 
 func TestScrapeLoopRunReportsTargetDownOnInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
 	var (
 		scraper  = &testScraper{}
 		appender = &collectResultAppender{}
@@ -1976,6 +2050,8 @@ func (app *errorAppender) Append(ref storage.SeriesRef, lset labels.Labels, t in
 }
 
 func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T) {
+	t.Parallel()
+
 	app := &errorAppender{}
 
 	sl := newScrapeLoop(context.Background(),
@@ -2014,6 +2090,8 @@ func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T
 }
 
 func TestScrapeLoopOutOfBoundsTimeError(t *testing.T) {
+	t.Parallel()
+
 	app := &collectResultAppender{}
 	sl := newScrapeLoop(context.Background(),
 		nil,
@@ -2047,6 +2125,8 @@ func TestScrapeLoopOutOfBoundsTimeError(t *testing.T) {
 }
 
 func TestTargetScraperScrapeOK(t *testing.T) {
+	t.Parallel()
+
 	const (
 		configTimeout   = 1500 * time.Millisecond
 		expectedTimeout = "1.5"
@@ -2094,6 +2174,8 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 }
 
 func TestTargetScrapeScrapeCancel(t *testing.T) {
+	t.Parallel()
+
 	block := make(chan struct{})
 
 	server := httptest.NewServer(
@@ -2149,6 +2231,8 @@ func TestTargetScrapeScrapeCancel(t *testing.T) {
 }
 
 func TestTargetScrapeScrapeNotFound(t *testing.T) {
+	t.Parallel()
+
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
@@ -2176,6 +2260,8 @@ func TestTargetScrapeScrapeNotFound(t *testing.T) {
 }
 
 func TestTargetScraperBodySizeLimit(t *testing.T) {
+	t.Parallel()
+
 	const (
 		bodySizeLimit = 15
 		responseBody  = "metric_a 1\nmetric_b 2\n"
@@ -2269,6 +2355,8 @@ func (ts *testScraper) scrape(ctx context.Context, w io.Writer) (string, error) 
 }
 
 func TestScrapeLoop_RespectTimestamps(t *testing.T) {
+	t.Parallel()
+
 	s := teststorage.New(t)
 	defer s.Close()
 
@@ -2307,6 +2395,8 @@ func TestScrapeLoop_RespectTimestamps(t *testing.T) {
 }
 
 func TestScrapeLoop_DiscardTimestamps(t *testing.T) {
+	t.Parallel()
+
 	s := teststorage.New(t)
 	defer s.Close()
 
@@ -2345,6 +2435,8 @@ func TestScrapeLoop_DiscardTimestamps(t *testing.T) {
 }
 
 func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
+	t.Parallel()
+
 	s := teststorage.New(t)
 	defer s.Close()
 
@@ -2393,6 +2485,8 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 }
 
 func TestScrapeLoopDiscardUnnamedMetrics(t *testing.T) {
+	t.Parallel()
+
 	s := teststorage.New(t)
 	defer s.Close()
 
@@ -2435,6 +2529,8 @@ func TestScrapeLoopDiscardUnnamedMetrics(t *testing.T) {
 }
 
 func TestReusableConfig(t *testing.T) {
+	t.Parallel()
+
 	variants := []*config.ScrapeConfig{
 		{
 			JobName:       "prometheus",
@@ -2502,6 +2598,8 @@ func TestReusableConfig(t *testing.T) {
 }
 
 func TestReuseScrapeCache(t *testing.T) {
+	t.Parallel()
+
 	var (
 		app = &nopAppendable{}
 		cfg = &config.ScrapeConfig{
@@ -2622,6 +2720,8 @@ func TestReuseScrapeCache(t *testing.T) {
 }
 
 func TestScrapeAddFast(t *testing.T) {
+	t.Parallel()
+
 	s := teststorage.New(t)
 	defer s.Close()
 
@@ -2661,6 +2761,8 @@ func TestScrapeAddFast(t *testing.T) {
 }
 
 func TestReuseCacheRace(t *testing.T) {
+	t.Parallel()
+
 	var (
 		app = &nopAppendable{}
 		cfg = &config.ScrapeConfig{
@@ -2698,6 +2800,8 @@ func TestReuseCacheRace(t *testing.T) {
 }
 
 func TestCheckAddError(t *testing.T) {
+	t.Parallel()
+
 	var appErrs appendErrors
 	sl := scrapeLoop{l: log.NewNopLogger()}
 	sl.checkAddError(nil, nil, nil, storage.ErrOutOfOrderSample, nil, &appErrs)
@@ -2705,6 +2809,8 @@ func TestCheckAddError(t *testing.T) {
 }
 
 func TestScrapeReportSingleAppender(t *testing.T) {
+	t.Parallel()
+
 	s := teststorage.New(t)
 	defer s.Close()
 
@@ -2773,6 +2879,8 @@ func TestScrapeReportSingleAppender(t *testing.T) {
 }
 
 func TestScrapeLoopLabelLimit(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		title           string
 		scrapeLabels    string
@@ -2837,46 +2945,53 @@ func TestScrapeLoopLabelLimit(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		app := &collectResultAppender{}
+	for i, test := range tests {
+		test := test
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 
-		discoveryLabels := &Target{
-			labels: labels.FromStrings(test.discoveryLabels...),
-		}
+			app := &collectResultAppender{}
 
-		sl := newScrapeLoop(context.Background(),
-			nil, nil, nil,
-			func(l labels.Labels) labels.Labels {
-				return mutateSampleLabels(l, discoveryLabels, false, nil)
-			},
-			func(l labels.Labels) labels.Labels {
-				return mutateReportSampleLabels(l, discoveryLabels)
-			},
-			func(ctx context.Context) storage.Appender { return app },
-			nil,
-			0,
-			true,
-			0,
-			&test.labelLimits,
-			0,
-			0,
-			false,
-		)
+			discoveryLabels := &Target{
+				labels: labels.FromStrings(test.discoveryLabels...),
+			}
 
-		slApp := sl.appender(context.Background())
-		_, _, _, err := sl.append(slApp, []byte(test.scrapeLabels), "", time.Now())
+			sl := newScrapeLoop(context.Background(),
+				nil, nil, nil,
+				func(l labels.Labels) labels.Labels {
+					return mutateSampleLabels(l, discoveryLabels, false, nil)
+				},
+				func(l labels.Labels) labels.Labels {
+					return mutateReportSampleLabels(l, discoveryLabels)
+				},
+				func(ctx context.Context) storage.Appender { return app },
+				nil,
+				0,
+				true,
+				0,
+				&test.labelLimits,
+				0,
+				0,
+				false,
+			)
 
-		t.Logf("Test:%s", test.title)
-		if test.expectErr {
-			require.Error(t, err)
-		} else {
-			require.NoError(t, err)
-			require.NoError(t, slApp.Commit())
-		}
+			slApp := sl.appender(context.Background())
+			_, _, _, err := sl.append(slApp, []byte(test.scrapeLabels), "", time.Now())
+
+			t.Logf("Test:%s", test.title)
+			if test.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NoError(t, slApp.Commit())
+			}
+		})
 	}
 }
 
 func TestTargetScrapeIntervalAndTimeoutRelabel(t *testing.T) {
+	t.Parallel()
+
 	interval, _ := model.ParseDuration("2s")
 	timeout, _ := model.ParseDuration("500ms")
 	config := &config.ScrapeConfig{

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -39,6 +39,8 @@ const (
 )
 
 func TestTargetLabels(t *testing.T) {
+	t.Parallel()
+
 	target := newTestTarget("example.com:80", 0, labels.FromStrings("job", "some_job", "foo", "bar"))
 	want := labels.FromStrings(model.JobLabel, "some_job", "foo", "bar")
 	got := target.Labels()
@@ -46,6 +48,8 @@ func TestTargetLabels(t *testing.T) {
 }
 
 func TestTargetOffset(t *testing.T) {
+	t.Parallel()
+
 	interval := 10 * time.Second
 	jitter := uint64(0)
 
@@ -93,6 +97,8 @@ func TestTargetOffset(t *testing.T) {
 }
 
 func TestTargetURL(t *testing.T) {
+	t.Parallel()
+
 	params := url.Values{
 		"abc": []string{"foo", "bar", "baz"},
 		"xyz": []string{"hoo"},
@@ -133,6 +139,8 @@ func newTestTarget(targetURL string, deadline time.Duration, lbls labels.Labels)
 }
 
 func TestNewHTTPBearerToken(t *testing.T) {
+	t.Parallel()
+
 	server := httptest.NewServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -160,6 +168,8 @@ func TestNewHTTPBearerToken(t *testing.T) {
 }
 
 func TestNewHTTPBearerTokenFile(t *testing.T) {
+	t.Parallel()
+
 	server := httptest.NewServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -187,6 +197,8 @@ func TestNewHTTPBearerTokenFile(t *testing.T) {
 }
 
 func TestNewHTTPBasicAuth(t *testing.T) {
+	t.Parallel()
+
 	server := httptest.NewServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -216,6 +228,8 @@ func TestNewHTTPBasicAuth(t *testing.T) {
 }
 
 func TestNewHTTPCACert(t *testing.T) {
+	t.Parallel()
+
 	server := httptest.NewUnstartedServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -244,6 +258,8 @@ func TestNewHTTPCACert(t *testing.T) {
 }
 
 func TestNewHTTPClientCert(t *testing.T) {
+	t.Parallel()
+
 	server := httptest.NewUnstartedServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -277,6 +293,8 @@ func TestNewHTTPClientCert(t *testing.T) {
 }
 
 func TestNewHTTPWithServerName(t *testing.T) {
+	t.Parallel()
+
 	server := httptest.NewUnstartedServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -306,6 +324,8 @@ func TestNewHTTPWithServerName(t *testing.T) {
 }
 
 func TestNewHTTPWithBadServerName(t *testing.T) {
+	t.Parallel()
+
 	server := httptest.NewUnstartedServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -355,6 +375,8 @@ func newTLSConfig(certName string, t *testing.T) *tls.Config {
 }
 
 func TestNewClientWithBadTLSConfig(t *testing.T) {
+	t.Parallel()
+
 	cfg := config_util.HTTPClientConfig{
 		TLSConfig: config_util.TLSConfig{
 			CAFile:   "testdata/nonexistent_ca.cer",
@@ -369,6 +391,8 @@ func TestNewClientWithBadTLSConfig(t *testing.T) {
 }
 
 func TestTargetsFromGroup(t *testing.T) {
+	t.Parallel()
+
 	expectedError := "instance 0 in group : no address"
 
 	targets, failures := TargetsFromGroup(&targetgroup.Group{Targets: []model.LabelSet{{}, {model.AddressLabel: "localhost:9090"}}}, &config.ScrapeConfig{})

--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestSampleRing(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		input []int64
 		delta int64
@@ -87,6 +89,8 @@ func TestSampleRing(t *testing.T) {
 }
 
 func TestBufferedSeriesIterator(t *testing.T) {
+	t.Parallel()
+
 	var it *BufferedSeriesIterator
 
 	bufferEq := func(exp []sample) {
@@ -153,6 +157,8 @@ func TestBufferedSeriesIterator(t *testing.T) {
 
 // At() should not be called once Next() returns false.
 func TestBufferedSeriesIteratorNoBadAt(t *testing.T) {
+	t.Parallel()
+
 	done := false
 
 	m := &mockSeriesIterator{

--- a/storage/memoized_iterator_test.go
+++ b/storage/memoized_iterator_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestMemoizedSeriesIterator(t *testing.T) {
+	t.Parallel()
+
 	var it *MemoizedSeriesIterator
 
 	sampleEq := func(ets int64, ev float64) {

--- a/storage/merge_test.go
+++ b/storage/merge_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestMergeQuerierWithChainMerger(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name                 string
 		primaryQuerierSeries []Series
@@ -175,7 +177,11 @@ func TestMergeQuerierWithChainMerger(t *testing.T) {
 			),
 		},
 	} {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			var p Querier
 			if tc.primaryQuerierSeries != nil {
 				p = &mockQuerier{toReturn: tc.primaryQuerierSeries}
@@ -212,6 +218,8 @@ func TestMergeQuerierWithChainMerger(t *testing.T) {
 }
 
 func TestMergeChunkQuerierWithNoVerticalChunkSeriesMerger(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name                    string
 		primaryChkQuerierSeries []ChunkSeries
@@ -350,7 +358,11 @@ func TestMergeChunkQuerierWithNoVerticalChunkSeriesMerger(t *testing.T) {
 			),
 		},
 	} {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			var p ChunkQuerier
 			if tc.primaryChkQuerierSeries != nil {
 				p = &mockChunkQurier{toReturn: tc.primaryChkQuerierSeries}
@@ -382,6 +394,8 @@ func TestMergeChunkQuerierWithNoVerticalChunkSeriesMerger(t *testing.T) {
 }
 
 func TestCompactingChunkSeriesMerger(t *testing.T) {
+	t.Parallel()
+
 	m := NewCompactingChunkSeriesMerger(ChainedSeriesMerge)
 
 	for _, tc := range []struct {
@@ -487,7 +501,10 @@ func TestCompactingChunkSeriesMerger(t *testing.T) {
 			),
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			merged := m(tc.input...)
 			require.Equal(t, tc.expected.Labels(), merged.Labels())
 			actChks, actErr := ExpandChunks(merged.Iterator())
@@ -592,6 +609,8 @@ func (m *mockChunkSeriesSet) Err() error { return nil }
 func (m *mockChunkSeriesSet) Warnings() Warnings { return nil }
 
 func TestChainSampleIterator(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		input    []chunkenc.Iterator
 		expected []tsdbutil.Sample
@@ -640,6 +659,8 @@ func TestChainSampleIterator(t *testing.T) {
 }
 
 func TestChainSampleIteratorSeek(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		input    []chunkenc.Iterator
 		seek     int64
@@ -835,6 +856,8 @@ func unwrapMockGenericQuerier(t *testing.T, qr genericQuerier) *mockGenericQueri
 }
 
 func TestMergeGenericQuerierWithSecondaries_ErrorHandling(t *testing.T) {
+	t.Parallel()
+
 	var (
 		errStorage  = errors.New("storage error")
 		warnStorage = errors.New("storage warning")
@@ -950,7 +973,11 @@ func TestMergeGenericQuerierWithSecondaries_ErrorHandling(t *testing.T) {
 			},
 		},
 	} {
+		tcase := tcase
+
 		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
 			q := &mergeGenericQuerier{
 				queriers: tcase.queriers,
 				mergeFn:  func(l ...Labels) Labels { return l[0] },

--- a/storage/remote/chunked_test.go
+++ b/storage/remote/chunked_test.go
@@ -29,6 +29,8 @@ func (f *mockedFlusher) Flush() {
 }
 
 func TestChunkedReaderCanReadFromChunkedWriter(t *testing.T) {
+	t.Parallel()
+
 	b := &bytes.Buffer{}
 	f := &mockedFlusher{}
 	w := NewChunkedWriter(b, f)
@@ -73,6 +75,8 @@ func TestChunkedReaderCanReadFromChunkedWriter(t *testing.T) {
 }
 
 func TestChunkedReader_Overflow(t *testing.T) {
+	t.Parallel()
+
 	b := &bytes.Buffer{}
 	_, err := NewChunkedWriter(b, &mockedFlusher{}).Write([]byte("twelve bytes"))
 	require.NoError(t, err)
@@ -90,6 +94,8 @@ func TestChunkedReader_Overflow(t *testing.T) {
 }
 
 func TestChunkedReader_CorruptedFrame(t *testing.T) {
+	t.Parallel()
+
 	b := &bytes.Buffer{}
 	w := NewChunkedWriter(b, &mockedFlusher{})
 

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -31,6 +31,8 @@ import (
 var longErrMessage = strings.Repeat("error message", maxErrMsgLen)
 
 func TestStoreHTTPErrorHandling(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		code int
 		err  error
@@ -85,6 +87,8 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 }
 
 func TestClientRetryAfter(t *testing.T) {
+	t.Parallel()
+
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, longErrMessage, 429)
@@ -127,6 +131,8 @@ func TestClientRetryAfter(t *testing.T) {
 }
 
 func TestRetryAfterDuration(t *testing.T) {
+	t.Parallel()
+
 	tc := []struct {
 		name     string
 		tInput   string

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -54,6 +54,8 @@ var writeRequestFixture = &prompb.WriteRequest{
 }
 
 func TestValidateLabelsAndMetricName(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		input       labels.Labels
 		expectedErr string
@@ -141,7 +143,11 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(test.description, func(t *testing.T) {
+			t.Parallel()
+
 			err := validateLabelsAndMetricName(test.input)
 			if test.expectedErr != "" {
 				require.Error(t, err)
@@ -154,6 +160,8 @@ func TestValidateLabelsAndMetricName(t *testing.T) {
 }
 
 func TestConcreteSeriesSet(t *testing.T) {
+	t.Parallel()
+
 	series1 := &concreteSeries{
 		labels:  labels.FromStrings("foo", "bar"),
 		samples: []prompb.Sample{{Value: 1, Timestamp: 2}},
@@ -173,6 +181,8 @@ func TestConcreteSeriesSet(t *testing.T) {
 }
 
 func TestConcreteSeriesClonesLabels(t *testing.T) {
+	t.Parallel()
+
 	lbls := labels.Labels{
 		labels.Label{Name: "a", Value: "b"},
 		labels.Label{Name: "c", Value: "d"},
@@ -192,6 +202,8 @@ func TestConcreteSeriesClonesLabels(t *testing.T) {
 }
 
 func TestFromQueryResultWithDuplicates(t *testing.T) {
+	t.Parallel()
+
 	ts1 := prompb.TimeSeries{
 		Labels: []prompb.Label{
 			{Name: "foo", Value: "bar"},
@@ -218,6 +230,8 @@ func TestFromQueryResultWithDuplicates(t *testing.T) {
 }
 
 func TestNegotiateResponseType(t *testing.T) {
+	t.Parallel()
+
 	r, err := NegotiateResponseType([]prompb.ReadRequest_ResponseType{
 		prompb.ReadRequest_STREAMED_XOR_CHUNKS,
 		prompb.ReadRequest_SAMPLES,
@@ -242,6 +256,8 @@ func TestNegotiateResponseType(t *testing.T) {
 }
 
 func TestMergeLabels(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		primary, secondary, expected []prompb.Label
 	}{
@@ -261,6 +277,8 @@ func TestMergeLabels(t *testing.T) {
 }
 
 func TestMetricTypeToMetricTypeProto(t *testing.T) {
+	t.Parallel()
+
 	tc := []struct {
 		desc     string
 		input    textparse.MetricType
@@ -284,7 +302,10 @@ func TestMetricTypeToMetricTypeProto(t *testing.T) {
 	}
 
 	for _, tt := range tc {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			m := metricTypeToMetricTypeProto(tt.input)
 			require.Equal(t, tt.expected, m)
 		})
@@ -292,6 +313,8 @@ func TestMetricTypeToMetricTypeProto(t *testing.T) {
 }
 
 func TestDecodeWriteRequest(t *testing.T) {
+	t.Parallel()
+
 	buf, _, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
 	require.NoError(t, err)
 

--- a/storage/remote/intern_test.go
+++ b/storage/remote/intern_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestIntern(t *testing.T) {
+	t.Parallel()
+
 	interner := newPool()
 	testString := "TestIntern"
 	interner.intern(testString)
@@ -37,6 +39,8 @@ func TestIntern(t *testing.T) {
 }
 
 func TestIntern_MultiRef(t *testing.T) {
+	t.Parallel()
+
 	interner := newPool()
 	testString := "TestIntern_MultiRef"
 
@@ -54,6 +58,8 @@ func TestIntern_MultiRef(t *testing.T) {
 }
 
 func TestIntern_DeleteRef(t *testing.T) {
+	t.Parallel()
+
 	interner := newPool()
 	testString := "TestIntern_DeleteRef"
 
@@ -69,6 +75,8 @@ func TestIntern_DeleteRef(t *testing.T) {
 }
 
 func TestIntern_MultiRef_Concurrent(t *testing.T) {
+	t.Parallel()
+
 	interner := newPool()
 	testString := "TestIntern_MultiRef_Concurrent"
 

--- a/storage/remote/metadata_watcher_test.go
+++ b/storage/remote/metadata_watcher_test.go
@@ -88,6 +88,8 @@ func (fm *fakeManager) TargetsActive() map[string][]*scrape.Target {
 }
 
 func TestWatchScrapeManager_NotReady(t *testing.T) {
+	t.Parallel()
+
 	wt := newMetadataWriteToMock()
 	smm := &scrapeManagerMock{
 		ready: false,
@@ -102,6 +104,8 @@ func TestWatchScrapeManager_NotReady(t *testing.T) {
 }
 
 func TestWatchScrapeManager_ReadyForCollection(t *testing.T) {
+	t.Parallel()
+
 	wt := newMetadataWriteToMock()
 
 	metadata := &TestMetaStore{

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -61,6 +61,8 @@ func newHighestTimestampMetric() *maxTimestamp {
 }
 
 func TestSampleDelivery(t *testing.T) {
+	t.Parallel()
+
 	testcases := []struct {
 		name      string
 		samples   bool
@@ -105,6 +107,7 @@ func TestSampleDelivery(t *testing.T) {
 		},
 	}
 
+	//nolint:paralleltest // TODO: Serial tests.
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
@@ -152,6 +155,8 @@ func TestSampleDelivery(t *testing.T) {
 }
 
 func TestMetadataDelivery(t *testing.T) {
+	t.Parallel()
+
 	c := NewTestWriteClient()
 
 	dir, err := ioutil.TempDir("", "TestMetadataDelivery")
@@ -188,6 +193,8 @@ func TestMetadataDelivery(t *testing.T) {
 }
 
 func TestSampleDeliveryTimeout(t *testing.T) {
+	t.Parallel()
+
 	// Let's send one less sample than batch size, and wait the timeout duration
 	n := 9
 	samples, series := createTimeseries(n, n)
@@ -221,6 +228,8 @@ func TestSampleDeliveryTimeout(t *testing.T) {
 }
 
 func TestSampleDeliveryOrder(t *testing.T) {
+	t.Parallel()
+
 	ts := 10
 	n := config.DefaultQueueConfig.MaxSamplesPerSend * ts
 	samples := make([]record.RefSample, 0, n)
@@ -262,6 +271,8 @@ func TestSampleDeliveryOrder(t *testing.T) {
 }
 
 func TestShutdown(t *testing.T) {
+	t.Parallel()
+
 	deadline := 1 * time.Second
 	c := NewTestBlockedWriteClient()
 
@@ -303,6 +314,8 @@ func TestShutdown(t *testing.T) {
 }
 
 func TestSeriesReset(t *testing.T) {
+	t.Parallel()
+
 	c := NewTestBlockedWriteClient()
 	deadline := 5 * time.Second
 	numSegments := 4
@@ -331,6 +344,8 @@ func TestSeriesReset(t *testing.T) {
 }
 
 func TestReshard(t *testing.T) {
+	t.Parallel()
+
 	size := 10 // Make bigger to find more races.
 	nSeries := 6
 	nSamples := config.DefaultQueueConfig.Capacity * size
@@ -374,6 +389,8 @@ func TestReshard(t *testing.T) {
 }
 
 func TestReshardRaceWithStop(t *testing.T) {
+	t.Parallel()
+
 	c := NewTestWriteClient()
 	var m *QueueManager
 	h := sync.Mutex{}
@@ -401,6 +418,8 @@ func TestReshardRaceWithStop(t *testing.T) {
 }
 
 func TestReleaseNoninternedString(t *testing.T) {
+	t.Parallel()
+
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
 	metrics := newQueueManagerMetrics(nil, "", "")
@@ -429,6 +448,8 @@ func TestReleaseNoninternedString(t *testing.T) {
 }
 
 func TestShouldReshard(t *testing.T) {
+	t.Parallel()
+
 	type testcase struct {
 		startingShards                           int
 		samplesIn, samplesOut, lastSendTimestamp int64
@@ -802,6 +823,8 @@ func BenchmarkStartup(b *testing.B) {
 }
 
 func TestProcessExternalLabels(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		labels         labels.Labels
 		externalLabels labels.Labels
@@ -861,6 +884,8 @@ func TestProcessExternalLabels(t *testing.T) {
 }
 
 func TestCalculateDesiredShards(t *testing.T) {
+	t.Parallel()
+
 	c := NewTestWriteClient()
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
@@ -942,6 +967,8 @@ func TestCalculateDesiredShards(t *testing.T) {
 }
 
 func TestQueueManagerMetrics(t *testing.T) {
+	t.Parallel()
+
 	reg := prometheus.NewPedanticRegistry()
 	metrics := newQueueManagerMetrics(reg, "name", "http://localhost:1234")
 

--- a/storage/remote/read_handler_test.go
+++ b/storage/remote/read_handler_test.go
@@ -33,6 +33,8 @@ import (
 )
 
 func TestSampledReadEndpoint(t *testing.T) {
+	t.Parallel()
+
 	suite, err := promql.NewTest(t, `
 		load 1m
 			test_metric1{foo="bar",baz="qux"} 1
@@ -113,6 +115,8 @@ func TestSampledReadEndpoint(t *testing.T) {
 }
 
 func TestStreamReadEndpoint(t *testing.T) {
+	t.Parallel()
+
 	// First with 120 samples. We expect 1 frame with 1 chunk.
 	// Second with 121 samples, We expect 1 frame with 2 chunks.
 	// Third with 241 samples. We expect 1 frame with 2 chunks, and 1 frame with 1 chunk for the same series due to bytes limit.

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -33,6 +33,8 @@ import (
 )
 
 func TestNoDuplicateReadConfigs(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "TestNoDuplicateReadConfigs")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -94,7 +96,11 @@ func TestNoDuplicateReadConfigs(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
+
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
 			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
 			conf := &config.Config{
 				GlobalConfig:      config.DefaultGlobalConfig,
@@ -110,6 +116,8 @@ func TestNoDuplicateReadConfigs(t *testing.T) {
 }
 
 func TestExternalLabelsQuerierAddExternalLabels(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		el          labels.Labels
 		inMatchers  []*labels.Matcher
@@ -176,6 +184,8 @@ func TestExternalLabelsQuerierAddExternalLabels(t *testing.T) {
 }
 
 func TestSeriesSetFilter(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		in       *prompb.QueryResult
 		toRemove labels.Labels
@@ -243,20 +253,9 @@ func (c *mockedRemoteClient) Read(_ context.Context, query *prompb.Query) (*prom
 	return q, nil
 }
 
-func (c *mockedRemoteClient) reset() {
-	c.got = nil
-}
-
 // NOTE: We don't need to test ChunkQuerier as it's uses querier for all operations anyway.
 func TestSampleAndChunkQueryableClient(t *testing.T) {
-	m := &mockedRemoteClient{
-		// Samples does not matter for below tests.
-		store: []*prompb.TimeSeries{
-			{Labels: []prompb.Label{{Name: "a", Value: "b"}}},
-			{Labels: []prompb.Label{{Name: "a", Value: "b3"}, {Name: "region", Value: "us"}}},
-			{Labels: []prompb.Label{{Name: "a", Value: "b2"}, {Name: "region", Value: "europe"}}},
-		},
-	}
+	t.Parallel()
 
 	for _, tc := range []struct {
 		name             string
@@ -480,8 +479,19 @@ func TestSampleAndChunkQueryableClient(t *testing.T) {
 			expectedSeries: nil, // Given matchers does not match with required ones, noop expected.
 		},
 	} {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
-			m.reset()
+			t.Parallel()
+
+			m := &mockedRemoteClient{
+				// Samples does not matter for below tests.
+				store: []*prompb.TimeSeries{
+					{Labels: []prompb.Label{{Name: "a", Value: "b"}}},
+					{Labels: []prompb.Label{{Name: "a", Value: "b3"}, {Name: "region", Value: "us"}}},
+					{Labels: []prompb.Label{{Name: "a", Value: "b2"}, {Name: "region", Value: "europe"}}},
+				},
+			}
 
 			c := NewSampleAndChunkQueryableClient(
 				m,

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 )
 
+//nolint:paralleltest // TODO: This test currently panics on accessing global metric when running in parallel.
 func TestStorageLifecycle(t *testing.T) {
 	dir, err := ioutil.TempDir("", "TestStorageLifecycle")
 	require.NoError(t, err)
@@ -64,6 +65,7 @@ func TestStorageLifecycle(t *testing.T) {
 	require.NoError(t, err)
 }
 
+//nolint:paralleltest // TODO: This test currently panics on accessing global metric when running in parallel.
 func TestUpdateRemoteReadConfigs(t *testing.T) {
 	dir, err := ioutil.TempDir("", "TestUpdateRemoteReadConfigs")
 	require.NoError(t, err)

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -32,6 +32,8 @@ import (
 )
 
 func TestRemoteWriteHandler(t *testing.T) {
+	t.Parallel()
+
 	buf, _, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
 	require.NoError(t, err)
 
@@ -65,6 +67,8 @@ func TestRemoteWriteHandler(t *testing.T) {
 }
 
 func TestOutOfOrderSample(t *testing.T) {
+	t.Parallel()
+
 	buf, _, err := buildWriteRequest([]prompb.TimeSeries{{
 		Labels:  []prompb.Label{{Name: "__name__", Value: "test_metric"}},
 		Samples: []prompb.Sample{{Value: 1, Timestamp: 0}},
@@ -90,6 +94,8 @@ func TestOutOfOrderSample(t *testing.T) {
 // don't fail on ingestion errors since the exemplar storage is
 // still experimental.
 func TestOutOfOrderExemplar(t *testing.T) {
+	t.Parallel()
+
 	buf, _, err := buildWriteRequest([]prompb.TimeSeries{{
 		Labels:    []prompb.Label{{Name: "__name__", Value: "test_metric"}},
 		Exemplars: []prompb.Exemplar{{Labels: []prompb.Label{{Name: "foo", Value: "bar"}}, Value: 1, Timestamp: 0}},
@@ -113,6 +119,8 @@ func TestOutOfOrderExemplar(t *testing.T) {
 }
 
 func TestCommitErr(t *testing.T) {
+	t.Parallel()
+
 	buf, _, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
 	require.NoError(t, err)
 

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -44,6 +44,8 @@ func testRemoteWriteConfig() *config.RemoteWriteConfig {
 }
 
 func TestNoDuplicateWriteConfigs(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "TestNoDuplicateWriteConfigs")
 	require.NoError(t, err)
 	defer func() {
@@ -132,6 +134,8 @@ func TestNoDuplicateWriteConfigs(t *testing.T) {
 }
 
 func TestRestartOnNameChange(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "TestRestartOnNameChange")
 	require.NoError(t, err)
 	defer func() {
@@ -166,6 +170,8 @@ func TestRestartOnNameChange(t *testing.T) {
 }
 
 func TestUpdateWithRegisterer(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "TestRestartWithRegisterer")
 	require.NoError(t, err)
 	defer func() {
@@ -210,6 +216,8 @@ func TestUpdateWithRegisterer(t *testing.T) {
 }
 
 func TestWriteStorageLifecycle(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "TestWriteStorageLifecycle")
 	require.NoError(t, err)
 	defer func() {
@@ -231,6 +239,8 @@ func TestWriteStorageLifecycle(t *testing.T) {
 }
 
 func TestUpdateExternalLabels(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "TestUpdateExternalLabels")
 	require.NoError(t, err)
 	defer func() {
@@ -264,6 +274,8 @@ func TestUpdateExternalLabels(t *testing.T) {
 }
 
 func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "TestWriteStorageApplyConfigsIdempotent")
 	require.NoError(t, err)
 	defer func() {
@@ -305,6 +317,8 @@ func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
 }
 
 func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "TestWriteStorageApplyConfigsPartialUpdate")
 	require.NoError(t, err)
 	defer func() {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestTemplateExpansion(t *testing.T) {
+	t.Parallel()
+
 	scenarios := []struct {
 		text        string
 		output      string

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 func TestUnsupported(t *testing.T) {
+	t.Parallel()
+
 	promAgentDir := t.TempDir()
 
 	opts := DefaultOptions()
@@ -46,22 +48,30 @@ func TestUnsupported(t *testing.T) {
 	}()
 
 	t.Run("Querier", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := s.Querier(context.TODO(), 0, 0)
 		require.Equal(t, err, ErrUnsupported)
 	})
 
 	t.Run("ChunkQuerier", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := s.ChunkQuerier(context.TODO(), 0, 0)
 		require.Equal(t, err, ErrUnsupported)
 	})
 
 	t.Run("ExemplarQuerier", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := s.ExemplarQuerier(context.TODO())
 		require.Equal(t, err, ErrUnsupported)
 	})
 }
 
 func TestCommit(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numDatapoints = 1000
 		numSeries     = 8
@@ -158,6 +168,8 @@ func TestCommit(t *testing.T) {
 }
 
 func TestRollback(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numDatapoints = 1000
 		numSeries     = 8
@@ -255,6 +267,8 @@ func TestRollback(t *testing.T) {
 }
 
 func TestFullTruncateWAL(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numDatapoints = 1000
 		numSeries     = 800
@@ -299,6 +313,8 @@ func TestFullTruncateWAL(t *testing.T) {
 }
 
 func TestPartialTruncateWAL(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numDatapoints = 1000
 		numSeries     = 800
@@ -360,6 +376,8 @@ func TestPartialTruncateWAL(t *testing.T) {
 }
 
 func TestWALReplay(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numDatapoints = 1000
 		numSeries     = 8

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -42,6 +42,8 @@ import (
 // to 2. We had a migration in place resetting it to 1 but we should move immediately to
 // version 3 next time to avoid confusion and issues.
 func TestBlockMetaMustNeverBeVersion2(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "metaversion")
 	require.NoError(t, err)
 	defer func() {
@@ -57,6 +59,8 @@ func TestBlockMetaMustNeverBeVersion2(t *testing.T) {
 }
 
 func TestSetCompactionFailed(t *testing.T) {
+	t.Parallel()
+
 	tmpdir, err := ioutil.TempDir("", "test")
 	require.NoError(t, err)
 	defer func() {
@@ -78,6 +82,8 @@ func TestSetCompactionFailed(t *testing.T) {
 }
 
 func TestCreateBlock(t *testing.T) {
+	t.Parallel()
+
 	tmpdir, err := ioutil.TempDir("", "test")
 	require.NoError(t, err)
 	defer func() {
@@ -91,6 +97,8 @@ func TestCreateBlock(t *testing.T) {
 }
 
 func TestCorruptedChunk(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name     string
 		corrFunc func(f *os.File) // Func that applies the corruption.
@@ -172,7 +180,11 @@ func TestCorruptedChunk(t *testing.T) {
 			iterErr: errors.New("cannot populate chunk 8: checksum mismatch expected:cfc0526c, actual:34815eae"),
 		},
 	} {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			tmpdir, err := ioutil.TempDir("", "test_open_block_chunk_corrupted")
 			require.NoError(t, err)
 			defer func() {
@@ -215,6 +227,8 @@ func TestCorruptedChunk(t *testing.T) {
 }
 
 func TestLabelValuesWithMatchers(t *testing.T) {
+	t.Parallel()
+
 	tmpdir, err := ioutil.TempDir("", "test_block_label_values_with_matchers")
 	require.NoError(t, err)
 	defer func() {
@@ -288,6 +302,7 @@ func TestLabelValuesWithMatchers(t *testing.T) {
 
 // TestBlockSize ensures that the block size is calculated correctly.
 func TestBlockSize(t *testing.T) {
+	t.Parallel()
 	tmpdir, err := ioutil.TempDir("", "test_blockSize")
 	require.NoError(t, err)
 	defer func() {
@@ -341,6 +356,8 @@ func TestBlockSize(t *testing.T) {
 }
 
 func TestReadIndexFormatV1(t *testing.T) {
+	t.Parallel()
+
 	/* The block here was produced at the commit
 	    706602daed1487f7849990678b4ece4599745905 used in 2.0.0 with:
 	   db, _ := Open("v1db", nil, nil, nil)
@@ -419,6 +436,8 @@ func BenchmarkLabelValuesWithMatchers(b *testing.B) {
 }
 
 func TestLabelNamesWithMatchers(t *testing.T) {
+	t.Parallel()
+
 	tmpdir, err := ioutil.TempDir("", "test_block_label_names_with_matchers")
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, os.RemoveAll(tmpdir)) })
@@ -486,7 +505,11 @@ func TestLabelNamesWithMatchers(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			actualNames, err := indexReader.LabelNames(tt.matchers...)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedNames, actualNames)

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -286,6 +286,7 @@ func TestLabelValuesWithMatchers(t *testing.T) {
 		},
 	}
 
+	//nolint:paralleltest // TODO: Serial tests.
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			actualValues, err := indexReader.SortedLabelValues(tt.labelName, tt.matchers...)

--- a/tsdb/blockwriter_test.go
+++ b/tsdb/blockwriter_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestBlockWriter(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	outputDir, err := ioutil.TempDir(os.TempDir(), "output")
 	require.NoError(t, err)

--- a/tsdb/chunkenc/bstream_test.go
+++ b/tsdb/chunkenc/bstream_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestBstreamReader(t *testing.T) {
+	t.Parallel()
+
 	// Write to the bit stream.
 	w := bstream{}
 	for _, bit := range []bit{true, false} {

--- a/tsdb/chunkenc/chunk_test.go
+++ b/tsdb/chunkenc/chunk_test.go
@@ -28,10 +28,16 @@ type pair struct {
 }
 
 func TestChunk(t *testing.T) {
+	t.Parallel()
+
 	for enc, nc := range map[Encoding]func() Chunk{
 		EncXOR: func() Chunk { return NewXORChunk() },
 	} {
+		nc := nc
+
 		t.Run(fmt.Sprintf("%v", enc), func(t *testing.T) {
+			t.Parallel()
+
 			for range make([]struct{}, 1) {
 				c := nc()
 				testChunk(t, c)

--- a/tsdb/chunks/chunks_test.go
+++ b/tsdb/chunks/chunks_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestReaderWithInvalidBuffer(t *testing.T) {
+	t.Parallel()
+
 	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
 	r := &Reader{bs: []ByteSlice{b}}
 

--- a/tsdb/chunks/head_chunks_test.go
+++ b/tsdb/chunks/head_chunks_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
 
+//nolint:paralleltest // TODO: This test currently fails when running in parallel.
 func TestChunkDiskMapper_WriteChunk_Chunk_IterateChunks(t *testing.T) {
 	hrw := testChunkDiskMapper(t)
 	defer func() {
@@ -159,6 +160,8 @@ func TestChunkDiskMapper_WriteChunk_Chunk_IterateChunks(t *testing.T) {
 // * Empty current file does not lead to creation of another file after truncation.
 // * Non-empty current file leads to creation of another file after truncation.
 func TestChunkDiskMapper_Truncate(t *testing.T) {
+	t.Parallel()
+
 	hrw := testChunkDiskMapper(t)
 	defer func() {
 		require.NoError(t, hrw.Close())
@@ -248,6 +251,8 @@ func TestChunkDiskMapper_Truncate(t *testing.T) {
 // This test exposes https://github.com/prometheus/prometheus/issues/7412 where the truncation
 // simply deleted all empty files instead of stopping once it encountered a non-empty file.
 func TestChunkDiskMapper_Truncate_PreservesFileSequence(t *testing.T) {
+	t.Parallel()
+
 	hrw := testChunkDiskMapper(t)
 	defer func() {
 		require.NoError(t, hrw.Close())
@@ -318,6 +323,8 @@ func TestChunkDiskMapper_Truncate_PreservesFileSequence(t *testing.T) {
 // TestHeadReadWriter_TruncateAfterIterateChunksError tests for
 // https://github.com/prometheus/prometheus/issues/7753
 func TestHeadReadWriter_TruncateAfterFailedIterateChunks(t *testing.T) {
+	t.Parallel()
+
 	hrw := testChunkDiskMapper(t)
 	defer func() {
 		require.NoError(t, hrw.Close())
@@ -344,6 +351,8 @@ func TestHeadReadWriter_TruncateAfterFailedIterateChunks(t *testing.T) {
 }
 
 func TestHeadReadWriter_ReadRepairOnEmptyLastFile(t *testing.T) {
+	t.Parallel()
+
 	hrw := testChunkDiskMapper(t)
 	defer func() {
 		require.NoError(t, hrw.Close())

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -375,6 +375,8 @@ func TestLeveledCompactor_plan(t *testing.T) {
 }
 
 func TestRangeWithFailedCompactionWontGetSelected(t *testing.T) {
+	t.Parallel()
+
 	compactor, err := NewLeveledCompactor(context.Background(), nil, nil, []int64{
 		20,
 		60,
@@ -425,6 +427,8 @@ func TestRangeWithFailedCompactionWontGetSelected(t *testing.T) {
 }
 
 func TestCompactionFailWillCleanUpTempDir(t *testing.T) {
+	t.Parallel()
+
 	compactor, err := NewLeveledCompactor(context.Background(), nil, log.NewNopLogger(), []int64{
 		20,
 		60,
@@ -485,6 +489,8 @@ func samplesForRange(minTime, maxTime int64, maxSamplesPerChunk int) (ret [][]sa
 }
 
 func TestCompaction_populateBlock(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		title              string
 		inputSeriesSamples [][]seriesSamples
@@ -933,7 +939,11 @@ func TestCompaction_populateBlock(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
+
 		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
 			blocks := make([]BlockReader, 0, len(tc.inputSeriesSamples))
 			for _, b := range tc.inputSeriesSamples {
 				ir, cr, mint, maxt := createIdxChkReaders(t, b)
@@ -1121,6 +1131,8 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 // This is needed for unit tests that rely on
 // checking state before and after a compaction.
 func TestDisableAutoCompactions(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -1174,6 +1186,8 @@ func TestDisableAutoCompactions(t *testing.T) {
 // TestCancelCompactions ensures that when the db is closed
 // any running compaction is cancelled to unblock closing the db.
 func TestCancelCompactions(t *testing.T) {
+	t.Parallel()
+
 	tmpdir, err := ioutil.TempDir("", "testCancelCompaction")
 	require.NoError(t, err)
 	defer func() {
@@ -1242,6 +1256,8 @@ func TestCancelCompactions(t *testing.T) {
 // TestDeleteCompactionBlockAfterFailedReload ensures that a failed reloadBlocks immediately after a compaction
 // deletes the resulting block to avoid creatings blocks with the same time range.
 func TestDeleteCompactionBlockAfterFailedReload(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]func(*DB) int{
 		"Test Head Compaction": func(db *DB) int {
 			rangeToTriggerCompaction := db.compactor.(*LeveledCompactor).ranges[0]/2*3 - 1
@@ -1276,7 +1292,11 @@ func TestDeleteCompactionBlockAfterFailedReload(t *testing.T) {
 	}
 
 	for title, bootStrap := range tests {
+		bootStrap := bootStrap
+
 		t.Run(title, func(t *testing.T) {
+			t.Parallel()
+
 			db := openTestDB(t, nil, []int64{1, 100})
 			defer func() {
 				require.NoError(t, db.Close())

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -37,6 +37,8 @@ import (
 )
 
 func TestSplitByRange(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		trange int64
 		ranges [][2]int64
@@ -141,6 +143,8 @@ func TestSplitByRange(t *testing.T) {
 
 // See https://github.com/prometheus/prometheus/issues/3064
 func TestNoPanicFor0Tombstones(t *testing.T) {
+	t.Parallel()
+
 	metas := []dirMeta{
 		{
 			dir: "1",
@@ -165,6 +169,8 @@ func TestNoPanicFor0Tombstones(t *testing.T) {
 }
 
 func TestLeveledCompactor_plan(t *testing.T) {
+	t.Parallel()
+
 	// This mimics our default ExponentialBlockRanges with min block size equals to 20.
 	compactor, err := NewLeveledCompactor(context.Background(), nil, nil, []int64{
 		20,

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -141,6 +141,8 @@ func queryChunks(t testing.TB, q storage.ChunkQuerier, matchers ...*labels.Match
 // Ensure that blocks are held in memory in their time order
 // and not in ULID order as they are read from the directory.
 func TestDB_reloadOrder(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -167,6 +169,8 @@ func TestDB_reloadOrder(t *testing.T) {
 }
 
 func TestDataAvailableOnlyAfterCommit(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -198,6 +202,8 @@ func TestDataAvailableOnlyAfterCommit(t *testing.T) {
 // TestNoPanicAfterWALCorruption ensures that querying the db after a WAL corruption doesn't cause a panic.
 // https://github.com/prometheus/prometheus/issues/7548
 func TestNoPanicAfterWALCorruption(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, &Options{WALSegmentSize: 32 * 1024}, nil)
 
 	// Append until the first mmaped head chunk.
@@ -257,6 +263,8 @@ func TestNoPanicAfterWALCorruption(t *testing.T) {
 }
 
 func TestDataNotAvailableAfterRollback(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -279,6 +287,8 @@ func TestDataNotAvailableAfterRollback(t *testing.T) {
 }
 
 func TestDBAppenderAddRef(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -337,6 +347,8 @@ func TestDBAppenderAddRef(t *testing.T) {
 }
 
 func TestAppendEmptyLabelsIgnored(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -360,6 +372,8 @@ func TestAppendEmptyLabelsIgnored(t *testing.T) {
 }
 
 func TestDeleteSimple(t *testing.T) {
+	t.Parallel()
+
 	numSamples := int64(10)
 
 	cases := []struct {
@@ -450,6 +464,8 @@ Outer:
 }
 
 func TestAmendDatapointCausesError(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -468,6 +484,8 @@ func TestAmendDatapointCausesError(t *testing.T) {
 }
 
 func TestDuplicateNaNDatapointNoAmendError(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -485,6 +503,8 @@ func TestDuplicateNaNDatapointNoAmendError(t *testing.T) {
 }
 
 func TestNonDuplicateNaNDatapointsCausesAmendError(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -502,6 +522,8 @@ func TestNonDuplicateNaNDatapointsCausesAmendError(t *testing.T) {
 }
 
 func TestEmptyLabelsetCausesError(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -515,6 +537,8 @@ func TestEmptyLabelsetCausesError(t *testing.T) {
 }
 
 func TestSkippingInvalidValuesInSameTxn(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -558,6 +582,8 @@ func TestSkippingInvalidValuesInSameTxn(t *testing.T) {
 }
 
 func TestDB_Snapshot(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 
 	// append data
@@ -609,6 +635,8 @@ func TestDB_Snapshot(t *testing.T) {
 // that are outside the set block time range.
 // See https://github.com/prometheus/prometheus/issues/5105
 func TestDB_Snapshot_ChunksOutsideOfCompactedRange(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 
 	ctx := context.Background()
@@ -660,6 +688,8 @@ func TestDB_Snapshot_ChunksOutsideOfCompactedRange(t *testing.T) {
 }
 
 func TestDB_SnapshotWithDelete(t *testing.T) {
+	t.Parallel()
+
 	numSamples := int64(10)
 
 	db := openTestDB(t, nil, nil)
@@ -751,6 +781,8 @@ Outer:
 }
 
 func TestDB_e2e(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numDatapoints = 1000
 		numRanges     = 1000
@@ -909,6 +941,8 @@ func TestDB_e2e(t *testing.T) {
 }
 
 func TestWALFlushedOnDBClose(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 
 	dirDb := db.Dir()
@@ -937,6 +971,8 @@ func TestWALFlushedOnDBClose(t *testing.T) {
 }
 
 func TestWALSegmentSizeOptions(t *testing.T) {
+	t.Parallel()
+
 	tests := map[int]func(dbdir string, segmentSize int){
 		// Default Wal Size.
 		0: func(dbDir string, segmentSize int) {
@@ -1008,6 +1044,8 @@ func TestWALSegmentSizeOptions(t *testing.T) {
 }
 
 func TestTombstoneClean(t *testing.T) {
+	t.Parallel()
+
 	numSamples := int64(10)
 
 	db := openTestDB(t, nil, nil)
@@ -1107,6 +1145,8 @@ func TestTombstoneClean(t *testing.T) {
 // TestTombstoneCleanResultEmptyBlock tests that a TombstoneClean that results in empty blocks (no timeseries)
 // will also delete the resultant block.
 func TestTombstoneCleanResultEmptyBlock(t *testing.T) {
+	t.Parallel()
+
 	numSamples := int64(10)
 
 	db := openTestDB(t, nil, nil)
@@ -1156,6 +1196,8 @@ func TestTombstoneCleanResultEmptyBlock(t *testing.T) {
 // When TombstoneClean errors the original block that should be rebuilt doesn't get deleted so
 // if TombstoneClean leaves any blocks behind these will overlap.
 func TestTombstoneCleanFail(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -1205,6 +1247,8 @@ func TestTombstoneCleanRetentionLimitsRace(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
+
+	t.Parallel()
 
 	opts := DefaultOptions()
 	var wg sync.WaitGroup
@@ -1305,6 +1349,8 @@ func (*mockCompactorFailing) Compact(string, []string, []*Block) (ulid.ULID, err
 }
 
 func TestTimeRetention(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, []int64{1000})
 	defer func() {
 		require.NoError(t, db.Close())
@@ -1336,6 +1382,8 @@ func TestTimeRetention(t *testing.T) {
 }
 
 func TestSizeRetention(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, []int64{100})
 	defer func() {
 		require.NoError(t, db.Close())
@@ -1445,6 +1493,8 @@ func TestSizeRetention(t *testing.T) {
 }
 
 func TestSizeRetentionMetric(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		maxBytes    int64
 		expMaxBytes int64
@@ -1454,20 +1504,27 @@ func TestSizeRetentionMetric(t *testing.T) {
 		{maxBytes: -1000, expMaxBytes: 0},
 	}
 
-	for _, c := range cases {
-		db := openTestDB(t, &Options{
-			MaxBytes: c.maxBytes,
-		}, []int64{100})
-		defer func() {
-			require.NoError(t, db.Close())
-		}()
+	for i, c := range cases {
+		c := c
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 
-		actMaxBytes := int64(prom_testutil.ToFloat64(db.metrics.maxBytes))
-		require.Equal(t, actMaxBytes, c.expMaxBytes, "metric retention limit bytes mismatch")
+			db := openTestDB(t, &Options{
+				MaxBytes: c.maxBytes,
+			}, []int64{100})
+			defer func() {
+				require.NoError(t, db.Close())
+			}()
+
+			actMaxBytes := int64(prom_testutil.ToFloat64(db.metrics.maxBytes))
+			require.Equal(t, actMaxBytes, c.expMaxBytes, "metric retention limit bytes mismatch")
+		})
 	}
 }
 
 func TestNotMatcherSelectsLabelsUnsetSeries(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -1561,6 +1618,8 @@ func expandSeriesSet(ss storage.SeriesSet) ([]labels.Labels, map[string][]sample
 }
 
 func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
+	t.Parallel()
+
 	// Create 10 blocks that does not overlap (0-10, 10-20, ..., 100-110) but in reverse order to ensure our algorithm
 	// will handle that.
 	metas := make([]BlockMeta, 11)
@@ -1654,6 +1713,8 @@ func TestOverlappingBlocksDetectsAllOverlaps(t *testing.T) {
 
 // Regression test for https://github.com/prometheus/tsdb/issues/347
 func TestChunkAtBlockBoundary(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -1711,6 +1772,8 @@ func TestChunkAtBlockBoundary(t *testing.T) {
 }
 
 func TestQuerierWithBoundaryChunks(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -1754,7 +1817,11 @@ func TestQuerierWithBoundaryChunks(t *testing.T) {
 //	- with blocks no WAL: set to the last block maxT
 // 	- with blocks with WAL: same as above
 func TestInitializeHeadTimestamp(t *testing.T) {
+	t.Parallel()
+
 	t.Run("clean", func(t *testing.T) {
+		t.Parallel()
+
 		dir, err := ioutil.TempDir("", "test_head_init")
 		require.NoError(t, err)
 		defer func() {
@@ -1779,6 +1846,8 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		require.Equal(t, int64(1000), db.head.MaxTime())
 	})
 	t.Run("wal-only", func(t *testing.T) {
+		t.Parallel()
+
 		dir, err := ioutil.TempDir("", "test_head_init")
 		require.NoError(t, err)
 		defer func() {
@@ -1811,6 +1880,8 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		require.Equal(t, int64(15000), db.head.MaxTime())
 	})
 	t.Run("existing-block", func(t *testing.T) {
+		t.Parallel()
+
 		dir, err := ioutil.TempDir("", "test_head_init")
 		require.NoError(t, err)
 		defer func() {
@@ -1827,6 +1898,8 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		require.Equal(t, int64(2000), db.head.MaxTime())
 	})
 	t.Run("existing-block-and-wal", func(t *testing.T) {
+		t.Parallel()
+
 		dir, err := ioutil.TempDir("", "test_head_init")
 		require.NoError(t, err)
 		defer func() {
@@ -1867,6 +1940,8 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 }
 
 func TestNoEmptyBlocks(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, []int64{100})
 	ctx := context.Background()
 	defer func() {
@@ -1970,6 +2045,8 @@ func TestNoEmptyBlocks(t *testing.T) {
 }
 
 func TestDB_LabelNames(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		// Add 'sampleLabels1' -> Test Head -> Compact -> Test Disk ->
 		// -> Add 'sampleLabels2' -> Test Head+Disk
@@ -2072,6 +2149,8 @@ func TestDB_LabelNames(t *testing.T) {
 }
 
 func TestCorrectNumTombstones(t *testing.T) {
+	t.Parallel()
+
 	db := openTestDB(t, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -2119,6 +2198,7 @@ func TestCorrectNumTombstones(t *testing.T) {
 // This ensures that a snapshot that includes the head and creates a block with a custom time range
 // will not overlap with the first block created by the next compaction.
 func TestBlockRanges(t *testing.T) {
+	t.Parallel()
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	ctx := context.Background()
 
@@ -2316,6 +2396,8 @@ func TestDBReadOnly(t *testing.T) {
 // TestDBReadOnlyClosing ensures that after closing the db
 // all api methods return an ErrClosed.
 func TestDBReadOnlyClosing(t *testing.T) {
+	t.Parallel()
+
 	dbDir, err := ioutil.TempDir("", "test")
 	require.NoError(t, err)
 
@@ -2333,6 +2415,8 @@ func TestDBReadOnlyClosing(t *testing.T) {
 }
 
 func TestDBReadOnly_FlushWAL(t *testing.T) {
+	t.Parallel()
+
 	var (
 		dbDir  string
 		logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
@@ -2407,6 +2491,8 @@ func TestDBReadOnly_FlushWAL(t *testing.T) {
 }
 
 func TestDBCannotSeePartialCommits(t *testing.T) {
+	t.Parallel()
+
 	tmpdir, _ := ioutil.TempDir("", "test")
 	defer func() {
 		require.NoError(t, os.RemoveAll(tmpdir))
@@ -2477,6 +2563,8 @@ func TestDBCannotSeePartialCommits(t *testing.T) {
 }
 
 func TestDBQueryDoesntSeeAppendsAfterCreation(t *testing.T) {
+	t.Parallel()
+
 	tmpdir, _ := ioutil.TempDir("", "test")
 	defer func() {
 		require.NoError(t, os.RemoveAll(tmpdir))
@@ -2545,6 +2633,8 @@ func TestDBQueryDoesntSeeAppendsAfterCreation(t *testing.T) {
 // TestChunkWriter_ReadAfterWrite ensures that chunk segment are cut at the set segment size and
 // that the resulted segments includes the expected chunks data.
 func TestChunkWriter_ReadAfterWrite(t *testing.T) {
+	t.Parallel()
+
 	chk1 := tsdbutil.ChunkFromSamples([]tsdbutil.Sample{sample{1, 1}})
 	chk2 := tsdbutil.ChunkFromSamples([]tsdbutil.Sample{sample{1, 2}})
 	chk3 := tsdbutil.ChunkFromSamples([]tsdbutil.Sample{sample{1, 3}})
@@ -2666,7 +2756,11 @@ func TestChunkWriter_ReadAfterWrite(t *testing.T) {
 	}
 
 	for i, test := range tests {
+		test := test
+
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
 			tempDir, err := ioutil.TempDir("", "test_chunk_writer")
 			require.NoError(t, err)
 			defer func() { require.NoError(t, os.RemoveAll(tempDir)) }()
@@ -2724,6 +2818,8 @@ func TestChunkWriter_ReadAfterWrite(t *testing.T) {
 }
 
 func TestRangeForTimestamp(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		t     int64
 		width int64
@@ -2748,6 +2844,8 @@ func TestRangeForTimestamp(t *testing.T) {
 // TestChunkReader_ConcurrentReads checks that the chunk result can be read concurrently.
 // Regression test for https://github.com/prometheus/prometheus/pull/6514.
 func TestChunkReader_ConcurrentReads(t *testing.T) {
+	t.Parallel()
+
 	chks := []chunks.Meta{
 		tsdbutil.ChunkFromSamples([]tsdbutil.Sample{sample{1, 1}}),
 		tsdbutil.ChunkFromSamples([]tsdbutil.Sample{sample{1, 2}}),
@@ -2795,6 +2893,8 @@ func TestChunkReader_ConcurrentReads(t *testing.T) {
 // * compacts the head; and
 // * queries the db to ensure the samples are present from the compacted head.
 func TestCompactHead(t *testing.T) {
+	t.Parallel()
+
 	dbDir, err := ioutil.TempDir("", "testFlush")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(dbDir)) }()
@@ -2878,6 +2978,8 @@ func deleteNonBlocks(dbDir string) error {
 }
 
 func TestOpen_VariousBlockStates(t *testing.T) {
+	t.Parallel()
+
 	tmpDir, err := ioutil.TempDir("", "test")
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -2989,6 +3091,8 @@ func TestOpen_VariousBlockStates(t *testing.T) {
 }
 
 func TestOneCheckpointPerCompactCall(t *testing.T) {
+	t.Parallel()
+
 	blockRange := int64(1000)
 	tsdbCfg := &Options{
 		RetentionDuration: blockRange * 1000,
@@ -3110,6 +3214,8 @@ func TestOneCheckpointPerCompactCall(t *testing.T) {
 }
 
 func TestNoPanicOnTSDBOpenError(t *testing.T) {
+	t.Parallel()
+
 	tmpdir, err := ioutil.TempDir("", "test")
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -3129,6 +3235,8 @@ func TestNoPanicOnTSDBOpenError(t *testing.T) {
 }
 
 func TestLockfileMetric(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		fileAlreadyExists bool
 		lockFileDisabled  bool
@@ -3157,7 +3265,11 @@ func TestLockfileMetric(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		c := c
+
 		t.Run(fmt.Sprintf("%+v", c), func(t *testing.T) {
+			t.Parallel()
+
 			tmpdir, err := ioutil.TempDir("", "test")
 			require.NoError(t, err)
 			t.Cleanup(func() {
@@ -3199,6 +3311,8 @@ func TestQuerier_ShouldNotPanicIfHeadChunkIsTruncatedWhileReadingQueriedChunks(t
 
 	for i := 1; i <= numRuns; i++ {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
 			testQuerierShouldNotPanicIfHeadChunkIsTruncatedWhileReadingQueriedChunks(t)
 		})
 	}
@@ -3335,6 +3449,8 @@ func TestChunkQuerier_ShouldNotPanicIfHeadChunkIsTruncatedWhileReadingQueriedChu
 
 	for i := 1; i <= numRuns; i++ {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
 			testChunkQuerierShouldNotPanicIfHeadChunkIsTruncatedWhileReadingQueriedChunks(t)
 		})
 	}

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -34,6 +34,7 @@ var eMetrics = NewExemplarMetrics(prometheus.DefaultRegisterer)
 
 // Tests the same exemplar cases as AddExemplar, but specifically the ValidateExemplar function so it can be relied on externally.
 func TestValidateExemplar(t *testing.T) {
+	t.Parallel()
 	exs, err := NewCircularExemplarStorage(2, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
@@ -93,6 +94,8 @@ func TestValidateExemplar(t *testing.T) {
 }
 
 func TestAddExemplar(t *testing.T) {
+	t.Parallel()
+
 	exs, err := NewCircularExemplarStorage(2, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
@@ -153,6 +156,8 @@ func TestAddExemplar(t *testing.T) {
 }
 
 func TestStorageOverflow(t *testing.T) {
+	t.Parallel()
+
 	// Test that circular buffer index and assignment
 	// works properly, adding more exemplars than can
 	// be stored and then querying for them.
@@ -191,6 +196,8 @@ func TestStorageOverflow(t *testing.T) {
 }
 
 func TestSelectExemplar(t *testing.T) {
+	t.Parallel()
+
 	exs, err := NewCircularExemplarStorage(5, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
@@ -222,6 +229,8 @@ func TestSelectExemplar(t *testing.T) {
 }
 
 func TestSelectExemplar_MultiSeries(t *testing.T) {
+	t.Parallel()
+
 	exs, err := NewCircularExemplarStorage(5, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
@@ -279,6 +288,8 @@ func TestSelectExemplar_MultiSeries(t *testing.T) {
 }
 
 func TestSelectExemplar_TimeRange(t *testing.T) {
+	t.Parallel()
+
 	var lenEs int64 = 5
 	exs, err := NewCircularExemplarStorage(lenEs, eMetrics)
 	require.NoError(t, err)
@@ -314,6 +325,8 @@ func TestSelectExemplar_TimeRange(t *testing.T) {
 // Test to ensure that even though a series matches more than one matcher from the
 // query that it's exemplars are only included in the result a single time.
 func TestSelectExemplar_DuplicateSeries(t *testing.T) {
+	t.Parallel()
+
 	exs, err := NewCircularExemplarStorage(4, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
@@ -355,6 +368,8 @@ func TestSelectExemplar_DuplicateSeries(t *testing.T) {
 }
 
 func TestIndexOverwrite(t *testing.T) {
+	t.Parallel()
+
 	exs, err := NewCircularExemplarStorage(2, eMetrics)
 	require.NoError(t, err)
 	es := exs.(*CircularExemplarStorage)
@@ -388,6 +403,8 @@ func TestIndexOverwrite(t *testing.T) {
 }
 
 func TestResize(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name              string
 		startSize         int64

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -464,7 +464,11 @@ func TestResize(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			exs, err := NewCircularExemplarStorage(tc.startSize, eMetrics)
 			require.NoError(t, err)
 			es := exs.(*CircularExemplarStorage)

--- a/tsdb/fileutil/flock_test.go
+++ b/tsdb/fileutil/flock_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestLocking(t *testing.T) {
+	t.Parallel()
+
 	dir := testutil.NewTemporaryDirectory("test_flock", t)
 	defer dir.Close()
 

--- a/tsdb/goversion/goversion_test.go
+++ b/tsdb/goversion/goversion_test.go
@@ -24,4 +24,6 @@ import (
 //
 // The blank import above is actually what invokes the test of this package. If
 // the import succeeds (the code compiles), the test passed.
-func Test(t *testing.T) {}
+func Test(t *testing.T) {
+	t.Parallel()
+}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -270,8 +270,14 @@ func BenchmarkLoadWAL(b *testing.B) {
 }
 
 func TestHead_ReadWAL(t *testing.T) {
+	t.Parallel()
+
 	for _, compress := range []bool{false, true} {
+		compress := compress
+
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
+			t.Parallel()
+
 			entries := []interface{}{
 				[]record.RefSeries{
 					{Ref: 10, Labels: labels.FromStrings("a", "1")},
@@ -345,6 +351,8 @@ func TestHead_ReadWAL(t *testing.T) {
 }
 
 func TestHead_WALMultiRef(t *testing.T) {
+	t.Parallel()
+
 	head, w := newTestHead(t, 1000, false)
 
 	require.NoError(t, head.Init(0))
@@ -405,6 +413,8 @@ func TestHead_WALMultiRef(t *testing.T) {
 }
 
 func TestHead_ActiveAppenders(t *testing.T) {
+	t.Parallel()
+
 	head, _ := newTestHead(t, 1000, false)
 	defer head.Close()
 
@@ -438,6 +448,8 @@ func TestHead_ActiveAppenders(t *testing.T) {
 }
 
 func TestHead_UnknownWALRecord(t *testing.T) {
+	t.Parallel()
+
 	head, w := newTestHead(t, 1000, false)
 	w.Log([]byte{255, 42})
 	require.NoError(t, head.Init(0))
@@ -445,6 +457,8 @@ func TestHead_UnknownWALRecord(t *testing.T) {
 }
 
 func TestHead_Truncate(t *testing.T) {
+	t.Parallel()
+
 	h, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, h.Close())
@@ -533,6 +547,8 @@ func TestHead_Truncate(t *testing.T) {
 // Validate various behaviors brought on by firstChunkID accounting for
 // garbage collected chunks.
 func TestMemSeries_truncateChunks(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "truncate_chunks")
 	require.NoError(t, err)
 	defer func() {
@@ -592,8 +608,14 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 }
 
 func TestHeadDeleteSeriesWithoutSamples(t *testing.T) {
+	t.Parallel()
+
 	for _, compress := range []bool{false, true} {
+		compress := compress
+
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
+			t.Parallel()
+
 			entries := []interface{}{
 				[]record.RefSeries{
 					{Ref: 10, Labels: labels.FromStrings("a", "1")},
@@ -622,6 +644,8 @@ func TestHeadDeleteSeriesWithoutSamples(t *testing.T) {
 }
 
 func TestHeadDeleteSimple(t *testing.T) {
+	t.Parallel()
+
 	buildSmpls := func(s []int64) []sample {
 		ss := make([]sample, 0, len(s))
 		for _, t := range s {
@@ -754,6 +778,8 @@ func TestHeadDeleteSimple(t *testing.T) {
 }
 
 func TestDeleteUntilCurMax(t *testing.T) {
+	t.Parallel()
+
 	hb, _ := newTestHead(t, 1000000, false)
 	defer func() {
 		require.NoError(t, hb.Close())
@@ -804,6 +830,8 @@ func TestDeleteUntilCurMax(t *testing.T) {
 }
 
 func TestDeletedSamplesAndSeriesStillInWALAfterCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	numSamples := 10000
 
 	// Enough samples to cause a checkpoint.
@@ -845,6 +873,8 @@ func TestDeletedSamplesAndSeriesStillInWALAfterCheckpoint(t *testing.T) {
 }
 
 func TestDelete_e2e(t *testing.T) {
+	t.Parallel()
+
 	numDatapoints := 1000
 	numRanges := 1000
 	timeInterval := int64(2)
@@ -1035,6 +1065,8 @@ Outer:
 }
 
 func TestComputeChunkEndTime(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		start, cur, max int64
 		res             int64
@@ -1077,6 +1109,8 @@ func TestComputeChunkEndTime(t *testing.T) {
 }
 
 func TestMemSeries_append(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "append")
 	require.NoError(t, err)
 	defer func() {
@@ -1134,6 +1168,8 @@ func TestMemSeries_append(t *testing.T) {
 }
 
 func TestGCChunkAccess(t *testing.T) {
+	t.Parallel()
+
 	// Put a chunk, select it. GC it and then access it.
 	h, _ := newTestHead(t, 1000, false)
 	defer func() {
@@ -1188,6 +1224,8 @@ func TestGCChunkAccess(t *testing.T) {
 }
 
 func TestGCSeriesAccess(t *testing.T) {
+	t.Parallel()
+
 	// Put a series, select it. GC it and then access it.
 	h, _ := newTestHead(t, 1000, false)
 	defer func() {
@@ -1244,6 +1282,8 @@ func TestGCSeriesAccess(t *testing.T) {
 }
 
 func TestUncommittedSamplesNotLostOnTruncate(t *testing.T) {
+	t.Parallel()
+
 	h, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, h.Close())
@@ -1274,6 +1314,8 @@ func TestUncommittedSamplesNotLostOnTruncate(t *testing.T) {
 }
 
 func TestRemoveSeriesAfterRollbackAndTruncate(t *testing.T) {
+	t.Parallel()
+
 	h, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, h.Close())
@@ -1305,8 +1347,14 @@ func TestRemoveSeriesAfterRollbackAndTruncate(t *testing.T) {
 }
 
 func TestHead_LogRollback(t *testing.T) {
+	t.Parallel()
+
 	for _, compress := range []bool{false, true} {
+		compress := compress
+
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
+			t.Parallel()
+
 			h, w := newTestHead(t, 1000, compress)
 			defer func() {
 				require.NoError(t, h.Close())
@@ -1331,6 +1379,8 @@ func TestHead_LogRollback(t *testing.T) {
 // TestWalRepair_DecodingError ensures that a repair is run for an error
 // when decoding a record.
 func TestWalRepair_DecodingError(t *testing.T) {
+	t.Parallel()
+
 	var enc record.Encoder
 	for name, test := range map[string]struct {
 		corrFunc  func(rec []byte) []byte // Func that applies the corruption to a record.
@@ -1364,7 +1414,11 @@ func TestWalRepair_DecodingError(t *testing.T) {
 		},
 	} {
 		for _, compress := range []bool{false, true} {
+			compress := compress
+
 			t.Run(fmt.Sprintf("%s,compress=%t", name, compress), func(t *testing.T) {
+				t.Parallel()
+
 				dir, err := ioutil.TempDir("", "wal_repair")
 				require.NoError(t, err)
 				defer func() {
@@ -1429,6 +1483,8 @@ func TestWalRepair_DecodingError(t *testing.T) {
 }
 
 func TestHeadReadWriterRepair(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "head_read_writer_repair")
 	require.NoError(t, err)
 	defer func() {
@@ -1499,6 +1555,8 @@ func TestHeadReadWriterRepair(t *testing.T) {
 }
 
 func TestNewWalSegmentOnTruncate(t *testing.T) {
+	t.Parallel()
+
 	h, wlog := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, h.Close())
@@ -1529,6 +1587,8 @@ func TestNewWalSegmentOnTruncate(t *testing.T) {
 }
 
 func TestAddDuplicateLabelName(t *testing.T) {
+	t.Parallel()
+
 	h, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, h.Close())
@@ -1547,6 +1607,8 @@ func TestAddDuplicateLabelName(t *testing.T) {
 }
 
 func TestMemSeriesIsolation(t *testing.T) {
+	t.Parallel()
+
 	// Put a series, select it. GC it and then access it.
 	lastValue := func(h *Head, maxAppendID uint64) int {
 		idx, err := h.Index()
@@ -1718,6 +1780,8 @@ func TestMemSeriesIsolation(t *testing.T) {
 }
 
 func TestIsolationRollback(t *testing.T) {
+	t.Parallel()
+
 	// Rollback after a failed append and test if the low watermark has progressed anyway.
 	hb, _ := newTestHead(t, 1000, false)
 	defer func() {
@@ -1746,6 +1810,8 @@ func TestIsolationRollback(t *testing.T) {
 }
 
 func TestIsolationLowWatermarkMonotonous(t *testing.T) {
+	t.Parallel()
+
 	hb, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, hb.Close())
@@ -1779,6 +1845,8 @@ func TestIsolationLowWatermarkMonotonous(t *testing.T) {
 }
 
 func TestIsolationAppendIDZeroIsNoop(t *testing.T) {
+	t.Parallel()
+
 	h, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, h.Close())
@@ -1794,12 +1862,16 @@ func TestIsolationAppendIDZeroIsNoop(t *testing.T) {
 }
 
 func TestHeadSeriesChunkRace(t *testing.T) {
+	t.Parallel()
+
 	for i := 0; i < 1000; i++ {
 		testHeadSeriesChunkRace(t)
 	}
 }
 
 func TestIsolationWithoutAdd(t *testing.T) {
+	t.Parallel()
+
 	hb, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, hb.Close())
@@ -1817,6 +1889,8 @@ func TestIsolationWithoutAdd(t *testing.T) {
 }
 
 func TestOutOfOrderSamplesMetric(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "test")
 	require.NoError(t, err)
 	defer func() {
@@ -1934,6 +2008,8 @@ func testHeadSeriesChunkRace(t *testing.T) {
 }
 
 func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
+	t.Parallel()
+
 	head, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, head.Close())
@@ -1994,6 +2070,8 @@ func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 }
 
 func TestHeadLabelValuesWithMatchers(t *testing.T) {
+	t.Parallel()
+
 	head, _ := newTestHead(t, 1000, false)
 	t.Cleanup(func() { require.NoError(t, head.Close()) })
 
@@ -2037,7 +2115,11 @@ func TestHeadLabelValuesWithMatchers(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			headIdxReader := head.indexRange(0, 200)
 
 			actualValues, err := headIdxReader.SortedLabelValues(tt.labelName, tt.matchers...)
@@ -2053,6 +2135,8 @@ func TestHeadLabelValuesWithMatchers(t *testing.T) {
 }
 
 func TestHeadLabelNamesWithMatchers(t *testing.T) {
+	t.Parallel()
+
 	head, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, head.Close())
@@ -2121,6 +2205,8 @@ func TestHeadLabelNamesWithMatchers(t *testing.T) {
 }
 
 func TestErrReuseAppender(t *testing.T) {
+	t.Parallel()
+
 	head, _ := newTestHead(t, 1000, false)
 	defer func() {
 		require.NoError(t, head.Close())
@@ -2156,6 +2242,8 @@ func TestErrReuseAppender(t *testing.T) {
 }
 
 func TestHeadMintAfterTruncation(t *testing.T) {
+	t.Parallel()
+
 	chunkRange := int64(2000)
 	head, _ := newTestHead(t, chunkRange, false)
 
@@ -2190,6 +2278,8 @@ func TestHeadMintAfterTruncation(t *testing.T) {
 }
 
 func TestHeadExemplars(t *testing.T) {
+	t.Parallel()
+
 	chunkRange := int64(2000)
 	head, _ := newTestHead(t, chunkRange, false)
 	app := head.Appender(context.Background())
@@ -2243,6 +2333,8 @@ func BenchmarkHeadLabelValuesWithMatchers(b *testing.B) {
 }
 
 func TestMemSafeIteratorSeekIntoBuffer(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "iterator_seek")
 	require.NoError(t, err)
 	defer func() {
@@ -2312,6 +2404,8 @@ func TestMemSafeIteratorSeekIntoBuffer(t *testing.T) {
 
 // Tests https://github.com/prometheus/prometheus/issues/8221.
 func TestChunkNotFoundHeadGCRace(t *testing.T) {
+	t.Parallel()
+
 	db := newTestDB(t)
 	db.DisableCompactions()
 
@@ -2377,6 +2471,8 @@ func TestChunkNotFoundHeadGCRace(t *testing.T) {
 
 // Tests https://github.com/prometheus/prometheus/issues/9079.
 func TestDataMissingOnQueryDuringCompaction(t *testing.T) {
+	t.Parallel()
+
 	db := newTestDB(t)
 	db.DisableCompactions()
 
@@ -2424,6 +2520,8 @@ func TestDataMissingOnQueryDuringCompaction(t *testing.T) {
 }
 
 func TestIsQuerierCollidingWithTruncation(t *testing.T) {
+	t.Parallel()
+
 	db := newTestDB(t)
 	db.DisableCompactions()
 
@@ -2469,6 +2567,8 @@ func TestIsQuerierCollidingWithTruncation(t *testing.T) {
 }
 
 func TestWaitForPendingReadersInTimeRange(t *testing.T) {
+	t.Parallel()
+
 	db := newTestDB(t)
 	db.DisableCompactions()
 
@@ -2526,6 +2626,8 @@ func TestWaitForPendingReadersInTimeRange(t *testing.T) {
 }
 
 func TestChunkSnapshot(t *testing.T) {
+	t.Parallel()
+
 	head, _ := newTestHead(t, 120*4, false)
 	defer func() {
 		head.opts.EnableMemorySnapshotOnShutdown = false
@@ -2768,6 +2870,8 @@ func TestChunkSnapshot(t *testing.T) {
 }
 
 func TestSnapshotError(t *testing.T) {
+	t.Parallel()
+
 	head, _ := newTestHead(t, 120*4, false)
 	defer func() {
 		head.opts.EnableMemorySnapshotOnShutdown = false

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -137,6 +137,8 @@ func (m mockIndex) Series(ref storage.SeriesRef, lset *labels.Labels, chks *[]ch
 }
 
 func TestIndexRW_Create_Open(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "test_index_create")
 	require.NoError(t, err)
 	defer func() {
@@ -166,6 +168,8 @@ func TestIndexRW_Create_Open(t *testing.T) {
 }
 
 func TestIndexRW_Postings(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "test_index_postings")
 	require.NoError(t, err)
 	defer func() {
@@ -250,6 +254,8 @@ func TestIndexRW_Postings(t *testing.T) {
 }
 
 func TestPostingsMany(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "test_postings_many")
 	require.NoError(t, err)
 	defer func() {
@@ -344,6 +350,8 @@ func TestPostingsMany(t *testing.T) {
 }
 
 func TestPersistence_index_e2e(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "test_persistence_e2e")
 	require.NoError(t, err)
 	defer func() {
@@ -486,6 +494,8 @@ func TestPersistence_index_e2e(t *testing.T) {
 }
 
 func TestDecbufUvarintWithInvalidBuffer(t *testing.T) {
+	t.Parallel()
+
 	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
 
 	db := encoding.NewDecbufUvarintAt(b, 0, castagnoliTable)
@@ -493,6 +503,8 @@ func TestDecbufUvarintWithInvalidBuffer(t *testing.T) {
 }
 
 func TestReaderWithInvalidBuffer(t *testing.T) {
+	t.Parallel()
+
 	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
 
 	_, err := NewReader(b)
@@ -501,6 +513,8 @@ func TestReaderWithInvalidBuffer(t *testing.T) {
 
 // TestNewFileReaderErrorNoOpenFiles ensures that in case of an error no file remains open.
 func TestNewFileReaderErrorNoOpenFiles(t *testing.T) {
+	t.Parallel()
+
 	dir := testutil.NewTemporaryDirectory("block", t)
 
 	idxName := filepath.Join(dir.Path(), "index")
@@ -515,6 +529,8 @@ func TestNewFileReaderErrorNoOpenFiles(t *testing.T) {
 }
 
 func TestSymbols(t *testing.T) {
+	t.Parallel()
+
 	buf := encoding.Encbuf{}
 
 	// Add prefix to the buffer to simulate symbols as part of larger buffer.

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestMemPostings_addFor(t *testing.T) {
+	t.Parallel()
+
 	p := NewMemPostings()
 	p.m[allPostingsKey.Name] = map[string][]storage.SeriesRef{}
 	p.m[allPostingsKey.Name][allPostingsKey.Value] = []storage.SeriesRef{1, 2, 3, 4, 6, 7, 8}
@@ -38,6 +40,8 @@ func TestMemPostings_addFor(t *testing.T) {
 }
 
 func TestMemPostings_ensureOrder(t *testing.T) {
+	t.Parallel()
+
 	p := NewUnorderedMemPostings()
 	p.m["a"] = map[string][]storage.SeriesRef{}
 
@@ -119,6 +123,8 @@ func BenchmarkMemPostings_ensureOrder(b *testing.B) {
 }
 
 func TestIntersect(t *testing.T) {
+	t.Parallel()
+
 	a := newListPostings(1, 2, 3)
 	b := newListPostings(2, 3, 4)
 
@@ -210,7 +216,11 @@ func TestIntersect(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		c := c
+
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
 			if c.res == nil {
 				t.Fatal("intersect result expectancy cannot be nil")
 			}
@@ -237,6 +247,8 @@ func TestIntersect(t *testing.T) {
 }
 
 func TestMultiIntersect(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		p   [][]storage.SeriesRef
 		res []storage.SeriesRef
@@ -365,6 +377,8 @@ func BenchmarkIntersect(t *testing.B) {
 }
 
 func TestMultiMerge(t *testing.T) {
+	t.Parallel()
+
 	i1 := newListPostings(1, 2, 3, 4, 5, 6, 1000, 1001)
 	i2 := newListPostings(2, 4, 5, 6, 7, 8, 999, 1001)
 	i3 := newListPostings(1, 2, 5, 6, 7, 8, 1001, 1200)
@@ -375,6 +389,8 @@ func TestMultiMerge(t *testing.T) {
 }
 
 func TestMergedPostings(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		in []Postings
 
@@ -452,7 +468,11 @@ func TestMergedPostings(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		c := c
+
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
 			if c.res == nil {
 				t.Fatal("merge result expectancy cannot be nil")
 			}
@@ -479,6 +499,8 @@ func TestMergedPostings(t *testing.T) {
 }
 
 func TestMergedPostingsSeek(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		a, b []storage.SeriesRef
 
@@ -541,6 +563,8 @@ func TestMergedPostingsSeek(t *testing.T) {
 }
 
 func TestRemovedPostings(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		a, b []storage.SeriesRef
 		res  []storage.SeriesRef
@@ -593,6 +617,8 @@ func TestRemovedPostings(t *testing.T) {
 }
 
 func TestRemovedNextStackoverflow(t *testing.T) {
+	t.Parallel()
+
 	var full []storage.SeriesRef
 	var remove []storage.SeriesRef
 
@@ -615,6 +641,8 @@ func TestRemovedNextStackoverflow(t *testing.T) {
 }
 
 func TestRemovedPostingsSeek(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		a, b []storage.SeriesRef
 
@@ -701,6 +729,8 @@ func TestRemovedPostingsSeek(t *testing.T) {
 }
 
 func TestBigEndian(t *testing.T) {
+	t.Parallel()
+
 	num := 1000
 	// mock a list as postings
 	ls := make([]uint32, num)
@@ -716,6 +746,8 @@ func TestBigEndian(t *testing.T) {
 	}
 
 	t.Run("Iteration", func(t *testing.T) {
+		t.Parallel()
+
 		bep := newBigEndianPostings(beLst)
 		for i := 0; i < num; i++ {
 			require.True(t, bep.Next())
@@ -727,6 +759,8 @@ func TestBigEndian(t *testing.T) {
 	})
 
 	t.Run("Seek", func(t *testing.T) {
+		t.Parallel()
+
 		table := []struct {
 			seek  uint32
 			val   uint32
@@ -775,6 +809,8 @@ func TestBigEndian(t *testing.T) {
 }
 
 func TestIntersectWithMerge(t *testing.T) {
+	t.Parallel()
+
 	// One of the reproducible cases for:
 	// https://github.com/prometheus/prometheus/issues/2616
 	a := newListPostings(21, 22, 23, 24, 25, 30)
@@ -792,6 +828,8 @@ func TestIntersectWithMerge(t *testing.T) {
 }
 
 func TestWithoutPostings(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		base Postings
 		drop Postings
@@ -843,7 +881,11 @@ func TestWithoutPostings(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		c := c
+
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
 			if c.res == nil {
 				t.Fatal("without result expectancy cannot be nil")
 			}
@@ -901,6 +943,8 @@ func BenchmarkPostings_Stats(b *testing.B) {
 }
 
 func TestMemPostings_Delete(t *testing.T) {
+	t.Parallel()
+
 	p := NewMemPostings()
 	p.Add(1, labels.FromStrings("lbl1", "a"))
 	p.Add(2, labels.FromStrings("lbl1", "b"))

--- a/tsdb/index/postingsstats_test.go
+++ b/tsdb/index/postingsstats_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestPostingsStats(t *testing.T) {
+	t.Parallel()
+
 	stats := &maxHeap{}
 	max := 3000000
 	heapLength := 10
@@ -40,6 +42,8 @@ func TestPostingsStats(t *testing.T) {
 }
 
 func TestPostingsStats2(t *testing.T) {
+	t.Parallel()
+
 	stats := &maxHeap{}
 	heapLength := 10
 

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -243,6 +243,8 @@ func testBlockQuerier(t *testing.T, c blockQuerierTestCase, ir IndexReader, cr C
 }
 
 func TestBlockQuerier(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []blockQuerierTestCase{
 		{
 			mint:    0,
@@ -371,7 +373,10 @@ func TestBlockQuerier(t *testing.T) {
 			}),
 		},
 	} {
+		c := c
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
 			ir, cr, _, _ := createIdxChkReaders(t, testData)
 			testBlockQuerier(t, c, ir, cr, tombstones.NewMemTombstones())
 		})
@@ -379,6 +384,8 @@ func TestBlockQuerier(t *testing.T) {
 }
 
 func TestBlockQuerier_AgainstHeadWithOpenChunks(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range []blockQuerierTestCase{
 		{
 			mint:    0,
@@ -457,7 +464,10 @@ func TestBlockQuerier_AgainstHeadWithOpenChunks(t *testing.T) {
 			}),
 		},
 	} {
+		c := c
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
 			opts := DefaultHeadOptions()
 			opts.ChunkRange = 2 * time.Hour.Milliseconds()
 			h, err := NewHead(nil, nil, nil, opts, nil)
@@ -514,6 +524,8 @@ var testData = []seriesSamples{
 }
 
 func TestBlockQuerierDelete(t *testing.T) {
+	t.Parallel()
+
 	stones := tombstones.NewTestMemTombstones([]tombstones.Intervals{
 		{{Mint: 1, Maxt: 3}},
 		{{Mint: 1, Maxt: 3}, {Mint: 6, Maxt: 10}},
@@ -598,7 +610,10 @@ func TestBlockQuerierDelete(t *testing.T) {
 			}),
 		},
 	} {
+		c := c
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
 			ir, cr, _, _ := createIdxChkReaders(t, testData)
 			testBlockQuerier(t, c, ir, cr, stones)
 		})
@@ -638,6 +653,8 @@ func (r *fakeChunksReader) Chunk(ref chunks.ChunkRef) (chunkenc.Chunk, error) {
 }
 
 func TestPopulateWithTombSeriesIterators(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name string
 		chks [][]tsdbutil.Sample
@@ -857,8 +874,13 @@ func TestPopulateWithTombSeriesIterators(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			t.Run("sample", func(t *testing.T) {
+				t.Parallel()
+
 				f, chkMetas := createFakeReaderAndNotPopulatedChunks(tc.chks...)
 				it := newPopulateWithDelGenericSeriesIterator(f, chkMetas, tc.intervals).toSeriesIterator()
 
@@ -879,6 +901,8 @@ func TestPopulateWithTombSeriesIterators(t *testing.T) {
 				require.Equal(t, tc.expected, r)
 			})
 			t.Run("chunk", func(t *testing.T) {
+				t.Parallel()
+
 				f, chkMetas := createFakeReaderAndNotPopulatedChunks(tc.chks...)
 				it := newPopulateWithDelGenericSeriesIterator(f, chkMetas, tc.intervals).toChunkSeriesIterator()
 
@@ -906,6 +930,8 @@ func rmChunkRefs(chks []chunks.Meta) {
 
 // Regression for: https://github.com/prometheus/tsdb/pull/97
 func TestPopulateWithDelSeriesIterator_DoubleSeek(t *testing.T) {
+	t.Parallel()
+
 	f, chkMetas := createFakeReaderAndNotPopulatedChunks(
 		[]tsdbutil.Sample{},
 		[]tsdbutil.Sample{sample{1, 1}, sample{2, 2}, sample{3, 3}},
@@ -924,6 +950,8 @@ func TestPopulateWithDelSeriesIterator_DoubleSeek(t *testing.T) {
 // Regression when seeked chunks were still found via binary search and we always
 // skipped to the end when seeking a value in the current chunk.
 func TestPopulateWithDelSeriesIterator_SeekInCurrentChunk(t *testing.T) {
+	t.Parallel()
+
 	f, chkMetas := createFakeReaderAndNotPopulatedChunks(
 		[]tsdbutil.Sample{},
 		[]tsdbutil.Sample{sample{1, 2}, sample{3, 4}, sample{5, 6}, sample{7, 8}},
@@ -943,6 +971,8 @@ func TestPopulateWithDelSeriesIterator_SeekInCurrentChunk(t *testing.T) {
 }
 
 func TestPopulateWithDelSeriesIterator_SeekWithMinTime(t *testing.T) {
+	t.Parallel()
+
 	f, chkMetas := createFakeReaderAndNotPopulatedChunks(
 		[]tsdbutil.Sample{sample{1, 6}, sample{5, 6}, sample{6, 8}},
 	)
@@ -955,6 +985,8 @@ func TestPopulateWithDelSeriesIterator_SeekWithMinTime(t *testing.T) {
 // Regression when calling Next() with a time bounded to fit within two samples.
 // Seek gets called and advances beyond the max time, which was just accepted as a valid sample.
 func TestPopulateWithDelSeriesIterator_NextWithMinTime(t *testing.T) {
+	t.Parallel()
+
 	f, chkMetas := createFakeReaderAndNotPopulatedChunks(
 		[]tsdbutil.Sample{sample{1, 6}, sample{5, 6}, sample{7, 8}},
 	)
@@ -1032,6 +1064,8 @@ func (cr mockChunkReader) Close() error {
 }
 
 func TestDeletedIterator(t *testing.T) {
+	t.Parallel()
+
 	chk := chunkenc.NewXORChunk()
 	app, err := chk.Appender()
 	require.NoError(t, err)
@@ -1092,6 +1126,8 @@ func TestDeletedIterator(t *testing.T) {
 }
 
 func TestDeletedIterator_WithSeek(t *testing.T) {
+	t.Parallel()
+
 	chk := chunkenc.NewXORChunk()
 	app, err := chk.Appender()
 	require.NoError(t, err)
@@ -1592,6 +1628,8 @@ func BenchmarkSetMatcher(b *testing.B) {
 
 // Refer to https://github.com/prometheus/prometheus/issues/2651.
 func TestFindSetMatches(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		pattern string
 		exp     []string
@@ -1654,6 +1692,8 @@ func TestFindSetMatches(t *testing.T) {
 }
 
 func TestPostingsForMatchers(t *testing.T) {
+	t.Parallel()
+
 	chunkDir, err := ioutil.TempDir("", "chunk_dir")
 	require.NoError(t, err)
 	defer func() {
@@ -1915,6 +1955,8 @@ func TestPostingsForMatchers(t *testing.T) {
 
 // TestClose ensures that calling Close more than once doesn't block and doesn't panic.
 func TestClose(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "test_storage")
 	if err != nil {
 		t.Fatalf("Opening test dir failed: %s", err)
@@ -2110,6 +2152,8 @@ func (m mockMatcherIndex) LabelNames(...*labels.Matcher) ([]string, error) {
 }
 
 func TestPostingsForMatcher(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		matcher  *labels.Matcher
 		hasError bool
@@ -2147,6 +2191,8 @@ func TestPostingsForMatcher(t *testing.T) {
 }
 
 func TestBlockBaseSeriesSet(t *testing.T) {
+	t.Parallel()
+
 	type refdSeries struct {
 		lset   labels.Labels
 		chunks []chunks.Meta

--- a/tsdb/record/record_test.go
+++ b/tsdb/record/record_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestRecord_EncodeDecode(t *testing.T) {
+	t.Parallel()
+
 	var enc Encoder
 	var dec Decoder
 
@@ -88,10 +90,14 @@ func TestRecord_EncodeDecode(t *testing.T) {
 // TestRecord_Corrupted ensures that corrupted records return the correct error.
 // Bugfix check for pull/521 and pull/523.
 func TestRecord_Corrupted(t *testing.T) {
+	t.Parallel()
+
 	var enc Encoder
 	var dec Decoder
 
 	t.Run("Test corrupted series record", func(t *testing.T) {
+		t.Parallel()
+
 		series := []RefSeries{
 			{
 				Ref:    100,
@@ -105,6 +111,8 @@ func TestRecord_Corrupted(t *testing.T) {
 	})
 
 	t.Run("Test corrupted sample record", func(t *testing.T) {
+		t.Parallel()
+
 		samples := []RefSample{
 			{Ref: 0, T: 12423423, V: 1.2345},
 		}
@@ -115,6 +123,8 @@ func TestRecord_Corrupted(t *testing.T) {
 	})
 
 	t.Run("Test corrupted tombstone record", func(t *testing.T) {
+		t.Parallel()
+
 		tstones := []tombstones.Stone{
 			{Ref: 123, Intervals: tombstones.Intervals{
 				{Mint: -1000, Maxt: 1231231},
@@ -128,6 +138,8 @@ func TestRecord_Corrupted(t *testing.T) {
 	})
 
 	t.Run("Test corrupted exemplar record", func(t *testing.T) {
+		t.Parallel()
+
 		exemplars := []RefExemplar{
 			{Ref: 0, T: 12423423, V: 1.2345, Labels: labels.FromStrings("traceID", "asdf")},
 		}
@@ -139,6 +151,8 @@ func TestRecord_Corrupted(t *testing.T) {
 }
 
 func TestRecord_Type(t *testing.T) {
+	t.Parallel()
+
 	var enc Encoder
 	var dec Decoder
 

--- a/tsdb/repair_test.go
+++ b/tsdb/repair_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestRepairBadIndexVersion(t *testing.T) {
+	t.Parallel()
+
 	tmpDir, err := ioutil.TempDir("", "test")
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tsdb/tombstones/tombstones_test.go
+++ b/tsdb/tombstones/tombstones_test.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -34,6 +35,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestWriteAndReadbackTombstones(t *testing.T) {
+	t.Parallel()
+
 	tmpdir, _ := ioutil.TempDir("", "test")
 	defer func() {
 		require.NoError(t, os.RemoveAll(tmpdir))
@@ -66,6 +69,8 @@ func TestWriteAndReadbackTombstones(t *testing.T) {
 }
 
 func TestDeletingTombstones(t *testing.T) {
+	t.Parallel()
+
 	stones := NewMemTombstones()
 
 	ref := storage.SeriesRef(42)
@@ -87,6 +92,8 @@ func TestDeletingTombstones(t *testing.T) {
 }
 
 func TestTruncateBefore(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		before  Intervals
 		beforeT int64
@@ -126,6 +133,8 @@ func TestTruncateBefore(t *testing.T) {
 }
 
 func TestAddingNewIntervals(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		exist Intervals
 		new   Interval
@@ -217,8 +226,12 @@ func TestAddingNewIntervals(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
-		t.Run("", func(t *testing.T) {
+	for i, c := range cases {
+		c := c
+
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, c.exp, c.exist.Add(c.new))
 		})
 	}
@@ -226,6 +239,8 @@ func TestAddingNewIntervals(t *testing.T) {
 
 // TestMemTombstonesConcurrency to make sure they are safe to access from different goroutines.
 func TestMemTombstonesConcurrency(t *testing.T) {
+	t.Parallel()
+
 	tomb := NewMemTombstones()
 	totalRuns := 100
 	var wg sync.WaitGroup

--- a/tsdb/tsdbutil/buffer_test.go
+++ b/tsdb/tsdbutil/buffer_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestSampleRing(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		input []int64
 		delta int64
@@ -83,6 +85,8 @@ func TestSampleRing(t *testing.T) {
 }
 
 func TestBufferedSeriesIterator(t *testing.T) {
+	t.Parallel()
+
 	var it *BufferedSeriesIterator
 
 	bufferEq := func(exp []sample) {

--- a/tsdb/wal/checkpoint_test.go
+++ b/tsdb/wal/checkpoint_test.go
@@ -32,6 +32,8 @@ import (
 )
 
 func TestLastCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	_, _, err := LastCheckpoint(dir)
@@ -75,6 +77,8 @@ func TestLastCheckpoint(t *testing.T) {
 }
 
 func TestDeleteCheckpoints(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	require.NoError(t, DeleteCheckpoints(dir, 0))
@@ -110,8 +114,14 @@ func TestDeleteCheckpoints(t *testing.T) {
 }
 
 func TestCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	for _, compress := range []bool{false, true} {
+		compress := compress
+
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
 
 			var enc record.Encoder
@@ -228,6 +238,8 @@ func TestCheckpoint(t *testing.T) {
 }
 
 func TestCheckpointNoTmpFolderAfterError(t *testing.T) {
+	t.Parallel()
+
 	// Create a new wal with invalid data.
 	dir := t.TempDir()
 	w, err := NewSize(nil, nil, dir, 64*1024, false)

--- a/tsdb/wal/reader_test.go
+++ b/tsdb/wal/reader_test.go
@@ -169,9 +169,16 @@ func encodedRecord(t recType, b []byte) []byte {
 
 // TestReader feeds the reader a stream of encoded records with different types.
 func TestReader(t *testing.T) {
+	t.Parallel()
+
 	for name, fn := range readerConstructors {
+		fn := fn
 		for i, c := range testReaderCases {
+			c := c
+
 			t.Run(fmt.Sprintf("%s/%d", name, i), func(t *testing.T) {
+				t.Parallel()
+
 				var buf []byte
 				for _, r := range c.t {
 					buf = append(buf, encodedRecord(r.t, r.b)...)
@@ -199,10 +206,14 @@ func TestReader(t *testing.T) {
 }
 
 func TestReader_Live(t *testing.T) {
+	t.Parallel()
+
 	logger := testutil.NewLogger(t)
 
 	for i := range testReaderCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
 			writeFd, err := ioutil.TempFile("", "TestReader_Live")
 			require.NoError(t, err)
 			defer os.Remove(writeFd.Name())
@@ -310,9 +321,17 @@ func allSegments(dir string) (io.ReadCloser, error) {
 }
 
 func TestReaderFuzz(t *testing.T) {
+	t.Parallel()
+
 	for name, fn := range readerConstructors {
+		fn := fn
+
 		for _, compress := range []bool{false, true} {
+			compress := compress
+
 			t.Run(fmt.Sprintf("%s,compress=%t", name, compress), func(t *testing.T) {
+				t.Parallel()
+
 				dir := t.TempDir()
 
 				w, err := NewSize(nil, nil, dir, 128*pageSize, compress)
@@ -349,9 +368,14 @@ func TestReaderFuzz(t *testing.T) {
 }
 
 func TestReaderFuzz_Live(t *testing.T) {
+	t.Parallel()
+
 	logger := testutil.NewLogger(t)
+
 	for _, compress := range []bool{false, true} {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
 
 			w, err := NewSize(nil, nil, dir, 128*pageSize, compress)
@@ -435,6 +459,8 @@ func TestReaderFuzz_Live(t *testing.T) {
 }
 
 func TestLiveReaderCorrupt_ShortFile(t *testing.T) {
+	t.Parallel()
+
 	// Write a corrupt WAL segment, there is one record of pageSize in length,
 	// but the segment is only half written.
 	logger := testutil.NewLogger(t)
@@ -476,6 +502,8 @@ func TestLiveReaderCorrupt_ShortFile(t *testing.T) {
 }
 
 func TestLiveReaderCorrupt_RecordTooLongAndShort(t *testing.T) {
+	t.Parallel()
+
 	// Write a corrupt WAL segment, when record len > page size.
 	logger := testutil.NewLogger(t)
 	dir := t.TempDir()
@@ -520,13 +548,19 @@ func TestLiveReaderCorrupt_RecordTooLongAndShort(t *testing.T) {
 }
 
 func TestReaderData(t *testing.T) {
+	t.Parallel()
+
 	dir := os.Getenv("WALDIR")
 	if dir == "" {
 		return
 	}
 
 	for name, fn := range readerConstructors {
+		fn := fn
+
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			w, err := New(nil, nil, dir, true)
 			require.NoError(t, err)
 

--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -38,6 +38,8 @@ func TestMain(m *testing.M) {
 // TestWALRepair_ReadingError ensures that a repair is run for an error
 // when reading a record.
 func TestWALRepair_ReadingError(t *testing.T) {
+	t.Parallel()
+
 	for name, test := range map[string]struct {
 		corrSgm    int              // Which segment to corrupt.
 		corrFunc   func(f *os.File) // Func that applies the corruption.
@@ -117,7 +119,11 @@ func TestWALRepair_ReadingError(t *testing.T) {
 			4,
 		},
 	} {
+		test := test
+
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
 
 			// We create 3 segments with 3 records each and
@@ -212,6 +218,8 @@ func TestWALRepair_ReadingError(t *testing.T) {
 // ensures that an error during reading that segment are correctly repaired before
 // moving to write more records to the WAL.
 func TestCorruptAndCarryOn(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	var (
@@ -336,6 +344,8 @@ func TestCorruptAndCarryOn(t *testing.T) {
 
 // TestClose ensures that calling Close more than once doesn't panic and doesn't block.
 func TestClose(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	w, err := NewSize(nil, nil, dir, pageSize, false)
 	require.NoError(t, err)
@@ -344,6 +354,8 @@ func TestClose(t *testing.T) {
 }
 
 func TestSegmentMetric(t *testing.T) {
+	t.Parallel()
+
 	var (
 		segmentSize = pageSize
 		recordSize  = (pageSize / 2) - recordHeaderSize
@@ -369,6 +381,8 @@ func TestSegmentMetric(t *testing.T) {
 }
 
 func TestCompression(t *testing.T) {
+	t.Parallel()
+
 	bootstrap := func(compressed bool) string {
 		const (
 			segmentSize = pageSize
@@ -408,6 +422,8 @@ func TestCompression(t *testing.T) {
 }
 
 func TestLogPartialWrite(t *testing.T) {
+	t.Parallel()
+
 	const segmentSize = pageSize * 2
 	record := []byte{1, 2, 3, 4, 5}
 
@@ -435,7 +451,11 @@ func TestLogPartialWrite(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
+
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
 			dirPath := t.TempDir()
 
 			w, err := NewSize(nil, nil, dirPath, segmentSize, false)

--- a/tsdb/wal/watcher_test.go
+++ b/tsdb/wal/watcher_test.go
@@ -104,12 +104,18 @@ func newWriteToMock() *writeToMock {
 }
 
 func TestTailSamples(t *testing.T) {
+	t.Parallel()
+
 	pageSize := 32 * 1024
 	const seriesCount = 10
 	const samplesCount = 250
 	const exemplarsCount = 25
 	for _, compress := range []bool{false, true} {
+		compress := compress
+
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
+			t.Parallel()
+
 			now := time.Now()
 
 			dir := t.TempDir()
@@ -196,13 +202,20 @@ func TestTailSamples(t *testing.T) {
 }
 
 func TestReadToEndNoCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	pageSize := 32 * 1024
 	const seriesCount = 10
 	const samplesCount = 250
 
 	for _, compress := range []bool{false, true} {
+		compress := compress
+
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
+
 			wdir := path.Join(dir, "wal")
 			err := os.Mkdir(wdir, 0o777)
 			require.NoError(t, err)
@@ -263,6 +276,8 @@ func TestReadToEndNoCheckpoint(t *testing.T) {
 }
 
 func TestReadToEndWithCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	segmentSize := 32 * 1024
 	// We need something similar to this # of series and samples
 	// in order to get enough segments for us to checkpoint.
@@ -270,7 +285,11 @@ func TestReadToEndWithCheckpoint(t *testing.T) {
 	const samplesCount = 250
 
 	for _, compress := range []bool{false, true} {
+		compress := compress
+
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
 
 			wdir := path.Join(dir, "wal")
@@ -352,12 +371,18 @@ func TestReadToEndWithCheckpoint(t *testing.T) {
 }
 
 func TestReadCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	pageSize := 32 * 1024
 	const seriesCount = 10
 	const samplesCount = 250
 
 	for _, compress := range []bool{false, true} {
+		compress := compress
+
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
 
 			wdir := path.Join(dir, "wal")
@@ -418,6 +443,8 @@ func TestReadCheckpoint(t *testing.T) {
 }
 
 func TestReadCheckpointMultipleSegments(t *testing.T) {
+	t.Parallel()
+
 	pageSize := 32 * 1024
 
 	const segments = 1
@@ -425,7 +452,11 @@ func TestReadCheckpointMultipleSegments(t *testing.T) {
 	const samplesCount = 300
 
 	for _, compress := range []bool{false, true} {
+		compress := compress
+
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
 
 			wdir := path.Join(dir, "wal")
@@ -489,6 +520,8 @@ func TestReadCheckpointMultipleSegments(t *testing.T) {
 }
 
 func TestCheckpointSeriesReset(t *testing.T) {
+	t.Parallel()
+
 	segmentSize := 32 * 1024
 	// We need something similar to this # of series and samples
 	// in order to get enough segments for us to checkpoint.
@@ -503,7 +536,11 @@ func TestCheckpointSeriesReset(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(fmt.Sprintf("compress=%t", tc.compress), func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
 
 			wdir := path.Join(dir, "wal")

--- a/tsdb/wal_test.go
+++ b/tsdb/wal_test.go
@@ -393,7 +393,11 @@ func TestWALRestoreCorrupted(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
+		c := c
+
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			// Generate testing data. It does not make semantic sense but
 			// for the purpose of this test.
 			dir, err := ioutil.TempDir("", "test_corrupted")

--- a/tsdb/wal_test.go
+++ b/tsdb/wal_test.go
@@ -39,6 +39,8 @@ import (
 )
 
 func TestSegmentWAL_cut(t *testing.T) {
+	t.Parallel()
+
 	tmpdir, err := ioutil.TempDir("", "test_wal_cut")
 	require.NoError(t, err)
 	defer func() {
@@ -82,6 +84,8 @@ func TestSegmentWAL_cut(t *testing.T) {
 }
 
 func TestSegmentWAL_Truncate(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numMetrics = 20000
 		batch      = 100
@@ -162,6 +166,8 @@ func TestSegmentWAL_Truncate(t *testing.T) {
 
 // Symmetrical test of reading and writing to the WAL via its main interface.
 func TestSegmentWAL_Log_Restore(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numMetrics = 50
 		iterations = 5
@@ -281,6 +287,8 @@ func TestSegmentWAL_Log_Restore(t *testing.T) {
 }
 
 func TestWALRestoreCorrupted_invalidSegment(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "test_wal_log_restore")
 	require.NoError(t, err)
 	defer func() {
@@ -321,6 +329,8 @@ func TestWALRestoreCorrupted_invalidSegment(t *testing.T) {
 
 // Test reading from a WAL that has been corrupted through various means.
 func TestWALRestoreCorrupted(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name string
 		f    func(*testing.T, *SegmentWAL)
@@ -464,6 +474,8 @@ func TestWALRestoreCorrupted(t *testing.T) {
 }
 
 func TestMigrateWAL_Empty(t *testing.T) {
+	t.Parallel()
+
 	// The migration procedure must properly deal with a zero-length segment,
 	// which is valid in the new format.
 	dir, err := ioutil.TempDir("", "walmigrate")
@@ -483,6 +495,8 @@ func TestMigrateWAL_Empty(t *testing.T) {
 }
 
 func TestMigrateWAL_Fuzz(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "walmigrate")
 	require.NoError(t, err)
 	defer func() {

--- a/util/httputil/compression_test.go
+++ b/util/httputil/compression_test.go
@@ -48,6 +48,7 @@ func getCompressionHandlerFunc() CompressionHandler {
 	}
 }
 
+//nolint:paralleltest // TODO: Tests use global mux and server right now.
 func TestCompressionHandler_PlainText(t *testing.T) {
 	tearDown := setup()
 	defer tearDown()
@@ -72,6 +73,7 @@ func TestCompressionHandler_PlainText(t *testing.T) {
 	require.Equal(t, expected, actual, "expected response with content")
 }
 
+//nolint:paralleltest // TODO: Tests use global mux and server right now.
 func TestCompressionHandler_Gzip(t *testing.T) {
 	tearDown := setup()
 	defer tearDown()
@@ -107,6 +109,7 @@ func TestCompressionHandler_Gzip(t *testing.T) {
 	require.Equal(t, expected, actual, "unexpected response content")
 }
 
+//nolint:paralleltest // TODO: Tests use global mux and server right now.
 func TestCompressionHandler_Deflate(t *testing.T) {
 	tearDown := setup()
 	defer tearDown()

--- a/util/httputil/cors_test.go
+++ b/util/httputil/cors_test.go
@@ -31,6 +31,8 @@ func getCORSHandlerFunc() http.Handler {
 }
 
 func TestCORSHandler(t *testing.T) {
+	t.Parallel()
+
 	tearDown := setup()
 	defer tearDown()
 	client := &http.Client{}

--- a/util/logging/dedupe_test.go
+++ b/util/logging/dedupe_test.go
@@ -28,6 +28,8 @@ func (c *counter) Log(keyvals ...interface{}) error {
 }
 
 func TestDedupe(t *testing.T) {
+	t.Parallel()
+
 	var c counter
 	d := Dedupe(&c, 100*time.Millisecond)
 	defer d.Stop()

--- a/util/logging/file_test.go
+++ b/util/logging/file_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestJSONFileLogger_basic(t *testing.T) {
+	t.Parallel()
+
 	f, err := ioutil.TempFile("", "logging")
 	require.NoError(t, err)
 	defer func() {
@@ -53,6 +55,8 @@ func TestJSONFileLogger_basic(t *testing.T) {
 }
 
 func TestJSONFileLogger_parallel(t *testing.T) {
+	t.Parallel()
+
 	f, err := ioutil.TempFile("", "logging")
 	require.NoError(t, err)
 	defer func() {

--- a/util/pool/pool_test.go
+++ b/util/pool/pool_test.go
@@ -24,6 +24,8 @@ func makeFunc(size int) interface{} {
 }
 
 func TestPool(t *testing.T) {
+	t.Parallel()
+
 	testPool := New(1, 8, 2, makeFunc)
 	cases := []struct {
 		size        int

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestTimerGroupNewTimer(t *testing.T) {
+	t.Parallel()
+
 	tg := NewTimerGroup()
 	timer := tg.GetTimer(ExecTotalTime)
 	duration := timer.Duration()
@@ -42,6 +44,8 @@ func TestTimerGroupNewTimer(t *testing.T) {
 }
 
 func TestQueryStatsWithTimers(t *testing.T) {
+	t.Parallel()
+
 	qt := NewQueryTimers()
 	timer := qt.GetTimer(ExecTotalTime)
 	timer.Start()
@@ -58,6 +62,8 @@ func TestQueryStatsWithTimers(t *testing.T) {
 }
 
 func TestQueryStatsWithSpanTimers(t *testing.T) {
+	t.Parallel()
+
 	qt := NewQueryTimers()
 	ctx := &testutil.MockContext{DoneCh: make(chan struct{})}
 	qst, _ := qt.GetSpanTimer(ctx, ExecQueueTime, prometheus.NewSummary(prometheus.SummaryOpts{}))
@@ -73,6 +79,8 @@ func TestQueryStatsWithSpanTimers(t *testing.T) {
 }
 
 func TestTimerGroup(t *testing.T) {
+	t.Parallel()
+
 	tg := NewTimerGroup()
 	require.Equal(t, "Exec total time: 0s", tg.GetTimer(ExecTotalTime).String())
 

--- a/util/strutil/quote_test.go
+++ b/util/strutil/quote_test.go
@@ -108,6 +108,8 @@ var misquoted = []string{
 }
 
 func TestUnquote(t *testing.T) {
+	t.Parallel()
+
 	for _, tt := range unquotetests {
 		out, err := Unquote(tt.in)
 		if err != nil {

--- a/util/strutil/strconv_test.go
+++ b/util/strutil/strconv_test.go
@@ -39,6 +39,8 @@ var linkTests = []linkTest{
 }
 
 func TestLink(t *testing.T) {
+	t.Parallel()
+
 	for _, tt := range linkTests {
 		graphLink := GraphLinkForExpression(tt.expression)
 		require.Equal(t, tt.expectedGraphLink, graphLink,
@@ -51,6 +53,8 @@ func TestLink(t *testing.T) {
 }
 
 func TestSanitizeLabelName(t *testing.T) {
+	t.Parallel()
+
 	actual := SanitizeLabelName("fooClientLABEL")
 	expected := "fooClientLABEL"
 	require.Equal(t, expected, actual, "SanitizeLabelName failed for label (%s)", expected)

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -209,25 +209,27 @@ func TestFederation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer suite.Close()
+	t.Cleanup(func() { suite.Close() })
 
 	if err := suite.Run(); err != nil {
 		t.Fatal(err)
-	}
-
-	h := &Handler{
-		localStorage:  &dbAdapter{suite.TSDB()},
-		lookbackDelta: 5 * time.Minute,
-		now:           func() model.Time { return 101 * 60 * 1000 }, // 101min after epoch.
-		config: &config.Config{
-			GlobalConfig: config.GlobalConfig{},
-		},
 	}
 
 	for name, scenario := range scenarios {
 		scenario := scenario
 
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			h := &Handler{
+				localStorage:  &dbAdapter{suite.TSDB()},
+				lookbackDelta: 5 * time.Minute,
+				now:           func() model.Time { return 101 * 60 * 1000 }, // 101min after epoch.
+				config: &config.Config{
+					GlobalConfig: config.GlobalConfig{},
+				},
+			}
+
 			h.config.GlobalConfig.ExternalLabels = scenario.externalLabels
 			req := httptest.NewRequest("GET", "http://example.org/federate?"+scenario.params, nil)
 			res := httptest.NewRecorder()

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -195,6 +195,8 @@ test_metric_without_labels{instance="baz"} 1001 6000000
 }
 
 func TestFederation(t *testing.T) {
+	t.Parallel()
+
 	suite, err := promql.NewTest(t, `
 		load 1m
 			test_metric1{foo="bar",instance="i"}    0+100x100
@@ -223,6 +225,8 @@ func TestFederation(t *testing.T) {
 	}
 
 	for name, scenario := range scenarios {
+		scenario := scenario
+
 		t.Run(name, func(t *testing.T) {
 			h.config.GlobalConfig.ExternalLabels = scenario.externalLabels
 			req := httptest.NewRequest("GET", "http://example.org/federate?"+scenario.params, nil)
@@ -253,8 +257,14 @@ func (notReadyReadStorage) Stats(string) (*tsdb.Stats, error) {
 
 // Regression test for https://github.com/prometheus/prometheus/issues/7181.
 func TestFederation_NotReady(t *testing.T) {
+	t.Parallel()
+
 	for name, scenario := range scenarios {
+		scenario := scenario
+
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			h := &Handler{
 				localStorage:  notReadyReadStorage{},
 				lookbackDelta: 5 * time.Minute,

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -50,6 +50,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestGlobalURL(t *testing.T) {
+	t.Parallel()
+
 	opts := &Options{
 		ListenAddress: ":9090",
 		ExternalURL: &url.URL{
@@ -332,6 +334,8 @@ func TestRoutePrefix(t *testing.T) {
 }
 
 func TestDebugHandler(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		prefix, url string
 		code        int
@@ -404,6 +408,8 @@ func TestHTTPMetrics(t *testing.T) {
 }
 
 func TestShutdownWithStaleConnection(t *testing.T) {
+	t.Parallel()
+
 	dbDir, err := ioutil.TempDir("", "tsdb-ready")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(dbDir)) }()
@@ -480,6 +486,8 @@ func TestShutdownWithStaleConnection(t *testing.T) {
 }
 
 func TestHandleMultipleQuitRequests(t *testing.T) {
+	t.Parallel()
+
 	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
 
 	opts := &Options{


### PR DESCRIPTION
This PR parallelizes tests in packages, where test execution time is higher than ~20 seconds. Only tests which seem safe to parallelize are executed in parallel (e.g. #7770 gets flaky when executed in parallel). Except mentioned #7770 I did not hit any test flakiness due to this changes.

On my i7-8750H, this cuts down slow tests execution time to ~2 minutes (on CI it takes ~15 minutes, I didn't have enough patience to check locally)
and short tests run ~20 seconds, rather than ~2-3 minutes.

It's a good idea to parallelize all tests by default and make exceptions for tests using global resources (env variables, default paths, default ports, global variables etc), but this is out of scope for this PR.