### PR TITLE
use monotonic clock for scheduling rules

### DIFF
--- a/cmd/promtool/rules.go
+++ b/cmd/promtool/rules.go
@@ -105,7 +105,7 @@ func (importer *ruleImporter) importRule(ctx context.Context, ruleExpr, ruleName
 		endOfBlock := startOfBlock + blockDuration - 1
 
 		currStart := max(startOfBlock/int64(time.Second/time.Millisecond), start.Unix())
-		startWithAlignment := grp.EvalTimestamp(time.Unix(currStart, 0).UTC().UnixNano())
+		startWithAlignment := grp.EvalTimestamp(time.Unix(currStart, 0).UTC())
 		for startWithAlignment.Unix() < currStart {
 			startWithAlignment = startWithAlignment.Add(grp.Interval())
 		}


### PR DESCRIPTION
I have some prometheus instances that falsely report `prometheus_rule_group_iterations_missed_total`. If I subtract `prometheus_rule_group_iterations_missed_total` from `prometheus_rule_group_iterations_total`, I get expected number of iterations for the rule interval. So all missed iterations are just extra. It happens mostly randomly after some days of uptime.

All this instances run on different machines setup than the rest. After some experiments I have concluded that `time.Ticker` used for scheduling rules fires occasionally a milisecond earlier and breaks missed rules calculation.

I have tried different solutions and I think that switch to a monotonic clock instead of a wall clock is the best one that works.

You can check if a time is monotonic like this `evalTimestamp != evalTimestamp.Round(0)`.

More info about monotonic clocks https://pkg.go.dev/time