### PR TITLE
tsdb: use simpler map key to improve exemplar ingest performance

### DIFF
--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -492,18 +492,23 @@ func BenchmarkAddExemplar(b *testing.B) {
 
 	for _, n := range []int{10000, 100000, 1000000} {
 		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
-			exs, err := NewCircularExemplarStorage(int64(n), eMetrics)
-			require.NoError(b, err)
-			es := exs.(*CircularExemplarStorage)
-
-			b.ResetTimer()
-			l := labels.Labels{{Name: "service", Value: strconv.Itoa(0)}}
-			for i := 0; i < n; i++ {
-				if i%100 == 0 {
-					l = labels.Labels{{Name: "service", Value: strconv.Itoa(i)}}
-				}
-				err = es.AddExemplar(l, exemplar.Exemplar{Value: float64(i), Ts: int64(i), Labels: exLabels})
+			for j := 0; j < b.N; j++ {
+				b.StopTimer()
+				exs, err := NewCircularExemplarStorage(int64(n), eMetrics)
 				require.NoError(b, err)
+				es := exs.(*CircularExemplarStorage)
+				l := labels.Labels{{Name: "service", Value: strconv.Itoa(0)}}
+				b.StartTimer()
+
+				for i := 0; i < n; i++ {
+					if i%100 == 0 {
+						l = labels.Labels{{Name: "service", Value: strconv.Itoa(i)}}
+					}
+					err = es.AddExemplar(l, exemplar.Exemplar{Value: float64(i), Ts: int64(i), Labels: exLabels})
+					if err != nil {
+						require.NoError(b, err)
+					}
+				}
 			}
 		})
 	}
