### PR TITLE
fix markdown lint issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
+# Changelog
+
 ## 2.35.0 / 2022-04-21
 
 This Prometheus release is built with go1.18, which contains two noticeable changes related to TLS:
 
-1. [TLS 1.0 and 1.1 disabled by default client-side](https://go.dev/doc/go1.18#tls10). 
+1. [TLS 1.0 and 1.1 disabled by default client-side](https://go.dev/doc/go1.18#tls10).
 Prometheus users can override this with the `min_version` parameter of [tls_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tls_config).
 2. [Certificates signed with the SHA-1 hash function are rejected](https://go.dev/doc/go1.18#sha1). This doesn't apply to self-signed root certificates.
 
 * [CHANGE] TSDB: Delete `*.tmp` WAL files when Prometheus starts. #10317
 * [CHANGE] promtool: Add new flag `--lint` (enabled by default) for the commands `check rules` and `check config`, resulting in a new exit code (`3`) for linter errors. #10435
 * [FEATURE] Support for automatically setting the variable `GOMAXPROCS` to the container CPU limit. Enable with the flag `--enable-feature=auto-gomaxprocs`. #10498
-* [FEATURE] PromQL: Extend statistics with total and peak number of samples in a query. Additionally, per-step statistics are available with  --enable-feature=promql-per-step-stats and using `stats=all` in the query API. 
+* [FEATURE] PromQL: Extend statistics with total and peak number of samples in a query. Additionally, per-step statistics are available with  --enable-feature=promql-per-step-stats and using `stats=all` in the query API.
 Enable with the flag `--enable-feature=per-step-stats`. #10369
 * [ENHANCEMENT] Prometheus is built with Go 1.18. #10501
 * [ENHANCEMENT] TSDB: more efficient sorting of postings read from WAL at startup. #10500
@@ -41,7 +43,7 @@ Enable with the flag `--enable-feature=per-step-stats`. #10369
 * [ENHANCEMENT] UI: Optimize the alerts page and add a search bar. #10142
 * [ENHANCEMENT] UI: Improve graph colors that were hard to see. #10179
 * [ENHANCEMENT] Config: Allow escaping of `$` with `$$` when using environment variables with external labels. #10129
-* [BUGFIX] PromQL: Properly return an error from histogram_quantile when metrics have the same labelset. #10140 
+* [BUGFIX] PromQL: Properly return an error from histogram_quantile when metrics have the same labelset. #10140
 * [BUGFIX] UI: Fix bug that sets the range input to the resolution. #10227
 * [BUGFIX] TSDB: Fix a query panic when `memory-snapshot-on-shutdown` is enabled. #10348
 * [BUGFIX] Parser: Specify type in metadata parser errors. #10269
@@ -360,7 +362,7 @@ Alertmanager API v2 was released in Alertmanager v0.16.0 (released in January
 2019).
 
 * [FEATURE] **experimental** API: Accept remote_write requests. Behind the --enable-feature=remote-write-receiver flag. #8424
-* [FEATURE] **experimental** PromQL: Add '@ <timestamp>' modifier. Behind the --enable-feature=promql-at-modifier flag. #8121 #8436 #8425
+* [FEATURE] **experimental** PromQL: Add `@ <timestamp>` modifier. Behind the --enable-feature=promql-at-modifier flag. #8121 #8436 #8425
 * [ENHANCEMENT] Add optional name property to testgroup for better test failure output. #8440
 * [ENHANCEMENT] Add warnings into React Panel on the Graph page. #8427
 * [ENHANCEMENT] TSDB: Increase the number of buckets for the compaction duration metric. #8342
@@ -405,12 +407,12 @@ Alertmanager API v2 was released in Alertmanager v0.16.0 (released in January
 
 * [CHANGE] UI: Make the React UI default. #8142
 * [CHANGE] Remote write: The following metrics were removed/renamed in remote write. #6815
-     - `prometheus_remote_storage_succeeded_samples_total` was removed and `prometheus_remote_storage_samples_total` was introduced for all the samples attempted to send.
-     - `prometheus_remote_storage_sent_bytes_total` was removed and replaced with `prometheus_remote_storage_samples_bytes_total` and `prometheus_remote_storage_metadata_bytes_total`.
-     - `prometheus_remote_storage_failed_samples_total` -> `prometheus_remote_storage_samples_failed_total` .
-     - `prometheus_remote_storage_retried_samples_total` -> `prometheus_remote_storage_samples_retried_total`.
-     - `prometheus_remote_storage_dropped_samples_total` -> `prometheus_remote_storage_samples_dropped_total`.
-     - `prometheus_remote_storage_pending_samples` -> `prometheus_remote_storage_samples_pending`.
+  * `prometheus_remote_storage_succeeded_samples_total` was removed and `prometheus_remote_storage_samples_total` was introduced for all the samples attempted to send.
+  * `prometheus_remote_storage_sent_bytes_total` was removed and replaced with `prometheus_remote_storage_samples_bytes_total` and `prometheus_remote_storage_metadata_bytes_total`.
+  * `prometheus_remote_storage_failed_samples_total` -> `prometheus_remote_storage_samples_failed_total` .
+  * `prometheus_remote_storage_retried_samples_total` -> `prometheus_remote_storage_samples_retried_total`.
+  * `prometheus_remote_storage_dropped_samples_total` -> `prometheus_remote_storage_samples_dropped_total`.
+  * `prometheus_remote_storage_pending_samples` -> `prometheus_remote_storage_samples_pending`.
 * [CHANGE] Remote: Do not collect non-initialized timestamp metrics. #8060
 * [FEATURE] [EXPERIMENTAL] Remote write: Allow metric metadata to be propagated via remote write. The following new metrics were introduced: `prometheus_remote_storage_metadata_total`, `prometheus_remote_storage_metadata_failed_total`, `prometheus_remote_storage_metadata_retried_total`, `prometheus_remote_storage_metadata_bytes_total`. #6815
 * [ENHANCEMENT] Remote write: Added a metric `prometheus_remote_storage_max_samples_per_send` for remote write. #8102
@@ -585,7 +587,6 @@ This release changes WAL compression from opt-in to default. WAL compression wil
 * [BUGFIX] React UI: Fixed multiselect legend on OSX. #6880
 * [BUGFIX] Remote Write: Fixed blocked resharding edge case. #7122
 * [BUGFIX] Remote Write: Fixed remote write not updating on relabel configs change. #7073
-
 
 ## 2.17.2 / 2020-04-20
 
@@ -1002,10 +1003,10 @@ We're rolling back the Dockerfile changes introduced in 2.6.0. If you made chang
 
 ## 2.4.2 / 2018-09-21
 
- The last release didn't have bugfix included due to a vendoring error.
+The last release didn't have bugfix included due to a vendoring error.
 
- * [BUGFIX] Handle WAL corruptions properly prometheus/tsdb#389
- * [BUGFIX] Handle WAL migrations correctly on Windows prometheus/tsdb#392
+* [BUGFIX] Handle WAL corruptions properly prometheus/tsdb#389
+* [BUGFIX] Handle WAL migrations correctly on Windows prometheus/tsdb#392
 
 ## 2.4.1 / 2018-09-19
 
@@ -1152,15 +1153,14 @@ This release includes multiple bugfixes and features. Further, the WAL implement
 * [BUGFIX] tsdb: Cleanup and do not retry failing compactions.
 * [BUGFIX] tsdb: Close WAL while shutting down.
 
-
 ## 2.0.0 / 2017-11-08
 
 This release includes a completely rewritten storage, huge performance
 improvements, but also many backwards incompatible changes. For more
 information, read the announcement blog post and migration guide.
 
-https://prometheus.io/blog/2017/11/08/announcing-prometheus-2-0/
-https://prometheus.io/docs/prometheus/2.0/migration/
+<https://prometheus.io/blog/2017/11/08/announcing-prometheus-2-0/>
+<https://prometheus.io/docs/prometheus/2.0/migration/>
 
 * [CHANGE] Completely rewritten storage layer, with WAL. This is not backwards compatible with 1.x storage, and many flags have changed/disappeared.
 * [CHANGE] New staleness behavior. Series now marked stale after target scrapes no longer return them, and soon after targets disappear from service discovery.
@@ -1570,7 +1570,7 @@ This release contains multiple breaking changes to the configuration schema.
 This version contains a breaking change to the query language. Please read
 the documentation on the grouping behavior of vector matching:
 
-https://prometheus.io/docs/querying/operators/#vector-matching
+<https://prometheus.io/docs/querying/operators/#vector-matching>
 
 * [FEATURE] Add experimental Microsoft Azure service discovery
 * [FEATURE] Add `ignoring` modifier for binary operations
@@ -1696,7 +1696,7 @@ BREAKING CHANGES:
   with InfluxDB 0.9.x. 0.8.x versions of InfluxDB are not supported anymore.
 * Escape sequences in double- and single-quoted string literals in rules or query
   expressions are now interpreted like escape sequences in Go string literals
-  (https://golang.org/ref/spec#String_literals).
+  (<https://golang.org/ref/spec#String_literals>).
 
 Future breaking changes / deprecated features:
 
@@ -1832,6 +1832,7 @@ All changes:
 * [CLEANUP] Resolve relative paths during configuration loading.
 
 ## 0.15.1 / 2015-07-27
+
 * [BUGFIX] Fix vector matching behavior when there is a mix of equality and
   non-equality matchers in a vector selector and one matcher matches no series.
 * [ENHANCEMENT] Allow overriding `GOARCH` and `GOOS` in Makefile.INCLUDE.
@@ -1949,6 +1950,7 @@ All changes:
 * [CLEANUP] Use new v1 HTTP API for querying and graphing.
 
 ## 0.14.0 / 2015-06-01
+
 * [CHANGE] Configuration format changed and switched to YAML.
   (See the provided [migration tool](https://github.com/prometheus/migrate/releases).)
 * [ENHANCEMENT] Redesign of state-preserving target discovery.
@@ -1974,9 +1976,11 @@ All changes:
 * [ENHANCEMENT] Limit retrievable samples to the storage's retention window.
 
 ## 0.13.4 / 2015-05-23
+
 * [BUGFIX] Fix a race while checkpointing fingerprint mappings.
 
 ## 0.13.3 / 2015-05-11
+
 * [BUGFIX] Handle fingerprint collisions properly.
 * [CHANGE] Comments in rules file must start with `#`. (The undocumented `//`
   and `/*...*/` comment styles are no longer supported.)
@@ -1987,6 +1991,7 @@ All changes:
 * [ENHANCEMENT] Terminate running queries during shutdown.
 
 ## 0.13.2 / 2015-05-05
+
 * [MAINTENANCE] Updated vendored dependencies to their newest versions.
 * [MAINTENANCE] Include rule_checker and console templates in release tarball.
 * [BUGFIX] Sort NaN as the lowest value.
@@ -1997,10 +2002,12 @@ All changes:
 * [BUGFIX] Show correct error on wrong DNS response.
 
 ## 0.13.1 / 2015-04-09
+
 * [BUGFIX] Treat memory series with zero chunks correctly in series maintenance.
 * [ENHANCEMENT] Improve readability of usage text even more.
 
 ## 0.13.0 / 2015-04-08
+
 * [ENHANCEMENT] Double-delta encoding for chunks, saving typically 40% of
   space, both in RAM and on disk.
 * [ENHANCEMENT] Redesign of chunk persistence queuing, increasing performance
@@ -2028,6 +2035,7 @@ All changes:
 * [MAINTENANCE] Updated vendored dependencies to their newest versions.
 
 ## 0.12.0 / 2015-03-04
+
 * [CHANGE] Use client_golang v0.3.1. THIS CHANGES FINGERPRINTING AND INVALIDATES
   ALL PERSISTED FINGERPRINTS. You have to wipe your storage to use this or
   later versions. There is a version guard in place that will prevent you to
@@ -2043,6 +2051,7 @@ All changes:
 * [CHANGE] Makefile uses Go 1.4.2.
 
 ## 0.11.1 / 2015-02-27
+
 * [BUGFIX] Make series maintenance complete again. (Ever since 0.9.0rc4,
   or commit 0851945, series would not be archived, chunk descriptors would
   not be evicted, and stale head chunks would never be closed. This happened
@@ -2055,6 +2064,7 @@ All changes:
 * [ENHANCEMENT] Limit the number of 'dirty' series counted during checkpointing.
 
 ## 0.11.0 / 2015-02-23
+
 * [FEATURE] Introduce new metric type Histogram with server-side aggregation.
 * [FEATURE] Add offset operator.
 * [FEATURE] Add floor, ceil and round functions.
@@ -2079,18 +2089,20 @@ All changes:
 * [CLEANUP] Various code cleanups.
 
 ## 0.10.0 / 2015-01-26
+
 * [CHANGE] More efficient JSON result format in query API. This requires
   up-to-date versions of PromDash and prometheus_cli, too.
 * [ENHANCEMENT] Excluded non-minified Bootstrap assets and the Bootstrap maps
   from embedding into the binary. Those files are only used for debugging,
   and then you can use -web.use-local-assets. By including fewer files, the
   RAM usage during compilation is much more manageable.
-* [ENHANCEMENT] Help link points to https://prometheus.github.io now.
+* [ENHANCEMENT] Help link points to <https://prometheus.github.io> now.
 * [FEATURE] Consoles for haproxy and cloudwatch.
 * [BUGFIX] Several fixes to graphs in consoles.
 * [CLEANUP] Removed a file size check that did not check anything.
 
 ## 0.9.0 / 2015-01-23
+
 * [CHANGE] Reworked command line flags, now more consistent and taking into
   account needs of the new storage backend (see below).
 * [CHANGE] Metric names are dropped after certain transformations.
@@ -2132,10 +2144,12 @@ All changes:
 * [CLEANUP] Removed dead code.
 
 ## 0.8.0 / 2014-09-04
+
 * [ENHANCEMENT] Stagger scrapes to spread out load.
 * [BUGFIX] Correctly quote HTTP Accept header.
 
 ## 0.7.0 / 2014-08-06
+
 * [FEATURE] Added new functions: abs(), topk(), bottomk(), drop_common_labels().
 * [FEATURE] Let console templates get graph links from expressions.
 * [FEATURE] Allow console templates to dynamically include other templates.
@@ -2150,6 +2164,7 @@ All changes:
 * [ENHANCEMENT] Dockerfile also builds Prometheus support tools now.
 
 ## 0.6.0 / 2014-06-30
+
 * [FEATURE] Added console and alert templates support, along with various template functions.
 * [PERFORMANCE] Much faster and more memory-efficient flushing to disk.
 * [ENHANCEMENT] Query results are now only logged when debugging.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
-## Prometheus Community Code of Conduct
+# Prometheus Community Code of Conduct
 
 Prometheus follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,6 @@ Prometheus uses GitHub to manage reviews of pull requests.
 
 * Be sure to sign off on the [DCO](https://github.com/probot/dco#how-it-works).
 
-
 ## Steps to Contribute
 
 Should you wish to work on an issue, please claim it first by commenting on the GitHub issue that you want to work on it. This is to prevent duplicated efforts from contributors on the same issue.
@@ -33,7 +32,8 @@ You can [spin up a prebuilt dev environment](https://gitpod.io/#https://github.c
 For complete instructions on how to compile see: [Building From Source](https://github.com/prometheus/prometheus#building-from-source)
 
 For quickly compiling and testing your changes do:
-```
+
+```bash
 # For building.
 go build ./cmd/prometheus/
 ./prometheus

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,5 @@
+# Maintainers
+
 Julien Pivotto (<roidelapluie@prometheus.io> / @roidelapluie) and Levi Harrison (<levi@leviharrison.dev> / @LeviHarrison) are the main/default maintainers, some parts of the codebase have other maintainers:
 
 * `cmd`

--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@ displays the results, and can trigger alerts when specified conditions are obser
 
 The features that distinguish Prometheus from other metrics and monitoring systems are:
 
-- A **multi-dimensional** data model (time series defined by metric name and set of key/value dimensions)
-- PromQL, a **powerful and flexible query language** to leverage this dimensionality
-- No dependency on distributed storage; **single server nodes are autonomous**
-- An HTTP **pull model** for time series collection
-- **Pushing time series** is supported via an intermediary gateway for batch jobs
-- Targets are discovered via **service discovery** or **static configuration**
-- Multiple modes of **graphing and dashboarding support**
-- Support for hierarchical and horizontal **federation**
+* A **multi-dimensional** data model (time series defined by metric name and set of key/value dimensions)
+* PromQL, a **powerful and flexible query language** to leverage this dimensionality
+* No dependency on distributed storage; **single server nodes are autonomous**
+* An HTTP **pull model** for time series collection
+* **Pushing time series** is supported via an intermediary gateway for batch jobs
+* Targets are discovered via **service discovery** or **static configuration**
+* Multiple modes of **graphing and dashboarding support**
+* Support for hierarchical and horizontal **federation**
 
 ## Architecture overview
 
-![](https://cdn.jsdelivr.net/gh/prometheus/prometheus@c34257d069c630685da35bcef084632ffd5d6209/documentation/images/architecture.svg)
+![Architecture overview](https://cdn.jsdelivr.net/gh/prometheus/prometheus@c34257d069c630685da35bcef084632ffd5d6209/documentation/images/architecture.svg)
 
 ## Install
 
@@ -49,13 +49,16 @@ Docker images are available on [Quay.io](https://quay.io/repository/prometheus/p
 
 You can launch a Prometheus container for trying it out with
 
-    $ docker run --name prometheus -d -p 127.0.0.1:9090:9090 prom/prometheus
+```bash
+docker run --name prometheus -d -p 127.0.0.1:9090:9090 prom/prometheus
+```
 
-Prometheus will now be reachable at http://localhost:9090/.
+Prometheus will now be reachable at <http://localhost:9090/>.
 
 ### Building from source
 
 To build Prometheus from source code, You need:
+
 * Go [version 1.16 or greater](https://golang.org/doc/install).
 * NodeJS [version 16 or greater](https://nodejs.org/).
 * npm [version 7 or greater](https://www.npmjs.com/).
@@ -63,8 +66,10 @@ To build Prometheus from source code, You need:
 You can directly use the `go` tool to download and install the `prometheus`
 and `promtool` binaries into your `GOPATH`:
 
-    $ GO111MODULE=on go install github.com/prometheus/prometheus/cmd/...
-    $ prometheus --config.file=your_config.yml
+```bash
+GO111MODULE=on go install github.com/prometheus/prometheus/cmd/...
+prometheus --config.file=your_config.yml
+```
 
 *However*, when using `go install` to build Prometheus, Prometheus will expect to be able to
 read its web assets from local filesystem directories under `web/ui/static` and
@@ -77,21 +82,23 @@ An example of the above configuration file can be found [here.](https://github.c
 You can also clone the repository yourself and build using `make build`, which will compile in
 the web assets so that Prometheus can be run from anywhere:
 
-    $ mkdir -p $GOPATH/src/github.com/prometheus
-    $ cd $GOPATH/src/github.com/prometheus
-    $ git clone https://github.com/prometheus/prometheus.git
-    $ cd prometheus
-    $ make build
-    $ ./prometheus --config.file=your_config.yml
+```bash
+mkdir -p $GOPATH/src/github.com/prometheus
+cd $GOPATH/src/github.com/prometheus
+git clone https://github.com/prometheus/prometheus.git
+cd prometheus
+make build
+./prometheus --config.file=your_config.yml
+```
 
 The Makefile provides several targets:
 
-  * *build*: build the `prometheus` and `promtool` binaries (includes building and compiling in web assets)
-  * *test*: run the tests
-  * *test-short*: run the short tests
-  * *format*: format the source code
-  * *vet*: check the source code for common errors
-  * *assets*: build the React UI
+* *build*: build the `prometheus` and `promtool` binaries (includes building and compiling in web assets)
+* *test*: run the tests
+* *test-short*: run the short tests
+* *format*: format the source code
+* *vet*: check the source code for common errors
+* *assets*: build the React UI
 
 ### Service discovery plugins
 
@@ -115,10 +122,12 @@ always, be extra careful when loading third party code.
 The `make docker` target is designed for use in our CI system.
 You can build a docker image locally with the following commands:
 
-    $ make promu
-    $ promu crossbuild -p linux/amd64
-    $ make npm_licenses
-    $ make common-docker-amd64
+```bash
+make promu
+promu crossbuild -p linux/amd64
+make npm_licenses
+make common-docker-amd64
+```
 
 *NB* if you are on a Mac, you will need [gnu-tar](https://formulae.brew.sh/formula/gnu-tar).
 
@@ -132,7 +141,7 @@ We are publishing our Remote Write protobuf independently at
 You can use that as a library:
 
 ```shell
-$ go get go.buf.build/protocolbuffers/go/prometheus/prometheus
+go get go.buf.build/protocolbuffers/go/prometheus/prometheus
 ```
 
 This is experimental.
@@ -145,8 +154,8 @@ Prometheus v2.y.z releases, we are publishing equivalent v0.y.z tags.
 
 Therefore, a user that would want to use Prometheus v2.35.0 as a library could do:
 
-```
-$ go get github.com/prometheus/prometheus@v0.35.0
+```shell
+go get github.com/prometheus/prometheus@v0.35.0
 ```
 
 This solution makes it clear that we might break our internal Go APIs between
@@ -159,9 +168,9 @@ For more information on building, running, and developing on the React-based UI,
 
 ## More information
 
-  * Godoc documentation is available via [pkg.go.dev](https://pkg.go.dev/github.com/prometheus/prometheus). Due to peculiarities of Go Modules, v2.x.y will be displayed as v0.x.y. 
-  * You will find a CircleCI configuration in [`.circleci/config.yml`](.circleci/config.yml).
-  * See the [Community page](https://prometheus.io/community) for how to reach the Prometheus developers and users on various communication channels.
+* Godoc documentation is available via [pkg.go.dev](https://pkg.go.dev/github.com/prometheus/prometheus). Due to peculiarities of Go Modules, v2.x.y will be displayed as v0.x.y.
+* You will find a CircleCI configuration in [`.circleci/config.yml`](.circleci/config.yml).
+* See the [Community page](https://prometheus.io/community) for how to reach the Prometheus developers and users on various communication channels.
 
 ## Contributing
 
@@ -170,7 +179,6 @@ Refer to [CONTRIBUTING.md](https://github.com/prometheus/prometheus/blob/main/CO
 ## License
 
 Apache License 2.0, see [LICENSE](https://github.com/prometheus/prometheus/blob/main/LICENSE).
-
 
 [hub]: https://hub.docker.com/r/prom/prometheus/
 [circleci]: https://circleci.com/gh/prometheus/prometheus

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -97,7 +97,7 @@ of these in pull requests, one per feature.
 
 #### Updating Go dependencies
 
-```
+```bash
 make update-go-deps
 git add go.mod go.sum
 git commit -m "Update dependencies"
@@ -114,10 +114,10 @@ In case you want to update the UI dependencies, you can run the following comman
 make update-npm-deps
 ```
 
-Once this step completes, please verify that no additional `node_modules` directory was created in any of the module subdirectories 
+Once this step completes, please verify that no additional `node_modules` directory was created in any of the module subdirectories
 (which could indicate conflicting dependency versions across modules). Then run `make ui-build` to verify that the build is still working.
 
-Note: Once in a while, the npm dependencies should also be updated to their latest release versions (major or minor) with `make upgrade-npm-deps`, 
+Note: Once in a while, the npm dependencies should also be updated to their latest release versions (major or minor) with `make upgrade-npm-deps`,
 though this may be done at convenient times (e.g. by the UI maintainers) that are out-of-sync with Prometheus releases.
 
 ### 1. Prepare your release
@@ -144,9 +144,9 @@ Entries in the `CHANGELOG.md` are meant to be in this order:
 Tag the new release via the following commands:
 
 ```bash
-$ tag="v$(< VERSION)"
-$ git tag -s "${tag}" -m "${tag}"
-$ git push origin "${tag}"
+tag="v$(< VERSION)"
+git tag -s "${tag}" -m "${tag}"
+git push origin "${tag}"
 ```
 
 Go modules versioning requires strict use of semver. Because we do not commit to
@@ -156,9 +156,9 @@ the Prometheus server, we use major version zero releases for the libraries.
 Tag the new library release via the following commands:
 
 ```bash
-$ tag="v$(sed s/2/0/ < VERSION)"
-$ git tag -s "${tag}" -m "${tag}"
-$ git push origin "${tag}"
+tag="v$(sed s/2/0/ < VERSION)"
+git tag -s "${tag}" -m "${tag}"
+git push origin "${tag}"
 ```
 
 Optionally, you can use this handy `.gitconfig` alias.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,4 +3,4 @@
 The Prometheus security policy, including how to report vulnerabilities, can be
 found here:
 
-https://prometheus.io/docs/operating/security/
+<https://prometheus.io/docs/operating/security/>


### PR DESCRIPTION
Signed-off-by: André Bauer <andre.bauer@staffbase.com>

This PR fixes mardown lint issues in all markdown files in the prometheus repo root directory. 

Some notable changes:

* changelog and maintainers files got a new top level header
* code of conduct header changed to toplevel
* made links clickable
* use bash code tags for command line parts without starting "$"
* use asterisk for unordered lists everywhere
* fixed whitespaces and blanklines

Initial motivation was to just fix SECURITY.md & CODE_OF_CONDUCT.md because they are synced to other prometheus community repos like https://github.com/prometheus-community/helm-charts and throwing markdown linting errors there like in: 

https://github.com/prometheus-community/helm-charts/pull/1983

Also changed the other markdown files in the repo while beeing on it. 

If this is not wanted i'm also open to adjust only the SECURITY.md & CODE_OF_CONDUCT.md files.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
