### PR TITLE
storage: Consolidate iterator method names (Values -> At)

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1643,7 +1643,7 @@ func (ev *evaluator) vectorSelectorSingle(it *storage.MemoizedSeriesIterator, no
 	}
 
 	if ok {
-		t, v = it.Values()
+		t, v = it.At()
 	}
 
 	if !ok || t > refTime {
@@ -1763,7 +1763,7 @@ func (ev *evaluator) matrixIterSlice(it *storage.BufferedSeriesIterator, mint, m
 	}
 	// The seeked sample might also be in the range.
 	if ok {
-		t, v := it.Values()
+		t, v := it.At()
 		if t == maxt && !value.IsStaleNaN(v) {
 			if ev.currentSamples >= ev.maxSamples {
 				ev.error(ErrTooManySamples(env))

--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -89,7 +89,7 @@ func (b *BufferedSeriesIterator) Seek(t int64) bool {
 		if !b.ok {
 			return false
 		}
-		b.lastTime, _ = b.Values()
+		b.lastTime, _ = b.At()
 	}
 
 	if b.lastTime >= t {
@@ -115,14 +115,14 @@ func (b *BufferedSeriesIterator) Next() bool {
 
 	b.ok = b.it.Next()
 	if b.ok {
-		b.lastTime, _ = b.Values()
+		b.lastTime, _ = b.At()
 	}
 
 	return b.ok
 }
 
-// Values returns the current element of the iterator.
-func (b *BufferedSeriesIterator) Values() (int64, float64) {
+// At returns the current element of the iterator.
+func (b *BufferedSeriesIterator) At() (int64, float64) {
 	return b.it.At()
 }
 

--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -99,7 +99,7 @@ func TestBufferedSeriesIterator(t *testing.T) {
 		require.Equal(t, exp, b, "buffer mismatch")
 	}
 	sampleEq := func(ets int64, ev float64) {
-		ts, v := it.Values()
+		ts, v := it.At()
 		require.Equal(t, ets, ts, "timestamp mismatch")
 		require.Equal(t, ev, v, "value mismatch")
 	}

--- a/storage/memoized_iterator.go
+++ b/storage/memoized_iterator.go
@@ -112,8 +112,8 @@ func (b *MemoizedSeriesIterator) Next() bool {
 	return b.ok
 }
 
-// Values returns the current element of the iterator.
-func (b *MemoizedSeriesIterator) Values() (int64, float64) {
+// At returns the current element of the iterator.
+func (b *MemoizedSeriesIterator) At() (int64, float64) {
 	return b.it.At()
 }
 

--- a/storage/memoized_iterator_test.go
+++ b/storage/memoized_iterator_test.go
@@ -23,7 +23,7 @@ func TestMemoizedSeriesIterator(t *testing.T) {
 	var it *MemoizedSeriesIterator
 
 	sampleEq := func(ets int64, ev float64) {
-		ts, v := it.Values()
+		ts, v := it.At()
 		require.Equal(t, ets, ts, "timestamp mismatch")
 		require.Equal(t, ev, v, "value mismatch")
 	}

--- a/web/federate.go
+++ b/web/federate.go
@@ -113,7 +113,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 
 		ok := it.Seek(maxt)
 		if ok {
-			t, v = it.Values()
+			t, v = it.At()
 		} else {
 			t, v, ok = it.PeekBack(1)
 			if !ok {


### PR DESCRIPTION
`BufferedSeriesIterator` and `MemoizedSeriesIterator` use a method
called `Values` for exactly the purpose for which all other iterators
of the same kind use a method called `At`. That alone is confusing,
but on top of that, the `Values` method only returns a single sample,
not multiple values. I assume the naming has historical reasons. This
commit makes it more consistent. It is now easier to read, and now
`BufferedSeriesIterator` and `MemoizedSeriesIterator` implement
`chunkenc.Iterator` like many other iterators, too.

Signed-off-by: beorn7 <beorn@grafana.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
