### PR TITLE
Fix misleading agent-only/server-only check messages.

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -114,7 +114,6 @@ func serverOnlyFlag(app *kingpin.Application, name, help string) *kingpin.FlagCl
 			serverOnlyFlags = append(serverOnlyFlags, "--"+name)
 			return nil
 		})
-
 }
 
 // agentOnlyFlag creates agent-only kingpin flag.


### PR DESCRIPTION
Issue:

```
[root@host01 ~]# docker run -it --net=host --rm -v /root/editor/prom-agent-batcopter.yaml:/etc/prometheus/prometheus.yaml -v /root/prom-batcopter-data:/prometheus -u root --name prom-agent-batcopter quay.io/prometheus/prometheus:main --enable-feature=agent --config.file=/etc/prometheus/prometheus.yaml --storage.tsdb.path=/prometheus --web.listen-address=:9091
ts=2021-11-02T16:00:59.789Z caller=main.go:205 level=info msg="Experimental agent mode enabled."
The following flag(s) can not be used in agent mode: ["--enable-feature"]
```

Problem was that PreAction gives us all parsed and used flags. Context does not give us any info on what flag clause it was defined on. Wrapping + preAction works better instead.

Also added info for flag help about being server or agent only.

cc @rfratto 

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>