### PR TITLE
Implement Unwrap() on errors returned from rulefmt

### DIFF
--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -48,6 +48,11 @@ func (err *Error) Error() string {
 	return errors.Wrapf(err.Err.err, "group %q, rule %d, %q", err.Group, err.Rule, err.RuleName).Error()
 }
 
+// Unwrap unpacks wrapped error for use in errors.Is & errors.As.
+func (err *Error) Unwrap() error {
+	return &err.Err
+}
+
 // WrappedError wraps error with the yaml node which can be used to represent
 // the line and column numbers of the error.
 type WrappedError struct {
@@ -64,6 +69,11 @@ func (we *WrappedError) Error() string {
 		return errors.Wrapf(we.err, "%d:%d", we.node.Line, we.node.Column).Error()
 	}
 	return we.err.Error()
+}
+
+// Unwrap unpacks wrapped error for use in errors.Is & errors.As.
+func (we *WrappedError) Unwrap() error {
+	return we.err
 }
 
 // RuleGroups is a set of rule groups that are typically exposed in a file.

--- a/model/rulefmt/rulefmt_test.go
+++ b/model/rulefmt/rulefmt_test.go
@@ -15,6 +15,7 @@ package rulefmt
 
 import (
 	"errors"
+	"io"
 	"path/filepath"
 	"testing"
 
@@ -296,6 +297,30 @@ func TestWrappedError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.wrappedError.Error()
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestErrorUnwrap(t *testing.T) {
+	err1 := errors.New("test error")
+
+	tests := []struct {
+		wrappedError   *Error
+		unwrappedError error
+	}{
+		{
+			wrappedError:   &Error{Err: WrappedError{err: err1}},
+			unwrappedError: err1,
+		},
+		{
+			wrappedError:   &Error{Err: WrappedError{err: io.ErrClosedPipe}},
+			unwrappedError: io.ErrClosedPipe,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.wrappedError.Error(), func(t *testing.T) {
+			require.ErrorIs(t, tt.wrappedError, tt.unwrappedError)
 		})
 	}
 }


### PR DESCRIPTION
I'd like to unwrap errors returned from rulefmt but both Error and WrappedError types are missing Unwrap() method.

Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
