### PR TITLE
fix overlapping click-targets of alert state checkboxes

### DIFF
--- a/web/ui/react-app/src/pages/alerts/AlertContents.tsx
+++ b/web/ui/react-app/src/pages/alerts/AlertContents.tsx
@@ -63,7 +63,7 @@ const AlertsContent: FC<AlertsProps> = ({ groups = [], statsCount }) => {
           return (
             <Checkbox
               key={state}
-              wrapperStyles={{ marginRight: 10 }}
+              wrapperStyles={{ marginRight: 20 }}
               checked={filter[state]}
               id={`${state}-toggler`}
               onChange={toggleFilter(state)}

--- a/web/ui/react-app/src/pages/alerts/__snapshots__/AlertContents.test.tsx.snap
+++ b/web/ui/react-app/src/pages/alerts/__snapshots__/AlertContents.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`AlertsContent matches a snapshot 1`] = `
       onChange={[Function]}
       wrapperStyles={
         Object {
-          "marginRight": 10,
+          "marginRight": 20,
         }
       }
     >
@@ -35,7 +35,7 @@ exports[`AlertsContent matches a snapshot 1`] = `
       onChange={[Function]}
       wrapperStyles={
         Object {
-          "marginRight": 10,
+          "marginRight": 20,
         }
       }
     >
@@ -58,7 +58,7 @@ exports[`AlertsContent matches a snapshot 1`] = `
       onChange={[Function]}
       wrapperStyles={
         Object {
-          "marginRight": 10,
+          "marginRight": 20,
         }
       }
     >


### PR DESCRIPTION
Fixes overlapping click-targets of alert state checkboxes, where the next checkbox covers the current label.
This does so using the same margin as checkboxes on top of /graph has.


old|
----|
![promui-margin](https://user-images.githubusercontent.com/1887628/148440698-6945575d-9849-4d20-adac-1f1818c1dd22.png)


new|
---|
![promui-margin-fix](https://user-images.githubusercontent.com/1887628/148441492-980effb5-cc34-457a-8641-09d0ac3d395c.png)


<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
