### PR TITLE
Feat UI metrics search

### DIFF
--- a/web/ui/react-app/src/pages/graph/MetricsExplorer.test.tsx
+++ b/web/ui/react-app/src/pages/graph/MetricsExplorer.test.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { mount, ReactWrapper} from 'enzyme';
+import MetricsExplorer from './MetricsExplorer';
+import { Input } from 'reactstrap';
+
+describe('MetricsExplorer', () => {
+  const spyInsertAtCursor = jest.fn().mockImplementation((value:string) => {});
+  const metricsExplorerProps = {
+    show: true,
+    updateShow:(show: boolean): void => {},
+    metrics:['go_test_1','prometheus_test_1'],
+    insertAtCursor: spyInsertAtCursor,
+  };
+
+  let metricsExplorer: ReactWrapper;
+  beforeEach(() => {
+    metricsExplorer = mount(<MetricsExplorer {...metricsExplorerProps} />);
+  });
+
+  it('renders an Input[type=text]', () => {
+    const input = metricsExplorer.find(Input);
+    expect(input.prop('type')).toEqual('text');
+  });
+
+  it('lists all metrics in props', () => {
+    const metrics = metricsExplorer.find('.metric');
+    expect(metrics).toHaveLength(metricsExplorerProps.metrics.length);
+  });
+
+  it('filters metrics with search', () => {
+    const input = metricsExplorer.find(Input);
+    input.simulate('change', { target: { value: 'go' }});
+    const metrics = metricsExplorer.find('.metric');
+    expect(metrics).toHaveLength(1);
+  });
+
+  it('handles click on metric', () => {
+    const metric = metricsExplorer.find('.metric').at(0);
+    metric.simulate('click');
+    expect(metricsExplorerProps.insertAtCursor).toHaveBeenCalled();
+  });
+
+/*  it('executes the query when clicking the execute button', () => {
+    const spyExecuteQuery = jest.fn();
+    const props = { ...expressionInputProps, executeQuery: spyExecuteQuery };
+    const wrapper = mount(<ExpressionInput {...props} />);
+    const btn = wrapper.find(Button).filterWhere((btn) => btn.hasClass('execute-btn'));
+    btn.simulate('click');
+    expect(spyExecuteQuery).toHaveBeenCalledTimes(1);
+  });  */
+});

--- a/web/ui/react-app/src/pages/graph/MetricsExplorer.test.tsx
+++ b/web/ui/react-app/src/pages/graph/MetricsExplorer.test.tsx
@@ -43,13 +43,4 @@ describe('MetricsExplorer', () => {
     metric.simulate('click');
     expect(metricsExplorerProps.insertAtCursor).toHaveBeenCalled();
   });
-
-  /*  it('executes the query when clicking the execute button', () => {
-    const spyExecuteQuery = jest.fn();
-    const props = { ...expressionInputProps, executeQuery: spyExecuteQuery };
-    const wrapper = mount(<ExpressionInput {...props} />);
-    const btn = wrapper.find(Button).filterWhere((btn) => btn.hasClass('execute-btn'));
-    btn.simulate('click');
-    expect(spyExecuteQuery).toHaveBeenCalledTimes(1);
-  });  */
 });

