### PR TITLE
Fix Example() function in TSDB

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -473,6 +473,10 @@ func (cdm *ChunkDiskMapper) CutNewFile() {
 	cdm.evtlPos.cutFileOnNextChunk()
 }
 
+func (cdm *ChunkDiskMapper) IsQueueEmpty() bool {
+	return cdm.writeQueue.queueIsEmpty()
+}
+
 // cutAndExpectRef creates a new m-mapped file.
 // The write lock should be held before calling this.
 // It ensures that the position in the new file matches the given chunk reference, if not then it errors.

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1461,6 +1461,10 @@ func TestSizeRetention(t *testing.T) {
 	}
 	require.NoError(t, headApp.Commit())
 
+	require.Eventually(t, func() bool {
+		return db.Head().chunkDiskMapper.IsQueueEmpty()
+	}, 2*time.Second, 100*time.Millisecond)
+
 	// Test that registered size matches the actual disk size.
 	require.NoError(t, db.reloadBlocks())                               // Reload the db to register the new db size.
 	require.Equal(t, len(blocks), len(db.Blocks()))                     // Ensure all blocks are registered.


### PR DESCRIPTION
I was not aware of the example function format (see https://go.dev/blog/examples) and ended up changing it in the last commit in https://github.com/prometheus/prometheus/pull/9451 which makes it not render in godoc. This PR just reverts the changes done to that function. I will merge on green.

cc @Dieterbe 