### PR TITLE
Update exemplar docs based on changes to exemplar storage configuration

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2849,5 +2849,6 @@ with this feature.
 Note that exemplar storage is still considered experimental and must be enabled via `--enable-feature=exemplar-storage`.
 
 ```yaml
-  # Configures the maximum size of the circular buffer used to store exemplars for all series. Resizable during runtime.
-  [ max_exemplars: <int> | default = 100000 ]
+# Configures the maximum size of the circular buffer used to store exemplars for all series. Resizable during runtime.
+[ max_exemplars: <int> | default = 100000 ]
+```

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -95,6 +95,10 @@ remote_write:
 # Settings related to the remote read feature.
 remote_read:
   [ - <remote_read> ... ]
+
+# Storage related settings that are runtime reloadable.
+storage:
+  [ - <exemplars> ... ]  
 ```
 
 ### `<scrape_config>`
@@ -2839,3 +2843,11 @@ tls_config:
 There is a list of
 [integrations](https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage)
 with this feature.
+
+### `<exemplars>`
+
+Note that exemplar storage is still considered experimental and must be enabled via `--enable-feature=exemplar-storage`.
+
+```yaml
+  # Configures the maximum size of the circular buffer used to store exemplars for all series. Resizable during runtime.
+  [ max_exemplars: <int> | default = 100000 ]

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -52,7 +52,7 @@ The remote write receiver allows Prometheus to accept remote write requests from
 
 [OpenMetrics](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars) introduces the ability for scrape targets to add exemplars to certain metrics. Exemplars are references to data outside of the MetricSet. A common use case are IDs of program traces.
 
-Exemplar storage is implemented as a fixed size circular buffer that stores exemplars in memory for all series. Enabling this feature will enable the storage of exemplars scraped by Prometheus. The flag `storage.exemplars.exemplars-limit` can be used to control the size of circular buffer by # of exemplars. An exemplar with just a `traceID=<jaeger-trace-id>` uses roughly 100 bytes of memory via the in-memory exemplar storage. If the exemplar storage is enabled, we will also append the exemplars to WAL for local persistence (for WAL duration).
+Exemplar storage is implemented as a fixed size circular buffer that stores exemplars in memory for all series. Enabling this feature will enable the storage of exemplars scraped by Prometheus. The config file block [storage](configuration/configuration.md#configuration-file)/[exemplars](configuration/configuration.md#exemplars) can be used to control the size of circular buffer by # of exemplars. An exemplar with just a `traceID=<jaeger-trace-id>` uses roughly 100 bytes of memory via the in-memory exemplar storage. If the exemplar storage is enabled, we will also append the exemplars to WAL for local persistence (for WAL duration).
 
 ## Memory snapshot on shutdown
 


### PR DESCRIPTION
@LeviHarrison pointed out that we hadn't updated the docs based on the changes from #8974

@roidelapluie not sure how we go about backporting docs into the right releases. Releases from 2.29 forward should have the docs changes from this PR (https://github.com/prometheus/prometheus/releases/tag/v2.29.0)

Signed-off-by: Callum Styan <callumstyan@gmail.com>