### PR TITLE
tsdb: reduce sleep time when reading WAL

### DIFF
--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -438,7 +438,7 @@ func (wp *walSubsetProcessor) waitUntilIdle() {
 	}
 	wp.input <- []record.RefSample{}
 	for len(wp.input) != 0 {
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(10 * time.Microsecond)
 		select {
 		case <-wp.output: // Allow output side to drain to avoid deadlock.
 		default:


### PR DESCRIPTION
The code sleeps for a short time to allow goroutines to finish, however it seems the duration can be reduced a lot, speeding up the reading process.

I checked using some WAL data from production, and the queue is almost always empty at the time we enter `waitForIdle()` so there is no danger of spinning in the tight loop.

Benchmarks from x64/Linux:
```
name                                                                                                     old time/op    new time/op    delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-4          1.15s ±24%     0.60s ±11%  -47.95%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0-4         1.03s ±26%     0.57s ±14%  -44.73%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0-4         1.20s ±42%     0.65s ±34%  -45.69%  (p=0.016 n=5+5)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0-4        1.21s ±20%     0.70s ±20%  -42.60%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-4          55.0s ±25%     11.1s ±18%  -79.85%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0-4          58.4s ± 8%     10.6s ±13%  -81.86%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-4          6.97s ±31%     1.21s ±29%  -82.60%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0-4          5.76s ±10%     1.42s ±17%  -75.32%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0-4          5.27s ±26%     1.31s ±19%  -75.13%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0-4         5.97s ±25%     1.30s ±13%  -78.21%  (p=0.008 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-4      67.4s ±14%     13.7s ±11%  -79.61%  (p=0.008 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800-4      67.0s ± 9%     15.1s ± 8%  -77.52%  (p=0.008 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800-4      65.9s ±14%     14.5s ±11%  -78.07%  (p=0.008 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800-4     71.0s ± 9%     15.0s ±19%  -78.90%  (p=0.008 n=5+5)
```

Benchmarks from M1/Darwin (which is quite remarkably faster at these tests):
```
name                                                                                                     old time/op    new time/op    delta
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-4          427ms ±11%     238ms ±23%  -44.21%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0-4         379ms ±23%     228ms ±12%  -40.02%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0-4         455ms ±20%     228ms ± 5%  -50.01%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0-4        441ms ± 6%     256ms ± 3%  -41.99%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-4          6.64s ±11%     0.69s ± 4%  -89.56%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0-4          5.46s ±26%     0.76s ±14%  -86.02%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-4          656ms ±13%     199ms ± 2%  -69.63%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0-4          686ms ±17%     201ms ± 5%  -70.76%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0-4          670ms ±38%     204ms ± 2%  -69.58%  (p=0.008 n=5+5)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0-4         959ms ±51%     226ms ± 2%  -76.47%  (p=0.008 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-4      6.57s ±23%     1.74s ± 5%  -73.52%  (p=0.008 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800-4      5.70s ±34%     1.77s ± 5%  -68.91%  (p=0.008 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800-4      4.48s ±21%     1.84s ± 2%  -58.85%  (p=0.008 n=5+5)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800-4     5.40s ± 4%     2.10s ± 4%  -61.11%  (p=0.008 n=5+5)
```

Timing the load of a 1GB WAL copied from production, again on M1:
```
name           old time/op    new time/op    delta
LoadFileWAL-4     14.1s ± 5%      5.2s ± 7%  -62.72%  (p=0.008 n=5+5)
```

cc @alanprot who brought this up https://github.com/prometheus/prometheus/pull/9856#issuecomment-1121846655