### PR TITLE
template: Fix failing tests on non-amd64 architectures

### DIFF
--- a/template/template_amd64_test.go
+++ b/template/template_amd64_test.go
@@ -1,0 +1,40 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template
+
+import (
+	"math"
+	"testing"
+)
+
+// Some test cases rely upon architecture-specific behaviors with respect
+// to numerical conversions. The logic remains the same across architectures,
+// but outputs can vary, so the cases are only run on amd64.
+// See https://github.com/prometheus/prometheus/issues/10185 for more details.
+func TestTemplateExpansionAMD64(t *testing.T) {
+	testTemplateExpansion(t, []scenario{
+		{
+			// HumanizeDuration - MaxInt64.
+			text:   "{{ humanizeDuration . }}",
+			input:  math.MaxInt64,
+			output: "-106751991167300d -15h -30m -8s",
+		},
+		{
+			// HumanizeDuration - MaxUint64.
+			text:   "{{ humanizeDuration . }}",
+			input:  uint(math.MaxUint64),
+			output: "-106751991167300d -15h -30m -8s",
+		},
+	})
+}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -27,16 +27,7 @@ import (
 )
 
 func TestTemplateExpansion(t *testing.T) {
-	scenarios := []struct {
-		text        string
-		output      string
-		input       interface{}
-		options     []string
-		queryResult promql.Vector
-		shouldFail  bool
-		html        bool
-		errorMsg    string
-	}{
+	testTemplateExpansion(t, []scenario{
 		{
 			// No template.
 			text:   "plain text",
@@ -353,14 +344,14 @@ func TestTemplateExpansion(t *testing.T) {
 		{
 			// HumanizeDuration - int.
 			text:   "{{ range . }}{{ humanizeDuration . }}:{{ end }}",
-			input:  []int{0, -1, 1, 1234567, math.MaxInt64},
-			output: "0s:-1s:1s:14d 6h 56m 7s:-106751991167300d -15h -30m -8s:",
+			input:  []int{0, -1, 1, 1234567},
+			output: "0s:-1s:1s:14d 6h 56m 7s:",
 		},
 		{
 			// HumanizeDuration - uint.
 			text:   "{{ range . }}{{ humanizeDuration . }}:{{ end }}",
-			input:  []uint{0, 1, 1234567, math.MaxUint64},
-			output: "0s:1s:14d 6h 56m 7s:-106751991167300d -15h -30m -8s:",
+			input:  []uint{0, 1, 1234567},
+			output: "0s:1s:14d 6h 56m 7s:",
 		},
 		{
 			// Humanize* Inf and NaN - float64.
@@ -489,8 +480,21 @@ func TestTemplateExpansion(t *testing.T) {
 			text:   "{{ printf \"%0.2f\" (parseDuration \"1h2m10ms\") }}",
 			output: "3720.01",
 		},
-	}
+	})
+}
 
+type scenario struct {
+	text        string
+	output      string
+	input       interface{}
+	options     []string
+	queryResult promql.Vector
+	shouldFail  bool
+	html        bool
+	errorMsg    string
+}
+
+func testTemplateExpansion(t *testing.T, scenarios []scenario) {
 	extURL, err := url.Parse("http://testhost:9090/path/prefix")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR moves tests that were failing on non-amd64 architectures into a separate `_amd64` file.

Fixes #10185

```
levi@Levis-MBP prometheus % go version
go version go1.17.2 darwin/arm64
levi@Levis-MBP prometheus % git branch
...
* main
...
levi@Levis-MBP prometheus % go test -v ./template
=== RUN   TestTemplateExpansion
    template_test.go:520:
        	Error Trace:	template_test.go:520
pick a9d942a32 Allow escaping a dollar sign when expanding external labels
        	Error:      	Not equal:
        	            	expected: "0s:-1s:1s:14d 6h 56m 7s:-106751991167300d -15h -30m -8s:"
        	            	actual  : "0s:-1s:1s:14d 6h 56m 7s:106751991167300d 15h 30m 7s:"

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-0s:-1s:1s:14d 6h 56m 7s:-106751991167300d -15h -30m -8s:
        	            	+0s:-1s:1s:14d 6h 56m 7s:106751991167300d 15h 30m 7s:
        	Test:       	TestTemplateExpansion
--- FAIL: TestTemplateExpansion (0.00s)
FAIL
FAIL	github.com/prometheus/prometheus/template	0.138s
FAIL
levi@Levis-MBP prometheus % git checkout amd64-template-tests
Switched to branch 'amd64-template-tests'
Your branch is up to date with 'origin/amd64-template-tests'.
levi@Levis-MBP prometheus % go test -v ./template
=== RUN   TestTemplateExpansion
--- PASS: TestTemplateExpansion (0.00s)
PASS
ok  	github.com/prometheus/prometheus/template	0.161s
```