### PR TITLE
fix potential goroutine leaks at TestWALRestoreCorrupted

### DIFF
--- a/tsdb/wal.go
+++ b/tsdb/wal.go
@@ -190,7 +190,7 @@ func OpenSegmentWAL(dir string, logger log.Logger, flushInterval time.Duration, 
 		flushInterval: flushInterval,
 		donec:         make(chan struct{}),
 		stopc:         make(chan struct{}),
-		actorc:        make(chan func() error, 1),
+		actorc:        make(chan func() error, 2),
 		segmentSize:   walSegmentSizeBytes,
 		crc32:         newCRC32(),
 	}


### PR DESCRIPTION
Signed-off-by: Shihao Xia <charlesxsh@hotmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
```
TestWALRestoreCorrupted

func TestWALRestoreCorrupted(t *testing.T) {
…
for _, c := range cases {
       t.Run(c.name, func(t *testing.T) {
           // line 1
           w, err := OpenSegmentWAL(dir, nil, 0, nil)
           require.NoError(t, w.cut())


      }
}
…
}


func OpenSegmentWAL(dir string, logger log.Logger, flushInterval time.Duration, r prometheus.Registerer) (*SegmentWAL, error) {
….
w := &SegmentWAL{
       dirFile:       df,
       logger:        logger,
       flushInterval: flushInterval,
       donec:         make(chan struct{}),
       stopc:         make(chan struct{}),
       actorc:        make(chan func() error, 1),   // line 2
       segmentSize:   walSegmentSizeBytes,
       crc32:         newCRC32(),
   }
…..

   go w.run(flushInterval)


}

func (w *SegmentWAL) run(interval time.Duration) {
….
for {
       // Processing all enqueued operations has precedence over shutdown and
       // background syncs.
       select {
       case f := <-w.actorc:  // line 3.1
           if err := f(); err != nil {
               level.Error(w.logger).Log("msg", "operation failed", "err", err)
           }
           continue
       default:
       }
       select {
       case <-w.stopc:  // line 5 
           return
       case f := <-w.actorc:   // line 3.2
           if err := f(); err != nil {
               level.Error(w.logger).Log("msg", "operation failed", "err", err)
           }
       case <-tick:
           if err := w.Sync(); err != nil {
               level.Error(w.logger).Log("msg", "sync failed", "err", err)
           }
       }
}
….

}

func (w *SegmentWAL) cut() error {
go func() {
           w.actorc <- func() error {    // line 4.1
….
            }
}


go func() {
       w.actorc <- func() error {  line 4.2
           return errors.Wrap(w.dirFile.Sync(), "sync WAL directory") 
       }
   }()
}

goroutine 127 [chan send]:
github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func2(0xc000406100)
   /repos/prometheus/tsdb/wal.go:627 +0xc5
created by github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut
   /repos/prometheus/tsdb/wal.go:625 +0x12d
 
goroutine 16 [chan send]:
github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func2(0xc0003f4000)
   /repos/prometheus/tsdb/wal.go:627 +0xc5
created by github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut
   /repos/prometheus/tsdb/wal.go:625 +0x12d
 
goroutine 234 [chan send]:
github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func2(0xc000406300)
   /repos/prometheus/tsdb/wal.go:627 +0xc5
created by github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut
   /repos/prometheus/tsdb/wal.go:625 +0x12d
```
Since there are three SegmentWAL created around line 1, three goroutines would be blocked if line 5 happened first. From line 2 we can see that channel already have 1 buffer, but `cut` has two send operations, call stack also shows that it will be blocked in second place.

