### PR TITLE
 tsdb/wal Use testing.T.TempDir() instead of ioutil.TempDir() in unit tests

### DIFF
--- a/tsdb/wal/checkpoint_test.go
+++ b/tsdb/wal/checkpoint_test.go
@@ -31,13 +31,9 @@ import (
 )
 
 func TestLastCheckpoint(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_checkpoint")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
-	_, _, err = LastCheckpoint(dir)
+	_, _, err := LastCheckpoint(dir)
 	require.Equal(t, record.ErrNotFound, err)
 
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "checkpoint.0000"), 0777))
@@ -78,11 +74,7 @@ func TestLastCheckpoint(t *testing.T) {
 }
 
 func TestDeleteCheckpoints(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_checkpoint")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	require.NoError(t, DeleteCheckpoints(dir, 0))
 
@@ -119,11 +111,7 @@ func TestDeleteCheckpoints(t *testing.T) {
 func TestCheckpoint(t *testing.T) {
 	for _, compress := range []bool{false, true} {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "test_checkpoint")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(dir))
-			}()
+			dir := t.TempDir()
 
 			var enc record.Encoder
 			// Create a dummy segment to bump the initial number.
@@ -240,11 +228,7 @@ func TestCheckpoint(t *testing.T) {
 
 func TestCheckpointNoTmpFolderAfterError(t *testing.T) {
 	// Create a new wal with invalid data.
-	dir, err := ioutil.TempDir("", "test_checkpoint")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 	w, err := NewSize(nil, nil, dir, 64*1024, false)
 	require.NoError(t, err)
 	var enc record.Encoder

--- a/tsdb/wal/reader_test.go
+++ b/tsdb/wal/reader_test.go
@@ -310,11 +310,7 @@ func TestReaderFuzz(t *testing.T) {
 	for name, fn := range readerConstructors {
 		for _, compress := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s,compress=%t", name, compress), func(t *testing.T) {
-				dir, err := ioutil.TempDir("", "wal_fuzz_live")
-				require.NoError(t, err)
-				defer func() {
-					require.NoError(t, os.RemoveAll(dir))
-				}()
+				dir := t.TempDir()
 
 				w, err := NewSize(nil, nil, dir, 128*pageSize, compress)
 				require.NoError(t, err)
@@ -347,11 +343,7 @@ func TestReaderFuzz_Live(t *testing.T) {
 	logger := testutil.NewLogger(t)
 	for _, compress := range []bool{false, true} {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "wal_fuzz_live")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(dir))
-			}()
+			dir := t.TempDir()
 
 			w, err := NewSize(nil, nil, dir, 128*pageSize, compress)
 			require.NoError(t, err)
@@ -432,11 +424,7 @@ func TestLiveReaderCorrupt_ShortFile(t *testing.T) {
 	// Write a corrupt WAL segment, there is one record of pageSize in length,
 	// but the segment is only half written.
 	logger := testutil.NewLogger(t)
-	dir, err := ioutil.TempDir("", "wal_live_corrupt")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	w, err := NewSize(nil, nil, dir, pageSize, false)
 	require.NoError(t, err)
@@ -476,11 +464,7 @@ func TestLiveReaderCorrupt_ShortFile(t *testing.T) {
 func TestLiveReaderCorrupt_RecordTooLongAndShort(t *testing.T) {
 	// Write a corrupt WAL segment, when record len > page size.
 	logger := testutil.NewLogger(t)
-	dir, err := ioutil.TempDir("", "wal_live_corrupt")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	w, err := NewSize(nil, nil, dir, pageSize*2, false)
 	require.NoError(t, err)

--- a/tsdb/wal/wal_test.go
+++ b/tsdb/wal/wal_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -119,11 +118,7 @@ func TestWALRepair_ReadingError(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "wal_repair")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(dir))
-			}()
+			dir := t.TempDir()
 
 			// We create 3 segments with 3 records each and
 			// then corrupt a given record in a given segment.
@@ -217,11 +212,7 @@ func TestWALRepair_ReadingError(t *testing.T) {
 // ensures that an error during reading that segment are correctly repaired before
 // moving to write more records to the WAL.
 func TestCorruptAndCarryOn(t *testing.T) {
-	dir, err := ioutil.TempDir("", "wal_repair")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	var (
 		logger      = testutil.NewLogger(t)
@@ -345,11 +336,7 @@ func TestCorruptAndCarryOn(t *testing.T) {
 
 // TestClose ensures that calling Close more than once doesn't panic and doesn't block.
 func TestClose(t *testing.T) {
-	dir, err := ioutil.TempDir("", "wal_repair")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 	w, err := NewSize(nil, nil, dir, pageSize, false)
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
@@ -362,11 +349,7 @@ func TestSegmentMetric(t *testing.T) {
 		recordSize  = (pageSize / 2) - recordHeaderSize
 	)
 
-	dir, err := ioutil.TempDir("", "segment_metric")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 	w, err := NewSize(nil, nil, dir, segmentSize, false)
 	require.NoError(t, err)
 
@@ -393,8 +376,7 @@ func TestCompression(t *testing.T) {
 			records     = 100
 		)
 
-		dirPath, err := ioutil.TempDir("", fmt.Sprintf("TestCompression_%t", compressed))
-		require.NoError(t, err)
+		dirPath := t.TempDir()
 
 		w, err := NewSize(nil, nil, dirPath, segmentSize, compressed)
 		require.NoError(t, err)
@@ -454,9 +436,7 @@ func TestLogPartialWrite(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			dirPath, err := ioutil.TempDir("", "logpartialwrite")
-			require.NoError(t, err)
-			defer func() { require.NoError(t, os.RemoveAll(dirPath)) }()
+			dirPath := t.TempDir()
 
 			w, err := NewSize(nil, nil, dirPath, segmentSize, false)
 			require.NoError(t, err)
@@ -527,11 +507,7 @@ func (f *faultySegmentFile) Write(p []byte) (int, error) {
 func BenchmarkWAL_LogBatched(b *testing.B) {
 	for _, compress := range []bool{true, false} {
 		b.Run(fmt.Sprintf("compress=%t", compress), func(b *testing.B) {
-			dir, err := ioutil.TempDir("", "bench_logbatch")
-			require.NoError(b, err)
-			defer func() {
-				require.NoError(b, os.RemoveAll(dir))
-			}()
+			dir := b.TempDir()
 
 			w, err := New(nil, nil, dir, compress)
 			require.NoError(b, err)
@@ -561,11 +537,7 @@ func BenchmarkWAL_LogBatched(b *testing.B) {
 func BenchmarkWAL_Log(b *testing.B) {
 	for _, compress := range []bool{true, false} {
 		b.Run(fmt.Sprintf("compress=%t", compress), func(b *testing.B) {
-			dir, err := ioutil.TempDir("", "bench_logsingle")
-			require.NoError(b, err)
-			defer func() {
-				require.NoError(b, os.RemoveAll(dir))
-			}()
+			dir := b.TempDir()
 
 			w, err := New(nil, nil, dir, compress)
 			require.NoError(b, err)

--- a/tsdb/wal/watcher_test.go
+++ b/tsdb/wal/watcher_test.go
@@ -14,7 +14,6 @@ package wal
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -110,14 +109,10 @@ func TestTailSamples(t *testing.T) {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
 			now := time.Now()
 
-			dir, err := ioutil.TempDir("", "readCheckpoint")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(dir))
-			}()
+			dir := t.TempDir()
 
 			wdir := path.Join(dir, "wal")
-			err = os.Mkdir(wdir, 0777)
+			err := os.Mkdir(wdir, 0777)
 			require.NoError(t, err)
 
 			enc := record.Encoder{}
@@ -204,13 +199,9 @@ func TestReadToEndNoCheckpoint(t *testing.T) {
 
 	for _, compress := range []bool{false, true} {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "readToEnd_noCheckpoint")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(dir))
-			}()
+			dir := t.TempDir()
 			wdir := path.Join(dir, "wal")
-			err = os.Mkdir(wdir, 0777)
+			err := os.Mkdir(wdir, 0777)
 			require.NoError(t, err)
 
 			w, err := NewSize(nil, nil, wdir, 128*pageSize, compress)
@@ -277,14 +268,10 @@ func TestReadToEndWithCheckpoint(t *testing.T) {
 
 	for _, compress := range []bool{false, true} {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "readToEnd_withCheckpoint")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(dir))
-			}()
+			dir := t.TempDir()
 
 			wdir := path.Join(dir, "wal")
-			err = os.Mkdir(wdir, 0777)
+			err := os.Mkdir(wdir, 0777)
 			require.NoError(t, err)
 
 			enc := record.Encoder{}
@@ -368,14 +355,10 @@ func TestReadCheckpoint(t *testing.T) {
 
 	for _, compress := range []bool{false, true} {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "readCheckpoint")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(dir))
-			}()
+			dir := t.TempDir()
 
 			wdir := path.Join(dir, "wal")
-			err = os.Mkdir(wdir, 0777)
+			err := os.Mkdir(wdir, 0777)
 			require.NoError(t, err)
 
 			os.Create(SegmentName(wdir, 30))
@@ -440,14 +423,10 @@ func TestReadCheckpointMultipleSegments(t *testing.T) {
 
 	for _, compress := range []bool{false, true} {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "readCheckpoint")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(dir))
-			}()
+			dir := t.TempDir()
 
 			wdir := path.Join(dir, "wal")
-			err = os.Mkdir(wdir, 0777)
+			err := os.Mkdir(wdir, 0777)
 			require.NoError(t, err)
 
 			enc := record.Encoder{}
@@ -522,14 +501,10 @@ func TestCheckpointSeriesReset(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("compress=%t", tc.compress), func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "seriesReset")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(dir))
-			}()
+			dir := t.TempDir()
 
 			wdir := path.Join(dir, "wal")
-			err = os.Mkdir(wdir, 0777)
+			err := os.Mkdir(wdir, 0777)
 			require.NoError(t, err)
 
 			enc := record.Encoder{}


### PR DESCRIPTION
Related to https://github.com/prometheus/prometheus/issues/9594
small PR to fix tsdb/wal directory