@@ -543,24 +548,24 @@ func BenchmarkResizeExemplars(b *testing.B) {
 	}
 
 	for _, tc := range testCases {
-		exs, err := NewCircularExemplarStorage(tc.startSize, eMetrics)
-		require.NoError(b, err)
-		es := exs.(*CircularExemplarStorage)
+		b.Run(fmt.Sprintf("%s-%d-to-%d", tc.name, tc.startSize, tc.endSize), func(b *testing.B) {
+			for j := 0; j < b.N; j++ {
+				b.StopTimer()
+				exs, err := NewCircularExemplarStorage(tc.startSize, eMetrics)
+				require.NoError(b, err)
+				es := exs.(*CircularExemplarStorage)
 
-		for i := 0; i < int(float64(tc.startSize)*float64(1.5)); i++ {
-			l := labels.FromStrings("service", strconv.Itoa(i))
+				for i := 0; i < int(float64(tc.startSize)*float64(1.5)); i++ {
+					l := labels.FromStrings("service", strconv.Itoa(i))
 
-			err = es.AddExemplar(l, exemplar.Exemplar{Value: float64(i), Ts: int64(i)})
-			require.NoError(b, err)
-		}
-		saveIndex := es.index
-		saveExemplars := es.exemplars
-
-		b.Run(fmt.Sprintf("%s-%d-to-%d", tc.name, tc.startSize, tc.endSize), func(t *testing.B) {
-			es.index = saveIndex
-			es.exemplars = saveExemplars
-			b.ResetTimer()
-			es.Resize(tc.endSize)
+					err = es.AddExemplar(l, exemplar.Exemplar{Value: float64(i), Ts: int64(i)})
+					if err != nil {
+						require.NoError(b, err)
+					}
+				}
+				b.StartTimer()
+				es.Resize(tc.endSize)
+			}
 		})
 	}
 }

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -112,7 +112,7 @@ func TestAddExemplar(t *testing.T) {
 	}
 
 	require.NoError(t, es.AddExemplar(l, e))
-	require.Equal(t, es.index[l.String()].newest, 0, "exemplar was not stored correctly")
+	require.Equal(t, es.index[string(l.Bytes(nil))].newest, 0, "exemplar was not stored correctly")
 
 	e2 := exemplar.Exemplar{
 		Labels: labels.Labels{
@@ -126,8 +126,8 @@ func TestAddExemplar(t *testing.T) {
 	}
 
 	require.NoError(t, es.AddExemplar(l, e2))
-	require.Equal(t, es.index[l.String()].newest, 1, "exemplar was not stored correctly, location of newest exemplar for series in index did not update")
-	require.True(t, es.exemplars[es.index[l.String()].newest].exemplar.Equals(e2), "exemplar was not stored correctly, expected %+v got: %+v", e2, es.exemplars[es.index[l.String()].newest].exemplar)
+	require.Equal(t, es.index[string(l.Bytes(nil))].newest, 1, "exemplar was not stored correctly, location of newest exemplar for series in index did not update")
+	require.True(t, es.exemplars[es.index[string(l.Bytes(nil))].newest].exemplar.Equals(e2), "exemplar was not stored correctly, expected %+v got: %+v", e2, es.exemplars[es.index[string(l.Bytes(nil))].newest].exemplar)
 
 	require.NoError(t, es.AddExemplar(l, e2), "no error is expected attempting to add duplicate exemplar")
 
@@ -300,7 +300,7 @@ func TestSelectExemplar_TimeRange(t *testing.T) {
 			Ts:    int64(101 + i),
 		})
 		require.NoError(t, err)
-		require.Equal(t, es.index[l.String()].newest, i, "exemplar was not stored correctly")
+		require.Equal(t, es.index[string(l.Bytes(nil))].newest, i, "exemplar was not stored correctly")
 	}
 
 	m, err := labels.NewMatcher(labels.MatchEqual, l[0].Name, l[0].Value)
@@ -376,14 +376,14 @@ func TestIndexOverwrite(t *testing.T) {
 
 	// Ensure index GC'ing is taking place, there should no longer be any
 	// index entry for series l1 since we just wrote two exemplars for series l2.
-	_, ok := es.index[l1.String()]
+	_, ok := es.index[string(l1.Bytes(nil))]
 	require.False(t, ok)
-	require.Equal(t, &indexEntry{1, 0, l2}, es.index[l2.String()])
+	require.Equal(t, &indexEntry{1, 0, l2}, es.index[string(l2.Bytes(nil))])
 
 	err = es.AddExemplar(l1, exemplar.Exemplar{Value: 4, Ts: 4})
 	require.NoError(t, err)
 
-	i := es.index[l2.String()]
+	i := es.index[string(l2.Bytes(nil))]
 	require.Equal(t, &indexEntry{0, 0, l2}, i)
 }
 


### PR DESCRIPTION
Prometheus holds an index of exemplars so it can discard the oldest one for a series when a new one is added.
Since the keys are not for human eyes, we can use a simpler format and save the effort of quoting label values.

Very similar to #9697

The buffer on the stack is to reduce heap allocations; I gave it the arbitrary size of 1024, which is enough for 20 label/value pairs where each string is 24 bytes long.

I also had to fix the benchmarks, which were reporting results like like 0.01 ns/op, which is nonsense.
Go benchmarks are expected to do an amount of work that varies with the `b.N` parameter.
After fixing:
```
name                                        old time/op  new time/op  delta
AddExemplar/10000-4                         6.72ms ± 4%  4.19ms ± 3%  -37.65%  (p=0.008 n=5+5)
AddExemplar/100000-4                        84.2ms ±48%  40.9ms ± 2%  -51.50%  (p=0.016 n=5+4)
AddExemplar/1000000-4                        676ms ± 2%   394ms ± 3%  -41.68%  (p=0.008 n=5+5)
ResizeExemplars/grow-100000-to-200000-4     55.6ms ±28%  35.0ms ±31%  -37.05%  (p=0.008 n=5+5)
ResizeExemplars/shrink-100000-to-50000-4    24.3ms ± 3%  20.3ms ±55%     ~     (p=0.190 n=4+5)
ResizeExemplars/grow-1000000-to-2000000-4    790ms ±19%   481ms ±13%  -39.13%  (p=0.008 n=5+5)
ResizeExemplars/shrink-1000000-to-500000-4   357ms ±15%   189ms ±18%  -47.23%  (p=0.008 n=5+5)
```
