### PR TITLE
fix potential goroutine leaks at TestTargetUpdatesOrder

### DIFF
--- a/discovery/legacymanager/manager_test.go
+++ b/discovery/legacymanager/manager_test.go
@@ -668,12 +668,15 @@ func TestTargetUpdatesOrder(t *testing.T) {
 			discoveryManager.updatert = 100 * time.Millisecond
 
 			var totalUpdatesCount int
-			provUpdates := make(chan []*targetgroup.Group)
 			for _, up := range tc.updates {
-				go newMockDiscoveryProvider(up...).Run(ctx, provUpdates)
 				if len(up) > 0 {
 					totalUpdatesCount += len(up)
 				}
+			}
+			provUpdates := make(chan []*targetgroup.Group, totalUpdatesCount)
+
+			for _, up := range tc.updates {
+				go newMockDiscoveryProvider(up...).Run(ctx, provUpdates)
 			}
 
 			for x := 0; x < totalUpdatesCount; x++ {

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -668,12 +668,15 @@ func TestTargetUpdatesOrder(t *testing.T) {
 			discoveryManager.updatert = 100 * time.Millisecond
 
 			var totalUpdatesCount int
-			provUpdates := make(chan []*targetgroup.Group)
 			for _, up := range tc.updates {
-				go newMockDiscoveryProvider(up...).Run(ctx, provUpdates)
 				if len(up) > 0 {
 					totalUpdatesCount += len(up)
 				}
+			}
+			provUpdates := make(chan []*targetgroup.Group, totalUpdatesCount)
+
+			for _, up := range tc.updates {
+				go newMockDiscoveryProvider(up...).Run(ctx, provUpdates)
 			}
 
 			for x := 0; x < totalUpdatesCount; x++ {


### PR DESCRIPTION
```
provUpdates := make(chan []*targetgroup.Group) // line 1
           for _, up := range tc.updates {
               go newMockDiscoveryProvider(up...).Run(ctx, provUpdates) // line 2
               if len(up) > 0 {
                   totalUpdatesCount += len(up)
               }
           }
for x := 0; x < totalUpdatesCount; x++ {
               select {
               case <-ctx.Done(): //line 4.1
                   t.Fatalf("%d: no update arrived within the timeout limit", x)
               case tgs := <-provUpdates: // line 3
                   discoveryManager.updateGroup(poolKey{setName: strconv.Itoa(i), provider: tc.title}, tgs)
                   for _, got := range discoveryManager.allGroups() {
                       // line 4.2
                       assertEqualGroups(t, got, tc.expectedTargets[x], func(got, expected string) string {
                           return fmt.Sprintf("%d: \ntargets mismatch \ngot: %v \nexpected: %v",
                               x,
                               got,
                               expected)
                       })
                   }
               }
           }
```
An unbuffered channel is created at line 1. And then it passed to many goroutine in a for-loop in line 2. Only receiver of this channel is line 3, however, either line 4.1 or line 4.2 may fail the test that leads to no receiver for this channel. So send operation will be blocked.
```
goroutine 33 [chan send]:
github.com/prometheus/prometheus/discovery.mockdiscoveryProvider.Run(0xc00028b980, 0x2, 0x2, 0xa008c8, 0xc00023a500, 0xc00002cb80)
   /repos/prometheus/discovery/manager_test.go:1308 +0x16b
created by github.com/prometheus/prometheus/discovery.TestTargetUpdatesOrder.func1
   /repos/prometheus/discovery/manager_test.go:681 +0x232
 
goroutine 185 [chan send]:
github.com/prometheus/prometheus/discovery.mockdiscoveryProvider.Run(0xc00028b9c0, 0x2, 0x2, 0xa008c8, 0xc00037e1e0, 0xc000281480)
   /repos/prometheus/discovery/manager_test.go:1308 +0x16b
created by github.com/prometheus/prometheus/discovery.TestTargetUpdatesOrder.func1
   /repos/prometheus/discovery/manager_test.go:681 +0x232
```