### PR TITLE
Expose Error function for WrappedError

### DIFF
--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -38,6 +38,16 @@ type Error struct {
 	Err      WrappedError
 }
 
+// Error prints the error message in a formatted string.
+func (err *Error) Error() string {
+	if err.Err.nodeAlt != nil {
+		return errors.Wrapf(err.Err.err, "%d:%d: %d:%d: group %q, rule %d, %q", err.Err.node.Line, err.Err.node.Column, err.Err.nodeAlt.Line, err.Err.nodeAlt.Column, err.Group, err.Rule, err.RuleName).Error()
+	} else if err.Err.node != nil {
+		return errors.Wrapf(err.Err.err, "%d:%d: group %q, rule %d, %q", err.Err.node.Line, err.Err.node.Column, err.Group, err.Rule, err.RuleName).Error()
+	}
+	return errors.Wrapf(err.Err.err, "group %q, rule %d, %q", err.Group, err.Rule, err.RuleName).Error()
+}
+
 // WrappedError wraps error with the yaml node which can be used to represent
 // the line and column numbers of the error.
 type WrappedError struct {
@@ -46,13 +56,14 @@ type WrappedError struct {
 	nodeAlt *yaml.Node
 }
 
-func (err *Error) Error() string {
-	if err.Err.nodeAlt != nil {
-		return errors.Wrapf(err.Err.err, "%d:%d: %d:%d: group %q, rule %d, %q", err.Err.node.Line, err.Err.node.Column, err.Err.nodeAlt.Line, err.Err.nodeAlt.Column, err.Group, err.Rule, err.RuleName).Error()
-	} else if err.Err.node != nil {
-		return errors.Wrapf(err.Err.err, "%d:%d: group %q, rule %d, %q", err.Err.node.Line, err.Err.node.Column, err.Group, err.Rule, err.RuleName).Error()
+// Error prints the error message in a formatted string.
+func (we *WrappedError) Error() string {
+	if we.nodeAlt != nil {
+		return errors.Wrapf(we.err, "%d:%d: %d:%d", we.node.Line, we.node.Column, we.nodeAlt.Line, we.nodeAlt.Column).Error()
+	} else if we.node != nil {
+		return errors.Wrapf(we.err, "%d:%d", we.node.Line, we.node.Column).Error()
 	}
-	return errors.Wrapf(err.Err.err, "group %q, rule %d, %q", err.Group, err.Rule, err.RuleName).Error()
+	return we.err.Error()
 }
 
 // RuleGroups is a set of rule groups that are typically exposed in a file.


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

### Description
[WrappedError](https://github.com/prometheus/prometheus/blob/main/pkg/rulefmt/rulefmt.go#L41-L47) is public and is returned from the [RuleNode.Validate()](https://github.com/prometheus/prometheus/blob/main/pkg/rulefmt/rulefmt.go#L134-L135) function, but we do not expose any fields or methods for the WrappedError as a result the callers cannot extract meaningful information from it. This PR exposes an Error() method so the callers can print the error returned