### PR TITLE
Switch per-step stats to serialize ints

### DIFF
--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
@@ -81,18 +80,16 @@ func (s QueryTiming) SpanOperation() string {
 // stepStat represents a single statistic for a given step timestamp.
 type stepStat struct {
 	T int64
-	V float64
+	V int64
 }
 
 func (s stepStat) String() string {
-	v := strconv.FormatFloat(s.V, 'f', -1, 64)
-	return fmt.Sprintf("%v @[%v]", v, s.T)
+	return fmt.Sprintf("%v @[%v]", s.V, s.T)
 }
 
 // MarshalJSON implements json.Marshaler.
 func (s stepStat) MarshalJSON() ([]byte, error) {
-	v := strconv.FormatFloat(s.V, 'f', -1, 64)
-	return json.Marshal([...]interface{}{float64(s.T) / 1000, v})
+	return json.Marshal([...]interface{}{float64(s.T) / 1000, s.V})
 }
 
 // queryTimings with all query timers mapped to durations.
@@ -185,7 +182,7 @@ func (qs *QuerySamples) totalSamplesPerStepPoints() []stepStat {
 
 	ts := make([]stepStat, len(qs.TotalSamplesPerStep))
 	for i, c := range qs.TotalSamplesPerStep {
-		ts[i] = stepStat{T: qs.startTimestamp + int64(i)*qs.interval, V: float64(c)}
+		ts[i] = stepStat{T: qs.startTimestamp + int64(i)*qs.interval, V: int64(c)}
 	}
 	return ts
 }

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -61,7 +61,7 @@ func TestQueryStatsWithTimersAndSamples(t *testing.T) {
 	require.True(t, match, "Expected timings with one non-zero entry.")
 
 	require.Regexpf(t, `[,{]"totalQueryableSamples":10[,}]`, string(actual), "expected totalQueryableSamples")
-	require.Regexpf(t, `[,{]"totalQueryableSamplesPerStep":\[\[20001,"5"\],\[21001,"0"\],\[22001,"0"\],\[23001,"0"\],\[24001,"0"\],\[25001,"5"\]\]`, string(actual), "expected totalQueryableSamplesPerStep")
+	require.Regexpf(t, `[,{]"totalQueryableSamplesPerStep":\[\[20001,5\],\[21001,0\],\[22001,0\],\[23001,0\],\[24001,0\],\[25001,5\]\]`, string(actual), "expected totalQueryableSamplesPerStep")
 }
 
 func TestQueryStatsWithSpanTimers(t *testing.T) {


### PR DESCRIPTION
Per @roidelapluie's feedback on #10369, we're choosing to be consistent with data types inside the stats structure (ints) rather than with the points format that is part of the normal query responses (strings). We have this option because this data cannot be NaN/Inf.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
