### PR TITLE
Fix scrape interval and duration tooltip not showing.

### DIFF
--- a/web/ui/react-app/src/pages/targets/TargetScrapeDuration.tsx
+++ b/web/ui/react-app/src/pages/targets/TargetScrapeDuration.tsx
@@ -24,6 +24,7 @@ const TargetScrapeDuration: FC<TargetScrapeDurationProps> = ({ duration, interva
         isOpen={scrapeTooltipOpen}
         toggle={() => setScrapeTooltipOpen(!scrapeTooltipOpen)}
         target={CSS.escape(id)}
+        placement={'right-end'}
         style={{ maxWidth: 'none', textAlign: 'left' }}
       >
         <Fragment>


### PR DESCRIPTION
I have the same problem as #10470. I just copy this prop from another tooltip and it works. This may fix #10470.