### PR TITLE
promql: Add first_over_time function

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -430,6 +430,7 @@ over time and return an instant vector with per-series aggregation results:
 * `stddev_over_time(range-vector)`: the population standard deviation of the values in the specified interval.
 * `stdvar_over_time(range-vector)`: the population standard variance of the values in the specified interval.
 * `last_over_time(range-vector)`: the most recent point value in specified interval.
+* `first_over_time(range-vector)`: the least recent point value in specified interval.
 * `present_over_time(range-vector)`: the value 1 for any series in the specified interval.
 
 Note that all values in the specified interval have the same weight in the

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1365,11 +1365,11 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 			points = points[:0]
 			it.Reset(s.Iterator())
 			metric := selVS.Series[i].Labels()
-			// The last_over_time function acts like offset; thus, it
+			// The [last/first]_over_time functions acts like offset; thus, it
 			// should keep the metric name.  For all the other range
 			// vector functions, the only change needed is to drop the
 			// metric name in the output.
-			if e.Func.Name != "last_over_time" {
+			if e.Func.Name != "last_over_time" && e.Func.Name != "first_over_time" {
 				metric = dropMetricName(metric)
 			}
 			ss := Series{

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -414,6 +414,16 @@ func funcLastOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNod
 	})
 }
 
+// === first_over_time(Matrix parser.ValueTypeMatrix) Vector ===
+func funcFirstOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	el := vals[0].(Matrix)[0]
+
+	return append(enh.Out, Sample{
+		Metric: el.Metric,
+		Point:  Point{V: el.Points[0].V},
+	})
+}
+
 // === max_over_time(Matrix parser.ValueTypeMatrix) Vector ===
 func funcMaxOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	return aggrOverTime(vals, enh, func(values []Point) float64 {
@@ -1093,6 +1103,7 @@ var FunctionCalls = map[string]FunctionCall{
 	"delta":              funcDelta,
 	"deriv":              funcDeriv,
 	"exp":                funcExp,
+	"first_over_time":    funcFirstOverTime,
 	"floor":              funcFloor,
 	"histogram_quantile": funcHistogramQuantile,
 	"holt_winters":       funcHoltWinters,

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -152,6 +152,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeVector},
 		ReturnType: ValueTypeVector,
 	},
+	"first_over_time": {
+		Name:       "first_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+	},
 	"floor": {
 		Name:       "floor",
 		ArgTypes:   []ValueType{ValueTypeVector},

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -787,6 +787,13 @@ eval instant at 1m last_over_time(data[1m])
 	data{type="some_nan3"} 1
 	data{type="only_nan"} NaN
 
+eval instant at 1m first_over_time(data[1m])
+	data{type="numbers"} 2
+	data{type="some_nan"} 2
+	data{type="some_nan2"} 2
+	data{type="some_nan3"} NaN
+	data{type="only_nan"} NaN
+
 clear
 
 # Test for absent()


### PR DESCRIPTION
Adding `first_over_time` function  to the Prometheus baseline.

The intent is to have a complementary function to the `last_over_time` one.
One usage of this function could be to be able to evaluate the growth of a time-series from a baseline ( first_over_time ) and check how it varies from there 