### PR TITLE
Pop intersected postings heap without popping

### DIFF
--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1047,7 +1047,7 @@ func TestPostingsWithIndexHeap(t *testing.T) {
 			require.Equal(t, expected, h.At())
 			require.NoError(t, h.Next())
 		}
-		require.Empty(t, h)
+		require.True(t, h.empty())
 	})
 
 	t.Run("pop", func(t *testing.T) {


### PR DESCRIPTION
See this comment for detailed explanation:

https://github.com/prometheus/prometheus/pull/9907#issuecomment-1002189932

TL;DR: if we don't call Pop() on the heap implementation, we don't need
to return our param as an `interface{}` so we save an allocation.
This would be popped for every label value, so it can be thousands of
saved allocations here (see benchmarks).

Benchmarks compared to current main (with changes from #9907):

```
name                                                                   old time/op    new time/op    delta
Querier/Head/labelValuesWithMatchers/i_with_n="1"                         107ms ± 2%     101ms ± 1%   -5.36%  (p=0.001 n=9+5)
Querier/Head/labelValuesWithMatchers/i_with_n="^.+$"                      178ms ± 3%     170ms ± 1%   -4.35%  (p=0.001 n=9+5)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j!="foo"                125ms ± 9%     116ms ± 1%   -6.93%  (p=0.001 n=10+5)
Querier/Head/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"      184ms ± 8%     171ms ± 2%   -7.32%  (p=0.003 n=10+5)
Querier/Head/labelValuesWithMatchers/n_with_j!="foo"                      130ms ± 0%     137ms ± 0%   +5.02%  (p=0.001 n=9+5)
Querier/Head/labelValuesWithMatchers/n_with_i="1"                        4.43µs ± 5%    4.54µs ± 2%   +2.57%  (p=0.040 n=10+5)
Querier/Block/labelValuesWithMatchers/i_with_n="1"                        111ms ± 0%     111ms ± 0%     ~     (p=0.953 n=10+5)
Querier/Block/labelValuesWithMatchers/i_with_n="^.+$"                     147ms ± 0%     144ms ± 0%   -1.80%  (p=0.001 n=10+5)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j!="foo"               118ms ± 1%     117ms ± 1%     ~     (p=0.298 n=9+5)
Querier/Block/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"     163ms ± 1%     162ms ± 0%     ~     (p=0.083 n=9+5)
Querier/Block/labelValuesWithMatchers/n_with_j!="foo"                     139ms ± 2%     153ms ± 0%  +10.05%  (p=0.001 n=10+5)
Querier/Block/labelValuesWithMatchers/n_with_i="1"                        928µs ± 3%     928µs ± 1%     ~     (p=0.190 n=9+5)

name                                                                   old alloc/op   new alloc/op   delta
Querier/Head/labelValuesWithMatchers/i_with_n="1"                        19.1MB ± 0%    17.5MB ± 0%   -8.37%  (p=0.000 n=10+5)
Querier/Head/labelValuesWithMatchers/i_with_n="^.+$"                     36.3MB ± 0%    34.7MB ± 0%   -4.40%  (p=0.000 n=10+5)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j!="foo"               19.1MB ± 0%    17.5MB ± 0%   -8.37%  (p=0.000 n=10+5)
Querier/Head/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"     20.7MB ± 0%    19.1MB ± 0%   -7.72%  (p=0.000 n=10+5)
Querier/Head/labelValuesWithMatchers/n_with_j!="foo"                     6.40kB ± 0%    5.70kB ± 0%  -11.00%  (p=0.000 n=10+5)
Querier/Head/labelValuesWithMatchers/n_with_i="1"                        4.30kB ± 0%    4.55kB ± 0%   +5.96%  (p=0.001 n=10+5)
Querier/Block/labelValuesWithMatchers/i_with_n="1"                       20.7MB ± 0%    19.1MB ± 0%   -7.73%  (p=0.000 n=10+5)
Querier/Block/labelValuesWithMatchers/i_with_n="^.+$"                    37.9MB ± 0%    36.3MB ± 0%   -4.21%  (p=0.000 n=10+5)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j!="foo"              20.7MB ± 0%    19.1MB ± 0%   -7.73%  (p=0.000 n=10+5)
Querier/Block/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"    22.3MB ± 0%    20.7MB ± 0%   -7.17%  (p=0.000 n=10+5)
Querier/Block/labelValuesWithMatchers/n_with_j!="foo"                    8.78kB ± 0%    8.29kB ± 0%   -5.55%  (p=0.000 n=10+5)
Querier/Block/labelValuesWithMatchers/n_with_i="1"                       5.86kB ± 0%    6.12kB ± 0%   +4.37%  (p=0.001 n=10+5)

name                                                                   old allocs/op  new allocs/op  delta
Querier/Head/labelValuesWithMatchers/i_with_n="1"                          300k ± 0%      200k ± 0%  -33.33%  (p=0.000 n=10+5)
Querier/Head/labelValuesWithMatchers/i_with_n="^.+$"                       400k ± 0%      300k ± 0%  -25.00%  (p=0.000 n=10+5)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j!="foo"                 300k ± 0%      200k ± 0%  -33.33%  (p=0.000 n=10+5)
Querier/Head/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"       300k ± 0%      200k ± 0%  -33.33%  (p=0.000 n=10+5)
Querier/Head/labelValuesWithMatchers/n_with_j!="foo"                        139 ± 0%        99 ± 0%  -28.78%  (p=0.000 n=10+5)
Querier/Head/labelValuesWithMatchers/n_with_i="1"                          87.0 ± 0%      87.0 ± 0%     ~     (all equal)
Querier/Block/labelValuesWithMatchers/i_with_n="1"                         400k ± 0%      300k ± 0%  -25.00%  (p=0.000 n=10+5)
Querier/Block/labelValuesWithMatchers/i_with_n="^.+$"                      500k ± 0%      400k ± 0%  -20.00%  (p=0.000 n=10+5)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j!="foo"                400k ± 0%      300k ± 0%  -25.00%  (p=0.000 n=10+5)
Querier/Block/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"      400k ± 0%      300k ± 0%  -25.00%  (p=0.000 n=10+5)
Querier/Block/labelValuesWithMatchers/n_with_j!="foo"                       174 ± 0%       143 ± 0%  -17.82%  (p=0.000 n=10+5)
Querier/Block/labelValuesWithMatchers/n_with_i="1"                          129 ± 0%       129 ± 0%     ~     (all equal)
```

_Pending to add benchmarks compared to pre-#9907 change, I accidentally removed them and it takes a while to run them :facepalm:_ 

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
