### PR TITLE
Add service discovery for OvhCloud

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/prometheus/prometheus/discovery/marathon"
 	"github.com/prometheus/prometheus/discovery/moby"
 	"github.com/prometheus/prometheus/discovery/openstack"
+	"github.com/prometheus/prometheus/discovery/ovhcloud"
 	"github.com/prometheus/prometheus/discovery/puppetdb"
 	"github.com/prometheus/prometheus/discovery/scaleway"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -913,6 +914,39 @@ var expectedConf = &Config{
 					Server:           "http://eureka.example.com:8761/eureka",
 					RefreshInterval:  model.Duration(30 * time.Second),
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
+				},
+			},
+		},
+		{
+			JobName: "ovhcloud",
+
+			HonorTimestamps:  true,
+			ScrapeInterval:   model.Duration(15 * time.Second),
+			ScrapeTimeout:    DefaultGlobalConfig.ScrapeTimeout,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+
+			ServiceDiscoveryConfigs: discovery.Configs{
+				&ovhcloud.SDConfig{
+					Endpoint:          "ovh-eu",
+					ApplicationKey:    "testAppKey",
+					ApplicationSecret: "testAppSecret",
+					ConsumerKey:       "testConsumerKey",
+					RefreshInterval:   model.Duration(60 * time.Second),
+					SourcesToDisable:  []string{"ovhcloud_dedicated_server"},
+					DisabledSources:   map[string]bool{"ovhcloud_dedicated_server": true},
+					NoAuthTest:        true,
+				},
+				&ovhcloud.SDConfig{
+					Endpoint:          "ovh-eu",
+					ApplicationKey:    "testAppKey",
+					ApplicationSecret: "testAppSecret",
+					ConsumerKey:       "testConsumerKey",
+					RefreshInterval:   model.Duration(60 * time.Second),
+					SourcesToDisable:  nil,
+					DisabledSources:   map[string]bool{},
+					NoAuthTest:        true,
 				},
 			},
 		},

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -345,6 +345,22 @@ scrape_configs:
     eureka_sd_configs:
       - server: "http://eureka.example.com:8761/eureka"
 
+  - job_name: ovhcloud
+    ovhcloud_sd_configs:
+      - endpoint: ovh-eu
+        application_key: testAppKey
+        application_secret: testAppSecret
+        consumer_key: testConsumerKey
+        refresh_interval: 1m
+        no_auth_test: true
+        sources_to_disable: [ovhcloud_dedicated_server]
+      - endpoint: ovh-eu
+        application_key: testAppKey
+        application_secret: testAppSecret
+        consumer_key: testConsumerKey
+        refresh_interval: 1m
+        no_auth_test: true
+
   - job_name: scaleway
     scaleway_sd_configs:
       - role: instance

--- a/config/testdata/ovhcloud_no_secret.bad.yml
+++ b/config/testdata/ovhcloud_no_secret.bad.yml
@@ -1,0 +1,3 @@
+ovhcloud_sd_configs:
+  - endpoint: ovh-eu
+    application_key: appKeyTest

--- a/discovery/install/install.go
+++ b/discovery/install/install.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/prometheus/prometheus/discovery/marathon"     // register marathon
 	_ "github.com/prometheus/prometheus/discovery/moby"         // register moby
 	_ "github.com/prometheus/prometheus/discovery/openstack"    // register openstack
+	_ "github.com/prometheus/prometheus/discovery/ovhcloud"     // register ovhcloud
 	_ "github.com/prometheus/prometheus/discovery/puppetdb"     // register puppetdb
 	_ "github.com/prometheus/prometheus/discovery/scaleway"     // register scaleway
 	_ "github.com/prometheus/prometheus/discovery/triton"       // register triton

