### PR TITLE
Revert "Replace vfsgen with embed for static web assets"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,8 @@ jobs:
           command: refreshenv
       - run:
           command: |
+            $env:GOARCH=""; $env:GOOS=""; cd web/ui; go generate
+            cd ../..
             $TestTargets = go list ./... | Where-Object { $_ -NotMatch "(github.com/prometheus/prometheus/discovery.*|github.com/prometheus/prometheus/config|github.com/prometheus/prometheus/web)"}
             go test $TestTargets -vet=off -v
           environment:

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ benchmark.txt
 
 npm_licenses.tar.bz2
 /web/ui/static/react
+/web/ui/assets_vfsdata.go
 
 /vendor
 /.build

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,12 @@ ui-lint:
 
 .PHONY: assets
 assets: ui-install ui-build
+	@echo ">> writing assets"
+	# Un-setting GOOS and GOARCH here because the generated Go code is always the same,
+	# but the cached object code is incompatible between architectures and OSes (which
+	# breaks cross-building for different combinations on CI in the same container).
+	cd $(UI_PATH) && GO111MODULE=$(GO111MODULE) GOOS= GOARCH= $(GO) generate -x -v $(GOOPTS)
+	@$(GOFMT) -w ./$(UI_PATH)
 
 .PHONY: test
 # If we only want to only test go code we have to change the test target

--- a/Makefile.common
+++ b/Makefile.common
@@ -238,11 +238,8 @@ endif
 
 .PHONY: common-build
 common-build: promu
-	@bash -c "trap 'echo \">> restoring assets\"; scripts/compress_assets.sh -d;' EXIT; \
-	          echo '>> compressing assets'; \
-	          scripts/compress_assets.sh; \
-	          echo '>> building binaries'; \
-	          GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX) $(PROMU_BINARIES)"
+	@echo ">> building binaries"
+	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX) $(PROMU_BINARIES)
 
 .PHONY: common-tarball
 common-tarball: promu

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/prometheus
 
