### PR TITLE
Fix discovery managers to be properly cancelled

### DIFF
--- a/discovery/legacymanager/manager.go
+++ b/discovery/legacymanager/manager.go
@@ -140,11 +140,9 @@ type Manager struct {
 // Run starts the background processing
 func (m *Manager) Run() error {
 	go m.sender()
-	for range m.ctx.Done() {
-		m.cancelDiscoverers()
-		return m.ctx.Err()
-	}
-	return nil
+	<-m.ctx.Done()
+	m.cancelDiscoverers()
+	return m.ctx.Err()
 }
 
 // SyncCh returns a read only channel used by all the clients to receive target updates.

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -166,11 +166,9 @@ type Manager struct {
 // Run starts the background processing.
 func (m *Manager) Run() error {
 	go m.sender()
-	for range m.ctx.Done() {
-		m.cancelDiscoverers()
-		return m.ctx.Err()
-	}
-	return nil
+	<-m.ctx.Done()
+	m.cancelDiscoverers()
+	return m.ctx.Err()
 }
 
 // SyncCh returns a read only channel used by all the clients to receive target updates.


### PR DESCRIPTION
`for range m.ctx.Done()` won't let the program touch its body; `m.ctx.Done()` will only close.

Although I don't know what `m.cancelDiscoverers` exaclty does, it seems to me that it must be called for graceful shutdown.

Here is the simple demo for comparing: https://go.dev/play/p/UDzf26J0zcs

@roidelapluie 