### PR TITLE
Removing global state modification on unit tests (fix #10033 #10034)

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"net/url"
 	"os"
 	"runtime/pprof"
 	"sort"
@@ -32,7 +31,6 @@ import (
 	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
 	client_testutil "github.com/prometheus/client_golang/prometheus/testutil"
-	common_config "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -84,20 +82,15 @@ func TestSampleDelivery(t *testing.T) {
 	queueConfig.BatchSendDeadline = model.Duration(100 * time.Millisecond)
 	queueConfig.MaxShards = 1
 
-	writeConfig := config.DefaultRemoteWriteConfig
 	// We need to set URL's so that metric creation doesn't panic.
-	writeConfig.URL = &common_config.URL{
-		URL: &url.URL{
-			Host: "http://test-storage.com",
-		},
-	}
+	writeConfig := baseRemoteWriteConfig("http://test-storage.com")
 	writeConfig.QueueConfig = queueConfig
 	writeConfig.SendExemplars = true
 
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
-			&writeConfig,
+			writeConfig,
 		},
 	}
 

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -127,30 +127,23 @@ func TestIgnoreExternalLabels(t *testing.T) {
 // baseRemoteWriteConfig copy values from global Default Write config
 // to avoid change global state and cross impact test execution
 func baseRemoteWriteConfig(host string) *config.RemoteWriteConfig {
-	return &config.RemoteWriteConfig{
-		RemoteTimeout:    config.DefaultRemoteWriteConfig.RemoteTimeout,
-		QueueConfig:      config.DefaultRemoteWriteConfig.QueueConfig,
-		MetadataConfig:   config.DefaultRemoteWriteConfig.MetadataConfig,
-		HTTPClientConfig: config.DefaultRemoteWriteConfig.HTTPClientConfig,
-		URL: &common_config.URL{
-			URL: &url.URL{
-				Host: host,
-			},
+	cfg := config.DefaultRemoteWriteConfig
+	cfg.URL = &common_config.URL{
+		URL: &url.URL{
+			Host: host,
 		},
 	}
+	return &cfg
 }
 
 // baseRemoteReadConfig copy values from global Default Read config
 // to avoid change global state and cross impact test execution
 func baseRemoteReadConfig(host string) *config.RemoteReadConfig {
-	return &config.RemoteReadConfig{
-		RemoteTimeout:        config.DefaultRemoteReadConfig.RemoteTimeout,
-		HTTPClientConfig:     config.DefaultRemoteReadConfig.HTTPClientConfig,
-		FilterExternalLabels: config.DefaultRemoteReadConfig.FilterExternalLabels,
-		URL: &common_config.URL{
-			URL: &url.URL{
-				Host: host,
-			},
+	cfg := config.DefaultRemoteReadConfig
+	cfg.URL = &common_config.URL{
+		URL: &url.URL{
+			Host: host,
 		},
 	}
+	return &cfg
 }

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -31,21 +31,11 @@ func TestStorageLifecycle(t *testing.T) {
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
-			&config.DefaultRemoteWriteConfig,
+			// We need to set URL's so that metric creation doesn't panic.
+			baseRemoteWriteConfig("http://test-storage.com"),
 		},
 		RemoteReadConfigs: []*config.RemoteReadConfig{
-			&config.DefaultRemoteReadConfig,
-		},
-	}
-	// We need to set URL's so that metric creation doesn't panic.
-	conf.RemoteWriteConfigs[0].URL = &common_config.URL{
-		URL: &url.URL{
-			Host: "http://test-storage.com",
-		},
-	}
-	conf.RemoteReadConfigs[0].URL = &common_config.URL{
-		URL: &url.URL{
-			Host: "http://test-storage.com",
+			baseRemoteReadConfig("http://test-storage.com"),
 		},
 	}
 
@@ -73,7 +63,7 @@ func TestUpdateRemoteReadConfigs(t *testing.T) {
 	require.Equal(t, 0, len(s.queryables))
 
 	conf.RemoteReadConfigs = []*config.RemoteReadConfig{
-		&config.DefaultRemoteReadConfig,
+		baseRemoteReadConfig("http://test-storage.com"),
 	}
 	require.NoError(t, s.ApplyConfig(conf))
 	require.Equal(t, 1, len(s.queryables))
@@ -96,7 +86,7 @@ func TestFilterExternalLabels(t *testing.T) {
 	require.Equal(t, 0, len(s.queryables))
 
 	conf.RemoteReadConfigs = []*config.RemoteReadConfig{
-		&config.DefaultRemoteReadConfig,
+		baseRemoteReadConfig("http://test-storage.com"),
 	}
 
 	require.NoError(t, s.ApplyConfig(conf))
@@ -121,7 +111,7 @@ func TestIgnoreExternalLabels(t *testing.T) {
 	require.Equal(t, 0, len(s.queryables))
 
 	conf.RemoteReadConfigs = []*config.RemoteReadConfig{
-		&config.DefaultRemoteReadConfig,
+		baseRemoteReadConfig("http://test-storage.com"),
 	}
 
 	conf.RemoteReadConfigs[0].FilterExternalLabels = false
@@ -132,4 +122,35 @@ func TestIgnoreExternalLabels(t *testing.T) {
 
 	err := s.Close()
 	require.NoError(t, err)
+}
+
+// baseRemoteWriteConfig copy values from global Default Write config
+// to avoid change global state and cross impact test execution
+func baseRemoteWriteConfig(host string) *config.RemoteWriteConfig {
+	return &config.RemoteWriteConfig{
+		RemoteTimeout:    config.DefaultRemoteWriteConfig.RemoteTimeout,
+		QueueConfig:      config.DefaultRemoteWriteConfig.QueueConfig,
+		MetadataConfig:   config.DefaultRemoteWriteConfig.MetadataConfig,
+		HTTPClientConfig: config.DefaultRemoteWriteConfig.HTTPClientConfig,
+		URL: &common_config.URL{
+			URL: &url.URL{
+				Host: host,
+			},
+		},
+	}
+}
+
+// baseRemoteReadConfig copy values from global Default Read config
+// to avoid change global state and cross impact test execution
+func baseRemoteReadConfig(host string) *config.RemoteReadConfig {
+	return &config.RemoteReadConfig{
+		RemoteTimeout:        config.DefaultRemoteReadConfig.RemoteTimeout,
+		HTTPClientConfig:     config.DefaultRemoteReadConfig.HTTPClientConfig,
+		FilterExternalLabels: config.DefaultRemoteReadConfig.FilterExternalLabels,
+		URL: &common_config.URL{
+			URL: &url.URL{
+				Host: host,
+			},
+		},
+	}
 }

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -202,7 +202,7 @@ func TestWriteStorageLifecycle(t *testing.T) {
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
-			&config.DefaultRemoteWriteConfig,
+			baseRemoteWriteConfig("http://test-storage.com"),
 		},
 	}
 	require.NoError(t, s.ApplyConfig(conf))
@@ -249,18 +249,7 @@ func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
-			{
-				RemoteTimeout:    config.DefaultRemoteWriteConfig.RemoteTimeout,
-				QueueConfig:      config.DefaultRemoteWriteConfig.QueueConfig,
-				MetadataConfig:   config.DefaultRemoteWriteConfig.MetadataConfig,
-				HTTPClientConfig: config.DefaultRemoteWriteConfig.HTTPClientConfig,
-				// We need to set URL's so that metric creation doesn't panic.
-				URL: &common_config.URL{
-					URL: &url.URL{
-						Host: "http://test-storage.com",
-					},
-				},
-			},
+			baseRemoteWriteConfig("http://test-storage.com"),
 		},
 	}
 	hash, err := toHash(conf.RemoteWriteConfigs[0])


### PR DESCRIPTION
The config.DefaultRemoteReadConfig and config.DefaultRemoteWriteConfig
instances hold global state. Unit tests were changing their url.URL reference
globally causing false positives when tests were ran through package.
Two helper functions were created to copy those global values instead of changing
them in place to fix null point when running unit tests by method instead of
by package.

Signed-off-by: Leonardo Zamariola <leonardo.zamariola@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
