### PR TITLE
Avoid literal integer overflows in 32 bit arches.

### DIFF
--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -43,12 +43,13 @@ func TestDeriv(t *testing.T) {
 
 	a := storage.Appender(context.Background())
 
+	var start, interval, i int64
 	metric := labels.FromStrings("__name__", "foo")
-	start := 1493712816939
-	interval := 30 * 1000
+	start = 1493712816939
+	interval = 30 * 1000
 	// Introduce some timestamp jitter to test 0 slope case.
 	// https://github.com/prometheus/prometheus/issues/7180
-	for i := 0; i < 15; i++ {
+	for i = 0; i < 15; i++ {
 		jitter := 12 * i % 2
 		a.Append(0, metric, int64(start+interval*i+jitter), 1)
 	}

--- a/template/template.go
+++ b/template/template.go
@@ -109,6 +109,10 @@ func convertToFloat(i interface{}) (float64, error) {
 		return float64(v), nil
 	case uint:
 		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case uint64:
+		return float64(v), nil
 	default:
 		return 0, fmt.Errorf("can't convert %T to float", v)
 	}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -272,13 +272,13 @@ func TestTemplateExpansion(t *testing.T) {
 		{
 			// Humanize - int.
 			text:   "{{ range . }}{{ humanize . }}:{{ end }}",
-			input:  []int{0, -1, 1, 1234567, math.MaxInt64},
+			input:  []int64{0, -1, 1, 1234567, math.MaxInt64},
 			output: "0:-1:1:1.235M:9.223E:",
 		},
 		{
 			// Humanize - uint.
 			text:   "{{ range . }}{{ humanize . }}:{{ end }}",
-			input:  []uint{0, 1, 1234567, math.MaxUint64},
+			input:  []uint64{0, 1, 1234567, math.MaxUint64},
 			output: "0:1:1.235M:18.45E:",
 		},
 		{
@@ -302,13 +302,13 @@ func TestTemplateExpansion(t *testing.T) {
 		{
 			// Humanize1024 - int.
 			text:   "{{ range . }}{{ humanize1024 . }}:{{ end }}",
-			input:  []int{0, -1, 1, 1234567, math.MaxInt64},
+			input:  []int64{0, -1, 1, 1234567, math.MaxInt64},
 			output: "0:-1:1:1.177Mi:8Ei:",
 		},
 		{
 			// Humanize1024 - uint.
 			text:   "{{ range . }}{{ humanize1024 . }}:{{ end }}",
-			input:  []uint{0, 1, 1234567, math.MaxUint64},
+			input:  []uint64{0, 1, 1234567, math.MaxUint64},
 			output: "0:1:1.177Mi:16Ei:",
 		},
 		{
@@ -373,13 +373,13 @@ func TestTemplateExpansion(t *testing.T) {
 		{
 			// HumanizePercentage - int.
 			text:   "{{ range . }}{{ humanizePercentage . }}:{{ end }}",
-			input:  []int{0, -1, 1, 1234567, math.MaxInt64},
+			input:  []int64{0, -1, 1, 1234567, math.MaxInt64},
 			output: "0%:-100%:100%:1.235e+08%:9.223e+20%:",
 		},
 		{
 			// HumanizePercentage - uint.
 			text:   "{{ range . }}{{ humanizePercentage . }}:{{ end }}",
-			input:  []uint{0, 1, 1234567, math.MaxUint64},
+			input:  []uint64{0, 1, 1234567, math.MaxUint64},
 			output: "0%:100%:1.235e+08%:1.845e+21%:",
 		},
 		{
@@ -396,26 +396,26 @@ func TestTemplateExpansion(t *testing.T) {
 		{
 			// HumanizeTimestamp - int.
 			text:   "{{ range . }}{{ humanizeTimestamp . }}:{{ end }}",
-			input:  []int{0, -1, 1, 1234567, 9223372036},
+			input:  []int64{0, -1, 1, 1234567, 9223372036},
 			output: "1970-01-01 00:00:00 +0000 UTC:1969-12-31 23:59:59 +0000 UTC:1970-01-01 00:00:01 +0000 UTC:1970-01-15 06:56:07 +0000 UTC:2262-04-11 23:47:16 +0000 UTC:",
 		},
 		{
 			// HumanizeTimestamp - uint.
 			text:   "{{ range . }}{{ humanizeTimestamp . }}:{{ end }}",
-			input:  []uint{0, 1, 1234567, 9223372036},
+			input:  []uint64{0, 1, 1234567, 9223372036},
 			output: "1970-01-01 00:00:00 +0000 UTC:1970-01-01 00:00:01 +0000 UTC:1970-01-15 06:56:07 +0000 UTC:2262-04-11 23:47:16 +0000 UTC:",
 		},
 		{
 			// HumanizeTimestamp - int with error.
 			text:       "{{ range . }}{{ humanizeTimestamp . }}:{{ end }}",
-			input:      []int{math.MinInt64, math.MaxInt64},
+			input:      []int64{math.MinInt64, math.MaxInt64},
 			shouldFail: true,
 			errorMsg:   `error executing template test: template: test:1:16: executing "test" at <humanizeTimestamp .>: error calling humanizeTimestamp: -9.223372036854776e+18 cannot be represented as a nanoseconds timestamp since it overflows int64`,
 		},
 		{
 			// HumanizeTimestamp - uint with error.
 			text:       "{{ range . }}{{ humanizeTimestamp . }}:{{ end }}",
-			input:      []uint{math.MaxUint64},
+			input:      []uint64{math.MaxUint64},
 			shouldFail: true,
 			errorMsg:   `error executing template test: template: test:1:16: executing "test" at <humanizeTimestamp .>: error calling humanizeTimestamp: 1.8446744073709552e+19 cannot be represented as a nanoseconds timestamp since it overflows int64`,
 		},


### PR DESCRIPTION
This commit ensures 64-bit integers are used in various tests that other wise
fail in 32-bit architectures.

It also adds support for int64 and uint64 types in the template.convertToFloat
function to support the test changes.

Fixes: #10481