### PR TITLE
Fix spacing in linode_sd_config

### DIFF
--- a/documentation/examples/prometheus-linode.yml
+++ b/documentation/examples/prometheus-linode.yml
@@ -11,7 +11,7 @@ scrape_configs:
   - job_name: "node"
     linode_sd_configs:
       - authorization:
-        credentials: "<replace with a Personal Access Token with linodes:read_only, ips:read_only, and events:read_only access>"
+          credentials: "<replace with a Personal Access Token with linodes:read_only, ips:read_only, and events:read_only access>"
     relabel_configs:
       # Only scrape targets that have a tag 'monitoring'.
       - source_labels: [__meta_linode_tags]


### PR DESCRIPTION
Fix spacing in linode_sd_config causing "credentials not found in type linode.plain"

Signed-off-by: Ryan Lonergan <rlonergan@linode.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
