### PR TITLE
feat:(kubernetes_sd): add __meta_kubernetes_service_port_number (#10945)

### DIFF
--- a/discovery/kubernetes/service.go
+++ b/discovery/kubernetes/service.go
@@ -150,6 +150,7 @@ const (
 	serviceAnnotationPrefix        = metaLabelPrefix + "service_annotation_"
 	serviceAnnotationPresentPrefix = metaLabelPrefix + "service_annotationpresent_"
 	servicePortNameLabel           = metaLabelPrefix + "service_port_name"
+	servicePortNumberLabel         = metaLabelPrefix + "service_port_number"
 	servicePortProtocolLabel       = metaLabelPrefix + "service_port_protocol"
 	serviceClusterIPLabel          = metaLabelPrefix + "service_cluster_ip"
 	serviceExternalNameLabel       = metaLabelPrefix + "service_external_name"
@@ -189,6 +190,7 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
 		labelSet := model.LabelSet{
 			model.AddressLabel:       lv(addr),
 			servicePortNameLabel:     lv(port.Name),
+			servicePortNumberLabel:   lv(strconv.FormatInt(int64(port.Port), 10)),
 			servicePortProtocolLabel: lv(string(port.Protocol)),
 			serviceType:              lv(string(svc.Spec.Type)),
 		}

--- a/discovery/kubernetes/service_test.go
+++ b/discovery/kubernetes/service_test.go
@@ -113,10 +113,11 @@ func TestServiceDiscoveryAdd(t *testing.T) {
 				Targets: []model.LabelSet{
 					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
-						"__address__":                          "testservice.default.svc:30900",
-						"__meta_kubernetes_service_type":       "ClusterIP",
-						"__meta_kubernetes_service_cluster_ip": "10.0.0.1",
-						"__meta_kubernetes_service_port_name":  "testport",
+						"__address__":                           "testservice.default.svc:30900",
+						"__meta_kubernetes_service_type":        "ClusterIP",
+						"__meta_kubernetes_service_cluster_ip":  "10.0.0.1",
+						"__meta_kubernetes_service_port_name":   "testport",
+						"__meta_kubernetes_service_port_number": "30900",
 					},
 				},
 				Labels: model.LabelSet{
@@ -132,6 +133,7 @@ func TestServiceDiscoveryAdd(t *testing.T) {
 						"__address__":                             "testservice-external.default.svc:31900",
 						"__meta_kubernetes_service_type":          "ExternalName",
 						"__meta_kubernetes_service_port_name":     "testport",
+						"__meta_kubernetes_service_port_number":   "31900",
 						"__meta_kubernetes_service_external_name": "FooExternalName",
 					},
 				},
@@ -178,17 +180,19 @@ func TestServiceDiscoveryUpdate(t *testing.T) {
 				Targets: []model.LabelSet{
 					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
-						"__address__":                          "testservice.default.svc:30900",
-						"__meta_kubernetes_service_type":       "ClusterIP",
-						"__meta_kubernetes_service_cluster_ip": "10.0.0.1",
-						"__meta_kubernetes_service_port_name":  "testport0",
+						"__address__":                           "testservice.default.svc:30900",
+						"__meta_kubernetes_service_type":        "ClusterIP",
+						"__meta_kubernetes_service_cluster_ip":  "10.0.0.1",
+						"__meta_kubernetes_service_port_name":   "testport0",
+						"__meta_kubernetes_service_port_number": "30900",
 					},
 					{
 						"__meta_kubernetes_service_port_protocol": "UDP",
-						"__address__":                          "testservice.default.svc:30901",
-						"__meta_kubernetes_service_type":       "ClusterIP",
-						"__meta_kubernetes_service_cluster_ip": "10.0.0.1",
-						"__meta_kubernetes_service_port_name":  "testport1",
+						"__address__":                           "testservice.default.svc:30901",
+						"__meta_kubernetes_service_type":        "ClusterIP",
+						"__meta_kubernetes_service_cluster_ip":  "10.0.0.1",
+						"__meta_kubernetes_service_port_name":   "testport1",
+						"__meta_kubernetes_service_port_number": "30901",
 					},
 				},
 				Labels: model.LabelSet{
@@ -223,10 +227,11 @@ func TestServiceDiscoveryNamespaces(t *testing.T) {
 				Targets: []model.LabelSet{
 					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
-						"__address__":                          "testservice.ns1.svc:30900",
-						"__meta_kubernetes_service_type":       "ClusterIP",
-						"__meta_kubernetes_service_cluster_ip": "10.0.0.1",
-						"__meta_kubernetes_service_port_name":  "testport",
+						"__address__":                           "testservice.ns1.svc:30900",
+						"__meta_kubernetes_service_type":        "ClusterIP",
+						"__meta_kubernetes_service_cluster_ip":  "10.0.0.1",
+						"__meta_kubernetes_service_port_name":   "testport",
+						"__meta_kubernetes_service_port_number": "30900",
 					},
 				},
 				Labels: model.LabelSet{
@@ -239,10 +244,11 @@ func TestServiceDiscoveryNamespaces(t *testing.T) {
 				Targets: []model.LabelSet{
 					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
-						"__address__":                          "testservice.ns2.svc:30900",
-						"__meta_kubernetes_service_type":       "ClusterIP",
-						"__meta_kubernetes_service_cluster_ip": "10.0.0.1",
-						"__meta_kubernetes_service_port_name":  "testport",
+						"__address__":                           "testservice.ns2.svc:30900",
+						"__meta_kubernetes_service_type":        "ClusterIP",
+						"__meta_kubernetes_service_cluster_ip":  "10.0.0.1",
+						"__meta_kubernetes_service_port_name":   "testport",
+						"__meta_kubernetes_service_port_number": "30900",
 					},
 				},
 				Labels: model.LabelSet{
@@ -273,10 +279,11 @@ func TestServiceDiscoveryOwnNamespace(t *testing.T) {
 				Targets: []model.LabelSet{
 					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
-						"__address__":                          "testservice.own-ns.svc:30900",
-						"__meta_kubernetes_service_type":       "ClusterIP",
-						"__meta_kubernetes_service_cluster_ip": "10.0.0.1",
-						"__meta_kubernetes_service_port_name":  "testport",
+						"__address__":                           "testservice.own-ns.svc:30900",
+						"__meta_kubernetes_service_type":        "ClusterIP",
+						"__meta_kubernetes_service_cluster_ip":  "10.0.0.1",
+						"__meta_kubernetes_service_port_name":   "testport",
+						"__meta_kubernetes_service_port_number": "30900",
 					},
 				},
 				Labels: model.LabelSet{
@@ -307,10 +314,11 @@ func TestServiceDiscoveryAllNamespaces(t *testing.T) {
 				Targets: []model.LabelSet{
 					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
-						"__address__":                          "testservice.own-ns.svc:30900",
-						"__meta_kubernetes_service_type":       "ClusterIP",
-						"__meta_kubernetes_service_cluster_ip": "10.0.0.1",
-						"__meta_kubernetes_service_port_name":  "testport",
+						"__address__":                           "testservice.own-ns.svc:30900",
+						"__meta_kubernetes_service_type":        "ClusterIP",
+						"__meta_kubernetes_service_cluster_ip":  "10.0.0.1",
+						"__meta_kubernetes_service_port_name":   "testport",
+						"__meta_kubernetes_service_port_number": "30900",
 					},
 				},
 				Labels: model.LabelSet{
@@ -323,10 +331,11 @@ func TestServiceDiscoveryAllNamespaces(t *testing.T) {
 				Targets: []model.LabelSet{
 					{
 						"__meta_kubernetes_service_port_protocol": "TCP",
-						"__address__":                          "testservice.non-own-ns.svc:30900",
-						"__meta_kubernetes_service_type":       "ClusterIP",
-						"__meta_kubernetes_service_cluster_ip": "10.0.0.1",
-						"__meta_kubernetes_service_port_name":  "testport",
+						"__address__":                           "testservice.non-own-ns.svc:30900",
+						"__meta_kubernetes_service_type":        "ClusterIP",
+						"__meta_kubernetes_service_cluster_ip":  "10.0.0.1",
+						"__meta_kubernetes_service_port_name":   "testport",
+						"__meta_kubernetes_service_port_number": "30900",
 					},
 				},
 				Labels: model.LabelSet{


### PR DESCRIPTION
The Kubernetes service port names may be automatically generated including some hash or random strings, and they have no meaning and are hard to remember. Using the port number can be very convenient in this case.

This PR add `__meta_kubernetes_service_port_number` for <kubernetes_sd_config>.

I have tested the regex, it works perfectly. Should I add some doc in this PR?

@brancz 
Related to: https://github.com/prometheus/prometheus/issues/10945
Signed-off-by: yngwiewang <yngwiewang@163.com>