### PR TITLE
fix missing db.Close() in order to avoid goroutine leak

### DIFF
--- a/web/web_test.go
+++ b/web/web_test.go
@@ -404,7 +404,9 @@ func TestShutdownWithStaleConnection(t *testing.T) {
 
 	db, err := tsdb.Open(dbDir, nil, nil, nil, nil)
 	require.NoError(t, err)
-
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
 	timeout := 10 * time.Second
 
 	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
Similiar to previous PR