### PR TITLE
Extract interface from ActivityQueryTracker and allows passing custom implementation

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -207,13 +207,14 @@ func contextErr(err error, env string) error {
 	}
 }
 
-// QueryTracker should provide access to two features: tracking of active query, that are logged on restart,
-// and control over maximum number of concurrent requests.
+// QueryTracker provides access to two features:
+// 1) tracking of active query that are logged on restart if PromQL engine crashes while executing the query, and
+// 2) enforcement of the maximum number of concurrent requests.
 type QueryTracker interface {
 	// GetMaxConcurrent returns maximum number of concurrent queries that are allowed by this tracker.
 	GetMaxConcurrent() int
 
-	// Insert inserts query into query tracker. This call can block if maximum number of queries is already running.
+	// Insert inserts query into query tracker. This call must block if maximum number of queries is already running.
 	// If Insert doesn't return error then returned integer value should be used in subsequent Delete call.
 	// Insert returns error if context is finished before query can proceed.
 	Insert(ctx context.Context, query string) (int, error)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -213,9 +213,9 @@ type QueryTracker interface {
 	// GetMaxConcurrent returns maximum number of concurrent queries that are allowed by this tracker.
 	GetMaxConcurrent() int
 
-	// Insert inserts query into activity tracker. This can block, if maximum number of queries is already running.
-	// If Insert doesn't return error, then returned integer value should be used in subsequent Delete call.
-	// Returns error if context is finished before query can proceed.
+	// Insert inserts query into query tracker. This call can block if maximum number of queries is already running.
+	// If Insert doesn't return error then returned integer value should be used in subsequent Delete call.
+	// Insert returns error if context is finished before query can proceed.
 	Insert(ctx context.Context, query string) (int, error)
 
 	// Delete removes query from activity tracker. InsertIndex is value returned by Insert call.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -214,7 +214,8 @@ type QueryTracker interface {
 	GetMaxConcurrent() int
 
 	// Insert inserts query into activity tracker. This can block, if maximum number of queries is already running.
-	// Returned value is used in Delete call.
+	// If Insert doesn't return error, then returned integer value should be used in subsequent Delete call.
+	// Returns error if context is finished before query can proceed.
 	Insert(ctx context.Context, query string) (int, error)
 
 	// Delete removes query from activity tracker. InsertIndex is value returned by Insert call.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -208,15 +208,18 @@ func contextErr(err error, env string) error {
 }
 
 // QueryTracker provides access to two features:
-// 1) tracking of active query that are logged on restart if PromQL engine crashes while executing the query, and
-// 2) enforcement of the maximum number of concurrent requests.
+//
+// 1) Tracking of active query. If PromQL engine crashes while executing any query, such query should be present
+// in the tracker on restart, hence logged. After the logging on restart, the tracker gets emptied.
+//
+// 2) Enforcement of the maximum number of concurrent queries.
 type QueryTracker interface {
 	// GetMaxConcurrent returns maximum number of concurrent queries that are allowed by this tracker.
 	GetMaxConcurrent() int
 
 	// Insert inserts query into query tracker. This call must block if maximum number of queries is already running.
 	// If Insert doesn't return error then returned integer value should be used in subsequent Delete call.
-	// Insert returns error if context is finished before query can proceed.
+	// Insert should return error if context is finished before query can proceed, and integer value returned in this case should be ignored by caller.
 	Insert(ctx context.Context, query string) (int, error)
 
 	// Delete removes query from activity tracker. InsertIndex is value returned by Insert call.


### PR DESCRIPTION
We would like to use custom implementation of Query Tracker, to extend its capabilities a bit. Specifically, we would like to log extra details from the context (tenant, traceID) and also use query tracker in other parts of the system, not just PromQL engine. 

To achieve that, this PR extracts `QueryTracker` interface from existing `ActivityQueryTracker` type, and allows passing this interface via `EngineOpts` to the PromQL Engine.