### PR TITLE
feat: linreg => slope 0 for const values

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -722,6 +722,7 @@ func linearRegression(samples []Point, interceptTime int64) (slope, intercept fl
 	initY = samples[0].V
 	constY = true
 	for i, sample := range samples {
+		// Reset constY to false if any new y values are encountered
 		if constY && i > 0 && sample.V != initY {
 			constY = false
 		}
@@ -733,8 +734,8 @@ func linearRegression(samples []Point, interceptTime int64) (slope, intercept fl
 		sumX2, cX2 = kahanSumInc(x*x, sumX2, cX2)
 	}
 	if constY {
-		if math.IsNaN(initY) || math.IsInf(initY, 0) {
-			return math.NaN(), math.NaN()
+		if math.IsInf(initY, 0) {
+			initY = math.NaN()
 		}
 		return 0, initY
 	}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -735,7 +735,7 @@ func linearRegression(samples []Point, interceptTime int64) (slope, intercept fl
 	}
 	if constY {
 		if math.IsInf(initY, 0) {
-			return math.NaN(),math.NaN()
+			return math.NaN(), math.NaN()
 		}
 		return 0, initY
 	}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -735,7 +735,7 @@ func linearRegression(samples []Point, interceptTime int64) (slope, intercept fl
 	}
 	if constY {
 		if math.IsInf(initY, 0) {
-			initY = math.NaN()
+			return Math.NaN(),Math.NaN()
 		}
 		return 0, initY
 	}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -732,7 +732,7 @@ func linearRegression(samples []Point, interceptTime int64) (slope, intercept fl
 		sumXY, cXY = kahanSumInc(x*sample.V, sumXY, cXY)
 		sumX2, cX2 = kahanSumInc(x*x, sumX2, cX2)
 	}
-	if constY == true {
+	if constY {
 		return 0, initY
 	}
 	sumX = sumX + cX

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -722,7 +722,7 @@ func linearRegression(samples []Point, interceptTime int64) (slope, intercept fl
 	initY = samples[0].V
 	constY = true
 	for i, sample := range samples {
-		// Reset constY to false if any new y values are encountered
+		// Set constY to false if any new y values are encountered.
 		if constY && i > 0 && sample.V != initY {
 			constY = false
 		}
@@ -735,7 +735,7 @@ func linearRegression(samples []Point, interceptTime int64) (slope, intercept fl
 	}
 	if constY {
 		if math.IsInf(initY, 0) {
-			return Math.NaN(),Math.NaN()
+			return math.NaN(),math.NaN()
 		}
 		return 0, initY
 	}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -716,8 +716,15 @@ func linearRegression(samples []Point, interceptTime int64) (slope, intercept fl
 		sumY, cY   float64
 		sumXY, cXY float64
 		sumX2, cX2 float64
+		initY      float64
+		constY     bool
 	)
-	for _, sample := range samples {
+	initY = samples[0].V
+	constY = true
+	for i, sample := range samples {
+		if constY && i > 0 && sample.V != initY {
+			constY = false
+		}
 		n += 1.0
 		x := float64(sample.T-interceptTime) / 1e3
 		sumX, cX = kahanSumInc(x, sumX, cX)
@@ -725,7 +732,9 @@ func linearRegression(samples []Point, interceptTime int64) (slope, intercept fl
 		sumXY, cXY = kahanSumInc(x*sample.V, sumXY, cXY)
 		sumX2, cX2 = kahanSumInc(x*x, sumX2, cX2)
 	}
-
+	if constY == true {
+		return 0, initY
+	}
 	sumX = sumX + cX
 	sumY = sumY + cY
 	sumXY = sumXY + cXY

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -733,6 +733,9 @@ func linearRegression(samples []Point, interceptTime int64) (slope, intercept fl
 		sumX2, cX2 = kahanSumInc(x*x, sumX2, cX2)
 	}
 	if constY {
+		if math.IsNaN(initY) || math.IsInf(initY, 0) {
+			return math.NaN(), math.NaN()
+		}
 		return 0, initY
 	}
 	sumX = sumX + cX

--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -46,7 +46,7 @@ func TestDeriv(t *testing.T) {
 	metric := labels.FromStrings("__name__", "foo")
 	start := 1493712816939
 	interval := 30 * 1000
-	// introduce some timestamp jitter to test 0 slope case
+	// Introduce some timestamp jitter to test 0 slope case.
 	// https://github.com/prometheus/prometheus/issues/7180
 	for i := 0; i < 15; i++ {
 		jitter := 12 * i % 2

--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -45,11 +45,12 @@ func TestDeriv(t *testing.T) {
 
 	metric := labels.FromStrings("__name__", "foo")
 	start := 1493712816939
+	interval := 30 * 1000
 	// introduce some timestamp jitter to test 0 slope case
 	// https://github.com/prometheus/prometheus/issues/7180
 	for i := 0; i < 15; i++ {
 		jitter := 12 * i % 2
-		a.Append(0, metric, int64(start+30*i+jitter), 1057)
+		a.Append(0, metric, int64(start+interval*i+jitter), 1)
 	}
 
 	require.NoError(t, a.Commit())

--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -44,8 +44,13 @@ func TestDeriv(t *testing.T) {
 	a := storage.Appender(context.Background())
 
 	metric := labels.FromStrings("__name__", "foo")
-	a.Append(0, metric, 1493712816939, 1.0)
-	a.Append(0, metric, 1493712846939, 1.0)
+	start := 1493712816939
+	// introduce some timestamp jitter to test 0 slope case
+	// https://github.com/prometheus/prometheus/issues/7180
+	for i := 0; i < 15; i++ {
+		jitter := 12*i%2
+		a.Append(0, metric, int64 (start + 30 * i + jitter), 1057)
+	}
 
 	require.NoError(t, a.Commit())
 

--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -48,8 +48,8 @@ func TestDeriv(t *testing.T) {
 	// introduce some timestamp jitter to test 0 slope case
 	// https://github.com/prometheus/prometheus/issues/7180
 	for i := 0; i < 15; i++ {
-		jitter := 12*i%2
-		a.Append(0, metric, int64 (start + 30 * i + jitter), 1057)
+		jitter := 12 * i % 2
+		a.Append(0, metric, int64(start+30*i+jitter), 1057)
 	}
 
 	require.NoError(t, a.Commit())


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

I tried reading over #7180 and it sounded like implementing a special case of returning zero slope for constant sample values could be worthwhile.

Let me know if I ought to add another test case for deriv since the existing test would probably hit this early return. 

Resolves #7180