### PR TITLE
export newCompleteStrategy to avoid client import errors

### DIFF
--- a/web/ui/module/codemirror-promql/src/index.ts
+++ b/web/ui/module/codemirror-promql/src/index.ts
@@ -12,6 +12,6 @@
 // limitations under the License.
 
 export { PrometheusClient } from './client';
-export { CompleteConfiguration, CompleteStrategy } from './complete';
+export { CompleteConfiguration, CompleteStrategy, newCompleteStrategy } from './complete';
 export { LintStrategy } from './lint';
 export { PromQLExtension, LanguageType, promQLLanguage } from './promql';


### PR DESCRIPTION
This will avoid library clients to choose manually between `cjs` or `esm` and play well with bundlers.

The issue was mentioned [here](https://github.com/prometheus/prometheus/pull/10396#issuecomment-1059774913)
