### PR TITLE
Fix exemplar docs.

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -99,7 +99,7 @@ remote_read:
 
 # Storage related settings that are runtime reloadable.
 storage:
-  [ - <exemplars> ... ]
+  [ exemplars: <exemplars> ]
 
 # Configures exporting traces.
 tracing:


### PR DESCRIPTION
The structure of the config "storage. exemplars" is not a list. 
```
storage:
  exemplars:
    max_exemplars: 100000
```

So I think the doc should be
```
[ exemplars: <exemplars> ]
```
but not
``` 
[ - <exemplars> ... ]
```