### PR TITLE
Recognize exemplar record type in WAL watcher metrics

### DIFF
--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -44,6 +44,21 @@ const (
 	Exemplars Type = 4
 )
 
+func (rt Type) String() string {
+	switch rt {
+	case Series:
+		return "series"
+	case Samples:
+		return "samples"
+	case Exemplars:
+		return "exemplars"
+	case Tombstones:
+		return "tombstones"
+	default:
+		return "unknown"
+	}
+}
+
 // ErrNotFound is returned if a looked up resource was not found. Duplicate ErrNotFound from head.go.
 var ErrNotFound = errors.New("not found")
 

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -589,6 +589,8 @@ func recordType(rt record.Type) string {
 		return "series"
 	case record.Samples:
 		return "samples"
+	case record.Exemplars:
+		return "exemplars"
 	case record.Tombstones:
 		return "tombstones"
 	default:

--- a/tsdb/wal/watcher.go
+++ b/tsdb/wal/watcher.go
@@ -481,7 +481,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 	)
 	for r.Next() && !isClosed(w.quit) {
 		rec := r.Record()
-		w.recordsReadMetric.WithLabelValues(recordType(dec.Type(rec))).Inc()
+		w.recordsReadMetric.WithLabelValues(dec.Type(rec).String()).Inc()
 
 		switch dec.Type(rec) {
 		case record.Series:
@@ -554,7 +554,7 @@ func (w *Watcher) readSegmentForGC(r *LiveReader, segmentNum int, _ bool) error 
 	)
 	for r.Next() && !isClosed(w.quit) {
 		rec := r.Record()
-		w.recordsReadMetric.WithLabelValues(recordType(dec.Type(rec))).Inc()
+		w.recordsReadMetric.WithLabelValues(dec.Type(rec).String()).Inc()
 
 		switch dec.Type(rec) {
 		case record.Series:
@@ -581,21 +581,6 @@ func (w *Watcher) readSegmentForGC(r *LiveReader, segmentNum int, _ bool) error 
 func (w *Watcher) SetStartTime(t time.Time) {
 	w.startTime = t
 	w.startTimestamp = timestamp.FromTime(t)
-}
-
-func recordType(rt record.Type) string {
-	switch rt {
-	case record.Series:
-		return "series"
-	case record.Samples:
-		return "samples"
-	case record.Exemplars:
-		return "exemplars"
-	case record.Tombstones:
-		return "tombstones"
-	default:
-		return "unknown"
-	}
 }
 
 type segmentReadFn func(w *Watcher, r *LiveReader, segmentNum int, tail bool) error


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

I think this was left out when exemplar support was added. Without it when an exemplar record is read `prometheus_wal_watcher_records_read_total{type="unknown"}` is incremented, not `...{type="exemplar"}`.