### PR TITLE
Add a tooltip for unix times (ISO strings)

### DIFF
--- a/web/ui/react-app/src/pages/graph/DataTable.tsx
+++ b/web/ui/react-app/src/pages/graph/DataTable.tsx
@@ -89,7 +89,7 @@ const DataTable: FC<QueryResult> = ({ data, useLocalTime }) => {
           );
         });
         return (
-          <tr key={index}>
+          <tr style={{ whiteSpace: 'pre' }} key={index}>
             <td>
               <SeriesName labels={s.metric} format={doFormat} />
             </td>

--- a/web/ui/react-app/src/pages/graph/DataTable.tsx
+++ b/web/ui/react-app/src/pages/graph/DataTable.tsx
@@ -5,6 +5,8 @@ import { Alert, Table } from 'reactstrap';
 import SeriesName from './SeriesName';
 import { Metric } from '../../types/types';
 
+import moment from 'moment';
+
 export interface QueryResult {
   data:
     | null
@@ -24,6 +26,7 @@ export interface QueryResult {
         resultType: 'string';
         result: string;
       };
+  useLocalTime: boolean;
 }
 
 interface InstantSample {
@@ -47,7 +50,7 @@ const limitSeries = <S extends InstantSample | RangeSamples>(series: S[]): S[] =
   return series;
 };
 
-const DataTable: FC<QueryResult> = ({ data }) => {
+const DataTable: FC<QueryResult> = ({ data, useLocalTime }) => {
   if (data === null) {
     return <Alert color="light">No data queried yet</Alert>;
   }
@@ -77,9 +80,10 @@ const DataTable: FC<QueryResult> = ({ data }) => {
     case 'matrix':
       rows = (limitSeries(data.result) as RangeSamples[]).map((s, index) => {
         const valuesAndTimes = s.values.map((v) => {
+          const printedDatetime = moment.unix(v[0]).toISOString(useLocalTime);
           return (
             <React.Fragment>
-              {v[1]} @{<span title={new Date(1000 * v[0]).toISOString()}>{v[0]}</span>}
+              {v[1]} @{<span title={printedDatetime}>{v[0]}</span>}
               <br />
             </React.Fragment>
           );

--- a/web/ui/react-app/src/pages/graph/DataTable.tsx
+++ b/web/ui/react-app/src/pages/graph/DataTable.tsx
@@ -76,17 +76,20 @@ const DataTable: FC<QueryResult> = ({ data }) => {
       break;
     case 'matrix':
       rows = (limitSeries(data.result) as RangeSamples[]).map((s, index) => {
-        const valueText = s.values
-          .map((v) => {
-            return v[1] + ' @' + v[0];
-          })
-          .join('\n');
+        const valuesAndTimes = s.values.map((v) => {
+          return (
+            <React.Fragment>
+              {v[1]} @{<span title={new Date(1000 * v[0]).toISOString()}>{v[0]}</span>}
+              <br />
+            </React.Fragment>
+          );
+        });
         return (
-          <tr style={{ whiteSpace: 'pre' }} key={index}>
+          <tr key={index}>
             <td>
               <SeriesName labels={s.metric} format={doFormat} />
             </td>
-            <td>{valueText}</td>
+            <td>{valuesAndTimes}</td>
           </tr>
         );
       });

--- a/web/ui/react-app/src/pages/graph/Panel.tsx
+++ b/web/ui/react-app/src/pages/graph/Panel.tsx
@@ -325,7 +325,7 @@ class Panel extends Component<PanelProps, PanelState> {
                         onChangeTime={this.handleChangeEndTime}
                       />
                     </div>
-                    <DataTable data={this.state.data} />
+                    <DataTable data={this.state.data} useLocalTime={this.props.useLocalTime} />
                   </>
                 )}
               </TabPane>


### PR DESCRIPTION
I find unix times in the UI quite hard to read, so I'm proposing adding a tooltip with an ISO string.

- Changed the layout logic a tiny bit (newlines -> `<br>`, because I now have React Fragments instead of plain textNodes)
- Formatted with Prettier
- Built and tested locally (Chrome, Firefox, Safari, all on macOS, though the HTML used is very basic)
- I have no prior React experience, so apologies if I misused some concepts
- Can create an issue/proposal if needed

cc @juliusv 

Signed-off-by: Ondrej Kokes <ondrej.kokes@gmail.com>

![Screenshot 2022-03-01 at 12 25 32](https://user-images.githubusercontent.com/8451755/156162032-15adf31d-5ddf-4031-ae7e-ffcb071aaee9.jpg)

