### PR TITLE
Hand-code remote-write protobuf

### DIFF
--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -336,7 +336,7 @@ func TestMetricTypeToMetricTypeProto(t *testing.T) {
 }
 
 func TestDecodeWriteRequest(t *testing.T) {
-	buf, _, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
+	buf, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
 	require.NoError(t, err)
 
 	actual, err := DecodeWriteRequest(bytes.NewReader(buf))

--- a/storage/remote/marshal.go
+++ b/storage/remote/marshal.go
@@ -1,4 +1,4 @@
-// Copyright 2013 The Prometheus Authors
+// Copyright 2021 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/storage/remote/marshal.go
+++ b/storage/remote/marshal.go
@@ -168,7 +168,7 @@ func sizeVarint(x uint64) (n int) {
 		n += 2
 	}
 	if x >= 1<<7 {
-		n += 1
+		n++
 	}
 	return n + 1
 }
@@ -188,7 +188,7 @@ func encodeVarint(data []byte, offset int, v uint64) int {
 // Special code for the common case that a size is less than 128
 func encodeSize(data []byte, offset, v int) int {
 	if v < 1<<7 {
-		offset -= 1
+		offset--
 		data[offset] = uint8(v)
 		return offset
 	}

--- a/storage/remote/marshal.go
+++ b/storage/remote/marshal.go
@@ -186,7 +186,7 @@ func encodeVarint(data []byte, offset int, v uint64) int {
 }
 
 // Special code for the common case that a size is less than 128
-func encodeSize(data []byte, offset int, v int) int {
+func encodeSize(data []byte, offset, v int) int {
 	if v < 1<<7 {
 		offset -= 1
 		data[offset] = uint8(v)

--- a/storage/remote/marshal.go
+++ b/storage/remote/marshal.go
@@ -1,0 +1,230 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	encoding_binary "encoding/binary"
+	"math"
+	math_bits "math/bits"
+
+	"github.com/prometheus/prometheus/prompb"
+)
+
+func marshalTimeseriesSliceToBuffer(timeseries []prompb.TimeSeries, dAtA []byte) (int, error) {
+	i := len(dAtA)
+	for iNdEx := len(timeseries) - 1; iNdEx >= 0; iNdEx-- {
+		size, err := marshalTimeseriesToSizedBuffer(&timeseries[iNdEx], dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func marshalTimeseriesToSizedBuffer(m *prompb.TimeSeries, dAtA []byte) (int, error) {
+	i := len(dAtA)
+	for iNdEx := len(m.Exemplars) - 1; iNdEx >= 0; iNdEx-- {
+		size, err := marshalExemplarToSizedBuffer(&m.Exemplars[iNdEx], dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	for iNdEx := len(m.Samples) - 1; iNdEx >= 0; iNdEx-- {
+		size, err := marshalSampleToSizedBuffer(&m.Samples[iNdEx], dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	for iNdEx := len(m.Labels) - 1; iNdEx >= 0; iNdEx-- {
+		size, err := marshalLabelToSizedBuffer(&m.Labels[iNdEx], dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func marshalExemplarToSizedBuffer(m *prompb.Exemplar, dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Timestamp != 0 {
+		i = encodeVarint(dAtA, i, uint64(m.Timestamp))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.Value != 0 {
+		i -= 8
+		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Value))))
+		i--
+		dAtA[i] = 0x11
+	}
+	for iNdEx := len(m.Labels) - 1; iNdEx >= 0; iNdEx-- {
+		size, err := marshalLabelToSizedBuffer(&m.Labels[iNdEx], dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func marshalSampleToSizedBuffer(m *prompb.Sample, dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Timestamp != 0 {
+		i = encodeVarint(dAtA, i, uint64(m.Timestamp))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Value != 0 {
+		i -= 8
+		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Value))))
+		i--
+		dAtA[i] = 0x9
+	}
+	return len(dAtA) - i, nil
+}
+
+func marshalLabelToSizedBuffer(m *prompb.Label, dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = encodeVarint(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarint(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func sov(x uint64) (n int) {
+	return (math_bits.Len64(x|1) + 6) / 7
+}
+
+func encodeVarint(dAtA []byte, offset int, v uint64) int {
+	offset -= sov(v)
+	base := offset
+	for v >= 1<<7 {
+		dAtA[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	dAtA[offset] = uint8(v)
+	return base
+}
+
+func timeseriesSliceSize(timeseries []prompb.TimeSeries) (n int) {
+	for _, e := range timeseries {
+		l := timeseriesSize(&e)
+		n += 1 + l + sov(uint64(l))
+	}
+	return n
+}
+
+func timeseriesSize(m *prompb.TimeSeries) (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	if len(m.Labels) > 0 {
+		for _, e := range m.Labels {
+			l = labelSize(&e)
+			n += 1 + l + sov(uint64(l))
+		}
+	}
+	if len(m.Samples) > 0 {
+		for _, e := range m.Samples {
+			l = sampleSize(&e)
+			n += 1 + l + sov(uint64(l))
+		}
+	}
+	if len(m.Exemplars) > 0 {
+		for _, e := range m.Exemplars {
+			l = exemplarSize(&e)
+			n += 1 + l + sov(uint64(l))
+		}
+	}
+	return n
+}
+
+func labelSize(m *prompb.Label) (n int) {
+	if m == nil {
+		return 0
+	}
+	l := len(m.Name)
+	if l > 0 {
+		n += 1 + l + sov(uint64(l))
+	}
+	l = len(m.Value)
+	if l > 0 {
+		n += 1 + l + sov(uint64(l))
+	}
+	return n
+}
+
+func sampleSize(m *prompb.Sample) (n int) {
+	if m == nil {
+		return 0
+	}
+	if m.Value != 0 {
+		n += 9
+	}
+	if m.Timestamp != 0 {
+		n += 1 + sov(uint64(m.Timestamp))
+	}
+	return n
+}
+
+func exemplarSize(m *prompb.Exemplar) (n int) {
+	if m == nil {
+		return 0
+	}
+	if len(m.Labels) > 0 {
+		for _, e := range m.Labels {
+			l := labelSize(&e)
+			n += 1 + l + sov(uint64(l))
+		}
+	}
+	if m.Value != 0 {
+		n += 9
+	}
+	if m.Timestamp != 0 {
+		n += 1 + sov(uint64(m.Timestamp))
+	}
+	return n
+}

--- a/storage/remote/marshal_test.go
+++ b/storage/remote/marshal_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013 The Prometheus Authors
+// Copyright 2021 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/storage/remote/marshal_test.go
+++ b/storage/remote/marshal_test.go
@@ -18,7 +18,7 @@ import (
 	math_bits "math/bits"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_sizeVarint(t *testing.T) {
@@ -27,7 +27,7 @@ func Test_sizeVarint(t *testing.T) {
 		t.Run(fmt.Sprint(x), func(t *testing.T) {
 			want := (math_bits.Len64(x|1) + 6) / 7 // Implementation used by protoc.
 			got := sizeVarint(x)
-			assert.Equal(t, want, got)
+			require.Equal(t, want, got)
 		})
 	}
 }

--- a/storage/remote/marshal_test.go
+++ b/storage/remote/marshal_test.go
@@ -1,0 +1,33 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"fmt"
+	math_bits "math/bits"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_sizeVarint(t *testing.T) {
+	for i := 0; i < 63; i++ {
+		x := uint64(1) << i
+		t.Run(fmt.Sprint(x), func(t *testing.T) {
+			want := (math_bits.Len64(x|1) + 6) / 7 // Implementation used by protoc.
+			got := sizeVarint(x)
+			assert.Equal(t, want, got)
+		})
+	}
+}

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1389,7 +1389,6 @@ func buildWriteRequest(samples []prompb.TimeSeries, metadata []prompb.MetricMeta
 	}
 
 	err := pBuf.Marshal(req)
-
 	if err != nil {
 		return nil, err
 	}

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestRemoteWriteHandler(t *testing.T) {
-	buf, _, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
+	buf, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("", "", bytes.NewReader(buf))
@@ -65,7 +65,7 @@ func TestRemoteWriteHandler(t *testing.T) {
 }
 
 func TestOutOfOrderSample(t *testing.T) {
-	buf, _, err := buildWriteRequest([]prompb.TimeSeries{{
+	buf, err := buildWriteRequest([]prompb.TimeSeries{{
 		Labels:  []prompb.Label{{Name: "__name__", Value: "test_metric"}},
 		Samples: []prompb.Sample{{Value: 1, Timestamp: 0}},
 	}}, nil, nil, nil)
@@ -90,7 +90,7 @@ func TestOutOfOrderSample(t *testing.T) {
 // don't fail on ingestion errors since the exemplar storage is
 // still experimental.
 func TestOutOfOrderExemplar(t *testing.T) {
-	buf, _, err := buildWriteRequest([]prompb.TimeSeries{{
+	buf, err := buildWriteRequest([]prompb.TimeSeries{{
 		Labels:    []prompb.Label{{Name: "__name__", Value: "test_metric"}},
 		Exemplars: []prompb.Exemplar{{Labels: []prompb.Label{{Name: "foo", Value: "bar"}}, Value: 1, Timestamp: 0}},
 	}}, nil, nil, nil)
@@ -113,7 +113,7 @@ func TestOutOfOrderExemplar(t *testing.T) {
 }
 
 func TestCommitErr(t *testing.T) {
-	buf, _, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
+	buf, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("", "", bytes.NewReader(buf))


### PR DESCRIPTION
Draft, as you may not want to add the complexity, but I thought it was worth seeing the performance achievable.

```
name          old time/op    new time/op    delta
SampleSend-4    1.70ms ± 0%    1.12ms ± 4%  -34.44%  (p=0.016 n=4+5)

name          old alloc/op   new alloc/op   delta
SampleSend-4    47.4kB ± 0%    29.6kB ± 1%  -37.57%  (p=0.008 n=5+5)

name          old allocs/op  new allocs/op  delta
SampleSend-4       140 ± 0%       110 ± 0%  -21.43%  (p=0.008 n=5+5)
```

The code is pretty much as generated by the proto compiler, but working off the data structure created in #9934. We benefit from not creating the intermediate structs that protoc normally uses. 
As an additional step I re-wrote some of the varint code to go directly to the number of 7-bit words required, and optimise for small numbers

Another step I experimented with was merging external labels at the point of marshalling rather than creating an additional slice for each series in `processExternalLabels` called from `StoreSeries`. This does reduce heap size but increases CPU about 15% on every send, so I left it out.