### PR TITLE
Don't fail compaction when context is canceled

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -888,7 +888,9 @@ func (db *DB) Compact() (returnErr error) {
 	db.cmtx.Lock()
 	defer db.cmtx.Unlock()
 	defer func() {
-		if returnErr != nil {
+		if returnErr != nil && !errors.Is(returnErr, context.Canceled) {
+			// If we got an error because context was canceled then we're most likely
+			// shutting down TSDB and we don't need to report this on metrics
 			db.metrics.compactionsFailed.Inc()
 		}
 	}()


### PR DESCRIPTION
When restarting Prometheus I sometimes see:

```
caller=db.go:832 level=error component=tsdb msg="compaction failed" err="compact head: persist head block: 2 errors: populate block: context canceled; context canceled"
```

And prometheus_tsdb_compactions_failed_total metric gets incremented.
This should't really be reported as an error so we should check for err
type and ignore context.Canceled errors."

Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
