### PR TITLE
Abort WAL replay if Prometheus is stopping

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -287,7 +287,7 @@ func TestTimeMetrics(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	reg := prometheus.NewRegistry()
-	db, err := openDBWithMetrics(tmpDir, log.NewNopLogger(), reg, nil, nil)
+	db, err := openDBWithMetrics(context.Background(), tmpDir, log.NewNopLogger(), reg, nil, nil)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, db.Close())

--- a/cmd/promtool/backfill_test.go
+++ b/cmd/promtool/backfill_test.go
@@ -699,7 +699,7 @@ after_eof 1 2
 			require.NoError(t, err)
 			options := tsdb.DefaultOptions()
 			options.RetentionDuration = int64(10 * 365 * 24 * time.Hour / time.Millisecond) // maximum duration tests require a long retention
-			db, err := tsdb.Open(outputDir, nil, nil, options, nil)
+			db, err := tsdb.Open(context.Background(), outputDir, nil, nil, options, nil)
 			require.NoError(t, err)
 			defer func() {
 				require.NoError(t, db.Close())

--- a/cmd/promtool/rules_test.go
+++ b/cmd/promtool/rules_test.go
@@ -118,7 +118,7 @@ func TestBackfillRuleIntegration(t *testing.T) {
 				}
 
 				opts := tsdb.DefaultOptions()
-				db, err := tsdb.Open(tmpDir, nil, nil, opts, nil)
+				db, err := tsdb.Open(context.Background(), tmpDir, nil, nil, opts, nil)
 				require.NoError(t, err)
 
 				blocks := db.Blocks()
@@ -245,7 +245,7 @@ func TestBackfillLabels(t *testing.T) {
 	}
 
 	opts := tsdb.DefaultOptions()
-	db, err := tsdb.Open(tmpDir, nil, nil, opts, nil)
+	db, err := tsdb.Open(context.Background(), tmpDir, nil, nil, opts, nil)
 	require.NoError(t, err)
 
 	q, err := db.Querier(math.MinInt64, math.MaxInt64)

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -88,7 +88,7 @@ func benchmarkWrite(outPath, samplesFile string, numMetrics, numScrapes int) err
 
 	l := log.With(b.logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
 
-	st, err := tsdb.Open(dir, l, nil, &tsdb.Options{
+	st, err := tsdb.Open(context.Background(), dir, l, nil, &tsdb.Options{
 		RetentionDuration: int64(15 * 24 * time.Hour / time.Millisecond),
 		MinBlockDuration:  int64(2 * time.Hour / time.Millisecond),
 	}, tsdb.NewDBStats())

--- a/cmd/promtool/tsdb_test.go
+++ b/cmd/promtool/tsdb_test.go
@@ -180,7 +180,7 @@ func TestTSDBDumpOpenMetricsRoundTrip(t *testing.T) {
 	// Import samples from OM format
 	err = backfill(5000, initialMetrics, dbDir, false, false, 2*time.Hour)
 	require.NoError(t, err)
-	db, err := tsdb.Open(dbDir, nil, nil, tsdb.DefaultOptions(), nil)
+	db, err := tsdb.Open(context.Background(), dbDir, nil, nil, tsdb.DefaultOptions(), nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -214,7 +214,7 @@ func BenchmarkRemoteWriteOOOSamples(b *testing.B) {
 	opts.OutOfOrderCapMax = 30
 	opts.OutOfOrderTimeWindow = 120 * time.Minute.Milliseconds()
 
-	db, err := tsdb.Open(dir, nil, nil, opts, nil)
+	db, err := tsdb.Open(context.Background(), dir, nil, nil, opts, nil)
 	require.NoError(b, err)
 
 	b.Cleanup(func() {

--- a/tsdb/blockwriter.go
+++ b/tsdb/blockwriter.go
@@ -79,7 +79,7 @@ func (w *BlockWriter) initHead() error {
 	}
 
 	w.head = h
-	return w.head.Init(math.MinInt64)
+	return w.head.Init(context.Background(), math.MinInt64)
 }
 
 // Appender returns a new appender on the database.

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1257,7 +1257,7 @@ func TestCancelCompactions(t *testing.T) {
 	// Measure the compaction time without interrupting it.
 	var timeCompactionUninterrupted time.Duration
 	{
-		db, err := open(tmpdir, log.NewNopLogger(), nil, DefaultOptions(), []int64{1, 2000}, nil)
+		db, err := open(context.Background(), tmpdir, log.NewNopLogger(), nil, DefaultOptions(), []int64{1, 2000}, nil)
 		require.NoError(t, err)
 		require.Len(t, db.Blocks(), 3, "initial block count mismatch")
 		require.Equal(t, 0.0, prom_testutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.Ran), "initial compaction counter mismatch")
@@ -1276,7 +1276,7 @@ func TestCancelCompactions(t *testing.T) {
 	}
 	// Measure the compaction time when closing the db in the middle of compaction.
 	{
-		db, err := open(tmpdirCopy, log.NewNopLogger(), nil, DefaultOptions(), []int64{1, 2000}, nil)
+		db, err := open(context.Background(), tmpdirCopy, log.NewNopLogger(), nil, DefaultOptions(), []int64{1, 2000}, nil)
 		require.NoError(t, err)
 		require.Len(t, db.Blocks(), 3, "initial block count mismatch")
 		require.Equal(t, 0.0, prom_testutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.Ran), "initial compaction counter mismatch")
@@ -1387,7 +1387,7 @@ func TestHeadCompactionWithHistograms(t *testing.T) {
 	for _, floatTest := range []bool{true, false} {
 		t.Run(fmt.Sprintf("float=%t", floatTest), func(t *testing.T) {
 			head, _ := newTestHead(t, DefaultBlockDuration, wlog.CompressionNone, false)
-			require.NoError(t, head.Init(0))
+			require.NoError(t, head.Init(context.Background(), 0))
 			t.Cleanup(func() {
 				require.NoError(t, head.Close())
 			})

--- a/tsdb/example_test.go
+++ b/tsdb/example_test.go
@@ -31,7 +31,7 @@ func Example() {
 	noErr(err)
 
 	// Open a TSDB for reading and/or writing.
-	db, err := Open(dir, nil, nil, DefaultOptions(), nil)
+	db, err := Open(context.Background(), dir, nil, nil, DefaultOptions(), nil)
 	noErr(err)
 
 	// Open an appender for writing.

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -299,7 +299,7 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 					defer func() {
 						require.NoError(t, h.Close())
 					}()
-					require.NoError(t, h.Init(0))
+					require.NoError(t, h.Init(context.Background(), 0))
 
 					s1, _, _ := h.getOrCreate(s1ID, s1Lset)
 					s1.ooo = &memSeriesOOOFields{}
@@ -1198,7 +1198,7 @@ func TestSortMetaByMinTimeAndMinRef(t *testing.T) {
 func newTestDBWithOpts(t *testing.T, opts *Options) *DB {
 	dir := t.TempDir()
 
-	db, err := Open(dir, nil, nil, opts, nil)
+	db, err := Open(context.Background(), dir, nil, nil, opts, nil)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3083,7 +3083,7 @@ func TestClose(t *testing.T) {
 	createBlock(t, dir, genSeries(1, 1, 0, 10))
 	createBlock(t, dir, genSeries(1, 1, 10, 20))
 
-	db, err := Open(dir, nil, nil, DefaultOptions(), nil)
+	db, err := Open(context.Background(), dir, nil, nil, DefaultOptions(), nil)
 	require.NoError(t, err, "Opening test storage failed: %s")
 	defer func() {
 		require.NoError(t, db.Close())

--- a/tsdb/repair_test.go
+++ b/tsdb/repair_test.go
@@ -93,7 +93,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	require.NoError(t, r.Close())
 
 	// On DB opening all blocks in the base dir should be repaired.
-	db, err := Open(tmpDir, nil, nil, nil, nil)
+	db, err := Open(context.Background(), tmpDir, nil, nil, nil, nil)
 	require.NoError(t, err)
 	db.Close()
 

--- a/util/teststorage/storage.go
+++ b/util/teststorage/storage.go
@@ -14,6 +14,7 @@
 package teststorage
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -40,7 +41,7 @@ func New(t testutil.T) *TestStorage {
 	opts.MaxBlockDuration = int64(24 * time.Hour / time.Millisecond)
 	opts.RetentionDuration = 0
 	opts.EnableNativeHistograms = true
-	db, err := tsdb.Open(dir, nil, nil, opts, tsdb.NewDBStats())
+	db, err := tsdb.Open(context.Background(), dir, nil, nil, opts, tsdb.NewDBStats())
 	require.NoError(t, err, "unexpected error while opening test storage")
 	reg := prometheus.NewRegistry()
 	eMetrics := tsdb.NewExemplarMetrics(reg)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -65,7 +65,7 @@ func TestReadyAndHealthy(t *testing.T) {
 
 	dbDir := t.TempDir()
 
-	db, err := tsdb.Open(dbDir, nil, nil, nil, nil)
+	db, err := tsdb.Open(context.Background(), dbDir, nil, nil, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())
@@ -189,7 +189,7 @@ func TestRoutePrefix(t *testing.T) {
 	t.Parallel()
 	dbDir := t.TempDir()
 
-	db, err := tsdb.Open(dbDir, nil, nil, nil, nil)
+	db, err := tsdb.Open(context.Background(), dbDir, nil, nil, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())
@@ -371,7 +371,7 @@ func TestHTTPMetrics(t *testing.T) {
 func TestShutdownWithStaleConnection(t *testing.T) {
 	dbDir := t.TempDir()
 
-	db, err := tsdb.Open(dbDir, nil, nil, nil, nil)
+	db, err := tsdb.Open(context.Background(), dbDir, nil, nil, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())


### PR DESCRIPTION
WAL replay can take a long time depending on the amount of scraped metrics. In our environment it often takes 20-40 minutes to complete it with 20-30M time series.
At the same time this process cannot be interrupted, which means that if I start Prometheus but decide I need to restart it for some reason before it completes WAL replay, I will have to wait twice for the WAL replay to finish - that's because it will only shutdown after it completes WAL replay and then when it starts again the whole process starts from scratch.
This change passes context down to WAL replay code so we can cancel it at any point, which will aboirt WAL replay and allow Prometheus to skip the long wait just to restart the whole process again.

Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
