### PR TITLE
unwrap paren expr with stepinvariant expr

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1698,8 +1698,7 @@ func createLabelsForAbsentFunction(expr parser.Expr) labels.Labels {
 }
 
 func stringFromArg(e parser.Expr) string {
-	tmp := unwrapStepInvariantExpr(e) // Unwrap StepInvariant
-	unwrapParenExpr(&tmp)             // Optionally unwrap ParenExpr
+	tmp := unwrapStepInvariantAndParenExprs(&e) // Unwrap StepInvariant
 	return tmp.(*parser.StringLiteral).Val
 }
 


### PR DESCRIPTION
ref - https://github.com/prometheus/prometheus/pull/9591#discussion_r746650891

Signed-off-by: darshanime <deathbullet@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
