### PR TITLE
Improve notifier queue test to reduce flakiness

### DIFF
--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -590,8 +590,13 @@ func TestHangingNotifier(t *testing.T) {
 				close(done)
 			}()
 
+			var calledOnce bool
 			// Setting up a bad server. This server hangs for 2 seconds.
 			badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if calledOnce {
+					t.Fatal("hanging server called multiple times")
+				}
+				calledOnce = true
 				select {
 				case <-done:
 				case <-time.After(2 * time.Second):
@@ -672,8 +677,8 @@ func TestHangingNotifier(t *testing.T) {
 			}()
 
 			select {
-			case <-time.After(300 * time.Millisecond):
-				t.Fatalf("Timeout after 300 milliseconds, targets not synced in time.")
+			case <-time.After(1 * time.Second):
+				t.Fatalf("Timeout after 1 second, targets not synced in time.")
 			case <-changed:
 				// The good server has been hit in less than 3 seconds, therefore
 				// targets have been updated before a second call could be made to the


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
