### PR TITLE
Azure Service Discovery resource group filter

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -564,6 +564,7 @@ var expectedConf = &Config{
 				&azure.SDConfig{
 					Environment:          "AzurePublicCloud",
 					SubscriptionID:       "11AAAA11-A11A-111A-A111-1111A1111A11",
+					ResourceGroup:        "my-resource-group",
 					TenantID:             "BBBB222B-B2B2-2B22-B222-2BB2222BB2B2",
 					ClientID:             "333333CC-3C33-3333-CCC3-33C3CCCCC33C",
 					ClientSecret:         "mysecret",

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -238,6 +238,7 @@ scrape_configs:
       - environment: AzurePublicCloud
         authentication_method: OAuth
         subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
+        resource_group: my-resource-group
         tenant_id: BBBB222B-B2B2-2B22-B222-2BB2222BB2B2
         client_id: 333333CC-3C33-3333-CCC3-33C3CCCCC33C
         client_secret: mysecret

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -86,6 +86,7 @@ type SDConfig struct {
 	ClientSecret         config_util.Secret `yaml:"client_secret,omitempty"`
 	RefreshInterval      model.Duration     `yaml:"refresh_interval,omitempty"`
 	AuthenticationMethod string             `yaml:"authentication_method,omitempty"`
+	ResourceGroup        string             `yaml:"resource_group,omitempty"`
 
 	HTTPClientConfig config_util.HTTPClientConfig `yaml:",inline"`
 }
@@ -187,12 +188,7 @@ func createAzureClient(cfg SDConfig) (azureClient, error) {
 
 	switch cfg.AuthenticationMethod {
 	case authMethodManagedIdentity:
-		msiEndpoint, err := adal.GetMSIVMEndpoint()
-		if err != nil {
-			return azureClient{}, err
-		}
-
-		spt, err = adal.NewServicePrincipalTokenFromMSI(msiEndpoint, resourceManagerEndpoint)
+		spt, err = adal.NewServicePrincipalTokenFromManagedIdentity(resourceManagerEndpoint, &adal.ManagedIdentityOptions{ClientID: cfg.ClientID})
 		if err != nil {
 			return azureClient{}, err
 		}
@@ -286,7 +282,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		return nil, errors.Wrap(err, "could not create Azure client")
 	}
 
-	machines, err := client.getVMs(ctx)
+	machines, err := client.getVMs(ctx, d.cfg.ResourceGroup)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get virtual machines")
 	}
@@ -294,7 +290,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	level.Debug(d.logger).Log("msg", "Found virtual machines during Azure discovery.", "count", len(machines))
 
 	// Load the vms managed by scale sets.
-	scaleSets, err := client.getScaleSets(ctx)
+	scaleSets, err := client.getScaleSets(ctx, d.cfg.ResourceGroup)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get virtual machine scale sets")
 	}
@@ -410,9 +406,15 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	return []*targetgroup.Group{&tg}, nil
 }
 
-func (client *azureClient) getVMs(ctx context.Context) ([]virtualMachine, error) {
+func (client *azureClient) getVMs(ctx context.Context, resourceGroup string) ([]virtualMachine, error) {
 	var vms []virtualMachine
-	result, err := client.vm.ListAll(ctx)
+	var result compute.VirtualMachineListResultPage
+	var err error
+	if len(resourceGroup) == 0 {
+		result, err = client.vm.ListAll(ctx)
+	} else {
+		result, err = client.vm.List(ctx, resourceGroup)
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "could not list virtual machines")
 	}
@@ -429,9 +431,25 @@ func (client *azureClient) getVMs(ctx context.Context) ([]virtualMachine, error)
 	return vms, nil
 }
 
-func (client *azureClient) getScaleSets(ctx context.Context) ([]compute.VirtualMachineScaleSet, error) {
+type VmssListResultPage interface {
+	NextWithContext(ctx context.Context) (err error)
+	NotDone() bool
+	Values() []compute.VirtualMachineScaleSet
+}
+
+func (client *azureClient) getScaleSets(ctx context.Context, resourceGroup string) ([]compute.VirtualMachineScaleSet, error) {
 	var scaleSets []compute.VirtualMachineScaleSet
-	result, err := client.vmss.ListAll(ctx)
+	var result VmssListResultPage
+	var err error
+	if len(resourceGroup) == 0 {
+		var rtn compute.VirtualMachineScaleSetListWithLinkResultPage
+		rtn, err = client.vmss.ListAll(ctx)
+		result = &rtn
+	} else {
+		var rtn compute.VirtualMachineScaleSetListResultPage
+		rtn, err = client.vmss.List(ctx, resourceGroup)
+		result = &rtn
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "could not list virtual machine scale sets")
 	}

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -444,15 +444,19 @@ func (client *azureClient) getScaleSets(ctx context.Context, resourceGroup strin
 	if len(resourceGroup) == 0 {
 		var rtn compute.VirtualMachineScaleSetListWithLinkResultPage
 		rtn, err = client.vmss.ListAll(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not list virtual machine scale sets")
+		}
 		result = &rtn
 	} else {
 		var rtn compute.VirtualMachineScaleSetListResultPage
 		rtn, err = client.vmss.List(ctx, resourceGroup)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not list virtual machine scale sets")
+		}
 		result = &rtn
 	}
-	if err != nil {
-		return nil, errors.Wrap(err, "could not list virtual machine scale sets")
-	}
+
 	for result.NotDone() {
 		scaleSets = append(scaleSets, result.Values()...)
 		err = result.NextWithContext(ctx)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -436,6 +436,9 @@ subscription_id: <string>
 # Optional client secret. Only required with authentication_method OAuth.
 [ client_secret: <secret> ]
 
+# Optional resource group name. Limits discovery to this resource group. 
+[ resource_group: <string> ]
+
 # Refresh interval to re-read the instance list.
 [ refresh_interval: <duration> | default = 300s ]
 


### PR DESCRIPTION
Added an optional `resource_group` configuration for Azure service discovery, which limits the discovery when specified. See issue [10253](https://github.com/prometheus/prometheus/issues/10253).

Also updated a deprecated azure auth call.