### PR TITLE
Fix focused expression input outline styling

### DIFF
--- a/web/ui/react-app/src/pages/graph/CMTheme.tsx
+++ b/web/ui/react-app/src/pages/graph/CMTheme.tsx
@@ -2,7 +2,7 @@ import { HighlightStyle, tags } from '@codemirror/highlight';
 import { EditorView } from '@codemirror/view';
 
 export const baseTheme = EditorView.theme({
-  '&': {
+  '&.cm-editor': {
     '&.cm-focused': {
       outline: 'none',
       outline_fallback: 'none',


### PR DESCRIPTION
This is necessary due to this change in upstream CodeMirror:

https://github.com/codemirror/view/commit/73ec1a70bebc41cdd7ffd32c14d67355bbbb8970#diff-0e21fb1c9519a397050defc2148a2d1b966a0982cc4cf196e1e6b007f8d095e5

Currently the expression input shows a weird dotted outline when focused.

Signed-off-by: Julius Volz <julius.volz@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
