### PR TITLE
Fix bug that sets the range input to the resolution

### DIFF
--- a/web/ui/react-app/src/pages/graph/GraphControls.tsx
+++ b/web/ui/react-app/src/pages/graph/GraphControls.tsx
@@ -58,7 +58,7 @@ class GraphControls extends Component<GraphControlsProps> {
   };
 
   changeRangeInput = (range: number): void => {
-    if (this.rangeRef.current) {
+    if (this.rangeRef.current !== null) {
       this.rangeRef.current.value = formatDuration(range);
     }
   };
@@ -84,7 +84,7 @@ class GraphControls extends Component<GraphControlsProps> {
   };
 
   changeResolutionInput = (resolution: number | null): void => {
-    if (this.resolutionRef.current) {
+    if (this.resolutionRef.current !== null) {
       this.resolutionRef.current.value = resolution !== null ? resolution.toString() : '';
     }
   };

--- a/web/ui/react-app/src/pages/graph/GraphControls.tsx
+++ b/web/ui/react-app/src/pages/graph/GraphControls.tsx
@@ -58,7 +58,9 @@ class GraphControls extends Component<GraphControlsProps> {
   };
 
   changeRangeInput = (range: number): void => {
-    this.setCurrentRangeValue(formatDuration(range));
+    if (this.rangeRef.current) {
+      this.rangeRef.current.value = formatDuration(range);
+    }
   };
 
   increaseRange = (): void => {
@@ -81,18 +83,18 @@ class GraphControls extends Component<GraphControlsProps> {
     }
   };
 
+  changeResolutionInput = (resolution: number | null): void => {
+    if (this.resolutionRef.current) {
+      this.resolutionRef.current.value = resolution !== null ? resolution.toString() : '';
+    }
+  };
+
   componentDidUpdate(prevProps: GraphControlsProps): void {
     if (prevProps.range !== this.props.range) {
       this.changeRangeInput(this.props.range);
     }
     if (prevProps.resolution !== this.props.resolution) {
-      this.setCurrentRangeValue(this.props.resolution !== null ? this.props.resolution.toString() : '');
-    }
-  }
-
-  setCurrentRangeValue(value: string): void {
-    if (this.rangeRef.current) {
-      this.rangeRef.current.value = value;
+      this.changeResolutionInput(this.props.resolution);
     }
   }
 


### PR DESCRIPTION
This got broken as part of https://github.com/prometheus/prometheus/commit/5bcf2e6511114f8c4ee47f08296b1ff62de6a388#diff-2c68c9a4b0cb4b034e6faa8c32d3f9eeadcd60b4e5282587bf45755258ad045c.

This fixes the bug and makes the code around setting the input fields a bit more consistent.

Signed-off-by: Julius Volz <julius.volz@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
