### PR TITLE
documentation: align kubernetes example with the community

### DIFF
--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -185,10 +185,10 @@ scrape_configs:
         regex: __meta_kubernetes_service_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_service_name]
         action: replace
-        target_label: kubernetes_name
+        target_label: service
 
   # Example scrape config for probing services via the Blackbox Exporter.
   #
@@ -217,9 +217,9 @@ scrape_configs:
       - action: labelmap
         regex: __meta_kubernetes_service_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_service_name]
-        target_label: kubernetes_name
+        target_label: service
 
   # Example scrape config for probing ingresses via the Blackbox Exporter.
   #
@@ -255,9 +255,9 @@ scrape_configs:
       - action: labelmap
         regex: __meta_kubernetes_ingress_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_ingress_name]
-        target_label: kubernetes_name
+        target_label: ingress
 
   # Example scrape config for pods
   #
@@ -294,7 +294,7 @@ scrape_configs:
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: kubernetes_pod_name
+        target_label: pod


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Throughout the last few years, there was a lot of development in the area of prometheus integration with kubernetes. During that time we have established some guidelines in how to name a few common, identifying labels to allow easy consumption of monitoring mixins, solidify integration between various tools, and improve UX. Some of those guidelines even got into prometheus documentation in the form of code comments  -https://github.com/prometheus/prometheus/blob/main/documentation/prometheus-mixin/config.libsonnet#L24.

This PR is an attempt to merge two conflicting guidelines, one that is advertised by prometheus as an example configuration and the other that is widely used by prometheus-operator, monitoring mixins, and other tools (like kube-state-metrics).

Since this is changing only an example configuration, I do not see this as a breaking change. However, I am open to being convinced otherwise :)

This is related to https://github.com/prometheus-operator/prometheus-operator/issues/4415

/cc @brancz @simonpasquier