### PR TITLE
Add Acceptance of 1.0.0 for OpenMetrics

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -748,7 +748,8 @@ type targetScraper struct {
 
 var errBodySizeLimit = errors.New("body size limit exceeded")
 
-const acceptHeader = `application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
+// TODO: Remove version=0.0.1 for openmetrics for Prometheus 3.0
+const acceptHeader = `application/openmetrics-text; version=1.0.0,application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
 
 var UserAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 


### PR DESCRIPTION
* Add commment about removing for Prometheus 3.0 since that is when a
  breaking change would be expected.

Relates to: https://github.com/prometheus/client_java/issues/702
Fixes: #9430
Supercedes: #9431 