### PR TITLE
refactor: use `T.TempDir()` and `B.TempDir` to create temporary directory

### DIFF
--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -53,12 +53,9 @@ type testRunner struct {
 func newTestRunner(t *testing.T) *testRunner {
 	t.Helper()
 
-	tmpDir, err := ioutil.TempDir("", "prometheus-file-sd")
-	require.NoError(t, err)
-
 	return &testRunner{
 		T:       t,
-		dir:     tmpDir,
+		dir:     t.TempDir(),
 		ch:      make(chan []*targetgroup.Group),
 		done:    make(chan struct{}),
 		stopped: make(chan struct{}),

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -913,11 +913,7 @@ func TestCalculateDesiredShardsDetail(t *testing.T) {
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
 
-	dir, err := ioutil.TempDir("", "TestCalculateDesiredShards")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	metrics := newQueueManagerMetrics(nil, "", "")
 	samplesIn := newEWMARate(ewmaWeight, shardUpdateDuration)

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -42,13 +41,9 @@ import (
 // to 2. We had a migration in place resetting it to 1 but we should move immediately to
 // version 3 next time to avoid confusion and issues.
 func TestBlockMetaMustNeverBeVersion2(t *testing.T) {
-	dir, err := ioutil.TempDir("", "metaversion")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
-	_, err = writeMetaFile(log.NewNopLogger(), dir, &BlockMeta{})
+	_, err := writeMetaFile(log.NewNopLogger(), dir, &BlockMeta{})
 	require.NoError(t, err)
 
 	meta, _, err := readMetaFile(dir)
@@ -57,11 +52,7 @@ func TestBlockMetaMustNeverBeVersion2(t *testing.T) {
 }
 
 func TestSetCompactionFailed(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "test")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpdir))
-	}()
+	tmpdir := t.TempDir()
 
 	blockDir := createBlock(t, tmpdir, genSeries(1, 1, 0, 1))
 	b, err := OpenBlock(nil, blockDir, nil)
@@ -78,11 +69,7 @@ func TestSetCompactionFailed(t *testing.T) {
 }
 
 func TestCreateBlock(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "test")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpdir))
-	}()
+	tmpdir := t.TempDir()
 	b, err := OpenBlock(nil, createBlock(t, tmpdir, genSeries(1, 1, 0, 10)), nil)
 	if err == nil {
 		require.NoError(t, b.Close())
@@ -173,11 +160,7 @@ func TestCorruptedChunk(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpdir, err := ioutil.TempDir("", "test_open_block_chunk_corrupted")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(tmpdir))
-			}()
+			tmpdir := t.TempDir()
 
 			series := storage.NewListSeries(labels.FromStrings("a", "b"), []tsdbutil.Sample{sample{1, 1}})
 			blockDir := createBlock(t, tmpdir, []storage.Series{series})
@@ -215,11 +198,7 @@ func TestCorruptedChunk(t *testing.T) {
 }
 
 func TestLabelValuesWithMatchers(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "test_block_label_values_with_matchers")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpdir))
-	}()
+	tmpdir := t.TempDir()
 
 	var seriesEntries []storage.Series
 	for i := 0; i < 100; i++ {
@@ -288,16 +267,13 @@ func TestLabelValuesWithMatchers(t *testing.T) {
 
 // TestBlockSize ensures that the block size is calculated correctly.
 func TestBlockSize(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "test_blockSize")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpdir))
-	}()
+	tmpdir := t.TempDir()
 
 	var (
 		blockInit    *Block
 		expSizeInit  int64
 		blockDirInit string
+		err          error
 	)
 
 	// Create a block and compare the reported size vs actual disk size.
