### PR TITLE
scrape: Update error message for label limits

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -619,7 +619,7 @@ func verifyLabelLimits(lset labels.Labels, limits *labelLimits) error {
 	if limits.labelLimit > 0 {
 		nbLabels := len(lset)
 		if nbLabels > int(limits.labelLimit) {
-			return fmt.Errorf("label_limit exceeded (metric: %.50s, number of label: %d, limit: %d)", met, nbLabels, limits.labelLimit)
+			return fmt.Errorf("label_limit exceeded (metric: %.50s, number of labels: %d, limit: %d)", met, nbLabels, limits.labelLimit)
 		}
 	}
 
@@ -631,14 +631,14 @@ func verifyLabelLimits(lset labels.Labels, limits *labelLimits) error {
 		if limits.labelNameLengthLimit > 0 {
 			nameLength := len(l.Name)
 			if nameLength > int(limits.labelNameLengthLimit) {
-				return fmt.Errorf("label_name_length_limit exceeded (metric: %.50s, label: %.50v, name length: %d, limit: %d)", met, l, nameLength, limits.labelNameLengthLimit)
+				return fmt.Errorf("label_name_length_limit exceeded (metric: %.50s, label name: %.50s, length: %d, limit: %d)", met, l.Name, nameLength, limits.labelNameLengthLimit)
 			}
 		}
 
 		if limits.labelValueLengthLimit > 0 {
 			valueLength := len(l.Value)
 			if valueLength > int(limits.labelValueLengthLimit) {
-				return fmt.Errorf("label_value_length_limit exceeded (metric: %.50s, label: %.50v, value length: %d, limit: %d)", met, l, valueLength, limits.labelValueLengthLimit)
+				return fmt.Errorf("label_value_length_limit exceeded (metric: %.50s, label name: %.50s, value: %.50q, length: %d, limit: %d)", met, l.Name, l.Value, valueLength, limits.labelValueLengthLimit)
 			}
 		}
 	}


### PR DESCRIPTION
scrape: Update error message for label limits to make it more readable

Signed-off-by: Jayapriya Pai <janantha@redhat.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

How the error message looks before and after change

before 
```
label_limit exceeded (metric: go_gc_cycles_automatic_gc_cycles_total, number of label: 3, limit: 1)
```

after
```
label_limit exceeded (metric: go_gc_cycles_automatic_gc_cycles_total, number of labels: 3, limit: 1)
```

before
```
label_name_length_limit exceeded (metric: go_gc_cycles_automatic_gc_cycles_total, label: {__name__ go_gc_cycles_automatic_gc_cycles_total}, name length: 8, limit: 5
```
after

```
label_name_length_limit exceeded (metric: go_gc_cycles_automatic_gc_cycles_total, label: __name__, name length: 8, limit: 5)
```

before

```
label_value_length_limit exceeded (metric: go_gc_cycles_automatic_gc_cycles_total, label: {__name__ go_gc_cycles_automatic_gc_cycles_total}, value length: 38, limit: 15)
```

after

```
label_value_length_limit exceeded (metric: go_gc_cycles_automatic_gc_cycles_total, label: __name__, value: go_gc_cycles_automatic_gc_cycles_total, value length: 38, limit: 15)
```