### PR TITLE
codemirror-promql moved to prometheus org

### DIFF
--- a/scripts/sync_codemirror.sh
+++ b/scripts/sync_codemirror.sh
@@ -11,7 +11,7 @@ branch="repo_sync_codemirror"
 commit_msg="Update codemirror"
 pr_title="Synchronize codemirror from prometheus/prometheus"
 pr_msg="Propagating changes from prometheus/prometheus default branch."
-target_repo="prometheus-community/codemirror-promql"
+target_repo="prometheus/codemirror-promql"
 source_path="web/ui/module/codemirror-promql"
 
 color_red='\e[31m'

--- a/web/ui/module/codemirror-promql/README.md
+++ b/web/ui/module/codemirror-promql/README.md
@@ -1,7 +1,7 @@
 CodeMirror-promql
 =================
-[![CircleCI](https://circleci.com/gh/prometheus-community/codemirror-promql.svg?style=shield)](https://circleci.com/gh/prometheus-community/codemirror-promql) [![GitHub license](https://img.shields.io/badge/license-Apache-blue.svg)](./LICENSE)
-[![NPM version](https://img.shields.io/npm/v/codemirror-promql.svg)](https://www.npmjs.org/package/codemirror-promql) [![codecov](https://codecov.io/gh/prometheus-community/codemirror-promql/branch/master/graph/badge.svg?token=1OSVPBDKZC)](https://codecov.io/gh/prometheus-community/codemirror-promql)
+[![CircleCI](https://circleci.com/gh/prometheus/codemirror-promql.svg?style=shield)](https://circleci.com/gh/prometheus/codemirror-promql) [![GitHub license](https://img.shields.io/badge/license-Apache-blue.svg)](./LICENSE)
+[![NPM version](https://img.shields.io/npm/v/codemirror-promql.svg)](https://www.npmjs.org/package/codemirror-promql) [![codecov](https://codecov.io/gh/prometheus/codemirror-promql/branch/master/graph/badge.svg?token=1OSVPBDKZC)](https://codecov.io/gh/prometheus/codemirror-promql)
 
 ## Overview
 
@@ -13,7 +13,7 @@ and autocompletion for PromQL ([Prometheus Query Language](https://prometheus.io
 ## Where does it come from?
 
 The authoritative copy of this code lives in `prometheus/prometheus` and is synced to 
-`prometheus-community/codemirror-promql` on a regular basis by a bot. Please contribute any code changes to the code 
+`prometheus/codemirror-promql` on a regular basis by a bot. Please contribute any code changes to the code 
 in https://github.com/prometheus/prometheus/tree/main/web/ui/module/codemirror-promql.
 
 ### Installation
@@ -222,7 +222,7 @@ const promQL = new PromQLExtension().setComplete({
 ##### Override the default Prometheus client
 
 In case you are not satisfied by our default Prometheus client, you can still provide your own. It has to implement the
-interface [PrometheusClient](https://github.com/prometheus-community/codemirror-promql/blob/master/src/lang-promql/client/prometheus.ts#L111-L117)
+interface [PrometheusClient](https://github.com/prometheus/codemirror-promql/blob/master/src/lang-promql/client/prometheus.ts#L111-L117)
 .
 
 ```typescript
@@ -246,4 +246,4 @@ Note: In case this parameter is provided, then the rest of the configuration is 
 
 ## License
 
-Apache License 2.0, see [LICENSE](https://github.com/prometheus-community/codemirror-promql/blob/master/LICENSE).
+Apache License 2.0, see [LICENSE](https://github.com/prometheus/codemirror-promql/blob/master/LICENSE).

--- a/web/ui/module/codemirror-promql/package.json
+++ b/web/ui/module/codemirror-promql/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/prometheus-community/codemirror-promql.git"
+    "url": "git+https://github.com/prometheus/codemirror-promql.git"
   },
   "keywords": [
     "promql",
@@ -27,9 +27,9 @@
   "author": "Prometheus Authors <prometheus-developers@googlegroups.com>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/prometheus-community/codemirror-promql/issues"
+    "url": "https://github.com/prometheus/codemirror-promql/issues"
   },
-  "homepage": "https://github.com/prometheus-community/codemirror-promql/blob/master/README.md",
+  "homepage": "https://github.com/prometheus/codemirror-promql/blob/master/README.md",
   "dependencies": {
     "lru-cache": "^6.0.0"
   },


### PR DESCRIPTION
`codemirror-promql` has been moved to the Prometheus org. So this fix is reflecting this move

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
