### PR TITLE
tsdb/agent: Ignore duplicate exemplars

### DIFF
--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -440,6 +440,8 @@ func (db *DB) loadWAL(r *wal.Reader, multiRef map[chunks.HeadSeriesRef]chunks.He
 				decoded <- samples
 			case record.Tombstones, record.Exemplars:
 				// We don't care about tombstones or exemplars during replay.
+				// TODO: If decide to decode exemplars, we should make sure to prepopulate
+				// stripeSeries.exemplars in the next block by using setLatestExemplar.
 				continue
 			default:
 				errCh <- &wal.CorruptionErr{
@@ -789,6 +791,16 @@ func (a *appender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exem
 		}
 	}
 
+	// Check for duplicate vs last stored exemplar for this series, and discard those.
+	// Otherwise, record the current exemplar as the latest.
+	// Prometheus' TSDB returns 0 when encountering duplicates, so we do the same here.
+	prevExemplar := a.series.GetLatestExemplar(s.ref)
+	if prevExemplar != nil && prevExemplar.Equals(e) {
+		// Duplicate, don't return an error but don't accept the exemplar.
+		return 0, nil
+	}
+	a.series.SetLatestExemplar(s.ref, &e)
+
 	a.pendingExamplars = append(a.pendingExamplars, record.RefExemplar{
 		Ref:    s.ref,
 		T:      e.Ts,
@@ -796,6 +808,7 @@ func (a *appender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exem
 		Labels: e.Labels,
 	})
 
+	a.metrics.totalAppendedExemplars.Inc()
 	return storage.SeriesRef(s.ref), nil
 }
 

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -494,6 +494,6 @@ func TestStorage_DuplicateExemplarsIgnored(t *testing.T) {
 		}
 	}
 
-	// We had 9 calls to AppendExemplar but only 4 of those should have gotten through
+	// We had 9 calls to AppendExemplar but only 4 of those should have gotten through.
 	require.Equal(t, 4, walExemplarsCount)
 }

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -127,7 +127,7 @@ func TestCommit(t *testing.T) {
 
 			e := exemplar.Exemplar{
 				Labels: lset,
-				Ts:     sample[0].T(),
+				Ts:     sample[0].T() + int64(i),
 				Value:  sample[0].V(),
 				HasTs:  true,
 			}

--- a/tsdb/agent/series.go
+++ b/tsdb/agent/series.go
@@ -16,6 +16,7 @@ package agent
 import (
 	"sync"
 
+	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
@@ -89,10 +90,11 @@ func (m seriesHashmap) Delete(hash uint64, ref chunks.HeadSeriesRef) {
 // Filling the padded space with the maps was profiled to be slower -
 // likely due to the additional pointer dereferences.
 type stripeSeries struct {
-	size   int
-	series []map[chunks.HeadSeriesRef]*memSeries
-	hashes []seriesHashmap
-	locks  []stripeLock
+	size      int
+	series    []map[chunks.HeadSeriesRef]*memSeries
+	hashes    []seriesHashmap
+	exemplars []map[chunks.HeadSeriesRef]*exemplar.Exemplar
+	locks     []stripeLock
 
 	gcMut sync.Mutex
 }
@@ -105,16 +107,20 @@ type stripeLock struct {
 
 func newStripeSeries(stripeSize int) *stripeSeries {
 	s := &stripeSeries{
-		size:   stripeSize,
-		series: make([]map[chunks.HeadSeriesRef]*memSeries, stripeSize),
-		hashes: make([]seriesHashmap, stripeSize),
-		locks:  make([]stripeLock, stripeSize),
+		size:      stripeSize,
+		series:    make([]map[chunks.HeadSeriesRef]*memSeries, stripeSize),
+		hashes:    make([]seriesHashmap, stripeSize),
+		exemplars: make([]map[chunks.HeadSeriesRef]*exemplar.Exemplar, stripeSize),
+		locks:     make([]stripeLock, stripeSize),
 	}
 	for i := range s.series {
 		s.series[i] = map[chunks.HeadSeriesRef]*memSeries{}
 	}
 	for i := range s.hashes {
 		s.hashes[i] = seriesHashmap{}
+	}
+	for i := range s.exemplars {
+		s.exemplars[i] = map[chunks.HeadSeriesRef]*exemplar.Exemplar{}
 	}
 	return s
 }
@@ -153,6 +159,10 @@ func (s *stripeSeries) GC(mint int64) map[chunks.HeadSeriesRef]struct{} {
 				deleted[series.ref] = struct{}{}
 				delete(s.series[refLock], series.ref)
 				s.hashes[hashLock].Delete(hash, series.ref)
+
+				// Since the series is gone, we'll also delete
+				// the latest stored exemplar.
+				delete(s.exemplars[refLock], series.ref)
 
 				if hashLock != refLock {
 					s.locks[refLock].Unlock()
@@ -200,4 +210,25 @@ func (s *stripeSeries) Set(hash uint64, series *memSeries) {
 	s.locks[hashLock].Lock()
 	s.hashes[hashLock].Set(hash, series)
 	s.locks[hashLock].Unlock()
+}
+
+func (s *stripeSeries) GetLatestExemplar(ref chunks.HeadSeriesRef) *exemplar.Exemplar {
+	i := uint64(ref) & uint64(s.size-1)
+
+	s.locks[i].RLock()
+	exemplar := s.exemplars[i][ref]
+	s.locks[i].RUnlock()
+
+	return exemplar
+}
+
+func (s *stripeSeries) SetLatestExemplar(ref chunks.HeadSeriesRef, exemplar *exemplar.Exemplar) {
+	i := uint64(ref) & uint64(s.size-1)
+
+	// Make sure that's a valid series id and record its latest exemplar
+	s.locks[i].Lock()
+	if s.series[i][ref] != nil {
+		s.exemplars[i][ref] = exemplar
+	}
+	s.locks[i].Unlock()
 }


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalist0@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
