### PR TITLE
release: Volunteer @beorn7 and @csmarchbanks for 2.33 and 2.34

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -37,7 +37,9 @@ Release cadence of first pre-releases being cut is 6 weeks.
 | v2.30          | 2021-09-08                                 | Ganesh Vernekar (GitHub: @codesome)         |
 | v2.31          | 2021-10-20                                 | Julien Pivotto (GitHub: @roidelapluie)      |
 | v2.32          | 2021-12-01                                 | Julius Volz (GitHub: @juliusv)              |
-| v2.33          | 2022-01-12                                 | **searching for volunteer**                 |
+| v2.33          | 2022-01-12                                 | Björn Rabenstein (GitHub: @beorn7)          |
+| v2.34          | 2022-02-23                                 | Chris Marchbanks (GitHub: @csmarchbanks)    |
+| v2.35          | 2022-04-06                                 | **searching for volunteer**                 |
 
 If you are interested in volunteering please create a pull request against the [prometheus/prometheus](https://github.com/prometheus/prometheus) repository and propose yourself for the release series of your choice.
 


### PR DESCRIPTION
In a meeting at Grafana Labs, we had the shocking revelation that the
next release is scheduled to happen soon, but there is no release
shepherd for it yet.

(Which reminds me: Perhaps we should make it a responsibility of the
release shepherd to make sure there is one for the next release, too?)

Given my current part-time commitment, I would actually try to avoid
being the release shepherd, but on the other hand, it's about time
that a Grafanista to do the job again, and the only one who could do
it at all in the room was me. @csmarchbanks volunteered for the next
release. So here we are.

Of course, if any other team member would like to jump in and do this
release or the next, we'll happily insert you into the list.

Signed-off-by: beorn7 <beorn@grafana.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
