### PR TITLE
Amend Protobuf docstrings referring to model/ packages

### DIFF
--- a/prompb/types.pb.go
+++ b/prompb/types.pb.go
@@ -127,7 +127,7 @@ func (Chunk_Encoding) EnumDescriptor() ([]byte, []int) {
 
 type MetricMetadata struct {
 	// Represents the metric type, these match the set from Prometheus.
-	// Refer to pkg/textparse/interface.go for details.
+	// Refer to model/textparse/interface.go for details.
 	Type                 MetricMetadata_MetricType `protobuf:"varint,1,opt,name=type,proto3,enum=prometheus.MetricMetadata_MetricType" json:"type,omitempty"`
 	MetricFamilyName     string                    `protobuf:"bytes,2,opt,name=metric_family_name,json=metricFamilyName,proto3" json:"metric_family_name,omitempty"`
 	Help                 string                    `protobuf:"bytes,4,opt,name=help,proto3" json:"help,omitempty"`
@@ -200,7 +200,7 @@ func (m *MetricMetadata) GetUnit() string {
 
 type Sample struct {
 	Value float64 `protobuf:"fixed64,1,opt,name=value,proto3" json:"value,omitempty"`
-	// timestamp is in ms format, see pkg/timestamp/timestamp.go for
+	// timestamp is in ms format, see model/timestamp/timestamp.go for
 	// conversion from time.Time to Prometheus timestamp.
 	Timestamp            int64    `protobuf:"varint,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -259,7 +259,7 @@ type Exemplar struct {
 	// Optional, can be empty.
 	Labels []Label `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels"`
 	Value  float64 `protobuf:"fixed64,2,opt,name=value,proto3" json:"value,omitempty"`
-	// timestamp is in ms format, see pkg/timestamp/timestamp.go for
+	// timestamp is in ms format, see model/timestamp/timestamp.go for
 	// conversion from time.Time to Prometheus timestamp.
 	Timestamp            int64    `protobuf:"varint,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/prompb/types.proto
+++ b/prompb/types.proto
@@ -31,7 +31,7 @@ message MetricMetadata {
   }
 
   // Represents the metric type, these match the set from Prometheus.
-  // Refer to pkg/textparse/interface.go for details.
+  // Refer to model/textparse/interface.go for details.
   MetricType type = 1;
   string metric_family_name = 2;
   string help = 4;
@@ -40,7 +40,7 @@ message MetricMetadata {
 
 message Sample {
   double value    = 1;
-  // timestamp is in ms format, see pkg/timestamp/timestamp.go for
+  // timestamp is in ms format, see model/timestamp/timestamp.go for
   // conversion from time.Time to Prometheus timestamp.
   int64 timestamp = 2;
 }
@@ -49,7 +49,7 @@ message Exemplar {
   // Optional, can be empty.
   repeated Label labels = 1 [(gogoproto.nullable) = false];
   double value = 2;
-  // timestamp is in ms format, see pkg/timestamp/timestamp.go for
+  // timestamp is in ms format, see model/timestamp/timestamp.go for
   // conversion from time.Time to Prometheus timestamp.
   int64 timestamp = 3;
 }


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalist0@gmail.com>

This PR amends some Protobuf docstrings referring to the previous pkg/ structure. Low value, might just trip someone who isn't aware of the previous structure and recent-ish change.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
