### PR TITLE
Allow downstream projects to use faster regexp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/google/pprof v0.0.0-20211214055906-6f57359322fd
 	github.com/gophercloud/gophercloud v0.24.0
 	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/grafana/regexp v0.0.0-20220202152701-6a046c4caf32
+	github.com/grafana/regexp v0.0.0-20220202152315-e74e38789280
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/consul/api v1.12.0
 	github.com/hashicorp/go-hclog v0.12.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/google/pprof v0.0.0-20211214055906-6f57359322fd
 	github.com/gophercloud/gophercloud v0.24.0
 	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/grafana/regexp v0.0.0-20220202152701-6a046c4caf32
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/consul/api v1.12.0
 	github.com/hashicorp/go-hclog v0.12.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -672,6 +672,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/grafana/regexp v0.0.0-20220202152701-6a046c4caf32 h1:M3wP8Hwic62qJsiydSgXtev03d4f92uN1I52nVjRgw0=
+github.com/grafana/regexp v0.0.0-20220202152701-6a046c4caf32/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/go.sum
+++ b/go.sum
@@ -672,8 +672,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/regexp v0.0.0-20220202152701-6a046c4caf32 h1:M3wP8Hwic62qJsiydSgXtev03d4f92uN1I52nVjRgw0=
-github.com/grafana/regexp v0.0.0-20220202152701-6a046c4caf32/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
+github.com/grafana/regexp v0.0.0-20220202152315-e74e38789280 h1:MOND6wXrwVXEzmL2bZ+Jcbgycwt1LD5q6NQbqz/Nlic=
+github.com/grafana/regexp v0.0.0-20220202152315-e74e38789280/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -14,9 +14,10 @@
 package labels
 
 import (
-	"regexp"
-	"regexp/syntax"
 	"strings"
+
+	"github.com/grafana/regexp"
+	"github.com/grafana/regexp/syntax"
 )
 
 type FastRegexMatcher struct {

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -14,10 +14,10 @@
 package labels
 
 import (
-	"regexp/syntax"
 	"strings"
 	"testing"
 
+	"github.com/grafana/regexp/syntax"
 	"github.com/stretchr/testify/require"
 )
 

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -15,6 +15,7 @@ package labels
 
 import (
 	"regexp/syntax"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -94,5 +95,44 @@ func TestOptimizeConcatRegex(t *testing.T) {
 		require.Equal(t, c.prefix, prefix)
 		require.Equal(t, c.suffix, suffix)
 		require.Equal(t, c.contains, contains)
+	}
+}
+
+func BenchmarkFastRegexMatcher(b *testing.B) {
+	var (
+		x = strings.Repeat("x", 50)
+		y = "foo" + x
+		z = x + "foo"
+	)
+	regexes := []string{
+		"foo",
+		"^foo",
+		"(foo|bar)",
+		"foo.*",
+		".*foo",
+		"^.*foo$",
+		"^.+foo$",
+		".*",
+		".+",
+		"foo.+",
+		".+foo",
+		".*foo.*",
+		"(?i:foo)",
+		"(prometheus|api_prom)_api_v1_.+",
+		"((fo(bar))|.+foo)",
+	}
+	for _, r := range regexes {
+		r := r
+		b.Run(r, func(b *testing.B) {
+			m, err := NewFastRegexMatcher(r)
+			require.NoError(b, err)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = m.MatchString(x)
+				_ = m.MatchString(y)
+				_ = m.MatchString(z)
+			}
+		})
+
 	}
 }


### PR DESCRIPTION
NOTE: This PR does not now change the regexp implementation used by Prometheus, just the package import path.

This PR makes it possible for downstream projects that use Prometheus code to take advantage of some optimisations I have submitted to the Go project:
* [regexp: allow patterns with no alternates to be one-pass](https://go-review.googlesource.com/c/go/+/353711)
* [regexp: speed up onepass prefix check](https://go-review.googlesource.com/c/go/+/354909)
* [regexp: handle prefix string with fold-case](https://go-review.googlesource.com/c/go/+/358756)
* [regexp: avoid copying each instruction executed](https://go-review.googlesource.com/c/go/+/355789)
* [regexp: allow prefix string anchored at beginning](https://go-review.googlesource.com/c/go/+/377294)

I have a [FOSDEM talk](https://fosdem.org/2022/schedule/event/go_finite_automata/) on Saturday 6th Feb about this. https://www.youtube.com/watch?v=iBTwVyfH9eY

I collected the optimisations into a new repo https://github.com/grafana/regexp; it exists purely to make PRs like this possible and can be retired once the changes land upstream.

I added a benchmark, largely using the patterns in existing tests - I didn't spend much time looking for patterns that flatter the optimisations:
```
name                                                old time/op  new time/op  delta
FastRegexMatcher/foo-4                               397ns ± 4%   187ns ± 2%  -52.86%  (p=0.008 n=5+5)
FastRegexMatcher/^foo-4                             37.7ns ± 2%  38.5ns ±10%     ~     (p=1.000 n=5+5)
FastRegexMatcher/(foo|bar)-4                         409ns ± 2%   366ns ± 2%  -10.47%  (p=0.008 n=5+5)
FastRegexMatcher/foo.*-4                            1.72µs ± 4%  1.61µs ± 2%   -6.30%  (p=0.008 n=5+5)
FastRegexMatcher/.*foo-4                            1.48µs ± 7%  1.40µs ± 4%     ~     (p=0.095 n=5+5)
FastRegexMatcher/^.*foo$-4                          1.52µs ± 5%  1.43µs ± 1%   -6.26%  (p=0.008 n=5+5)
FastRegexMatcher/^.+foo$-4                          1.51µs ± 7%  1.44µs ± 2%     ~     (p=0.056 n=5+5)
FastRegexMatcher/.*-4                               5.06µs ± 5%  4.86µs ± 3%     ~     (p=0.222 n=5+5)
FastRegexMatcher/.+-4                               5.18µs ± 6%  4.83µs ± 3%   -6.62%  (p=0.016 n=5+5)
FastRegexMatcher/foo.+-4                            1.72µs ± 4%  1.63µs ± 3%   -5.64%  (p=0.016 n=5+5)
FastRegexMatcher/.+foo-4                            1.46µs ± 4%  1.42µs ± 3%     ~     (p=0.222 n=5+5)
FastRegexMatcher/.*foo.*-4                          4.73µs ± 1%  4.59µs ± 2%   -3.08%  (p=0.008 n=5+5)
FastRegexMatcher/(?i:foo)-4                          386ns ± 3%   213ns ± 2%  -44.72%  (p=0.008 n=5+5)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-4  55.8ns ± 3%  55.1ns ± 4%     ~     (p=0.548 n=5+5)
FastRegexMatcher/((fo(bar))|.+foo)-4                5.88µs ± 0%  5.57µs ± 3%   -5.27%  (p=0.016 n=4+5)
```

Note that some regexps are optimised away by `FastRegexMatcher` so don't see any benefit.