--- a/discovery/ovhcloud/dedicated_server.go
+++ b/discovery/ovhcloud/dedicated_server.go
@@ -1,0 +1,142 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovhcloud
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/fatih/structs"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/ovh/go-ovh/ovh"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/discovery/refresh"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+const dedicatedServerAPIPath = "/dedicated/server"
+
+// DedicatedServer struct
+type DedicatedServer struct {
+	State           string `json:"state"`
+	IPs             IPs    `json:"ips" label:"-"`
+	CommercialRange string `json:"commercialRange"`
+	LinkSpeed       int    `json:"linkSpeed"`
+	Rack            string `json:"rack"`
+	NoIntervention  bool   `json:"noIntervention"`
+	Os              string `json:"os"`
+	SupportLevel    string `json:"supportLevel"`
+	ServerID        int64  `json:"serverId"`
+	Reverse         string `json:"reverse"`
+	Datacenter      string `json:"datacenter"`
+	Name            string `json:"name"`
+}
+
+const (
+	dedicatedServerLabelPrefix = metaLabelPrefix + "dedicatedServer_"
+)
+
+type dedicatedServerDiscovery struct {
+	*refresh.Discovery
+	config *SDConfig
+	logger log.Logger
+}
+
+func newDedicatedServerDiscovery(conf *SDConfig, logger log.Logger) *dedicatedServerDiscovery {
+	return &dedicatedServerDiscovery{config: conf, logger: logger}
+}
+
+func getDedicatedServerList(client *ovh.Client) ([]string, error) {
+	var dedicatedListName []string
+	err := client.Get(dedicatedServerAPIPath, &dedicatedListName)
+	if err != nil {
+		return nil, err
+	}
+
+	return dedicatedListName, nil
+}
+
+func getDedicatedServerDetails(client *ovh.Client, serverName string) (*DedicatedServer, error) {
+	var dedicatedServerDetails DedicatedServer
+	err := client.Get(fmt.Sprintf("%s/%s", dedicatedServerAPIPath, url.QueryEscape(serverName)), &dedicatedServerDetails)
+	if err != nil {
+		return nil, err
+	}
+
+	var ips []string
+	err = client.Get(fmt.Sprintf("%s/%s/ips", dedicatedServerAPIPath, url.QueryEscape(serverName)), &ips)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedIPs, err := ParseIPList(ips)
+	if err != nil {
+		return nil, err
+	}
+
+	dedicatedServerDetails.IPs = *parsedIPs
+	return &dedicatedServerDetails, nil
+}
+
+func (d *dedicatedServerDiscovery) getSource() string {
+	return "ovhcloud_dedicated_server"
+}
+
+func (d *dedicatedServerDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	client, err := (d.config).CreateClient()
+	if err != nil {
+		return nil, err
+	}
+	var dedicatedServerDetailedList []DedicatedServer
+	dedicatedServerList, err := getDedicatedServerList(client)
+	if err != nil {
+		return nil, err
+	}
+	for _, dedicatedServerName := range dedicatedServerList {
+		dedicatedServer, err := getDedicatedServerDetails(client, dedicatedServerName)
+		if err != nil {
+			err := level.Warn(d.logger).Log("msg", fmt.Sprintf("%s: Could not get details of %s", d.getSource(), dedicatedServerName), "err", err.Error())
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		dedicatedServerDetailedList = append(dedicatedServerDetailedList, *dedicatedServer)
+	}
+	var targets []model.LabelSet
+
+	for _, server := range dedicatedServerDetailedList {
+		defaultIP := server.IPs.IPV4
+		if defaultIP == "" {
+			defaultIP = server.IPs.IPV6
+		}
+		labels := model.LabelSet{
+			model.AddressLabel:  model.LabelValue(defaultIP),
+			model.InstanceLabel: model.LabelValue(server.Name),
+		}
+
+		fields := structs.Fields(server)
+		addFieldsOnLabels(fields, labels, dedicatedServerLabelPrefix)
+
+		IPsFields := structs.Fields(server.IPs)
+		addFieldsOnLabels(IPsFields, labels, dedicatedServerLabelPrefix)
+
+		targets = append(targets, labels)
+	}
+
+	return []*targetgroup.Group{{Source: d.getSource(), Targets: targets}}, nil
+}

--- a/discovery/ovhcloud/dedicated_server_test.go
+++ b/discovery/ovhcloud/dedicated_server_test.go
@@ -1,0 +1,317 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovhcloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+type DedicatedServerData struct {
+	DedicatedServer DedicatedServer
+	Err             error
+	IPs             []string
+	IPsErr          error
+}
+
+func initMockErrorDedicatedServerList(err error) {
+	initMockAuth(123456)
+	gock.New(mockURL).
+		MatchHeader("Accept", "application/json").
+		Get("/dedicated/server").
+		ReplyError(err)
+}
+
+func initMockDedicatedServer(dedicatedServerList map[string]DedicatedServerData) {
+	initMockAuth(123456)
+
+	var dedicatedServerListName []string
+	for dedicatedServerName := range dedicatedServerList {
+		dedicatedServerListName = append(dedicatedServerListName, dedicatedServerName)
+	}
+
+	gock.New(mockURL).
+		MatchHeader("Accept", "application/json").
+		Get("/dedicated/server").
+		Reply(200).
+		JSON(dedicatedServerListName)
+
+	for dedicatedServerName := range dedicatedServerList {
+		if dedicatedServerList[dedicatedServerName].Err != nil {
+			gock.New(mockURL).
+				MatchHeader("Accept", "application/json").
+				Get(fmt.Sprintf("/dedicated/server/%s", dedicatedServerName)).
+				ReplyError(dedicatedServerList[dedicatedServerName].Err)
+		} else {
+			gock.New(mockURL).
+				MatchHeader("Accept", "application/json").
+				Get(fmt.Sprintf("/dedicated/server/%s", dedicatedServerName)).
+				Reply(200).
+				JSON(dedicatedServerList[dedicatedServerName].DedicatedServer)
+			if dedicatedServerList[dedicatedServerName].IPsErr != nil {
+				gock.New(mockURL).
+					MatchHeader("Accept", "application/json").
+					Get(fmt.Sprintf("/dedicated/server/%s/ips", dedicatedServerName)).
+					ReplyError(dedicatedServerList[dedicatedServerName].IPsErr)
+			} else {
+				gock.New(mockURL).
+					MatchHeader("Accept", "application/json").
+					Get(fmt.Sprintf("/dedicated/server/%s/ips", dedicatedServerName)).
+					Reply(200).
+					JSON(dedicatedServerList[dedicatedServerName].IPs)
+			}
+		}
+	}
+}
+
+func TestDedicatedServerWithBadConf(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	conf.ApplicationKey = ""
+	logger := testutil.NewLogger(t)
+	d := newDedicatedServerDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	_, err = d.refresh(ctx)
+	require.ErrorContains(t, err, "missing application key")
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestErrorDedicatedServerList(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+	errTest := errors.New("error on get dedicated server list")
+	initMockErrorDedicatedServerList(errTest)
+
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	//  conf.Endpoint = mockURL
+	logger := testutil.NewLogger(t)
+	d := newDedicatedServerDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	_, err = d.refresh(ctx)
+	require.ErrorIs(t, err, errTest)
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestErrorDedicatedServerDetail(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	dedicatedServer := DedicatedServer{
+		State: "test",
+	}
+
+	errTest := errors.New("error on get dedicated server detail")
+	initMockDedicatedServer(map[string]DedicatedServerData{"abcde": {DedicatedServer: dedicatedServer, IPs: []string{"1.2.3.5", "2001:0db8:0000:0000:0000:0000:0000:0001"}}, "errorTest": {Err: errTest}})
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	//  conf.Endpoint = mockURL
+	logger := testutil.NewLogger(t)
+	d := newDedicatedServerDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(tgs))
+
+	tgDedicatedServer := tgs[0]
+	require.NotNil(t, tgDedicatedServer)
+	require.NotNil(t, tgDedicatedServer.Targets)
+	require.Equal(t, 1, len(tgDedicatedServer.Targets))
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestBadIpDedicatedServer(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	dedicatedServer := DedicatedServer{
+		State: "test",
+	}
+
+	initMockDedicatedServer(map[string]DedicatedServerData{"abcde": {DedicatedServer: dedicatedServer, IPs: []string{"1.2.3.5.6"}}})
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	//  conf.Endpoint = mockURL
+	logger := testutil.NewLogger(t)
+	d := newDedicatedServerDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(tgs))
+
+	tgDedicatedServer := tgs[0]
+	require.NotNil(t, tgDedicatedServer)
+	require.Nil(t, tgDedicatedServer.Targets)
+}
+
+func TestDedicatedServerCallWithoutIPv4(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	dedicatedServer := DedicatedServer{
+		State:           "test",
+		CommercialRange: "Advance-1 Gen 2",
+		LinkSpeed:       123,
+		Rack:            "TESTRACK",
+		NoIntervention:  false,
+		Os:              "debian11_64",
+		SupportLevel:    "pro",
+		ServerID:        1234,
+		Reverse:         "abcde-rev",
+		Datacenter:      "gra3",
+		Name:            "abcde",
+	}
+
+	initMockDedicatedServer(map[string]DedicatedServerData{"abcde": {DedicatedServer: dedicatedServer, IPs: []string{"2001:0db8:0000:0000:0000:0000:0000:0001"}}})
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	//  conf.Endpoint = mockURL
+	logger := testutil.NewLogger(t)
+	d := newDedicatedServerDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(tgs))
+
+	tgDedicatedServer := tgs[0]
+	require.NotNil(t, tgDedicatedServer)
+	require.NotNil(t, tgDedicatedServer.Targets)
+	require.Equal(t, 1, len(tgDedicatedServer.Targets))
+
+	for i, lbls := range []model.LabelSet{
+		{
+			"__address__": "2001:0db8:0000:0000:0000:0000:0000:0001",
+			"__meta_ovhcloud_dedicatedServer_commercialRange": "Advance-1 Gen 2",
+			"__meta_ovhcloud_dedicatedServer_datacenter":      "gra3",
+			"__meta_ovhcloud_dedicatedServer_ipv4":            "",
+			"__meta_ovhcloud_dedicatedServer_ipv6":            "2001:0db8:0000:0000:0000:0000:0000:0001",
+			"__meta_ovhcloud_dedicatedServer_linkSpeed":       "123",
+			"__meta_ovhcloud_dedicatedServer_name":            "abcde",
+			"__meta_ovhcloud_dedicatedServer_noIntervention":  "false",
+			"__meta_ovhcloud_dedicatedServer_os":              "debian11_64",
+			"__meta_ovhcloud_dedicatedServer_rack":            "TESTRACK",
+			"__meta_ovhcloud_dedicatedServer_reverse":         "abcde-rev",
+			"__meta_ovhcloud_dedicatedServer_serverId":        "1234",
+			"__meta_ovhcloud_dedicatedServer_state":           "test",
+			"__meta_ovhcloud_dedicatedServer_supportLevel":    "pro",
+			"instance": "abcde",
+		},
+	} {
+		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
+			require.Equal(t, lbls, tgDedicatedServer.Targets[i])
+		})
+	}
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestDedicatedServerCall(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	dedicatedServer := DedicatedServer{
+		State:           "test",
+		CommercialRange: "Advance-1 Gen 2",
+		LinkSpeed:       123,
+		Rack:            "TESTRACK",
+		NoIntervention:  false,
+		Os:              "debian11_64",
+		SupportLevel:    "pro",
+		ServerID:        1234,
+		Reverse:         "abcde-rev",
+		Datacenter:      "gra3",
+		Name:            "abcde",
+	}
+
+	initMockDedicatedServer(map[string]DedicatedServerData{"abcde": {DedicatedServer: dedicatedServer, IPs: []string{"1.2.3.5", "2001:0db8:0000:0000:0000:0000:0000:0001"}}})
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	//  conf.Endpoint = mockURL
+	logger := testutil.NewLogger(t)
+	d := newDedicatedServerDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(tgs))
+
+	tgDedicatedServer := tgs[0]
+	require.NotNil(t, tgDedicatedServer)
+	require.NotNil(t, tgDedicatedServer.Targets)
+	require.Equal(t, 1, len(tgDedicatedServer.Targets))
+
+	for i, lbls := range []model.LabelSet{
+		{
+			"__address__": "1.2.3.5",
+			"__meta_ovhcloud_dedicatedServer_commercialRange": "Advance-1 Gen 2",
+			"__meta_ovhcloud_dedicatedServer_datacenter":      "gra3",
+			"__meta_ovhcloud_dedicatedServer_ipv4":            "1.2.3.5",
+			"__meta_ovhcloud_dedicatedServer_ipv6":            "2001:0db8:0000:0000:0000:0000:0000:0001",
+			"__meta_ovhcloud_dedicatedServer_linkSpeed":       "123",
+			"__meta_ovhcloud_dedicatedServer_name":            "abcde",
+			"__meta_ovhcloud_dedicatedServer_noIntervention":  "false",
+			"__meta_ovhcloud_dedicatedServer_os":              "debian11_64",
+			"__meta_ovhcloud_dedicatedServer_rack":            "TESTRACK",
+			"__meta_ovhcloud_dedicatedServer_reverse":         "abcde-rev",
+			"__meta_ovhcloud_dedicatedServer_serverId":        "1234",
+			"__meta_ovhcloud_dedicatedServer_state":           "test",
+			"__meta_ovhcloud_dedicatedServer_supportLevel":    "pro",
+			"instance": "abcde",
+		},
+	} {
+		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
+			require.Equal(t, lbls, tgDedicatedServer.Targets[i])
+		})
+	}
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}

