### PR TITLE
add stripDomain to template function

### DIFF
--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -76,6 +76,7 @@ versions.
 | graphLink  | expr | string | Returns path to graph view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
 | tableLink  | expr | string | Returns path to tabular ("Table") view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
 | parseDuration | string | float | Parses a duration string such as "1h" into the number of seconds it represents. |
+| stripDomain | string | string | Split string into host and port, then if host is not IPv4 / IPv6, removes all the domain path elements, leaving only the first one |
 
 ### Others
 

--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -76,7 +76,7 @@ versions.
 | graphLink  | expr | string | Returns path to graph view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
 | tableLink  | expr | string | Returns path to tabular ("Table") view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
 | parseDuration | string | float | Parses a duration string such as "1h" into the number of seconds it represents. |
-| stripDomain | string | string | Split string into host and port, then if host is not IPv4 / IPv6, removes all the domain path elements, leaving only the first one and the port. |
+| stripDomain | string | string | Removes the domain part of a FQDN. Leaves port untouched. |
 
 ### Others
 

--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -76,7 +76,7 @@ versions.
 | graphLink  | expr | string | Returns path to graph view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
 | tableLink  | expr | string | Returns path to tabular ("Table") view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
 | parseDuration | string | float | Parses a duration string such as "1h" into the number of seconds it represents. |
-| stripDomain | string | string | Split string into host and port, then if host is not IPv4 / IPv6, removes all the domain path elements, leaving only the first one |
+| stripDomain | string | string | Split string into host and port, then if host is not IPv4 / IPv6, removes all the domain path elements, leaving only the first one and the port. |
 
 ### Others
 

--- a/template/template.go
+++ b/template/template.go
@@ -192,6 +192,21 @@ func NewTemplateExpander(
 				}
 				return host
 			},
