### PR TITLE
Improve error logging for missing config and QL dir

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -428,7 +428,21 @@ func main() {
 	// Throw error for invalid config before starting other components.
 	var cfgFile *config.Config
 	if cfgFile, err = config.LoadFile(cfg.configFile, agentMode, false, log.NewNopLogger()); err != nil {
-		level.Error(logger).Log("msg", fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "err", err)
+		// Try and log a full path to aid in debugging, even if we received a
+		// relative one
+		fullpath := "unknown"
+		if !filepath.IsAbs(cfg.configFile) {
+			// If Getwd() returns an error, things are very broken, and we will
+			// just error-log "unknown" as the full path
+			cwd, err := os.Getwd()
+			if err == nil {
+				fullpath = filepath.Join(cwd, cfg.configFile)
+			}
+		} else {
+			fullpath = cfg.configFile
+		}
+
+		level.Error(logger).Log("msg", fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "fullpath", fullpath, "err", err)
 		os.Exit(2)
 	}
 	if cfg.tsdb.EnableExemplarStorage {

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -428,8 +428,8 @@ func main() {
 	// Throw error for invalid config before starting other components.
 	var cfgFile *config.Config
 	if cfgFile, err = config.LoadFile(cfg.configFile, agentMode, false, log.NewNopLogger()); err != nil {
-		absPath, err := filepath.Abs(cfg.configFile)
-		if err != nil {
+		absPath, pathErr := filepath.Abs(cfg.configFile)
+		if pathErr != nil {
 			absPath = cfg.configFile
 		}
 		level.Error(logger).Log("msg", fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "absPath", absPath, "err", err)

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -429,19 +429,12 @@ func main() {
 	var cfgFile *config.Config
 	if cfgFile, err = config.LoadFile(cfg.configFile, agentMode, false, log.NewNopLogger()); err != nil {
 		// Try and log a full path to aid in debugging, even if we received a
-		// relative one
-		fullpath := "unknown"
-		if !filepath.IsAbs(cfg.configFile) {
-			// If Getwd() returns an error, things are very broken, and we will
-			// just error-log "unknown" as the full path
-			cwd, err := os.Getwd()
-			if err == nil {
-				fullpath = filepath.Join(cwd, cfg.configFile)
-			}
-		} else {
+		// relative one. if filepath.Abs returns an error, we just log the base
+		// path as received.
+		fullpath, err := filepath.Abs(cfg.configFile)
+		if err == nil {
 			fullpath = cfg.configFile
 		}
-
 		level.Error(logger).Log("msg", fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "fullpath", fullpath, "err", err)
 		os.Exit(2)
 	}

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -432,7 +432,7 @@ func main() {
 		if pathErr != nil {
 			absPath = cfg.configFile
 		}
-		level.Error(logger).Log("msg", fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "absPath", absPath, "err", err)
+		level.Error(logger).Log("msg", fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "file", cfg.configFile, "absPath", absPath, "err", err)
 		os.Exit(2)
 	}
 	if cfg.tsdb.EnableExemplarStorage {

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -428,14 +428,11 @@ func main() {
 	// Throw error for invalid config before starting other components.
 	var cfgFile *config.Config
 	if cfgFile, err = config.LoadFile(cfg.configFile, agentMode, false, log.NewNopLogger()); err != nil {
-		// Try and log a full path to aid in debugging, even if we received a
-		// relative one. if filepath.Abs returns an error, we just log the base
-		// path as received.
-		fullpath, err := filepath.Abs(cfg.configFile)
-		if err == nil {
-			fullpath = cfg.configFile
+		absPath, err := filepath.Abs(cfg.configFile)
+		if err != nil {
+			absPath = cfg.configFile
 		}
-		level.Error(logger).Log("msg", fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "fullpath", fullpath, "err", err)
+		level.Error(logger).Log("msg", fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "absPath", absPath, "err", err)
 		os.Exit(2)
 	}
 	if cfg.tsdb.EnableExemplarStorage {

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -432,7 +432,7 @@ func main() {
 		if pathErr != nil {
 			absPath = cfg.configFile
 		}
-		level.Error(logger).Log("msg", fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "file", cfg.configFile, "absPath", absPath, "err", err)
+		level.Error(logger).Log("msg", fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "file", absPath, "err", err)
 		os.Exit(2)
 	}
 	if cfg.tsdb.EnableExemplarStorage {

--- a/promql/query_logger.go
+++ b/promql/query_logger.go
@@ -84,16 +84,10 @@ func getMMapedFile(filename string, filesize int, logger log.Logger) ([]byte, er
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o666)
 	if err != nil {
 		// Try and log a full path to aid in debugging, even if we received a
-		// relative one
-		fullpath := "unknown"
-		if !filepath.IsAbs(filename) {
-			// If Getwd() returns an error, things are very broken, and we will
-			// just error-log the filename as we received it
-			cwd, err := os.Getwd()
-			if err == nil {
-				fullpath = filepath.Join(cwd, filename)
-			}
-		} else {
+		// relative one. if filepath.Abs returns an error, we just log the base
+		// path as received.
+		fullpath, err := filepath.Abs(filename)
+		if err == nil {
 			fullpath = filename
 		}
 		level.Error(logger).Log("msg", "Error opening query log file", "file", filename, "fullpath", fullpath, "err", err)

--- a/promql/query_logger.go
+++ b/promql/query_logger.go
@@ -83,8 +83,8 @@ func logUnfinishedQueries(filename string, filesize int, logger log.Logger) {
 func getMMapedFile(filename string, filesize int, logger log.Logger) ([]byte, error) {
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o666)
 	if err != nil {
-		absPath, err := filepath.Abs(filename)
-		if err != nil {
+		absPath, pathErr := filepath.Abs(filename)
+		if pathErr != nil {
 			absPath = filename
 		}
 		level.Error(logger).Log("msg", "Error opening query log file", "file", absPath, "err", err)

--- a/promql/query_logger.go
+++ b/promql/query_logger.go
@@ -83,7 +83,20 @@ func logUnfinishedQueries(filename string, filesize int, logger log.Logger) {
 func getMMapedFile(filename string, filesize int, logger log.Logger) ([]byte, error) {
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o666)
 	if err != nil {
-		level.Error(logger).Log("msg", "Error opening query log file", "file", filename, "err", err)
+		// Try and log a full path to aid in debugging, even if we received a
+		// relative one
+		fullpath := "unknown"
+		if !filepath.IsAbs(filename) {
+			// If Getwd() returns an error, things are very broken, and we will
+			// just error-log the filename as we received it
+			cwd, err := os.Getwd()
+			if err == nil {
+				fullpath = filepath.Join(cwd, filename)
+			}
+		} else {
+			fullpath = filename
+		}
+		level.Error(logger).Log("msg", "Error opening query log file", "file", filename, "fullpath", fullpath, "err", err)
 		return nil, err
 	}
 

--- a/promql/query_logger.go
+++ b/promql/query_logger.go
@@ -83,14 +83,11 @@ func logUnfinishedQueries(filename string, filesize int, logger log.Logger) {
 func getMMapedFile(filename string, filesize int, logger log.Logger) ([]byte, error) {
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o666)
 	if err != nil {
-		// Try and log a full path to aid in debugging, even if we received a
-		// relative one. if filepath.Abs returns an error, we just log the base
-		// path as received.
-		fullpath, err := filepath.Abs(filename)
-		if err == nil {
-			fullpath = filename
+		absPath, err := filepath.Abs(filename)
+		if err != nil {
+			absPath = filename
 		}
-		level.Error(logger).Log("msg", "Error opening query log file", "file", filename, "fullpath", fullpath, "err", err)
+		level.Error(logger).Log("msg", "Error opening query log file", "file", absPath, "err", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Currently, when Prometheus can't open its config file or the query logging dir under the data dir, it only logs what it has been given default or commandline/config. Depending on the environment this can be less than helpful, since the working directory may be unclear to the user. I have specifically kept the existing error messages as intact as possible to a) still log the parameter as given and b) cause as little disruption for log-parsers/-analyzers as possible.

So in case of the config file or the data dir being non-absolute paths, I use os.GetWd to find the working dir and assemble an absolute path for error logging purposes. If GetWd fails, we just log "unknown", as recovering from an error there would be very complex measure, likely not worth the code/effort.

Example errors:

```
$ ./prometheus
ts=2022-02-06T16:00:53.034Z caller=main.go:445 level=error msg="Error loading config (--config.file=prometheus.yml)" fullpath=/home/klausman/src/prometheus/prometheus.yml err="open prometheus.yml: no such file or directory"
$ touch prometheus.yml
$ ./prometheus
[...]
ts=2022-02-06T16:01:00.992Z caller=query_logger.go:99 level=error component=activeQueryTracker msg="Error opening query log file" file=data/queries.active fullpath=/home/klausman/src/prometheus/data/queries.active err="open data/queries.active: permission denied"
panic: Unable to create mmap-ed active query log
[...]
$
```

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
