### PR TITLE
Align some struct fields

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,3 +37,7 @@ linters-settings:
     local-prefixes: github.com/prometheus/prometheus
   gofumpt:
     extra-rules: true
+  govet:
+    # TODO: Enable additioanl govet linting.
+    # enable:
+    #   - fieldalignment

--- a/cmd/prometheus/query_log_test.go
+++ b/cmd/prometheus/query_log_test.go
@@ -45,12 +45,12 @@ const (
 
 // queryLogTest defines a query log test.
 type queryLogTest struct {
-	origin         origin   // Kind of queries tested: api, console, rules.
+	configFile     *os.File // The configuration file.
 	prefix         string   // Set as --web.route-prefix.
 	host           string   // Used in --web.listen-address. Used with 127.0.0.1 and ::1.
-	port           int      // Used in --web.listen-address.
 	cwd            string   // Directory where the test is running. Required to find the rules in testdata.
-	configFile     *os.File // The configuration file.
+	origin         origin   // Kind of queries tested: api, console, rules.
+	port           int      // Used in --web.listen-address.
 	enabledAtStart bool     // Whether query log is enabled at startup.
 }
 
@@ -375,12 +375,6 @@ func (p *queryLogTest) run(t *testing.T) {
 }
 
 type queryLogLine struct {
-	Params struct {
-		Query string `json:"query"`
-		Step  int    `json:"step"`
-		Start string `json:"start"`
-		End   string `json:"end"`
-	} `json:"params"`
 	Request struct {
 		Path     string `json:"path"`
 		ClientIP string `json:"clientIP"`
@@ -389,6 +383,12 @@ type queryLogLine struct {
 		File string `json:"file"`
 		Name string `json:"name"`
 	} `json:"ruleGroup"`
+	Params struct {
+		Query string `json:"query"`
+		Start string `json:"start"`
+		End   string `json:"end"`
+		Step  int    `json:"step"`
+	} `json:"params"`
 }
 
 // readQueryLog unmarshal a json-formatted query log into query log lines.

--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -87,9 +87,9 @@ type EC2SDConfig struct {
 	SecretKey       config.Secret  `yaml:"secret_key,omitempty"`
 	Profile         string         `yaml:"profile,omitempty"`
 	RoleARN         string         `yaml:"role_arn,omitempty"`
+	Filters         []*EC2Filter   `yaml:"filters"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
 	Port            int            `yaml:"port"`
-	Filters         []*EC2Filter   `yaml:"filters"`
 }
 
 // Name returns the name of the EC2 Config.

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -422,8 +422,8 @@ func TestUnmarshalConfig(t *testing.T) {
 	cases := []struct {
 		name       string
 		config     string
-		expected   SDConfig
 		errMessage string
+		expected   SDConfig
 	}{
 		{
 			name: "good",

--- a/discovery/gce/gce.go
+++ b/discovery/gce/gce.go
@@ -110,14 +110,14 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // the Discoverer interface.
 type Discovery struct {
 	*refresh.Discovery
-	project      string
-	zone         string
-	filter       string
 	client       *http.Client
 	svc          *compute.Service
 	isvc         *compute.InstancesService
-	port         int
+	project      string
+	zone         string
+	filter       string
 	tagSeparator string
+	port         int
 }
 
 // NewDiscovery returns a new Discovery which periodically refreshes its targets.

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -118,9 +118,9 @@ type SDConfig struct {
 	APIServer          config.URL              `yaml:"api_server,omitempty"`
 	Role               Role                    `yaml:"role"`
 	KubeConfig         string                  `yaml:"kubeconfig_file"`
-	HTTPClientConfig   config.HTTPClientConfig `yaml:",inline"`
 	NamespaceDiscovery NamespaceDiscovery      `yaml:"namespaces,omitempty"`
 	Selectors          []SelectorConfig        `yaml:"selectors,omitempty"`
+	HTTPClientConfig   config.HTTPClientConfig `yaml:",inline"`
 }
 
 // Name returns the name of the Config.

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -295,13 +295,13 @@ type network struct {
 
 // App describes a service running on Marathon.
 type app struct {
-	ID              string            `json:"id"`
-	Tasks           []task            `json:"tasks"`
-	RunningTasks    int               `json:"tasksRunning"`
 	Labels          map[string]string `json:"labels"`
+	ID              string            `json:"id"`
 	Container       container         `json:"container"`
+	Tasks           []task            `json:"tasks"`
 	PortDefinitions []portDefinition  `json:"portDefinitions"`
 	Networks        []network         `json:"networks"`
+	RunningTasks    int               `json:"tasksRunning"`
 	RequirePorts    bool              `json:"requirePorts"`
 }
 

--- a/discovery/moby/docker.go
+++ b/discovery/moby/docker.go
@@ -65,14 +65,12 @@ func init() {
 
 // DockerSDConfig is the configuration for Docker (non-swarm) based service discovery.
 type DockerSDConfig struct {
-	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
-
-	Host               string   `yaml:"host"`
-	Port               int      `yaml:"port"`
-	Filters            []Filter `yaml:"filters"`
-	HostNetworkingHost string   `yaml:"host_networking_host"`
-
-	RefreshInterval model.Duration `yaml:"refresh_interval"`
+	Host               string                  `yaml:"host"`
+	HostNetworkingHost string                  `yaml:"host_networking_host"`
+	Filters            []Filter                `yaml:"filters"`
+	HTTPClientConfig   config.HTTPClientConfig `yaml:",inline"`
+	Port               int                     `yaml:"port"`
+	RefreshInterval    model.Duration          `yaml:"refresh_interval"`
 }
 
 // Name returns the name of the Config.

--- a/discovery/puppetdb/resources.go
+++ b/discovery/puppetdb/resources.go
@@ -23,15 +23,15 @@ import (
 )
 
 type Resource struct {
+	Parameters  Parameters `json:"parameters"`
 	Certname    string     `json:"certname"`
 	Resource    string     `json:"resource"`
 	Type        string     `json:"type"`
 	Title       string     `json:"title"`
-	Exported    bool       `json:"exported"`
-	Tags        []string   `json:"tags"`
 	File        string     `json:"file"`
 	Environment string     `json:"environment"`
-	Parameters  Parameters `json:"parameters"`
+	Tags        []string   `json:"tags"`
+	Exported    bool       `json:"exported"`
 }
 
 type Parameters map[string]interface{}

--- a/discovery/refresh/refresh.go
+++ b/discovery/refresh/refresh.go
@@ -49,11 +49,10 @@ func init() {
 // Discovery implements the Discoverer interface.
 type Discovery struct {
 	logger   log.Logger
-	interval time.Duration
-	refreshf func(ctx context.Context) ([]*targetgroup.Group, error)
-
 	failures prometheus.Counter
 	duration prometheus.Observer
+	refreshf func(ctx context.Context) ([]*targetgroup.Group, error)
+	interval time.Duration
 }
 
 // NewDiscovery returns a Discoverer function that calls a refresh() function at every interval.

--- a/discovery/scaleway/baremetal.go
+++ b/discovery/scaleway/baremetal.go
@@ -35,13 +35,13 @@ import (
 type baremetalDiscovery struct {
 	*refresh.Discovery
 	client     *scw.Client
-	port       int
 	zone       string
 	project    string
 	accessKey  string
 	secretKey  string
 	nameFilter string
 	tagsFilter []string
+	port       int
 }
 
 const (

--- a/discovery/targetgroup/targetgroup.go
+++ b/discovery/targetgroup/targetgroup.go
@@ -22,14 +22,15 @@ import (
 
 // Group is a set of targets with a common label set(production , test, staging etc.).
 type Group struct {
-	// Targets is a list of targets identified by a label set. Each target is
-	// uniquely identifiable in the group by its address label.
-	Targets []model.LabelSet
 	// Labels is a set of labels that is common across all targets in the group.
 	Labels model.LabelSet
 
 	// Source is an identifier that describes a group of targets.
 	Source string
+
+	// Targets is a list of targets identified by a label set. Each target is
+	// uniquely identifiable in the group by its address label.
+	Targets []model.LabelSet
 }
 
 func (tg Group) String() string {

--- a/discovery/triton/triton.go
+++ b/discovery/triton/triton.go
@@ -112,12 +112,12 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // DiscoveryResponse models a JSON response from the Triton discovery.
 type DiscoveryResponse struct {
 	Containers []struct {
-		Groups      []string `json:"groups"`
 		ServerUUID  string   `json:"server_uuid"`
 		VMAlias     string   `json:"vm_alias"`
 		VMBrand     string   `json:"vm_brand"`
 		VMImageUUID string   `json:"vm_image_uuid"`
 		VMUUID      string   `json:"vm_uuid"`
+		Groups      []string `json:"groups"`
 	} `json:"containers"`
 }
 

--- a/discovery/uyuni/uyuni.go
+++ b/discovery/uyuni/uyuni.go
@@ -65,15 +65,15 @@ type SDConfig struct {
 	Server           config.URL              `yaml:"server"`
 	Username         string                  `yaml:"username"`
 	Password         config.Secret           `yaml:"password"`
-	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 	Entitlement      string                  `yaml:"entitlement,omitempty"`
 	Separator        string                  `yaml:"separator,omitempty"`
+	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 	RefreshInterval  model.Duration          `yaml:"refresh_interval,omitempty"`
 }
 
 type systemGroupID struct {
-	GroupID   int    `xmlrpc:"id"`
 	GroupName string `xmlrpc:"name"`
+	GroupID   int    `xmlrpc:"id"`
 }
 
 type networkInfo struct {


### PR DESCRIPTION
Use govet fieldalignment to suggest improvements to struct ordering to
reduce memory use.
* Add TODO since there is a lot of this to do in the `tsdb` dir.

Signed-off-by: SuperQ <superq@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
