### PR TITLE
Add exit code constants in promtool

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -57,9 +57,10 @@ import (
 )
 
 const (
-	successExitCode = 0
-	failureExitCode = 1
-	// exit code 3 is used for "one or more lint issues detected".
+	successExitCode   = 0
+	failureExitCode   = 1
+	configErrExitCode = 2
+	// Exit code 3 is used for "one or more lint issues detected".
 	lintErrExitCode = 3
 )
 

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -57,9 +57,8 @@ import (
 )
 
 const (
-	successExitCode   = 0
-	failureExitCode   = 1
-	configErrExitCode = 2
+	successExitCode = 0
+	failureExitCode = 1
 	// Exit code 3 is used for "one or more lint issues detected".
 	lintErrExitCode = 3
 )

--- a/cmd/promtool/sd.go
+++ b/cmd/promtool/sd.go
@@ -43,7 +43,7 @@ func CheckSD(sdConfigFiles, sdJobName string, sdTimeout time.Duration) int {
 	cfg, err := config.LoadFile(sdConfigFiles, false, false, logger)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Cannot load config", err)
-		return 2
+		return configErrExitCode
 	}
 
 	var scrapeConfig *config.ScrapeConfig
@@ -63,7 +63,7 @@ func CheckSD(sdConfigFiles, sdJobName string, sdTimeout time.Duration) int {
 		for _, job := range jobs {
 			fmt.Fprintf(os.Stderr, "\t%s\n", job)
 		}
-		return 1
+		return failureExitCode
 	}
 
 	targetGroupChan := make(chan []*targetgroup.Group)
@@ -74,7 +74,7 @@ func CheckSD(sdConfigFiles, sdJobName string, sdTimeout time.Duration) int {
 		d, err := cfg.NewDiscoverer(discovery.DiscovererOptions{Logger: logger})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Could not create new discoverer", err)
-			return 2
+			return configErrExitCode
 		}
 		go d.Run(ctx, targetGroupChan)
 	}
@@ -100,11 +100,11 @@ outerLoop:
 	res, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not marshal result json: %s", err)
-		return 2
+		return configErrExitCode
 	}
 
 	fmt.Printf("%s", res)
-	return 0
+	return successExitCode
 }
 
 func getSDCheckResult(targetGroups []*targetgroup.Group, scrapeConfig *config.ScrapeConfig) []sdCheckResult {

--- a/cmd/promtool/sd.go
+++ b/cmd/promtool/sd.go
@@ -74,7 +74,7 @@ func CheckSD(sdConfigFiles, sdJobName string, sdTimeout time.Duration) int {
 		d, err := cfg.NewDiscoverer(discovery.DiscovererOptions{Logger: logger})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Could not create new discoverer", err)
-			return configErrExitCode
+			return failureExitCode
 		}
 		go d.Run(ctx, targetGroupChan)
 	}
@@ -100,7 +100,7 @@ outerLoop:
 	res, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not marshal result json: %s", err)
-		return configErrExitCode
+		return failureExitCode
 	}
 
 	fmt.Printf("%s", res)

--- a/cmd/promtool/sd.go
+++ b/cmd/promtool/sd.go
@@ -43,7 +43,7 @@ func CheckSD(sdConfigFiles, sdJobName string, sdTimeout time.Duration) int {
 	cfg, err := config.LoadFile(sdConfigFiles, false, false, logger)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Cannot load config", err)
-		return configErrExitCode
+		return failureExitCode
 	}
 
 	var scrapeConfig *config.ScrapeConfig

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -56,9 +56,9 @@ func RulesUnitTest(queryOpts promql.LazyLoaderOpts, files ...string) int {
 		fmt.Println()
 	}
 	if failed {
-		return 1
+		return failureExitCode
 	}
-	return 0
+	return successExitCode
 }
 
 func ruleUnitTest(filename string, queryOpts promql.LazyLoaderOpts) []error {


### PR DESCRIPTION
This PR adds constants for the exit codes in promtool for readability. 

It was not clear to me what exit code 3 was suppose to indicate in promtool main.go. Back in this PR, it is documented to be "one or more lint issues": https://github.com/prometheus/prometheus/pull/2605#discussion_r111264047


Signed-off-by: jessicagreben <jessicagrebens@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
