### PR TITLE
tsdb: more efficient sorting of postings read from WAL at startup

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -238,9 +238,11 @@ func (p *MemPostings) EnsureOrder() {
 
 	for i := 0; i < n; i++ {
 		go func() {
+			var sortable seriesRefSlice
 			for job := range workc {
 				for _, l := range job {
-					sort.Sort(seriesRefSlice(l))
+					sortable = l
+					sort.Sort(&sortable)
 				}
 
 				job = job[:0]

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -39,7 +39,8 @@ const ensureOrderBatchSize = 1024
 // ensureOrderBatchPool is a pool used to recycle batches passed to workers in MemPostings.EnsureOrder().
 var ensureOrderBatchPool = sync.Pool{
 	New: func() interface{} {
-		return make([][]storage.SeriesRef, 0, ensureOrderBatchSize)
+		x := make([][]storage.SeriesRef, 0, ensureOrderBatchSize)
+		return &x // Return pointer type as preferred by Pool.
 	},
 }
 
@@ -231,7 +232,7 @@ func (p *MemPostings) EnsureOrder() {
 	}
 
 	n := runtime.GOMAXPROCS(0)
-	workc := make(chan [][]storage.SeriesRef)
+	workc := make(chan *[][]storage.SeriesRef)
 
 	var wg sync.WaitGroup
 	wg.Add(n)
@@ -240,32 +241,32 @@ func (p *MemPostings) EnsureOrder() {
 		go func() {
 			var sortable seriesRefSlice
 			for job := range workc {
-				for _, l := range job {
+				for _, l := range *job {
 					sortable = l
 					sort.Sort(&sortable)
 				}
 
-				job = job[:0]
-				ensureOrderBatchPool.Put(job) //nolint:staticcheck // Ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
+				*job = (*job)[:0]
+				ensureOrderBatchPool.Put(job)
 			}
 			wg.Done()
 		}()
 	}
 
-	nextJob := ensureOrderBatchPool.Get().([][]storage.SeriesRef)
+	nextJob := ensureOrderBatchPool.Get().(*[][]storage.SeriesRef)
 	for _, e := range p.m {
 		for _, l := range e {
-			nextJob = append(nextJob, l)
+			*nextJob = append(*nextJob, l)
 
-			if len(nextJob) >= ensureOrderBatchSize {
+			if len(*nextJob) >= ensureOrderBatchSize {
 				workc <- nextJob
-				nextJob = ensureOrderBatchPool.Get().([][]storage.SeriesRef)
+				nextJob = ensureOrderBatchPool.Get().(*[][]storage.SeriesRef)
 			}
 		}
 	}
 
 	// If the last job was partially filled, we need to push it to workers too.
-	if len(nextJob) > 0 {
+	if len(*nextJob) > 0 {
 		workc <- nextJob
 	}
 


### PR DESCRIPTION
This was something I noticed in passing.

Benchmark stats:
```
name                                                old time/op    new time/op    delta
MemPostings_ensureOrder/many_values_per_label-4        568ms ± 2%     567ms ± 2%      ~     (p=0.690 n=5+5)
MemPostings_ensureOrder/few_values_per_label-4         649ms ± 0%     659ms ± 5%      ~     (p=0.190 n=4+5)
MemPostings_ensureOrder/few_refs_per_label_value-4    28.5ms ± 3%    21.5ms ± 2%   -24.53%  (p=0.008 n=5+5)

name                                                old alloc/op   new alloc/op   delta
MemPostings_ensureOrder/many_values_per_label-4       24.0MB ± 0%     0.0MB ± 1%   -99.91%  (p=0.008 n=5+5)
MemPostings_ensureOrder/few_values_per_label-4        24.0MB ± 0%     0.0MB ± 0%   -99.90%  (p=0.016 n=5+4)
MemPostings_ensureOrder/few_refs_per_label_value-4    24.0MB ± 0%     0.0MB ± 6%  -100.00%  (p=0.008 n=5+5)

name                                                old allocs/op  new allocs/op  delta
MemPostings_ensureOrder/many_values_per_label-4        1.00M ± 0%     0.00M ± 0%  -100.00%  (p=0.008 n=5+5)
MemPostings_ensureOrder/few_values_per_label-4         1.00M ± 0%     0.00M ±12%  -100.00%  (p=0.008 n=5+5)
MemPostings_ensureOrder/few_refs_per_label_value-4     1.00M ± 0%     0.00M ± 0%  -100.00%  (p=0.008 n=5+5)
```

Most of the benefit comes from avoiding slice-to-interface allocation, by pulling the `seriesRefSlice` out of the loop, so the compiler doesn't allocate a new one on the heap every time.

The second commit to use a pointer type in the `Pool` reduces allocations two more orders of magnitude: this is almost invisible in benchmark timings after the first commit, but I couldn't leave it with a staticcheck warning :-)

Removed a comment that said fixing this has a performance penalty: not borne out by benchmarks.

Since `benchstat` rounded the numbers, the first commit goes to 987 allocs/iter, and the second to 9.
