### PR TITLE
(storage): move from github.com/pkg/errors to 'errors' and 'fmt'

### DIFF
--- a/storage/merge.go
+++ b/storage/merge.go
@@ -16,11 +16,10 @@ package storage
 import (
 	"bytes"
 	"container/heap"
+	"fmt"
 	"math"
 	"sort"
 	"sync"
-
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -159,7 +158,7 @@ func (l labelGenericQueriers) SplitByHalf() (labelGenericQueriers, labelGenericQ
 func (q *mergeGenericQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, Warnings, error) {
 	res, ws, err := q.lvals(q.queriers, name, matchers...)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "LabelValues() from merge generic querier for label %s", name)
+		return nil, nil, fmt.Errorf("LabelValues() from merge generic querier for label %s: %w", name, err)
 	}
 	return res, ws, nil
 }
@@ -227,7 +226,7 @@ func (q *mergeGenericQuerier) LabelNames(matchers ...*labels.Matcher) ([]string,
 			warnings = append(warnings, wrn...)
 		}
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "LabelNames() from merge generic querier")
+			return nil, nil, fmt.Errorf("LabelNames() from merge generic querier: %w", err)
 		}
 		for _, name := range names {
 			labelNamesMap[name] = struct{}{}

--- a/storage/merge_test.go
+++ b/storage/merge_test.go
@@ -14,13 +14,13 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sort"
 	"sync"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"

--- a/storage/remote/chunked.go
+++ b/storage/remote/chunked.go
@@ -16,13 +16,14 @@ package remote
 import (
 	"bufio"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"hash"
 	"hash/crc32"
 	"io"
 	"net/http"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 // DefaultChunkedReadLimit is the default value for the maximum size of the protobuf frame client allows.
@@ -119,7 +120,7 @@ func (r *ChunkedReader) Next() ([]byte, error) {
 	}
 
 	if size > r.sizeLimit {
-		return nil, errors.Errorf("chunkedReader: message size exceeded the limit %v bytes; got: %v bytes", r.sizeLimit, size)
+		return nil, fmt.Errorf("chunkedReader: message size exceeded the limit %v bytes; got: %v bytes", r.sizeLimit, size)
 	}
 
 	if cap(r.data) < int(size) {

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -15,6 +15,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -22,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"

--- a/storage/remote/metadata_watcher.go
+++ b/storage/remote/metadata_watcher.go
@@ -15,11 +15,11 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/scrape"

--- a/storage/remote/metadata_watcher_test.go
+++ b/storage/remote/metadata_watcher_test.go
@@ -15,10 +15,10 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -15,8 +15,8 @@ package remote
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -164,12 +164,12 @@ func (q *querier) Select(sortSeries bool, hints *storage.SelectHints, matchers .
 	m, added := q.addExternalLabels(matchers)
 	query, err := ToQuery(q.mint, q.maxt, m, hints)
 	if err != nil {
-		return storage.ErrSeriesSet(errors.Wrap(err, "toQuery"))
+		return storage.ErrSeriesSet(fmt.Errorf("toQuery: %w", err))
 	}
 
 	res, err := q.client.Read(q.ctx, query)
 	if err != nil {
-		return storage.ErrSeriesSet(errors.Wrap(err, "remote_read"))
+		return storage.ErrSeriesSet(fmt.Errorf("remote_read: %w", err))
 	}
 	return newSeriesSetFilter(FromQueryResult(sortSeries, res), added)
 }

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -15,11 +15,11 @@ package remote
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"sort"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/stretchr/testify/require"
@@ -209,7 +209,7 @@ type mockedRemoteClient struct {
 
 func (c *mockedRemoteClient) Read(_ context.Context, query *prompb.Query) (*prompb.QueryResult, error) {
 	if c.got != nil {
-		return nil, errors.Errorf("expected only one call to remote client got: %v", query)
+		return nil, fmt.Errorf("expected only one call to remote client got: %v", query)
 	}
 	c.got = query
 

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -15,12 +15,12 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/prompb"
@@ -67,10 +67,11 @@ func (h *writeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // checkAppendExemplarError modifies the AppendExamplar's returned error based on the error cause.
 func (h *writeHandler) checkAppendExemplarError(err error, e exemplar.Exemplar, outOfOrderErrs *int) error {
-	switch errors.Cause(err) {
-	case storage.ErrNotFound:
+	unwrapedErr := errors.Unwrap(err)
+	switch {
+	case errors.Is(unwrapedErr, storage.ErrNotFound):
 		return storage.ErrNotFound
-	case storage.ErrOutOfOrderExemplar:
+	case errors.Is(unwrapedErr, storage.ErrOutOfOrderExemplar):
 		*outOfOrderErrs++
 		level.Debug(h.logger).Log("msg", "Out of order exemplar", "exemplar", fmt.Sprintf("%+v", e))
 		return nil
@@ -97,8 +98,8 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 		for _, s := range ts.Samples {
 			_, err = app.Append(0, labels, s.Timestamp, s.Value)
 			if err != nil {
-				switch errors.Cause(err) {
-				case storage.ErrOutOfOrderSample, storage.ErrOutOfBounds, storage.ErrDuplicateSampleForTimestamp:
+				unwrapedErr := errors.Unwrap(err)
+				if errors.Is(unwrapedErr, storage.ErrOutOfOrderSample) || errors.Is(unwrapedErr, storage.ErrOutOfBounds) || errors.Is(unwrapedErr, storage.ErrDuplicateSampleForTimestamp) {
 					level.Error(h.logger).Log("msg", "Out of order sample from remote write", "err", err.Error(), "series", labels.String(), "timestamp", s.Timestamp)
 				}
 				return err


### PR DESCRIPTION
The package https://github.com/pkg/errors is not maintained anymore.
This PR replaces https://github.com/pkg/errors with official errors and fmt golang packages in storage package


Signed-off-by: Matthieu MOREL <mmorel-35@users.noreply.github.com>