### PR TITLE
Create `promtool tsdb chunks` command with DoubleDelta & RLE encoding

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -43,7 +43,7 @@ import (
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web"
 	"gopkg.in/alecthomas/kingpin.v2"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -162,6 +162,11 @@ func main() {
 	analyzeLimit := tsdbAnalyzeCmd.Flag("limit", "How many items to show in each list.").Default("20").Int()
 	analyzeRunExtended := tsdbAnalyzeCmd.Flag("extended", "Run extended analysis.").Bool()
 
+	tsdbChunksCmd := tsdbCmd.Command("chunks", "Analyze the chunks of a block.")
+	analyzeChunksPath := tsdbChunksCmd.Arg("db path", "Database path (default is "+defaultDBPath+").").Default(defaultDBPath).String()
+	analyzeChunksBlockID := tsdbChunksCmd.Arg("block id", "Block to analyze (default is the last block).").String()
+	analyzeChunksLimit := tsdbChunksCmd.Flag("limit", "How many items to show in each list.").Default("20").Int()
+
 	tsdbListCmd := tsdbCmd.Command("list", "List tsdb blocks.")
 	listHumanReadable := tsdbListCmd.Flag("human-readable", "Print human readable values.").Short('r').Bool()
 	listPath := tsdbListCmd.Arg("db path", "Database path (default is "+defaultDBPath+").").Default(defaultDBPath).String()
@@ -268,6 +273,9 @@ func main() {
 
 	case tsdbAnalyzeCmd.FullCommand():
 		os.Exit(checkErr(analyzeBlock(*analyzePath, *analyzeBlockID, *analyzeLimit, *analyzeRunExtended)))
+
+	case tsdbChunksCmd.FullCommand():
+		os.Exit(checkErr(analyzeBlockChunks(*analyzeChunksPath, *analyzeChunksBlockID, *analyzeChunksLimit)))
 
 	case tsdbListCmd.FullCommand():
 		os.Exit(checkErr(listBlocks(*listPath, *listHumanReadable)))

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -31,6 +31,8 @@ func (e Encoding) String() string {
 		return "XOR"
 	case EncDoubleDelta:
 		return "DoubleDelta"
+	case EncRunLength:
+		return "RunLength"
 	}
 	return "<unknown>"
 }
@@ -40,6 +42,7 @@ const (
 	EncNone Encoding = iota
 	EncXOR
 	EncDoubleDelta
+	EncRunLength
 )
 
 // Chunk holds a sequence of sample pairs that can be iterated over and appended to.

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -29,6 +29,8 @@ func (e Encoding) String() string {
 		return "none"
 	case EncXOR:
 		return "XOR"
+	case EncDoubleDelta:
+		return "DoubleDelta"
 	}
 	return "<unknown>"
 }
@@ -37,6 +39,7 @@ func (e Encoding) String() string {
 const (
 	EncNone Encoding = iota
 	EncXOR
+	EncDoubleDelta
 )
 
 // Chunk holds a sequence of sample pairs that can be iterated over and appended to.

--- a/tsdb/chunkenc/doubledelta.go
+++ b/tsdb/chunkenc/doubledelta.go
@@ -1,3 +1,16 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package chunkenc
 
 import (
@@ -90,7 +103,7 @@ func (a *doubleDeltaAppender) Append(t int64, vf float64) {
 		}
 	} else if num == 1 {
 		tDelta := uint64(t - a.t)
-		vDelta := uint64(v - a.v)
+		vDelta := uint64(v) - uint64(a.v)
 
 		buf := make([]byte, binary.MaxVarintLen64)
 		for _, b := range buf[:binary.PutUvarint(buf, tDelta)] {
@@ -125,7 +138,7 @@ func (a *doubleDeltaAppender) Append(t int64, vf float64) {
 		}
 
 		tDelta := uint64(t - a.t)
-		vDelta := uint64(v - a.v)
+		vDelta := uint64(v) - uint64(a.v)
 		tDoD := int64(tDelta - a.tDelta)
 		vDoD := int64(vDelta - a.vDelta)
 

--- a/tsdb/chunkenc/doubledelta.go
+++ b/tsdb/chunkenc/doubledelta.go
@@ -1,0 +1,310 @@
+package chunkenc
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+// DoubleDeltaChunk holds double delta encoded sample data.
+type DoubleDeltaChunk struct {
+	b bstream
+}
+
+func NewDoubleDeltaChunk() *DoubleDeltaChunk {
+	b := make([]byte, 2, 128)
+	return &DoubleDeltaChunk{b: bstream{stream: b, count: 0}}
+}
+
+func (c *DoubleDeltaChunk) Encoding() Encoding {
+	return EncDoubleDelta
+}
+
+func (c *DoubleDeltaChunk) Bytes() []byte {
+	return c.b.bytes()
+}
+
+func (c *DoubleDeltaChunk) NumSamples() int {
+	return int(binary.BigEndian.Uint16(c.Bytes()))
+}
+
+func (c *DoubleDeltaChunk) Compact() {
+	// TODO
+}
+
+func (c *DoubleDeltaChunk) Appender() (Appender, error) {
+	it := c.iterator(nil)
+	for it.Next() {
+	}
+	if err := it.Err(); err != nil {
+		return nil, err
+	}
+
+	a := &doubleDeltaAppender{
+		b:      &c.b,
+		t:      it.t,
+		v:      it.v,
+		tDelta: it.tDelta,
+		vDelta: it.vDelta,
+	}
+	return a, nil
+}
+
+func (c *DoubleDeltaChunk) iterator(it Iterator) *doubleDeltaIterator {
+	if ddIter, ok := it.(*doubleDeltaIterator); ok {
+		ddIter.Reset(c.b.bytes())
+		return ddIter
+	}
+	return &doubleDeltaIterator{
+		br:       newBReader(c.b.bytes()[2:]),
+		numTotal: binary.BigEndian.Uint16(c.b.bytes()),
+		t:        math.MinInt64,
+	}
+}
+
+func (c *DoubleDeltaChunk) Iterator(it Iterator) Iterator {
+	return c.iterator(it)
+}
+
+type doubleDeltaAppender struct {
+	b *bstream
+
+	t      int64
+	v      int64
+	tDelta uint64
+	vDelta uint64
+}
+
+func (a *doubleDeltaAppender) Append(t int64, vf float64) {
+	// We convert float64 to int64, so make sure not a single value has decimals before using this chunk!
+	v := int64(vf)
+
+	num := binary.BigEndian.Uint16(a.b.bytes())
+
+	if num == 0 {
+		buf := make([]byte, binary.MaxVarintLen64)
+		for _, b := range buf[:binary.PutVarint(buf, t)] {
+			a.b.writeByte(b)
+		}
+		for _, b := range buf[:binary.PutVarint(buf, v)] {
+			a.b.writeByte(b)
+		}
+	} else if num == 1 {
+		tDelta := uint64(t - a.t)
+		vDelta := uint64(v - a.v)
+
+		buf := make([]byte, binary.MaxVarintLen64)
+		for _, b := range buf[:binary.PutUvarint(buf, tDelta)] {
+			a.b.writeByte(b)
+		}
+		for _, b := range buf[:binary.PutUvarint(buf, vDelta)] {
+			a.b.writeByte(b)
+		}
+
+		a.tDelta = tDelta
+		a.vDelta = vDelta
+	} else {
+		writeDoD := func(dod int64) {
+			// Gorilla has a max resolution of seconds, Prometheus milliseconds.
+			// Thus we use higher value range steps with larger bit size.
+			switch {
+			case dod == 0:
+				a.b.writeBit(zero)
+			case bitRange(dod, 14):
+				a.b.writeBits(0b10, 2)
+				a.b.writeBits(uint64(dod), 14)
+			case bitRange(dod, 17):
+				a.b.writeBits(0b110, 3)
+				a.b.writeBits(uint64(dod), 17)
+			case bitRange(dod, 20):
+				a.b.writeBits(0b1110, 4)
+				a.b.writeBits(uint64(dod), 20)
+			default:
+				a.b.writeBits(0b1111, 4)
+				a.b.writeBits(uint64(dod), 64)
+			}
+		}
+
+		tDelta := uint64(t - a.t)
+		vDelta := uint64(v - a.v)
+		tDoD := int64(tDelta - a.tDelta)
+		vDoD := int64(vDelta - a.vDelta)
+
+		writeDoD(tDoD)
+		writeDoD(vDoD)
+
+		a.tDelta = tDelta
+		a.vDelta = vDelta
+	}
+
+	a.t = t
+	a.v = v
+	binary.BigEndian.PutUint16(a.b.bytes(), num+1)
+}
+
+type doubleDeltaIterator struct {
+	br       bstreamReader
+	numTotal uint16
+	numRead  uint16
+
+	t      int64
+	v      int64
+	tDelta uint64
+	vDelta uint64
+
+	err error
+}
+
+func (it *doubleDeltaIterator) Seek(t int64) bool {
+	if it.err != nil {
+		return false
+	}
+
+	for t > it.t || it.numRead == 0 {
+		if !it.Next() {
+			return false
+		}
+	}
+	return true
+}
+
+func (it *doubleDeltaIterator) At() (int64, float64) {
+	return it.t, float64(it.v)
+}
+
+func (it *doubleDeltaIterator) Err() error {
+	return it.err
+}
+
+func (it *doubleDeltaIterator) Reset(b []byte) {
+	// The first 2 bytes contain chunk headers.
+	// We skip that for actual samples.
+	it.br = newBReader(b[2:])
+	it.numTotal = binary.BigEndian.Uint16(b)
+
+	it.numRead = 0
+	it.t = 0
+	it.v = 0
+	it.tDelta = 0
+	it.vDelta = 0
+	it.err = nil
+}
+
+func (it *doubleDeltaIterator) Next() bool {
+	if it.err != nil || it.numRead == it.numTotal {
+		return false
+	}
+
+	if it.numRead == 0 {
+		t, err := binary.ReadVarint(&it.br)
+		if err != nil {
+			it.err = err
+			return false
+		}
+		v, err := binary.ReadVarint(&it.br)
+		if err != nil {
+			it.err = err
+			return false
+		}
+		it.t = t
+		it.v = v
+		it.numRead++
+		return true
+	} else if it.numRead == 1 {
+		tDelta, err := binary.ReadUvarint(&it.br)
+		if err != nil {
+			it.err = err
+			return false
+		}
+		vDelta, err := binary.ReadUvarint(&it.br)
+		if err != nil {
+			it.err = err
+			return false
+		}
+
+		it.tDelta = tDelta
+		it.t = it.t + int64(it.tDelta)
+		it.vDelta = vDelta
+		it.v = it.v + int64(it.vDelta)
+
+		it.numRead++
+		return true
+	}
+
+	tDoD, next := it.readDoD()
+	if !next {
+		return next
+	}
+
+	vDoD, next := it.readDoD()
+	if !next {
+		return next
+	}
+
+	it.tDelta = uint64(int64(it.tDelta) + tDoD)
+	it.t = it.t + int64(it.tDelta)
+
+	it.vDelta = uint64(int64(it.vDelta) + vDoD)
+	it.v = it.v + int64(it.vDelta)
+
+	it.numRead++
+	return true
+}
+
+func (it *doubleDeltaIterator) readDoD() (int64, bool) {
+	var d byte
+	for i := 0; i < 4; i++ {
+		d <<= 1
+		bit, err := it.br.readBitFast()
+		if err != nil {
+			bit, err = it.br.readBit()
+		}
+		if err != nil {
+			it.err = err
+			return 0, false
+		}
+		if bit == zero {
+			break
+		}
+		d |= 1
+	}
+	var sz uint8
+	var dod int64
+	switch d {
+	case 0b0:
+		// dod == 0
+	case 0b10:
+		sz = 14
+	case 0b110:
+		sz = 17
+	case 0b1110:
+		sz = 20
+	case 0b1111:
+		// Do not use fast because it's very unlikely it will succeed.
+		bits, err := it.br.readBits(64)
+		if err != nil {
+			it.err = err
+			return 0, false
+		}
+
+		dod = int64(bits)
+	}
+
+	if sz != 0 {
+		bits, err := it.br.readBitsFast(sz)
+		if err != nil {
+			bits, err = it.br.readBits(sz)
+		}
+		if err != nil {
+			it.err = err
+			return 0, false
+		}
+
+		// Account for negative numbers, which come back as high unsigned numbers.
+		// See docs/bstream.md.
+		if bits > (1 << (sz - 1)) {
+			bits -= 1 << sz
+		}
+		dod = int64(bits)
+	}
+	return dod, true
+}

--- a/tsdb/chunkenc/runlength.go
+++ b/tsdb/chunkenc/runlength.go
@@ -1,0 +1,347 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunkenc
+
+import (
+	"encoding/binary"
+)
+
+type RunLength struct {
+	bt bstream // holds the stream for timestamps
+	bv bstream // holds the stream for values
+}
+
+// NewRunLength returns a new chunk with run-length encoding.
+func NewRunLength() *RunLength {
+	return &RunLength{
+		bt: bstream{stream: make([]byte, 2, 128)},
+		bv: bstream{stream: make([]byte, 4, 128)},
+	}
+}
+
+// Encoding returns the encoding type.
+func (c *RunLength) Encoding() Encoding {
+	return EncRunLength
+}
+
+func (c *RunLength) Bytes() []byte {
+	b := make([]byte, len(c.bt.bytes())+len(c.bv.bytes()))
+	copy(b, c.bt.bytes())
+	copy(b, c.bv.bytes())
+	return b
+}
+
+func (c *RunLength) NumSamples() int {
+	return int(binary.BigEndian.Uint16(c.Bytes()))
+}
+
+func (c *RunLength) Compact() {
+	//TODO implement me
+}
+
+func (c *RunLength) Appender() (Appender, error) {
+	it := c.iterator(nil)
+	for it.Next() {
+	}
+	if err := it.Err(); err != nil {
+		return nil, err
+	}
+
+	a := &runLengthAppender{
+		bt: &c.bt,
+		bv: &c.bv,
+
+		t:      it.t,
+		v:      uint64(it.v),
+		tDelta: it.tDelta,
+	}
+	return a, nil
+}
+
+func (c *RunLength) iterator(it Iterator) *runLengthIterator {
+	if rleIter, ok := it.(*runLengthIterator); ok {
+		rleIter.Reset(c.bt.bytes(), c.bv.bytes())
+		return rleIter
+	}
+	return &runLengthIterator{
+		tbr: newBReader(c.bt.bytes()[2:]),
+		vbr: newBReader(c.bv.bytes()[4:]),
+
+		numTotal: binary.BigEndian.Uint16(c.bt.bytes()),
+	}
+}
+
+func (c *RunLength) Iterator(it Iterator) Iterator {
+	return c.iterator(it)
+}
+
+type runLengthAppender struct {
+	bt *bstream
+	bv *bstream
+
+	t      int64
+	tDelta uint64
+
+	v uint64
+}
+
+func (a *runLengthAppender) Append(t int64, vf float64) {
+	//// We convert float64 to uint64 for storing.
+	//v := math.Float64bits(vf)
+	v := uint64(vf) // Only works with integers
+
+	num := binary.BigEndian.Uint16(a.bt.bytes())
+
+	if num == 0 {
+		buf := make([]byte, binary.MaxVarintLen64)
+		for _, b := range buf[:binary.PutVarint(buf, t)] {
+			a.bt.writeByte(b)
+		}
+	} else if num == 1 {
+		tDelta := uint64(t - a.t)
+
+		buf := make([]byte, binary.MaxVarintLen64)
+		for _, b := range buf[:binary.PutUvarint(buf, tDelta)] {
+			a.bt.writeByte(b)
+		}
+		a.tDelta = tDelta
+	} else {
+		tDelta := uint64(t - a.t)
+		dod := int64(tDelta - a.tDelta)
+
+		// Gorilla has a max resolution of seconds, Prometheus milliseconds.
+		// Thus, we use higher value range steps with larger bit size.
+		switch {
+		case dod == 0:
+			a.bt.writeBit(zero)
+		case bitRange(dod, 14):
+			a.bt.writeBits(0b10, 2)
+			a.bt.writeBits(uint64(dod), 14)
+		case bitRange(dod, 17):
+			a.bt.writeBits(0b110, 3)
+			a.bt.writeBits(uint64(dod), 17)
+		case bitRange(dod, 20):
+			a.bt.writeBits(0b1110, 4)
+			a.bt.writeBits(uint64(dod), 20)
+		default:
+			a.bt.writeBits(0b1111, 4)
+			a.bt.writeBits(uint64(dod), 64)
+		}
+
+		a.tDelta = tDelta
+	}
+
+	// Always append the first value regardless of its value.
+	// Then always write the next new value when the values differ.
+	// Otherwise, simply increase the count of the current value.
+	if num == 0 || a.v != v {
+		buf := make([]byte, binary.MaxVarintLen64)
+		for _, b := range buf[:binary.PutUvarint(buf, v)] {
+			a.bv.writeByte(b)
+		}
+
+		buf = make([]byte, 2)
+		binary.BigEndian.PutUint16(buf, 1)
+		for _, b := range buf {
+			a.bv.writeByte(b)
+		}
+
+		vals := binary.BigEndian.Uint16(a.bv.bytes()[2:])
+		binary.BigEndian.PutUint16(a.bv.bytes()[2:], vals+1)
+	} else {
+		b := a.bv.bytes()
+		// Read the last 3 bytes as the bstream always appends a trailing 0,
+		// and we need to two bytes before for the length uint16.
+		count := binary.BigEndian.Uint16(b[len(b)-3:])
+		binary.BigEndian.PutUint16(a.bv.bytes()[len(b)-3:], count+1)
+	}
+
+	a.t = t
+	a.v = v
+	binary.BigEndian.PutUint16(a.bt.bytes(), num+1)
+}
+
+type runLengthIterator struct {
+	tbr bstreamReader
+	vbr bstreamReader
+
+	numTotal uint16
+	numRead  uint16
+
+	t int64
+	v float64
+
+	// lengthLeft stores how often we need to still iterate over the same value
+	lengthLeft uint16
+
+	// vals stores how many values we have yet to see
+	vals uint16
+
+	err    error
+	tDelta uint64
+}
+
+func (it *runLengthIterator) Seek(t int64) bool {
+	if it.err != nil {
+		return false
+	}
+
+	for t > it.t || it.numRead == 0 {
+		if !it.Next() {
+			return false
+		}
+	}
+	return true
+}
+
+func (it *runLengthIterator) At() (int64, float64) {
+	return it.t, it.v
+}
+
+func (it *runLengthIterator) Err() error {
+	return it.err
+}
+
+func (it *runLengthIterator) Reset(bt []byte, bv []byte) {
+	it.tbr = newBReader(bt[2:])
+	it.vbr = newBReader(bv[4:])
+	it.numTotal = binary.BigEndian.Uint16(bt)
+
+	it.numRead = 0
+	it.t = 0
+	it.v = 0
+	it.lengthLeft = 0
+	it.vals = 0
+	it.tDelta = 0
+	it.err = nil
+}
+
+func (it *runLengthIterator) Next() bool {
+	if it.err != nil || it.numRead == it.numTotal {
+		return false
+	}
+
+	if it.numRead == 0 {
+		t, err := binary.ReadVarint(&it.tbr)
+		if err != nil {
+			it.err = err
+			return false
+		}
+		it.t = t
+	} else if it.numRead == 1 {
+		tDelta, err := binary.ReadUvarint(&it.tbr)
+		if err != nil {
+			it.err = err
+			return false
+		}
+		it.tDelta = tDelta
+		it.t = it.t + int64(it.tDelta)
+	} else {
+		var d byte
+		// read delta-of-delta
+		for i := 0; i < 4; i++ {
+			d <<= 1
+			bit, err := it.tbr.readBitFast()
+			if err != nil {
+				bit, err = it.tbr.readBit()
+			}
+			if err != nil {
+				it.err = err
+				return false
+			}
+			if bit == zero {
+				break
+			}
+			d |= 1
+		}
+		var sz uint8
+		var dod int64
+		switch d {
+		case 0b0:
+			// dod == 0
+		case 0b10:
+			sz = 14
+		case 0b110:
+			sz = 17
+		case 0b1110:
+			sz = 20
+		case 0b1111:
+			// Do not use fast because it's very unlikely it will succeed.
+			bits, err := it.tbr.readBits(64)
+			if err != nil {
+				it.err = err
+				return false
+			}
+
+			dod = int64(bits)
+		}
+
+		if sz != 0 {
+			bits, err := it.tbr.readBitsFast(sz)
+			if err != nil {
+				bits, err = it.tbr.readBits(sz)
+			}
+			if err != nil {
+				it.err = err
+				return false
+			}
+
+			// Account for negative numbers, which come back as high unsigned numbers.
+			// See docs/bstream.md.
+			if bits > (1 << (sz - 1)) {
+				bits -= 1 << sz
+			}
+			dod = int64(bits)
+		}
+
+		it.tDelta = uint64(int64(it.tDelta) + dod)
+		it.t = it.t + int64(it.tDelta)
+	}
+
+	if it.lengthLeft == 0 {
+		v, err := binary.ReadUvarint(&it.vbr)
+		if err != nil {
+			it.err = err
+			return false
+		}
+		//it.v = math.Float64frombits(v)
+		it.v = float64(v) // only works with integers
+
+		lengthBytes := make([]byte, 2)
+		for i := 0; i < 2; i++ {
+			b, err := it.vbr.ReadByte()
+			if err != nil {
+				it.err = err
+				return false
+			}
+			lengthBytes[i] = b
+		}
+		it.vals--
+		if it.vals > 0 {
+			it.lengthLeft = binary.BigEndian.Uint16(lengthBytes) - 1 // we've already read the first one
+		}
+		if it.vals == 0 {
+			// We can't read the length bytes of the last value, because it may
+			// be actively written to, so we infer it from how many samples we
+			// know must be left. This is safe because we know this is the last
+			// value.
+			it.lengthLeft = it.numTotal - it.numRead
+		}
+	} else {
+		it.lengthLeft--
+	}
+
+	it.numRead++
+	return true
+}


### PR DESCRIPTION
This is a first experiment on possibly adding double delta and run length encoding to Prometheus blocks for values as discussed in #5865.

The command can be invoke by running:
```bash
promtool tsdb chunks # uses ./data by default
promtool tsdb chunks /var/lib/prometheus/data # reads the block from the given directory
promtool tsdb chunks /var/lib/prometheus/data 01FP8B0B94BN6X2DN0HXPYJ2A7 # reads specific block from directory
```

When running the command it'll loop over all chunks (postings) in the block and then encode the chunks with double delta and run length encoding additionally. 
Finally it'll choose the smallest byte size of all chunks and add it to the overall stats.

## Example with local Prometheus

Running this command on my local Prometheus setup (that scrapes both Prometheus and node-exporter) we get the following output:
```
Encoding   |Chunks   |      |OldBytes   |NewBytes   |Savings
ALL        |10167    |      |2284946    |2045901    |10%
XOR        |2997     |29%   |1294438    |1294438    | 0%
Delta      |584      |6%    |193453     |137908     |29%
RLE        |6586     |65%   |797055     |613555     |23%
```
The `ALL` row is the total number of chunks it's old bytes and all chunks combined given the better (size) encodings. At the end we can see for this block we'd save ~10% of disk.
The `XOR` row contains the amount of chunks that are still best encoded with XOR and we obviously won't safe any bytes.
Now for `Delta` and `RLE` (Run Length Encoding) we can see that the number of chunks better compressed with each is 6% and 65%. 
Overall, RLE seems a lot more common compared to double delta encoding.

## Example with 14d Thanos block

I downloaded an older 14d block from object storage. It's ~300MB of an index for 8 chunk files that in total is around 4GB.
The cluster that the data is from runs kube-prometheus with various other targets (web apps etc).
```
Encoding   |Chunks     |      |OldBytes     |NewBytes     |Savings
ALL        |41514163   |      |3731025811   |3041915431   |18%
XOR        |21380054   |52%   |2382976689   |2382976689   | 0%
Delta      |1106651    |3%    |220541939    |155606985    |29%
RLE        |19027458   |46%   |1127507183   |503331757    |55%
```

Again, it seems that RLE would make the biggest difference compared to double delta encoding as for the number of chunks.

## Moving forward

From the handful different environments I ran the command in, it seems that adding RLE would certainly make an impact. Not so much for double delta encoding for values. Given the complexity of implementing not only one but two more encoding I'd propose to focus on RLE going forward.

However, it would be beneficial if you all could build promtool with this command and then run it in your environments so we can gather a lot more data on my previous assumption. 

Eventually, if we agree to go forward in one way or another, I'm happy to either get coding based on the beginnings made in this PR or start with a more thorough design doc.