### PR TITLE
Run gofumpt on all files

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.0
+          version: v1.44.2

--- a/Makefile.common
+++ b/Makefile.common
@@ -83,7 +83,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.42.0
+GOLANGCI_LINT_VERSION ?= v1.44.2
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))

--- a/cmd/promtool/rules.go
+++ b/cmd/promtool/rules.go
@@ -95,7 +95,8 @@ func (importer *ruleImporter) importAll(ctx context.Context) (errs []error) {
 
 // importRule queries a prometheus API to evaluate rules at times in the past.
 func (importer *ruleImporter) importRule(ctx context.Context, ruleExpr, ruleName string, ruleLabels labels.Labels, start, end time.Time,
-	maxBlockDuration int64, grp *rules.Group) (err error) {
+	maxBlockDuration int64, grp *rules.Group,
+) (err error) {
 	blockDuration := getCompatibleBlockDuration(maxBlockDuration)
 	startInMs := start.Unix() * int64(time.Second/time.Millisecond)
 	endInMs := end.Unix() * int64(time.Second/time.Millisecond)

--- a/discovery/openstack/hypervisor.go
+++ b/discovery/openstack/hypervisor.go
@@ -50,7 +50,8 @@ type HypervisorDiscovery struct {
 
 // newHypervisorDiscovery returns a new hypervisor discovery.
 func newHypervisorDiscovery(provider *gophercloud.ProviderClient, opts *gophercloud.AuthOptions,
-	port int, region string, availability gophercloud.Availability, l log.Logger) *HypervisorDiscovery {
+	port int, region string, availability gophercloud.Availability, l log.Logger,
+) *HypervisorDiscovery {
 	return &HypervisorDiscovery{
 		provider: provider, authOpts: opts,
 		region: region, port: port, availability: availability, logger: l,

--- a/discovery/openstack/instance.go
+++ b/discovery/openstack/instance.go
@@ -59,7 +59,8 @@ type InstanceDiscovery struct {
 
 // NewInstanceDiscovery returns a new instance discovery.
 func newInstanceDiscovery(provider *gophercloud.ProviderClient, opts *gophercloud.AuthOptions,
-	port int, region string, allTenants bool, availability gophercloud.Availability, l log.Logger) *InstanceDiscovery {
+	port int, region string, allTenants bool, availability gophercloud.Availability, l log.Logger,
+) *InstanceDiscovery {
 	if l == nil {
 		l = log.NewNopLogger()
 	}

--- a/discovery/targetgroup/targetgroup_test.go
+++ b/discovery/targetgroup/targetgroup_test.go
@@ -176,21 +176,19 @@ func TestTargetGroupYamlUnmarshal(t *testing.T) {
 
 func TestString(t *testing.T) {
 	// String() should return only the source, regardless of other attributes.
-	group1 :=
-		Group{
-			Targets: []model.LabelSet{
-				{"__address__": "localhost:9090"},
-				{"__address__": "localhost:9091"},
-			},
-			Source: "<source>",
-			Labels: model.LabelSet{"foo": "bar", "bar": "baz"},
-		}
-	group2 :=
-		Group{
-			Targets: []model.LabelSet{},
-			Source:  "<source>",
-			Labels:  model.LabelSet{},
-		}
+	group1 := Group{
+		Targets: []model.LabelSet{
+			{"__address__": "localhost:9090"},
+			{"__address__": "localhost:9091"},
+		},
+		Source: "<source>",
+		Labels: model.LabelSet{"foo": "bar", "bar": "baz"},
+	}
+	group2 := Group{
+		Targets: []model.LabelSet{},
+		Source:  "<source>",
+		Labels:  model.LabelSet{},
+	}
 	require.Equal(t, "<source>", group1.String())
 	require.Equal(t, "<source>", group2.String())
 	require.Equal(t, group1.String(), group2.String())

--- a/documentation/examples/custom-sd/adapter/adapter.go
+++ b/documentation/examples/custom-sd/adapter/adapter.go
@@ -84,7 +84,6 @@ func generateTargetGroups(allTargetGroups map[string][]*targetgroup.Group) map[s
 			}
 
 			sdGroup := customSD{
-
 				Targets: newTargets,
 				Labels:  newLabels,
 			}

--- a/promql/parser/lex_test.go
+++ b/promql/parser/lex_test.go
@@ -611,7 +611,6 @@ var tests = []struct {
 			{ // Nested Subquery.
 				input: `min_over_time(rate(foo{bar="baz"}[2s])[5m:])[4m:3s]`,
 				expected: []Item{
-
 					{IDENTIFIER, 0, `min_over_time`},
 					{LEFT_PAREN, 13, `(`},
 					{IDENTIFIER, 14, `rate`},
@@ -660,7 +659,6 @@ var tests = []struct {
 			{
 				input: `min_over_time(rate(foo{bar="baz"}[2s])[5m:] offset 6m)[4m:3s]`,
 				expected: []Item{
-
 					{IDENTIFIER, 0, `min_over_time`},
 					{LEFT_PAREN, 13, `(`},
 					{IDENTIFIER, 14, `rate`},

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -191,7 +191,6 @@ type Appender interface {
 	// Rollback rolls back all modifications made in the appender so far.
 	// Appender has to be discarded after rollback.
 	Rollback() error
-
 	ExemplarAppender
 }
 

--- a/tsdb/wal/checkpoint_test.go
+++ b/tsdb/wal/checkpoint_test.go
@@ -252,7 +252,7 @@ func TestCheckpointNoTmpFolderAfterError(t *testing.T) {
 	// Walk the wal dir to make sure there are no tmp folder left behind after the error.
 	err = filepath.Walk(w.Dir(), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.Wrapf(err, "access err %q: %v\n", path, err)
+			return errors.Wrapf(err, "access err %q: %v", path, err)
 		}
 		if info.IsDir() && strings.HasSuffix(info.Name(), ".tmp") {
 			return fmt.Errorf("wal dir contains temporary folder:%s", info.Name())

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -50,7 +50,6 @@ type WriteTo interface {
 	// Once returned, the WAL Watcher will not attempt to pass that data again.
 	Append([]record.RefSample) bool
 	AppendExemplars([]record.RefExemplar) bool
-
 	StoreSeries([]record.RefSeries, int)
 
 	// Next two methods are intended for garbage-collection: first we call

--- a/util/runtime/statfs_linux_386.go
+++ b/util/runtime/statfs_linux_386.go
@@ -23,7 +23,6 @@ import (
 
 // Statfs returns the file system type (Unix only)
 func Statfs(path string) string {
-
 	// Types of file systems that may be returned by `statfs`
 	fsTypes := map[int32]string{
 		0xadf5:     "ADFS_SUPER_MAGIC",

--- a/util/runtime/statfs_uint32.go
+++ b/util/runtime/statfs_uint32.go
@@ -23,7 +23,6 @@ import (
 
 // Statfs returns the file system type (Unix only)
 func Statfs(path string) string {
-
 	// Types of file systems that may be returned by `statfs`
 	fsTypes := map[uint32]string{
 		0xadf5:     "ADFS_SUPER_MAGIC",

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -150,7 +150,6 @@ type TSDBAdminStats interface {
 	CleanTombstones() error
 	Delete(mint, maxt int64, ms ...*labels.Matcher) error
 	Snapshot(dir string, withHead bool) error
-
 	Stats(statsByLabelName string) (*tsdb.Stats, error)
 	WALReplayStatus() (tsdb.WALReplayStatus, error)
 }


### PR DESCRIPTION
Getting golangci-lint errors when building on my laptop, possibly because I have newer version of gofumpt then what it was formatted with.
Run gofumpt -w -extra on all files as it will be needed in the future anyway.

Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
