### PR TITLE
Close DB in Agent tests

### DIFF
--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -107,6 +107,8 @@ func TestCommit(t *testing.T) {
 		require.NoError(t, a.Commit())
 	}
 
+	require.NoError(t, s.Close())
+
 	// Read records from WAL and check for expected count of series and samples.
 	walSeriesCount := 0
 	walSamplesCount := 0
@@ -195,6 +197,8 @@ func TestRollback(t *testing.T) {
 	}
 
 	require.NoError(t, a.Rollback())
+
+	require.NoError(t, s.Close())
 
 	// Read records from WAL and check for expected count of series and samples.
 	walSeriesCount := 0
@@ -392,6 +396,8 @@ func TestWALReplay(t *testing.T) {
 	}
 
 	require.NoError(t, a.Commit())
+
+	require.NoError(t, s.Close())
 
 	restartOpts := DefaultOptions()
 	restartLogger := log.NewNopLogger()

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -18,8 +18,6 @@ package agent
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -39,11 +37,7 @@ import (
 )
 
 func TestUnsupported(t *testing.T) {
-	promAgentDir, err := ioutil.TempDir("", "TestUnsupported")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(promAgentDir))
-	})
+	promAgentDir := t.TempDir()
 
 	opts := DefaultOptions()
 	logger := log.NewNopLogger()
@@ -76,17 +70,16 @@ func TestCommit(t *testing.T) {
 		numSeries     = 8
 	)
 
-	promAgentDir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(promAgentDir))
-	})
+	promAgentDir := t.TempDir()
 
 	lbls := labelsForTest(t.Name(), numSeries)
 	opts := DefaultOptions()
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
+	defer func() {
+		require.NoError(t, remoteStorage.Close())
+	}()
 
 	s, err := Open(logger, reg, remoteStorage, promAgentDir, opts)
 	require.NoError(t, err)
@@ -113,6 +106,9 @@ func TestCommit(t *testing.T) {
 
 	reg = prometheus.NewRegistry()
 	remoteStorage = remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
+	defer func() {
+		require.NoError(t, remoteStorage.Close())
+	}()
 
 	s1, err := Open(logger, nil, remoteStorage, promAgentDir, opts)
 	require.NoError(t, err)
@@ -167,17 +163,16 @@ func TestRollback(t *testing.T) {
 		numSeries     = 8
 	)
 
-	promAgentDir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(promAgentDir))
-	})
+	promAgentDir := t.TempDir()
 
 	lbls := labelsForTest(t.Name(), numSeries)
 	opts := DefaultOptions()
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
+	defer func() {
+		require.NoError(t, remoteStorage.Close())
+	}()
 
 	s, err := Open(logger, reg, remoteStorage, promAgentDir, opts)
 	require.NoError(t, err)
@@ -205,6 +200,9 @@ func TestRollback(t *testing.T) {
 
 	reg = prometheus.NewRegistry()
 	remoteStorage = remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
+	defer func() {
+		require.NoError(t, remoteStorage.Close())
+	}()
 
 	s1, err := Open(logger, nil, remoteStorage, promAgentDir, opts)
 	require.NoError(t, err)
@@ -260,11 +258,7 @@ func TestFullTruncateWAL(t *testing.T) {
 		lastTs        = 500
 	)
 
-	promAgentDir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(promAgentDir))
-	})
+	promAgentDir := t.TempDir()
 
 	lbls := labelsForTest(t.Name(), numSeries)
 	opts := DefaultOptions()
@@ -272,6 +266,9 @@ func TestFullTruncateWAL(t *testing.T) {
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
+	defer func() {
+		require.NoError(t, remoteStorage.Close())
+	}()
 
 	s, err := Open(logger, reg, remoteStorage, promAgentDir, opts)
 	require.NoError(t, err)
@@ -304,17 +301,16 @@ func TestPartialTruncateWAL(t *testing.T) {
 		numSeries     = 800
 	)
 
-	promAgentDir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(promAgentDir))
-	})
+	promAgentDir := t.TempDir()
 
 	opts := DefaultOptions()
 	opts.TruncateFrequency = time.Minute * 2
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
+	defer func() {
+		require.NoError(t, remoteStorage.Close())
+	}()
 
 	s, err := Open(logger, reg, remoteStorage, promAgentDir, opts)
 	require.NoError(t, err)
