### PR TITLE
Fix retention boundary so 2h retention deletes blocks right at the 2h boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+* [CHANGE] TSDB: Fix the predicate checking for blocks which are beyond the retention period to include the ones right at the retention boundary. #9633
+
 ## 2.50.1 / 2024-02-26
 
 * [BUGFIX] API: Fix metadata API using wrong field names. #13633

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1615,7 +1615,7 @@ func BeyondTimeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struc
 	for i, block := range blocks {
 		// The difference between the first block and this block is larger than
 		// the retention period so any blocks after that are added as deletable.
-		if i > 0 && blocks[0].Meta().MaxTime-block.Meta().MaxTime > db.opts.RetentionDuration {
+		if i > 0 && blocks[0].Meta().MaxTime-block.Meta().MaxTime >= db.opts.RetentionDuration {
 			for _, b := range blocks[i:] {
 				deletable[b.meta.ULID] = struct{}{}
 			}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -681,6 +681,34 @@ func TestDB_Snapshot(t *testing.T) {
 	require.Equal(t, 1000.0, sum)
 }
 
+func TestDB_BeyondTimeRetention(t *testing.T) {
+	opts := DefaultOptions()
+	opts.RetentionDuration = 100
+	db := openTestDB(t, opts, nil)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	// We have 4 blocks, 3 of which are beyond the retention duration.
+	metas := []BlockMeta{
+		{MinTime: 300, MaxTime: 500},
+		{MinTime: 200, MaxTime: 300},
+		{MinTime: 100, MaxTime: 200},
+		{MinTime: 0, MaxTime: 100},
+	}
+
+	for _, m := range metas {
+		createBlock(t, db.Dir(), genSeries(1, 1, m.MinTime, m.MaxTime))
+	}
+
+	// Reloading should truncate the 3 blocks which are >= the retention period.
+	require.NoError(t, db.reloadBlocks())
+	blocks := db.Blocks()
+	require.Len(t, blocks, 1)
+	require.Equal(t, metas[0].MinTime, blocks[0].Meta().MinTime)
+	require.Equal(t, metas[0].MaxTime, blocks[0].Meta().MaxTime)
+}
+
 // TestDB_Snapshot_ChunksOutsideOfCompactedRange ensures that a snapshot removes chunks samples
 // that are outside the set block time range.
 // See https://github.com/prometheus/prometheus/issues/5105


### PR DESCRIPTION
Signed-off-by: darshanime <deathbullet@gmail.com>
closes https://github.com/prometheus/prometheus/issues/9595
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
