### PR TITLE
Fix iteration of FloatHistogram

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -235,7 +235,7 @@ func (r *floatBucketIterator) Next() bool {
 		r.currIdx += span.Offset
 	}
 
-	r.currCount = r.buckets[r.bucketsIdx]
+	r.currCount += r.buckets[r.bucketsIdx]
 	if r.positive {
 		r.currUpper = getBound(r.currIdx, r.schema)
 		r.currLower = getBound(r.currIdx-1, r.schema)


### PR DESCRIPTION
**Note: This is going into sparsehistogram branch**

Buckets are delta encoded. Seems to be done right for integer buckets.