### PR TITLE
__param_<name> label description, in docs

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2415,7 +2415,9 @@ The `__address__` label is set to the `<host>:<port>` address of the target.
 After relabeling, the `instance` label is set to the value of `__address__` by default if
 it was not set during relabeling. The `__scheme__` and `__metrics_path__` labels
 are set to the scheme and metrics path of the target respectively. The `__param_<name>`
-label is set to the value of the first passed URL parameter called `<name>`.
+label is set to the value of the first passed URL parameter called `<name>`. 
+Additionally, the `__param_<name>` label may be configured, which will set a URL parameter
+called `<name>` in the outgoing scrape request.
 
 The `__scrape_interval__` and `__scrape_timeout__` labels are set to the target's
 interval and timeout. This is **experimental** and could change in the future.


### PR DESCRIPTION
Hi,

A brief explanation of this pull request, which is just making a small change in the docs.  Consider this text:  

```
 The `__param_<name>` label is set to the value of the first passed URL parameter called `<name>`.
```

If you parse the meaning of the sentence, it seems to be saying that you have a URL parameter called `<name>`, and `__param_<name>` _gets set_ to whatever that value is.  

The cause and effect are backwards. More likely it should be:
 
1. You proactively set `__param_<name>`  .   (not passive wording "is set".)
2. That, in turn, will cause a URL parameter to be set.

Signed-off-by: sdarwin <samuel.d.darwin@gmail.com>


<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
