### PR TITLE
deactivate dependabot for web dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/web/ui"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
As dependabot is spamming too much when it tries to upgrade the web dependencies, we spent to much by reviewing each PRs. So it doesn't worth it to keep it.

It would be far more interesting if it was able to open a single PR containing all the necessary update at once.

I'm looking at other options like suggested in the issue: https://github.com/dependabot/dependabot-core/issues/1190#issuecomment-954264074. Potentially the others tools can do the job in a better way.

I didn't deactivate it for the go dependencies as it was less time consumming from my point of view.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