@@ -376,11 +352,7 @@ func TestReadIndexFormatV1(t *testing.T) {
 }
 
 func BenchmarkLabelValuesWithMatchers(b *testing.B) {
-	tmpdir, err := ioutil.TempDir("", "bench_block_label_values_with_matchers")
-	require.NoError(b, err)
-	defer func() {
-		require.NoError(b, os.RemoveAll(tmpdir))
-	}()
+	tmpdir := b.TempDir()
 
 	var seriesEntries []storage.Series
 	metricCount := 1000000
@@ -419,9 +391,7 @@ func BenchmarkLabelValuesWithMatchers(b *testing.B) {
 }
 
 func TestLabelNamesWithMatchers(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "test_block_label_names_with_matchers")
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, os.RemoveAll(tmpdir)) })
+	tmpdir := t.TempDir()
 
 	var seriesEntries []storage.Series
 	for i := 0; i < 100; i++ {

--- a/tsdb/blockwriter_test.go
+++ b/tsdb/blockwriter_test.go
@@ -15,9 +15,7 @@ package tsdb
 
 import (
 	"context"
-	"io/ioutil"
 	"math"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,9 +28,7 @@ import (
 
 func TestBlockWriter(t *testing.T) {
 	ctx := context.Background()
-	outputDir, err := ioutil.TempDir(os.TempDir(), "output")
-	require.NoError(t, err)
-	defer func() { require.NoError(t, os.RemoveAll(outputDir)) }()
+	outputDir := t.TempDir()
 	w, err := NewBlockWriter(log.NewNopLogger(), outputDir, DefaultBlockDuration)
 	require.NoError(t, err)
 

--- a/tsdb/chunks/head_chunks_test.go
+++ b/tsdb/chunks/head_chunks_test.go
@@ -450,12 +450,7 @@ func TestHeadReadWriter_ReadRepairOnEmptyLastFile(t *testing.T) {
 
 func createChunkDiskMapper(t *testing.T, dir string) *ChunkDiskMapper {
 	if dir == "" {
-		var err error
-		dir, err = ioutil.TempDir("", "data")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, os.RemoveAll(dir))
-		})
+		dir = t.TempDir()
 	}
 
 	hrw, err := NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), DefaultWriteBufferSize, DefaultWriteQueueSize)

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -16,7 +16,6 @@ package tsdb
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -435,11 +434,7 @@ func TestCompactionFailWillCleanUpTempDir(t *testing.T) {
 	}, nil, nil)
 	require.NoError(t, err)
 
-	tmpdir, err := ioutil.TempDir("", "test")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpdir))
-	}()
+	tmpdir := t.TempDir()
 
 	require.Error(t, compactor.write(tmpdir, &BlockMeta{}, erringBReader{}))
 	_, err = os.Stat(filepath.Join(tmpdir, BlockMeta{}.ULID.String()) + tmpForCreationBlockDirSuffix)
