### PR TITLE
cmd: use t.TempDir instead of ioutil.TempDir on tests

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -288,12 +288,7 @@ func TestMaxBlockChunkSegmentSizeBounds(t *testing.T) {
 }
 
 func TestTimeMetrics(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "time_metrics_e2e")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpDir))
-	}()
+	tmpDir := t.TempDir()
 
 	reg := prometheus.NewRegistry()
 	db, err := openDBWithMetrics(tmpDir, log.NewNopLogger(), reg, nil, nil)

--- a/cmd/prometheus/query_log_test.go
+++ b/cmd/prometheus/query_log_test.go
@@ -248,11 +248,7 @@ func (p *queryLogTest) run(t *testing.T) {
 		p.setQueryLog(t, "")
 	}
 
-	dir, err := ioutil.TempDir("", "query_log_test")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	params := append([]string{
 		"-test.main",

--- a/cmd/promtool/backfill_test.go
+++ b/cmd/promtool/backfill_test.go
@@ -15,9 +15,7 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"math"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -687,13 +685,9 @@ after_eof 1 2
 		t.Run(test.Description, func(t *testing.T) {
 			t.Logf("Test:%s", test.Description)
 
-			outputDir, err := ioutil.TempDir("", "myDir")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(outputDir))
-			}()
+			outputDir := t.TempDir()
 
-			err = backfill(test.MaxSamplesInAppender, []byte(test.ToParse), outputDir, false, false, test.MaxBlockDuration)
+			err := backfill(test.MaxSamplesInAppender, []byte(test.ToParse), outputDir, false, false, test.MaxBlockDuration)
 
 			if !test.IsOk {
 				require.Error(t, err, test.Description)

--- a/cmd/promtool/rules_test.go
+++ b/cmd/promtool/rules_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"io/ioutil"
 	"math"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -72,11 +71,7 @@ func TestBackfillRuleIntegration(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", "backfilldata")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(tmpDir))
-			}()
+			tmpDir := t.TempDir()
 			ctx := context.Background()
 
 			// Execute the test more than once to simulate running the rule importer twice with the same data.
@@ -219,11 +214,7 @@ func createMultiRuleTestFiles(path string) error {
 // TestBackfillLabels confirms that the labels in the rule file override the labels from the metrics
 // received from Prometheus Query API, including the __name__ label.
 func TestBackfillLabels(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "backfilldata")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpDir))
-	}()
+	tmpDir := t.TempDir()
 	ctx := context.Background()
 
 	start := time.Date(2009, time.November, 10, 6, 34, 0, 0, time.UTC)


### PR DESCRIPTION
Updates #9594