### PR TITLE
Do not lint duplicate rules when checking Prometheus config.

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -94,7 +94,7 @@ func main() {
 	checkConfigLint := checkConfigCmd.Flag(
 		"lint",
 		"Linting checks to apply to the rules specified in the config. Available options are: "+strings.Join(lintOptions, ", ")+". Use --lint=none to disable linting",
-	).Default(lintOptionDuplicateRules).String()
+	).Default(lintOptionNone).String()
 
 	checkWebConfigCmd := checkCmd.Command("web-config", "Check if the web config files are valid or not.")
 	webConfigFiles := checkWebConfigCmd.Arg(


### PR DESCRIPTION
Linting rules by default is a breaking change that broke our users' CI
pipeline with false positive. Let's exclude this by default.

Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
