### PR TITLE
Send target and metadata cache in context (again)

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -124,6 +124,9 @@ func NewManager(o *Options, logger log.Logger, app storage.Appendable) *Manager 
 // Options are the configuration parameters to the scrape manager.
 type Options struct {
 	ExtraMetrics bool
+	// Option used by downstream scraper users like OpenTelemetry Collector
+	// to help lookup metric metadata. Should be false for Prometheus.
+	PassMetadataInContext bool
 
 	// Optional HTTP client options to use when scraping.
 	HTTPClientOptions []config_util.HTTPClientOption
@@ -195,7 +198,7 @@ func (m *Manager) reload() {
 				level.Error(m.logger).Log("msg", "error reloading target set", "err", "invalid config id:"+setName)
 				continue
 			}
-			sp, err := newScrapePool(scrapeConfig, m.append, m.jitterSeed, log.With(m.logger, "scrape_pool", setName), m.opts.ExtraMetrics, m.opts.HTTPClientOptions)
+			sp, err := newScrapePool(scrapeConfig, m.append, m.jitterSeed, log.With(m.logger, "scrape_pool", setName), m.opts.ExtraMetrics, m.opts.PassMetadataInContext, m.opts.HTTPClientOptions)
 			if err != nil {
 				level.Error(m.logger).Log("msg", "error creating new scrape pool", "err", err, "scrape_pool", setName)
 				continue

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -590,6 +590,8 @@ func TestScrapeLoopStopBeforeRun(t *testing.T) {
 		1,
 		0,
 		false,
+		nil,
+		nil,
 	)
 
 	// The scrape pool synchronizes on stopping scrape loops. However, new scrape
@@ -659,6 +661,8 @@ func TestScrapeLoopStop(t *testing.T) {
 		10*time.Millisecond,
 		time.Hour,
 		false,
+		nil,
+		nil,
 	)
 
 	// Terminate loop after 2 scrapes.
@@ -731,6 +735,8 @@ func TestScrapeLoopRun(t *testing.T) {
 		time.Second,
 		time.Hour,
 		false,
+		nil,
+		nil,
 	)
 
 	// The loop must terminate during the initial offset if the context
@@ -783,6 +789,8 @@ func TestScrapeLoopRun(t *testing.T) {
 		time.Second,
 		100*time.Millisecond,
 		false,
+		nil,
+		nil,
 	)
 
 	go func() {
@@ -839,6 +847,8 @@ func TestScrapeLoopForcedErr(t *testing.T) {
 		time.Second,
 		time.Hour,
 		false,
+		nil,
+		nil,
 	)
 
 	forcedErr := fmt.Errorf("forced err")
@@ -894,6 +904,8 @@ func TestScrapeLoopMetadata(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 	defer cancel()
 
@@ -948,6 +960,8 @@ func simpleTestScrapeLoop(t testing.TB) (context.Context, *scrapeLoop) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 	t.Cleanup(func() { cancel() })
 
@@ -1038,6 +1052,8 @@ func TestScrapeLoopRunCreatesStaleMarkersOnFailedScrape(t *testing.T) {
 		10*time.Millisecond,
 		time.Hour,
 		false,
+		nil,
+		nil,
 	)
 	// Succeed once, several failures, then stop.
 	numScrapes := 0
@@ -1097,6 +1113,8 @@ func TestScrapeLoopRunCreatesStaleMarkersOnParseFailure(t *testing.T) {
 		10*time.Millisecond,
 		time.Hour,
 		false,
+		nil,
+		nil,
 	)
 
 	// Succeed once, several failures, then stop.
@@ -1160,6 +1178,8 @@ func TestScrapeLoopCache(t *testing.T) {
 		10*time.Millisecond,
 		time.Hour,
 		false,
+		nil,
+		nil,
 	)
 
 	numScrapes := 0
@@ -1239,6 +1259,8 @@ func TestScrapeLoopCacheMemoryExhaustionProtection(t *testing.T) {
 		10*time.Millisecond,
 		time.Hour,
 		false,
+		nil,
+		nil,
 	)
 
 	numScrapes := 0
@@ -1350,6 +1372,8 @@ func TestScrapeLoopAppend(t *testing.T) {
 			0,
 			0,
 			false,
+			nil,
+			nil,
 		)
 
 		now := time.Now()
@@ -1437,7 +1461,7 @@ func TestScrapeLoopAppendForConflictingPrefixedLabels(t *testing.T) {
 					return mutateSampleLabels(l, &Target{labels: labels.FromStrings(tc.targetLabels...)}, false, nil)
 				},
 				nil,
-				func(ctx context.Context) storage.Appender { return app }, nil, 0, true, 0, nil, 0, 0, false,
+				func(ctx context.Context) storage.Appender { return app }, nil, 0, true, 0, nil, 0, 0, false, nil, nil,
 			)
 			slApp := sl.appender(context.Background())
 			_, _, _, err := sl.append(slApp, []byte(tc.exposedLabels), "", time.Date(2000, 1, 1, 1, 0, 0, 0, time.UTC))
@@ -1473,6 +1497,8 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 
 	fakeRef := storage.SeriesRef(1)
@@ -1528,6 +1554,8 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 
 	// Get the value of the Counter before performing the append.
@@ -1602,6 +1630,8 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 
 	now := time.Now()
@@ -1647,6 +1677,8 @@ func TestScrapeLoopAppendStaleness(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 
 	now := time.Now()
@@ -1695,6 +1727,8 @@ func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 
 	now := time.Now()
@@ -1803,6 +1837,8 @@ metric_total{n="2"} 2 # {t="2"} 2.0 20000
 				0,
 				0,
 				false,
+				nil,
+				nil,
 			)
 
 			now := time.Now()
@@ -1865,6 +1901,8 @@ func TestScrapeLoopAppendExemplarSeries(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 
 	now := time.Now()
@@ -1914,6 +1952,8 @@ func TestScrapeLoopRunReportsTargetDownOnScrapeError(t *testing.T) {
 		10*time.Millisecond,
 		time.Hour,
 		false,
+		nil,
+		nil,
 	)
 
 	scraper.scrapeFunc = func(ctx context.Context, w io.Writer) error {
@@ -1947,6 +1987,8 @@ func TestScrapeLoopRunReportsTargetDownOnInvalidUTF8(t *testing.T) {
 		10*time.Millisecond,
 		time.Hour,
 		false,
+		nil,
+		nil,
 	)
 
 	scraper.scrapeFunc = func(ctx context.Context, w io.Writer) error {
@@ -1993,6 +2035,8 @@ func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 
 	now := time.Unix(1, 0)
@@ -2035,6 +2079,8 @@ func TestScrapeLoopOutOfBoundsTimeError(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 
 	now := time.Now().Add(20 * time.Minute)
@@ -2289,6 +2335,8 @@ func TestScrapeLoop_RespectTimestamps(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 
 	now := time.Now()
@@ -2327,6 +2375,8 @@ func TestScrapeLoop_DiscardTimestamps(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 
 	now := time.Now()
@@ -2364,6 +2414,8 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 	defer cancel()
 
@@ -2419,6 +2471,8 @@ func TestScrapeLoopDiscardUnnamedMetrics(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 	defer cancel()
 
@@ -2692,6 +2746,8 @@ func TestScrapeAddFast(t *testing.T) {
 		0,
 		0,
 		false,
+		nil,
+		nil,
 	)
 	defer cancel()
 
@@ -2780,6 +2836,8 @@ func TestScrapeReportSingleAppender(t *testing.T) {
 		10*time.Millisecond,
 		time.Hour,
 		false,
+		nil,
+		nil,
 	)
 
 	numScrapes := 0
@@ -2979,6 +3037,8 @@ func TestScrapeLoopLabelLimit(t *testing.T) {
 			0,
 			0,
 			false,
+			nil,
+			nil,
 		)
 
 		slApp := sl.appender(context.Background())


### PR DESCRIPTION
The previous attempt was rolled back in #10590 due to memory issues.

`sl.parentCtx` and `sl.ctx` both had a copy of the cache and target info
in the previous attempt and it was hard to pin-point where the context
was being retained causing the memory increase.

I've experimented a bunch in #10627 to figure out that this approach doesn't
cause memory increase. Beyond that, just using this info in _any_ other context
is causing a memory increase. I'm hoping just this won't cause issues but doing the following on top:

```diff
diff --git a/scrape/scrape.go b/scrape/scrape.go
index 76739b9cb..8efa431f0 100644
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1288,7 +1288,7 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
        }

        var contentType string
-       scrapeCtx, cancel := context.WithTimeout(sl.parentCtx, sl.timeout)
+       scrapeCtx, cancel := context.WithTimeout(sl.appCtx, sl.timeout)
        contentType, scrapeErr = sl.scraper.scrape(scrapeCtx, buf)
        cancel()
```

still causes a slight memory increase. So at this point, I'm not sure how to debug it.

<img width="483" alt="Screenshot 2022-04-27 at 11 03 28" src="https://user-images.githubusercontent.com/7354143/165590792-de7a0ab4-6fad-402c-a4ba-6ad3ef9fadd7.png">

The change fixed a bunch of long-standing in the OTel Collector that the
community was waiting on and release is blocked on a few downstream distrubutions
of OTel Collector waiting on a fix. I propose to merge this change in while
I investigate what is happening.