### PR TITLE
Make clear that `go install` needs to be run in the cloned repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ git clone https://github.com/prometheus/prometheus.git
 cd prometheus
 ```
 
-You can directly use the `go` tool to download and install the `prometheus`
+You can use the `go` tool to build and install the `prometheus`
 and `promtool` binaries into your `GOPATH`:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ To build Prometheus from source code, You need:
 Start by cloning the repository:
 
 ```bash
-mkdir -p $GOPATH/src/github.com/prometheus
-cd $GOPATH/src/github.com/prometheus
 git clone https://github.com/prometheus/prometheus.git
 cd prometheus
 ```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ To build Prometheus from source code, You need:
 * NodeJS [version 16 or greater](https://nodejs.org/).
 * npm [version 7 or greater](https://www.npmjs.com/).
 
+Start by cloning the repository:
+
+```bash
+mkdir -p $GOPATH/src/github.com/prometheus
+cd $GOPATH/src/github.com/prometheus
+git clone https://github.com/prometheus/prometheus.git
+cd prometheus
+```
+
 You can directly use the `go` tool to download and install the `prometheus`
 and `promtool` binaries into your `GOPATH`:
 
@@ -79,14 +88,10 @@ React UI unless it has been built explicitly using `make assets` or `make build`
 
 An example of the above configuration file can be found [here.](https://github.com/prometheus/prometheus/blob/main/documentation/examples/prometheus.yml)
 
-You can also clone the repository yourself and build using `make build`, which will compile in
-the web assets so that Prometheus can be run from anywhere:
+You can also build using `make build`, which will compile in the web assets so that
+Prometheus can be run from anywhere:
 
 ```bash
-mkdir -p $GOPATH/src/github.com/prometheus
-cd $GOPATH/src/github.com/prometheus
-git clone https://github.com/prometheus/prometheus.git
-cd prometheus
 make build
 ./prometheus --config.file=your_config.yml
 ```


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

I moved the instructions for cloning into a separate block above the building methods so that it's clear that both need to be done in the root of the cloned repo. I don't think an explicit message is needed.

Side note: Does the repo need to be cloned in the `$GOPATH` anymore? I think I read somewhere that it doesn't and I've had mine in a separate directory for a while.

Fixes #10816 