### PR TITLE
Drop extra string held in relabel.Regexp struct

### DIFF
--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -142,17 +142,13 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // Regexp encapsulates a regexp.Regexp and makes it YAML marshalable.
 type Regexp struct {
 	*regexp.Regexp
-	original string
 }
 
 // NewRegexp creates a new anchored Regexp and returns an error if the
 // passed-in regular expression does not compile.
 func NewRegexp(s string) (Regexp, error) {
 	regex, err := regexp.Compile("^(?:" + s + ")$")
-	return Regexp{
-		Regexp:   regex,
-		original: s,
-	}, err
+	return Regexp{Regexp: regex}, err
 }
 
 // MustNewRegexp works like NewRegexp, but panics if the regular expression does not compile.
@@ -180,8 +176,11 @@ func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // MarshalYAML implements the yaml.Marshaler interface.
 func (re Regexp) MarshalYAML() (interface{}, error) {
-	if re.original != "" {
-		return re.original, nil
+	if re.String() != "" {
+		str := re.String()
+		str = strings.TrimPrefix(str, "^(?:")
+		str = strings.TrimSuffix(str, ")$")
+		return str, nil
 	}
 	return nil, nil
 }

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -177,12 +177,16 @@ func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // MarshalYAML implements the yaml.Marshaler interface.
 func (re Regexp) MarshalYAML() (interface{}, error) {
 	if re.String() != "" {
-		str := re.String()
-		str = strings.TrimPrefix(str, "^(?:")
-		str = strings.TrimSuffix(str, ")$")
-		return str, nil
+		return re.String(), nil
 	}
 	return nil, nil
+}
+
+// String returns the original string used to compile the regular expression.
+func (re Regexp) String() string {
+	str := re.Regexp.String()
+	// Trim the anchor `^(?:` prefix and `)$` suffix.
+	return str[4 : len(str)-2]
 }
 
 // Process returns a relabeled copy of the given label set. The relabel configurations

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -461,7 +461,7 @@ func TestRelabel(t *testing.T) {
 			if cfg.Separator == "" {
 				cfg.Separator = DefaultRelabelConfig.Separator
 			}
-			if cfg.Regex.original == "" {
+			if cfg.Regex.Regexp == nil || cfg.Regex.String() == "" {
 				cfg.Regex = DefaultRelabelConfig.Regex
 			}
 			if cfg.Replacement == "" {


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalist0@gmail.com>

This was initially pointed out by @rfratto when experimenting with something on the Agent. Looking at [grafana/regexp](https://github.com/grafana/regexp/blob/2e8d9baf4ac26b43e1eb1e8a62fb920a6efaef81/regexp.go#L82-L107), the result of the regexp.String() call returns what was passed to Compile when creating the Regexp object. 

Trimming the prefix and suffix manually would give us the same string back, trading some extra instructions for memory as we won't have to keep around an extra copy of the original string around anymore.

Do you feel that's worth it as a change?


## Benchmarks
I've run [this](https://github.com/tpaschalis/prometheus/commit/34a6ce345223c42b3735d7ea2406587c22948e76) benchmark on main (f2ba2a0), and then on main with this change applied.

While the results aren't spectacular, they showed some slight improvement even for a single relabel_config step.

```
$ go test ./... -run=None -bench=. -benchmem -benchtime=5s -count=10 > before
$ go test ./... -run=None -bench=. -benchmem -benchtime=5s -count=10 > after

$ benchstat before after
name                  old time/op    new time/op    delta
RegexpDropOriginal-8    18.1µs ± 2%    17.6µs ± 0%  -2.90%  (p=0.000 n=9+10)

name                  old alloc/op   new alloc/op   delta
RegexpDropOriginal-8    27.6kB ± 0%    27.5kB ± 0%  -0.33%  (p=0.000 n=10+10)

name                  old allocs/op  new allocs/op  delta
RegexpDropOriginal-8       230 ± 0%       227 ± 0%  -1.30%  (p=0.000 n=10+10)
```