--- a/discovery/ovhcloud/ovhcloud.go
+++ b/discovery/ovhcloud/ovhcloud.go
@@ -1,0 +1,217 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovhcloud
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"inet.af/netaddr"
+
+	"github.com/fatih/structs"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/go-playground/validator/v10"
+	"github.com/grafana/regexp"
+	"github.com/ovh/go-ovh/ovh"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/refresh"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+// metaLabelPrefix is the meta prefix used for all meta labels.
+// in this discovery.
+const (
+	metaLabelPrefix = model.MetaLabelPrefix + "ovhcloud_"
+)
+
+func addFieldsOnLabels(fields []*structs.Field, labels model.LabelSet, prefix string) {
+	for _, f := range fields {
+		labelName := f.Tag("label")
+		if labelName == "-" {
+			// Skip labels with -
+			continue
+		}
+		if labelName == "" {
+			labelName = f.Tag("json")
+		}
+
+		if labelName != "" {
+			labels[model.LabelName(prefix+labelName)] = model.LabelValue(fmt.Sprintf("%+v", f.Value()))
+		}
+	}
+}
+
+type refresher interface {
+	refresh(context.Context) ([]*targetgroup.Group, error)
+	getSource() string
+}
+
+// OvhCloud type to list refreshers
+type OvhCloud struct {
+	RefresherList []refresher
+	logger        log.Logger
+	config        *SDConfig
+}
+
+// AuthDetails partial
+type AuthDetails struct {
+	User string `json:"user"`
+}
+
+// SDConfig sd config
+type SDConfig struct {
+	Endpoint          string          `yaml:"endpoint" validate:"required"`
+	ApplicationKey    string          `yaml:"application_key" validate:"required"`
+	ApplicationSecret string          `yaml:"application_secret" validate:"required"`
+	ConsumerKey       string          `yaml:"consumer_key" validate:"required"`
+	RefreshInterval   model.Duration  `yaml:"refresh_interval" validate:"required"`
+	SourcesToDisable  []string        `yaml:"sources_to_disable"`
+	DisabledSources   map[string]bool `yaml:"-"`
+	NoAuthTest        bool            `yaml:"no_auth_test"`
+}
+
+// IPs struct to store IPV4 and IPV6
+type IPs struct {
+	IPV4 string `json:"ipv4" label:"ipv4"`
+	IPV6 string `json:"ipv6" label:"ipv6"`
+}
+
+// Name get name
+func (c SDConfig) Name() string {
+	return "ovhcloud"
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain SDConfig
+	err := unmarshal((*plain)(c))
+	if err != nil {
+		return err
+	}
+
+	validate := validator.New()
+
+	if err := validate.Struct(c); err != nil {
+		return fmt.Errorf("failed to validate SDConfig err: %w", err)
+	}
+
+	c.DisabledSources = map[string]bool{}
+	for _, sourceName := range c.SourcesToDisable {
+		c.DisabledSources[sourceName] = true
+	}
+
+	client, err := c.CreateClient()
+	if err != nil {
+		return err
+	}
+
+	if !c.NoAuthTest {
+		var authDetails AuthDetails
+		fmt.Print("Test auth/details\n")
+		return client.Get("/auth/details", &authDetails)
+	}
+
+	return nil
+}
+
+// CreateClient get client
+func (c SDConfig) CreateClient() (*ovh.Client, error) {
+	return ovh.NewClient(c.Endpoint, c.ApplicationKey, c.ApplicationSecret, c.ConsumerKey)
+}
+
+// NewDiscoverer new discoverer
+func (c SDConfig) NewDiscoverer(options discovery.DiscovererOptions) (discovery.Discoverer, error) {
+	return NewDiscovery(&c, options.Logger), nil
+}
+
+func init() {
+	discovery.RegisterConfig(&SDConfig{})
+}
+
+// ParseIPList Parse ip list to store on IPV4 and IPV6 on IPs type
+func ParseIPList(ipList []string) (*IPs, error) {
+	var IPs IPs
+	reg := regexp.MustCompile(`^([0-9a-f\.:]+)(\/(\d+))?$`)
+	for _, ip := range ipList {
+		netmask := reg.ReplaceAllString(ip, "${3}")
+		ip = reg.ReplaceAllString(ip, "${1}")
+
+		netIP, err := netaddr.ParseIP(ip)
+		if err == nil && !netIP.IsUnspecified() {
+			if netIP.Is4() {
+				if netmask != "" && netmask != "32" {
+					continue
+				}
+				IPs.IPV4 = ip
+			} else if netIP.Is6() {
+				if netmask != "" && netmask != "128" {
+					continue
+				}
+				IPs.IPV6 = ip
+			}
+		}
+	}
+
+	if IPs.IPV4 == "" && IPs.IPV6 == "" {
+		return nil, errors.New("could not parse IP addresses from list")
+	}
+	return &IPs, nil
+}
+
+// NewDiscovery ovhcloud create a newOvhCloudDiscovery and call refresh
+func NewDiscovery(conf *SDConfig, logger log.Logger) *refresh.Discovery {
+	ovhcloud := newOvhCloudDiscovery(conf, logger)
+
+	return refresh.NewDiscovery(
+		logger,
+		"ovhcloud",
+		time.Duration(conf.RefreshInterval),
+		ovhcloud.refresh,
+	)
+}
+
+func newOvhCloudDiscovery(conf *SDConfig, logger log.Logger) *OvhCloud {
+	vpsRefresher := newVpsDiscovery(conf, logger)
+
+	dedicatedCloudRefresher := newDedicatedServerDiscovery(conf, logger)
+
+	ovhC := OvhCloud{config: conf, RefresherList: []refresher{vpsRefresher, dedicatedCloudRefresher}, logger: logger}
+	return &ovhC
+}
+
+func (c OvhCloud) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	var groups []*targetgroup.Group
+	for _, r := range c.RefresherList {
+		source := r.getSource()
+		isDisabled := c.config.DisabledSources[source]
+
+		if !isDisabled {
+			rGroups, err := r.refresh(ctx)
+			if err != nil {
+				err := level.Error(c.logger).Log("msg", fmt.Sprintf("Unable to refresh %s", source), "err", err.Error())
+				if err != nil {
+					return nil, err
+				}
+			}
+			groups = append(groups, rGroups...)
+		}
+	}
+
+	return groups, nil
+}

