### PR TITLE
Move tsdbblockutil.go into tsdbutil package

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil/block"
 	"hash/crc32"
 	"io/ioutil"
 	"math/rand"
@@ -496,7 +497,7 @@ func TestLabelNamesWithMatchers(t *testing.T) {
 
 // createBlock creates a block with given set of series and returns its dir.
 func createBlock(tb testing.TB, dir string, series []storage.Series) string {
-	blockDir, err := CreateBlock(series, dir, 0, log.NewNopLogger())
+	blockDir, err := block.CreateBlock(series, dir, 0, log.NewNopLogger())
 	require.NoError(tb, err)
 	return blockDir
 }

--- a/tsdb/tsdbutil/block/block.go
+++ b/tsdb/tsdbutil/block/block.go
@@ -11,11 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tsdb
+package block
 
 import (
 	"context"
 	"fmt"
+	"github.com/prometheus/prometheus/tsdb"
 	"path/filepath"
 
 	"github.com/go-kit/log"
@@ -28,13 +29,13 @@ var ErrInvalidTimes = fmt.Errorf("max time is lesser than min time")
 // CreateBlock creates a chunkrange block from the samples passed to it, and writes it to disk.
 func CreateBlock(series []storage.Series, dir string, chunkRange int64, logger log.Logger) (string, error) {
 	if chunkRange == 0 {
-		chunkRange = DefaultBlockDuration
+		chunkRange = tsdb.DefaultBlockDuration
 	}
 	if chunkRange < 0 {
 		return "", ErrInvalidTimes
 	}
 
-	w, err := NewBlockWriter(logger, dir, chunkRange)
+	w, err := tsdb.NewBlockWriter(logger, dir, chunkRange)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
After a quick look I realized that tsdbblockutil.go was only used by
testing files and that there was an existing package for this same
purpose called tsdbutil.

This commit is simply moving the file into the tsdbutil package and also
renaming it to block.go following the internal structure of the package
for other utilitary functions like chunks.go.
