### PR TITLE
Labels: optimise creation of signature with/without labels

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -202,11 +202,11 @@ func (ls Labels) HashWithoutLabels(b []byte, names ...string) (uint64, []byte) {
 	return xxhash.Sum64(b), b
 }
 
-// WithLabels returns a new labels.Labels from ls that only contains labels matching names.
+// BytesWithLabels is just as Bytes(), but only for labels matching names.
 // 'names' have to be sorted in ascending order.
-func (ls Labels) WithLabels(names ...string) Labels {
-	ret := make([]Label, 0, len(ls))
-
+func (ls Labels) BytesWithLabels(buf []byte, names ...string) []byte {
+	b := bytes.NewBuffer(buf[:0])
+	b.WriteByte(labelSep)
 	i, j := 0, 0
 	for i < len(ls) && j < len(names) {
 		if names[j] < ls[i].Name {
@@ -214,30 +214,40 @@ func (ls Labels) WithLabels(names ...string) Labels {
 		} else if ls[i].Name < names[j] {
 			i++
 		} else {
-			ret = append(ret, ls[i])
+			if b.Len() > 1 {
+				b.WriteByte(seps[0])
+			}
+			b.WriteString(ls[i].Name)
+			b.WriteByte(seps[0])
+			b.WriteString(ls[i].Value)
 			i++
 			j++
 		}
 	}
-	return ret
+	return b.Bytes()
 }
 
-// WithoutLabels returns a new labels.Labels from ls that contains labels not matching names.
+// BytesWithoutLabels is just as Bytes(), but only for labels not matching names.
 // 'names' have to be sorted in ascending order.
-func (ls Labels) WithoutLabels(names ...string) Labels {
-	ret := make([]Label, 0, len(ls))
-
+func (ls Labels) BytesWithoutLabels(buf []byte, names ...string) []byte {
+	b := bytes.NewBuffer(buf[:0])
+	b.WriteByte(labelSep)
 	j := 0
 	for i := range ls {
 		for j < len(names) && names[j] < ls[i].Name {
 			j++
 		}
-		if ls[i].Name == MetricName || (j < len(names) && ls[i].Name == names[j]) {
+		if j < len(names) && ls[i].Name == names[j] {
 			continue
 		}
-		ret = append(ret, ls[i])
+		if b.Len() > 1 {
+			b.WriteByte(seps[0])
+		}
+		b.WriteString(ls[i].Name)
+		b.WriteByte(seps[0])
+		b.WriteString(ls[i].Value)
 	}
-	return ret
+	return b.Bytes()
 }
 
 // Copy returns a copy of the labels.

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -436,6 +436,20 @@ func (b *Builder) Del(ns ...string) *Builder {
 	return b
 }
 
+// Keep removes all labels from the base except those with the given names.
+func (b *Builder) Keep(ns ...string) *Builder {
+Outer:
+	for _, l := range b.base {
+		for _, n := range ns {
+			if l.Name == n {
+				continue Outer
+			}
+		}
+		b.del = append(b.del, l.Name)
+	}
+	return b
+}
+
 // Set the name/value pair as a label.
 func (b *Builder) Set(n, v string) *Builder {
 	if v == "" {
@@ -477,8 +491,9 @@ Outer:
 		}
 		res = append(res, l)
 	}
-	res = append(res, b.add...)
-	sort.Sort(res)
-
+	if len(b.add) > 0 { // Base is already in order, so we only need to sort if we add to it.
+		res = append(res, b.add...)
+		sort.Sort(res)
+	}
 	return res
 }

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -624,13 +624,14 @@ func TestLabels_Map(t *testing.T) {
 	require.Equal(t, map[string]string{"aaa": "111", "bbb": "222"}, Labels{{"aaa", "111"}, {"bbb", "222"}}.Map())
 }
 
-func TestLabels_WithLabels(t *testing.T) {
-	require.Equal(t, Labels{{"aaa", "111"}, {"bbb", "222"}}, Labels{{"aaa", "111"}, {"bbb", "222"}, {"ccc", "333"}}.WithLabels("aaa", "bbb"))
+func TestLabels_BytesWithLabels(t *testing.T) {
+	require.Equal(t, Labels{{"aaa", "111"}, {"bbb", "222"}}.Bytes(nil), Labels{{"aaa", "111"}, {"bbb", "222"}, {"ccc", "333"}}.BytesWithLabels(nil, "aaa", "bbb"))
+	require.Equal(t, Labels{}.Bytes(nil), Labels{{"aaa", "111"}, {"bbb", "222"}, {"ccc", "333"}}.BytesWithLabels(nil))
 }
 
-func TestLabels_WithoutLabels(t *testing.T) {
-	require.Equal(t, Labels{{"aaa", "111"}}, Labels{{"aaa", "111"}, {"bbb", "222"}, {"ccc", "333"}}.WithoutLabels("bbb", "ccc"))
-	require.Equal(t, Labels{{"aaa", "111"}}, Labels{{"aaa", "111"}, {"bbb", "222"}, {MetricName, "333"}}.WithoutLabels("bbb"))
+func TestLabels_BytesWithoutLabels(t *testing.T) {
+	require.Equal(t, Labels{{"aaa", "111"}}.Bytes(nil), Labels{{"aaa", "111"}, {"bbb", "222"}, {"ccc", "333"}}.BytesWithoutLabels(nil, "bbb", "ccc"))
+	require.Equal(t, Labels{{"aaa", "111"}}.Bytes(nil), Labels{{MetricName, "333"}, {"aaa", "111"}, {"bbb", "222"}}.BytesWithoutLabels(nil, MetricName, "bbb"))
 }
 
 func TestBulider_NewBulider(t *testing.T) {

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -638,6 +638,7 @@ func TestBuilder(t *testing.T) {
 	for i, tcase := range []struct {
 		base Labels
 		del  []string
+		keep []string
 		set  []Label
 		want Labels
 	}{
@@ -681,11 +682,31 @@ func TestBuilder(t *testing.T) {
 			set:  []Label{{"bbb", ""}},
 			want: FromStrings("aaa", "111", "ccc", "333"),
 		},
+		{
+			base: FromStrings("aaa", "111", "bbb", "222", "ccc", "333"),
+			keep: []string{"bbb"},
+			want: FromStrings("bbb", "222"),
+		},
+		{
+			base: FromStrings("aaa", "111", "bbb", "222", "ccc", "333"),
+			keep: []string{"aaa", "ccc"},
+			want: FromStrings("aaa", "111", "ccc", "333"),
+		},
+		{
+			base: FromStrings("aaa", "111", "bbb", "222", "ccc", "333"),
+			del:  []string{"bbb"},
+			set:  []Label{{"ddd", "444"}},
+			keep: []string{"aaa", "ddd"},
+			want: FromStrings("aaa", "111", "ddd", "444"),
+		},
 	} {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			b := NewBuilder(tcase.base)
 			for _, lbl := range tcase.set {
 				b.Set(lbl.Name, lbl.Value)
+			}
+			if len(tcase.keep) > 0 {
+				b.Keep(tcase.keep...)
 			}
 			b.Del(tcase.del...)
 			require.Equal(t, tcase.want, b.Labels())

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2050,14 +2050,16 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 }
 
 func signatureFunc(on bool, b []byte, names ...string) func(labels.Labels) string {
-	sort.Strings(names)
 	if on {
+	sort.Strings(names)
 		return func(lset labels.Labels) string {
-			return string(lset.WithLabels(names...).Bytes(b))
+			return string(lset.BytesWithLabels(b, names...))
 		}
 	}
+	names = append([]string{labels.MetricName}, names...)
+	sort.Strings(names)
 	return func(lset labels.Labels) string {
-		return string(lset.WithoutLabels(names...).Bytes(b))
+		return string(lset.BytesWithoutLabels(b, names...))
 	}
 }
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2051,7 +2051,7 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 
 func signatureFunc(on bool, b []byte, names ...string) func(labels.Labels) string {
 	if on {
-	sort.Strings(names)
+		sort.Strings(names)
 		return func(lset labels.Labels) string {
 			return string(lset.BytesWithLabels(b, names...))
 		}
@@ -2094,15 +2094,7 @@ func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.V
 
 	if matching.Card == parser.CardOneToOne {
 		if matching.On {
-		Outer:
-			for _, l := range lhs {
-				for _, n := range matching.MatchingLabels {
-					if l.Name == n {
-						continue Outer
-					}
-				}
-				enh.lb.Del(l.Name)
-			}
+			enh.lb.Keep(matching.MatchingLabels...)
 		} else {
 			enh.lb.Del(matching.MatchingLabels...)
 		}
@@ -2297,16 +2289,14 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		group, ok := result[groupingKey]
 		// Add a new group if it doesn't exist.
 		if !ok {
-			var m labels.Labels
-
+			lb.Reset(metric)
 			if without {
-				lb.Reset(metric)
 				lb.Del(grouping...)
 				lb.Del(labels.MetricName)
-				m = lb.Labels()
 			} else {
-				m = metric.WithLabels(grouping...)
+				lb.Keep(grouping...)
 			}
+			m := lb.Labels()
 			newAgg := &groupedAggregation{
 				labels:     m,
 				value:      s.V,

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -791,7 +791,6 @@ func funcPredictLinear(vals []parser.Value, args parser.Expressions, enh *EvalNo
 func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	q := vals[0].(Vector)[0].V
 	inVec := vals[1].(Vector)
-	sigf := signatureFunc(false, enh.lblBuf, labels.BucketLabel)
 
 	if enh.signatureToMetricWithBuckets == nil {
 		enh.signatureToMetricWithBuckets = map[string]*metricWithBuckets{}
@@ -809,19 +808,15 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 			// TODO(beorn7): Issue a warning somehow.
 			continue
 		}
-		l := sigf(el.Metric)
-		// Add the metric name (which is always removed) to the signature to prevent combining multiple histograms
-		// with the same label set. See https://github.com/prometheus/prometheus/issues/9910
-		l = l + el.Metric.Get(model.MetricNameLabel)
-
-		mb, ok := enh.signatureToMetricWithBuckets[l]
+		enh.lblBuf = el.Metric.BytesWithoutLabels(enh.lblBuf, labels.BucketLabel)
+		mb, ok := enh.signatureToMetricWithBuckets[string(enh.lblBuf)]
 		if !ok {
 			el.Metric = labels.NewBuilder(el.Metric).
 				Del(excludedLabels...).
 				Labels()
 
 			mb = &metricWithBuckets{el.Metric, nil}
-			enh.signatureToMetricWithBuckets[l] = mb
+			enh.signatureToMetricWithBuckets[string(enh.lblBuf)] = mb
 		}
 		mb.buckets = append(mb.buckets, bucket{upperBound, el.V})
 	}


### PR DESCRIPTION
Instead of creating a new `Labels` slice then converting to signature, go directly to the signature and save time.

Since there is only one other place where `Labels.WithLabels()` is called, add a `Keep()` function to `Builder` 
that lets us replace `Labels.WithLabels`. In `engine.resultMetric()` we can call `Keep()` instead of checking and calling `Del()`.

Avoid calling `Sort()` in `Builder.Labels()` if we didn't add anything, so that `Keep()` has the same performance as `WithLabels()`.

Also, refactor Builder tests. Have one test with a range of cases, and have them check the final output rather than checking the internal structure of the Builder.

Add a couple of cases where the value is `""`, which should be interpreted as 'delete'.

This PR is split into three commits that focus on different parts of the change.

Benchmarks - `histogram_quantile` is the only place where this shows up as material:
```
name                                                                            old time/op    new time/op    delta
RangeQuery/expr=a_hundred,steps=1000-8                                            2.76ms ± 1%    2.77ms ± 0%     ~     (p=0.111 n=5+4)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-8                                  6.06ms ± 1%    6.06ms ± 1%     ~     (p=0.556 n=4+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-8                                 67.9ms ± 0%    68.4ms ± 1%   +0.72%  (p=0.016 n=4+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-8                 5.70s ± 0%     5.70s ± 0%     ~     (p=0.413 n=4+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-8                                795ms ± 1%     796ms ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-8                                   793ms ± 1%     796ms ± 0%     ~     (p=0.190 n=5+4)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-8                       256ms ± 1%     261ms ± 3%     ~     (p=0.310 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-8                                           2.85ms ± 1%    2.88ms ± 0%   +1.10%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                                45.8ms ± 0%    45.9ms ± 1%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-8                                469ms ± 0%     472ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8               19.7ms ± 0%    19.8ms ± 0%   +0.80%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8                29.3ms ± 1%    29.7ms ± 0%   +1.11%  (p=0.016 n=5+4)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8            19.7ms ± 1%    19.8ms ± 1%     ~     (p=0.190 n=4+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-8                4.01ms ± 0%    4.03ms ± 0%   +0.43%  (p=0.032 n=5+4)
RangeQuery/expr=abs(a_hundred),steps=1000-8                                       26.3ms ± 6%    26.4ms ± 4%     ~     (p=0.310 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8    29.4ms ± 0%    30.0ms ± 1%   +2.12%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8           29.3ms ± 1%    29.9ms ± 5%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-8                                       5.03ms ± 1%    5.08ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-8                           66.5ms ± 1%    65.7ms ± 0%   -1.19%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-8                          96.6ms ± 2%    93.0ms ± 0%   -3.76%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-8                                92.2ms ± 0%    94.3ms ± 2%   +2.25%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-8                               65.6ms ± 0%    66.0ms ± 0%     ~     (p=0.063 n=5+4)
RangeQuery/expr=count_values('value',_h_hundred),steps=1000-8                      7.37s ± 3%     7.41s ± 2%     ~     (p=0.686 n=4+4)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-8                                   5.78ms ± 1%    5.70ms ± 4%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-8            49.9ms ± 0%    50.2ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-8                 8.41ms ± 0%    8.36ms ± 0%   -0.59%  (p=0.029 n=4+4)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-8          284ms ± 0%     210ms ± 2%  -25.80%  (p=0.016 n=4+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8                  9.86ms ± 0%    9.85ms ± 0%     ~     (p=0.690 n=5+5)

name                                                                            old alloc/op   new alloc/op   delta
RangeQuery/expr=a_hundred,steps=1000-8                                             309kB ± 0%     309kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-8                                   323kB ± 0%     320kB ± 0%   -0.74%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-8                                 5.91MB ± 0%    5.86MB ± 0%   -0.85%  (p=0.016 n=5+4)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-8                5.87MB ± 1%    5.82MB ± 1%     ~     (p=0.206 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-8                               5.86MB ± 3%    5.81MB ± 3%     ~     (p=0.079 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-8                                  6.05MB ± 0%    5.95MB ± 5%     ~     (p=0.190 n=4+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-8                      7.57MB ± 0%    7.52MB ± 0%   -0.67%  (p=0.029 n=4+4)
RangeQuery/expr=-a_hundred,steps=1000-8                                            343kB ± 0%     341kB ± 0%   -0.70%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                                3.28MB ± 0%    3.26MB ± 0%   -0.63%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-8                               37.3MB ± 0%    37.2MB ± 0%   -0.24%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8               3.73MB ± 0%    3.72MB ± 0%   -0.27%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8                7.44MB ± 0%    7.43MB ± 0%   -0.13%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8            3.73MB ± 0%    3.72MB ± 0%   -0.24%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-8                 396kB ± 0%     390kB ± 0%   -1.60%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-8                                       2.05MB ± 0%    2.05MB ± 0%   -0.10%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8    2.17MB ± 0%    2.17MB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8           2.23MB ± 0%    2.23MB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-8                                        795kB ± 0%     795kB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-8                           7.13MB ± 0%    6.87MB ± 0%   -3.72%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-8                          34.6MB ± 0%    32.2MB ± 0%   -6.94%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-8                                32.2MB ± 0%    32.2MB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-8                               6.87MB ± 0%    6.87MB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=1000-8                     1.17GB ± 0%    1.17GB ± 0%     ~     (p=1.000 n=4+4)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-8                                    844kB ± 0%     844kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-8            3.30MB ± 0%    3.29MB ± 0%   -0.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-8                  802kB ± 0%     775kB ± 0%   -3.31%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-8          155MB ± 0%       8MB ± 0%  -94.67%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8                  1.23MB ± 0%    1.22MB ± 0%   -0.53%  (p=0.008 n=5+5)

name                                                                            old allocs/op  new allocs/op  delta
RangeQuery/expr=a_hundred,steps=1000-8                                             5.32k ± 0%     5.32k ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-8                                   5.37k ± 0%     5.27k ± 0%   -1.86%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-8                                  84.1k ± 0%     83.4k ± 0%   -0.77%  (p=0.029 n=4+4)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-8                 77.8k ± 0%     77.2k ± 0%   -0.83%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-8                                77.7k ± 0%     77.1k ± 0%   -0.84%  (p=0.016 n=4+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-8                                   77.8k ± 0%     77.1k ± 0%   -0.83%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-8                       77.7k ± 0%     77.1k ± 0%     ~     (p=0.079 n=4+5)
RangeQuery/expr=-a_hundred,steps=1000-8                                            5.74k ± 0%     5.64k ± 0%   -1.74%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                                 22.9k ± 0%     22.6k ± 0%   -1.39%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-8                                 280k ± 0%      279k ± 0%   -0.47%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8                21.3k ± 0%     21.2k ± 0%   -0.72%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8                 26.3k ± 0%     26.1k ± 0%   -0.56%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8             21.3k ± 0%     21.2k ± 0%   -0.72%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-8                 7.69k ± 0%     7.59k ± 0%   -1.26%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-8                                        14.2k ± 0%     14.1k ± 0%   -0.66%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8     18.7k ± 0%     18.7k ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8            20.5k ± 0%     20.5k ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-8                                        12.5k ± 0%     12.5k ± 0%     ~     (all equal)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-8                             103k ± 0%       92k ± 0%  -10.70%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-8                            387k ± 0%      287k ± 0%  -25.89%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-8                                  287k ± 0%      287k ± 0%     ~     (p=0.254 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-8                                91.8k ± 0%     91.8k ± 0%     ~     (p=0.167 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=1000-8                      8.97M ± 0%     8.97M ± 0%     ~     (p=0.686 n=4+4)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-8                                    13.5k ± 0%     13.5k ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-8             23.0k ± 0%     22.5k ± 0%   -2.16%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-8                  13.5k ± 0%     12.4k ± 0%   -8.15%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-8          3.48M ± 0%     0.17M ± 0%  -95.08%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8                   9.44k ± 0%     9.34k ± 0%   -1.06%  (p=0.008 n=5+5)
```