### PR TITLE
Allow setting the search term on alerts, targets, and discovery pages via the URL

### DIFF
--- a/web/ui/react-app/src/components/SearchBar.tsx
+++ b/web/ui/react-app/src/components/SearchBar.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC } from 'react';
+import React, { ChangeEvent, FC, useEffect } from 'react';
 import { Input, InputGroup, InputGroupAddon, InputGroupText } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
@@ -18,6 +18,10 @@ const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder, defaultValue
       handleChange(e.target.value);
     }, 300);
   };
+
+  useEffect(() => {
+    handleChange(defaultValue);
+  }, []);
 
   return (
     <InputGroup>

--- a/web/ui/react-app/src/components/SearchBar.tsx
+++ b/web/ui/react-app/src/components/SearchBar.tsx
@@ -6,9 +6,10 @@ import { faSearch } from '@fortawesome/free-solid-svg-icons';
 export interface SearchBarProps {
   handleChange: (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
   placeholder: string;
+  defaultValue: string;
 }
 
-const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder }) => {
+const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder, defaultValue }) => {
   let filterTimeout: NodeJS.Timeout;
 
   const handleSearchChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
@@ -23,7 +24,7 @@ const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder }) => {
       <InputGroupAddon addonType="prepend">
         <InputGroupText>{<FontAwesomeIcon icon={faSearch} />}</InputGroupText>
       </InputGroupAddon>
-      <Input autoFocus onChange={handleSearchChange} placeholder={placeholder} />
+      <Input autoFocus onChange={handleSearchChange} placeholder={placeholder} defaultValue={defaultValue} />
     </InputGroup>
   );
 };

--- a/web/ui/react-app/src/components/SearchBar.tsx
+++ b/web/ui/react-app/src/components/SearchBar.tsx
@@ -21,7 +21,7 @@ const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder, defaultValue
 
   useEffect(() => {
     handleChange(defaultValue);
-  }, []);
+  }, [defaultValue]);
 
   return (
     <InputGroup>

--- a/web/ui/react-app/src/components/SearchBar.tsx
+++ b/web/ui/react-app/src/components/SearchBar.tsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 
 export interface SearchBarProps {
-  handleChange: (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+  handleChange: (e: string) => void;
   placeholder: string;
   defaultValue: string;
 }
@@ -15,7 +15,7 @@ const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder, defaultValue
   const handleSearchChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     clearTimeout(filterTimeout);
     filterTimeout = setTimeout(() => {
-      handleChange(e);
+      handleChange(e.target.value);
     }, 300);
   };
 

--- a/web/ui/react-app/src/components/SearchBar.tsx
+++ b/web/ui/react-app/src/components/SearchBar.tsx
@@ -21,7 +21,7 @@ const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder, defaultValue
 
   useEffect(() => {
     handleChange(defaultValue);
-  }, [defaultValue]);
+  }, []);
 
   return (
     <InputGroup>

--- a/web/ui/react-app/src/components/SearchBar.tsx
+++ b/web/ui/react-app/src/components/SearchBar.tsx
@@ -21,8 +21,7 @@ const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder, defaultValue
 
   useEffect(() => {
     handleChange(defaultValue);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [defaultValue]);
+  }, [defaultValue, handleChange]);
 
   return (
     <InputGroup>

--- a/web/ui/react-app/src/components/SearchBar.tsx
+++ b/web/ui/react-app/src/components/SearchBar.tsx
@@ -21,7 +21,7 @@ const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder, defaultValue
 
   useEffect(() => {
     handleChange(defaultValue);
-  }, [defaultValue]);
+  }, [defaultValue]); //eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <InputGroup>

