### PR TITLE
Use sync.Mutex for chunk write queue locks

### DIFF
--- a/tsdb/chunks/chunk_write_queue.go
+++ b/tsdb/chunks/chunk_write_queue.go
@@ -38,7 +38,7 @@ type chunkWriteJob struct {
 type chunkWriteQueue struct {
 	jobs chan chunkWriteJob
 
-	chunkRefMapMtx sync.RWMutex
+	chunkRefMapMtx sync.Mutex
 	chunkRefMap    map[ChunkDiskMapperRef]chunkenc.Chunk
 
 	isRunningMtx sync.Mutex // Protects the isRunning property.
@@ -138,8 +138,8 @@ func (c *chunkWriteQueue) addJob(job chunkWriteJob) (err error) {
 }
 
 func (c *chunkWriteQueue) get(ref ChunkDiskMapperRef) chunkenc.Chunk {
-	c.chunkRefMapMtx.RLock()
-	defer c.chunkRefMapMtx.RUnlock()
+	c.chunkRefMapMtx.Lock()
+	defer c.chunkRefMapMtx.Unlock()
 
 	chk, ok := c.chunkRefMap[ref]
 	if ok {


### PR DESCRIPTION
sync.RWMutex seem to be starving get operations when there's a lot of write operations because AFAIK it's a write preferring lock.
During compaction or other operation that end up issuing a lot of chunk writes this lock can starve reads and cause a visible delay for rule evaluation.
Switch to sync.Mutex so that all operations are equal and reads have a better chance of being serviced in time.

Fixes #10377

Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
