### PR TITLE
Fix type byte of WAL metadata records

### DIFF
--- a/tsdb/docs/format/wal.md
+++ b/tsdb/docs/format/wal.md
@@ -125,7 +125,7 @@ Metadata records encode the metadata updates associated with a series.
 
 ```
 ┌────────────────────────────────────────────┐
-│ type = 5 <1b>                              │
+│ type = 6 <1b>                              │
 ├────────────────────────────────────────────┤
 │ ┌────────────────────────────────────────┐ │
 │ │ series_id <uvarint>                    │ │


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalist0@gmail.com>

In our last PR, we changed the Metadata [record type](https://github.com/prometheus/prometheus/blob/a5fea2cdd0a6b35e8e6ed59e60182e42ab93091c/tsdb/record/record.go#L46-L47) to be encoded as '6'.

Unfortunately, I forgot to update the relevant part where we document it in the Markdown document, so this is a small docs update change.