### PR TITLE
add a negative boost for some trigonometric functions that can overlapp other regular promQL functions

### DIFF
--- a/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
+++ b/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
@@ -142,6 +142,7 @@ export const functionIdentifierTerms = [
     detail: 'function',
     info: 'Calculate the cosine, in radians, for input series',
     type: 'function',
+    // Avoid ranking higher than `count`.
     boost: -1,
   },
   {
@@ -149,6 +150,7 @@ export const functionIdentifierTerms = [
     detail: 'function',
     info: 'Calculate the hyperbolic cosine, in radians, for input series',
     type: 'function',
+    // Avoid ranking higher than `count`.
     boost: -1,
   },
   {
@@ -180,6 +182,7 @@ export const functionIdentifierTerms = [
     detail: 'function',
     info: 'Convert radians to degrees for input series',
     type: 'function',
+    // Avoid ranking higher than `delta`.
     boost: -1,
   },
   {
@@ -331,6 +334,7 @@ export const functionIdentifierTerms = [
     detail: 'function',
     info: 'Convert degrees to radians for input series',
     type: 'function',
+    // Avoid ranking higher than `rate`.
     boost: -1,
   },
   {

--- a/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
+++ b/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
@@ -142,12 +142,14 @@ export const functionIdentifierTerms = [
     detail: 'function',
     info: 'Calculate the cosine, in radians, for input series',
     type: 'function',
+    boost: -1,
   },
   {
     label: 'cosh',
     detail: 'function',
     info: 'Calculate the hyperbolic cosine, in radians, for input series',
     type: 'function',
+    boost: -1,
   },
   {
     label: 'count_over_time',
@@ -178,6 +180,7 @@ export const functionIdentifierTerms = [
     detail: 'function',
     info: 'Convert radians to degrees for input series',
     type: 'function',
+    boost: -1,
   },
   {
     label: 'delta',
@@ -328,6 +331,7 @@ export const functionIdentifierTerms = [
     detail: 'function',
     info: 'Convert degrees to radians for input series',
     type: 'function',
+    boost: -1,
   },
   {
     label: 'rate',


### PR DESCRIPTION
Signed-off-by: Augustin Husson <husson.augustin@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
