### PR TITLE
prompb: Modify layout of histograms

### DIFF
--- a/documentation/examples/remote_storage/example_write_adapter/server.go
+++ b/documentation/examples/remote_storage/example_write_adapter/server.go
@@ -52,7 +52,7 @@ func main() {
 
 			for _, hp := range ts.Histograms {
 				h := remote.HistogramProtoToHistogram(hp)
-				fmt.Printf("\tHistogram:  %s\n", (&h).String())
+				fmt.Printf("\tHistogram:  %s\n", h.String())
 			}
 		}
 	})

--- a/prompb/types.pb.go
+++ b/prompb/types.pb.go
@@ -379,13 +379,25 @@ type Histogram struct {
 	// Types that are valid to be assigned to ZeroCount:
 	//	*Histogram_ZeroCountInt
 	//	*Histogram_ZeroCountFloat
-	ZeroCount       isHistogram_ZeroCount `protobuf_oneof:"zero_count"`
-	NegativeBuckets *Buckets              `protobuf:"bytes,8,opt,name=negative_buckets,json=negativeBuckets,proto3" json:"negative_buckets,omitempty"`
-	PositiveBuckets *Buckets              `protobuf:"bytes,9,opt,name=positive_buckets,json=positiveBuckets,proto3" json:"positive_buckets,omitempty"`
-	ResetHint       Histogram_ResetHint   `protobuf:"varint,10,opt,name=reset_hint,json=resetHint,proto3,enum=prometheus.Histogram_ResetHint" json:"reset_hint,omitempty"`
+	ZeroCount isHistogram_ZeroCount `protobuf_oneof:"zero_count"`
+	// Negative Buckets.
+	NegativeSpans []*BucketSpan `protobuf:"bytes,8,rep,name=negative_spans,json=negativeSpans,proto3" json:"negative_spans,omitempty"`
+	// Use either "negative_deltas" or "negative_counts", the former for
+	// regular histograms with integer counts, the latter for float
+	// histograms.
+	NegativeDeltas []int64   `protobuf:"zigzag64,9,rep,packed,name=negative_deltas,json=negativeDeltas,proto3" json:"negative_deltas,omitempty"`
+	NegativeCounts []float64 `protobuf:"fixed64,10,rep,packed,name=negative_counts,json=negativeCounts,proto3" json:"negative_counts,omitempty"`
+	// Positive Buckets.
+	PositiveSpans []*BucketSpan `protobuf:"bytes,11,rep,name=positive_spans,json=positiveSpans,proto3" json:"positive_spans,omitempty"`
+	// Use either "positive_deltas" or "positive_counts", the former for
+	// regular histograms with integer counts, the latter for float
+	// histograms.
+	PositiveDeltas []int64             `protobuf:"zigzag64,12,rep,packed,name=positive_deltas,json=positiveDeltas,proto3" json:"positive_deltas,omitempty"`
+	PositiveCounts []float64           `protobuf:"fixed64,13,rep,packed,name=positive_counts,json=positiveCounts,proto3" json:"positive_counts,omitempty"`
+	ResetHint      Histogram_ResetHint `protobuf:"varint,14,opt,name=reset_hint,json=resetHint,proto3,enum=prometheus.Histogram_ResetHint" json:"reset_hint,omitempty"`
 	// timestamp is in ms format, see model/timestamp/timestamp.go for
 	// conversion from time.Time to Prometheus timestamp.
-	Timestamp            int64    `protobuf:"varint,11,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Timestamp            int64    `protobuf:"varint,15,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -515,16 +527,44 @@ func (m *Histogram) GetZeroCountFloat() float64 {
 	return 0
 }
 
