### PR TITLE
template: adding toTime function to TemplateExpander

### DIFF
--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -51,13 +51,14 @@ If functions are used in a pipeline, the pipeline value is passed as the last ar
 
 ### Numbers
 
-| Name               | Arguments        | Returns |  Notes    |
-| ------------------ | -----------------| --------| --------- |
-| humanize           | number or string | string  | Converts a number to a more readable format, using [metric prefixes](https://en.wikipedia.org/wiki/Metric_prefix).
-| humanize1024       | number or string | string  | Like `humanize`, but uses 1024 as the base rather than 1000. |
-| humanizeDuration   | number or string | string  | Converts a duration in seconds to a more readable format. |
-| humanizePercentage | number or string | string  | Converts a ratio value to a fraction of 100. |
-| humanizeTimestamp  | number or string | string  | Converts a Unix timestamp in seconds to a more readable format. |
+| Name                | Arguments        | Returns |  Notes    |
+|---------------------| -----------------| --------| --------- |
+| humanize            | number or string | string  | Converts a number to a more readable format, using [metric prefixes](https://en.wikipedia.org/wiki/Metric_prefix).
+| humanize1024        | number or string | string  | Like `humanize`, but uses 1024 as the base rather than 1000. |
+| humanizeDuration    | number or string | string  | Converts a duration in seconds to a more readable format. |
+| humanizePercentage  | number or string | string  | Converts a ratio value to a fraction of 100. |
+| humanizeTimestamp   | number or string | string     | Converts a Unix timestamp in seconds to a more readable format. |
+| toTime              | number or string | *time.Time | Converts a Unix timestamp in seconds to a time.Time.            |
 
 Humanizing functions are intended to produce reasonable output for consumption
 by humans, and are not guaranteed to return the same results between Prometheus


### PR DESCRIPTION
This PR adds a `formatTime` function in the TemplateExpander. As it stands now, the way to get the current time of a PromQL execution is to do something like this: `{{ query "time()" | first | value || humanizeTime }}`. This works great but only allows one format of time to be expressed. I'm proposing a simple function that does virtually the exact same thing as `humanizeTime` except that it allows you to pass in the format you expect to get back like this: `{{ query "time()" | first | value || formatTime "2006-01-02 15:04:05" }}`