### PR TITLE
Clarify that WAL might be raw but not always

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -24,8 +24,8 @@ of deleting the data immediately from the chunk segments).
 The current block for incoming samples is kept in memory and is not fully
 persisted. It is secured against crashes by a write-ahead log (WAL) that can be
 replayed when the Prometheus server restarts. Write-ahead log files are stored
-in the `wal` directory in 128MB segments. These files contain raw data that
-has not yet been compacted; thus they are significantly larger than regular block
+in the `wal` directory in 128MB segments. These files may contain raw data that
+has not yet been compacted (WAL compression enabled by default in 2.20.0); thus they are significantly larger than regular block
 files. Prometheus will retain a minimum of three write-ahead log files.
 High-traffic servers may retain more than three WAL files in order to keep at
 least two hours of raw data.


### PR DESCRIPTION
Since prometheus now defaults to having wal compression enabled I think the documentation should mention that it might be raw but not always.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
