### PR TITLE
Use kahan summation for better numerical stability

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -367,7 +367,7 @@ func aggrOverTime(vals []parser.Value, enh *EvalNodeHelper, aggrFn func([]Point)
 // === avg_over_time(Matrix parser.ValueTypeMatrix) Vector ===
 func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	return aggrOverTime(vals, enh, func(values []Point) float64 {
-		var mean, count float64
+		var mean, count, c float64
 		for _, v := range values {
 			count++
 			if math.IsInf(mean, 0) {
@@ -387,9 +387,13 @@ func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 					continue
 				}
 			}
-			mean += v.V/count - mean/count
+			mean, c = kahanSummationIter(v.V/count-mean/count, mean, c)
 		}
-		return mean
+
+		if math.IsInf(mean, 0) {
+			return mean
+		}
+		return mean + c
 	})
 }
 

--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -15,6 +15,7 @@ package promql
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -70,4 +71,10 @@ func TestFunctionList(t *testing.T) {
 		_, ok := FunctionCalls[i]
 		require.True(t, ok, "function %s exists in parser package, but not in promql package", i)
 	}
+}
+
+func TestKahanSummation(t *testing.T) {
+	vals := []float64{1.0, math.Pow(10, 100), 1.0, -1 * math.Pow(10, 100)}
+	expected := 2.0
+	require.Equal(t, expected, kahanSummation(vals))
 }

--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -73,8 +73,8 @@ func TestFunctionList(t *testing.T) {
 	}
 }
 
-func TestKahanSummation(t *testing.T) {
+func TestKahanSum(t *testing.T) {
 	vals := []float64{1.0, math.Pow(10, 100), 1.0, -1 * math.Pow(10, 100)}
 	expected := 2.0
-	require.Equal(t, expected, kahanSummation(vals))
+	require.Equal(t, expected, kahanSum(vals))
 }


### PR DESCRIPTION
Signed-off-by: darshanime <deathbullet@gmail.com>

related: https://github.com/prometheus/prometheus/issues/5400, https://github.com/prometheus/prometheus/issues/7180, https://github.com/prometheus/prometheus/issues/5692
 

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
