### PR TITLE
Add hidden flag to configure discovery loop interval

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -127,22 +127,23 @@ func agentOnlyFlag(app *kingpin.Application, name, help string) *kingpin.FlagCla
 type flagConfig struct {
 	configFile string
 
-	agentStoragePath    string
-	serverStoragePath   string
-	notifier            notifier.Options
-	forGracePeriod      model.Duration
-	outageTolerance     model.Duration
-	resendDelay         model.Duration
-	web                 web.Options
-	scrape              scrape.Options
-	tsdb                tsdbOptions
-	agent               agentOptions
-	lookbackDelta       model.Duration
-	webTimeout          model.Duration
-	queryTimeout        model.Duration
-	queryConcurrency    int
-	queryMaxSamples     int
-	RemoteFlushDeadline model.Duration
+	agentStoragePath        string
+	serverStoragePath       string
+	notifier                notifier.Options
+	forGracePeriod          model.Duration
+	outageTolerance         model.Duration
+	resendDelay             model.Duration
+	web                     web.Options
+	scrape                  scrape.Options
+	tsdb                    tsdbOptions
+	agent                   agentOptions
+	lookbackDelta           model.Duration
+	webTimeout              model.Duration
+	queryTimeout            model.Duration
+	queryConcurrency        int
+	queryMaxSamples         int
+	RemoteFlushDeadline     model.Duration
+	DiscoveryReloadInterval model.Duration
 
 	featureList []string
 	// These options are extracted from featureList
@@ -386,6 +387,9 @@ func main() {
 
 	serverOnlyFlag(a, "query.max-samples", "Maximum number of samples a single query can load into memory. Note that queries will fail if they try to load more samples than this into memory, so this also limits the number of samples a query can return.").
 		Default("50000000").IntVar(&cfg.queryMaxSamples)
+
+	a.Flag("discovery.reload.interval", "Reloading interval to refresh target groups (default 5s).").
+		Hidden().Default("5s").SetValue(&cfg.scrape.DiscoveryReloadInterval)
 
 	a.Flag("enable-feature", "Comma separated feature names to enable. Valid options: agent, exemplar-storage, expand-external-labels, memory-snapshot-on-shutdown, promql-at-modifier, promql-negative-offset, promql-per-step-stats, remote-write-receiver (DEPRECATED), extra-scrape-metrics, new-service-discovery-manager, auto-gomaxprocs. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details.").
 		Default("").StringsVar(&cfg.featureList)

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -388,7 +388,7 @@ func main() {
 	serverOnlyFlag(a, "query.max-samples", "Maximum number of samples a single query can load into memory. Note that queries will fail if they try to load more samples than this into memory, so this also limits the number of samples a query can return.").
 		Default("50000000").IntVar(&cfg.queryMaxSamples)
 
-	a.Flag("scrape.discovery-reload-interval", "Interval used by scrape manager to throttle target groups.").
+	a.Flag("scrape.discovery-reload-interval", "Interval used by scrape manager to throttle target groups updates.").
 		Hidden().Default("5s").SetValue(&cfg.scrape.DiscoveryReloadInterval)
 
 	a.Flag("enable-feature", "Comma separated feature names to enable. Valid options: agent, exemplar-storage, expand-external-labels, memory-snapshot-on-shutdown, promql-at-modifier, promql-negative-offset, promql-per-step-stats, remote-write-receiver (DEPRECATED), extra-scrape-metrics, new-service-discovery-manager, auto-gomaxprocs. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details.").

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -388,7 +388,7 @@ func main() {
 	serverOnlyFlag(a, "query.max-samples", "Maximum number of samples a single query can load into memory. Note that queries will fail if they try to load more samples than this into memory, so this also limits the number of samples a query can return.").
 		Default("50000000").IntVar(&cfg.queryMaxSamples)
 
-	a.Flag("discovery.reload.interval", "Reloading interval to refresh target groups (default 5s).").
+	a.Flag("scrape.discovery-reload-interval", "Interval used by scrape manager to throttle target groups.").
 		Hidden().Default("5s").SetValue(&cfg.scrape.DiscoveryReloadInterval)
 
 	a.Flag("enable-feature", "Comma separated feature names to enable. Valid options: agent, exemplar-storage, expand-external-labels, memory-snapshot-on-shutdown, promql-at-modifier, promql-negative-offset, promql-per-step-stats, remote-write-receiver (DEPRECATED), extra-scrape-metrics, new-service-discovery-manager, auto-gomaxprocs. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details.").

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -127,23 +127,22 @@ func agentOnlyFlag(app *kingpin.Application, name, help string) *kingpin.FlagCla
 type flagConfig struct {
 	configFile string
 
-	agentStoragePath        string
-	serverStoragePath       string
-	notifier                notifier.Options
-	forGracePeriod          model.Duration
-	outageTolerance         model.Duration
-	resendDelay             model.Duration
-	web                     web.Options
-	scrape                  scrape.Options
-	tsdb                    tsdbOptions
-	agent                   agentOptions
-	lookbackDelta           model.Duration
-	webTimeout              model.Duration
-	queryTimeout            model.Duration
-	queryConcurrency        int
-	queryMaxSamples         int
-	RemoteFlushDeadline     model.Duration
-	DiscoveryReloadInterval model.Duration
+	agentStoragePath    string
+	serverStoragePath   string
+	notifier            notifier.Options
+	forGracePeriod      model.Duration
+	outageTolerance     model.Duration
+	resendDelay         model.Duration
+	web                 web.Options
+	scrape              scrape.Options
+	tsdb                tsdbOptions
+	agent               agentOptions
+	lookbackDelta       model.Duration
+	webTimeout          model.Duration
+	queryTimeout        model.Duration
+	queryConcurrency    int
+	queryMaxSamples     int
+	RemoteFlushDeadline model.Duration
 
 	featureList []string
 	// These options are extracted from featureList

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -173,7 +173,13 @@ func (m *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) error {
 }
 
 func (m *Manager) reloader() {
-	ticker := time.NewTicker(time.Duration(m.opts.DiscoveryReloadInterval))
+	reloadIntervalDuration := m.opts.DiscoveryReloadInterval
+	if reloadIntervalDuration < model.Duration(5*time.Second) {
+		reloadIntervalDuration = model.Duration(5 * time.Second)
+	}
+
+	ticker := time.NewTicker(time.Duration(reloadIntervalDuration))
+
 	defer ticker.Stop()
 
 	for {

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -127,6 +128,8 @@ type Options struct {
 	// Option used by downstream scraper users like OpenTelemetry Collector
 	// to help lookup metric metadata. Should be false for Prometheus.
 	PassMetadataInContext bool
+	// Option to increase the interval used by scrape manager to throttle target groups updates.
+	DiscoveryReloadInterval model.Duration
 
 	// Optional HTTP client options to use when scraping.
 	HTTPClientOptions []config_util.HTTPClientOption
@@ -170,7 +173,7 @@ func (m *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) error {
 }
 
 func (m *Manager) reloader() {
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(time.Duration(m.opts.DiscoveryReloadInterval))
 	defer ticker.Stop()
 
 	for {

--- a/web/web.go
+++ b/web/web.go
@@ -253,7 +253,6 @@ type Options struct {
 	RemoteReadBytesInFrame     int
 	EnableRemoteWriteReceiver  bool
 	IsAgent                    bool
-	DiscoveryReloadInterval    string
 
 	Gatherer   prometheus.Gatherer
 	Registerer prometheus.Registerer

--- a/web/web.go
+++ b/web/web.go
@@ -253,6 +253,7 @@ type Options struct {
 	RemoteReadBytesInFrame     int
 	EnableRemoteWriteReceiver  bool
 	IsAgent                    bool
+	DiscoveryReloadInterval    string
 
 	Gatherer   prometheus.Gatherer
 	Registerer prometheus.Registerer


### PR DESCRIPTION
Added hidden flag `--discovery.reload.interval` to give the possibility to change the interval between TargetGroup reloads.
It mitigates https://github.com/prometheus/prometheus/issues/8014 by reducing the number of times the targets are fully reload.

It is not enough for https://github.com/prometheus/prometheus/issues/8014, and I may want to work on it further. I will comment there.

Below is a prometheus having a pod discovery (6K pods), scraping nothing (relabel drop everything)
Left side (before 10:00) is reload interval = 5seconds (default), right side is 30s. 
<img width="953" alt="prometheus_discov ery_reload_30s" src="https://user-images.githubusercontent.com/25080995/165296983-c43a22a2-60fe-4954-9cc1-f52d83369dcf.png">

Flag is hidden because most users don't need it.