### PR TITLE
Add an option to use the external labels as selectors for the remote read endpoint

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -203,8 +203,9 @@ var (
 
 	// DefaultRemoteReadConfig is the default remote read configuration.
 	DefaultRemoteReadConfig = RemoteReadConfig{
-		RemoteTimeout:    model.Duration(1 * time.Minute),
-		HTTPClientConfig: config.DefaultHTTPClientConfig,
+		RemoteTimeout:        model.Duration(1 * time.Minute),
+		HTTPClientConfig:     config.DefaultHTTPClientConfig,
+		FilterExternalLabels: true,
 	}
 
 	// DefaultStorageConfig is the default TSDB/Exemplar storage configuration.
@@ -854,9 +855,9 @@ type RemoteReadConfig struct {
 	// RequiredMatchers is an optional list of equality matchers which have to
 	// be present in a selector to query the remote read endpoint.
 	RequiredMatchers model.LabelSet `yaml:"required_matchers,omitempty"`
-	// An option to ignore external_labels, will keep reading data that has already
-	// been written if true, default is false.
-	IgnoreExternalLabels bool `yaml:"ignore_external_labels,omitempty"`
+
+	// Whether to use the external labels as selectors for the remote read endpoint.
+	FilterExternalLabels bool `yaml:"filter_external_labels,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.

--- a/config/config.go
+++ b/config/config.go
@@ -854,6 +854,9 @@ type RemoteReadConfig struct {
 	// RequiredMatchers is an optional list of equality matchers which have to
 	// be present in a selector to query the remote read endpoint.
 	RequiredMatchers model.LabelSet `yaml:"required_matchers,omitempty"`
+	// An option to ignore external_labels, will keep reading data that has already
+	// been written if true, default is false.
+	IgnoreExternalLabels bool `yaml:"ignore_external_labels,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -130,11 +130,12 @@ var expectedConf = &Config{
 
 	RemoteReadConfigs: []*RemoteReadConfig{
 		{
-			URL:              mustParseURL("http://remote1/read"),
-			RemoteTimeout:    model.Duration(1 * time.Minute),
-			ReadRecent:       true,
-			Name:             "default",
-			HTTPClientConfig: config.DefaultHTTPClientConfig,
+			URL:                  mustParseURL("http://remote1/read"),
+			RemoteTimeout:        model.Duration(1 * time.Minute),
+			ReadRecent:           true,
+			Name:                 "default",
+			HTTPClientConfig:     config.DefaultHTTPClientConfig,
+			FilterExternalLabels: true,
 		},
 		{
 			URL:              mustParseURL("http://remote3/read"),
@@ -149,6 +150,7 @@ var expectedConf = &Config{
 				},
 				FollowRedirects: true,
 			},
+			FilterExternalLabels: true,
 		},
 	},
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2868,6 +2868,10 @@ tls_config:
 
 # Configure whether HTTP requests follow HTTP 3xx redirects.
 [ follow_redirects: <boolean> | default = true ]
+
+# Whether ignore external_labels, will keep reading data that 
+# has already been written if true.
+[ ignore_external_labels: <boolean> | default = false ]
 ```
 
 There is a list of

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2869,9 +2869,8 @@ tls_config:
 # Configure whether HTTP requests follow HTTP 3xx redirects.
 [ follow_redirects: <boolean> | default = true ]
 
-# Whether ignore external_labels, will keep reading data that 
-# has already been written if true.
-[ ignore_external_labels: <boolean> | default = false ]
+# Whether to use the external labels as selectors for the remote read endpoint.
+[ filter_external_labels: <boolean> | default = true ]
 ```
 
 There is a list of

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -117,10 +117,13 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		if err != nil {
 			return err
 		}
-
+		externalLabels := conf.GlobalConfig.ExternalLabels
+		if rrConf.IgnoreExternalLabels {
+			externalLabels = make(labels.Labels, 0)
+		}
 		queryables = append(queryables, NewSampleAndChunkQueryableClient(
 			c,
-			conf.GlobalConfig.ExternalLabels,
+			externalLabels,
 			labelsToEqualityMatchers(rrConf.RequiredMatchers),
 			rrConf.ReadRecent,
 			s.localStartTimeCallback,

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -117,8 +117,9 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		if err != nil {
 			return err
 		}
+
 		externalLabels := conf.GlobalConfig.ExternalLabels
-		if rrConf.IgnoreExternalLabels {
+		if !rrConf.FilterExternalLabels {
 			externalLabels = make(labels.Labels, 0)
 		}
 		queryables = append(queryables, NewSampleAndChunkQueryableClient(

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 func TestStorageLifecycle(t *testing.T) {
@@ -76,6 +77,58 @@ func TestUpdateRemoteReadConfigs(t *testing.T) {
 	}
 	require.NoError(t, s.ApplyConfig(conf))
 	require.Equal(t, 1, len(s.queryables))
+
+	err := s.Close()
+	require.NoError(t, err)
+}
+
+func TestNotIgnoreExternalLabels(t *testing.T) {
+	dir := t.TempDir()
+
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+
+	conf := &config.Config{
+		GlobalConfig: config.GlobalConfig{
+			ExternalLabels: labels.Labels{labels.Label{Name: "foo", Value: "bar"}},
+		},
+	}
+	require.NoError(t, s.ApplyConfig(conf))
+	require.Equal(t, 0, len(s.queryables))
+
+	conf.RemoteReadConfigs = []*config.RemoteReadConfig{
+		&config.DefaultRemoteReadConfig,
+	}
+
+	require.NoError(t, s.ApplyConfig(conf))
+	require.Equal(t, 1, len(s.queryables))
+	require.Equal(t, 1, len(s.queryables[0].(*sampleAndChunkQueryableClient).externalLabels))
+
+	err := s.Close()
+	require.NoError(t, err)
+}
+
+func TestIgnoreExternalLabels(t *testing.T) {
+	dir := t.TempDir()
+
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+
+	conf := &config.Config{
+		GlobalConfig: config.GlobalConfig{
+			ExternalLabels: labels.Labels{labels.Label{Name: "foo", Value: "bar"}},
+		},
+	}
+	require.NoError(t, s.ApplyConfig(conf))
+	require.Equal(t, 0, len(s.queryables))
+
+	conf.RemoteReadConfigs = []*config.RemoteReadConfig{
+		&config.DefaultRemoteReadConfig,
+	}
+
+	conf.RemoteReadConfigs[0].IgnoreExternalLabels = true
+
+	require.NoError(t, s.ApplyConfig(conf))
+	require.Equal(t, 1, len(s.queryables))
+	require.Equal(t, 0, len(s.queryables[0].(*sampleAndChunkQueryableClient).externalLabels))
 
 	err := s.Close()
 	require.NoError(t, err)

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -82,7 +82,7 @@ func TestUpdateRemoteReadConfigs(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestNotIgnoreExternalLabels(t *testing.T) {
+func TestFilterExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
 	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
@@ -124,7 +124,7 @@ func TestIgnoreExternalLabels(t *testing.T) {
 		&config.DefaultRemoteReadConfig,
 	}
 
-	conf.RemoteReadConfigs[0].IgnoreExternalLabels = true
+	conf.RemoteReadConfigs[0].FilterExternalLabels = false
 
 	require.NoError(t, s.ApplyConfig(conf))
 	require.Equal(t, 1, len(s.queryables))


### PR DESCRIPTION
Resolves https://github.com/prometheus/prometheus/issues/10158.

Signed-off-by: DrAuYueng <ouyang1204@gmail.com>