### PR TITLE
Add stripPort to template function

### DIFF
--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -70,6 +70,7 @@ versions.
 | title         | string        | string  | [strings.Title](https://golang.org/pkg/strings/#Title), capitalises first character of each word.|
 | toUpper       | string        | string  | [strings.ToUpper](https://golang.org/pkg/strings/#ToUpper), converts all characters to upper case.|
 | toLower       | string        | string  | [strings.ToLower](https://golang.org/pkg/strings/#ToLower), converts all characters to lower case.|
+| stripPort     | string        | string  | [net.SplitHostPort](https://pkg.go.dev/net#SplitHostPort), splits string into host and port, then returns only host.|
 | match         | pattern, text | boolean | [regexp.MatchString](https://golang.org/pkg/regexp/#MatchString) Tests for a unanchored regexp match. |
 | reReplaceAll  | pattern, replacement, text | string | [Regexp.ReplaceAllString](https://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
 | graphLink  | expr | string | Returns path to graph view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |

--- a/template/template.go
+++ b/template/template.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	html_template "html/template"
 	"math"
+	"net"
 	"net/url"
 	"regexp"
 	"sort"
@@ -183,6 +184,13 @@ func NewTemplateExpander(
 				sorter := queryResultByLabelSorter{v[:], label}
 				sort.Stable(sorter)
 				return v
+			},
+			"stripPort": func(hostPort string) string {
+				host, _, err := net.SplitHostPort(hostPort)
+				if err != nil {
+					return hostPort
+				}
+				return host
 			},
 			"humanize": func(i interface{}) (string, error) {
 				v, err := convertToFloat(i)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -162,6 +162,41 @@ func TestTemplateExpansion(t *testing.T) {
 			output: "a:11: b:21: ",
 		},
 		{
+			// Simple hostname.
+			text:   "{{ \"foo.example.com\" | stripPort }}",
+			output: "foo.example.com",
+		},
+		{
+			// Hostname with port.
+			text:   "{{ \"foo.example.com:12345\" | stripPort }}",
+			output: "foo.example.com",
+		},
+		{
+			// Simple IPv4 address.
+			text:   "{{ \"192.0.2.1\" | stripPort }}",
+			output: "192.0.2.1",
+		},
+		{
+			// IPv4 address with port.
+			text:   "{{ \"192.0.2.1:12345\" | stripPort }}",
+			output: "192.0.2.1",
+		},
+		{
+			// Simple IPv6 address.
+			text:   "{{ \"2001:0DB8::1\" | stripPort }}",
+			output: "2001:0DB8::1",
+		},
+		{
+			// IPv6 address with port.
+			text:   "{{ \"[2001:0DB8::1]:12345\" | stripPort }}",
+			output: "2001:0DB8::1",
+		},
+		{
+			// Value can't be split into host and port.
+			text:   "{{ \"[2001:0DB8::1]::12345\" | stripPort }}",
+			output: "[2001:0DB8::1]::12345",
+		},
+		{
 			// Missing value is no value for nil options.
 			text:   "{{ .Foo }}",
 			output: "<no value>",


### PR DESCRIPTION
This PR adds a new template function which was proposed in #9932 to prometheus.
A new funtion name is `stripPort` which split string to host and port with [net.SplitHostPort](https://pkg.go.dev/net#SplitHostPort), and return only host. If it couldn't split, return original string.