### PR TITLE
fix missing db.Close() in order to avoid goroutine leak

### DIFF
--- a/web/web_test.go
+++ b/web/web_test.go
@@ -116,7 +116,9 @@ func TestReadyAndHealthy(t *testing.T) {
 
 	db, err := tsdb.Open(dbDir, nil, nil, nil, nil)
 	require.NoError(t, err)
-
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
 	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
 
 	opts := &Options{
@@ -237,6 +239,9 @@ func TestRoutePrefix(t *testing.T) {
 
 	db, err := tsdb.Open(dbDir, nil, nil, nil, nil)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
 
 	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
 
@@ -404,7 +409,9 @@ func TestShutdownWithStaleConnection(t *testing.T) {
 
 	db, err := tsdb.Open(dbDir, nil, nil, nil, nil)
 	require.NoError(t, err)
-
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
 	timeout := 10 * time.Second
 
 	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Many goroutines are leak because of no proper way to release db.

```
goroutine 153 [select]:
github.com/prometheus/prometheus/tsdb/wal.(*WAL).run(0xc0002cc5a0)
	/repos/prometheus/tsdb/wal/wal.go:388 +0x832
created by github.com/prometheus/prometheus/tsdb/wal.NewSize
	/repos/prometheus/tsdb/wal/wal.go:312 +0x433

goroutine 434 [select]:
github.com/prometheus/prometheus/tsdb.(*DB).run(0xc0002fc000)
	/repos/prometheus/tsdb/db.go:1026 +0x2772
created by github.com/prometheus/prometheus/tsdb.open
	/repos/prometheus/tsdb/db.go:752 +0x885

goroutine 646 [chan send]:
github.com/prometheus/prometheus/web.(*Handler).Run.func2(0xc00003cd00, 0x115f6a8, 0xc0008990e0, 0xc000450c00, 0x0, 0x0, 0xc000442200)
	/repos/prometheus/web/web.go:605 +0xf5
created by github.com/prometheus/prometheus/web.(*Handler).Run
	/repos/prometheus/web/web.go:603 +0x8bc
```
