### PR TITLE
New way of adding histograms together with a merge iterator over buckets

### DIFF
--- a/model/histogram/merge.go
+++ b/model/histogram/merge.go
@@ -1,0 +1,176 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package histogram
+
+import (
+	"container/heap"
+	"math"
+)
+
+// NewMergeFloatBucketIterator returns an iterator which merges the results from
+// all the given iterators. Buckets with same upper bound are merged by summing their counts.
+//
+// All iterators should have the same schema. TODO(codesome): support having mixed schemas.
+//
+// All the passed iterators should either have positive buckets or negative buckets
+// and not a mix of both.
+func NewMergeFloatBucketIterator(its ...FloatBucketIterator) FloatBucketIterator {
+	var h floatBucketIteratorHeap
+	for _, it := range its {
+		if it.Next() {
+			heap.Push(&h, it)
+		}
+	}
+
+	return &mergeFloatBucketIterator{
+		heap: h,
+	}
+}
+
+type mergeFloatBucketIterator struct {
+	// Heap based on the upper bound of the buckets.
+	heap floatBucketIteratorHeap
+
+	// currentIters contains the iterators that correspond to the
+	// current iteration element and are not in the heap.
+	currentIters []FloatBucketIterator
+}
+
+func (m *mergeFloatBucketIterator) Next() bool {
+	for _, it := range m.currentIters {
+		if it.Next() {
+			heap.Push(&m.heap, it)
+		}
+	}
+
+	if len(m.heap) == 0 {
+		return false
+	}
+
+	m.currentIters = nil
+	currUpper := m.heap[0].At().Upper
+	for len(m.heap) > 0 && m.heap[0].At().Upper == currUpper {
+		it := heap.Pop(&m.heap).(FloatBucketIterator)
+		m.currentIters = append(m.currentIters, it)
+	}
+
+	return true
+}
+
+func (m *mergeFloatBucketIterator) At() FloatBucket {
+	if len(m.currentIters) == 0 {
+		return FloatBucket{}
+	}
+	// Add all the counts for the same bucket boundaries.
+	fb := m.currentIters[0].At()
+	for _, it := range m.currentIters[1:] {
+		fb.Count += it.At().Count
+	}
+	return fb
+}
+
+// floatBucketIteratorHeap is a min-heap based on the bucket's
+// index in the schema boundary.
+type floatBucketIteratorHeap []FloatBucketIterator
+
+func (h floatBucketIteratorHeap) Len() int      { return len(h) }
+func (h floatBucketIteratorHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+func (h floatBucketIteratorHeap) Less(i, j int) bool {
+	return h[i].At().Index < h[j].At().Index
+}
+
+func (h *floatBucketIteratorHeap) Push(x interface{}) {
+	*h = append(*h, x.(FloatBucketIterator))
+}
+
+func (h *floatBucketIteratorHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+// MergeHistograms adds all histograms together into a single histogram
+// by adding counts of the corresponding buckets and their count and sum
+// including the zero count.
+//
+// Important: All the histograms must have the same schema and zero threshold, else the behaviour is undefined.
+// TODO(codesome): Fix the above.
+func MergeHistograms(hists ...FloatHistogram) FloatHistogram {
+	if len(hists) == 0 {
+		return FloatHistogram{}
+	}
+
+	res := FloatHistogram{
+		Schema:        hists[0].Schema,
+		ZeroThreshold: hists[0].ZeroThreshold,
+	}
+
+	// Merge positive buckets.
+	its := make([]FloatBucketIterator, 0, len(hists))
+	for _, h := range hists {
+		if h.Schema != res.Schema || h.ZeroThreshold != res.ZeroThreshold {
+			// Not supported yet.
+			return FloatHistogram{}
+		}
+
+		its = append(its, h.PositiveBucketIterator())
+		res.Count += h.Count
+		res.ZeroCount += h.ZeroCount
+		res.Sum += h.Sum
+	}
+	it := NewMergeFloatBucketIterator(its...)
+	res.PositiveBuckets, res.PositiveSpans = generateSpansFromBucketIterator(it)
+
+	// Merge negative buckets.
+	its = its[:0]
+	for _, h := range hists {
+		its = append(its, h.NegativeBucketIterator())
+	}
+	it = NewMergeFloatBucketIterator(its...)
+	res.NegativeBuckets, res.NegativeSpans = generateSpansFromBucketIterator(it)
+
+	return res
+}
+
+func generateSpansFromBucketIterator(it FloatBucketIterator) (buckets []float64, spans []Span) {
+	lastIdx := int32(math.MinInt32)
+	for it.Next() {
+		b := it.At()
+		buckets = append(buckets, b.Count)
+
+		if len(spans) == 0 {
+			// First bucket.
+			spans = append(spans, Span{
+				Offset: b.Index,
+				Length: 1,
+			})
+			lastIdx = b.Index
+			continue
+		}
+
+		gap := b.Index - lastIdx - 1
+		if gap > 0 {
+			// TODO(codesome): allow some tolerance. i.e. >0 gap.
+			spans = append(spans, Span{Offset: gap})
+		}
+
+		lastIdx = b.Index
+		spans[len(spans)-1].Length++
+	}
+
+	return buckets, spans
+}

--- a/model/histogram/merge_test.go
+++ b/model/histogram/merge_test.go
@@ -1,0 +1,134 @@
+package histogram
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeFloatBucketIterator(t *testing.T) {
+	cases := []struct {
+		histograms      []Histogram
+		expectedBuckets []FloatBucket
+	}{
+		{
+			histograms: []Histogram{
+				{
+					Schema: 0,
+					PositiveSpans: []Span{
+						{Offset: 0, Length: 2},
+						{Offset: 1, Length: 2},
+					},
+					PositiveBuckets: []int64{1, 1, -1, 0},
+				},
+				{
+					Schema: 0,
+					PositiveSpans: []Span{
+						{Offset: 1, Length: 4},
+						{Offset: 2, Length: 0},
+						{Offset: 2, Length: 3},
+					},
+					PositiveBuckets: []int64{1, 2, -2, 1, -1, 0, 0},
+				},
+			},
+			expectedBuckets: []FloatBucket{
+				{Lower: 0.5, Upper: 1, Count: 1, LowerInclusive: false, UpperInclusive: true, Index: 0},
+				{Lower: 1, Upper: 2, Count: 3, LowerInclusive: false, UpperInclusive: true, Index: 1},
+				{Lower: 2, Upper: 4, Count: 3, LowerInclusive: false, UpperInclusive: true, Index: 2},
+				{Lower: 4, Upper: 8, Count: 2, LowerInclusive: false, UpperInclusive: true, Index: 3},
+				{Lower: 8, Upper: 16, Count: 3, LowerInclusive: false, UpperInclusive: true, Index: 4},
+				{Lower: 256, Upper: 512, Count: 1, LowerInclusive: false, UpperInclusive: true, Index: 9},
+				{Lower: 512, Upper: 1024, Count: 1, LowerInclusive: false, UpperInclusive: true, Index: 10},
+				{Lower: 1024, Upper: 2048, Count: 1, LowerInclusive: false, UpperInclusive: true, Index: 11},
+			},
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			its := make([]FloatBucketIterator, 0, len(c.histograms))
+			for _, h := range c.histograms {
+				its = append(its, h.ToFloat().PositiveBucketIterator())
+			}
+
+			it := NewMergeFloatBucketIterator(its...)
+			actualBuckets := make([]FloatBucket, 0, len(c.expectedBuckets))
+			for it.Next() {
+				actualBuckets = append(actualBuckets, it.At())
+			}
+			require.Equal(t, c.expectedBuckets, actualBuckets)
+		})
+	}
+}
+
+func TestMergeHistograms(t *testing.T) {
+	cases := []struct {
+		histograms []FloatHistogram
+		expected   FloatHistogram
+	}{
+		{
+			histograms: []FloatHistogram{
+				{
+					Schema:        0,
+					Count:         9,
+					Sum:           1234.5,
+					ZeroThreshold: 0.001,
+					ZeroCount:     4,
+					PositiveSpans: []Span{
+						{Offset: 0, Length: 2},
+						{Offset: 1, Length: 2},
+					},
+					PositiveBuckets: []float64{1, 2, 1, 1},
+					NegativeSpans: []Span{
+						{Offset: 0, Length: 2},
+						{Offset: 2, Length: 2},
+					},
+					NegativeBuckets: []float64{2, 4, 1, 9},
+				},
+				{
+					Schema:        0,
+					Count:         15,
+					Sum:           2345.6,
+					ZeroThreshold: 0.001,
+					ZeroCount:     5,
+					PositiveSpans: []Span{
+						{Offset: 0, Length: 4},
+						{Offset: 0, Length: 0},
+						{Offset: 0, Length: 3},
+					},
+					PositiveBuckets: []float64{1, 3, 1, 2, 1, 1, 1},
+					NegativeSpans: []Span{
+						{Offset: 1, Length: 4},
+						{Offset: 2, Length: 0},
+						{Offset: 2, Length: 3},
+					},
+					NegativeBuckets: []float64{1, 4, 2, 7, 5, 5, 2},
+				},
+			},
+			expected: FloatHistogram{
+				Schema:        0,
+				ZeroThreshold: 0.001,
+				ZeroCount:     9,
+				Count:         24,
+				Sum:           3580.1,
+				PositiveSpans: []Span{
+					{Offset: 0, Length: 7},
+				},
+				PositiveBuckets: []float64{2, 5, 1, 3, 2, 1, 1},
+				NegativeSpans: []Span{
+					{Offset: 0, Length: 6},
+					{Offset: 3, Length: 3},
+				},
+				NegativeBuckets: []float64{2, 5, 4, 2, 8, 9, 5, 5, 2},
+			},
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			res := MergeHistograms(c.histograms...)
+			require.Equal(t, c.expected, res)
+		})
+	}
+}


