### PR TITLE
fixes wrong metric name in documentation 

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1023,8 +1023,8 @@ address defaults to the `host_ip` attribute of the hypervisor.
 The following meta labels are available on targets during [relabeling](#relabel_config):
 
 * `__meta_openstack_hypervisor_host_ip`: the hypervisor node's IP address.
-* `__meta_openstack_hypervisor_id`: the hypervisor node's ID.
 * `__meta_openstack_hypervisor_hostname`: the hypervisor node's name.
+* `__meta_openstack_hypervisor_id`: the hypervisor node's ID.
 * `__meta_openstack_hypervisor_state`: the hypervisor node's state.
 * `__meta_openstack_hypervisor_status`: the hypervisor node's status.
 * `__meta_openstack_hypervisor_type`: the hypervisor node's type.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1024,7 +1024,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 
 * `__meta_openstack_hypervisor_host_ip`: the hypervisor node's IP address.
 * `__meta_openstack_hypervisor_id`: the hypervisor node's ID.
-* `__meta_openstack_hypervisor_name`: the hypervisor node's name.
+* `__meta_openstack_hypervisor_hostname`: the hypervisor node's name.
 * `__meta_openstack_hypervisor_state`: the hypervisor node's state.
 * `__meta_openstack_hypervisor_status`: the hypervisor node's status.
 * `__meta_openstack_hypervisor_type`: the hypervisor node's type.


### PR DESCRIPTION
see https://github.com/prometheus/prometheus/blob/main/discovery/openstack/hypervisor.go#L35

Signed-off-by: teuto.net Netzdienste GmbH <github@teuto.net>