--- a/web/ui/react-app/src/components/SearchBar.tsx
+++ b/web/ui/react-app/src/components/SearchBar.tsx
@@ -21,7 +21,8 @@ const SearchBar: FC<SearchBarProps> = ({ handleChange, placeholder, defaultValue
 
   useEffect(() => {
     handleChange(defaultValue);
-  }, [defaultValue]); //eslint-disable-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultValue]);
 
   return (
     <InputGroup>

--- a/web/ui/react-app/src/pages/alerts/AlertContents.tsx
+++ b/web/ui/react-app/src/pages/alerts/AlertContents.tsx
@@ -2,13 +2,12 @@ import React, { FC, Fragment, useEffect, useMemo, useState } from 'react';
 import { Badge, Col, Row } from 'reactstrap';
 import CollapsibleAlertPanel from './CollapsibleAlertPanel';
 import Checkbox from '../../components/Checkbox';
-import { isPresent } from '../../utils';
+import { getQuerySearchFilter, isPresent, setQuerySearchFilter } from '../../utils';
 import { Rule } from '../../types/types';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import CustomInfiniteScroll, { InfiniteScrollItemsProps } from '../../components/CustomInfiniteScroll';
 import { KVSearch } from '@nexucis/kvsearch';
 import SearchBar from '../../components/SearchBar';
-import { encodeToQueryString } from '../../utils/index';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RuleState = keyof RuleStatus<any>;
@@ -79,13 +78,8 @@ const AlertsContent: FC<AlertsProps> = ({ groups = [], statsCount }) => {
     });
   };
 
-  const updateURL = (expr: string): void => {
-    const query = encodeToQueryString(expr);
-    window.history.pushState({}, '', query);
-  };
-
   const handleSearchChange = (value: string) => {
-    updateURL(value);
+    setQuerySearchFilter(value);
     if (value !== '') {
       const pattern = value.trim();
       const result: RuleGroup[] = [];
@@ -106,13 +100,7 @@ const AlertsContent: FC<AlertsProps> = ({ groups = [], statsCount }) => {
     }
   };
 
-  const defaultValue = useMemo(() => {
-    const locationSearch = window.location.search;
-    const params = new URLSearchParams(locationSearch);
-    const search = params.get('expr') || '';
-    handleSearchChange(search);
-    return search;
-  }, []);
+  const defaultValue = useMemo(getQuerySearchFilter, []);
 
   useEffect(() => {
     const result: RuleGroup[] = [];

--- a/web/ui/react-app/src/pages/alerts/AlertContents.tsx
+++ b/web/ui/react-app/src/pages/alerts/AlertContents.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment, useEffect, useMemo, useState } from 'react';
+import React, { FC, Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { Badge, Col, Row } from 'reactstrap';
 import CollapsibleAlertPanel from './CollapsibleAlertPanel';
 import Checkbox from '../../components/Checkbox';
@@ -78,27 +78,30 @@ const AlertsContent: FC<AlertsProps> = ({ groups = [], statsCount }) => {
     });
   };
 
-  const handleSearchChange = (value: string) => {
-    setQuerySearchFilter(value);
-    if (value !== '') {
-      const pattern = value.trim();
-      const result: RuleGroup[] = [];
-      for (const group of groups) {
-        const ruleFilterList = kvSearchRule.filter(pattern, group.rules);
-        if (ruleFilterList.length > 0) {
-          result.push({
-            file: group.file,
-            name: group.name,
-            interval: group.interval,
-            rules: ruleFilterList.map((value) => value.original),
-          });
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setQuerySearchFilter(value);
+      if (value !== '') {
+        const pattern = value.trim();
+        const result: RuleGroup[] = [];
+        for (const group of groups) {
+          const ruleFilterList = kvSearchRule.filter(pattern, group.rules);
+          if (ruleFilterList.length > 0) {
+            result.push({
+              file: group.file,
+              name: group.name,
+              interval: group.interval,
+              rules: ruleFilterList.map((value) => value.original),
+            });
+          }
         }
+        setGroupList(result);
+      } else {
+        setGroupList(groups);
       }
-      setGroupList(result);
-    } else {
-      setGroupList(groups);
-    }
-  };
+    },
+    [groups]
+  );
 
   const defaultValue = useMemo(getQuerySearchFilter, []);
 

--- a/web/ui/react-app/src/pages/alerts/__snapshots__/AlertContents.test.tsx.snap
+++ b/web/ui/react-app/src/pages/alerts/__snapshots__/AlertContents.test.tsx.snap
@@ -100,6 +100,7 @@ exports[`AlertsContent matches a snapshot 1`] = `
       }
     >
       <SearchBar
+        defaultValue=""
         handleChange={[Function]}
         placeholder="Filter by name or labels"
       />

--- a/web/ui/react-app/src/pages/serviceDiscovery/Services.tsx
+++ b/web/ui/react-app/src/pages/serviceDiscovery/Services.tsx
@@ -4,13 +4,12 @@ import { LabelsTable } from './LabelsTable';
 import { DroppedTarget, Labels, Target } from '../targets/target';
 
 import { withStatusIndicator } from '../../components/withStatusIndicator';
-import { mapObjEntries } from '../../utils';
+import { setQuerySearchFilter, mapObjEntries, getQuerySearchFilter } from '../../utils';
 import { usePathPrefix } from '../../contexts/PathPrefixContext';
 import { API_PATH } from '../../constants/constants';
 import { KVSearch } from '@nexucis/kvsearch';
 import { Container } from 'reactstrap';
 import SearchBar from '../../components/SearchBar';
-import { encodeToQueryString } from '../../utils/index';
 
 interface ServiceMap {
   activeTargets: Target[];
@@ -90,18 +89,13 @@ export const processTargets = (activeTargets: Target[], droppedTargets: DroppedT
   return labels;
 };
 
-const updateURL = (expr: string): void => {
-  const query = encodeToQueryString(expr);
-  window.history.pushState({}, '', query);
-};
-
 export const ServiceDiscoveryContent: FC<ServiceMap> = ({ activeTargets, droppedTargets }) => {
   const [activeTargetList, setActiveTargetList] = useState(activeTargets);
   const [targetList, setTargetList] = useState(processSummary(activeTargets, droppedTargets));
   const [labelList, setLabelList] = useState(processTargets(activeTargets, droppedTargets));
 
   const handleSearchChange = (value: string) => {
-    updateURL(value);
+    setQuerySearchFilter(value);
     if (value !== '') {
       const result = kvSearch.filter(value.trim(), activeTargets);
       setActiveTargetList(result.map((value) => value.original));
@@ -110,13 +104,7 @@ export const ServiceDiscoveryContent: FC<ServiceMap> = ({ activeTargets, dropped
     }
   };
 
-  const defaultValue = useMemo(() => {
-    const locationSearch = window.location.search;
-    const params = new URLSearchParams(locationSearch);
-    const search = params.get('expr') || '';
-    handleSearchChange(search);
-    return search;
-  }, []);
+  const defaultValue = useMemo(getQuerySearchFilter, []);
 
   useEffect(() => {
     setTargetList(processSummary(activeTargetList, droppedTargets));

--- a/web/ui/react-app/src/pages/serviceDiscovery/Services.tsx
+++ b/web/ui/react-app/src/pages/serviceDiscovery/Services.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useFetch } from '../../hooks/useFetch';
 import { LabelsTable } from './LabelsTable';
 import { DroppedTarget, Labels, Target } from '../targets/target';
@@ -96,28 +96,27 @@ const updateURL = (expr: string): void => {
 };
 
 export const ServiceDiscoveryContent: FC<ServiceMap> = ({ activeTargets, droppedTargets }) => {
-  useEffect(() => {
-    const search = window.location.search;
-    const params = new URLSearchParams(search);
-    const expr = params.get('expr');
-    setDefaultValue(expr || '');
-  }, []);
-
-  const [defaultValue, setDefaultValue] = useState('');
   const [activeTargetList, setActiveTargetList] = useState(activeTargets);
   const [targetList, setTargetList] = useState(processSummary(activeTargets, droppedTargets));
   const [labelList, setLabelList] = useState(processTargets(activeTargets, droppedTargets));
 
-  const handleSearchChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-    if (e.target.value !== '') {
-      updateURL(e.target.value);
-      const result = kvSearch.filter(e.target.value.trim(), activeTargets);
+  const handleSearchChange = (value: string) => {
+    updateURL(value);
+    if (value !== '') {
+      const result = kvSearch.filter(value.trim(), activeTargets);
       setActiveTargetList(result.map((value) => value.original));
     } else {
-      updateURL(e.target.value);
       setActiveTargetList(activeTargets);
     }
   };
+
+  const defaultValue = useMemo(() => {
+    const locationSearch = window.location.search;
+    const params = new URLSearchParams(locationSearch);
+    const search = params.get('expr') || '';
+    handleSearchChange(search);
+    return search;
+  }, []);
 
   useEffect(() => {
     setTargetList(processSummary(activeTargetList, droppedTargets));

--- a/web/ui/react-app/src/pages/serviceDiscovery/Services.tsx
+++ b/web/ui/react-app/src/pages/serviceDiscovery/Services.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useFetch } from '../../hooks/useFetch';
 import { LabelsTable } from './LabelsTable';
 import { DroppedTarget, Labels, Target } from '../targets/target';
@@ -94,15 +94,18 @@ export const ServiceDiscoveryContent: FC<ServiceMap> = ({ activeTargets, dropped
   const [targetList, setTargetList] = useState(processSummary(activeTargets, droppedTargets));
   const [labelList, setLabelList] = useState(processTargets(activeTargets, droppedTargets));
 
-  const handleSearchChange = (value: string) => {
-    setQuerySearchFilter(value);
-    if (value !== '') {
-      const result = kvSearch.filter(value.trim(), activeTargets);
-      setActiveTargetList(result.map((value) => value.original));
-    } else {
-      setActiveTargetList(activeTargets);
-    }
-  };
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setQuerySearchFilter(value);
+      if (value !== '') {
+        const result = kvSearch.filter(value.trim(), activeTargets);
+        setActiveTargetList(result.map((value) => value.original));
+      } else {
+        setActiveTargetList(activeTargets);
+      }
+    },
+    [activeTargets]
+  );
 
   const defaultValue = useMemo(getQuerySearchFilter, []);
 

--- a/web/ui/react-app/src/pages/targets/ScrapePoolList.tsx
+++ b/web/ui/react-app/src/pages/targets/ScrapePoolList.tsx
@@ -12,7 +12,7 @@ import { useLocalStorage } from '../../hooks/useLocalStorage';
 import styles from './ScrapePoolPanel.module.css';
 import { ToggleMoreLess } from '../../components/ToggleMoreLess';
 import SearchBar from '../../components/SearchBar';
-import { encodeToQueryString } from '../../utils/index';
+import { setQuerySearchFilter, getQuerySearchFilter } from '../../utils/index';
 
 interface ScrapePoolListProps {
   activeTargets: Target[];
@@ -73,13 +73,8 @@ const ScrapePoolListContent: FC<ScrapePoolListProps> = ({ activeTargets }) => {
   const [expanded, setExpanded] = useLocalStorage('targets-page-expansion-state', initialExpanded);
   const { showHealthy, showUnhealthy } = filter;
 
-  const updateURL = (expr: string): void => {
-    const query = encodeToQueryString(expr);
-    window.history.pushState({}, '', query);
-  };
-
   const handleSearchChange = (value: string) => {
-    updateURL(value);
+    setQuerySearchFilter(value);
     if (value !== '') {
       const result = kvSearch.filter(value.trim(), activeTargets);
       setTargetList(result.map((value) => value.original));
@@ -88,13 +83,7 @@ const ScrapePoolListContent: FC<ScrapePoolListProps> = ({ activeTargets }) => {
     }
   };
 
-  const defaultValue = useMemo(() => {
-    const locationSearch = window.location.search;
-    const params = new URLSearchParams(locationSearch);
-    const search = params.get('expr') || '';
-    handleSearchChange(search);
-    return search;
-  }, []);
+  const defaultValue = useMemo(getQuerySearchFilter, []);
 
   useEffect(() => {
     const list = targetList.filter((t) => showHealthy || t.health.toLowerCase() !== 'up');

--- a/web/ui/react-app/src/pages/targets/ScrapePoolList.tsx
+++ b/web/ui/react-app/src/pages/targets/ScrapePoolList.tsx
@@ -113,7 +113,7 @@ const ScrapePoolListContent: FC<ScrapePoolListProps> = ({ activeTargets }) => {
             defaultValue={defaultValue}
             handleChange={handleSearchChange}
             placeholder="Filter by endpoint or labels"
-         />
+          />
         </Col>
       </Row>
       {Object.keys(poolList)

--- a/web/ui/react-app/src/pages/targets/ScrapePoolList.tsx
+++ b/web/ui/react-app/src/pages/targets/ScrapePoolList.tsx
@@ -109,10 +109,11 @@ const ScrapePoolListContent: FC<ScrapePoolListProps> = ({ activeTargets }) => {
           <Filter filter={filter} setFilter={setFilter} expanded={expanded} setExpanded={setExpanded} />
         </Col>
         <Col xs="6">
-          <SearchBar 
-            defaultValue={defaultValue} 
-            handleChange={handleSearchChange} 
-            placeholder="Filter by endpoint or labels" />
+          <SearchBar
+            defaultValue={defaultValue}
+            handleChange={handleSearchChange}
+            placeholder="Filter by endpoint or labels"
+         />
         </Col>
       </Row>
       {Object.keys(poolList)

--- a/web/ui/react-app/src/pages/targets/ScrapePoolList.tsx
+++ b/web/ui/react-app/src/pages/targets/ScrapePoolList.tsx
@@ -4,7 +4,7 @@ import { useFetch } from '../../hooks/useFetch';
 import { API_PATH } from '../../constants/constants';
 import { groupTargets, ScrapePool, ScrapePools, Target } from './target';
 import { withStatusIndicator } from '../../components/withStatusIndicator';
-import { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Col, Collapse, Row } from 'reactstrap';
 import { ScrapePoolContent } from './ScrapePoolContent';
 import Filter, { Expanded, FilterData } from './Filter';
@@ -73,15 +73,18 @@ const ScrapePoolListContent: FC<ScrapePoolListProps> = ({ activeTargets }) => {
   const [expanded, setExpanded] = useLocalStorage('targets-page-expansion-state', initialExpanded);
   const { showHealthy, showUnhealthy } = filter;
 
-  const handleSearchChange = (value: string) => {
-    setQuerySearchFilter(value);
-    if (value !== '') {
-      const result = kvSearch.filter(value.trim(), activeTargets);
-      setTargetList(result.map((value) => value.original));
-    } else {
-      setTargetList(activeTargets);
-    }
-  };
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setQuerySearchFilter(value);
+      if (value !== '') {
+        const result = kvSearch.filter(value.trim(), activeTargets);
+        setTargetList(result.map((value) => value.original));
+      } else {
+        setTargetList(activeTargets);
+      }
+    },
+    [activeTargets]
+  );
 
   const defaultValue = useMemo(getQuerySearchFilter, []);
 

--- a/web/ui/react-app/src/utils/index.ts
+++ b/web/ui/react-app/src/utils/index.ts
@@ -243,8 +243,15 @@ export const encodePanelOptionsToQueryString = (panels: PanelMeta[]): string => 
   return `?${panels.map(toQueryString).join('&')}`;
 };
 
-export const encodeToQueryString = (expr: string): string => {
-  return `?expr=${expr}`;
+export const setQuerySearchFilter = (expr: string) => {
+  window.history.pushState({}, '', `?expr=${expr}`);
+};
+
+export const getQuerySearchFilter = (): string => {
+  const locationSearch = window.location.search;
+  const params = new URLSearchParams(locationSearch);
+  const search = params.get('expr') || '';
+  return search;
 };
 
 export const createExpressionLink = (expr: string): string => {

--- a/web/ui/react-app/src/utils/index.ts
+++ b/web/ui/react-app/src/utils/index.ts
@@ -243,9 +243,26 @@ export const encodePanelOptionsToQueryString = (panels: PanelMeta[]): string => 
   return `?${panels.map(toQueryString).join('&')}`;
 };
 
+export const encodeToQueryString = (expr: string): string => {
+  return `?expr=${expr}`;
+};
+
 export const createExpressionLink = (expr: string): string => {
   return `../graph?g0.expr=${encodeURIComponent(expr)}&g0.tab=1&g0.stacked=0&g0.show_exemplars=0.g0.range_input=1h.`;
 };
+
+export const createExpressionLinkAlert = (expr: string): string => {
+  return `../alerts?expr=${encodeURIComponent(expr)}`;
+};
+
+export const createExpressionLinkTarget = (expr: string): string => {
+  return `../targets?expr=${encodeURIComponent(expr)}`;
+};
+
+export const createExpressionLinkServiceDiscovery = (expr: string): string => {
+  return `../service-discovery?expr=${encodeURIComponent(expr)}`;
+};
+
 export const mapObjEntries = <T, key extends keyof T, Z>(
   o: T,
   cb: ([k, v]: [string, T[key]], i: number, arr: [string, T[key]][]) => Z

--- a/web/ui/react-app/src/utils/index.ts
+++ b/web/ui/react-app/src/utils/index.ts
@@ -251,18 +251,6 @@ export const createExpressionLink = (expr: string): string => {
   return `../graph?g0.expr=${encodeURIComponent(expr)}&g0.tab=1&g0.stacked=0&g0.show_exemplars=0.g0.range_input=1h.`;
 };
 
-export const createExpressionLinkAlert = (expr: string): string => {
-  return `../alerts?expr=${encodeURIComponent(expr)}`;
-};
-
-export const createExpressionLinkTarget = (expr: string): string => {
-  return `../targets?expr=${encodeURIComponent(expr)}`;
-};
-
-export const createExpressionLinkServiceDiscovery = (expr: string): string => {
-  return `../service-discovery?expr=${encodeURIComponent(expr)}`;
-};
-
 export const mapObjEntries = <T, key extends keyof T, Z>(
   o: T,
   cb: ([k, v]: [string, T[key]], i: number, arr: [string, T[key]][]) => Z

--- a/web/ui/react-app/src/utils/index.ts
+++ b/web/ui/react-app/src/utils/index.ts
@@ -243,14 +243,14 @@ export const encodePanelOptionsToQueryString = (panels: PanelMeta[]): string => 
   return `?${panels.map(toQueryString).join('&')}`;
 };
 
-export const setQuerySearchFilter = (expr: string) => {
-  window.history.pushState({}, '', `?expr=${expr}`);
+export const setQuerySearchFilter = (search: string) => {
+  window.history.pushState({}, '', `?search=${search}`);
 };
 
 export const getQuerySearchFilter = (): string => {
   const locationSearch = window.location.search;
   const params = new URLSearchParams(locationSearch);
-  const search = params.get('expr') || '';
+  const search = params.get('search') || '';
   return search;
 };
 


### PR DESCRIPTION
Add expr in service discovery, targets and alerts url, fixes issue #10171

Example:
alert?expr='expression'