### PR TITLE
changes in files of the expr in alerts, service and targets

### DIFF
--- a/web/ui/react-app/src/components/SearchBar.tsx
+++ b/web/ui/react-app/src/components/SearchBar.tsx
@@ -6,9 +6,10 @@ import { faSearch } from '@fortawesome/free-solid-svg-icons';
 export interface SearchBarProps {
   handleChange: (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
   placeholder: string;
+  defaultValue: string;
 }
 
-const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder }) => {
+const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder, defaultValue }) => {
   let filterTimeout: NodeJS.Timeout;
 
   const handleSearchChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
@@ -23,7 +24,7 @@ const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder }) => {
       <InputGroupAddon addonType="prepend">
         <InputGroupText>{<FontAwesomeIcon icon={faSearch} />}</InputGroupText>
       </InputGroupAddon>
-      <Input autoFocus onChange={handleSearchChange} placeholder={placeholder} />
+      <Input autoFocus onChange={handleSearchChange} placeholder={placeholder} defaultValue={defaultValue} />
     </InputGroup>
   );
 };

--- a/web/ui/react-app/src/pages/alerts/AlertContents.tsx
+++ b/web/ui/react-app/src/pages/alerts/AlertContents.tsx
@@ -8,6 +8,7 @@ import { useLocalStorage } from '../../hooks/useLocalStorage';
 import CustomInfiniteScroll, { InfiniteScrollItemsProps } from '../../components/CustomInfiniteScroll';
 import { KVSearch } from '@nexucis/kvsearch';
 import SearchBar from '../../components/SearchBar';
