### PR TITLE
Add histogram_fraction function

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -152,7 +152,13 @@ Special cases are:
 `floor(v instant-vector)` rounds the sample values of all elements in `v` down
 to the nearest integer.
 
+## `histogram_fraction()`
+
+TODO(beorn7): Add documentation.
+
 ## `histogram_quantile()`
+
+TODO(beorn7): This needs a lot of updates for Histograms as sample value types.
 
 `histogram_quantile(φ scalar, b instant-vector)` calculates the φ-quantile (0 ≤ φ
 ≤ 1) from the buckets `b` of a

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3244,15 +3244,15 @@ func TestSparseHistogram_HistogramQuantile(t *testing.T) {
 				},
 				{ // Zero bucket.
 					quantile: "1",
-					value:    0.001,
+					value:    0,
 				},
 				{ // Zero bucket.
 					quantile: "0.99",
-					value:    0.0008799999999999991,
+					value:    -6.000000000000048e-05,
 				},
 				{ // Zero bucket.
 					quantile: "0.9",
-					value:    -0.00019999999999999933,
+					value:    -0.0005999999999999996,
 				},
 				{
 					quantile: "0.5",

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -864,6 +864,25 @@ func funcPredictLinear(vals []parser.Value, args parser.Expressions, enh *EvalNo
 	})
 }
 
+// === histogram_fraction(lower, upper parser.ValueTypeScalar, Vector parser.ValueTypeVector) Vector ===
+func funcHistogramFraction(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	lower := vals[0].(Vector)[0].V
+	upper := vals[1].(Vector)[0].V
+	inVec := vals[2].(Vector)
+
+	for _, sample := range inVec {
+		// Skip non-histogram samples.
+		if sample.H == nil {
+			continue
+		}
+		enh.Out = append(enh.Out, Sample{
+			Metric: enh.DropMetricName(sample.Metric),
+			Point:  Point{V: histogramFraction(lower, upper, sample.H)},
+		})
+	}
+	return enh.Out
+}
+
 // === histogram_quantile(k parser.ValueTypeScalar, Vector parser.ValueTypeVector) Vector ===
 func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	q := vals[0].(Vector)[0].V
@@ -1205,6 +1224,7 @@ var FunctionCalls = map[string]FunctionCall{
 	"deriv":              funcDeriv,
 	"exp":                funcExp,
 	"floor":              funcFloor,
+	"histogram_fraction": funcHistogramFraction,
 	"histogram_quantile": funcHistogramQuantile,
 	"holt_winters":       funcHoltWinters,
 	"hour":               funcHour,

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -163,6 +163,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeVector},
 		ReturnType: ValueTypeVector,
 	},
