### PR TITLE
storage/remote: use t.TempDir instead of ioutil.TempDir on tests

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -75,11 +75,7 @@ func TestSampleDelivery(t *testing.T) {
 	// batch timeout case.
 	n := 3
 
-	dir, err := ioutil.TempDir("", "TestSampleDelivery")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
 	defer s.Close()
@@ -154,9 +150,7 @@ func TestSampleDelivery(t *testing.T) {
 func TestMetadataDelivery(t *testing.T) {
 	c := NewTestWriteClient()
 
-	dir, err := ioutil.TempDir("", "TestMetadataDelivery")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
@@ -198,11 +192,7 @@ func TestSampleDeliveryTimeout(t *testing.T) {
 	cfg.MaxShards = 1
 	cfg.BatchSendDeadline = model.Duration(100 * time.Millisecond)
 
-	dir, err := ioutil.TempDir("", "TestSampleDeliveryTimeout")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	metrics := newQueueManagerMetrics(nil, "", "")
 	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
@@ -241,11 +231,7 @@ func TestSampleDeliveryOrder(t *testing.T) {
 	c := NewTestWriteClient()
 	c.expectSamples(samples, series)
 
-	dir, err := ioutil.TempDir("", "TestSampleDeliveryOrder")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
@@ -265,11 +251,7 @@ func TestShutdown(t *testing.T) {
 	deadline := 1 * time.Second
 	c := NewTestBlockedWriteClient()
 
-	dir, err := ioutil.TempDir("", "TestShutdown")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
@@ -308,11 +290,7 @@ func TestSeriesReset(t *testing.T) {
 	numSegments := 4
 	numSeries := 25
 
-	dir, err := ioutil.TempDir("", "TestSeriesReset")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
@@ -343,11 +321,7 @@ func TestReshard(t *testing.T) {
 	mcfg := config.DefaultMetadataConfig
 	cfg.MaxShards = 1
 
-	dir, err := ioutil.TempDir("", "TestReshard")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	metrics := newQueueManagerMetrics(nil, "", "")
 	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
@@ -740,9 +714,7 @@ func BenchmarkSampleDelivery(b *testing.B) {
 	cfg.BatchSendDeadline = model.Duration(100 * time.Millisecond)
 	cfg.MaxShards = 1
 
-	dir, err := ioutil.TempDir("", "BenchmarkSampleDelivery")
-	require.NoError(b, err)
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 
 	metrics := newQueueManagerMetrics(nil, "", "")
 	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
@@ -865,11 +837,7 @@ func TestCalculateDesiredShards(t *testing.T) {
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
 
-	dir, err := ioutil.TempDir("", "TestCalculateDesiredShards")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	metrics := newQueueManagerMetrics(nil, "", "")
 	samplesIn := newEWMARate(ewmaWeight, shardUpdateDuration)

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -15,9 +15,7 @@ package remote
 
 import (
 	"context"
-	"io/ioutil"
 	"net/url"
-	"os"
 	"sort"
 	"testing"
 
@@ -33,9 +31,7 @@ import (
 )
 
 func TestNoDuplicateReadConfigs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestNoDuplicateReadConfigs")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cfg1 := config.RemoteReadConfig{
 		Name: "write-1",

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -14,9 +14,7 @@
 package remote
 
 import (
-	"io/ioutil"
 	"net/url"
-	"os"
 	"testing"
 
 	common_config "github.com/prometheus/common/config"
@@ -26,9 +24,7 @@ import (
 )
 
 func TestStorageLifecycle(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestStorageLifecycle")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
 	conf := &config.Config{
@@ -60,14 +56,12 @@ func TestStorageLifecycle(t *testing.T) {
 	// make sure remote write has a queue.
 	require.Equal(t, 1, len(s.queryables))
 
-	err = s.Close()
+	err := s.Close()
 	require.NoError(t, err)
 }
 
 func TestUpdateRemoteReadConfigs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestUpdateRemoteReadConfigs")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
 
@@ -83,6 +77,6 @@ func TestUpdateRemoteReadConfigs(t *testing.T) {
 	require.NoError(t, s.ApplyConfig(conf))
 	require.Equal(t, 1, len(s.queryables))
 
-	err = s.Close()
+	err := s.Close()
 	require.NoError(t, err)
 }

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -14,9 +14,7 @@
 package remote
 
 import (
-	"io/ioutil"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
@@ -44,11 +42,7 @@ func testRemoteWriteConfig() *config.RemoteWriteConfig {
 }
 
 func TestNoDuplicateWriteConfigs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestNoDuplicateWriteConfigs")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	cfg1 := config.RemoteWriteConfig{
 		Name: "write-1",
@@ -132,11 +126,7 @@ func TestNoDuplicateWriteConfigs(t *testing.T) {
 }
 
 func TestRestartOnNameChange(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestRestartOnNameChange")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	cfg := testRemoteWriteConfig()
 
@@ -166,11 +156,7 @@ func TestRestartOnNameChange(t *testing.T) {
 }
 
 func TestUpdateWithRegisterer(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestRestartWithRegisterer")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Millisecond, nil)
 	c1 := &config.RemoteWriteConfig{
@@ -205,16 +191,12 @@ func TestUpdateWithRegisterer(t *testing.T) {
 		require.Equal(t, 10, queue.cfg.MaxShards)
 	}
 
-	err = s.Close()
+	err := s.Close()
 	require.NoError(t, err)
 }
 
 func TestWriteStorageLifecycle(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestWriteStorageLifecycle")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil)
 	conf := &config.Config{
@@ -226,16 +208,12 @@ func TestWriteStorageLifecycle(t *testing.T) {
 	require.NoError(t, s.ApplyConfig(conf))
 	require.Equal(t, 1, len(s.queues))
 
-	err = s.Close()
+	err := s.Close()
 	require.NoError(t, err)
 }
 
 func TestUpdateExternalLabels(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestUpdateExternalLabels")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Second, nil)
 
@@ -264,11 +242,7 @@ func TestUpdateExternalLabels(t *testing.T) {
 }
 
 func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestWriteStorageApplyConfigsIdempotent")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil)
 
@@ -305,11 +279,7 @@ func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
 }
 
 func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestWriteStorageApplyConfigsPartialUpdate")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil)
 
@@ -383,7 +353,7 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 	secondClient := s.queues[hashes[1]].client()
 	// Update c1.
 	c1.HTTPClientConfig.BearerToken = "bar"
-	err = s.ApplyConfig(conf)
+	err := s.ApplyConfig(conf)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(s.queues))
 


### PR DESCRIPTION
Updates  #9594

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
