### PR TITLE
error for invalid media type should not be completely swallowed

### DIFF
--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -62,22 +62,18 @@ type Parser interface {
 
 // New returns a new parser of the byte slice.
 //
-// If content type is empty (NewPromParser(b), nil) is returned.
-// Any other invalid content type will return (nil, err).
-func New(b []byte, contentType string) (Parser, error) {
+// This function always returns a valid parser, but might additionally
+// return an error if the content type cannot be parsed.
+func New(b []byte, contentType string) (p Parser, warning error) {
 	if contentType == "" {
 		return NewPromParser(b), nil
 	}
 
 	mediaType, _, err := mime.ParseMediaType(contentType)
-	if err != nil {
-		return nil, err
-	}
-
-	if mediaType == "application/openmetrics-text" {
+	if err == nil && mediaType == "application/openmetrics-text" {
 		return NewOpenMetricsParser(b), nil
 	}
-	return NewPromParser(b), nil
+	return NewPromParser(b), err
 }
 
 // Entry represents the type of a parsed entry.

--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -16,6 +16,8 @@ package textparse
 import (
 	"mime"
 
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
 )
@@ -61,9 +63,11 @@ type Parser interface {
 }
 
 // New returns a new parser of the byte slice.
-func New(b []byte, contentType string) Parser {
+func New(b []byte, contentType string, l log.Logger) Parser {
 	mediaType, _, err := mime.ParseMediaType(contentType)
-	if err == nil && mediaType == "application/openmetrics-text" {
+	if err != nil {
+		level.Debug(l).Log("msg", "Invalid media type", "media-type", contentType, "err", err)
+	} else if mediaType == "application/openmetrics-text" {
 		return NewOpenMetricsParser(b)
 	}
 	return NewPromParser(b)

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -1,0 +1,86 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textparse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	requirePromParser := func(t *testing.T, p Parser) {
+		require.NotNil(t, p)
+		_, ok := p.(*PromParser)
+		require.True(t, ok)
+	}
+
+	requireOpenMetricsParser := func(t *testing.T, p Parser) {
+		require.NotNil(t, p)
+		_, ok := p.(*OpenMetricsParser)
+		require.True(t, ok)
+	}
+
+	requireNil := func(t *testing.T, p Parser) {
+		require.Nil(t, p)
+	}
+
+	for name, tt := range map[string]*struct {
+		contentType    string
+		validateParser func(*testing.T, Parser)
+		err            string
+	}{
+		"empty-string": {
+			contentType:    "",
+			validateParser: requirePromParser,
+			err:            "",
+		},
+		"invalid-content-type": {
+			contentType:    "application/openmetrics-text; charset=UTF-8; charset=utf-8",
+			validateParser: requireNil,
+			err:            "duplicate parameter name",
+		},
+		"application/openmetrics-text": {
+			contentType:    "application/openmetrics-text",
+			validateParser: requireOpenMetricsParser,
+			err:            "",
+		},
+		"text/plain": {
+			contentType:    "text/plain",
+			validateParser: requirePromParser,
+			err:            "",
+		},
+		"some-other-valid-content-type": {
+			contentType:    "text/html",
+			validateParser: requirePromParser,
+			err:            "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tt := tt // copy to local var before going parallel
+			t.Parallel()
+
+			p, err := New([]byte{}, tt.contentType)
+			tt.validateParser(t, p)
+			if tt.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.err)
+			}
+		})
+	}
+}

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNew(t *testing.T) {
+func TestNewParser(t *testing.T) {
 	t.Parallel()
 
 	requirePromParser := func(t *testing.T, p Parser) {

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -96,7 +96,7 @@ func TestNewParser(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			tt := tt // copy to local var before going parallel
+			tt := tt // Copy to local variable before going parallel.
 			t.Parallel()
 
 			p, err := New([]byte{}, tt.contentType)

--- a/promql/fuzz.go
+++ b/promql/fuzz.go
@@ -20,7 +20,6 @@ package promql
 import (
 	"io"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -64,6 +63,7 @@ func fuzzParseMetricWithContentType(in []byte, contentType string) int {
 		// in this context
 		panic(err)
 	}
+
 	for {
 		_, err = p.Next()
 		if err != nil {

--- a/promql/fuzz.go
+++ b/promql/fuzz.go
@@ -20,6 +20,7 @@ package promql
 import (
 	"io"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -57,7 +58,7 @@ const (
 )
 
 func fuzzParseMetricWithContentType(in []byte, contentType string) int {
-	p := textparse.New(in, contentType)
+	p := textparse.New(in, contentType, log.NewNopLogger())
 	var err error
 	for {
 		_, err = p.Next()

--- a/promql/fuzz.go
+++ b/promql/fuzz.go
@@ -59,8 +59,8 @@ const (
 func fuzzParseMetricWithContentType(in []byte, contentType string) int {
 	p, warning := textparse.New(in, contentType)
 	if warning != nil {
-		// an invalid content type is being passed, which should not happen
-		// in this context
+		// An invalid content type is being passed, which should not happen
+		// in this context.
 		panic(warning)
 	}
 

--- a/promql/fuzz.go
+++ b/promql/fuzz.go
@@ -57,13 +57,14 @@ const (
 )
 
 func fuzzParseMetricWithContentType(in []byte, contentType string) int {
-	p, err := textparse.New(in, contentType)
-	if err != nil {
+	p, warning := textparse.New(in, contentType)
+	if warning != nil {
 		// an invalid content type is being passed, which should not happen
 		// in this context
-		panic(err)
+		panic(warning)
 	}
 
+	var err error
 	for {
 		_, err = p.Next()
 		if err != nil {

--- a/promql/fuzz.go
+++ b/promql/fuzz.go
@@ -58,8 +58,12 @@ const (
 )
 
 func fuzzParseMetricWithContentType(in []byte, contentType string) int {
-	p := textparse.New(in, contentType, log.NewNopLogger())
-	var err error
+	p, err := textparse.New(in, contentType)
+	if err != nil {
+		// an invalid content type is being passed, which should not happen
+		// in this context
+		panic(err)
+	}
 	for {
 		_, err = p.Next()
 		if err != nil {

--- a/promql/fuzz_test.go
+++ b/promql/fuzz_test.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Only build when go-fuzz is in use
+//go:build gofuzz
+// +build gofuzz
+
+package promql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestfuzzParseMetricWithContentTypePanicOnInvalid(t *testing.T) {
+	defer func() {
+		if p := recover(); p == nil {
+			t.Error("invalid content type should panic")
+		} else {
+			err, ok := p.(error)
+			require.True(t, ok)
+			require.Contains(t, err.Error(), "duplicate parameter name")
+		}
+	}()
+
+	const invalidContentType = "application/openmetrics-text; charset=UTF-8; charset=utf-8"
+	fuzzParseMetricWithContentType([]byte{}, invalidContentType)
+}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"mime"
 	"net/http"
 	"reflect"
 	"sort"
@@ -1418,6 +1419,10 @@ type appendErrors struct {
 }
 
 func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string, ts time.Time) (total, added, seriesAdded int, err error) {
+	if _, _, err := mime.ParseMediaType(contentType); err != nil {
+		level.Debug(sl.l).Log("msg", "Invalid media type", "media-type", contentType, "err", err)
+	}
+
 	var (
 		p              = textparse.New(b, contentType)
 		defTime        = timestamp.FromTime(ts)

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
-	"mime"
 	"net/http"
 	"reflect"
 	"sort"
@@ -1419,12 +1418,8 @@ type appendErrors struct {
 }
 
 func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string, ts time.Time) (total, added, seriesAdded int, err error) {
-	if _, _, err := mime.ParseMediaType(contentType); err != nil {
-		level.Debug(sl.l).Log("msg", "Invalid media type", "media-type", contentType, "err", err)
-	}
-
 	var (
-		p              = textparse.New(b, contentType)
+		p              = textparse.New(b, contentType, sl.l)
 		defTime        = timestamp.FromTime(ts)
 		appErrs        = appendErrors{}
 		sampleLimitErr error

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1418,8 +1418,14 @@ type appendErrors struct {
 }
 
 func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string, ts time.Time) (total, added, seriesAdded int, err error) {
+	p, pErr := textparse.New(b, contentType)
+	if pErr != nil {
+		p = textparse.NewPromParser(b)
+		// we are tolerant with wrong content types, but a log can be handy for debugging
+		level.Debug(sl.l).Log("msg", "Invalid Content-Type", "content-type", contentType, "err", pErr)
+	}
+
 	var (
-		p              = textparse.New(b, contentType, sl.l)
 		defTime        = timestamp.FromTime(ts)
 		appErrs        = appendErrors{}
 		sampleLimitErr error

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1418,11 +1418,13 @@ type appendErrors struct {
 }
 
 func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string, ts time.Time) (total, added, seriesAdded int, err error) {
-	p, pErr := textparse.New(b, contentType)
-	if pErr != nil {
-		p = textparse.NewPromParser(b)
-		// we are tolerant with wrong content types, but a log can be handy for debugging
-		level.Debug(sl.l).Log("msg", "Invalid Content-Type", "content-type", contentType, "err", pErr)
+	p, warning := textparse.New(b, contentType)
+	if warning != nil {
+		level.Warn(sl.l).Log(
+			"msg", "Invalid content type on scrape, using prometheus parser as fallback",
+			"content-type", contentType,
+			"err", warning,
+		)
 	}
 
 	var (

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1420,7 +1420,7 @@ type appendErrors struct {
 func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string, ts time.Time) (total, added, seriesAdded int, err error) {
 	p, warning := textparse.New(b, contentType)
 	if warning != nil {
-		level.Warn(sl.l).Log(
+		level.Debug(sl.l).Log(
 			"msg", "Invalid content type on scrape, using prometheus parser as fallback",
 			"content-type", contentType,
 			"err", warning,

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1479,7 +1479,7 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 	fakeRef := storage.SeriesRef(1)
 	expValue := float64(1)
 	metric := `metric{n="1"} 1`
-	p := textparse.New([]byte(metric), "")
+	p := textparse.New([]byte(metric), "", log.NewNopLogger())
 
 	var lset labels.Labels
 	p.Next()

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1479,8 +1479,8 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 	fakeRef := storage.SeriesRef(1)
 	expValue := float64(1)
 	metric := `metric{n="1"} 1`
-	p, err := textparse.New([]byte(metric), "")
-	require.NoError(t, err)
+	p, warning := textparse.New([]byte(metric), "")
+	require.NoError(t, warning)
 
 	var lset labels.Labels
 	p.Next()
@@ -1492,7 +1492,7 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 	now := time.Now()
 
 	slApp := sl.appender(context.Background())
-	_, _, _, err = sl.append(slApp, []byte(metric), "", now)
+	_, _, _, err := sl.append(slApp, []byte(metric), "", now)
 	require.NoError(t, err)
 	require.NoError(t, slApp.Commit())
 

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1479,7 +1479,8 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 	fakeRef := storage.SeriesRef(1)
 	expValue := float64(1)
 	metric := `metric{n="1"} 1`
-	p := textparse.New([]byte(metric), "", log.NewNopLogger())
+	p, err := textparse.New([]byte(metric), "")
+	require.NoError(t, err)
 
 	var lset labels.Labels
 	p.Next()
@@ -1491,7 +1492,7 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 	now := time.Now()
 
 	slApp := sl.appender(context.Background())
-	_, _, _, err := sl.append(slApp, []byte(metric), "", now)
+	_, _, _, err = sl.append(slApp, []byte(metric), "", now)
 	require.NoError(t, err)
 	require.NoError(t, slApp.Commit())
 


### PR DESCRIPTION
Hi all!

I'm developing a `/metrics` endpoint for a proprietary product and found that my server was sending this header in the response:

```
Content-Type: application/openmetrics-text; version=1.0.0; charset=utf-8; charset=UTF-8
```

As a result, `mime.ParseMediaType(contentType)` will return `errors.New("mime: duplicate parameter name")` because of the `charset` that appears twice (this is a bug that I will fix on my side, of course).

However, `textparse.New()` swallows this error and just fallbacks to `NewPromParser()` (when I wanted it to return `NewOpenMetricsParser()`), which is okay but not great, since it was hard for me to find this bug.

So I thought this debug-level log could be helpful to other people. Cheers!