### PR TITLE
Check postings bytes length when decoding

### DIFF
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"hash"
 	"hash/crc32"
 	"io"
@@ -1782,7 +1783,13 @@ func (dec *Decoder) Postings(b []byte) (int, Postings, error) {
 	d := encoding.Decbuf{B: b}
 	n := d.Be32int()
 	l := d.Get()
-	return n, newBigEndianPostings(l), d.Err()
+	if d.Err() != nil {
+		return 0, nil, d.Err()
+	}
+	if len(l) != 4*n {
+		return 0, nil, fmt.Errorf("unexpected postings length, should be %d bytes for %d postings, got %d bytes", 4*n, n, len(l))
+	}
+	return n, newBigEndianPostings(l), nil
 }
 
 // LabelNamesOffsetsFor decodes the offsets of the name symbols for a given series.

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -560,3 +560,8 @@ func TestSymbols(t *testing.T) {
 	}
 	require.NoError(t, iter.Err())
 }
+
+func TestDecoder_Postings_WrongInput(t *testing.T) {
+	_, _, err := (&Decoder{}).Postings([]byte("the cake is a lie"))
+	require.Error(t, err)
+}


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Added validation to expected postings length compared to the bytes slice length. 
With 32bit postings, we expect to have 4 bytes per each posting.
If the number doesn't add up, we know that the input data is not compatible with our code (maybe data is cut, or padded with trash, or even written in a different coded).

This is needed in downstream projects to correctly identify cached postings written with an unknown codec, but it's also a good idea to validate it here.
