### PR TITLE
use npm workspace flag for the build instead of manually navigate through the folders

### DIFF
--- a/web/ui/build_ui.sh
+++ b/web/ui/build_ui.sh
@@ -14,28 +14,24 @@
 # limitations under the License.
 
 set -e
-current=$(pwd)
+
 if ! [[ -w  $HOME ]]
 then
   export npm_config_cache=$(mktemp -d)
 fi
 
-buildOrder=(module/lezer-promql module/codemirror-promql)
+buildOrder=(lezer-promql codemirror-promql)
 
 function buildModule() {
   for module in "${buildOrder[@]}"; do
-    cd "${module}"
     echo "build ${module}"
-    npm run build
-    cd "${current}"
+    npm run build -w "${module}"
   done
 }
 
 function buildReactApp() {
-  cd react-app
   echo "build react-app"
-  npm run build
-  cd "${current}"
+  npm run build -w react-app
   rm -rf ./static/react
   mv ./react-app/build ./static/react
 }


### PR DESCRIPTION
I'm just simplifying a bit the `build` script.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
