### PR TITLE
docs/operators: fix a typo

### DIFF
--- a/docs/querying/operators.md
+++ b/docs/querying/operators.md
@@ -222,7 +222,7 @@ or
 both `(label1, label2)` and `(label1, label2,)` are valid syntax.
 
 `without` removes the listed labels from the result vector, while
-all other labels are preserved the output. `by` does the opposite and drops
+all other labels are preserved in the output. `by` does the opposite and drops
 labels that are not listed in the `by` clause, even if their label values are
 identical between all elements of the vector.
 


### PR DESCRIPTION
s/are preserved the output/are preserved in the output

Signed-off-by: Julian Wiedmann <jwi@linux.ibm.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
