### PR TITLE
Specify type in metadata parser errors

### DIFF
--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -241,13 +241,13 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 	case tEOF:
 		return EntryInvalid, errors.New("data does not end with # EOF")
 	case tHelp, tType, tUnit:
-		switch t := p.nextToken(); t {
+		switch t2 := p.nextToken(); t2 {
 		case tMName:
 			p.offsets = append(p.offsets, p.l.start, p.l.i)
 		default:
-			return EntryInvalid, parseError("expected metric name after HELP", t)
+			return EntryInvalid, parseError("expected metric name after "+t.String(), t2)
 		}
-		switch t := p.nextToken(); t {
+		switch t2 := p.nextToken(); t2 {
 		case tText:
 			if len(p.l.buf()) > 1 {
 				p.text = p.l.buf()[1 : len(p.l.buf())-1]
@@ -255,7 +255,7 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 				p.text = []byte{}
 			}
 		default:
-			return EntryInvalid, parseError("expected text in HELP", t)
+			return EntryInvalid, fmt.Errorf("expected text in %s, got none", t.String())
 		}
 		switch t {
 		case tType:

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -255,7 +255,7 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 				p.text = []byte{}
 			}
 		default:
-			return EntryInvalid, fmt.Errorf("expected text in %s, got none", t.String())
+			return EntryInvalid, fmt.Errorf("expected text in %s", t.String())
 		}
 		switch t {
 		case tType:

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -342,7 +342,7 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 		},
 		{
 			input: "# TYPE m\n#EOF\n",
-			err:   "expected text in TYPE, got none",
+			err:   "expected text in TYPE",
 		},
 		{
 			input: "# UNIT metric suffix\n#EOF\n",
@@ -362,7 +362,7 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 		},
 		{
 			input: "# UNIT m\n#EOF\n",
-			err:   "expected text in UNIT, got none",
+			err:   "expected text in UNIT",
 		},
 		{
 			input: "# HELP \n#EOF\n",
@@ -370,7 +370,7 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 		},
 		{
 			input: "# HELP m\n#EOF\n",
-			err:   "expected text in HELP, got none",
+			err:   "expected text in HELP",
 		},
 		{
 			input: "a\t1\n#EOF\n",

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -337,6 +337,14 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 			err:   "\"INVALID\" \" \" is not a valid start token",
 		},
 		{
+			input: "# TYPE \n#EOF\n",
+			err:   "expected metric name after TYPE, got \"INVALID\"",
+		},
+		{
+			input: "# TYPE m\n#EOF\n",
+			err:   "expected text in TYPE, got none",
+		},
+		{
 			input: "# UNIT metric suffix\n#EOF\n",
 			err:   "unit not a suffix of metric \"metric\"",
 		},
@@ -349,8 +357,20 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 			err:   "unit not a suffix of metric \"m\"",
 		},
 		{
+			input: "# UNIT \n#EOF\n",
+			err:   "expected metric name after UNIT, got \"INVALID\"",
+		},
+		{
+			input: "# UNIT m\n#EOF\n",
+			err:   "expected text in UNIT, got none",
+		},
+		{
+			input: "# HELP \n#EOF\n",
+			err:   "expected metric name after HELP, got \"INVALID\"",
+		},
+		{
 			input: "# HELP m\n#EOF\n",
-			err:   "expected text in HELP, got \"INVALID\"",
+			err:   "expected text in HELP, got none",
 		},
 		{
 			input: "a\t1\n#EOF\n",

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -285,7 +285,7 @@ func (p *PromParser) Next() (Entry, error) {
 				p.text = []byte{}
 			}
 		default:
-			return EntryInvalid, fmt.Errorf("expected text in %s, got none", t.String())
+			return EntryInvalid, fmt.Errorf("expected text in %s", t.String())
 		}
 		switch t {
 		case tType:

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -271,13 +271,13 @@ func (p *PromParser) Next() (Entry, error) {
 		return p.Next()
 
 	case tHelp, tType:
-		switch t := p.nextToken(); t {
+		switch t2 := p.nextToken(); t2 {
 		case tMName:
 			p.offsets = append(p.offsets, p.l.start, p.l.i)
 		default:
-			return EntryInvalid, parseError("expected metric name after HELP", t)
+			return EntryInvalid, parseError("expected metric name after "+t.String(), t2)
 		}
-		switch t := p.nextToken(); t {
+		switch t2 := p.nextToken(); t2 {
 		case tText:
 			if len(p.l.buf()) > 1 {
 				p.text = p.l.buf()[1:]
@@ -285,7 +285,7 @@ func (p *PromParser) Next() (Entry, error) {
 				p.text = []byte{}
 			}
 		default:
-			return EntryInvalid, parseError("expected text in HELP", t)
+			return EntryInvalid, fmt.Errorf("expected text in %s, got none", t.String())
 		}
 		switch t {
 		case tType:

--- a/model/textparse/promparse_test.go
+++ b/model/textparse/promparse_test.go
@@ -270,6 +270,14 @@ func TestPromParseErrors(t *testing.T) {
 			input: `{a="ok"} 1`,
 			err:   `"INVALID" is not a valid start token`,
 		},
+		{
+			input: "# TYPE #\n#EOF\n",
+			err:   "expected metric name after TYPE, got \"INVALID\"",
+		},
+		{
+			input: "# HELP #\n#EOF\n",
+			err:   "expected metric name after HELP, got \"INVALID\"",
+		},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR fixes metadata parser errors which assume that they are dealing with a `HELP` comment, when it could actually also be a `TYPE` or `UNIT` comment.

Fixes #10258