### PR TITLE
Remove "This function was added in Prometheus 2.0"

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -405,8 +405,6 @@ expression is to be evaluated.
 `timestamp(v instant-vector)` returns the timestamp of each of the samples of
 the given vector as the number of seconds since January 1, 1970 UTC.
 
-*This function was added in Prometheus 2.0*
-
 ## `vector()`
 
 `vector(s scalar)` returns the scalar `s` as a vector with no labels.


### PR DESCRIPTION
Since Prometheus documentation is versioned, do not write down that a
specific function was added in Prom 2.0, for consistency.

Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
