### PR TITLE
Readd deprecated packages

### DIFF
--- a/pkg/exemplar/deprecated.go
+++ b/pkg/exemplar/deprecated.go
@@ -1,0 +1,8 @@
+package exemplar
+
+import "github.com/prometheus/prometheus/model/exemplar"
+
+const ExemplarMaxLabelSetLength = exemplar.ExemplarMaxLabelSetLength
+
+type Exemplar = exemplar.Exemplar
+type QueryResult = exemplar.QueryResult

--- a/pkg/exemplar/deprecated.go
+++ b/pkg/exemplar/deprecated.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package exemplar is deprecated and replaced with github.com/prometheus/prometheus/model/exemplar.
 package exemplar
 

--- a/pkg/exemplar/deprecated.go
+++ b/pkg/exemplar/deprecated.go
@@ -18,5 +18,7 @@ import "github.com/prometheus/prometheus/model/exemplar"
 
 const ExemplarMaxLabelSetLength = exemplar.ExemplarMaxLabelSetLength
 
-type Exemplar = exemplar.Exemplar
-type QueryResult = exemplar.QueryResult
+type (
+	Exemplar    = exemplar.Exemplar
+	QueryResult = exemplar.QueryResult
+)

--- a/pkg/exemplar/deprecated.go
+++ b/pkg/exemplar/deprecated.go
@@ -1,3 +1,4 @@
+// Package exemplar is deprecated and replaced with github.com/prometheus/prometheus/model/exemplar.
 package exemplar
 
 import "github.com/prometheus/prometheus/model/exemplar"

--- a/pkg/gate/deprecated.go
+++ b/pkg/gate/deprecated.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package gate is deprecated and replaced with github.com/prometheus/prometheus/util/gate.
 package gate
 

--- a/pkg/gate/deprecated.go
+++ b/pkg/gate/deprecated.go
@@ -1,3 +1,4 @@
+// Package gate is deprecated and replaced with github.com/prometheus/prometheus/util/gate.
 package gate
 
 import "github.com/prometheus/prometheus/util/gate"

--- a/pkg/gate/deprecated.go
+++ b/pkg/gate/deprecated.go
@@ -1,0 +1,7 @@
+package gate
+
+import "github.com/prometheus/prometheus/util/gate"
+
+type Gate = gate.Gate
+
+var New = gate.New

--- a/pkg/labels/deprecated.go
+++ b/pkg/labels/deprecated.go
@@ -16,28 +16,34 @@ package labels
 
 import "github.com/prometheus/prometheus/model/labels"
 
-const MetricName = labels.MetricName
-const MatchEqual = labels.MatchEqual
-const MatchNotEqual = labels.MatchNotEqual
-const MatchRegexp = labels.MatchRegexp
-const MatchNotRegexp = labels.MatchNotRegexp
+const (
+	MetricName     = labels.MetricName
+	MatchEqual     = labels.MatchEqual
+	MatchNotEqual  = labels.MatchNotEqual
+	MatchRegexp    = labels.MatchRegexp
+	MatchNotRegexp = labels.MatchNotRegexp
+)
 
-var Compare = labels.Compare
-var Equal = labels.Equal
-var NewBuilder = labels.NewBuilder
-var NewFastRegexMatcher = labels.NewFastRegexMatcher
-var FromMap = labels.FromMap
-var FromStrings = labels.FromStrings
-var New = labels.New
-var ReadLabels = labels.ReadLabels
-var MustNewMatcher = labels.MustNewMatcher
-var NewMatcher = labels.NewMatcher
+var (
+	Compare             = labels.Compare
+	Equal               = labels.Equal
+	NewBuilder          = labels.NewBuilder
+	NewFastRegexMatcher = labels.NewFastRegexMatcher
+	FromMap             = labels.FromMap
+	FromStrings         = labels.FromStrings
+	New                 = labels.New
+	ReadLabels          = labels.ReadLabels
+	MustNewMatcher      = labels.MustNewMatcher
+	NewMatcher          = labels.NewMatcher
+)
 
