### PR TITLE
Do not build for arm64

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -34,4 +34,7 @@ crossbuild:
         - linux
         - netbsd
         - openbsd
-        - windows
+        # Commented until we support windows/arm64.
+        # - windows
+        - windows/i386
+        - windows/amd64


### PR DESCRIPTION
Latest promu release builds for windows/arm64 by default. This pull request does
not attempt to build prometheus for it until Prometheus supports it.

Refs #9701

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
