### PR TITLE
promtool: Fix credentials file check

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -353,8 +353,10 @@ func checkConfig(agentMode bool, filename string) ([]string, error) {
 	}
 
 	for _, scfg := range cfg.ScrapeConfigs {
-		if err := checkFileExists(scfg.HTTPClientConfig.BearerTokenFile); err != nil {
-			return nil, errors.Wrapf(err, "error checking bearer token file %q", scfg.HTTPClientConfig.BearerTokenFile)
+		if scfg.HTTPClientConfig.Authorization != nil {
+			if err := checkFileExists(scfg.HTTPClientConfig.Authorization.CredentialsFile); err != nil {
+				return nil, errors.Wrapf(err, "error checking authorization credentials or bearer token file %q", scfg.HTTPClientConfig.Authorization.CredentialsFile)
+			}
 		}
 
 		if err := checkTLSConfig(scfg.HTTPClientConfig.TLSConfig); err != nil {

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -203,3 +203,33 @@ func TestCheckTargetConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestAuthorizationConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		file string
+		err  string
+	}{
+		{
+			name: "authorization_credentials_file.bad",
+			file: "authorization_credentials_file.bad.yml",
+			err:  "error checking authorization credentials or bearer token file",
+		},
+		{
+			name: "authorization_credentials_file.good",
+			file: "authorization_credentials_file.good.yml",
+			err:  "",
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := checkConfig(false, "testdata/"+test.file)
+			if test.err != "" {
+				require.Contains(t, err.Error(), test.err, "Expected error to contain %q, got %q", test.err, err.Error())
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/cmd/promtool/testdata/authorization_credentials_file.bad.yml
+++ b/cmd/promtool/testdata/authorization_credentials_file.bad.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - job_name: test
+    authorization:
+      credentials_file: "/random/file/which/does/not/exist.yml"

--- a/cmd/promtool/testdata/authorization_credentials_file.good.yml
+++ b/cmd/promtool/testdata/authorization_credentials_file.good.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - job_name: test
+    authorization:
+      credentials_file: "."


### PR DESCRIPTION
The promtool check config command still uses the bearer_token_file
field which is deprecated in favour of authorization.credentials_file.

This commit modifies the command to use the new field insted.

Fixes #9874

Signed-off-by: fpetkovski <filip.petkovsky@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
