### PR TITLE
discovery/kubernetes: improve test logic for waiting for discoverers

### DIFF
--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -86,15 +86,18 @@ func (d k8sDiscoveryTest) Run(t *testing.T) {
 	// Ensure that discovery has a discoverer set. This prevents a race
 	// condition where the above go routine may or may not have set a
 	// discoverer yet.
+	lastDiscoverersCount := 0
+	dis := d.discovery.(*Discovery)
 	for {
-		dis := d.discovery.(*Discovery)
 		dis.RLock()
 		l := len(dis.discoverers)
 		dis.RUnlock()
-		if l > 0 {
+		if l > 0 && l == lastDiscoverersCount {
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
+
+		lastDiscoverersCount = l
 	}
 
 	resChan := make(chan map[string]*targetgroup.Group)


### PR DESCRIPTION
When running tests in parallel, 10 milliseconds may not be enough for
all discoverers to register, which will make test flaky.

This commit changes the waiting logic to wait for number of discoverers
to stop increasing during given time frame, which should be large enough
for single discoverer to register in test environment.

A following run passes with this commit:

go test -failfast -race -count 100 -v ./discovery/kubernetes/

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>