### PR TITLE
Prettifier: Add spaces with non-callable keywords

### DIFF
--- a/promql/parser/printer.go
+++ b/promql/parser/printer.go
@@ -77,9 +77,9 @@ func (node *AggregateExpr) getAggOpStr() string {
 
 	switch {
 	case node.Without:
-		aggrString += fmt.Sprintf(" without(%s) ", strings.Join(node.Grouping, ", "))
+		aggrString += fmt.Sprintf(" without (%s) ", strings.Join(node.Grouping, ", "))
 	case len(node.Grouping) > 0:
-		aggrString += fmt.Sprintf(" by(%s) ", strings.Join(node.Grouping, ", "))
+		aggrString += fmt.Sprintf(" by (%s) ", strings.Join(node.Grouping, ", "))
 	}
 
 	return aggrString
@@ -103,14 +103,14 @@ func (node *BinaryExpr) getMatchingStr() string {
 		if vm.On {
 			vmTag = "on"
 		}
-		matching = fmt.Sprintf(" %s(%s)", vmTag, strings.Join(vm.MatchingLabels, ", "))
+		matching = fmt.Sprintf(" %s (%s)", vmTag, strings.Join(vm.MatchingLabels, ", "))
 
 		if vm.Card == CardManyToOne || vm.Card == CardOneToMany {
 			vmCard := "right"
 			if vm.Card == CardManyToOne {
 				vmCard = "left"
 			}
-			matching += fmt.Sprintf(" group_%s(%s)", vmCard, strings.Join(vm.Include, ", "))
+			matching += fmt.Sprintf(" group_%s (%s)", vmCard, strings.Join(vm.Include, ", "))
 		}
 	}
 	return matching

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -33,13 +33,16 @@ func TestExprString(t *testing.T) {
 			out: `sum(task:errors:rate10s{job="s"})`,
 		},
 		{
-			in: `sum by(code) (task:errors:rate10s{job="s"})`,
+			in:  `sum by(code) (task:errors:rate10s{job="s"})`,
+			out: `sum by (code) (task:errors:rate10s{job="s"})`,
 		},
 		{
-			in: `sum without() (task:errors:rate10s{job="s"})`,
+			in:  `sum without() (task:errors:rate10s{job="s"})`,
+			out: `sum without () (task:errors:rate10s{job="s"})`,
 		},
 		{
-			in: `sum without(instance) (task:errors:rate10s{job="s"})`,
+			in:  `sum without(instance) (task:errors:rate10s{job="s"})`,
+			out: `sum without (instance) (task:errors:rate10s{job="s"})`,
 		},
 		{
 			in: `topk(5, task:errors:rate10s{job="s"})`,
@@ -48,26 +51,32 @@ func TestExprString(t *testing.T) {
 			in: `count_values("value", task:errors:rate10s{job="s"})`,
 		},
 		{
-			in: `a - on() c`,
+			in:  `a - on() c`,
+			out: `a - on () c`,
 		},
 		{
-			in: `a - on(b) c`,
+			in:  `a - on(b) c`,
+			out: `a - on (b) c`,
 		},
 		{
-			in: `a - on(b) group_left(x) c`,
+			in:  `a - on(b) group_left(x) c`,
+			out: `a - on (b) group_left (x) c`,
 		},
 		{
-			in: `a - on(b) group_left(x, y) c`,
+			in:  `a - on(b) group_left(x, y) c`,
+			out: `a - on (b) group_left (x, y) c`,
 		},
 		{
 			in:  `a - on(b) group_left c`,
-			out: `a - on(b) group_left() c`,
+			out: `a - on (b) group_left () c`,
 		},
 		{
-			in: `a - on(b) group_left() (c)`,
+			in:  `a - on(b) group_left() (c)`,
+			out: `a - on (b) group_left () (c)`,
 		},
 		{
-			in: `a - ignoring(b) c`,
+			in:  `a - ignoring(b) c`,
+			out: `a - ignoring (b) c`,
 		},
 		{
 			in:  `a - ignoring() c`,


### PR DESCRIPTION
I prefer to have a difference between, on one side: functions calls, end(), start(), and on the other side with, without, ignoring, by and group_rrigt, group_left.

The reasoning is that the former ones are not calls, while other are
functions. Additionally, it matches the examples in our documentation.

Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
