### PR TITLE
Corrected custom prometheus client docs

### DIFF
--- a/web/ui/module/codemirror-promql/README.md
+++ b/web/ui/module/codemirror-promql/README.md
@@ -217,7 +217,7 @@ interface [PrometheusClient](https://github.com/prometheus/codemirror-promql/blo
 .
 
 ```typescript
-const promQL = new PromQLExtension().setComplete({remote: {prometheusClient: MyPrometheusClient}})
+const promQL = new PromQLExtension().setComplete({remote: MyPrometheusClient})
 ```
 
 #### Provide your own implementation of the autocompletion


### PR DESCRIPTION
`remote` takes a `PrometheusClient` object directly: https://github.com/prometheus/prometheus/blob/main/web/ui/module/codemirror-promql/src/complete/index.ts#L26

Signed-off-by: Jaseel <12792882+Spikatrix@users.noreply.github.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
