### PR TITLE
promtool: Add `--syntax-only` flag for `check config`

### DIFF
--- a/cmd/promtool/testdata/config_with_rule_files.yml
+++ b/cmd/promtool/testdata/config_with_rule_files.yml
@@ -1,0 +1,3 @@
+rule_files:
+  - non-existent-file.yml
+  - /etc/non/existent/file.yml

--- a/cmd/promtool/testdata/config_with_service_discovery_files.yml
+++ b/cmd/promtool/testdata/config_with_service_discovery_files.yml
@@ -1,0 +1,12 @@
+scrape_configs:
+  - job_name: prometheus
+    file_sd_configs:
+      - files:
+          - nonexistent_file.yml
+alerting:
+  alertmanagers:
+    - scheme: http
+      api_version: v1
+      file_sd_configs:
+        - files:
+            - nonexistent_file.yml

--- a/cmd/promtool/testdata/config_with_tls_files.yml
+++ b/cmd/promtool/testdata/config_with_tls_files.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: "some job"
+    tls_config:
+      cert_file: nonexistent_cert_file.yml
+      key_file: nonexistent_key_file.yml


### PR DESCRIPTION
This commit adds a `--syntax-only` flag for `promtool check config`.
When passing in this flag, promtool will omit various file existence
checks that would cause the check to fail (e.g. the check would not
fail if `rule_files` files don't exist at their respective paths).

This functionality will allow CI systems to check the syntax of
configs without worrying about referenced files.

Fixes: #5222
Signed-off-by: zzehring <zack.zehring@grafana.com>