### PR TITLE
fix head chunks write queue size

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -586,7 +586,7 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64) {
 	if opts.HeadChunksWriteBufferSize <= 0 {
 		opts.HeadChunksWriteBufferSize = chunks.DefaultWriteBufferSize
 	}
-	if opts.HeadChunksWriteQueueSize < 0 {
+	if opts.HeadChunksWriteQueueSize <= 0 {
 		opts.HeadChunksWriteQueueSize = chunks.DefaultWriteQueueSize
 	}
 	if opts.MaxBlockChunkSegmentSize <= 0 {


### PR DESCRIPTION
Without this change the chunk write queue size will always be set to `0`, leading to bad performance because this means that essentially there is no queue while there are additional mutexes and synchronization between go routines in the write path.