### PR TITLE
Followup on k8s' "own namespace" feature

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1182,6 +1182,14 @@ var expectedErrors = []struct {
 		errMsg:   "to use custom HTTP client configuration please provide the 'api_server' URL explicitly",
 	},
 	{
+		filename: "kubernetes_kubeconfig_with_own_namespace.bad.yml",
+		errMsg:   "cannot use 'kubeconfig_file' and 'namespaces.own_namespace' simultaneously",
+	},
+	{
+		filename: "kubernetes_api_server_with_own_namespace.bad.yml",
+		errMsg:   "cannot use 'api_server' and 'namespaces.own_namespace' simultaneously",
+	},
+	{
 		filename: "kubernetes_kubeconfig_with_apiserver.bad.yml",
 		errMsg:   "cannot use 'kubeconfig_file' and 'api_server' simultaneously",
 	},

--- a/config/testdata/kubernetes_api_server_with_own_namespace.bad.yml
+++ b/config/testdata/kubernetes_api_server_with_own_namespace.bad.yml
@@ -1,0 +1,7 @@
+scrape_configs:
+  - job_name: prometheus
+    kubernetes_sd_configs:
+      - role: endpoints
+        api_server: 'https://localhost:1234'
+        namespaces:
+          own_namespace: true

--- a/config/testdata/kubernetes_kubeconfig_with_own_namespace.bad.yml
+++ b/config/testdata/kubernetes_kubeconfig_with_own_namespace.bad.yml
@@ -1,0 +1,7 @@
+scrape_configs:
+  - job_name: prometheus
+    kubernetes_sd_configs:
+      - role: endpoints
+        kubeconfig_file: /home/User1/.kubeconfig
+        namespaces:
+          own_namespace: true


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
