### PR TITLE
model/relabel: prototype `action: template`

### DIFF
--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -193,10 +193,10 @@ func (re Regexp) MarshalYAML() (interface{}, error) {
 func Process(labels labels.Labels, cfgs ...*Config) (labels.Labels, error) {
 	for _, cfg := range cfgs {
 		result, err := relabel(labels, cfg)
-		if result == nil {
-			return nil, nil
-		} else if err != nil {
+		if err != nil {
 			return labels, err
+		} else if result == nil {
+			return nil, nil
 		}
 		labels = result
 	}

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -447,11 +447,14 @@ func TestRelabel(t *testing.T) {
 			input: labels.FromMap(map[string]string{}),
 			relabel: []*Config{{
 				TargetLabel: "out",
-				Template:    MustNewTemplateExpr(`{{ GetEnv "USER" }}`),
-				Action:      Template,
+				Template: func() TemplateExpr {
+					os.Setenv("TEST_ENV", "Hello, world!")
+					return MustNewTemplateExpr(`{{ GetEnv "TEST_ENV" }}`)
+				}(),
+				Action: Template,
 			}},
 			output: labels.FromMap(map[string]string{
-				"out": os.Getenv("USER"),
+				"out": "Hello, world!",
 			}),
 		},
 	}

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -476,7 +476,8 @@ func TestRelabel(t *testing.T) {
 			}
 		}
 
-		res := Process(test.input, test.relabel...)
+		res, err := Process(test.input, test.relabel...)
+		require.NoError(t, err)
 		require.Equal(t, test.output, res)
 	}
 }
@@ -525,7 +526,7 @@ func BenchmarkTemplate(b *testing.B) {
 		}}
 
 		for i := 0; i < b.N; i++ {
-			_ = Process(inLabels, rules...)
+			_, _ = Process(inLabels, rules...)
 		}
 	})
 
@@ -539,7 +540,7 @@ func BenchmarkTemplate(b *testing.B) {
 		}}
 
 		for i := 0; i < b.N; i++ {
-			_ = Process(inLabels, rules...)
+			_, _ = Process(inLabels, rules...)
 		}
 	})
 }

