### PR TITLE
Histogram: Fix allFloatBucketIterator

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -655,7 +655,9 @@ func (h *FloatHistogram) NegativeReverseBucketIterator() FloatBucketIterator {
 
 // AllBucketIterator returns a FloatBucketIterator to iterate over all negative,
 // zero, and positive buckets in ascending order (starting at the lowest bucket
-// and going up).
+// and going up). If the highest negative bucket or the lowest positive bucket
+// overlap with the zero bucket, their upper or lower boundary, respectively, is
+// set to the zero threshold.
 func (h *FloatHistogram) AllBucketIterator() FloatBucketIterator {
 	return &allFloatBucketIterator{
 		h:       h,
@@ -1071,6 +1073,9 @@ func (r *allFloatBucketIterator) Next() bool {
 	case -1:
 		if r.negIter.Next() {
 			r.currBucket = r.negIter.At()
+			if r.currBucket.Upper > -r.h.ZeroThreshold {
+				r.currBucket.Upper = -r.h.ZeroThreshold
+			}
 			return true
 		}
 		r.state = 0
@@ -1092,6 +1097,9 @@ func (r *allFloatBucketIterator) Next() bool {
 	case 1:
 		if r.posIter.Next() {
 			r.currBucket = r.posIter.At()
+			if r.currBucket.Lower < r.h.ZeroThreshold {
+				r.currBucket.Lower = r.h.ZeroThreshold
+			}
 			return true
 		}
 		r.state = 42


### PR DESCRIPTION
_This is only for the sparsehistogram branch._

If the zero threshold overlaps with the highest negative bucket and/or
the lowest positive bucket, its upper or lower boundary, respectively,
has to be adjusted. In valid histograms, only ever the highest
negative bucket and/or the lowest positive bucket may overlap with the
zero bucket. This is assumed in this code to simplify the checks.

Signed-off-by: beorn7 <beorn@grafana.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