-func (m *Histogram) GetNegativeBuckets() *Buckets {
+func (m *Histogram) GetNegativeSpans() []*BucketSpan {
 	if m != nil {
-		return m.NegativeBuckets
+		return m.NegativeSpans
 	}
 	return nil
 }
 
-func (m *Histogram) GetPositiveBuckets() *Buckets {
+func (m *Histogram) GetNegativeDeltas() []int64 {
 	if m != nil {
-		return m.PositiveBuckets
+		return m.NegativeDeltas
+	}
+	return nil
+}
+
+func (m *Histogram) GetNegativeCounts() []float64 {
+	if m != nil {
+		return m.NegativeCounts
+	}
+	return nil
+}
+
+func (m *Histogram) GetPositiveSpans() []*BucketSpan {
+	if m != nil {
+		return m.PositiveSpans
+	}
+	return nil
+}
+
+func (m *Histogram) GetPositiveDeltas() []int64 {
+	if m != nil {
+		return m.PositiveDeltas
+	}
+	return nil
+}
+
+func (m *Histogram) GetPositiveCounts() []float64 {
+	if m != nil {
+		return m.PositiveCounts
 	}
 	return nil
 }
@@ -553,79 +593,12 @@ func (*Histogram) XXX_OneofWrappers() []interface{} {
 	}
 }
 
-// Sparse buckets.
-type Buckets struct {
-	Span []*Buckets_Span `protobuf:"bytes,1,rep,name=span,proto3" json:"span,omitempty"`
-	// Only one of "delta" or "count" may be used, the former for regular
-	// histograms with integer counts, the latter for float histograms.
-	Delta                []int64   `protobuf:"zigzag64,2,rep,packed,name=delta,proto3" json:"delta,omitempty"`
-	Count                []float64 `protobuf:"fixed64,3,rep,packed,name=count,proto3" json:"count,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
-	XXX_unrecognized     []byte    `json:"-"`
-	XXX_sizecache        int32     `json:"-"`
-}
-
-func (m *Buckets) Reset()         { *m = Buckets{} }
-func (m *Buckets) String() string { return proto.CompactTextString(m) }
-func (*Buckets) ProtoMessage()    {}
-func (*Buckets) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d938547f84707355, []int{4}
-}
-func (m *Buckets) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *Buckets) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_Buckets.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *Buckets) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Buckets.Merge(m, src)
-}
-func (m *Buckets) XXX_Size() int {
-	return m.Size()
-}
-func (m *Buckets) XXX_DiscardUnknown() {
-	xxx_messageInfo_Buckets.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Buckets proto.InternalMessageInfo
-
-func (m *Buckets) GetSpan() []*Buckets_Span {
-	if m != nil {
-		return m.Span
-	}
-	return nil
-}
-
-func (m *Buckets) GetDelta() []int64 {
-	if m != nil {
-		return m.Delta
-	}
-	return nil
-}
-
-func (m *Buckets) GetCount() []float64 {
-	if m != nil {
-		return m.Count
-	}
-	return nil
-}
-
-// A Span is a given number of consecutive buckets at a given
-// offset. Logically, it would be more straightforward to include
-// the bucket counts in the Span. However, the protobuf
-// representation is more compact in the way the data is structured
-// here (with all the buckets in a single array separate from the
-// Spans).
-type Buckets_Span struct {
+// A BucketSpan defines a number of consecutive buckets with their
+// offset. Logically, it would be more straightforward to include the
+// bucket counts in the Span. However, the protobuf representation is
+// more compact in the way the data is structured here (with all the
+// buckets in a single array separate from the Spans).
+type BucketSpan struct {
 	Offset               int32    `protobuf:"zigzag32,1,opt,name=offset,proto3" json:"offset,omitempty"`
 	Length               uint32   `protobuf:"varint,2,opt,name=length,proto3" json:"length,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -633,18 +606,18 @@ type Buckets_Span struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *Buckets_Span) Reset()         { *m = Buckets_Span{} }
-func (m *Buckets_Span) String() string { return proto.CompactTextString(m) }
-func (*Buckets_Span) ProtoMessage()    {}
-func (*Buckets_Span) Descriptor() ([]byte, []int) {
-	return fileDescriptor_d938547f84707355, []int{4, 0}
+func (m *BucketSpan) Reset()         { *m = BucketSpan{} }
+func (m *BucketSpan) String() string { return proto.CompactTextString(m) }
+func (*BucketSpan) ProtoMessage()    {}
+func (*BucketSpan) Descriptor() ([]byte, []int) {
+	return fileDescriptor_d938547f84707355, []int{4}
 }
-func (m *Buckets_Span) XXX_Unmarshal(b []byte) error {
+func (m *BucketSpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *Buckets_Span) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *BucketSpan) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_Buckets_Span.Marshal(b, m, deterministic)
+		return xxx_messageInfo_BucketSpan.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -654,26 +627,26 @@ func (m *Buckets_Span) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
-func (m *Buckets_Span) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Buckets_Span.Merge(m, src)
+func (m *BucketSpan) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BucketSpan.Merge(m, src)
 }
-func (m *Buckets_Span) XXX_Size() int {
+func (m *BucketSpan) XXX_Size() int {
 	return m.Size()
 }
-func (m *Buckets_Span) XXX_DiscardUnknown() {
-	xxx_messageInfo_Buckets_Span.DiscardUnknown(m)
+func (m *BucketSpan) XXX_DiscardUnknown() {
+	xxx_messageInfo_BucketSpan.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_Buckets_Span proto.InternalMessageInfo
+var xxx_messageInfo_BucketSpan proto.InternalMessageInfo
 
-func (m *Buckets_Span) GetOffset() int32 {
+func (m *BucketSpan) GetOffset() int32 {
 	if m != nil {
 		return m.Offset
 	}
 	return 0
 }
 
-func (m *Buckets_Span) GetLength() uint32 {
+func (m *BucketSpan) GetLength() uint32 {
 	if m != nil {
 		return m.Length
 	}
@@ -1155,8 +1128,7 @@ func init() {
 	proto.RegisterType((*Sample)(nil), "prometheus.Sample")
 	proto.RegisterType((*Exemplar)(nil), "prometheus.Exemplar")
 	proto.RegisterType((*Histogram)(nil), "prometheus.Histogram")
-	proto.RegisterType((*Buckets)(nil), "prometheus.Buckets")
-	proto.RegisterType((*Buckets_Span)(nil), "prometheus.Buckets.Span")
+	proto.RegisterType((*BucketSpan)(nil), "prometheus.BucketSpan")
 	proto.RegisterType((*TimeSeries)(nil), "prometheus.TimeSeries")
 	proto.RegisterType((*Label)(nil), "prometheus.Label")
 	proto.RegisterType((*Labels)(nil), "prometheus.Labels")
@@ -1169,74 +1141,75 @@ func init() {
 func init() { proto.RegisterFile("types.proto", fileDescriptor_d938547f84707355) }
 
 var fileDescriptor_d938547f84707355 = []byte{
-	// 1064 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x56, 0xdd, 0x6e, 0x1b, 0x45,
-	0x14, 0xce, 0xfe, 0x78, 0xed, 0x3d, 0x4e, 0xcc, 0x66, 0x48, 0xc1, 0x44, 0x34, 0x35, 0x2b, 0x15,
-	0x59, 0xa8, 0x72, 0x54, 0x83, 0x10, 0x15, 0x08, 0x29, 0xa9, 0x9c, 0x1f, 0xd1, 0xb5, 0xd5, 0xb1,
-	0x23, 0x28, 0x37, 0xd6, 0xd8, 0x9e, 0xd8, 0xab, 0xee, 0x1f, 0x3b, 0xe3, 0x2a, 0xe6, 0x3d, 0xb8,
-	0x02, 0x1e, 0x82, 0x7b, 0x1e, 0xa0, 0x97, 0x3c, 0x01, 0x42, 0xb9, 0xe2, 0x31, 0xd0, 0x9c, 0xdd,
-	0xcd, 0xda, 0x4d, 0x40, 0x2a, 0x77, 0x73, 0xbe, 0xf3, 0x7d, 0x33, 0x67, 0xe6, 0xfc, 0xec, 0x42,
-	0x5d, 0xae, 0x12, 0x2e, 0x3a, 0x49, 0x1a, 0xcb, 0x98, 0x40, 0x92, 0xc6, 0x21, 0x97, 0x0b, 0xbe,
-	0x14, 0xfb, 0x7b, 0xf3, 0x78, 0x1e, 0x23, 0x7c, 0xa8, 0x56, 0x19, 0xc3, 0xfd, 0x45, 0x87, 0x86,
-	0xc7, 0x65, 0xea, 0x4f, 0x3d, 0x2e, 0xd9, 0x8c, 0x49, 0x46, 0x9e, 0x80, 0xa9, 0xf6, 0x68, 0x6a,
-	0x2d, 0xad, 0xdd, 0xe8, 0x3e, 0xec, 0x94, 0x7b, 0x74, 0x36, 0x99, 0xb9, 0x39, 0x5a, 0x25, 0x9c,
-	0xa2, 0x84, 0x3c, 0x02, 0x12, 0x22, 0x36, 0xbe, 0x64, 0xa1, 0x1f, 0xac, 0xc6, 0x11, 0x0b, 0x79,
-	0x53, 0x6f, 0x69, 0x6d, 0x9b, 0x3a, 0x99, 0xe7, 0x04, 0x1d, 0x7d, 0x16, 0x72, 0x42, 0xc0, 0x5c,
-	0xf0, 0x20, 0x69, 0x9a, 0xe8, 0xc7, 0xb5, 0xc2, 0x96, 0x91, 0x2f, 0x9b, 0x95, 0x0c, 0x53, 0x6b,
-	0x77, 0x05, 0x50, 0x9e, 0x44, 0xea, 0x50, 0xbd, 0xe8, 0x7f, 0xd3, 0x1f, 0x7c, 0xdb, 0x77, 0xb6,
-	0x94, 0xf1, 0x74, 0x70, 0xd1, 0x1f, 0xf5, 0xa8, 0xa3, 0x11, 0x1b, 0x2a, 0xa7, 0x47, 0x17, 0xa7,
-	0x3d, 0x47, 0x27, 0x3b, 0x60, 0x9f, 0x9d, 0x0f, 0x47, 0x83, 0x53, 0x7a, 0xe4, 0x39, 0x06, 0x21,
-	0xd0, 0x40, 0x4f, 0x89, 0x99, 0x4a, 0x3a, 0xbc, 0xf0, 0xbc, 0x23, 0xfa, 0xc2, 0xa9, 0x90, 0x1a,
-	0x98, 0xe7, 0xfd, 0x93, 0x81, 0x63, 0x91, 0x6d, 0xa8, 0x0d, 0x47, 0x47, 0xa3, 0xde, 0xb0, 0x37,
-	0x72, 0xaa, 0xee, 0x57, 0x60, 0x0d, 0x59, 0x98, 0x04, 0x9c, 0xec, 0x41, 0xe5, 0x15, 0x0b, 0x96,
-	0xd9, 0xb3, 0x68, 0x34, 0x33, 0xc8, 0x87, 0x60, 0x4b, 0x3f, 0xe4, 0x42, 0xb2, 0x30, 0xc1, 0x7b,
-	0x1a, 0xb4, 0x04, 0xdc, 0x18, 0x6a, 0xbd, 0x2b, 0x1e, 0x26, 0x01, 0x4b, 0xc9, 0x21, 0x58, 0x01,
-	0x9b, 0xf0, 0x40, 0x34, 0xb5, 0x96, 0xd1, 0xae, 0x77, 0x77, 0xd7, 0xdf, 0xf5, 0x99, 0xf2, 0x1c,
-	0x9b, 0xaf, 0xff, 0x7c, 0xb0, 0x45, 0x73, 0x5a, 0x79, 0xa0, 0xfe, 0xaf, 0x07, 0x1a, 0x6f, 0x1e,
-	0xf8, 0xab, 0x09, 0xf6, 0x99, 0x2f, 0x64, 0x3c, 0x4f, 0x59, 0x48, 0xee, 0x83, 0x3d, 0x8d, 0x97,
-	0x91, 0x1c, 0xfb, 0x91, 0xc4, 0xb0, 0xcd, 0xb3, 0x2d, 0x5a, 0x43, 0xe8, 0x3c, 0x92, 0xe4, 0x23,
-	0xa8, 0x67, 0xee, 0xcb, 0x20, 0x66, 0x32, 0x3b, 0xe6, 0x6c, 0x8b, 0x02, 0x82, 0x27, 0x0a, 0x23,
-	0x0e, 0x18, 0x62, 0x19, 0xe2, 0x39, 0x1a, 0x55, 0x4b, 0xf2, 0x1e, 0x58, 0x62, 0xba, 0xe0, 0x21,
-	0xc3, 0xac, 0xed, 0xd2, 0xdc, 0x22, 0x0f, 0xa1, 0xf1, 0x23, 0x4f, 0xe3, 0xb1, 0x5c, 0xa4, 0x5c,
-	0x2c, 0xe2, 0x60, 0x86, 0x19, 0xd4, 0xe8, 0x8e, 0x42, 0x47, 0x05, 0x48, 0x3e, 0xce, 0x69, 0x65,
-	0x5c, 0x16, 0xc6, 0xa5, 0xd1, 0x6d, 0x85, 0x3f, 0x2d, 0x62, 0xfb, 0x04, 0x9c, 0x35, 0x5e, 0x16,
-	0x60, 0x15, 0x03, 0xd4, 0x68, 0xe3, 0x86, 0x99, 0x05, 0xf9, 0x35, 0x38, 0x11, 0x9f, 0x33, 0xe9,
-	0xbf, 0xe2, 0xe3, 0xc9, 0x72, 0xfa, 0x92, 0x4b, 0xd1, 0xac, 0xb5, 0xb4, 0x76, 0xbd, 0xfb, 0xee,
-	0xfa, 0x1b, 0x1f, 0x67, 0x2e, 0xfa, 0x4e, 0x41, 0xce, 0x01, 0xa5, 0x4f, 0x62, 0xe1, 0x6f, 0xe8,
-	0xed, 0xff, 0xd0, 0x17, 0xe4, 0x52, 0x0f, 0x29, 0x17, 0x5c, 0x8e, 0x17, 0xea, 0x3e, 0x80, 0x5d,
-	0xf3, 0x60, 0x5d, 0x79, 0x93, 0x91, 0x0e, 0x55, 0xbc, 0x33, 0x3f, 0x92, 0xd4, 0x4e, 0x8b, 0xe5,
-	0x66, 0x4a, 0xeb, 0x6f, 0xa6, 0xf4, 0x33, 0xb0, 0x6f, 0x54, 0x9b, 0xb5, 0x5f, 0x05, 0xe3, 0x45,
-	0x6f, 0xe8, 0x68, 0xc4, 0x02, 0xbd, 0x3f, 0x70, 0xf4, 0xb2, 0xfe, 0x8d, 0xe3, 0x2a, 0x54, 0xf0,
-	0xe9, 0x8e, 0xb7, 0x01, 0xca, 0x87, 0x74, 0x7f, 0xd6, 0xa0, 0x5a, 0x84, 0xfd, 0x08, 0x4c, 0x91,
-	0xb0, 0x28, 0x2f, 0xc7, 0xe6, 0x1d, 0x57, 0xed, 0x0c, 0x13, 0x16, 0x51, 0x64, 0xa9, 0x6a, 0x9c,
-	0xf1, 0x40, 0xb2, 0xa6, 0xde, 0x32, 0xda, 0x84, 0x66, 0x86, 0x42, 0x71, 0xe3, 0xa6, 0xd1, 0x32,
-	0x54, 0x8d, 0xa2, 0xb1, 0xff, 0x39, 0x98, 0x4a, 0xa9, 0x6a, 0x25, 0xbe, 0xbc, 0x14, 0x3c, 0x2b,
-	0xbe, 0x5d, 0x9a, 0x5b, 0x0a, 0x0f, 0x78, 0x34, 0x97, 0x0b, 0xac, 0xb9, 0x1d, 0x9a, 0x5b, 0xee,
-	0xdf, 0x1a, 0xc0, 0xc8, 0x0f, 0xf9, 0x90, 0xa7, 0x3e, 0x17, 0x6f, 0xdf, 0x31, 0x5d, 0xa8, 0x0a,
-	0x6c, 0x56, 0x81, 0x51, 0xd6, 0xbb, 0x64, 0x5d, 0x91, 0xf5, 0x71, 0x2e, 0x29, 0x88, 0xe4, 0x0b,
-	0xb0, 0x79, 0xde, 0xa2, 0x02, 0x6f, 0x51, 0xef, 0xee, 0xad, 0xab, 0x8a, 0xfe, 0xcd, 0x75, 0x25,
-	0x99, 0x7c, 0x09, 0xb0, 0x28, 0x12, 0x2b, 0x9a, 0x26, 0x4a, 0xef, 0xdd, 0x99, 0xf6, 0x5c, 0xbb,
-	0x46, 0x77, 0x1f, 0x43, 0x05, 0x6f, 0xa0, 0xe6, 0x1d, 0xce, 0x48, 0x2d, 0x9b, 0x77, 0x6a, 0xbd,
-	0xd9, 0xf9, 0x76, 0xde, 0xf9, 0xee, 0x13, 0xb0, 0x9e, 0x65, 0xf7, 0x7c, 0xdb, 0x87, 0x71, 0x7f,
-	0xd2, 0x60, 0x1b, 0x71, 0x8f, 0xc9, 0xe9, 0x82, 0xa7, 0xe4, 0xf1, 0xc6, 0x88, 0xbf, 0x7f, 0x4b,
-	0x9f, 0xf3, 0x3a, 0x6b, 0xa3, 0xbd, 0x08, 0x54, 0xbf, 0x2b, 0x50, 0x63, 0x3d, 0xd0, 0x36, 0x98,
-	0x38, 0xa8, 0x2d, 0xd0, 0x7b, 0xcf, 0xb3, 0x3a, 0xed, 0xf7, 0x9e, 0x67, 0x75, 0x4a, 0xd5, 0x70,
-	0x56, 0x00, 0xed, 0x39, 0x86, 0xfb, 0x9b, 0xa6, 0x8a, 0x9b, 0xcd, 0x54, 0x6d, 0x0b, 0xf2, 0x3e,
-	0x54, 0x85, 0xe4, 0xc9, 0x38, 0x14, 0x18, 0x97, 0x41, 0x2d, 0x65, 0x7a, 0x42, 0x1d, 0x7d, 0xb9,
-	0x8c, 0xa6, 0xc5, 0xd1, 0x6a, 0x4d, 0x3e, 0x80, 0x9a, 0x90, 0x2c, 0x95, 0x8a, 0x9d, 0x8d, 0xc1,
-	0x2a, 0xda, 0x9e, 0x20, 0xf7, 0xc0, 0xe2, 0xd1, 0x6c, 0x8c, 0x49, 0x51, 0x8e, 0x0a, 0x8f, 0x66,
-	0x9e, 0x20, 0xfb, 0x50, 0x9b, 0xa7, 0xf1, 0x32, 0xf1, 0xa3, 0x79, 0xb3, 0xd2, 0x32, 0xda, 0x36,
-	0xbd, 0xb1, 0x49, 0x03, 0xf4, 0xc9, 0x0a, 0x47, 0x51, 0x8d, 0xea, 0x93, 0x95, 0xda, 0x3d, 0x65,
-	0xd1, 0x9c, 0xab, 0x4d, 0xaa, 0xd9, 0xee, 0x68, 0x7b, 0xc2, 0xfd, 0x5d, 0x83, 0xca, 0xd3, 0xc5,
-	0x32, 0x7a, 0x49, 0x0e, 0xa0, 0x1e, 0xfa, 0xd1, 0x58, 0xb5, 0x6a, 0x19, 0xb3, 0x1d, 0xfa, 0x91,
-	0xaa, 0x61, 0x4f, 0xa0, 0x9f, 0x5d, 0xdd, 0xf8, 0xf3, 0xaf, 0x43, 0xc8, 0xae, 0x72, 0x7f, 0x27,
-	0x4f, 0x82, 0x81, 0x49, 0xd8, 0x5f, 0x4f, 0x02, 0x1e, 0xd0, 0xe9, 0x45, 0xd3, 0x78, 0xe6, 0x47,
-	0xf3, 0x32, 0x03, 0xea, 0xab, 0x8b, 0xb7, 0xda, 0xa6, 0xb8, 0x76, 0x0f, 0xa1, 0x56, 0xb0, 0x6e,
-	0x0d, 0x87, 0xef, 0x06, 0xea, 0xa3, 0xb8, 0xf1, 0x25, 0xd4, 0xdd, 0x1f, 0x60, 0x07, 0x37, 0xe7,
-	0xb3, 0xff, 0xdb, 0x65, 0x87, 0x60, 0x4d, 0xd5, 0x0e, 0x45, 0x93, 0xed, 0xde, 0x0a, 0xbc, 0x10,
-	0x64, 0xb4, 0xe3, 0xbd, 0xd7, 0xd7, 0x07, 0xda, 0x1f, 0xd7, 0x07, 0xda, 0x5f, 0xd7, 0x07, 0xda,
-	0xf7, 0x96, 0x62, 0x27, 0x93, 0x89, 0x85, 0xff, 0x1f, 0x9f, 0xfe, 0x13, 0x00, 0x00, 0xff, 0xff,
-	0xe8, 0xcc, 0xd6, 0xc9, 0xb0, 0x08, 0x00, 0x00,
+	// 1075 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x56, 0xdd, 0x8e, 0xdb, 0x44,
+	0x14, 0x5e, 0xdb, 0x89, 0x13, 0x9f, 0xfc, 0xd4, 0x3b, 0xda, 0x16, 0x53, 0xd1, 0x6d, 0xb0, 0x54,
+	0x88, 0x10, 0xca, 0xaa, 0x85, 0x0b, 0x2a, 0x0a, 0xd2, 0x6e, 0xc9, 0xfe, 0x88, 0x26, 0x51, 0x27,
+	0x59, 0x41, 0xb9, 0x89, 0x66, 0x93, 0xd9, 0xc4, 0xaa, 0xff, 0xf0, 0x4c, 0xaa, 0x0d, 0xef, 0xc1,
+	0x1d, 0x2f, 0xc1, 0x3d, 0x12, 0xb7, 0xbd, 0xe4, 0x09, 0x10, 0xda, 0x2b, 0x1e, 0x03, 0xcd, 0xb1,
+	0x1d, 0x3b, 0xdd, 0x82, 0x54, 0xee, 0xe6, 0x7c, 0xe7, 0x3b, 0x33, 0x9f, 0xe7, 0xfc, 0x8c, 0xa1,
+	0x21, 0xd7, 0x31, 0x17, 0xbd, 0x38, 0x89, 0x64, 0x44, 0x20, 0x4e, 0xa2, 0x80, 0xcb, 0x25, 0x5f,
+	0x89, 0xbb, 0x7b, 0x8b, 0x68, 0x11, 0x21, 0x7c, 0xa0, 0x56, 0x29, 0xc3, 0xfd, 0x45, 0x87, 0xf6,
+	0x80, 0xcb, 0xc4, 0x9b, 0x0d, 0xb8, 0x64, 0x73, 0x26, 0x19, 0x79, 0x0c, 0x15, 0xb5, 0x87, 0xa3,
+	0x75, 0xb4, 0x6e, 0xfb, 0xd1, 0x83, 0x5e, 0xb1, 0x47, 0x6f, 0x9b, 0x99, 0x99, 0x93, 0x75, 0xcc,
+	0x29, 0x86, 0x90, 0x4f, 0x81, 0x04, 0x88, 0x4d, 0x2f, 0x59, 0xe0, 0xf9, 0xeb, 0x69, 0xc8, 0x02,
+	0xee, 0xe8, 0x1d, 0xad, 0x6b, 0x51, 0x3b, 0xf5, 0x1c, 0xa3, 0x63, 0xc8, 0x02, 0x4e, 0x08, 0x54,
+	0x96, 0xdc, 0x8f, 0x9d, 0x0a, 0xfa, 0x71, 0xad, 0xb0, 0x55, 0xe8, 0x49, 0xa7, 0x9a, 0x62, 0x6a,
+	0xed, 0xae, 0x01, 0x8a, 0x93, 0x48, 0x03, 0x6a, 0xe7, 0xc3, 0x6f, 0x87, 0xa3, 0xef, 0x86, 0xf6,
+	0x8e, 0x32, 0x9e, 0x8e, 0xce, 0x87, 0x93, 0x3e, 0xb5, 0x35, 0x62, 0x41, 0xf5, 0xe4, 0xf0, 0xfc,
+	0xa4, 0x6f, 0xeb, 0xa4, 0x05, 0xd6, 0xe9, 0xd9, 0x78, 0x32, 0x3a, 0xa1, 0x87, 0x03, 0xdb, 0x20,
+	0x04, 0xda, 0xe8, 0x29, 0xb0, 0x8a, 0x0a, 0x1d, 0x9f, 0x0f, 0x06, 0x87, 0xf4, 0x85, 0x5d, 0x25,
+	0x75, 0xa8, 0x9c, 0x0d, 0x8f, 0x47, 0xb6, 0x49, 0x9a, 0x50, 0x1f, 0x4f, 0x0e, 0x27, 0xfd, 0x71,
+	0x7f, 0x62, 0xd7, 0xdc, 0x27, 0x60, 0x8e, 0x59, 0x10, 0xfb, 0x9c, 0xec, 0x41, 0xf5, 0x15, 0xf3,
+	0x57, 0xe9, 0xb5, 0x68, 0x34, 0x35, 0xc8, 0x07, 0x60, 0x49, 0x2f, 0xe0, 0x42, 0xb2, 0x20, 0xc6,
+	0xef, 0x34, 0x68, 0x01, 0xb8, 0x11, 0xd4, 0xfb, 0x57, 0x3c, 0x88, 0x7d, 0x96, 0x90, 0x03, 0x30,
+	0x7d, 0x76, 0xc1, 0x7d, 0xe1, 0x68, 0x1d, 0xa3, 0xdb, 0x78, 0xb4, 0x5b, 0xbe, 0xd7, 0x67, 0xca,
+	0x73, 0x54, 0x79, 0xfd, 0xe7, 0xfd, 0x1d, 0x9a, 0xd1, 0x8a, 0x03, 0xf5, 0x7f, 0x3d, 0xd0, 0x78,
+	0xf3, 0xc0, 0xdf, 0xab, 0x60, 0x9d, 0x7a, 0x42, 0x46, 0x8b, 0x84, 0x05, 0xe4, 0x1e, 0x58, 0xb3,
+	0x68, 0x15, 0xca, 0xa9, 0x17, 0x4a, 0x94, 0x5d, 0x39, 0xdd, 0xa1, 0x75, 0x84, 0xce, 0x42, 0x49,
+	0x3e, 0x84, 0x46, 0xea, 0xbe, 0xf4, 0x23, 0x26, 0xd3, 0x63, 0x4e, 0x77, 0x28, 0x20, 0x78, 0xac,
+	0x30, 0x62, 0x83, 0x21, 0x56, 0x01, 0x9e, 0xa3, 0x51, 0xb5, 0x24, 0x77, 0xc0, 0x14, 0xb3, 0x25,
+	0x0f, 0x18, 0x66, 0x6d, 0x97, 0x66, 0x16, 0x79, 0x00, 0xed, 0x9f, 0x78, 0x12, 0x4d, 0xe5, 0x32,
+	0xe1, 0x62, 0x19, 0xf9, 0x73, 0xcc, 0xa0, 0x46, 0x5b, 0x0a, 0x9d, 0xe4, 0x20, 0xf9, 0x28, 0xa3,
+	0x15, 0xba, 0x4c, 0xd4, 0xa5, 0xd1, 0xa6, 0xc2, 0x9f, 0xe6, 0xda, 0x3e, 0x01, 0xbb, 0xc4, 0x4b,
+	0x05, 0xd6, 0x50, 0xa0, 0x46, 0xdb, 0x1b, 0x66, 0x2a, 0xf2, 0x2b, 0x68, 0x87, 0x7c, 0xc1, 0xa4,
+	0xf7, 0x8a, 0x4f, 0x45, 0xcc, 0x42, 0xe1, 0xd4, 0xf1, 0x86, 0xef, 0x94, 0x6f, 0xf8, 0x68, 0x35,
+	0x7b, 0xc9, 0xe5, 0x38, 0x66, 0x21, 0x6d, 0xe5, 0x6c, 0x65, 0x09, 0xf2, 0x31, 0xdc, 0xda, 0x84,
+	0xcf, 0xb9, 0x2f, 0x99, 0x70, 0xac, 0x8e, 0xd1, 0x25, 0x74, 0xb3, 0xeb, 0x37, 0x88, 0x6e, 0x11,
+	0x51, 0x97, 0x70, 0xa0, 0x63, 0x74, 0xb5, 0x82, 0x88, 0xa2, 0x84, 0x12, 0x14, 0x47, 0xc2, 0x2b,
+	0x09, 0x6a, 0xfc, 0xb7, 0xa0, 0x9c, 0xbd, 0x11, 0xb4, 0x09, 0xcf, 0x04, 0x35, 0x53, 0x41, 0x39,
+	0x5c, 0x08, 0xda, 0x10, 0x33, 0x41, 0xad, 0x54, 0x50, 0x0e, 0x67, 0x82, 0xbe, 0x06, 0x48, 0xb8,
+	0xe0, 0x72, 0xba, 0x54, 0x37, 0xde, 0xc6, 0xbe, 0xbe, 0x5f, 0x16, 0xb3, 0xa9, 0x99, 0x1e, 0x55,
+	0xbc, 0x53, 0x2f, 0x94, 0xd4, 0x4a, 0xf2, 0xe5, 0x76, 0xd1, 0xdd, 0x7a, 0xb3, 0xe8, 0x3e, 0x07,
+	0x6b, 0x13, 0xb5, 0xdd, 0x9d, 0x35, 0x30, 0x5e, 0xf4, 0xc7, 0xb6, 0x46, 0x4c, 0xd0, 0x87, 0x23,
+	0x5b, 0x2f, 0x3a, 0xd4, 0x38, 0xaa, 0x41, 0x15, 0x35, 0x1f, 0x35, 0x01, 0x8a, 0x54, 0xbb, 0x4f,
+	0x00, 0x8a, 0x9b, 0x51, 0xd5, 0x16, 0x5d, 0x5e, 0x0a, 0x9e, 0x96, 0xef, 0x2e, 0xcd, 0x2c, 0x85,
+	0xfb, 0x3c, 0x5c, 0xc8, 0x25, 0x56, 0x6d, 0x8b, 0x66, 0x96, 0xfb, 0xb7, 0x06, 0x30, 0xf1, 0x02,
+	0x3e, 0xe6, 0x89, 0xc7, 0xc5, 0xbb, 0xf7, 0xdc, 0x23, 0xa8, 0x09, 0x6c, 0x77, 0xe1, 0xe8, 0x18,
+	0x41, 0xca, 0x11, 0xe9, 0x24, 0xc8, 0x42, 0x72, 0x22, 0xf9, 0x02, 0x2c, 0x9e, 0x35, 0xb9, 0x70,
+	0x0c, 0x8c, 0xda, 0x2b, 0x47, 0xe5, 0x13, 0x20, 0x8b, 0x2b, 0xc8, 0xe4, 0x4b, 0x80, 0x65, 0x7e,
+	0xf1, 0xc2, 0xa9, 0x60, 0xe8, 0xed, 0xb7, 0xa6, 0x25, 0x8b, 0x2d, 0xd1, 0xdd, 0x87, 0x50, 0xc5,
+	0x2f, 0x50, 0x13, 0x13, 0xa7, 0xac, 0x96, 0x4e, 0x4c, 0xb5, 0xde, 0x9e, 0x1d, 0x56, 0x36, 0x3b,
+	0xdc, 0xc7, 0x60, 0x3e, 0x4b, 0xbf, 0xf3, 0x5d, 0x2f, 0xc6, 0xfd, 0x59, 0x83, 0x26, 0xe2, 0x03,
+	0x26, 0x67, 0x4b, 0x9e, 0x90, 0x87, 0x5b, 0x8f, 0xc4, 0xbd, 0x1b, 0xf1, 0x19, 0xaf, 0x57, 0x7a,
+	0x1c, 0x72, 0xa1, 0xfa, 0xdb, 0x84, 0x1a, 0x65, 0xa1, 0x5d, 0xa8, 0xe0, 0xa8, 0x37, 0x41, 0xef,
+	0x3f, 0x4f, 0xeb, 0x68, 0xd8, 0x7f, 0x9e, 0xd6, 0x11, 0x55, 0xe3, 0x5d, 0x01, 0xb4, 0x6f, 0x1b,
+	0xee, 0xaf, 0x9a, 0x2a, 0x3e, 0x36, 0x57, 0xb5, 0x27, 0xc8, 0x7b, 0x50, 0x13, 0x92, 0xc7, 0xd3,
+	0x40, 0xa0, 0x2e, 0x83, 0x9a, 0xca, 0x1c, 0x08, 0x75, 0xf4, 0xe5, 0x2a, 0x9c, 0xe5, 0x47, 0xab,
+	0x35, 0x79, 0x1f, 0xea, 0x42, 0xb2, 0x44, 0x2a, 0x76, 0x3a, 0x48, 0x6b, 0x68, 0x0f, 0x04, 0xb9,
+	0x0d, 0x26, 0x0f, 0xe7, 0x53, 0x4c, 0x8a, 0x72, 0x54, 0x79, 0x38, 0x1f, 0x08, 0x72, 0x17, 0xea,
+	0x8b, 0x24, 0x5a, 0xc5, 0x5e, 0xb8, 0x70, 0xaa, 0x1d, 0xa3, 0x6b, 0xd1, 0x8d, 0x4d, 0xda, 0xa0,
+	0x5f, 0xac, 0x71, 0x98, 0xd5, 0xa9, 0x7e, 0xb1, 0x56, 0xbb, 0x27, 0x2c, 0x5c, 0x70, 0xb5, 0x49,
+	0x2d, 0xdd, 0x1d, 0xed, 0x81, 0x70, 0x7f, 0xd3, 0xa0, 0xfa, 0x74, 0xb9, 0x0a, 0x5f, 0x92, 0x7d,
+	0x68, 0x04, 0x5e, 0x38, 0x55, 0xad, 0x54, 0x68, 0xb6, 0x02, 0x2f, 0x54, 0x35, 0x3c, 0x10, 0xe8,
+	0x67, 0x57, 0x1b, 0x7f, 0xf6, 0xbe, 0x04, 0xec, 0x2a, 0xf3, 0xf7, 0xb2, 0x24, 0x18, 0x98, 0x84,
+	0xbb, 0xe5, 0x24, 0xe0, 0x01, 0xbd, 0x7e, 0x38, 0x8b, 0xe6, 0x5e, 0xb8, 0x28, 0x32, 0xa0, 0xde,
+	0x6d, 0xfc, 0xaa, 0x26, 0xc5, 0xb5, 0x7b, 0x00, 0xf5, 0x9c, 0x75, 0xa3, 0x79, 0xbf, 0x1f, 0xa9,
+	0x67, 0x75, 0xeb, 0x2d, 0xd5, 0xdd, 0x1f, 0xa1, 0x85, 0x9b, 0xf3, 0xf9, 0xff, 0xed, 0xb2, 0x03,
+	0x30, 0x67, 0x6a, 0x87, 0xbc, 0xc9, 0x76, 0x6f, 0x08, 0xcf, 0x03, 0x52, 0xda, 0xd1, 0xde, 0xeb,
+	0xeb, 0x7d, 0xed, 0x8f, 0xeb, 0x7d, 0xed, 0xaf, 0xeb, 0x7d, 0xed, 0x07, 0x53, 0xb1, 0xe3, 0x8b,
+	0x0b, 0x13, 0xff, 0x60, 0x3e, 0xfb, 0x27, 0x00, 0x00, 0xff, 0xff, 0x36, 0xd7, 0x1e, 0xb4, 0xf2,
+	0x08, 0x00, 0x00,
 }
 
 func (m *MetricMetadata) Marshal() (dAtA []byte, err error) {
@@ -1409,36 +1382,98 @@ func (m *Histogram) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	if m.Timestamp != 0 {
 		i = encodeVarintTypes(dAtA, i, uint64(m.Timestamp))
 		i--
-		dAtA[i] = 0x58
+		dAtA[i] = 0x78
 	}
 	if m.ResetHint != 0 {
 		i = encodeVarintTypes(dAtA, i, uint64(m.ResetHint))
 		i--
-		dAtA[i] = 0x50
+		dAtA[i] = 0x70
 	}
-	if m.PositiveBuckets != nil {
-		{
-			size, err := m.PositiveBuckets.MarshalToSizedBuffer(dAtA[:i])
-			if err != nil {
-				return 0, err
-			}
-			i -= size
-			i = encodeVarintTypes(dAtA, i, uint64(size))
+	if len(m.PositiveCounts) > 0 {
+		for iNdEx := len(m.PositiveCounts) - 1; iNdEx >= 0; iNdEx-- {
+			f1 := math.Float64bits(float64(m.PositiveCounts[iNdEx]))
+			i -= 8
+			encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(f1))
 		}
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.PositiveCounts)*8))
+		i--
+		dAtA[i] = 0x6a
+	}
+	if len(m.PositiveDeltas) > 0 {
+		var j2 int
+		dAtA4 := make([]byte, len(m.PositiveDeltas)*10)
+		for _, num := range m.PositiveDeltas {
+			x3 := (uint64(num) << 1) ^ uint64((num >> 63))
+			for x3 >= 1<<7 {
+				dAtA4[j2] = uint8(uint64(x3)&0x7f | 0x80)
+				j2++
+				x3 >>= 7
+			}
+			dAtA4[j2] = uint8(x3)
+			j2++
+		}
+		i -= j2
+		copy(dAtA[i:], dAtA4[:j2])
+		i = encodeVarintTypes(dAtA, i, uint64(j2))
+		i--
+		dAtA[i] = 0x62
+	}
+	if len(m.PositiveSpans) > 0 {
+		for iNdEx := len(m.PositiveSpans) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.PositiveSpans[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTypes(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x5a
+		}
+	}
+	if len(m.NegativeCounts) > 0 {
+		for iNdEx := len(m.NegativeCounts) - 1; iNdEx >= 0; iNdEx-- {
+			f5 := math.Float64bits(float64(m.NegativeCounts[iNdEx]))
+			i -= 8
+			encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(f5))
+		}
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.NegativeCounts)*8))
+		i--
+		dAtA[i] = 0x52
+	}
+	if len(m.NegativeDeltas) > 0 {
+		var j6 int
+		dAtA8 := make([]byte, len(m.NegativeDeltas)*10)
+		for _, num := range m.NegativeDeltas {
+			x7 := (uint64(num) << 1) ^ uint64((num >> 63))
+			for x7 >= 1<<7 {
+				dAtA8[j6] = uint8(uint64(x7)&0x7f | 0x80)
+				j6++
+				x7 >>= 7
+			}
+			dAtA8[j6] = uint8(x7)
+			j6++
+		}
+		i -= j6
+		copy(dAtA[i:], dAtA8[:j6])
+		i = encodeVarintTypes(dAtA, i, uint64(j6))
 		i--
 		dAtA[i] = 0x4a
 	}
-	if m.NegativeBuckets != nil {
-		{
-			size, err := m.NegativeBuckets.MarshalToSizedBuffer(dAtA[:i])
-			if err != nil {
-				return 0, err
+	if len(m.NegativeSpans) > 0 {
+		for iNdEx := len(m.NegativeSpans) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.NegativeSpans[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTypes(dAtA, i, uint64(size))
 			}
-			i -= size
-			i = encodeVarintTypes(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x42
 		}
-		i--
-		dAtA[i] = 0x42
 	}
 	if m.ZeroCount != nil {
 		{
@@ -1528,7 +1563,7 @@ func (m *Histogram_ZeroCountFloat) MarshalToSizedBuffer(dAtA []byte) (int, error
 	dAtA[i] = 0x39
 	return len(dAtA) - i, nil
 }
-func (m *Buckets) Marshal() (dAtA []byte, err error) {
+func (m *BucketSpan) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1538,82 +1573,12 @@ func (m *Buckets) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *Buckets) MarshalTo(dAtA []byte) (int, error) {
+func (m *BucketSpan) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *Buckets) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if len(m.Count) > 0 {
-		for iNdEx := len(m.Count) - 1; iNdEx >= 0; iNdEx-- {
-			f3 := math.Float64bits(float64(m.Count[iNdEx]))
-			i -= 8
-			encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(f3))
-		}
-		i = encodeVarintTypes(dAtA, i, uint64(len(m.Count)*8))
-		i--
-		dAtA[i] = 0x1a
-	}
-	if len(m.Delta) > 0 {
-		var j4 int
-		dAtA6 := make([]byte, len(m.Delta)*10)
-		for _, num := range m.Delta {
-			x5 := (uint64(num) << 1) ^ uint64((num >> 63))
-			for x5 >= 1<<7 {
-				dAtA6[j4] = uint8(uint64(x5)&0x7f | 0x80)
-				j4++
-				x5 >>= 7
-			}
-			dAtA6[j4] = uint8(x5)
-			j4++
-		}
-		i -= j4
-		copy(dAtA[i:], dAtA6[:j4])
-		i = encodeVarintTypes(dAtA, i, uint64(j4))
-		i--
-		dAtA[i] = 0x12
-	}
-	if len(m.Span) > 0 {
-		for iNdEx := len(m.Span) - 1; iNdEx >= 0; iNdEx-- {
-			{
-				size, err := m.Span[iNdEx].MarshalToSizedBuffer(dAtA[:i])
-				if err != nil {
-					return 0, err
-				}
-				i -= size
-				i = encodeVarintTypes(dAtA, i, uint64(size))
-			}
-			i--
-			dAtA[i] = 0xa
-		}
-	}
-	return len(dAtA) - i, nil
-}
-
-func (m *Buckets_Span) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *Buckets_Span) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *Buckets_Span) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *BucketSpan) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -2124,13 +2089,37 @@ func (m *Histogram) Size() (n int) {
 	if m.ZeroCount != nil {
 		n += m.ZeroCount.Size()
 	}
-	if m.NegativeBuckets != nil {
-		l = m.NegativeBuckets.Size()
-		n += 1 + l + sovTypes(uint64(l))
+	if len(m.NegativeSpans) > 0 {
+		for _, e := range m.NegativeSpans {
+			l = e.Size()
+			n += 1 + l + sovTypes(uint64(l))
+		}
 	}
-	if m.PositiveBuckets != nil {
-		l = m.PositiveBuckets.Size()
-		n += 1 + l + sovTypes(uint64(l))
+	if len(m.NegativeDeltas) > 0 {
+		l = 0
+		for _, e := range m.NegativeDeltas {
+			l += sozTypes(uint64(e))
+		}
+		n += 1 + sovTypes(uint64(l)) + l
+	}
+	if len(m.NegativeCounts) > 0 {
+		n += 1 + sovTypes(uint64(len(m.NegativeCounts)*8)) + len(m.NegativeCounts)*8
+	}
+	if len(m.PositiveSpans) > 0 {
+		for _, e := range m.PositiveSpans {
+			l = e.Size()
+			n += 1 + l + sovTypes(uint64(l))
+		}
+	}
+	if len(m.PositiveDeltas) > 0 {
+		l = 0
+		for _, e := range m.PositiveDeltas {
+			l += sozTypes(uint64(e))
+		}
+		n += 1 + sovTypes(uint64(l)) + l
+	}
+	if len(m.PositiveCounts) > 0 {
+		n += 1 + sovTypes(uint64(len(m.PositiveCounts)*8)) + len(m.PositiveCounts)*8
 	}
 	if m.ResetHint != 0 {
 		n += 1 + sovTypes(uint64(m.ResetHint))
@@ -2180,35 +2169,7 @@ func (m *Histogram_ZeroCountFloat) Size() (n int) {
 	n += 9
 	return n
 }
-func (m *Buckets) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	if len(m.Span) > 0 {
-		for _, e := range m.Span {
-			l = e.Size()
-			n += 1 + l + sovTypes(uint64(l))
-		}
-	}
-	if len(m.Delta) > 0 {
-		l = 0
-		for _, e := range m.Delta {
-			l += sozTypes(uint64(e))
-		}
-		n += 1 + sovTypes(uint64(l)) + l
-	}
-	if len(m.Count) > 0 {
-		n += 1 + sovTypes(uint64(len(m.Count)*8)) + len(m.Count)*8
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
-	return n
-}
-
-func (m *Buckets_Span) Size() (n int) {
+func (m *BucketSpan) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -2913,7 +2874,7 @@ func (m *Histogram) Unmarshal(dAtA []byte) error {
 			m.ZeroCount = &Histogram_ZeroCountFloat{float64(math.Float64frombits(v))}
 		case 8:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field NegativeBuckets", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field NegativeSpans", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2940,16 +2901,146 @@ func (m *Histogram) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.NegativeBuckets == nil {
-				m.NegativeBuckets = &Buckets{}
-			}
-			if err := m.NegativeBuckets.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			m.NegativeSpans = append(m.NegativeSpans, &BucketSpan{})
+			if err := m.NegativeSpans[len(m.NegativeSpans)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
 		case 9:
+			if wireType == 0 {
+				var v uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowTypes
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
+				m.NegativeDeltas = append(m.NegativeDeltas, int64(v))
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowTypes
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return ErrInvalidLengthTypes
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return ErrInvalidLengthTypes
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				var count int
+				for _, integer := range dAtA[iNdEx:postIndex] {
+					if integer < 128 {
+						count++
+					}
+				}
+				elementCount = count
+				if elementCount != 0 && len(m.NegativeDeltas) == 0 {
+					m.NegativeDeltas = make([]int64, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
+					m.NegativeDeltas = append(m.NegativeDeltas, int64(v))
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field NegativeDeltas", wireType)
+			}
+		case 10:
+			if wireType == 1 {
+				var v uint64
+				if (iNdEx + 8) > l {
+					return io.ErrUnexpectedEOF
+				}
+				v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+				iNdEx += 8
+				v2 := float64(math.Float64frombits(v))
+				m.NegativeCounts = append(m.NegativeCounts, v2)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowTypes
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return ErrInvalidLengthTypes
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return ErrInvalidLengthTypes
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				elementCount = packedLen / 8
+				if elementCount != 0 && len(m.NegativeCounts) == 0 {
+					m.NegativeCounts = make([]float64, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v uint64
+					if (iNdEx + 8) > l {
+						return io.ErrUnexpectedEOF
+					}
+					v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+					iNdEx += 8
+					v2 := float64(math.Float64frombits(v))
+					m.NegativeCounts = append(m.NegativeCounts, v2)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field NegativeCounts", wireType)
+			}
+		case 11:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field PositiveBuckets", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field PositiveSpans", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2976,14 +3067,144 @@ func (m *Histogram) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.PositiveBuckets == nil {
-				m.PositiveBuckets = &Buckets{}
-			}
-			if err := m.PositiveBuckets.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			m.PositiveSpans = append(m.PositiveSpans, &BucketSpan{})
+			if err := m.PositiveSpans[len(m.PositiveSpans)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
-		case 10:
+		case 12:
+			if wireType == 0 {
+				var v uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowTypes
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
+				m.PositiveDeltas = append(m.PositiveDeltas, int64(v))
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowTypes
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return ErrInvalidLengthTypes
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return ErrInvalidLengthTypes
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				var count int
+				for _, integer := range dAtA[iNdEx:postIndex] {
+					if integer < 128 {
+						count++
+					}
+				}
+				elementCount = count
+				if elementCount != 0 && len(m.PositiveDeltas) == 0 {
+					m.PositiveDeltas = make([]int64, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
+					m.PositiveDeltas = append(m.PositiveDeltas, int64(v))
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field PositiveDeltas", wireType)
+			}
+		case 13:
+			if wireType == 1 {
+				var v uint64
+				if (iNdEx + 8) > l {
+					return io.ErrUnexpectedEOF
+				}
+				v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+				iNdEx += 8
+				v2 := float64(math.Float64frombits(v))
+				m.PositiveCounts = append(m.PositiveCounts, v2)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowTypes
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return ErrInvalidLengthTypes
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return ErrInvalidLengthTypes
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				elementCount = packedLen / 8
+				if elementCount != 0 && len(m.PositiveCounts) == 0 {
+					m.PositiveCounts = make([]float64, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v uint64
+					if (iNdEx + 8) > l {
+						return io.ErrUnexpectedEOF
+					}
+					v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+					iNdEx += 8
+					v2 := float64(math.Float64frombits(v))
+					m.PositiveCounts = append(m.PositiveCounts, v2)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field PositiveCounts", wireType)
+			}
+		case 14:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ResetHint", wireType)
 			}
@@ -3002,7 +3223,7 @@ func (m *Histogram) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 11:
+		case 15:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
 			}
@@ -3043,7 +3264,7 @@ func (m *Histogram) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *Buckets) Unmarshal(dAtA []byte) error {
+func (m *BucketSpan) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -3066,227 +3287,10 @@ func (m *Buckets) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: Buckets: wiretype end group for non-group")
+			return fmt.Errorf("proto: BucketSpan: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Buckets: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Span", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthTypes
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Span = append(m.Span, &Buckets_Span{})
-			if err := m.Span[len(m.Span)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		case 2:
-			if wireType == 0 {
-				var v uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowTypes
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					v |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
-				m.Delta = append(m.Delta, int64(v))
-			} else if wireType == 2 {
-				var packedLen int
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowTypes
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					packedLen |= int(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				if packedLen < 0 {
-					return ErrInvalidLengthTypes
-				}
-				postIndex := iNdEx + packedLen
-				if postIndex < 0 {
-					return ErrInvalidLengthTypes
-				}
-				if postIndex > l {
-					return io.ErrUnexpectedEOF
-				}
-				var elementCount int
-				var count int
-				for _, integer := range dAtA[iNdEx:postIndex] {
-					if integer < 128 {
-						count++
-					}
-				}
-				elementCount = count
-				if elementCount != 0 && len(m.Delta) == 0 {
-					m.Delta = make([]int64, 0, elementCount)
-				}
-				for iNdEx < postIndex {
-					var v uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowTypes
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						v |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
-					m.Delta = append(m.Delta, int64(v))
-				}
-			} else {
-				return fmt.Errorf("proto: wrong wireType = %d for field Delta", wireType)
-			}
-		case 3:
-			if wireType == 1 {
-				var v uint64
-				if (iNdEx + 8) > l {
-					return io.ErrUnexpectedEOF
-				}
-				v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
-				iNdEx += 8
-				v2 := float64(math.Float64frombits(v))
-				m.Count = append(m.Count, v2)
-			} else if wireType == 2 {
-				var packedLen int
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowTypes
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					packedLen |= int(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				if packedLen < 0 {
-					return ErrInvalidLengthTypes
-				}
-				postIndex := iNdEx + packedLen
-				if postIndex < 0 {
-					return ErrInvalidLengthTypes
-				}
-				if postIndex > l {
-					return io.ErrUnexpectedEOF
-				}
-				var elementCount int
-				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Count) == 0 {
-					m.Count = make([]float64, 0, elementCount)
-				}
-				for iNdEx < postIndex {
-					var v uint64
-					if (iNdEx + 8) > l {
-						return io.ErrUnexpectedEOF
-					}
-					v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
-					iNdEx += 8
-					v2 := float64(math.Float64frombits(v))
-					m.Count = append(m.Count, v2)
-				}
-			} else {
-				return fmt.Errorf("proto: wrong wireType = %d for field Count", wireType)
-			}
-		default:
-			iNdEx = preIndex
-			skippy, err := skipTypes(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if (skippy < 0) || (iNdEx+skippy) < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *Buckets_Span) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowTypes
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: Span: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Span: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: BucketSpan: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/prompb/types.proto
+++ b/prompb/types.proto
@@ -86,40 +86,46 @@ message Histogram {
     uint64 zero_count_int     = 6;
     double zero_count_float   = 7;
   }
-  Buckets negative_buckets  = 8;
-  Buckets positive_buckets  = 9;
-  ResetHint reset_hint      = 10;
+  
+  // Negative Buckets.
+  repeated BucketSpan negative_spans =  8;
+  // Use either "negative_deltas" or "negative_counts", the former for
+  // regular histograms with integer counts, the latter for float
+  // histograms.
+  repeated sint64 negative_deltas    =  9; // Count delta of each bucket compared to previous one (or to zero for 1st bucket).
+  repeated double negative_counts    = 10; // Absolute count of each bucket.
+
+  // Positive Buckets.
+  repeated BucketSpan positive_spans = 11;
+  // Use either "positive_deltas" or "positive_counts", the former for
+  // regular histograms with integer counts, the latter for float
+  // histograms.
+  repeated sint64 positive_deltas    = 12; // Count delta of each bucket compared to previous one (or to zero for 1st bucket).
+  repeated double positive_counts    = 13; // Absolute count of each bucket.
+
+  ResetHint reset_hint               = 14;
   // timestamp is in ms format, see model/timestamp/timestamp.go for
   // conversion from time.Time to Prometheus timestamp.
-  int64 timestamp = 11;
+  int64 timestamp = 15;
 } 
 
-// Sparse buckets.
-message Buckets {
-  // A Span is a given number of consecutive buckets at a given
-  // offset. Logically, it would be more straightforward to include
-  // the bucket counts in the Span. However, the protobuf
-  // representation is more compact in the way the data is structured
-  // here (with all the buckets in a single array separate from the
-  // Spans).
-  message Span {
-    sint32 offset = 1; // Gap to previous span, or starting point for 1st span (which can be negative).
-    uint32 length = 2; // Length of consecutive buckets.
-  }
-  repeated Span span = 1;
-  // Only one of "delta" or "count" may be used, the former for regular
-  // histograms with integer counts, the latter for float histograms.
-  repeated sint64 delta = 2; // Count delta of each bucket compared to previous one (or to zero for 1st bucket).
-  repeated double count = 3; // Absolute count of each bucket.
+// A BucketSpan defines a number of consecutive buckets with their
+// offset. Logically, it would be more straightforward to include the
+// bucket counts in the Span. However, the protobuf representation is
+// more compact in the way the data is structured here (with all the
+// buckets in a single array separate from the Spans).
+message BucketSpan {
+  sint32 offset = 1; // Gap to previous span, or starting point for 1st span (which can be negative).
+  uint32 length = 2; // Length of consecutive buckets.
 }
 
 // TimeSeries represents samples and labels for a single time series.
 message TimeSeries {
   // For a timeseries to be valid, and for the samples and exemplars
   // to be ingested by the remote system properly, the labels field is required.
-  repeated Label labels   = 1 [(gogoproto.nullable) = false];
-  repeated Sample samples = 2 [(gogoproto.nullable) = false];
-  repeated Exemplar exemplars = 3 [(gogoproto.nullable) = false];
+  repeated Label labels         = 1 [(gogoproto.nullable) = false];
+  repeated Sample samples       = 2 [(gogoproto.nullable) = false];
+  repeated Exemplar exemplars   = 3 [(gogoproto.nullable) = false];
   repeated Histogram histograms = 4 [(gogoproto.nullable) = false];
 }
 

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -502,28 +502,24 @@ func exemplarProtoToExemplar(ep prompb.Exemplar) exemplar.Exemplar {
 	}
 }
 
-func HistogramProtoToHistogram(hp prompb.Histogram) histogram.Histogram {
-	h := histogram.Histogram{
+// HistogramProtoToHistogram extracts a (normal integer) Histogram from the
+// provided proto message. The caller has to make sure that the proto message
+// represents an interger histogram and not a float histogram.
+func HistogramProtoToHistogram(hp prompb.Histogram) *histogram.Histogram {
+	return &histogram.Histogram{
 		Schema:          hp.Schema,
 		ZeroThreshold:   hp.ZeroThreshold,
 		ZeroCount:       hp.GetZeroCountInt(),
 		Count:           hp.GetCountInt(),
 		Sum:             hp.Sum,
-		PositiveBuckets: hp.PositiveBuckets.GetDelta(),
-		NegativeBuckets: hp.NegativeBuckets.GetDelta(),
+		PositiveSpans:   spansProtoToSpans(hp.GetPositiveSpans()),
+		PositiveBuckets: hp.GetPositiveDeltas(),
+		NegativeSpans:   spansProtoToSpans(hp.GetNegativeSpans()),
+		NegativeBuckets: hp.GetNegativeDeltas(),
 	}
-
-	if hp.PositiveBuckets != nil {
-		h.PositiveSpans = spansProtoToSpans(hp.PositiveBuckets.Span)
-	}
-	if hp.NegativeBuckets != nil {
-		h.NegativeSpans = spansProtoToSpans(hp.NegativeBuckets.Span)
-	}
-
-	return h
 }
 
-func spansProtoToSpans(s []*prompb.Buckets_Span) []histogram.Span {
+func spansProtoToSpans(s []*prompb.BucketSpan) []histogram.Span {
 	spans := make([]histogram.Span, len(s))
 	for i := 0; i < len(s); i++ {
 		spans[i] = histogram.Span{Offset: s[i].Offset, Length: s[i].Length}
@@ -534,27 +530,23 @@ func spansProtoToSpans(s []*prompb.Buckets_Span) []histogram.Span {
 
 func histogramToHistogramProto(timestamp int64, h *histogram.Histogram) prompb.Histogram {
 	return prompb.Histogram{
-		Count:         &prompb.Histogram_CountInt{CountInt: h.Count},
-		Sum:           h.Sum,
-		Schema:        h.Schema,
-		ZeroThreshold: h.ZeroThreshold,
-		ZeroCount:     &prompb.Histogram_ZeroCountInt{ZeroCountInt: h.ZeroCount},
-		NegativeBuckets: &prompb.Buckets{
-			Span:  spansToSpansProto(h.NegativeSpans),
-			Delta: h.NegativeBuckets,
-		},
-		PositiveBuckets: &prompb.Buckets{
-			Span:  spansToSpansProto(h.PositiveSpans),
-			Delta: h.PositiveBuckets,
-		},
-		Timestamp: timestamp,
+		Count:          &prompb.Histogram_CountInt{CountInt: h.Count},
+		Sum:            h.Sum,
+		Schema:         h.Schema,
+		ZeroThreshold:  h.ZeroThreshold,
+		ZeroCount:      &prompb.Histogram_ZeroCountInt{ZeroCountInt: h.ZeroCount},
+		NegativeSpans:  spansToSpansProto(h.NegativeSpans),
+		NegativeDeltas: h.NegativeBuckets,
+		PositiveSpans:  spansToSpansProto(h.PositiveSpans),
+		PositiveDeltas: h.PositiveBuckets,
+		Timestamp:      timestamp,
 	}
 }
 
-func spansToSpansProto(s []histogram.Span) []*prompb.Buckets_Span {
-	spans := make([]*prompb.Buckets_Span, len(s))
+func spansToSpansProto(s []histogram.Span) []*prompb.BucketSpan {
+	spans := make([]*prompb.BucketSpan, len(s))
 	for i := 0; i < len(s); i++ {
-		spans[i] = &prompb.Buckets_Span{Offset: s[i].Offset, Length: s[i].Length}
+		spans[i] = &prompb.BucketSpan{Offset: s[i].Offset, Length: s[i].Length}
 	}
 
 	return spans

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -120,7 +120,7 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 
 		for _, hp := range ts.Histograms {
 			hs := HistogramProtoToHistogram(hp)
-			_, err = app.AppendHistogram(0, labels, hp.Timestamp, &hs)
+			_, err = app.AppendHistogram(0, labels, hp.Timestamp, hs)
 			if err != nil {
 				unwrappedErr := errors.Unwrap(err)
 				// Althogh AppendHistogram does not currently return ErrDuplicateSampleForTimestamp there is

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -66,7 +66,7 @@ func TestRemoteWriteHandler(t *testing.T) {
 
 		for _, hp := range ts.Histograms {
 			h := HistogramProtoToHistogram(hp)
-			require.Equal(t, mockHistogram{labels, hp.Timestamp, &h}, appendable.histograms[k])
+			require.Equal(t, mockHistogram{labels, hp.Timestamp, h}, appendable.histograms[k])
 			k++
 		}
 	}


### PR DESCRIPTION
Note: This is deliberately an incompatible change. Since we have never
used histograms in remote read/write yet, there is no point in keeping
compatibility. This _is_, however, compatible to the state in the main
branch.

This is triggered by a discussion [here](https://github.com/prometheus/prometheus/pull/11001#discussion_r919192317). cc'ing @bboreham because we discussed this proto file before.

This commit flattens the bucket message into top-level fields. This
has the disadvantage of now having two triples of fields prefixed with
`negative_...` or `positive_...`. However, with this structure, we
save one tag on the wire. And, perhaps more importantly, we mirror the
structure of the `histogram.Histogram` Go type.

This commit also adjusts `repeated` fields to use names in the plural
form, as it is also the case for the fields that already existed.

Signed-off-by: beorn7 <beorn@grafana.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
