### PR TITLE
bugfix:storage:avoid panic when iterater exhauested

### DIFF
--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -82,7 +82,7 @@ func (b *BufferedSeriesIterator) Seek(t int64) bool {
 
 	// If the delta would cause us to seek backwards, preserve the buffer
 	// and just continue regular advancement while filling the buffer on the way.
-	if t0 > b.lastTime {
+	if b.ok && t0 > b.lastTime {
 		b.buf.reset()
 
 		b.ok = b.it.Seek(t0)

--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -149,6 +149,7 @@ func TestBufferedSeriesIterator(t *testing.T) {
 	bufferEq([]sample{{t: 99, v: 8}, {t: 100, v: 9}})
 
 	require.False(t, it.Next(), "next succeeded unexpectedly")
+	require.False(t, it.Seek(1024), "seek succeeded unexpectedly")
 }
 
 // At() should not be called once Next() returns false.

--- a/storage/memoized_iterator.go
+++ b/storage/memoized_iterator.go
@@ -71,7 +71,7 @@ func (b *MemoizedSeriesIterator) PeekPrev() (t int64, v float64, ok bool) {
 func (b *MemoizedSeriesIterator) Seek(t int64) bool {
 	t0 := t - b.delta
 
-	if t0 > b.lastTime {
+	if b.ok && t0 > b.lastTime {
 		// Reset the previously stored element because the seek advanced
 		// more than the delta.
 		b.prevTime = math.MinInt64

--- a/storage/memoized_iterator_test.go
+++ b/storage/memoized_iterator_test.go
@@ -68,6 +68,7 @@ func TestMemoizedSeriesIterator(t *testing.T) {
 	prevSampleEq(100, 9, true)
 
 	require.False(t, it.Next(), "next succeeded unexpectedly")
+	require.False(t, it.Seek(1024), "seek succeeded unexpectedly")
 }
 
 func BenchmarkMemoizedSeriesIterator(b *testing.B) {


### PR DESCRIPTION
Hello. 
Found the panic when remote read api return the incomplete series. This PR avoids prometheus panic when underlying SeriesIterator is exhausted and mode detail see the adding tests

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