### PR DESCRIPTION
**Note: This is pointing to sparsehistogram branch. Only interesting to @beorn7 for now.**

This implements new way of adding histograms together as said in https://github.com/prometheus/prometheus/pull/9926#discussion_r762973794.

And I have also added a benchmark to compare old and new ways. I am happy that I wrote the benchmark because the new proposed way is very slow compared to current way of adding 1 histogram at a time. This PR is hence just a FYI and **not to be merged**.

**Benchmark comparison:**
```
benchmark                                                 old ns/op     new ns/op     delta
BenchmarkHistogramAdd/numHists=10,maxBuckets=10-8         0.00          0.00          +584.27%
BenchmarkHistogramAdd/numHists=10,maxBuckets=30-8         0.00          0.00          +616.57%
BenchmarkHistogramAdd/numHists=10,maxBuckets=50-8         0.00          0.00          +663.60%
BenchmarkHistogramAdd/numHists=10,maxBuckets=100-8        0.00          0.00          +610.48%
BenchmarkHistogramAdd/numHists=10,maxBuckets=150-8        0.00          0.00          +640.42%
BenchmarkHistogramAdd/numHists=100,maxBuckets=10-8        0.00          0.00          +854.62%
BenchmarkHistogramAdd/numHists=100,maxBuckets=30-8        0.00          0.00          +1169.91%
BenchmarkHistogramAdd/numHists=100,maxBuckets=50-8        0.00          0.00          +931.03%
BenchmarkHistogramAdd/numHists=100,maxBuckets=100-8       0.00          0.00          +1009.01%
BenchmarkHistogramAdd/numHists=100,maxBuckets=150-8       0.00          0.01          +909.20%
BenchmarkHistogramAdd/numHists=1000,maxBuckets=10-8       0.00          0.01          +1064.22%
BenchmarkHistogramAdd/numHists=1000,maxBuckets=30-8       0.00          0.02          +1236.43%
BenchmarkHistogramAdd/numHists=1000,maxBuckets=50-8       0.00          0.03          +1134.73%
BenchmarkHistogramAdd/numHists=1000,maxBuckets=100-8      0.00          0.05          +1114.13%
BenchmarkHistogramAdd/numHists=1000,maxBuckets=150-8      0.01          0.06          +1028.35%
BenchmarkHistogramAdd/numHists=10000,maxBuckets=10-8      0.00          0.08          +1658.94%
BenchmarkHistogramAdd/numHists=10000,maxBuckets=30-8      0.01          0.25          +1916.06%
BenchmarkHistogramAdd/numHists=10000,maxBuckets=50-8      0.02          0.38          +1843.54%
BenchmarkHistogramAdd/numHists=10000,maxBuckets=100-8     0.04          0.64          +1687.98%
BenchmarkHistogramAdd/numHists=10000,maxBuckets=150-8     0.05          5769          +11154192.34%
```