-go 1.16
+go 1.14
 
 require (
 	github.com/Azure/azure-sdk-for-go v58.3.0+incompatible
@@ -49,11 +49,11 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.32.1
-	github.com/prometheus/common/assets v0.1.0
 	github.com/prometheus/common/sigv4 v0.1.0
 	github.com/prometheus/exporter-toolkit v0.7.0
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210223165440-c65ae3540d44
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
+	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546
 	github.com/stretchr/testify v1.7.0
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible
@@ -117,5 +117,3 @@ exclude (
 	k8s.io/client-go v9.0.0+incompatible
 	k8s.io/client-go v9.0.0-invalid+incompatible
 )
-
-replace github.com/prometheus/common/assets => github.com/jan--f/common/assets v0.0.0-20211112085804-0bbedfb4d189

--- a/go.sum
+++ b/go.sum
@@ -348,6 +348,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
@@ -853,8 +854,6 @@ github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mq
 github.com/influxdata/tdigest v0.0.2-0.20210216194612-fc98d27c9e8b/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=
 github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368/go.mod h1:Wbbw6tYNvwa5dlB6304Sd+82Z3f7PmVZHVKU637d4po=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-github.com/jan--f/common/assets v0.0.0-20211112085804-0bbedfb4d189 h1:zm38/UrVgy0o0/4D7mV+rtVZs1FjlEzZyIP/Y82eoh0=
-github.com/jan--f/common/assets v0.0.0-20211112085804-0bbedfb4d189/go.mod h1:D17UVUE12bHbim7HzwUvtqm6gwBEaDQ0F+hIGbFbccI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -1216,6 +1215,7 @@ github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06B
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
+github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 h1:pXY9qYc/MP5zdvqWEUH6SjNiu7VhSjuVFTFiTcphaLU=
 github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/simonpasquier/klog-gokit v0.3.0 h1:TkFK21cbwDRS+CiystjqbAiq5ubJcVTk9hLUck5Ntcs=
 github.com/simonpasquier/klog-gokit v0.3.0/go.mod h1:+SUlDQNrhVtGt2FieaqNftzzk8P72zpWlACateWxA9k=
@@ -1431,6 +1431,7 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
+golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -1784,8 +1785,10 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.6.0/go.mod h1:9mxDZsDKxgMAuccQkewq682L+0eCu4dCN2yonUJTCLU=
+gonum.org/v1/gonum v0.8.2 h1:CCXrcPKiGGotvnN6jfUsKk4rRqm7q09/YbKb5xCEvtM=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/netlib v0.0.0-20181029234149-ec6d1f5cefe6/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
+gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/scripts/compress_assets.sh
+++ b/scripts/compress_assets.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-#
-# [de]compress static assets
-
-find web/ui/templates web/ui/static -type f -exec gzip "$@" {} \;

--- a/util/modtimevfs/modtimevfs.go
+++ b/util/modtimevfs/modtimevfs.go
@@ -1,0 +1,67 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package modtimevfs implements a virtual file system that returns a fixed
+// modification time for all files and directories.
+package modtimevfs
+
+import (
+	"net/http"
+	"os"
+	"time"
+)
+
+type timefs struct {
+	fs http.FileSystem
+	t  time.Time
+}
+
+// New returns a file system that returns constant modification time for all files.
+func New(fs http.FileSystem, t time.Time) http.FileSystem {
+	return &timefs{fs: fs, t: t}
+}
+
+type file struct {
+	http.File
+	os.FileInfo
+	t time.Time
+}
+
+func (t *timefs) Open(name string) (http.File, error) {
+	f, err := t.fs.Open(name)
+	if err != nil {
+		return f, err
+	}
+	defer func() {
+		if err != nil {
+			f.Close()
+		}
+	}()
+
+	fstat, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	return &file{f, fstat, t.t}, nil
+}
+
+// Stat implements the http.File interface.
+func (f *file) Stat() (os.FileInfo, error) {
+	return f, nil
+}
+
+// ModTime implements the os.FileInfo interface.
+func (f *file) ModTime() time.Time {
+	return f.t
+}

--- a/web/ui/README.md
+++ b/web/ui/README.md
@@ -1,12 +1,11 @@
 ## Overview
-The `ui` directory contains static files and templates used in the web UI. For
-easier distribution they are compressend (c.f. Makefile) and statically compiled 
-into the Prometheus binary using the embed package.
 
-During development it is more convenient to always use the files on disk to 
-directly see changes without recompiling.
-To make this work, remove the `builtinassets` build tag in the `flags` entry
-in `.promu.yml`, and then `make build` (or build Prometheus using
+The `ui` directory contains static files and templates used in the web UI. For easier distribution they are statically
+compiled into the Prometheus binary using the vfsgen library (c.f. Makefile).
+
+During development it is more convenient to always use the files on disk to directly see changes without recompiling. To
+make this work, remove the `builtinassets` build tag in the `flags` entry in `.promu.yml`, and then `make build` (or
+build Prometheus using
 `go build ./cmd/prometheus`).
 
 This will serve all files from your local filesystem. This is for development purposes only.

--- a/web/ui/doc.go
+++ b/web/ui/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Prometheus Authors
+// Copyright 2018 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,18 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build builtinassets
-// +build builtinassets
-
+// Package ui provides the assets via a virtual filesystem.
 package ui
 
 import (
-	"embed"
-	"github.com/prometheus/common/assets"
-	"net/http"
+	// The blank import is to make Go modules happy.
+	_ "github.com/shurcooL/httpfs/filter"
+	_ "github.com/shurcooL/httpfs/union"
+	_ "github.com/shurcooL/vfsgen"
 )
 
-//go:embed static templates
-var EmbedFS embed.FS
-
-var Assets = http.FS(assets.New(EmbedFS))
+//go:generate go run assets_generate.go


### PR DESCRIPTION
Reverts prometheus/prometheus#9719

- points to an unreleased version of common
- changes the makefile.common in a way that only works for prometheus/prometheus, breaking other repositories