### PR TITLE
Tidy postingsWithIndexHeap

### DIFF
--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1041,11 +1041,11 @@ func TestPostingsWithIndexHeap(t *testing.T) {
 		for _, node := range h {
 			node.p.Next()
 		}
-		h.Init()
+		heap.Init(&h)
 
 		for _, expected := range []storage.SeriesRef{1, 5, 10, 20, 25, 30, 50} {
-			require.Equal(t, expected, h.At())
-			require.NoError(t, h.Next())
+			require.Equal(t, expected, h.at())
+			require.NoError(t, h.next())
 		}
 		require.True(t, h.empty())
 	})
@@ -1059,13 +1059,13 @@ func TestPostingsWithIndexHeap(t *testing.T) {
 		for _, node := range h {
 			node.p.Next()
 		}
-		h.Init()
+		heap.Init(&h)
 
 		for _, expected := range []storage.SeriesRef{1, 5, 10, 20} {
-			require.Equal(t, expected, h.At())
-			require.NoError(t, h.Next())
+			require.Equal(t, expected, h.at())
+			require.NoError(t, h.next())
 		}
-		require.Equal(t, storage.SeriesRef(25), h.At())
+		require.Equal(t, storage.SeriesRef(25), h.at())
 		node := heap.Pop(&h).(postingsWithIndex)
 		require.Equal(t, 2, node.index)
 		require.Equal(t, storage.SeriesRef(25), node.p.At())


### PR DESCRIPTION
While writing https://github.com/prometheus/prometheus/pull/10092 I noticed that I wasn't proud of how I left the code around `postingsWithIndexHeap`: some methods were inconsistently exported, comments missing, etc.

This commit just unexports `postingsWithIndexHeap`'s methods that don't need to be exported, and adds detailed comments.

No logic changes.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
