### PR TITLE
refactor (tracing): move from github.com/pkg/errors to 'errors' and 'fmt'

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -15,12 +15,12 @@ package tracing
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/version"
 	"go.opentelemetry.io/otel"
@@ -79,7 +79,7 @@ func (m *Manager) ApplyConfig(cfg *config.Config) error {
 
 	if m.shutdownFunc != nil {
 		if err := m.shutdownFunc(); err != nil {
-			return errors.Wrap(err, "failed to shut down the tracer provider")
+			return fmt.Errorf("failed to shut down the tracer provider: %w", err)
 		}
 	}
 
@@ -94,7 +94,7 @@ func (m *Manager) ApplyConfig(cfg *config.Config) error {
 
 	tp, shutdownFunc, err := buildTracerProvider(context.Background(), cfg.TracingConfig)
 	if err != nil {
-		return errors.Wrap(err, "failed to install a new tracer provider")
+		return fmt.Errorf("failed to install a new tracer provider: %w", err)
 	}
 
 	m.shutdownFunc = shutdownFunc


### PR DESCRIPTION
The package https://github.com/pkg/errors is not maintained anymore.
This PR replaces https://github.com/pkg/errors with official errors and fmt golang packages in tracing package

Signed-off-by: Matthieu MOREL [mmorel-35@users.noreply.github.com](mailto:mmorel-35@users.noreply.github.com)