### PR TITLE
Target parameter labels should not be overridden by config params

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -3153,4 +3154,164 @@ func TestTargetScrapeIntervalAndTimeoutRelabel(t *testing.T) {
 
 	require.Equal(t, "3s", sp.ActiveTargets()[0].labels.Get(model.ScrapeIntervalLabel))
 	require.Equal(t, "750ms", sp.ActiveTargets()[0].labels.Get(model.ScrapeTimeoutLabel))
+}
+
+func TestTargetScrapeConfigWithLabels(t *testing.T) {
+	const (
+		configTimeout        = 1500 * time.Millisecond
+		expectedTimeout      = "1.5"
+		expectedTimeoutLabel = "1s500ms"
+		secondTimeout        = 500 * time.Millisecond
+		secondTimeoutLabel   = "500ms"
+		expectedParam        = "value1"
+		secondParam          = "value2"
+		expectedPath         = "/metric-ok"
+		secondPath           = "/metric-nok"
+	)
+	var (
+		app    = &nopAppendable{}
+		logger = log.NewLogfmtLogger(os.Stderr)
+	)
+
+	newServer := func(t *testing.T, done chan struct{}) *url.URL {
+		server := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer close(done)
+				require.Equal(t, r.Header.Get("X-Prometheus-Scrape-Timeout-Seconds"), expectedTimeout)
+				require.Equal(t, expectedParam, r.URL.Query().Get("param"))
+				require.Equal(t, expectedPath, r.URL.Path)
+
+				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+				w.Write([]byte("metric_a 1\nmetric_b 2\n"))
+			}),
+		)
+		t.Cleanup(server.Close)
+		serverURL, err := url.Parse(server.URL)
+		require.NoError(t, err)
+		return serverURL
+	}
+
+	t.Run("Everything in scrape config", func(t *testing.T) {
+		done := make(chan struct{})
+		srvURL := newServer(t, done)
+
+		cfg := &config.ScrapeConfig{
+			ScrapeInterval: model.Duration(2 * time.Second),
+			ScrapeTimeout:  model.Duration(configTimeout),
+			Params:         url.Values{"param": []string{expectedParam}},
+			JobName:        "test",
+			Scheme:         "http",
+			MetricsPath:    expectedPath,
+		}
+		sp, err := newScrapePool(cfg, app, 0, logger, false, false, nil)
+		require.NoError(t, err)
+		defer sp.stop()
+
+		targets := []*targetgroup.Group{
+			{
+				Targets: []model.LabelSet{
+					{model.AddressLabel: model.LabelValue(srvURL.Host)},
+				},
+			},
+		}
+		sp.Sync(targets)
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timeout after 10 seconds")
+		}
+	})
+	t.Run("Overridden in target", func(t *testing.T) {
+		done := make(chan struct{})
+		srvURL := newServer(t, done)
+
+		cfg := &config.ScrapeConfig{
+			ScrapeInterval: model.Duration(2 * time.Second),
+			ScrapeTimeout:  model.Duration(secondTimeout),
+			JobName:        "test",
+			Scheme:         "http",
+			MetricsPath:    secondPath,
+			Params:         url.Values{"param": []string{secondParam}},
+		}
+		sp, err := newScrapePool(cfg, app, 0, logger, false, false, nil)
+		require.NoError(t, err)
+		defer sp.stop()
+
+		targets := []*targetgroup.Group{
+			{
+				Targets: []model.LabelSet{
+					{
+						model.AddressLabel:       model.LabelValue(srvURL.Host),
+						model.ScrapeTimeoutLabel: expectedTimeoutLabel,
+						model.MetricsPathLabel:   expectedPath,
+						"__param_param":          expectedParam,
+					},
+				},
+			},
+		}
+		sp.Sync(targets)
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timeout after 10 seconds")
+		}
+	})
+	t.Run("Overridden in relabel_config", func(t *testing.T) {
+		done := make(chan struct{})
+		srvURL := newServer(t, done)
+
+		cfg := &config.ScrapeConfig{
+			ScrapeInterval: model.Duration(2 * time.Second),
+			ScrapeTimeout:  model.Duration(secondTimeout),
+			JobName:        "test",
+			Scheme:         "http",
+			MetricsPath:    secondPath,
+			Params:         url.Values{"param": []string{secondParam}},
+			RelabelConfigs: []*relabel.Config{
+				{
+					Action:       relabel.DefaultRelabelConfig.Action,
+					Regex:        relabel.DefaultRelabelConfig.Regex,
+					SourceLabels: relabel.DefaultRelabelConfig.SourceLabels,
+					TargetLabel:  model.ScrapeTimeoutLabel,
+					Replacement:  expectedTimeoutLabel,
+				},
+				{
+					Action:       relabel.DefaultRelabelConfig.Action,
+					Regex:        relabel.DefaultRelabelConfig.Regex,
+					SourceLabels: relabel.DefaultRelabelConfig.SourceLabels,
+					TargetLabel:  "__param_param",
+					Replacement:  expectedParam,
+				},
+				{
+					Action:       relabel.DefaultRelabelConfig.Action,
+					Regex:        relabel.DefaultRelabelConfig.Regex,
+					SourceLabels: relabel.DefaultRelabelConfig.SourceLabels,
+					TargetLabel:  model.MetricsPathLabel,
+					Replacement:  expectedPath,
+				},
+			},
+		}
+		sp, err := newScrapePool(cfg, app, 0, logger, false, false, nil)
+		require.NoError(t, err)
+		defer sp.stop()
+
+		targets := []*targetgroup.Group{
+			{
+				Targets: []model.LabelSet{
+					{
+						model.AddressLabel:       model.LabelValue(srvURL.Host),
+						model.ScrapeTimeoutLabel: secondTimeoutLabel,
+						model.MetricsPathLabel:   secondPath,
+						"__param_param":          secondParam,
+					},
+				},
+			},
+		}
+		sp.Sync(targets)
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timeout after 10 seconds")
+		}
+	})
 }

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -369,8 +369,8 @@ func PopulateLabels(lset labels.Labels, cfg *config.ScrapeConfig) (res, orig lab
 	}
 	// Encode scrape query parameters as labels.
 	for k, v := range cfg.Params {
-		if len(v) > 0 {
-			lb.Set(model.ParamLabelPrefix+k, v[0])
+		if name := model.ParamLabelPrefix + k; len(v) > 0 && lset.Get(name) == "" {
+			lb.Set(name, v[0])
 		}
 	}
 


### PR DESCRIPTION
The following configuration snippet calls
http://127.0.0.1:8000/?foo=value1 instead of
http://127.0.0.1:8000/?foo=value2.
This is incorrect, the labels of the target should be prefered.

```yaml
- job_name: local
  params:
    foo: [value1]
  static_configs:
    - targets: ['127.0.0.1:8000']
      labels:
        __param_foo: value2
```

Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
