### PR TITLE
Rules: simplify map key for stale series detection

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -652,7 +652,8 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 						level.Warn(g.logger).Log("msg", "Rule evaluation result discarded", "err", err, "sample", s)
 					}
 				} else {
-					seriesReturned[s.Metric.String()] = s.Metric
+					buf := [1024]byte{}
+					seriesReturned[string(s.Metric.Bytes(buf[:]))] = s.Metric
 				}
 			}
 			if numOutOfOrder > 0 {
@@ -672,7 +673,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 						// Do not count these in logging, as this is expected if series
 						// is exposed from a different rule.
 					default:
-						level.Warn(g.logger).Log("msg", "Adding stale sample failed", "sample", metric, "err", err)
+						level.Warn(g.logger).Log("msg", "Adding stale sample failed", "sample", lset.String(), "err", err)
 					}
 				}
 			}


### PR DESCRIPTION
The rules manager keeps a note of which series were generated by the last run, so it can write a stale marker to those that disappeared. 
Since the keys are not for human eyes, we can use a simpler format and save the effort of quoting label values.

I don't have a benchmark, but this was the profile that made me want to change it: in a process doing just rule evaluation, about 4% of all CPU was spent on string quoting:
```
github.com/prometheus/prometheus/rules.(*Group).Eval.func1
/.../vendor/github.com/prometheus/prometheus/rules/manager.go

  Total:           0      880ms (flat, cum)  7.75%
    639            .          .           			for _, s := range vector { 
    640            .       10ms           				if _, err := app.Append(0, s.Metric, s.T, s.V); err != nil { 
[...]
    654            .          .           				} else { 
    655            .      590ms           					seriesReturned[s.Metric.String()] = s.Metric 
    656            .          .           				} 
    657            .          .           			} 

github.com/prometheus/prometheus/pkg/labels.Labels.String
/.../vendor/github.com/prometheus/prometheus/pkg/labels/labels.go

  Total:           0      580ms (flat, cum)  5.11%
     52            .          .            
     53            .          .           	b.WriteByte('{') 
     54            .          .           	for i, l := range ls { 
     55            .          .           		if i > 0 { 
     56            .          .           			b.WriteByte(',') 
     57            .       20ms           			b.WriteByte(' ') 
     58            .          .           		} 
     59            .       20ms           		b.WriteString(l.Name) 
     60            .       10ms           		b.WriteByte('=') 
     61            .      500ms           		b.WriteString(strconv.Quote(l.Value)) 
     62            .          .           	} 
     63            .          .           	b.WriteByte('}') 
     64            .       30ms           	return b.String() 
     65            .          .           } 
     66            .          .            
```