### PR TITLE
refactor (notifier): move from github.com/pkg/errors to 'errors' and 'fmt'

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -30,7 +30,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/go-openapi/strfmt"
-	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
@@ -588,7 +587,7 @@ func (n *Manager) sendOne(ctx context.Context, c *http.Client, url string, b []b
 
 	// Any HTTP status 2xx is OK.
 	if resp.StatusCode/100 != 2 {
-		return errors.Errorf("bad response status %s", resp.Status)
+		return fmt.Errorf("bad response status %s", resp.Status)
 	}
 
 	return nil
@@ -742,7 +741,7 @@ func AlertmanagerFromGroup(tg *targetgroup.Group, cfg *config.AlertmanagerConfig
 			case "https":
 				addr = addr + ":443"
 			default:
-				return nil, nil, errors.Errorf("invalid scheme: %q", cfg.Scheme)
+				return nil, nil, fmt.Errorf("invalid scheme: %q", cfg.Scheme)
 			}
 			lb.Set(model.AddressLabel, addr)
 		}

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -88,11 +87,11 @@ func TestHandlerNextBatch(t *testing.T) {
 
 func alertsEqual(a, b []*Alert) error {
 	if len(a) != len(b) {
-		return errors.Errorf("length mismatch: %v != %v", a, b)
+		return fmt.Errorf("length mismatch: %v != %v", a, b)
 	}
 	for i, alert := range a {
 		if !labels.Equal(alert.Labels, b[i].Labels) {
-			return errors.Errorf("label mismatch at index %d: %s != %s", i, alert.Labels, b[i].Labels)
+			return fmt.Errorf("label mismatch at index %d: %s != %s", i, alert.Labels, b[i].Labels)
 		}
 	}
 	return nil
@@ -121,14 +120,14 @@ func TestHandlerSendAll(t *testing.T) {
 			}()
 			user, pass, _ := r.BasicAuth()
 			if user != u || pass != p {
-				err = errors.Errorf("unexpected user/password: %s/%s != %s/%s", user, pass, u, p)
+				err = fmt.Errorf("unexpected user/password: %s/%s != %s/%s", user, pass, u, p)
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
 
 			b, err := io.ReadAll(r.Body)
 			if err != nil {
-				err = errors.Errorf("error reading body: %v", err)
+				err = fmt.Errorf("error reading body: %w", err)
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}


### PR DESCRIPTION
The package https://github.com/pkg/errors is not maintained anymore.
This PR replaces https://github.com/pkg/errors with official errors and fmt golang packages in notifier package

Signed-off-by: Matthieu MOREL [mmorel-35@users.noreply.github.com](mailto:mmorel-35@users.noreply.github.com)