### PR TITLE
discovery/targetgroup: support marshaling to JSON

### DIFF
--- a/discovery/targetgroup/targetgroup.go
+++ b/discovery/targetgroup/targetgroup.go
@@ -92,7 +92,7 @@ func (tg *Group) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// MarshalYAML implements the json.Marshaler interface.
+// MarshalJSON implements the json.Marshaler interface.
 func (tg Group) MarshalJSON() ([]byte, error) {
 	g := &struct {
 		Targets []string       `json:"targets"`

--- a/discovery/targetgroup/targetgroup.go
+++ b/discovery/targetgroup/targetgroup.go
@@ -91,3 +91,18 @@ func (tg *Group) UnmarshalJSON(b []byte) error {
 	tg.Labels = g.Labels
 	return nil
 }
+
+// MarshalYAML implements the json.Marshaler interface.
+func (tg Group) MarshalJSON() ([]byte, error) {
+	g := &struct {
+		Targets []string       `json:"targets"`
+		Labels  model.LabelSet `json:"labels,omitempty"`
+	}{
+		Targets: make([]string, 0, len(tg.Targets)),
+		Labels:  tg.Labels,
+	}
+	for _, t := range tg.Targets {
+		g.Targets = append(g.Targets, string(t[model.AddressLabel]))
+	}
+	return json.Marshal(g)
+}

--- a/discovery/targetgroup/targetgroup_test.go
+++ b/discovery/targetgroup/targetgroup_test.go
@@ -59,6 +59,39 @@ func TestTargetGroupStrictJsonUnmarshal(t *testing.T) {
 	}
 }
 
+func TestTargetGroupJsonMarshal(t *testing.T) {
+	tests := []struct {
+		expectedJson string
+		expectedErr  error
+		group        Group
+	}{
+		{
+			// labels should be omitted if empty.
+			group:        Group{},
+			expectedJson: `{"targets": []}`,
+			expectedErr:  nil,
+		},
+		{
+			// targets only exposes addresses.
+			group: Group{
+				Targets: []model.LabelSet{
+					{"__address__": "localhost:9090"},
+					{"__address__": "localhost:9091"},
+				},
+				Labels: model.LabelSet{"foo": "bar", "bar": "baz"},
+			},
+			expectedJson: `{"targets": ["localhost:9090", "localhost:9091"], "labels": {"bar": "baz", "foo": "bar"}}`,
+			expectedErr:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := test.group.MarshalJSON()
+		require.Equal(t, test.expectedErr, err)
+		require.JSONEq(t, test.expectedJson, string(actual))
+	}
+}
+
 func TestTargetGroupYamlMarshal(t *testing.T) {
 	marshal := func(g interface{}) []byte {
 		d, err := yaml.Marshal(g)

--- a/discovery/targetgroup/targetgroup_test.go
+++ b/discovery/targetgroup/targetgroup_test.go
@@ -61,14 +61,14 @@ func TestTargetGroupStrictJsonUnmarshal(t *testing.T) {
 
 func TestTargetGroupJsonMarshal(t *testing.T) {
 	tests := []struct {
-		expectedJson string
+		expectedJSON string
 		expectedErr  error
 		group        Group
 	}{
 		{
 			// labels should be omitted if empty.
 			group:        Group{},
-			expectedJson: `{"targets": []}`,
+			expectedJSON: `{"targets": []}`,
 			expectedErr:  nil,
 		},
 		{
@@ -80,7 +80,7 @@ func TestTargetGroupJsonMarshal(t *testing.T) {
 				},
 				Labels: model.LabelSet{"foo": "bar", "bar": "baz"},
 			},
-			expectedJson: `{"targets": ["localhost:9090", "localhost:9091"], "labels": {"bar": "baz", "foo": "bar"}}`,
+			expectedJSON: `{"targets": ["localhost:9090", "localhost:9091"], "labels": {"bar": "baz", "foo": "bar"}}`,
 			expectedErr:  nil,
 		},
 	}
@@ -88,7 +88,7 @@ func TestTargetGroupJsonMarshal(t *testing.T) {
 	for _, test := range tests {
 		actual, err := test.group.MarshalJSON()
 		require.Equal(t, test.expectedErr, err)
-		require.JSONEq(t, test.expectedJson, string(actual))
+		require.JSONEq(t, test.expectedJSON, string(actual))
 	}
 }
 

--- a/discovery/targetgroup/targetgroup_test.go
+++ b/discovery/targetgroup/targetgroup_test.go
@@ -22,7 +22,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TestTargetGroupStrictJsonUnmarshal(t *testing.T) {
+func TestTargetGroupStrictJSONUnmarshal(t *testing.T) {
 	tests := []struct {
 		json          string
 		expectedReply error
@@ -59,7 +59,7 @@ func TestTargetGroupStrictJsonUnmarshal(t *testing.T) {
 	}
 }
 
-func TestTargetGroupJsonMarshal(t *testing.T) {
+func TestTargetGroupJSONMarshal(t *testing.T) {
 	tests := []struct {
 		expectedJSON string
 		expectedErr  error


### PR DESCRIPTION
targetgroup.Group is able to be marshaled to and from YAML, but not with JSON. JSON is used for the http_sd API representation, so users implementing the API were required to implement their own type which is expected by the JSON unmarshaler.

Signed-off-by: Robert Fratto <robertfratto@gmail.com>