@@ -367,11 +363,7 @@ func TestWALReplay(t *testing.T) {
 		lastTs        = 500
 	)
 
-	promAgentDir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(promAgentDir))
-	})
+	promAgentDir := t.TempDir()
 
 	lbls := labelsForTest(t.Name(), numSeries)
 	opts := DefaultOptions()
@@ -379,6 +371,9 @@ func TestWALReplay(t *testing.T) {
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
+	defer func() {
+		require.NoError(t, remoteStorage.Close())
+	}()
 
 	s, err := Open(logger, reg, remoteStorage, promAgentDir, opts)
 	require.NoError(t, err)

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -215,6 +215,9 @@ func TestRollback(t *testing.T) {
 	if err == nil {
 		sr, err := wal.NewSegmentsReader(s1.wal.Dir())
 		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, sr.Close())
+		}()
 
 		r := wal.NewReader(sr)
 		seriesPool := sync.Pool{

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -49,10 +49,10 @@ func TestUnsupported(t *testing.T) {
 	logger := log.NewNopLogger()
 
 	s, err := Open(logger, prometheus.DefaultRegisterer, nil, promAgentDir, opts)
-	if err != nil {
-		t.Fatalf("unable to create storage for the agent: %v", err)
-	}
-	defer s.Close()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
 
 	t.Run("Querier", func(t *testing.T) {
 		_, err := s.Querier(context.TODO(), 0, 0)
@@ -89,9 +89,10 @@ func TestCommit(t *testing.T) {
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
 
 	s, err := Open(logger, reg, remoteStorage, promAgentDir, opts)
-	if err != nil {
-		t.Fatalf("unable to create storage for the agent: %v", err)
-	}
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
 
 	a := s.Appender(context.TODO())
 
@@ -114,9 +115,7 @@ func TestCommit(t *testing.T) {
 	remoteStorage = remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
 
 	s, err = Open(logger, nil, remoteStorage, promAgentDir, opts)
-	if err != nil {
-		t.Fatalf("unable to create storage for the agent: %v", err)
-	}
+	require.NoError(t, err)
 
 	var dec record.Decoder
 
@@ -178,9 +177,10 @@ func TestRollback(t *testing.T) {
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
 
 	s, err := Open(logger, reg, remoteStorage, promAgentDir, opts)
-	if err != nil {
-		t.Fatalf("unable to create storage for the agent: %v", err)
-	}
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
 
 	a := s.Appender(context.TODO())
 
@@ -204,9 +204,7 @@ func TestRollback(t *testing.T) {
 	remoteStorage = remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
 
 	s, err = Open(logger, nil, remoteStorage, promAgentDir, opts)
-	if err != nil {
-		t.Fatalf("unable to create storage for the agent: %v", err)
-	}
+	require.NoError(t, err)
 
 	var dec record.Decoder
 
@@ -270,9 +268,10 @@ func TestFullTruncateWAL(t *testing.T) {
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
 
 	s, err := Open(logger, reg, remoteStorage, promAgentDir, opts)
-	if err != nil {
-		t.Fatalf("unable to create storage for the agent: %v", err)
-	}
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
 
 	a := s.Appender(context.TODO())
 
@@ -312,9 +311,10 @@ func TestPartialTruncateWAL(t *testing.T) {
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
 
 	s, err := Open(logger, reg, remoteStorage, promAgentDir, opts)
-	if err != nil {
-		t.Fatalf("unable to create storage for the agent: %v", err)
-	}
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
 
 	a := s.Appender(context.TODO())
 
@@ -375,9 +375,10 @@ func TestWALReplay(t *testing.T) {
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
 
 	s, err := Open(logger, reg, remoteStorage, promAgentDir, opts)
-	if err != nil {
-		t.Fatalf("unable to create storage for the agent: %v", err)
-	}
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
 
 	a := s.Appender(context.TODO())
 
@@ -397,9 +398,7 @@ func TestWALReplay(t *testing.T) {
 	restartReg := prometheus.NewRegistry()
 
 	s, err = Open(restartLogger, restartReg, nil, promAgentDir, restartOpts)
-	if err != nil {
-		t.Fatalf("unable to create storage for the agent: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Check if all the series are retrieved back from the WAL.
 	m := gatherFamily(t, restartReg, "prometheus_agent_active_series")

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -77,9 +77,9 @@ func TestCommit(t *testing.T) {
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
-	defer func() {
-		require.NoError(t, remoteStorage.Close())
-	}()
+	defer func(rs *remote.Storage) {
+		require.NoError(t, rs.Close())
+	}(remoteStorage)
 
 	s, err := Open(logger, reg, remoteStorage, promAgentDir, opts)
 	require.NoError(t, err)
@@ -121,6 +121,9 @@ func TestCommit(t *testing.T) {
 	if err == nil {
 		sr, err := wal.NewSegmentsReader(s1.wal.Dir())
 		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, sr.Close())
+		}()
 
 		r := wal.NewReader(sr)
 		seriesPool := sync.Pool{
@@ -170,9 +173,9 @@ func TestRollback(t *testing.T) {
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 	remoteStorage := remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
-	defer func() {
-		require.NoError(t, remoteStorage.Close())
-	}()
+	defer func(rs *remote.Storage) {
+		require.NoError(t, rs.Close())
+	}(remoteStorage)
 
 	s, err := Open(logger, reg, remoteStorage, promAgentDir, opts)
 	require.NoError(t, err)

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -107,8 +107,6 @@ func TestCommit(t *testing.T) {
 		require.NoError(t, a.Commit())
 	}
 
-	require.NoError(t, s.Close())
-
 	// Read records from WAL and check for expected count of series and samples.
 	walSeriesCount := 0
 	walSamplesCount := 0
@@ -116,13 +114,16 @@ func TestCommit(t *testing.T) {
 	reg = prometheus.NewRegistry()
 	remoteStorage = remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
 
-	s, err = Open(logger, nil, remoteStorage, promAgentDir, opts)
+	s1, err := Open(logger, nil, remoteStorage, promAgentDir, opts)
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, s1.Close())
+	}()
 
 	var dec record.Decoder
 
 	if err == nil {
-		sr, err := wal.NewSegmentsReader(s.wal.Dir())
+		sr, err := wal.NewSegmentsReader(s1.wal.Dir())
 		require.NoError(t, err)
 
 		r := wal.NewReader(sr)
@@ -198,8 +199,6 @@ func TestRollback(t *testing.T) {
 
 	require.NoError(t, a.Rollback())
 
-	require.NoError(t, s.Close())
-
 	// Read records from WAL and check for expected count of series and samples.
 	walSeriesCount := 0
 	walSamplesCount := 0
@@ -207,13 +206,16 @@ func TestRollback(t *testing.T) {
 	reg = prometheus.NewRegistry()
 	remoteStorage = remote.NewStorage(log.With(logger, "component", "remote"), reg, startTime, promAgentDir, time.Second*30, nil)
 
-	s, err = Open(logger, nil, remoteStorage, promAgentDir, opts)
+	s1, err := Open(logger, nil, remoteStorage, promAgentDir, opts)
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, s1.Close())
+	}()
 
 	var dec record.Decoder
 
 	if err == nil {
-		sr, err := wal.NewSegmentsReader(s.wal.Dir())
+		sr, err := wal.NewSegmentsReader(s1.wal.Dir())
 		require.NoError(t, err)
 
 		r := wal.NewReader(sr)

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
-// +build !windows
-
 package agent
 
 import (


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

The DB wasn't being closed in most of the tests in `agent/db_test.go`, causing an error when removing the data directory.

Fixes #9621