### PR TITLE
Set CI=true when running UI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ui-build-module:
 
 .PHONY: ui-test
 ui-test:
-	cd $(UI_PATH) && npm run test:coverage
+	cd $(UI_PATH) && CI=true npm run test:coverage
 
 .PHONY: ui-lint
 ui-lint:


### PR DESCRIPTION
At the moment when I run make to build Prometheus npm tests are run as part of the process.
By default jest will run in interactive mode, unless CI env variable is set, meaning that it will run forever watching for file changes. This means that to build the binary I need to wait for jest to start and then press Q to exit it, which seems unnecessary.
Set CI=true for npm scripts so it always run in as a single run instead of watch mode.

Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
