### PR TITLE
Add datacenter to Consul service discovery logs

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -487,7 +487,7 @@ func (d *Discovery) watchService(ctx context.Context, ch chan<- []*targetgroup.G
 
 // Get updates for a service.
 func (srv *consulService) watch(ctx context.Context, ch chan<- []*targetgroup.Group, health *consul.Health, lastIndex *uint64) {
-	level.Debug(srv.logger).Log("msg", "Watching service", "service", srv.name, "tags", strings.Join(srv.tags, ","))
+	level.Debug(srv.logger).Log("msg", "Watching service", "service", srv.name, "datacenter", srv.labels[datacenterLabel], "tags", strings.Join(srv.tags, ","))
 
 	opts := &consul.QueryOptions{
 		WaitIndex:  *lastIndex,
@@ -510,7 +510,7 @@ func (srv *consulService) watch(ctx context.Context, ch chan<- []*targetgroup.Gr
 	}
 
 	if err != nil {
-		level.Error(srv.logger).Log("msg", "Error refreshing service", "service", srv.name, "tags", strings.Join(srv.tags, ","), "err", err)
+		level.Error(srv.logger).Log("msg", "Error refreshing service", "service", srv.name, "datacenter", srv.labels[datacenterLabel], "tags", strings.Join(srv.tags, ","), "err", err)
 		rpcFailuresCount.Inc()
 		time.Sleep(retryInterval)
 		return

--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -297,6 +297,7 @@ func (d *Discovery) getDatacenter() error {
 	}
 
 	d.clientDatacenter = dc
+	d.logger = log.With(d.logger, "datacenter", dc)
 	return nil
 }
 
@@ -487,7 +488,7 @@ func (d *Discovery) watchService(ctx context.Context, ch chan<- []*targetgroup.G
 
 // Get updates for a service.
 func (srv *consulService) watch(ctx context.Context, ch chan<- []*targetgroup.Group, health *consul.Health, lastIndex *uint64) {
-	level.Debug(srv.logger).Log("msg", "Watching service", "service", srv.name, "datacenter", srv.labels[datacenterLabel], "tags", strings.Join(srv.tags, ","))
+	level.Debug(srv.logger).Log("msg", "Watching service", "service", srv.name, "tags", strings.Join(srv.tags, ","))
 
 	opts := &consul.QueryOptions{
 		WaitIndex:  *lastIndex,
@@ -510,7 +511,7 @@ func (srv *consulService) watch(ctx context.Context, ch chan<- []*targetgroup.Gr
 	}
 
 	if err != nil {
-		level.Error(srv.logger).Log("msg", "Error refreshing service", "service", srv.name, "datacenter", srv.labels[datacenterLabel], "tags", strings.Join(srv.tags, ","), "err", err)
+		level.Error(srv.logger).Log("msg", "Error refreshing service", "service", srv.name, "tags", strings.Join(srv.tags, ","), "err", err)
 		rpcFailuresCount.Inc()
 		time.Sleep(retryInterval)
 		return


### PR DESCRIPTION
Signed-off-by: Conor Evans <coevans@tcd.ie>

In a federated Prometheus scenario, one may well be scraping the same service in several datacenters. Knowing to which datacenter an error log message refers would be helpful.

I don't see any tests that could be modified.

closes #9667
