### PR TITLE
Restart scrape loops when __scrape_interval__ is changed

### DIFF
--- a/scrape/target.go
+++ b/scrape/target.go
@@ -144,17 +144,8 @@ func (t *Target) SetMetadataStore(s MetricMetadataStore) {
 func (t *Target) hash() uint64 {
 	h := fnv.New64a()
 
-	// We must build a label set without the scrape interval and timeout
-	// labels because those aren't defining attributes of a target
-	// and can be changed without qualifying its parent as a new target,
-	// therefore they should not effect its unique hash.
-	l := t.labels.Map()
-	delete(l, model.ScrapeIntervalLabel)
-	delete(l, model.ScrapeTimeoutLabel)
-	lset := labels.FromMap(l)
-
 	//nolint: errcheck
-	h.Write([]byte(fmt.Sprintf("%016d", lset.Hash())))
+	h.Write([]byte(fmt.Sprintf("%016d", t.labels.Hash())))
 	//nolint: errcheck
 	h.Write([]byte(t.URL().String()))
 

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -382,29 +382,3 @@ func TestTargetsFromGroup(t *testing.T) {
 		t.Fatalf("Expected error %s, got %s", expectedError, failures[0])
 	}
 }
-
-func TestTargetHash(t *testing.T) {
-	target1 := &Target{
-		labels: labels.Labels{
-			{Name: model.AddressLabel, Value: "localhost"},
-			{Name: model.SchemeLabel, Value: "http"},
-			{Name: model.MetricsPathLabel, Value: "/metrics"},
-			{Name: model.ScrapeIntervalLabel, Value: "15s"},
-			{Name: model.ScrapeTimeoutLabel, Value: "500ms"},
-		},
-	}
-	hash1 := target1.hash()
-
-	target2 := &Target{
-		labels: labels.Labels{
-			{Name: model.AddressLabel, Value: "localhost"},
-			{Name: model.SchemeLabel, Value: "http"},
-			{Name: model.MetricsPathLabel, Value: "/metrics"},
-			{Name: model.ScrapeIntervalLabel, Value: "14s"},
-			{Name: model.ScrapeTimeoutLabel, Value: "600ms"},
-		},
-	}
-	hash2 := target2.hash()
-
-	require.Equal(t, hash1, hash2, "Scrape interval and duration labels should not effect hash.")
-}


### PR DESCRIPTION
Fix #9527 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
