### PR TITLE
fallback mocha to the previous version since ts-mocha required v8

### DIFF
--- a/web/ui/module/codemirror-promql/package.json
+++ b/web/ui/module/codemirror-promql/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-prettier": "^4.0.0",
     "isomorphic-fetch": "^3.0.0",
-    "mocha": "^9.1.3",
+    "mocha": "^8.4.0",
     "nock": "^13.0.11",
     "nyc": "^15.1.0",
     "prettier": "^2.4.1",

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -43,7 +43,7 @@
         "eslint-plugin-import": "^2.25.3",
         "eslint-plugin-prettier": "^4.0.0",
         "isomorphic-fetch": "^3.0.0",
-        "mocha": "^9.1.3",
+        "mocha": "^8.4.0",
         "nock": "^13.0.11",
         "nyc": "^15.1.0",
         "prettier": "^2.4.1",
@@ -1263,7 +1263,8 @@
     },
     "node_modules/@codemirror/language": {
       "version": "0.19.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.5.tgz",
+      "integrity": "sha512-FnIST07vaM99mv1mJaMMLvxiHSDGgP3wdlcEZzmidndWdbxjrYYYnJzVUOEkeZJNGOfrtPRMF62UCyrTjQMR3g==",
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -1578,18 +1579,16 @@
     },
     "node_modules/@types/cheerio": {
       "version": "0.22.30",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.30.tgz",
-      "integrity": "sha512-t7ZVArWZlq3dFa9Yt33qFBQIK4CQd1Q3UJp0V+UhP6vgLWLM6Qug7vZuRSGXg45zXeB1Fm5X2vmBkEX58LV2Tw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/enzyme": {
       "version": "3.10.10",
-      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.10.tgz",
-      "integrity": "sha512-/D4wFhiEjUDfPu+j5FVK0g/jf7rqeEIpNfAI+kyxzLpw5CKO0drnW3W5NC38alIjsWgnyQ8pbuPF5+UD+vhVyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/cheerio": "*",
         "@types/react": "*"
@@ -2008,8 +2007,9 @@
     },
     "node_modules/@wojtekmaj/enzyme-adapter-react-17": {
       "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.6.5.tgz",
+      "integrity": "sha512-ChIObUiXXYUiqzXPqOai+p6KF5dlbItpDDYsftUOQiAiygbMDlLeJIjynC6ZrJIa2U2MpRp4YJmtR2GQyIHjgA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@wojtekmaj/enzyme-adapter-utils": "^0.1.1",
         "enzyme-shallow-equal": "^1.0.0",
@@ -2028,8 +2028,9 @@
     },
     "node_modules/@wojtekmaj/enzyme-adapter-utils": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-utils/-/enzyme-adapter-utils-0.1.1.tgz",
+      "integrity": "sha512-bNPWtN/d8huKOkC6j1E3EkSamnRrHHT7YuR6f9JppAQqtoAm3v4/vERe4J14jQKmHLCyEBHXrlgb7H6l817hVg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "function.prototype.name": "^1.1.0",
         "has": "^1.0.0",
@@ -2203,8 +2204,9 @@
     },
     "node_modules/array.prototype.filter": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.1.tgz",
+      "integrity": "sha512-Dk3Ty7N42Odk7PjU/Ci3zT4pLj20YvuVnneG/58ICM6bt4Ij5kZaJTVQ9TSaWaIECX2sFyz4KItkVZqHNnciqw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -2279,10 +2281,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2426,8 +2439,9 @@
     },
     "node_modules/cheerio": {
       "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cheerio-select": "^1.5.0",
         "dom-serializer": "^1.3.2",
@@ -2446,8 +2460,9 @@
     },
     "node_modules/cheerio-select": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "css-select": "^4.1.3",
         "css-what": "^5.0.1",
@@ -2461,8 +2476,9 @@
     },
     "node_modules/cheerio/node_modules/tslib": {
       "version": "2.3.1",
-      "dev": true,
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
     },
     "node_modules/chokidar": {
       "version": "3.5.1",
@@ -2545,8 +2561,9 @@
     },
     "node_modules/commander": {
       "version": "2.20.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -2599,8 +2616,9 @@
     },
     "node_modules/css-select": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^5.0.0",
@@ -2614,8 +2632,9 @@
     },
     "node_modules/css-what": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
       },
