### PR TITLE
fix: storage.tsdb.path randomly initialised to data-agent/

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -129,6 +129,7 @@ func agentOnlyFlag(app *kingpin.Application, name, help string) *kingpin.FlagCla
 type flagConfig struct {
 	configFile string
 
+	agentStoragePath    string
 	localStoragePath    string
 	notifier            notifier.Options
 	forGracePeriod      model.Duration
@@ -311,7 +312,7 @@ func main() {
 		Hidden().Default("true").BoolVar(&cfg.tsdb.WALCompression)
 
 	agentOnlyFlag(a, "storage.agent.path", "Base path for metrics storage.").
-		Default("data-agent/").StringVar(&cfg.localStoragePath)
+		Default("data-agent/").StringVar(&cfg.agentStoragePath)
 
 	agentOnlyFlag(a, "storage.agent.wal-segment-size",
 		"Size at which to split WAL segment files. Example: 100MB").
@@ -984,14 +985,14 @@ func main() {
 					logger,
 					prometheus.DefaultRegisterer,
 					remoteStorage,
-					cfg.localStoragePath,
+					cfg.agentStoragePath,
 					&opts,
 				)
 				if err != nil {
 					return errors.Wrap(err, "opening storage failed")
 				}
 
-				switch fsType := prom_runtime.Statfs(cfg.localStoragePath); fsType {
+				switch fsType := prom_runtime.Statfs(cfg.agentStoragePath); fsType {
 				case "NFS_SUPER_MAGIC":
 					level.Warn(logger).Log("fs_type", fsType, "msg", "This filesystem is not supported and may lead to data corruption and data loss. Please carefully read https://prometheus.io/docs/prometheus/latest/storage/ to learn more about supported filesystems.")
 				default:


### PR DESCRIPTION
Using the same variable for `storage.tsdb.path` and `storage.agent.path`
as below in main.go causes `cfg.localStoragePath` to be `data/` or
`data-agent/` at random.

```
  a.Flag("storage.tsdb.path", "Base path for metrics storage.").
      PreAction(serverOnlySetting()).
      Default("data/").StringVar(&cfg.localStoragePath)

  a.Flag("storage.agent.path", "Base path for metrics storage.").
      PreAction(agentOnlySetting()).
      Default("data-agent/").StringVar(&cfg.localStoragePath)
```

This patch fixes it by using a different variable for `storage.agent.path`

Signed-off-by: Sunil Thaha <sthaha@redhat.com>
