### PR TITLE
Add access function for restoration state of alerting rule

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -291,6 +291,13 @@ func (r *AlertingRule) SetRestored(restored bool) {
 	r.restored = restored
 }
 
+// Restored returns the if restoration state of the alerting rule.
+func (r *AlertingRule) Restored() bool {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return r.restored
+}
+
 // resolvedRetention is the duration for which a resolved alert instance
 // is kept in memory state and consequently repeatedly sent to the AlertManager.
 const resolvedRetention = 15 * time.Minute

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -291,7 +291,7 @@ func (r *AlertingRule) SetRestored(restored bool) {
 	r.restored = restored
 }
 
-// Restored returns the if restoration state of the alerting rule.
+// Restored returns the restoration state of the alerting rule.
 func (r *AlertingRule) Restored() bool {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
Was working on https://github.com/cortexproject/cortex/issues/4435
The issue that we have to enable the ruler HA on cortex is the activeAt attribute for alerting rule which the value need to be aligned between replicas. We was thinking about doing a continuously pulling for ALERTS_FOR_STATE metric and update local activeAt. By doing that we need the access of alerting rules' restoration state outside of prometheus package
Add access function for restoration state of alerting rule