@@ -1049,11 +1044,7 @@ func BenchmarkCompaction(b *testing.B) {
 	for _, c := range cases {
 		nBlocks := len(c.ranges)
 		b.Run(fmt.Sprintf("type=%s,blocks=%d,series=%d,samplesPerSeriesPerBlock=%d", c.compactionType, nBlocks, nSeries, c.ranges[0][1]-c.ranges[0][0]+1), func(b *testing.B) {
-			dir, err := ioutil.TempDir("", "bench_compaction")
-			require.NoError(b, err)
-			defer func() {
-				require.NoError(b, os.RemoveAll(dir))
-			}()
+			dir := b.TempDir()
 			blockDirs := make([]string, 0, len(c.ranges))
 			var blocks []*Block
 			for _, r := range c.ranges {
@@ -1080,20 +1071,12 @@ func BenchmarkCompaction(b *testing.B) {
 }
 
 func BenchmarkCompactionFromHead(b *testing.B) {
-	dir, err := ioutil.TempDir("", "bench_compaction_from_head")
-	require.NoError(b, err)
-	defer func() {
-		require.NoError(b, os.RemoveAll(dir))
-	}()
+	dir := b.TempDir()
 	totalSeries := 100000
 	for labelNames := 1; labelNames < totalSeries; labelNames *= 10 {
 		labelValues := totalSeries / labelNames
 		b.Run(fmt.Sprintf("labelnames=%d,labelvalues=%d", labelNames, labelValues), func(b *testing.B) {
-			chunkDir, err := ioutil.TempDir("", "chunk_dir")
-			require.NoError(b, err)
-			defer func() {
-				require.NoError(b, os.RemoveAll(chunkDir))
-			}()
+			chunkDir := b.TempDir()
 			opts := DefaultHeadOptions()
 			opts.ChunkRange = 1000
 			opts.ChunkDirRoot = chunkDir
@@ -1175,11 +1158,7 @@ func TestDisableAutoCompactions(t *testing.T) {
 // TestCancelCompactions ensures that when the db is closed
 // any running compaction is cancelled to unblock closing the db.
 func TestCancelCompactions(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "testCancelCompaction")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpdir))
-	}()
+	tmpdir := t.TempDir()
 
 	// Create some blocks to fall within the compaction range.
 	createBlock(t, tmpdir, genSeries(1, 10000, 0, 1000))
@@ -1188,7 +1167,7 @@ func TestCancelCompactions(t *testing.T) {
 
 	// Copy the db so we have an exact copy to compare compaction times.
 	tmpdirCopy := tmpdir + "Copy"
-	err = fileutil.CopyDirs(tmpdir, tmpdirCopy)
+	err := fileutil.CopyDirs(tmpdir, tmpdirCopy)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, os.RemoveAll(tmpdirCopy))

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -14,8 +14,6 @@
 package tsdb
 
 import (
-	"io/ioutil"
-	"os"
 	"strconv"
 	"testing"
 
@@ -27,11 +25,7 @@ import (
 )
 
 func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
-	chunkDir, err := ioutil.TempDir("", "chunk_dir")
-	require.NoError(b, err)
-	defer func() {
-		require.NoError(b, os.RemoveAll(chunkDir))
-	}()
+	chunkDir := b.TempDir()
 	// Put a series, select it. GC it and then access it.
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
@@ -46,11 +40,7 @@ func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 }
 
 func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
-	chunkDir, err := ioutil.TempDir("", "chunk_dir")
-	require.NoError(b, err)
-	defer func() {
-		require.NoError(b, os.RemoveAll(chunkDir))
-	}()
+	chunkDir := b.TempDir()
 	// Put a series, select it. GC it and then access it.
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
@@ -70,11 +60,7 @@ func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 }
 
 func BenchmarkHeadStripeSeriesCreate_PreCreationFailure(b *testing.B) {
-	chunkDir, err := ioutil.TempDir("", "chunk_dir")
-	require.NoError(b, err)
-	defer func() {
-		require.NoError(b, os.RemoveAll(chunkDir))
-	}()
+	chunkDir := b.TempDir()
 	// Put a series, select it. GC it and then access it.
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -51,8 +51,7 @@ import (
 )
 
 func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.WAL) {
-	dir, err := ioutil.TempDir("", "test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 	wlog, err := wal.NewSize(nil, nil, filepath.Join(dir, "wal"), 32768, compressWAL)
 	require.NoError(t, err)
 
@@ -67,9 +66,6 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 
 	require.NoError(t, h.chunkDiskMapper.IterateAllChunks(func(_ chunks.HeadSeriesRef, _ chunks.ChunkDiskMapperRef, _, _ int64, _ uint16) error { return nil }))
 
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(dir))
-	})
 	return h, wlog
 }
 
@@ -183,11 +179,7 @@ func BenchmarkLoadWAL(b *testing.B) {
 			// fmt.Println("exemplars per series: ", exemplarsPerSeries)
 			b.Run(fmt.Sprintf("batches=%d,seriesPerBatch=%d,samplesPerSeries=%d,exemplarsPerSeries=%d,mmappedChunkT=%d", c.batches, c.seriesPerBatch, c.samplesPerSeries, exemplarsPerSeries, c.mmappedChunkT),
 				func(b *testing.B) {
-					dir, err := ioutil.TempDir("", "test_load_wal")
-					require.NoError(b, err)
-					defer func() {
-						require.NoError(b, os.RemoveAll(dir))
-					}()
+					dir := b.TempDir()
 
 					w, err := wal.New(nil, nil, dir, false)
 					require.NoError(b, err)
@@ -724,11 +716,7 @@ func TestHead_Truncate(t *testing.T) {
 // Validate various behaviors brought on by firstChunkID accounting for
 // garbage collected chunks.
 func TestMemSeries_truncateChunks(t *testing.T) {
-	dir, err := ioutil.TempDir("", "truncate_chunks")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 	// This is usually taken from the Head, but passing manually here.
 	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
 	require.NoError(t, err)
@@ -1268,11 +1256,7 @@ func TestComputeChunkEndTime(t *testing.T) {
 }
 
 func TestMemSeries_append(t *testing.T) {
-	dir, err := ioutil.TempDir("", "append")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 	// This is usually taken from the Head, but passing manually here.
 	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
 	require.NoError(t, err)
@@ -1556,11 +1540,7 @@ func TestWalRepair_DecodingError(t *testing.T) {
 	} {
 		for _, compress := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s,compress=%t", name, compress), func(t *testing.T) {
-				dir, err := ioutil.TempDir("", "wal_repair")
-				require.NoError(t, err)
-				defer func() {
-					require.NoError(t, os.RemoveAll(dir))
-				}()
+				dir := t.TempDir()
 
 				// Fill the wal and corrupt it.
 				{
@@ -1620,11 +1600,7 @@ func TestWalRepair_DecodingError(t *testing.T) {
 }
 
 func TestHeadReadWriterRepair(t *testing.T) {
-	dir, err := ioutil.TempDir("", "head_read_writer_repair")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	const chunkRange = 1000
 
@@ -2030,11 +2006,7 @@ func TestIsolationWithoutAdd(t *testing.T) {
 }
 
 func TestOutOfOrderSamplesMetric(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	db, err := Open(dir, nil, nil, DefaultOptions(), nil)
 	require.NoError(t, err)
@@ -2456,11 +2428,7 @@ func BenchmarkHeadLabelValuesWithMatchers(b *testing.B) {
 }
 
 func TestMemSafeIteratorSeekIntoBuffer(t *testing.T) {
-	dir, err := ioutil.TempDir("", "iterator_seek")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 	// This is usually taken from the Head, but passing manually here.
 	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
 	require.NoError(t, err)

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -137,11 +137,7 @@ func (m mockIndex) Series(ref storage.SeriesRef, lset *labels.Labels, chks *[]ch
 }
 
 func TestIndexRW_Create_Open(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_index_create")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	fn := filepath.Join(dir, indexFilename)
 
@@ -166,11 +162,7 @@ func TestIndexRW_Create_Open(t *testing.T) {
 }
 
 func TestIndexRW_Postings(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_index_postings")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	fn := filepath.Join(dir, indexFilename)
 
@@ -250,11 +242,7 @@ func TestIndexRW_Postings(t *testing.T) {
 }
 
 func TestPostingsMany(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_postings_many")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	fn := filepath.Join(dir, indexFilename)
 
@@ -344,11 +332,7 @@ func TestPostingsMany(t *testing.T) {
 }
 
 func TestPersistence_index_e2e(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_persistence_e2e")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	lbls, err := labels.ReadLabels(filepath.Join("..", "testdata", "20kseries.json"), 20000)
 	require.NoError(t, err)

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -16,8 +16,6 @@ package tsdb
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strconv"
 	"testing"
 
@@ -32,11 +30,7 @@ const (
 )
 
 func BenchmarkQuerier(b *testing.B) {
-	chunkDir, err := ioutil.TempDir("", "chunk_dir")
-	require.NoError(b, err)
-	defer func() {
-		require.NoError(b, os.RemoveAll(chunkDir))
-	}()
+	chunkDir := b.TempDir()
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
 	opts.ChunkDirRoot = chunkDir
@@ -74,11 +68,7 @@ func BenchmarkQuerier(b *testing.B) {
 		})
 	})
 
-	tmpdir, err := ioutil.TempDir("", "test_benchpostingsformatchers")
-	require.NoError(b, err)
-	defer func() {
-		require.NoError(b, os.RemoveAll(tmpdir))
-	}()
+	tmpdir := b.TempDir()
 
 	blockdir := createBlockFromHead(b, tmpdir, h)
 	block, err := OpenBlock(nil, blockdir, nil)
@@ -186,11 +176,7 @@ func benchmarkLabelValuesWithMatchers(b *testing.B, ir IndexReader) {
 }
 
 func BenchmarkQuerierSelect(b *testing.B) {
-	chunkDir, err := ioutil.TempDir("", "chunk_dir")
-	require.NoError(b, err)
-	defer func() {
-		require.NoError(b, os.RemoveAll(chunkDir))
-	}()
+	chunkDir := b.TempDir()
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
 	opts.ChunkDirRoot = chunkDir
@@ -230,11 +216,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 		bench(b, h, true)
 	})
 
-	tmpdir, err := ioutil.TempDir("", "test_benchquerierselect")
-	require.NoError(b, err)
-	defer func() {
-		require.NoError(b, os.RemoveAll(tmpdir))
-	}()
+	tmpdir := b.TempDir()
 
 	blockdir := createBlockFromHead(b, tmpdir, h)
 	block, err := OpenBlock(nil, blockdir, nil)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -16,10 +16,8 @@ package tsdb
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -1329,11 +1327,7 @@ func BenchmarkQueryIterator(b *testing.B) {
 				c.numBlocks, c.numSeries, c.numSamplesPerSeriesPerBlock, overlapPercentage)
 
 			b.Run(benchMsg, func(b *testing.B) {
-				dir, err := ioutil.TempDir("", "bench_query_iterator")
-				require.NoError(b, err)
-				defer func() {
-					require.NoError(b, os.RemoveAll(dir))
-				}()
+				dir := b.TempDir()
 
 				var (
 					blocks          []*Block
@@ -1396,11 +1390,7 @@ func BenchmarkQuerySeek(b *testing.B) {
 				c.numBlocks, c.numSeries, c.numSamplesPerSeriesPerBlock, overlapPercentage)
 
 			b.Run(benchMsg, func(b *testing.B) {
-				dir, err := ioutil.TempDir("", "bench_query_iterator")
-				require.NoError(b, err)
-				defer func() {
-					require.NoError(b, os.RemoveAll(dir))
-				}()
+				dir := b.TempDir()
 
 				var (
 					blocks          []*Block
@@ -1451,7 +1441,6 @@ func BenchmarkQuerySeek(b *testing.B) {
 					require.NoError(b, it.Err())
 				}
 				require.NoError(b, ss.Err())
-				require.NoError(b, err)
 				require.Equal(b, 0, len(ss.Warnings()))
 			})
 		}
@@ -1537,11 +1526,7 @@ func BenchmarkSetMatcher(b *testing.B) {
 	}
 
 	for _, c := range cases {
-		dir, err := ioutil.TempDir("", "bench_postings_for_matchers")
-		require.NoError(b, err)
-		defer func() {
-			require.NoError(b, os.RemoveAll(dir))
-		}()
+		dir := b.TempDir()
 
 		var (
 			blocks          []*Block
@@ -1654,11 +1639,7 @@ func TestFindSetMatches(t *testing.T) {
 }
 
 func TestPostingsForMatchers(t *testing.T) {
-	chunkDir, err := ioutil.TempDir("", "chunk_dir")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(chunkDir))
-	}()
+	chunkDir := t.TempDir()
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
 	opts.ChunkDirRoot = chunkDir
@@ -1915,13 +1896,7 @@ func TestPostingsForMatchers(t *testing.T) {
 
 // TestClose ensures that calling Close more than once doesn't block and doesn't panic.
 func TestClose(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_storage")
-	if err != nil {
-		t.Fatalf("Opening test dir failed: %s", err)
-	}
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	createBlock(t, dir, genSeries(1, 1, 0, 10))
 	createBlock(t, dir, genSeries(1, 1, 10, 20))
@@ -1982,11 +1957,7 @@ func BenchmarkQueries(b *testing.B) {
 	for title, selectors := range cases {
 		for _, nSeries := range []int{10} {
 			for _, nSamples := range []int64{1000, 10000, 100000} {
-				dir, err := ioutil.TempDir("", "test_persisted_query")
-				require.NoError(b, err)
-				defer func() {
-					require.NoError(b, os.RemoveAll(dir))
-				}()
+				dir := b.TempDir()
 
 				series := genSeries(nSeries, 5, 1, nSamples)
 
@@ -2024,11 +1995,7 @@ func BenchmarkQueries(b *testing.B) {
 				queryTypes["_3-Blocks"] = storage.NewMergeQuerier(qs[0:3], nil, storage.ChainedSeriesMerge)
 				queryTypes["_10-Blocks"] = storage.NewMergeQuerier(qs, nil, storage.ChainedSeriesMerge)
 
-				chunkDir, err := ioutil.TempDir("", "chunk_dir")
-				require.NoError(b, err)
-				defer func() {
-					require.NoError(b, os.RemoveAll(chunkDir))
-				}()
+				chunkDir := b.TempDir()
 				head := createHead(b, nil, series, chunkDir)
 				qHead, err := NewBlockQuerier(head, 1, nSamples)
 				require.NoError(b, err)

--- a/tsdb/repair_test.go
+++ b/tsdb/repair_test.go
@@ -14,7 +14,6 @@
 package tsdb
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,11 +27,7 @@ import (
 )
 
 func TestRepairBadIndexVersion(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(tmpDir))
-	})
+	tmpDir := t.TempDir()
 
 	// The broken index used in this test was written by the following script
 	// at a broken revision.
@@ -74,7 +69,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 
 	// Check the current db.
 	// In its current state, lookups should fail with the fixed code.
-	_, _, err = readMetaFile(tmpDbDir)
+	_, _, err := readMetaFile(tmpDbDir)
 	require.Error(t, err)
 
 	// Touch chunks dir in block to imitate them.

--- a/tsdb/tombstones/tombstones_test.go
+++ b/tsdb/tombstones/tombstones_test.go
@@ -14,10 +14,8 @@
 package tombstones
 
 import (
-	"io/ioutil"
 	"math"
 	"math/rand"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -34,10 +32,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestWriteAndReadbackTombstones(t *testing.T) {
-	tmpdir, _ := ioutil.TempDir("", "test")
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpdir))
-	}()
+	tmpdir := t.TempDir()
 
 	ref := uint64(0)
 

--- a/tsdb/wal_test.go
+++ b/tsdb/wal_test.go
@@ -39,11 +39,7 @@ import (
 )
 
 func TestSegmentWAL_cut(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "test_wal_cut")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpdir))
-	}()
+	tmpdir := t.TempDir()
 
 	// This calls cut() implicitly the first time without a previous tail.
 	w, err := OpenSegmentWAL(tmpdir, nil, 0, nil)
@@ -89,11 +85,7 @@ func TestSegmentWAL_Truncate(t *testing.T) {
 	series, err := labels.ReadLabels(filepath.Join("testdata", "20kseries.json"), numMetrics)
 	require.NoError(t, err)
 
-	dir, err := ioutil.TempDir("", "test_wal_log_truncate")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	w, err := OpenSegmentWAL(dir, nil, 0, nil)
 	require.NoError(t, err)
@@ -172,11 +164,7 @@ func TestSegmentWAL_Log_Restore(t *testing.T) {
 	series, err := labels.ReadLabels(filepath.Join("testdata", "20kseries.json"), numMetrics)
 	require.NoError(t, err)
 
-	dir, err := ioutil.TempDir("", "test_wal_log_restore")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	var (
 		recordedSeries  [][]record.RefSeries
@@ -281,11 +269,7 @@ func TestSegmentWAL_Log_Restore(t *testing.T) {
 }
 
 func TestWALRestoreCorrupted_invalidSegment(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_wal_log_restore")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	wal, err := OpenSegmentWAL(dir, nil, 0, nil)
 	require.NoError(t, err)
@@ -386,11 +370,7 @@ func TestWALRestoreCorrupted(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			// Generate testing data. It does not make semantic sense but
 			// for the purpose of this test.
-			dir, err := ioutil.TempDir("", "test_corrupted")
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, os.RemoveAll(dir))
-			}()
+			dir := t.TempDir()
 
 			w, err := OpenSegmentWAL(dir, nil, 0, nil)
 			require.NoError(t, err)
@@ -466,11 +446,7 @@ func TestWALRestoreCorrupted(t *testing.T) {
 func TestMigrateWAL_Empty(t *testing.T) {
 	// The migration procedure must properly deal with a zero-length segment,
 	// which is valid in the new format.
-	dir, err := ioutil.TempDir("", "walmigrate")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	wdir := path.Join(dir, "wal")
 
@@ -483,11 +459,7 @@ func TestMigrateWAL_Empty(t *testing.T) {
 }
 
 func TestMigrateWAL_Fuzz(t *testing.T) {
-	dir, err := ioutil.TempDir("", "walmigrate")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	wdir := path.Join(dir, "wal")
 


### PR DESCRIPTION
We can write less code by using the `TempDir()` function from the `testing` package to create temporary directory. The directory created by `T.TempDir()` and `B.TempDir()` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir
Reference: https://pkg.go.dev/testing#B.TempDir