### PR TITLE
Agent: Add a boolean to the index to indicate agent mode.

### DIFF
--- a/web/ui/react-app/public/index.html
+++ b/web/ui/react-app/public/index.html
@@ -10,12 +10,15 @@
     <meta name="theme-color" content="#000000" />
 
     <!--
-      The GLOBAL_CONSOLES_LINK placeholder magic value is replaced during serving by Prometheus
-      and set to the consoles link if it exists. It will render a "Consoles" link in the navbar when
-      it is non-empty.
+      Placeholders replaced by Prometheus during serving:
+      - GLOBAL_CONSOLES_LINK is replaced and set to the consoles link if it exists.
+        It will render a "Consoles" link in the navbar when it is non-empty.
+      - PROMETHEUS_AGENT_MODE is replaced by a boolean indicating if Prometheus is running in agent mode.
+        It true, it will disable querying capacities in the UI and generally adapt the UI to the agent mode.
     -->
     <script>
       const GLOBAL_CONSOLES_LINK='CONSOLES_LINK_PLACEHOLDER';
+      const GLOBAL_PROMETHEUS_AGENT_MODE=PROMETHEUS_AGENT_MODE_PLACEHOLDER;
     </script>
 
     <!--

--- a/web/web.go
+++ b/web/web.go
@@ -32,6 +32,7 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	template_text "text/template"
@@ -408,6 +409,7 @@ func New(logger log.Logger, o *Options) *Handler {
 		}
 		replacedIdx := bytes.ReplaceAll(idx, []byte("CONSOLES_LINK_PLACEHOLDER"), []byte(h.consolesPath()))
 		replacedIdx = bytes.ReplaceAll(replacedIdx, []byte("TITLE_PLACEHOLDER"), []byte(h.options.PageTitle))
+		replacedIdx = bytes.ReplaceAll(replacedIdx, []byte("PROMETHEUS_AGENT_MODE_PLACEHOLDER"), []byte(strconv.FormatBool(h.options.IsAgent)))
 		w.Write(replacedIdx)
 	}
 


### PR DESCRIPTION
I would like to avoid extra API call's to determine if we are running in
Agent Mode, so I think we could use this approach.

This is a bootstrap of #9612

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