+	"histogram_fraction": {
+		Name:       "histogram_fraction",
+		ArgTypes:   []ValueType{ValueTypeScalar, ValueTypeScalar, ValueTypeVector},
+		ReturnType: ValueTypeVector,
+	},
 	"histogram_quantile": {
 		Name:       "histogram_quantile",
 		ArgTypes:   []ValueType{ValueTypeScalar, ValueTypeVector},

--- a/promql/quantile.go
+++ b/promql/quantile.go
@@ -141,6 +141,8 @@ func bucketQuantile(q float64, buckets buckets) float64 {
 // If q<0, -Inf is returned.
 //
 // If q>1, +Inf is returned.
+//
+// If q is NaN, NaN is returned.
 func histogramQuantile(q float64, h *histogram.FloatHistogram) float64 {
 	if q < 0 {
 		return math.Inf(-1)
@@ -149,7 +151,7 @@ func histogramQuantile(q float64, h *histogram.FloatHistogram) float64 {
 		return math.Inf(+1)
 	}
 
-	if h.Count == 0 {
+	if h.Count == 0 || math.IsNaN(q) {
 		return math.NaN()
 	}
 
@@ -193,6 +195,99 @@ func histogramQuantile(q float64, h *histogram.FloatHistogram) float64 {
 	rank -= count - bucket.Count
 	// TODO(codesome): Use a better estimation than linear.
 	return bucket.Lower + (bucket.Upper-bucket.Lower)*(rank/bucket.Count)
+}
+
+// histogramFraction calculates the fraction of observations between the
+// provided lower and upper bounds, based on the provided histogram.
+//
+// histogramFraction is in a certain way the inverse of histogramQuantile.  If
+// histogramQuantile(0.9, h) returns 123.4, then histogramFraction(-Inf, 123.4, h)
+// returns 0.9.
+//
+// The same notes (and TODOs) with regard to interpolation and assumptions about
+// the zero bucket boundaries apply as for histogramQuantile.
+//
+// Whether either boundary is inclusive or exclusive doesn’t actually matter as
+// long as interpolation has to be performed anyway. In the case of a boundary
+// coinciding with a bucket boundary, the inclusive or exclusive nature of the
+// boundary determines the exact behavior of the threshold. With the current
+// implementation, that means that lower is exclusive for positive values and
+// inclusive for negative values, while upper is inclusive for positive values
+// and exclusive for negative values.
+//
+// Special cases:
+//
+// If the histogram has 0 observations, NaN is returned.
+//
+// Use a lower bound of -Inf to get the fraction of all observations below the
+// upper bound.
+//
+// Use an upper bound of +Inf to get the fraction of all observations above the
+// lower bound.
+//
+// If lower or upper is NaN, NaN is returned.
+//
+// If lower >= upper and the histogram has at least 1 observation, zero is returned.
+func histogramFraction(lower, upper float64, h *histogram.FloatHistogram) float64 {
+	if h.Count == 0 || math.IsNaN(lower) || math.IsNaN(upper) {
+		return math.NaN()
+	}
+	if lower >= upper {
+		return 0
+	}
+
+	var (
+		rank, lowerRank, upperRank float64
+		lowerSet, upperSet         bool
+		it                         = h.AllBucketIterator()
+	)
+	for it.Next() {
+		b := it.At()
+		if b.Lower < 0 && b.Upper > 0 {
+			if len(h.NegativeBuckets) == 0 && len(h.PositiveBuckets) > 0 {
+				// This is the zero bucket and the histogram has only
+				// positive buckets. So we consider 0 to be the lower
+				// bound.
+				b.Lower = 0
+			} else if len(h.PositiveBuckets) == 0 && len(h.NegativeBuckets) > 0 {
+				// This is in the zero bucket and the histogram has only
+				// negative buckets. So we consider 0 to be the upper
+				// bound.
+				b.Upper = 0
+			}
+		}
+		if !lowerSet && b.Lower >= lower {
+			lowerRank = rank
+			lowerSet = true
+		}
+		if !upperSet && b.Lower >= upper {
+			upperRank = rank
+			upperSet = true
+		}
+		if lowerSet && upperSet {
+			break
+		}
+		if !lowerSet && b.Lower < lower && b.Upper > lower {
+			lowerRank = rank + b.Count*(lower-b.Lower)/(b.Upper-b.Lower)
+			lowerSet = true
+		}
+		if !upperSet && b.Lower < upper && b.Upper > upper {
+			upperRank = rank + b.Count*(upper-b.Lower)/(b.Upper-b.Lower)
+			upperSet = true
+		}
+		if lowerSet && upperSet {
+			break
+		}
+		rank += b.Count
+	}
+	if !lowerSet || lowerRank > h.Count {
+		lowerRank = h.Count
+	}
+	if !upperSet || upperRank > h.Count {
+		upperRank = h.Count
+	}
+
+	return (upperRank - lowerRank) / h.Count
 }
 
 // coalesceBuckets merges buckets with the same upper bound.

--- a/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
+++ b/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
@@ -216,9 +216,15 @@ export const functionIdentifierTerms = [
     type: 'function',
   },
   {
+    label: 'histogram_fraction',
+    detail: 'function',
+    info: 'Calculate fractions of observations within an interval from a native histogram',
+    type: 'function',
+  },
+  {
     label: 'histogram_quantile',
     detail: 'function',
-    info: 'Calculate quantiles from histogram buckets',
+    info: 'Calculate quantiles from native histograms and from legacy histogram buckets',
     type: 'function',
   },
   {

--- a/web/ui/module/codemirror-promql/src/parser/parser.test.ts
+++ b/web/ui/module/codemirror-promql/src/parser/parser.test.ts
@@ -715,6 +715,20 @@ describe('promql operations', () => {
       expectedDiag: [],
     },
     {
+      expr:
+        'histogram_fraction(                                      # Root of the query, final result, approximates a fraction of observations within an interval.\n' +
+        '  -Inf,                                                  # 1st argument to histogram_fraction(), start of the interval.\n' +
+        '  123.4,                                                 # 2nd argument to histogram_fraction(), end of the interval.\n' +
+        '  sum by(method, path) (                                 # 3rd argument to histogram_fraction(), an aggregated histogram.\n' +
+        '    rate(                                                # Argument to sum(), the per-second increase of a histogram over 5m.\n' +
+        '      demo_api_request_duration_seconds{job="demo"}[5m]  # Argument to rate(), a vector of sparse histogram series over the last 5m.\n' +
+        '    )\n' +
+        '  )\n' +
+        ')',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
       expr: '1 @ start()',
       expectedValueType: ValueType.scalar,
       expectedDiag: [

--- a/web/ui/module/codemirror-promql/src/types/function.ts
+++ b/web/ui/module/codemirror-promql/src/types/function.ts
@@ -39,6 +39,7 @@ import {
   Deriv,
   Exp,
   Floor,
+  HistogramFraction,
   HistogramQuantile,
   HoltWinters,
   Hour,
@@ -258,6 +259,12 @@ const promqlFunctions: { [key: number]: PromQLFunction } = {
   [Floor]: {
     name: 'floor',
     argTypes: [ValueType.vector],
+    variadic: 0,
+    returnType: ValueType.vector,
+  },
+  [HistogramFraction]: {
+    name: 'histogram_fraction',
+    argTypes: [ValueType.scalar, ValueType.scalar, ValueType.vector],
     variadic: 0,
     returnType: ValueType.vector,
   },

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -146,6 +146,7 @@ FunctionIdentifier {
   Deriv |
   Exp |
   Floor |
+  HistogramFraction |
   HistogramQuantile |
   HoltWinters |
   Hour |
@@ -387,6 +388,7 @@ NumberLiteral  {
   Deriv { condFn<"deriv"> }
   Exp { condFn<"exp"> }
   Floor { condFn<"floor"> }
+  HistogramFraction { condFn<"histogram_fraction"> }
   HistogramQuantile { condFn<"histogram_quantile"> }
   HoltWinters { condFn<"holt_winters"> }
   Hour { condFn<"hour"> }


### PR DESCRIPTION
_This is only for the sparsehistogram branch._

@codesome early preview. I still plan to add a test similar to the test for `histogram_quantile`. (It would be much easier if we already had native histograms integrated in the PromQL testing framework, but that's still a TODO.)