### PR TITLE
Discovery.Manager: close sync ch after sender() is stopped

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -318,8 +318,10 @@ func (m *Manager) updater(ctx context.Context, p *provider, updates chan []*targ
 
 func (m *Manager) sender() {
 	ticker := time.NewTicker(m.updatert)
-	defer ticker.Stop()
-
+	defer func() {
+		ticker.Stop()
+		close(m.syncCh)
+	}()
 	for {
 		select {
 		case <-m.ctx.Done():


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

this PR is to fix #10217  ,  a possible memory leak when quoating `manager.Sync()` outside manager's lifecycle
also see more discuss in https://github.com/grafana/loki/pull/5238

There is a great design for this channel——send ops only happens within  goroutine of `sender()`，any other place references the channel is via read-mode, see below :
https://github.com/prometheus/prometheus/blob/4cc25c0cb0b96042a7d36a0dd53dc6970ad607fd/cmd/prometheus/main.go#L1542

 so I suggested we can close it after `sender()` is stopped naturally( in `defer` process,so there is no worry about sending to a closed channel). 