@@ -2710,8 +2729,9 @@
     },
     "node_modules/discontinuous-range": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+      "dev": true
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -2839,8 +2859,9 @@
     },
     "node_modules/enzyme": {
       "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
+      "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array.prototype.flat": "^1.2.3",
         "cheerio": "^1.0.0-rc.3",
@@ -2871,8 +2892,9 @@
     },
     "node_modules/enzyme-shallow-equal": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.4.tgz",
+      "integrity": "sha512-MttIwB8kKxypwHvRynuC3ahyNc+cFbR8mjVIltnmzQ0uKGqmsfO4bfBuLxb0beLNPhjblUEYvEbsg+VSygvF1Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has": "^1.0.3",
         "object-is": "^1.1.2"
@@ -2935,8 +2957,9 @@
     },
     "node_modules/es-array-method-boxes-properly": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "dev": true
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
@@ -3381,6 +3404,13 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "license": "MIT",
@@ -3573,8 +3603,9 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -3595,8 +3626,9 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
+      "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3834,8 +3866,9 @@
     },
     "node_modules/html-element-map": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
+      "integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array.prototype.filter": "^1.0.0",
         "call-bind": "^1.0.2"
@@ -4161,8 +4194,9 @@
     },
     "node_modules/is-subset": {
       "version": "0.1.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
@@ -4461,8 +4495,9 @@
     },
     "node_modules/lodash.escape": {
       "version": "4.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
+      "dev": true
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
@@ -4471,8 +4506,9 @@
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4789,14 +4825,16 @@
     },
     "node_modules/moment": {
       "version": "2.29.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/moment-timezone": {
       "version": "0.5.34",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
+      "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
       "dependencies": {
         "moment": ">= 2.9.0"
       },
@@ -4806,13 +4844,21 @@
     },
     "node_modules/moo": {
       "version": "0.5.1",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
+      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.1.20",
@@ -4833,8 +4879,9 @@
     },
     "node_modules/nearley": {
       "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "commander": "^2.19.0",
         "moo": "^0.5.0",
@@ -4918,8 +4965,9 @@
     },
     "node_modules/nth-check": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -5117,7 +5165,8 @@
     },
     "node_modules/object-is": {
       "version": "1.1.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -5155,8 +5204,9 @@
     },
     "node_modules/object.entries": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -5168,8 +5218,9 @@
     },
     "node_modules/object.fromentries": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -5290,13 +5341,15 @@
     },
     "node_modules/parse5": {
       "version": "6.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "parse5": "^6.0.1"
       }
@@ -5348,8 +5401,9 @@
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -5481,21 +5535,24 @@
     },
     "node_modules/raf": {
       "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "performance-now": "^2.1.0"
       }
     },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "CC0-1.0"
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+      "dev": true
     },
     "node_modules/randexp": {
       "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "discontinuous-range": "1.0.0",
         "ret": "~0.1.10"
@@ -5555,7 +5612,8 @@
     },
     "node_modules/react-shallow-renderer": {
       "version": "16.14.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
       "dependencies": {
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0"
@@ -5566,7 +5624,8 @@
     },
     "node_modules/react-test-renderer": {
       "version": "17.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
       "dependencies": {
         "object-assign": "^4.1.1",
         "react-is": "^17.0.2",
@@ -5674,8 +5733,9 @@
     },
     "node_modules/ret": {
       "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.12"
       }
@@ -5705,8 +5765,9 @@
     },
     "node_modules/rst-selector-parser": {
       "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "lodash.flattendeep": "^4.4.0",
         "nearley": "^2.7.10"
@@ -5958,8 +6019,9 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.5.tgz",
+      "integrity": "sha512-Lnh17webJVsD6ECeovpVN17RlAKjmz4rF9S+8Y45CkMc/ufVpTkU3vZIyIC7sllQ1FCvObZnnCdNs/HXTUOTlg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -11360,15 +11422,6 @@
         "node": ">= 8.0.0"
       }
     },