+			"stripDomain": func(hostPort string) string {
+				host, _, err := net.SplitHostPort(hostPort)
+				if err == nil {
+					hostPort = host
+				}
+				ip := net.ParseIP(hostPort)
+				if ip != nil {
+					return hostPort
+				}
+				ss := strings.Split(hostPort, ".")
+				if len(ss) > 0 {
+					return ss[0]
+				}
+				return hostPort
+			},
 			"humanize": func(i interface{}) (string, error) {
 				v, err := convertToFloat(i)
 				if err != nil {

--- a/template/template.go
+++ b/template/template.go
@@ -195,23 +195,17 @@ func NewTemplateExpander(
 			"stripDomain": func(hostPort string) (ret string) {
 				host, port, err := net.SplitHostPort(hostPort)
 				if err != nil {
-					// if hostPort does not contains port, then host equals to hostPort
 					host = hostPort
 				}
 				ip := net.ParseIP(host)
 				if ip != nil {
-					// if host part is ipv4 or v6, return the hostPort
 					ret = hostPort
 					return
 				}
 				ss := strings.Split(host, ".")
-				if len(ss) == 0 {
-					ret = hostPort
-					return
-				}
 				ret = ss[0]
 				if port != "" {
-					ret = ss[0] + ":" + port
+					ret = net.JoinHostPort(ss[0], port)
 				}
 				return
 			},

--- a/template/template.go
+++ b/template/template.go
@@ -192,20 +192,28 @@ func NewTemplateExpander(
 				}
 				return host
 			},
-			"stripDomain": func(hostPort string) string {
-				host, _, err := net.SplitHostPort(hostPort)
-				if err == nil {
-					hostPort = host
+			"stripDomain": func(hostPort string) (ret string) {
+				host, port, err := net.SplitHostPort(hostPort)
+				if err != nil {
+					// if hostPort does not contains port, then host equals to hostPort
+					host = hostPort
 				}
-				ip := net.ParseIP(hostPort)
+				ip := net.ParseIP(host)
 				if ip != nil {
-					return hostPort
+					// if host part is ipv4 or v6, return the hostPort
+					ret = hostPort
+					return
 				}
-				ss := strings.Split(hostPort, ".")
-				if len(ss) > 0 {
-					return ss[0]
+				ss := strings.Split(host, ".")
+				if len(ss) == 0 {
+					ret = hostPort
+					return
 				}
-				return hostPort
+				ret = ss[0]
+				if port != "" {
+					ret = ss[0] + ":" + port
+				}
+				return
 			},
 			"humanize": func(i interface{}) (string, error) {
 				v, err := convertToFloat(i)

--- a/template/template.go
+++ b/template/template.go
@@ -192,7 +192,8 @@ func NewTemplateExpander(
 				}
 				return host
 			},
-			"stripDomain": func(hostPort string) (ret string) {
+			"stripDomain": func(hostPort string) string {
+				ret := ""
 				host, port, err := net.SplitHostPort(hostPort)
 				if err != nil {
 					host = hostPort
@@ -200,14 +201,14 @@ func NewTemplateExpander(
 				ip := net.ParseIP(host)
 				if ip != nil {
 					ret = hostPort
-					return
+					return ret
 				}
 				ss := strings.Split(host, ".")
 				ret = ss[0]
 				if port != "" {
 					ret = net.JoinHostPort(ss[0], port)
 				}
-				return
+				return ret
 			},
 			"humanize": func(i interface{}) (string, error) {
 				v, err := convertToFloat(i)

--- a/template/template.go
+++ b/template/template.go
@@ -193,22 +193,19 @@ func NewTemplateExpander(
 				return host
 			},
 			"stripDomain": func(hostPort string) string {
-				ret := ""
 				host, port, err := net.SplitHostPort(hostPort)
 				if err != nil {
 					host = hostPort
 				}
 				ip := net.ParseIP(host)
 				if ip != nil {
-					ret = hostPort
-					return ret
+					return hostPort
 				}
-				ss := strings.Split(host, ".")
-				ret = ss[0]
+				host = strings.Split(host, ".")[0]
 				if port != "" {
-					ret = net.JoinHostPort(ss[0], port)
+					return net.JoinHostPort(host, port)
 				}
-				return ret
+				return host
 			},
 			"humanize": func(i interface{}) (string, error) {
 				v, err := convertToFloat(i)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -488,7 +488,7 @@ func TestTemplateExpansion(t *testing.T) {
 		{
 			// Hostname with port.
 			text:   "{{ \"foo.example.com:12345\" | stripDomain }}",
-			output: "foo",
+			output: "foo:12345",
 		},
 		{
 			// Simple IPv4 address.
@@ -498,7 +498,7 @@ func TestTemplateExpansion(t *testing.T) {
 		{
 			// IPv4 address with port.
 			text:   "{{ \"192.0.2.1:12345\" | stripDomain }}",
-			output: "192.0.2.1",
+			output: "192.0.2.1:12345",
 		},
 		{
 			// Simple IPv6 address.
@@ -508,7 +508,7 @@ func TestTemplateExpansion(t *testing.T) {
 		{
 			// IPv6 address with port.
 			text:   "{{ \"[2001:0DB8::1]:12345\" | stripDomain }}",
-			output: "2001:0DB8::1",
+			output: "[2001:0DB8::1]:12345",
 		},
 		{
 			// Value can't be split into host and port.

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -480,6 +480,41 @@ func TestTemplateExpansion(t *testing.T) {
 			text:   "{{ printf \"%0.2f\" (parseDuration \"1h2m10ms\") }}",
 			output: "3720.01",
 		},
+		{
+			// Simple hostname.
+			text:   "{{ \"foo.example.com\" | stripDomain }}",
+			output: "foo",
+		},
+		{
+			// Hostname with port.
+			text:   "{{ \"foo.example.com:12345\" | stripDomain }}",
+			output: "foo",
+		},
+		{
+			// Simple IPv4 address.
+			text:   "{{ \"192.0.2.1\" | stripDomain }}",
+			output: "192.0.2.1",
+		},
+		{
+			// IPv4 address with port.
+			text:   "{{ \"192.0.2.1:12345\" | stripDomain }}",
+			output: "192.0.2.1",
+		},
+		{
+			// Simple IPv6 address.
+			text:   "{{ \"2001:0DB8::1\" | stripDomain }}",
+			output: "2001:0DB8::1",
+		},
+		{
+			// IPv6 address with port.
+			text:   "{{ \"[2001:0DB8::1]:12345\" | stripDomain }}",
+			output: "2001:0DB8::1",
+		},
+		{
+			// Value can't be split into host and port.
+			text:   "{{ \"[2001:0DB8::1]::12345\" | stripDomain }}",
+			output: "[2001:0DB8::1]::12345",
+		},
 	})
 }
 


### PR DESCRIPTION
This PR add a new function 'stripDomain' to template functions, which is proposed in #9932 .

The function will split string into host and port, then if host is not IPv4 / IPv6, removes all the domain path elements, leaving only the first one.

