### PR TITLE
bump @nexucis/kvsearch v0.6.0

### DIFF
--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -2969,9 +2969,9 @@
       "integrity": "sha512-Z1+ADKY0fxdBE28REraWhUCNy+Bp5UmpK3Tc/5wdCDpY+6fXh8l2csMtbPGaqEBsyGLxJz9wUYGCf+CW9unyvQ=="
     },
     "node_modules/@nexucis/kvsearch": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@nexucis/kvsearch/-/kvsearch-0.5.0.tgz",
-      "integrity": "sha512-7TtH+Ug7o7Cjm8HogsXCgq8JNihINE0zZj7JMJXF5PxhF7MhwC9yHe6Gm4+ckt6seOXOFf+g/cZ6hWtVMiR3cQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@nexucis/kvsearch/-/kvsearch-0.6.0.tgz",
+      "integrity": "sha512-sv2WWXUMRMoM2g3y02m4+9MK08l9nposveNqn5sPKSGpgZ0DxvmD84SAJHb0SvVazgL31C85kST2kySpF0+/Dw==",
       "dependencies": {
         "@nexucis/fuzzy": "^0.3.0"
       }
@@ -17341,7 +17341,7 @@
         "@fortawesome/free-solid-svg-icons": "6.1.1",
         "@fortawesome/react-fontawesome": "0.1.17",
         "@nexucis/fuzzy": "^0.3.0",
-        "@nexucis/kvsearch": "^0.5.0",
+        "@nexucis/kvsearch": "^0.6.0",
         "bootstrap": "^4.6.1",
         "codemirror-promql": "0.19.0",
         "css.escape": "^1.5.1",
@@ -19509,9 +19509,9 @@
       "integrity": "sha512-Z1+ADKY0fxdBE28REraWhUCNy+Bp5UmpK3Tc/5wdCDpY+6fXh8l2csMtbPGaqEBsyGLxJz9wUYGCf+CW9unyvQ=="
     },
     "@nexucis/kvsearch": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@nexucis/kvsearch/-/kvsearch-0.5.0.tgz",
-      "integrity": "sha512-7TtH+Ug7o7Cjm8HogsXCgq8JNihINE0zZj7JMJXF5PxhF7MhwC9yHe6Gm4+ckt6seOXOFf+g/cZ6hWtVMiR3cQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@nexucis/kvsearch/-/kvsearch-0.6.0.tgz",
+      "integrity": "sha512-sv2WWXUMRMoM2g3y02m4+9MK08l9nposveNqn5sPKSGpgZ0DxvmD84SAJHb0SvVazgL31C85kST2kySpF0+/Dw==",
       "requires": {
         "@nexucis/fuzzy": "^0.3.0"
       }
@@ -23964,7 +23964,7 @@
         "@fortawesome/free-solid-svg-icons": "6.1.1",
         "@fortawesome/react-fontawesome": "0.1.17",
         "@nexucis/fuzzy": "^0.3.0",
-        "@nexucis/kvsearch": "^0.5.0",
+        "@nexucis/kvsearch": "^0.6.0",
         "@testing-library/react-hooks": "^7.0.1",
         "@types/enzyme": "^3.10.10",
         "@types/flot": "0.0.32",

--- a/web/ui/react-app/package.json
+++ b/web/ui/react-app/package.json
@@ -20,7 +20,7 @@
     "@fortawesome/free-solid-svg-icons": "6.1.1",
     "@fortawesome/react-fontawesome": "0.1.17",
     "@nexucis/fuzzy": "^0.3.0",
-    "@nexucis/kvsearch": "^0.5.0",
+    "@nexucis/kvsearch": "^0.6.0",
     "bootstrap": "^4.6.1",
     "codemirror-promql": "0.19.0",
     "css.escape": "^1.5.1",


### PR DESCRIPTION
It doesn't change much. It's just the way the package is organised with `esm` and `cjs` module that changed. I followed what was done in Perses, it's much cleaner like it's done there.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
