### PR TITLE
cmd/prometheus: wait for Prometheus to shutdown in tests

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -224,6 +224,7 @@ func TestWALSegmentSizeBounds(t *testing.T) {
 				t.Errorf("prometheus should be still running: %v", err)
 			case <-time.After(5 * time.Second):
 				prom.Process.Kill()
+				<-done
 			}
 			continue
 		}
@@ -266,6 +267,7 @@ func TestMaxBlockChunkSegmentSizeBounds(t *testing.T) {
 				t.Errorf("prometheus should be still running: %v", err)
 			case <-time.After(5 * time.Second):
 				prom.Process.Kill()
+				<-done
 			}
 			continue
 		}
@@ -436,6 +438,7 @@ func TestModeSpecificFlags(t *testing.T) {
 					t.Errorf("prometheus should be still running: %v", err)
 				case <-time.After(5 * time.Second):
 					prom.Process.Kill()
+					<-done
 				}
 				return
 			}


### PR DESCRIPTION
So temporary data directory can be successfully removed, as on Windows,
directory cannot be in used while removal.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>

Refs #9621