### PR TITLE
refactor: move from github.com/pkg/errors to 'errors' and 'fmt' packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,13 +10,13 @@ output:
 linters:
   enable:
     - depguard
+    - errorlint
     - gofumpt
     - goimports
     - revive
     - misspell
 
 issues:
-  max-same-issues: 0
   exclude-rules:
     - path: _test.go
       linters:
@@ -30,6 +30,7 @@ linters-settings:
       - sync/atomic: "Use go.uber.org/atomic instead of sync/atomic"
       - github.com/stretchr/testify/assert: "Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert"
       - github.com/go-kit/kit/log: "Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
+      - github.com/pkg/errors: "Use 'errors' or 'fmt' instead of github.com/pkg/errors"
       - io/ioutil: "Use corresponding 'os' or 'io' functions instead."
       - regexp: "Use github.com/grafana/regexp instead of regexp"
   errcheck:

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/bits"
@@ -38,7 +39,6 @@ import (
 	"github.com/grafana/regexp"
 	conntrack "github.com/mwitkow/go-conntrack"
 	"github.com/oklog/run"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promlog"
@@ -394,7 +394,7 @@ func main() {
 
 	_, err := a.Parse(os.Args[1:])
 	if err != nil {
-		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error parsing commandline arguments"))
+		fmt.Fprintln(os.Stderr, fmt.Errorf("Error parsing commandline arguments %w", err))
 		a.Usage(os.Args[1:])
 		os.Exit(2)
 	}
@@ -402,7 +402,7 @@ func main() {
 	logger := promlog.New(&cfg.promlogConfig)
 
 	if err := cfg.setFeatureListOptions(logger); err != nil {
-		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error parsing feature list"))
+		fmt.Fprintln(os.Stderr, fmt.Errorf("Error parsing feature list %w", err))
 		os.Exit(1)
 	}
 
@@ -423,13 +423,13 @@ func main() {
 
 	cfg.web.ExternalURL, err = computeExternalURL(cfg.prometheusURL, cfg.web.ListenAddress)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "parse external URL %q", cfg.prometheusURL))
+		fmt.Fprintln(os.Stderr, fmt.Errorf("parse external URL %q %w", cfg.prometheusURL, err))
 		os.Exit(2)
 	}
 
 	cfg.web.CORSOrigin, err = compileCORSRegexString(cfg.corsRegexString)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "could not compile CORS regex string %q", cfg.corsRegexString))
+		fmt.Fprintln(os.Stderr, fmt.Errorf("could not compile CORS regex string %q %w", cfg.corsRegexString, err))
 		os.Exit(2)
 	}
 
@@ -729,7 +729,7 @@ func main() {
 					fs, err := filepath.Glob(pat)
 					if err != nil {
 						// The only error can be a bad pattern.
-						return errors.Wrapf(err, "error retrieving rule files for %s", pat)
+						return fmt.Errorf("error retrieving rule files for %s %w", pat, err)
 					}
 					files = append(files, fs...)
 				}
@@ -921,7 +921,7 @@ func main() {
 				}
 
 				if err := reloadConfig(cfg.configFile, cfg.enableExpandExternalLabels, cfg.tsdb.EnableExemplarStorage, logger, noStepSubqueryInterval, reloaders...); err != nil {
-					return errors.Wrapf(err, "error loading config from %q", cfg.configFile)
+					return fmt.Errorf("error loading config from %q %w", cfg.configFile, err)
 				}
 
 				reloadReady.Close()
@@ -968,7 +968,7 @@ func main() {
 
 				db, err := openDBWithMetrics(localStoragePath, logger, prometheus.DefaultRegisterer, &opts, localStorage.getStats())
 				if err != nil {
-					return errors.Wrapf(err, "opening storage failed")
+					return fmt.Errorf("opening storage failed %w", err)
 				}
 
 				switch fsType := prom_runtime.Statfs(localStoragePath); fsType {
@@ -1024,7 +1024,7 @@ func main() {
 					&opts,
 				)
 				if err != nil {
-					return errors.Wrap(err, "opening storage failed")
+					return fmt.Errorf("opening storage failed %w", err)
 				}
 
 				switch fsType := prom_runtime.Statfs(localStoragePath); fsType {
@@ -1062,7 +1062,7 @@ func main() {
 		g.Add(
 			func() error {
 				if err := webHandler.Run(ctxWeb, listener, *webConfig); err != nil {
-					return errors.Wrapf(err, "error starting web server")
+					return fmt.Errorf("error starting web server %w", err)
 				}
 				return nil
 			},
@@ -1172,7 +1172,7 @@ func reloadConfig(filename string, expandExternalLabels, enableExemplarStorage b
 
 	conf, err := config.LoadFile(filename, agentMode, expandExternalLabels, logger)
 	if err != nil {
-		return errors.Wrapf(err, "couldn't load configuration (--config.file=%q)", filename)
+		return fmt.Errorf("couldn't load configuration (--config.file=%q) %w", filename, err)
 	}
 
 	if enableExemplarStorage {
@@ -1191,7 +1191,7 @@ func reloadConfig(filename string, expandExternalLabels, enableExemplarStorage b
 		timings = append(timings, rl.name, time.Since(rstart))
 	}
 	if failed {
-		return errors.Errorf("one or more errors occurred while applying the new configuration (--config.file=%q)", filename)
+		return fmt.Errorf("one or more errors occurred while applying the new configuration (--config.file=%q)", filename)
 	}
 
 	noStepSuqueryInterval.Set(conf.GlobalConfig.EvaluationInterval)

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -394,7 +394,7 @@ func main() {
 
 	_, err := a.Parse(os.Args[1:])
 	if err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Errorf("Error parsing commandline arguments %w", err))
+		fmt.Fprintln(os.Stderr, fmt.Errorf("Error parsing commandline arguments: %w", err))
 		a.Usage(os.Args[1:])
 		os.Exit(2)
 	}
@@ -402,7 +402,7 @@ func main() {
 	logger := promlog.New(&cfg.promlogConfig)
 
 	if err := cfg.setFeatureListOptions(logger); err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Errorf("Error parsing feature list %w", err))
+		fmt.Fprintln(os.Stderr, fmt.Errorf("Error parsing feature list: %w", err))
 		os.Exit(1)
 	}
 
@@ -423,13 +423,13 @@ func main() {
 
 	cfg.web.ExternalURL, err = computeExternalURL(cfg.prometheusURL, cfg.web.ListenAddress)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Errorf("parse external URL %q %w", cfg.prometheusURL, err))
+		fmt.Fprintln(os.Stderr, fmt.Errorf("parse external URL %q: %w", cfg.prometheusURL, err))
 		os.Exit(2)
 	}
 
 	cfg.web.CORSOrigin, err = compileCORSRegexString(cfg.corsRegexString)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Errorf("could not compile CORS regex string %q %w", cfg.corsRegexString, err))
+		fmt.Fprintln(os.Stderr, fmt.Errorf("could not compile CORS regex string %q: %w", cfg.corsRegexString, err))
 		os.Exit(2)
 	}
 
@@ -729,7 +729,7 @@ func main() {
 					fs, err := filepath.Glob(pat)
 					if err != nil {
 						// The only error can be a bad pattern.
-						return fmt.Errorf("error retrieving rule files for %s %w", pat, err)
+						return fmt.Errorf("error retrieving rule files for %s: %w", pat, err)
 					}
 					files = append(files, fs...)
 				}
@@ -921,7 +921,7 @@ func main() {
 				}
 
 				if err := reloadConfig(cfg.configFile, cfg.enableExpandExternalLabels, cfg.tsdb.EnableExemplarStorage, logger, noStepSubqueryInterval, reloaders...); err != nil {
-					return fmt.Errorf("error loading config from %q %w", cfg.configFile, err)
+					return fmt.Errorf("error loading config from %q: %w", cfg.configFile, err)
 				}
 
 				reloadReady.Close()
@@ -968,7 +968,7 @@ func main() {
 
 				db, err := openDBWithMetrics(localStoragePath, logger, prometheus.DefaultRegisterer, &opts, localStorage.getStats())
 				if err != nil {
-					return fmt.Errorf("opening storage failed %w", err)
+					return fmt.Errorf("opening storage failed: %w", err)
 				}
 
 				switch fsType := prom_runtime.Statfs(localStoragePath); fsType {
@@ -1024,7 +1024,7 @@ func main() {
 					&opts,
 				)
 				if err != nil {
-					return fmt.Errorf("opening storage failed %w", err)
+					return fmt.Errorf("opening storage failed: %w", err)
 				}
 
 				switch fsType := prom_runtime.Statfs(localStoragePath); fsType {
@@ -1062,7 +1062,7 @@ func main() {
 		g.Add(
 			func() error {
 				if err := webHandler.Run(ctxWeb, listener, *webConfig); err != nil {
-					return fmt.Errorf("error starting web server %w", err)
+					return fmt.Errorf("error starting web server: %w", err)
 				}
 				return nil
 			},
@@ -1172,7 +1172,7 @@ func reloadConfig(filename string, expandExternalLabels, enableExemplarStorage b
 
 	conf, err := config.LoadFile(filename, agentMode, expandExternalLabels, logger)
 	if err != nil {
-		return fmt.Errorf("couldn't load configuration (--config.file=%q) %w", filename, err)
+		return fmt.Errorf("couldn't load configuration (--config.file=%q): %w", filename, err)
 	}
 
 	if enableExemplarStorage {

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -16,6 +16,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -120,8 +121,8 @@ func TestFailedStartupExitCode(t *testing.T) {
 	prom := exec.Command(promPath, "-test.main", "--config.file="+fakeInputFile)
 	err := prom.Run()
 	require.Error(t, err)
-
-	if exitError, ok := err.(*exec.ExitError); ok {
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
 		status := exitError.Sys().(syscall.WaitStatus)
 		require.Equal(t, expectedExitStatus, status.ExitStatus())
 	} else {
@@ -233,7 +234,8 @@ func TestWALSegmentSizeBounds(t *testing.T) {
 
 		err = prom.Wait()
 		require.Error(t, err)
-		if exitError, ok := err.(*exec.ExitError); ok {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
 			status := exitError.Sys().(syscall.WaitStatus)
 			require.Equal(t, expectedExitStatus, status.ExitStatus())
 		} else {
@@ -278,7 +280,8 @@ func TestMaxBlockChunkSegmentSizeBounds(t *testing.T) {
 
 		err = prom.Wait()
 		require.Error(t, err)
-		if exitError, ok := err.(*exec.ExitError); ok {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
 			status := exitError.Sys().(syscall.WaitStatus)
 			require.Equal(t, expectedExitStatus, status.ExitStatus())
 		} else {
@@ -467,7 +470,8 @@ func TestModeSpecificFlags(t *testing.T) {
 
 			err = prom.Wait()
 			require.Error(t, err)
-			if exitError, ok := err.(*exec.ExitError); ok {
+			var exitError *exec.ExitError
+			if errors.As(err, &exitError) {
 				status := exitError.Sys().(syscall.WaitStatus)
 				require.Equal(t, tc.exitStatus, status.ExitStatus())
 			} else {

--- a/cmd/promtool/archive.go
+++ b/cmd/promtool/archive.go
@@ -31,7 +31,7 @@ type tarGzFileWriter struct {
 func newTarGzFileWriter(archiveName string) (*tarGzFileWriter, error) {
 	file, err := os.Create(archiveName)
 	if err != nil {
-		return nil, fmt.Errorf("error creating archive %q %w", archiveName, err)
+		return nil, fmt.Errorf("error creating archive %q: %w", archiveName, err)
 	}
 	gzw := gzip.NewWriter(file)
 	tw := tar.NewWriter(gzw)

--- a/cmd/promtool/archive.go
+++ b/cmd/promtool/archive.go
@@ -16,9 +16,8 @@ package main
 import (
 	"archive/tar"
 	"compress/gzip"
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 const filePerm = 0o666
@@ -32,7 +31,7 @@ type tarGzFileWriter struct {
 func newTarGzFileWriter(archiveName string) (*tarGzFileWriter, error) {
 	file, err := os.Create(archiveName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error creating archive %q", archiveName)
+		return nil, fmt.Errorf("error creating archive %q %w", archiveName, err)
 	}
 	gzw := gzip.NewWriter(file)
 	tw := tar.NewWriter(gzw)

--- a/cmd/promtool/backfill.go
+++ b/cmd/promtool/backfill.go
@@ -15,12 +15,13 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"math"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/textparse"
@@ -33,11 +34,11 @@ func getMinAndMaxTimestamps(p textparse.Parser) (int64, int64, error) {
 
 	for {
 		entry, err := p.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
-			return 0, 0, errors.Wrap(err, "next")
+			return 0, 0, fmt.Errorf("next %w", err)
 		}
 
 		if entry != textparse.EntrySeries {
@@ -46,7 +47,7 @@ func getMinAndMaxTimestamps(p textparse.Parser) (int64, int64, error) {
 
 		_, ts, _ := p.Series()
 		if ts == nil {
-			return 0, 0, errors.Errorf("expected timestamp for series got none")
+			return 0, 0, fmt.Errorf("expected timestamp for series got none")
 		}
 
 		if *ts > maxt {
@@ -118,7 +119,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 			// original interval later.
 			w, err := tsdb.NewBlockWriter(log.NewNopLogger(), outputDir, 2*blockDuration)
 			if err != nil {
-				return errors.Wrap(err, "block writer")
+				return fmt.Errorf("block writer %w", err)
 			}
 			defer func() {
 				err = tsdb_errors.NewMulti(err, w.Close()).Err()
@@ -130,11 +131,11 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 			samplesCount := 0
 			for {
 				e, err := p.Next()
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					break
 				}
 				if err != nil {
-					return errors.Wrap(err, "parse")
+					return fmt.Errorf("parse %w", err)
 				}
 				if e != textparse.EntrySeries {
 					continue
@@ -144,7 +145,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				if ts == nil {
 					l := labels.Labels{}
 					p.Metric(&l)
-					return errors.Errorf("expected timestamp for series %v, got none", l)
+					return fmt.Errorf("expected timestamp for series %v, got none", l)
 				}
 				if *ts < t {
 					continue
@@ -160,7 +161,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				p.Metric(&l)
 
 				if _, err := app.Append(0, l, *ts, v); err != nil {
-					return errors.Wrap(err, "add sample")
+					return fmt.Errorf("add sample %w", err)
 				}
 
 				samplesCount++
@@ -172,7 +173,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				// Therefore the old appender is committed and a new one is created.
 				// This prevents keeping too many samples lined up in an appender and thus in RAM.
 				if err := app.Commit(); err != nil {
-					return errors.Wrap(err, "commit")
+					return fmt.Errorf("commit %w", err)
 				}
 
 				app = w.Appender(ctx)
@@ -180,18 +181,18 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 			}
 
 			if err := app.Commit(); err != nil {
-				return errors.Wrap(err, "commit")
+				return fmt.Errorf("commit %w", err)
 			}
 
 			block, err := w.Flush(ctx)
-			switch err {
-			case nil:
+			switch {
+			case err == nil:
 				if quiet {
 					break
 				}
 				blocks, err := db.Blocks()
 				if err != nil {
-					return errors.Wrap(err, "get blocks")
+					return fmt.Errorf("get blocks %w", err)
 				}
 				for _, b := range blocks {
 					if b.Meta().ULID == block {
@@ -200,15 +201,15 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 						break
 					}
 				}
-			case tsdb.ErrNoSeriesAppended:
+			case errors.Is(err, tsdb.ErrNoSeriesAppended):
 			default:
-				return errors.Wrap(err, "flush")
+				return fmt.Errorf("flush %w", err)
 			}
 
 			return nil
 		}()
 		if err != nil {
-			return errors.Wrap(err, "process blocks")
+			return fmt.Errorf("process blocks %w", err)
 		}
 	}
 	return nil
@@ -218,7 +219,7 @@ func backfill(maxSamplesInAppender int, input []byte, outputDir string, humanRea
 	p := textparse.NewOpenMetricsParser(input)
 	maxt, mint, err := getMinAndMaxTimestamps(p)
 	if err != nil {
-		return errors.Wrap(err, "getting min and max timestamp")
+		return fmt.Errorf("getting min and max timestamp %w", err)
 	}
-	return errors.Wrap(createBlocks(input, mint, maxt, int64(maxBlockDuration/time.Millisecond), maxSamplesInAppender, outputDir, humanReadable, quiet), "block creation")
+	return fmt.Errorf("block creation %w", createBlocks(input, mint, maxt, int64(maxBlockDuration/time.Millisecond), maxSamplesInAppender, outputDir, humanReadable, quiet))
 }

--- a/cmd/promtool/backfill.go
+++ b/cmd/promtool/backfill.go
@@ -220,6 +220,9 @@ func backfill(maxSamplesInAppender int, input []byte, outputDir string, humanRea
 	maxt, mint, err := getMinAndMaxTimestamps(p)
 	if err != nil {
 		return fmt.Errorf("getting min and max timestamp: %w", err)
+	}	
+	if err = createBlocks(input, mint, maxt, int64(maxBlockDuration/time.Millisecond), maxSamplesInAppender, outputDir, humanReadable, quiet); err != nil {
+		return fmt.Errorf("block creation: %w", err)
 	}
-	return fmt.Errorf("block creation: %w", createBlocks(input, mint, maxt, int64(maxBlockDuration/time.Millisecond), maxSamplesInAppender, outputDir, humanReadable, quiet))
+	return nil
 }

--- a/cmd/promtool/backfill.go
+++ b/cmd/promtool/backfill.go
@@ -38,7 +38,7 @@ func getMinAndMaxTimestamps(p textparse.Parser) (int64, int64, error) {
 			break
 		}
 		if err != nil {
-			return 0, 0, fmt.Errorf("next %w", err)
+			return 0, 0, fmt.Errorf("next: %w", err)
 		}
 
 		if entry != textparse.EntrySeries {
@@ -119,7 +119,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 			// original interval later.
 			w, err := tsdb.NewBlockWriter(log.NewNopLogger(), outputDir, 2*blockDuration)
 			if err != nil {
-				return fmt.Errorf("block writer %w", err)
+				return fmt.Errorf("block writer: %w", err)
 			}
 			defer func() {
 				err = tsdb_errors.NewMulti(err, w.Close()).Err()
@@ -135,7 +135,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 					break
 				}
 				if err != nil {
-					return fmt.Errorf("parse %w", err)
+					return fmt.Errorf("parse: %w", err)
 				}
 				if e != textparse.EntrySeries {
 					continue
@@ -161,7 +161,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				p.Metric(&l)
 
 				if _, err := app.Append(0, l, *ts, v); err != nil {
-					return fmt.Errorf("add sample %w", err)
+					return fmt.Errorf("add sample: %w", err)
 				}
 
 				samplesCount++
@@ -173,7 +173,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				// Therefore the old appender is committed and a new one is created.
 				// This prevents keeping too many samples lined up in an appender and thus in RAM.
 				if err := app.Commit(); err != nil {
-					return fmt.Errorf("commit %w", err)
+					return fmt.Errorf("commit: %w", err)
 				}
 
 				app = w.Appender(ctx)
@@ -181,7 +181,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 			}
 
 			if err := app.Commit(); err != nil {
-				return fmt.Errorf("commit %w", err)
+				return fmt.Errorf("commit: %w", err)
 			}
 
 			block, err := w.Flush(ctx)
@@ -192,7 +192,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				}
 				blocks, err := db.Blocks()
 				if err != nil {
-					return fmt.Errorf("get blocks %w", err)
+					return fmt.Errorf("get blocks: %w", err)
 				}
 				for _, b := range blocks {
 					if b.Meta().ULID == block {
@@ -203,13 +203,13 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				}
 			case errors.Is(err, tsdb.ErrNoSeriesAppended):
 			default:
-				return fmt.Errorf("flush %w", err)
+				return fmt.Errorf("flush: %w", err)
 			}
 
 			return nil
 		}()
 		if err != nil {
-			return fmt.Errorf("process blocks %w", err)
+			return fmt.Errorf("process blocks: %w", err)
 		}
 	}
 	return nil
@@ -219,7 +219,7 @@ func backfill(maxSamplesInAppender int, input []byte, outputDir string, humanRea
 	p := textparse.NewOpenMetricsParser(input)
 	maxt, mint, err := getMinAndMaxTimestamps(p)
 	if err != nil {
-		return fmt.Errorf("getting min and max timestamp %w", err)
+		return fmt.Errorf("getting min and max timestamp: %w", err)
 	}
-	return fmt.Errorf("block creation %w", createBlocks(input, mint, maxt, int64(maxBlockDuration/time.Millisecond), maxSamplesInAppender, outputDir, humanReadable, quiet))
+	return fmt.Errorf("block creation: %w", createBlocks(input, mint, maxt, int64(maxBlockDuration/time.Millisecond), maxSamplesInAppender, outputDir, humanReadable, quiet))
 }

--- a/cmd/promtool/backfill.go
+++ b/cmd/promtool/backfill.go
@@ -220,7 +220,7 @@ func backfill(maxSamplesInAppender int, input []byte, outputDir string, humanRea
 	maxt, mint, err := getMinAndMaxTimestamps(p)
 	if err != nil {
 		return fmt.Errorf("getting min and max timestamp: %w", err)
-	}	
+	}
 	if err = createBlocks(input, mint, maxt, int64(maxBlockDuration/time.Millisecond), maxSamplesInAppender, outputDir, humanReadable, quiet); err != nil {
 		return fmt.Errorf("block creation: %w", err)
 	}

--- a/cmd/promtool/debug.go
+++ b/cmd/promtool/debug.go
@@ -28,7 +28,7 @@ type debugWriterConfig struct {
 func debugWrite(cfg debugWriterConfig) error {
 	archiver, err := newTarGzFileWriter(cfg.tarballName)
 	if err != nil {
-		return fmt.Errorf("error creating a new archiver %w", err)
+		return fmt.Errorf("error creating a new archiver: %w", err)
 	}
 
 	for _, endPointGroup := range cfg.endPointGroups {
@@ -37,28 +37,28 @@ func debugWrite(cfg debugWriterConfig) error {
 			fmt.Println("collecting:", url)
 			res, err := http.Get(url)
 			if err != nil {
-				return fmt.Errorf("error executing HTTP request %w", err)
+				return fmt.Errorf("error executing HTTP request: %w", err)
 			}
 			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
-				return fmt.Errorf("error reading the response body %w", err)
+				return fmt.Errorf("error reading the response body: %w", err)
 			}
 
 			if endPointGroup.postProcess != nil {
 				body, err = endPointGroup.postProcess(body)
 				if err != nil {
-					return fmt.Errorf("error post-processing HTTP response body %w", err)
+					return fmt.Errorf("error post-processing HTTP response body: %w", err)
 				}
 			}
 			if err := archiver.write(filename, body); err != nil {
-				return fmt.Errorf("error writing into the archive %w", err)
+				return fmt.Errorf("error writing into the archive: %w", err)
 			}
 		}
 	}
 
 	if err := archiver.close(); err != nil {
-		return fmt.Errorf("error closing archive writer %w", err)
+		return fmt.Errorf("error closing archive writer: %w", err)
 	}
 
 	fmt.Printf("Compiling debug information complete, all files written in %q.\n", cfg.tarballName)

--- a/cmd/promtool/debug.go
+++ b/cmd/promtool/debug.go
@@ -17,8 +17,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 type debugWriterConfig struct {
@@ -30,7 +28,7 @@ type debugWriterConfig struct {
 func debugWrite(cfg debugWriterConfig) error {
 	archiver, err := newTarGzFileWriter(cfg.tarballName)
 	if err != nil {
-		return errors.Wrap(err, "error creating a new archiver")
+		return fmt.Errorf("error creating a new archiver %w", err)
 	}
 
 	for _, endPointGroup := range cfg.endPointGroups {
@@ -39,28 +37,28 @@ func debugWrite(cfg debugWriterConfig) error {
 			fmt.Println("collecting:", url)
 			res, err := http.Get(url)
 			if err != nil {
-				return errors.Wrap(err, "error executing HTTP request")
+				return fmt.Errorf("error executing HTTP request %w", err)
 			}
 			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
-				return errors.Wrap(err, "error reading the response body")
+				return fmt.Errorf("error reading the response body %w", err)
 			}
 
 			if endPointGroup.postProcess != nil {
 				body, err = endPointGroup.postProcess(body)
 				if err != nil {
-					return errors.Wrap(err, "error post-processing HTTP response body")
+					return fmt.Errorf("error post-processing HTTP response body %w", err)
 				}
 			}
 			if err := archiver.write(filename, body); err != nil {
-				return errors.Wrap(err, "error writing into the archive")
+				return fmt.Errorf("error writing into the archive %w", err)
 			}
 		}
 	}
 
 	if err := archiver.close(); err != nil {
-		return errors.Wrap(err, "error closing archive writer")
+		return fmt.Errorf("error closing archive writer %w", err)
 	}
 
 	fmt.Printf("Compiling debug information complete, all files written in %q.\n", cfg.tarballName)

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -416,7 +416,7 @@ func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]strin
 					return nil, fmt.Errorf("%q does not point to an existing file", rf)
 				}
 				if err := checkFileExists(rfs[0]); err != nil {
-					return nil, fmt.Errorf("error checking rule file %q %w", rfs[0], err)
+					return nil, fmt.Errorf("error checking rule file %q: %w", rfs[0], err)
 				}
 			}
 			ruleFiles = append(ruleFiles, rfs...)
@@ -426,7 +426,7 @@ func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]strin
 	for _, scfg := range cfg.ScrapeConfigs {
 		if !checkSyntaxOnly && scfg.HTTPClientConfig.Authorization != nil {
 			if err := checkFileExists(scfg.HTTPClientConfig.Authorization.CredentialsFile); err != nil {
-				return nil, fmt.Errorf("error checking authorization credentials or bearer token file %q %w", scfg.HTTPClientConfig.Authorization.CredentialsFile, err)
+				return nil, fmt.Errorf("error checking authorization credentials or bearer token file %q: %w", scfg.HTTPClientConfig.Authorization.CredentialsFile, err)
 			}
 		}
 
@@ -524,10 +524,10 @@ func checkTLSConfig(tlsConfig config_util.TLSConfig, checkSyntaxOnly bool) error
 	}
 
 	if err := checkFileExists(tlsConfig.CertFile); err != nil {
-		return fmt.Errorf("error checking client cert file %q %w", tlsConfig.CertFile, err)
+		return fmt.Errorf("error checking client cert file %q: %w", tlsConfig.CertFile, err)
 	}
 	if err := checkFileExists(tlsConfig.KeyFile); err != nil {
-		return fmt.Errorf("error checking client key file %q %w", tlsConfig.KeyFile, err)
+		return fmt.Errorf("error checking client key file %q: %w", tlsConfig.KeyFile, err)
 	}
 
 	return nil
@@ -991,14 +991,14 @@ func parseStartTimeAndEndTime(start, end string) (time.Time, time.Time, error) {
 	if start != "" {
 		stime, err = parseTime(start)
 		if err != nil {
-			return stime, etime, fmt.Errorf("error parsing start time %w", err)
+			return stime, etime, fmt.Errorf("error parsing start time: %w", err)
 		}
 	}
 
 	if end != "" {
 		etime, err = parseTime(end)
 		if err != nil {
-			return stime, etime, fmt.Errorf("error parsing end time %w", err)
+			return stime, etime, fmt.Errorf("error parsing end time: %w", err)
 		}
 	}
 	return stime, etime, nil
@@ -1038,7 +1038,7 @@ var (
 				}
 				var buf bytes.Buffer
 				if err := p.WriteUncompressed(&buf); err != nil {
-					return nil, fmt.Errorf("writing the profile to the buffer %w", err)
+					return nil, fmt.Errorf("writing the profile to the buffer: %w", err)
 				}
 
 				return buf.Bytes(), nil

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -32,7 +33,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -413,10 +413,10 @@ func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]strin
 			// If an explicit file was given, error if it is not accessible.
 			if !strings.Contains(rf, "*") {
 				if len(rfs) == 0 {
-					return nil, errors.Errorf("%q does not point to an existing file", rf)
+					return nil, fmt.Errorf("%q does not point to an existing file", rf)
 				}
 				if err := checkFileExists(rfs[0]); err != nil {
-					return nil, errors.Wrapf(err, "error checking rule file %q", rfs[0])
+					return nil, fmt.Errorf("error checking rule file %q %w", rfs[0], err)
 				}
 			}
 			ruleFiles = append(ruleFiles, rfs...)
@@ -426,7 +426,7 @@ func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]strin
 	for _, scfg := range cfg.ScrapeConfigs {
 		if !checkSyntaxOnly && scfg.HTTPClientConfig.Authorization != nil {
 			if err := checkFileExists(scfg.HTTPClientConfig.Authorization.CredentialsFile); err != nil {
-				return nil, errors.Wrapf(err, "error checking authorization credentials or bearer token file %q", scfg.HTTPClientConfig.Authorization.CredentialsFile)
+				return nil, fmt.Errorf("error checking authorization credentials or bearer token file %q %w", scfg.HTTPClientConfig.Authorization.CredentialsFile, err)
 			}
 		}
 
@@ -454,7 +454,7 @@ func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]strin
 							var targetGroups []*targetgroup.Group
 							targetGroups, err = checkSDFile(f)
 							if err != nil {
-								return nil, errors.Errorf("checking SD file %q: %v", file, err)
+								return nil, fmt.Errorf("checking SD file %q: %w", file, err)
 							}
 							if err := checkTargetGroupsForScrapeConfig(targetGroups, scfg); err != nil {
 								return nil, err
@@ -490,7 +490,7 @@ func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]strin
 							var targetGroups []*targetgroup.Group
 							targetGroups, err = checkSDFile(f)
 							if err != nil {
-								return nil, errors.Errorf("checking SD file %q: %v", file, err)
+								return nil, fmt.Errorf("checking SD file %q: %w", file, err)
 							}
 
 							if err := checkTargetGroupsForAlertmanager(targetGroups, amcfg); err != nil {
@@ -513,10 +513,10 @@ func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]strin
 
 func checkTLSConfig(tlsConfig config_util.TLSConfig, checkSyntaxOnly bool) error {
 	if len(tlsConfig.CertFile) > 0 && len(tlsConfig.KeyFile) == 0 {
-		return errors.Errorf("client cert file %q specified without client key file", tlsConfig.CertFile)
+		return fmt.Errorf("client cert file %q specified without client key file", tlsConfig.CertFile)
 	}
 	if len(tlsConfig.KeyFile) > 0 && len(tlsConfig.CertFile) == 0 {
-		return errors.Errorf("client key file %q specified without client cert file", tlsConfig.KeyFile)
+		return fmt.Errorf("client key file %q specified without client cert file", tlsConfig.KeyFile)
 	}
 
 	if checkSyntaxOnly {
@@ -524,10 +524,10 @@ func checkTLSConfig(tlsConfig config_util.TLSConfig, checkSyntaxOnly bool) error
 	}
 
 	if err := checkFileExists(tlsConfig.CertFile); err != nil {
-		return errors.Wrapf(err, "error checking client cert file %q", tlsConfig.CertFile)
+		return fmt.Errorf("error checking client cert file %q %w", tlsConfig.CertFile, err)
 	}
 	if err := checkFileExists(tlsConfig.KeyFile); err != nil {
-		return errors.Wrapf(err, "error checking client key file %q", tlsConfig.KeyFile)
+		return fmt.Errorf("error checking client key file %q %w", tlsConfig.KeyFile, err)
 	}
 
 	return nil
@@ -557,12 +557,12 @@ func checkSDFile(filename string) ([]*targetgroup.Group, error) {
 			return nil, err
 		}
 	default:
-		return nil, errors.Errorf("invalid file extension: %q", ext)
+		return nil, fmt.Errorf("invalid file extension: %q", ext)
 	}
 
 	for i, tg := range targetGroups {
 		if tg == nil {
-			return nil, errors.Errorf("nil target group item found (index %d)", i)
+			return nil, fmt.Errorf("nil target group item found (index %d)", i)
 		}
 	}
 
@@ -991,14 +991,14 @@ func parseStartTimeAndEndTime(start, end string) (time.Time, time.Time, error) {
 	if start != "" {
 		stime, err = parseTime(start)
 		if err != nil {
-			return stime, etime, errors.Wrap(err, "error parsing start time")
+			return stime, etime, fmt.Errorf("error parsing start time %w", err)
 		}
 	}
 
 	if end != "" {
 		etime, err = parseTime(end)
 		if err != nil {
-			return stime, etime, errors.Wrap(err, "error parsing end time")
+			return stime, etime, fmt.Errorf("error parsing end time %w", err)
 		}
 	}
 	return stime, etime, nil
@@ -1012,7 +1012,7 @@ func parseTime(s string) (time.Time, error) {
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 		return t, nil
 	}
-	return time.Time{}, errors.Errorf("cannot parse %q to a valid timestamp", s)
+	return time.Time{}, fmt.Errorf("cannot parse %q to a valid timestamp", s)
 }
 
 type endpointsGroup struct {
@@ -1038,7 +1038,7 @@ var (
 				}
 				var buf bytes.Buffer
 				if err := p.WriteUncompressed(&buf); err != nil {
-					return nil, errors.Wrap(err, "writing the profile to the buffer")
+					return nil, fmt.Errorf("writing the profile to the buffer %w", err)
 				}
 
 				return buf.Bytes(), nil
@@ -1148,13 +1148,13 @@ func importRules(url *url.URL, start, end, outputDir string, evalInterval, maxBl
 	} else {
 		etime, err = parseTime(end)
 		if err != nil {
-			return fmt.Errorf("error parsing end time: %v", err)
+			return fmt.Errorf("error parsing end time: %w", err)
 		}
 	}
 
 	stime, err = parseTime(start)
 	if err != nil {
-		return fmt.Errorf("error parsing start time: %v", err)
+		return fmt.Errorf("error parsing start time: %w", err)
 	}
 
 	if !stime.Before(etime) {
@@ -1172,14 +1172,14 @@ func importRules(url *url.URL, start, end, outputDir string, evalInterval, maxBl
 		Address: url.String(),
 	})
 	if err != nil {
-		return fmt.Errorf("new api client error: %v", err)
+		return fmt.Errorf("new api client error: %w", err)
 	}
 
 	ruleImporter := newRuleImporter(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), cfg, v1.NewAPI(client))
 	errs := ruleImporter.loadGroups(ctx, files)
 	for _, err := range errs {
 		if err != nil {
-			return fmt.Errorf("rule importer parse error: %v", err)
+			return fmt.Errorf("rule importer parse error: %w", err)
 		}
 	}
 

--- a/cmd/promtool/rules.go
+++ b/cmd/promtool/rules.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
@@ -122,7 +121,7 @@ func (importer *ruleImporter) importRule(ctx context.Context, ruleExpr, ruleName
 			},
 		)
 		if err != nil {
-			return errors.Wrap(err, "query range")
+			return fmt.Errorf("query range %w", err)
 		}
 		if warnings != nil {
 			level.Warn(importer.logger).Log("msg", "Range query returned warnings.", "warnings", warnings)
@@ -136,7 +135,7 @@ func (importer *ruleImporter) importRule(ctx context.Context, ruleExpr, ruleName
 		// original interval later.
 		w, err := tsdb.NewBlockWriter(log.NewNopLogger(), importer.config.outputDir, 2*blockDuration)
 		if err != nil {
-			return errors.Wrap(err, "new block writer")
+			return fmt.Errorf("new block writer %w", err)
 		}
 		var closed bool
 		defer func() {
@@ -167,7 +166,7 @@ func (importer *ruleImporter) importRule(ctx context.Context, ruleExpr, ruleName
 
 				for _, value := range sample.Values {
 					if err := app.add(ctx, lb.Labels(), timestamp.FromTime(value.Timestamp.Time()), float64(value.Value)); err != nil {
-						return errors.Wrap(err, "add")
+						return fmt.Errorf("add %w", err)
 					}
 				}
 			}
@@ -176,7 +175,7 @@ func (importer *ruleImporter) importRule(ctx context.Context, ruleExpr, ruleName
 		}
 
 		if err := app.flushAndCommit(ctx); err != nil {
-			return errors.Wrap(err, "flush and commit")
+			return fmt.Errorf("flush and commit %w", err)
 		}
 		err = tsdb_errors.NewMulti(err, w.Close()).Err()
 		closed = true
@@ -204,7 +203,7 @@ type multipleAppender struct {
 
 func (m *multipleAppender) add(ctx context.Context, l labels.Labels, t int64, v float64) error {
 	if _, err := m.appender.Append(0, l, t, v); err != nil {
-		return errors.Wrap(err, "multiappender append")
+		return fmt.Errorf("multiappender append %w", err)
 	}
 	m.currentSampleCount++
 	if m.currentSampleCount >= m.maxSamplesInMemory {
@@ -218,7 +217,7 @@ func (m *multipleAppender) commit(ctx context.Context) error {
 		return nil
 	}
 	if err := m.appender.Commit(); err != nil {
-		return errors.Wrap(err, "multiappender commit")
+		return fmt.Errorf("multiappender commit %w", err)
 	}
 	m.appender = m.writer.Appender(ctx)
 	m.currentSampleCount = 0
@@ -230,7 +229,7 @@ func (m *multipleAppender) flushAndCommit(ctx context.Context) error {
 		return err
 	}
 	if _, err := m.writer.Flush(ctx); err != nil {
-		return errors.Wrap(err, "multiappender flush")
+		return fmt.Errorf("multiappender flush %w", err)
 	}
 	return nil
 }

--- a/cmd/promtool/rules.go
+++ b/cmd/promtool/rules.go
@@ -121,7 +121,7 @@ func (importer *ruleImporter) importRule(ctx context.Context, ruleExpr, ruleName
 			},
 		)
 		if err != nil {
-			return fmt.Errorf("query range %w", err)
+			return fmt.Errorf("query range: %w", err)
 		}
 		if warnings != nil {
 			level.Warn(importer.logger).Log("msg", "Range query returned warnings.", "warnings", warnings)
@@ -135,7 +135,7 @@ func (importer *ruleImporter) importRule(ctx context.Context, ruleExpr, ruleName
 		// original interval later.
 		w, err := tsdb.NewBlockWriter(log.NewNopLogger(), importer.config.outputDir, 2*blockDuration)
 		if err != nil {
-			return fmt.Errorf("new block writer %w", err)
+			return fmt.Errorf("new block writer: %w", err)
 		}
 		var closed bool
 		defer func() {
@@ -166,7 +166,7 @@ func (importer *ruleImporter) importRule(ctx context.Context, ruleExpr, ruleName
 
 				for _, value := range sample.Values {
 					if err := app.add(ctx, lb.Labels(), timestamp.FromTime(value.Timestamp.Time()), float64(value.Value)); err != nil {
-						return fmt.Errorf("add %w", err)
+						return fmt.Errorf("add: %w", err)
 					}
 				}
 			}
@@ -175,7 +175,7 @@ func (importer *ruleImporter) importRule(ctx context.Context, ruleExpr, ruleName
 		}
 
 		if err := app.flushAndCommit(ctx); err != nil {
-			return fmt.Errorf("flush and commit %w", err)
+			return fmt.Errorf("flush and commit: %w", err)
 		}
 		err = tsdb_errors.NewMulti(err, w.Close()).Err()
 		closed = true
@@ -203,7 +203,7 @@ type multipleAppender struct {
 
 func (m *multipleAppender) add(ctx context.Context, l labels.Labels, t int64, v float64) error {
 	if _, err := m.appender.Append(0, l, t, v); err != nil {
-		return fmt.Errorf("multiappender append %w", err)
+		return fmt.Errorf("multiappender append: %w", err)
 	}
 	m.currentSampleCount++
 	if m.currentSampleCount >= m.maxSamplesInMemory {
@@ -217,7 +217,7 @@ func (m *multipleAppender) commit(ctx context.Context) error {
 		return nil
 	}
 	if err := m.appender.Commit(); err != nil {
-		return fmt.Errorf("multiappender commit %w", err)
+		return fmt.Errorf("multiappender commit: %w", err)
 	}
 	m.appender = m.writer.Appender(ctx)
 	m.currentSampleCount = 0
@@ -229,7 +229,7 @@ func (m *multipleAppender) flushAndCommit(ctx context.Context) error {
 		return err
 	}
 	if _, err := m.writer.Flush(ctx); err != nil {
-		return fmt.Errorf("multiappender flush %w", err)
+		return fmt.Errorf("multiappender flush: %w", err)
 	}
 	return nil
 }

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -679,7 +679,7 @@ func backfillOpenMetrics(path, outputDir string, humanReadable, quiet bool, maxB
 	defer inputFile.Close()
 
 	if err := os.MkdirAll(outputDir, 0o777); err != nil {
-		return checkErr(fmt.Errorf("create output dir %w", err))
+		return checkErr(fmt.Errorf("create output dir: %w", err))
 	}
 
 	return checkErr(backfill(5000, inputFile.Bytes(), outputDir, humanReadable, quiet, maxBlockDuration))

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/alecthomas/units"
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
@@ -236,29 +235,29 @@ func (b *writeBenchmark) startProfiling() error {
 	// Start CPU profiling.
 	b.cpuprof, err = os.Create(filepath.Join(b.outPath, "cpu.prof"))
 	if err != nil {
-		return fmt.Errorf("bench: could not create cpu profile: %v", err)
+		return fmt.Errorf("bench: could not create cpu profile: %w", err)
 	}
 	if err := pprof.StartCPUProfile(b.cpuprof); err != nil {
-		return fmt.Errorf("bench: could not start CPU profile: %v", err)
+		return fmt.Errorf("bench: could not start CPU profile: %w", err)
 	}
 
 	// Start memory profiling.
 	b.memprof, err = os.Create(filepath.Join(b.outPath, "mem.prof"))
 	if err != nil {
-		return fmt.Errorf("bench: could not create memory profile: %v", err)
+		return fmt.Errorf("bench: could not create memory profile: %w", err)
 	}
 	runtime.MemProfileRate = 64 * 1024
 
 	// Start fatal profiling.
 	b.blockprof, err = os.Create(filepath.Join(b.outPath, "block.prof"))
 	if err != nil {
-		return fmt.Errorf("bench: could not create block profile: %v", err)
+		return fmt.Errorf("bench: could not create block profile: %w", err)
 	}
 	runtime.SetBlockProfileRate(20)
 
 	b.mtxprof, err = os.Create(filepath.Join(b.outPath, "mutex.prof"))
 	if err != nil {
-		return fmt.Errorf("bench: could not create mutex profile: %v", err)
+		return fmt.Errorf("bench: could not create mutex profile: %w", err)
 	}
 	runtime.SetMutexProfileFraction(20)
 	return nil
@@ -272,14 +271,14 @@ func (b *writeBenchmark) stopProfiling() error {
 	}
 	if b.memprof != nil {
 		if err := pprof.Lookup("heap").WriteTo(b.memprof, 0); err != nil {
-			return fmt.Errorf("error writing mem profile: %v", err)
+			return fmt.Errorf("error writing mem profile: %w", err)
 		}
 		b.memprof.Close()
 		b.memprof = nil
 	}
 	if b.blockprof != nil {
 		if err := pprof.Lookup("block").WriteTo(b.blockprof, 0); err != nil {
-			return fmt.Errorf("error writing block profile: %v", err)
+			return fmt.Errorf("error writing block profile: %w", err)
 		}
 		b.blockprof.Close()
 		b.blockprof = nil
@@ -287,7 +286,7 @@ func (b *writeBenchmark) stopProfiling() error {
 	}
 	if b.mtxprof != nil {
 		if err := pprof.Lookup("mutex").WriteTo(b.mtxprof, 0); err != nil {
-			return fmt.Errorf("error writing mutex profile: %v", err)
+			return fmt.Errorf("error writing mutex profile: %w", err)
 		}
 		b.mtxprof.Close()
 		b.mtxprof = nil
@@ -680,7 +679,7 @@ func backfillOpenMetrics(path, outputDir string, humanReadable, quiet bool, maxB
 	defer inputFile.Close()
 
 	if err := os.MkdirAll(outputDir, 0o777); err != nil {
-		return checkErr(errors.Wrap(err, "create output dir"))
+		return checkErr(fmt.Errorf("create output dir %w", err))
 	}
 
 	return checkErr(backfill(5000, inputFile.Bytes(), outputDir, humanReadable, quiet, maxBlockDuration))

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -355,7 +355,7 @@ Outer:
 		for _, s := range testCase.ExpSamples {
 			lb, err := parser.ParseMetric(s.Labels)
 			if err != nil {
-				err = fmt.Errorf("labels %q %w", s.Labels, err)
+				err = fmt.Errorf("labels %q: %w", s.Labels, err)
 				errs = append(errs, fmt.Errorf("    expr: %q, time: %s, err: %w", testCase.Expr,
 					testCase.EvalTime.String(), err))
 				continue Outer

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,7 +26,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	yaml "gopkg.in/yaml.v2"
 
@@ -87,7 +87,7 @@ func ruleUnitTest(filename string, queryOpts promql.LazyLoaderOpts) []error {
 	groupOrderMap := make(map[string]int)
 	for i, gn := range unitTestInp.GroupEvalOrder {
 		if _, ok := groupOrderMap[gn]; ok {
-			return []error{errors.Errorf("group name repeated in evaluation order: %s", gn)}
+			return []error{fmt.Errorf("group name repeated in evaluation order: %s", gn)}
 		}
 		groupOrderMap[gn] = i
 	}
@@ -195,7 +195,7 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 			if tg.TestGroupName != "" {
 				testGroupLog = fmt.Sprintf(" (in TestGroup %s)", tg.TestGroupName)
 			}
-			return []error{errors.Errorf("an item under alert_rule_test misses required attribute alertname at eval_time %v%s", alert.EvalTime, testGroupLog)}
+			return []error{fmt.Errorf("an item under alert_rule_test misses required attribute alertname at eval_time %v%s", alert.EvalTime, testGroupLog)}
 		}
 		alertEvalTimesMap[alert.EvalTime] = struct{}{}
 
@@ -240,7 +240,7 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 				g.Eval(suite.Context(), ts)
 				for _, r := range g.Rules() {
 					if r.LastError() != nil {
-						evalErrs = append(evalErrs, errors.Errorf("    rule: %s, time: %s, err: %v",
+						evalErrs = append(evalErrs, fmt.Errorf("    rule: %s, time: %s, err: %w",
 							r.Name(), ts.Sub(time.Unix(0, 0).UTC()), r.LastError()))
 					}
 				}
@@ -323,7 +323,7 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 					}
 					expString := indentLines(expAlerts.String(), "            ")
 					gotString := indentLines(gotAlerts.String(), "            ")
-					errs = append(errs, errors.Errorf("%s    alertname: %s, time: %s, \n        exp:%v, \n        got:%v",
+					errs = append(errs, fmt.Errorf("%s    alertname: %s, time: %s, \n        exp:%v, \n        got:%v",
 						testName, testcase.Alertname, testcase.EvalTime.String(), expString, gotString))
 				}
 			}
@@ -338,8 +338,8 @@ Outer:
 		got, err := query(suite.Context(), testCase.Expr, mint.Add(time.Duration(testCase.EvalTime)),
 			suite.QueryEngine(), suite.Queryable())
 		if err != nil {
-			errs = append(errs, errors.Errorf("    expr: %q, time: %s, err: %s", testCase.Expr,
-				testCase.EvalTime.String(), err.Error()))
+			errs = append(errs, fmt.Errorf("    expr: %q, time: %s, err: %w", testCase.Expr,
+				testCase.EvalTime.String(), err))
 			continue
 		}
 
@@ -355,9 +355,9 @@ Outer:
 		for _, s := range testCase.ExpSamples {
 			lb, err := parser.ParseMetric(s.Labels)
 			if err != nil {
-				err = errors.Wrapf(err, "labels %q", s.Labels)
-				errs = append(errs, errors.Errorf("    expr: %q, time: %s, err: %s", testCase.Expr,
-					testCase.EvalTime.String(), err.Error()))
+				err = fmt.Errorf("labels %q %w", s.Labels, err)
+				errs = append(errs, fmt.Errorf("    expr: %q, time: %s, err: %w", testCase.Expr,
+					testCase.EvalTime.String(), err))
 				continue Outer
 			}
 			expSamples = append(expSamples, parsedSample{
@@ -373,7 +373,7 @@ Outer:
 			return labels.Compare(gotSamples[i].Labels, gotSamples[j].Labels) <= 0
 		})
 		if !reflect.DeepEqual(expSamples, gotSamples) {
-			errs = append(errs, errors.Errorf("    expr: %q, time: %s,\n        exp: %v\n        got: %v", testCase.Expr,
+			errs = append(errs, fmt.Errorf("    expr: %q, time: %s,\n        exp: %v\n        got: %v", testCase.Expr,
 				testCase.EvalTime.String(), parsedSamplesString(expSamples), parsedSamplesString(gotSamples)))
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -108,7 +108,7 @@ func LoadFile(filename string, agentMode, expandExternalLabels bool, logger log.
 	}
 	cfg, err := Load(string(content), expandExternalLabels, logger)
 	if err != nil {
-		return nil, fmt.Errorf("parsing YAML file %s %w", filename, err)
+		return nil, fmt.Errorf("parsing YAML file %s: %w", filename, err)
 	}
 
 	if agentMode {

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -25,7 +26,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/regexp"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/sigv4"
@@ -108,7 +108,7 @@ func LoadFile(filename string, agentMode, expandExternalLabels bool, logger log.
 	}
 	cfg, err := Load(string(content), expandExternalLabels, logger)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing YAML file %s", filename)
+		return nil, fmt.Errorf("parsing YAML file %s %w", filename, err)
 	}
 
 	if agentMode {
@@ -276,7 +276,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	for _, rf := range c.RuleFiles {
 		if !patRulePath.MatchString(rf) {
-			return errors.Errorf("invalid rule file path %q", rf)
+			return fmt.Errorf("invalid rule file path %q", rf)
 		}
 	}
 	// Do global overrides and validate unique names.
@@ -291,7 +291,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			scfg.ScrapeInterval = c.GlobalConfig.ScrapeInterval
 		}
 		if scfg.ScrapeTimeout > scfg.ScrapeInterval {
-			return errors.Errorf("scrape timeout greater than scrape interval for scrape config with job name %q", scfg.JobName)
+			return fmt.Errorf("scrape timeout greater than scrape interval for scrape config with job name %q", scfg.JobName)
 		}
 		if scfg.ScrapeTimeout == 0 {
 			if c.GlobalConfig.ScrapeTimeout > scfg.ScrapeInterval {
@@ -302,7 +302,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 
 		if _, ok := jobNames[scfg.JobName]; ok {
-			return errors.Errorf("found multiple scrape configs with job name %q", scfg.JobName)
+			return fmt.Errorf("found multiple scrape configs with job name %q", scfg.JobName)
 		}
 		jobNames[scfg.JobName] = struct{}{}
 	}
@@ -313,7 +313,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 		// Skip empty names, we fill their name with their config hash in remote write code.
 		if _, ok := rwNames[rwcfg.Name]; ok && rwcfg.Name != "" {
-			return errors.Errorf("found multiple remote write configs with job name %q", rwcfg.Name)
+			return fmt.Errorf("found multiple remote write configs with job name %q", rwcfg.Name)
 		}
 		rwNames[rwcfg.Name] = struct{}{}
 	}
@@ -324,7 +324,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 		// Skip empty names, we fill their name with their config hash in remote read code.
 		if _, ok := rrNames[rrcfg.Name]; ok && rrcfg.Name != "" {
-			return errors.Errorf("found multiple remote read configs with job name %q", rrcfg.Name)
+			return fmt.Errorf("found multiple remote read configs with job name %q", rrcfg.Name)
 		}
 		rrNames[rrcfg.Name] = struct{}{}
 	}
@@ -363,10 +363,10 @@ func (c *GlobalConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	for _, l := range gc.ExternalLabels {
 		if !model.LabelName(l.Name).IsValid() {
-			return errors.Errorf("%q is not a valid label name", l.Name)
+			return fmt.Errorf("%q is not a valid label name", l.Name)
 		}
 		if !model.LabelValue(l.Value).IsValid() {
-			return errors.Errorf("%q is not a valid label value", l.Value)
+			return fmt.Errorf("%q is not a valid label value", l.Value)
 		}
 	}
 
@@ -741,7 +741,7 @@ func checkStaticTargets(configs discovery.Configs) error {
 func CheckTargetAddress(address model.LabelValue) error {
 	// For now check for a URL, we may want to expand this later.
 	if strings.Contains(string(address), "/") {
-		return errors.Errorf("%q is not a valid hostname", address)
+		return fmt.Errorf("%q is not a valid hostname", address)
 	}
 	return nil
 }
@@ -810,7 +810,7 @@ func validateHeadersForTracing(headers map[string]string) error {
 			return errors.New("custom authorization header configuration is not yet supported")
 		}
 		if _, ok := reservedHeaders[strings.ToLower(header)]; ok {
-			return errors.Errorf("%s is a reserved header. It must not be changed", header)
+			return fmt.Errorf("%s is a reserved header. It must not be changed", header)
 		}
 	}
 	return nil
@@ -822,7 +822,7 @@ func validateHeaders(headers map[string]string) error {
 			return errors.New("authorization header must be changed via the basic_auth, authorization, oauth2, or sigv4 parameter")
 		}
 		if _, ok := reservedHeaders[strings.ToLower(header)]; ok {
-			return errors.Errorf("%s is a reserved header. It must not be changed", header)
+			return fmt.Errorf("%s is a reserved header. It must not be changed", header)
 		}
 	}
 	return nil

--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -179,7 +179,7 @@ func (d *EC2Discovery) ec2Client(ctx context.Context) (*ec2.EC2, error) {
 		Profile: d.cfg.Profile,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("could not create aws session %w", err)
+		return nil, fmt.Errorf("could not create aws session: %w", err)
 	}
 
 	if d.cfg.RoleARN != "" {
@@ -332,7 +332,7 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 		if errors.As(err, &awsErr) && (awsErr.Code() == "AuthFailure" || awsErr.Code() == "UnauthorizedOperation") {
 			d.ec2 = nil
 		}
-		return nil, fmt.Errorf("could not describe instances %w", err)
+		return nil, fmt.Errorf("could not describe instances: %w", err)
 	}
 	return []*targetgroup.Group{tg}, nil
 }

--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -15,6 +15,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -29,7 +30,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
@@ -179,7 +179,7 @@ func (d *EC2Discovery) ec2Client(ctx context.Context) (*ec2.EC2, error) {
 		Profile: d.cfg.Profile,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create aws session")
+		return nil, fmt.Errorf("could not create aws session %w", err)
 	}
 
 	if d.cfg.RoleARN != "" {
@@ -328,10 +328,11 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 		}
 		return true
 	}); err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && (awsErr.Code() == "AuthFailure" || awsErr.Code() == "UnauthorizedOperation") {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && (awsErr.Code() == "AuthFailure" || awsErr.Code() == "UnauthorizedOperation") {
 			d.ec2 = nil
 		}
-		return nil, errors.Wrap(err, "could not describe instances")
+		return nil, fmt.Errorf("could not describe instances %w", err)
 	}
 	return []*targetgroup.Group{tg}, nil
 }

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -152,7 +152,7 @@ func (d *LightsailDiscovery) lightsailClient() (*lightsail.Lightsail, error) {
 		Profile: d.cfg.Profile,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("could not create aws session %w", err)
+		return nil, fmt.Errorf("could not create aws session: %w", err)
 	}
 
 	if d.cfg.RoleARN != "" {
@@ -183,7 +183,7 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 		if errors.As(err, &awsErr) && (awsErr.Code() == "AuthFailure" || awsErr.Code() == "UnauthorizedOperation") {
 			d.lightsail = nil
 		}
-		return nil, fmt.Errorf("could not get instances %w", err)
+		return nil, fmt.Errorf("could not get instances: %w", err)
 	}
 
 	for _, inst := range output.Instances {

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -15,6 +15,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -28,7 +29,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lightsail"
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
@@ -152,7 +152,7 @@ func (d *LightsailDiscovery) lightsailClient() (*lightsail.Lightsail, error) {
 		Profile: d.cfg.Profile,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create aws session")
+		return nil, fmt.Errorf("could not create aws session %w", err)
 	}
 
 	if d.cfg.RoleARN != "" {
@@ -179,10 +179,11 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 
 	output, err := lightsailClient.GetInstancesWithContext(ctx, input)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && (awsErr.Code() == "AuthFailure" || awsErr.Code() == "UnauthorizedOperation") {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && (awsErr.Code() == "AuthFailure" || awsErr.Code() == "UnauthorizedOperation") {
 			d.lightsail = nil
 		}
-		return nil, errors.Wrap(err, "could not get instances")
+		return nil, fmt.Errorf("could not get instances %w", err)
 	}
 
 	for _, inst := range output.Instances {

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -15,6 +15,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -29,7 +30,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -109,7 +109,7 @@ func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Di
 
 func validateAuthParam(param, name string) error {
 	if len(param) == 0 {
-		return errors.Errorf("azure SD configuration requires a %s", name)
+		return fmt.Errorf("azure SD configuration requires a %s", name)
 	}
 	return nil
 }
@@ -140,7 +140,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	if c.AuthenticationMethod != authMethodOAuth && c.AuthenticationMethod != authMethodManagedIdentity {
-		return errors.Errorf("unknown authentication_type %q. Supported types are %q or %q", c.AuthenticationMethod, authMethodOAuth, authMethodManagedIdentity)
+		return fmt.Errorf("unknown authentication_type %q. Supported types are %q or %q", c.AuthenticationMethod, authMethodOAuth, authMethodManagedIdentity)
 	}
 
 	return nil
@@ -271,7 +271,7 @@ func newAzureResourceFromID(id string, logger log.Logger) (azureResource, error)
 	// /subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP/providers/PROVIDER/TYPE/NAME/TYPE/NAME
 	s := strings.Split(id, "/")
 	if len(s) != 9 && len(s) != 11 {
-		err := errors.Errorf("invalid ID '%s'. Refusing to create azureResource", id)
+		err := fmt.Errorf("invalid ID '%s'. Refusing to create azureResource", id)
 		level.Error(logger).Log("err", err)
 		return azureResource{}, err
 	}
@@ -288,13 +288,13 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	client, err := createAzureClient(*d.cfg)
 	if err != nil {
 		failuresCount.Inc()
-		return nil, errors.Wrap(err, "could not create Azure client")
+		return nil, fmt.Errorf("could not create Azure client %w", err)
 	}
 
 	machines, err := client.getVMs(ctx, d.cfg.ResourceGroup)
 	if err != nil {
 		failuresCount.Inc()
-		return nil, errors.Wrap(err, "could not get virtual machines")
+		return nil, fmt.Errorf("could not get virtual machines %w", err)
 	}
 
 	level.Debug(d.logger).Log("msg", "Found virtual machines during Azure discovery.", "count", len(machines))
@@ -303,14 +303,14 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	scaleSets, err := client.getScaleSets(ctx, d.cfg.ResourceGroup)
 	if err != nil {
 		failuresCount.Inc()
-		return nil, errors.Wrap(err, "could not get virtual machine scale sets")
+		return nil, fmt.Errorf("could not get virtual machine scale sets %w", err)
 	}
 
 	for _, scaleSet := range scaleSets {
 		scaleSetVms, err := client.getScaleSetVMs(ctx, scaleSet)
 		if err != nil {
 			failuresCount.Inc()
-			return nil, errors.Wrap(err, "could not get virtual machine scale set vms")
+			return nil, fmt.Errorf("could not get virtual machine scale set vms %w", err)
 		}
 		machines = append(machines, scaleSetVms...)
 	}
@@ -396,7 +396,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 						}
 						// If we made it here, we don't have a private IP which should be impossible.
 						// Return an empty target and error to ensure an all or nothing situation.
-						err = errors.Errorf("unable to find a private IP for VM %s", vm.Name)
+						err = fmt.Errorf("unable to find a private IP for VM %s", vm.Name)
 						ch <- target{labelSet: nil, err: err}
 						return
 					}
@@ -412,7 +412,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	for tgt := range ch {
 		if tgt.err != nil {
 			failuresCount.Inc()
-			return nil, errors.Wrap(tgt.err, "unable to complete Azure service discovery")
+			return nil, fmt.Errorf("unable to complete Azure service discovery %w", tgt.err)
 		}
 		if tgt.labelSet != nil {
 			tg.Targets = append(tg.Targets, tgt.labelSet)
@@ -432,7 +432,7 @@ func (client *azureClient) getVMs(ctx context.Context, resourceGroup string) ([]
 		result, err = client.vm.List(ctx, resourceGroup)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "could not list virtual machines")
+		return nil, fmt.Errorf("could not list virtual machines %w", err)
 	}
 	for result.NotDone() {
 		for _, vm := range result.Values() {
@@ -440,7 +440,7 @@ func (client *azureClient) getVMs(ctx context.Context, resourceGroup string) ([]
 		}
 		err = result.NextWithContext(ctx)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not list virtual machines")
+			return nil, fmt.Errorf("could not list virtual machines %w", err)
 		}
 	}
 
@@ -461,14 +461,14 @@ func (client *azureClient) getScaleSets(ctx context.Context, resourceGroup strin
 		var rtn compute.VirtualMachineScaleSetListWithLinkResultPage
 		rtn, err = client.vmss.ListAll(ctx)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not list virtual machine scale sets")
+			return nil, fmt.Errorf("could not list virtual machine scale sets %w", err)
 		}
 		result = &rtn
 	} else {
 		var rtn compute.VirtualMachineScaleSetListResultPage
 		rtn, err = client.vmss.List(ctx, resourceGroup)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not list virtual machine scale sets")
+			return nil, fmt.Errorf("could not list virtual machine scale sets %w", err)
 		}
 		result = &rtn
 	}
@@ -477,7 +477,7 @@ func (client *azureClient) getScaleSets(ctx context.Context, resourceGroup strin
 		scaleSets = append(scaleSets, result.Values()...)
 		err = result.NextWithContext(ctx)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not list virtual machine scale sets")
+			return nil, fmt.Errorf("could not list virtual machine scale sets %w", err)
 		}
 	}
 
@@ -489,12 +489,12 @@ func (client *azureClient) getScaleSetVMs(ctx context.Context, scaleSet compute.
 	// TODO do we really need to fetch the resourcegroup this way?
 	r, err := newAzureResourceFromID(*scaleSet.ID, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not parse scale set ID")
+		return nil, fmt.Errorf("could not parse scale set ID %w", err)
 	}
 
 	result, err := client.vmssvm.List(ctx, r.ResourceGroup, *(scaleSet.Name), "", "", "")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not list virtual machine scale set vms")
+		return nil, fmt.Errorf("could not list virtual machine scale set vms %w", err)
 	}
 	for result.NotDone() {
 		for _, vm := range result.Values() {
@@ -502,7 +502,7 @@ func (client *azureClient) getScaleSetVMs(ctx context.Context, scaleSet compute.
 		}
 		err = result.NextWithContext(ctx)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not list virtual machine scale set vms")
+			return nil, fmt.Errorf("could not list virtual machine scale set vms %w", err)
 		}
 	}
 

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -288,13 +288,13 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	client, err := createAzureClient(*d.cfg)
 	if err != nil {
 		failuresCount.Inc()
-		return nil, fmt.Errorf("could not create Azure client %w", err)
+		return nil, fmt.Errorf("could not create Azure client: %w", err)
 	}
 
 	machines, err := client.getVMs(ctx, d.cfg.ResourceGroup)
 	if err != nil {
 		failuresCount.Inc()
-		return nil, fmt.Errorf("could not get virtual machines %w", err)
+		return nil, fmt.Errorf("could not get virtual machines: %w", err)
 	}
 
 	level.Debug(d.logger).Log("msg", "Found virtual machines during Azure discovery.", "count", len(machines))
@@ -303,14 +303,14 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	scaleSets, err := client.getScaleSets(ctx, d.cfg.ResourceGroup)
 	if err != nil {
 		failuresCount.Inc()
-		return nil, fmt.Errorf("could not get virtual machine scale sets %w", err)
+		return nil, fmt.Errorf("could not get virtual machine scale sets: %w", err)
 	}
 
 	for _, scaleSet := range scaleSets {
 		scaleSetVms, err := client.getScaleSetVMs(ctx, scaleSet)
 		if err != nil {
 			failuresCount.Inc()
-			return nil, fmt.Errorf("could not get virtual machine scale set vms %w", err)
+			return nil, fmt.Errorf("could not get virtual machine scale set vms: %w", err)
 		}
 		machines = append(machines, scaleSetVms...)
 	}
@@ -412,7 +412,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	for tgt := range ch {
 		if tgt.err != nil {
 			failuresCount.Inc()
-			return nil, fmt.Errorf("unable to complete Azure service discovery %w", tgt.err)
+			return nil, fmt.Errorf("unable to complete Azure service discovery: %w", tgt.err)
 		}
 		if tgt.labelSet != nil {
 			tg.Targets = append(tg.Targets, tgt.labelSet)
@@ -432,7 +432,7 @@ func (client *azureClient) getVMs(ctx context.Context, resourceGroup string) ([]
 		result, err = client.vm.List(ctx, resourceGroup)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("could not list virtual machines %w", err)
+		return nil, fmt.Errorf("could not list virtual machines: %w", err)
 	}
 	for result.NotDone() {
 		for _, vm := range result.Values() {
@@ -440,7 +440,7 @@ func (client *azureClient) getVMs(ctx context.Context, resourceGroup string) ([]
 		}
 		err = result.NextWithContext(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("could not list virtual machines %w", err)
+			return nil, fmt.Errorf("could not list virtual machines: %w", err)
 		}
 	}
 
@@ -461,14 +461,14 @@ func (client *azureClient) getScaleSets(ctx context.Context, resourceGroup strin
 		var rtn compute.VirtualMachineScaleSetListWithLinkResultPage
 		rtn, err = client.vmss.ListAll(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("could not list virtual machine scale sets %w", err)
+			return nil, fmt.Errorf("could not list virtual machine scale sets: %w", err)
 		}
 		result = &rtn
 	} else {
 		var rtn compute.VirtualMachineScaleSetListResultPage
 		rtn, err = client.vmss.List(ctx, resourceGroup)
 		if err != nil {
-			return nil, fmt.Errorf("could not list virtual machine scale sets %w", err)
+			return nil, fmt.Errorf("could not list virtual machine scale sets: %w", err)
 		}
 		result = &rtn
 	}
@@ -477,7 +477,7 @@ func (client *azureClient) getScaleSets(ctx context.Context, resourceGroup strin
 		scaleSets = append(scaleSets, result.Values()...)
 		err = result.NextWithContext(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("could not list virtual machine scale sets %w", err)
+			return nil, fmt.Errorf("could not list virtual machine scale sets: %w", err)
 		}
 	}
 
@@ -489,12 +489,12 @@ func (client *azureClient) getScaleSetVMs(ctx context.Context, scaleSet compute.
 	// TODO do we really need to fetch the resourcegroup this way?
 	r, err := newAzureResourceFromID(*scaleSet.ID, nil)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse scale set ID %w", err)
+		return nil, fmt.Errorf("could not parse scale set ID: %w", err)
 	}
 
 	result, err := client.vmssvm.List(ctx, r.ResourceGroup, *(scaleSet.Name), "", "", "")
 	if err != nil {
-		return nil, fmt.Errorf("could not list virtual machine scale set vms %w", err)
+		return nil, fmt.Errorf("could not list virtual machine scale set vms: %w", err)
 	}
 	for result.NotDone() {
 		for _, vm := range result.Values() {
@@ -502,7 +502,7 @@ func (client *azureClient) getScaleSetVMs(ctx context.Context, scaleSet compute.
 		}
 		err = result.NextWithContext(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("could not list virtual machine scale set vms %w", err)
+			return nil, fmt.Errorf("could not list virtual machine scale set vms: %w", err)
 		}
 	}
 

--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -15,6 +15,7 @@ package consul
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -24,7 +25,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	consul "github.com/hashicorp/consul/api"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -291,7 +291,7 @@ func (d *Discovery) getDatacenter() error {
 
 	dc, ok := info["Config"]["Datacenter"].(string)
 	if !ok {
-		err := errors.Errorf("invalid value '%v' for Config.Datacenter", info["Config"]["Datacenter"])
+		err := fmt.Errorf("invalid value '%v' for Config.Datacenter", info["Config"]["Datacenter"])
 		level.Error(d.logger).Log("msg", "Error retrieving datacenter name", "err", err)
 		return err
 	}

--- a/discovery/dns/dns.go
+++ b/discovery/dns/dns.go
@@ -265,7 +265,7 @@ func (d *Discovery) refreshOne(ctx context.Context, name string, ch chan<- *targ
 func lookupWithSearchPath(name string, qtype uint16, logger log.Logger) (*dns.Msg, error) {
 	conf, err := dns.ClientConfigFromFile(resolvConf)
 	if err != nil {
-		return nil, fmt.Errorf("could not load resolv.conf %w", err)
+		return nil, fmt.Errorf("could not load resolv.conf: %w", err)
 	}
 
 	allResponsesValid := true

--- a/discovery/dns/dns.go
+++ b/discovery/dns/dns.go
@@ -15,6 +15,7 @@ package dns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -24,7 +25,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/miekg/dns"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
@@ -105,7 +105,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			return errors.New("a port is required in DNS-SD configs for all record types except SRV")
 		}
 	default:
-		return errors.Errorf("invalid DNS-SD records type %s", c.Type)
+		return fmt.Errorf("invalid DNS-SD records type %s", c.Type)
 	}
 	return nil
 }
@@ -163,7 +163,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	wg.Add(len(d.names))
 	for _, name := range d.names {
 		go func(n string) {
-			if err := d.refreshOne(ctx, n, ch); err != nil && err != context.Canceled {
+			if err := d.refreshOne(ctx, n, ch); err != nil && !errors.Is(err, context.Canceled) {
 				level.Error(d.logger).Log("msg", "Error refreshing DNS targets", "err", err)
 			}
 			wg.Done()
@@ -265,7 +265,7 @@ func (d *Discovery) refreshOne(ctx context.Context, name string, ch chan<- *targ
 func lookupWithSearchPath(name string, qtype uint16, logger log.Logger) (*dns.Msg, error) {
 	conf, err := dns.ClientConfigFromFile(resolvConf)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not load resolv.conf")
+		return nil, fmt.Errorf("could not load resolv.conf %w", err)
 	}
 
 	allResponsesValid := true
@@ -291,7 +291,7 @@ func lookupWithSearchPath(name string, qtype uint16, logger log.Logger) (*dns.Ms
 		return &dns.Msg{}, nil
 	}
 	// Outcome 3: boned.
-	return nil, errors.Errorf("could not resolve %q: all servers responded with errors to at least one search domain", name)
+	return nil, fmt.Errorf("could not resolve %q: all servers responded with errors to at least one search domain", name)
 }
 
 // lookupFromAnyServer uses all configured servers to try and resolve a specific
@@ -327,7 +327,7 @@ func lookupFromAnyServer(name string, qtype uint16, conf *dns.ClientConfig, logg
 		}
 	}
 
-	return nil, errors.Errorf("could not resolve %s: no servers returned a viable answer", name)
+	return nil, fmt.Errorf("could not resolve %s: no servers returned a viable answer", name)
 }
 
 // askServerForName makes a request to a specific DNS server for a specific

--- a/discovery/eureka/client.go
+++ b/discovery/eureka/client.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/version"
 )
 
@@ -99,13 +98,13 @@ func fetchApps(ctx context.Context, server string, client *http.Client) (*Applic
 	}()
 
 	if resp.StatusCode/100 != 2 {
-		return nil, errors.Errorf("non 2xx status '%d' response during eureka service discovery", resp.StatusCode)
+		return nil, fmt.Errorf("non 2xx status '%d' response during eureka service discovery", resp.StatusCode)
 	}
 
 	var apps Applications
 	err = xml.NewDecoder(resp.Body).Decode(&apps)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%q", url)
+		return nil, fmt.Errorf("%q %w", url, err)
 	}
 	return &apps, nil
 }

--- a/discovery/eureka/client.go
+++ b/discovery/eureka/client.go
@@ -104,7 +104,7 @@ func fetchApps(ctx context.Context, server string, client *http.Client) (*Applic
 	var apps Applications
 	err = xml.NewDecoder(resp.Body).Decode(&apps)
 	if err != nil {
-		return nil, fmt.Errorf("%q %w", url, err)
+		return nil, fmt.Errorf("%q: %w", url, err)
 	}
 	return &apps, nil
 }

--- a/discovery/eureka/eureka.go
+++ b/discovery/eureka/eureka.go
@@ -15,6 +15,7 @@ package eureka
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/url"
@@ -22,7 +23,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -16,6 +16,7 @@ package file
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,7 +29,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/regexp"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -99,7 +99,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	for _, name := range c.Files {
 		if !patFileSDName.MatchString(name) {
-			return errors.Errorf("path name %q is not valid for file discovery", name)
+			return fmt.Errorf("path name %q is not valid for file discovery", name)
 		}
 	}
 	return nil
@@ -398,7 +398,7 @@ func (d *Discovery) readFile(filename string) ([]*targetgroup.Group, error) {
 			return nil, err
 		}
 	default:
-		panic(errors.Errorf("discovery.File.readFile: unhandled file extension %q", ext))
+		panic(fmt.Errorf("discovery.File.readFile: unhandled file extension %q", ext))
 	}
 
 	for i, tg := range targetGroups {

--- a/discovery/gce/gce.go
+++ b/discovery/gce/gce.go
@@ -15,6 +15,7 @@ package gce
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -22,7 +23,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
@@ -132,11 +132,11 @@ func NewDiscovery(conf SDConfig, logger log.Logger) (*Discovery, error) {
 	var err error
 	d.client, err = google.DefaultClient(context.Background(), compute.ComputeReadonlyScope)
 	if err != nil {
-		return nil, errors.Wrap(err, "error setting up communication with GCE service")
+		return nil, fmt.Errorf("error setting up communication with GCE service %w", err)
 	}
 	d.svc, err = compute.NewService(context.Background(), option.WithHTTPClient(d.client))
 	if err != nil {
-		return nil, errors.Wrap(err, "error setting up communication with GCE service")
+		return nil, fmt.Errorf("error setting up communication with GCE service %w", err)
 	}
 	d.isvc = compute.NewInstancesService(d.svc)
 
@@ -221,7 +221,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "error retrieving refresh targets from gce")
+		return nil, fmt.Errorf("error retrieving refresh targets from gce %w", err)
 	}
 	return []*targetgroup.Group{tg}, nil
 }

--- a/discovery/gce/gce.go
+++ b/discovery/gce/gce.go
@@ -132,11 +132,11 @@ func NewDiscovery(conf SDConfig, logger log.Logger) (*Discovery, error) {
 	var err error
 	d.client, err = google.DefaultClient(context.Background(), compute.ComputeReadonlyScope)
 	if err != nil {
-		return nil, fmt.Errorf("error setting up communication with GCE service %w", err)
+		return nil, fmt.Errorf("error setting up communication with GCE service: %w", err)
 	}
 	d.svc, err = compute.NewService(context.Background(), option.WithHTTPClient(d.client))
 	if err != nil {
-		return nil, fmt.Errorf("error setting up communication with GCE service %w", err)
+		return nil, fmt.Errorf("error setting up communication with GCE service: %w", err)
 	}
 	d.isvc = compute.NewInstancesService(d.svc)
 
@@ -221,7 +221,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving refresh targets from gce %w", err)
+		return nil, fmt.Errorf("error retrieving refresh targets from gce: %w", err)
 	}
 	return []*targetgroup.Group{tg}, nil
 }

--- a/discovery/hetzner/hetzner.go
+++ b/discovery/hetzner/hetzner.go
@@ -15,11 +15,12 @@ package hetzner
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/hetznercloud/hcloud-go/hcloud"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
@@ -95,7 +96,7 @@ func (c *role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	case hetznerRoleRobot, hetznerRoleHcloud:
 		return nil
 	default:
-		return errors.Errorf("unknown role %q", *c)
+		return fmt.Errorf("unknown role %q", *c)
 	}
 }
 

--- a/discovery/hetzner/robot.go
+++ b/discovery/hetzner/robot.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
@@ -89,7 +88,7 @@ func (d *robotDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, err
 	}()
 
 	if resp.StatusCode/100 != 2 {
-		return nil, errors.Errorf("non 2xx status '%d' response during hetzner service discovery with role robot", resp.StatusCode)
+		return nil, fmt.Errorf("non 2xx status '%d' response during hetzner service discovery with role robot", resp.StatusCode)
 	}
 
 	b, err := io.ReadAll(resp.Body)

--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -16,6 +16,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,7 +27,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/regexp"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -162,12 +162,12 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		failuresCount.Inc()
-		return nil, errors.Errorf("server returned HTTP status %s", resp.Status)
+		return nil, fmt.Errorf("server returned HTTP status %s", resp.Status)
 	}
 
 	if !matchContentType.MatchString(strings.TrimSpace(resp.Header.Get("Content-Type"))) {
 		failuresCount.Inc()
-		return nil, errors.Errorf("unsupported content type %q", resp.Header.Get("Content-Type"))
+		return nil, fmt.Errorf("unsupported content type %q", resp.Header.Get("Content-Type"))
 	}
 
 	b, err := io.ReadAll(resp.Body)

--- a/discovery/kubernetes/endpointslice.go
+++ b/discovery/kubernetes/endpointslice.go
@@ -15,12 +15,13 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"strconv"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/discovery/v1"
@@ -137,7 +138,7 @@ func (e *EndpointSlice) Run(ctx context.Context, ch chan<- []*targetgroup.Group)
 	defer e.queue.ShutDown()
 
 	if !cache.WaitForCacheSync(ctx.Done(), e.endpointSliceInf.HasSynced, e.serviceInf.HasSynced, e.podInf.HasSynced) {
-		if ctx.Err() != context.Canceled {
+		if !errors.Is(ctx.Err(), context.Canceled) {
 			level.Error(e.logger).Log("msg", "endpointslice informer unable to sync cache")
 		}
 		return
@@ -193,7 +194,7 @@ func (e *EndpointSlice) getEndpointSliceAdaptor(o interface{}) (endpointSliceAda
 	case *v1beta1.EndpointSlice:
 		return newEndpointSliceAdaptorFromV1beta1(endpointSlice), nil
 	default:
-		return nil, errors.Errorf("received unexpected object: %v", o)
+		return nil, fmt.Errorf("received unexpected object: %v", o)
 	}
 }
 

--- a/discovery/kubernetes/ingress.go
+++ b/discovery/kubernetes/ingress.go
@@ -15,11 +15,12 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -78,7 +79,7 @@ func (i *Ingress) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	defer i.queue.ShutDown()
 
 	if !cache.WaitForCacheSync(ctx.Done(), i.informer.HasSynced) {
-		if ctx.Err() != context.Canceled {
+		if !errors.Is(ctx.Err(), context.Canceled) {
 			level.Error(i.logger).Log("msg", "ingress informer unable to sync cache")
 		}
 		return
@@ -123,7 +124,7 @@ func (i *Ingress) process(ctx context.Context, ch chan<- []*targetgroup.Group) b
 		ia = newIngressAdaptorFromV1beta1(ingress)
 	default:
 		level.Error(i.logger).Log("msg", "converting to Ingress object failed", "err",
-			errors.Errorf("received unexpected object: %v", o))
+			fmt.Errorf("received unexpected object: %v", o))
 		return true
 	}
 	send(ctx, ch, i.buildIngress(ia))

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -15,6 +15,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -24,7 +25,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -114,7 +114,7 @@ func (c *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	case RoleNode, RolePod, RoleService, RoleEndpoint, RoleEndpointSlice, RoleIngress:
 		return nil
 	default:
-		return errors.Errorf("unknown Kubernetes SD role %q", *c)
+		return fmt.Errorf("unknown Kubernetes SD role %q", *c)
 	}
 }
 
@@ -178,7 +178,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	if c.Role == "" {
-		return errors.Errorf("role missing (one of: pod, service, endpoints, endpointslice, node, ingress)")
+		return fmt.Errorf("role missing (one of: pod, service, endpoints, endpointslice, node, ingress)")
 	}
 	err = c.HTTPClientConfig.Validate()
 	if err != nil {
@@ -186,20 +186,20 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	if c.APIServer.URL != nil && c.KubeConfig != "" {
 		// Api-server and kubeconfig_file are mutually exclusive
-		return errors.Errorf("cannot use 'kubeconfig_file' and 'api_server' simultaneously")
+		return fmt.Errorf("cannot use 'kubeconfig_file' and 'api_server' simultaneously")
 	}
 	if c.KubeConfig != "" && !reflect.DeepEqual(c.HTTPClientConfig, config.DefaultHTTPClientConfig) {
 		// Kubeconfig_file and custom http config are mutually exclusive
-		return errors.Errorf("cannot use a custom HTTP client configuration together with 'kubeconfig_file'")
+		return fmt.Errorf("cannot use a custom HTTP client configuration together with 'kubeconfig_file'")
 	}
 	if c.APIServer.URL == nil && !reflect.DeepEqual(c.HTTPClientConfig, config.DefaultHTTPClientConfig) {
-		return errors.Errorf("to use custom HTTP client configuration please provide the 'api_server' URL explicitly")
+		return fmt.Errorf("to use custom HTTP client configuration please provide the 'api_server' URL explicitly")
 	}
 	if c.APIServer.URL != nil && c.NamespaceDiscovery.IncludeOwnNamespace {
-		return errors.Errorf("cannot use 'api_server' and 'namespaces.own_namespace' simultaneously")
+		return fmt.Errorf("cannot use 'api_server' and 'namespaces.own_namespace' simultaneously")
 	}
 	if c.KubeConfig != "" && c.NamespaceDiscovery.IncludeOwnNamespace {
-		return errors.Errorf("cannot use 'kubeconfig_file' and 'namespaces.own_namespace' simultaneously")
+		return fmt.Errorf("cannot use 'kubeconfig_file' and 'namespaces.own_namespace' simultaneously")
 	}
 
 	foundSelectorRoles := make(map[Role]struct{})
@@ -214,12 +214,12 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	for _, selector := range c.Selectors {
 		if _, ok := foundSelectorRoles[selector.Role]; ok {
-			return errors.Errorf("duplicated selector role: %s", selector.Role)
+			return fmt.Errorf("duplicated selector role: %s", selector.Role)
 		}
 		foundSelectorRoles[selector.Role] = struct{}{}
 
 		if _, ok := allowedSelectors[c.Role]; !ok {
-			return errors.Errorf("invalid role: %q, expecting one of: pod, service, endpoints, endpointslice, node or ingress", c.Role)
+			return fmt.Errorf("invalid role: %q, expecting one of: pod, service, endpoints, endpointslice, node or ingress", c.Role)
 		}
 		var allowed bool
 		for _, role := range allowedSelectors[c.Role] {
@@ -230,7 +230,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 
 		if !allowed {
-			return errors.Errorf("%s role supports only %s selectors", c.Role, strings.Join(allowedSelectors[c.Role], ", "))
+			return fmt.Errorf("%s role supports only %s selectors", c.Role, strings.Join(allowedSelectors[c.Role], ", "))
 		}
 
 		_, err := fields.ParseSelector(selector.Field)

--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -16,11 +16,11 @@ package kubernetes
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"

--- a/discovery/kubernetes/node.go
+++ b/discovery/kubernetes/node.go
@@ -15,12 +15,13 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"strconv"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -85,7 +86,7 @@ func (n *Node) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	defer n.queue.ShutDown()
 
 	if !cache.WaitForCacheSync(ctx.Done(), n.informer.HasSynced) {
-		if ctx.Err() != context.Canceled {
+		if !errors.Is(ctx.Err(), context.Canceled) {
 			level.Error(n.logger).Log("msg", "node informer unable to sync cache")
 		}
 		return
@@ -136,7 +137,7 @@ func convertToNode(o interface{}) (*apiv1.Node, error) {
 		return node, nil
 	}
 
-	return nil, errors.Errorf("received unexpected object: %v", o)
+	return nil, fmt.Errorf("received unexpected object: %v", o)
 }
 
 func nodeSource(n *apiv1.Node) string {

--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -15,13 +15,14 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -118,7 +119,7 @@ func (p *Pod) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	}
 
 	if !cache.WaitForCacheSync(ctx.Done(), cacheSyncs...) {
-		if ctx.Err() != context.Canceled {
+		if !errors.Is(ctx.Err(), context.Canceled) {
 			level.Error(p.logger).Log("msg", "pod informer unable to sync cache")
 		}
 		return
@@ -169,7 +170,7 @@ func convertToPod(o interface{}) (*apiv1.Pod, error) {
 		return pod, nil
 	}
 
-	return nil, errors.Errorf("received unexpected object: %v", o)
+	return nil, fmt.Errorf("received unexpected object: %v", o)
 }
 
 const (

--- a/discovery/kubernetes/service.go
+++ b/discovery/kubernetes/service.go
@@ -15,12 +15,13 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"strconv"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -81,7 +82,7 @@ func (s *Service) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	defer s.queue.ShutDown()
 
 	if !cache.WaitForCacheSync(ctx.Done(), s.informer.HasSynced) {
-		if ctx.Err() != context.Canceled {
+		if !errors.Is(ctx.Err(), context.Canceled) {
 			level.Error(s.logger).Log("msg", "service informer unable to sync cache")
 		}
 		return
@@ -131,7 +132,7 @@ func convertToService(o interface{}) (*apiv1.Service, error) {
 	if ok {
 		return service, nil
 	}
-	return nil, errors.Errorf("received unexpected object: %v", o)
+	return nil, fmt.Errorf("received unexpected object: %v", o)
 }
 
 func serviceSource(s *apiv1.Service) string {

--- a/discovery/legacymanager/registry.go
+++ b/discovery/legacymanager/registry.go
@@ -14,6 +14,7 @@
 package legacymanager
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -248,7 +249,8 @@ func writeConfigs(structVal reflect.Value, configs discovery.Configs) error {
 }
 
 func replaceYAMLTypeError(err error, oldTyp, newTyp reflect.Type) error {
-	if e, ok := err.(*yaml.TypeError); ok {
+	var e *yaml.TypeError
+	if errors.As(err, &e) {
 		oldStr := oldTyp.String()
 		newStr := newTyp.String()
 		for i, s := range e.Errors {

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -188,7 +188,7 @@ func newAuthTokenFileRoundTripper(tokenFile string, rt http.RoundTripper) (http.
 	// fail-fast if we can't read the file.
 	_, err := os.ReadFile(tokenFile)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read auth token file %s %w", tokenFile, err)
+		return nil, fmt.Errorf("unable to read auth token file %s: %w", tokenFile, err)
 	}
 	return &authTokenFileRoundTripper{tokenFile, rt}, nil
 }
@@ -196,7 +196,7 @@ func newAuthTokenFileRoundTripper(tokenFile string, rt http.RoundTripper) (http.
 func (rt *authTokenFileRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	b, err := os.ReadFile(rt.authTokenFile)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read auth token file %s %w", rt.authTokenFile, err)
+		return nil, fmt.Errorf("unable to read auth token file %s: %w", rt.authTokenFile, err)
 	}
 	authToken := strings.TrimSpace(string(b))
 
@@ -347,7 +347,7 @@ func fetchApps(ctx context.Context, client *http.Client, url string) (*appList, 
 	var apps appList
 	err = json.Unmarshal(b, &apps)
 	if err != nil {
-		return nil, fmt.Errorf("%q %w", url, err)
+		return nil, fmt.Errorf("%q: %w", url, err)
 	}
 	return &apps, nil
 }

--- a/discovery/marathon/marathon.go
+++ b/discovery/marathon/marathon.go
@@ -16,6 +16,7 @@ package marathon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -27,7 +28,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
@@ -188,7 +188,7 @@ func newAuthTokenFileRoundTripper(tokenFile string, rt http.RoundTripper) (http.
 	// fail-fast if we can't read the file.
 	_, err := os.ReadFile(tokenFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to read auth token file %s", tokenFile)
+		return nil, fmt.Errorf("unable to read auth token file %s %w", tokenFile, err)
 	}
 	return &authTokenFileRoundTripper{tokenFile, rt}, nil
 }
@@ -196,7 +196,7 @@ func newAuthTokenFileRoundTripper(tokenFile string, rt http.RoundTripper) (http.
 func (rt *authTokenFileRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	b, err := os.ReadFile(rt.authTokenFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to read auth token file %s", rt.authTokenFile)
+		return nil, fmt.Errorf("unable to read auth token file %s %w", rt.authTokenFile, err)
 	}
 	authToken := strings.TrimSpace(string(b))
 
@@ -336,7 +336,7 @@ func fetchApps(ctx context.Context, client *http.Client, url string) (*appList, 
 	}()
 
 	if (resp.StatusCode < 200) || (resp.StatusCode >= 300) {
-		return nil, errors.Errorf("non 2xx status '%v' response during marathon service discovery", resp.StatusCode)
+		return nil, fmt.Errorf("non 2xx status '%v' response during marathon service discovery", resp.StatusCode)
 	}
 
 	b, err := io.ReadAll(resp.Body)
@@ -347,7 +347,7 @@ func fetchApps(ctx context.Context, client *http.Client, url string) (*appList, 
 	var apps appList
 	err = json.Unmarshal(b, &apps)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%q", url)
+		return nil, fmt.Errorf("%q %w", url, err)
 	}
 	return &apps, nil
 }

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -54,7 +54,7 @@ func TestMarathonSDHandleError(t *testing.T) {
 		}
 	)
 	tgs, err := testUpdateServices(client)
-	if err != errTesting {
+	if !errors.Is(err, errTesting) {
 		t.Fatalf("Expected error: %s", err)
 	}
 	if len(tgs) != 0 {

--- a/discovery/openstack/hypervisor.go
+++ b/discovery/openstack/hypervisor.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors"
 	"github.com/gophercloud/gophercloud/pagination"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -62,14 +61,14 @@ func (h *HypervisorDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group
 	h.provider.Context = ctx
 	err := openstack.Authenticate(h.provider, *h.authOpts)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not authenticate to OpenStack")
+		return nil, fmt.Errorf("could not authenticate to OpenStack %w", err)
 	}
 
 	client, err := openstack.NewComputeV2(h.provider, gophercloud.EndpointOpts{
 		Region: h.region, Availability: h.availability,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create OpenStack compute session")
+		return nil, fmt.Errorf("could not create OpenStack compute session %w", err)
 	}
 
 	tg := &targetgroup.Group{
@@ -81,7 +80,7 @@ func (h *HypervisorDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group
 	err = pagerHypervisors.EachPage(func(page pagination.Page) (bool, error) {
 		hypervisorList, err := hypervisors.ExtractHypervisors(page)
 		if err != nil {
-			return false, errors.Wrap(err, "could not extract hypervisors")
+			return false, fmt.Errorf("could not extract hypervisors %w", err)
 		}
 		for _, hypervisor := range hypervisorList {
 			labels := model.LabelSet{}

--- a/discovery/openstack/hypervisor.go
+++ b/discovery/openstack/hypervisor.go
@@ -61,14 +61,14 @@ func (h *HypervisorDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group
 	h.provider.Context = ctx
 	err := openstack.Authenticate(h.provider, *h.authOpts)
 	if err != nil {
-		return nil, fmt.Errorf("could not authenticate to OpenStack %w", err)
+		return nil, fmt.Errorf("could not authenticate to OpenStack: %w", err)
 	}
 
 	client, err := openstack.NewComputeV2(h.provider, gophercloud.EndpointOpts{
 		Region: h.region, Availability: h.availability,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("could not create OpenStack compute session %w", err)
+		return nil, fmt.Errorf("could not create OpenStack compute session: %w", err)
 	}
 
 	tg := &targetgroup.Group{
@@ -80,7 +80,7 @@ func (h *HypervisorDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group
 	err = pagerHypervisors.EachPage(func(page pagination.Page) (bool, error) {
 		hypervisorList, err := hypervisors.ExtractHypervisors(page)
 		if err != nil {
-			return false, fmt.Errorf("could not extract hypervisors %w", err)
+			return false, fmt.Errorf("could not extract hypervisors: %w", err)
 		}
 		for _, hypervisor := range hypervisorList {
 			labels := model.LabelSet{}

--- a/discovery/openstack/instance.go
+++ b/discovery/openstack/instance.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/pagination"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -79,14 +78,14 @@ func (i *InstanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 	i.provider.Context = ctx
 	err := openstack.Authenticate(i.provider, *i.authOpts)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not authenticate to OpenStack")
+		return nil, fmt.Errorf("could not authenticate to OpenStack %w", err)
 	}
 
 	client, err := openstack.NewComputeV2(i.provider, gophercloud.EndpointOpts{
 		Region: i.region, Availability: i.availability,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create OpenStack compute session")
+		return nil, fmt.Errorf("could not create OpenStack compute session %w", err)
 	}
 
 	// OpenStack API reference
@@ -97,7 +96,7 @@ func (i *InstanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 	err = pagerFIP.EachPage(func(page pagination.Page) (bool, error) {
 		result, err := floatingips.ExtractFloatingIPs(page)
 		if err != nil {
-			return false, errors.Wrap(err, "could not extract floatingips")
+			return false, fmt.Errorf("could not extract floatingips %w", err)
 		}
 		for _, ip := range result {
 			// Skip not associated ips
@@ -124,11 +123,11 @@ func (i *InstanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 	}
 	err = pager.EachPage(func(page pagination.Page) (bool, error) {
 		if ctx.Err() != nil {
-			return false, errors.Wrap(ctx.Err(), "could not extract instances")
+			return false, fmt.Errorf("could not extract instances %w", ctx.Err())
 		}
 		instanceList, err := servers.ExtractServers(page)
 		if err != nil {
-			return false, errors.Wrap(err, "could not extract instances")
+			return false, fmt.Errorf("could not extract instances %w", err)
 		}
 
 		for _, s := range instanceList {

--- a/discovery/openstack/instance.go
+++ b/discovery/openstack/instance.go
@@ -78,14 +78,14 @@ func (i *InstanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 	i.provider.Context = ctx
 	err := openstack.Authenticate(i.provider, *i.authOpts)
 	if err != nil {
-		return nil, fmt.Errorf("could not authenticate to OpenStack %w", err)
+		return nil, fmt.Errorf("could not authenticate to OpenStack: %w", err)
 	}
 
 	client, err := openstack.NewComputeV2(i.provider, gophercloud.EndpointOpts{
 		Region: i.region, Availability: i.availability,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("could not create OpenStack compute session %w", err)
+		return nil, fmt.Errorf("could not create OpenStack compute session: %w", err)
 	}
 
 	// OpenStack API reference
@@ -96,7 +96,7 @@ func (i *InstanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 	err = pagerFIP.EachPage(func(page pagination.Page) (bool, error) {
 		result, err := floatingips.ExtractFloatingIPs(page)
 		if err != nil {
-			return false, fmt.Errorf("could not extract floatingips %w", err)
+			return false, fmt.Errorf("could not extract floatingips: %w", err)
 		}
 		for _, ip := range result {
 			// Skip not associated ips
@@ -123,11 +123,11 @@ func (i *InstanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 	}
 	err = pager.EachPage(func(page pagination.Page) (bool, error) {
 		if ctx.Err() != nil {
-			return false, fmt.Errorf("could not extract instances %w", ctx.Err())
+			return false, fmt.Errorf("could not extract instances: %w", ctx.Err())
 		}
 		instanceList, err := servers.ExtractServers(page)
 		if err != nil {
-			return false, fmt.Errorf("could not extract instances %w", err)
+			return false, fmt.Errorf("could not extract instances: %w", err)
 		}
 
 		for _, s := range instanceList {

--- a/discovery/openstack/openstack.go
+++ b/discovery/openstack/openstack.go
@@ -15,6 +15,7 @@ package openstack
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -23,7 +24,6 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	conntrack "github.com/mwitkow/go-conntrack"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
@@ -100,7 +100,7 @@ func (c *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	case OpenStackRoleHypervisor, OpenStackRoleInstance:
 		return nil
 	default:
-		return errors.Errorf("unknown OpenStack SD role %q", *c)
+		return fmt.Errorf("unknown OpenStack SD role %q", *c)
 	}
 }
 

--- a/discovery/puppetdb/puppetdb.go
+++ b/discovery/puppetdb/puppetdb.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/regexp"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
@@ -191,11 +190,11 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("server returned HTTP status %s", resp.Status)
+		return nil, fmt.Errorf("server returned HTTP status %s", resp.Status)
 	}
 
 	if ct := resp.Header.Get("Content-Type"); !matchContentType.MatchString(ct) {
-		return nil, errors.Errorf("unsupported content type %s", resp.Header.Get("Content-Type"))
+		return nil, fmt.Errorf("unsupported content type %s", resp.Header.Get("Content-Type"))
 	}
 
 	b, err := io.ReadAll(resp.Body)

--- a/discovery/refresh/refresh.go
+++ b/discovery/refresh/refresh.go
@@ -15,6 +15,7 @@ package refresh
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/go-kit/log"
@@ -75,7 +76,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	// Get an initial set right away.
 	tgs, err := d.refresh(ctx)
 	if err != nil {
-		if ctx.Err() != context.Canceled {
+		if !errors.Is(ctx.Err(), context.Canceled) {
 			level.Error(d.logger).Log("msg", "Unable to refresh target groups", "err", err.Error())
 		}
 	} else {
@@ -94,7 +95,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 		case <-ticker.C:
 			tgs, err := d.refresh(ctx)
 			if err != nil {
-				if ctx.Err() != context.Canceled {
+				if !errors.Is(ctx.Err(), context.Canceled) {
 					level.Error(d.logger).Log("msg", "Unable to refresh target groups", "err", err.Error())
 				}
 				continue

--- a/discovery/registry.go
+++ b/discovery/registry.go
@@ -14,6 +14,7 @@
 package discovery
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -247,7 +248,8 @@ func writeConfigs(structVal reflect.Value, configs Configs) error {
 }
 
 func replaceYAMLTypeError(err error, oldTyp, newTyp reflect.Type) error {
-	if e, ok := err.(*yaml.TypeError); ok {
+	var e *yaml.TypeError
+	if errors.As(err, &e) {
 		oldStr := oldTyp.String()
 		newStr := newTyp.String()
 		for i, s := range e.Errors {

--- a/discovery/scaleway/scaleway.go
+++ b/discovery/scaleway/scaleway.go
@@ -229,7 +229,7 @@ func newAuthTokenFileRoundTripper(tokenFile string, rt http.RoundTripper) (http.
 	// fail-fast if we can't read the file.
 	_, err := os.ReadFile(tokenFile)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read auth token file %s %w", tokenFile, err)
+		return nil, fmt.Errorf("unable to read auth token file %s: %w", tokenFile, err)
 	}
 	return &authTokenFileRoundTripper{tokenFile, rt}, nil
 }
@@ -237,7 +237,7 @@ func newAuthTokenFileRoundTripper(tokenFile string, rt http.RoundTripper) (http.
 func (rt *authTokenFileRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	b, err := os.ReadFile(rt.authTokenFile)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read auth token file %s %w", rt.authTokenFile, err)
+		return nil, fmt.Errorf("unable to read auth token file %s: %w", rt.authTokenFile, err)
 	}
 	authToken := strings.TrimSpace(string(b))
 

--- a/discovery/scaleway/scaleway.go
+++ b/discovery/scaleway/scaleway.go
@@ -15,13 +15,14 @@ package scaleway
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -61,7 +62,7 @@ func (c *role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	case roleInstance, roleBaremetal:
 		return nil
 	default:
-		return errors.Errorf("unknown role %q", *c)
+		return fmt.Errorf("unknown role %q", *c)
 	}
 }
 
@@ -228,7 +229,7 @@ func newAuthTokenFileRoundTripper(tokenFile string, rt http.RoundTripper) (http.
 	// fail-fast if we can't read the file.
 	_, err := os.ReadFile(tokenFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to read auth token file %s", tokenFile)
+		return nil, fmt.Errorf("unable to read auth token file %s %w", tokenFile, err)
 	}
 	return &authTokenFileRoundTripper{tokenFile, rt}, nil
 }
@@ -236,7 +237,7 @@ func newAuthTokenFileRoundTripper(tokenFile string, rt http.RoundTripper) (http.
 func (rt *authTokenFileRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	b, err := os.ReadFile(rt.authTokenFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to read auth token file %s", rt.authTokenFile)
+		return nil, fmt.Errorf("unable to read auth token file %s %w", rt.authTokenFile, err)
 	}
 	authToken := strings.TrimSpace(string(b))
 

--- a/discovery/triton/triton.go
+++ b/discovery/triton/triton.go
@@ -202,7 +202,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	req = req.WithContext(ctx)
 	resp, err := d.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred when requesting targets from the discovery endpoint %w", err)
+		return nil, fmt.Errorf("an error occurred when requesting targets from the discovery endpoint: %w", err)
 	}
 
 	defer func() {
@@ -212,7 +212,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred when reading the response body %w", err)
+		return nil, fmt.Errorf("an error occurred when reading the response body: %w", err)
 	}
 
 	// The JSON response body is different so it needs to be processed/mapped separately.
@@ -234,7 +234,7 @@ func (d *Discovery) processContainerResponse(data []byte, endpoint string) ([]*t
 	dr := DiscoveryResponse{}
 	err := json.Unmarshal(data, &dr)
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred unmarshaling the discovery response json %w", err)
+		return nil, fmt.Errorf("an error occurred unmarshaling the discovery response json: %w", err)
 	}
 
 	for _, container := range dr.Containers {
@@ -267,7 +267,7 @@ func (d *Discovery) processComputeNodeResponse(data []byte, endpoint string) ([]
 	dr := ComputeNodeDiscoveryResponse{}
 	err := json.Unmarshal(data, &dr)
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred unmarshaling the compute node discovery response json %w", err)
+		return nil, fmt.Errorf("an error occurred unmarshaling the compute node discovery response json: %w", err)
 	}
 
 	for _, cn := range dr.ComputeNodes {

--- a/discovery/triton/triton.go
+++ b/discovery/triton/triton.go
@@ -16,6 +16,7 @@ package triton
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,7 +26,6 @@ import (
 
 	"github.com/go-kit/log"
 	conntrack "github.com/mwitkow/go-conntrack"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
@@ -202,7 +202,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	req = req.WithContext(ctx)
 	resp, err := d.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "an error occurred when requesting targets from the discovery endpoint")
+		return nil, fmt.Errorf("an error occurred when requesting targets from the discovery endpoint %w", err)
 	}
 
 	defer func() {
@@ -212,7 +212,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, "an error occurred when reading the response body")
+		return nil, fmt.Errorf("an error occurred when reading the response body %w", err)
 	}
 
 	// The JSON response body is different so it needs to be processed/mapped separately.
@@ -234,7 +234,7 @@ func (d *Discovery) processContainerResponse(data []byte, endpoint string) ([]*t
 	dr := DiscoveryResponse{}
 	err := json.Unmarshal(data, &dr)
 	if err != nil {
-		return nil, errors.Wrap(err, "an error occurred unmarshaling the discovery response json")
+		return nil, fmt.Errorf("an error occurred unmarshaling the discovery response json %w", err)
 	}
 
 	for _, container := range dr.Containers {
@@ -267,7 +267,7 @@ func (d *Discovery) processComputeNodeResponse(data []byte, endpoint string) ([]
 	dr := ComputeNodeDiscoveryResponse{}
 	err := json.Unmarshal(data, &dr)
 	if err != nil {
-		return nil, errors.Wrap(err, "an error occurred unmarshaling the compute node discovery response json")
+		return nil, fmt.Errorf("an error occurred unmarshaling the compute node discovery response json %w", err)
 	}
 
 	for _, cn := range dr.ComputeNodes {

--- a/discovery/uyuni/uyuni.go
+++ b/discovery/uyuni/uyuni.go
@@ -15,6 +15,7 @@ package uyuni
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -24,7 +25,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/kolo/xmlrpc"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
@@ -131,7 +131,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	_, err = url.Parse(c.Server)
 	if err != nil {
-		return errors.Wrap(err, "Uyuni Server URL is not valid")
+		return fmt.Errorf("Uyuni Server URL is not valid %w", err)
 	}
 
 	if c.Username == "" {
@@ -276,7 +276,7 @@ func (d *Discovery) getTargetsForSystems(
 
 	systemGroupIDsBySystemID, err := getSystemGroupsInfoOfMonitoredClients(rpcClient, d.token, entitlement)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get the managed system groups information of monitored clients")
+		return nil, fmt.Errorf("unable to get the managed system groups information of monitored clients %w", err)
 	}
 
 	systemIDs := make([]int, 0, len(systemGroupIDsBySystemID))
@@ -286,12 +286,12 @@ func (d *Discovery) getTargetsForSystems(
 
 	endpointInfos, err := getEndpointInfoForSystems(rpcClient, d.token, systemIDs)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get endpoints information")
+		return nil, fmt.Errorf("unable to get endpoints information %w", err)
 	}
 
 	networkInfoBySystemID, err := getNetworkInformationForSystems(rpcClient, d.token, systemIDs)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get the systems network information")
+		return nil, fmt.Errorf("unable to get the systems network information %w", err)
 	}
 
 	for _, endpoint := range endpointInfos {
@@ -317,7 +317,7 @@ func (d *Discovery) refresh(_ context.Context) ([]*targetgroup.Group, error) {
 		// Uyuni API takes duration in seconds.
 		d.token, err = login(rpcClient, d.username, d.password, int(tokenDuration.Seconds()))
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to login to Uyuni API")
+			return nil, fmt.Errorf("unable to login to Uyuni API %w", err)
 		}
 		// Login again at half the token lifetime.
 		d.tokenExpiration = time.Now().Add(tokenDuration / 2)

--- a/discovery/uyuni/uyuni.go
+++ b/discovery/uyuni/uyuni.go
@@ -131,7 +131,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	_, err = url.Parse(c.Server)
 	if err != nil {
-		return fmt.Errorf("Uyuni Server URL is not valid %w", err)
+		return fmt.Errorf("Uyuni Server URL is not valid: %w", err)
 	}
 
 	if c.Username == "" {
@@ -276,7 +276,7 @@ func (d *Discovery) getTargetsForSystems(
 
 	systemGroupIDsBySystemID, err := getSystemGroupsInfoOfMonitoredClients(rpcClient, d.token, entitlement)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get the managed system groups information of monitored clients %w", err)
+		return nil, fmt.Errorf("unable to get the managed system groups information of monitored clients: %w", err)
 	}
 
 	systemIDs := make([]int, 0, len(systemGroupIDsBySystemID))
@@ -286,12 +286,12 @@ func (d *Discovery) getTargetsForSystems(
 
 	endpointInfos, err := getEndpointInfoForSystems(rpcClient, d.token, systemIDs)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get endpoints information %w", err)
+		return nil, fmt.Errorf("unable to get endpoints information: %w", err)
 	}
 
 	networkInfoBySystemID, err := getNetworkInformationForSystems(rpcClient, d.token, systemIDs)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get the systems network information %w", err)
+		return nil, fmt.Errorf("unable to get the systems network information: %w", err)
 	}
 
 	for _, endpoint := range endpointInfos {
@@ -317,7 +317,7 @@ func (d *Discovery) refresh(_ context.Context) ([]*targetgroup.Group, error) {
 		// Uyuni API takes duration in seconds.
 		d.token, err = login(rpcClient, d.username, d.password, int(tokenDuration.Seconds()))
 		if err != nil {
-			return nil, fmt.Errorf("unable to login to Uyuni API %w", err)
+			return nil, fmt.Errorf("unable to login to Uyuni API: %w", err)
 		}
 		// Login again at half the token lifetime.
 		d.tokenExpiration = time.Now().Add(tokenDuration / 2)

--- a/discovery/xds/kuma.go
+++ b/discovery/xds/kuma.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -92,7 +91,7 @@ func (c *KumaSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	if len(c.Server) == 0 {
-		return errors.Errorf("kuma SD server must not be empty: %s", c.Server)
+		return fmt.Errorf("kuma SD server must not be empty: %s", c.Server)
 	}
 	parsedURL, err := url.Parse(c.Server)
 	if err != nil {
@@ -100,7 +99,7 @@ func (c *KumaSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	if len(parsedURL.Scheme) == 0 || len(parsedURL.Host) == 0 {
-		return errors.Errorf("kuma SD server must not be empty and have a scheme: %s", c.Server)
+		return fmt.Errorf("kuma SD server must not be empty and have a scheme: %s", c.Server)
 	}
 
 	return c.HTTPClientConfig.Validate()
@@ -159,7 +158,7 @@ func convertKumaUserLabels(labels map[string]string) model.LabelSet {
 // kumaMadsV1ResourceParser is an xds.resourceParser.
 func kumaMadsV1ResourceParser(resources []*anypb.Any, typeURL string) ([]model.LabelSet, error) {
 	if typeURL != KumaMadsV1ResourceTypeURL {
-		return nil, errors.Errorf("received invalid typeURL for Kuma MADS v1 Resource: %s", typeURL)
+		return nil, fmt.Errorf("received invalid typeURL for Kuma MADS v1 Resource: %s", typeURL)
 	}
 
 	var targets []model.LabelSet

--- a/discovery/xds/kuma_test.go
+++ b/discovery/xds/kuma_test.go
@@ -15,12 +15,12 @@ package xds
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"

--- a/discovery/zookeeper/zookeeper.go
+++ b/discovery/zookeeper/zookeeper.go
@@ -16,6 +16,7 @@ package zookeeper
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -24,7 +25,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-zookeeper/zk"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/discovery"
@@ -80,7 +80,7 @@ func (c *ServersetSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 	}
 	for _, path := range c.Paths {
 		if !strings.HasPrefix(path, "/") {
-			return errors.Errorf("serverset SD config paths must begin with '/': %s", path)
+			return fmt.Errorf("serverset SD config paths must begin with '/': %s", path)
 		}
 	}
 	return nil
@@ -117,7 +117,7 @@ func (c *NerveSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	for _, path := range c.Paths {
 		if !strings.HasPrefix(path, "/") {
-			return errors.Errorf("nerve SD config paths must begin with '/': %s", path)
+			return fmt.Errorf("nerve SD config paths must begin with '/': %s", path)
 		}
 	}
 	return nil
@@ -263,7 +263,7 @@ func parseServersetMember(data []byte, path string) (model.LabelSet, error) {
 	member := serversetMember{}
 
 	if err := json.Unmarshal(data, &member); err != nil {
-		return nil, errors.Wrapf(err, "error unmarshaling serverset member %q", path)
+		return nil, fmt.Errorf("error unmarshaling serverset member %q %w", path, err)
 	}
 
 	labels := model.LabelSet{}
@@ -305,7 +305,7 @@ func parseNerveMember(data []byte, path string) (model.LabelSet, error) {
 	member := nerveMember{}
 	err := json.Unmarshal(data, &member)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error unmarshaling nerve member %q", path)
+		return nil, fmt.Errorf("error unmarshaling nerve member %q %w", path, err)
 	}
 
 	labels := model.LabelSet{}

--- a/discovery/zookeeper/zookeeper.go
+++ b/discovery/zookeeper/zookeeper.go
@@ -263,7 +263,7 @@ func parseServersetMember(data []byte, path string) (model.LabelSet, error) {
 	member := serversetMember{}
 
 	if err := json.Unmarshal(data, &member); err != nil {
-		return nil, fmt.Errorf("error unmarshaling serverset member %q %w", path, err)
+		return nil, fmt.Errorf("error unmarshaling serverset member %q: %w", path, err)
 	}
 
 	labels := model.LabelSet{}
@@ -305,7 +305,7 @@ func parseNerveMember(data []byte, path string) (model.LabelSet, error) {
 	member := nerveMember{}
 	err := json.Unmarshal(data, &member)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling nerve member %q %w", path, err)
+		return nil, fmt.Errorf("error unmarshaling nerve member %q: %w", path, err)
 	}
 
 	labels := model.LabelSet{}

--- a/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
@@ -15,6 +15,7 @@ package influxdb
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -23,7 +24,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	influx "github.com/influxdata/influxdb/client/v2"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
@@ -174,7 +174,7 @@ func (c *Client) buildCommand(q *prompb.Query) (string, error) {
 		case prompb.LabelMatcher_NRE:
 			matchers = append(matchers, fmt.Sprintf("%q !~ /^%s$/", m.Name, escapeSlashes(m.Value)))
 		default:
-			return "", errors.Errorf("unknown match type %v", m.Type)
+			return "", fmt.Errorf("unknown match type %v", m.Type)
 		}
 	}
 	matchers = append(matchers, fmt.Sprintf("time >= %vms", q.StartTimestampMs))
@@ -253,27 +253,27 @@ func valuesToSamples(values [][]interface{}) ([]prompb.Sample, error) {
 	samples := make([]prompb.Sample, 0, len(values))
 	for _, v := range values {
 		if len(v) != 2 {
-			return nil, errors.Errorf("bad sample tuple length, expected [<timestamp>, <value>], got %v", v)
+			return nil, fmt.Errorf("bad sample tuple length, expected [<timestamp>, <value>], got %v", v)
 		}
 
 		jsonTimestamp, ok := v[0].(json.Number)
 		if !ok {
-			return nil, errors.Errorf("bad timestamp: %v", v[0])
+			return nil, fmt.Errorf("bad timestamp: %v", v[0])
 		}
 
 		jsonValue, ok := v[1].(json.Number)
 		if !ok {
-			return nil, errors.Errorf("bad sample value: %v", v[1])
+			return nil, fmt.Errorf("bad sample value: %v", v[1])
 		}
 
 		timestamp, err := jsonTimestamp.Int64()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to convert sample timestamp to int64")
+			return nil, fmt.Errorf("unable to convert sample timestamp to int64 %w", err)
 		}
 
 		value, err := jsonValue.Float64()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to convert sample value to float64")
+			return nil, fmt.Errorf("unable to convert sample value to float64 %w", err)
 		}
 
 		samples = append(samples, prompb.Sample{

--- a/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
@@ -268,12 +268,12 @@ func valuesToSamples(values [][]interface{}) ([]prompb.Sample, error) {
 
 		timestamp, err := jsonTimestamp.Int64()
 		if err != nil {
-			return nil, fmt.Errorf("unable to convert sample timestamp to int64 %w", err)
+			return nil, fmt.Errorf("unable to convert sample timestamp to int64: %w", err)
 		}
 
 		value, err := jsonValue.Float64()
 		if err != nil {
-			return nil, fmt.Errorf("unable to convert sample value to float64 %w", err)
+			return nil, fmt.Errorf("unable to convert sample value to float64: %w", err)
 		}
 
 		samples = append(samples, prompb.Sample{

--- a/documentation/examples/remote_storage/remote_storage_adapter/main.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -30,7 +31,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	influx "github.com/influxdata/influxdb/client/v2"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/model"
@@ -148,7 +148,7 @@ func parseFlags() *config {
 
 	_, err := a.Parse(os.Args[1:])
 	if err != nil {
-		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error parsing commandline arguments"))
+		fmt.Fprintln(os.Stderr, fmt.Errorf("Error parsing commandline arguments %w", err))
 		a.Usage(os.Args[1:])
 		os.Exit(2)
 	}

--- a/documentation/examples/remote_storage/remote_storage_adapter/main.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/main.go
@@ -148,7 +148,7 @@ func parseFlags() *config {
 
 	_, err := a.Parse(os.Args[1:])
 	if err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Errorf("Error parsing commandline arguments %w", err))
+		fmt.Fprintln(os.Stderr, fmt.Errorf("Error parsing commandline arguments: %w", err))
 		a.Usage(os.Args[1:])
 		os.Exit(2)
 	}

--- a/documentation/examples/remote_storage/remote_storage_adapter/opentsdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/opentsdb/client.go
@@ -17,6 +17,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"math"
 	"net/http"
@@ -25,7 +27,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 )
 
@@ -136,7 +137,7 @@ func (c *Client) Write(samples model.Samples) error {
 	if err := json.Unmarshal(buf, &r); err != nil {
 		return err
 	}
-	return errors.Errorf("failed to write %d samples to OpenTSDB, %d succeeded", r["failed"], r["success"])
+	return fmt.Errorf("failed to write %d samples to OpenTSDB, %d succeeded", r["failed"], r["success"])
 }
 
 // Name identifies the client as an OpenTSDB client.

--- a/documentation/examples/remote_storage/remote_storage_adapter/opentsdb/tagvalue.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/opentsdb/tagvalue.go
@@ -15,9 +15,9 @@ package opentsdb
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 )
 
@@ -98,13 +98,13 @@ func (tv *TagValue) UnmarshalJSON(json []byte) error {
 	for i, b := range json {
 		if i == 0 {
 			if b != '"' {
-				return errors.Errorf("expected '\"', got %q", b)
+				return fmt.Errorf("expected '\"', got %q", b)
 			}
 			continue
 		}
 		if i == len(json)-1 {
 			if b != '"' {
-				return errors.Errorf("expected '\"', got %q", b)
+				return fmt.Errorf("expected '\"', got %q", b)
 			}
 			break
 		}
@@ -130,7 +130,7 @@ func (tv *TagValue) UnmarshalJSON(json []byte) error {
 				parsedByte = (b - 55) << 4
 				escapeLevel = 2
 			default:
-				return errors.Errorf(
+				return fmt.Errorf(
 					"illegal escape sequence at byte %d (%c)",
 					i, b,
 				)
@@ -142,7 +142,7 @@ func (tv *TagValue) UnmarshalJSON(json []byte) error {
 			case b >= 'A' && b <= 'F': // A-F
 				parsedByte += b - 55
 			default:
-				return errors.Errorf(
+				return fmt.Errorf(
 					"illegal escape sequence at byte %d (%c)",
 					i, b,
 				)

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/oklog/ulid v1.3.1
 	github.com/opencontainers/image-spec v1.0.2 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/alertmanager v0.24.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0

--- a/model/labels/test_utils.go
+++ b/model/labels/test_utils.go
@@ -15,11 +15,10 @@ package labels
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"sort"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Slice is a sortable slice of label sets.
@@ -81,7 +80,7 @@ func ReadLabels(fn string, n int) ([]Labels, error) {
 	}
 
 	if i != n {
-		return mets, errors.Errorf("requested %d metrics but found %d", n, i)
+		return mets, fmt.Errorf("requested %d metrics but found %d", n, i)
 	}
 	return mets, nil
 }

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/grafana/regexp"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -67,7 +66,7 @@ func (a *Action) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		*a = act
 		return nil
 	}
-	return errors.Errorf("unknown relabel action %q", s)
+	return fmt.Errorf("unknown relabel action %q", s)
 }
 
 // Config is the configuration for relabeling of target label sets.
@@ -101,22 +100,22 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		c.Regex = MustNewRegexp("")
 	}
 	if c.Action == "" {
-		return errors.Errorf("relabel action cannot be empty")
+		return fmt.Errorf("relabel action cannot be empty")
 	}
 	if c.Modulus == 0 && c.Action == HashMod {
-		return errors.Errorf("relabel configuration for hashmod requires non-zero modulus")
+		return fmt.Errorf("relabel configuration for hashmod requires non-zero modulus")
 	}
 	if (c.Action == Replace || c.Action == HashMod) && c.TargetLabel == "" {
-		return errors.Errorf("relabel configuration for %s action requires 'target_label' value", c.Action)
+		return fmt.Errorf("relabel configuration for %s action requires 'target_label' value", c.Action)
 	}
 	if c.Action == Replace && !relabelTarget.MatchString(c.TargetLabel) {
-		return errors.Errorf("%q is invalid 'target_label' for %s action", c.TargetLabel, c.Action)
+		return fmt.Errorf("%q is invalid 'target_label' for %s action", c.TargetLabel, c.Action)
 	}
 	if c.Action == LabelMap && !relabelTarget.MatchString(c.Replacement) {
-		return errors.Errorf("%q is invalid 'replacement' for %s action", c.Replacement, c.Action)
+		return fmt.Errorf("%q is invalid 'replacement' for %s action", c.Replacement, c.Action)
 	}
 	if c.Action == HashMod && !model.LabelName(c.TargetLabel).IsValid() {
-		return errors.Errorf("%q is invalid 'target_label' for %s action", c.TargetLabel, c.Action)
+		return fmt.Errorf("%q is invalid 'target_label' for %s action", c.TargetLabel, c.Action)
 	}
 
 	if c.Action == LabelDrop || c.Action == LabelKeep {
@@ -125,7 +124,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			c.Modulus != DefaultRelabelConfig.Modulus ||
 			c.Separator != DefaultRelabelConfig.Separator ||
 			c.Replacement != DefaultRelabelConfig.Replacement {
-			return errors.Errorf("%s action requires only 'regex', and no other fields", c.Action)
+			return fmt.Errorf("%s action requires only 'regex', and no other fields", c.Action)
 		}
 	}
 
@@ -251,7 +250,7 @@ func relabel(lset labels.Labels, cfg *Config) labels.Labels {
 			}
 		}
 	default:
-		panic(errors.Errorf("relabel: unknown relabel action type %q", cfg.Action))
+		panic(fmt.Errorf("relabel: unknown relabel action type %q", cfg.Action))
 	}
 
 	return lb.Labels()

--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -16,12 +16,13 @@ package rulefmt
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	yaml "gopkg.in/yaml.v3"
 
@@ -41,11 +42,11 @@ type Error struct {
 // Error prints the error message in a formatted string.
 func (err *Error) Error() string {
 	if err.Err.nodeAlt != nil {
-		return errors.Wrapf(err.Err.err, "%d:%d: %d:%d: group %q, rule %d, %q", err.Err.node.Line, err.Err.node.Column, err.Err.nodeAlt.Line, err.Err.nodeAlt.Column, err.Group, err.Rule, err.RuleName).Error()
+		return fmt.Errorf("%d:%d: %d:%d: group %q, rule %d, %q %w", err.Err.node.Line, err.Err.node.Column, err.Err.nodeAlt.Line, err.Err.nodeAlt.Column, err.Group, err.Rule, err.RuleName, err.Err.err).Error()
 	} else if err.Err.node != nil {
-		return errors.Wrapf(err.Err.err, "%d:%d: group %q, rule %d, %q", err.Err.node.Line, err.Err.node.Column, err.Group, err.Rule, err.RuleName).Error()
+		return fmt.Errorf("%d:%d: group %q, rule %d, %q %w", err.Err.node.Line, err.Err.node.Column, err.Group, err.Rule, err.RuleName, err.Err.err).Error()
 	}
-	return errors.Wrapf(err.Err.err, "group %q, rule %d, %q", err.Group, err.Rule, err.RuleName).Error()
+	return fmt.Errorf("group %q, rule %d, %q %w", err.Group, err.Rule, err.RuleName, err.Err.err).Error()
 }
 
 // WrappedError wraps error with the yaml node which can be used to represent
@@ -59,9 +60,9 @@ type WrappedError struct {
 // Error prints the error message in a formatted string.
 func (we *WrappedError) Error() string {
 	if we.nodeAlt != nil {
-		return errors.Wrapf(we.err, "%d:%d: %d:%d", we.node.Line, we.node.Column, we.nodeAlt.Line, we.nodeAlt.Column).Error()
+		return fmt.Errorf("%d:%d: %d:%d %w", we.node.Line, we.node.Column, we.nodeAlt.Line, we.nodeAlt.Column, we.err).Error()
 	} else if we.node != nil {
-		return errors.Wrapf(we.err, "%d:%d", we.node.Line, we.node.Column).Error()
+		return fmt.Errorf("%d:%d %w", we.node.Line, we.node.Column, we.err).Error()
 	}
 	return we.err.Error()
 }
@@ -81,13 +82,13 @@ func (g *RuleGroups) Validate(node ruleGroups) (errs []error) {
 
 	for j, g := range g.Groups {
 		if g.Name == "" {
-			errs = append(errs, errors.Errorf("%d:%d: Groupname must not be empty", node.Groups[j].Line, node.Groups[j].Column))
+			errs = append(errs, fmt.Errorf("%d:%d: Groupname must not be empty", node.Groups[j].Line, node.Groups[j].Column))
 		}
 
 		if _, ok := set[g.Name]; ok {
 			errs = append(
 				errs,
-				errors.Errorf("%d:%d: groupname: \"%s\" is repeated in the same file", node.Groups[j].Line, node.Groups[j].Column, g.Name),
+				fmt.Errorf("%d:%d: groupname: \"%s\" is repeated in the same file", node.Groups[j].Line, node.Groups[j].Column, g.Name),
 			)
 		}
 
@@ -146,7 +147,7 @@ type RuleNode struct {
 func (r *RuleNode) Validate() (nodes []WrappedError) {
 	if r.Record.Value != "" && r.Alert.Value != "" {
 		nodes = append(nodes, WrappedError{
-			err:     errors.Errorf("only one of 'record' and 'alert' must be set"),
+			err:     fmt.Errorf("only one of 'record' and 'alert' must be set"),
 			node:    &r.Record,
 			nodeAlt: &r.Alert,
 		})
@@ -154,12 +155,12 @@ func (r *RuleNode) Validate() (nodes []WrappedError) {
 	if r.Record.Value == "" && r.Alert.Value == "" {
 		if r.Record.Value == "0" {
 			nodes = append(nodes, WrappedError{
-				err:  errors.Errorf("one of 'record' or 'alert' must be set"),
+				err:  fmt.Errorf("one of 'record' or 'alert' must be set"),
 				node: &r.Alert,
 			})
 		} else {
 			nodes = append(nodes, WrappedError{
-				err:  errors.Errorf("one of 'record' or 'alert' must be set"),
+				err:  fmt.Errorf("one of 'record' or 'alert' must be set"),
 				node: &r.Record,
 			})
 		}
@@ -167,31 +168,31 @@ func (r *RuleNode) Validate() (nodes []WrappedError) {
 
 	if r.Expr.Value == "" {
 		nodes = append(nodes, WrappedError{
-			err:  errors.Errorf("field 'expr' must be set in rule"),
+			err:  fmt.Errorf("field 'expr' must be set in rule"),
 			node: &r.Expr,
 		})
 	} else if _, err := parser.ParseExpr(r.Expr.Value); err != nil {
 		nodes = append(nodes, WrappedError{
-			err:  errors.Wrapf(err, "could not parse expression"),
+			err:  fmt.Errorf("could not parse expression %w", err),
 			node: &r.Expr,
 		})
 	}
 	if r.Record.Value != "" {
 		if len(r.Annotations) > 0 {
 			nodes = append(nodes, WrappedError{
-				err:  errors.Errorf("invalid field 'annotations' in recording rule"),
+				err:  fmt.Errorf("invalid field 'annotations' in recording rule"),
 				node: &r.Record,
 			})
 		}
 		if r.For != 0 {
 			nodes = append(nodes, WrappedError{
-				err:  errors.Errorf("invalid field 'for' in recording rule"),
+				err:  fmt.Errorf("invalid field 'for' in recording rule"),
 				node: &r.Record,
 			})
 		}
 		if !model.IsValidMetricName(model.LabelValue(r.Record.Value)) {
 			nodes = append(nodes, WrappedError{
-				err:  errors.Errorf("invalid recording rule name: %s", r.Record.Value),
+				err:  fmt.Errorf("invalid recording rule name: %s", r.Record.Value),
 				node: &r.Record,
 			})
 		}
@@ -200,13 +201,13 @@ func (r *RuleNode) Validate() (nodes []WrappedError) {
 	for k, v := range r.Labels {
 		if !model.LabelName(k).IsValid() || k == model.MetricNameLabel {
 			nodes = append(nodes, WrappedError{
-				err: errors.Errorf("invalid label name: %s", k),
+				err: fmt.Errorf("invalid label name: %s", k),
 			})
 		}
 
 		if !model.LabelValue(v).IsValid() {
 			nodes = append(nodes, WrappedError{
-				err: errors.Errorf("invalid label value: %s", v),
+				err: fmt.Errorf("invalid label value: %s", v),
 			})
 		}
 	}
@@ -214,7 +215,7 @@ func (r *RuleNode) Validate() (nodes []WrappedError) {
 	for k := range r.Annotations {
 		if !model.LabelName(k).IsValid() {
 			nodes = append(nodes, WrappedError{
-				err: errors.Errorf("invalid annotation name: %s", k),
+				err: fmt.Errorf("invalid annotation name: %s", k),
 			})
 		}
 	}
@@ -260,7 +261,7 @@ func testTemplateParsing(rl *RuleNode) (errs []error) {
 	for k, val := range rl.Labels {
 		err := parseTest(val)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "label %q", k))
+			errs = append(errs, fmt.Errorf("label %q %w", k, err))
 		}
 	}
 
@@ -268,7 +269,7 @@ func testTemplateParsing(rl *RuleNode) (errs []error) {
 	for k, val := range rl.Annotations {
 		err := parseTest(val)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "annotation %q", k))
+			errs = append(errs, fmt.Errorf("annotation %q %w", k, err))
 		}
 	}
 
@@ -287,7 +288,7 @@ func Parse(content []byte) (*RuleGroups, []error) {
 	decoder.KnownFields(true)
 	err := decoder.Decode(&groups)
 	// Ignore io.EOF which happens with empty input.
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		errs = append(errs, err)
 	}
 	err = yaml.Unmarshal(content, &node)
@@ -306,11 +307,11 @@ func Parse(content []byte) (*RuleGroups, []error) {
 func ParseFile(file string) (*RuleGroups, []error) {
 	b, err := os.ReadFile(file)
 	if err != nil {
-		return nil, []error{errors.Wrap(err, file)}
+		return nil, []error{fmt.Errorf("%s %w", file, err)}
 	}
 	rgs, errs := Parse(b)
 	for i := range errs {
-		errs[i] = errors.Wrap(errs[i], file)
+		errs[i] = fmt.Errorf("%s %w", file, errs[i])
 	}
 	return rgs, errs
 }

--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -42,11 +42,11 @@ type Error struct {
 // Error prints the error message in a formatted string.
 func (err *Error) Error() string {
 	if err.Err.nodeAlt != nil {
-		return fmt.Errorf("%d:%d: %d:%d: group %q, rule %d, %q %w", err.Err.node.Line, err.Err.node.Column, err.Err.nodeAlt.Line, err.Err.nodeAlt.Column, err.Group, err.Rule, err.RuleName, err.Err.err).Error()
+		return fmt.Errorf("%d:%d: %d:%d: group %q, rule %d, %q: %w", err.Err.node.Line, err.Err.node.Column, err.Err.nodeAlt.Line, err.Err.nodeAlt.Column, err.Group, err.Rule, err.RuleName, err.Err.err).Error()
 	} else if err.Err.node != nil {
-		return fmt.Errorf("%d:%d: group %q, rule %d, %q %w", err.Err.node.Line, err.Err.node.Column, err.Group, err.Rule, err.RuleName, err.Err.err).Error()
+		return fmt.Errorf("%d:%d: group %q, rule %d, %q: %w", err.Err.node.Line, err.Err.node.Column, err.Group, err.Rule, err.RuleName, err.Err.err).Error()
 	}
-	return fmt.Errorf("group %q, rule %d, %q %w", err.Group, err.Rule, err.RuleName, err.Err.err).Error()
+	return fmt.Errorf("group %q, rule %d, %q: %w", err.Group, err.Rule, err.RuleName, err.Err.err).Error()
 }
 
 // WrappedError wraps error with the yaml node which can be used to represent
@@ -60,9 +60,9 @@ type WrappedError struct {
 // Error prints the error message in a formatted string.
 func (we *WrappedError) Error() string {
 	if we.nodeAlt != nil {
-		return fmt.Errorf("%d:%d: %d:%d %w", we.node.Line, we.node.Column, we.nodeAlt.Line, we.nodeAlt.Column, we.err).Error()
+		return fmt.Errorf("%d:%d: %d:%d: %w", we.node.Line, we.node.Column, we.nodeAlt.Line, we.nodeAlt.Column, we.err).Error()
 	} else if we.node != nil {
-		return fmt.Errorf("%d:%d %w", we.node.Line, we.node.Column, we.err).Error()
+		return fmt.Errorf("%d:%d: %w", we.node.Line, we.node.Column, we.err).Error()
 	}
 	return we.err.Error()
 }
@@ -173,7 +173,7 @@ func (r *RuleNode) Validate() (nodes []WrappedError) {
 		})
 	} else if _, err := parser.ParseExpr(r.Expr.Value); err != nil {
 		nodes = append(nodes, WrappedError{
-			err:  fmt.Errorf("could not parse expression %w", err),
+			err:  fmt.Errorf("could not parse expression: %w", err),
 			node: &r.Expr,
 		})
 	}
@@ -261,7 +261,7 @@ func testTemplateParsing(rl *RuleNode) (errs []error) {
 	for k, val := range rl.Labels {
 		err := parseTest(val)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("label %q %w", k, err))
+			errs = append(errs, fmt.Errorf("label %q: %w", k, err))
 		}
 	}
 
@@ -269,7 +269,7 @@ func testTemplateParsing(rl *RuleNode) (errs []error) {
 	for k, val := range rl.Annotations {
 		err := parseTest(val)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("annotation %q %w", k, err))
+			errs = append(errs, fmt.Errorf("annotation %q: %w", k, err))
 		}
 	}
 
@@ -307,11 +307,11 @@ func Parse(content []byte) (*RuleGroups, []error) {
 func ParseFile(file string) (*RuleGroups, []error) {
 	b, err := os.ReadFile(file)
 	if err != nil {
-		return nil, []error{fmt.Errorf("%s %w", file, err)}
+		return nil, []error{fmt.Errorf("%s: %w", file, err)}
 	}
 	rgs, errs := Parse(b)
 	for i := range errs {
-		errs[i] = fmt.Errorf("%s %w", file, errs[i])
+		errs[i] = fmt.Errorf("%s: %w", file, errs[i])
 	}
 	return rgs, errs
 }

--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -41,12 +41,15 @@ type Error struct {
 
 // Error prints the error message in a formatted string.
 func (err *Error) Error() string {
-	if err.Err.nodeAlt != nil {
-		return fmt.Errorf("%d:%d: %d:%d: group %q, rule %d, %q: %w", err.Err.node.Line, err.Err.node.Column, err.Err.nodeAlt.Line, err.Err.nodeAlt.Column, err.Group, err.Rule, err.RuleName, err.Err.err).Error()
-	} else if err.Err.node != nil {
-		return fmt.Errorf("%d:%d: group %q, rule %d, %q: %w", err.Err.node.Line, err.Err.node.Column, err.Group, err.Rule, err.RuleName, err.Err.err).Error()
+	if err.Err.err != nil {
+		if err.Err.nodeAlt != nil {
+			return fmt.Errorf("%d:%d: %d:%d: group %q, rule %d, %q: %w", err.Err.node.Line, err.Err.node.Column, err.Err.nodeAlt.Line, err.Err.nodeAlt.Column, err.Group, err.Rule, err.RuleName, err.Err.err).Error()
+		} else if err.Err.node != nil {
+			return fmt.Errorf("%d:%d: group %q, rule %d, %q: %w", err.Err.node.Line, err.Err.node.Column, err.Group, err.Rule, err.RuleName, err.Err.err).Error()
+		}
+		return fmt.Errorf("group %q, rule %d, %q: %w", err.Group, err.Rule, err.RuleName, err.Err.err).Error()
 	}
-	return fmt.Errorf("group %q, rule %d, %q: %w", err.Group, err.Rule, err.RuleName, err.Err.err).Error()
+	return nil
 }
 
 // WrappedError wraps error with the yaml node which can be used to represent
@@ -59,12 +62,15 @@ type WrappedError struct {
 
 // Error prints the error message in a formatted string.
 func (we *WrappedError) Error() string {
-	if we.nodeAlt != nil {
-		return fmt.Errorf("%d:%d: %d:%d: %w", we.node.Line, we.node.Column, we.nodeAlt.Line, we.nodeAlt.Column, we.err).Error()
-	} else if we.node != nil {
-		return fmt.Errorf("%d:%d: %w", we.node.Line, we.node.Column, we.err).Error()
+	if we.err != nil {
+		if we.nodeAlt != nil {
+			return fmt.Errorf("%d:%d: %d:%d: %w", we.node.Line, we.node.Column, we.nodeAlt.Line, we.nodeAlt.Column, we.err).Error()
+		} else if we.node != nil {
+			return fmt.Errorf("%d:%d: %w", we.node.Line, we.node.Column, we.err).Error()
+		}
+		return we.err.Error()
 	}
-	return we.err.Error()
+	return nil
 }
 
 // RuleGroups is a set of rule groups that are typically exposed in a file.

--- a/model/rulefmt/rulefmt_test.go
+++ b/model/rulefmt/rulefmt_test.go
@@ -182,8 +182,12 @@ groups:
 `
 	_, errs := Parse([]byte(group))
 	require.Len(t, errs, 2, "Expected two errors")
-	err0 := errs[0].(*Error).Err.node
-	err1 := errs[1].(*Error).Err.node
+	var err00 *Error
+	errors.As(errs[0], &err00)
+	err0 := err00.Err.node
+	var err01 *Error
+	errors.As(errs[1], &err01)
+	err1 := err01.Err.node
 	require.NotEqual(t, err0, err1, "Error nodes should not be the same")
 }
 

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -18,14 +18,13 @@ package textparse
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
 	"sort"
 	"strings"
 	"unicode/utf8"
-
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
@@ -276,7 +275,7 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 			case "unknown":
 				p.mtype = MetricTypeUnknown
 			default:
-				return EntryInvalid, errors.Errorf("invalid metric type %q", s)
+				return EntryInvalid, fmt.Errorf("invalid metric type %q", s)
 			}
 		case tHelp:
 			if !utf8.Valid(p.text) {
@@ -293,7 +292,7 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 			u := yoloString(p.text)
 			if len(u) > 0 {
 				if !strings.HasSuffix(m, u) || len(m) < len(u)+1 || p.l.b[p.offsets[1]-len(u)-1] != '_' {
-					return EntryInvalid, errors.Errorf("unit not a suffix of metric %q", m)
+					return EntryInvalid, fmt.Errorf("unit not a suffix of metric %q", m)
 				}
 			}
 			return EntryUnit, nil
@@ -353,7 +352,7 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 		return EntrySeries, nil
 
 	default:
-		err = errors.Errorf("%q %q is not a valid start token", t, string(p.l.cur()))
+		err = fmt.Errorf("%q %q is not a valid start token", t, string(p.l.cur()))
 	}
 	return EntryInvalid, err
 }

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -14,6 +14,7 @@
 package textparse
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -223,7 +224,7 @@ foo_total 17.0 1520879607.789 # {xx="yy"} 5`
 
 	for {
 		et, err := p.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)

--- a/model/textparse/promlex.l.go
+++ b/model/textparse/promlex.l.go
@@ -16,7 +16,7 @@
 package textparse
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 const (
@@ -47,7 +47,7 @@ yystate0:
 
 	switch yyt := l.state; yyt {
 	default:
-		panic(errors.Errorf(`invalid start condition %d`, yyt))
+		panic(fmt.Errorf(`invalid start condition %d`, yyt))
 	case 0: // start condition: INITIAL
 		goto yystart1
 	case 1: // start condition: sComment

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -17,6 +17,7 @@
 package textparse
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -25,8 +26,6 @@ import (
 	"strings"
 	"unicode/utf8"
 	"unsafe"
-
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
@@ -252,7 +251,7 @@ func (p *PromParser) nextToken() token {
 }
 
 func parseError(exp string, got token) error {
-	return errors.Errorf("%s, got %q", exp, got)
+	return fmt.Errorf("%s, got %q", exp, got)
 }
 
 // Next advances the parser to the next sample. It returns false if no
@@ -301,11 +300,11 @@ func (p *PromParser) Next() (Entry, error) {
 			case "untyped":
 				p.mtype = MetricTypeUnknown
 			default:
-				return EntryInvalid, errors.Errorf("invalid metric type %q", s)
+				return EntryInvalid, fmt.Errorf("invalid metric type %q", s)
 			}
 		case tHelp:
 			if !utf8.Valid(p.text) {
-				return EntryInvalid, errors.Errorf("help text is not a valid utf8 string")
+				return EntryInvalid, fmt.Errorf("help text is not a valid utf8 string")
 			}
 		}
 		if t := p.nextToken(); t != tLinebreak {
@@ -364,7 +363,7 @@ func (p *PromParser) Next() (Entry, error) {
 		return EntrySeries, nil
 
 	default:
-		err = errors.Errorf("%q is not a valid start token", t)
+		err = fmt.Errorf("%q is not a valid start token", t)
 	}
 	return EntryInvalid, err
 }
@@ -388,7 +387,7 @@ func (p *PromParser) parseLVals() error {
 			return parseError("expected label value", t)
 		}
 		if !utf8.Valid(p.l.buf()) {
-			return errors.Errorf("invalid UTF-8 label value")
+			return fmt.Errorf("invalid UTF-8 label value")
 		}
 
 		// The promlexer ensures the value string is quoted. Strip first

--- a/model/textparse/promparse_test.go
+++ b/model/textparse/promparse_test.go
@@ -16,6 +16,7 @@ package textparse
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -176,7 +177,7 @@ testmetric{label="\"bar\""} 1`
 
 	for {
 		et, err := p.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)
@@ -378,7 +379,7 @@ func BenchmarkParse(b *testing.B) {
 						t, err := p.Next()
 						switch t {
 						case EntryInvalid:
-							if err == io.EOF {
+							if errors.Is(err, io.EOF) {
 								break Outer
 							}
 							b.Fatal(err)
@@ -406,7 +407,7 @@ func BenchmarkParse(b *testing.B) {
 						t, err := p.Next()
 						switch t {
 						case EntryInvalid:
-							if err == io.EOF {
+							if errors.Is(err, io.EOF) {
 								break Outer
 							}
 							b.Fatal(err)
@@ -439,7 +440,7 @@ func BenchmarkParse(b *testing.B) {
 						t, err := p.Next()
 						switch t {
 						case EntryInvalid:
-							if err == io.EOF {
+							if errors.Is(err, io.EOF) {
 								break Outer
 							}
 							b.Fatal(err)

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -30,7 +30,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/go-openapi/strfmt"
-	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
@@ -588,7 +587,7 @@ func (n *Manager) sendOne(ctx context.Context, c *http.Client, url string, b []b
 
 	// Any HTTP status 2xx is OK.
 	if resp.StatusCode/100 != 2 {
-		return errors.Errorf("bad response status %s", resp.Status)
+		return fmt.Errorf("bad response status %s", resp.Status)
 	}
 
 	return nil
@@ -742,7 +741,7 @@ func AlertmanagerFromGroup(tg *targetgroup.Group, cfg *config.AlertmanagerConfig
 			case "https":
 				addr = addr + ":443"
 			default:
-				return nil, nil, errors.Errorf("invalid scheme: %q", cfg.Scheme)
+				return nil, nil, fmt.Errorf("invalid scheme: %q", cfg.Scheme)
 			}
 			lb.Set(model.AddressLabel, addr)
 		}

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -88,11 +87,11 @@ func TestHandlerNextBatch(t *testing.T) {
 
 func alertsEqual(a, b []*Alert) error {
 	if len(a) != len(b) {
-		return errors.Errorf("length mismatch: %v != %v", a, b)
+		return fmt.Errorf("length mismatch: %v != %v", a, b)
 	}
 	for i, alert := range a {
 		if !labels.Equal(alert.Labels, b[i].Labels) {
-			return errors.Errorf("label mismatch at index %d: %s != %s", i, alert.Labels, b[i].Labels)
+			return fmt.Errorf("label mismatch at index %d: %s != %s", i, alert.Labels, b[i].Labels)
 		}
 	}
 	return nil
@@ -121,14 +120,14 @@ func TestHandlerSendAll(t *testing.T) {
 			}()
 			user, pass, _ := r.BasicAuth()
 			if user != u || pass != p {
-				err = errors.Errorf("unexpected user/password: %s/%s != %s/%s", user, pass, u, p)
+				err = fmt.Errorf("unexpected user/password: %s/%s != %s/%s", user, pass, u, p)
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
 
 			b, err := io.ReadAll(r.Body)
 			if err != nil {
-				err = errors.Errorf("error reading body: %v", err)
+				err = fmt.Errorf("error reading body: %w", err)
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"container/heap"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -29,7 +30,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/regexp"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"go.opentelemetry.io/otel"
@@ -208,10 +208,10 @@ func contextDone(ctx context.Context, env string) error {
 }
 
 func contextErr(err error, env string) error {
-	switch err {
-	case context.Canceled:
+	switch {
+	case errors.Is(err, context.Canceled):
 		return ErrQueryCanceled(env)
-	case context.DeadlineExceeded:
+	case errors.Is(err, context.DeadlineExceeded):
 		return ErrQueryTimeout(env)
 	default:
 		return err
@@ -416,7 +416,7 @@ func (ng *Engine) NewRangeQuery(q storage.Queryable, opts *QueryOpts, qs string,
 		return nil, err
 	}
 	if expr.Type() != parser.ValueTypeVector && expr.Type() != parser.ValueTypeScalar {
-		return nil, errors.Errorf("invalid expression type %q for range query, must be Scalar or instant Vector", parser.DocumentedType(expr.Type()))
+		return nil, fmt.Errorf("invalid expression type %q for range query, must be Scalar or instant Vector", parser.DocumentedType(expr.Type()))
 	}
 	qry, err := ng.newQuery(q, opts, expr, start, end, interval)
 	if err != nil {
@@ -597,7 +597,7 @@ func (ng *Engine) exec(ctx context.Context, q *query) (v parser.Value, ws storag
 		return nil, nil, s(ctx)
 	}
 
-	panic(errors.Errorf("promql.Engine.exec: unhandled statement of type %T", q.Statement()))
+	panic(fmt.Errorf("promql.Engine.exec: unhandled statement of type %T", q.Statement()))
 }
 
 func timeMilliseconds(t time.Time) int64 {
@@ -657,7 +657,7 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *parser.Eval
 		case String:
 			return result, warnings, nil
 		default:
-			panic(errors.Errorf("promql.Engine.exec: invalid expression type %q", val.Type()))
+			panic(fmt.Errorf("promql.Engine.exec: invalid expression type %q", val.Type()))
 		}
 
 		query.matrix = mat
@@ -676,7 +676,7 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *parser.Eval
 		case parser.ValueTypeMatrix:
 			return mat, warnings, nil
 		default:
-			panic(errors.Errorf("promql.Engine.exec: unexpected expression type %q", s.Expr.Type()))
+			panic(fmt.Errorf("promql.Engine.exec: unexpected expression type %q", s.Expr.Type()))
 		}
 	}
 
@@ -701,7 +701,7 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *parser.Eval
 
 	mat, ok := val.(Matrix)
 	if !ok {
-		panic(errors.Errorf("promql.Engine.exec: invalid expression type %q", val.Type()))
+		panic(fmt.Errorf("promql.Engine.exec: invalid expression type %q", val.Type()))
 	}
 	query.matrix = mat
 
@@ -928,7 +928,7 @@ type evaluator struct {
 
 // errorf causes a panic with the input formatted into an error.
 func (ev *evaluator) errorf(format string, args ...interface{}) {
-	ev.error(errors.Errorf(format, args...))
+	ev.error(fmt.Errorf(format, args...))
 }
 
 // error causes a panic with the given error.
@@ -950,7 +950,7 @@ func (ev *evaluator) recover(ws *storage.Warnings, errp *error) {
 		buf = buf[:runtime.Stack(buf, false)]
 
 		level.Error(ev.logger).Log("msg", "runtime panic in parser", "err", e, "stacktrace", string(buf))
-		*errp = errors.Wrap(err, "unexpected error")
+		*errp = fmt.Errorf("unexpected error %w", err)
 	case errWithWarnings:
 		*errp = err.err
 		*ws = append(*ws, err.warnings...)
@@ -1344,7 +1344,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 		ws, err := checkAndExpandSeriesSet(ev.ctx, sel)
 		warnings = append(warnings, ws...)
 		if err != nil {
-			ev.error(errWithWarnings{errors.Wrap(err, "expanding series"), warnings})
+			ev.error(errWithWarnings{fmt.Errorf("expanding series %w", err), warnings})
 		}
 		mat := make(Matrix, 0, len(selVS.Series)) // Output matrix.
 		offset := durationMilliseconds(selVS.Offset)
@@ -1541,7 +1541,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 	case *parser.VectorSelector:
 		ws, err := checkAndExpandSeriesSet(ev.ctx, e)
 		if err != nil {
-			ev.error(errWithWarnings{errors.Wrap(err, "expanding series"), ws})
+			ev.error(errWithWarnings{fmt.Errorf("expanding series %w", err), ws})
 		}
 		mat := make(Matrix, 0, len(e.Series))
 		it := storage.NewMemoizedEmptyIterator(durationMilliseconds(ev.lookbackDelta))
@@ -1657,11 +1657,11 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 		// with changed timestamps.
 		mat, ok := res.(Matrix)
 		if !ok {
-			panic(errors.Errorf("unexpected result in StepInvariantExpr evaluation: %T", expr))
+			panic(fmt.Errorf("unexpected result in StepInvariantExpr evaluation: %T", expr))
 		}
 		for i := range mat {
 			if len(mat[i].Points) != 1 {
-				panic(errors.Errorf("unexpected number of samples"))
+				panic(fmt.Errorf("unexpected number of samples"))
 			}
 			for ts := ev.startTimestamp + ev.interval; ts <= ev.endTimestamp; ts = ts + ev.interval {
 				mat[i].Points = append(mat[i].Points, Point{
@@ -1678,14 +1678,14 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 		return res, ws
 	}
 
-	panic(errors.Errorf("unhandled expression of type: %T", expr))
+	panic(fmt.Errorf("unhandled expression of type: %T", expr))
 }
 
 // vectorSelector evaluates a *parser.VectorSelector expression.
 func (ev *evaluator) vectorSelector(node *parser.VectorSelector, ts int64) (Vector, storage.Warnings) {
 	ws, err := checkAndExpandSeriesSet(ev.ctx, node)
 	if err != nil {
-		ev.error(errWithWarnings{errors.Wrap(err, "expanding series"), ws})
+		ev.error(errWithWarnings{fmt.Errorf("expanding series %w", err), ws})
 	}
 	vec := make(Vector, 0, len(node.Series))
 	it := storage.NewMemoizedEmptyIterator(durationMilliseconds(ev.lookbackDelta))
@@ -1769,7 +1769,7 @@ func (ev *evaluator) matrixSelector(node *parser.MatrixSelector) (Matrix, storag
 	)
 	ws, err := checkAndExpandSeriesSet(ev.ctx, node)
 	if err != nil {
-		ev.error(errWithWarnings{errors.Wrap(err, "expanding series"), ws})
+		ev.error(errWithWarnings{fmt.Errorf("expanding series %w", err), ws})
 	}
 
 	series := vs.Series
@@ -2187,7 +2187,7 @@ func scalarBinop(op parser.ItemType, lhs, rhs float64) float64 {
 	case parser.ATAN2:
 		return math.Atan2(lhs, rhs)
 	}
-	panic(errors.Errorf("operator %q not allowed for Scalar operations", op))
+	panic(fmt.Errorf("operator %q not allowed for Scalar operations", op))
 }
 
 // vectorElemBinop evaluates a binary operation between two Vector elements.
@@ -2220,7 +2220,7 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64) (float64, bool) {
 	case parser.ATAN2:
 		return math.Atan2(lhs, rhs), true
 	}
-	panic(errors.Errorf("operator %q not allowed for operations between Vectors", op))
+	panic(fmt.Errorf("operator %q not allowed for operations between Vectors", op))
 }
 
 type groupedAggregation struct {
@@ -2431,7 +2431,7 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 			group.heap = append(group.heap, s)
 
 		default:
-			panic(errors.Errorf("expected aggregation operator but got %q", op))
+			panic(fmt.Errorf("expected aggregation operator but got %q", op))
 		}
 	}
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -950,7 +950,7 @@ func (ev *evaluator) recover(ws *storage.Warnings, errp *error) {
 		buf = buf[:runtime.Stack(buf, false)]
 
 		level.Error(ev.logger).Log("msg", "runtime panic in parser", "err", e, "stacktrace", string(buf))
-		*errp = fmt.Errorf("unexpected error %w", err)
+		*errp = fmt.Errorf("unexpected error: %w", err)
 	case errWithWarnings:
 		*errp = err.err
 		*ws = append(*ws, err.warnings...)
@@ -1344,7 +1344,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 		ws, err := checkAndExpandSeriesSet(ev.ctx, sel)
 		warnings = append(warnings, ws...)
 		if err != nil {
-			ev.error(errWithWarnings{fmt.Errorf("expanding series %w", err), warnings})
+			ev.error(errWithWarnings{fmt.Errorf("expanding series: %w", err), warnings})
 		}
 		mat := make(Matrix, 0, len(selVS.Series)) // Output matrix.
 		offset := durationMilliseconds(selVS.Offset)
@@ -1541,7 +1541,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 	case *parser.VectorSelector:
 		ws, err := checkAndExpandSeriesSet(ev.ctx, e)
 		if err != nil {
-			ev.error(errWithWarnings{fmt.Errorf("expanding series %w", err), ws})
+			ev.error(errWithWarnings{fmt.Errorf("expanding series: %w", err), ws})
 		}
 		mat := make(Matrix, 0, len(e.Series))
 		it := storage.NewMemoizedEmptyIterator(durationMilliseconds(ev.lookbackDelta))
@@ -1685,7 +1685,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 func (ev *evaluator) vectorSelector(node *parser.VectorSelector, ts int64) (Vector, storage.Warnings) {
 	ws, err := checkAndExpandSeriesSet(ev.ctx, node)
 	if err != nil {
-		ev.error(errWithWarnings{fmt.Errorf("expanding series %w", err), ws})
+		ev.error(errWithWarnings{fmt.Errorf("expanding series: %w", err), ws})
 	}
 	vec := make(Vector, 0, len(node.Series))
 	it := storage.NewMemoizedEmptyIterator(durationMilliseconds(ev.lookbackDelta))
@@ -1769,7 +1769,7 @@ func (ev *evaluator) matrixSelector(node *parser.MatrixSelector) (Matrix, storag
 	)
 	ws, err := checkAndExpandSeriesSet(ev.ctx, node)
 	if err != nil {
-		ev.error(errWithWarnings{fmt.Errorf("expanding series %w", err), ws})
+		ev.error(errWithWarnings{fmt.Errorf("expanding series: %w", err), ws})
 	}
 
 	series := vs.Series

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -14,6 +14,7 @@
 package promql
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"strconv"
@@ -21,7 +22,6 @@ import (
 	"time"
 
 	"github.com/grafana/regexp"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -223,10 +223,10 @@ func funcHoltWinters(vals []parser.Value, args parser.Expressions, enh *EvalNode
 
 	// Sanity check the input.
 	if sf <= 0 || sf >= 1 {
-		panic(errors.Errorf("invalid smoothing factor. Expected: 0 < sf < 1, got: %f", sf))
+		panic(fmt.Errorf("invalid smoothing factor. Expected: 0 < sf < 1, got: %f", sf))
 	}
 	if tf <= 0 || tf >= 1 {
-		panic(errors.Errorf("invalid trend factor. Expected: 0 < tf < 1, got: %f", tf))
+		panic(fmt.Errorf("invalid trend factor. Expected: 0 < tf < 1, got: %f", tf))
 	}
 
 	l := len(samples.Points)
@@ -890,10 +890,10 @@ func funcLabelReplace(vals []parser.Value, args parser.Expressions, enh *EvalNod
 		var err error
 		enh.regex, err = regexp.Compile("^(?:" + regexStr + ")$")
 		if err != nil {
-			panic(errors.Errorf("invalid regular expression in label_replace(): %s", regexStr))
+			panic(fmt.Errorf("invalid regular expression in label_replace(): %s", regexStr))
 		}
 		if !model.LabelNameRE.MatchString(dst) {
-			panic(errors.Errorf("invalid destination label name in label_replace(): %s", dst))
+			panic(fmt.Errorf("invalid destination label name in label_replace(): %s", dst))
 		}
 		enh.Dmn = make(map[uint64]labels.Labels, len(enh.Out))
 	}
@@ -955,13 +955,13 @@ func funcLabelJoin(vals []parser.Value, args parser.Expressions, enh *EvalNodeHe
 	for i := 3; i < len(args); i++ {
 		src := stringFromArg(args[i])
 		if !model.LabelName(src).IsValid() {
-			panic(errors.Errorf("invalid source label name in label_join(): %s", src))
+			panic(fmt.Errorf("invalid source label name in label_join(): %s", src))
 		}
 		srcLabels[i-3] = src
 	}
 
 	if !model.LabelName(dst).IsValid() {
-		panic(errors.Errorf("invalid destination label name in label_join(): %s", dst))
+		panic(fmt.Errorf("invalid destination label name in label_join(): %s", dst))
 	}
 
 	srcVals := make([]string, len(srcLabels))

--- a/promql/fuzz.go
+++ b/promql/fuzz.go
@@ -18,6 +18,7 @@
 package promql
 
 import (
+	"errors"
 	"io"
 
 	"github.com/prometheus/prometheus/model/textparse"
@@ -71,7 +72,7 @@ func fuzzParseMetricWithContentType(in []byte, contentType string) int {
 			break
 		}
 	}
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		err = nil
 	}
 

--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -15,9 +15,8 @@ package parser
 
 import (
 	"context"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -394,7 +393,7 @@ func Children(node Node) []Node {
 		// nothing to do
 		return []Node{}
 	default:
-		panic(errors.Errorf("promql.Children: unhandled node type %T", node))
+		panic(fmt.Errorf("promql.Children: unhandled node type %T", node))
 	}
 }
 

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -14,6 +14,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -23,7 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -224,7 +224,7 @@ func ParseSeriesDesc(input string) (labels labels.Labels, values []SequenceValue
 
 // addParseErrf formats the error and appends it to the list of parsing errors.
 func (p *parser) addParseErrf(positionRange PositionRange, format string, args ...interface{}) {
-	p.addParseErr(positionRange, errors.Errorf(format, args...))
+	p.addParseErr(positionRange, fmt.Errorf(format, args...))
 }
 
 // addParseErr appends the provided error to the list of parsing errors.
@@ -801,7 +801,7 @@ func MustLabelMatcher(mt labels.MatchType, name, val string) *labels.Matcher {
 func MustGetFunction(name string) *Function {
 	f, ok := getFunction(name)
 	if !ok {
-		panic(errors.Errorf("function %q does not exist", name))
+		panic(fmt.Errorf("function %q does not exist", name))
 	}
 	return f
 }

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -14,13 +14,13 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
@@ -3570,7 +3570,8 @@ func TestParseExpressions(t *testing.T) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), test.errMsg, "unexpected error on input '%s', expected '%s', got '%s'", test.input, test.errMsg, err.Error())
 
-				errorList, ok := err.(ParseErrors)
+				var errorList ParseErrors
+				ok := errors.As(err, &errorList)
 
 				require.True(t, ok, "unexpected error type")
 

--- a/promql/test.go
+++ b/promql/test.go
@@ -546,14 +546,14 @@ func (t *Test) exec(tc testCommand) error {
 				if cmd.fail {
 					continue
 				}
-				return fmt.Errorf("error evaluating query %q (line %d) %w", iq.expr, cmd.line, res.Err)
+				return fmt.Errorf("error evaluating query %q (line %d): %w", iq.expr, cmd.line, res.Err)
 			}
 			if res.Err == nil && cmd.fail {
 				return fmt.Errorf("expected error evaluating query %q (line %d) but got none", iq.expr, cmd.line)
 			}
 			err = cmd.compareResult(res.Value)
 			if err != nil {
-				return fmt.Errorf("error in %s %s %w", cmd, iq.expr, err)
+				return fmt.Errorf("error in %s %s: %w", cmd, iq.expr, err)
 			}
 
 			// Check query returns same result in range mode,
@@ -564,7 +564,7 @@ func (t *Test) exec(tc testCommand) error {
 			}
 			rangeRes := q.Exec(t.context)
 			if rangeRes.Err != nil {
-				return fmt.Errorf("error evaluating query %q (line %d) in range mode %w", iq.expr, cmd.line, rangeRes.Err)
+				return fmt.Errorf("error evaluating query %q (line %d) in range mode: %w", iq.expr, cmd.line, rangeRes.Err)
 			}
 			defer q.Close()
 			if cmd.ordered {
@@ -587,7 +587,7 @@ func (t *Test) exec(tc testCommand) error {
 				err = cmd.compareResult(vec)
 			}
 			if err != nil {
-				return fmt.Errorf("error in %s %s (line %d) range mode %w", cmd, iq.expr, cmd.line, err)
+				return fmt.Errorf("error in %s %s (line %d) range mode: %w", cmd, iq.expr, cmd.line, err)
 			}
 
 		}
@@ -661,7 +661,7 @@ func parseNumber(s string) (float64, error) {
 		f, err = strconv.ParseFloat(s, 64)
 	}
 	if err != nil {
-		return 0, fmt.Errorf("error parsing number %w", err)
+		return 0, fmt.Errorf("error parsing number: %w", err)
 	}
 	return f, nil
 }

--- a/promql/test.go
+++ b/promql/test.go
@@ -15,6 +15,7 @@ package promql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -23,7 +24,6 @@ import (
 	"time"
 
 	"github.com/grafana/regexp"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
@@ -122,7 +122,7 @@ func (t *Test) ExemplarQueryable() storage.ExemplarQueryable {
 func raise(line int, format string, v ...interface{}) error {
 	return &parser.ParseErr{
 		LineOffset: line,
-		Err:        errors.Errorf(format, v...),
+		Err:        fmt.Errorf(format, v...),
 	}
 }
 
@@ -146,7 +146,8 @@ func parseLoad(lines []string, i int) (int, *loadCmd, error) {
 		}
 		metric, vals, err := parser.ParseSeriesDesc(defLine)
 		if err != nil {
-			if perr, ok := err.(*parser.ParseErr); ok {
+			var perr *parser.ParseErr
+			if errors.As(err, &perr) {
 				perr.LineOffset = i
 			}
 			return i, nil, err
@@ -168,7 +169,8 @@ func (t *Test) parseEval(lines []string, i int) (int, *evalCmd, error) {
 	)
 	_, err := parser.ParseExpr(expr)
 	if err != nil {
-		if perr, ok := err.(*parser.ParseErr); ok {
+		var perr *parser.ParseErr
+		if errors.As(err, &perr) {
 			perr.LineOffset = i
 			posOffset := parser.Pos(strings.Index(lines[i], expr))
 			perr.PositionRange.Start += posOffset
@@ -205,7 +207,8 @@ func (t *Test) parseEval(lines []string, i int) (int, *evalCmd, error) {
 		}
 		metric, vals, err := parser.ParseSeriesDesc(defLine)
 		if err != nil {
-			if perr, ok := err.(*parser.ParseErr); ok {
+			var perr *parser.ParseErr
+			if errors.As(err, &perr) {
 				perr.LineOffset = i
 			}
 			return i, nil, err
@@ -388,14 +391,14 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 		for pos, v := range val {
 			fp := v.Metric.Hash()
 			if _, ok := ev.metrics[fp]; !ok {
-				return errors.Errorf("unexpected metric %s in result", v.Metric)
+				return fmt.Errorf("unexpected metric %s in result", v.Metric)
 			}
 			exp := ev.expected[fp]
 			if ev.ordered && exp.pos != pos+1 {
-				return errors.Errorf("expected metric %s with %v at position %d but was at %d", v.Metric, exp.vals, exp.pos, pos+1)
+				return fmt.Errorf("expected metric %s with %v at position %d but was at %d", v.Metric, exp.vals, exp.pos, pos+1)
 			}
 			if !almostEqual(exp.vals[0].Value, v.V) {
-				return errors.Errorf("expected %v for %s but got %v", exp.vals[0].Value, v.Metric, v.V)
+				return fmt.Errorf("expected %v for %s but got %v", exp.vals[0].Value, v.Metric, v.V)
 			}
 
 			seen[fp] = true
@@ -406,17 +409,17 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 				for _, ss := range val {
 					fmt.Println("    ", ss.Metric, ss.Point)
 				}
-				return errors.Errorf("expected metric %s with %v not found", ev.metrics[fp], expVals)
+				return fmt.Errorf("expected metric %s with %v not found", ev.metrics[fp], expVals)
 			}
 		}
 
 	case Scalar:
 		if !almostEqual(ev.expected[0].vals[0].Value, val.V) {
-			return errors.Errorf("expected Scalar %v but got %v", val.V, ev.expected[0].vals[0].Value)
+			return fmt.Errorf("expected Scalar %v but got %v", val.V, ev.expected[0].vals[0].Value)
 		}
 
 	default:
-		panic(errors.Errorf("promql.Test.compareResult: unexpected result type %T", result))
+		panic(fmt.Errorf("promql.Test.compareResult: unexpected result type %T", result))
 	}
 	return nil
 }
@@ -543,14 +546,14 @@ func (t *Test) exec(tc testCommand) error {
 				if cmd.fail {
 					continue
 				}
-				return errors.Wrapf(res.Err, "error evaluating query %q (line %d)", iq.expr, cmd.line)
+				return fmt.Errorf("error evaluating query %q (line %d) %w", iq.expr, cmd.line, res.Err)
 			}
 			if res.Err == nil && cmd.fail {
-				return errors.Errorf("expected error evaluating query %q (line %d) but got none", iq.expr, cmd.line)
+				return fmt.Errorf("expected error evaluating query %q (line %d) but got none", iq.expr, cmd.line)
 			}
 			err = cmd.compareResult(res.Value)
 			if err != nil {
-				return errors.Wrapf(err, "error in %s %s", cmd, iq.expr)
+				return fmt.Errorf("error in %s %s %w", cmd, iq.expr, err)
 			}
 
 			// Check query returns same result in range mode,
@@ -561,7 +564,7 @@ func (t *Test) exec(tc testCommand) error {
 			}
 			rangeRes := q.Exec(t.context)
 			if rangeRes.Err != nil {
-				return errors.Wrapf(rangeRes.Err, "error evaluating query %q (line %d) in range mode", iq.expr, cmd.line)
+				return fmt.Errorf("error evaluating query %q (line %d) in range mode %w", iq.expr, cmd.line, rangeRes.Err)
 			}
 			defer q.Close()
 			if cmd.ordered {
@@ -584,7 +587,7 @@ func (t *Test) exec(tc testCommand) error {
 				err = cmd.compareResult(vec)
 			}
 			if err != nil {
-				return errors.Wrapf(err, "error in %s %s (line %d) range mode", cmd, iq.expr, cmd.line)
+				return fmt.Errorf("error in %s %s (line %d) range mode %w", cmd, iq.expr, cmd.line, err)
 			}
 
 		}
@@ -658,7 +661,7 @@ func parseNumber(s string) (float64, error) {
 		f, err = strconv.ParseFloat(s, 64)
 	}
 	if err != nil {
-		return 0, errors.Wrap(err, "error parsing number")
+		return 0, fmt.Errorf("error parsing number %w", err)
 	}
 	return f, nil
 }

--- a/promql/value.go
+++ b/promql/value.go
@@ -15,11 +15,10 @@ package promql
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	yaml "gopkg.in/yaml.v2"
 
@@ -73,7 +72,7 @@ func (s AlertState) String() string {
 	case StateFiring:
 		return "firing"
 	}
-	panic(errors.Errorf("unknown alert state: %d", s))
+	panic(fmt.Errorf("unknown alert state: %d", s))
 }
 
 // Alert is the user-level representation of a single instance of an alerting rule.
@@ -454,7 +453,7 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 
 	if limit > 0 && numActivePending > limit {
 		r.active = map[uint64]*Alert{}
-		return nil, errors.Errorf("exceeded limit of %d with %d alerts", limit, numActivePending)
+		return nil, fmt.Errorf("exceeded limit of %d with %d alerts", limit, numActivePending)
 	}
 
 	return vec, nil

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -15,12 +15,12 @@ package rules
 
 import (
 	"context"
+	"errors"
 	"html/template"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -1075,7 +1075,7 @@ func (m *Manager) LoadGroups(
 			for _, r := range rg.Rules {
 				expr, err := m.opts.GroupLoader.Parse(r.Expr.Value)
 				if err != nil {
-					return nil, []error{fmt.Errorf("%s %w", fn, err)}
+					return nil, []error{fmt.Errorf("%s: %w", fn, err)}
 				}
 
 				if r.Alert.Value != "" {

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -14,6 +14,7 @@
 package scrape
 
 import (
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"reflect"
@@ -22,7 +23,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -273,7 +273,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed 
 	client, err := config_util.NewClientFromConfig(cfg.HTTPClientConfig, cfg.JobName, httpOpts...)
 	if err != nil {
 		targetScrapePoolsFailed.Inc()
-		return nil, fmt.Errorf("error creating HTTP client %w", err)
+		return nil, fmt.Errorf("error creating HTTP client: %w", err)
 	}
 
 	buffers := pool.New(1e3, 100e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) })
@@ -385,7 +385,7 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 	client, err := config_util.NewClientFromConfig(cfg.HTTPClientConfig, cfg.JobName, sp.httpOpts...)
 	if err != nil {
 		targetScrapePoolReloadsFailed.Inc()
-		return fmt.Errorf("error creating HTTP client %w", err)
+		return fmt.Errorf("error creating HTTP client: %w", err)
 	}
 
 	reuseCache := reusableCache(sp.config, cfg)

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -31,7 +32,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -273,7 +273,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed 
 	client, err := config_util.NewClientFromConfig(cfg.HTTPClientConfig, cfg.JobName, httpOpts...)
 	if err != nil {
 		targetScrapePoolsFailed.Inc()
-		return nil, errors.Wrap(err, "error creating HTTP client")
+		return nil, fmt.Errorf("error creating HTTP client %w", err)
 	}
 
 	buffers := pool.New(1e3, 100e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) })
@@ -385,7 +385,7 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 	client, err := config_util.NewClientFromConfig(cfg.HTTPClientConfig, cfg.JobName, sp.httpOpts...)
 	if err != nil {
 		targetScrapePoolReloadsFailed.Inc()
-		return errors.Wrap(err, "error creating HTTP client")
+		return fmt.Errorf("error creating HTTP client %w", err)
 	}
 
 	reuseCache := reusableCache(sp.config, cfg)
@@ -777,7 +777,7 @@ func (s *targetScraper) scrape(ctx context.Context, w io.Writer) (string, error)
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf("server returned HTTP status %s", resp.Status)
+		return "", fmt.Errorf("server returned HTTP status %s", resp.Status)
 	}
 
 	if s.bodySizeLimit <= 0 {
@@ -1455,7 +1455,7 @@ loop:
 			sampleAdded bool
 		)
 		if et, err = p.Next(); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				err = nil
 			}
 			break
@@ -1528,7 +1528,7 @@ loop:
 		ref, err = app.Append(ref, lset, t, v)
 		sampleAdded, err = sl.checkAddError(ce, met, tp, err, &sampleLimitErr, &appErrs)
 		if err != nil {
-			if err != storage.ErrNotFound {
+			if !errors.Is(err, storage.ErrNotFound) {
 				level.Debug(sl.l).Log("msg", "Unexpected error", "series", string(met), "err", err)
 			}
 			break loop
@@ -1586,8 +1586,8 @@ loop:
 		sl.cache.forEachStale(func(lset labels.Labels) bool {
 			// Series no longer exposed, mark it stale.
 			_, err = app.Append(0, lset, defTime, math.Float64frombits(value.StaleNaN))
-			switch errors.Cause(err) {
-			case storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp:
+			switch {
+			case errors.Is(errors.Unwrap(err), storage.ErrOutOfOrderSample), errors.Is(errors.Unwrap(err), storage.ErrDuplicateSampleForTimestamp):
 				// Do not count these in logging, as this is expected if a target
 				// goes away and comes back again with a new scrape loop.
 				err = nil
@@ -1605,30 +1605,30 @@ func yoloString(b []byte) string {
 // Adds samples to the appender, checking the error, and then returns the # of samples added,
 // whether the caller should continue to process more samples, and any sample limit errors.
 func (sl *scrapeLoop) checkAddError(ce *cacheEntry, met []byte, tp *int64, err error, sampleLimitErr *error, appErrs *appendErrors) (bool, error) {
-	switch errors.Cause(err) {
-	case nil:
+	switch {
+	case errors.Unwrap(err) == nil:
 		if tp == nil && ce != nil {
 			sl.cache.trackStaleness(ce.hash, ce.lset)
 		}
 		return true, nil
-	case storage.ErrNotFound:
+	case errors.Is(errors.Unwrap(err), storage.ErrNotFound):
 		return false, storage.ErrNotFound
-	case storage.ErrOutOfOrderSample:
+	case errors.Is(errors.Unwrap(err), storage.ErrOutOfOrderSample):
 		appErrs.numOutOfOrder++
 		level.Debug(sl.l).Log("msg", "Out of order sample", "series", string(met))
 		targetScrapeSampleOutOfOrder.Inc()
 		return false, nil
-	case storage.ErrDuplicateSampleForTimestamp:
+	case errors.Is(errors.Unwrap(err), storage.ErrDuplicateSampleForTimestamp):
 		appErrs.numDuplicates++
 		level.Debug(sl.l).Log("msg", "Duplicate sample for timestamp", "series", string(met))
 		targetScrapeSampleDuplicate.Inc()
 		return false, nil
-	case storage.ErrOutOfBounds:
+	case errors.Is(errors.Unwrap(err), storage.ErrOutOfBounds):
 		appErrs.numOutOfBounds++
 		level.Debug(sl.l).Log("msg", "Out of bounds metric", "series", string(met))
 		targetScrapeSampleOutOfBounds.Inc()
 		return false, nil
-	case errSampleLimit:
+	case errors.Is(errors.Unwrap(err), errSampleLimit):
 		// Keep on parsing output if we hit the limit, so we report the correct
 		// total number of samples scraped.
 		*sampleLimitErr = err
@@ -1639,10 +1639,10 @@ func (sl *scrapeLoop) checkAddError(ce *cacheEntry, met []byte, tp *int64, err e
 }
 
 func (sl *scrapeLoop) checkAddExemplarError(err error, e exemplar.Exemplar, appErrs *appendErrors) error {
-	switch errors.Cause(err) {
-	case storage.ErrNotFound:
+	switch {
+	case errors.Is(errors.Unwrap(err), storage.ErrNotFound):
 		return storage.ErrNotFound
-	case storage.ErrOutOfOrderExemplar:
+	case errors.Is(errors.Unwrap(err), storage.ErrOutOfOrderExemplar):
 		appErrs.numExemplarOutOfOrder++
 		level.Debug(sl.l).Log("msg", "Out of order exemplar", "exemplar", fmt.Sprintf("%+v", e))
 		targetScrapeExemplarOutOfOrder.Inc()
@@ -1756,13 +1756,13 @@ func (sl *scrapeLoop) addReportSample(app storage.Appender, s string, t int64, v
 	}
 
 	ref, err := app.Append(ref, lset, t, v)
-	switch errors.Cause(err) {
-	case nil:
+	switch {
+	case errors.Unwrap(err) == nil:
 		if !ok {
 			sl.cache.addRef(s, ref, lset, lset.Hash())
 		}
 		return nil
-	case storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp:
+	case errors.Is(errors.Unwrap(err), storage.ErrOutOfOrderSample), errors.Is(errors.Unwrap(err), storage.ErrDuplicateSampleForTimestamp):
 		// Do not log here, as this is expected if a target goes away and comes back
 		// again with a new scrape loop.
 		return nil

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -29,7 +30,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -792,7 +792,7 @@ func TestScrapeLoopRun(t *testing.T) {
 
 	select {
 	case err := <-errc:
-		if err != context.DeadlineExceeded {
+		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("Expected timeout error but got: %s", err)
 		}
 	case <-time.After(3 * time.Second):
@@ -856,7 +856,7 @@ func TestScrapeLoopForcedErr(t *testing.T) {
 
 	select {
 	case err := <-errc:
-		if err != forcedErr {
+		if !errors.Is(err, forcedErr) {
 			t.Fatalf("Expected forced error but got: %s", err)
 		}
 	case <-time.After(3 * time.Second):
@@ -1540,7 +1540,7 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 	now := time.Now()
 	slApp := sl.appender(context.Background())
 	total, added, seriesAdded, err := sl.append(app, []byte("metric_a 1\nmetric_b 1\nmetric_c 1\n"), "", now)
-	if err != errSampleLimit {
+	if !errors.Is(err, errSampleLimit) {
 		t.Fatalf("Did not see expected sample limit error: %s", err)
 	}
 	require.NoError(t, slApp.Rollback())
@@ -1571,7 +1571,7 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 	now = time.Now()
 	slApp = sl.appender(context.Background())
 	total, added, seriesAdded, err = sl.append(slApp, []byte("metric_a 1\nmetric_b 1\nmetric_c{deleteme=\"yes\"} 1\nmetric_d 1\nmetric_e 1\nmetric_f 1\nmetric_g 1\nmetric_h{deleteme=\"yes\"} 1\nmetric_i{deleteme=\"yes\"} 1\n"), "", now)
-	if err != errSampleLimit {
+	if !errors.Is(err, errSampleLimit) {
 		t.Fatalf("Did not see expected sample limit error: %s", err)
 	}
 	require.NoError(t, slApp.Rollback())
@@ -2131,8 +2131,8 @@ func TestTargetScrapeScrapeCancel(t *testing.T) {
 		_, err := ts.scrape(ctx, io.Discard)
 		if err == nil {
 			errc <- errors.New("Expected error but got nil")
-		} else if ctx.Err() != context.Canceled {
-			errc <- errors.Errorf("Expected context cancellation error but got: %s", ctx.Err())
+		} else if !errors.Is(ctx.Err(), context.Canceled) {
+			errc <- fmt.Errorf("Expected context cancellation error but got: %w", ctx.Err())
 		} else {
 			close(errc)
 		}

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -14,6 +14,7 @@
 package scrape
 
 import (
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"net"
@@ -22,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/config"
@@ -283,12 +283,12 @@ func (t *Target) intervalAndTimeout(defaultInterval, defaultDuration time.Durati
 	intervalLabel := t.labels.Get(model.ScrapeIntervalLabel)
 	interval, err := model.ParseDuration(intervalLabel)
 	if err != nil {
-		return defaultInterval, defaultDuration, errors.Errorf("Error parsing interval label %q: %v", intervalLabel, err)
+		return defaultInterval, defaultDuration, fmt.Errorf("Error parsing interval label %q: %w", intervalLabel, err)
 	}
 	timeoutLabel := t.labels.Get(model.ScrapeTimeoutLabel)
 	timeout, err := model.ParseDuration(timeoutLabel)
 	if err != nil {
-		return defaultInterval, defaultDuration, errors.Errorf("Error parsing timeout label %q: %v", timeoutLabel, err)
+		return defaultInterval, defaultDuration, fmt.Errorf("Error parsing timeout label %q: %w", timeoutLabel, err)
 	}
 
 	return time.Duration(interval), time.Duration(timeout), nil
@@ -409,7 +409,7 @@ func PopulateLabels(lset labels.Labels, cfg *config.ScrapeConfig) (res, orig lab
 		case "https":
 			addr = addr + ":443"
 		default:
-			return nil, nil, errors.Errorf("invalid scheme: %q", cfg.Scheme)
+			return nil, nil, fmt.Errorf("invalid scheme: %q", cfg.Scheme)
 		}
 		lb.Set(model.AddressLabel, addr)
 	}
@@ -421,7 +421,7 @@ func PopulateLabels(lset labels.Labels, cfg *config.ScrapeConfig) (res, orig lab
 	interval := lset.Get(model.ScrapeIntervalLabel)
 	intervalDuration, err := model.ParseDuration(interval)
 	if err != nil {
-		return nil, nil, errors.Errorf("error parsing scrape interval: %v", err)
+		return nil, nil, fmt.Errorf("error parsing scrape interval: %w", err)
 	}
 	if time.Duration(intervalDuration) == 0 {
 		return nil, nil, errors.New("scrape interval cannot be 0")
@@ -430,14 +430,14 @@ func PopulateLabels(lset labels.Labels, cfg *config.ScrapeConfig) (res, orig lab
 	timeout := lset.Get(model.ScrapeTimeoutLabel)
 	timeoutDuration, err := model.ParseDuration(timeout)
 	if err != nil {
-		return nil, nil, errors.Errorf("error parsing scrape timeout: %v", err)
+		return nil, nil, fmt.Errorf("error parsing scrape timeout: %w", err)
 	}
 	if time.Duration(timeoutDuration) == 0 {
 		return nil, nil, errors.New("scrape timeout cannot be 0")
 	}
 
 	if timeoutDuration > intervalDuration {
-		return nil, nil, errors.Errorf("scrape timeout cannot be greater than scrape interval (%q > %q)", timeout, interval)
+		return nil, nil, fmt.Errorf("scrape timeout cannot be greater than scrape interval (%q > %q)", timeout, interval)
 	}
 
 	// Meta labels are deleted after relabelling. Other internal labels propagate to
@@ -457,7 +457,7 @@ func PopulateLabels(lset labels.Labels, cfg *config.ScrapeConfig) (res, orig lab
 	for _, l := range res {
 		// Check label values are valid, drop the target if not.
 		if !model.LabelValue(l.Value).IsValid() {
-			return nil, nil, errors.Errorf("invalid label value for %q: %q", l.Name, l.Value)
+			return nil, nil, fmt.Errorf("invalid label value for %q: %q", l.Name, l.Value)
 		}
 	}
 	return res, preRelabelLabels, nil
@@ -484,7 +484,7 @@ func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig) ([]*Targe
 
 		lbls, origLabels, err := PopulateLabels(lset, cfg)
 		if err != nil {
-			failures = append(failures, errors.Wrapf(err, "instance %d in group %s", i, tg))
+			failures = append(failures, fmt.Errorf("instance %d in group %s %w", i, tg, err))
 		}
 		if lbls != nil || origLabels != nil {
 			targets = append(targets, NewTarget(lbls, origLabels, cfg.Params))

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -484,7 +484,7 @@ func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig) ([]*Targe
 
 		lbls, origLabels, err := PopulateLabels(lset, cfg)
 		if err != nil {
-			failures = append(failures, fmt.Errorf("instance %d in group %s %w", i, tg, err))
+			failures = append(failures, fmt.Errorf("instance %d in group %s: %w", i, tg, err))
 		}
 		if lbls != nil || origLabels != nil {
 			targets = append(targets, NewTarget(lbls, origLabels, cfg.Params))

--- a/storage/fanout_test.go
+++ b/storage/fanout_test.go
@@ -15,9 +15,9 @@ package storage_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 

--- a/storage/merge.go
+++ b/storage/merge.go
@@ -158,7 +158,7 @@ func (l labelGenericQueriers) SplitByHalf() (labelGenericQueriers, labelGenericQ
 func (q *mergeGenericQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, Warnings, error) {
 	res, ws, err := q.lvals(q.queriers, name, matchers...)
 	if err != nil {
-		return nil, nil, fmt.Errorf("LabelValues() from merge generic querier for label %s %w", name, err)
+		return nil, nil, fmt.Errorf("LabelValues() from merge generic querier for label %s: %w", name, err)
 	}
 	return res, ws, nil
 }
@@ -226,7 +226,7 @@ func (q *mergeGenericQuerier) LabelNames(matchers ...*labels.Matcher) ([]string,
 			warnings = append(warnings, wrn...)
 		}
 		if err != nil {
-			return nil, nil, fmt.Errorf("LabelNames() from merge generic querier %w", err)
+			return nil, nil, fmt.Errorf("LabelNames() from merge generic querier: %w", err)
 		}
 		for _, name := range names {
 			labelNamesMap[name] = struct{}{}

--- a/storage/merge.go
+++ b/storage/merge.go
@@ -16,11 +16,10 @@ package storage
 import (
 	"bytes"
 	"container/heap"
+	"fmt"
 	"math"
 	"sort"
 	"sync"
-
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -159,7 +158,7 @@ func (l labelGenericQueriers) SplitByHalf() (labelGenericQueriers, labelGenericQ
 func (q *mergeGenericQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, Warnings, error) {
 	res, ws, err := q.lvals(q.queriers, name, matchers...)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "LabelValues() from merge generic querier for label %s", name)
+		return nil, nil, fmt.Errorf("LabelValues() from merge generic querier for label %s %w", name, err)
 	}
 	return res, ws, nil
 }
@@ -227,7 +226,7 @@ func (q *mergeGenericQuerier) LabelNames(matchers ...*labels.Matcher) ([]string,
 			warnings = append(warnings, wrn...)
 		}
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "LabelNames() from merge generic querier")
+			return nil, nil, fmt.Errorf("LabelNames() from merge generic querier %w", err)
 		}
 		for _, name := range names {
 			labelNamesMap[name] = struct{}{}

--- a/storage/merge_test.go
+++ b/storage/merge_test.go
@@ -14,13 +14,13 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sort"
 	"sync"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"

--- a/storage/remote/chunked.go
+++ b/storage/remote/chunked.go
@@ -16,13 +16,14 @@ package remote
 import (
 	"bufio"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"hash"
 	"hash/crc32"
 	"io"
 	"net/http"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 // DefaultChunkedReadLimit is the default value for the maximum size of the protobuf frame client allows.
@@ -119,7 +120,7 @@ func (r *ChunkedReader) Next() ([]byte, error) {
 	}
 
 	if size > r.sizeLimit {
-		return nil, errors.Errorf("chunkedReader: message size exceeded the limit %v bytes; got: %v bytes", r.sizeLimit, size)
+		return nil, fmt.Errorf("chunkedReader: message size exceeded the limit %v bytes; got: %v bytes", r.sizeLimit, size)
 	}
 
 	if cap(r.data) < int(size) {

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -222,7 +221,7 @@ func (c *Client) Store(ctx context.Context, req []byte) error {
 		if scanner.Scan() {
 			line = scanner.Text()
 		}
-		err = errors.Errorf("server returned HTTP status %s: %s", httpResp.Status, line)
+		err = fmt.Errorf("server returned HTTP status %s: %s", httpResp.Status, line)
 	}
 	if httpResp.StatusCode/100 == 5 {
 		return RecoverableError{err, defaultBackoff}
@@ -273,13 +272,13 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query) (*prompb.QueryRe
 	}
 	data, err := proto.Marshal(req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to marshal read request")
+		return nil, fmt.Errorf("unable to marshal read request %w", err)
 	}
 
 	compressed := snappy.Encode(nil, data)
 	httpReq, err := http.NewRequest("POST", c.url.String(), bytes.NewReader(compressed))
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create request")
+		return nil, fmt.Errorf("unable to create request %w", err)
 	}
 	httpReq.Header.Add("Content-Encoding", "snappy")
 	httpReq.Header.Add("Accept-Encoding", "snappy")
@@ -296,7 +295,7 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query) (*prompb.QueryRe
 	start := time.Now()
 	httpResp, err := c.Client.Do(httpReq.WithContext(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "error sending request")
+		return nil, fmt.Errorf("error sending request %w", err)
 	}
 	defer func() {
 		io.Copy(io.Discard, httpResp.Body)
@@ -307,26 +306,26 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query) (*prompb.QueryRe
 
 	compressed, err = io.ReadAll(httpResp.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error reading response. HTTP status code: %s", httpResp.Status))
+		return nil, fmt.Errorf("error reading response. HTTP status code: %s %w", httpResp.Status, err)
 	}
 
 	if httpResp.StatusCode/100 != 2 {
-		return nil, errors.Errorf("remote server %s returned HTTP status %s: %s", c.url.String(), httpResp.Status, strings.TrimSpace(string(compressed)))
+		return nil, fmt.Errorf("remote server %s returned HTTP status %s: %s", c.url.String(), httpResp.Status, strings.TrimSpace(string(compressed)))
 	}
 
 	uncompressed, err := snappy.Decode(nil, compressed)
 	if err != nil {
-		return nil, errors.Wrap(err, "error reading response")
+		return nil, fmt.Errorf("error reading response %w", err)
 	}
 
 	var resp prompb.ReadResponse
 	err = proto.Unmarshal(uncompressed, &resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to unmarshal response body")
+		return nil, fmt.Errorf("unable to unmarshal response body %w", err)
 	}
 
 	if len(resp.Results) != len(req.Queries) {
-		return nil, errors.Errorf("responses: want %d, got %d", len(req.Queries), len(resp.Results))
+		return nil, fmt.Errorf("responses: want %d, got %d", len(req.Queries), len(resp.Results))
 	}
 
 	return resp.Results[0], nil

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -15,6 +15,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -22,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -111,7 +111,8 @@ func TestClientRetryAfter(t *testing.T) {
 
 	c := getClient(conf)
 	err = c.Store(context.Background(), []byte{})
-	_, ok := err.(RecoverableError)
+	var re RecoverableError
+	ok := errors.As(err, &re)
 	require.False(t, ok, "Recoverable error not expected.")
 
 	conf = &ClientConfig{
@@ -122,7 +123,7 @@ func TestClientRetryAfter(t *testing.T) {
 
 	c = getClient(conf)
 	err = c.Store(context.Background(), []byte{})
-	_, ok = err.(RecoverableError)
+	ok = errors.As(err, &re)
 	require.True(t, ok, "Recoverable error was expected.")
 }
 

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -14,6 +14,7 @@
 package remote
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,7 +23,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -180,7 +180,7 @@ func NegotiateResponseType(accepted []prompb.ReadRequest_ResponseType) (prompb.R
 			return resType, nil
 		}
 	}
-	return 0, errors.Errorf("server does not support any of the requested response types: %v; supported: %v", accepted, supported)
+	return 0, fmt.Errorf("server does not support any of the requested response types: %v; supported: %v", accepted, supported)
 }
 
 // StreamChunkedReadResponses iterates over series, builds chunks and streams those to the caller.
@@ -214,7 +214,7 @@ func StreamChunkedReadResponses(
 			chk := iter.At()
 
 			if chk.Chunk == nil {
-				return ss.Warnings(), errors.Errorf("StreamChunkedReadResponses: found not populated chunk returned by SeriesSet at ref: %v", chk.Ref)
+				return ss.Warnings(), fmt.Errorf("StreamChunkedReadResponses: found not populated chunk returned by SeriesSet at ref: %v", chk.Ref)
 			}
 
 			// Cut the chunk.
@@ -239,11 +239,11 @@ func StreamChunkedReadResponses(
 				QueryIndex: queryIndex,
 			})
 			if err != nil {
-				return ss.Warnings(), errors.Wrap(err, "marshal ChunkedReadResponse")
+				return ss.Warnings(), fmt.Errorf("marshal ChunkedReadResponse %w", err)
 			}
 
 			if _, err := stream.Write(b); err != nil {
-				return ss.Warnings(), errors.Wrap(err, "write to stream")
+				return ss.Warnings(), fmt.Errorf("write to stream %w", err)
 			}
 			chks = chks[:0]
 		}
@@ -395,16 +395,16 @@ func (c *concreteSeriesIterator) Err() error {
 func validateLabelsAndMetricName(ls labels.Labels) error {
 	for i, l := range ls {
 		if l.Name == labels.MetricName && !model.IsValidMetricName(model.LabelValue(l.Value)) {
-			return errors.Errorf("invalid metric name: %v", l.Value)
+			return fmt.Errorf("invalid metric name: %v", l.Value)
 		}
 		if !model.LabelName(l.Name).IsValid() {
-			return errors.Errorf("invalid label name: %v", l.Name)
+			return fmt.Errorf("invalid label name: %v", l.Name)
 		}
 		if !model.LabelValue(l.Value).IsValid() {
-			return errors.Errorf("invalid label value: %v", l.Value)
+			return fmt.Errorf("invalid label value: %v", l.Value)
 		}
 		if i > 0 && l.Name == ls[i-1].Name {
-			return errors.Errorf("duplicate label with name: %v", l.Name)
+			return fmt.Errorf("duplicate label with name: %v", l.Name)
 		}
 	}
 	return nil

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -239,11 +239,11 @@ func StreamChunkedReadResponses(
 				QueryIndex: queryIndex,
 			})
 			if err != nil {
-				return ss.Warnings(), fmt.Errorf("marshal ChunkedReadResponse %w", err)
+				return ss.Warnings(), fmt.Errorf("marshal ChunkedReadResponse: %w", err)
 			}
 
 			if _, err := stream.Write(b); err != nil {
-				return ss.Warnings(), fmt.Errorf("write to stream %w", err)
+				return ss.Warnings(), fmt.Errorf("write to stream: %w", err)
 			}
 			chks = chks[:0]
 		}

--- a/storage/remote/metadata_watcher.go
+++ b/storage/remote/metadata_watcher.go
@@ -15,11 +15,11 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/scrape"

--- a/storage/remote/metadata_watcher_test.go
+++ b/storage/remote/metadata_watcher_test.go
@@ -15,10 +15,10 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1374,8 +1374,8 @@ func sendWriteRequestWithBackoff(ctx context.Context, cfg config.QueueConfig, l 
 		}
 
 		// If the error is unrecoverable, we should not retry.
-		backoffErr, ok := err.(RecoverableError)
-		if !ok {
+		var backoffErr RecoverableError
+		if !errors.As(err, &backoffErr) {
 			return err
 		}
 

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -15,8 +15,8 @@ package remote
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -164,12 +164,12 @@ func (q *querier) Select(sortSeries bool, hints *storage.SelectHints, matchers .
 	m, added := q.addExternalLabels(matchers)
 	query, err := ToQuery(q.mint, q.maxt, m, hints)
 	if err != nil {
-		return storage.ErrSeriesSet(errors.Wrap(err, "toQuery"))
+		return storage.ErrSeriesSet(fmt.Errorf("toQuery %w", err))
 	}
 
 	res, err := q.client.Read(q.ctx, query)
 	if err != nil {
-		return storage.ErrSeriesSet(errors.Wrap(err, "remote_read"))
+		return storage.ErrSeriesSet(fmt.Errorf("remote_read %w", err))
 	}
 	return newSeriesSetFilter(FromQueryResult(sortSeries, res), added)
 }

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -164,12 +164,12 @@ func (q *querier) Select(sortSeries bool, hints *storage.SelectHints, matchers .
 	m, added := q.addExternalLabels(matchers)
 	query, err := ToQuery(q.mint, q.maxt, m, hints)
 	if err != nil {
-		return storage.ErrSeriesSet(fmt.Errorf("toQuery %w", err))
+		return storage.ErrSeriesSet(fmt.Errorf("toQuery: %w", err))
 	}
 
 	res, err := q.client.Read(q.ctx, query)
 	if err != nil {
-		return storage.ErrSeriesSet(fmt.Errorf("remote_read %w", err))
+		return storage.ErrSeriesSet(fmt.Errorf("remote_read: %w", err))
 	}
 	return newSeriesSetFilter(FromQueryResult(sortSeries, res), added)
 }

--- a/storage/remote/read_handler.go
+++ b/storage/remote/read_handler.go
@@ -15,6 +15,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sort"
 
@@ -164,7 +165,8 @@ func (h *readHandler) remoteReadSamples(
 			}
 			return nil
 		}(); err != nil {
-			if httpErr, ok := err.(HTTPError); ok {
+			var httpErr HTTPError
+			if errors.As(err, &httpErr) {
 				http.Error(w, httpErr.Error(), httpErr.Status())
 				return
 			}
@@ -235,7 +237,8 @@ func (h *readHandler) remoteReadStreamedXORChunks(ctx context.Context, w http.Re
 			}
 			return nil
 		}(); err != nil {
-			if httpErr, ok := err.(HTTPError); ok {
+			var httpErr HTTPError
+			if errors.As(err, &httpErr) {
 				http.Error(w, httpErr.Error(), httpErr.Status())
 				return
 			}

--- a/storage/remote/read_handler_test.go
+++ b/storage/remote/read_handler_test.go
@@ -15,6 +15,7 @@ package remote
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -194,7 +195,7 @@ func TestStreamReadEndpoint(t *testing.T) {
 	for {
 		res := &prompb.ChunkedReadResponse{}
 		err := stream.NextProto(res)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -15,11 +15,11 @@ package remote
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"sort"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/stretchr/testify/require"
@@ -209,7 +209,7 @@ type mockedRemoteClient struct {
 
 func (c *mockedRemoteClient) Read(_ context.Context, query *prompb.Query) (*prompb.QueryResult, error) {
 	if c.got != nil {
-		return nil, errors.Errorf("expected only one call to remote client got: %v", query)
+		return nil, fmt.Errorf("expected only one call to remote client got: %v", query)
 	}
 	c.got = query
 

--- a/template/template.go
+++ b/template/template.go
@@ -16,6 +16,7 @@ package template
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	html_template "html/template"
 	"math"
@@ -28,7 +29,6 @@ import (
 	"time"
 
 	"github.com/grafana/regexp"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
@@ -375,7 +375,7 @@ func (te Expander) Expand() (result string, resultErr error) {
 			var ok bool
 			resultErr, ok = r.(error)
 			if !ok {
-				resultErr = errors.Errorf("panic expanding template %v: %v", te.name, r)
+				resultErr = fmt.Errorf("panic expanding template %v: %v", te.name, r)
 			}
 		}
 		if resultErr != nil {
@@ -389,12 +389,12 @@ func (te Expander) Expand() (result string, resultErr error) {
 	tmpl.Option(te.options...)
 	tmpl, err := tmpl.Parse(te.text)
 	if err != nil {
-		return "", errors.Wrapf(err, "error parsing template %v", te.name)
+		return "", fmt.Errorf("error parsing template %v %w", te.name, err)
 	}
 	var buffer bytes.Buffer
 	err = tmpl.Execute(&buffer, te.data)
 	if err != nil {
-		return "", errors.Wrapf(err, "error executing template %v", te.name)
+		return "", fmt.Errorf("error executing template %v %w", te.name, err)
 	}
 	return buffer.String(), nil
 }
@@ -406,7 +406,7 @@ func (te Expander) ExpandHTML(templateFiles []string) (result string, resultErr 
 			var ok bool
 			resultErr, ok = r.(error)
 			if !ok {
-				resultErr = errors.Errorf("panic expanding template %s: %v", te.name, r)
+				resultErr = fmt.Errorf("panic expanding template %s: %v", te.name, r)
 			}
 		}
 	}()
@@ -422,18 +422,18 @@ func (te Expander) ExpandHTML(templateFiles []string) (result string, resultErr 
 	})
 	tmpl, err := tmpl.Parse(te.text)
 	if err != nil {
-		return "", errors.Wrapf(err, "error parsing template %v", te.name)
+		return "", fmt.Errorf("error parsing template %v %w", te.name, err)
 	}
 	if len(templateFiles) > 0 {
 		_, err = tmpl.ParseFiles(templateFiles...)
 		if err != nil {
-			return "", errors.Wrapf(err, "error parsing template files for %v", te.name)
+			return "", fmt.Errorf("error parsing template files for %v %w", te.name, err)
 		}
 	}
 	var buffer bytes.Buffer
 	err = tmpl.Execute(&buffer, te.data)
 	if err != nil {
-		return "", errors.Wrapf(err, "error executing template %v", te.name)
+		return "", fmt.Errorf("error executing template %v %w", te.name, err)
 	}
 	return buffer.String(), nil
 }

--- a/template/template.go
+++ b/template/template.go
@@ -389,12 +389,12 @@ func (te Expander) Expand() (result string, resultErr error) {
 	tmpl.Option(te.options...)
 	tmpl, err := tmpl.Parse(te.text)
 	if err != nil {
-		return "", fmt.Errorf("error parsing template %v %w", te.name, err)
+		return "", fmt.Errorf("error parsing template %v: %w", te.name, err)
 	}
 	var buffer bytes.Buffer
 	err = tmpl.Execute(&buffer, te.data)
 	if err != nil {
-		return "", fmt.Errorf("error executing template %v %w", te.name, err)
+		return "", fmt.Errorf("error executing template %v: %w", te.name, err)
 	}
 	return buffer.String(), nil
 }
@@ -422,18 +422,18 @@ func (te Expander) ExpandHTML(templateFiles []string) (result string, resultErr 
 	})
 	tmpl, err := tmpl.Parse(te.text)
 	if err != nil {
-		return "", fmt.Errorf("error parsing template %v %w", te.name, err)
+		return "", fmt.Errorf("error parsing template %v: %w", te.name, err)
 	}
 	if len(templateFiles) > 0 {
 		_, err = tmpl.ParseFiles(templateFiles...)
 		if err != nil {
-			return "", fmt.Errorf("error parsing template files for %v %w", te.name, err)
+			return "", fmt.Errorf("error parsing template files for %v: %w", te.name, err)
 		}
 	}
 	var buffer bytes.Buffer
 	err = tmpl.Execute(&buffer, te.data)
 	if err != nil {
-		return "", fmt.Errorf("error executing template %v %w", te.name, err)
+		return "", fmt.Errorf("error executing template %v: %w", te.name, err)
 	}
 	return buffer.String(), nil
 }

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -79,7 +79,7 @@ func (m *Manager) ApplyConfig(cfg *config.Config) error {
 
 	if m.shutdownFunc != nil {
 		if err := m.shutdownFunc(); err != nil {
-			return fmt.Errorf("failed to shut down the tracer provider %w", err)
+			return fmt.Errorf("failed to shut down the tracer provider: %w", err)
 		}
 	}
 
@@ -94,7 +94,7 @@ func (m *Manager) ApplyConfig(cfg *config.Config) error {
 
 	tp, shutdownFunc, err := buildTracerProvider(context.Background(), cfg.TracingConfig)
 	if err != nil {
-		return fmt.Errorf("failed to install a new tracer provider %w", err)
+		return fmt.Errorf("failed to install a new tracer provider: %w", err)
 	}
 
 	m.shutdownFunc = shutdownFunc

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -15,12 +15,12 @@ package tracing
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/version"
 	"go.opentelemetry.io/otel"
@@ -79,7 +79,7 @@ func (m *Manager) ApplyConfig(cfg *config.Config) error {
 
 	if m.shutdownFunc != nil {
 		if err := m.shutdownFunc(); err != nil {
-			return errors.Wrap(err, "failed to shut down the tracer provider")
+			return fmt.Errorf("failed to shut down the tracer provider %w", err)
 		}
 	}
 
@@ -94,7 +94,7 @@ func (m *Manager) ApplyConfig(cfg *config.Config) error {
 
 	tp, shutdownFunc, err := buildTracerProvider(context.Background(), cfg.TracingConfig)
 	if err != nil {
-		return errors.Wrap(err, "failed to install a new tracer provider")
+		return fmt.Errorf("failed to install a new tracer provider %w", err)
 	}
 
 	m.shutdownFunc = shutdownFunc

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -255,7 +255,7 @@ func Open(l log.Logger, reg prometheus.Registerer, rs *remote.Storage, dir strin
 
 	w, err := wal.NewSize(l, reg, dir, opts.WALSegmentSize, opts.WALCompression)
 	if err != nil {
-		return nil, fmt.Errorf("creating WAL %w", err)
+		return nil, fmt.Errorf("creating WAL: %w", err)
 	}
 
 	db := &DB{
@@ -292,7 +292,7 @@ func Open(l log.Logger, reg prometheus.Registerer, rs *remote.Storage, dir strin
 	if err := db.replayWAL(); err != nil {
 		level.Warn(db.logger).Log("msg", "encountered WAL read error, attempting repair", "err", err)
 		if err := w.Repair(err); err != nil {
-			return nil, fmt.Errorf("repair corrupted WAL %w", err)
+			return nil, fmt.Errorf("repair corrupted WAL: %w", err)
 		}
 	}
 
@@ -334,7 +334,7 @@ func (db *DB) replayWAL() error {
 
 	dir, startFrom, err := wal.LastCheckpoint(db.wal.Dir())
 	if err != nil && !errors.Is(err, record.ErrNotFound) {
-		return fmt.Errorf("find last checkpoint %w", err)
+		return fmt.Errorf("find last checkpoint: %w", err)
 	}
 
 	multiRef := map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{}
@@ -342,7 +342,7 @@ func (db *DB) replayWAL() error {
 	if err == nil {
 		sr, err := wal.NewSegmentsReader(dir)
 		if err != nil {
-			return fmt.Errorf("open checkpoint %w", err)
+			return fmt.Errorf("open checkpoint: %w", err)
 		}
 		defer func() {
 			if err := sr.Close(); err != nil {
@@ -353,7 +353,7 @@ func (db *DB) replayWAL() error {
 		// A corrupted checkpoint is a hard error for now and requires user
 		// intervention. There's likely little data that can be recovered anyway.
 		if err := db.loadWAL(wal.NewReader(sr), multiRef); err != nil {
-			return fmt.Errorf("backfill checkpoint %w", err)
+			return fmt.Errorf("backfill checkpoint: %w", err)
 		}
 		startFrom++
 		level.Info(db.logger).Log("msg", "WAL checkpoint loaded")
@@ -362,14 +362,14 @@ func (db *DB) replayWAL() error {
 	// Find the last segment.
 	_, last, err := wal.Segments(db.wal.Dir())
 	if err != nil {
-		return fmt.Errorf("finding WAL segments %w", err)
+		return fmt.Errorf("finding WAL segments: %w", err)
 	}
 
 	// Backfil segments from the most recent checkpoint onwards.
 	for i := startFrom; i <= last; i++ {
 		seg, err := wal.OpenReadSegment(wal.SegmentName(db.wal.Dir(), i))
 		if err != nil {
-			return fmt.Errorf("open WAL segment: %d %w", i, err)
+			return fmt.Errorf("open WAL segment: %d: %w", i, err)
 		}
 
 		sr := wal.NewSegmentBufReader(seg)
@@ -419,7 +419,7 @@ func (db *DB) loadWAL(r *wal.Reader, multiRef map[chunks.HeadSeriesRef]chunks.He
 				series, err = dec.Series(rec, series)
 				if err != nil {
 					errCh <- &wal.CorruptionErr{
-						Err:     fmt.Errorf("decode series %w", err),
+						Err:     fmt.Errorf("decode series: %w", err),
 						Segment: r.Segment(),
 						Offset:  r.Offset(),
 					}
@@ -431,7 +431,7 @@ func (db *DB) loadWAL(r *wal.Reader, multiRef map[chunks.HeadSeriesRef]chunks.He
 				samples, err = dec.Samples(rec, samples)
 				if err != nil {
 					errCh <- &wal.CorruptionErr{
-						Err:     fmt.Errorf("decode samples %w", err),
+						Err:     fmt.Errorf("decode samples: %w", err),
 						Segment: r.Segment(),
 						Offset:  r.Offset(),
 					}
@@ -507,7 +507,7 @@ func (db *DB) loadWAL(r *wal.Reader, multiRef map[chunks.HeadSeriesRef]chunks.He
 		return err
 	default:
 		if r.Err() != nil {
-			return fmt.Errorf("read records %w", r.Err())
+			return fmt.Errorf("read records: %w", r.Err())
 		}
 		return nil
 	}
@@ -561,14 +561,14 @@ func (db *DB) truncate(mint int64) error {
 
 	first, last, err := wal.Segments(db.wal.Dir())
 	if err != nil {
-		return fmt.Errorf("get segment range %w", err)
+		return fmt.Errorf("get segment range: %w", err)
 	}
 
 	// Start a new segment so low ingestion volume instances don't have more WAL
 	// than needed.
 	err = db.wal.NextSegment()
 	if err != nil {
-		return fmt.Errorf("next segment %w", err)
+		return fmt.Errorf("next segment: %w", err)
 	}
 
 	last-- // Never consider most recent segment for checkpoint
@@ -600,7 +600,7 @@ func (db *DB) truncate(mint int64) error {
 		if errors.As(errors.Unwrap(err), &ce) {
 			db.metrics.walCorruptionsTotal.Inc()
 		}
-		return fmt.Errorf("create checkpoint %w", err)
+		return fmt.Errorf("create checkpoint: %w", err)
 	}
 	if err := db.wal.Truncate(last + 1); err != nil {
 		// If truncating fails, we'll just try it again at the next checkpoint.
@@ -711,7 +711,7 @@ func (a *appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v flo
 		// equivalent validation code in the TSDB's headAppender.
 		l = l.WithoutEmpty()
 		if len(l) == 0 {
-			return 0, fmt.Errorf("empty labelset %w", tsdb.ErrInvalidSample)
+			return 0, fmt.Errorf("empty labelset: %w", tsdb.ErrInvalidSample)
 		}
 
 		if lbl, dup := l.HasDuplicateLabelNames(); dup {

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -441,13 +441,13 @@ func (r blockIndexReader) SortedLabelValues(name string, matchers ...*labels.Mat
 		}
 	}
 
-	return st, fmt.Errorf("block: %s %w", r.b.Meta().ULID, err)
+	return st, fmt.Errorf("block: %s: %w", r.b.Meta().ULID, err)
 }
 
 func (r blockIndexReader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
 	if len(matchers) == 0 {
 		st, err := r.ir.LabelValues(name)
-		return st, fmt.Errorf("block: %s %w", r.b.Meta().ULID, err)
+		return st, fmt.Errorf("block: %s: %w", r.b.Meta().ULID, err)
 	}
 
 	return labelValuesWithMatchers(r.ir, name, matchers...)
@@ -464,7 +464,7 @@ func (r blockIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, err
 func (r blockIndexReader) Postings(name string, values ...string) (index.Postings, error) {
 	p, err := r.ir.Postings(name, values...)
 	if err != nil {
-		return p, fmt.Errorf("block: %s %w", r.b.Meta().ULID, err)
+		return p, fmt.Errorf("block: %s: %w", r.b.Meta().ULID, err)
 	}
 	return p, nil
 }
@@ -475,7 +475,7 @@ func (r blockIndexReader) SortedPostings(p index.Postings) index.Postings {
 
 func (r blockIndexReader) Series(ref storage.SeriesRef, lset *labels.Labels, chks *[]chunks.Meta) error {
 	if err := r.ir.Series(ref, lset, chks); err != nil {
-		return fmt.Errorf("block: %s %w", r.b.Meta().ULID, err)
+		return fmt.Errorf("block: %s: %w", r.b.Meta().ULID, err)
 	}
 	return nil
 }
@@ -527,7 +527,7 @@ func (pb *Block) Delete(mint, maxt int64, ms ...*labels.Matcher) error {
 
 	p, err := PostingsForMatchers(pb.indexr, ms...)
 	if err != nil {
-		return fmt.Errorf("select series %w", err)
+		return fmt.Errorf("select series: %w", err)
 	}
 
 	ir := pb.indexr
@@ -615,12 +615,12 @@ func (pb *Block) CleanTombstones(dest string, c Compactor) (*ulid.ULID, bool, er
 func (pb *Block) Snapshot(dir string) error {
 	blockDir := filepath.Join(dir, pb.meta.ULID.String())
 	if err := os.MkdirAll(blockDir, 0o777); err != nil {
-		return fmt.Errorf("create snapshot block dir %w", err)
+		return fmt.Errorf("create snapshot block dir: %w", err)
 	}
 
 	chunksDir := chunkDir(blockDir)
 	if err := os.MkdirAll(chunksDir, 0o777); err != nil {
-		return fmt.Errorf("create snapshot chunk dir %w", err)
+		return fmt.Errorf("create snapshot chunk dir: %w", err)
 	}
 
 	// Hardlink meta, index and tombstones
@@ -630,7 +630,7 @@ func (pb *Block) Snapshot(dir string) error {
 		tombstones.TombstonesFilename,
 	} {
 		if err := os.Link(filepath.Join(pb.dir, fname), filepath.Join(blockDir, fname)); err != nil {
-			return fmt.Errorf("create snapshot %s %w", fname, err)
+			return fmt.Errorf("create snapshot %s: %w", fname, err)
 		}
 	}
 
@@ -638,13 +638,13 @@ func (pb *Block) Snapshot(dir string) error {
 	curChunkDir := chunkDir(pb.dir)
 	files, err := os.ReadDir(curChunkDir)
 	if err != nil {
-		return fmt.Errorf("ReadDir the current chunk dir %w", err)
+		return fmt.Errorf("ReadDir the current chunk dir: %w", err)
 	}
 
 	for _, f := range files {
 		err := os.Link(filepath.Join(curChunkDir, f.Name()), filepath.Join(chunksDir, f.Name()))
 		if err != nil {
-			return fmt.Errorf("hardlink a chunk %w", err)
+			return fmt.Errorf("hardlink a chunk: %w", err)
 		}
 	}
 

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -16,6 +16,8 @@ package tsdb
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -25,7 +27,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid"
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -210,7 +211,7 @@ func readMetaFile(dir string) (*BlockMeta, int64, error) {
 		return nil, 0, err
 	}
 	if m.Version != metaVersion1 {
-		return nil, 0, errors.Errorf("unexpected meta file version %d", m.Version)
+		return nil, 0, fmt.Errorf("unexpected meta file version %d", m.Version)
 	}
 
 	return &m, int64(len(b)), nil
@@ -440,13 +441,13 @@ func (r blockIndexReader) SortedLabelValues(name string, matchers ...*labels.Mat
 		}
 	}
 
-	return st, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
+	return st, fmt.Errorf("block: %s %w", r.b.Meta().ULID, err)
 }
 
 func (r blockIndexReader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
 	if len(matchers) == 0 {
 		st, err := r.ir.LabelValues(name)
-		return st, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
+		return st, fmt.Errorf("block: %s %w", r.b.Meta().ULID, err)
 	}
 
 	return labelValuesWithMatchers(r.ir, name, matchers...)
@@ -463,7 +464,7 @@ func (r blockIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, err
 func (r blockIndexReader) Postings(name string, values ...string) (index.Postings, error) {
 	p, err := r.ir.Postings(name, values...)
 	if err != nil {
-		return p, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
+		return p, fmt.Errorf("block: %s %w", r.b.Meta().ULID, err)
 	}
 	return p, nil
 }
@@ -474,7 +475,7 @@ func (r blockIndexReader) SortedPostings(p index.Postings) index.Postings {
 
 func (r blockIndexReader) Series(ref storage.SeriesRef, lset *labels.Labels, chks *[]chunks.Meta) error {
 	if err := r.ir.Series(ref, lset, chks); err != nil {
-		return errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
+		return fmt.Errorf("block: %s %w", r.b.Meta().ULID, err)
 	}
 	return nil
 }
@@ -526,7 +527,7 @@ func (pb *Block) Delete(mint, maxt int64, ms ...*labels.Matcher) error {
 
 	p, err := PostingsForMatchers(pb.indexr, ms...)
 	if err != nil {
-		return errors.Wrap(err, "select series")
+		return fmt.Errorf("select series %w", err)
 	}
 
 	ir := pb.indexr
@@ -614,12 +615,12 @@ func (pb *Block) CleanTombstones(dest string, c Compactor) (*ulid.ULID, bool, er
 func (pb *Block) Snapshot(dir string) error {
 	blockDir := filepath.Join(dir, pb.meta.ULID.String())
 	if err := os.MkdirAll(blockDir, 0o777); err != nil {
-		return errors.Wrap(err, "create snapshot block dir")
+		return fmt.Errorf("create snapshot block dir %w", err)
 	}
 
 	chunksDir := chunkDir(blockDir)
 	if err := os.MkdirAll(chunksDir, 0o777); err != nil {
-		return errors.Wrap(err, "create snapshot chunk dir")
+		return fmt.Errorf("create snapshot chunk dir %w", err)
 	}
 
 	// Hardlink meta, index and tombstones
@@ -629,7 +630,7 @@ func (pb *Block) Snapshot(dir string) error {
 		tombstones.TombstonesFilename,
 	} {
 		if err := os.Link(filepath.Join(pb.dir, fname), filepath.Join(blockDir, fname)); err != nil {
-			return errors.Wrapf(err, "create snapshot %s", fname)
+			return fmt.Errorf("create snapshot %s %w", fname, err)
 		}
 	}
 
@@ -637,13 +638,13 @@ func (pb *Block) Snapshot(dir string) error {
 	curChunkDir := chunkDir(pb.dir)
 	files, err := os.ReadDir(curChunkDir)
 	if err != nil {
-		return errors.Wrap(err, "ReadDir the current chunk dir")
+		return fmt.Errorf("ReadDir the current chunk dir %w", err)
 	}
 
 	for _, f := range files {
 		err := os.Link(filepath.Join(curChunkDir, f.Name()), filepath.Join(chunksDir, f.Name()))
 		if err != nil {
-			return errors.Wrap(err, "hardlink a chunk")
+			return fmt.Errorf("hardlink a chunk %w", err)
 		}
 	}
 

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -440,14 +440,19 @@ func (r blockIndexReader) SortedLabelValues(name string, matchers ...*labels.Mat
 			sort.Strings(st)
 		}
 	}
-
-	return st, fmt.Errorf("block: %s: %w", r.b.Meta().ULID, err)
+	if err != nil {
+		return st, fmt.Errorf("block: %s: %w", r.b.Meta().ULID, err)
+	}
+	return st, nil
 }
 
 func (r blockIndexReader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
 	if len(matchers) == 0 {
 		st, err := r.ir.LabelValues(name)
-		return st, fmt.Errorf("block: %s: %w", r.b.Meta().ULID, err)
+		if err != nil {
+			return st, fmt.Errorf("block: %s: %w", r.b.Meta().ULID, err)
+		}
+		return st, nil
 	}
 
 	return labelValuesWithMatchers(r.ir, name, matchers...)

--- a/tsdb/blockwriter.go
+++ b/tsdb/blockwriter.go
@@ -66,7 +66,7 @@ func NewBlockWriter(logger log.Logger, dir string, blockSize int64) (*BlockWrite
 func (w *BlockWriter) initHead() error {
 	chunkDir, err := os.MkdirTemp(os.TempDir(), "head")
 	if err != nil {
-		return fmt.Errorf("create temp dir %w", err)
+		return fmt.Errorf("create temp dir: %w", err)
 	}
 	w.chunkDir = chunkDir
 	opts := DefaultHeadOptions()
@@ -74,7 +74,7 @@ func (w *BlockWriter) initHead() error {
 	opts.ChunkDirRoot = w.chunkDir
 	h, err := NewHead(nil, w.logger, nil, opts, NewHeadStats())
 	if err != nil {
-		return fmt.Errorf("tsdb.NewHead %w", err)
+		return fmt.Errorf("tsdb.NewHead: %w", err)
 	}
 
 	w.head = h
@@ -102,11 +102,11 @@ func (w *BlockWriter) Flush(ctx context.Context) (ulid.ULID, error) {
 		[]int64{w.blockSize},
 		chunkenc.NewPool(), nil)
 	if err != nil {
-		return ulid.ULID{}, fmt.Errorf("create leveled compactor %w", err)
+		return ulid.ULID{}, fmt.Errorf("create leveled compactor: %w", err)
 	}
 	id, err := compactor.Write(w.destinationDir, w.head, mint, maxt, nil)
 	if err != nil {
-		return ulid.ULID{}, fmt.Errorf("compactor write %w", err)
+		return ulid.ULID{}, fmt.Errorf("compactor write: %w", err)
 	}
 
 	return id, nil

--- a/tsdb/blockwriter.go
+++ b/tsdb/blockwriter.go
@@ -15,13 +15,14 @@ package tsdb
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math"
 	"os"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid"
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/storage"
@@ -39,7 +40,7 @@ type BlockWriter struct {
 }
 
 // ErrNoSeriesAppended is returned if the series count is zero while flushing blocks.
-var ErrNoSeriesAppended error = errors.New("no series appended, aborting")
+var ErrNoSeriesAppended = errors.New("no series appended, aborting")
 
 // NewBlockWriter create a new block writer.
 //
@@ -65,7 +66,7 @@ func NewBlockWriter(logger log.Logger, dir string, blockSize int64) (*BlockWrite
 func (w *BlockWriter) initHead() error {
 	chunkDir, err := os.MkdirTemp(os.TempDir(), "head")
 	if err != nil {
-		return errors.Wrap(err, "create temp dir")
+		return fmt.Errorf("create temp dir %w", err)
 	}
 	w.chunkDir = chunkDir
 	opts := DefaultHeadOptions()
@@ -73,7 +74,7 @@ func (w *BlockWriter) initHead() error {
 	opts.ChunkDirRoot = w.chunkDir
 	h, err := NewHead(nil, w.logger, nil, opts, NewHeadStats())
 	if err != nil {
-		return errors.Wrap(err, "tsdb.NewHead")
+		return fmt.Errorf("tsdb.NewHead %w", err)
 	}
 
 	w.head = h
@@ -101,11 +102,11 @@ func (w *BlockWriter) Flush(ctx context.Context) (ulid.ULID, error) {
 		[]int64{w.blockSize},
 		chunkenc.NewPool(), nil)
 	if err != nil {
-		return ulid.ULID{}, errors.Wrap(err, "create leveled compactor")
+		return ulid.ULID{}, fmt.Errorf("create leveled compactor %w", err)
 	}
 	id, err := compactor.Write(w.destinationDir, w.head, mint, maxt, nil)
 	if err != nil {
-		return ulid.ULID{}, errors.Wrap(err, "compactor write")
+		return ulid.ULID{}, fmt.Errorf("compactor write %w", err)
 	}
 
 	return id, nil

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -14,10 +14,9 @@
 package chunkenc
 
 import (
+	"fmt"
 	"math"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 // Encoding is the identifier for a chunk encoding.
@@ -161,7 +160,7 @@ func (p *pool) Get(e Encoding, b []byte) (Chunk, error) {
 		c.b.count = 0
 		return c, nil
 	}
-	return nil, errors.Errorf("invalid chunk encoding %q", e)
+	return nil, fmt.Errorf("invalid chunk encoding %q", e)
 }
 
 func (p *pool) Put(c Chunk) error {
@@ -178,7 +177,7 @@ func (p *pool) Put(c Chunk) error {
 		xc.b.count = 0
 		p.xor.Put(c)
 	default:
-		return errors.Errorf("invalid chunk encoding %q", c.Encoding())
+		return fmt.Errorf("invalid chunk encoding %q", c.Encoding())
 	}
 	return nil
 }
@@ -191,5 +190,5 @@ func FromData(e Encoding, d []byte) (Chunk, error) {
 	case EncXOR:
 		return &XORChunk{b: bstream{count: 0, stream: d}}, nil
 	}
-	return nil, errors.Errorf("invalid chunk encoding %q", e)
+	return nil, fmt.Errorf("invalid chunk encoding %q", e)
 }

--- a/tsdb/chunkenc/chunk_test.go
+++ b/tsdb/chunkenc/chunk_test.go
@@ -14,6 +14,7 @@
 package chunkenc
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -153,7 +154,7 @@ func benchmarkIterator(b *testing.B, newChunk func() Chunk) {
 			res = v
 			i++
 		}
-		if it.Err() != io.EOF {
+		if !errors.Is(it.Err(), io.EOF) {
 			require.NoError(b, it.Err())
 		}
 		_ = res

--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -272,12 +272,12 @@ func (w *Writer) cut() error {
 func cutSegmentFile(dirFile *os.File, magicNumber uint32, chunksFormat byte, allocSize int64) (headerSize int, newFile *os.File, seq int, returnErr error) {
 	p, seq, err := nextSequenceFile(dirFile.Name())
 	if err != nil {
-		return 0, nil, 0, fmt.Errorf("next sequence file %w", err)
+		return 0, nil, 0, fmt.Errorf("next sequence file: %w", err)
 	}
 	ptmp := p + ".tmp"
 	f, err := os.OpenFile(ptmp, os.O_WRONLY|os.O_CREATE, 0o666)
 	if err != nil {
-		return 0, nil, 0, fmt.Errorf("open temp file %w", err)
+		return 0, nil, 0, fmt.Errorf("open temp file: %w", err)
 	}
 	defer func() {
 		if returnErr != nil {
@@ -292,11 +292,11 @@ func cutSegmentFile(dirFile *os.File, magicNumber uint32, chunksFormat byte, all
 	}()
 	if allocSize > 0 {
 		if err = fileutil.Preallocate(f, allocSize, true); err != nil {
-			return 0, nil, 0, fmt.Errorf("preallocate %w", err)
+			return 0, nil, 0, fmt.Errorf("preallocate: %w", err)
 		}
 	}
 	if err = dirFile.Sync(); err != nil {
-		return 0, nil, 0, fmt.Errorf("sync directory %w", err)
+		return 0, nil, 0, fmt.Errorf("sync directory: %w", err)
 	}
 
 	// Write header metadata for new file.
@@ -306,24 +306,24 @@ func cutSegmentFile(dirFile *os.File, magicNumber uint32, chunksFormat byte, all
 
 	n, err := f.Write(metab)
 	if err != nil {
-		return 0, nil, 0, fmt.Errorf("write header %w", err)
+		return 0, nil, 0, fmt.Errorf("write header: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		return 0, nil, 0, fmt.Errorf("close temp file %w", err)
+		return 0, nil, 0, fmt.Errorf("close temp file: %w", err)
 	}
 	f = nil
 
 	if err := fileutil.Rename(ptmp, p); err != nil {
-		return 0, nil, 0, fmt.Errorf("replace file %w", err)
+		return 0, nil, 0, fmt.Errorf("replace file: %w", err)
 	}
 
 	f, err = os.OpenFile(p, os.O_WRONLY, 0o666)
 	if err != nil {
-		return 0, nil, 0, fmt.Errorf("open final file %w", err)
+		return 0, nil, 0, fmt.Errorf("open final file: %w", err)
 	}
 	// Skip header for further writes.
 	if _, err := f.Seek(int64(n), 0); err != nil {
-		return 0, nil, 0, fmt.Errorf("seek in final file %w", err)
+		return 0, nil, 0, fmt.Errorf("seek in final file: %w", err)
 	}
 	return n, f, seq, nil
 }
@@ -480,7 +480,7 @@ func newReader(bs []ByteSlice, cs []io.Closer, pool chunkenc.Pool) (*Reader, err
 	cr := Reader{pool: pool, bs: bs, cs: cs}
 	for i, b := range cr.bs {
 		if b.Len() < SegmentHeaderSize {
-			return nil, fmt.Errorf("invalid segment header in segment %d %w", i, errInvalidSize)
+			return nil, fmt.Errorf("invalid segment header in segment %d: %w", i, errInvalidSize)
 		}
 		// Verify magic number.
 		if m := binary.BigEndian.Uint32(b.Range(0, MagicChunksSize)); m != MagicChunks {
@@ -515,7 +515,7 @@ func NewDirReader(dir string, pool chunkenc.Pool) (*Reader, error) {
 		f, err := fileutil.OpenMmapFile(fn)
 		if err != nil {
 			return nil, tsdb_errors.NewMulti(
-				fmt.Errorf("mmap files %w", err),
+				fmt.Errorf("mmap files: %w", err),
 				tsdb_errors.CloseAll(cs),
 			).Err()
 		}

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -96,7 +96,7 @@ type CorruptionErr struct {
 }
 
 func (e *CorruptionErr) Error() string {
-	return fmt.Errorf("corruption in head chunk file %s %w", segmentFile(e.Dir, e.FileIndex), e.Err).Error()
+	return fmt.Errorf("corruption in head chunk file %s: %w", segmentFile(e.Dir, e.FileIndex), e.Err).Error()
 }
 
 // chunkPos keeps track of the position in the head chunk files.
@@ -289,7 +289,7 @@ func (cdm *ChunkDiskMapper) openMMapFiles() (returnErr error) {
 	for seq, fn := range files {
 		f, err := fileutil.OpenMmapFile(fn)
 		if err != nil {
-			return fmt.Errorf("mmap files, file: %s %w", fn, err)
+			return fmt.Errorf("mmap files, file: %s: %w", fn, err)
 		}
 		cdm.closers[seq] = f
 		cdm.mmappedChunkFiles[seq] = &mmappedChunkFile{byteSlice: realByteSlice(f.Bytes())}
@@ -311,7 +311,7 @@ func (cdm *ChunkDiskMapper) openMMapFiles() (returnErr error) {
 
 	for i, b := range cdm.mmappedChunkFiles {
 		if b.byteSlice.Len() < HeadChunkFileHeaderSize {
-			return fmt.Errorf("%s: invalid head chunk file header %w", files[i], errInvalidSize)
+			return fmt.Errorf("%s: invalid head chunk file header: %w", files[i], errInvalidSize)
 		}
 		// Verify magic number.
 		if m := binary.BigEndian.Uint32(b.byteSlice.Range(0, MagicChunksSize)); m != MagicHeadChunks {
@@ -363,12 +363,12 @@ func repairLastChunkFile(files map[int]string) (_ map[int]string, returnErr erro
 
 	info, err := os.Stat(files[lastFile])
 	if err != nil {
-		return files, fmt.Errorf("file stat during last head chunk file repair %w", err)
+		return files, fmt.Errorf("file stat during last head chunk file repair: %w", err)
 	}
 	if info.Size() == 0 {
 		// Corrupt file, hence remove it.
 		if err := os.RemoveAll(files[lastFile]); err != nil {
-			return files, fmt.Errorf("delete corrupted, empty head chunk file during last file repair %w", err)
+			return files, fmt.Errorf("delete corrupted, empty head chunk file during last file repair: %w", err)
 		}
 		delete(files, lastFile)
 	}
@@ -943,7 +943,7 @@ func (cdm *ChunkDiskMapper) DeleteCorrupted(originalErr error) error {
 	err := errors.Unwrap(originalErr) // So that we can pick up errors even if wrapped.
 	var cerr *CorruptionErr
 	if !errors.As(err, &cerr) {
-		return fmt.Errorf("cannot handle error %w", originalErr)
+		return fmt.Errorf("cannot handle error: %w", originalErr)
 	}
 
 	// Delete all the head chunk files following the corrupt head chunk file.

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -474,7 +474,7 @@ func (c *LeveledCompactor) Compact(dest string, dirs []string, open []*Block) (u
 	if !errors.Is(err, context.Canceled) {
 		for _, b := range bs {
 			if err := b.setCompactionFailed(); err != nil {
-				errs.Add(fmt.Errorf("setting compaction failed for block: %s %w", b.Dir(), err))
+				errs.Add(fmt.Errorf("setting compaction failed for block: %s: %w", b.Dir(), err))
 			}
 		}
 	}
@@ -575,7 +575,7 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockRe
 
 	chunkw, err = chunks.NewWriterWithSegSize(chunkDir(tmp), c.maxBlockChunkSegmentSize)
 	if err != nil {
-		return fmt.Errorf("open chunk writer %w", err)
+		return fmt.Errorf("open chunk writer: %w", err)
 	}
 	closers = append(closers, chunkw)
 	// Record written chunk sizes on level 1 compactions.
@@ -590,12 +590,12 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockRe
 
 	indexw, err := index.NewWriter(c.ctx, filepath.Join(tmp, indexFilename))
 	if err != nil {
-		return fmt.Errorf("open index writer %w", err)
+		return fmt.Errorf("open index writer: %w", err)
 	}
 	closers = append(closers, indexw)
 
 	if err := c.populateBlock(blocks, meta, indexw, chunkw); err != nil {
-		return fmt.Errorf("populate block %w", err)
+		return fmt.Errorf("populate block: %w", err)
 	}
 
 	select {
@@ -623,17 +623,17 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockRe
 	}
 
 	if _, err = writeMetaFile(c.logger, tmp, meta); err != nil {
-		return fmt.Errorf("write merged meta %w", err)
+		return fmt.Errorf("write merged meta: %w", err)
 	}
 
 	// Create an empty tombstones file.
 	if _, err := tombstones.WriteFile(c.logger, tmp, tombstones.NewMemTombstones()); err != nil {
-		return fmt.Errorf("write new tombstones file %w", err)
+		return fmt.Errorf("write new tombstones file: %w", err)
 	}
 
 	df, err := fileutil.OpenDir(tmp)
 	if err != nil {
-		return fmt.Errorf("open temporary block dir %w", err)
+		return fmt.Errorf("open temporary block dir: %w", err)
 	}
 	defer func() {
 		if df != nil {
@@ -642,18 +642,18 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blocks ...BlockRe
 	}()
 
 	if err := df.Sync(); err != nil {
-		return fmt.Errorf("sync temporary dir file %w", err)
+		return fmt.Errorf("sync temporary dir file: %w", err)
 	}
 
 	// Close temp dir before rename block dir (for windows platform).
 	if err = df.Close(); err != nil {
-		return fmt.Errorf("close temporary dir %w", err)
+		return fmt.Errorf("close temporary dir: %w", err)
 	}
 	df = nil
 
 	// Block successfully written, make it visible in destination dir by moving it from tmp one.
 	if err := fileutil.Replace(tmp, dir); err != nil {
-		return fmt.Errorf("rename block dir %w", err)
+		return fmt.Errorf("rename block dir: %w", err)
 	}
 
 	return nil
@@ -676,7 +676,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 	defer func() {
 		errs := tsdb_errors.NewMulti(err)
 		if cerr := tsdb_errors.CloseAll(closers); cerr != nil {
-			errs.Add(fmt.Errorf("close %w", cerr))
+			errs.Add(fmt.Errorf("close: %w", cerr))
 		}
 		err = errs.Err()
 		c.metrics.populatingBlocks.Set(0)
@@ -704,19 +704,19 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 
 		indexr, err := b.Index()
 		if err != nil {
-			return fmt.Errorf("open index reader for block %+v %w", b.Meta(), err)
+			return fmt.Errorf("open index reader for block %+v: %w", b.Meta(), err)
 		}
 		closers = append(closers, indexr)
 
 		chunkr, err := b.Chunks()
 		if err != nil {
-			return fmt.Errorf("open chunk reader for block %+v %w", b.Meta(), err)
+			return fmt.Errorf("open chunk reader for block %+v: %w", b.Meta(), err)
 		}
 		closers = append(closers, chunkr)
 
 		tombsr, err := b.Tombstones()
 		if err != nil {
-			return fmt.Errorf("open tombstone reader for block %+v %w", b.Meta(), err)
+			return fmt.Errorf("open tombstone reader for block %+v: %w", b.Meta(), err)
 		}
 		closers = append(closers, tombsr)
 
@@ -738,11 +738,11 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 
 	for symbols.Next() {
 		if err := indexw.AddSymbol(symbols.At()); err != nil {
-			return fmt.Errorf("add symbol %w", err)
+			return fmt.Errorf("add symbol: %w", err)
 		}
 	}
 	if symbols.Err() != nil {
-		return fmt.Errorf("next symbol %w", symbols.Err())
+		return fmt.Errorf("next symbol: %w", symbols.Err())
 	}
 
 	var (
@@ -773,7 +773,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 			chks = append(chks, chksIter.At())
 		}
 		if chksIter.Err() != nil {
-			return fmt.Errorf("chunk iter %w", chksIter.Err())
+			return fmt.Errorf("chunk iter: %w", chksIter.Err())
 		}
 
 		// Skip the series with all deleted chunks.
@@ -782,10 +782,10 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		}
 
 		if err := chunkw.WriteChunks(chks...); err != nil {
-			return fmt.Errorf("write chunks %w", err)
+			return fmt.Errorf("write chunks: %w", err)
 		}
 		if err := indexw.AddSeries(ref, s.Labels(), chks...); err != nil {
-			return fmt.Errorf("add series %w", err)
+			return fmt.Errorf("add series: %w", err)
 		}
 
 		meta.Stats.NumChunks += uint64(len(chks))
@@ -796,13 +796,13 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 
 		for _, chk := range chks {
 			if err := c.chunkPool.Put(chk.Chunk); err != nil {
-				return fmt.Errorf("put chunk %w", err)
+				return fmt.Errorf("put chunk: %w", err)
 			}
 		}
 		ref++
 	}
 	if set.Err() != nil {
-		return fmt.Errorf("iterate compaction set %w", set.Err())
+		return fmt.Errorf("iterate compaction set: %w", set.Err())
 	}
 
 	return nil

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -15,6 +15,7 @@ package tsdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -25,7 +26,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
-	"github.com/pkg/errors"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -16,6 +16,7 @@ package tsdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -31,7 +32,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
 
@@ -341,7 +341,7 @@ type DBReadOnly struct {
 // OpenDBReadOnly opens DB in the given directory for read only operations.
 func OpenDBReadOnly(dir string, l log.Logger) (*DBReadOnly, error) {
 	if _, err := os.Stat(dir); err != nil {
-		return nil, errors.Wrap(err, "opening the db dir")
+		return nil, fmt.Errorf("opening the db dir %w", err)
 	}
 
 	if l == nil {
@@ -362,7 +362,7 @@ func OpenDBReadOnly(dir string, l log.Logger) (*DBReadOnly, error) {
 func (db *DBReadOnly) FlushWAL(dir string) (returnErr error) {
 	blockReaders, err := db.Blocks()
 	if err != nil {
-		return errors.Wrap(err, "read blocks")
+		return fmt.Errorf("read blocks %w", err)
 	}
 	maxBlockTime := int64(math.MinInt64)
 	if len(blockReaders) > 0 {
@@ -381,13 +381,13 @@ func (db *DBReadOnly) FlushWAL(dir string) (returnErr error) {
 	defer func() {
 		returnErr = tsdb_errors.NewMulti(
 			returnErr,
-			errors.Wrap(head.Close(), "closing Head"),
+			fmt.Errorf("closing Head %w", head.Close()),
 		).Err()
 	}()
 	// Set the min valid time for the ingested wal samples
 	// to be no lower than the maxt of the last block.
 	if err := head.Init(maxBlockTime); err != nil {
-		return errors.Wrap(err, "read WAL")
+		return fmt.Errorf("read WAL %w", err)
 	}
 	mint := head.MinTime()
 	maxt := head.MaxTime()
@@ -401,12 +401,12 @@ func (db *DBReadOnly) FlushWAL(dir string) (returnErr error) {
 		nil,
 	)
 	if err != nil {
-		return errors.Wrap(err, "create leveled compactor")
+		return fmt.Errorf("create leveled compactor %w", err)
 	}
 	// Add +1 millisecond to block maxt because block intervals are half-open: [b.MinTime, b.MaxTime).
 	// Because of this block intervals are always +1 than the total samples it includes.
 	_, err = compactor.Write(dir, rh, mint, maxt+1, nil)
-	return errors.Wrap(err, "writing WAL")
+	return fmt.Errorf("writing WAL %w", err)
 }
 
 func (db *DBReadOnly) loadDataAsQueryable(maxt int64) (storage.SampleAndChunkQueryable, error) {
@@ -457,7 +457,7 @@ func (db *DBReadOnly) loadDataAsQueryable(maxt int64) (storage.SampleAndChunkQue
 		// Set the min valid time for the ingested wal samples
 		// to be no lower than the maxt of the last block.
 		if err := head.Init(maxBlockTime); err != nil {
-			return nil, errors.Wrap(err, "read WAL")
+			return nil, fmt.Errorf("read WAL %w", err)
 		}
 		// Set the wal to nil to disable all wal operations.
 		// This is mainly to avoid blocking when closing the head.
@@ -519,7 +519,7 @@ func (db *DBReadOnly) Blocks() ([]BlockReader, error) {
 		}
 		errs := tsdb_errors.NewMulti()
 		for ulid, err := range corrupted {
-			errs.Add(errors.Wrapf(err, "corrupted block %s", ulid.String()))
+			errs.Add(fmt.Errorf("corrupted block %s %w", ulid.String(), err))
 		}
 		return nil, errs.Err()
 	}
@@ -630,19 +630,19 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 
 	// Fixup bad format written by Prometheus 2.1.
 	if err := repairBadIndexVersion(l, dir); err != nil {
-		return nil, errors.Wrap(err, "repair bad index version")
+		return nil, fmt.Errorf("repair bad index version %w", err)
 	}
 
 	walDir := filepath.Join(dir, "wal")
 
 	// Migrate old WAL if one exists.
 	if err := MigrateWAL(l, walDir); err != nil {
-		return nil, errors.Wrap(err, "migrate WAL")
+		return nil, fmt.Errorf("migrate WAL %w", err)
 	}
 	for _, tmpDir := range []string{walDir, dir} {
 		// Remove tmp dirs.
 		if err := removeBestEffortTmpDirs(l, tmpDir); err != nil {
-			return nil, errors.Wrap(err, "remove tmp dirs")
+			return nil, fmt.Errorf("remove tmp dirs %w", err)
 		}
 	}
 
@@ -667,7 +667,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 
 		returnedErr = tsdb_errors.NewMulti(
 			returnedErr,
-			errors.Wrap(db.Close(), "close DB after failed startup"),
+			fmt.Errorf("close DB after failed startup %w", db.Close()),
 		).Err()
 	}()
 
@@ -690,7 +690,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	db.compactor, err = NewLeveledCompactorWithChunkSize(ctx, r, l, rngs, db.chunkPool, opts.MaxBlockChunkSegmentSize, nil)
 	if err != nil {
 		cancel()
-		return nil, errors.Wrap(err, "create leveled compactor")
+		return nil, fmt.Errorf("create leveled compactor %w", err)
 	}
 	db.compactCancel = cancel
 
@@ -751,7 +751,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		db.head.metrics.walCorruptionsTotal.Inc()
 		level.Warn(db.logger).Log("msg", "Encountered WAL read error, attempting repair", "err", initErr)
 		if err := wlog.Repair(initErr); err != nil {
-			return nil, errors.Wrap(err, "repair corrupted WAL")
+			return nil, fmt.Errorf("repair corrupted WAL %w", err)
 		}
 	}
 
@@ -897,7 +897,7 @@ func (db *DB) Compact() (returnErr error) {
 	defer func() {
 		returnErr = tsdb_errors.NewMulti(
 			returnErr,
-			errors.Wrap(db.head.truncateWAL(lastBlockMaxt), "WAL truncation in Compact defer"),
+			fmt.Errorf("WAL truncation in Compact defer %w", db.head.truncateWAL(lastBlockMaxt)),
 		).Err()
 	}()
 
@@ -924,7 +924,7 @@ func (db *DB) Compact() (returnErr error) {
 		// consistently, we explicitly remove the last value
 		// from the block interval here.
 		if err := db.compactHead(NewRangeHead(db.head, mint, maxt-1)); err != nil {
-			return errors.Wrap(err, "compact head")
+			return fmt.Errorf("compact head %w", err)
 		}
 		// Consider only successful compactions for WAL truncation.
 		lastBlockMaxt = maxt
@@ -933,7 +933,7 @@ func (db *DB) Compact() (returnErr error) {
 	// Clear some disk space before compacting blocks, especially important
 	// when Head compaction happened over a long time range.
 	if err := db.head.truncateWAL(lastBlockMaxt); err != nil {
-		return errors.Wrap(err, "WAL truncation in Compact")
+		return fmt.Errorf("WAL truncation in Compact %w", err)
 	}
 
 	compactionDuration := time.Since(start)
@@ -953,11 +953,11 @@ func (db *DB) CompactHead(head *RangeHead) error {
 	defer db.cmtx.Unlock()
 
 	if err := db.compactHead(head); err != nil {
-		return errors.Wrap(err, "compact head")
+		return fmt.Errorf("compact head %w", err)
 	}
 
 	if err := db.head.truncateWAL(head.BlockMaxTime()); err != nil {
-		return errors.Wrap(err, "WAL truncation")
+		return fmt.Errorf("WAL truncation %w", err)
 	}
 	return nil
 }
@@ -967,20 +967,20 @@ func (db *DB) CompactHead(head *RangeHead) error {
 func (db *DB) compactHead(head *RangeHead) error {
 	uid, err := db.compactor.Write(db.dir, head, head.MinTime(), head.BlockMaxTime(), nil)
 	if err != nil {
-		return errors.Wrap(err, "persist head block")
+		return fmt.Errorf("persist head block %w", err)
 	}
 
 	if err := db.reloadBlocks(); err != nil {
 		if errRemoveAll := os.RemoveAll(filepath.Join(db.dir, uid.String())); errRemoveAll != nil {
 			return tsdb_errors.NewMulti(
-				errors.Wrap(err, "reloadBlocks blocks"),
-				errors.Wrapf(errRemoveAll, "delete persisted head block after failed db reloadBlocks:%s", uid),
+				fmt.Errorf("reloadBlocks blocks %w", err),
+				fmt.Errorf("delete persisted head block after failed db reloadBlocks:%s %w", uid, errRemoveAll),
 			).Err()
 		}
-		return errors.Wrap(err, "reloadBlocks blocks")
+		return fmt.Errorf("reloadBlocks blocks %w", err)
 	}
 	if err = db.head.truncateMemory(head.BlockMaxTime()); err != nil {
-		return errors.Wrap(err, "head memory truncate")
+		return fmt.Errorf("head memory truncate %w", err)
 	}
 	return nil
 }
@@ -992,7 +992,7 @@ func (db *DB) compactBlocks() (err error) {
 	for {
 		plan, err := db.compactor.Plan(db.dir)
 		if err != nil {
-			return errors.Wrap(err, "plan compaction")
+			return fmt.Errorf("plan compaction %w", err)
 		}
 		if len(plan) == 0 {
 			break
@@ -1006,14 +1006,14 @@ func (db *DB) compactBlocks() (err error) {
 
 		uid, err := db.compactor.Compact(db.dir, plan, db.blocks)
 		if err != nil {
-			return errors.Wrapf(err, "compact %s", plan)
+			return fmt.Errorf("compact %s %w", plan, err)
 		}
 
 		if err := db.reloadBlocks(); err != nil {
 			if err := os.RemoveAll(filepath.Join(db.dir, uid.String())); err != nil {
-				return errors.Wrapf(err, "delete compacted block after failed db reloadBlocks:%s", uid)
+				return fmt.Errorf("delete compacted block after failed db reloadBlocks:%s %w", uid, err)
 			}
-			return errors.Wrap(err, "reloadBlocks blocks")
+			return fmt.Errorf("reloadBlocks blocks %w", err)
 		}
 	}
 
@@ -1034,13 +1034,13 @@ func getBlock(allBlocks []*Block, id ulid.ULID) (*Block, bool) {
 // reload reloads blocks and truncates the head and its WAL.
 func (db *DB) reload() error {
 	if err := db.reloadBlocks(); err != nil {
-		return errors.Wrap(err, "reloadBlocks")
+		return fmt.Errorf("reloadBlocks %w", err)
 	}
 	if len(db.blocks) == 0 {
 		return nil
 	}
 	if err := db.head.Truncate(db.blocks[len(db.blocks)-1].MaxTime()); err != nil {
-		return errors.Wrap(err, "head truncate")
+		return fmt.Errorf("head truncate %w", err)
 	}
 	return nil
 }
@@ -1094,7 +1094,7 @@ func (db *DB) reloadBlocks() (err error) {
 		}
 		errs := tsdb_errors.NewMulti()
 		for ulid, err := range corrupted {
-			errs.Add(errors.Wrapf(err, "corrupted block %s", ulid.String()))
+			errs.Add(fmt.Errorf("corrupted block %s %w", ulid.String(), err))
 		}
 		return errs.Err()
 	}
@@ -1121,7 +1121,7 @@ func (db *DB) reloadBlocks() (err error) {
 	})
 	if !db.opts.AllowOverlappingBlocks {
 		if err := validateBlockSequence(toLoad); err != nil {
-			return errors.Wrap(err, "invalid block sequence")
+			return fmt.Errorf("invalid block sequence %w", err)
 		}
 	}
 
@@ -1144,7 +1144,7 @@ func (db *DB) reloadBlocks() (err error) {
 		}
 	}
 	if err := db.deleteBlocks(deletable); err != nil {
-		return errors.Wrapf(err, "delete %v blocks", len(deletable))
+		return fmt.Errorf("delete %v blocks %w", len(deletable), err)
 	}
 	return nil
 }
@@ -1152,7 +1152,7 @@ func (db *DB) reloadBlocks() (err error) {
 func openBlocks(l log.Logger, dir string, loaded []*Block, chunkPool chunkenc.Pool) (blocks []*Block, corrupted map[ulid.ULID]error, err error) {
 	bDirs, err := blockDirs(dir)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "find blocks")
+		return nil, nil, fmt.Errorf("find blocks %w", err)
 	}
 
 	corrupted = make(map[ulid.ULID]error)
@@ -1278,16 +1278,16 @@ func (db *DB) deleteBlocks(blocks map[ulid.ULID]*Block) error {
 			// Noop.
 			continue
 		} else if err != nil {
-			return errors.Wrapf(err, "stat dir %v", toDelete)
+			return fmt.Errorf("stat dir %v %w", toDelete, err)
 		}
 
 		// Replace atomically to avoid partial block when process would crash during deletion.
 		tmpToDelete := filepath.Join(db.dir, fmt.Sprintf("%s%s", ulid, tmpForDeletionBlockDirSuffix))
 		if err := fileutil.Replace(toDelete, tmpToDelete); err != nil {
-			return errors.Wrapf(err, "replace of obsolete block for deletion %s", ulid)
+			return fmt.Errorf("replace of obsolete block for deletion %s %w", ulid, err)
 		}
 		if err := os.RemoveAll(tmpToDelete); err != nil {
-			return errors.Wrapf(err, "delete obsolete block %s", ulid)
+			return fmt.Errorf("delete obsolete block %s %w", ulid, err)
 		}
 		level.Info(db.logger).Log("msg", "Deleting obsolete block", "block", ulid)
 	}
@@ -1308,7 +1308,7 @@ func validateBlockSequence(bs []*Block) error {
 
 	overlaps := OverlappingBlocks(metas)
 	if len(overlaps) > 0 {
-		return errors.Errorf("block time ranges overlap: %s", overlaps)
+		return fmt.Errorf("block time ranges overlap: %s", overlaps)
 	}
 
 	return nil
@@ -1478,10 +1478,10 @@ func (db *DB) EnableCompactions() {
 // will create a new block containing all data that's currently in the memory buffer/WAL.
 func (db *DB) Snapshot(dir string, withHead bool) error {
 	if dir == db.dir {
-		return errors.Errorf("cannot snapshot into base directory")
+		return fmt.Errorf("cannot snapshot into base directory")
 	}
 	if _, err := ulid.ParseStrict(dir); err == nil {
-		return errors.Errorf("dir must not be a valid ULID")
+		return fmt.Errorf("dir must not be a valid ULID")
 	}
 
 	db.cmtx.Lock()
@@ -1494,7 +1494,7 @@ func (db *DB) Snapshot(dir string, withHead bool) error {
 		level.Info(db.logger).Log("msg", "Snapshotting block", "block", b)
 
 		if err := b.Snapshot(dir); err != nil {
-			return errors.Wrapf(err, "error snapshotting block: %s", b.Dir())
+			return fmt.Errorf("error snapshotting block: %s %w", b.Dir(), err)
 		}
 	}
 	if !withHead {
@@ -1507,7 +1507,7 @@ func (db *DB) Snapshot(dir string, withHead bool) error {
 	// Add +1 millisecond to block maxt because block intervals are half-open: [b.MinTime, b.MaxTime).
 	// Because of this block intervals are always +1 than the total samples it includes.
 	if _, err := db.compactor.Write(dir, head, mint, maxt+1, nil); err != nil {
-		return errors.Wrap(err, "snapshot head block")
+		return fmt.Errorf("snapshot head block %w", err)
 	}
 	return nil
 }
@@ -1530,7 +1530,7 @@ func (db *DB) Querier(_ context.Context, mint, maxt int64) (storage.Querier, err
 		var err error
 		headQuerier, err = NewBlockQuerier(rh, mint, maxt)
 		if err != nil {
-			return nil, errors.Wrapf(err, "open querier for head %s", rh)
+			return nil, fmt.Errorf("open querier for head %s %w", rh, err)
 		}
 
 		// Getting the querier above registers itself in the queue that the truncation waits on.
@@ -1539,7 +1539,7 @@ func (db *DB) Querier(_ context.Context, mint, maxt int64) (storage.Querier, err
 		shouldClose, getNew, newMint := db.head.IsQuerierCollidingWithTruncation(mint, maxt)
 		if shouldClose {
 			if err := headQuerier.Close(); err != nil {
-				return nil, errors.Wrapf(err, "closing head querier %s", rh)
+				return nil, fmt.Errorf("closing head querier %s %w", rh, err)
 			}
 			headQuerier = nil
 		}
@@ -1547,7 +1547,7 @@ func (db *DB) Querier(_ context.Context, mint, maxt int64) (storage.Querier, err
 			rh := NewRangeHead(db.head, newMint, maxt)
 			headQuerier, err = NewBlockQuerier(rh, newMint, maxt)
 			if err != nil {
-				return nil, errors.Wrapf(err, "open querier for head while getting new querier %s", rh)
+				return nil, fmt.Errorf("open querier for head while getting new querier %s %w", rh, err)
 			}
 		}
 	}
@@ -1564,7 +1564,7 @@ func (db *DB) Querier(_ context.Context, mint, maxt int64) (storage.Querier, err
 			// TODO(bwplotka): Handle error.
 			_ = q.Close()
 		}
-		return nil, errors.Wrapf(err, "open querier for block %s", b)
+		return nil, fmt.Errorf("open querier for block %s %w", b, err)
 	}
 	if headQuerier != nil {
 		blockQueriers = append(blockQueriers, headQuerier)
@@ -1590,7 +1590,7 @@ func (db *DB) ChunkQuerier(_ context.Context, mint, maxt int64) (storage.ChunkQu
 		var err error
 		headQuerier, err = NewBlockChunkQuerier(rh, mint, maxt)
 		if err != nil {
-			return nil, errors.Wrapf(err, "open querier for head %s", rh)
+			return nil, fmt.Errorf("open querier for head %s %w", rh, err)
 		}
 
 		// Getting the querier above registers itself in the queue that the truncation waits on.
@@ -1599,7 +1599,7 @@ func (db *DB) ChunkQuerier(_ context.Context, mint, maxt int64) (storage.ChunkQu
 		shouldClose, getNew, newMint := db.head.IsQuerierCollidingWithTruncation(mint, maxt)
 		if shouldClose {
 			if err := headQuerier.Close(); err != nil {
-				return nil, errors.Wrapf(err, "closing head querier %s", rh)
+				return nil, fmt.Errorf("closing head querier %s %w", rh, err)
 			}
 			headQuerier = nil
 		}
@@ -1607,7 +1607,7 @@ func (db *DB) ChunkQuerier(_ context.Context, mint, maxt int64) (storage.ChunkQu
 			rh := NewRangeHead(db.head, newMint, maxt)
 			headQuerier, err = NewBlockChunkQuerier(rh, newMint, maxt)
 			if err != nil {
-				return nil, errors.Wrapf(err, "open querier for head while getting new querier %s", rh)
+				return nil, fmt.Errorf("open querier for head while getting new querier %s %w", rh, err)
 			}
 		}
 	}
@@ -1624,7 +1624,7 @@ func (db *DB) ChunkQuerier(_ context.Context, mint, maxt int64) (storage.ChunkQu
 			// TODO(bwplotka): Handle error.
 			_ = q.Close()
 		}
-		return nil, errors.Wrapf(err, "open querier for block %s", b)
+		return nil, fmt.Errorf("open querier for block %s %w", b, err)
 	}
 	if headQuerier != nil {
 		blockQueriers = append(blockQueriers, headQuerier)
@@ -1683,7 +1683,7 @@ func (db *DB) CleanTombstones() (err error) {
 		for _, pb := range db.Blocks() {
 			uid, safeToDelete, cleanErr := pb.CleanTombstones(db.Dir(), db.compactor)
 			if cleanErr != nil {
-				return errors.Wrapf(cleanErr, "clean tombstones: %s", pb.Dir())
+				return fmt.Errorf("clean tombstones: %s %w", pb.Dir(), cleanErr)
 			}
 			if !safeToDelete {
 				// There was nothing to clean.
@@ -1711,7 +1711,7 @@ func (db *DB) CleanTombstones() (err error) {
 					level.Error(db.logger).Log("msg", "failed to delete block after failed `CleanTombstones`", "dir", dir, "err", err)
 				}
 			}
-			return errors.Wrap(err, "reload blocks")
+			return fmt.Errorf("reload blocks %w", err)
 		}
 	}
 	return nil

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"errors"
 	"flag"
 	"fmt"
 	"hash/crc32"
@@ -34,7 +35,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
@@ -314,7 +314,7 @@ func TestDBAppenderAddRef(t *testing.T) {
 
 	// Missing labels & invalid refs should fail.
 	_, err = app2.Append(9999999, nil, 1, 1)
-	require.Equal(t, ErrInvalidSample, errors.Cause(err))
+	require.Equal(t, ErrInvalidSample, errors.Unwrap(err))
 
 	require.NoError(t, app2.Commit())
 
@@ -2899,7 +2899,7 @@ func deleteNonBlocks(dbDir string) error {
 	}
 	for _, dir := range dirs {
 		if ok := isBlockDir(dir); !ok {
-			return errors.Errorf("root folder:%v still hase non block directory:%v", dbDir, dir.Name())
+			return fmt.Errorf("root folder:%v still hase non block directory:%v", dbDir, dir.Name())
 		}
 	}
 	return nil

--- a/tsdb/encoding/encoding.go
+++ b/tsdb/encoding/encoding.go
@@ -15,13 +15,14 @@ package encoding
 
 import (
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"hash"
 	"hash/crc32"
 	"math"
 	"unsafe"
 
 	"github.com/dennwc/varint"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -153,7 +154,7 @@ func NewDecbufUvarintAt(bs ByteSlice, off int, castagnoliTable *crc32.Table) Dec
 
 	l, n := varint.Uvarint(b)
 	if n <= 0 || n > binary.MaxVarintLen32 {
-		return Decbuf{E: errors.Errorf("invalid uvarint %d", n)}
+		return Decbuf{E: fmt.Errorf("invalid uvarint %d", n)}
 	}
 
 	if bs.Len() < off+n+int(l)+4 {

--- a/tsdb/errors/errors.go
+++ b/tsdb/errors/errors.go
@@ -16,6 +16,7 @@ package errors
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -37,7 +38,8 @@ func (es *multiError) Add(errs ...error) {
 		if err == nil {
 			continue
 		}
-		if merr, ok := err.(nonNilMultiError); ok {
+		var merr nonNilMultiError
+		if errors.As(err, &merr) {
 			*es = append(*es, merr.errs...)
 			continue
 		}

--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -15,6 +15,7 @@ package tsdb
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"sync"
 	"unicode/utf8"
@@ -345,7 +346,7 @@ func (ce *CircularExemplarStorage) AddExemplar(l labels.Labels, e exemplar.Exemp
 
 	err := ce.validateExemplar(seriesLabels, e, true)
 	if err != nil {
-		if err == storage.ErrDuplicateExemplar {
+		if errors.Is(err, storage.ErrDuplicateExemplar) {
 			// Duplicate exemplar, noop.
 			return nil
 		}

--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -14,9 +14,8 @@
 package fileutil
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 type MmapFile struct {
@@ -31,7 +30,7 @@ func OpenMmapFile(path string) (*MmapFile, error) {
 func OpenMmapFileWithSize(path string, size int) (mf *MmapFile, retErr error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "try lock file")
+		return nil, fmt.Errorf("try lock file %w", err)
 	}
 	defer func() {
 		if retErr != nil {
@@ -41,14 +40,14 @@ func OpenMmapFileWithSize(path string, size int) (mf *MmapFile, retErr error) {
 	if size <= 0 {
 		info, err := f.Stat()
 		if err != nil {
-			return nil, errors.Wrap(err, "stat")
+			return nil, fmt.Errorf("stat %w", err)
 		}
 		size = int(info.Size())
 	}
 
 	b, err := mmap(f, size)
 	if err != nil {
-		return nil, errors.Wrapf(err, "mmap, size %d", size)
+		return nil, fmt.Errorf("mmap, size %d %w", size, err)
 	}
 
 	return &MmapFile{f: f, b: b}, nil

--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -30,7 +30,7 @@ func OpenMmapFile(path string) (*MmapFile, error) {
 func OpenMmapFileWithSize(path string, size int) (mf *MmapFile, retErr error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("try lock file %w", err)
+		return nil, fmt.Errorf("try lock file: %w", err)
 	}
 	defer func() {
 		if retErr != nil {
@@ -40,14 +40,14 @@ func OpenMmapFileWithSize(path string, size int) (mf *MmapFile, retErr error) {
 	if size <= 0 {
 		info, err := f.Stat()
 		if err != nil {
-			return nil, fmt.Errorf("stat %w", err)
+			return nil, fmt.Errorf("stat: %w", err)
 		}
 		size = int(info.Size())
 	}
 
 	b, err := mmap(f, size)
 	if err != nil {
-		return nil, fmt.Errorf("mmap, size %d %w", size, err)
+		return nil, fmt.Errorf("mmap, size %d: %w", size, err)
 	}
 
 	return &MmapFile{f: f, b: b}, nil

--- a/tsdb/fileutil/preallocate_linux.go
+++ b/tsdb/fileutil/preallocate_linux.go
@@ -15,6 +15,7 @@
 package fileutil
 
 import (
+	"errors"
 	"os"
 	"syscall"
 )
@@ -23,10 +24,10 @@ func preallocExtend(f *os.File, sizeInBytes int64) error {
 	// use mode = 0 to change size
 	err := syscall.Fallocate(int(f.Fd()), 0, 0, sizeInBytes)
 	if err != nil {
-		errno, ok := err.(syscall.Errno)
+		var errno syscall.Errno
 		// not supported; fallback
 		// fallocate EINTRs frequently in some environments; fallback
-		if ok && (errno == syscall.ENOTSUP || errno == syscall.EINTR) {
+		if errors.As(err, &errno) && (errno == syscall.ENOTSUP || errno == syscall.EINTR) {
 			return preallocExtendTrunc(f, sizeInBytes)
 		}
 	}
@@ -37,9 +38,9 @@ func preallocFixed(f *os.File, sizeInBytes int64) error {
 	// use mode = 1 to keep size; see FALLOC_FL_KEEP_SIZE
 	err := syscall.Fallocate(int(f.Fd()), 1, 0, sizeInBytes)
 	if err != nil {
-		errno, ok := err.(syscall.Errno)
+		var errno syscall.Errno
 		// treat not supported as nil error
-		if ok && errno == syscall.ENOTSUP {
+		if errors.As(err, &errno) && errno == syscall.ENOTSUP {
 			return nil
 		}
 	}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -674,7 +674,7 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 		}
 		return nil
 	}); err != nil {
-		return nil, fmt.Errorf("iterate on on-disk chunks")
+		return nil, fmt.Errorf("iterate on on-disk chunks: %w", err)
 	}
 	return mmappedChunks, nil
 }

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -252,7 +252,7 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 		// Ensure no empty labels have gotten through.
 		lset = lset.WithoutEmpty()
 		if len(lset) == 0 {
-			return 0, fmt.Errorf("empty labelset %w", ErrInvalidSample)
+			return 0, fmt.Errorf("empty labelset: %w", ErrInvalidSample)
 		}
 
 		if l, dup := lset.HasDuplicateLabelNames(); dup {
@@ -386,7 +386,7 @@ func (a *headAppender) log() error {
 		buf = rec[:0]
 
 		if err := a.head.wal.Log(rec); err != nil {
-			return fmt.Errorf("log series %w", err)
+			return fmt.Errorf("log series: %w", err)
 		}
 	}
 	if len(a.samples) > 0 {
@@ -394,7 +394,7 @@ func (a *headAppender) log() error {
 		buf = rec[:0]
 
 		if err := a.head.wal.Log(rec); err != nil {
-			return fmt.Errorf("log samples %w", err)
+			return fmt.Errorf("log samples: %w", err)
 		}
 	}
 	if len(a.exemplars) > 0 {
@@ -402,7 +402,7 @@ func (a *headAppender) log() error {
 		buf = rec[:0]
 
 		if err := a.head.wal.Log(rec); err != nil {
-			return fmt.Errorf("log exemplars %w", err)
+			return fmt.Errorf("log exemplars: %w", err)
 		}
 	}
 	return nil
@@ -430,7 +430,7 @@ func (a *headAppender) Commit() (err error) {
 
 	if err := a.log(); err != nil {
 		_ = a.Rollback() // Most likely the same error will happen again.
-		return fmt.Errorf("write to WAL %w", err)
+		return fmt.Errorf("write to WAL: %w", err)
 	}
 
 	// No errors logging to WAL, so pass the exemplars along to the in memory storage.

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -14,10 +14,10 @@
 package tsdb
 
 import (
+	"errors"
 	"strconv"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -131,7 +131,7 @@ func (h *headIndexReader) SortedPostings(p index.Postings) index.Postings {
 		}
 	}
 	if err := p.Err(); err != nil {
-		return index.ErrPostings(fmt.Errorf("expand postings %w", err))
+		return index.ErrPostings(fmt.Errorf("expand postings: %w", err))
 	}
 
 	sort.Slice(series, func(i, j int) bool {

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -14,6 +14,7 @@
 package tsdb
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -25,7 +26,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -85,8 +85,8 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[chunks.HeadSeriesRef]chunks.H
 
 	defer func() {
 		// For CorruptionErr ensure to terminate all workers before exiting.
-		_, ok := err.(*wal.CorruptionErr)
-		if ok || seriesCreationErr != nil {
+		var ce *wal.CorruptionErr
+		if errors.As(err, &ce) || seriesCreationErr != nil {
 			for i := 0; i < n; i++ {
 				processors[i].closeAndDrain()
 			}
@@ -124,7 +124,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[chunks.HeadSeriesRef]chunks.H
 			// At the moment the only possible error here is out of order exemplars, which we shouldn't see when
 			// replaying the WAL, so lets just log the error if it's not that type.
 			err = h.exemplars.AddExemplar(ms.lset, exemplar.Exemplar{Ts: e.T, Value: e.V, Labels: e.Labels})
-			if err != nil && err == storage.ErrOutOfOrderExemplar {
+			if err != nil && errors.Is(err, storage.ErrOutOfOrderExemplar) {
 				level.Warn(h.logger).Log("msg", "Unexpected error when replaying WAL on exemplar record", "err", err)
 			}
 		}
@@ -141,7 +141,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[chunks.HeadSeriesRef]chunks.H
 				series, err = dec.Series(rec, series)
 				if err != nil {
 					decodeErr = &wal.CorruptionErr{
-						Err:     errors.Wrap(err, "decode series"),
+						Err:     fmt.Errorf("decode series %w", err),
 						Segment: r.Segment(),
 						Offset:  r.Offset(),
 					}
@@ -153,7 +153,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[chunks.HeadSeriesRef]chunks.H
 				samples, err = dec.Samples(rec, samples)
 				if err != nil {
 					decodeErr = &wal.CorruptionErr{
-						Err:     errors.Wrap(err, "decode samples"),
+						Err:     fmt.Errorf("decode samples %w", err),
 						Segment: r.Segment(),
 						Offset:  r.Offset(),
 					}
@@ -165,7 +165,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[chunks.HeadSeriesRef]chunks.H
 				tstones, err = dec.Tombstones(rec, tstones)
 				if err != nil {
 					decodeErr = &wal.CorruptionErr{
-						Err:     errors.Wrap(err, "decode tombstones"),
+						Err:     fmt.Errorf("decode tombstones %w", err),
 						Segment: r.Segment(),
 						Offset:  r.Offset(),
 					}
@@ -177,7 +177,7 @@ func (h *Head) loadWAL(r *wal.Reader, multiRef map[chunks.HeadSeriesRef]chunks.H
 				exemplars, err = dec.Exemplars(rec, exemplars)
 				if err != nil {
 					decodeErr = &wal.CorruptionErr{
-						Err:     errors.Wrap(err, "decode exemplars"),
+						Err:     fmt.Errorf("decode exemplars %w", err),
 						Segment: r.Segment(),
 						Offset:  r.Offset(),
 					}
@@ -330,7 +330,7 @@ Outer:
 	wg.Wait()
 
 	if r.Err() != nil {
-		return errors.Wrap(r.Err(), "read records")
+		return fmt.Errorf("read records %w", r.Err())
 	}
 
 	if unknownRefs.Load() > 0 || unknownExemplarRefs.Load() > 0 {
@@ -496,7 +496,7 @@ func decodeSeriesFromChunkSnapshot(b []byte) (csr chunkSnapshotRecord, err error
 	dec := encoding.Decbuf{B: b}
 
 	if flag := dec.Byte(); flag != chunkSnapshotRecordTypeSeries {
-		return csr, errors.Errorf("invalid record type %x", flag)
+		return csr, fmt.Errorf("invalid record type %x", flag)
 	}
 
 	csr.ref = chunks.HeadSeriesRef(dec.Be64())
@@ -525,7 +525,7 @@ func decodeSeriesFromChunkSnapshot(b []byte) (csr chunkSnapshotRecord, err error
 
 	chk, err := chunkenc.FromData(enc, chunkBytesCopy)
 	if err != nil {
-		return csr, errors.Wrap(err, "chunk from data")
+		return csr, fmt.Errorf("chunk from data %w", err)
 	}
 	csr.mc.chunk = chk
 
@@ -536,7 +536,7 @@ func decodeSeriesFromChunkSnapshot(b []byte) (csr chunkSnapshotRecord, err error
 
 	err = dec.Err()
 	if err != nil && len(dec.B) > 0 {
-		err = errors.Errorf("unexpected %d bytes left in entry", len(dec.B))
+		err = fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 
 	return
@@ -548,7 +548,7 @@ func encodeTombstonesToSnapshotRecord(tr tombstones.Reader) ([]byte, error) {
 	buf.PutByte(chunkSnapshotRecordTypeTombstones)
 	b, err := tombstones.Encode(tr)
 	if err != nil {
-		return nil, errors.Wrap(err, "encode tombstones")
+		return nil, fmt.Errorf("encode tombstones %w", err)
 	}
 	buf.PutUvarintBytes(b)
 
@@ -559,11 +559,11 @@ func decodeTombstonesSnapshotRecord(b []byte) (tombstones.Reader, error) {
 	dec := encoding.Decbuf{B: b}
 
 	if flag := dec.Byte(); flag != chunkSnapshotRecordTypeTombstones {
-		return nil, errors.Errorf("invalid record type %x", flag)
+		return nil, fmt.Errorf("invalid record type %x", flag)
 	}
 
 	tr, err := tombstones.Decode(dec.UvarintBytes())
-	return tr, errors.Wrap(err, "decode tombstones")
+	return tr, fmt.Errorf("decode tombstones %w", err)
 }
 
 const chunkSnapshotPrefix = "chunk_snapshot."
@@ -590,13 +590,13 @@ func (h *Head) ChunkSnapshot() (*ChunkSnapshotStats, error) {
 	stats := &ChunkSnapshotStats{}
 
 	wlast, woffset, err := h.wal.LastSegmentAndOffset()
-	if err != nil && err != record.ErrNotFound {
-		return stats, errors.Wrap(err, "get last wal segment and offset")
+	if err != nil && !errors.Is(err, record.ErrNotFound) {
+		return stats, fmt.Errorf("get last wal segment and offset %w", err)
 	}
 
 	_, cslast, csoffset, err := LastChunkSnapshot(h.opts.ChunkDirRoot)
-	if err != nil && err != record.ErrNotFound {
-		return stats, errors.Wrap(err, "find last chunk snapshot")
+	if err != nil && !errors.Is(err, record.ErrNotFound) {
+		return stats, fmt.Errorf("find last chunk snapshot %w", err)
 	}
 
 	if wlast == cslast && woffset == csoffset {
@@ -611,11 +611,11 @@ func (h *Head) ChunkSnapshot() (*ChunkSnapshotStats, error) {
 	stats.Dir = cpdir
 
 	if err := os.MkdirAll(cpdirtmp, 0o777); err != nil {
-		return stats, errors.Wrap(err, "create chunk snapshot dir")
+		return stats, fmt.Errorf("create chunk snapshot dir %w", err)
 	}
 	cp, err := wal.New(nil, nil, cpdirtmp, h.wal.CompressionEnabled())
 	if err != nil {
-		return stats, errors.Wrap(err, "open chunk snapshot")
+		return stats, fmt.Errorf("open chunk snapshot %w", err)
 	}
 
 	// Ensures that an early return caused by an error doesn't leave any tmp files.
@@ -644,7 +644,7 @@ func (h *Head) ChunkSnapshot() (*ChunkSnapshotStats, error) {
 			if len(buf) > 10*1024*1024 {
 				if err := cp.Log(recs...); err != nil {
 					h.series.locks[i].RUnlock()
-					return stats, errors.Wrap(err, "flush records")
+					return stats, fmt.Errorf("flush records %w", err)
 				}
 				buf, recs = buf[:0], recs[:0]
 			}
@@ -657,16 +657,16 @@ func (h *Head) ChunkSnapshot() (*ChunkSnapshotStats, error) {
 	// Add tombstones to the snapshot.
 	tombstonesReader, err := h.Tombstones()
 	if err != nil {
-		return stats, errors.Wrap(err, "get tombstones")
+		return stats, fmt.Errorf("get tombstones %w", err)
 	}
 	rec, err := encodeTombstonesToSnapshotRecord(tombstonesReader)
 	if err != nil {
-		return stats, errors.Wrap(err, "encode tombstones")
+		return stats, fmt.Errorf("encode tombstones %w", err)
 	}
 	recs = append(recs, rec)
 	// Flush remaining series records and tombstones.
 	if err := cp.Log(recs...); err != nil {
-		return stats, errors.Wrap(err, "flush records")
+		return stats, fmt.Errorf("flush records %w", err)
 	}
 	buf = buf[:0]
 
@@ -685,7 +685,7 @@ func (h *Head) ChunkSnapshot() (*ChunkSnapshotStats, error) {
 		encbuf.PutByte(chunkSnapshotRecordTypeExemplars)
 		enc.EncodeExemplarsIntoBuffer(batch, &encbuf)
 		if err := cp.Log(encbuf.Get()); err != nil {
-			return errors.Wrap(err, "log exemplars")
+			return fmt.Errorf("log exemplars %w", err)
 		}
 		buf, batch = buf[:0], batch[:0]
 		return nil
@@ -693,7 +693,7 @@ func (h *Head) ChunkSnapshot() (*ChunkSnapshotStats, error) {
 	err = h.exemplars.IterateExemplars(func(seriesLabels labels.Labels, e exemplar.Exemplar) error {
 		if len(batch) >= maxExemplarsPerRecord {
 			if err := flushExemplars(); err != nil {
-				return errors.Wrap(err, "flush exemplars")
+				return fmt.Errorf("flush exemplars %w", err)
 			}
 		}
 
@@ -711,19 +711,19 @@ func (h *Head) ChunkSnapshot() (*ChunkSnapshotStats, error) {
 		return nil
 	})
 	if err != nil {
-		return stats, errors.Wrap(err, "iterate exemplars")
+		return stats, fmt.Errorf("iterate exemplars %w", err)
 	}
 
 	// Flush remaining exemplars.
 	if err := flushExemplars(); err != nil {
-		return stats, errors.Wrap(err, "flush exemplars at the end")
+		return stats, fmt.Errorf("flush exemplars at the end %w", err)
 	}
 
 	if err := cp.Close(); err != nil {
-		return stats, errors.Wrap(err, "close chunk snapshot")
+		return stats, fmt.Errorf("close chunk snapshot %w", err)
 	}
 	if err := fileutil.Replace(cpdirtmp, cpdir); err != nil {
-		return stats, errors.Wrap(err, "rename chunk snapshot directory")
+		return stats, fmt.Errorf("rename chunk snapshot directory %w", err)
 	}
 
 	if err := DeleteChunkSnapshots(h.opts.ChunkDirRoot, wlast, woffset); err != nil {
@@ -747,7 +747,7 @@ func (h *Head) performChunkSnapshot() error {
 	if err == nil {
 		level.Info(h.logger).Log("msg", "chunk snapshot complete", "duration", elapsed.String(), "num_series", stats.TotalSeries, "dir", stats.Dir)
 	}
-	return errors.Wrap(err, "chunk snapshot")
+	return fmt.Errorf("chunk snapshot %w", err)
 }
 
 // ChunkSnapshotStats returns stats about a created chunk snapshot.
@@ -772,7 +772,7 @@ func LastChunkSnapshot(dir string) (string, int, int, error) {
 			continue
 		}
 		if !fi.IsDir() {
-			return "", 0, 0, errors.Errorf("chunk snapshot %s is not a directory", fi.Name())
+			return "", 0, 0, fmt.Errorf("chunk snapshot %s is not a directory", fi.Name())
 		}
 
 		splits := strings.Split(fi.Name()[len(chunkSnapshotPrefix):], ".")
@@ -845,16 +845,16 @@ func DeleteChunkSnapshots(dir string, maxIndex, maxOffset int) error {
 func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSeries, error) {
 	dir, snapIdx, snapOffset, err := LastChunkSnapshot(h.opts.ChunkDirRoot)
 	if err != nil {
-		if err == record.ErrNotFound {
+		if errors.Is(err, record.ErrNotFound) {
 			return snapIdx, snapOffset, nil, nil
 		}
-		return snapIdx, snapOffset, nil, errors.Wrap(err, "find last chunk snapshot")
+		return snapIdx, snapOffset, nil, fmt.Errorf("find last chunk snapshot %w", err)
 	}
 
 	start := time.Now()
 	sr, err := wal.NewSegmentsReader(dir)
 	if err != nil {
-		return snapIdx, snapOffset, nil, errors.Wrap(err, "open chunk snapshot")
+		return snapIdx, snapOffset, nil, fmt.Errorf("open chunk snapshot %w", err)
 	}
 	defer func() {
 		if err := sr.Close(); err != nil {
@@ -940,7 +940,7 @@ Outer:
 			numSeries++
 			csr, err := decodeSeriesFromChunkSnapshot(rec)
 			if err != nil {
-				loopErr = errors.Wrap(err, "decode series record")
+				loopErr = fmt.Errorf("decode series record %w", err)
 				break Outer
 			}
 			recordChan <- csr
@@ -948,7 +948,7 @@ Outer:
 		case chunkSnapshotRecordTypeTombstones:
 			tr, err := decodeTombstonesSnapshotRecord(rec)
 			if err != nil {
-				loopErr = errors.Wrap(err, "decode tombstones")
+				loopErr = fmt.Errorf("decode tombstones %w", err)
 				break Outer
 			}
 
@@ -956,7 +956,7 @@ Outer:
 				h.tombstones.AddInterval(ref, ivs...)
 				return nil
 			}); err != nil {
-				loopErr = errors.Wrap(err, "iterate tombstones")
+				loopErr = fmt.Errorf("iterate tombstones %w", err)
 				break Outer
 			}
 
@@ -984,7 +984,7 @@ Outer:
 			exemplarBuf = exemplarBuf[:0]
 			exemplarBuf, err = dec.ExemplarsFromBuffer(&decbuf, exemplarBuf)
 			if err != nil {
-				loopErr = errors.Wrap(err, "exemplars from buffer")
+				loopErr = fmt.Errorf("exemplars from buffer %w", err)
 				break Outer
 			}
 
@@ -1000,7 +1000,7 @@ Outer:
 					Value:  e.V,
 					Ts:     e.T,
 				}); err != nil {
-					loopErr = errors.Wrap(err, "add exemplar")
+					loopErr = fmt.Errorf("add exemplar %w", err)
 					break Outer
 				}
 			}
@@ -1008,7 +1008,7 @@ Outer:
 		default:
 			// This is a record type we don't understand. It is either and old format from earlier versions,
 			// or a new format and the code was rolled back to old version.
-			loopErr = errors.Errorf("unsuported snapshot record type 0b%b", rec[0])
+			loopErr = fmt.Errorf("unsuported snapshot record type 0b%b", rec[0])
 			break Outer
 		}
 	}
@@ -1018,16 +1018,16 @@ Outer:
 	}
 
 	close(errChan)
-	merr := tsdb_errors.NewMulti(errors.Wrap(loopErr, "decode loop"))
+	merr := tsdb_errors.NewMulti(fmt.Errorf("decode loop %w", loopErr))
 	for err := range errChan {
-		merr.Add(errors.Wrap(err, "record processing"))
+		merr.Add(fmt.Errorf("record processing %w", err))
 	}
 	if err := merr.Err(); err != nil {
 		return -1, -1, nil, err
 	}
 
 	if r.Err() != nil {
-		return -1, -1, nil, errors.Wrap(r.Err(), "read records")
+		return -1, -1, nil, fmt.Errorf("read records %w", r.Err())
 	}
 
 	if len(refSeries) == 0 {

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1612,7 +1612,10 @@ func (r *Reader) Series(id storage.SeriesRef, lbls *labels.Labels, chks *[]chunk
 	if d.Err() != nil {
 		return d.Err()
 	}
-	return fmt.Errorf("read series: %w", r.dec.Series(d.Get(), lbls, chks))
+	if err := r.dec.Series(d.Get(), lbls, chks); err != nil {
+		return fmt.Errorf("read series: %w", err)
+	}
+	return nil
 }
 
 func (r *Reader) Postings(name string, values ...string) (Postings, error) {

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -115,7 +115,7 @@ func (m mockIndex) Postings(name string, values ...string) (Postings, error) {
 func (m mockIndex) SortedPostings(p Postings) Postings {
 	ep, err := ExpandPostings(p)
 	if err != nil {
-		return ErrPostings(fmt.Errorf("expand postings %w", err))
+		return ErrPostings(fmt.Errorf("expand postings: %w", err))
 	}
 
 	sort.Slice(ep, func(i, j int) bool {

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -16,11 +16,10 @@ package index
 import (
 	"container/heap"
 	"encoding/binary"
+	"fmt"
 	"runtime"
 	"sort"
 	"sync"
-
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -916,7 +915,7 @@ func (h *postingsWithIndexHeap) next() error {
 	}
 
 	if err := pi.p.Err(); err != nil {
-		return errors.Wrapf(err, "postings %d", pi.index)
+		return fmt.Errorf("postings %d %w", pi.index, err)
 	}
 	h.popIndex()
 	return nil

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -915,7 +915,7 @@ func (h *postingsWithIndexHeap) next() error {
 	}
 
 	if err := pi.p.Err(); err != nil {
-		return fmt.Errorf("postings %d %w", pi.index, err)
+		return fmt.Errorf("postings %d: %w", pi.index, err)
 	}
 	h.popIndex()
 	return nil

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -17,13 +17,13 @@ import (
 	"container/heap"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/rand"
 	"sort"
 	"strconv"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"

--- a/tsdb/mocks_test.go
+++ b/tsdb/mocks_test.go
@@ -14,7 +14,7 @@
 package tsdb
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -41,7 +41,7 @@ func (m *mockIndexWriter) AddSeries(_ storage.SeriesRef, l labels.Labels, chks .
 	for i, chk := range chks {
 		c, err := copyChunk(chk.Chunk)
 		if err != nil {
-			return errors.Wrap(err, "mockIndexWriter: copy chunk")
+			return fmt.Errorf("mockIndexWriter: copy chunk %w", err)
 		}
 		chksNew[i] = chunks.Meta{MaxTime: chk.MaxTime, MinTime: chk.MinTime, Chunk: c}
 	}

--- a/tsdb/mocks_test.go
+++ b/tsdb/mocks_test.go
@@ -41,7 +41,7 @@ func (m *mockIndexWriter) AddSeries(_ storage.SeriesRef, l labels.Labels, chks .
 	for i, chk := range chks {
 		c, err := copyChunk(chk.Chunk)
 		if err != nil {
-			return fmt.Errorf("mockIndexWriter: copy chunk %w", err)
+			return fmt.Errorf("mockIndexWriter: copy chunk: %w", err)
 		}
 		chksNew[i] = chunks.Meta{MaxTime: chk.MaxTime, MinTime: chk.MinTime, Chunk: c}
 	}

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -57,18 +57,18 @@ type blockBaseQuerier struct {
 func newBlockBaseQuerier(b BlockReader, mint, maxt int64) (*blockBaseQuerier, error) {
 	indexr, err := b.Index()
 	if err != nil {
-		return nil, fmt.Errorf("open index reader %w", err)
+		return nil, fmt.Errorf("open index reader: %w", err)
 	}
 	chunkr, err := b.Chunks()
 	if err != nil {
 		indexr.Close()
-		return nil, fmt.Errorf("open chunk reader %w", err)
+		return nil, fmt.Errorf("open chunk reader: %w", err)
 	}
 	tombsr, err := b.Tombstones()
 	if err != nil {
 		indexr.Close()
 		chunkr.Close()
-		return nil, fmt.Errorf("open tombstone reader %w", err)
+		return nil, fmt.Errorf("open tombstone reader: %w", err)
 	}
 
 	if tombsr == nil {
@@ -377,23 +377,23 @@ func inversePostingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Posting
 func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Matcher) ([]string, error) {
 	p, err := PostingsForMatchers(r, matchers...)
 	if err != nil {
-		return nil, fmt.Errorf("fetching postings for matchers %w", err)
+		return nil, fmt.Errorf("fetching postings for matchers: %w", err)
 	}
 
 	allValues, err := r.LabelValues(name)
 	if err != nil {
-		return nil, fmt.Errorf("fetching values of label %s %w", name, err)
+		return nil, fmt.Errorf("fetching values of label %s: %w", name, err)
 	}
 	valuesPostings := make([]index.Postings, len(allValues))
 	for i, value := range allValues {
 		valuesPostings[i], err = r.Postings(name, value)
 		if err != nil {
-			return nil, fmt.Errorf("fetching postings for %s=%q %w", name, value, err)
+			return nil, fmt.Errorf("fetching postings for %s=%q: %w", name, value, err)
 		}
 	}
 	indexes, err := index.FindIntersectingPostings(p, valuesPostings)
 	if err != nil {
-		return nil, fmt.Errorf("intersecting postings %w", err)
+		return nil, fmt.Errorf("intersecting postings: %w", err)
 	}
 
 	values := make([]string, 0, len(indexes))
@@ -415,7 +415,7 @@ func labelNamesWithMatchers(r IndexReader, matchers ...*labels.Matcher) ([]strin
 		postings = append(postings, p.At())
 	}
 	if p.Err() != nil {
-		return nil, fmt.Errorf("postings for label names with matches %w", p.Err())
+		return nil, fmt.Errorf("postings for label names with matches: %w", p.Err())
 	}
 
 	return r.LabelNamesFor(postings...)
@@ -447,7 +447,7 @@ func (b *blockBaseSeriesSet) Next() bool {
 			if errors.Is(errors.Unwrap(err), storage.ErrNotFound) {
 				continue
 			}
-			b.err = fmt.Errorf("get series %d %w", b.p.At(), err)
+			b.err = fmt.Errorf("get series %d: %w", b.p.At(), err)
 			return false
 		}
 
@@ -457,7 +457,7 @@ func (b *blockBaseSeriesSet) Next() bool {
 
 		intervals, err := b.tombstones.Get(b.p.At())
 		if err != nil {
-			b.err = fmt.Errorf("get tombstones %w", err)
+			b.err = fmt.Errorf("get tombstones: %w", err)
 			return false
 		}
 
@@ -571,7 +571,7 @@ func (p *populateWithDelGenericSeriesIterator) next() bool {
 
 	p.currChkMeta.Chunk, p.err = p.chunks.Chunk(p.currChkMeta.Ref)
 	if p.err != nil {
-		p.err = fmt.Errorf("cannot populate chunk %d %w", p.currChkMeta.Ref, p.err)
+		p.err = fmt.Errorf("cannot populate chunk %d: %w", p.currChkMeta.Ref, p.err)
 		return false
 	}
 
@@ -686,12 +686,12 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 
 	if !p.currDelIter.Next() {
 		if err := p.currDelIter.Err(); err != nil {
-			p.err = fmt.Errorf("iterate chunk while re-encoding %w", err)
+			p.err = fmt.Errorf("iterate chunk while re-encoding: %w", err)
 			return false
 		}
 
 		// Empty chunk, this should not happen, as we assume full deletions being filtered before this iterator.
-		p.err = fmt.Errorf("populateWithDelChunkSeriesIterator: unexpected empty chunk found while rewriting chunk %w", err)
+		p.err = fmt.Errorf("populateWithDelChunkSeriesIterator: unexpected empty chunk found while rewriting chunk: %w", err)
 		return false
 	}
 
@@ -704,7 +704,7 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 		app.Append(t, v)
 	}
 	if err := p.currDelIter.Err(); err != nil {
-		p.err = fmt.Errorf("iterate chunk while re-encoding %w", err)
+		p.err = fmt.Errorf("iterate chunk while re-encoding: %w", err)
 		return false
 	}
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -14,12 +14,12 @@
 package tsdb
 
 import (
+	"errors"
+	"fmt"
 	"math"
 	"sort"
 	"strings"
 	"unicode/utf8"
-
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -57,18 +57,18 @@ type blockBaseQuerier struct {
 func newBlockBaseQuerier(b BlockReader, mint, maxt int64) (*blockBaseQuerier, error) {
 	indexr, err := b.Index()
 	if err != nil {
-		return nil, errors.Wrap(err, "open index reader")
+		return nil, fmt.Errorf("open index reader %w", err)
 	}
 	chunkr, err := b.Chunks()
 	if err != nil {
 		indexr.Close()
-		return nil, errors.Wrap(err, "open chunk reader")
+		return nil, fmt.Errorf("open chunk reader %w", err)
 	}
 	tombsr, err := b.Tombstones()
 	if err != nil {
 		indexr.Close()
 		chunkr.Close()
-		return nil, errors.Wrap(err, "open tombstone reader")
+		return nil, fmt.Errorf("open tombstone reader %w", err)
 	}
 
 	if tombsr == nil {
@@ -377,23 +377,23 @@ func inversePostingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Posting
 func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Matcher) ([]string, error) {
 	p, err := PostingsForMatchers(r, matchers...)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching postings for matchers")
+		return nil, fmt.Errorf("fetching postings for matchers %w", err)
 	}
 
 	allValues, err := r.LabelValues(name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "fetching values of label %s", name)
+		return nil, fmt.Errorf("fetching values of label %s %w", name, err)
 	}
 	valuesPostings := make([]index.Postings, len(allValues))
 	for i, value := range allValues {
 		valuesPostings[i], err = r.Postings(name, value)
 		if err != nil {
-			return nil, errors.Wrapf(err, "fetching postings for %s=%q", name, value)
+			return nil, fmt.Errorf("fetching postings for %s=%q %w", name, value, err)
 		}
 	}
 	indexes, err := index.FindIntersectingPostings(p, valuesPostings)
 	if err != nil {
-		return nil, errors.Wrap(err, "intersecting postings")
+		return nil, fmt.Errorf("intersecting postings %w", err)
 	}
 
 	values := make([]string, 0, len(indexes))
@@ -415,7 +415,7 @@ func labelNamesWithMatchers(r IndexReader, matchers ...*labels.Matcher) ([]strin
 		postings = append(postings, p.At())
 	}
 	if p.Err() != nil {
-		return nil, errors.Wrapf(p.Err(), "postings for label names with matchers")
+		return nil, fmt.Errorf("postings for label names with matches %w", p.Err())
 	}
 
 	return r.LabelNamesFor(postings...)
@@ -444,10 +444,10 @@ func (b *blockBaseSeriesSet) Next() bool {
 	for b.p.Next() {
 		if err := b.index.Series(b.p.At(), &b.bufLbls, &b.bufChks); err != nil {
 			// Postings may be stale. Skip if no underlying series exists.
-			if errors.Cause(err) == storage.ErrNotFound {
+			if errors.Is(errors.Unwrap(err), storage.ErrNotFound) {
 				continue
 			}
-			b.err = errors.Wrapf(err, "get series %d", b.p.At())
+			b.err = fmt.Errorf("get series %d %w", b.p.At(), err)
 			return false
 		}
 
@@ -457,7 +457,7 @@ func (b *blockBaseSeriesSet) Next() bool {
 
 		intervals, err := b.tombstones.Get(b.p.At())
 		if err != nil {
-			b.err = errors.Wrap(err, "get tombstones")
+			b.err = fmt.Errorf("get tombstones %w", err)
 			return false
 		}
 
@@ -571,7 +571,7 @@ func (p *populateWithDelGenericSeriesIterator) next() bool {
 
 	p.currChkMeta.Chunk, p.err = p.chunks.Chunk(p.currChkMeta.Ref)
 	if p.err != nil {
-		p.err = errors.Wrapf(p.err, "cannot populate chunk %d", p.currChkMeta.Ref)
+		p.err = fmt.Errorf("cannot populate chunk %d %w", p.currChkMeta.Ref, p.err)
 		return false
 	}
 
@@ -686,12 +686,12 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 
 	if !p.currDelIter.Next() {
 		if err := p.currDelIter.Err(); err != nil {
-			p.err = errors.Wrap(err, "iterate chunk while re-encoding")
+			p.err = fmt.Errorf("iterate chunk while re-encoding %w", err)
 			return false
 		}
 
 		// Empty chunk, this should not happen, as we assume full deletions being filtered before this iterator.
-		p.err = errors.Wrap(err, "populateWithDelChunkSeriesIterator: unexpected empty chunk found while rewriting chunk")
+		p.err = fmt.Errorf("populateWithDelChunkSeriesIterator: unexpected empty chunk found while rewriting chunk %w", err)
 		return false
 	}
 
@@ -704,7 +704,7 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 		app.Append(t, v)
 	}
 	if err := p.currDelIter.Err(); err != nil {
-		p.err = errors.Wrap(err, "iterate chunk while re-encoding")
+		p.err = fmt.Errorf("iterate chunk while re-encoding %w", err)
 		return false
 	}
 

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -15,6 +15,7 @@ package tsdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -24,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -630,7 +630,7 @@ func createFakeReaderAndNotPopulatedChunks(s ...[]tsdbutil.Sample) (*fakeChunksR
 func (r *fakeChunksReader) Chunk(ref chunks.ChunkRef) (chunkenc.Chunk, error) {
 	chk, ok := r.chks[ref]
 	if !ok {
-		return nil, errors.Errorf("chunk not found at ref %v", ref)
+		return nil, fmt.Errorf("chunk not found at ref %v", ref)
 	}
 	return chk, nil
 }
@@ -1161,7 +1161,7 @@ func (m mockIndex) Symbols() index.StringIter {
 
 func (m *mockIndex) AddSeries(ref storage.SeriesRef, l labels.Labels, chunks ...chunks.Meta) error {
 	if _, ok := m.series[ref]; ok {
-		return errors.Errorf("series with reference %d already added", ref)
+		return fmt.Errorf("series with reference %d already added", ref)
 	}
 	for _, lbl := range l {
 		m.symbols[lbl.Name] = struct{}{}
@@ -1182,7 +1182,7 @@ func (m *mockIndex) AddSeries(ref storage.SeriesRef, l labels.Labels, chunks ...
 func (m mockIndex) WritePostings(name, value string, it index.Postings) error {
 	l := labels.Label{Name: name, Value: value}
 	if _, ok := m.postings[l]; ok {
-		return errors.Errorf("postings for %s already added", l)
+		return fmt.Errorf("postings for %s already added", l)
 	}
 	ep, err := index.ExpandPostings(it)
 	if err != nil {
@@ -1256,7 +1256,7 @@ func (m mockIndex) Postings(name string, values ...string) (index.Postings, erro
 func (m mockIndex) SortedPostings(p index.Postings) index.Postings {
 	ep, err := index.ExpandPostings(p)
 	if err != nil {
-		return index.ErrPostings(errors.Wrap(err, "expand postings"))
+		return index.ErrPostings(fmt.Errorf("expand postings %w", err))
 	}
 
 	sort.Slice(ep, func(i, j int) bool {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1256,7 +1256,7 @@ func (m mockIndex) Postings(name string, values ...string) (index.Postings, erro
 func (m mockIndex) SortedPostings(p index.Postings) index.Postings {
 	ep, err := index.ExpandPostings(p)
 	if err != nil {
-		return index.ErrPostings(fmt.Errorf("expand postings %w", err))
+		return index.ErrPostings(fmt.Errorf("expand postings: %w", err))
 	}
 
 	sort.Slice(ep, func(i, j int) bool {

--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -16,10 +16,10 @@
 package record
 
 import (
+	"errors"
+	"fmt"
 	"math"
 	"sort"
-
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -112,7 +112,7 @@ func (d *Decoder) Series(rec []byte, series []RefSeries) ([]RefSeries, error) {
 		return nil, dec.Err()
 	}
 	if len(dec.B) > 0 {
-		return nil, errors.Errorf("unexpected %d bytes left in entry", len(dec.B))
+		return nil, fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 	return series, nil
 }
@@ -144,10 +144,10 @@ func (d *Decoder) Samples(rec []byte, samples []RefSample) ([]RefSample, error) 
 	}
 
 	if dec.Err() != nil {
-		return nil, errors.Wrapf(dec.Err(), "decode error after %d samples", len(samples))
+		return nil, fmt.Errorf("decode error after %d samples %w", len(samples), dec.Err())
 	}
 	if len(dec.B) > 0 {
-		return nil, errors.Errorf("unexpected %d bytes left in entry", len(dec.B))
+		return nil, fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 	return samples, nil
 }
@@ -171,7 +171,7 @@ func (d *Decoder) Tombstones(rec []byte, tstones []tombstones.Stone) ([]tombston
 		return nil, dec.Err()
 	}
 	if len(dec.B) > 0 {
-		return nil, errors.Errorf("unexpected %d bytes left in entry", len(dec.B))
+		return nil, fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 	return tstones, nil
 }
@@ -215,10 +215,10 @@ func (d *Decoder) ExemplarsFromBuffer(dec *encoding.Decbuf, exemplars []RefExemp
 	}
 
 	if dec.Err() != nil {
-		return nil, errors.Wrapf(dec.Err(), "decode error after %d exemplars", len(exemplars))
+		return nil, fmt.Errorf("decode error after %d exemplars %w", len(exemplars), dec.Err())
 	}
 	if len(dec.B) > 0 {
-		return nil, errors.Errorf("unexpected %d bytes left in entry", len(dec.B))
+		return nil, fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 	return exemplars, nil
 }

--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -144,7 +144,7 @@ func (d *Decoder) Samples(rec []byte, samples []RefSample) ([]RefSample, error) 
 	}
 
 	if dec.Err() != nil {
-		return nil, fmt.Errorf("decode error after %d samples %w", len(samples), dec.Err())
+		return nil, fmt.Errorf("decode error after %d samples: %w", len(samples), dec.Err())
 	}
 	if len(dec.B) > 0 {
 		return nil, fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
@@ -215,7 +215,7 @@ func (d *Decoder) ExemplarsFromBuffer(dec *encoding.Decbuf, exemplars []RefExemp
 	}
 
 	if dec.Err() != nil {
-		return nil, fmt.Errorf("decode error after %d exemplars %w", len(exemplars), dec.Err())
+		return nil, fmt.Errorf("decode error after %d exemplars: %w", len(exemplars), dec.Err())
 	}
 	if len(dec.B) > 0 {
 		return nil, fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))

--- a/tsdb/record/record_test.go
+++ b/tsdb/record/record_test.go
@@ -15,9 +15,9 @@
 package record
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -111,7 +111,7 @@ func TestRecord_Corrupted(t *testing.T) {
 
 		corrupted := enc.Samples(samples, nil)[:8]
 		_, err := dec.Samples(corrupted, nil)
-		require.Equal(t, errors.Cause(err), encoding.ErrInvalidSize)
+		require.Equal(t, errors.Unwrap(err), encoding.ErrInvalidSize)
 	})
 
 	t.Run("Test corrupted tombstone record", func(t *testing.T) {
@@ -134,7 +134,7 @@ func TestRecord_Corrupted(t *testing.T) {
 
 		corrupted := enc.Exemplars(exemplars, nil)[:8]
 		_, err := dec.Exemplars(corrupted, nil)
-		require.Equal(t, errors.Cause(err), encoding.ErrInvalidSize)
+		require.Equal(t, errors.Unwrap(err), encoding.ErrInvalidSize)
 	})
 }
 

--- a/tsdb/repair.go
+++ b/tsdb/repair.go
@@ -15,13 +15,13 @@ package tsdb
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
@@ -34,7 +34,7 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 	// We must actually set the index file version to 2 and revert the meta.json version back to 1.
 	dirs, err := blockDirs(dir)
 	if err != nil {
-		return errors.Wrapf(err, "list block dirs in %q", dir)
+		return fmt.Errorf("list block dirs in %q %w", dir, err)
 	}
 
 	tmpFiles := make([]string, 0, len(dirs))
@@ -70,44 +70,43 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 
 		repl, err := os.Create(filepath.Join(d, "index.repaired"))
 		if err != nil {
-			return errors.Wrapf(err, "create index.repaired for block dir: %v", d)
+			return fmt.Errorf("create index.repaired for block dir: %v %w", d, err)
 		}
 		tmpFiles = append(tmpFiles, repl.Name())
 
 		broken, err := os.Open(filepath.Join(d, indexFilename))
 		if err != nil {
-			return errors.Wrapf(err, "open broken index for block dir: %v", d)
+			return fmt.Errorf("open broken index for block dir: %v %w", d, err)
 		}
 		if _, err := io.Copy(repl, broken); err != nil {
-			return errors.Wrapf(err, "copy content of index to index.repaired for block dir: %v", d)
+			return fmt.Errorf("copy content of index to index.repaired for block dir: %v %w", d, err)
 		}
-
 		// Set the 5th byte to 2 to indicate the correct file format version.
 		if _, err := repl.WriteAt([]byte{2}, 4); err != nil {
 			return tsdb_errors.NewMulti(
-				errors.Wrapf(err, "rewrite of index.repaired for block dir: %v", d),
-				errors.Wrap(repl.Close(), "close"),
+				fmt.Errorf("rewrite of index.repaired for block dir: %v %w", d, err),
+				fmt.Errorf("close %w", repl.Close()),
 			).Err()
 		}
 		if err := repl.Sync(); err != nil {
 			return tsdb_errors.NewMulti(
-				errors.Wrapf(err, "sync of index.repaired for block dir: %v", d),
-				errors.Wrap(repl.Close(), "close"),
+				fmt.Errorf("sync of index.repaired for block dir: %v %w", d, err),
+				fmt.Errorf("close %w", repl.Close()),
 			).Err()
 		}
 		if err := repl.Close(); err != nil {
-			return errors.Wrapf(repl.Close(), "close repaired index for block dir: %v", d)
+			return fmt.Errorf("close repaired index for block dir: %v %w", d, repl.Close())
 		}
 		if err := broken.Close(); err != nil {
-			return errors.Wrapf(repl.Close(), "close broken index for block dir: %v", d)
+			return fmt.Errorf("close broken index for block dir: %v %w", d, repl.Close())
 		}
 		if err := fileutil.Replace(repl.Name(), broken.Name()); err != nil {
-			return errors.Wrapf(repl.Close(), "replaced broken index with index.repaired for block dir: %v", d)
+			return fmt.Errorf("replaced broken index with index.repaired for block dir: %v %w", d, repl.Close())
 		}
 		// Reset version of meta.json to 1.
 		meta.Version = metaVersion1
 		if _, err := writeMetaFile(logger, d, meta); err != nil {
-			return errors.Wrapf(repl.Close(), "write meta for block dir: %v", d)
+			return fmt.Errorf("write meta for block dir: %v %w", d, repl.Close())
 		}
 	}
 	return nil
@@ -124,7 +123,7 @@ func readBogusMetaFile(dir string) (*BlockMeta, error) {
 		return nil, err
 	}
 	if m.Version != metaVersion1 && m.Version != 2 {
-		return nil, errors.Errorf("unexpected meta file version %d", m.Version)
+		return nil, fmt.Errorf("unexpected meta file version %d", m.Version)
 	}
 	return &m, nil
 }

--- a/tsdb/repair.go
+++ b/tsdb/repair.go
@@ -34,7 +34,7 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 	// We must actually set the index file version to 2 and revert the meta.json version back to 1.
 	dirs, err := blockDirs(dir)
 	if err != nil {
-		return fmt.Errorf("list block dirs in %q %w", dir, err)
+		return fmt.Errorf("list block dirs in %q: %w", dir, err)
 	}
 
 	tmpFiles := make([]string, 0, len(dirs))
@@ -70,43 +70,43 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 
 		repl, err := os.Create(filepath.Join(d, "index.repaired"))
 		if err != nil {
-			return fmt.Errorf("create index.repaired for block dir: %v %w", d, err)
+			return fmt.Errorf("create index.repaired for block dir: %v: %w", d, err)
 		}
 		tmpFiles = append(tmpFiles, repl.Name())
 
 		broken, err := os.Open(filepath.Join(d, indexFilename))
 		if err != nil {
-			return fmt.Errorf("open broken index for block dir: %v %w", d, err)
+			return fmt.Errorf("open broken index for block dir: %v: %w", d, err)
 		}
 		if _, err := io.Copy(repl, broken); err != nil {
-			return fmt.Errorf("copy content of index to index.repaired for block dir: %v %w", d, err)
+			return fmt.Errorf("copy content of index to index.repaired for block dir: %v: %w", d, err)
 		}
 		// Set the 5th byte to 2 to indicate the correct file format version.
 		if _, err := repl.WriteAt([]byte{2}, 4); err != nil {
 			return tsdb_errors.NewMulti(
-				fmt.Errorf("rewrite of index.repaired for block dir: %v %w", d, err),
-				fmt.Errorf("close %w", repl.Close()),
+				fmt.Errorf("rewrite of index.repaired for block dir: %v: %w", d, err),
+				fmt.Errorf("close: %w", repl.Close()),
 			).Err()
 		}
 		if err := repl.Sync(); err != nil {
 			return tsdb_errors.NewMulti(
-				fmt.Errorf("sync of index.repaired for block dir: %v %w", d, err),
-				fmt.Errorf("close %w", repl.Close()),
+				fmt.Errorf("sync of index.repaired for block dir: %v: %w", d, err),
+				fmt.Errorf("close: %w", repl.Close()),
 			).Err()
 		}
 		if err := repl.Close(); err != nil {
-			return fmt.Errorf("close repaired index for block dir: %v %w", d, repl.Close())
+			return fmt.Errorf("close repaired index for block dir: %v: %w", d, repl.Close())
 		}
 		if err := broken.Close(); err != nil {
-			return fmt.Errorf("close broken index for block dir: %v %w", d, repl.Close())
+			return fmt.Errorf("close broken index for block dir: %v: %w", d, repl.Close())
 		}
 		if err := fileutil.Replace(repl.Name(), broken.Name()); err != nil {
-			return fmt.Errorf("replaced broken index with index.repaired for block dir: %v %w", d, repl.Close())
+			return fmt.Errorf("replaced broken index with index.repaired for block dir: %v: %w", d, repl.Close())
 		}
 		// Reset version of meta.json to 1.
 		meta.Version = metaVersion1
 		if _, err := writeMetaFile(logger, d, meta); err != nil {
-			return fmt.Errorf("write meta for block dir: %v %w", d, repl.Close())
+			return fmt.Errorf("write meta for block dir: %v: %w", d, repl.Close())
 		}
 	}
 	return nil

--- a/tsdb/tombstones/tombstones.go
+++ b/tsdb/tombstones/tombstones.go
@@ -107,17 +107,17 @@ func WriteFile(logger log.Logger, dir string, tr Reader) (int64, error) {
 
 	bytes, err := Encode(tr)
 	if err != nil {
-		return 0, fmt.Errorf("encoding tombstones %w", err)
+		return 0, fmt.Errorf("encoding tombstones: %w", err)
 	}
 
 	// Ignore first byte which is the format type. We do this for compatibility.
 	if _, err := hash.Write(bytes[tombstoneFormatVersionSize:]); err != nil {
-		return 0, fmt.Errorf("calculating hash for tombstones %w", err)
+		return 0, fmt.Errorf("calculating hash for tombstones: %w", err)
 	}
 
 	n, err = f.Write(bytes)
 	if err != nil {
-		return 0, fmt.Errorf("writing tombstones %w", err)
+		return 0, fmt.Errorf("writing tombstones: %w", err)
 	}
 	size += n
 
@@ -196,7 +196,7 @@ func ReadTombstones(dir string) (Reader, int64, error) {
 	}
 
 	if len(b) < tombstonesHeaderSize {
-		return nil, 0, fmt.Errorf("tombstones header %w", encoding.ErrInvalidSize)
+		return nil, 0, fmt.Errorf("tombstones header: %w", encoding.ErrInvalidSize)
 	}
 
 	d := &encoding.Decbuf{B: b[:len(b)-tombstonesCRCSize]}
@@ -208,10 +208,10 @@ func ReadTombstones(dir string) (Reader, int64, error) {
 	hash := newCRC32()
 	// Ignore first byte which is the format type.
 	if _, err := hash.Write(d.Get()[tombstoneFormatVersionSize:]); err != nil {
-		return nil, 0, fmt.Errorf("write to hash %w", err)
+		return nil, 0, fmt.Errorf("write to hash: %w", err)
 	}
 	if binary.BigEndian.Uint32(b[len(b)-tombstonesCRCSize:]) != hash.Sum32() {
-		return nil, 0, fmt.Errorf("checksum did not match %w", err)
+		return nil, 0, fmt.Errorf("checksum did not match: %w", err)
 	}
 
 	if d.Err() != nil {

--- a/tsdb/tsdbutil/dir_locker.go
+++ b/tsdb/tsdbutil/dir_locker.go
@@ -14,13 +14,13 @@
 package tsdbutil
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
@@ -83,7 +83,7 @@ func (l *DirLocker) Lock() error {
 
 	lockf, _, err := fileutil.Flock(l.path)
 	if err != nil {
-		return errors.Wrap(err, "lock DB directory")
+		return fmt.Errorf("lock DB directory %w", err)
 	}
 	l.releaser = lockf
 	return nil

--- a/tsdb/tsdbutil/dir_locker.go
+++ b/tsdb/tsdbutil/dir_locker.go
@@ -83,7 +83,7 @@ func (l *DirLocker) Lock() error {
 
 	lockf, _, err := fileutil.Flock(l.path)
 	if err != nil {
-		return fmt.Errorf("lock DB directory %w", err)
+		return fmt.Errorf("lock DB directory: %w", err)
 	}
 	l.releaser = lockf
 	return nil

--- a/tsdb/wal.go
+++ b/tsdb/wal.go
@@ -16,6 +16,7 @@ package tsdb
 import (
 	"bufio"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash"
 	"hash/crc32"
@@ -29,7 +30,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -211,7 +211,7 @@ func OpenSegmentWAL(dir string, logger log.Logger, flushInterval time.Duration, 
 
 		for _, fn := range fns[i:] {
 			if err := os.Remove(fn); err != nil {
-				return w, errors.Wrap(err, "removing segment failed")
+				return w, fmt.Errorf("removing segment failed %w", err)
 			}
 		}
 		break
@@ -238,8 +238,8 @@ func (r *repairingWALReader) Read(
 	if err == nil {
 		return nil
 	}
-	cerr, ok := errors.Cause(err).(walCorruptionErr)
-	if !ok {
+	var cerr walCorruptionErr
+	if !errors.As(errors.Unwrap(err), &cerr) {
 		return err
 	}
 	r.wal.metrics.corruptions.Inc()
@@ -310,7 +310,7 @@ func (w *SegmentWAL) Truncate(mint int64, keep func(chunks.HeadSeriesRef) bool) 
 		// Past WAL files are closed. We have to reopen them for another read.
 		f, err := w.openSegmentFile(sf.Name())
 		if err != nil {
-			return errors.Wrap(err, "open old WAL segment for read")
+			return fmt.Errorf("open old WAL segment for read %w", err)
 		}
 		candidates = append(candidates, &segmentFile{
 			File:      f,
@@ -327,7 +327,7 @@ func (w *SegmentWAL) Truncate(mint int64, keep func(chunks.HeadSeriesRef) bool) 
 	// Create a new tmp file.
 	f, err := w.createSegmentFile(filepath.Join(w.dirFile.Name(), "compact.tmp"))
 	if err != nil {
-		return errors.Wrap(err, "create compaction segment")
+		return fmt.Errorf("create compaction segment %w", err)
 	}
 	defer func() {
 		if err := os.RemoveAll(f.Name()); err != nil {
@@ -353,7 +353,7 @@ func (w *SegmentWAL) Truncate(mint int64, keep func(chunks.HeadSeriesRef) bool) 
 
 		err := r.decodeSeries(flag, byt, &decSeries)
 		if err != nil {
-			return errors.Wrap(err, "decode samples while truncating")
+			return fmt.Errorf("decode samples while truncating %w", err)
 		}
 		for _, s := range decSeries {
 			if keep(s.Ref) {
@@ -368,11 +368,11 @@ func (w *SegmentWAL) Truncate(mint int64, keep func(chunks.HeadSeriesRef) bool) 
 		w.putBuffer(buf)
 
 		if err != nil {
-			return errors.Wrap(err, "write to compaction segment")
+			return fmt.Errorf("write to compaction segment %w", err)
 		}
 	}
 	if r.Err() != nil {
-		return errors.Wrap(r.Err(), "read candidate WAL files")
+		return fmt.Errorf("read candidate WAL files %w", r.Err())
 	}
 
 	off, err := csf.Seek(0, io.SeekCurrent)
@@ -391,12 +391,12 @@ func (w *SegmentWAL) Truncate(mint int64, keep func(chunks.HeadSeriesRef) bool) 
 
 	_ = candidates[0].Close() // need close before remove on platform windows
 	if err := fileutil.Replace(csf.Name(), candidates[0].Name()); err != nil {
-		return errors.Wrap(err, "rename compaction segment")
+		return fmt.Errorf("rename compaction segment %w", err)
 	}
 	for _, f := range candidates[1:] {
 		f.Close() // need close before remove on platform windows
 		if err := os.RemoveAll(f.Name()); err != nil {
-			return errors.Wrap(err, "delete WAL segment file")
+			return fmt.Errorf("delete WAL segment file %w", err)
 		}
 	}
 	if err := w.dirFile.Sync(); err != nil {
@@ -436,7 +436,7 @@ func (w *SegmentWAL) LogSeries(series []record.RefSeries) error {
 	w.putBuffer(buf)
 
 	if err != nil {
-		return errors.Wrap(err, "log series")
+		return fmt.Errorf("log series %w", err)
 	}
 
 	tf := w.head()
@@ -463,7 +463,7 @@ func (w *SegmentWAL) LogSamples(samples []record.RefSample) error {
 	w.putBuffer(buf)
 
 	if err != nil {
-		return errors.Wrap(err, "log series")
+		return fmt.Errorf("log series %w", err)
 	}
 	tf := w.head()
 
@@ -489,7 +489,7 @@ func (w *SegmentWAL) LogDeletes(stones []tombstones.Stone) error {
 	w.putBuffer(buf)
 
 	if err != nil {
-		return errors.Wrap(err, "log series")
+		return fmt.Errorf("log series %w", err)
 	}
 	tf := w.head()
 
@@ -523,16 +523,16 @@ func (w *SegmentWAL) openSegmentFile(name string) (*os.File, error) {
 	}()
 
 	if n, err := f.Read(metab); err != nil {
-		return nil, errors.Wrapf(err, "validate meta %q", f.Name())
+		return nil, fmt.Errorf("validate meta %q %w", f.Name(), err)
 	} else if n != 8 {
-		return nil, errors.Errorf("invalid header size %d in %q", n, f.Name())
+		return nil, fmt.Errorf("invalid header size %d in %q", n, f.Name())
 	}
 
 	if m := binary.BigEndian.Uint32(metab[:4]); m != WALMagic {
-		return nil, errors.Errorf("invalid magic header %x in %q", m, f.Name())
+		return nil, fmt.Errorf("invalid magic header %x in %q", m, f.Name())
 	}
 	if metab[4] != WALFormatDefault {
-		return nil, errors.Errorf("unknown WAL segment format %d in %q", metab[4], f.Name())
+		return nil, fmt.Errorf("unknown WAL segment format %d in %q", metab[4], f.Name())
 	}
 	hasError = false
 	return f, nil
@@ -573,16 +573,16 @@ func (w *SegmentWAL) cut() error {
 			w.actorc <- func() error {
 				off, err := hf.Seek(0, io.SeekCurrent)
 				if err != nil {
-					return errors.Wrapf(err, "finish old segment %s", hf.Name())
+					return fmt.Errorf("finish old segment %s %w", hf.Name(), err)
 				}
 				if err := hf.Truncate(off); err != nil {
-					return errors.Wrapf(err, "finish old segment %s", hf.Name())
+					return fmt.Errorf("finish old segment %s %w", hf.Name(), err)
 				}
 				if err := hf.Sync(); err != nil {
-					return errors.Wrapf(err, "finish old segment %s", hf.Name())
+					return fmt.Errorf("finish old segment %s %w", hf.Name(), err)
 				}
 				if err := hf.Close(); err != nil {
-					return errors.Wrapf(err, "finish old segment %s", hf.Name())
+					return fmt.Errorf("finish old segment %s %w", hf.Name(), err)
 				}
 				return nil
 			}
@@ -600,7 +600,7 @@ func (w *SegmentWAL) cut() error {
 
 	go func() {
 		w.actorc <- func() error {
-			return errors.Wrap(w.dirFile.Sync(), "sync WAL directory")
+			return fmt.Errorf("sync WAL directory %w", w.dirFile.Sync())
 		}
 	}()
 
@@ -635,7 +635,7 @@ func (w *SegmentWAL) Sync() error {
 		head = w.head()
 	}()
 	if err != nil {
-		return errors.Wrap(err, "flush buffer")
+		return fmt.Errorf("flush buffer %w", err)
 	}
 	if head != nil {
 		// But only fsync the head segment after releasing the mutex as it will block on disk I/O.
@@ -726,11 +726,11 @@ func (w *SegmentWAL) Close() error {
 	// only the current segment will still be open.
 	if hf := w.head(); hf != nil {
 		if err := hf.Close(); err != nil {
-			return errors.Wrapf(err, "closing WAL head %s", hf.Name())
+			return fmt.Errorf("closing WAL head %s %w", hf.Name(), err)
 		}
 	}
 
-	return errors.Wrapf(w.dirFile.Close(), "closing WAL dir %s", w.dirFile.Name())
+	return fmt.Errorf("closing WAL dir %s %w", w.dirFile.Name(), w.dirFile.Close())
 }
 
 func (w *SegmentWAL) write(t WALEntryType, flag uint8, buf []byte) error {
@@ -930,7 +930,7 @@ func (r *walReader) Read(
 
 			err = r.decodeSeries(flag, b, &series)
 			if err != nil {
-				err = errors.Wrap(err, "decode series entry")
+				err = fmt.Errorf("decode series entry %w", err)
 				break
 			}
 			datac <- series
@@ -951,7 +951,7 @@ func (r *walReader) Read(
 
 			err = r.decodeSamples(flag, b, &samples)
 			if err != nil {
-				err = errors.Wrap(err, "decode samples entry")
+				err = fmt.Errorf("decode samples entry %w", err)
 				break
 			}
 			datac <- samples
@@ -973,7 +973,7 @@ func (r *walReader) Read(
 
 			err = r.decodeDeletes(flag, b, &deletes)
 			if err != nil {
-				err = errors.Wrap(err, "decode delete entry")
+				err = fmt.Errorf("decode delete entry %w", err)
 				break
 			}
 			datac <- deletes
@@ -996,7 +996,7 @@ func (r *walReader) Read(
 		return err
 	}
 	if r.Err() != nil {
-		return errors.Wrap(r.Err(), "read entry")
+		return fmt.Errorf("read entry %w", r.Err())
 	}
 	return nil
 }
@@ -1024,7 +1024,7 @@ func (r *walReader) next() bool {
 	// If we reached the end of the reader, advance to the next one
 	// and close.
 	// Do not close on the last one as it will still be appended to.
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		if r.cur == len(r.files)-1 {
 			return false
 		}
@@ -1065,7 +1065,7 @@ func (e walCorruptionErr) Error() string {
 
 func (r *walReader) corruptionErr(s string, args ...interface{}) error {
 	return walCorruptionErr{
-		err:        errors.Errorf(s, args...),
+		err:        fmt.Errorf(s, args...),
 		file:       r.cur,
 		lastOffset: r.lastOffset,
 	}
@@ -1141,7 +1141,7 @@ func (r *walReader) decodeSeries(flag byte, b []byte, res *[]record.RefSeries) e
 		return dec.Err()
 	}
 	if len(dec.B) > 0 {
-		return errors.Errorf("unexpected %d bytes left in entry", len(dec.B))
+		return fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 	return nil
 }
@@ -1170,10 +1170,10 @@ func (r *walReader) decodeSamples(flag byte, b []byte, res *[]record.RefSample) 
 	}
 
 	if dec.Err() != nil {
-		return errors.Wrapf(dec.Err(), "decode error after %d samples", len(*res))
+		return fmt.Errorf("decode error after %d samples %w", len(*res), dec.Err())
 	}
 	if len(dec.B) > 0 {
-		return errors.Errorf("unexpected %d bytes left in entry", len(dec.B))
+		return fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 	return nil
 }
@@ -1193,7 +1193,7 @@ func (r *walReader) decodeDeletes(flag byte, b []byte, res *[]tombstones.Stone) 
 		return dec.Err()
 	}
 	if len(dec.B) > 0 {
-		return errors.Errorf("unexpected %d bytes left in entry", len(dec.B))
+		return fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 	return nil
 }
@@ -1202,7 +1202,7 @@ func deprecatedWALExists(logger log.Logger, dir string) (bool, error) {
 	// Detect whether we still have the old WAL.
 	fns, err := sequenceFiles(dir)
 	if err != nil && !os.IsNotExist(err) {
-		return false, errors.Wrap(err, "list sequence files")
+		return false, fmt.Errorf("list sequence files %w", err)
 	}
 	if len(fns) == 0 {
 		return false, nil // No WAL at all yet.
@@ -1211,13 +1211,13 @@ func deprecatedWALExists(logger log.Logger, dir string) (bool, error) {
 	// old WAL.
 	f, err := os.Open(fns[0])
 	if err != nil {
-		return false, errors.Wrap(err, "check first existing segment")
+		return false, fmt.Errorf("check first existing segment %w", err)
 	}
 	defer f.Close()
 
 	var hdr [4]byte
 	if _, err := f.Read(hdr[:]); err != nil && err != io.EOF {
-		return false, errors.Wrap(err, "read header from first segment")
+		return false, fmt.Errorf("read header from first segment %w", err)
 	}
 	// If we cannot read the magic header for segments of the old WAL, abort.
 	// Either it's migrated already or there's a corruption issue with which
@@ -1240,11 +1240,11 @@ func MigrateWAL(logger log.Logger, dir string) (err error) {
 
 	tmpdir := dir + ".tmp"
 	if err := os.RemoveAll(tmpdir); err != nil {
-		return errors.Wrap(err, "cleanup replacement dir")
+		return fmt.Errorf("cleanup replacement dir %w", err)
 	}
 	repl, err := wal.New(logger, nil, tmpdir, false)
 	if err != nil {
-		return errors.Wrap(err, "open new WAL")
+		return fmt.Errorf("open new WAL %w", err)
 	}
 
 	// It should've already been closed as part of the previous finalization.
@@ -1257,7 +1257,7 @@ func MigrateWAL(logger log.Logger, dir string) (err error) {
 
 	w, err := OpenSegmentWAL(dir, logger, time.Minute, nil)
 	if err != nil {
-		return errors.Wrap(err, "open old WAL")
+		return fmt.Errorf("open old WAL %w", err)
 	}
 	defer w.Close()
 
@@ -1288,22 +1288,22 @@ func MigrateWAL(logger log.Logger, dir string) (err error) {
 		},
 	)
 	if decErr != nil {
-		return errors.Wrap(err, "decode old entries")
+		return fmt.Errorf("decode old entries %w", err)
 	}
 	if err != nil {
-		return errors.Wrap(err, "write new entries")
+		return fmt.Errorf("write new entries %w", err)
 	}
 	// We explicitly close even when there is a defer for Windows to be
 	// able to delete it. The defer is in place to close it in-case there
 	// are errors above.
 	if err := w.Close(); err != nil {
-		return errors.Wrap(err, "close old WAL")
+		return fmt.Errorf("close old WAL %w", err)
 	}
 	if err := repl.Close(); err != nil {
-		return errors.Wrap(err, "close new WAL")
+		return fmt.Errorf("close new WAL %w", err)
 	}
 	if err := fileutil.Replace(tmpdir, dir); err != nil {
-		return errors.Wrap(err, "replace old WAL")
+		return fmt.Errorf("replace old WAL %w", err)
 	}
 	return nil
 }

--- a/tsdb/wal/checkpoint.go
+++ b/tsdb/wal/checkpoint.go
@@ -15,6 +15,7 @@
 package wal
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -26,7 +27,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
@@ -99,8 +99,8 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id chunks.Hea
 	{
 		var sgmRange []SegmentRange
 		dir, idx, err := LastCheckpoint(w.Dir())
-		if err != nil && err != record.ErrNotFound {
-			return nil, errors.Wrap(err, "find last checkpoint")
+		if err != nil && !errors.Is(err, record.ErrNotFound) {
+			return nil, fmt.Errorf("find last checkpoint %w", err)
 		}
 		last := idx + 1
 		if err == nil {
@@ -116,7 +116,7 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id chunks.Hea
 		sgmRange = append(sgmRange, SegmentRange{Dir: w.Dir(), First: from, Last: to})
 		sgmReader, err = NewSegmentsRangeReader(sgmRange...)
 		if err != nil {
-			return nil, errors.Wrap(err, "create segment reader")
+			return nil, fmt.Errorf("create segment reader %w", err)
 		}
 		defer sgmReader.Close()
 	}
@@ -125,15 +125,15 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id chunks.Hea
 	cpdirtmp := cpdir + ".tmp"
 
 	if err := os.RemoveAll(cpdirtmp); err != nil {
-		return nil, errors.Wrap(err, "remove previous temporary checkpoint dir")
+		return nil, fmt.Errorf("remove previous temporary checkpoint dir %w", err)
 	}
 
 	if err := os.MkdirAll(cpdirtmp, 0o777); err != nil {
-		return nil, errors.Wrap(err, "create checkpoint dir")
+		return nil, fmt.Errorf("create checkpoint dir %w", err)
 	}
 	cp, err := New(nil, nil, cpdirtmp, w.CompressionEnabled())
 	if err != nil {
-		return nil, errors.Wrap(err, "open checkpoint")
+		return nil, fmt.Errorf("open checkpoint %w", err)
 	}
 
 	// Ensures that an early return caused by an error doesn't leave any tmp files.
@@ -167,7 +167,7 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id chunks.Hea
 		case record.Series:
 			series, err = dec.Series(rec, series)
 			if err != nil {
-				return nil, errors.Wrap(err, "decode series")
+				return nil, fmt.Errorf("decode series %w", err)
 			}
 			// Drop irrelevant series in place.
 			repl := series[:0]
@@ -185,7 +185,7 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id chunks.Hea
 		case record.Samples:
 			samples, err = dec.Samples(rec, samples)
 			if err != nil {
-				return nil, errors.Wrap(err, "decode samples")
+				return nil, fmt.Errorf("decode samples %w", err)
 			}
 			// Drop irrelevant samples in place.
 			repl := samples[:0]
@@ -203,7 +203,7 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id chunks.Hea
 		case record.Tombstones:
 			tstones, err = dec.Tombstones(rec, tstones)
 			if err != nil {
-				return nil, errors.Wrap(err, "decode deletes")
+				return nil, fmt.Errorf("decode deletes %w", err)
 			}
 			// Drop irrelevant tombstones in place.
 			repl := tstones[:0]
@@ -224,7 +224,7 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id chunks.Hea
 		case record.Exemplars:
 			exemplars, err = dec.Exemplars(rec, exemplars)
 			if err != nil {
-				return nil, errors.Wrap(err, "decode exemplars")
+				return nil, fmt.Errorf("decode exemplars %w", err)
 			}
 			// Drop irrelevant exemplars in place.
 			repl := exemplars[:0]
@@ -250,7 +250,7 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id chunks.Hea
 		// Flush records in 1 MB increments.
 		if len(buf) > 1*1024*1024 {
 			if err := cp.Log(recs...); err != nil {
-				return nil, errors.Wrap(err, "flush records")
+				return nil, fmt.Errorf("flush records %w", err)
 			}
 			buf, recs = buf[:0], recs[:0]
 		}
@@ -258,32 +258,32 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id chunks.Hea
 	// If we hit any corruption during checkpointing, repairing is not an option.
 	// The head won't know which series records are lost.
 	if r.Err() != nil {
-		return nil, errors.Wrap(r.Err(), "read segments")
+		return nil, fmt.Errorf("read segments %w", r.Err())
 	}
 
 	// Flush remaining records.
 	if err := cp.Log(recs...); err != nil {
-		return nil, errors.Wrap(err, "flush records")
+		return nil, fmt.Errorf("flush records %w", err)
 	}
 	if err := cp.Close(); err != nil {
-		return nil, errors.Wrap(err, "close checkpoint")
+		return nil, fmt.Errorf("close checkpoint %w", err)
 	}
 
 	// Sync temporary directory before rename.
 	df, err := fileutil.OpenDir(cpdirtmp)
 	if err != nil {
-		return nil, errors.Wrap(err, "open temporary checkpoint directory")
+		return nil, fmt.Errorf("open temporary checkpoint directory %w", err)
 	}
 	if err := df.Sync(); err != nil {
 		df.Close()
-		return nil, errors.Wrap(err, "sync temporary checkpoint directory")
+		return nil, fmt.Errorf("sync temporary checkpoint directory %w", err)
 	}
 	if err = df.Close(); err != nil {
-		return nil, errors.Wrap(err, "close temporary checkpoint directory")
+		return nil, fmt.Errorf("close temporary checkpoint directory %w", err)
 	}
 
 	if err := fileutil.Replace(cpdirtmp, cpdir); err != nil {
-		return nil, errors.Wrap(err, "rename checkpoint directory")
+		return nil, fmt.Errorf("rename checkpoint directory %w", err)
 	}
 
 	return stats, nil
@@ -310,7 +310,7 @@ func listCheckpoints(dir string) (refs []checkpointRef, err error) {
 			continue
 		}
 		if !fi.IsDir() {
-			return nil, errors.Errorf("checkpoint %s is not a directory", fi.Name())
+			return nil, fmt.Errorf("checkpoint %s is not a directory", fi.Name())
 		}
 		idx, err := strconv.Atoi(fi.Name()[len(checkpointPrefix):])
 		if err != nil {

--- a/tsdb/wal/checkpoint_test.go
+++ b/tsdb/wal/checkpoint_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -251,7 +250,7 @@ func TestCheckpointNoTmpFolderAfterError(t *testing.T) {
 	// Walk the wal dir to make sure there are no tmp folder left behind after the error.
 	err = filepath.Walk(w.Dir(), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.Wrapf(err, "access err %q: %v", path, err)
+			return fmt.Errorf("access err %q: %w", path, err)
 		}
 		if info.IsDir() && strings.HasSuffix(info.Name(), ".tmp") {
 			return fmt.Errorf("wal dir contains temporary folder:%s", info.Name())

--- a/tsdb/wal/live_reader.go
+++ b/tsdb/wal/live_reader.go
@@ -16,6 +16,7 @@ package wal
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -23,7 +24,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/golang/snappy"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -96,7 +96,7 @@ type LiveReader struct {
 // not be used again.  It is up to the user to decide when to stop trying should
 // io.EOF be returned.
 func (r *LiveReader) Err() error {
-	if r.eofNonErr && r.err == io.EOF {
+	if r.eofNonErr && errors.Is(r.err, io.EOF) {
 		return nil
 	}
 	return r.err
@@ -128,7 +128,7 @@ func (r *LiveReader) Next() bool {
 		// has checks the records fit in pages.
 		if ok, err := r.buildRecord(); ok {
 			return true
-		} else if err != nil && err != io.EOF {
+		} else if err != nil && !errors.Is(err, io.EOF) {
 			r.err = err
 			return false
 		}
@@ -150,7 +150,7 @@ func (r *LiveReader) Next() bool {
 
 		if r.writeIndex != pageSize {
 			n, err := r.fillBuffer()
-			if n == 0 || (err != nil && err != io.EOF) {
+			if n == 0 || (err != nil && !errors.Is(err, io.EOF)) {
 				r.err = err
 				return false
 			}
@@ -251,7 +251,7 @@ func validateRecord(typ recType, i int) error {
 		}
 		return nil
 	default:
-		return errors.Errorf("unexpected record type %d", typ)
+		return fmt.Errorf("unexpected record type %d", typ)
 	}
 }
 
@@ -308,7 +308,7 @@ func (r *LiveReader) readRecord() ([]byte, int, error) {
 
 	rec := r.buf[r.readIndex+recordHeaderSize : r.readIndex+recordHeaderSize+length]
 	if c := crc32.Checksum(rec, castagnoliTable); c != crc {
-		return nil, 0, errors.Errorf("unexpected checksum %x, expected %x", c, crc)
+		return nil, 0, fmt.Errorf("unexpected checksum %x, expected %x", c, crc)
 	}
 
 	return rec, length + recordHeaderSize, nil

--- a/tsdb/wal/reader.go
+++ b/tsdb/wal/reader.go
@@ -69,7 +69,7 @@ func (r *Reader) next() (err error) {
 	i := 0
 	for {
 		if _, err = io.ReadFull(r.rdr, hdr[:1]); err != nil {
-			return fmt.Errorf("read first header byte %w", err)
+			return fmt.Errorf("read first header byte: %w", err)
 		}
 		r.total++
 		r.curRecTyp = recTypeFromHeader(hdr[0])
@@ -91,7 +91,7 @@ func (r *Reader) next() (err error) {
 			}
 			n, err := io.ReadFull(r.rdr, buf[:k])
 			if err != nil {
-				return fmt.Errorf("read remaining zeros %w", err)
+				return fmt.Errorf("read remaining zeros: %w", err)
 			}
 			r.total += int64(n)
 
@@ -104,7 +104,7 @@ func (r *Reader) next() (err error) {
 		}
 		n, err := io.ReadFull(r.rdr, hdr[1:])
 		if err != nil {
-			return fmt.Errorf("read remaining header %w", err)
+			return fmt.Errorf("read remaining header: %w", err)
 		}
 		r.total += int64(n)
 

--- a/tsdb/wal/reader.go
+++ b/tsdb/wal/reader.go
@@ -16,11 +16,12 @@ package wal
 
 import (
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"hash/crc32"
 	"io"
 
 	"github.com/golang/snappy"
-	"github.com/pkg/errors"
 )
 
 // Reader reads WAL records from an io.Reader.
@@ -43,7 +44,7 @@ func NewReader(r io.Reader) *Reader {
 // It must not be called again after it returned false.
 func (r *Reader) Next() bool {
 	err := r.next()
-	if errors.Cause(err) == io.EOF {
+	if errors.Is(errors.Unwrap(err), io.EOF) {
 		// The last WAL segment record shouldn't be torn(should be full or last).
 		// The last record would be torn after a crash just before
 		// the last record part could be persisted to disk.
@@ -68,7 +69,7 @@ func (r *Reader) next() (err error) {
 	i := 0
 	for {
 		if _, err = io.ReadFull(r.rdr, hdr[:1]); err != nil {
-			return errors.Wrap(err, "read first header byte")
+			return fmt.Errorf("read first header byte %w", err)
 		}
 		r.total++
 		r.curRecTyp = recTypeFromHeader(hdr[0])
@@ -90,7 +91,7 @@ func (r *Reader) next() (err error) {
 			}
 			n, err := io.ReadFull(r.rdr, buf[:k])
 			if err != nil {
-				return errors.Wrap(err, "read remaining zeros")
+				return fmt.Errorf("read remaining zeros %w", err)
 			}
 			r.total += int64(n)
 
@@ -103,7 +104,7 @@ func (r *Reader) next() (err error) {
 		}
 		n, err := io.ReadFull(r.rdr, hdr[1:])
 		if err != nil {
-			return errors.Wrap(err, "read remaining header")
+			return fmt.Errorf("read remaining header %w", err)
 		}
 		r.total += int64(n)
 
@@ -113,7 +114,7 @@ func (r *Reader) next() (err error) {
 		)
 
 		if length > pageSize-recordHeaderSize {
-			return errors.Errorf("invalid record size %d", length)
+			return fmt.Errorf("invalid record size %d", length)
 		}
 		n, err = io.ReadFull(r.rdr, buf[:length])
 		if err != nil {
@@ -122,10 +123,10 @@ func (r *Reader) next() (err error) {
 		r.total += int64(n)
 
 		if n != int(length) {
-			return errors.Errorf("invalid size: expected %d, got %d", length, n)
+			return fmt.Errorf("invalid size: expected %d, got %d", length, n)
 		}
 		if c := crc32.Checksum(buf[:length], castagnoliTable); c != crc {
-			return errors.Errorf("unexpected checksum %x, expected %x", c, crc)
+			return fmt.Errorf("unexpected checksum %x, expected %x", c, crc)
 		}
 
 		if compressed {

--- a/tsdb/wal/wal.go
+++ b/tsdb/wal/wal.go
@@ -17,6 +17,7 @@ package wal
 import (
 	"bufio"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -30,7 +31,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/golang/snappy"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/prometheus/prometheus/tsdb/fileutil"
@@ -135,7 +135,7 @@ func OpenWriteSegment(logger log.Logger, dir string, k int) (*Segment, error) {
 		level.Warn(logger).Log("msg", "Last page of the wal is torn, filling it with zeros", "segment", segName)
 		if _, err := f.Write(make([]byte, pageSize-d)); err != nil {
 			f.Close()
-			return nil, errors.Wrap(err, "zero-pad torn page")
+			return nil, fmt.Errorf("zero-pad torn page %w", err)
 		}
 	}
 	return &Segment{SegmentFile: f, i: k, dir: dir}, nil
@@ -260,7 +260,7 @@ func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSi
 		return nil, errors.New("invalid segment size")
 	}
 	if err := os.MkdirAll(dir, 0o777); err != nil {
-		return nil, errors.Wrap(err, "create dir")
+		return nil, fmt.Errorf("create dir %w", err)
 	}
 	if logger == nil {
 		logger = log.NewNopLogger()
@@ -278,7 +278,7 @@ func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSi
 
 	_, last, err := Segments(w.Dir())
 	if err != nil {
-		return nil, errors.Wrap(err, "get segment range")
+		return nil, fmt.Errorf("get segment range %w", err)
 	}
 
 	// Index of the Segment we want to open and write to.
@@ -351,11 +351,10 @@ func (w *WAL) Repair(origErr error) error {
 	// But that's not generally applicable if the records have any kind of causality.
 	// Maybe as an extra mode in the future if mid-WAL corruptions become
 	// a frequent concern.
-	err := errors.Cause(origErr) // So that we can pick up errors even if wrapped.
-
-	cerr, ok := err.(*CorruptionErr)
-	if !ok {
-		return errors.Wrap(origErr, "cannot handle error")
+	err := errors.Unwrap(origErr) // So that we can pick up errors even if wrapped.
+	var cerr *CorruptionErr
+	if !errors.As(err, &cerr) {
+		return fmt.Errorf("cannot handle error %w", origErr)
 	}
 	if cerr.Segment < 0 {
 		return errors.New("corruption error does not specify position")
@@ -366,7 +365,7 @@ func (w *WAL) Repair(origErr error) error {
 	// All segments behind the corruption can no longer be used.
 	segs, err := listSegments(w.Dir())
 	if err != nil {
-		return errors.Wrap(err, "list segments")
+		return fmt.Errorf("list segments %w", err)
 	}
 	level.Warn(w.logger).Log("msg", "Deleting all segments newer than corrupted segment", "segment", cerr.Segment)
 
@@ -377,14 +376,14 @@ func (w *WAL) Repair(origErr error) error {
 			// as we set the current segment to repaired file
 			// below.
 			if err := w.segment.Close(); err != nil {
-				return errors.Wrap(err, "close active segment")
+				return fmt.Errorf("close active segment %w", err)
 			}
 		}
 		if s.index <= cerr.Segment {
 			continue
 		}
 		if err := os.Remove(filepath.Join(w.Dir(), s.name)); err != nil {
-			return errors.Wrapf(err, "delete segment:%v", s.index)
+			return fmt.Errorf("delete segment:%v %w", s.index, err)
 		}
 	}
 	// Regardless of the corruption offset, no record reaches into the previous segment.
@@ -409,7 +408,7 @@ func (w *WAL) Repair(origErr error) error {
 
 	f, err := os.Open(tmpfn)
 	if err != nil {
-		return errors.Wrap(err, "open segment")
+		return fmt.Errorf("open segment %w", err)
 	}
 	defer f.Close()
 
@@ -421,24 +420,24 @@ func (w *WAL) Repair(origErr error) error {
 			break
 		}
 		if err := w.Log(r.Record()); err != nil {
-			return errors.Wrap(err, "insert record")
+			return fmt.Errorf("insert record %w", err)
 		}
 	}
 	// We expect an error here from r.Err(), so nothing to handle.
 
 	// We need to pad to the end of the last page in the repaired segment
 	if err := w.flushPage(true); err != nil {
-		return errors.Wrap(err, "flush page in repair")
+		return fmt.Errorf("flush page in repair %w", err)
 	}
 
 	// We explicitly close even when there is a defer for Windows to be
 	// able to delete it. The defer is in place to close it in-case there
 	// are errors above.
 	if err := f.Close(); err != nil {
-		return errors.Wrap(err, "close corrupted file")
+		return fmt.Errorf("close corrupted file %w", err)
 	}
 	if err := os.Remove(tmpfn); err != nil {
-		return errors.Wrap(err, "delete corrupted segment")
+		return fmt.Errorf("delete corrupted segment %w", err)
 	}
 
 	// Explicitly close the segment we just repaired to avoid issues with Windows.
@@ -480,7 +479,7 @@ func (w *WAL) nextSegment() error {
 	}
 	next, err := CreateSegment(w.Dir(), w.segment.Index()+1)
 	if err != nil {
-		return errors.Wrap(err, "create new segment file")
+		return fmt.Errorf("create new segment file %w", err)
 	}
 	prev := w.segment
 	if err := w.setSegment(next); err != nil {
@@ -843,7 +842,7 @@ func NewSegmentsRangeReader(sr ...SegmentRange) (io.ReadCloser, error) {
 	for _, sgmRange := range sr {
 		refs, err := listSegments(sgmRange.Dir)
 		if err != nil {
-			return nil, errors.Wrapf(err, "list segment in dir:%v", sgmRange.Dir)
+			return nil, fmt.Errorf("list segment in dir:%v %w", sgmRange.Dir, err)
 		}
 
 		for _, r := range refs {
@@ -855,7 +854,7 @@ func NewSegmentsRangeReader(sr ...SegmentRange) (io.ReadCloser, error) {
 			}
 			s, err := OpenReadSegment(filepath.Join(sgmRange.Dir, r.name))
 			if err != nil {
-				return nil, errors.Wrapf(err, "open segment:%v in dir:%v", r.name, sgmRange.Dir)
+				return nil, fmt.Errorf("open segment:%v in dir:%v %w", r.name, sgmRange.Dir, err)
 			}
 			segs = append(segs, s)
 		}

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -14,6 +14,7 @@
 package wal
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -26,7 +27,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -224,7 +224,7 @@ func (w *Watcher) loop() {
 func (w *Watcher) Run() error {
 	_, lastSegment, err := w.firstAndLast()
 	if err != nil {
-		return errors.Wrap(err, "wal.Segments")
+		return fmt.Errorf("wal.Segments %w", err)
 	}
 
 	// We want to ensure this is false across iterations since
@@ -235,13 +235,13 @@ func (w *Watcher) Run() error {
 
 	// Backfill from the checkpoint first if it exists.
 	lastCheckpoint, checkpointIndex, err := LastCheckpoint(w.walDir)
-	if err != nil && err != record.ErrNotFound {
-		return errors.Wrap(err, "tsdb.LastCheckpoint")
+	if err != nil && !errors.Is(err, record.ErrNotFound) {
+		return fmt.Errorf("tsdb.LastCheckpoint %w", err)
 	}
 
 	if err == nil {
 		if err = w.readCheckpoint(lastCheckpoint, (*Watcher).readSegment); err != nil {
-			return errors.Wrap(err, "readCheckpoint")
+			return fmt.Errorf("readCheckpoint %w", err)
 		}
 	}
 	w.lastCheckpoint = lastCheckpoint
@@ -356,7 +356,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 		var err error
 		size, err = getSegmentSize(w.walDir, segmentNum)
 		if err != nil {
-			return errors.Wrap(err, "getSegmentSize")
+			return fmt.Errorf("getSegmentSize %w", err)
 		}
 	}
 
@@ -389,7 +389,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 		case <-segmentTicker.C:
 			_, last, err := w.firstAndLast()
 			if err != nil {
-				return errors.Wrap(err, "segments")
+				return fmt.Errorf("segments %w", err)
 			}
 
 			// Check if new segments exists.
@@ -401,7 +401,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 
 			// Ignore errors reading to end of segment whilst replaying the WAL.
 			if !tail {
-				if err != nil && errors.Cause(err) != io.EOF {
+				if err != nil && !errors.Is(errors.Unwrap(err), io.EOF) {
 					level.Warn(w.logger).Log("msg", "Ignoring error reading to end of segment, may have dropped data", "err", err)
 				} else if reader.Offset() != size {
 					level.Warn(w.logger).Log("msg", "Expected to have read whole segment, may have dropped data", "segment", segmentNum, "read", reader.Offset(), "size", size)
@@ -410,7 +410,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 			}
 
 			// Otherwise, when we are tailing, non-EOFs are fatal.
-			if errors.Cause(err) != io.EOF {
+			if !errors.Is(errors.Unwrap(err), io.EOF) {
 				return err
 			}
 
@@ -421,7 +421,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 
 			// Ignore all errors reading to end of segment whilst replaying the WAL.
 			if !tail {
-				if err != nil && errors.Cause(err) != io.EOF {
+				if err != nil && !errors.Is(errors.Unwrap(err), io.EOF) {
 					level.Warn(w.logger).Log("msg", "Ignoring error reading to end of segment, may have dropped data", "segment", segmentNum, "err", err)
 				} else if reader.Offset() != size {
 					level.Warn(w.logger).Log("msg", "Expected to have read whole segment, may have dropped data", "segment", segmentNum, "read", reader.Offset(), "size", size)
@@ -430,7 +430,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 			}
 
 			// Otherwise, when we are tailing, non-EOFs are fatal.
-			if errors.Cause(err) != io.EOF {
+			if !errors.Is(errors.Unwrap(err), io.EOF) {
 				return err
 			}
 		}
@@ -439,8 +439,8 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 
 func (w *Watcher) garbageCollectSeries(segmentNum int) error {
 	dir, _, err := LastCheckpoint(w.walDir)
-	if err != nil && err != record.ErrNotFound {
-		return errors.Wrap(err, "tsdb.LastCheckpoint")
+	if err != nil && !errors.Is(err, record.ErrNotFound) {
+		return fmt.Errorf("tsdb.LastCheckpoint %w", err)
 	}
 
 	if dir == "" || dir == w.lastCheckpoint {
@@ -450,7 +450,7 @@ func (w *Watcher) garbageCollectSeries(segmentNum int) error {
 
 	index, err := checkpointNum(dir)
 	if err != nil {
-		return errors.Wrap(err, "error parsing checkpoint filename")
+		return fmt.Errorf("error parsing checkpoint filename %w", err)
 	}
 
 	if index >= segmentNum {
@@ -461,7 +461,7 @@ func (w *Watcher) garbageCollectSeries(segmentNum int) error {
 	level.Debug(w.logger).Log("msg", "New checkpoint detected", "new", dir, "currentSegment", segmentNum)
 
 	if err = w.readCheckpoint(dir, (*Watcher).readSegmentForGC); err != nil {
-		return errors.Wrap(err, "readCheckpoint")
+		return fmt.Errorf("readCheckpoint %w", err)
 	}
 
 	// Clear series with a checkpoint or segment index # lower than the checkpoint we just read.
@@ -542,7 +542,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			w.recordDecodeFailsMetric.Inc()
 		}
 	}
-	return errors.Wrapf(r.Err(), "segment %d: %v", segmentNum, r.Err())
+	return fmt.Errorf("segment %d: %w", segmentNum, r.Err())
 }
 
 // Go through all series in a segment updating the segmentNum, so we can delete older series.
@@ -575,7 +575,7 @@ func (w *Watcher) readSegmentForGC(r *LiveReader, segmentNum int, _ bool) error 
 			w.recordDecodeFailsMetric.Inc()
 		}
 	}
-	return errors.Wrapf(r.Err(), "segment %d: %v", segmentNum, r.Err())
+	return fmt.Errorf("segment %d: %w", segmentNum, r.Err())
 }
 
 func (w *Watcher) SetStartTime(t time.Time) {
@@ -603,29 +603,29 @@ func (w *Watcher) readCheckpoint(checkpointDir string, readFn segmentReadFn) err
 	level.Debug(w.logger).Log("msg", "Reading checkpoint", "dir", checkpointDir)
 	index, err := checkpointNum(checkpointDir)
 	if err != nil {
-		return errors.Wrap(err, "checkpointNum")
+		return fmt.Errorf("checkpointNum %w", err)
 	}
 
 	// Ensure we read the whole contents of every segment in the checkpoint dir.
 	segs, err := w.segments(checkpointDir)
 	if err != nil {
-		return errors.Wrap(err, "Unable to get segments checkpoint dir")
+		return fmt.Errorf("Unable to get segments checkpoint dir %w", err)
 	}
 	for _, seg := range segs {
 		size, err := getSegmentSize(checkpointDir, seg)
 		if err != nil {
-			return errors.Wrap(err, "getSegmentSize")
+			return fmt.Errorf("getSegmentSize %w", err)
 		}
 
 		sr, err := OpenReadSegment(SegmentName(checkpointDir, seg))
 		if err != nil {
-			return errors.Wrap(err, "unable to open segment")
+			return fmt.Errorf("unable to open segment %w", err)
 		}
 		defer sr.Close()
 
 		r := NewLiveReader(w.logger, w.readerMetrics, sr)
-		if err := readFn(w, r, index, false); errors.Cause(err) != io.EOF && err != nil {
-			return errors.Wrap(err, "readSegment")
+		if err := readFn(w, r, index, false); !errors.Is(errors.Unwrap(err), io.EOF) && err != nil {
+			return fmt.Errorf("readSegment %w", err)
 		}
 
 		if r.Offset() != size {
@@ -642,12 +642,12 @@ func checkpointNum(dir string) (int, error) {
 	// dir may contain a hidden directory, so only check the base directory
 	chunks := strings.Split(path.Base(dir), ".")
 	if len(chunks) != 2 {
-		return 0, errors.Errorf("invalid checkpoint dir string: %s", dir)
+		return 0, fmt.Errorf("invalid checkpoint dir string: %s", dir)
 	}
 
 	result, err := strconv.Atoi(chunks[1])
 	if err != nil {
-		return 0, errors.Errorf("invalid checkpoint dir string: %s", dir)
+		return 0, fmt.Errorf("invalid checkpoint dir string: %s", dir)
 	}
 
 	return result, nil

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -542,7 +542,10 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			w.recordDecodeFailsMetric.Inc()
 		}
 	}
-	return fmt.Errorf("segment %d: %w", segmentNum, r.Err())
+	if r.Err() != nil {
+		return fmt.Errorf("segment %d: %w", segmentNum, r.Err())
+	}
+	return nil
 }
 
 // Go through all series in a segment updating the segmentNum, so we can delete older series.
@@ -575,7 +578,10 @@ func (w *Watcher) readSegmentForGC(r *LiveReader, segmentNum int, _ bool) error 
 			w.recordDecodeFailsMetric.Inc()
 		}
 	}
-	return fmt.Errorf("segment %d: %w", segmentNum, r.Err())
+	if r.Err() != nil {
+		return fmt.Errorf("segment %d: %w", segmentNum, r.Err())
+	}
+	return nil
 }
 
 func (w *Watcher) SetStartTime(t time.Time) {

--- a/util/logging/file.go
+++ b/util/logging/file.go
@@ -40,7 +40,7 @@ func NewJSONFileLogger(s string) (*JSONFileLogger, error) {
 
 	f, err := os.OpenFile(s, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o666)
 	if err != nil {
-		return nil, fmt.Errorf("can't create json logger %w", err)
+		return nil, fmt.Errorf("can't create json logger: %w", err)
 	}
 
 	return &JSONFileLogger{

--- a/util/logging/file.go
+++ b/util/logging/file.go
@@ -14,11 +14,11 @@
 package logging
 
 import (
+	"fmt"
 	"os"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 )
 
 var timestampFormat = log.TimestampFormat(
@@ -40,7 +40,7 @@ func NewJSONFileLogger(s string) (*JSONFileLogger, error) {
 
 	f, err := os.OpenFile(s, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o666)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't create json logger")
+		return nil, fmt.Errorf("can't create json logger %w", err)
 	}
 
 	return &JSONFileLogger{

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -15,6 +15,7 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -33,7 +34,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/regexp"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
@@ -274,7 +274,7 @@ func NewAPI(
 }
 
 func setUnavailStatusOnTSDBNotReady(r apiFuncResult) apiFuncResult {
-	if r.err != nil && errors.Cause(r.err.err) == tsdb.ErrNotReady {
+	if r.err != nil && errors.Is(errors.Unwrap(r.err.err), tsdb.ErrNotReady) {
 		r.err.typ = errorUnavailable
 	}
 	return r
@@ -367,7 +367,7 @@ type queryData struct {
 
 func invalidParamError(err error, parameter string) apiFuncResult {
 	return apiFuncResult{nil, &apiError{
-		errorBadData, errors.Wrapf(err, "invalid parameter %q", parameter),
+		errorBadData, fmt.Errorf("invalid parameter %q %w", parameter, err),
 	}, nil, nil}
 }
 
@@ -552,13 +552,15 @@ func returnAPIError(err error) *apiError {
 	if err == nil {
 		return nil
 	}
-
-	switch errors.Cause(err).(type) {
-	case promql.ErrQueryCanceled:
+	var eqc promql.ErrQueryCanceled
+	var eqt promql.ErrQueryTimeout
+	var es promql.ErrStorage
+	switch {
+	case errors.As(errors.Unwrap(err), &eqc):
 		return &apiError{errorCanceled, err}
-	case promql.ErrQueryTimeout:
+	case errors.As(errors.Unwrap(err), &eqt):
 		return &apiError{errorTimeout, err}
-	case promql.ErrStorage:
+	case errors.As(errors.Unwrap(err), &es):
 		return &apiError{errorInternal, err}
 	}
 
@@ -629,7 +631,7 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 	name := route.Param(ctx, "name")
 
 	if !model.LabelNameRE.MatchString(name) {
-		return apiFuncResult{nil, &apiError{errorBadData, errors.Errorf("invalid label name: %q", name)}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("invalid label name: %q", name)}, nil, nil}
 	}
 
 	start, err := parseTimeParam(r, "start", minTime)
@@ -710,7 +712,7 @@ var (
 
 func (api *API) series(r *http.Request) (result apiFuncResult) {
 	if err := r.ParseForm(); err != nil {
-		return apiFuncResult{nil, &apiError{errorBadData, errors.Wrapf(err, "error parsing form values")}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("error parsing form values %w", err)}, nil, nil}
 	}
 	if len(r.Form["match[]"]) == 0 {
 		return apiFuncResult{nil, &apiError{errorBadData, errors.New("no match[] parameter provided")}, nil, nil}
@@ -927,7 +929,7 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 						if err == nil && lastErrStr == "" {
 							return ""
 						} else if err != nil {
-							return errors.Wrapf(err, lastErrStr).Error()
+							return fmt.Errorf("%s %w", lastErrStr, err).Error()
 						}
 						return lastErrStr
 					}(),
@@ -1221,7 +1223,7 @@ func (api *API) rules(r *http.Request) apiFuncResult {
 	typ := strings.ToLower(r.URL.Query().Get("type"))
 
 	if typ != "" && typ != "alert" && typ != "record" {
-		return invalidParamError(errors.Errorf("not supported value %q", typ), "type")
+		return invalidParamError(fmt.Errorf("not supported value %q", typ), "type")
 	}
 
 	returnAlerts := typ == "" || typ == "alert"
@@ -1278,7 +1280,7 @@ func (api *API) rules(r *http.Request) apiFuncResult {
 					Type:           "recording",
 				}
 			default:
-				err := errors.Errorf("failed to assert type of rule '%v'", rule.Name())
+				err := fmt.Errorf("failed to assert type of rule '%v'", rule.Name())
 				return apiFuncResult{nil, &apiError{errorInternal, err}, nil, nil}
 			}
 			if enrichedRule != nil {
@@ -1357,7 +1359,7 @@ func (api *API) serveTSDBStatus(*http.Request) apiFuncResult {
 	}
 	metrics, err := api.gatherer.Gather()
 	if err != nil {
-		return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("error gathering runtime status: %s", err)}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("error gathering runtime status: %w", err)}, nil, nil}
 	}
 	chunkCount := int64(math.NaN())
 	for _, mF := range metrics {
@@ -1425,7 +1427,7 @@ func (api *API) deleteSeries(r *http.Request) apiFuncResult {
 		return apiFuncResult{nil, &apiError{errorUnavailable, errors.New("admin APIs disabled")}, nil, nil}
 	}
 	if err := r.ParseForm(); err != nil {
-		return apiFuncResult{nil, &apiError{errorBadData, errors.Wrap(err, "error parsing form values")}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("error parsing form values %w", err)}, nil, nil}
 	}
 	if len(r.Form["match[]"]) == 0 {
 		return apiFuncResult{nil, &apiError{errorBadData, errors.New("no match[] parameter provided")}, nil, nil}
@@ -1464,7 +1466,7 @@ func (api *API) snapshot(r *http.Request) apiFuncResult {
 	if r.FormValue("skip_head") != "" {
 		skipHead, err = strconv.ParseBool(r.FormValue("skip_head"))
 		if err != nil {
-			return invalidParamError(errors.Wrapf(err, "unable to parse boolean"), "skip_head")
+			return invalidParamError(fmt.Errorf("unable to parse boolean %w", err), "skip_head")
 		}
 	}
 
@@ -1476,10 +1478,10 @@ func (api *API) snapshot(r *http.Request) apiFuncResult {
 		dir = filepath.Join(snapdir, name)
 	)
 	if err := os.MkdirAll(dir, 0o777); err != nil {
-		return apiFuncResult{nil, &apiError{errorInternal, errors.Wrap(err, "create snapshot directory")}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("create snapshot directory %w", err)}, nil, nil}
 	}
 	if err := api.db.Snapshot(dir, !skipHead); err != nil {
-		return apiFuncResult{nil, &apiError{errorInternal, errors.Wrap(err, "create snapshot")}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("create snapshot %w", err)}, nil, nil}
 	}
 
 	return apiFuncResult{struct {
@@ -1567,7 +1569,7 @@ func parseTimeParam(r *http.Request, paramName string, defaultValue time.Time) (
 	}
 	result, err := parseTime(val)
 	if err != nil {
-		return time.Time{}, errors.Wrapf(err, "Invalid time value for '%s'", paramName)
+		return time.Time{}, fmt.Errorf("Invalid time value for '%s' %w", paramName, err)
 	}
 	return result, nil
 }
@@ -1592,21 +1594,21 @@ func parseTime(s string) (time.Time, error) {
 	case maxTimeFormatted:
 		return maxTime, nil
 	}
-	return time.Time{}, errors.Errorf("cannot parse %q to a valid timestamp", s)
+	return time.Time{}, fmt.Errorf("cannot parse %q to a valid timestamp", s)
 }
 
 func parseDuration(s string) (time.Duration, error) {
 	if d, err := strconv.ParseFloat(s, 64); err == nil {
 		ts := d * float64(time.Second)
 		if ts > float64(math.MaxInt64) || ts < float64(math.MinInt64) {
-			return 0, errors.Errorf("cannot parse %q to a valid duration. It overflows int64", s)
+			return 0, fmt.Errorf("cannot parse %q to a valid duration. It overflows int64", s)
 		}
 		return time.Duration(ts), nil
 	}
 	if d, err := model.ParseDuration(s); err == nil {
 		return time.Duration(d), nil
 	}
-	return 0, errors.Errorf("cannot parse %q to a valid duration", s)
+	return 0, fmt.Errorf("cannot parse %q to a valid duration", s)
 }
 
 func parseMatchersParam(matchers []string) ([][]*labels.Matcher, error) {

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -367,7 +367,7 @@ type queryData struct {
 
 func invalidParamError(err error, parameter string) apiFuncResult {
 	return apiFuncResult{nil, &apiError{
-		errorBadData, fmt.Errorf("invalid parameter %q %w", parameter, err),
+		errorBadData, fmt.Errorf("invalid parameter %q: %w", parameter, err),
 	}, nil, nil}
 }
 
@@ -712,7 +712,7 @@ var (
 
 func (api *API) series(r *http.Request) (result apiFuncResult) {
 	if err := r.ParseForm(); err != nil {
-		return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("error parsing form values %w", err)}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("error parsing form values: %w", err)}, nil, nil}
 	}
 	if len(r.Form["match[]"]) == 0 {
 		return apiFuncResult{nil, &apiError{errorBadData, errors.New("no match[] parameter provided")}, nil, nil}
@@ -929,7 +929,7 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 						if err == nil && lastErrStr == "" {
 							return ""
 						} else if err != nil {
-							return fmt.Errorf("%s %w", lastErrStr, err).Error()
+							return fmt.Errorf("%s: %w", lastErrStr, err).Error()
 						}
 						return lastErrStr
 					}(),
@@ -1427,7 +1427,7 @@ func (api *API) deleteSeries(r *http.Request) apiFuncResult {
 		return apiFuncResult{nil, &apiError{errorUnavailable, errors.New("admin APIs disabled")}, nil, nil}
 	}
 	if err := r.ParseForm(); err != nil {
-		return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("error parsing form values %w", err)}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("error parsing form values: %w", err)}, nil, nil}
 	}
 	if len(r.Form["match[]"]) == 0 {
 		return apiFuncResult{nil, &apiError{errorBadData, errors.New("no match[] parameter provided")}, nil, nil}
@@ -1466,7 +1466,7 @@ func (api *API) snapshot(r *http.Request) apiFuncResult {
 	if r.FormValue("skip_head") != "" {
 		skipHead, err = strconv.ParseBool(r.FormValue("skip_head"))
 		if err != nil {
-			return invalidParamError(fmt.Errorf("unable to parse boolean %w", err), "skip_head")
+			return invalidParamError(fmt.Errorf("unable to parse boolean: %w", err), "skip_head")
 		}
 	}
 
@@ -1478,10 +1478,10 @@ func (api *API) snapshot(r *http.Request) apiFuncResult {
 		dir = filepath.Join(snapdir, name)
 	)
 	if err := os.MkdirAll(dir, 0o777); err != nil {
-		return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("create snapshot directory %w", err)}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("create snapshot directory: %w", err)}, nil, nil}
 	}
 	if err := api.db.Snapshot(dir, !skipHead); err != nil {
-		return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("create snapshot %w", err)}, nil, nil}
+		return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("create snapshot: %w", err)}, nil, nil}
 	}
 
 	return apiFuncResult{struct {
@@ -1569,7 +1569,7 @@ func parseTimeParam(r *http.Request, paramName string, defaultValue time.Time) (
 	}
 	result, err := parseTime(val)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("Invalid time value for '%s' %w", paramName, err)
+		return time.Time{}, fmt.Errorf("Invalid time value for '%s': %w", paramName, err)
 	}
 	return result, nil
 }

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -16,6 +16,7 @@ package v1
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -33,7 +34,6 @@ import (
 	"github.com/prometheus/prometheus/util/stats"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -2309,7 +2309,7 @@ func (f *fakeDB) WALReplayStatus() (tsdb.WALReplayStatus, error) {
 }
 
 func TestAdminEndpoints(t *testing.T) {
-	tsdb, tsdbWithError, tsdbNotReady := &fakeDB{}, &fakeDB{err: errors.New("some error")}, &fakeDB{err: errors.Wrap(tsdb.ErrNotReady, "wrap")}
+	tsdb, tsdbWithError, tsdbNotReady := &fakeDB{}, &fakeDB{err: errors.New("some error")}, &fakeDB{err: fmt.Errorf("wrap %w", tsdb.ErrNotReady)}
 	snapshotAPI := func(api *API) apiFunc { return api.snapshot }
 	cleanAPI := func(api *API) apiFunc { return api.cleanTombstones }
 	deleteAPI := func(api *API) apiFunc { return api.deleteSeries }
@@ -2605,7 +2605,7 @@ func TestParseTimeParam(t *testing.T) {
 				asTime: time.Time{},
 				asError: func() error {
 					_, err := parseTime("baz")
-					return errors.Wrapf(err, "Invalid time value for '%s'", "foo")
+					return fmt.Errorf("Invalid time value for '%s' %w", "foo", err)
 				},
 			},
 		},
@@ -2948,19 +2948,19 @@ func TestReturnAPIError(t *testing.T) {
 			err:      promql.ErrStorage{Err: errors.New("storage error")},
 			expected: errorInternal,
 		}, {
-			err:      errors.Wrap(promql.ErrStorage{Err: errors.New("storage error")}, "wrapped"),
+			err:      fmt.Errorf("wrapped %w", promql.ErrStorage{Err: errors.New("storage error")}),
 			expected: errorInternal,
 		}, {
 			err:      promql.ErrQueryTimeout("timeout error"),
 			expected: errorTimeout,
 		}, {
-			err:      errors.Wrap(promql.ErrQueryTimeout("timeout error"), "wrapped"),
+			err:      fmt.Errorf("wrapped %w", promql.ErrQueryTimeout("timeout error")),
 			expected: errorTimeout,
 		}, {
 			err:      promql.ErrQueryCanceled("canceled error"),
 			expected: errorCanceled,
 		}, {
-			err:      errors.Wrap(promql.ErrQueryCanceled("canceled error"), "wrapped"),
+			err:      fmt.Errorf("wrapped %w", promql.ErrQueryCanceled("canceled error")),
 			expected: errorCanceled,
 		}, {
 			err:      errors.New("exec error"),

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2309,7 +2309,7 @@ func (f *fakeDB) WALReplayStatus() (tsdb.WALReplayStatus, error) {
 }
 
 func TestAdminEndpoints(t *testing.T) {
-	tsdb, tsdbWithError, tsdbNotReady := &fakeDB{}, &fakeDB{err: errors.New("some error")}, &fakeDB{err: fmt.Errorf("wrap %w", tsdb.ErrNotReady)}
+	tsdb, tsdbWithError, tsdbNotReady := &fakeDB{}, &fakeDB{err: errors.New("some error")}, &fakeDB{err: fmt.Errorf("wrap: %w", tsdb.ErrNotReady)}
 	snapshotAPI := func(api *API) apiFunc { return api.snapshot }
 	cleanAPI := func(api *API) apiFunc { return api.cleanTombstones }
 	deleteAPI := func(api *API) apiFunc { return api.deleteSeries }
@@ -2605,7 +2605,7 @@ func TestParseTimeParam(t *testing.T) {
 				asTime: time.Time{},
 				asError: func() error {
 					_, err := parseTime("baz")
-					return fmt.Errorf("Invalid time value for '%s' %w", "foo", err)
+					return fmt.Errorf("Invalid time value for '%s': %w", "foo", err)
 				},
 			},
 		},
@@ -2948,19 +2948,19 @@ func TestReturnAPIError(t *testing.T) {
 			err:      promql.ErrStorage{Err: errors.New("storage error")},
 			expected: errorInternal,
 		}, {
-			err:      fmt.Errorf("wrapped %w", promql.ErrStorage{Err: errors.New("storage error")}),
+			err:      fmt.Errorf("wrapped: %w", promql.ErrStorage{Err: errors.New("storage error")}),
 			expected: errorInternal,
 		}, {
 			err:      promql.ErrQueryTimeout("timeout error"),
 			expected: errorTimeout,
 		}, {
-			err:      fmt.Errorf("wrapped %w", promql.ErrQueryTimeout("timeout error")),
+			err:      fmt.Errorf("wrapped: %w", promql.ErrQueryTimeout("timeout error")),
 			expected: errorTimeout,
 		}, {
 			err:      promql.ErrQueryCanceled("canceled error"),
 			expected: errorCanceled,
 		}, {
-			err:      fmt.Errorf("wrapped %w", promql.ErrQueryCanceled("canceled error")),
+			err:      fmt.Errorf("wrapped: %w", promql.ErrQueryCanceled("canceled error")),
 			expected: errorCanceled,
 		}, {
 			err:      errors.New("exec error"),

--- a/web/federate.go
+++ b/web/federate.go
@@ -14,13 +14,13 @@
 package web
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
 
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/proto"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -80,7 +80,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 	q, err := h.localStorage.Querier(req.Context(), mint, maxt)
 	if err != nil {
 		federationErrors.Inc()
-		if errors.Cause(err) == tsdb.ErrNotReady {
+		if errors.Is(errors.Unwrap(err), tsdb.ErrNotReady) {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			return
 		}

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -240,15 +240,15 @@ type notReadyReadStorage struct {
 }
 
 func (notReadyReadStorage) Querier(context.Context, int64, int64) (storage.Querier, error) {
-	return nil, fmt.Errorf("wrap %w", tsdb.ErrNotReady)
+	return nil, fmt.Errorf("wrap: %w", tsdb.ErrNotReady)
 }
 
 func (notReadyReadStorage) StartTime() (int64, error) {
-	return 0, fmt.Errorf("wrap %w", tsdb.ErrNotReady)
+	return 0, fmt.Errorf("wrap: %w", tsdb.ErrNotReady)
 }
 
 func (notReadyReadStorage) Stats(string) (*tsdb.Stats, error) {
-	return nil, fmt.Errorf("wrap %w", tsdb.ErrNotReady)
+	return nil, fmt.Errorf("wrap: %w", tsdb.ErrNotReady)
 }
 
 // Regression test for https://github.com/prometheus/prometheus/issues/7181.

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -16,6 +16,7 @@ package web
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -23,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
@@ -240,15 +240,15 @@ type notReadyReadStorage struct {
 }
 
 func (notReadyReadStorage) Querier(context.Context, int64, int64) (storage.Querier, error) {
-	return nil, errors.Wrap(tsdb.ErrNotReady, "wrap")
+	return nil, fmt.Errorf("wrap %w", tsdb.ErrNotReady)
 }
 
 func (notReadyReadStorage) StartTime() (int64, error) {
-	return 0, errors.Wrap(tsdb.ErrNotReady, "wrap")
+	return 0, fmt.Errorf("wrap %w", tsdb.ErrNotReady)
 }
 
 func (notReadyReadStorage) Stats(string) (*tsdb.Stats, error) {
-	return nil, errors.Wrap(tsdb.ErrNotReady, "wrap")
+	return nil, fmt.Errorf("wrap %w", tsdb.ErrNotReady)
 }
 
 // Regression test for https://github.com/prometheus/prometheus/issues/7181.

--- a/web/web.go
+++ b/web/web.go
@@ -39,7 +39,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/regexp"
 	conntrack "github.com/mwitkow/go-conntrack"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	io_prometheus_client "github.com/prometheus/client_model/go"
@@ -708,7 +707,7 @@ func (h *Handler) runtimeInfo() (api_v1.RuntimeInfo, error) {
 
 	metrics, err := h.gatherer.Gather()
 	if err != nil {
-		return status, errors.Errorf("error gathering runtime status: %s", err)
+		return status, fmt.Errorf("error gathering runtime status: %w", err)
 	}
 	for _, mF := range metrics {
 		switch *mF.Name {


### PR DESCRIPTION
The package https://github.com/pkg/errors is not maintained anymore.
This PR replaces https://github.com/pkg/errors with official errors and fmt golang packages

Signed-off-by: Matthieu MOREL <mmorel-35@users.noreply.github.com>


