### PR TITLE
tsdb/wal: Avoid writing closed channel.

### DIFF
--- a/tsdb/wal/wal.go
+++ b/tsdb/wal/wal.go
@@ -472,6 +472,10 @@ func (w *WAL) NextSegment() error {
 
 // nextSegment creates the next segment and closes the previous one.
 func (w *WAL) nextSegment() error {
+	if w.closed {
+		return errors.New("wal is closed")
+	}
+
 	// Only flush the current page if it actually holds data.
 	if w.page.alloc > 0 {
 		if err := w.flushPage(true); err != nil {


### PR DESCRIPTION
The possibility of writing a closed channel still exists. 

https://github.com/prometheus/prometheus/blob/ca29b35d53d8b02c53d40959dce62fe37d1c73fd/tsdb/wal/wal.go#L496-L503

https://github.com/prometheus/prometheus/blob/ca29b35d53d8b02c53d40959dce62fe37d1c73fd/tsdb/wal/wal.go#L336

The `func (a *headAppender) Commit() (err error)` and `func (h *Head) Close() error` are able to run simultaneously.

