### PR TITLE
Write & mmap chunks in the background

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1106,7 +1106,7 @@ func (db *DB) Compact() (returnErr error) {
 	}
 
 	// At the very end mmap all but last head chunk to save memory
-	db.mmapHead()
+	db.head.mmapHeadChunks()
 
 	return nil
 }
@@ -1225,7 +1225,7 @@ func (db *DB) compactOOO(dest string, oooHead *OOOCompactionHead) (_ []ulid.ULID
 // compactHead compacts the given RangeHead.
 // The compaction mutex should be held before calling this method.
 func (db *DB) compactHead(head *RangeHead) error {
-	db.mmapHead()
+	db.head.mmapHeadChunks()
 	uid, err := db.compactor.Write(db.dir, head, head.MinTime(), head.BlockMaxTime(), nil)
 	if err != nil {
 		return errors.Wrap(err, "persist head block")
@@ -1244,14 +1244,6 @@ func (db *DB) compactHead(head *RangeHead) error {
 		return errors.Wrap(err, "head memory truncate")
 	}
 	return nil
-}
-
-func (db *DB) mmapHead() {
-	start := time.Now()
-	mmapped := db.head.series.mmapHeadChunks(db.head.chunkDiskMapper)
-	if mmapped > 0 {
-		level.Info(db.logger).Log("msg", "Finished mmapping head chunks", "chunks", mmapped, "duration", time.Since(start).String())
-	}
 }
 
 // compactBlocks compacts all the eligible on-disk blocks.
@@ -1285,7 +1277,7 @@ func (db *DB) compactBlocks() (err error) {
 			return errors.Wrap(err, "reloadBlocks blocks")
 		}
 
-		db.mmapHead()
+		db.head.mmapHeadChunks()
 	}
 
 	return nil

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1499,6 +1499,7 @@ func TestSizeRetention(t *testing.T) {
 		}
 	}
 	require.NoError(t, headApp.Commit())