-type Builder = labels.Builder
-type FastRegexMatcher = labels.FastRegexMatcher
-type Label = labels.Label
-type Labels = labels.Labels
-type MatchType = labels.MatchType
-type Matcher = labels.Matcher
-type Selector = labels.Selector
-type Slice = labels.Slice
+type (
+	Builder          = labels.Builder
+	FastRegexMatcher = labels.FastRegexMatcher
+	Label            = labels.Label
+	Labels           = labels.Labels
+	MatchType        = labels.MatchType
+	Matcher          = labels.Matcher
+	Selector         = labels.Selector
+	Slice            = labels.Slice
+)

--- a/pkg/labels/deprecated.go
+++ b/pkg/labels/deprecated.go
@@ -1,3 +1,4 @@
+// Package labels is deprecated and replaced with github.com/prometheus/prometheus/model/labels.
 package labels
 
 import "github.com/prometheus/prometheus/model/labels"

--- a/pkg/labels/deprecated.go
+++ b/pkg/labels/deprecated.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package labels is deprecated and replaced with github.com/prometheus/prometheus/model/labels.
 package labels
 

--- a/pkg/labels/deprecated.go
+++ b/pkg/labels/deprecated.go
@@ -27,4 +27,3 @@ type MatchType = labels.MatchType
 type Matcher = labels.Matcher
 type Selector = labels.Selector
 type Slice = labels.Slice
-type StringMatcher = labels.StringMatcher

--- a/pkg/labels/deprecated.go
+++ b/pkg/labels/deprecated.go
@@ -1,0 +1,30 @@
+package labels
+
+import "github.com/prometheus/prometheus/model/labels"
+
+const MetricName = labels.MetricName
+const MatchEqual = labels.MatchEqual
+const MatchNotEqual = labels.MatchNotEqual
+const MatchRegexp = labels.MatchRegexp
+const MatchNotRegexp = labels.MatchNotRegexp
+
+var Compare = labels.Compare
+var Equal = labels.Equal
+var NewBuilder = labels.NewBuilder
+var NewFastRegexMatcher = labels.NewFastRegexMatcher
+var FromMap = labels.FromMap
+var FromStrings = labels.FromStrings
+var New = labels.New
+var ReadLabels = labels.ReadLabels
+var MustNewMatcher = labels.MustNewMatcher
+var NewMatcher = labels.NewMatcher
+
+type Builder = labels.Builder
+type FastRegexMatcher = labels.FastRegexMatcher
+type Label = labels.Label
+type Labels = labels.Labels
+type MatchType = labels.MatchType
+type Matcher = labels.Matcher
+type Selector = labels.Selector
+type Slice = labels.Slice
+type StringMatcher = labels.StringMatcher

--- a/pkg/relabel/deprecated.go
+++ b/pkg/relabel/deprecated.go
@@ -1,3 +1,4 @@
+// Package relabel is deprecated and replaced with github.com/prometheus/prometheus/model/relabel.
 package relabel
 
 import "github.com/prometheus/prometheus/model/relabel"

--- a/pkg/relabel/deprecated.go
+++ b/pkg/relabel/deprecated.go
@@ -18,18 +18,24 @@ import "github.com/prometheus/prometheus/model/relabel"
 
 var DefaultRelabelConfig = relabel.DefaultRelabelConfig
 
-const Replace = relabel.Replace
-const Keep = relabel.Keep
-const Drop = relabel.Drop
-const HashMod = relabel.HashMod
-const LabelMap = relabel.LabelMap
-const LabelDrop = relabel.LabelDrop
-const LabelKeep = relabel.LabelKeep
+const (
+	Replace   = relabel.Replace
+	Keep      = relabel.Keep
+	Drop      = relabel.Drop
+	HashMod   = relabel.HashMod
+	LabelMap  = relabel.LabelMap
+	LabelDrop = relabel.LabelDrop
+	LabelKeep = relabel.LabelKeep
+)
 
