### PR TITLE
discovery/kubernetes: add container image as metadata

### DIFF
--- a/discovery/kubernetes/endpoints.go
+++ b/discovery/kubernetes/endpoints.go
@@ -322,6 +322,7 @@ func (e *Endpoints) buildEndpoints(eps *apiv1.Endpoints) *targetgroup.Group {
 					ports := strconv.FormatUint(uint64(port.Port), 10)
 
 					target[podContainerNameLabel] = lv(c.Name)
+					target[podContainerImageLabel] = lv(c.Image)
 					target[podContainerPortNameLabel] = lv(cport.Name)
 					target[podContainerPortNumberLabel] = lv(ports)
 					target[podContainerPortProtocolLabel] = lv(string(port.Protocol))
@@ -380,6 +381,7 @@ func (e *Endpoints) buildEndpoints(eps *apiv1.Endpoints) *targetgroup.Group {
 				target := model.LabelSet{
 					model.AddressLabel:            lv(a),
 					podContainerNameLabel:         lv(c.Name),
+					podContainerImageLabel:        lv(c.Image),
 					podContainerPortNameLabel:     lv(cport.Name),
 					podContainerPortNumberLabel:   lv(ports),
 					podContainerPortProtocolLabel: lv(string(cport.Protocol)),

--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -128,7 +128,8 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 			NodeName: "testnode",
 			Containers: []v1.Container{
 				{
-					Name: "c1",
+					Name:  "c1",
+					Image: "c1:latest",
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "mainport",
@@ -138,7 +139,8 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 					},
 				},
 				{
-					Name: "c2",
+					Name:  "c2",
+					Image: "c2:latest",
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "sideport",
@@ -206,6 +208,7 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 						"__meta_kubernetes_pod_node_name":                "testnode",
 						"__meta_kubernetes_pod_host_ip":                  "2.3.4.5",
 						"__meta_kubernetes_pod_container_name":           "c1",
+						"__meta_kubernetes_pod_container_image":          "c1:latest",
 						"__meta_kubernetes_pod_container_port_name":      "mainport",
 						"__meta_kubernetes_pod_container_port_number":    "9000",
 						"__meta_kubernetes_pod_container_port_protocol":  "TCP",
@@ -220,6 +223,7 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 						"__meta_kubernetes_pod_node_name":               "testnode",
 						"__meta_kubernetes_pod_host_ip":                 "2.3.4.5",
 						"__meta_kubernetes_pod_container_name":          "c2",
+						"__meta_kubernetes_pod_container_image":         "c2:latest",
 						"__meta_kubernetes_pod_container_port_name":     "sideport",
 						"__meta_kubernetes_pod_container_port_number":   "9001",
 						"__meta_kubernetes_pod_container_port_protocol": "TCP",
@@ -649,7 +653,8 @@ func TestEndpointsDiscoveryNamespaces(t *testing.T) {
 				NodeName: "testnode",
 				Containers: []v1.Container{
 					{
-						Name: "c1",
+						Name:  "c1",
+						Image: "c1:latest",
 						Ports: []v1.ContainerPort{
 							{
 								Name:          "mainport",
@@ -720,6 +725,7 @@ func TestEndpointsDiscoveryNamespaces(t *testing.T) {
 						"__meta_kubernetes_pod_node_name":                "testnode",
 						"__meta_kubernetes_pod_host_ip":                  "2.3.4.5",
 						"__meta_kubernetes_pod_container_name":           "c1",
+						"__meta_kubernetes_pod_container_image":          "c1:latest",
 						"__meta_kubernetes_pod_container_port_name":      "mainport",
 						"__meta_kubernetes_pod_container_port_number":    "9000",
 						"__meta_kubernetes_pod_container_port_protocol":  "TCP",
@@ -753,7 +759,8 @@ func TestEndpointsDiscoveryOwnNamespace(t *testing.T) {
 			NodeName: "testnode",
 			Containers: []v1.Container{
 				{
-					Name: "p1",
+					Name:  "p1",
+					Image: "p1:latest",
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "mainport",

--- a/discovery/kubernetes/endpointslice.go
+++ b/discovery/kubernetes/endpointslice.go
@@ -350,6 +350,7 @@ func (e *EndpointSlice) buildEndpointSlice(eps endpointSliceAdaptor) *targetgrou
 					ports := strconv.FormatUint(uint64(*port.port()), 10)
 
 					target[podContainerNameLabel] = lv(c.Name)
+					target[podContainerImageLabel] = lv(c.Image)
 					target[podContainerPortNameLabel] = lv(cport.Name)
 					target[podContainerPortNumberLabel] = lv(ports)
 					target[podContainerPortProtocolLabel] = lv(string(cport.Protocol))
@@ -398,6 +399,7 @@ func (e *EndpointSlice) buildEndpointSlice(eps endpointSliceAdaptor) *targetgrou
 				target := model.LabelSet{
 					model.AddressLabel:            lv(a),
 					podContainerNameLabel:         lv(c.Name),
+					podContainerImageLabel:        lv(c.Image),
 					podContainerPortNameLabel:     lv(cport.Name),
 					podContainerPortNumberLabel:   lv(ports),
 					podContainerPortProtocolLabel: lv(string(cport.Protocol)),

--- a/discovery/kubernetes/endpointslice_test.go
+++ b/discovery/kubernetes/endpointslice_test.go
@@ -234,7 +234,8 @@ func TestEndpointSliceDiscoveryAdd(t *testing.T) {
 			NodeName: "testnode",
 			Containers: []corev1.Container{
 				{
-					Name: "c1",
+					Name:  "c1",
+					Image: "c1:latest",
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "mainport",
@@ -244,7 +245,8 @@ func TestEndpointSliceDiscoveryAdd(t *testing.T) {
 					},
 				},
 				{
-					Name: "c2",
+					Name:  "c2",
+					Image: "c2:latest",
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "sideport",
@@ -307,6 +309,7 @@ func TestEndpointSliceDiscoveryAdd(t *testing.T) {
 						"__meta_kubernetes_endpointslice_port_name":                 "testport",
 						"__meta_kubernetes_endpointslice_port_protocol":             "TCP",
 						"__meta_kubernetes_pod_container_name":                      "c1",
+						"__meta_kubernetes_pod_container_image":                     "c1:latest",
 						"__meta_kubernetes_pod_container_port_name":                 "mainport",
 						"__meta_kubernetes_pod_container_port_number":               "9000",
 						"__meta_kubernetes_pod_container_port_protocol":             "TCP",
@@ -321,6 +324,7 @@ func TestEndpointSliceDiscoveryAdd(t *testing.T) {
 					{
 						"__address__":                                   "1.2.3.4:9001",
 						"__meta_kubernetes_pod_container_name":          "c2",
+						"__meta_kubernetes_pod_container_image":         "c2:latest",
 						"__meta_kubernetes_pod_container_port_name":     "sideport",
 						"__meta_kubernetes_pod_container_port_number":   "9001",
 						"__meta_kubernetes_pod_container_port_protocol": "TCP",
@@ -878,7 +882,8 @@ func TestEndpointSliceDiscoveryNamespaces(t *testing.T) {
 				NodeName: "testnode",
 				Containers: []corev1.Container{
 					{
-						Name: "c1",
+						Name:  "c1",
+						Image: "c1:latest",
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "mainport",
@@ -953,6 +958,7 @@ func TestEndpointSliceDiscoveryNamespaces(t *testing.T) {
 						"__meta_kubernetes_endpointslice_port_name":           "testport",
 						"__meta_kubernetes_endpointslice_port_protocol":       "TCP",
 						"__meta_kubernetes_pod_container_name":                "c1",
+						"__meta_kubernetes_pod_container_image":               "c1:latest",
 						"__meta_kubernetes_pod_container_port_name":           "mainport",
 						"__meta_kubernetes_pod_container_port_number":         "9000",
 						"__meta_kubernetes_pod_container_port_protocol":       "TCP",
@@ -993,7 +999,8 @@ func TestEndpointSliceDiscoveryOwnNamespace(t *testing.T) {
 			NodeName: "testnode",
 			Containers: []corev1.Container{
 				{
-					Name: "p1",
+					Name:  "p1",
+					Image: "p1:latest",
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "mainport",

--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -177,6 +177,7 @@ const (
 	podNameLabel                  = metaLabelPrefix + "pod_name"
 	podIPLabel                    = metaLabelPrefix + "pod_ip"
 	podContainerNameLabel         = metaLabelPrefix + "pod_container_name"
+	podContainerImageLabel        = metaLabelPrefix + "pod_container_image"
 	podContainerPortNameLabel     = metaLabelPrefix + "pod_container_port_name"
 	podContainerPortNumberLabel   = metaLabelPrefix + "pod_container_port_number"
 	podContainerPortProtocolLabel = metaLabelPrefix + "pod_container_port_protocol"
@@ -266,9 +267,10 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
 			// We don't have a port so we just set the address label to the pod IP.
 			// The user has to add a port manually.
 			tg.Targets = append(tg.Targets, model.LabelSet{
-				model.AddressLabel:    lv(pod.Status.PodIP),
-				podContainerNameLabel: lv(c.Name),
-				podContainerIsInit:    lv(strconv.FormatBool(isInit)),
+				model.AddressLabel:     lv(pod.Status.PodIP),
+				podContainerNameLabel:  lv(c.Name),
+				podContainerImageLabel: lv(c.Image),
+				podContainerIsInit:     lv(strconv.FormatBool(isInit)),
 			})
 			continue
 		}
@@ -280,6 +282,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
 			tg.Targets = append(tg.Targets, model.LabelSet{
 				model.AddressLabel:            lv(addr),
 				podContainerNameLabel:         lv(c.Name),
+				podContainerImageLabel:        lv(c.Image),
 				podContainerPortNumberLabel:   lv(ports),
 				podContainerPortNameLabel:     lv(port.Name),
 				podContainerPortProtocolLabel: lv(string(port.Protocol)),

--- a/discovery/kubernetes/pod_test.go
+++ b/discovery/kubernetes/pod_test.go
@@ -50,7 +50,8 @@ func makeMultiPortPods() *v1.Pod {
 			NodeName: "testnode",
 			Containers: []v1.Container{
 				{
-					Name: "testcontainer0",
+					Name:  "testcontainer0",
+					Image: "testcontainer0:latest",
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "testport0",
@@ -65,7 +66,8 @@ func makeMultiPortPods() *v1.Pod {
 					},
 				},
 				{
-					Name: "testcontainer1",
+					Name:  "testcontainer1",
+					Image: "testcontainer1:latest",
 				},
 			},
 		},
@@ -94,7 +96,8 @@ func makePods() *v1.Pod {
 			NodeName: "testnode",
 			Containers: []v1.Container{
 				{
-					Name: "testcontainer",
+					Name:  "testcontainer",
+					Image: "testcontainer:latest",
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "testport",
@@ -130,7 +133,8 @@ func makeInitContainerPods() *v1.Pod {
 			NodeName: "testnode",
 			Containers: []v1.Container{
 				{
-					Name: "testcontainer",
+					Name:  "testcontainer",
+					Image: "testcontainer:latest",
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "testport",
@@ -143,7 +147,8 @@ func makeInitContainerPods() *v1.Pod {
 
 			InitContainers: []v1.Container{
 				{
-					Name: "initcontainer",
+					Name:  "initcontainer",
+					Image: "initcontainer:latest",
 				},
 			},
 		},
@@ -169,6 +174,7 @@ func expectedPodTargetGroups(ns string) map[string]*targetgroup.Group {
 				{
 					"__address__":                                   "1.2.3.4:9000",
 					"__meta_kubernetes_pod_container_name":          "testcontainer",
+					"__meta_kubernetes_pod_container_image":         "testcontainer:latest",
 					"__meta_kubernetes_pod_container_port_name":     "testport",
 					"__meta_kubernetes_pod_container_port_number":   "9000",
 					"__meta_kubernetes_pod_container_port_protocol": "TCP",
@@ -219,6 +225,7 @@ func TestPodDiscoveryBeforeRun(t *testing.T) {
 					{
 						"__address__":                                   "1.2.3.4:9000",
 						"__meta_kubernetes_pod_container_name":          "testcontainer0",
+						"__meta_kubernetes_pod_container_image":         "testcontainer0:latest",
 						"__meta_kubernetes_pod_container_port_name":     "testport0",
 						"__meta_kubernetes_pod_container_port_number":   "9000",
 						"__meta_kubernetes_pod_container_port_protocol": "TCP",
@@ -227,15 +234,17 @@ func TestPodDiscoveryBeforeRun(t *testing.T) {
 					{
 						"__address__":                                   "1.2.3.4:9001",
 						"__meta_kubernetes_pod_container_name":          "testcontainer0",
+						"__meta_kubernetes_pod_container_image":         "testcontainer0:latest",
 						"__meta_kubernetes_pod_container_port_name":     "testport1",
 						"__meta_kubernetes_pod_container_port_number":   "9001",
 						"__meta_kubernetes_pod_container_port_protocol": "UDP",
 						"__meta_kubernetes_pod_container_init":          "false",
 					},
 					{
-						"__address__":                          "1.2.3.4",
-						"__meta_kubernetes_pod_container_name": "testcontainer1",
-						"__meta_kubernetes_pod_container_init": "false",
+						"__address__":                           "1.2.3.4",
+						"__meta_kubernetes_pod_container_name":  "testcontainer1",
+						"__meta_kubernetes_pod_container_image": "testcontainer1:latest",
+						"__meta_kubernetes_pod_container_init":  "false",
 					},
 				},
 				Labels: model.LabelSet{
@@ -267,9 +276,10 @@ func TestPodDiscoveryInitContainer(t *testing.T) {
 	key := fmt.Sprintf("pod/%s/testpod", ns)
 	expected := expectedPodTargetGroups(ns)
 	expected[key].Targets = append(expected[key].Targets, model.LabelSet{
-		"__address__":                          "1.2.3.4",
-		"__meta_kubernetes_pod_container_name": "initcontainer",
-		"__meta_kubernetes_pod_container_init": "true",
+		"__address__":                           "1.2.3.4",
+		"__meta_kubernetes_pod_container_name":  "initcontainer",
+		"__meta_kubernetes_pod_container_image": "initcontainer:latest",
+		"__meta_kubernetes_pod_container_init":  "true",
 	})
 	expected[key].Labels["__meta_kubernetes_pod_phase"] = "Pending"
 	expected[key].Labels["__meta_kubernetes_pod_ready"] = "false"
@@ -329,7 +339,8 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 			NodeName: "testnode",
 			Containers: []v1.Container{
 				{
-					Name: "testcontainer",
+					Name:  "testcontainer",
+					Image: "testcontainer:latest",
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "testport",


### PR DESCRIPTION
This commits adds `__meta_kubernetes_pod_container_image` as a new metadata label. This can be used to alert on mismatched versions of targets who don't have a build_info metric, as well as injecting it into log lines for other consumers of discovery/kubernetes (e.g., Promtail).

A Grafana Agent user was asking for this metadata to be available for feature parity with Datadog.

Signed-off-by: Robert Fratto <robertfratto@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