--- a/discovery/ovhcloud/ovhcloud_test.go
+++ b/discovery/ovhcloud/ovhcloud_test.go
@@ -1,0 +1,449 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovhcloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+	"gopkg.in/yaml.v2"
+
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+var (
+	testApplicationKey    = "appKeyTest"
+	testApplicationSecret = "appSecretTest"
+	testConsumerKey       = "consumerTest"
+)
+
+const (
+	mockURL = "https://localhost:1234"
+)
+
+func getMockConf() (SDConfig, error) {
+	confString := fmt.Sprintf(`
+endpoint: %s
+application_key: %s
+application_secret: %s
+consumer_key: %s
+refresh_interval: 1m
+`, mockURL, testApplicationKey, testApplicationSecret, testConsumerKey)
+
+	return getMockConfFromString(confString)
+}
+
+func getMockConfFromString(confString string) (SDConfig, error) {
+	var conf SDConfig
+	err := yaml.UnmarshalStrict([]byte(confString), &conf)
+	return conf, err
+}
+
+func initMockAuth(time int) {
+	gock.New(mockURL).
+		Get("/auth/time").
+		Reply(200).
+		JSON(time)
+}
+
+func initMockAuthDetails(time int, result map[string]string) {
+	initMockAuth(time)
+
+	gock.New(mockURL).
+		MatchHeader("Accept", "application/json").
+		Get("/auth/details").
+		Reply(200).
+		JSON(result)
+}
+
+func initErrorMockAuthDetails(err error) {
+	initMockAuth(123456)
+
+	gock.New(mockURL).
+		Get("/auth/details").
+		ReplyError(err)
+}
+
+func TestErrorCallAuthDetails(t *testing.T) {
+	errTest := errors.New("There is an error on get /auth/details")
+	initErrorMockAuthDetails(errTest)
+
+	_, err := getMockConf()
+	require.ErrorIs(t, err, errTest)
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestOvhcloudRefresh(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	modelV := Model{
+		Name:                "vps 2019 v1",
+		Disk:                40,
+		MaximumAdditionalIP: 1,
+		Memory:              2048,
+		Offer:               "VPS abc",
+		Version:             "2019v1",
+		Vcore:               1,
+	}
+
+	vps := Vps{
+		Model:       modelV,
+		Zone:        "zone",
+		Cluster:     "cluster_test",
+		DisplayName: "test_name",
+		Name:        "abc",
+		NetbootMode: "local",
+		State:       "running",
+		MemoryLimit: 2048,
+		OfferType:   "ssd",
+	}
+
+	vpsMap := map[string]VpsData{"abc": {Vps: vps, IPs: []string{"192.0.2.1", "2001:0db8:0000:0000:0000:0000:0000:0001"}}}
+	initMockVps(vpsMap)
+
+	dedicatedIPs := IPs{
+		IPV4: "192.0.2.2",
+		IPV6: "2001:0db8:0000:0000:0000:0000:0000:0001",
+	}
+	dedicatedServer := DedicatedServer{
+		State:           "test",
+		IPs:             dedicatedIPs,
+		CommercialRange: "Advance-1 Gen 2",
+		LinkSpeed:       123,
+		Rack:            "TESTRACK",
+		NoIntervention:  false,
+		Os:              "debian11_64",
+		SupportLevel:    "pro",
+		ServerID:        1234,
+		Reverse:         "abcde-rev",
+		Datacenter:      "gra3",
+		Name:            "abcde",
+	}
+
+	initMockDedicatedServer(map[string]DedicatedServerData{"abcde": {DedicatedServer: dedicatedServer, IPs: []string{"192.0.2.2", "2001:0db8:0000:0000:0000:0000:0000:0001"}}})
+
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	//	conf.Endpoint = mockURL
+	logger := testutil.NewLogger(t)
+	d := newOvhCloudDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	require.NoError(t, err)
+
+	// 2 tgs, one for VPS and one for dedicatedServer
+	require.Equal(t, 2, len(tgs))
+
+	tgVps := tgs[0]
+	require.NotNil(t, tgVps)
+	require.NotNil(t, tgVps.Targets)
+	require.Equal(t, 1, len(tgVps.Targets))
+
+	for i, lbls := range []model.LabelSet{
+		{
+			"__address__":                             "192.0.2.1",
+			"__meta_ovhcloud_vps_ipv4":                "192.0.2.1",
+			"__meta_ovhcloud_vps_ipv6":                "2001:0db8:0000:0000:0000:0000:0000:0001",
+			"__meta_ovhcloud_vps_cluster":             "cluster_test",
+			"__meta_ovhcloud_vps_datacenter":          "[]",
+			"__meta_ovhcloud_vps_disk":                "40",
+			"__meta_ovhcloud_vps_displayName":         "test_name",
+			"__meta_ovhcloud_vps_maximumAdditionalIp": "1",
+			"__meta_ovhcloud_vps_memory":              "2048",
+			"__meta_ovhcloud_vps_memoryLimit":         "2048",
+			"__meta_ovhcloud_vps_name":                "abc",
+			"__meta_ovhcloud_vps_model_name":          "vps 2019 v1",
+			"__meta_ovhcloud_vps_netbootMode":         "local",
+			"__meta_ovhcloud_vps_offer":               "VPS abc",
+			"__meta_ovhcloud_vps_offerType":           "ssd",
+			"__meta_ovhcloud_vps_state":               "running",
+			"__meta_ovhcloud_vps_vcore":               "1",
+			"__meta_ovhcloud_vps_version":             "2019v1",
+			"__meta_ovhcloud_vps_zone":                "zone",
+			"instance":                                "abc",
+		},
+	} {
+		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
+			require.Equal(t, lbls, tgVps.Targets[i])
+		})
+	}
+
+	tgDedicatedServer := tgs[1]
+	require.NotNil(t, tgDedicatedServer)
+	require.NotNil(t, tgDedicatedServer.Targets)
+	require.Equal(t, 1, len(tgDedicatedServer.Targets))
+
+	for i, lbls := range []model.LabelSet{
+		{
+			"__address__": "192.0.2.2",
+			"__meta_ovhcloud_dedicatedServer_commercialRange": "Advance-1 Gen 2",
+			"__meta_ovhcloud_dedicatedServer_datacenter":      "gra3",
+			"__meta_ovhcloud_dedicatedServer_ipv4":            "192.0.2.2",
+			"__meta_ovhcloud_dedicatedServer_ipv6":            "2001:0db8:0000:0000:0000:0000:0000:0001",
+			"__meta_ovhcloud_dedicatedServer_linkSpeed":       "123",
+			"__meta_ovhcloud_dedicatedServer_name":            "abcde",
+			"__meta_ovhcloud_dedicatedServer_noIntervention":  "false",
+			"__meta_ovhcloud_dedicatedServer_os":              "debian11_64",
+			"__meta_ovhcloud_dedicatedServer_rack":            "TESTRACK",
+			"__meta_ovhcloud_dedicatedServer_reverse":         "abcde-rev",
+			"__meta_ovhcloud_dedicatedServer_serverId":        "1234",
+			"__meta_ovhcloud_dedicatedServer_state":           "test",
+			"__meta_ovhcloud_dedicatedServer_supportLevel":    "pro",
+			"instance": "abcde",
+		},
+	} {
+		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
+			require.Equal(t, lbls, tgDedicatedServer.Targets[i])
+		})
+	}
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestOvhcloudRefreshFailedOnDedicatedServer(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	vps := Vps{}
+
+	vpsMap := map[string]VpsData{"abc": {Vps: vps, IPs: []string{"192.0.2.1", "2001:0db8:0000:0000:0000:0000:0000:0001"}}}
+	initMockVps(vpsMap)
+
+	errTest := errors.New("error on get dedicated server list")
+	initMockErrorDedicatedServerList(errTest)
+
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	//	conf.Endpoint = mockURL
+	logger := testutil.NewLogger(t)
+	d := newOvhCloudDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	require.NoError(t, err)
+
+	// 1 tgs, for VPS only because error on dedicatedServer
+	require.Equal(t, 1, len(tgs))
+
+	tgVps := tgs[0]
+	require.NotNil(t, tgVps)
+	require.NotNil(t, tgVps.Targets)
+	require.Equal(t, 1, len(tgVps.Targets))
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestOvhcloudMissingAuthArguments(t *testing.T) {
+	confString := `
+refresh_interval: 30s
+`
+
+	_, err := getMockConfFromString(confString)
+	for _, params := range []string{"ApplicationKey", "ApplicationSecret", "ConsumerKey", "Endpoint"} {
+		require.ErrorContains(t, err, fmt.Sprintf("Key: 'SDConfig.%s' Error:Field validation for '%s' failed on the 'required' tag", params, params))
+	}
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestOvhcloudBadRefreshInterval(t *testing.T) {
+	confString := `
+refresh_interval: 30
+`
+
+	_, err := getMockConfFromString(confString)
+	require.ErrorContains(t, err, "not a valid duration string")
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestOvhcloudAllArgumentsOk(t *testing.T) {
+	initMockAuthDetails(132456, map[string]string{"name": "test_name"})
+	_, err := getMockConf()
+
+	require.NoError(t, err)
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestDisabledDedicatedServer(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(1235234, map[string]string{"name": "test_name"})
+
+	vps := Vps{}
+
+	vpsMap := map[string]VpsData{"abc": {Vps: vps, IPs: []string{"192.0.2.1", "2001:0db8:0000:0000:0000:0000:0000:0001"}}}
+	initMockVps(vpsMap)
+
+	confString := fmt.Sprintf(`
+endpoint: %s
+application_key: %s
+application_secret: %s
+consumer_key: %s
+refresh_interval: 1m
+sources_to_disable: [ovhcloud_dedicated_server]
+`, mockURL, testApplicationKey, testApplicationSecret, testConsumerKey)
+
+	conf, err := getMockConfFromString(confString)
+	require.NoError(t, err)
+
+	//  conf.Endpoint = mockURL
+	logger := testutil.NewLogger(t)
+	d := newOvhCloudDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	require.NoError(t, err)
+
+	// 1 tgs for VPS
+	require.Equal(t, 1, len(tgs))
+	tgVps := tgs[0]
+	require.NotNil(t, tgVps)
+	require.NotNil(t, tgVps.Targets)
+	require.Equal(t, "ovhcloud_vps", tgVps.Source)
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestDisabledVps(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12352354, map[string]string{"name": "test_name"})
+
+	dedicatedServer := DedicatedServer{}
+
+	dedicatedServerMap := map[string]DedicatedServerData{"abc": {DedicatedServer: dedicatedServer, IPs: []string{"192.0.2.2"}}}
+	initMockDedicatedServer(dedicatedServerMap)
+
+	confString := fmt.Sprintf(`
+endpoint: %s
+application_key: %s
+application_secret: %s
+consumer_key: %s
+refresh_interval: 1m
+sources_to_disable: [ovhcloud_vps]
+`, mockURL, testApplicationKey, testApplicationSecret, testConsumerKey)
+
+	conf, err := getMockConfFromString(confString)
+	require.NoError(t, err)
+
+	//  conf.Endpoint = mockURL
+	logger := testutil.NewLogger(t)
+	d := newOvhCloudDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	require.NoError(t, err)
+
+	// 1 tgs for DedicatedServer
+	require.Equal(t, 1, len(tgs))
+	tgDedicatedServer := tgs[0]
+	require.NotNil(t, tgDedicatedServer)
+	require.NotNil(t, tgDedicatedServer.Targets)
+	require.Equal(t, "ovhcloud_dedicated_server", tgDedicatedServer.Source)
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestErrorInitClientOnUnmarshal(t *testing.T) {
+	confString := fmt.Sprintf(`
+endpoint: test-fail
+application_key: %s
+application_secret: %s
+consumer_key: %s
+`, testApplicationKey, testApplicationSecret, testConsumerKey)
+
+	conf, _ := getMockConfFromString(confString)
+
+	_, err := conf.CreateClient()
+
+	require.ErrorContains(t, err, "unknown endpoint")
+}
+
+func TestErrorInitClient(t *testing.T) {
+	confString := fmt.Sprintf(`
+endpoint: %s
+
+`, mockURL)
+
+	conf, _ := getMockConfFromString(confString)
+
+	_, err := conf.CreateClient()
+
+	require.ErrorContains(t, err, "missing application key")
+}
+
+func TestParseIPv4Failed(t *testing.T) {
+	_, err := ParseIPList([]string{"A.b"})
+	require.ErrorContains(t, err, "could not parse IP addresses from list")
+}
+
+func TestParseZeroIPFailed(t *testing.T) {
+	_, err := ParseIPList([]string{"0.0.0.0"})
+	require.ErrorContains(t, err, "could not parse IP addresses from list")
+}
+
+func TestParseVoidIPFailed(t *testing.T) {
+	_, err := ParseIPList([]string{""})
+	require.ErrorContains(t, err, "could not parse IP addresses from list")
+}
+
+func TestParseIPv6Ok(t *testing.T) {
+	_, err := ParseIPList([]string{"2001:0db8:0000:0000:0000:0000:0000:0001"})
+	require.NoError(t, err)
+}
+
+func TestParseIPv6Failed(t *testing.T) {
+	_, err := ParseIPList([]string{"bbb:cccc:1111"})
+	require.ErrorContains(t, err, "could not parse IP addresses from list")
+}
+
+func TestParseIPv4BadMask(t *testing.T) {
+	_, err := ParseIPList([]string{"192.0.2.1/23"})
+	require.ErrorContains(t, err, "could not parse IP addresses from list")
+}
+
+func TestParseIPv4MaskOk(t *testing.T) {
+	_, err := ParseIPList([]string{"192.0.2.1/32"})
+	require.NoError(t, err)
+}
+
+func TestDiscoverer(t *testing.T) {
+	conf, _ := getMockConf()
+	logger := testutil.NewLogger(t)
+	_, err := conf.NewDiscoverer(discovery.DiscovererOptions{
+		Logger: logger,
+	})
+
+	require.NoError(t, err)
+}

--- a/discovery/ovhcloud/vps.go
+++ b/discovery/ovhcloud/vps.go
@@ -1,0 +1,163 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovhcloud
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/fatih/structs"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/ovh/go-ovh/ovh"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/discovery/refresh"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+const vpsAPIPath = "/vps"
+
+// Model struct from API
+type Model struct {
+	MaximumAdditionalIP int      `json:"maximumAdditionnalIp" label:"maximumAdditionalIp"`
+	Offer               string   `json:"offer"`
+	Datacenter          []string `json:"datacenter"`
+	Vcore               int      `json:"vcore"`
+	Version             string   `json:"version"`
+	Name                string   `json:"name" label:"model_name"`
+	Disk                int      `json:"disk"`
+	Memory              int      `json:"memory"`
+}
+
+// Vps struct from API
+type Vps struct {
+	IPs                IPs      `json:"ips" label:"-"`
+	Keymap             []string `json:"keymap" label:"-"`
+	Zone               string   `json:"zone"`
+	Model              Model    `json:"model" label:"-"`
+	DisplayName        string   `json:"displayName"`
+	MonitoringIPBlocks []string `json:"monitoringIpBlocks" label:"-"`
+	Cluster            string   `json:"cluster"`
+	State              string   `json:"state"`
+	Name               string   `json:"name"`
+	NetbootMode        string   `json:"netbootMode"`
+	MemoryLimit        int      `json:"memoryLimit"`
+	OfferType          string   `json:"offerType"`
+	Vcore              int      `json:"vcore"`
+}
+
+const (
+	vpsLabelPrefix = metaLabelPrefix + "vps_"
+)
+
+type vpsDiscovery struct {
+	*refresh.Discovery
+	config *SDConfig
+	logger log.Logger
+}
+
+func newVpsDiscovery(conf *SDConfig, logger log.Logger) *vpsDiscovery {
+	return &vpsDiscovery{config: conf, logger: logger}
+}
+
+func getVpsDetails(client *ovh.Client, vpsName string) (*Vps, error) {
+	var vpsDetails Vps
+	vpsNamePath := fmt.Sprintf("%s/%s", vpsAPIPath, url.QueryEscape(vpsName))
+
+	err := client.Get(vpsNamePath, &vpsDetails)
+	if err != nil {
+		return nil, err
+	}
+
+	var ips []string
+	err = client.Get(fmt.Sprintf("%s/ips", vpsNamePath), &ips)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedIPs, err := ParseIPList(ips)
+	if err != nil {
+		return nil, err
+	}
+	vpsDetails.IPs = *parsedIPs
+
+	return &vpsDetails, nil
+}
+
+func getVpsList(client *ovh.Client) ([]string, error) {
+	var vpsListName []string
+
+	err := client.Get(vpsAPIPath, &vpsListName)
+	if err != nil {
+		return nil, err
+	}
+
+	return vpsListName, nil
+}
+
+func (d *vpsDiscovery) getSource() string {
+	return "ovhcloud_vps"
+}
+
+func (d *vpsDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	client, err := (d.config).CreateClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var vpsDetailedList []Vps
+	vpsList, err := getVpsList(client)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vpsName := range vpsList {
+		vpsDetailed, err := getVpsDetails(client, vpsName)
+		if err != nil {
+			err := level.Warn(d.logger).Log("msg", fmt.Sprintf("%s: Could not get details of %s", d.getSource(), vpsName), "err", err.Error())
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		vpsDetailedList = append(vpsDetailedList, *vpsDetailed)
+	}
+
+	var targets []model.LabelSet
+	for _, server := range vpsDetailedList {
+		defaultIP := server.IPs.IPV4
+		if defaultIP == "" {
+			defaultIP = server.IPs.IPV6
+		}
+		labels := model.LabelSet{
+			model.AddressLabel:  model.LabelValue(defaultIP),
+			model.InstanceLabel: model.LabelValue(server.Name),
+		}
+
+		fields := structs.Fields(server)
+		addFieldsOnLabels(fields, labels, vpsLabelPrefix)
+
+		modelFields := structs.Fields(server.Model)
+		addFieldsOnLabels(modelFields, labels, vpsLabelPrefix)
+
+		IPsFields := structs.Fields(server.IPs)
+		addFieldsOnLabels(IPsFields, labels, vpsLabelPrefix)
+
+		targets = append(targets, labels)
+	}
+
+	return []*targetgroup.Group{{Source: d.getSource(), Targets: targets}}, nil
+}

--- a/discovery/ovhcloud/vps_test.go
+++ b/discovery/ovhcloud/vps_test.go
@@ -1,0 +1,446 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovhcloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+type VpsData struct {
+	Vps    Vps
+	Err    error
+	IPs    []string
+	IPsErr error
+}
+
+func initMockErrorVpsList(err error) {
+	initMockAuth(123562)
+	gock.New(mockURL).
+		MatchHeader("Accept", "application/json").
+		Get("/vps").
+		ReplyError(err)
+}
+
+func initMockVps(vpsList map[string]VpsData) {
+	initMockAuth(123562)
+
+	var vpsListName []string
+	for vpsName := range vpsList {
+		vpsListName = append(vpsListName, vpsName)
+	}
+
+	gock.New(mockURL).
+		MatchHeader("Accept", "application/json").
+		Get("/vps").
+		Reply(200).
+		JSON(vpsListName)
+
+	for vpsName := range vpsList {
+		if vpsList[vpsName].Err != nil {
+			gock.New(mockURL).
+				MatchHeader("Accept", "application/json").
+				Get(fmt.Sprintf("/vps/%s", vpsName)).
+				ReplyError(vpsList[vpsName].Err)
+		} else {
+			gock.New(mockURL).
+				MatchHeader("Accept", "application/json").
+				Get(fmt.Sprintf("/vps/%s", vpsName)).
+				Reply(200).
+				JSON(vpsList[vpsName].Vps)
+			if vpsList[vpsName].IPsErr != nil {
+				gock.New(mockURL).
+					MatchHeader("Accept", "application/json").
+					Get(fmt.Sprintf("/vps/%s/ips", vpsName)).
+					ReplyError(vpsList[vpsName].IPsErr)
+			} else {
+				gock.New(mockURL).
+					MatchHeader("Accept", "application/json").
+					Get(fmt.Sprintf("/vps/%s/ips", vpsName)).
+					Reply(200).
+					JSON(vpsList[vpsName].IPs)
+			}
+		}
+	}
+}
+
+func TestVpsErrorOnList(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	errTest := errors.New("error on get list")
+	initMockErrorVpsList(errTest)
+
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	logger := testutil.NewLogger(t)
+	d := newVpsDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	_, err = d.refresh(ctx)
+	require.ErrorIs(t, err, errTest)
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestVpsWithBadConf(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	conf.ApplicationKey = ""
+	logger := testutil.NewLogger(t)
+	d := newVpsDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	_, err = d.refresh(ctx)
+	require.ErrorContains(t, err, "missing application key")
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestVpsErrorOnDetail(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	errTest := errors.New("error on get detail")
+	modelV := Model{
+		Name:                "model name test",
+		Disk:                40,
+		MaximumAdditionalIP: 1,
+		Memory:              2048,
+		Offer:               "VPS abc",
+		Version:             "2019v1",
+		Vcore:               1,
+	}
+
+	vps := Vps{
+		Model:       modelV,
+		Zone:        "zone",
+		Cluster:     "cluster_test",
+		DisplayName: "test_name",
+		Name:        "abc",
+		NetbootMode: "local",
+		State:       "running",
+		MemoryLimit: 2048,
+		OfferType:   "ssd",
+	}
+
+	vpsMap := map[string]VpsData{"abc": {Vps: vps, IPs: []string{"192.0.2.1", "2001:0db8:0000:0000:0000:0000:0000:0001"}}, "def": {Err: errTest}}
+	initMockVps(vpsMap)
+
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	logger := testutil.NewLogger(t)
+	d := newVpsDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	// When we have an error on a detail, we continue and the server is skipped
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(tgs))
+
+	tgVps := tgs[0]
+
+	require.NotNil(t, tgVps)
+	require.NotNil(t, tgVps.Targets)
+	require.Equal(t, 1, len(tgVps.Targets))
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestVpsErrorOnIps(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	errTest := errors.New("error on get ips")
+	modelV := Model{
+		Name:                "model name test",
+		Disk:                40,
+		MaximumAdditionalIP: 1,
+		Memory:              2048,
+		Offer:               "VPS abc",
+		Version:             "2019v1",
+		Vcore:               1,
+	}
+
+	vps := Vps{
+		Model:       modelV,
+		Zone:        "zone",
+		Cluster:     "cluster_test",
+		DisplayName: "test_name",
+		Name:        "abc",
+		NetbootMode: "local",
+		State:       "running",
+		MemoryLimit: 2048,
+		OfferType:   "ssd",
+	}
+
+	vpsMap := map[string]VpsData{"abc": {Vps: vps, IPs: []string{"192.0.2.1", "2001:0db8:0000:0000:0000:0000:0000:0001"}}, "def": {Vps: vps, IPsErr: errTest}}
+	initMockVps(vpsMap)
+
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	logger := testutil.NewLogger(t)
+	d := newVpsDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	// When we have an error on a detail, we continue and the server is skipped
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(tgs))
+
+	tgVps := tgs[0]
+
+	require.NotNil(t, tgVps)
+	require.NotNil(t, tgVps.Targets)
+	require.Equal(t, 1, len(tgVps.Targets))
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestBadIpVps(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	modelV := Model{
+		Name:                "model name test",
+		Disk:                40,
+		MaximumAdditionalIP: 1,
+		Memory:              2048,
+		Offer:               "VPS abc",
+		Version:             "2019v1",
+		Vcore:               1,
+	}
+
+	vps := Vps{
+		Model:       modelV,
+		Zone:        "zone",
+		Cluster:     "cluster_test",
+		DisplayName: "test_name",
+		Name:        "abc",
+		NetbootMode: "local",
+		State:       "running",
+		MemoryLimit: 2048,
+		OfferType:   "ssd",
+	}
+
+	vpsMap := map[string]VpsData{"abc": {Vps: vps, IPs: []string{"192.0.2.1.6"}}}
+	initMockVps(vpsMap)
+
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	//  conf.Endpoint = mockURL
+	logger := testutil.NewLogger(t)
+	d := newVpsDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(tgs))
+
+	tgVps := tgs[0]
+	require.NotNil(t, tgVps)
+	require.Nil(t, tgVps.Targets)
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestVpsRefreshWithoutIPv4(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	modelV := Model{
+		Name:                "model name test",
+		Disk:                40,
+		MaximumAdditionalIP: 1,
+		Memory:              2048,
+		Offer:               "VPS abc",
+		Version:             "2019v1",
+		Vcore:               1,
+	}
+
+	vps := Vps{
+		Model:       modelV,
+		Zone:        "zone",
+		Cluster:     "cluster_test",
+		DisplayName: "test_name",
+		Name:        "abc",
+		NetbootMode: "local",
+		State:       "running",
+		MemoryLimit: 2048,
+		OfferType:   "ssd",
+	}
+
+	vpsMap := map[string]VpsData{"abc": {Vps: vps, IPs: []string{"2001:0db8:0000:0000:0000:0000:0000:0001"}}}
+	initMockVps(vpsMap)
+
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	//  conf.Endpoint = mockURL
+	logger := testutil.NewLogger(t)
+	d := newVpsDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(tgs))
+
+	tgVps := tgs[0]
+	require.NotNil(t, tgVps)
+	require.NotNil(t, tgVps.Targets)
+	require.Equal(t, 1, len(tgVps.Targets))
+
+	for i, lbls := range []model.LabelSet{
+		{
+			"__address__":                             "2001:0db8:0000:0000:0000:0000:0000:0001",
+			"__meta_ovhcloud_vps_ipv4":                "",
+			"__meta_ovhcloud_vps_ipv6":                "2001:0db8:0000:0000:0000:0000:0000:0001",
+			"__meta_ovhcloud_vps_cluster":             "cluster_test",
+			"__meta_ovhcloud_vps_datacenter":          "[]",
+			"__meta_ovhcloud_vps_disk":                "40",
+			"__meta_ovhcloud_vps_displayName":         "test_name",
+			"__meta_ovhcloud_vps_maximumAdditionalIp": "1",
+			"__meta_ovhcloud_vps_memory":              "2048",
+			"__meta_ovhcloud_vps_memoryLimit":         "2048",
+			"__meta_ovhcloud_vps_model_name":          "model name test",
+			"__meta_ovhcloud_vps_name":                "abc",
+			"__meta_ovhcloud_vps_netbootMode":         "local",
+			"__meta_ovhcloud_vps_offer":               "VPS abc",
+			"__meta_ovhcloud_vps_offerType":           "ssd",
+			"__meta_ovhcloud_vps_state":               "running",
+			"__meta_ovhcloud_vps_vcore":               "1",
+			"__meta_ovhcloud_vps_version":             "2019v1",
+			"__meta_ovhcloud_vps_zone":                "zone",
+			"instance":                                "abc",
+		},
+	} {
+		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
+			require.Equal(t, lbls, tgVps.Targets[i])
+		})
+	}
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}
+
+func TestVpsRefresh(t *testing.T) {
+	defer gock.Off()
+
+	initMockAuthDetails(12345, map[string]string{"name": "test_name"})
+
+	modelV := Model{
+		Name:                "model name test",
+		Disk:                40,
+		MaximumAdditionalIP: 1,
+		Memory:              2048,
+		Offer:               "VPS abc",
+		Version:             "2019v1",
+		Vcore:               1,
+	}
+
+	vps := Vps{
+		Model:       modelV,
+		Zone:        "zone",
+		Cluster:     "cluster_test",
+		DisplayName: "test_name",
+		Name:        "abc",
+		NetbootMode: "local",
+		State:       "running",
+		MemoryLimit: 2048,
+		OfferType:   "ssd",
+	}
+
+	vpsMap := map[string]VpsData{"abc": {Vps: vps, IPs: []string{"192.0.2.1", "2001:0db8:0000:0000:0000:0000:0000:0001"}}}
+	initMockVps(vpsMap)
+
+	conf, err := getMockConf()
+	require.NoError(t, err)
+
+	//	conf.Endpoint = mockURL
+	logger := testutil.NewLogger(t)
+	d := newVpsDiscovery(&conf, logger)
+
+	ctx := context.Background()
+	tgs, err := d.refresh(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(tgs))
+
+	tgVps := tgs[0]
+	require.NotNil(t, tgVps)
+	require.NotNil(t, tgVps.Targets)
+	require.Equal(t, 1, len(tgVps.Targets))
+
+	for i, lbls := range []model.LabelSet{
+		{
+			"__address__":                             "192.0.2.1",
+			"__meta_ovhcloud_vps_ipv4":                "192.0.2.1",
+			"__meta_ovhcloud_vps_ipv6":                "2001:0db8:0000:0000:0000:0000:0000:0001",
+			"__meta_ovhcloud_vps_cluster":             "cluster_test",
+			"__meta_ovhcloud_vps_datacenter":          "[]",
+			"__meta_ovhcloud_vps_disk":                "40",
+			"__meta_ovhcloud_vps_displayName":         "test_name",
+			"__meta_ovhcloud_vps_maximumAdditionalIp": "1",
+			"__meta_ovhcloud_vps_memory":              "2048",
+			"__meta_ovhcloud_vps_memoryLimit":         "2048",
+			"__meta_ovhcloud_vps_model_name":          "model name test",
+			"__meta_ovhcloud_vps_name":                "abc",
+			"__meta_ovhcloud_vps_netbootMode":         "local",
+			"__meta_ovhcloud_vps_offer":               "VPS abc",
+			"__meta_ovhcloud_vps_offerType":           "ssd",
+			"__meta_ovhcloud_vps_state":               "running",
+			"__meta_ovhcloud_vps_vcore":               "1",
+			"__meta_ovhcloud_vps_version":             "2019v1",
+			"__meta_ovhcloud_vps_zone":                "zone",
+			"instance":                                "abc",
+		},
+	} {
+		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
+			require.Equal(t, lbls, tgVps.Targets[i])
+		})
+	}
+
+	// Verify that we don't have pending mocks
+	require.Equal(t, gock.IsDone(), true)
+}

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -289,6 +289,10 @@ nerve_sd_configs:
 openstack_sd_configs:
   [ - <openstack_sd_config> ... ]
 
+# List of OVHcloud service discovery configurations.
+ovhcloud_sd_configs:
+  [ - <ovhcloud_sd_config> ... ]
+
 # List of PuppetDB service discovery configurations.
 puppetdb_sd_configs:
   [ - <puppetdb_sd_config> ... ]
@@ -1159,6 +1163,64 @@ region: <string>
 # TLS configuration.
 tls_config:
   [ <tls_config> ]
+```
+
+### `<ovhcloud_sd_config>`
+OVHcloud SD configurations allow retrieving scrape targets from OVHcloud's [dedicated servers](https://www.ovhcloud.com/en/bare-metal/) and [VPS](https://www.ovhcloud.com/en/vps/) using
+their [API](https://api.ovh.com/).  
+Prometheus will periodically check the REST endpoint and create a target for every discovered server.  
+The role will try to use the public IPv4 address as default address, if there's none it will try to use the IPv6 one. This may be changed with relabeling.   
+For OVHcloud's [public cloud instances](https://www.ovhcloud.com/en/public-cloud/) you can use the [openstack_sd_config](#openstack_sd_config).
+
+#### VPS
+* `__meta_ovhcloud_vps_ipv4`: the ipv4 of the server
+* `__meta_ovhcloud_vps_ipv6`: the ipv6 of the server
+* `__meta_ovhcloud_vps_keymap`: the KVM keyboard layout on VPS Cloud
+* `__meta_ovhcloud_vps_zone`: the zone of the server
+* `__meta_ovhcloud_vps_maximumAdditionalIp`: the maximumAdditionalIp of the server
+* `__meta_ovhcloud_vps_offer`: the offer of the server
+* `__meta_ovhcloud_vps_datacenter`: the datacenter of the server
+* `__meta_ovhcloud_vps_vcore`: the vcore of the server
+* `__meta_ovhcloud_vps_version`: the version of the server
+* `__meta_ovhcloud_vps_name`: the name of the server
+* `__meta_ovhcloud_vps_disk`: the disk of the server
+* `__meta_ovhcloud_vps_memory`: the memory of the server
+* `__meta_ovhcloud_vps_displayName`: the name displayed in ManagerV6 for your VPS
+* `__meta_ovhcloud_vps_monitoringIpBlocks`: the Ip blocks for OVH monitoring servers
+* `__meta_ovhcloud_vps_cluster`: the cluster of the server
+* `__meta_ovhcloud_vps_state`: the state of the server
+* `__meta_ovhcloud_vps_name`: the name of the server
+* `__meta_ovhcloud_vps_netbootMode`: the netbootMode of the server
+* `__meta_ovhcloud_vps_memoryLimit`: the memoryLimit of the server
+* `__meta_ovhcloud_vps_offerType`: the offerType of the server
+* `__meta_ovhcloud_vps_vcore`: the vcore of the server
+
+#### Dedicated servers
+* `__meta_ovhcloud_dedicated_server_state`: the state of the server
+* `__meta_ovhcloud_dedicated_server_ipv4`: the ipv4 of the server
+* `__meta_ovhcloud_dedicated_server_ipv6`: the ipv6 of the server
+* `__meta_ovhcloud_dedicated_server_commercialRange`: the dedicated server commercial range
+* `__meta_ovhcloud_dedicated_server_linkSpeed`: the linkSpeed of the server
+* `__meta_ovhcloud_dedicated_server_rack`: the rack of the server
+* `__meta_ovhcloud_dedicated_server_os`: operating system
+* `__meta_ovhcloud_dedicated_server_supportLevel`: the supportLevel of the server
+* `__meta_ovhcloud_dedicated_server_serverId`: your server id
+* `__meta_ovhcloud_dedicated_server_reverse`: dedicated server reverse
+* `__meta_ovhcloud_dedicated_server_datacenter`: the dedicated datacenter localisation
+* `__meta_ovhcloud_dedicated_server_name`: the dedicated server name
+
+See below for the configuration options for OVHcloud discovery:
+
+```yaml
+# Access key to use. https://api.ovh.com
+application_key: <string>
+application_secret: <string>
+consumer_key: <string>
+# API endpoint. https://github.com/ovh/go-ovh#supported-apis
+endpoint: <string>
+
+# Refresh interval to re-read the resources list.
+refresh_interval: <duration>
 ```
 
 ### `<puppetdb_sd_config>`
@@ -2869,6 +2931,10 @@ nerve_sd_configs:
 # List of OpenStack service discovery configurations.
 openstack_sd_configs:
   [ - <openstack_sd_config> ... ]
+
+# List of OVHcloud service discovery configurations.
+ovhcloud_sd_configs:
+  [ - <ovhcloud_sd_config> ... ]
 
 # List of PuppetDB service discovery configurations.
 puppetdb_sd_configs:

--- a/documentation/examples/prometheus-ovhcloud.yml
+++ b/documentation/examples/prometheus-ovhcloud.yml
@@ -1,0 +1,11 @@
+# An example scrape configuration for running Prometheus with Ovhcloud.
+scrape_configs:
+  - job_name: 'ovhcloud'
+    ovhcloud_sd_configs:
+      - application_key: XXX
+        application_secret: XXX
+        consumer_key: XXX
+        endpoint: ovh-eu
+        refresh_interval: 1m
+        ### only for tests to remove
+        no_auth_test: true

--- a/go.mod
+++ b/go.mod
@@ -16,10 +16,12 @@ require (
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1
 	github.com/envoyproxy/protoc-gen-validate v0.6.7
+	github.com/fatih/structs v1.1.0
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/go-kit/log v0.2.1
 	github.com/go-logfmt/logfmt v0.5.1
 	github.com/go-openapi/strfmt v0.21.2
+	github.com/go-playground/validator/v10 v10.4.1
 	github.com/go-zookeeper/zk v1.0.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v0.0.4
@@ -37,6 +39,7 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/oklog/run v1.1.0
 	github.com/oklog/ulid v1.3.1
+	github.com/ovh/go-ovh v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/alertmanager v0.24.0
 	github.com/prometheus/client_golang v1.12.2
@@ -70,8 +73,10 @@ require (
 	google.golang.org/grpc v1.46.2
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/h2non/gock.v1 v1.1.2
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0
+	inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0
 	k8s.io/client-go v0.24.0
@@ -116,6 +121,8 @@ require (
 	github.com/go-openapi/spec v0.20.4 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/go-openapi/validate v0.21.0 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
@@ -129,6 +136,7 @@ require (
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.2 // indirect
+	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v0.12.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.2.0 // indirect
@@ -142,6 +150,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
@@ -167,6 +176,8 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.7.0 // indirect
 	go.opentelemetry.io/otel/metric v0.30.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.16.0 // indirect
+	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
+	go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
@@ -175,6 +186,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.57.0 // indirect
 	gotest.tools/v3 v3.0.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,7 @@ github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
@@ -222,6 +223,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
@@ -286,9 +289,13 @@ github.com/go-openapi/swag v0.21.1 h1:wm0rhTb5z7qpJRHBdPOMuY4QjVUMbF6/kwoYeRAOrK
 github.com/go-openapi/swag v0.21.1/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-openapi/validate v0.21.0 h1:+Wqk39yKOhfpLqNLEC0/eViCkzM5FVXVqrvt526+wcI=
 github.com/go-openapi/validate v0.21.0/go.mod h1:rjnrwK57VJ7A8xqfpAOEKRH8yQSGUriMu5/zuPSQ1hg=
+github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
+github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
+github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48 h1:JVrqSeQfdhYRFk24TvhTZWU0q8lfCojxZQFi3Ou7+uY=
 github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
@@ -437,6 +444,7 @@ github.com/googleapis/gax-go/v2 v2.3.0 h1:nRJtk3y8Fm770D42QV6T90ZnvFZyk7agSo3Q+Z
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
 github.com/gophercloud/gophercloud v0.24.0 h1:jDsIMGJ1KZpAjYfQgGI2coNQj5Q83oPzuiGJRFWgMzw=
 github.com/gophercloud/gophercloud v0.24.0/go.mod h1:Q8fZtyi5zZxPS/j9aj3sSxtvj41AdQMDwyo1myduD5c=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -455,6 +463,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.2 h1:ERKrevVTnCw3Wu4I3mtR15QU3gtWy86cBo6De0jEohg=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.2/go.mod h1:chrfS3YoLAlKTRE5cFWvCbt8uGAjshktT4PveTUpsFQ=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/api v1.12.0 h1:k3y1FYv6nuKyNTqj6w9gXOx5r5CfLj/k/euUeBXj1OY=
 github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUoTD2XXb/VrZVy0=
@@ -546,6 +556,7 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
@@ -572,6 +583,7 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -654,6 +666,8 @@ github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzE
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
@@ -692,6 +706,8 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/ovh/go-ovh v1.1.0 h1:bHXZmw8nTgZin4Nv7JuaLs0KG5x54EQR7migYTd1zrk=
+github.com/ovh/go-ovh v1.1.0/go.mod h1:AxitLZ5HBRPyUd+Zl60Ajaag+rNTdVXWIkzfrVuTXWA=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
@@ -788,7 +804,9 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
@@ -888,6 +906,10 @@ go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
+go4.org/intern v0.0.0-20211027215823-ae77deb06f29 h1:UXLjNohABv4S58tHmeuIZDO6e3mHpW2Dx33gaNt03LE=
+go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 h1:Tx9kY6yUkLge/pFG7IEMwDZy6CS2ajFc9TvQdPCW0uA=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -1416,8 +1438,12 @@ gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qS
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
+gopkg.in/h2non/gock.v1 v1.1.2 h1:jBbHXgGBK/AoPVfJh5x4r/WxIrElvbLel8TCZkkZJoY=
+gopkg.in/h2non/gock.v1 v1.1.2/go.mod h1:n7UGz/ckNChHiK05rDoiC4MYSunEC/lyaUm2WWaDva0=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/ini.v1 v1.57.0 h1:9unxIsFcTt4I55uWluz+UmL95q4kdJ0buvQ1ZIqVQww=
+gopkg.in/ini.v1 v1.57.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/telebot.v3 v3.0.0/go.mod h1:7rExV8/0mDDNu9epSrDm/8j22KLaActH1Tbee6YjzWg=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
@@ -1450,6 +1476,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6 h1:acCzuUSQ79tGsM/O50VRFySfMm19IoMKL+sZztZkCxw=
+inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6/go.mod h1:y3MGhcFMlh0KZPMuXXow8mpjxxAk3yoDNsp4cQz54i8=
 k8s.io/api v0.24.0 h1:J0hann2hfxWr1hinZIDefw7Q96wmCBx6SSB8IY0MdDg=
 k8s.io/api v0.24.0/go.mod h1:5Jl90IUrJHUJYEMANRURMiVvJ0g7Ax7r3R1bqO8zx8I=
 k8s.io/apimachinery v0.24.0 h1:ydFCyC/DjCvFCHK5OPMKBlxayQytB8pxy8YQInd5UyQ=

--- a/plugins.yml
+++ b/plugins.yml
@@ -12,6 +12,7 @@
 - github.com/prometheus/prometheus/discovery/marathon
 - github.com/prometheus/prometheus/discovery/moby
 - github.com/prometheus/prometheus/discovery/openstack
+- github.com/prometheus/prometheus/discovery/ovhcloud
 - github.com/prometheus/prometheus/discovery/puppetdb
 - github.com/prometheus/prometheus/discovery/scaleway
 - github.com/prometheus/prometheus/discovery/triton

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -58,6 +58,9 @@ import (
 	// Register openstack plugin.
 	_ "github.com/prometheus/prometheus/discovery/openstack"
 
+	// Register ovhcloud plugin.
+	_ "github.com/prometheus/prometheus/discovery/ovhcloud"
+
 	// Register puppetdb plugin.
 	_ "github.com/prometheus/prometheus/discovery/puppetdb"
 


### PR DESCRIPTION
This PR adds a new service disocvery for [Ovhcloud Bare Metal Cloud](https://www.ovhcloud.com/en/bare-metal/) based on the work that has been done for Ionos and Scaleway.
The service discovery allows users to create scrape targets based on servers tied to an OVHcloud account.

Thank you for your time on this PR.

Signed-off-by: Marine Bal <marine.bal@ovhcloud.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
