### PR TITLE
remote-write: slow down retries to avoid DDOS

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -188,7 +188,7 @@ var (
 
 		// Backoff times for retrying a batch of samples on recoverable errors.
 		MinBackoff: model.Duration(30 * time.Millisecond),
-		MaxBackoff: model.Duration(100 * time.Millisecond),
+		MaxBackoff: model.Duration(5 * time.Second),
 	}
 
 	// DefaultMetadataConfig is the default metadata configuration for a remote write endpoint.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2752,7 +2752,7 @@ queue_config:
   # Initial retry delay. Gets doubled for every retry.
   [ min_backoff: <duration> | default = 30ms ]
   # Maximum retry delay.
-  [ max_backoff: <duration> | default = 100ms ]
+  [ max_backoff: <duration> | default = 5s ]
   # Retry upon receiving a 429 status code from the remote-write storage.
   # This is experimental and might change in the future.
   [ retry_on_http_429: <boolean> | default = false ]


### PR DESCRIPTION
Increase the default max retry time from 100ms to 5 seconds.

Remote write calls are retried after a recoverable error such as the back-end returning 500. Prometheus waits the minimum time and retries, then doubles the wait on each subsequent retry until the maximum is reached.

If some data is still getting through, remote-write will also increase shards, and the default maximum shards is 200.
200 shards sending every 100ms is 20 calls per second, to a back-end that is already in trouble. If you have multiple such Prometheus sending to your back-end, it's now a DDOS.

5 seconds was chosen to match the default BatchSendDeadline: if we can afford to wait that long for no response, then we can wait the same time to retry. We will reach 5 seconds after 9 successive failures.