### PR TITLE
Histogram: Fix crash when compacting only empty buckets

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -471,7 +471,7 @@ func compactBuckets(buckets []float64, spans []Span, maxEmptyBuckets int) ([]flo
 			iSpan++
 		}
 	}
-	if maxEmptyBuckets == 0 {
+	if maxEmptyBuckets == 0 || len(buckets) == 0 {
 		return buckets, spans
 	}
 

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -889,6 +889,22 @@ func TestFloatHistogramCompact(t *testing.T) {
 				NegativeBuckets: []float64{3.1, 3, 0, 0, 0, 1.234e5, 1000, 0, 3, 4},
 			},
 		},
+		{
+			"only empty buckets and maxEmptyBuckets greater zero",
+			&FloatHistogram{
+				PositiveSpans:   []Span{{-4, 6}, {3, 3}},
+				PositiveBuckets: []float64{0, 0, 0, 0, 0, 0, 0, 0, 0},
+				NegativeSpans:   []Span{{0, 7}},
+				NegativeBuckets: []float64{0, 0, 0, 0, 0, 0, 0},
+			},
+			3,
+			&FloatHistogram{
+				PositiveSpans:   []Span{},
+				PositiveBuckets: []float64{},
+				NegativeSpans:   []Span{},
+				NegativeBuckets: []float64{},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
__This is just going to the sparsehistogram branch.__

@codesome this seems trivial enough that I will just merge on green. (I expected this bug to be way more subtle… oh well.)