**Raw data (since it's showing 0.00 above)**

Old:
```
BenchmarkHistogramAdd/numHists=10,maxBuckets=10-8         	1000000000	         0.0000089 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10,maxBuckets=30-8         	1000000000	         0.0000175 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10,maxBuckets=50-8         	1000000000	         0.0000239 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10,maxBuckets=100-8        	1000000000	         0.0000477 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10,maxBuckets=150-8        	1000000000	         0.0000621 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=100,maxBuckets=10-8        	1000000000	         0.0000628 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=100,maxBuckets=30-8        	1000000000	         0.0001419 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=100,maxBuckets=50-8        	1000000000	         0.0002610 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=100,maxBuckets=100-8       	1000000000	         0.0004238 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=100,maxBuckets=150-8       	1000000000	         0.0006416 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=1000,maxBuckets=10-8       	1000000000	         0.0005584 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=1000,maxBuckets=30-8       	1000000000	         0.001400 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=1000,maxBuckets=50-8       	1000000000	         0.002309 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=1000,maxBuckets=100-8      	1000000000	         0.003778 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=1000,maxBuckets=150-8      	1000000000	         0.005485 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10000,maxBuckets=10-8      	1000000000	         0.004725 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10000,maxBuckets=30-8      	1000000000	         0.01245 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10000,maxBuckets=50-8      	1000000000	         0.01966 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10000,maxBuckets=100-8     	1000000000	         0.03594 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10000,maxBuckets=150-8     	1000000000	         0.05172 ns/op	       0 B/op	       0 allocs/op
```

New:
```
BenchmarkHistogramAdd/numHists=10,maxBuckets=10-8         	1000000000	         0.0000609 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10,maxBuckets=30-8         	1000000000	         0.0001254 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10,maxBuckets=50-8         	1000000000	         0.0001825 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10,maxBuckets=100-8        	1000000000	         0.0003389 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10,maxBuckets=150-8        	1000000000	         0.0004598 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=100,maxBuckets=10-8        	1000000000	         0.0005995 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=100,maxBuckets=30-8        	1000000000	         0.001802 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=100,maxBuckets=50-8        	1000000000	         0.002691 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=100,maxBuckets=100-8       	1000000000	         0.004700 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=100,maxBuckets=150-8       	1000000000	         0.006475 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=1000,maxBuckets=10-8       	1000000000	         0.006501 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=1000,maxBuckets=30-8       	1000000000	         0.01871 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=1000,maxBuckets=50-8       	1000000000	         0.02851 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=1000,maxBuckets=100-8      	1000000000	         0.04587 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=1000,maxBuckets=150-8      	1000000000	         0.06189 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10000,maxBuckets=10-8      	1000000000	         0.08311 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10000,maxBuckets=30-8      	1000000000	         0.2510 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10000,maxBuckets=50-8      	1000000000	         0.3821 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10000,maxBuckets=100-8     	1000000000	         0.6426 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogramAdd/numHists=10000,maxBuckets=150-8     	  174598	      5769 ns/op	     652 B/op	       0 allocs/op
```