### PR TITLE
remote-write: group data into batches to be sent over shards 

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -277,7 +277,7 @@ func TestShutdown(t *testing.T) {
 
 	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, nil, nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false)
 	n := 2 * config.DefaultQueueConfig.MaxSamplesPerSend
-	samples, series := createTimeseries(n, n)
+	samples, series := createTimeseries(1, n)
 	m.StoreSeries(series, 0)
 	m.Start()
 


### PR DESCRIPTION
This is a "competitor" to #9830.

This is far more efficient than sending each sample or exemplar individually over a chan.

Instead of each chan having the configured Capacity, the chan has length 1 and we limit the size of batch that we will send to Capacity.

I updated the benchmark to use 20 shards and focus on the sending effort.

Benchmark result for this PR:
```
name          old time/op    new time/op    delta
SampleSend-4    4.85ms ±19%    3.61ms ±16%  -25.50%  (p=0.008 n=5+5)

name          old alloc/op   new alloc/op   delta
SampleSend-4     925kB ± 5%     141kB ± 9%  -84.74%  (p=0.008 n=5+5)

name          old allocs/op  new allocs/op  delta
SampleSend-4     10.2k ± 0%      0.2k ± 3%  -98.00%  (p=0.008 n=5+5)
```

Comparing #9830 also:
```
name \ time/op    before.txt   9830.txt     9904.txt
SampleSend-4      4.85ms ±19%  3.70ms ± 4%  3.61ms ±16%

name \ alloc/op   before.txt   9830.txt     9904.txt
SampleSend-4       925kB ± 5%   902kB ± 1%   141kB ± 9%

name \ allocs/op  before.txt   9830.txt     9904.txt
SampleSend-4       10.2k ± 0%   10.2k ± 0%    0.2k ± 3%
```

I think much of the memory improvement comes from using a concrete struct rather than `interface{}`; this change could be applied to #9830 too.

Also changed `TestShutdown()` where assumptions on when things would happen were broken.
Possibly this tells me `Append()` should go through its input in stages rather than copying everything at the start.