--- a/web/ui/react-app/src/pages/graph/MetricsExplorer.test.tsx
+++ b/web/ui/react-app/src/pages/graph/MetricsExplorer.test.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
-import { mount, ReactWrapper} from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import MetricsExplorer from './MetricsExplorer';
 import { Input } from 'reactstrap';
 
 describe('MetricsExplorer', () => {
-  const spyInsertAtCursor = jest.fn().mockImplementation((value:string) => {});
+  const spyInsertAtCursor = jest.fn().mockImplementation((value: string) => {
+    value = value;
+  });
   const metricsExplorerProps = {
     show: true,
-    updateShow:(show: boolean): void => {},
-    metrics:['go_test_1','prometheus_test_1'],
+    updateShow: (show: boolean): void => {
+      show = show;
+    },
+    metrics: ['go_test_1', 'prometheus_test_1'],
     insertAtCursor: spyInsertAtCursor,
   };
 
@@ -29,7 +33,7 @@ describe('MetricsExplorer', () => {
 
   it('filters metrics with search', () => {
     const input = metricsExplorer.find(Input);
-    input.simulate('change', { target: { value: 'go' }});
+    input.simulate('change', { target: { value: 'go' } });
     const metrics = metricsExplorer.find('.metric');
     expect(metrics).toHaveLength(1);
   });
@@ -40,7 +44,7 @@ describe('MetricsExplorer', () => {
     expect(metricsExplorerProps.insertAtCursor).toHaveBeenCalled();
   });
 
-/*  it('executes the query when clicking the execute button', () => {
+  /*  it('executes the query when clicking the execute button', () => {
     const spyExecuteQuery = jest.fn();
     const props = { ...expressionInputProps, executeQuery: spyExecuteQuery };
     const wrapper = mount(<ExpressionInput {...props} />);

--- a/web/ui/react-app/src/pages/graph/MetricsExplorer.tsx
+++ b/web/ui/react-app/src/pages/graph/MetricsExplorer.tsx
@@ -1,6 +1,7 @@
 import React, { Component, ChangeEvent } from 'react';
 import { Modal, ModalBody, ModalHeader, Input } from 'reactstrap';
 import { Fuzzy, FuzzyResult } from '@nexucis/fuzzy';
+
 const fuz = new Fuzzy({ pre: '<strong>', post: '</strong>', shouldSort: true });
 
 interface Props {
@@ -9,9 +10,11 @@ interface Props {
   metrics: string[];
   insertAtCursor(value: string): void;
 }
+
 type MetricsExplorerState = {
   searchTerm: string;
 };
+
 class MetricsExplorer extends Component<Props, MetricsExplorerState> {
   constructor(props: Props) {
     super(props);

--- a/web/ui/react-app/src/pages/graph/MetricsExplorer.tsx
+++ b/web/ui/react-app/src/pages/graph/MetricsExplorer.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, ChangeEvent } from 'react';
 import { Modal, ModalBody, ModalHeader, Input } from 'reactstrap';
 
 interface Props {
@@ -15,7 +15,7 @@ class MetricsExplorer extends Component<Props, MetricsExplorerState> {
     super(props);
     this.state = { searchTerm: '' };
   }
-  handleSearchTerm = (event: any): void => {
+  handleSearchTerm = (event: ChangeEvent<HTMLInputElement>): void => {
     this.setState({ searchTerm: event.target.value });
   };
   handleMetricClick = (query: string): void => {

--- a/web/ui/react-app/src/pages/graph/MetricsExplorer.tsx
+++ b/web/ui/react-app/src/pages/graph/MetricsExplorer.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Modal, ModalBody, ModalHeader } from 'reactstrap';
+import { Modal, ModalBody, ModalHeader, Input } from 'reactstrap';
 
 interface Props {
   show: boolean;
@@ -7,27 +7,42 @@ interface Props {
   metrics: string[];
   insertAtCursor(value: string): void;
 }
-
-class MetricsExplorer extends Component<Props> {
+type MetricsExplorerState = {
+  searchTerm: string;
+};
+class MetricsExplorer extends Component<Props, MetricsExplorerState> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { searchTerm: '' };
+  }
+  handleSearchTerm = (event: any): void => {
+    this.setState({ searchTerm: event.target.value });
+  };
   handleMetricClick = (query: string): void => {
     this.props.insertAtCursor(query);
     this.props.updateShow(false);
+    this.setState({ searchTerm: '' });
   };
 
   toggle = (): void => {
     this.props.updateShow(!this.props.show);
   };
-
   render(): JSX.Element {
     return (
-      <Modal isOpen={this.props.show} toggle={this.toggle} className="metrics-explorer">
+      <Modal isOpen={this.props.show} toggle={this.toggle} className="metrics-explorer" scrollable>
         <ModalHeader toggle={this.toggle}>Metrics Explorer</ModalHeader>
         <ModalBody>
-          {this.props.metrics.map((metric) => (
-            <p key={metric} className="metric" onClick={this.handleMetricClick.bind(this, metric)}>
-              {metric}
-            </p>
-          ))}
+          <Input placeholder="Search" value={this.state.searchTerm} type="text" onChange={this.handleSearchTerm} />
+          {this.props.metrics
+            .filter((metric) => {
+              if (this.state.searchTerm === '') return true;
+              return metric.toLowerCase().includes(this.state.searchTerm.toLowerCase());
+            })
+            .map((metric) => (
+              <p key={metric} className="metric" onClick={this.handleMetricClick.bind(this, metric)}>
+                {metric}
+              </p>
+            ))}
         </ModalBody>
       </Modal>
     );

--- a/web/ui/react-app/src/pages/graph/MetricsExplorer.tsx
+++ b/web/ui/react-app/src/pages/graph/MetricsExplorer.tsx
@@ -4,7 +4,7 @@ import { Fuzzy, FuzzyResult } from '@nexucis/fuzzy';
 
 const fuz = new Fuzzy({ pre: '<strong>', post: '</strong>', shouldSort: true });
 
-interface Props {
+interface MetricsExplorerProps {
   show: boolean;
   updateShow(show: boolean): void;
   metrics: string[];
@@ -15,8 +15,8 @@ type MetricsExplorerState = {
   searchTerm: string;
 };
 
-class MetricsExplorer extends Component<Props, MetricsExplorerState> {
-  constructor(props: Props) {
+class MetricsExplorer extends Component<MetricsExplorerProps, MetricsExplorerState> {
+  constructor(props: MetricsExplorerProps) {
     super(props);
     this.state = { searchTerm: '' };
   }

--- a/web/ui/react-app/src/pages/graph/MetricsExplorer.tsx
+++ b/web/ui/react-app/src/pages/graph/MetricsExplorer.tsx
@@ -1,5 +1,7 @@
 import React, { Component, ChangeEvent } from 'react';
 import { Modal, ModalBody, ModalHeader, Input } from 'reactstrap';
+import { Fuzzy, FuzzyResult } from '@nexucis/fuzzy';
+const fuz = new Fuzzy({ pre: '<strong>', post: '</strong>', shouldSort: true });
 
 interface Props {
   show: boolean;
@@ -33,12 +35,19 @@ class MetricsExplorer extends Component<Props, MetricsExplorerState> {
         <ModalHeader toggle={this.toggle}>Metrics Explorer</ModalHeader>
         <ModalBody>
           <Input placeholder="Search" value={this.state.searchTerm} type="text" onChange={this.handleSearchTerm} />
-          {this.props.metrics
-            .filter((metric) => {
-              if (this.state.searchTerm === '') return true;
-              return metric.toLowerCase().includes(this.state.searchTerm.toLowerCase());
-            })
-            .map((metric) => (
+          {this.state.searchTerm.length > 0 &&
+            fuz
+              .filter(this.state.searchTerm, this.props.metrics)
+              .map((result: FuzzyResult) => (
+                <p
+                  key={result.original}
+                  className="metric"
+                  onClick={this.handleMetricClick.bind(this, result.original)}
+                  dangerouslySetInnerHTML={{ __html: result.rendered }}
+                ></p>
+              ))}
+          {this.state.searchTerm.length === 0 &&
+            this.props.metrics.map((metric) => (
               <p key={metric} className="metric" onClick={this.handleMetricClick.bind(this, metric)}>
                 {metric}
               </p>


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
This PR resolves #9628 by adding search field for metrics explorer in the React UI.

This PR also adds UI tests for MetricsExplorer component as well.

![Screen Shot 2021-10-30 at 11 07 48 PM](https://user-images.githubusercontent.com/3792749/139565471-ee61ed8e-d250-40e5-b040-5f890914f12f.png)

I tried to `--signoff` option but I'm not sure I did it correctly.
