### PR TITLE
Improve resource isolation in test code

### DIFF
--- a/cmd/prometheus/main_unix_test.go
+++ b/cmd/prometheus/main_unix_test.go
@@ -31,7 +31,7 @@ func TestStartupInterrupt(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	prom := exec.Command(promPath, "-test.main", "--config.file="+promConfig, "--storage.tsdb.path="+promData)
+	prom := exec.Command(promPath, "-test.main", "--config.file="+promConfig, "--storage.tsdb.path="+t.TempDir())
 	err := prom.Start()
 	if err != nil {
 		t.Errorf("execution error: %v", err)

--- a/cmd/prometheus/query_log_test.go
+++ b/cmd/prometheus/query_log_test.go
@@ -31,6 +31,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/util/testutil"
 )
 
 type origin int
@@ -412,7 +414,6 @@ func TestQueryLog(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 
-	port := 15000
 	for _, host := range []string{"127.0.0.1", "[::1]"} {
 		for _, prefix := range []string{"", "/foobar"} {
 			for _, enabledAtStart := range []bool{true, false} {
@@ -422,7 +423,7 @@ func TestQueryLog(t *testing.T) {
 						host:           host,
 						enabledAtStart: enabledAtStart,
 						prefix:         prefix,
-						port:           port,
+						port:           testutil.RandomUnprivilegedPort(t),
 						cwd:            cwd,
 					}
 

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -307,11 +307,15 @@ func TestNoTargets(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ch := make(chan []*targetgroup.Group)
-	go d.Run(ctx, ch)
+	go func() {
+		d.Run(ctx, ch)
+		close(ch)
+	}()
 
 	targets := (<-ch)[0].Targets
 	require.Equal(t, 0, len(targets))
 	cancel()
+	<-ch
 }
 
 // Watch only the test service.

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -29,11 +29,14 @@ import (
 var (
 	marathonValidLabel = map[string]string{"prometheus": "yes"}
 	testServers        = []string{"http://localhost:8080"}
-	conf               = SDConfig{Servers: testServers}
 )
 
+func testConfig() SDConfig {
+	return SDConfig{Servers: testServers}
+}
+
 func testUpdateServices(client appListClient) ([]*targetgroup.Group, error) {
-	md, err := NewDiscovery(conf, nil)
+	md, err := NewDiscovery(testConfig(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +129,7 @@ func TestMarathonSDSendGroup(t *testing.T) {
 }
 
 func TestMarathonSDRemoveApp(t *testing.T) {
-	md, err := NewDiscovery(conf, nil)
+	md, err := NewDiscovery(testConfig(), nil)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
@@ -278,13 +281,6 @@ func Test500ErrorHttpResponseWithValidJSONBody(t *testing.T) {
 	// Create a test server with mock HTTP handler.
 	ts := httptest.NewServer(http.HandlerFunc(respHandler))
 	defer ts.Close()
-	// Backup conf for future tests.
-	backupConf := conf
-	defer func() {
-		conf = backupConf
-	}()
-	// Setup conf for the test case.
-	conf = SDConfig{Servers: []string{ts.URL}}
 	// Execute test case and validate behavior.
 	_, err := testUpdateServices(nil)
 	if err == nil {

--- a/discovery/xds/client_test.go
+++ b/discovery/xds/client_test.go
@@ -26,15 +26,17 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
-var httpResourceConf = &HTTPResourceClientConfig{
-	HTTPClientConfig: config.HTTPClientConfig{
-		TLSConfig: config.TLSConfig{InsecureSkipVerify: true},
-	},
-	ResourceType: "monitoring",
-	// Some known type.
-	ResourceTypeURL: "type.googleapis.com/envoy.service.discovery.v3.DiscoveryRequest",
-	Server:          "http://localhost",
-	ClientID:        "test-id",
+func testHTTPResourceConfig() *HTTPResourceClientConfig {
+	return &HTTPResourceClientConfig{
+		HTTPClientConfig: config.HTTPClientConfig{
+			TLSConfig: config.TLSConfig{InsecureSkipVerify: true},
+		},
+		ResourceType: "monitoring",
+		// Some known type.
+		ResourceTypeURL: "type.googleapis.com/envoy.service.discovery.v3.DiscoveryRequest",
+		Server:          "http://localhost",
+		ClientID:        "test-id",
+	}
 }
 
 func urlMustParse(str string) *url.URL {
@@ -106,7 +108,7 @@ func createTestHTTPResourceClient(t *testing.T, conf *HTTPResourceClientConfig, 
 }
 
 func TestHTTPResourceClientFetchEmptyResponse(t *testing.T) {
-	client, cleanup := createTestHTTPResourceClient(t, httpResourceConf, ProtocolV3, func(request *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
+	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(request *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		return nil, nil
 	})
 	defer cleanup()
@@ -117,7 +119,7 @@ func TestHTTPResourceClientFetchEmptyResponse(t *testing.T) {
 }
 
 func TestHTTPResourceClientFetchFullResponse(t *testing.T) {
-	client, cleanup := createTestHTTPResourceClient(t, httpResourceConf, ProtocolV3, func(request *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
+	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(request *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		if request.VersionInfo == "1" {
 			return nil, nil
 		}
@@ -146,7 +148,7 @@ func TestHTTPResourceClientFetchFullResponse(t *testing.T) {
 }
 
 func TestHTTPResourceClientServerError(t *testing.T) {
-	client, cleanup := createTestHTTPResourceClient(t, httpResourceConf, ProtocolV3, func(request *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
+	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(request *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		return nil, errors.New("server error")
 	})
 	defer cleanup()

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -218,7 +218,7 @@ func TestWriteStorageLifecycle(t *testing.T) {
 			&config.DefaultRemoteWriteConfig,
 		},
 	}
-	s.ApplyConfig(conf)
+	require.NoError(t, s.ApplyConfig(conf))
 	require.Equal(t, 1, len(s.queues))
 
 	err = s.Close()
@@ -243,14 +243,14 @@ func TestUpdateExternalLabels(t *testing.T) {
 	}
 	hash, err := toHash(conf.RemoteWriteConfigs[0])
 	require.NoError(t, err)
-	s.ApplyConfig(conf)
+	require.NoError(t, s.ApplyConfig(conf))
 	require.Equal(t, 1, len(s.queues))
 	require.Equal(t, labels.Labels(nil), s.queues[hash].externalLabels)
 
 	conf.GlobalConfig.ExternalLabels = externalLabels
 	hash, err = toHash(conf.RemoteWriteConfigs[0])
 	require.NoError(t, err)
-	s.ApplyConfig(conf)
+	require.NoError(t, s.ApplyConfig(conf))
 	require.Equal(t, 1, len(s.queues))
 	require.Equal(t, externalLabels, s.queues[hash].externalLabels)
 
@@ -282,10 +282,10 @@ func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
 	hash, err := toHash(conf.RemoteWriteConfigs[0])
 	require.NoError(t, err)
 
-	s.ApplyConfig(conf)
+	require.NoError(t, s.ApplyConfig(conf))
 	require.Equal(t, 1, len(s.queues))
 
-	s.ApplyConfig(conf)
+	require.NoError(t, s.ApplyConfig(conf))
 	require.Equal(t, 1, len(s.queues))
 	_, hashExists := s.queues[hash]
 	require.True(t, hashExists, "Queue pointer should have remained the same")
@@ -391,7 +391,7 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 		GlobalConfig:       config.GlobalConfig{},
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{c1, c2},
 	}
-	s.ApplyConfig(conf)
+	require.NoError(t, s.ApplyConfig(conf))
 	require.Equal(t, 2, len(s.queues))
 
 	_, hashExists = s.queues[hashes[0]]

--- a/util/testutil/port.go
+++ b/util/testutil/port.go
@@ -1,0 +1,35 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"net"
+	"testing"
+)
+
+// RandomUnprivilegedPort returns valid unprivileged random port number which can be used for testing.
+func RandomUnprivilegedPort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Listening on random port: %v", err)
+	}
+
+	if err := listener.Close(); err != nil {
+		t.Fatalf("Closing listener: %v", err)
+	}
+
+	return listener.Addr().(*net.TCPAddr).Port
+}

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -253,18 +253,19 @@ func (notReadyReadStorage) Stats(string) (*tsdb.Stats, error) {
 
 // Regression test for https://github.com/prometheus/prometheus/issues/7181.
 func TestFederation_NotReady(t *testing.T) {
-	h := &Handler{
-		localStorage:  notReadyReadStorage{},
-		lookbackDelta: 5 * time.Minute,
-		now:           func() model.Time { return 101 * 60 * 1000 }, // 101min after epoch.
-		config: &config.Config{
-			GlobalConfig: config.GlobalConfig{},
-		},
-	}
-
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			h.config.GlobalConfig.ExternalLabels = scenario.externalLabels
+			h := &Handler{
+				localStorage:  notReadyReadStorage{},
+				lookbackDelta: 5 * time.Minute,
+				now:           func() model.Time { return 101 * 60 * 1000 }, // 101min after epoch.
+				config: &config.Config{
+					GlobalConfig: config.GlobalConfig{
+						ExternalLabels: scenario.externalLabels,
+					},
+				},
+			}
+
 			req := httptest.NewRequest("GET", "http://example.org/federate?"+scenario.params, nil)
 			res := httptest.NewRecorder()
 

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/util/testutil"
 )
 
 func TestMain(m *testing.M) {
@@ -118,8 +119,10 @@ func TestReadyAndHealthy(t *testing.T) {
 	db, err := tsdb.Open(dbDir, nil, nil, nil, nil)
 	require.NoError(t, err)
 
+	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
+
 	opts := &Options{
-		ListenAddress:  ":9090",
+		ListenAddress:  port,
 		ReadTimeout:    30 * time.Second,
 		MaxConnections: 512,
 		Context:        nil,
@@ -134,7 +137,7 @@ func TestReadyAndHealthy(t *testing.T) {
 		EnableAdminAPI: true,
 		ExternalURL: &url.URL{
 			Scheme: "http",
-			Host:   "localhost:9090",
+			Host:   "localhost" + port,
 			Path:   "/",
 		},
 		Version:  &PrometheusVersion{},
@@ -165,20 +168,22 @@ func TestReadyAndHealthy(t *testing.T) {
 	// to be up before starting tests.
 	time.Sleep(5 * time.Second)
 
-	resp, err := http.Get("http://localhost:9090/-/healthy")
+	baseURL := "http://localhost" + port
+
+	resp, err := http.Get(baseURL + "/-/healthy")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	cleanupTestResponse(t, resp)
 
 	for _, u := range []string{
-		"http://localhost:9090/-/ready",
-		"http://localhost:9090/classic/graph",
-		"http://localhost:9090/classic/flags",
-		"http://localhost:9090/classic/rules",
-		"http://localhost:9090/classic/service-discovery",
-		"http://localhost:9090/classic/targets",
-		"http://localhost:9090/classic/status",
-		"http://localhost:9090/classic/config",
+		baseURL + "/-/ready",
+		baseURL + "/classic/graph",
+		baseURL + "/classic/flags",
+		baseURL + "/classic/rules",
+		baseURL + "/classic/service-discovery",
+		baseURL + "/classic/targets",
+		baseURL + "/classic/status",
+		baseURL + "/classic/config",
 	} {
 		resp, err = http.Get(u)
 		require.NoError(t, err)
@@ -186,12 +191,12 @@ func TestReadyAndHealthy(t *testing.T) {
 		cleanupTestResponse(t, resp)
 	}
 
-	resp, err = http.Post("http://localhost:9090/api/v1/admin/tsdb/snapshot", "", strings.NewReader(""))
+	resp, err = http.Post(baseURL+"/api/v1/admin/tsdb/snapshot", "", strings.NewReader(""))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 	cleanupTestResponse(t, resp)
 
-	resp, err = http.Post("http://localhost:9090/api/v1/admin/tsdb/delete_series", "", strings.NewReader("{}"))
+	resp, err = http.Post(baseURL+"/api/v1/admin/tsdb/delete_series", "", strings.NewReader("{}"))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 	cleanupTestResponse(t, resp)
@@ -200,15 +205,15 @@ func TestReadyAndHealthy(t *testing.T) {
 	webHandler.Ready()
 
 	for _, u := range []string{
-		"http://localhost:9090/-/healthy",
-		"http://localhost:9090/-/ready",
-		"http://localhost:9090/classic/graph",
-		"http://localhost:9090/classic/flags",
-		"http://localhost:9090/classic/rules",
-		"http://localhost:9090/classic/service-discovery",
-		"http://localhost:9090/classic/targets",
-		"http://localhost:9090/classic/status",
-		"http://localhost:9090/classic/config",
+		baseURL + "/-/healthy",
+		baseURL + "/-/ready",
+		baseURL + "/classic/graph",
+		baseURL + "/classic/flags",
+		baseURL + "/classic/rules",
+		baseURL + "/classic/service-discovery",
+		baseURL + "/classic/targets",
+		baseURL + "/classic/status",
+		baseURL + "/classic/config",
 	} {
 		resp, err = http.Get(u)
 		require.NoError(t, err)
@@ -216,13 +221,13 @@ func TestReadyAndHealthy(t *testing.T) {
 		cleanupTestResponse(t, resp)
 	}
 
-	resp, err = http.Post("http://localhost:9090/api/v1/admin/tsdb/snapshot", "", strings.NewReader(""))
+	resp, err = http.Post(baseURL+"/api/v1/admin/tsdb/snapshot", "", strings.NewReader(""))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	cleanupSnapshot(t, dbDir, resp)
 	cleanupTestResponse(t, resp)
 
-	resp, err = http.Post("http://localhost:9090/api/v1/admin/tsdb/delete_series?match[]=up", "", nil)
+	resp, err = http.Post(baseURL+"/api/v1/admin/tsdb/delete_series?match[]=up", "", nil)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	cleanupTestResponse(t, resp)
@@ -237,8 +242,10 @@ func TestRoutePrefix(t *testing.T) {
 	db, err := tsdb.Open(dbDir, nil, nil, nil, nil)
 	require.NoError(t, err)
 
+	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
+
 	opts := &Options{
-		ListenAddress:  ":9091",
+		ListenAddress:  port,
 		ReadTimeout:    30 * time.Second,
 		MaxConnections: 512,
 		Context:        nil,
@@ -252,7 +259,7 @@ func TestRoutePrefix(t *testing.T) {
 		RoutePrefix:    "/prometheus",
 		EnableAdminAPI: true,
 		ExternalURL: &url.URL{
-			Host:   "localhost.localdomain:9090",
+			Host:   "localhost.localdomain" + port,
 			Scheme: "http",
 		},
 	}
@@ -277,22 +284,24 @@ func TestRoutePrefix(t *testing.T) {
 	// to be up before starting tests.
 	time.Sleep(5 * time.Second)
 
-	resp, err := http.Get("http://localhost:9091" + opts.RoutePrefix + "/-/healthy")
+	baseURL := "http://localhost" + port
+
+	resp, err := http.Get(baseURL + opts.RoutePrefix + "/-/healthy")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	cleanupTestResponse(t, resp)
 
-	resp, err = http.Get("http://localhost:9091" + opts.RoutePrefix + "/-/ready")
+	resp, err = http.Get(baseURL + opts.RoutePrefix + "/-/ready")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 	cleanupTestResponse(t, resp)
 
-	resp, err = http.Post("http://localhost:9091"+opts.RoutePrefix+"/api/v1/admin/tsdb/snapshot", "", strings.NewReader(""))
+	resp, err = http.Post(baseURL+opts.RoutePrefix+"/api/v1/admin/tsdb/snapshot", "", strings.NewReader(""))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 	cleanupTestResponse(t, resp)
 
-	resp, err = http.Post("http://localhost:9091"+opts.RoutePrefix+"/api/v1/admin/tsdb/delete_series", "", strings.NewReader("{}"))
+	resp, err = http.Post(baseURL+opts.RoutePrefix+"/api/v1/admin/tsdb/delete_series", "", strings.NewReader("{}"))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 	cleanupTestResponse(t, resp)
@@ -300,23 +309,23 @@ func TestRoutePrefix(t *testing.T) {
 	// Set to ready.
 	webHandler.Ready()
 
-	resp, err = http.Get("http://localhost:9091" + opts.RoutePrefix + "/-/healthy")
+	resp, err = http.Get(baseURL + opts.RoutePrefix + "/-/healthy")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	cleanupTestResponse(t, resp)
 
-	resp, err = http.Get("http://localhost:9091" + opts.RoutePrefix + "/-/ready")
+	resp, err = http.Get(baseURL + opts.RoutePrefix + "/-/ready")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	cleanupTestResponse(t, resp)
 
-	resp, err = http.Post("http://localhost:9091"+opts.RoutePrefix+"/api/v1/admin/tsdb/snapshot", "", strings.NewReader(""))
+	resp, err = http.Post(baseURL+opts.RoutePrefix+"/api/v1/admin/tsdb/snapshot", "", strings.NewReader(""))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	cleanupSnapshot(t, dbDir, resp)
 	cleanupTestResponse(t, resp)
 
-	resp, err = http.Post("http://localhost:9091"+opts.RoutePrefix+"/api/v1/admin/tsdb/delete_series?match[]=up", "", nil)
+	resp, err = http.Post(baseURL+opts.RoutePrefix+"/api/v1/admin/tsdb/delete_series?match[]=up", "", nil)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	cleanupTestResponse(t, resp)
@@ -404,8 +413,10 @@ func TestShutdownWithStaleConnection(t *testing.T) {
 
 	timeout := 10 * time.Second
 
+	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
+
 	opts := &Options{
-		ListenAddress:  ":9090",
+		ListenAddress:  port,
 		ReadTimeout:    timeout,
 		MaxConnections: 512,
 		Context:        nil,
@@ -419,7 +430,7 @@ func TestShutdownWithStaleConnection(t *testing.T) {
 		RoutePrefix:    "/",
 		ExternalURL: &url.URL{
 			Scheme: "http",
-			Host:   "localhost:9090",
+			Host:   "localhost" + port,
 			Path:   "/",
 		},
 		Version:  &PrometheusVersion{},
@@ -454,7 +465,7 @@ func TestShutdownWithStaleConnection(t *testing.T) {
 
 	// Open a socket, and don't use it. This connection should then be closed
 	// after the ReadTimeout.
-	c, err := net.Dial("tcp", "localhost:9090")
+	c, err := net.Dial("tcp", opts.ExternalURL.Host)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, c.Close()) })
 
@@ -469,14 +480,16 @@ func TestShutdownWithStaleConnection(t *testing.T) {
 }
 
 func TestHandleMultipleQuitRequests(t *testing.T) {
+	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
+
 	opts := &Options{
-		ListenAddress:   ":9090",
+		ListenAddress:   port,
 		MaxConnections:  512,
 		EnableLifecycle: true,
 		RoutePrefix:     "/",
 		ExternalURL: &url.URL{
 			Scheme: "http",
-			Host:   "localhost:9090",
+			Host:   "localhost" + port,
 			Path:   "/",
 		},
 	}
@@ -501,6 +514,8 @@ func TestHandleMultipleQuitRequests(t *testing.T) {
 	// to be up before starting tests.
 	time.Sleep(5 * time.Second)
 
+	baseURL := opts.ExternalURL.Scheme + "://" + opts.ExternalURL.Host
+
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 	for i := 0; i < 3; i++ {
@@ -508,7 +523,7 @@ func TestHandleMultipleQuitRequests(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			resp, err := http.Post("http://localhost:9090/-/quit", "", strings.NewReader(""))
+			resp, err := http.Post(baseURL+"/-/quit", "", strings.NewReader(""))
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode)
 		}()


### PR DESCRIPTION
As a prerequisite to #9514, which enables parallel execution for all tests, this PR fixes various code, which shares objects between the tests, which when executed in parallel will result in races or flaky tests.