### PR TITLE
bump @nexucis/kvsearch to v0.4.0

### DIFF
--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -1598,9 +1598,9 @@
       "integrity": "sha512-Z1+ADKY0fxdBE28REraWhUCNy+Bp5UmpK3Tc/5wdCDpY+6fXh8l2csMtbPGaqEBsyGLxJz9wUYGCf+CW9unyvQ=="
     },
     "node_modules/@nexucis/kvsearch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@nexucis/kvsearch/-/kvsearch-0.3.0.tgz",
-      "integrity": "sha512-tHIH6W/mRUZZ0ZQyRbgp2uhat+2O1c1jX1EC6NHv7/8OIeHx1HBZ5ZZb0KSUVWl4jkNzYw6AO39OoTELtrjaQw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nexucis/kvsearch/-/kvsearch-0.4.0.tgz",
+      "integrity": "sha512-5kWxzjLhCucArZshf0bCcmU61aGFgrm98iG6/LEeKejOuoTq1M7sumcjGQ5FR0xMKQWmwC9mr7OvWgAmolxWSg==",
       "dependencies": {
         "@nexucis/fuzzy": "^0.3.0"
       }
@@ -7272,7 +7272,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.7.2",
         "@fortawesome/react-fontawesome": "^0.1.16",
         "@nexucis/fuzzy": "^0.3.0",
-        "@nexucis/kvsearch": "^0.3.0",
+        "@nexucis/kvsearch": "^0.4.0",
         "bootstrap": "^4.6.1",
         "codemirror-promql": "0.19.0",
         "css.escape": "^1.5.1",
@@ -27696,9 +27696,9 @@
       "integrity": "sha512-Z1+ADKY0fxdBE28REraWhUCNy+Bp5UmpK3Tc/5wdCDpY+6fXh8l2csMtbPGaqEBsyGLxJz9wUYGCf+CW9unyvQ=="
     },
     "@nexucis/kvsearch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@nexucis/kvsearch/-/kvsearch-0.3.0.tgz",
-      "integrity": "sha512-tHIH6W/mRUZZ0ZQyRbgp2uhat+2O1c1jX1EC6NHv7/8OIeHx1HBZ5ZZb0KSUVWl4jkNzYw6AO39OoTELtrjaQw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nexucis/kvsearch/-/kvsearch-0.4.0.tgz",
+      "integrity": "sha512-5kWxzjLhCucArZshf0bCcmU61aGFgrm98iG6/LEeKejOuoTq1M7sumcjGQ5FR0xMKQWmwC9mr7OvWgAmolxWSg==",
       "requires": {
         "@nexucis/fuzzy": "^0.3.0"
       }
@@ -29725,7 +29725,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.7.2",
         "@fortawesome/react-fontawesome": "^0.1.16",
         "@nexucis/fuzzy": "^0.3.0",
-        "@nexucis/kvsearch": "^0.3.0",
+        "@nexucis/kvsearch": "^0.4.0",
         "@testing-library/react-hooks": "^7.0.1",
         "@types/enzyme": "^3.10.10",
         "@types/flot": "0.0.32",

--- a/web/ui/react-app/package.json
+++ b/web/ui/react-app/package.json
@@ -20,7 +20,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.7.2",
     "@fortawesome/react-fontawesome": "^0.1.16",
     "@nexucis/fuzzy": "^0.3.0",
-    "@nexucis/kvsearch": "^0.3.0",
+    "@nexucis/kvsearch": "^0.4.0",
     "bootstrap": "^4.6.1",
     "codemirror-promql": "0.19.0",
     "css.escape": "^1.5.1",


### PR DESCRIPTION
This PR is upgrading the dependency `@nexucis/kvsearch` that is doing the search in the Service Discovery and in the Target pages.

This new version improved the performance of the search.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
