### PR TITLE
promtool: Allow regexp matching on annotations in unit tests

### DIFF
--- a/cmd/promtool/testdata/bad-fields.yaml
+++ b/cmd/promtool/testdata/bad-fields.yaml
@@ -1,0 +1,3 @@
+unknown_fields:
+  foo:
+  bar:

--- a/cmd/promtool/testdata/unittest.yml
+++ b/cmd/promtool/testdata/unittest.yml
@@ -102,8 +102,26 @@ tests:
               instance: localhost:9090
               job: prometheus
             exp_annotations:
-              summary: "Instance localhost:9090 down"
-              description: "localhost:9090 of job prometheus has been down for more than 5 minutes."
+              summary:
+                match: regexp
+                value: "Instance localhost:9090 .*"
+              description:
+                match: equal
+                value: "localhost:9090 of job prometheus has been down for more than 5 minutes."
+
+      - eval_time: 1d
+        alertname: InstanceDown
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              instance: localhost:9090
+              job: prometheus
+            exp_annotations:
+              summary: Instance localhost:9090 down
+              description:
+                match: regexp
+                value: "localhost:9090 of job prometheus has been down for more than 5 minutes."
+
 
       - eval_time: 0
         alertname: AlwaysFiring

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -63,13 +63,15 @@ func RulesUnitTest(queryOpts promql.LazyLoaderOpts, files ...string) int {
 func ruleUnitTest(filename string, queryOpts promql.LazyLoaderOpts) []error {
 	fmt.Println("Unit Testing: ", filename)
 
-	b, err := os.ReadFile(filename)
+	b, err := os.Open(filename)
 	if err != nil {
 		return []error{err}
 	}
 
 	var unitTestInp unitTestFile
-	if err := yaml.UnmarshalStrict(b, &unitTestInp); err != nil {
+	decoder := yaml.NewDecoder(b)
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&unitTestInp); err != nil {
 		return []error{err}
 	}
 	if err := resolveAndGlobFilepaths(filepath.Dir(filename), &unitTestInp); err != nil {

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -44,6 +44,13 @@ func TestRulesUnitTest(t *testing.T) {
 			want: 0,
 		},
 		{
+			name: "Bad fields",
+			args: args{
+				files: []string{"./testdata/bad-fields.yaml"},
+			},
+			want: 1,
+		},
+		{
 			name: "Bad input series",
 			args: args{
 				files: []string{"./testdata/bad-input-series.yml"},


### PR DESCRIPTION
This allows regexp matching on annotations (not labels) in alert tests.

It achieves this by switching to yaml-v3 for just the unit tests, which means we can use a `yaml.Node` and therefore accept data with different "shapes", i.e. a string or a map.

It supports either YAML tags, or a map structure, as YAML tags may be hard to generate from JSON (many people actually write unit tests directly, hence why supporting the slightly nicer syntax, but not requiring it).

YAML tag:

```yaml
exp_annotations:
  foo: !regexp "some.*thing"
```

Mapping:

```yaml
exp_annotations:
  foo:
    match: regexp
    value: some.*thing
```

Note switching to yaml-v3 is not without risk, but I don't think any of the known issues will affect unit tests, and we use v3 for the rule files without issue now.

Partially addresses #7370.