### PR TITLE
Implement scrape-time rule evaluation

### DIFF
--- a/scrape/helpers_test.go
+++ b/scrape/helpers_test.go
@@ -46,6 +46,12 @@ type sample struct {
 	v      float64
 }
 
+type collectResultAppendable struct{}
+
+func (c collectResultAppendable) Appender(_ context.Context) storage.Appender {
+	return &collectResultAppender{}
+}
+
 // collectResultAppender records all samples that were added through the appender.
 // It can be used as its zero value or be backed by another appender it writes samples through.
 type collectResultAppender struct {

--- a/scrape/rule_appender.go
+++ b/scrape/rule_appender.go
@@ -1,0 +1,196 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scrape
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+)
+
+type ruleAppender struct {
+	targetLabels labels.Labels
+	rules        []*config.AggregationRuleConfig
+	appendable   storage.Appendable
+	engine       *promql.Engine
+}
+
+type batch struct {
+	targetLabels labels.Labels
+	rules        []*config.AggregationRuleConfig
+	samples      []*batchSample
+	appender     storage.Appender
+	engine       *promql.Engine
+}
+
+type batchSample struct {
+	metric labels.Labels
+	t      int64
+	v      float64
+}
+
+func newRuleAppender(targetLabels labels.Labels, appendable storage.Appendable, rules []*config.AggregationRuleConfig) storage.Appendable {
+	return &ruleAppender{
+		targetLabels: targetLabels,
+		rules:        rules,
+		appendable:   appendable,
+		engine: promql.NewEngine(promql.EngineOpts{
+			MaxSamples:    50000000,
+			Timeout:       10 * time.Second,
+			LookbackDelta: 15 * time.Minute,
+		}),
+	}
+}
+
+func (a ruleAppender) Appender(ctx context.Context) storage.Appender {
+	return &batch{
+		targetLabels: a.targetLabels,
+		appender:     a.appendable.Appender(ctx),
+		rules:        a.rules,
+		samples:      make([]*batchSample, 0),
+		engine:       a.engine,
+	}
+}
+
+func (b *batch) Append(ref storage.SeriesRef, l labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
+	b.samples = append(b.samples, &batchSample{metric: l, t: t, v: v})
+	return b.appender.Append(ref, l, t, v)
+}
+
+func (b *batch) Commit() error {
+	err := b.evaluateRules()
+	if err != nil {
+		return err
+	}
+
+	return b.appender.Commit()
+}
+
+func (b *batch) evaluateRules() error {
+	if len(b.samples) == 0 {
+		return nil
+	}
+
+	for _, rule := range b.rules {
+		queryable := storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+			return b, nil
+		})
+		ts := b.samples[0].t
+		query, err := b.engine.NewInstantQuery(queryable, nil, rule.Expr, time.UnixMilli(ts))
+		if err != nil {
+			return err
+		}
+
+		result := query.Exec(context.Background())
+		samples, err := result.Vector()
+		if err != nil {
+			return err
+		}
+
+		for _, s := range samples {
+			lbls := s.Metric.WithoutLabels("__name__")
+			lbls = append(lbls, labels.Label{
+				Name:  "__name__",
+				Value: rule.Record,
+			})
+			lbls = append(lbls, b.targetLabels...)
+			_, err := b.appender.Append(0, lbls, s.T, s.V)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (b *batch) Rollback() error {
+	return b.appender.Rollback()
+}
+
+func (b *batch) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	return b.appender.AppendExemplar(ref, l, e)
+}
+
+func (b *batch) Select(_ bool, _ *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	var samples []*batchSample
+	for _, s := range b.samples {
+		match := true
+		for _, matcher := range matchers {
+			if !matcher.Matches(s.metric.Get(matcher.Name)) {
+				match = false
+				break
+			}
+		}
+		if match {
+			samples = append(samples, s)
+		}
+	}
+
+	return &seriesSet{
+		i:       -1,
+		samples: samples,
+	}
+}
+
+func (b *batch) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (b *batch) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (b *batch) Close() error {
+	return nil
+}
+
+type seriesSet struct {
+	i       int
+	samples []*batchSample
+}
+
+func (s *seriesSet) Next() bool {
+	s.i++
+	if s.i == len(s.samples) {
+		return false
+	}
+	return true
+}
+
+func (s *seriesSet) At() storage.Series {
+	sample := s.samples[s.i]
+	return promql.NewStorageSeries(promql.Series{
+		Metric: sample.metric,
+		Points: []promql.Point{
+			{
+				T: sample.t,
+				V: sample.v,
+			},
+		},
+	})
+}
+
+func (s *seriesSet) Err() error {
+	return nil
+}
+
+func (s *seriesSet) Warnings() storage.Warnings {
+	return nil
+}

--- a/scrape/rule_appender_test.go
+++ b/scrape/rule_appender_test.go
@@ -1,0 +1,69 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scrape
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregatorAppender(t *testing.T) {
+	now := time.Now()
+	samples := []sample{
+		{
+			metric: []labels.Label{{Name: "__name__", Value: "http_requests_total"}, {Name: "code", Value: "200"}, {Name: "handler", Value: "/"}},
+			t:      now.UnixMilli(),
+			v:      10,
+		},
+		{
+			metric: []labels.Label{{Name: "__name__", Value: "http_requests_total"}, {Name: "code", Value: "200"}, {Name: "handler", Value: "/metrics"}},
+			t:      now.UnixMilli(),
+			v:      6,
+		},
+	}
+	rules := []*config.AggregationRuleConfig{
+		{
+			Expr:   "sum by (code) (http_requests_total)",
+			Record: "code:http_requests_total:sum",
+		},
+	}
+	instanceLabels := []labels.Label{{Name: "instance", Value: "127.0.0.1"}}
+	aggregator := newRuleAppender(instanceLabels, collectResultAppendable{}, rules)
+	appender := aggregator.Appender(context.Background())
+	for _, s := range samples {
+		if _, err := appender.Append(0, s.metric, s.t, s.v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err := appender.Commit()
+	require.NoError(t, err)
+
+	result := appender.(*batch).appender.(*collectResultAppender).result
+	if len(result) != 3 {
+		t.Fatalf("Invalid sample count, got %d, want %d", len(result), 3)
+	}
+
+	expectedSamples := append(samples, sample{
+		metric: append(labels.Labels{{Name: "code", Value: "200"}, {Name: "__name__", Value: "code:http_requests_total:sum"}}, instanceLabels...),
+		t:      now.UnixMilli(),
+		v:      16,
+	})
+	require.Equal(t, expectedSamples, result)
+}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -306,6 +306,10 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed 
 		// Store the cache in the context.
 		loopCtx := ContextWithMetricMetadataStore(ctx, cache)
 
+		if len(cfg.AggregationRules) > 0 {
+			app = newRuleAppender(opts.target.Labels(), app, cfg.AggregationRules)
+		}
+
 		return newScrapeLoop(
 			loopCtx,
 			opts.scraper,


### PR DESCRIPTION
This commit extends Prometheus with the option to run aggregation rules
during scrape time. All rules are executed independently for each target
in the context of individual scrapes. The newly calculated samples are
committed to TSDB atomically with all samples from that scrape.

Relates to #394

Signed-off-by: fpetkovski <filip.petkovsky@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
