### PR TITLE
continuously syncing activeAt for alerts

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -258,6 +258,42 @@ func (r *AlertingRule) forStateSample(alert *Alert, ts time.Time, v float64) pro
 	return s
 }
 
+// forStateSample returns the series for ALERTS_FOR_STATE.
+func (r *AlertingRule) queryforStateSample(alert *Alert, q storage.Querier) (storage.Series, error) {
+	smpl := r.forStateSample(alert, time.Now(), 0)
+	var matchers []*labels.Matcher
+	for _, l := range smpl.Metric {
+		mt, err := labels.NewMatcher(labels.MatchEqual, l.Name, l.Value)
+		if err != nil {
+			panic(err)
+		}
+		matchers = append(matchers, mt)
+	}
+	sset := q.Select(false, nil, matchers...)
+
+	var s storage.Series
+	for sset.Next() {
+		// Query assures that smpl.Metric is included in sset.At().Labels(),
+		// hence just checking the length would act like equality.
+		// (This is faster than calling labels.Compare again as we already have some info).
+		if len(sset.At().Labels()) == len(matchers) {
+			s = sset.At()
+			break
+		}
+	}
+
+	if err := sset.Err(); err != nil {
+		// Querier Warnings are ignored. We do not care unless we have an error.
+		return nil, err
+	}
+
+	if s == nil {
+		return nil, nil
+	}
+
+	return s, nil
+}
+
 // SetEvaluationDuration updates evaluationDuration to the duration it took to evaluate the rule on its last evaluation.
 func (r *AlertingRule) SetEvaluationDuration(dur time.Duration) {
 	r.mtx.Lock()

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/template"
 	"github.com/prometheus/prometheus/util/strutil"
+	"github.com/prometheus/prometheus/storage"
 )
 
 const (

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -422,6 +422,7 @@ func (g *Group) run(ctx context.Context) {
 					g.metrics.IterationsScheduled.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))
 				}
 				evalTimestamp = evalTimestamp.Add((missed + 1) * g.interval)
+				g.SyncForState(time.Now())
 				iter()
 			}
 		}
@@ -705,6 +706,82 @@ func (g *Group) cleanupStaleSeries(ctx context.Context, ts time.Time) {
 		level.Warn(g.logger).Log("msg", "Stale sample appending for previous configuration failed", "err", err)
 	} else {
 		g.staleSeries = nil
+	}
+}
+
+// SyncForState sync the 'for' state of the alerts
+// by looking up last ActiveAt from storage.
+func (g *Group) SyncForState(ts time.Time) {
+	maxtMS := int64(model.TimeFromUnixNano(ts.UnixNano()))
+	// We allow sync only if alerts were active before after certain time.
+	mint := ts.Add(-g.opts.OutageTolerance)
+	mintMS := int64(model.TimeFromUnixNano(mint.UnixNano()))
+	q, err := g.opts.Queryable.Querier(g.opts.Context, mintMS, maxtMS)
+	if err != nil {
+		level.Error(g.logger).Log("msg", "Failed to get Querier", "err", err)
+		return
+	}
+	defer func() {
+		if err := q.Close(); err != nil {
+			level.Error(g.logger).Log("msg", "Failed to close Querier", "err", err)
+		}
+	}()
+
+	for _, rule := range g.Rules() {
+		alertRule, ok := rule.(*AlertingRule)
+		if !ok {
+			continue
+		}
+
+		alertRule.ForEachActiveAlert(func(a *Alert) {
+			if !alertRule.restored {
+				return
+			}
+
+			var s storage.Series
+			s, err := alertRule.queryforStateSample(a, q)
+			if err != nil {
+				// Querier Warnings are ignored. We do not care unless we have an error.
+				level.Error(g.logger).Log(
+					"msg", "Failed to sync 'for' state",
+					labels.AlertName, alertRule.Name(),
+					"stage", "Select",
+					"err", err,
+				)
+				return
+			}
+
+			if s == nil {
+				return
+			}
+
+			// Series found for the 'for' state.
+			var v float64
+			it := s.Iterator()
+			for it.Next() {
+				_, v = it.At()
+			}
+			if it.Err() != nil {
+				level.Error(g.logger).Log("msg", "Failed to sync 'for' state",
+					labels.AlertName, alertRule.Name(), "stage", "Iterator", "err", it.Err())
+				return
+			}
+			if value.IsStaleNaN(v) { // Alert was not active.
+				return
+			}
+
+			restoredActiveAt := time.Unix(int64(v), 0).UTC()
+			compare := restoredActiveAt.Sub(a.ActiveAt)
+
+			if compare <= 0 {
+				// We have another ruler instance evaluating the same rule group ealier
+				a.ActiveAt = restoredActiveAt
+			}
+
+			level.Debug(g.logger).Log("msg", "'for' state synced",
+				labels.AlertName, alertRule.Name(), "restored_time", a.ActiveAt.Format(time.RFC850),
+				"labels", a.Labels.String())
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This is use for prometheus ruler running in the upstream project that can support HA such as Cortexhttps://github.com/cortexproject/cortex/issues/4435

When the same rule groups evaluating by different rulers, the activeAt can be different since the time when each rulers start to evaluating the rule is different. We also see ingestion of ALERTS_FOR_STATE metrics is having "duplicate sample for timestamp" error because of that. 

In order to keep the activeAt consistent across the replicas, I purpose to SyncForState for each rule groups' evaluation period