### PR TITLE
Fix OpenMetrics parser to sort uppercase labels correctly.

### DIFF
--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -175,9 +175,8 @@ func (p *OpenMetricsParser) Metric(l *labels.Labels) string {
 		*l = append(*l, labels.Label{Name: s[a:b], Value: s[c:d]})
 	}
 
-	// Sort labels. We can skip the first entry since the metric name is
-	// already at the right place.
-	sort.Sort((*l)[1:])
+	// Sort labels.
+	sort.Sort(*l)
 
 	return s
 }

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -52,6 +52,7 @@ ii{foo="bar"} 1
 # TYPE ss stateset
 ss{ss="foo"} 1
 ss{ss="bar"} 0
+ss{A="a"} 0
 # TYPE un unknown
 _metric_starting_with_underscore 1
 testmetric{_label_starting_with_underscore="foo"} 1
@@ -177,6 +178,10 @@ foo_total 17.0 1520879607.789 # {xx="yy"} 5`
 			m:    `ss{ss="bar"}`,
 			v:    0,
 			lset: labels.FromStrings("__name__", "ss", "ss", "bar"),
+		}, {
+			m:    `ss{A="a"}`,
+			v:    0,
+			lset: labels.FromStrings("A", "a", "__name__", "ss"),
 		}, {
 			m:   "un",
 			typ: MetricTypeUnknown,


### PR DESCRIPTION
This PR fixes OpenMetrics parser to sort labels starting with uppercase characters correctly. Since this parser is also used by `promtool tsdb create-blocks-from openmetrics` command, it fixes TSDB blocks generated by promtool backfilling.