### PR TITLE
promql: Add a guard against a nil histogram in sum aggregation

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2321,7 +2321,12 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		case parser.SUM:
 			if s.H != nil {
 				group.hasHistogram = true
-				group.histogramValue.Add(s.H)
+				if group.histogramValue != nil {
+					group.histogramValue.Add(s.H)
+				}
+				// Otherwise the aggregation contained floats
+				// previously and will be invalid anyway. No
+				// point in copying the histogram in that case.
 			} else {
 				group.hasFloat = true
 				group.value += s.V


### PR DESCRIPTION
__Experimental histogram work, goes only into the sparsehistogram branch.__

This can happen if the aggregation starts with a float and later
encounters a histogram. In that case, the newly encountered histogram
would have been added to a nil histogram.

This should be tested, of course, but that's best done within the
PromQL testing framework, which we still need to enable for histograms
(for which we have a TODO in the code and now also a card in the GH
project).

@codesome mostly FYI. I assume this is trivial enough to just merge on green.