### PR TITLE
adding internal label global config 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -344,6 +344,8 @@ type GlobalConfig struct {
 	QueryLogFile string `yaml:"query_log_file,omitempty"`
 	// The labels to add to any timeseries that this Prometheus instance scrapes.
 	ExternalLabels labels.Labels `yaml:"external_labels,omitempty"`
+	// The labels to remove for any external systems: remote_write, federation, alerting
+	InternalLabels []relabel.Regexp `yaml:"internal_labels,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.


### PR DESCRIPTION
**Context** 
To implement remote write routing to different storage (for instance, long term, short term and none) we typically set labels like __retention to recording rules. We have to drop those  labels on alerting and remote write but it still appears in federation.

**Proposal**
As a solution, I propose to add an internal_labels section that will automatically drop said labels to all external systems (federation, remote_write, remote_read and alerting). That would allow to define at a single place in stead of having to remove it from all remote write and in any prometheus that would federate it.

I was wondering if this would be potentially accepted before diving into the full dev.

Left to do (at least):
- Remove them from remote read
- Remove them from Alerts
- tests and doc
