### PR TITLE
fix: update docs to reflect new go 1.17 version minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Prometheus will now be reachable at <http://localhost:9090/>.
 
 To build Prometheus from source code, You need:
 
-* Go [version 1.16 or greater](https://golang.org/doc/install).
+* Go [version 1.17 or greater](https://golang.org/doc/install).
 * NodeJS [version 16 or greater](https://nodejs.org/).
 * npm [version 7 or greater](https://www.npmjs.com/).
 


### PR DESCRIPTION
The minimum go version was bumped to 1.17 in
29b58448e13d9c841683acf194a2aa70cff3a49c, but the main README still
referenced go 1.16 as the minimum version required. This updates that.

I took a quick look through the other docs in the repo (ie, I did some
naive grepping), and this is the only reference I spotted.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
