### PR TITLE
Store compiled web ui in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,9 @@ jobs:
       - run: make ui-lint
       - run: make ui-build-module
       - run: make ui-test
+      - run: make assets-tarball -o assets
+      - store_artifacts:
+          path: web/ui/static.tar.gz
       - save_cache:
           key: v3-npm-deps-{{ checksum "web/ui/package-lock.json" }}
           paths:

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,14 @@ ui-lint:
 assets: ui-install ui-build
 
 .PHONY: assets-compress
-assets-compress:
+assets-compress: assets
 	@echo '>> compressing assets'
 	scripts/compress_assets.sh
+
+.PHONY: assets-tarball
+assets-tarball: assets-compress
+	@echo '>> packaging assets'
+	scripts/package_assets.sh
 
 .PHONY: test
 # If we only want to only test go code we have to change the test target

--- a/scripts/package_assets.sh
+++ b/scripts/package_assets.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# compress static assets
+
+set -euo pipefail
+
+cd web/ui
+find static -type f -name '*.gz' -print0 | xargs -0 tar cf static.tar.gz


### PR DESCRIPTION
Some downstream distros fail to compile Prometheus UI (Debian, NixOS).

This is an attempt to store compiled UI in circleci for them to consume
it. Currently we do not expose this outside of circleci.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
