### PR TITLE
Add the ability to disable service discoveries at build time

### DIFF
--- a/discovery/aws/disabled.go
+++ b/discovery/aws/disabled.go
@@ -1,0 +1,53 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build noaws
+// +build noaws
+
+package aws
+
+import (
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/disabled"
+)
+
+type EC2SDConfig struct {
+	disabled.SDConfig
+}
+
+func (*EC2SDConfig) Name() string {
+	return "ec2"
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (s *EC2SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return s.Error(s.Name())
+}
+
+type LightsailSDConfig struct {
+	disabled.SDConfig
+}
+
+func (*LightsailSDConfig) Name() string {
+	return "lightsail"
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (s *LightsailSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return s.Error(s.Name())
+}
+
+func init() {
+	discovery.RegisterConfig(&LightsailSDConfig{})
+	discovery.RegisterConfig(&EC2SDConfig{})
+}

--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !noaws
+// +build !noaws
+
 package aws
 
 import (

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !noaws
+// +build !noaws
+
 package aws
 
 import (

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !noazure
+// +build !noazure
+
 package azure
 
 import (

--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !noazure
+// +build !noazure
+
 package azure
 
 import (

--- a/discovery/azure/disabled.go
+++ b/discovery/azure/disabled.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build noazure
+// +build noazure
+
+package azure
+
+import (
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/disabled"
+)
+
+type SDConfig struct {
+	disabled.SDConfig
+}
+
+func (*SDConfig) Name() string {
+	return "azure"
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (s *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return s.Error(s.Name())
+}
+
+func init() {
+	discovery.RegisterConfig(&SDConfig{})
+}

--- a/discovery/disabled/disabled.go
+++ b/discovery/disabled/disabled.go
@@ -1,0 +1,46 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disabled
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/prometheus/prometheus/discovery"
+)
+
+// SDConfig is an empty config used to error out when unmarshalling.
+type SDConfig struct {
+}
+
+// Error returns an error. This is used to have consistent error messages
+// between disabled SD's. It should be called during UnmarshalYAML.
+func (s *SDConfig) Error(name string) error {
+	return fmt.Errorf("service discovery %s has been disabled at build time", name)
+}
+
+// SetDirectory joins any relative file paths with dir.
+func (s *SDConfig) SetDirectory(dir string) {
+}
+
+// UnmarshalYAML implements the Unmarshaler interface and should be overriden by
+// disabled SD's.
+func (s *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return s.Error("n/a")
+}
+
+// NewDiscoverer implementes the Discoverer interface.
+func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Discoverer, error) {
+	return nil, errors.New("service discovery has been disabled.")
+}

--- a/discovery/gce/disabled.go
+++ b/discovery/gce/disabled.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build nogce
+// +build nogce
+
+package gce
+
+import (
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/disabled"
+)
+
+type SDConfig struct {
+	disabled.SDConfig
+}
+
+func (*SDConfig) Name() string {
+	return "gce"
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (s *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return s.Error(s.Name())
+}
+
+func init() {
+	discovery.RegisterConfig(&SDConfig{})
+}

--- a/discovery/gce/gce.go
+++ b/discovery/gce/gce.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nogce
+// +build !nogce
+
 package gce
 
 import (


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
