### PR TITLE
mixin: Add 'cluster' template variable to Prometheus Overview dashboard

### DIFF
--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -14,7 +14,8 @@ local template = grafana.template;
         '%(prefix)sOverview' % $._config.grafanaPrometheus
       )
       .addMultiTemplate('job', 'prometheus_build_info{%(prometheusSelector)s}' % $._config, 'job')
-      .addMultiTemplate('instance', 'prometheus_build_info{job=~"$job"}', 'instance')
+      .addMultiTemplate('cluster', 'kube_pod_container_info{image=~".*prometheus.*"}', 'cluster')
+      .addMultiTemplate('instance', 'prometheus_build_info{job=~"$job", cluster=~"$cluster"}', 'instance')
       .addRow(
         g.row('Prometheus Stats')
         .addPanel(


### PR DESCRIPTION
Same Purpose [#9723](https://github.com/prometheus/prometheus/pull/9723)

> I want to filter `instance` variable with `cluster` variable. I see too many `instance` values.

