### PR TITLE
Add semver_compare function

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -377,6 +377,18 @@ Given a single-element input vector, `scalar(v instant-vector)` returns the
 sample value of that single element as a scalar. If the input vector does not
 have exactly one element, `scalar` will return `NaN`.
 
+## `semver_compare()`
+
+`semver_compare(v instant-vector, label_name string, version string)` performs
+a semantic versioning comparison between the value of the specified label (a)
+and a given version string (b).
+
+Values returned are:
+
+- 0 if a == b
+- -1 if a < b
+- +1 if a > b
+
 ## `sgn()`
 
 `sgn(v instant-vector)` returns a vector with all sample values converted to their sign, defined as this: 1 if v is positive, -1 if v is negative and 0 if v is equal to zero.

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/uber/jaeger-lib v2.4.1+incompatible
 	go.uber.org/atomic v1.9.0
 	go.uber.org/goleak v1.1.12
+	golang.org/x/mod v0.4.2
 	golang.org/x/net v0.0.0-20211020060615-d418f374d309
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -287,6 +287,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeVector},
 		ReturnType: ValueTypeScalar,
 	},
+	"semver_compare": {
+		Name:       "semver_compare",
+		ArgTypes:   []ValueType{ValueTypeVector, ValueTypeString, ValueTypeString},
+		ReturnType: ValueTypeVector,
+	},
 	"sgn": {
 		Name:       "sgn",
 		ArgTypes:   []ValueType{ValueTypeVector},

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -1023,3 +1023,37 @@ eval instant at 5m log10(exp_root_log - 20)
 	{l="y"} -Inf
 
 clear
+
+# Tests for semver_compare.
+load 5m
+  testmetric{version="v1.0.0", instance="a"} 1
+  testmetric{version="v1.1.0", instance="b"} 1
+  testmetric{version="v1.2.0", instance="c"} 1
+  testmetric{version="v0.9.0", instance="d"} 1
+  testmetric{version="1.1.0", instance="e"} 1
+  badmetric{version="v", instance="f"} 1
+  prefixmetric{goversion="go1.17.1", instance="g"} 1
+
+eval instant at 0m semver_compare(testmetric, "version", "v1.0.0")
+  {version="v1.0.0", instance="a"} 0
+  {version="v1.1.0", instance="b"} 1
+  {version="v1.2.0", instance="c"} 1
+  {version="v0.9.0", instance="d"} -1
+  {version="1.1.0", instance="e"} 1
+
+eval instant at 0m semver_compare(testmetric, "version", "v1.1.0")
+  {version="v1.0.0", instance="a"} -1
+  {version="v1.1.0", instance="b"} 0
+  {version="v1.2.0", instance="c"} 1
+  {version="v0.9.0", instance="d"} -1
+  {version="1.1.0", instance="e"} 0
+
+eval instant at 0m semver_compare(badmetric, "version", "v0.0.1")
+  {version="v", instance="f"} -1
+
+# Check that comparing with relabeling works correctly
+eval instant at 0m semver_compare(label_replace(prefixmetric, "version", "v$1", "goversion", "go(.+)"), "version", "1.17.1")
+  {goversion="go1.17.1", version="v1.17.1", instance="g"} 0
+
+eval instant at 0m semver_compare(prefixmetric, "goversion", "1.17.1")
+  {goversion="go1.17.1", instance="g"} -1


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Rough draft of a new function to compare semantic versioning formatted labels.