### PR TITLE
Fix Uyuni SD initialization (#9924)

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -227,7 +227,6 @@ var expectedConf = &Config{
 			},
 		},
 		{
-
 			JobName: "service-x",
 
 			HonorTimestamps: true,
@@ -954,7 +953,7 @@ var expectedConf = &Config{
 			Scheme:           DefaultScrapeConfig.Scheme,
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&uyuni.SDConfig{
-					Server:          kubernetesSDHostURL(),
+					Server:          "https://localhost:1234",
 					Username:        "gopher",
 					Password:        "hole",
 					Entitlement:     "monitoring_entitled",
@@ -1433,6 +1432,10 @@ var expectedErrors = []struct {
 	{
 		filename: "empty_scrape_config_action.bad.yml",
 		errMsg:   "relabel action cannot be empty",
+	},
+	{
+		filename: "uyuni_no_server.bad.yml",
+		errMsg:   "Uyuni SD configuration requires server host",
 	},
 }
 

--- a/config/testdata/uyuni_no_server.bad.yml
+++ b/config/testdata/uyuni_no_server.bad.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - job_name: uyuni
+    uyuni_sd_configs:
+      - server:

--- a/discovery/uyuni/uyuni_test.go
+++ b/discovery/uyuni/uyuni_test.go
@@ -1,0 +1,58 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uyuni
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+func testUpdateServices(respHandler http.HandlerFunc) ([]*targetgroup.Group, error) {
+	// Create a test server with mock HTTP handler.
+	ts := httptest.NewServer(respHandler)
+	defer ts.Close()
+
+	conf := SDConfig{
+		Server: ts.URL,
+	}
+
+	md, err := NewDiscovery(&conf, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return md.refresh(context.Background())
+}
+
+func TestUyuniSDHandleError(t *testing.T) {
+	var (
+		errTesting  = "unable to login to Uyuni API: request error: bad status code - 500"
+		respHandler = func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Header().Set("Content-Type", "application/xml")
+			io.WriteString(w, ``)
+		}
+	)
+	tgs, err := testUpdateServices(respHandler)
+
+	require.EqualError(t, err, errTesting)
+	require.Equal(t, len(tgs), 0)
+}


### PR DESCRIPTION
* Fix Uyuni SD initialization

The change prevents null pointer exception during SD initialization.

Signed-off-by: Witek Bedyk <witold.bedyk@suse.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