-type Action = relabel.Action
-type Config = relabel.Config
-type Regexp = relabel.Regexp
+type (
+	Action = relabel.Action
+	Config = relabel.Config
+	Regexp = relabel.Regexp
+)
 
-var Process = relabel.Process
-var MustNewRegexp = relabel.MustNewRegexp
-var NewRegexp = relabel.NewRegexp
+var (
+	Process       = relabel.Process
+	MustNewRegexp = relabel.MustNewRegexp
+	NewRegexp     = relabel.NewRegexp
+)

--- a/pkg/relabel/deprecated.go
+++ b/pkg/relabel/deprecated.go
@@ -1,0 +1,21 @@
+package relabel
+
+import "github.com/prometheus/prometheus/model/relabel"
+
+var DefaultRelabelConfig = relabel.DefaultRelabelConfig
+
+const Replace = relabel.Replace
+const Keep = relabel.Keep
+const Drop = relabel.Drop
+const HashMod = relabel.HashMod
+const LabelMap = relabel.LabelMap
+const LabelDrop = relabel.LabelDrop
+const LabelKeep = relabel.LabelKeep
+
+type Action = relabel.Action
+type Config = relabel.Config
+type Regexp = relabel.Regexp
+
+var Process = relabel.Process
+var MustNewRegexp = relabel.MustNewRegexp
+var NewRegexp = relabel.NewRegexp

--- a/pkg/relabel/deprecated.go
+++ b/pkg/relabel/deprecated.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package relabel is deprecated and replaced with github.com/prometheus/prometheus/model/relabel.
 package relabel
 

--- a/pkg/rulefmt/deprecated.go
+++ b/pkg/rulefmt/deprecated.go
@@ -1,3 +1,4 @@
+// Package rulefmt is deprecated and replaced with github.com/prometheus/prometheus/model/rulefmt.
 package rulefmt
 
 import "github.com/prometheus/prometheus/model/rulefmt"

--- a/pkg/rulefmt/deprecated.go
+++ b/pkg/rulefmt/deprecated.go
@@ -1,0 +1,13 @@
+package rulefmt
+
+import "github.com/prometheus/prometheus/model/rulefmt"
+
+type Error = rulefmt.Error
+type Rule = rulefmt.Rule
+type RuleGroup = rulefmt.RuleGroup
+type RuleGroups = rulefmt.RuleGroups
+type RuleNode = rulefmt.RuleNode
+type WrappedError = rulefmt.WrappedError
+
+var Parse = rulefmt.Parse
+var ParseFile = rulefmt.ParseFile

--- a/pkg/rulefmt/deprecated.go
+++ b/pkg/rulefmt/deprecated.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package rulefmt is deprecated and replaced with github.com/prometheus/prometheus/model/rulefmt.
 package rulefmt
 

--- a/pkg/rulefmt/deprecated.go
+++ b/pkg/rulefmt/deprecated.go
@@ -16,12 +16,16 @@ package rulefmt
 
 import "github.com/prometheus/prometheus/model/rulefmt"
 
-type Error = rulefmt.Error
-type Rule = rulefmt.Rule
-type RuleGroup = rulefmt.RuleGroup
-type RuleGroups = rulefmt.RuleGroups
-type RuleNode = rulefmt.RuleNode
-type WrappedError = rulefmt.WrappedError
+type (
+	Error        = rulefmt.Error
+	Rule         = rulefmt.Rule
+	RuleGroup    = rulefmt.RuleGroup
+	RuleGroups   = rulefmt.RuleGroups
+	RuleNode     = rulefmt.RuleNode
+	WrappedError = rulefmt.WrappedError
+)
 
-var Parse = rulefmt.Parse
-var ParseFile = rulefmt.ParseFile
+var (
+	Parse     = rulefmt.Parse
+	ParseFile = rulefmt.ParseFile
+)

