### PR TITLE
codemirror-promql: fix the way to verify if it's a prometheusClient

### DIFF
--- a/web/ui/module/codemirror-promql/src/complete/index.test.ts
+++ b/web/ui/module/codemirror-promql/src/complete/index.test.ts
@@ -1,0 +1,27 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { isPrometheusClient } from './index';
+import { HTTPPrometheusClient } from '../client/prometheus';
+
+describe('type of remoteConfig', () => {
+  it('should be a prometheusClient', () => {
+    const client = new HTTPPrometheusClient({});
+    expect(isPrometheusClient(client)).toBe(true);
+  });
+
+  it('should be a remote config', () => {
+    const remote = { url: 'https://prometheus.io' };
+    expect(isPrometheusClient(remote)).toBe(false);
+  });
+});

--- a/web/ui/module/codemirror-promql/src/complete/index.ts
+++ b/web/ui/module/codemirror-promql/src/complete/index.ts
@@ -31,16 +31,14 @@ export interface CompleteConfiguration {
   completeStrategy?: CompleteStrategy;
 }
 
-function isPrometheusConfig(remoteConfig: PrometheusConfig | PrometheusClient): remoteConfig is PrometheusConfig {
-  const cfg = remoteConfig as PrometheusConfig;
+export function isPrometheusClient(remoteConfig: PrometheusConfig | PrometheusClient): remoteConfig is PrometheusClient {
+  const client = remoteConfig as PrometheusClient;
   return (
-    cfg.url !== undefined ||
-    cfg.lookbackInterval !== undefined ||
-    cfg.httpErrorHandler !== undefined ||
-    cfg.fetchFn !== undefined ||
-    cfg.cache !== undefined ||
-    cfg.httpMethod !== undefined ||
-    cfg.apiPrefix !== undefined
+    typeof client.labelNames === 'function' &&
+    typeof client.labelValues === 'function' &&
+    typeof client.metricMetadata === 'function' &&
+    typeof client.series === 'function' &&
+    typeof client.metricNames === 'function'
   );
 }
 
@@ -49,7 +47,7 @@ export function newCompleteStrategy(conf?: CompleteConfiguration): CompleteStrat
     return conf.completeStrategy;
   }
   if (conf?.remote) {
-    if (!isPrometheusConfig(conf.remote)) {
+    if (isPrometheusClient(conf.remote)) {
       return new HybridComplete(conf.remote, conf.maxMetricsMetadata);
     }
     return new HybridComplete(new CachedPrometheusClient(new HTTPPrometheusClient(conf.remote), conf.remote.cache), conf.maxMetricsMetadata);


### PR DESCRIPTION
Signed-off-by: Augustin Husson <husson.augustin@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
