### PR TITLE
Added pathPrefix function to the template reference documentation

### DIFF
--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -84,6 +84,7 @@ versions.
 | args          | []interface{} | map[string]interface{} | This converts a list of objects to a map with keys arg0, arg1 etc. This is intended to allow multiple arguments to be passed to templates. |
 | tmpl          | string, []interface{} | nothing  | Like the built-in `template`, but allows non-literals as the template name. Note that the result is assumed to be safe, and will not be auto-escaped. Only available in consoles. |
 | safeHtml      | string        | string  | Marks string as HTML not requiring auto-escaping. |
+| pathPrefix    | _none_        | string  | The external URL [Path](https://pkg.go.dev/net/url#URL) value for use in console templates. |
 
 ## Template type differences
 

--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -84,7 +84,7 @@ versions.
 | args          | []interface{} | map[string]interface{} | This converts a list of objects to a map with keys arg0, arg1 etc. This is intended to allow multiple arguments to be passed to templates. |
 | tmpl          | string, []interface{} | nothing  | Like the built-in `template`, but allows non-literals as the template name. Note that the result is assumed to be safe, and will not be auto-escaped. Only available in consoles. |
 | safeHtml      | string        | string  | Marks string as HTML not requiring auto-escaping. |
-| pathPrefix    | _none_        | string  | The external URL [Path](https://pkg.go.dev/net/url#URL) value for use in console templates. |
+| pathPrefix    | _none_        | string  | The external URL [path](https://pkg.go.dev/net/url#URL). Only available in console templates. |
 
 ## Template type differences
 

--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -84,7 +84,7 @@ versions.
 | args          | []interface{} | map[string]interface{} | This converts a list of objects to a map with keys arg0, arg1 etc. This is intended to allow multiple arguments to be passed to templates. |
 | tmpl          | string, []interface{} | nothing  | Like the built-in `template`, but allows non-literals as the template name. Note that the result is assumed to be safe, and will not be auto-escaped. Only available in consoles. |
 | safeHtml      | string        | string  | Marks string as HTML not requiring auto-escaping. |
-| pathPrefix    | _none_        | string  | The external URL [path](https://pkg.go.dev/net/url#URL). Only available in console templates. |
+| pathPrefix    | _none_        | string  | The external URL [path](https://pkg.go.dev/net/url#URL) for use in console templates. |
 
 ## Template type differences
 


### PR DESCRIPTION
For issue 'Missing documentation for some rule template variables' https://github.com/prometheus/prometheus/issues/10216.