+import { encodeToQueryString } from '../../utils/index';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RuleState = keyof RuleStatus<any>;
@@ -63,6 +64,13 @@ function GroupContent(showAnnotations: boolean) {
 }
 
 const AlertsContent: FC<AlertsProps> = ({ groups = [], statsCount }) => {
+  useEffect(() => {
+    const search = window.location.search;
+    const params = new URLSearchParams(search);
+    const expr = params.get('expr');
+    setDefaultValue(expr || '');
+  }, []);
+
   const [groupList, setGroupList] = useState(groups);
   const [filteredList, setFilteredList] = useState(groups);
   const [filter, setFilter] = useLocalStorage('alerts-status-filter', {
@@ -71,7 +79,7 @@ const AlertsContent: FC<AlertsProps> = ({ groups = [], statsCount }) => {
     inactive: true,
   });
   const [showAnnotations, setShowAnnotations] = useLocalStorage('alerts-annotations-status', { checked: false });
-
+  const [defaultValue, setDefaultValue] = useState('');
   const toggleFilter = (ruleState: RuleState) => () => {
     setFilter({
       ...filter,
@@ -79,8 +87,15 @@ const AlertsContent: FC<AlertsProps> = ({ groups = [], statsCount }) => {
     });
   };
 
+  const updateURL = (expr: string): void => {
+    const query = encodeToQueryString(expr);
+    window.history.pushState({}, '', query);
+  };
+
   const handleSearchChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    console.log('e:', e);
     if (e.target.value !== '') {
+      updateURL(e.target.value);
       const pattern = e.target.value.trim();
       const result: RuleGroup[] = [];
       for (const group of groups) {
@@ -96,6 +111,7 @@ const AlertsContent: FC<AlertsProps> = ({ groups = [], statsCount }) => {
       }
       setGroupList(result);
     } else {
+      updateURL(e.target.value);
       setGroupList(groups);
     }
   };
@@ -131,7 +147,7 @@ const AlertsContent: FC<AlertsProps> = ({ groups = [], statsCount }) => {
           })}
         </Col>
         <Col lg="5" md="4">
-          <SearchBar handleChange={handleSearchChange} placeholder="Filter by name or labels" />
+          <SearchBar defaultValue={defaultValue} handleChange={handleSearchChange} placeholder="Filter by name or labels" />
         </Col>
         <Col className="d-flex flex-row-reverse" md="3">
           <Checkbox

--- a/web/ui/react-app/src/pages/alerts/AlertContents.tsx
+++ b/web/ui/react-app/src/pages/alerts/AlertContents.tsx
@@ -93,7 +93,6 @@ const AlertsContent: FC<AlertsProps> = ({ groups = [], statsCount }) => {
   };
 
   const handleSearchChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-    console.log('e:', e);
     if (e.target.value !== '') {
       updateURL(e.target.value);
       const pattern = e.target.value.trim();

--- a/web/ui/react-app/src/pages/targets/ScrapePoolList.tsx
+++ b/web/ui/react-app/src/pages/targets/ScrapePoolList.tsx
@@ -12,6 +12,7 @@ import { useLocalStorage } from '../../hooks/useLocalStorage';
 import styles from './ScrapePoolPanel.module.css';
 import { ToggleMoreLess } from '../../components/ToggleMoreLess';
 import SearchBar from '../../components/SearchBar';
+import { encodeToQueryString } from '../../utils/index';
 
 interface ScrapePoolListProps {
   activeTargets: Target[];
@@ -56,6 +57,13 @@ const ScrapePoolListContent: FC<ScrapePoolListProps> = ({ activeTargets }) => {
   const [poolList, setPoolList] = useState<ScrapePools>(initialPoolList);
   const [targetList, setTargetList] = useState(activeTargets);
 
+  useEffect(() => {
+    const search = window.location.search;
+    const params = new URLSearchParams(search);
+    const expr = params.get('expr');
+    setDefaultValue(expr || '');
+  }, []);
+
   const initialFilter: FilterData = {
     showHealthy: true,
     showUnhealthy: true,
@@ -71,12 +79,20 @@ const ScrapePoolListContent: FC<ScrapePoolListProps> = ({ activeTargets }) => {
   );
   const [expanded, setExpanded] = useLocalStorage('targets-page-expansion-state', initialExpanded);
   const { showHealthy, showUnhealthy } = filter;
+  const [defaultValue, setDefaultValue] = useState('');
+
+  const updateURL = (expr: string): void => {
+    const query = encodeToQueryString(expr);
+    window.history.pushState({}, '', query);
+  };
 
   const handleSearchChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     if (e.target.value !== '') {
+      updateURL(e.target.value);
       const result = kvSearch.filter(e.target.value.trim(), activeTargets);
       setTargetList(result.map((value) => value.original));
     } else {
+      updateURL(e.target.value);
       setTargetList(activeTargets);
     }
   };
@@ -93,7 +109,11 @@ const ScrapePoolListContent: FC<ScrapePoolListProps> = ({ activeTargets }) => {
           <Filter filter={filter} setFilter={setFilter} expanded={expanded} setExpanded={setExpanded} />
         </Col>
         <Col xs="6">
-          <SearchBar handleChange={handleSearchChange} placeholder="Filter by endpoint or labels" />
+          <SearchBar
+            defaultValue={defaultValue}
+            handleChange={handleSearchChange}
+            placeholder="Filter by endpoint or labels"
+          />
         </Col>
       </Row>
       {Object.keys(poolList)

--- a/web/ui/react-app/src/utils/index.ts
+++ b/web/ui/react-app/src/utils/index.ts
@@ -1,3 +1,4 @@
+import { debug } from 'console';
 import moment from 'moment-timezone';
 
 import { PanelOptions, PanelType, PanelDefaultOptions } from '../pages/graph/Panel';
@@ -243,9 +244,26 @@ export const encodePanelOptionsToQueryString = (panels: PanelMeta[]): string => 
   return `?${panels.map(toQueryString).join('&')}`;
 };
 
+export const encodeToQueryString = (expr: string): string => {
+  return `?expr=${expr}`;
+};
+
 export const createExpressionLink = (expr: string): string => {
   return `../graph?g0.expr=${encodeURIComponent(expr)}&g0.tab=1&g0.stacked=0&g0.show_exemplars=0.g0.range_input=1h.`;
 };
+
+export const createExpressionLinkAlert = (expr: string): string => {
+  return `../alerts?expr=${encodeURIComponent(expr)}`;
+};
+
+export const createExpressionLinkTarget = (expr: string): string => {
+  return `../targets?expr=${encodeURIComponent(expr)}`;
+};
+
+export const createExpressionLinkServiceDiscovery = (expr: string): string => {
+  return `../service-discovery?expr=${encodeURIComponent(expr)}`;
+};
+
 export const mapObjEntries = <T, key extends keyof T, Z>(
   o: T,
   cb: ([k, v]: [string, T[key]], i: number, arr: [string, T[key]][]) => Z


### PR DESCRIPTION
changes in the url, adding the 'expr' of Service Discovery, Targets and Alerts, related to what was inserted in the expression search bar.

Example: 
alerts?expr='expresion'