### PR TITLE
Add Alert PrometheusScrapeBodySizeLimitHit

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -276,6 +276,20 @@
             },
           },
           {
+            alert: 'PrometheusScrapeBodySizeLimitHit',
+            expr: |||
+              increase(prometheus_target_scrapes_exceeded_body_size_limit_total{%(prometheusSelector)s}[5m]) > 0
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Prometheus has dropped some targets that exceeded body size limit.',
+              description: 'Prometheus %(prometheusName)s has dropped {{ printf "%%.0f" $value }} targets because some targets exceeded the configured body_size_limit.' % $._config,
+            },
+          },
+          {
             alert: 'PrometheusTargetSyncFailure',
             expr: |||
               increase(prometheus_target_sync_failed_total{%(prometheusSelector)s}[30m]) > 0
@@ -389,11 +403,11 @@
               (
                   prometheus_tsdb_clean_start{%(prometheusSelector)s} == 0
                 and
-                  ( 
+                  (
                     count by (%(prometheusHAGroupLabels)s) (
                       changes(process_start_time_seconds{%(prometheusSelector)s}[1h]) > 1
-                    ) 
-                    / 
+                    )
+                    /
                     count by (%(prometheusHAGroupLabels)s) (
                       up{%(prometheusSelector)s}
                     )


### PR DESCRIPTION
This PR adds a new alert to prometheus mixins that alerts user when it scrapes a target responding with a HTTP body exceeding its `body_size_limit`.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