-    "react-app/node_modules/bindings": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "react-app/node_modules/bluebird": {
       "version": "3.7.2",
       "dev": true,
@@ -14233,12 +14286,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "react-app/node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "react-app/node_modules/filesize": {
       "version": "6.1.0",
@@ -19716,12 +19763,6 @@
       "version": "0.3.7",
       "dev": true,
       "license": "MIT"
-    },
-    "react-app/node_modules/nan": {
-      "version": "2.15.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "react-app/node_modules/nanoid": {
       "version": "3.1.25",
@@ -27371,6 +27412,8 @@
     },
     "@codemirror/language": {
       "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.5.tgz",
+      "integrity": "sha512-FnIST07vaM99mv1mJaMMLvxiHSDGgP3wdlcEZzmidndWdbxjrYYYnJzVUOEkeZJNGOfrtPRMF62UCyrTjQMR3g==",
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -27604,8 +27647,6 @@
     },
     "@types/cheerio": {
       "version": "0.22.30",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.30.tgz",
-      "integrity": "sha512-t7ZVArWZlq3dFa9Yt33qFBQIK4CQd1Q3UJp0V+UhP6vgLWLM6Qug7vZuRSGXg45zXeB1Fm5X2vmBkEX58LV2Tw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -27613,8 +27654,6 @@
     },
     "@types/enzyme": {
       "version": "3.10.10",
-      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.10.tgz",
-      "integrity": "sha512-/D4wFhiEjUDfPu+j5FVK0g/jf7rqeEIpNfAI+kyxzLpw5CKO0drnW3W5NC38alIjsWgnyQ8pbuPF5+UD+vhVyg==",
       "dev": true,
       "requires": {
         "@types/cheerio": "*",
@@ -27871,6 +27910,8 @@
     },
     "@wojtekmaj/enzyme-adapter-react-17": {
       "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.6.5.tgz",
+      "integrity": "sha512-ChIObUiXXYUiqzXPqOai+p6KF5dlbItpDDYsftUOQiAiygbMDlLeJIjynC6ZrJIa2U2MpRp4YJmtR2GQyIHjgA==",
       "dev": true,
       "requires": {
         "@wojtekmaj/enzyme-adapter-utils": "^0.1.1",
@@ -27885,6 +27926,8 @@
     },
     "@wojtekmaj/enzyme-adapter-utils": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-utils/-/enzyme-adapter-utils-0.1.1.tgz",
+      "integrity": "sha512-bNPWtN/d8huKOkC6j1E3EkSamnRrHHT7YuR6f9JppAQqtoAm3v4/vERe4J14jQKmHLCyEBHXrlgb7H6l817hVg==",
       "dev": true,
       "requires": {
         "function.prototype.name": "^1.1.0",
@@ -27993,6 +28036,8 @@
     },
     "array.prototype.filter": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.1.tgz",
+      "integrity": "sha512-Dk3Ty7N42Odk7PjU/Ci3zT4pLj20YvuVnneG/58ICM6bt4Ij5kZaJTVQ9TSaWaIECX2sFyz4KItkVZqHNnciqw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -28034,8 +28079,20 @@
     "binary-extensions": {
       "version": "2.2.0"
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "boolbase": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
     "brace-expansion": {
@@ -28126,6 +28183,8 @@
     },
     "cheerio": {
       "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
       "dev": true,
       "requires": {
         "cheerio-select": "^1.5.0",
@@ -28139,12 +28198,16 @@
       "dependencies": {
         "tslib": {
           "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
     },
     "cheerio-select": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
       "dev": true,
       "requires": {
         "css-select": "^4.1.3",
@@ -28218,7 +28281,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "isomorphic-fetch": "^3.0.0",
         "lru-cache": "^6.0.0",
-        "mocha": "^9.1.3",
+        "mocha": "^8.4.0",
         "nock": "^13.0.11",
         "nyc": "^15.1.0",
         "prettier": "^2.4.1",
@@ -28604,6 +28667,8 @@
     },
     "commander": {
       "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
     "commondir": {
@@ -28646,6 +28711,8 @@
     },
     "css-select": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
@@ -28657,6 +28724,8 @@
     },
     "css-what": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
       "dev": true
     },
     "csstype": {
@@ -28711,6 +28780,8 @@
     },
     "discontinuous-range": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
       "dev": true
     },
     "doctrine": {
@@ -28793,6 +28864,8 @@
     },
     "enzyme": {
       "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
+      "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
       "dev": true,
       "requires": {
         "array.prototype.flat": "^1.2.3",
@@ -28821,6 +28894,8 @@
     },
     "enzyme-shallow-equal": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.4.tgz",
+      "integrity": "sha512-MttIwB8kKxypwHvRynuC3ahyNc+cFbR8mjVIltnmzQ0uKGqmsfO4bfBuLxb0beLNPhjblUEYvEbsg+VSygvF1Q==",
       "dev": true,
       "requires": {
         "has": "^1.0.3",
@@ -28869,6 +28944,8 @@
     },
     "es-array-method-boxes-properly": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
       "dev": true
     },
     "es-to-primitive": {
@@ -29173,6 +29250,13 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "requires": {
@@ -29284,6 +29368,8 @@
     },
     "function.prototype.name": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -29298,6 +29384,8 @@
     },
     "functions-have-names": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
+      "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==",
       "dev": true
     },
     "gensync": {
@@ -32452,14 +32540,6 @@
             "tryer": "^1.0.1"
           }
         },
-        "bindings": {
-          "version": "1.5.0",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "file-uri-to-path": "1.0.0"
-          }
-        },
         "bluebird": {
           "version": "3.7.2",
           "dev": true
@@ -34443,11 +34523,6 @@
               }
             }
           }
