### PR TITLE
Remote Write: Rename confusing `walDir` parameter to `dir`

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -374,7 +374,11 @@ type QueueManager struct {
 	highestRecvTimestamp *maxTimestamp
 }
 
-// NewQueueManager builds a new QueueManager.
+// NewQueueManager builds a new QueueManager and starts a new
+// WAL watcher with queue manager as the WriteTo destination.
+// The WAL watcher takes the dir parameter as the base directory
+// for where the WAL shall be located. Note that the full path to
+// the WAL directory will be constructed as <dir>/wal.
 func NewQueueManager(
 	metrics *queueManagerMetrics,
 	watcherMetrics *wal.WatcherMetrics,

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -380,7 +380,7 @@ func NewQueueManager(
 	watcherMetrics *wal.WatcherMetrics,
 	readerMetrics *wal.LiveReaderMetrics,
 	logger log.Logger,
-	walDir string,
+	dir string,
 	samplesIn *ewmaRate,
 	cfg config.QueueConfig,
 	mCfg config.MetadataConfig,
@@ -426,7 +426,7 @@ func NewQueueManager(
 		highestRecvTimestamp: highestRecvTimestamp,
 	}
 
-	t.watcher = wal.NewWatcher(watcherMetrics, readerMetrics, logger, client.Name(), t, walDir, enableExemplarRemoteWrite)
+	t.watcher = wal.NewWatcher(watcherMetrics, readerMetrics, logger, client.Name(), t, dir, enableExemplarRemoteWrite)
 	if t.mcfg.Send {
 		t.metadataWatcher = NewMetadataWatcher(logger, sm, client.Name(), t, t.mcfg.SendInterval, flushDeadline)
 	}

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -55,7 +55,7 @@ type WriteStorage struct {
 	watcherMetrics    *wal.WatcherMetrics
 	liveReaderMetrics *wal.LiveReaderMetrics
 	externalLabels    labels.Labels
-	walDir            string
+	dir               string
 	queues            map[string]*QueueManager
 	samplesIn         *ewmaRate
 	flushDeadline     time.Duration
@@ -68,7 +68,7 @@ type WriteStorage struct {
 }
 
 // NewWriteStorage creates and runs a WriteStorage.
-func NewWriteStorage(logger log.Logger, reg prometheus.Registerer, walDir string, flushDeadline time.Duration, sm ReadyScrapeManager) *WriteStorage {
+func NewWriteStorage(logger log.Logger, reg prometheus.Registerer, dir string, flushDeadline time.Duration, sm ReadyScrapeManager) *WriteStorage {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -80,7 +80,7 @@ func NewWriteStorage(logger log.Logger, reg prometheus.Registerer, walDir string
 		reg:               reg,
 		flushDeadline:     flushDeadline,
 		samplesIn:         newEWMARate(ewmaWeight, shardUpdateDuration),
-		walDir:            walDir,
+		dir:               dir,
 		interner:          newPool(),
 		scraper:           sm,
 		quit:              make(chan struct{}),
@@ -175,7 +175,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			rws.watcherMetrics,
 			rws.liveReaderMetrics,
 			rws.logger,
-			rws.walDir,
+			rws.dir,
 			rws.samplesIn,
 			rwConf.QueueConfig,
 			rwConf.MetadataConfig,

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -145,7 +145,7 @@ func NewWatcherMetrics(reg prometheus.Registerer) *WatcherMetrics {
 }
 
 // NewWatcher creates a new WAL watcher for a given WriteTo.
-func NewWatcher(metrics *WatcherMetrics, readerMetrics *LiveReaderMetrics, logger log.Logger, name string, writer WriteTo, walDir string, sendExemplars bool) *Watcher {
+func NewWatcher(metrics *WatcherMetrics, readerMetrics *LiveReaderMetrics, logger log.Logger, name string, writer WriteTo, dir string, sendExemplars bool) *Watcher {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -154,7 +154,7 @@ func NewWatcher(metrics *WatcherMetrics, readerMetrics *LiveReaderMetrics, logge
 		writer:        writer,
 		metrics:       metrics,
 		readerMetrics: readerMetrics,
-		walDir:        path.Join(walDir, "wal"),
+		walDir:        path.Join(dir, "wal"),
 		name:          name,
 		sendExemplars: sendExemplars,
 


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

As I was working the remote write storage code in https://github.com/thanos-io/thanos/pull/5242, I have noticed that in `WriteStorage` struct (and related methods), the field / parameter called `walDir` is confusing. The name indicates that the full path to WAL should be provided. However, internally, in the WAL watcher method the actual `wal` [subdirectory is appended](https://github.com/prometheus/prometheus/blob/main/tsdb/wal/watcher.go#L157). This means a user has to provide the 'base' directory when initializing remote write rather than the path to the WAL subdirectory. 

The change aims to rename this to simply `dir` to prevent the confusion. This would also align behavior with how the parameter / WAL directory is constructed in [agent](https://github.com/prometheus/prometheus/blob/main/tsdb/agent/db.go#L254) and [TSDB](https://github.com/prometheus/prometheus/blob/main/tsdb/db.go#L636) code.