### PR TITLE
Compare equality of label.Label structs directly

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -307,7 +307,7 @@ func Equal(ls, o Labels) bool {
 		return false
 	}
 	for i, l := range ls {
-		if l.Name != o[i].Name || l.Value != o[i].Value {
+		if l != o[i] {
 			return false
 		}
 	}

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -593,18 +593,18 @@ func BenchmarkLabels_Equals(b *testing.B) {
 	}{
 		{
 			"equal",
-			Labels{{"aaa", "111"}, {"bbb", "222"}},
-			Labels{{"aaa", "111"}, {"bbb", "222"}},
+			Labels{{"a_label_name", "a_label_value"}, {"another_label_name", "another_label_value"}},
+			Labels{{"a_label_name", "a_label_value"}, {"another_label_name", "another_label_value"}},
 		},
 		{
 			"not equal",
-			Labels{{"aaa", "111"}, {"bbb", "222"}},
-			Labels{{"aaa", "111"}, {"bbb", "333"}},
+			Labels{{"a_label_name", "a_label_value"}, {"another_label_name", "another_label_value"}},
+			Labels{{"a_label_name", "a_label_value"}, {"another_label_name", "a_different_label_value"}},
 		},
 		{
 			"different sizes",
-			Labels{{"aaa", "111"}, {"bbb", "222"}},
-			Labels{{"aaa", "111"}},
+			Labels{{"a_label_name", "a_label_value"}, {"another_label_name", "another_label_value"}},
+			Labels{{"a_label_name", "a_label_value"}},
 		},
 	} {
 		b.Run(scenario.desc, func(b *testing.B) {

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -586,6 +586,36 @@ func BenchmarkLabels_Get(b *testing.B) {
 	}
 }
 
+func BenchmarkLabels_Equals(b *testing.B) {
+	for _, scenario := range []struct {
+		desc        string
+		base, other Labels
+	}{
+		{
+			"equal",
+			Labels{{"aaa", "111"}, {"bbb", "222"}},
+			Labels{{"aaa", "111"}, {"bbb", "222"}},
+		},
+		{
+			"not equal",
+			Labels{{"aaa", "111"}, {"bbb", "222"}},
+			Labels{{"aaa", "111"}, {"bbb", "333"}},
+		},
+		{
+			"different sizes",
+			Labels{{"aaa", "111"}, {"bbb", "222"}},
+			Labels{{"aaa", "111"}},
+		},
+	} {
+		b.Run(scenario.desc, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = Equal(scenario.base, scenario.other)
+			}
+		})
+	}
+}
+
 func TestLabels_Copy(t *testing.T) {
 	require.Equal(t, Labels{{"aaa", "111"}, {"bbb", "222"}}, Labels{{"aaa", "111"}, {"bbb", "222"}}.Copy())
 }


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

Compare the structs using `==` instead of the name and value of each label. This is functionally equivalent and about ~10% faster in my testing.

The go spec says that using `==` for structs is valid as long as each field is comparable which they are in this case since `Name` and `Value` are strings: https://go.dev/ref/spec#Comparison_operators
    
The numbers here are very small (nano-seconds) but in Cortex Ingesters, `labels.Equal` is about 7% of CPU time.

The following commands can be run to verify the benchmark results:

Previous version:
```
git checkout 5183c96b23f926314e78a3922fdddfc74a6562e4 && go test -cpu 1 -count=10 -run=XXX -benchmem -bench=BenchmarkLabels_Equals ./model/labels | tee old.txt
```

New version:
```
git checkout 884feec8750d23940acd5be98800444239b30b0b && go test -cpu 1 -count=10 -run=XXX -benchmem -bench=BenchmarkLabels_Equals ./model/labels | tee new.txt
```

Comparison:
```
benchstat old.txt new.txt 
name                           old time/op    new time/op    delta
Labels_Equals/equal              10.4ns ± 1%     9.2ns ± 5%  -11.93%  (p=0.000 n=9+10)
Labels_Equals/not_equal          12.4ns ± 1%    10.0ns ± 1%  -19.38%  (p=0.000 n=8+8)
Labels_Equals/different_sizes    2.28ns ± 1%    2.29ns ± 2%     ~     (p=0.141 n=9+9)

name                           old alloc/op   new alloc/op   delta
Labels_Equals/equal               0.00B          0.00B          ~     (all equal)
Labels_Equals/not_equal           0.00B          0.00B          ~     (all equal)
Labels_Equals/different_sizes     0.00B          0.00B          ~     (all equal)

name                           old allocs/op  new allocs/op  delta
Labels_Equals/equal                0.00           0.00          ~     (all equal)
Labels_Equals/not_equal            0.00           0.00          ~     (all equal)
Labels_Equals/different_sizes      0.00           0.00          ~     (all equal)
```


<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