--- a/pkg/textparse/deprecated.go
+++ b/pkg/textparse/deprecated.go
@@ -16,28 +16,36 @@ package textparse
 
 import "github.com/prometheus/prometheus/model/textparse"
 
-const EntryInvalid = textparse.EntryInvalid
-const EntryType = textparse.EntryType
-const EntryHelp = textparse.EntryHelp
-const EntrySeries = textparse.EntrySeries
-const EntryComment = textparse.EntryComment
-const EntryUnit = textparse.EntryUnit
+const (
+	EntryInvalid = textparse.EntryInvalid
+	EntryType    = textparse.EntryType
+	EntryHelp    = textparse.EntryHelp
+	EntrySeries  = textparse.EntrySeries
+	EntryComment = textparse.EntryComment
+	EntryUnit    = textparse.EntryUnit
+)
 
-const MetricTypeCounter = textparse.MetricTypeCounter
-const MetricTypeGauge = textparse.MetricTypeGauge
-const MetricTypeHistogram = textparse.MetricTypeHistogram
-const MetricTypeGaugeHistogram = textparse.MetricTypeGaugeHistogram
-const MetricTypeSummary = textparse.MetricTypeSummary
-const MetricTypeInfo = textparse.MetricTypeInfo
-const MetricTypeStateset = textparse.MetricTypeStateset
-const MetricTypeUnknown = textparse.MetricTypeUnknown
+const (
+	MetricTypeCounter        = textparse.MetricTypeCounter
+	MetricTypeGauge          = textparse.MetricTypeGauge
+	MetricTypeHistogram      = textparse.MetricTypeHistogram
+	MetricTypeGaugeHistogram = textparse.MetricTypeGaugeHistogram
+	MetricTypeSummary        = textparse.MetricTypeSummary
+	MetricTypeInfo           = textparse.MetricTypeInfo
+	MetricTypeStateset       = textparse.MetricTypeStateset
+	MetricTypeUnknown        = textparse.MetricTypeUnknown
+)
 
-type Entry = textparse.Entry
-type MetricType = textparse.MetricType
-type OpenMetricsParser = textparse.OpenMetricsParser
-type Parser = textparse.Parser
-type PromParser = textparse.PromParser
+type (
+	Entry             = textparse.Entry
+	MetricType        = textparse.MetricType
+	OpenMetricsParser = textparse.OpenMetricsParser
+	Parser            = textparse.Parser
+	PromParser        = textparse.PromParser
+)
 
-var New = textparse.New
-var NewOpenMetricsParser = textparse.NewOpenMetricsParser
-var NewPromParser = textparse.NewPromParser
+var (
+	New                  = textparse.New
+	NewOpenMetricsParser = textparse.NewOpenMetricsParser
+	NewPromParser        = textparse.NewPromParser
+)

--- a/pkg/textparse/deprecated.go
+++ b/pkg/textparse/deprecated.go
@@ -1,3 +1,4 @@
+// Package textparse is deprecated and replaced with github.com/prometheus/prometheus/model/textparse.
 package textparse
 
 import "github.com/prometheus/prometheus/model/textparse"

--- a/pkg/textparse/deprecated.go
+++ b/pkg/textparse/deprecated.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package textparse is deprecated and replaced with github.com/prometheus/prometheus/model/textparse.
 package textparse
 

