### PR TITLE
ui/compress: Do not change git worktree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,6 @@ assets-compress:
 	@echo '>> compressing assets'
 	scripts/compress_assets.sh
 
-.PHONY: assets-decompress
-assets-decompress:
-	@echo '>> decompressing assets'
-	scripts/compress_assets.sh -d
-
 .PHONY: test
 # If we only want to only test go code we have to change the test target
 # which is called by all.
@@ -84,7 +79,7 @@ tarball: npm_licenses common-tarball
 docker: npm_licenses common-docker
 
 .PHONY: build
-build: assets assets-compress common-build assets-decompress
+build: assets assets-compress common-build
 
 .PHONY: bench_tsdb
 bench_tsdb: $(PROMU)
@@ -97,6 +92,3 @@ bench_tsdb: $(PROMU)
 	@$(GO) tool pprof --alloc_space -svg $(PROMTOOL) $(TSDB_BENCHMARK_OUTPUT_DIR)/mem.prof > $(TSDB_BENCHMARK_OUTPUT_DIR)/memprof.alloc.svg
 	@$(GO) tool pprof -svg $(PROMTOOL) $(TSDB_BENCHMARK_OUTPUT_DIR)/block.prof > $(TSDB_BENCHMARK_OUTPUT_DIR)/blockprof.svg
 	@$(GO) tool pprof -svg $(PROMTOOL) $(TSDB_BENCHMARK_OUTPUT_DIR)/mutex.prof > $(TSDB_BENCHMARK_OUTPUT_DIR)/mutexprof.svg
-
-.PHONY: clean
-clean: assets-decompress

--- a/scripts/compress_assets.sh
+++ b/scripts/compress_assets.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 #
-# [de]compress static assets
+# compress static assets
 
-find web/ui/static -type f -exec gzip "$@" {} \;
+set -euo pipefail
+
+cd web/ui
+cp embed.go.tmpl embed.go
+find static -type f -name '*.gz' -delete
+find static -type f -exec gzip -fk '{}' \; -print0 | xargs -0 -I % echo %.gz | xargs echo //go:embed >> embed.go
+echo var EmbedFS embed.FS >> embed.go

--- a/web/ui/.gitignore
+++ b/web/ui/.gitignore
@@ -1,0 +1,2 @@
+*.gz
+embed.go

--- a/web/ui/embed.go.tmpl
+++ b/web/ui/embed.go.tmpl
@@ -1,4 +1,4 @@
-// Copyright 2021 The Prometheus Authors
+// Copyright 2022 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,10 +16,5 @@
 
 package ui
 
-import (
-	"net/http"
+import "embed"
 
-	"github.com/prometheus/common/assets"
-)
-
-var Assets = http.FS(assets.New(EmbedFS))


### PR DESCRIPTION
This change makes sure that the git worktree is not changed while
compressing assets, making it better for local development.

To achieve this, the compression script keeps the un-compressed assets
and generates the go:embed directory when compressing the files.

A .gitignore file has been added to ignore generated files.

cc @jan--f 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
