### PR TITLE
enable dependabot for github.com/prometheus/prometheus/documentation/examples/remote_storage module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "gomod"
+    directory: "/documentation/examples/remote_storage"
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "npm"
     directory: "/web/ui"
     schedule:


### PR DESCRIPTION
Setup dependabot to manage github.com/prometheus/prometheus/documentation/examples/remote_storage module dependencies update.

Signed-off-by: Matthieu MOREL <mmorel-35@users.noreply.github.com>
