### PR TITLE
Changing TotalQueryableSamples from int to int64

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1398,7 +1398,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 				enh.Ts = ts
 				// Make the function call.
 				outVec := call(inArgs, e.Args, enh)
-				ev.samplesStats.IncrementSamplesAtStep(step, len(points))
+				ev.samplesStats.IncrementSamplesAtStep(step, int64(len(points)))
 				enh.Out = outVec[:0]
 				if len(outVec) > 0 {
 					ss.Points = append(ss.Points, Point{V: outVec[0].Point.V, T: ts})
@@ -1783,7 +1783,7 @@ func (ev *evaluator) matrixSelector(node *parser.MatrixSelector) (Matrix, storag
 		}
 
 		ss.Points = ev.matrixIterSlice(it, mint, maxt, getPointSlice(16))
-		ev.samplesStats.IncrementSamplesAtTimestamp(ev.startTimestamp, len(ss.Points))
+		ev.samplesStats.IncrementSamplesAtTimestamp(ev.startTimestamp, int64(len(ss.Points)))
 
 		if len(ss.Points) > 0 {
 			matrix = append(matrix, ss)

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -747,7 +747,6 @@ load 10s
   metricWith3SampleEvery10Seconds{a="2",b="2"} 1+1x100
   metricWith3SampleEvery10Seconds{a="3",b="2"} 1+1x100
 `)
-
 	require.NoError(t, err)
 	defer test.Close()
 
@@ -757,7 +756,7 @@ load 10s
 	cases := []struct {
 		Query               string
 		SkipMaxCheck        bool
-		TotalSamples        int
+		TotalSamples        int64
 		TotalSamplesPerStep stats.TotalSamplesPerStep
 		PeakSamples         int
 		Start               time.Time

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -104,7 +104,7 @@ type queryTimings struct {
 
 type querySamples struct {
 	TotalQueryableSamplesPerStep []stepStat `json:"totalQueryableSamplesPerStep,omitempty"`
-	TotalQueryableSamples        int        `json:"totalQueryableSamples"`
+	TotalQueryableSamples        int64      `json:"totalQueryableSamples"`
 	PeakSamples                  int        `json:"peakSamples"`
 }
 
@@ -182,7 +182,7 @@ func (qs *QuerySamples) totalSamplesPerStepPoints() []stepStat {
 
 	ts := make([]stepStat, len(qs.TotalSamplesPerStep))
 	for i, c := range qs.TotalSamplesPerStep {
-		ts[i] = stepStat{T: qs.startTimestamp + int64(i)*qs.interval, V: int64(c)}
+		ts[i] = stepStat{T: qs.startTimestamp + int64(i)*qs.interval, V: c}
 	}
 	return ts
 }
@@ -236,14 +236,14 @@ type QuerySamples struct {
 
 	// TotalSamples represents the total number of samples scanned
 	// while evaluating a query.
-	TotalSamples int
+	TotalSamples int64
 
 	// TotalSamplesPerStep represents the total number of samples scanned
 	// per step while evaluating a query. Each step should be identical to the
 	// TotalSamples when a step is run as an instant query, which means
 	// we intentionally do not account for optimizations that happen inside the
 	// range query engine that reduce the actual work that happens.
-	TotalSamplesPerStep []int
+	TotalSamplesPerStep []int64
 
 	EnablePerStepStats bool
 	startTimestamp     int64
@@ -261,13 +261,13 @@ func (qs *QuerySamples) InitStepTracking(start, end, interval int64) {
 	}
 
 	numSteps := int((end-start)/interval) + 1
-	qs.TotalSamplesPerStep = make([]int, numSteps)
+	qs.TotalSamplesPerStep = make([]int64, numSteps)
 	qs.startTimestamp = start
 	qs.interval = interval
 }
 
 // IncrementSamplesAtStep increments the total samples count. Use this if you know the step index.
-func (qs *QuerySamples) IncrementSamplesAtStep(i, samples int) {
+func (qs *QuerySamples) IncrementSamplesAtStep(i int, samples int64) {
 	if qs == nil {
 		return
 	}
@@ -280,7 +280,7 @@ func (qs *QuerySamples) IncrementSamplesAtStep(i, samples int) {
 
 // IncrementSamplesAtTimestamp increments the total samples count. Use this if you only have the corresponding step
 // timestamp.
-func (qs *QuerySamples) IncrementSamplesAtTimestamp(t int64, samples int) {
+func (qs *QuerySamples) IncrementSamplesAtTimestamp(t, samples int64) {
 	if qs == nil {
 		return
 	}


### PR DESCRIPTION
Follow up of https://github.com/prometheus/prometheus/pull/10369

`int` can only count up to ~2B and for some very big query_ranges is possible have an overflow.

The `stepStat ` struct was already an `int64` but some internal data structures and the `totalQueryableSamples` is using int.

https://github.com/prometheus/prometheus/blob/a236166c71b6eaae622d585f35f3f27459971c1c/util/stats/query_stats.go#L105-L109

https://github.com/prometheus/prometheus/blob/a236166c71b6eaae622d585f35f3f27459971c1c/util/stats/query_stats.go#L81-L84
