### PR TITLE
Add agent mode identifier

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -510,7 +510,14 @@ func main() {
 	klogv2.ClampLevel(6)
 	klogv2.SetLogger(log.With(logger, "component", "k8s_client_runtime"))
 
-	level.Info(logger).Log("msg", "Starting Prometheus", "version", version.Info())
+	modeAppName := "Prometheus Server"
+	mode := "server"
+	if agentMode {
+		modeAppName = "Prometheus Agent"
+		mode = "agent"
+	}
+
+	level.Info(logger).Log("msg", "Starting "+modeAppName, "mode", mode, "version", version.Info())
 	if bits.UintSize < 64 {
 		level.Warn(logger).Log("msg", "This Prometheus binary has not been compiled for a 64-bit architecture. Due to virtual memory constraints of 32-bit systems, it is highly recommended to switch to a 64-bit binary of Prometheus.", "GOARCH", runtime.GOARCH)
 	}
@@ -604,6 +611,7 @@ func main() {
 	cfg.web.Notifier = notifierManager
 	cfg.web.LookbackDelta = time.Duration(cfg.lookbackDelta)
 	cfg.web.IsAgent = agentMode
+	cfg.web.AppName = modeAppName
 
 	cfg.web.Version = &web.PrometheusVersion{
 		Version:   version.Version,

--- a/web/web.go
+++ b/web/web.go
@@ -254,6 +254,7 @@ type Options struct {
 	RemoteReadBytesInFrame     int
 	EnableRemoteWriteReceiver  bool
 	IsAgent                    bool
+	AppName                    string
 
 	Gatherer   prometheus.Gatherer
 	Registerer prometheus.Registerer
@@ -463,11 +464,11 @@ func New(logger log.Logger, o *Options) *Handler {
 
 	router.Get("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "Prometheus is Healthy.\n")
+		fmt.Fprintf(w, o.AppName+" is Healthy.\n")
 	})
 	router.Get("/-/ready", readyf(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "Prometheus is Ready.\n")
+		fmt.Fprintf(w, o.AppName+" is Ready.\n")
 	}))
 
 	return h


### PR DESCRIPTION
Identify in the logs and liveness endpoints if the server is running in
Agent mode or not.

Signed-off-by: SuperQ <superq@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
