### PR TITLE
Adds support to lazy-load tsdb blocks for querying.

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -64,14 +64,14 @@ func TestSetCompactionFailed(t *testing.T) {
 	}()
 
 	blockDir := createBlock(t, tmpdir, genSeries(1, 1, 0, 1))
-	b, err := OpenBlock(nil, blockDir, nil)
+	b, err := OpenBlock(nil, blockDir, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, false, b.meta.Compaction.Failed)
 	require.NoError(t, b.setCompactionFailed())
 	require.Equal(t, true, b.meta.Compaction.Failed)
 	require.NoError(t, b.Close())
 
-	b, err = OpenBlock(nil, blockDir, nil)
+	b, err = OpenBlock(nil, blockDir, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, true, b.meta.Compaction.Failed)
 	require.NoError(t, b.Close())
@@ -83,7 +83,7 @@ func TestCreateBlock(t *testing.T) {
 	defer func() {
 		require.NoError(t, os.RemoveAll(tmpdir))
 	}()
-	b, err := OpenBlock(nil, createBlock(t, tmpdir, genSeries(1, 1, 0, 10)), nil)
+	b, err := OpenBlock(nil, createBlock(t, tmpdir, genSeries(1, 1, 0, 10)), nil, nil)
 	if err == nil {
 		require.NoError(t, b.Close())
 	}
@@ -193,7 +193,7 @@ func TestCorruptedChunk(t *testing.T) {
 			require.NoError(t, f.Close())
 
 			// Check open err.
-			b, err := OpenBlock(nil, blockDir, nil)
+			b, err := OpenBlock(nil, blockDir, nil, nil)
 			if tc.openErr != nil {
 				require.Equal(t, tc.openErr.Error(), err.Error())
 				return
@@ -235,7 +235,7 @@ func TestLabelValuesWithMatchers(t *testing.T) {
 	require.Greater(t, len(files), 0, "No chunk created.")
 
 	// Check open err.
-	block, err := OpenBlock(nil, blockDir, nil)
+	block, err := OpenBlock(nil, blockDir, nil, nil)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, block.Close()) }()
 
@@ -303,7 +303,7 @@ func TestBlockSize(t *testing.T) {
 	// Create a block and compare the reported size vs actual disk size.
 	{
 		blockDirInit = createBlock(t, tmpdir, genSeries(10, 1, 1, 100))
-		blockInit, err = OpenBlock(nil, blockDirInit, nil)
+		blockInit, err = OpenBlock(nil, blockDirInit, nil, nil)
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, blockInit.Close())
@@ -327,7 +327,7 @@ func TestBlockSize(t *testing.T) {
 		require.NoError(t, err)
 		blockDirAfterCompact, err := c.Compact(tmpdir, []string{blockInit.Dir()}, nil)
 		require.NoError(t, err)
-		blockAfterCompact, err := OpenBlock(nil, filepath.Join(tmpdir, blockDirAfterCompact.String()), nil)
+		blockAfterCompact, err := OpenBlock(nil, filepath.Join(tmpdir, blockDirAfterCompact.String()), nil, nil)
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, blockAfterCompact.Close())
@@ -358,7 +358,7 @@ func TestReadIndexFormatV1(t *testing.T) {
 	*/
 
 	blockDir := filepath.Join("testdata", "index_format_v1")
-	block, err := OpenBlock(nil, blockDir, nil)
+	block, err := OpenBlock(nil, blockDir, nil, nil)
 	require.NoError(t, err)
 
 	q, err := NewBlockQuerier(block, 0, 1000)
@@ -398,7 +398,7 @@ func BenchmarkLabelValuesWithMatchers(b *testing.B) {
 	require.Greater(b, len(files), 0, "No chunk created.")
 
 	// Check open err.
-	block, err := OpenBlock(nil, blockDir, nil)
+	block, err := OpenBlock(nil, blockDir, nil, nil)
 	require.NoError(b, err)
 	defer func() { require.NoError(b, block.Close()) }()
 
@@ -452,7 +452,7 @@ func TestLabelNamesWithMatchers(t *testing.T) {
 	require.Greater(t, len(files), 0, "No chunk created.")
 
 	// Check open err.
-	block, err := OpenBlock(nil, blockDir, nil)
+	block, err := OpenBlock(nil, blockDir, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, block.Close()) })
 

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -360,6 +360,9 @@ func TestReadIndexFormatV1(t *testing.T) {
 	blockDir := filepath.Join("testdata", "index_format_v1")
 	block, err := OpenBlock(nil, blockDir, nil, nil)
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, block.Close())
+	}()
 
 	q, err := NewBlockQuerier(block, 0, 1000)
 	require.NoError(t, err)

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -102,7 +102,7 @@ func TestCorruptedChunk(t *testing.T) {
 			corrFunc: func(f *os.File) {
 				require.NoError(t, f.Truncate(1))
 			},
-			openErr: errors.New("invalid segment header in segment 0: invalid size"),
+			openErr: errors.New("load lazy-reader: invalid segment header in segment 0: invalid size"),
 		},
 		{
 			name: "invalid magic number",
@@ -118,7 +118,7 @@ func TestCorruptedChunk(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, chunks.MagicChunksSize, n)
 			},
-			openErr: errors.New("invalid magic number 0"),
+			openErr: errors.New("load lazy-reader: invalid magic number 0"),
 		},
 		{
 			name: "invalid chunk format version",
@@ -134,7 +134,7 @@ func TestCorruptedChunk(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, chunks.ChunksFormatVersionSize, n)
 			},
-			openErr: errors.New("invalid chunk format version 0"),
+			openErr: errors.New("load lazy-reader: invalid chunk format version 0"),
 		},
 		{
 			name: "chunk not enough bytes to read the chunk length",

--- a/tsdb/blockwriter_test.go
+++ b/tsdb/blockwriter_test.go
@@ -50,7 +50,7 @@ func TestBlockWriter(t *testing.T) {
 
 	// Confirm the block has the correct data.
 	blockpath := filepath.Join(outputDir, id.String())
-	b, err := OpenBlock(nil, blockpath, nil)
+	b, err := OpenBlock(nil, blockpath, nil, nil)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, b.Close()) }()
 	q, err := NewBlockQuerier(b, math.MinInt64, math.MaxInt64)

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -418,7 +418,7 @@ func (c *LeveledCompactor) Compact(dest string, dirs []string, open []*Block) (u
 
 		if b == nil {
 			var err error
-			b, err = OpenBlock(c.logger, d, c.chunkPool)
+			b, err = OpenBlock(c.logger, d, c.chunkPool, nil)
 			if err != nil {
 				return uid, err
 			}

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1056,7 +1056,7 @@ func BenchmarkCompaction(b *testing.B) {
 			blockDirs := make([]string, 0, len(c.ranges))
 			var blocks []*Block
 			for _, r := range c.ranges {
-				block, err := OpenBlock(nil, createBlock(b, dir, genSeries(nSeries, 10, r[0], r[1])), nil)
+				block, err := OpenBlock(nil, createBlock(b, dir, genSeries(nSeries, 10, r[0], r[1])), nil, nil)
 				require.NoError(b, err)
 				blocks = append(blocks, block)
 				defer func() {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1167,7 +1167,7 @@ func openBlocks(l log.Logger, dir string, loaded []*Block, chunkPool chunkenc.Po
 		// See if we already have the block in memory or open it otherwise.
 		block, open := getBlock(loaded, meta.ULID)
 		if !open {
-			block, err = OpenBlock(l, bDir, chunkPool)
+			block, err = OpenBlock(l, bDir, chunkPool, nil)
 			if err != nil {
 				corrupted[meta.ULID] = err
 				continue

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1168,7 +1168,7 @@ func TestTombstoneCleanFail(t *testing.T) {
 	totalBlocks := 2
 	for i := 0; i < totalBlocks; i++ {
 		blockDir := createBlock(t, db.Dir(), genSeries(1, 1, int64(i), int64(i)+1))
-		block, err := OpenBlock(nil, blockDir, nil)
+		block, err := OpenBlock(nil, blockDir, nil, nil)
 		require.NoError(t, err)
 		// Add some fake tombstones to trigger the compaction.
 		tomb := tombstones.NewMemTombstones()
@@ -1218,7 +1218,7 @@ func TestTombstoneCleanRetentionLimitsRace(t *testing.T) {
 		// Generate some blocks with old mint (near epoch).
 		for j := 0; j < totalBlocks; j++ {
 			blockDir := createBlock(t, dbDir, genSeries(10, 1, int64(j), int64(j)+1))
-			block, err := OpenBlock(nil, blockDir, nil)
+			block, err := OpenBlock(nil, blockDir, nil, nil)
 			require.NoError(t, err)
 			// Cover block with tombstones so it can be deleted with CleanTombstones() as well.
 			tomb := tombstones.NewMemTombstones()
@@ -1277,7 +1277,7 @@ func (c *mockCompactorFailing) Write(dest string, b BlockReader, mint, maxt int6
 		return ulid.ULID{}, fmt.Errorf("the compactor already did the maximum allowed blocks so it is time to fail")
 	}
 
-	block, err := OpenBlock(nil, createBlock(c.t, dest, genSeries(1, 1, 0, 1)), nil)
+	block, err := OpenBlock(nil, createBlock(c.t, dest, genSeries(1, 1, 0, 1)), nil, nil)
 	require.NoError(c.t, err)
 	require.NoError(c.t, block.Close()) // Close block as we won't be using anywhere.
 	c.blocks = append(c.blocks, block)

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1099,7 +1099,7 @@ func TestTombstoneClean(t *testing.T) {
 		require.Equal(t, 0, len(res.Warnings()))
 
 		for _, b := range db.Blocks() {
-			require.Equal(t, tombstones.NewMemTombstones(), b.tombstones)
+			require.Equal(t, tombstones.NewMemTombstones(), b.reader.tombstones)
 		}
 	}
 }
@@ -1173,7 +1173,7 @@ func TestTombstoneCleanFail(t *testing.T) {
 		// Add some fake tombstones to trigger the compaction.
 		tomb := tombstones.NewMemTombstones()
 		tomb.AddInterval(0, tombstones.Interval{Mint: int64(i), Maxt: int64(i) + 1})
-		block.tombstones = tomb
+		block.reader.tombstones = tomb
 
 		db.blocks = append(db.blocks, block)
 		oldBlockDirs = append(oldBlockDirs, blockDir)
@@ -1223,7 +1223,7 @@ func TestTombstoneCleanRetentionLimitsRace(t *testing.T) {
 			// Cover block with tombstones so it can be deleted with CleanTombstones() as well.
 			tomb := tombstones.NewMemTombstones()
 			tomb.AddInterval(0, tombstones.Interval{Mint: int64(j), Maxt: int64(j) + 1})
-			block.tombstones = tomb
+			block.reader.tombstones = tomb
 
 			db.blocks = append(db.blocks, block)
 		}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1196,6 +1196,10 @@ func TestTombstoneCleanFail(t *testing.T) {
 	// Only one block should have been replaced by a new block.
 	require.Equal(t, len(oldBlockDirs), len(actualBlockDirs))
 	require.Equal(t, len(intersection(oldBlockDirs, actualBlockDirs)), len(actualBlockDirs)-1)
+
+	for _, b := range db.blocks {
+		require.NoError(t, b.Close())
+	}
 }
 
 // TestTombstoneCleanRetentionLimitsRace tests that a CleanTombstones operation

--- a/tsdb/lazy_block.go
+++ b/tsdb/lazy_block.go
@@ -1,0 +1,206 @@
+// Copyright 2021 The Prometheus Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"context"
+	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+	"io"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+
+	"github.com/go-kit/log"
+
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
+)
+
+// LazyReader represents a directory of time series data covering a continuous time range.
+type LazyReader struct {
+	ctx    context.Context
+	mtx    sync.RWMutex
+	logger log.Logger
+
+	dir  string
+	pool chunkenc.Pool
+
+	chunkr     ChunkReader
+	indexr     IndexReader
+	tombstones tombstones.Reader
+	stats      ReaderStats
+
+	lastUsed   atomic.Time
+	unmapAfter time.Duration
+	isActive   atomic.Bool
+}
+
+type ReaderStats struct {
+	symbolTableSize   uint64
+	numBytesChunks    int64
+	numBytesIndex     int64
+	numBytesTombstone int64
+}
+
+// NewLazyReader opens the block in the directory. It can be passed a chunk pool, which is used
+// to instantiate chunk structs.
+func NewLazyReader(ctx context.Context, logger log.Logger, dir string, pool chunkenc.Pool) *LazyReader {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+
+	return &LazyReader{
+		ctx:    ctx,
+		dir:    dir,
+		logger: logger,
+		pool:   pool,
+	}
+}
+
+func (lb *LazyReader) Index() (IndexReader, error) {
+	if err := lb.load(); err != nil {
+		return nil, errors.Wrap(err, "load")
+	}
+	return lb.indexr, nil
+}
+
+func (lb *LazyReader) Chunks() (ChunkReader, error) {
+	if err := lb.load(); err != nil {
+		return nil, errors.Wrap(err, "load")
+	}
+	return lb.chunkr, nil
+}
+
+func (lb *LazyReader) Tombstones() (tombstones.Reader, error) {
+	if err := lb.load(); err != nil {
+		return nil, errors.Wrap(err, "load")
+	}
+	return lb.tombstones, nil
+}
+
+func (lb *LazyReader) UpdateTombstones(stones tombstones.Reader) error {
+	if err := lb.load(); err != nil {
+		return errors.Wrap(err, "load")
+	}
+	lb.tombstones = stones
+	return nil
+}
+
+func (lb *LazyReader) Stats() ReaderStats {
+	lb.mtx.RLock()
+	defer lb.mtx.RUnlock()
+	return lb.stats
+}
+
+// load the block contents into (mmap) memory. It is go-routine safe.
+func (lb *LazyReader) load() (err error) {
+	lb.mtx.Lock()
+	defer lb.mtx.Unlock()
+
+	lb.lastUsed.Store(time.Now())
+	if lb.isActive.Load() {
+		// Block already loaded, skip.
+		return nil
+	}
+
+	var closers []io.Closer
+	defer func() {
+		if err != nil {
+			err = tsdb_errors.NewMulti(err, tsdb_errors.CloseAll(closers)).Err()
+		}
+	}()
+
+	ir, err := index.NewFileReader(filepath.Join(lb.dir, indexFilename))
+	if err != nil {
+		return err
+	}
+	closers = append(closers, ir)
+
+	cr, err := chunks.NewDirReader(chunkDir(lb.dir), lb.pool)
+	if err != nil {
+		return err
+	}
+	closers = append(closers, cr)
+
+	tr, sizeTomb, err := tombstones.ReadTombstones(lb.dir)
+	if err != nil {
+		return err
+	}
+
+	lb.indexr = ir
+	lb.chunkr = cr
+	lb.tombstones = tr
+
+	// Update size whenever we load.
+	lb.stats.numBytesIndex = ir.Size()
+	lb.stats.symbolTableSize = ir.SymbolTableSize()
+	lb.stats.numBytesChunks = cr.Size()
+	lb.stats.numBytesTombstone = sizeTomb
+
+	closers = append(closers, tr)
+	lb.lastUsed.Store(time.Now()) // Update last used as loading block contents can take time.
+
+	go lb.unmapRoutine()
+
+	return nil
+}
+
+// unmapRoutine checks if the lastUsed > unmapAfter and unmaps the block and exits.
+func (lb *LazyReader) unmapRoutine() {
+	if lb.isActive.Load() {
+		// Block not loaded, hence watching last used is of no use.
+		return
+	}
+	check := time.NewTicker(time.Minute)
+	defer check.Stop()
+
+	lb.isActive.Store(true)
+
+	closeReaders := func() {
+		lb.mtx.Lock()
+		defer lb.mtx.Unlock()
+		if err := lb.chunkr.Close(); err != nil {
+			level.Error(lb.logger).Log("msg", "error closing chunk reader", "err", err)
+		}
+		if err := lb.indexr.Close(); err != nil {
+			level.Error(lb.logger).Log("msg", "error closing index reader", "err", err)
+		}
+		if err := lb.tombstones.Close(); err != nil {
+			level.Error(lb.logger).Log("msg", "error closing tombstones", "err", err)
+		}
+		lb.isActive.Store(false)
+	}
+
+	for {
+		select {
+		case <-lb.ctx.Done():
+			// Return to avoid stalls in graceful shutdowns.
+			closeReaders()
+			return
+		case <-check.C:
+		}
+
+		if time.Since(lb.lastUsed.Load()) >= lb.unmapAfter {
+			closeReaders()
+			return
+		}
+	}
+}

--- a/tsdb/lazy_reader_test.go
+++ b/tsdb/lazy_reader_test.go
@@ -1,0 +1,70 @@
+// Copyright 2021 The Prometheus Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLazyReader(t *testing.T) {
+	db := openTestDB(t, DefaultOptions(), nil)
+	dir := db.Dir()
+	app := db.Appender(context.Background())
+	series := genSeries(3, 3, 0, 10)
+	for _, s := range series {
+		itr := s.Iterator()
+		for itr.Next() {
+			ts, val := itr.At()
+			_, err := app.Append(0, s.Labels(), ts, val)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, app.Commit())
+	snapshotDir := filepath.Join(dir, "snapshot")
+	require.NoError(t, db.Snapshot(snapshotDir, true))
+	require.NoError(t, db.Close())
+
+	db, err := Open(snapshotDir, nil, nil, DefaultOptions(), nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(db.Blocks()))
+	defer db.Close()
+
+	firstBlockName := db.Blocks()[0].String()
+	blockDir := filepath.Join(snapshotDir, firstBlockName)
+
+	block, err := OpenBlock(log.NewNopLogger(), blockDir, nil, &UnmapStrategy{time.Second * 5, time.Second})
+	require.NoError(t, err)
+
+	defer func() { require.NoError(t, block.Close()) }()
+
+	// Make sure that block is loaded when its opened.
+	reader := block.reader
+	require.True(t, reader.isMMapped.Load())
+	require.NotEqual(t, ReaderStats{}, reader.Stats()) // Non-empty stats.
+
+	time.Sleep(time.Second * 2)
+	require.True(t, reader.isMMapped.Load())
+	require.NotEqual(t, ReaderStats{}, reader.Stats()) // Non-empty stats.
+
+	time.Sleep(time.Second * 4)
+	require.False(t, reader.isMMapped.Load())
+	require.NotEqual(t, ReaderStats{}, reader.Stats()) // Non-empty stats, even if readers are unmapped.
+}

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -76,7 +76,7 @@ func BenchmarkPostingsForMatchers(b *testing.B) {
 	}()
 
 	blockdir := createBlockFromHead(b, tmpdir, h)
-	block, err := OpenBlock(nil, blockdir, nil)
+	block, err := OpenBlock(nil, blockdir, nil, nil)
 	require.NoError(b, err)
 	defer func() {
 		require.NoError(b, block.Close())
@@ -195,7 +195,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 	}()
 
 	blockdir := createBlockFromHead(b, tmpdir, h)
-	block, err := OpenBlock(nil, blockdir, nil)
+	block, err := OpenBlock(nil, blockdir, nil, nil)
 	require.NoError(b, err)
 	defer func() {
 		require.NoError(b, block.Close())

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1302,7 +1302,7 @@ func BenchmarkQueryIterator(b *testing.B) {
 					} else {
 						generatedSeries = populateSeries(prefilledLabels, mint, maxt)
 					}
-					block, err := OpenBlock(nil, createBlock(b, dir, generatedSeries), nil)
+					block, err := OpenBlock(nil, createBlock(b, dir, generatedSeries), nil, nil)
 					require.NoError(b, err)
 					blocks = append(blocks, block)
 					defer block.Close()
@@ -1369,7 +1369,7 @@ func BenchmarkQuerySeek(b *testing.B) {
 					} else {
 						generatedSeries = populateSeries(prefilledLabels, mint, maxt)
 					}
-					block, err := OpenBlock(nil, createBlock(b, dir, generatedSeries), nil)
+					block, err := OpenBlock(nil, createBlock(b, dir, generatedSeries), nil, nil)
 					require.NoError(b, err)
 					blocks = append(blocks, block)
 					defer block.Close()
@@ -1508,7 +1508,7 @@ func BenchmarkSetMatcher(b *testing.B) {
 			} else {
 				generatedSeries = populateSeries(prefilledLabels, mint, maxt)
 			}
-			block, err := OpenBlock(nil, createBlock(b, dir, generatedSeries), nil)
+			block, err := OpenBlock(nil, createBlock(b, dir, generatedSeries), nil, nil)
 			require.NoError(b, err)
 			blocks = append(blocks, block)
 			defer block.Close()
@@ -1963,7 +1963,7 @@ func BenchmarkQueries(b *testing.B) {
 
 				qs := make([]storage.Querier, 0, 10)
 				for x := 0; x <= 10; x++ {
-					block, err := OpenBlock(nil, createBlock(b, dir, series), nil)
+					block, err := OpenBlock(nil, createBlock(b, dir, series), nil, nil)
 					require.NoError(b, err)
 					q, err := NewBlockQuerier(block, 1, int64(nSamples))
 					require.NoError(b, err)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1965,6 +1965,7 @@ func BenchmarkQueries(b *testing.B) {
 				for x := 0; x <= 10; x++ {
 					block, err := OpenBlock(nil, createBlock(b, dir, series), nil, nil)
 					require.NoError(b, err)
+					defer block.Close()
 					q, err := NewBlockQuerier(block, 1, int64(nSamples))
 					require.NoError(b, err)
 					qs = append(qs, q)


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Fixes: #8518 

cc @codesome 
