### PR TITLE
Introduce Prometheus Slim variant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,10 @@ workflows:
             branches:
               ignore: /^(main|release-.*|.*build-all.*)$/
       - prometheus/build:
-          name: build_all
+          name: build_all_slim
+          environment: &slim
+            PLUGINS_FILE: plugins-slim.yml
+            DOCKER_IMAGE_NAME: prometheus-slim
           parallelism: 12
           filters:
             branches:
@@ -162,6 +165,18 @@ workflows:
             - test_go
             - test_ui
             - build_all
+          filters:
+            branches:
+              only: main
+          image: circleci/golang:1-node
+      - prometheus/publish_main_slim:
+          name: publish_main_slim
+          context: org-context
+          environment: *slim
+          requires:
+            - test_go
+            - test_ui
+            - build_all_slim
           filters:
             branches:
               only: main

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ TSDB_BENCHMARK_OUTPUT_DIR ?= ./benchout
 
 GOLANGCI_LINT_OPTS ?= --timeout 4m
 
+PLUGINS_FILE ?= plugins.yml
+
 include Makefile.common
 
 DOCKER_IMAGE_NAME       ?= prometheus
@@ -78,15 +80,13 @@ tarball: npm_licenses common-tarball
 .PHONY: docker
 docker: npm_licenses common-docker
 
-plugins/plugins.go: plugins.yml plugins/generate.go
-	@echo ">> creating plugins list"
-	$(GO) generate -tags plugins ./plugins
-
 .PHONY: plugins
-plugins: plugins/plugins.go
+plugins:
+	@echo ">> creating plugins list"
+	$(GO) generate -tags plugins ./plugins $(PLUGINS_FILE)
 
 .PHONY: build
-build: assets assets-compress common-build plugins
+build: assets assets-compress plugins common-build
 
 .PHONY: bench_tsdb
 bench_tsdb: $(PROMU)

--- a/plugins-slim.yml
+++ b/plugins-slim.yml
@@ -1,0 +1,2 @@
+- github.com/prometheus/prometheus/discovery/consul
+- github.com/prometheus/prometheus/discovery/kubernetes

--- a/plugins/generate.go
+++ b/plugins/generate.go
@@ -30,7 +30,14 @@ import (
 //go:generate go run generate.go
 
 func main() {
-	data, err := ioutil.ReadFile(filepath.Join("..", "plugins.yml"))
+	file := filepath.Join("..", "plugins.yml")
+	if envFile := os.Getenv("PLUGINS_FILE"); envFile != "" {
+		file = envFile
+		if !filepath.IsAbs(file) {
+			file = filepath.Join("..", file)
+		}
+	}
+	data, err := ioutil.ReadFile(file)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Introduces a Prometheus-Slim variant with only kubernetes and consul
service discovery.

Currently not publishing releases, just a light docker image.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
