### PR TITLE
Fix assets tarball

### DIFF
--- a/scripts/package_assets.sh
+++ b/scripts/package_assets.sh
@@ -5,4 +5,4 @@
 set -euo pipefail
 
 cd web/ui
-find static -type f -name '*.gz' -print0 | xargs -0 tar cf static.tar.gz
+find static -type f -not -name '*.gz' -print0 | xargs -0 tar czf static.tar.gz


### PR DESCRIPTION
The tarball should be compressed and only use uncompressed assets. In
that way, uit can be used by downstream distros easily. they can either
download the assets and serve it as is or use the compress script to
have it in the binary.
