### PR TITLE
Shortcut `ContainsSameLabelset()`

### DIFF
--- a/promql/value.go
+++ b/promql/value.go
@@ -181,15 +181,22 @@ func (m Matrix) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 // Such a behavior is semantically undefined.
 // https://github.com/prometheus/prometheus/issues/4562
 func (m Matrix) ContainsSameLabelset() bool {
-	l := make(map[uint64]struct{}, len(m))
-	for _, ss := range m {
-		hash := ss.Metric.Hash()
-		if _, ok := l[hash]; ok {
-			return true
+	switch len(m) {
+	case 0, 1:
+		return false
+	case 2:
+		return m[0].Metric.Hash() == m[1].Metric.Hash()
+	default:
+		l := make(map[uint64]struct{}, len(m))
+		for _, ss := range m {
+			hash := ss.Metric.Hash()
+			if _, ok := l[hash]; ok {
+				return true
+			}
+			l[hash] = struct{}{}
 		}
-		l[hash] = struct{}{}
+		return false
 	}
-	return false
 }
 
 // Result holds the resulting value of an execution or an error

--- a/promql/value.go
+++ b/promql/value.go
@@ -138,15 +138,22 @@ func (vec Vector) String() string {
 // Such a behavior is semantically undefined
 // https://github.com/prometheus/prometheus/issues/4562
 func (vec Vector) ContainsSameLabelset() bool {
-	l := make(map[uint64]struct{}, len(vec))
-	for _, s := range vec {
-		hash := s.Metric.Hash()
-		if _, ok := l[hash]; ok {
-			return true
+	switch len(vec) {
+	case 0, 1:
+		return false
+	case 2:
+		return vec[0].Metric.Hash() == vec[1].Metric.Hash()
+	default:
+		l := make(map[uint64]struct{}, len(vec))
+		for _, ss := range vec {
+			hash := ss.Metric.Hash()
+			if _, ok := l[hash]; ok {
+				return true
+			}
+			l[hash] = struct{}{}
 		}
-		l[hash] = struct{}{}
+		return false
 	}
-	return false
 }
 
 // Matrix is a slice of Series that implements sort.Interface and

--- a/promql/value_test.go
+++ b/promql/value_test.go
@@ -1,0 +1,53 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestMatrix_ContainsSameLabelset(t *testing.T) {
+	for name, tc := range map[string]struct {
+		matrix   Matrix
+		expected bool
+	}{
+		"empty matrix": {
+			matrix:   Matrix{},
+			expected: false,
+		},
+		"matrix with one series": {
+			matrix: Matrix{
+				{Metric: labels.FromStrings("lbl", "a")},
+			},
+			expected: false,
+		},
+		"matrix with two different series": {
+			matrix: Matrix{
+				{Metric: labels.FromStrings("lbl", "a")},
+				{Metric: labels.FromStrings("lbl", "b")},
+			},
+			expected: false,
+		},
+		"matrix with two equal series": {
+			matrix: Matrix{
+				{Metric: labels.FromStrings("lbl", "a")},
+				{Metric: labels.FromStrings("lbl", "a")},
+			},
+			expected: true,
+		},
+		"matrix with three series, two equal": {
+			matrix: Matrix{
+				{Metric: labels.FromStrings("lbl", "a")},
+				{Metric: labels.FromStrings("lbl", "b")},
+				{Metric: labels.FromStrings("lbl", "a")},
+			},
+			expected: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.matrix.ContainsSameLabelset())
+		})
+	}
+}

--- a/promql/value_test.go
+++ b/promql/value_test.go
@@ -21,6 +21,50 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
+func TestVector_ContainsSameLabelset(t *testing.T) {
+	for name, tc := range map[string]struct {
+		vector   Vector
+		expected bool
+	}{
+		"empty vector": {
+			vector:   Vector{},
+			expected: false,
+		},
+		"vector with one series": {
+			vector: Vector{
+				{Metric: labels.FromStrings("lbl", "a")},
+			},
+			expected: false,
+		},
+		"vector with two different series": {
+			vector: Vector{
+				{Metric: labels.FromStrings("lbl", "a")},
+				{Metric: labels.FromStrings("lbl", "b")},
+			},
+			expected: false,
+		},
+		"vector with two equal series": {
+			vector: Vector{
+				{Metric: labels.FromStrings("lbl", "a")},
+				{Metric: labels.FromStrings("lbl", "a")},
+			},
+			expected: true,
+		},
+		"vector with three series, two equal": {
+			vector: Vector{
+				{Metric: labels.FromStrings("lbl", "a")},
+				{Metric: labels.FromStrings("lbl", "b")},
+				{Metric: labels.FromStrings("lbl", "a")},
+			},
+			expected: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.vector.ContainsSameLabelset())
+		})
+	}
+}
+
 func TestMatrix_ContainsSameLabelset(t *testing.T) {
 	for name, tc := range map[string]struct {
 		matrix   Matrix

--- a/promql/value_test.go
+++ b/promql/value_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package promql
 
 import (


### PR DESCRIPTION
It's quite often to execute this check on a Matrix or a Vector that has zero or only one series. There's no need to allocate a map for those cases.

There's also a one-liner for two-series case, so why not using it?