### PR TITLE
Don't count added labels when initializing slice

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -452,7 +452,7 @@ func (b *Builder) Labels() Labels {
 
 	// In the general case, labels are removed, modified or moved
 	// rather than added.
-	res := make(Labels, 0, len(b.base)+len(b.add))
+	res := make(Labels, 0, len(b.base))
 Outer:
 	for _, l := range b.base {
 		for _, n := range b.del {


### PR DESCRIPTION
This was added in #10749 but based on feedback it might be over-allocating so worth removing.

Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
