### PR TITLE
tsdb/wal: add support for saving and restoring read segments

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -644,7 +644,7 @@ func (t *QueueManager) updatePendingData(dataCount, dataSegment int) {
 	// This could cause our saved segment to lag behind multiple segments
 	// depending on the rate that new segments are created and how long
 	// data in other segments takes to be processed.
-	if dataSegment < t.lastMarkedSegment {
+	if dataSegment <= t.latestDataSegment {
 		return
 	}
 

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -16,6 +16,7 @@ package remote
 import (
 	"context"
 	"errors"
+	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -458,7 +459,7 @@ func (t *QueueManager) LastCheckpointedSegment() (segment *int) {
 	}
 
 	fname := filepath.Join(dir, "segment")
-	bb, err := os.ReadFile(fname)
+	bb, err := ioutil.ReadFile(fname)
 	if os.IsNotExist(err) {
 		level.Warn(t.logger).Log("msg", "checkpoint segment file does not exist")
 		return
@@ -490,7 +491,7 @@ func (t *QueueManager) CheckpointSegment(segment int) {
 		tmp   = fname + ".tmp"
 	)
 
-	if err := os.WriteFile(tmp, []byte(segmentText), 0o660); err != nil {
+	if err := ioutil.WriteFile(tmp, []byte(segmentText), 0o660); err != nil {
 		level.Error(t.logger).Log("msg", "could not create segment checkpoint file", "file", tmp, "err", err)
 		return
 	}

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -467,18 +467,18 @@ func (t *QueueManager) LastCheckpointedSegment() (segment *int) {
 		return
 	}
 
-	if i, err := strconv.Atoi(string(bb)); err != nil {
+	savedSegment, err := strconv.Atoi(string(bb))
+	if err != nil {
 		level.Error(t.logger).Log("msg", "could not read segment checkpoint file", "file", fname, "err", err)
 		return
-	} else {
-		return &i
 	}
+	return &savedSegment
 }
 
 // CheckpointSegment implements wal.Checkpointer. segment will be saved to a queue-specific file.
 func (t *QueueManager) CheckpointSegment(segment int) {
 	dir := filepath.Join(t.walDir, "remote", t.client().Name())
-	if err := os.MkdirAll(dir, 0770); err != nil {
+	if err := os.MkdirAll(dir, 0o770); err != nil {
 		level.Error(t.logger).Log("msg", "could not create segment checkpoint folder", "dir", dir, "err", err)
 		return
 	}
@@ -490,7 +490,7 @@ func (t *QueueManager) CheckpointSegment(segment int) {
 		tmp   = fname + ".tmp"
 	)
 
-	if err := os.WriteFile(tmp, []byte(segmentText), 0660); err != nil {
+	if err := os.WriteFile(tmp, []byte(segmentText), 0o660); err != nil {
 		level.Error(t.logger).Log("msg", "could not create segment checkpoint file", "file", tmp, "err", err)
 		return
 	}

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -345,17 +345,16 @@ type WriteClient interface {
 type QueueManager struct {
 	lastSendTimestamp atomic.Int64
 
-	logger             log.Logger
-	flushDeadline      time.Duration
-	cfg                config.QueueConfig
-	mcfg               config.MetadataConfig
-	externalLabels     labels.Labels
-	relabelConfigs     []*relabel.Config
-	sendExemplars      bool
-	watcher            *wal.Watcher
-	metadataWatcher    *MetadataWatcher
-	walDir             string
-	defaultLastSegment *int
+	logger          log.Logger
+	flushDeadline   time.Duration
+	cfg             config.QueueConfig
+	mcfg            config.MetadataConfig
+	externalLabels  labels.Labels
+	relabelConfigs  []*relabel.Config
+	sendExemplars   bool
+	watcher         *wal.Watcher
+	metadataWatcher *MetadataWatcher
+	walDir          string
 
 	clientMtx   sync.RWMutex
 	storeClient WriteClient
@@ -405,16 +404,15 @@ func NewQueueManager(
 
 	logger = log.With(logger, remoteName, client.Name(), endpoint, client.Endpoint())
 	t := &QueueManager{
-		logger:             logger,
-		flushDeadline:      flushDeadline,
-		cfg:                cfg,
-		mcfg:               mCfg,
-		externalLabels:     externalLabels,
-		relabelConfigs:     relabelConfigs,
-		storeClient:        client,
-		sendExemplars:      enableExemplarRemoteWrite,
-		walDir:             walDir,
-		defaultLastSegment: wal.CheckpointerReadAllSegments,
+		logger:         logger,
+		flushDeadline:  flushDeadline,
+		cfg:            cfg,
+		mcfg:           mCfg,
+		externalLabels: externalLabels,
+		relabelConfigs: relabelConfigs,
+		storeClient:    client,
+		sendExemplars:  enableExemplarRemoteWrite,
+		walDir:         walDir,
 
 		seriesLabels:         make(map[chunks.HeadSeriesRef]labels.Labels),
 		seriesSegmentIndexes: make(map[chunks.HeadSeriesRef]int),
@@ -444,11 +442,9 @@ func NewQueueManager(
 }
 
 // LastCheckpointedSegment implements wal.Checkpointer. It returns the last
-// read segment from the queue-specific file. Requests the WAL watcher to read
-// all samples from the WAL if the checkpoint file doesn't exist yet.
+// read segment from the queue-specific file. Requests the WAL watcher to start
+// at the end of the WAL if the checkpoint file doesn't exist yet.
 func (t *QueueManager) LastCheckpointedSegment() (segment *int) {
-	segment = t.defaultLastSegment
-
 	dir := filepath.Join(t.walDir, "remote", t.client().Name())
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		level.Warn(t.logger).Log("msg", "checkpoint segment does not exist")

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -488,7 +488,7 @@ func (t *QueueManager) LastMarkedSegment() (segment *int) {
 
 func (t *QueueManager) markSegment(segment int) {
 	dir := filepath.Join(t.walDir, "remote", t.client().Name())
-	if err := os.MkdirAll(dir, 0o770); err != nil {
+	if err := os.MkdirAll(dir, 0o777); err != nil {
 		level.Error(t.logger).Log("msg", "could not create segment marker folder", "dir", dir, "err", err)
 		return
 	}
@@ -500,7 +500,7 @@ func (t *QueueManager) markSegment(segment int) {
 		tmp   = fname + ".tmp"
 	)
 
-	if err := ioutil.WriteFile(tmp, []byte(segmentText), 0o660); err != nil {
+	if err := ioutil.WriteFile(tmp, []byte(segmentText), 0o666); err != nil {
 		level.Error(t.logger).Log("msg", "could not create segment marker file", "file", tmp, "err", err)
 		return
 	}

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -46,9 +46,9 @@ var (
 	readAllSegments = -1
 
 	// CheckpointerReadAllSegments will read samples from all segments.
-	CheckpointerReadAllSegments *int = &readAllSegments
+	CheckpointerReadAllSegments = &readAllSegments
 	// CheckpointerReadNewSegments will only read samples from new segments.
-	CheckpointerReadNewSegments *int = nil
+	CheckpointerReadNewSegments = (*int)(nil)
 )
 
 // WriteTo is an interface used by the Watcher to send the samples it's read

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -41,16 +41,6 @@ const (
 	consumer           = "consumer"
 )
 
-// Default values that LastCheckpointedSegment can return.
-var (
-	readAllSegments = -1
-
-	// CheckpointerReadAllSegments will read samples from all segments.
-	CheckpointerReadAllSegments = &readAllSegments
-	// CheckpointerReadNewSegments will only read samples from new segments.
-	CheckpointerReadNewSegments = (*int)(nil)
-)
-
 // WriteTo is an interface used by the Watcher to send the samples it's read
 // from the WAL on to somewhere else. Functions will be called concurrently
 // and it is left to the implementer to make sure they are safe.

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -158,8 +158,8 @@ func NewWatcherMetrics(reg prometheus.Registerer) *WatcherMetrics {
 	return m
 }
 
-// NewWatcher creates a new WAL watcher for a given WriteTo. cp will be used
-// for saving and restoring consumed segments, if non nil.
+// NewWatcher creates a new WAL watcher for a given WriteTo. Reading will start
+// at the segment returned by marker if marker is non-nil.
 func NewWatcher(metrics *WatcherMetrics, readerMetrics *LiveReaderMetrics, logger log.Logger, name string, writer WriteTo, marker Marker, walDir string, sendExemplars bool) *Watcher {
 	if logger == nil {
 		logger = log.NewNopLogger()

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheu Authors
+// Copyright 2018 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/tsdb/wal/watcher_test.go
+++ b/tsdb/wal/watcher_test.go
@@ -57,12 +57,12 @@ type writeToMock struct {
 	seriesSegmentIndexes map[chunks.HeadSeriesRef]int
 }
 
-func (wtm *writeToMock) Append(s []record.RefSample) bool {
+func (wtm *writeToMock) Append(s []record.RefSample, segment int) bool {
 	wtm.samplesAppended += len(s)
 	return true
 }
 
-func (wtm *writeToMock) AppendExemplars(e []record.RefExemplar) bool {
+func (wtm *writeToMock) AppendExemplars(e []record.RefExemplar, segment int) bool {
 	wtm.exemplarsAppended += len(e)
 	return true
 }

--- a/tsdb/wal/watcher_test.go
+++ b/tsdb/wal/watcher_test.go
@@ -167,7 +167,7 @@ func TestTailSamples(t *testing.T) {
 			require.NoError(t, err)
 
 			wt := newWriteToMock()
-			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, true)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, nil, dir, true)
 			watcher.SetStartTime(now)
 
 			// Set the Watcher's metrics so they're not nil pointers.
@@ -249,7 +249,7 @@ func TestReadToEndNoCheckpoint(t *testing.T) {
 			require.NoError(t, err)
 
 			wt := newWriteToMock()
-			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, nil, dir, false)
 			go watcher.Start()
 
 			expected := seriesCount
@@ -338,7 +338,7 @@ func TestReadToEndWithCheckpoint(t *testing.T) {
 			_, _, err = Segments(w.Dir())
 			require.NoError(t, err)
 			wt := newWriteToMock()
-			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, nil, dir, false)
 			go watcher.Start()
 
 			expected := seriesCount * 2
@@ -404,7 +404,7 @@ func TestReadCheckpoint(t *testing.T) {
 			require.NoError(t, err)
 
 			wt := newWriteToMock()
-			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, nil, dir, false)
 			go watcher.Start()
 
 			expectedSeries := seriesCount
@@ -473,7 +473,7 @@ func TestReadCheckpointMultipleSegments(t *testing.T) {
 			}
 
 			wt := newWriteToMock()
-			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, nil, dir, false)
 			watcher.MaxSegment = -1
 
 			// Set the Watcher's metrics so they're not nil pointers.
@@ -545,7 +545,7 @@ func TestCheckpointSeriesReset(t *testing.T) {
 			require.NoError(t, err)
 
 			wt := newWriteToMock()
-			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, nil, dir, false)
 			watcher.MaxSegment = -1
 			go watcher.Start()
 


### PR DESCRIPTION
This PR updates the WAL watcher with a new Marker interface to specify what segment WAL reading should start at.When the WAL watcher starts, it will ask the Marker interface for the last saved segment. Samples will be delivered for the first segment after that last saved segment. 

QueueManager implements the Marker interface and will read and write marked segments to disk. Marked segments are written to disk if all data for a segment has been processed by shards. This check is performed when receiving samples for a segment that hasn't been seen before. 

Related to #7710.
Related to #8918.
Related to #8809.

Opening in draft form to collect early feedback on the approach.

This approach has drawbacks. Depending on the rate at which data is processed by shards and new segments are created, the marked segment on disk may lag multiple segments behind. This can cause re-writing more data than necessary when starting the QueueManager. 

Signed-off-by: Robert Fratto <robertfratto@gmail.com>
