### PR TITLE
Build the UI when making UI tarball

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,9 @@ jobs:
           keys:
             - v3-npm-deps-{{ checksum "web/ui/package-lock.json" }}
             - v3-npm-deps-
-      - run: make ui-install
+      - run: make assets-tarball
       - run: make ui-lint
-      - run: make ui-build-module
       - run: make ui-test
-      - run: make assets-tarball -o assets
       - persist_to_workspace:
           root: .
           paths:

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ assets-compress: assets
 	scripts/compress_assets.sh
 
 .PHONY: assets-tarball
-assets-tarball: assets-compress
+assets-tarball: assets
 	@echo '>> packaging assets'
 	scripts/package_assets.sh
 


### PR DESCRIPTION
We run ui-install on ci but not ui-build. This PR resolves that.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
