### PR TITLE
Race condition when gc'ing a serie and receiving a sample at the same…

### DIFF
--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1105,7 +1105,7 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 // This is needed for unit tests that rely on
 // checking state before and after a compaction.
 func TestDisableAutoCompactions(t *testing.T) {
-	db := openTestDB(t, nil, nil)
+	db := openTestDB(t, nil, nil, nil)
 	defer func() {
 		require.NoError(t, db.Close())
 	}()
@@ -1257,7 +1257,7 @@ func TestDeleteCompactionBlockAfterFailedReload(t *testing.T) {
 
 	for title, bootStrap := range tests {
 		t.Run(title, func(t *testing.T) {
-			db := openTestDB(t, nil, []int64{1, 100})
+			db := openTestDB(t, nil, []int64{1, 100}, nil)
 			defer func() {
 				require.NoError(t, db.Close())
 			}()

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1393,6 +1393,9 @@ func (s *stripeSeries) gc(mint int64) (map[storage.SeriesRef]struct{}, int, int6
 					continue
 				}
 
+				// Mark the series as deleted inside the lock to prevent reusing this object
+				series.deleted = true
+
 				// The series is gone entirely. We need to keep the series lock
 				// and make sure we have acquired the stripe locks for hash and ID of the
 				// series alike.
@@ -1532,6 +1535,8 @@ type memSeries struct {
 	sampleBuf [4]sample
 
 	pendingCommit bool // Whether there are samples waiting to be committed to this series.
+
+	deleted bool // Whether the series as GC'ed
 
 	// Current appender for the head chunk. Set when a new head chunk is cut.
 	// It is nil only if headChunk is nil. E.g. if there was an appender that created a new series, but rolled back the commit

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -274,7 +274,7 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 	}
 
 	s.Lock()
-	if err := s.appendable(t, v); err != nil {
+	if err := s.appendable(t, v); err != nil || s.deleted {
 		s.Unlock()
 		if err == storage.ErrOutOfOrderSample {
 			a.head.metrics.outOfOrderSamples.Inc()


### PR DESCRIPTION
Fix https://github.com/prometheus/prometheus/issues/9879

When we receive samples for a series that is being gc'ed at the same time, the appender can end up with a already gc'ed `memSeries` reference.

The CRUX of this cr is that we have a race condition [here](https://github.com/prometheus/prometheus/blob/fc3f1b8ded810a1263f72d37db9db4e8ce726120/tsdb/head_append.go#L250-L277) as nothing is locking the `memSeries` yet and so, it can be gc'ed [here](https://github.com/prometheus/prometheus/blob/fc3f1b8ded810a1263f72d37db9db4e8ce726120/tsdb/head.go#L1408). When this happens, the appender hold an already invalid series reference.


Im still not sure if this can really can cause duplicated samples in the tsdb but for sure it makes prometheus accept invalid samples and causes a warning during wall replay:

```
level=warn ts=2022-04-20T20:42:43.234426112Z caller=head_wal.go:361 msg="Unknown series references" samples=1 exemplars=0
```

This change is just making sure that we don't reuse the invalid object in the append.

Just for simplicity i just returned `ErrOutOfOrderSample` on this case (for now) just to make easier to read the PR.
I think in this case we should discard the `memSeries` reference and try to get the valid one.


Before: 

```
dev-dsk-approtas-2a-1fab6ae0 % go clean -testcache && go test  ./tsdb -test.run '^\\QTestDB_appendAndCompactHeadConcurrently\E$' -v
=== RUN   TestDB_alan
    db_test.go:180:
        	Error Trace:	db_test.go:180
        	Error:      	Received unexpected error:

        	            	metric output does not match expectation; want:

        	            	# HELP prometheus_tsdb_head_samples_appended_total Total number of appended samples.
        	            	# TYPE prometheus_tsdb_head_samples_appended_total counter
        	            	prometheus_tsdb_head_samples_appended_total 11520

        	            	got:

        	            	# HELP prometheus_tsdb_head_samples_appended_total Total number of appended samples.
        	            	# TYPE prometheus_tsdb_head_samples_appended_total counter
        	            	prometheus_tsdb_head_samples_appended_total 11521
        	Test:       	TestDB_alan
--- FAIL: TestDB_appendAndCompactHeadConcurrently (0.29s)
FAIL
FAIL	github.com/prometheus/prometheus/tsdb	0.302s
FAIL
```

Looking the the following comment seems that this is not expected at all:
( The intention is to never receive a sample when we are deleting a series)

https://github.com/prometheus/prometheus/blob/fc3f1b8ded810a1263f72d37db9db4e8ce726120/tsdb/head.go#L1396-L1400