### PR TITLE
Followup on tracing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -558,7 +558,7 @@ func (t *TracingConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	if err := validateHeaders(t.Headers); err != nil {
+	if err := validateHeadersForTracing(t.Headers); err != nil {
 		return err
 	}
 
@@ -802,6 +802,18 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 		return fmt.Errorf("at most one of basic_auth, authorization, oauth2, & sigv4 must be configured")
 	}
 
+	return nil
+}
+
+func validateHeadersForTracing(headers map[string]string) error {
+	for header := range headers {
+		if strings.ToLower(header) == "authorization" {
+			return errors.New("custom authorization header configuration is not yet supported")
+		}
+		if _, ok := reservedHeaders[strings.ToLower(header)]; ok {
+			return errors.Errorf("%s is a reserved header. It must not be changed", header)
+		}
+	}
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1465,6 +1465,10 @@ var expectedErrors = []struct {
 		errMsg:   "x-prometheus-remote-write-version is a reserved header. It must not be changed",
 	},
 	{
+		filename: "tracing_invalid_authorization_header.bad.yml",
+		errMsg:   "authorization header configuration is not yet supported.",
+	},
+	{
 		filename: "tracing_invalid_compression.bad.yml",
 		errMsg:   "invalid compression type foo provided, valid options: gzip",
 	},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1466,7 +1466,7 @@ var expectedErrors = []struct {
 	},
 	{
 		filename: "tracing_invalid_authorization_header.bad.yml",
-		errMsg:   "authorization header configuration is not yet supported.",
+		errMsg:   "authorization header configuration is not yet supported",
 	},
 	{
 		filename: "tracing_invalid_compression.bad.yml",

--- a/config/testdata/tracing_invalid_authorization_header.bad.yml
+++ b/config/testdata/tracing_invalid_authorization_header.bad.yml
@@ -1,0 +1,5 @@
+tracing:
+  sampling_fraction: 1
+  endpoint: "localhost:4317"
+  headers:
+    "authorization": foo

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -194,15 +194,11 @@ func getClient(tracingCfg config.TracingConfig) (otlptrace.Client, error) {
 			opts = append(opts, otlptracegrpc.WithTimeout(time.Duration(tracingCfg.Timeout)))
 		}
 
-		// Configure TLS only if config is not empty.
-		var blankTLSConfig config_util.TLSConfig
-		if tracingCfg.TLSConfig != blankTLSConfig {
-			tlsConf, err := config_util.NewTLSConfig(&tracingCfg.TLSConfig)
-			if err != nil {
-				return nil, err
-			}
-			opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(tlsConf)))
+		tlsConf, err := config_util.NewTLSConfig(&tracingCfg.TLSConfig)
+		if err != nil {
+			return nil, err
 		}
+		opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(tlsConf)))
 
 		client = otlptracegrpc.NewClient(opts...)
 	case config.TracingClientHTTP:
@@ -221,15 +217,11 @@ func getClient(tracingCfg config.TracingConfig) (otlptrace.Client, error) {
 			opts = append(opts, otlptracehttp.WithTimeout(time.Duration(tracingCfg.Timeout)))
 		}
 
-		// Configure TLS only if config is not empty.
-		var blankTLSConfig config_util.TLSConfig
-		if tracingCfg.TLSConfig != blankTLSConfig {
-			tlsConf, err := config_util.NewTLSConfig(&tracingCfg.TLSConfig)
-			if err != nil {
-				return nil, err
-			}
-			opts = append(opts, otlptracehttp.WithTLSClientConfig(tlsConf))
+		tlsConf, err := config_util.NewTLSConfig(&tracingCfg.TLSConfig)
+		if err != nil {
+			return nil, err
 		}
+		opts = append(opts, otlptracehttp.WithTLSClientConfig(tlsConf))
 
 		client = otlptracehttp.NewClient(opts...)
 	}


### PR DESCRIPTION
- Simplify code by letting prometheus/common deal with empty TLS config
- Improve error message if we notice a user is putting an authorization header into its configuration.