--- a/model/relabel/template.go
+++ b/model/relabel/template.go
@@ -1,0 +1,93 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package relabel
+
+import (
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// TemplateFuncs are functions made available to templates when using the
+// Template relabel action.
+var TemplateFuncs = template.FuncMap{
+	"GetEnv": os.Getenv,
+}
+
+// TemplateExpr encapsulates a *template.Template and makes it YAML
+// marshalable.
+type TemplateExpr struct {
+	*template.Template
+	original string
+}
+
+// NewTemplateExpr creates a new TemplateExpr and returns an error if the
+// passed-in template does not parse or fails to execute with an empty
+// label set.
+//
+// The functions available to the template are set to TemplateFuncs.
+func NewTemplateExpr(expr string) (TemplateExpr, error) {
+	t, err := template.New("relabel").Funcs(TemplateFuncs).Parse(expr)
+	return TemplateExpr{Template: t, original: expr}, err
+}
+
+// MustNewTemplateExpr is like NewTemplateExpr but panics if it returns a
+// non-nil error.
+func MustNewTemplateExpr(expr string) TemplateExpr {
+	te, err := NewTemplateExpr(expr)
+	if err != nil {
+		panic(err)
+	}
+	return te
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (te *TemplateExpr) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	t, err := NewTemplateExpr(s)
+	if err != nil {
+		return err
+	}
+	*te = t
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface.
+func (te TemplateExpr) MarshalYAML() (interface{}, error) {
+	if te.original != "" {
+		return te.original, nil
+	}
+	return nil, nil
+}
+
+// Execute runs TemplateExpr for a set of labels.
+func (te TemplateExpr) Execute(lset labels.Labels) (string, error) {
+	var sb strings.Builder
+
+	ctx := templateContext{Labels: lset.Map()}
+	if err := te.Template.Execute(&sb, ctx); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
+}
+
+// templateContext is used as the context data when executing templates.
+type templateContext struct {
+	Labels map[string]string
+}

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -636,7 +636,7 @@ func TestScrapeLoopStopBeforeRun(t *testing.T) {
 	}
 }
 
-func nopMutator(l labels.Labels) labels.Labels { return l }
+func nopMutator(l labels.Labels) (labels.Labels, error) { return l, nil }
 
 func TestScrapeLoopStop(t *testing.T) {
 	var (
@@ -1336,10 +1336,10 @@ func TestScrapeLoopAppend(t *testing.T) {
 
 		sl := newScrapeLoop(context.Background(),
 			nil, nil, nil,
-			func(l labels.Labels) labels.Labels {
+			func(l labels.Labels) (labels.Labels, error) {
 				return mutateSampleLabels(l, discoveryLabels, test.honorLabels, nil)
 			},
-			func(l labels.Labels) labels.Labels {
+			func(l labels.Labels) (labels.Labels, error) {
 				return mutateReportSampleLabels(l, discoveryLabels)
 			},
 			func(ctx context.Context) storage.Appender { return app },
@@ -1434,7 +1434,7 @@ func TestScrapeLoopAppendForConflictingPrefixedLabels(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			app := &collectResultAppender{}
 			sl := newScrapeLoop(context.Background(), nil, nil, nil,
-				func(l labels.Labels) labels.Labels {
+				func(l labels.Labels) (labels.Labels, error) {
 					return mutateSampleLabels(l, &Target{labels: labels.FromStrings(tc.targetLabels...)}, false, nil)
 				},
 				nil,
@@ -1512,11 +1512,11 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 
 	sl := newScrapeLoop(context.Background(),
 		nil, nil, nil,
-		func(l labels.Labels) labels.Labels {
+		func(l labels.Labels) (labels.Labels, error) {
 			if l.Has("deleteme") {
-				return nil
+				return nil, nil
 			}
-			return l
+			return l, nil
 		},
 		nopMutator,
 		func(ctx context.Context) storage.Appender { return app },
@@ -1788,10 +1788,10 @@ metric_total{n="2"} 2 # {t="2"} 2.0 20000
 
 			sl := newScrapeLoop(context.Background(),
 				nil, nil, nil,
-				func(l labels.Labels) labels.Labels {
+				func(l labels.Labels) (labels.Labels, error) {
 					return mutateSampleLabels(l, discoveryLabels, false, nil)
 				},
-				func(l labels.Labels) labels.Labels {
+				func(l labels.Labels) (labels.Labels, error) {
 					return mutateReportSampleLabels(l, discoveryLabels)
 				},
 				func(ctx context.Context) storage.Appender { return app },
@@ -1850,10 +1850,10 @@ func TestScrapeLoopAppendExemplarSeries(t *testing.T) {
 
 	sl := newScrapeLoop(context.Background(),
 		nil, nil, nil,
-		func(l labels.Labels) labels.Labels {
+		func(l labels.Labels) (labels.Labels, error) {
 			return mutateSampleLabels(l, discoveryLabels, false, nil)
 		},
-		func(l labels.Labels) labels.Labels {
+		func(l labels.Labels) (labels.Labels, error) {
 			return mutateReportSampleLabels(l, discoveryLabels)
 		},
 		func(ctx context.Context) storage.Appender { return app },
@@ -2403,11 +2403,11 @@ func TestScrapeLoopDiscardUnnamedMetrics(t *testing.T) {
 	sl := newScrapeLoop(context.Background(),
 		&testScraper{},
 		nil, nil,
-		func(l labels.Labels) labels.Labels {
+		func(l labels.Labels) (labels.Labels, error) {
 			if l.Has("drop") {
-				return labels.Labels{}
+				return labels.Labels{}, nil
 			}
-			return l
+			return l, nil
 		},
 		nopMutator,
 		func(ctx context.Context) storage.Appender { return app },
@@ -2913,10 +2913,10 @@ func TestScrapeLoopLabelLimit(t *testing.T) {
 
 		sl := newScrapeLoop(context.Background(),
 			nil, nil, nil,
-			func(l labels.Labels) labels.Labels {
+			func(l labels.Labels) (labels.Labels, error) {
 				return mutateSampleLabels(l, discoveryLabels, false, nil)
 			},
-			func(l labels.Labels) labels.Labels {
+			func(l labels.Labels) (labels.Labels, error) {
 				return mutateReportSampleLabels(l, discoveryLabels)
 			},
 			func(ctx context.Context) storage.Appender { return app },

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -375,7 +375,10 @@ func PopulateLabels(lset labels.Labels, cfg *config.ScrapeConfig) (res, orig lab
 	}
 
 	preRelabelLabels := lb.Labels()
-	lset = relabel.Process(preRelabelLabels, cfg.RelabelConfigs...)
+	lset, err = relabel.Process(preRelabelLabels, cfg.RelabelConfigs...)
+	if err != nil {
+		return nil, nil, errors.Errorf("error while relabeling: %v", err)
+	}
 
 	// Check if the target was dropped.
 	if lset == nil {


### PR DESCRIPTION
Prototype a new `template` action that can be used to emulate similar behavior to Grafana Agent's "host filtering mode."

Closes #9637.

I'm opening this in draft since it's obviously not complete; no relabel action was possible to fail before, but this can. It's not immediately obvious how template execution errors should be exposed back to the user. 

This PR also includes benchmarks. As expected, templates are roughly 3x slower than their non-template equivalent:

```
BenchmarkTemplate/Template-10         	  797946	      1507   ns/op
BenchmarkTemplate/Replacement-10      	 1926429	       597.2 ns/op
```