### PR TITLE
Drop OpenBSD from promu config

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -35,5 +35,4 @@ crossbuild:
         - illumos
         - linux
         - netbsd
-        - openbsd
         - windows


### PR DESCRIPTION
Per https://groups.google.com/d/msgid/prometheus-developers/20210615134617.GA683113%40oxygen which was nearly exactly a year ago...

It pains me to do, as I've run OpenBSD systems quite happily in the past, but the lack of unified read + mmap cache makes this quite hard, right now the binary we're offering will potentially lose data; maybe the lack of a binary will spur someone to do the work...
