### PR TITLE
[WIP] Reduce lock contention in chunk write queue

### DIFF
--- a/tsdb/chunks/chunk_write_queue.go
+++ b/tsdb/chunks/chunk_write_queue.go
@@ -32,7 +32,7 @@ type chunkWriteJob struct {
 	callback  func(error)
 }
 
-const chunkRefMapShards = 1024
+const chunkRefMapShards = 16384
 
 // chunkWriteQueue is a queue for writing chunks to disk in a non-blocking fashion.
 // Chunks that shall be written get added to the queue, which is consumed asynchronously.

--- a/tsdb/chunks/chunk_write_queue_test.go
+++ b/tsdb/chunks/chunk_write_queue_test.go
@@ -43,14 +43,16 @@ func TestChunkWriteQueue_GettingChunkFromQueue(t *testing.T) {
 
 	testChunk := chunkenc.NewXORChunk()
 	var ref ChunkDiskMapperRef
+	var seriesRef HeadSeriesRef
 	job := chunkWriteJob{
-		chk: testChunk,
-		ref: ref,
+		chk:       testChunk,
+		ref:       ref,
+		seriesRef: seriesRef,
 	}
 	require.NoError(t, q.addJob(job))
 
 	// Retrieve chunk from the queue.
-	gotChunk := q.get(ref, 0)
+	gotChunk := q.get(ref, seriesRef)
 	require.Equal(t, testChunk, gotChunk)
 }
 