--- a/pkg/textparse/deprecated.go
+++ b/pkg/textparse/deprecated.go
@@ -1,0 +1,29 @@
+package textparse
+
+import "github.com/prometheus/prometheus/model/textparse"
+
+const EntryInvalid = textparse.EntryInvalid
+const EntryType = textparse.EntryType
+const EntryHelp = textparse.EntryHelp
+const EntrySeries = textparse.EntrySeries
+const EntryComment = textparse.EntryComment
+const EntryUnit = textparse.EntryUnit
+
+const MetricTypeCounter = textparse.MetricTypeCounter
+const MetricTypeGauge = textparse.MetricTypeGauge
+const MetricTypeHistogram = textparse.MetricTypeHistogram
+const MetricTypeGaugeHistogram = textparse.MetricTypeGaugeHistogram
+const MetricTypeSummary = textparse.MetricTypeSummary
+const MetricTypeInfo = textparse.MetricTypeInfo
+const MetricTypeStateset = textparse.MetricTypeStateset
+const MetricTypeUnknown = textparse.MetricTypeUnknown
+
+type Entry = textparse.Entry
+type MetricType = textparse.MetricType
+type OpenMetricsParser = textparse.OpenMetricsParser
+type Parser = textparse.Parser
+type PromParser = textparse.PromParser
+
+var New = textparse.New
+var NewOpenMetricsParser = textparse.NewOpenMetricsParser
+var NewPromParser = textparse.NewPromParser

--- a/pkg/timestamp/deprecated.go
+++ b/pkg/timestamp/deprecated.go
@@ -1,0 +1,7 @@
+package timestamp
+
+import "github.com/prometheus/prometheus/model/timestamp"
+
+var FromFloatSeconds = timestamp.FromFloatSeconds
+var FromTime = timestamp.FromTime
+var Time = timestamp.Time

--- a/pkg/timestamp/deprecated.go
+++ b/pkg/timestamp/deprecated.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package timestamp is deprecated and replaced with github.com/prometheus/prometheus/model/timestamp.
 package timestamp
 

--- a/pkg/timestamp/deprecated.go
+++ b/pkg/timestamp/deprecated.go
@@ -1,3 +1,4 @@
+// Package timestamp is deprecated and replaced with github.com/prometheus/prometheus/model/timestamp.
 package timestamp
 
 import "github.com/prometheus/prometheus/model/timestamp"

--- a/pkg/timestamp/deprecated.go
+++ b/pkg/timestamp/deprecated.go
@@ -16,6 +16,8 @@ package timestamp
 
 import "github.com/prometheus/prometheus/model/timestamp"
 
-var FromFloatSeconds = timestamp.FromFloatSeconds
-var FromTime = timestamp.FromTime
-var Time = timestamp.Time
+var (
+	FromFloatSeconds = timestamp.FromFloatSeconds
+	FromTime         = timestamp.FromTime
+	Time             = timestamp.Time
+)

--- a/pkg/value/deprecated.go
+++ b/pkg/value/deprecated.go
@@ -1,0 +1,8 @@
+package value
+
+import "github.com/prometheus/prometheus/model/value"
+
+const NormalNaN = value.NormalNaN
+const StateNan = value.StaleNaN
+
+var IsStaleNaN = value.IsStaleNaN

--- a/pkg/value/deprecated.go
+++ b/pkg/value/deprecated.go
@@ -1,3 +1,4 @@
+// Package value is deprecated and replaced with github.com/prometheus/prometheus/model/value.
 package value
 
 import "github.com/prometheus/prometheus/model/value"

--- a/pkg/value/deprecated.go
+++ b/pkg/value/deprecated.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package value is deprecated and replaced with github.com/prometheus/prometheus/model/value.
 package value
 

--- a/pkg/value/deprecated.go
+++ b/pkg/value/deprecated.go
@@ -16,7 +16,9 @@ package value
 
 import "github.com/prometheus/prometheus/model/value"
 
-const NormalNaN = value.NormalNaN
-const StateNan = value.StaleNaN
+const (
+	NormalNaN = value.NormalNaN
+	StateNan  = value.StaleNaN
+)
 
 var IsStaleNaN = value.IsStaleNaN


### PR DESCRIPTION
This PR adds back packages under `pkg/*` that were moved to `model` and `util`. This is required to update Thanos and Cortex to latest Prometheus main. Unfortunately Cortex and Thanos depend on each other and cannot be updated both at the same time. It is possible to update Thanos with latest Prometheus with this PR applied.