+	db.Head().series.mmapHeadChunks(db.Head().chunkDiskMapper)
 
 	require.Eventually(t, func() bool {
 		return db.Head().chunkDiskMapper.IsQueueEmpty()

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -235,6 +235,7 @@ func TestNoPanicAfterWALCorruption(t *testing.T) {
 			require.NoError(t, app.Commit())
 			maxt++
 		}
+		db.head.mmapHeadChunks()
 		require.NoError(t, db.Close())
 	}
 
@@ -5787,12 +5788,14 @@ func TestDiskFillingUpAfterDisablingOOO(t *testing.T) {
 
 	// Check that m-map files gets deleted properly after compactions.
 
+	db.head.mmapHeadChunks()
 	checkMmapFileContents([]string{"000001", "000002"}, nil)
 	require.NoError(t, db.Compact())
 	checkMmapFileContents([]string{"000002"}, []string{"000001"})
 	require.Equal(t, 0, len(ms.oooMmappedChunks), "OOO mmap chunk was not compacted")
 
 	addSamples(501, 650)
+	db.head.mmapHeadChunks()
 	checkMmapFileContents([]string{"000002", "000003"}, []string{"000001"})
 	require.NoError(t, db.Compact())
 	checkMmapFileContents(nil, []string{"000001", "000002", "000003"})

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1499,7 +1499,7 @@ func TestSizeRetention(t *testing.T) {
 		}
 	}
 	require.NoError(t, headApp.Commit())
-	db.Head().series.mmapHeadChunks(db.Head().chunkDiskMapper)
+	db.Head().mmapHeadChunks()
 
 	require.Eventually(t, func() bool {
 		return db.Head().chunkDiskMapper.IsQueueEmpty()

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1551,6 +1551,14 @@ func (h *Head) getOrCreateWithID(id chunks.HeadSeriesRef, hash uint64, lset labe
 	return s, true, nil
 }
 
+func (h *Head) mmapHeadChunks() {
+	start := time.Now()
+	mmapped := h.series.mmapHeadChunks(h.chunkDiskMapper)
+	if mmapped > 0 {
+		level.Info(h.logger).Log("msg", "Finished mmapping head chunks", "chunks", mmapped, "duration", time.Since(start).String())
+	}
+}
+
 // seriesHashmap is a simple hashmap for memSeries by their label set. It is built
 // on top of a regular hashmap and holds a slice of series to resolve hash collisions.
 // Its methods require the hash to be submitted with it to avoid re-computations throughout

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1490,10 +1490,13 @@ func (h *Head) compactable() bool {
 // Close flushes the WAL and closes the head.
 // It also takes a snapshot of in-memory chunks if enabled.
 func (h *Head) Close() error {
-	h.mmapHeadChunks()
 	h.closedMtx.Lock()
 	defer h.closedMtx.Unlock()
 	h.closed = true
+
+	// mmap all but last chunk in case we're performing snapshot since that only
+	// takes samples from head chunk
+	h.mmapHeadChunks()
 
 	errs := tsdb_errors.NewMulti(h.chunkDiskMapper.Close())
 	if errs.Err() == nil && h.opts.EnableMemorySnapshotOnShutdown {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2947,7 +2947,7 @@ func TestHistogramInWALAndMmapChunk(t *testing.T) {
 	}
 	require.NoError(t, app.Commit())
 
-	head.series.mmapHeadChunks(head.chunkDiskMapper)
+	head.mmapHeadChunks()
 	// There should be 3 mmap chunks in s1.
 	ms := head.series.getByHash(s1.Hash(), s1)
 	require.Len(t, ms.mmappedChunks, 3)
@@ -3432,7 +3432,7 @@ func TestHistogramStaleSample(t *testing.T) {
 	expHistograms = append(expHistograms, timedHistogram{100*int64(len(expHistograms)) + 1, &histogram.Histogram{Sum: math.Float64frombits(value.StaleNaN)}})
 	require.NoError(t, app.Commit())
 
-	head.series.mmapHeadChunks(head.chunkDiskMapper)
+	head.mmapHeadChunks()
 	// Total 2 chunks, 1 m-mapped.
 	s = head.series.getByHash(l.Hash(), l)
 	require.NotNil(t, s)
@@ -3463,7 +3463,7 @@ func TestHistogramCounterResetHeader(t *testing.T) {
 
 		ms, _, err := head.getOrCreate(l.Hash(), l)
 		require.NoError(t, err)
-		head.series.mmapHeadChunks(head.chunkDiskMapper)
+		head.mmapHeadChunks()
 		require.Len(t, ms.mmappedChunks, len(expHeaders)-1) // One is the head chunk.
 
 		for i, mmapChunk := range ms.mmappedChunks {
@@ -3587,7 +3587,7 @@ func TestAppendingDifferentEncodingToSameSeries(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, created)
 		require.NotNil(t, ms)
-		db.Head().series.mmapHeadChunks(db.Head().chunkDiskMapper)
+		db.Head().mmapHeadChunks()
 		require.Len(t, ms.mmappedChunks, count-1) // One will be the head chunk.
 	}
 
@@ -4151,7 +4151,7 @@ func TestReplayAfterMmapReplayError(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	openHead()
-	h.series.mmapHeadChunks(h.chunkDiskMapper)
+	h.mmapHeadChunks()
 
 	// There should be less m-map files due to corruption.
 	files, err = os.ReadDir(filepath.Join(dir, "chunks_head"))


### PR DESCRIPTION
Mmapping chunks is expensive and so we should avoid having this done on the hot path to avoid blocking scrapes and rule evaluations.
This change allows tsdb to keep most recent chunks in-memory and write & mmap them on a schedule by a background goroutine.

Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

This is an attempt to address #10377, early testing shows that it does in fact resolve most of the issue for me.

@codesome / @replay 