### PR TITLE
Increase time range for PrometheusHAGroupCrashlooping alert

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -403,7 +403,7 @@
               or
               (
                 count by (%(prometheusHAGroupLabels)s) (
-                  changes(process_start_time_seconds{%(prometheusSelector)s}[1h]) > 4
+                  changes(process_start_time_seconds{%(prometheusSelector)s}[30m]) > 4
                 )
               /
                 count by (%(prometheusHAGroupLabels)s) (
@@ -418,7 +418,7 @@
             },
             annotations: {
               summary: 'More than half of the Prometheus instances within the same HA group are crashlooping.',
-              description: '{{ $value | humanizePercentage }} of Prometheus instances within the %(prometheusHAGroupName)s HA group have had at least 5 total restarts or 2 unclean restarts in the last 1h.' % $._config,
+              description: '{{ $value | humanizePercentage }} of Prometheus instances within the %(prometheusHAGroupName)s HA group have had at least 5 recent total restarts or 2 recent unclean restarts.' % $._config,
             },
           },
         ],

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -418,7 +418,7 @@
             },
             annotations: {
               summary: 'More than half of the Prometheus instances within the same HA group are crashlooping.',
-              description: '{{ $value | humanizePercentage }} of Prometheus instances within the %(prometheusHAGroupName)s HA group have had at least 5 recent total restarts or 2 recent unclean restarts.' % $._config,
+              description: '{{ $value | humanizePercentage }} of Prometheus instances within the %(prometheusHAGroupName)s HA group have had at least 5 total restarts in the last 30m or 2 unclean restarts in the last 1h.' % $._config,
             },
           },
         ],

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -391,7 +391,7 @@
                 and
                   ( 
                     count by (%(prometheusHAGroupLabels)s) (
-                      changes(process_start_time_seconds{%(prometheusSelector)s}[30m]) > 1
+                      changes(process_start_time_seconds{%(prometheusSelector)s}[1h]) > 1
                     ) 
                     / 
                     count by (%(prometheusHAGroupLabels)s) (
@@ -403,7 +403,7 @@
               or
               (
                 count by (%(prometheusHAGroupLabels)s) (
-                  changes(process_start_time_seconds{%(prometheusSelector)s}[30m]) > 4
+                  changes(process_start_time_seconds{%(prometheusSelector)s}[1h]) > 4
                 )
               /
                 count by (%(prometheusHAGroupLabels)s) (
@@ -418,7 +418,7 @@
             },
             annotations: {
               summary: 'More than half of the Prometheus instances within the same HA group are crashlooping.',
-              description: '{{ $value | humanizePercentage }} of Prometheus instances within the %(prometheusHAGroupName)s HA group have had at least 5 total restarts or 2 unclean restarts in the last 30m.' % $._config,
+              description: '{{ $value | humanizePercentage }} of Prometheus instances within the %(prometheusHAGroupName)s HA group have had at least 5 total restarts or 2 unclean restarts in the last 1h.' % $._config,
             },
           },
         ],


### PR DESCRIPTION
Increase the PrometheusHAGroupCrashlooping alert time range to 1 hour, as 30 minutes does not catch all crashlooping systems.

Signed-off-by: Niko Smeds <nikosmeds@gmail.com>