### PR TITLE
Improve content-type error handling

### DIFF
--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -64,7 +64,7 @@ type Parser interface {
 //
 // This function always returns a valid parser, but might additionally
 // return an error if the content type cannot be parsed.
-func New(b []byte, contentType string) (p Parser, warning error) {
+func New(b []byte, contentType string) (Parser, error) {
 	if contentType == "" {
 		return NewPromParser(b), nil
 	}

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -37,62 +37,54 @@ func TestNewParser(t *testing.T) {
 	for name, tt := range map[string]*struct {
 		contentType    string
 		validateParser func(*testing.T, Parser)
-		warning        string
+		err            string
 	}{
 		"empty-string": {
-			contentType:    "",
 			validateParser: requirePromParser,
-			warning:        "",
 		},
 		"invalid-content-type-1": {
 			contentType:    "invalid/",
 			validateParser: requirePromParser,
-			warning:        "expected token after slash",
+			err:            "expected token after slash",
 		},
 		"invalid-content-type-2": {
 			contentType:    "invalid/invalid/invalid",
 			validateParser: requirePromParser,
-			warning:        "unexpected content after media subtype",
+			err:            "unexpected content after media subtype",
 		},
 		"invalid-content-type-3": {
 			contentType:    "/",
 			validateParser: requirePromParser,
-			warning:        "no media type",
+			err:            "no media type",
 		},
 		"invalid-content-type-4": {
 			contentType:    "application/openmetrics-text; charset=UTF-8; charset=utf-8",
 			validateParser: requirePromParser,
-			warning:        "duplicate parameter name",
+			err:            "duplicate parameter name",
 		},
 		"openmetrics": {
 			contentType:    "application/openmetrics-text",
 			validateParser: requireOpenMetricsParser,
-			warning:        "",
 		},
 		"openmetrics-with-charset": {
 			contentType:    "application/openmetrics-text; charset=utf-8",
 			validateParser: requireOpenMetricsParser,
-			warning:        "",
 		},
 		"openmetrics-with-charset-and-version": {
 			contentType:    "application/openmetrics-text; version=1.0.0; charset=utf-8",
 			validateParser: requireOpenMetricsParser,
-			warning:        "",
 		},
 		"plain-text": {
 			contentType:    "text/plain",
 			validateParser: requirePromParser,
-			warning:        "",
 		},
 		"plain-text-with-version": {
 			contentType:    "text/plain; version=0.0.4",
 			validateParser: requirePromParser,
-			warning:        "",
 		},
 		"some-other-valid-content-type": {
 			contentType:    "text/html",
 			validateParser: requirePromParser,
-			warning:        "",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -101,11 +93,11 @@ func TestNewParser(t *testing.T) {
 
 			p, err := New([]byte{}, tt.contentType)
 			tt.validateParser(t, p)
-			if tt.warning == "" {
+			if tt.err == "" {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.warning)
+				require.Contains(t, err.Error(), tt.err)
 			}
 		})
 	}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1418,12 +1418,12 @@ type appendErrors struct {
 }
 
 func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string, ts time.Time) (total, added, seriesAdded int, err error) {
-	p, warning := textparse.New(b, contentType)
-	if warning != nil {
+	p, err := textparse.New(b, contentType)
+	if err != nil {
 		level.Debug(sl.l).Log(
-			"msg", "Invalid content type on scrape, using prometheus parser as fallback",
-			"content-type", contentType,
-			"err", warning,
+			"msg", "Invalid content type on scrape, using prometheus parser as fallback.",
+			"content_type", contentType,
+			"err", err,
 		)
 	}
 


### PR DESCRIPTION
- Call err everywhere
- Change log message to underscore-separated field

Followup on #10186

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
