### PR TITLE
chore(discoveryManager): expose Discoverer refresh function 

### DIFF
--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -136,12 +136,12 @@ func NewDiscovery(conf *SDConfig, logger log.Logger, clientOpts []config.HTTPCli
 		logger,
 		"http",
 		time.Duration(conf.RefreshInterval),
-		d.refresh,
+		d.Refresh,
 	)
 	return d, nil
 }
 
-func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+func (d *Discovery) Refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	req, err := http.NewRequest("GET", d.url, nil)
 	if err != nil {
 		return nil, err

--- a/discovery/http/http_test.go
+++ b/discovery/http/http_test.go
@@ -45,7 +45,7 @@ func TestHTTPValidRefresh(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	tgs, err := d.refresh(ctx)
+	tgs, err := d.Refresh(ctx)
 	require.NoError(t, err)
 
 	expectedTargets := []*targetgroup.Group{
@@ -83,7 +83,7 @@ func TestHTTPInvalidCode(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	_, err = d.refresh(ctx)
+	_, err = d.Refresh(ctx)
 	require.EqualError(t, err, "server returned HTTP status 400 Bad Request")
 	require.Equal(t, 1.0, getFailureCount())
 }
@@ -105,7 +105,7 @@ func TestHTTPInvalidFormat(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	_, err = d.refresh(ctx)
+	_, err = d.Refresh(ctx)
 	require.EqualError(t, err, `unsupported content type "text/plain; charset=utf-8"`)
 	require.Equal(t, 1.0, getFailureCount())
 }
@@ -423,7 +423,7 @@ func TestSourceDisappeared(t *testing.T) {
 		ctx := context.Background()
 		for i, res := range test.responses {
 			stubResponse = res
-			tgs, err := d.refresh(ctx)
+			tgs, err := d.Refresh(ctx)
 			require.NoError(t, err)
 			require.Equal(t, test.expectedTargets[i], tgs)
 		}

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -102,6 +102,10 @@ func (p *Provider) IsStarted() bool {
 	return p.cancel != nil
 }
 
+func (p *Provider) Config() interface{} {
+	return p.config
+}
+
 // NewManager is the Discovery Manager constructor.
 func NewManager(ctx context.Context, logger log.Logger, options ...func(*Manager)) *Manager {
 	if logger == nil {

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -172,7 +172,7 @@ type Manager struct {
 	lastProvider uint
 }
 
-// Providers returns the currently configured SD providers
+// Providers returns the currently configured SD providers.
 func (m *Manager) Providers() []*Provider {
 	return m.providers
 }

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -339,7 +339,7 @@ func (m *Manager) sender() {
 			case <-m.triggerSend:
 				sentUpdates.WithLabelValues(m.name).Inc()
 				select {
-				case m.syncCh <- m.allGroups():
+				case m.syncCh <- m.AllGroups():
 				default:
 					delayedUpdates.WithLabelValues(m.name).Inc()
 					level.Debug(m.logger).Log("msg", "Discovery receiver's channel was full so will retry the next cycle")
@@ -378,7 +378,8 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
 	}
 }
 
-func (m *Manager) allGroups() map[string][]*targetgroup.Group {
+// AllGroups updates and returns all target groups of this manager.
+func (m *Manager) AllGroups() map[string][]*targetgroup.Group {
 	tSets := map[string][]*targetgroup.Group{}
 	n := map[string]int{}
 

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -685,7 +685,7 @@ func TestTargetUpdatesOrder(t *testing.T) {
 					t.Fatalf("%d: no update arrived within the timeout limit", x)
 				case tgs := <-provUpdates:
 					discoveryManager.updateGroup(poolKey{setName: strconv.Itoa(i), provider: tc.title}, tgs)
-					for _, got := range discoveryManager.AllGroups() {
+					for _, got := range discoveryManager.allGroups() {
 						assertEqualGroups(t, got, tc.expectedTargets[x], func(got, expected string) string {
 							return fmt.Sprintf("%d: \ntargets mismatch \ngot: %v \nexpected: %v",
 								x,

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -685,7 +685,7 @@ func TestTargetUpdatesOrder(t *testing.T) {
 					t.Fatalf("%d: no update arrived within the timeout limit", x)
 				case tgs := <-provUpdates:
 					discoveryManager.updateGroup(poolKey{setName: strconv.Itoa(i), provider: tc.title}, tgs)
-					for _, got := range discoveryManager.allGroups() {
+					for _, got := range discoveryManager.AllGroups() {
 						assertEqualGroups(t, got, tc.expectedTargets[x], func(got, expected string) string {
 							return fmt.Sprintf("%d: \ntargets mismatch \ngot: %v \nexpected: %v",
 								x,


### PR DESCRIPTION
This PR exposes the `allGroups` function to consumers of the package.    

Signed-off-by: secustor <sebastian@poxhofer.at>
