### PR TITLE
feat: tune api requrest page sizes in linode SD

### DIFF
--- a/discovery/linode/linode.go
+++ b/discovery/linode/linode.go
@@ -161,8 +161,12 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 	if d.lastResults != nil && d.eventPollingEnabled {
 		// Check to see if there have been any events. If so, refresh our data.
-		opts := linodego.NewListOptions(1, fmt.Sprintf(filterTemplate, d.lastRefreshTimestamp.Format("2006-01-02T15:04:05")))
-		events, err := d.client.ListEvents(ctx, opts)
+		opts := linodego.ListOptions{
+			PageOptions: &linodego.PageOptions{Page: 1},
+			PageSize:    25,
+			Filter:      fmt.Sprintf(filterTemplate, d.lastRefreshTimestamp.Format("2006-01-02T15:04:05")),
+		}
+		events, err := d.client.ListEvents(ctx, &opts)
 		if err != nil {
 			var e *linodego.Error
 			if errors.As(err, &e) && e.Code == http.StatusUnauthorized {
@@ -205,13 +209,13 @@ func (d *Discovery) refreshData(ctx context.Context) ([]*targetgroup.Group, erro
 	}
 
 	// Gather all linode instances.
-	instances, err := d.client.ListInstances(ctx, &linodego.ListOptions{})
+	instances, err := d.client.ListInstances(ctx, &linodego.ListOptions{PageSize: 500})
 	if err != nil {
 		return nil, err
 	}
 
 	// Gather detailed IP address info for all IPs on all linode instances.
-	detailedIPs, err := d.client.ListIPAddresses(ctx, &linodego.ListOptions{})
+	detailedIPs, err := d.client.ListIPAddresses(ctx, &linodego.ListOptions{PageSize: 500})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The default page size for Linode APIv4 is
[`100`](https://www.linode.com/docs/api/#pagination). For larger/busier
accounts, this value can be tuned a bit.

This commit tunes the page sizes for the different API requests that are
associated with Linode SD:
- When checking account events to poll for changes, we refresh on _any
  event detected_, so we can always explicitly ask for the minimum page
size (`25`).
- When listing an account's instances/IPs, we can make the page size as
  large as possible (`500`) to reduce the number of paginated requests
and be kinder to rate limits.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
