### PR TITLE
fix: test commands should run only project related tests

### DIFF
--- a/web/ui/module/codemirror-promql/package.json
+++ b/web/ui/module/codemirror-promql/package.json
@@ -8,8 +8,8 @@
     "build": "npm run build:grammar && npm run build:lib",
     "build:grammar": "npx lezer-generator src/grammar/promql.grammar -o src/grammar/parser",
     "build:lib": "bash ./build.sh",
-    "test": "npm run build:grammar && ts-mocha -p tsconfig.json ./**/*.test.ts",
-    "test:coverage": "npm run build:grammar && nyc ts-mocha -p ./tsconfig.json ./**/*.test.ts",
+    "test": "npm run build:grammar && ts-mocha -p tsconfig.json src/**/*.test.ts",
+    "test:coverage": "npm run build:grammar && nyc ts-mocha -p tsconfig.json src/**/*.test.ts",
     "codecov": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "lint": "eslint src/ --ext .ts",
     "lint:fix": "eslint --fix src/ --ext .ts"


### PR DESCRIPTION
test commands should run only tests related to the project and not `node_modules`

This should address: https://github.com/prometheus/codemirror-promql/pull/184

Signed-off-by: Gabriel Bernal <gbernal@redhat.com>
