### PR TITLE
Support lookback from request

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -219,7 +219,8 @@ func BenchmarkRangeQuery(b *testing.B) {
 				qry, err := engine.NewRangeQuery(
 					stor, nil, c.expr,
 					time.Unix(int64((numIntervals-c.steps)*10), 0),
-					time.Unix(int64(numIntervals*10), 0), time.Second*10)
+					time.Unix(int64(numIntervals*10), 0), time.Second*10,
+					0)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -431,7 +431,7 @@ func (ng *Engine) newQuery(q storage.Queryable, opts *QueryOpts, expr parser.Exp
 	if delta == 0 {
 		delta = ng.lookbackDelta
 	}
-	
+
 	if err := ng.validateOpts(expr); err != nil {
 		return nil, err
 	}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -414,7 +414,7 @@ func (ng *Engine) NewRangeQuery(q storage.Queryable, opts *QueryOpts, qs string,
 	if delta == 0 {
 		delta = ng.lookbackDelta
 	}
-	
+
 	expr, err := parser.ParseExpr(qs)
 	if err != nil {
 		return nil, err
@@ -442,10 +442,10 @@ func (ng *Engine) newQuery(q storage.Queryable, opts *QueryOpts, expr parser.Exp
 	}
 
 	es := &parser.EvalStmt{
-		Expr:     PreprocessExpr(expr, start, end),
-		Start:    start,
-		End:      end,
-		Interval: interval,
+		Expr:          PreprocessExpr(expr, start, end),
+		Start:         start,
+		End:           end,
+		Interval:      interval,
 		LookbackDelta: delta,
 	}
 	qry := &query{

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -411,10 +411,6 @@ func (ng *Engine) NewInstantQuery(q storage.Queryable, opts *QueryOpts, qs strin
 // NewRangeQuery returns an evaluation query for the given time range and with
 // the resolution set by the interval.
 func (ng *Engine) NewRangeQuery(q storage.Queryable, opts *QueryOpts, qs string, start, end time.Time, interval time.Duration, delta time.Duration) (Query, error) {
-	if delta == 0 {
-		delta = ng.lookbackDelta
-	}
-
 	expr, err := parser.ParseExpr(qs)
 	if err != nil {
 		return nil, err
@@ -432,6 +428,10 @@ func (ng *Engine) NewRangeQuery(q storage.Queryable, opts *QueryOpts, qs string,
 }
 
 func (ng *Engine) newQuery(q storage.Queryable, opts *QueryOpts, expr parser.Expr, start, end time.Time, interval time.Duration, delta time.Duration) (*query, error) {
+	if delta == 0 {
+		delta = ng.lookbackDelta
+	}
+	
 	if err := ng.validateOpts(expr); err != nil {
 		return nil, err
 	}

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -564,7 +564,7 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 			if tc.end == 0 {
 				query, err = engine.NewInstantQuery(hintsRecorder, nil, tc.query, timestamp.Time(tc.start))
 			} else {
-				query, err = engine.NewRangeQuery(hintsRecorder, nil, tc.query, timestamp.Time(tc.start), timestamp.Time(tc.end), time.Second)
+				query, err = engine.NewRangeQuery(hintsRecorder, nil, tc.query, timestamp.Time(tc.start), timestamp.Time(tc.end), time.Second, 0)
 			}
 			require.NoError(t, err)
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -724,7 +724,7 @@ load 10s
 			if c.Interval == 0 {
 				qry, err = test.QueryEngine().NewInstantQuery(test.Queryable(), nil, c.Query, c.Start)
 			} else {
-				qry, err = test.QueryEngine().NewRangeQuery(test.Queryable(), nil, c.Query, c.Start, c.End, c.Interval)
+				qry, err = test.QueryEngine().NewRangeQuery(test.Queryable(), nil, c.Query, c.Start, c.End, c.Interval, 0)
 			}
 			require.NoError(t, err)
 
@@ -1201,7 +1201,7 @@ load 10s
 				if c.Interval == 0 {
 					qry, err = engine.NewInstantQuery(test.Queryable(), opts, c.Query, c.Start)
 				} else {
-					qry, err = engine.NewRangeQuery(test.Queryable(), opts, c.Query, c.Start, c.End, c.Interval)
+					qry, err = engine.NewRangeQuery(test.Queryable(), opts, c.Query, c.Start, c.End, c.Interval, 0)
 				}
 				require.NoError(t, err)
 
@@ -1384,7 +1384,7 @@ load 10s
 				if c.Interval == 0 {
 					qry, err = engine.NewInstantQuery(test.Queryable(), nil, c.Query, c.Start)
 				} else {
-					qry, err = engine.NewRangeQuery(test.Queryable(), nil, c.Query, c.Start, c.End, c.Interval)
+					qry, err = engine.NewRangeQuery(test.Queryable(), nil, c.Query, c.Start, c.End, c.Interval, 0)
 				}
 				require.NoError(t, err)
 
@@ -1625,7 +1625,7 @@ load 1ms
 			if c.end == 0 {
 				qry, err = test.QueryEngine().NewInstantQuery(test.Queryable(), nil, c.query, start)
 			} else {
-				qry, err = test.QueryEngine().NewRangeQuery(test.Queryable(), nil, c.query, start, end, interval)
+				qry, err = test.QueryEngine().NewRangeQuery(test.Queryable(), nil, c.query, start, end, interval, 0)
 			}
 			require.NoError(t, err)
 
@@ -2964,7 +2964,7 @@ func TestEngineOptsValidation(t *testing.T) {
 	for _, c := range cases {
 		eng := NewEngine(c.opts)
 		_, err1 := eng.NewInstantQuery(nil, nil, c.query, time.Unix(10, 0))
-		_, err2 := eng.NewRangeQuery(nil, nil, c.query, time.Unix(0, 0), time.Unix(10, 0), time.Second)
+		_, err2 := eng.NewRangeQuery(nil, nil, c.query, time.Unix(0, 0), time.Unix(10, 0), time.Second, 0)
 		if c.fail {
 			require.Equal(t, c.expError, err1)
 			require.Equal(t, c.expError, err2)
@@ -3111,7 +3111,7 @@ func TestRangeQuery(t *testing.T) {
 			err = test.Run()
 			require.NoError(t, err)
 
-			qry, err := test.QueryEngine().NewRangeQuery(test.Queryable(), nil, c.Query, c.Start, c.End, c.Interval)
+			qry, err := test.QueryEngine().NewRangeQuery(test.Queryable(), nil, c.Query, c.Start, c.End, c.Interval, 0)
 			require.NoError(t, err)
 
 			res := qry.Exec(test.Context())

--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -68,6 +68,8 @@ type EvalStmt struct {
 	Start, End time.Time
 	// Time between two evaluated instants for the range [Start:End].
 	Interval time.Duration
+	// Look back delta
+	LookbackDelta time.Duration
 }
 
 func (*EvalStmt) PromQLStmt() {}

--- a/promql/test.go
+++ b/promql/test.go
@@ -558,7 +558,7 @@ func (t *Test) exec(tc testCommand) error {
 
 			// Check query returns same result in range mode,
 			// by checking against the middle step.
-			q, err = t.queryEngine.NewRangeQuery(t.storage, nil, iq.expr, iq.evalTime.Add(-time.Minute), iq.evalTime.Add(time.Minute), time.Minute)
+			q, err = t.queryEngine.NewRangeQuery(t.storage, nil, iq.expr, iq.evalTime.Add(-time.Minute), iq.evalTime.Add(time.Minute), time.Minute, 0)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR enabling passing `lookback delta` to range query from the api.
it comes handful where you have multiple scrape intervals and each needs a different lookback for querying.
if not provided, would be taken from config as default.

Signed-off-by: Oron Sharabi <oron.sh@coralogix.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
