### PR TITLE
Publish UI artefact as part of the release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,10 @@ jobs:
       - run: make ui-build-module
       - run: make ui-test
       - run: make assets-tarball -o assets
-      - store_artifacts:
-          path: web/ui/static.tar.gz
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .tarballs
       - save_cache:
           key: v3-npm-deps-{{ checksum "web/ui/package-lock.json" }}
           paths:

--- a/scripts/package_assets.sh
+++ b/scripts/package_assets.sh
@@ -4,5 +4,7 @@
 
 set -euo pipefail
 
+version="$(< VERSION)"
+mkdir -p .tarballs
 cd web/ui
-find static -type f -not -name '*.gz' -print0 | xargs -0 tar czf static.tar.gz
+find static -type f -not -name '*.gz' -print0 | xargs -0 tar czf ../../.tarballs/prometheus-web-ui-${version}.tar.gz


### PR DESCRIPTION
This will make UI static files part of the release artefacts, for
consumption by downstream distributions.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