-        },
-        "file-uri-to-path": {
-          "version": "1.0.0",
-          "dev": true,
-          "optional": true
         },
         "filesize": {
           "version": "6.1.0",
@@ -38109,11 +38184,6 @@
         "mutationobserver-shim": {
           "version": "0.3.7",
           "dev": true
-        },
-        "nan": {
-          "version": "2.15.0",
-          "dev": true,
-          "optional": true
         },
         "nanoid": {
           "version": "3.1.25"
@@ -43281,6 +43351,8 @@
     },
     "html-element-map": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
+      "integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
       "dev": true,
       "requires": {
         "array.prototype.filter": "^1.0.0",
@@ -43465,6 +43537,8 @@
     },
     "is-subset": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
       "dev": true
     },
     "is-symbol": {
@@ -43666,6 +43740,8 @@
     },
     "lodash.escape": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
       "dev": true
     },
     "lodash.flattendeep": {
@@ -43674,6 +43750,8 @@
     },
     "lodash.isequal": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.merge": {
@@ -43880,21 +43958,34 @@
       }
     },
     "moment": {
-      "version": "2.29.1"
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moment-timezone": {
       "version": "0.5.34",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
+      "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
       "requires": {
         "moment": ">= 2.9.0"
       }
     },
     "moo": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
       "dev": true
     },
     "ms": {
       "version": "2.1.2",
       "dev": true
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -43907,6 +43998,8 @@
     },
     "nearley": {
       "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
@@ -43961,6 +44054,8 @@
     },
     "nth-check": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0"
@@ -44098,6 +44193,8 @@
     },
     "object-is": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -44118,6 +44215,8 @@
     },
     "object.entries": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -44127,6 +44226,8 @@
     },
     "object.fromentries": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -44206,10 +44307,14 @@
     },
     "parse5": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
     "parse5-htmlparser2-tree-adapter": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
       "dev": true,
       "requires": {
         "parse5": "^6.0.1"
@@ -44241,6 +44346,8 @@
     },
     "performance-now": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "picomatch": {
@@ -44314,6 +44421,8 @@
     },
     "raf": {
       "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
@@ -44321,10 +44430,14 @@
     },
     "railroad-diagrams": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
       "dev": true
     },
     "randexp": {
       "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
       "dev": true,
       "requires": {
         "discontinuous-range": "1.0.0",
@@ -44367,6 +44480,8 @@
     },
     "react-shallow-renderer": {
       "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
       "requires": {
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0"
@@ -44374,6 +44489,8 @@
     },
     "react-test-renderer": {
       "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
       "requires": {
         "object-assign": "^4.1.1",
         "react-is": "^17.0.2",
@@ -44443,6 +44560,8 @@
     },
     "ret": {
       "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
     "reusify": {
@@ -44458,6 +44577,8 @@
     },
     "rst-selector-parser": {
       "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
       "dev": true,
       "requires": {
         "lodash.flattendeep": "^4.4.0",
@@ -44630,6 +44751,8 @@
     },
     "string.prototype.trim": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.5.tgz",
+      "integrity": "sha512-Lnh17webJVsD6ECeovpVN17RlAKjmz4rF9S+8Y45CkMc/ufVpTkU3vZIyIC7sllQ1FCvObZnnCdNs/HXTUOTlg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",


### PR DESCRIPTION
With the codemirror synchronization (https://github.com/prometheus/codemirror-promql/pull/163) , I just noticed dependabot made a mistake by increasing the version of `mocha`. `ts-mocha` required the v8 and cannot work with the v9.

In prometheus I look at the deps installed and actually there are two `mocha` versions installed (the v8 and the v9). So I suspect that it used actually the v8 and not the v9.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
