### PR TITLE
Add scrape_body_size_bytes metric (behind feature flag)

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -71,6 +71,7 @@ When enabled, for each instance scrape, Prometheus stores a sample in the follow
 - `scrape_timeout_seconds`. The configured `scrape_timeout` for a target. This allows you to measure each target to find out how close they are to timing out with `scrape_duration_seconds / scrape_timeout_seconds`.
 - `scrape_sample_limit`. The configured `sample_limit` for a target. This allows you to measure each target
   to find out how close they are to reaching the limit with `scrape_samples_post_metric_relabeling / scrape_sample_limit`. Note that `scrape_sample_limit` can be zero if there is no limit configured, which means that the query above can return `+Inf` for targets with no limit (as we divide by zero). If you want to query only for targets that do have a sample limit use this query: `scrape_samples_post_metric_relabeling / (scrape_sample_limit > 0)`.
+- `scrape_body_size_bytes`. The uncompressed size of the most recent scrape response, if successful. Scrapes failing because `body_size_limit` is exceeded report `-1`, other scrape failures report `0`.
 
 ## New service discovery manager
 


### PR DESCRIPTION
Fixes #9520

Hide behind a feature flag to avoid additional cardinality by default. This is my first _scrape_ metric implementation!

But I don't know how to test it. Can someone please enlighten my way, so I can test it in the right way!

Waiting your feedback!

PTAL: @roidelapluie @tomwilkie

Signed-off-by: Furkan <furkan.turkal@trendyol.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
