### PR TITLE
downgrade bootstrap to v4

### DIFF
--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -2471,6 +2471,19 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "node_modules/bootstrap": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
+      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bootstrap"
+      },
+      "peerDependencies": {
+        "jquery": "1.9.1 - 3",
+        "popper.js": "^1.16.1"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "dev": true,
@@ -4593,6 +4606,11 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -5695,6 +5713,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/postcss": {
@@ -7204,7 +7232,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.7.1",
         "@fortawesome/react-fontawesome": "^0.1.16",
         "@nexucis/fuzzy": "^0.3.0",
-        "bootstrap": "^5.1.3",
+        "bootstrap": "^4.6.1",
         "codemirror-promql": "0.18.0",
         "css.escape": "^1.5.1",
         "downshift": "^6.1.7",
@@ -11720,18 +11748,6 @@
         "dns-txt": "^2.0.2",
         "multicast-dns": "^6.0.1",
         "multicast-dns-service-types": "^1.1.0"
-      }
-    },
-    "react-app/node_modules/bootstrap": {
-      "version": "4.6.0",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
-      "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
       }
     },
     "react-app/node_modules/brorand": {
@@ -19248,10 +19264,6 @@
         "node": ">=8"
       }
     },
-    "react-app/node_modules/jquery": {
-      "version": "3.6.0",
-      "license": "MIT"
-    },
     "react-app/node_modules/jquery.flot.tooltip": {
       "version": "0.9.0",
       "license": "MIT"
@@ -20479,14 +20491,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "react-app/node_modules/popper.js": {
-      "version": "1.16.1",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "react-app/node_modules/portfinder": {
@@ -28225,6 +28229,12 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "bootstrap": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
+      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "requires": {}
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "dev": true,
@@ -29642,7 +29652,7 @@
         "@types/sanitize-html": "^2.5.0",
         "@types/sinon": "^10.0.6",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",
-        "bootstrap": "^5.1.3",
+        "bootstrap": "^4.6.1",
         "codemirror-promql": "0.18.0",
         "css.escape": "^1.5.1",
         "downshift": "^6.1.7",
@@ -32618,10 +32628,6 @@
             "multicast-dns": "^6.0.1",
             "multicast-dns-service-types": "^1.1.0"
           }
-        },
-        "bootstrap": {
-          "version": "4.6.0",
-          "requires": {}
         },
         "brorand": {
           "version": "1.1.0",
@@ -37694,9 +37700,6 @@
             }
           }
         },
-        "jquery": {
-          "version": "3.6.0"
-        },
         "jquery.flot.tooltip": {
           "version": "0.9.0"
         },
@@ -38547,9 +38550,6 @@
           "requires": {
             "ts-pnp": "^1.1.6"
           }
-        },
-        "popper.js": {
-          "version": "1.16.1"
         },
         "portfinder": {
           "version": "1.0.28",
@@ -43533,6 +43533,11 @@
       "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==",
       "dev": true
     },
+    "jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+    },
     "js-tokens": {
       "version": "4.0.0"
     },
@@ -44287,6 +44292,11 @@
       "requires": {
         "find-up": "^2.1.0"
       }
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "postcss": {
       "version": "8.3.11",

--- a/web/ui/react-app/package.json
+++ b/web/ui/react-app/package.json
@@ -20,7 +20,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.7.1",
     "@fortawesome/react-fontawesome": "^0.1.16",
     "@nexucis/fuzzy": "^0.3.0",
-    "bootstrap": "^5.1.3",
+    "bootstrap": "^4.6.1",
     "codemirror-promql": "0.18.0",
     "css.escape": "^1.5.1",
     "downshift": "^6.1.7",


### PR DESCRIPTION
I'm downgrading bootstrap to the previous version.

To be able to upgrade this version, we will have to:
* Replace `@forevolve/bootstrap-dark` because it doesn't support bootstrap 5 currently. I asked [here](https://github.com/ForEvolve/bootstrap-dark/issues/52) if they would like to support.
* Upgrade `reactstrap` to v9 and adapt the code accordingly to the breaking changes introduced.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>