@@ -243,7 +245,7 @@ func BenchmarkChunkWriteQueue_addJob(b *testing.B) {
 					go func() {
 						for range issueReadSignal {
 							// We don't care about the ID we're getting, we just want to grab the lock.
-							_ = q.get(ChunkDiskMapperRef(0), 0)
+							_ = q.get(ChunkDiskMapperRef(0), HeadSeriesRef(0))
 						}
 					}()
 

--- a/tsdb/chunks/chunk_write_queue_test.go
+++ b/tsdb/chunks/chunk_write_queue_test.go
@@ -50,7 +50,7 @@ func TestChunkWriteQueue_GettingChunkFromQueue(t *testing.T) {
 	require.NoError(t, q.addJob(job))
 
 	// Retrieve chunk from the queue.
-	gotChunk := q.get(ref)
+	gotChunk := q.get(ref, 0)
 	require.Equal(t, testChunk, gotChunk)
 }
 
@@ -243,7 +243,7 @@ func BenchmarkChunkWriteQueue_addJob(b *testing.B) {
 					go func() {
 						for range issueReadSignal {
 							// We don't care about the ID we're getting, we just want to grab the lock.
-							_ = q.get(ChunkDiskMapperRef(0))
+							_ = q.get(ChunkDiskMapperRef(0), 0)
 						}
 					}()
 
@@ -364,7 +364,7 @@ func benchmarkChunkWriteQueue_lockContentionOnChunkRefMap(b *testing.B, readConc
 
 			for jobID := startPos; jobID < startPos+concurrencyAdjustedBN; jobID++ {
 				jobIDWrapped := jobID % queueSize
-				q.get(ChunkDiskMapperRef(jobIDWrapped))
+				q.get(ChunkDiskMapperRef(jobIDWrapped), HeadSeriesRef(jobIDWrapped))
 			}
 		}(readerID)
 	}

--- a/tsdb/chunks/chunk_write_queue_test.go
+++ b/tsdb/chunks/chunk_write_queue_test.go
@@ -269,100 +269,117 @@ func BenchmarkChunkWriteQueue_addJob(b *testing.B) {
 }
 
 func BenchmarkChunkWriteQueue_lockContentionOnChunkRefMap(b *testing.B) {
-	for _, concurrency := range []int{1, 10, 100} {
-		b.Run(fmt.Sprintf("read concurrency %d", concurrency), func(b *testing.B) {
-			for _, queueSize := range []int{1000, 1000000} {
-				b.Run(fmt.Sprintf("with queueSize %d", queueSize), func(b *testing.B) {
-					writeBlocker := make(chan struct{})
-					shutdown := make(chan struct{})
-					var writeCount uint64
+	readConcurrencies := []int{10, 100}
+	writeConcurrencies := []int{100, 1000}
+	queueSizes := []int{1000, 1000000}
 
-					q := newChunkWriteQueue(nil, queueSize, func(ref HeadSeriesRef, i, i2 int64, chunk chunkenc.Chunk, ref2 ChunkDiskMapperRef, b bool) error {
-						select {
-						// The blocking of writes is controlled by the writeBlocker chan.
-						case writeBlocker <- struct{}{}:
-							writeCount++
-						case <-shutdown:
-						}
-						return nil
-					})
-
-					jobs := make([]chunkWriteJob, queueSize)
-					for jobID := range jobs {
-						jobs[jobID] = chunkWriteJob{
-							seriesRef: HeadSeriesRef(jobID),
-							ref:       ChunkDiskMapperRef(jobID),
-						}
-
-						// Fill chunk write queue while the writeChunk callback is blocked.
-						q.addJob(jobs[jobID])
+	for _, readConcurrency := range readConcurrencies {
+		b.Run(fmt.Sprintf("read concurrency %d", readConcurrency), func(b *testing.B) {
+			for _, writeConcurrency := range writeConcurrencies {
+				b.Run(fmt.Sprintf("write concurrency %d", writeConcurrency), func(b *testing.B) {
+					for _, queueSize := range queueSizes {
+						b.Run(fmt.Sprintf("with queueSize %d", queueSize), func(b *testing.B) {
+							benchmarkChunkWriteQueue_lockContentionOnChunkRefMap(b, readConcurrency, writeConcurrency, queueSize)
+						})
 					}
-
-					var writerDoneWg, writerReadyWg sync.WaitGroup
-					writerDoneWg.Add(1)
-					writerReadyWg.Add(1)
-					go func() {
-						defer writerDoneWg.Done()
-						writerReadyWg.Done()
-
-						jobID := 0
-						for {
-							select {
-							// Allow one successful write.
-							case <-writeBlocker:
-							case <-shutdown:
-								return
-							}
-
-							err := q.addJob(jobs[jobID])
-							require.NoError(b, err)
-
-							jobID = (jobID + 1) % queueSize
-						}
-					}()
-
-					b.Cleanup(func() {
-						close(shutdown)
-						writerDoneWg.Wait()
-						b.Cleanup(q.stop)
-					})
-
-					var readersReadyWg, readersDoneWg sync.WaitGroup
-					readersReadyWg.Add(concurrency)
-					readersDoneWg.Add(concurrency)
-
-					startBenchmark := make(chan struct{})
-
-					for i := 0; i < concurrency; i++ {
-						go func() {
-							defer readersDoneWg.Done()
-							readersReadyWg.Done()
-
-							concurrencyAdjustedBN := b.N / concurrency
-							<-startBenchmark
-
-							for i := 0; i < concurrencyAdjustedBN; i++ {
-								jobID := i % queueSize
-								q.get(ChunkDiskMapperRef(jobID))
-							}
-						}()
-					}
-
-					// Wait until the writer and all reader routines are ready.
-					writerReadyWg.Wait()
-					readersReadyWg.Wait()
-
-					b.ResetTimer()
-
-					// Signal all reader routines to start the benchmark.
-					close(startBenchmark)
-
-					// Wait until all reader routines are done.
-					readersDoneWg.Wait()
-
-					b.Logf("Performed %d writes", writeCount)
 				})
 			}
 		})
 	}
+}
+
+func benchmarkChunkWriteQueue_lockContentionOnChunkRefMap(b *testing.B, readConcurrency, writeConcurrency, queueSize int) {
+	writeBlocker := make(chan struct{})
+	shutdown := make(chan struct{})
+	var writeCount uint64
+
+	q := newChunkWriteQueue(nil, queueSize, func(_ HeadSeriesRef, _, _ int64, _ chunkenc.Chunk, _ ChunkDiskMapperRef, _ bool) error {
+		select {
+		// The blocking of writes is controlled by the writeBlocker chan.
+		case writeBlocker <- struct{}{}:
+			writeCount++
+		case <-shutdown:
+		}
+		return nil
+	})
+
+	jobs := make([]chunkWriteJob, queueSize)
+	for jobID := range jobs {
+		jobs[jobID] = chunkWriteJob{
+			seriesRef: HeadSeriesRef(jobID),
+			ref:       ChunkDiskMapperRef(jobID),
+		}
+
+		// Fill chunk write queue while the writeChunk callback is blocked.
+		q.addJob(jobs[jobID])
+	}
+
+	var writersDoneWg, writersReadyWg sync.WaitGroup
+	writersDoneWg.Add(writeConcurrency)
+	writersReadyWg.Add(writeConcurrency)
+	var writerJobID atomic.Int32
+	for writerID := 0; writerID < writeConcurrency; writerID++ {
+		go func() {
+			defer writersDoneWg.Done()
+			writersReadyWg.Done()
+
+			for {
+				select {
+				// Allow one successful write.
+				case <-writeBlocker:
+				case <-shutdown:
+					return
+				}
+
+				jobID := int(writerJobID.Inc()) % queueSize
+				err := q.addJob(jobs[jobID])
+				require.NoError(b, err)
+			}
+		}()
+	}
+
+	b.Cleanup(func() {
+		close(shutdown)
+		writersDoneWg.Wait()
+		b.Cleanup(q.stop)
+	})
+
+	startBenchmark := make(chan struct{})
+
+	var readersReadyWg, readersDoneWg sync.WaitGroup
+	readersReadyWg.Add(readConcurrency)
+	readersDoneWg.Add(readConcurrency)
+
+	for readerID := 0; readerID < readConcurrency; readerID++ {
+		go func(readerID int) {
+			defer readersDoneWg.Done()
+			readersReadyWg.Done()
+
+			concurrencyAdjustedBN := b.N / readConcurrency
+
+			// Evenly distribute the start positions over the range from 0 to queueSize.
+			startPos := queueSize / readConcurrency * readerID
+
+			<-startBenchmark
+
+			for jobID := startPos; jobID < startPos+concurrencyAdjustedBN; jobID++ {
+				jobIDWrapped := jobID % queueSize
+				q.get(ChunkDiskMapperRef(jobIDWrapped))
+			}
+		}(readerID)
+	}
+
+	// Wait until the writer and all reader routines are ready.
+	writersReadyWg.Wait()
+	readersReadyWg.Wait()
+
+	b.ResetTimer()
+
+	// Signal all reader routines to start the benchmark.
+	close(startBenchmark)
+
+	// Wait until all reader routines are done.
+	readersDoneWg.Wait()
+
+	b.Logf("Performed %d writes", writeCount)
 }

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -602,7 +602,7 @@ func (cdm *ChunkDiskMapper) Chunk(ref ChunkDiskMapperRef) (chunkenc.Chunk, error
 		return nil, ErrChunkDiskMapperClosed
 	}
 
-	chunk := cdm.writeQueue.get(ref)
+	chunk := cdm.writeQueue.get(ref, 0)
 	if chunk != nil {
 		return chunk, nil
 	}

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -591,7 +591,7 @@ func (cdm *ChunkDiskMapper) flushBuffer() error {
 }
 
 // Chunk returns a chunk from a given reference.
-func (cdm *ChunkDiskMapper) Chunk(ref ChunkDiskMapperRef) (chunkenc.Chunk, error) {
+func (cdm *ChunkDiskMapper) Chunk(ref ChunkDiskMapperRef, seriesRef HeadSeriesRef) (chunkenc.Chunk, error) {
 	cdm.readPathMtx.RLock()
 	// We hold this read lock for the entire duration because if Close()
 	// is called, the data in the byte slice will get corrupted as the mmapped
@@ -602,7 +602,7 @@ func (cdm *ChunkDiskMapper) Chunk(ref ChunkDiskMapperRef) (chunkenc.Chunk, error
 		return nil, ErrChunkDiskMapperClosed
 	}
 
-	chunk := cdm.writeQueue.get(ref, 0)
+	chunk := cdm.writeQueue.get(ref, seriesRef)
 	if chunk != nil {
 		return chunk, nil
 	}

--- a/tsdb/chunks/head_chunks_test.go
+++ b/tsdb/chunks/head_chunks_test.go
@@ -121,7 +121,7 @@ func TestChunkDiskMapper_WriteChunk_Chunk_IterateChunks(t *testing.T) {
 
 	// Testing reading of chunks.
 	for _, exp := range expectedData {
-		actChunk, err := hrw.Chunk(exp.chunkRef)
+		actChunk, err := hrw.Chunk(exp.chunkRef, exp.seriesRef)
 		require.NoError(t, err)
 		require.Equal(t, exp.chunk.Bytes(), actChunk.Bytes())
 	}
@@ -142,7 +142,7 @@ func TestChunkDiskMapper_WriteChunk_Chunk_IterateChunks(t *testing.T) {
 		require.Equal(t, expData.maxt, maxt)
 		require.Equal(t, expData.numSamples, numSamples)
 
-		actChunk, err := hrw.Chunk(expData.chunkRef)
+		actChunk, err := hrw.Chunk(expData.chunkRef, expData.seriesRef)
 		require.NoError(t, err)
 		require.Equal(t, expData.chunk.Bytes(), actChunk.Bytes())
 

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -314,7 +314,7 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 		}
 		return s.headChunk, false, nil
 	}
-	chk, err := chunkDiskMapper.Chunk(s.mmappedChunks[ix].ref)
+	chk, err := chunkDiskMapper.Chunk(s.mmappedChunks[ix].ref, s.ref)
 	if err != nil {
 		if _, ok := err.(*chunks.CorruptionErr); ok {
 			panic(err)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1302,7 +1302,7 @@ func TestMemSeries_append(t *testing.T) {
 
 	// All chunks but the first and last should now be moderately full.
 	for i, c := range s.mmappedChunks[1:] {
-		chk, err := chunkDiskMapper.Chunk(c.ref)
+		chk, err := chunkDiskMapper.Chunk(c.ref, s.ref)
 		require.NoError(t, err)
 		require.Greater(t, chk.NumSamples(), 100, "unexpected small chunk %d of length %d", i, chk.NumSamples())
 	}


### PR DESCRIPTION
This is a prototype where I wanted to test whether we could reduce the lock contention on `chunkWriteQueue.chunkRefMapMtx` by sharding the map which it protects. In this prototype I divided it into `1024`, which is an arbitrary number and likely subject to change.

The first commit adds a benchmark which tries to measure the read performance while constantly writing through the queue.
The second commit implements the sharding of the `chunkRefMapMtx`.

This is the benchstat comparison of the benchmark results with/without the second commit:
```
ChunkWriteQueue_lockContentionOnChunkRefMap/read_concurrency_1/with_queueSize_1000-4         1.17µs ± 0%    0.05µs ± 0%  -95.59%
ChunkWriteQueue_lockContentionOnChunkRefMap/read_concurrency_1/with_queueSize_1000000-4      2.22µs ± 0%    0.22µs ± 0%  -90.08%
ChunkWriteQueue_lockContentionOnChunkRefMap/read_concurrency_10/with_queueSize_1000-4         139ns ± 0%      21ns ± 0%  -84.55%
ChunkWriteQueue_lockContentionOnChunkRefMap/read_concurrency_10/with_queueSize_1000000-4      271ns ± 0%      60ns ± 0%  -77.70%
ChunkWriteQueue_lockContentionOnChunkRefMap/read_concurrency_100/with_queueSize_1000-4        112ns ± 0%      19ns ± 0%  -82.64%
ChunkWriteQueue_lockContentionOnChunkRefMap/read_concurrency_100/with_queueSize_1000000-4     142ns ± 0%      58ns ± 0%  -59.02%
```

TBH this looks a bit too good to be true, @codesome if you get a chance it would be great if you could also take a look at these changes to check if they make sense.

Related: https://github.com/prometheus/prometheus/issues/10377