### PR TITLE
tsdb/wal: Fix comment of w.writer.Append(...) in function wal.watcher…

### DIFF
--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -45,9 +45,14 @@ const (
 // from the WAL on to somewhere else. Functions will be called concurrently
 // and it is left to the implementer to make sure they are safe.
 type WriteTo interface {
+	// Append and AppendExemplar should block until the samples are fully accepted,
+	// whether enqueued in memory or successfully written to it's final destination.
+	// Once returned, the WAL Watcher will not attempt to pass that data again.
 	Append([]record.RefSample) bool
 	AppendExemplars([]record.RefExemplar) bool
+
 	StoreSeries([]record.RefSeries, int)
+
 	// Next two methods are intended for garbage-collection: first we call
 	// UpdateSeriesSegment on all current series
 	UpdateSeriesSegment([]record.RefSeries, int)
@@ -511,7 +516,6 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 				}
 			}
 			if len(send) > 0 {
-				// Blocks  until the sample is sent to all remote write endpoints or closed (because enqueue blocks).
 				w.writer.Append(send)
 				send = send[:0]
 			}


### PR DESCRIPTION
Fix comment of call w.writer.Append(....)

In remote storage, once wal.watcher tail samples, it will append them by writer.Append(...), the writer variable here is QueueManager which is create by a remote write config.
  
So writer.Append(...) only send samples to the remote write config of the QueueManager.
