### PR TITLE
Expose functions in storage/remote.

### DIFF
--- a/storage/remote/ewma.go
+++ b/storage/remote/ewma.go
@@ -20,8 +20,8 @@ import (
 	"go.uber.org/atomic"
 )
 
-// ewmaRate tracks an exponentially weighted moving average of a per-second rate.
-type ewmaRate struct {
+// EWMARate tracks an exponentially weighted moving average of a per-second rate.
+type EWMARate struct {
 	newEvents atomic.Int64
 
 	alpha    float64
@@ -31,24 +31,24 @@ type ewmaRate struct {
 	mutex    sync.Mutex
 }
 
-// newEWMARate always allocates a new ewmaRate, as this guarantees the atomically
+// NewEWMARate always allocates a new ewmaRate, as this guarantees the atomically
 // accessed int64 will be aligned on ARM.  See prometheus#2666.
-func newEWMARate(alpha float64, interval time.Duration) *ewmaRate {
-	return &ewmaRate{
+func NewEWMARate(alpha float64, interval time.Duration) *EWMARate {
+	return &EWMARate{
 		alpha:    alpha,
 		interval: interval,
 	}
 }
 
-// rate returns the per-second rate.
-func (r *ewmaRate) rate() float64 {
+// Rate returns the per-second rate.
+func (r *EWMARate) Rate() float64 {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	return r.lastRate
 }
 
-// tick assumes to be called every r.interval.
-func (r *ewmaRate) tick() {
+// Tick assumes to be called every r.interval.
+func (r *EWMARate) Tick() {
 	newEvents := r.newEvents.Swap(0)
 	instantRate := float64(newEvents) / r.interval.Seconds()
 
@@ -63,7 +63,7 @@ func (r *ewmaRate) tick() {
 	}
 }
 
-// inc counts one event.
-func (r *ewmaRate) incr(incr int64) {
+// Incr counts one event.
+func (r *EWMARate) Incr(incr int64) {
 	r.newEvents.Add(incr)
 }

--- a/storage/remote/intern.go
+++ b/storage/remote/intern.go
@@ -33,7 +33,7 @@ var noReferenceReleases = promauto.NewCounter(prometheus.CounterOpts{
 	Help:      "The number of times release has been called for strings that are not interned.",
 })
 
-type pool struct {
+type Pool struct {
 	mtx  sync.RWMutex
 	pool map[string]*entry
 }
@@ -48,13 +48,13 @@ func newEntry(s string) *entry {
 	return &entry{s: s}
 }
 
-func newPool() *pool {
-	return &pool{
+func NewPool() *Pool {
+	return &Pool{
 		pool: map[string]*entry{},
 	}
 }
 
-func (p *pool) intern(s string) string {
+func (p *Pool) Intern(s string) string {
 	if s == "" {
 		return ""
 	}
@@ -78,7 +78,7 @@ func (p *pool) intern(s string) string {
 	return s
 }
 
-func (p *pool) release(s string) {
+func (p *Pool) Release(s string) {
 	p.mtx.RLock()
 	interned, ok := p.pool[s]
 	p.mtx.RUnlock()

--- a/storage/remote/intern_test.go
+++ b/storage/remote/intern_test.go
@@ -27,9 +27,9 @@ import (
 )
 
 func TestIntern(t *testing.T) {
-	interner := newPool()
+	interner := NewPool()
 	testString := "TestIntern"
-	interner.intern(testString)
+	interner.Intern(testString)
 	interned, ok := interner.pool[testString]
 
 	require.Equal(t, true, ok)
@@ -37,16 +37,16 @@ func TestIntern(t *testing.T) {
 }
 
 func TestIntern_MultiRef(t *testing.T) {
-	interner := newPool()
+	interner := NewPool()
 	testString := "TestIntern_MultiRef"
 
-	interner.intern(testString)
+	interner.Intern(testString)
 	interned, ok := interner.pool[testString]
 
 	require.Equal(t, true, ok)
 	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))
 
-	interner.intern(testString)
+	interner.Intern(testString)
 	interned, ok = interner.pool[testString]
 
 	require.Equal(t, true, ok)
@@ -54,32 +54,32 @@ func TestIntern_MultiRef(t *testing.T) {
 }
 
 func TestIntern_DeleteRef(t *testing.T) {
-	interner := newPool()
+	interner := NewPool()
 	testString := "TestIntern_DeleteRef"
 
-	interner.intern(testString)
+	interner.Intern(testString)
 	interned, ok := interner.pool[testString]
 
 	require.Equal(t, true, ok)
 	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))
 
-	interner.release(testString)
+	interner.Release(testString)
 	_, ok = interner.pool[testString]
 	require.Equal(t, false, ok)
 }
 
 func TestIntern_MultiRef_Concurrent(t *testing.T) {
-	interner := newPool()
+	interner := NewPool()
 	testString := "TestIntern_MultiRef_Concurrent"
 
-	interner.intern(testString)
+	interner.Intern(testString)
 	interned, ok := interner.pool[testString]
 	require.Equal(t, true, ok)
 	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))
 
-	go interner.release(testString)
+	go interner.Release(testString)
 
-	interner.intern(testString)
+	interner.Intern(testString)
 
 	time.Sleep(time.Millisecond)
 

--- a/storage/remote/max_timestamp.go
+++ b/storage/remote/max_timestamp.go
@@ -19,13 +19,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type maxTimestamp struct {
+type MaxTimestamp struct {
 	mtx   sync.Mutex
 	value float64
 	prometheus.Gauge
 }
 
-func (m *maxTimestamp) Set(value float64) {
+func (m *MaxTimestamp) Set(value float64) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	if value > m.value {
@@ -34,13 +34,13 @@ func (m *maxTimestamp) Set(value float64) {
 	}
 }
 
-func (m *maxTimestamp) Get() float64 {
+func (m *MaxTimestamp) Get() float64 {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	return m.value
 }
 
-func (m *maxTimestamp) Collect(c chan<- prometheus.Metric) {
+func (m *MaxTimestamp) Collect(c chan<- prometheus.Metric) {
 	if m.Get() > 0 {
 		m.Gauge.Collect(c)
 	}

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -49,8 +49,8 @@ import (
 
 const defaultFlushDeadline = 1 * time.Minute
 
-func newHighestTimestampMetric() *maxTimestamp {
-	return &maxTimestamp{
+func newHighestTimestampMetric() *MaxTimestamp {
+	return &MaxTimestamp{
 		Gauge: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
@@ -155,8 +155,8 @@ func TestMetadataDelivery(t *testing.T) {
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
 
-	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
+	metrics := NewQueueManagerMetrics(nil, "", "")
+	m := NewQueueManager(metrics, nil, nil, nil, dir, NewEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, NewPool(), newHighestTimestampMetric(), nil, false)
 	m.Start()
 	defer m.Stop()
 
@@ -194,8 +194,8 @@ func TestSampleDeliveryTimeout(t *testing.T) {
 
 	dir := t.TempDir()
 
-	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
+	metrics := NewQueueManagerMetrics(nil, "", "")
+	m := NewQueueManager(metrics, nil, nil, nil, dir, NewEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, NewPool(), newHighestTimestampMetric(), nil, false)
 	m.StoreSeries(series, 0)
 	m.Start()
 	defer m.Stop()
@@ -236,8 +236,8 @@ func TestSampleDeliveryOrder(t *testing.T) {
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
 
-	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
+	metrics := NewQueueManagerMetrics(nil, "", "")
+	m := NewQueueManager(metrics, nil, nil, nil, dir, NewEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, NewPool(), newHighestTimestampMetric(), nil, false)
 	m.StoreSeries(series, 0)
 
 	m.Start()
@@ -255,9 +255,9 @@ func TestShutdown(t *testing.T) {
 
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
-	metrics := newQueueManagerMetrics(nil, "", "")
+	metrics := NewQueueManagerMetrics(nil, "", "")
 
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false)
+	m := NewQueueManager(metrics, nil, nil, nil, dir, NewEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, deadline, NewPool(), newHighestTimestampMetric(), nil, false)
 	n := 2 * config.DefaultQueueConfig.MaxSamplesPerSend
 	samples, series := createTimeseries(n, n)
 	m.StoreSeries(series, 0)
@@ -294,8 +294,8 @@ func TestSeriesReset(t *testing.T) {
 
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
-	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false)
+	metrics := NewQueueManagerMetrics(nil, "", "")
+	m := NewQueueManager(metrics, nil, nil, nil, dir, NewEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, deadline, NewPool(), newHighestTimestampMetric(), nil, false)
 	for i := 0; i < numSegments; i++ {
 		series := []record.RefSeries{}
 		for j := 0; j < numSeries; j++ {
@@ -323,8 +323,8 @@ func TestReshard(t *testing.T) {
 
 	dir := t.TempDir()
 
-	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
+	metrics := NewQueueManagerMetrics(nil, "", "")
+	m := NewQueueManager(metrics, nil, nil, nil, dir, NewEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, NewPool(), newHighestTimestampMetric(), nil, false)
 	m.StoreSeries(series, 0)
 
 	m.Start()
@@ -358,8 +358,8 @@ func TestReshardRaceWithStop(t *testing.T) {
 	mcfg := config.DefaultMetadataConfig
 	go func() {
 		for {
-			metrics := newQueueManagerMetrics(nil, "", "")
-			m = NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
+			metrics := NewQueueManagerMetrics(nil, "", "")
+			m = NewQueueManager(metrics, nil, nil, nil, "", NewEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, NewPool(), newHighestTimestampMetric(), nil, false)
 			m.Start()
 			h.Unlock()
 			h.Lock()
@@ -377,9 +377,9 @@ func TestReshardRaceWithStop(t *testing.T) {
 func TestReleaseNoninternedString(t *testing.T) {
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
-	metrics := newQueueManagerMetrics(nil, "", "")
+	metrics := NewQueueManagerMetrics(nil, "", "")
 	c := NewTestWriteClient()
-	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
+	m := NewQueueManager(metrics, nil, nil, nil, "", NewEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, NewPool(), newHighestTimestampMetric(), nil, false)
 	m.Start()
 	defer m.Stop()
 
@@ -429,12 +429,12 @@ func TestShouldReshard(t *testing.T) {
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
 	for _, c := range cases {
-		metrics := newQueueManagerMetrics(nil, "", "")
+		metrics := NewQueueManagerMetrics(nil, "", "")
 		client := NewTestWriteClient()
-		m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, client, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
+		m := NewQueueManager(metrics, nil, nil, nil, "", NewEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, client, defaultFlushDeadline, NewPool(), newHighestTimestampMetric(), nil, false)
 		m.numShards = c.startingShards
-		m.dataIn.incr(c.samplesIn)
-		m.dataOut.incr(c.samplesOut)
+		m.DataIn.Incr(c.samplesIn)
+		m.DataOut.Incr(c.samplesOut)
 		m.lastSendTimestamp.Store(c.lastSendTimestamp)
 
 		m.Start()
@@ -716,8 +716,8 @@ func BenchmarkSampleDelivery(b *testing.B) {
 
 	dir := b.TempDir()
 
-	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
+	metrics := NewQueueManagerMetrics(nil, "", "")
+	m := NewQueueManager(metrics, nil, nil, nil, dir, NewEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, defaultFlushDeadline, NewPool(), newHighestTimestampMetric(), nil, false)
 	m.StoreSeries(series, 0)
 
 	// These should be received by the client.
@@ -761,11 +761,11 @@ func BenchmarkStartup(b *testing.B) {
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
 	for n := 0; n < b.N; n++ {
-		metrics := newQueueManagerMetrics(nil, "", "")
+		metrics := NewQueueManagerMetrics(nil, "", "")
 		c := NewTestBlockedWriteClient()
 		m := NewQueueManager(metrics, nil, nil, logger, dir,
-			newEWMARate(ewmaWeight, shardUpdateDuration),
-			cfg, mcfg, nil, nil, c, 1*time.Minute, newPool(), newHighestTimestampMetric(), nil, false)
+			NewEWMARate(ewmaWeight, shardUpdateDuration),
+			cfg, mcfg, nil, nil, c, 1*time.Minute, NewPool(), newHighestTimestampMetric(), nil, false)
 		m.watcher.SetStartTime(timestamp.Time(math.MaxInt64))
 		m.watcher.MaxSegment = segments[len(segments)-2]
 		err := m.watcher.Run()
@@ -839,9 +839,9 @@ func TestCalculateDesiredShards(t *testing.T) {
 
 	dir := t.TempDir()
 
-	metrics := newQueueManagerMetrics(nil, "", "")
-	samplesIn := newEWMARate(ewmaWeight, shardUpdateDuration)
-	m := NewQueueManager(metrics, nil, nil, nil, dir, samplesIn, cfg, mcfg, nil, nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false)
+	metrics := NewQueueManagerMetrics(nil, "", "")
+	samplesIn := NewEWMARate(ewmaWeight, shardUpdateDuration)
+	m := NewQueueManager(metrics, nil, nil, nil, dir, samplesIn, cfg, mcfg, nil, nil, c, defaultFlushDeadline, NewPool(), newHighestTimestampMetric(), nil, false)
 
 	// Need to start the queue manager so the proper metrics are initialized.
 	// However we can stop it right away since we don't need to do any actual
@@ -858,8 +858,8 @@ func TestCalculateDesiredShards(t *testing.T) {
 	// helper function for adding samples.
 	addSamples := func(s int64, ts time.Duration) {
 		pendingSamples += s
-		samplesIn.incr(s)
-		samplesIn.tick()
+		samplesIn.Incr(s)
+		samplesIn.Tick()
 
 		m.highestRecvTimestamp.Set(float64(startedAt.Add(ts).Unix()))
 	}
@@ -867,8 +867,8 @@ func TestCalculateDesiredShards(t *testing.T) {
 	// helper function for sending samples.
 	sendSamples := func(s int64, ts time.Duration) {
 		pendingSamples -= s
-		m.dataOut.incr(s)
-		m.dataOutDuration.incr(int64(m.numShards) * int64(shardUpdateDuration))
+		m.DataOut.Incr(s)
+		m.DataOutDuration.Incr(int64(m.numShards) * int64(shardUpdateDuration))
 
 		// highest sent is how far back pending samples would be at our input rate.
 		highestSent := startedAt.Add(ts - time.Duration(pendingSamples/inputRate)*time.Second)
@@ -911,7 +911,7 @@ func TestCalculateDesiredShards(t *testing.T) {
 
 func TestQueueManagerMetrics(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
-	metrics := newQueueManagerMetrics(reg, "name", "http://localhost:1234")
+	metrics := NewQueueManagerMetrics(reg, "name", "http://localhost:1234")
 
 	// Make sure metrics pass linting.
 	problems, err := client_testutil.GatherAndLint(reg)
@@ -920,7 +920,7 @@ func TestQueueManagerMetrics(t *testing.T) {
 
 	// Make sure all metrics were unregistered. A failure here means you need
 	// unregister a metric in `queueManagerMetrics.unregister()`.
-	metrics.unregister()
+	metrics.Unregister()
 	err = client_testutil.GatherAndCompare(reg, strings.NewReader(""))
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR exposes some go objects in `storage/remote` package so that community tools can reuse them. While developing a remote-write benchmarker (in Promscale repo), we found these would help us along with other projects in the community that are dependent on `remote` package.

