### PR TITLE
tsdb/agent: fix validation of default options

### DIFF
--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -322,6 +322,9 @@ func validateOptions(opts *Options) *Options {
 	if opts.MaxWALTime <= 0 {
 		opts.MaxWALTime = DefaultMaxWALTime
 	}
+	if opts.MinWALTime > opts.MaxWALTime {
+		opts.MaxWALTime = opts.MinWALTime
+	}
 
 	if t := int64(opts.TruncateFrequency / time.Millisecond); opts.MaxWALTime < t {
 		opts.MaxWALTime = t

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -317,7 +317,7 @@ func validateOptions(opts *Options) *Options {
 		opts.TruncateFrequency = DefaultTruncateFrequency
 	}
 	if opts.MinWALTime <= 0 {
-		opts.MinWALTime = 0
+		opts.MinWALTime = DefaultMinWALTime
 	}
 	if opts.MaxWALTime <= 0 {
 		opts.MaxWALTime = DefaultMaxWALTime

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -323,7 +323,7 @@ func validateOptions(opts *Options) *Options {
 		opts.MaxWALTime = DefaultMaxWALTime
 	}
 
-	if t := int64(opts.TruncateFrequency * time.Hour / time.Millisecond); opts.MaxWALTime < t {
+	if t := int64(opts.TruncateFrequency / time.Millisecond); opts.MaxWALTime < t {
 		opts.MaxWALTime = t
 	}
 	return opts

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -535,3 +535,7 @@ func TestStorage_DuplicateExemplarsIgnored(t *testing.T) {
 	// We had 9 calls to AppendExemplar but only 4 of those should have gotten through.
 	require.Equal(t, 4, walExemplarsCount)
 }
+
+func Test_validateOptions_Defaults(t *testing.T) {
+	require.Equal(t, DefaultOptions(), validateOptions(nil))
+}


### PR DESCRIPTION
MaxTS is supposed to be constrained to no less than the truncation interval, but this calculation was incorrect causing MaxTS to be multiplied by 1h.

Signed-off-by: Robert Fratto <robertfratto@gmail.com>