### PR TITLE
Keep relabeled scrape interval and timeout on reloads

### DIFF
--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -405,8 +405,10 @@ scrape_configs:
 		return noopLoop()
 	}
 	sp := &scrapePool{
-		appendable:    &nopAppendable{},
-		activeTargets: map[uint64]*Target{},
+		appendable: &nopAppendable{},
+		activeTargets: map[uint64]*Target{
+			1: {},
+		},
 		loops: map[uint64]loop{
 			1: noopLoop(),
 		},

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -426,8 +426,9 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 			cache = newScrapeCache()
 		}
 
+		t := sp.activeTargets[fp]
+		interval, timeout, err := t.intervalAndTimeout(interval, timeout)
 		var (
-			t       = sp.activeTargets[fp]
 			s       = &targetScraper{Target: t, client: sp.client, timeout: timeout, bodySizeLimit: bodySizeLimit}
 			newLoop = sp.newLoop(scrapeLoopOptions{
 				target:          t,
@@ -442,6 +443,9 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 				timeout:         timeout,
 			})
 		)
+		if err != nil {
+			newLoop.setForcedError(err)
+		}
 		wg.Add(1)
 
 		go func(oldLoop, newLoop loop) {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -250,10 +250,10 @@ func TestScrapePoolReload(t *testing.T) {
 	// On starting to run, new loops created on reload check whether their preceding
 	// equivalents have been stopped.
 	newLoop := func(opts scrapeLoopOptions) loop {
-		l := &testLoop{interval: time.Duration(reloadCfg.ScrapeInterval), timeout: time.Duration(reloadCfg.ScrapeTimeout)}
+		l := &testLoop{interval: time.Duration(opts.interval), timeout: time.Duration(opts.timeout)}
 		l.startFunc = func(interval, timeout time.Duration, errc chan<- error) {
-			require.Equal(t, 3*time.Second, interval, "Unexpected scrape interval")
-			require.Equal(t, 2*time.Second, timeout, "Unexpected scrape timeout")
+			require.Equal(t, 5*time.Second, interval, "Unexpected scrape interval")
+			require.Equal(t, 3*time.Second, timeout, "Unexpected scrape timeout")
 
 			mtx.Lock()
 			targetScraper := opts.scraper.(*targetScraper)
@@ -276,7 +276,11 @@ func TestScrapePoolReload(t *testing.T) {
 	// one terminated.
 
 	for i := 0; i < numTargets; i++ {
-		labels := labels.FromStrings(model.AddressLabel, fmt.Sprintf("example.com:%d", i))
+		labels := labels.FromStrings(
+			model.AddressLabel, fmt.Sprintf("example.com:%d", i),
+			model.ScrapeIntervalLabel, "5s",
+			model.ScrapeTimeoutLabel, "3s",
+		)
 		t := &Target{
 			labels:           labels,
 			discoveredLabels: labels,


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR is trying to fix a problem that scrape interval and scrape timeout relabel configs no longer take effect after reloads. For example, for the following config:
```
scrape_configs:
  - job_name: static-target
    scrape_timeout: 1s
    static_configs:
    - targets:
      - localhost:8000
    relabel_configs:
    - source_labels:
      - __address__
      target_label: __scrape_timeout__
      replacement: 5s
```
If we change anything (e.g., set `honor_labels: true`) and reloads, the scrape timeout will drop back to the job default (1s).
![image](https://user-images.githubusercontent.com/7052824/175782108-55e388dc-7b9e-445d-bc40-f3e3588c7f90.png)
