### PR TITLE
tsdb/chunks: preallocate at least some space on non-Windows systems

### DIFF
--- a/tsdb/chunks/head_chunks_other.go
+++ b/tsdb/chunks/head_chunks_other.go
@@ -17,5 +17,6 @@
 package chunks
 
 // HeadChunkFilePreallocationSize is the size to which the m-map file should be preallocated when a new file is cut.
-// Windows needs pre-allocations while the other OS does not.
-var HeadChunkFilePreallocationSize int64
+// Windows needs pre-allocations while the other OS does not. But we observed that a 0 pre-allocation causes unit tests to flake.
+// This small allocation for non-Windows OSes removes the flake.
+var HeadChunkFilePreallocationSize int64 = MinWriteBufferSize * 2


### PR DESCRIPTION
To avoid potential chunk corruption read, which I am not sure why is happening.

See #9561 for more details.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>

Opening this PR as a RFC, as I'm not very familiar with tsdb chunks code and mmaping, so it's hard for me to tell what is the correct solution for the problem.