### PR TITLE
Fix two trivial lint warnings

### DIFF
--- a/discovery/xds/kuma.go
+++ b/discovery/xds/kuma.go
@@ -103,11 +103,7 @@ func (c *KumaSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return errors.Errorf("kuma SD server must not be empty and have a scheme: %s", c.Server)
 	}
 
-	if err := c.HTTPClientConfig.Validate(); err != nil {
-		return err
-	}
-
-	return nil
+	return c.HTTPClientConfig.Validate()
 }
 
 func (c *KumaSDConfig) Name() string {

--- a/tsdb/wal/wal.go
+++ b/tsdb/wal/wal.go
@@ -452,10 +452,7 @@ func (w *WAL) Repair(origErr error) error {
 	if err != nil {
 		return err
 	}
-	if err := w.setSegment(s); err != nil {
-		return err
-	}
-	return nil
+	return w.setSegment(s)
 }
 
 // SegmentName builds a segment name for the directory.


### PR DESCRIPTION
Not sure why those show up for me locally but not if run by the CI.

Signed-off-by: beorn7 <beorn@grafana.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
