### PR TITLE
Allow formatting PromQL expressions in the UI

### DIFF
--- a/web/ui/react-app/src/pages/graph/ExpressionInput.tsx
+++ b/web/ui/react-app/src/pages/graph/ExpressionInput.tsx
@@ -18,7 +18,7 @@ import {
 import { baseTheme, lightTheme, darkTheme, promqlHighlighter } from './CMTheme';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSearch, faSpinner, faGlobeEurope, faIndent } from '@fortawesome/free-solid-svg-icons';
+import { faSearch, faSpinner, faGlobeEurope, faIndent, faCheck } from '@fortawesome/free-solid-svg-icons';
 import MetricsExplorer from './MetricsExplorer';
 import { usePathPrefix } from '../../contexts/PathPrefixContext';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -101,6 +101,7 @@ const ExpressionInput: FC<CMExpressionInputProps> = ({
 
   const [formatError, setFormatError] = useState<string | null>(null);
   const [isFormatting, setIsFormatting] = useState<boolean>(false);
+  const [exprFormatted, setExprFormatted] = useState<boolean>(false);
 
   // (Re)initialize editor based on settings / setting changes.
   useEffect(() => {
@@ -173,7 +174,10 @@ const ExpressionInput: FC<CMExpressionInputProps> = ({
             ])
           ),
           EditorView.updateListener.of((update: ViewUpdate): void => {
-            onExpressionChange(update.state.doc.toString());
+            if (update.docChanged) {
+              onExpressionChange(update.state.doc.toString());
+              setExprFormatted(false);
+            }
           }),
         ],
       });
@@ -244,6 +248,7 @@ const ExpressionInput: FC<CMExpressionInputProps> = ({
         }
 
         view.dispatch(view.state.update({ changes: { from: 0, to: view.state.doc.length, insert: json.data } }));
+        setExprFormatted(true);
       })
       .catch((err) => {
         setFormatError(err.message);
@@ -265,11 +270,17 @@ const ExpressionInput: FC<CMExpressionInputProps> = ({
         <InputGroupAddon addonType="append">
           <Button
             className="expression-input-action-btn"
-            title="Format expression"
+            title={isFormatting ? 'Formatting expression' : exprFormatted ? 'Expression formatted' : 'Format expression'}
             onClick={formatExpression}
-            disabled={isFormatting}
+            disabled={isFormatting || exprFormatted}
           >
-            {isFormatting ? <FontAwesomeIcon icon={faSpinner} spin /> : <FontAwesomeIcon icon={faIndent} />}
+            {isFormatting ? (
+              <FontAwesomeIcon icon={faSpinner} spin />
+            ) : exprFormatted ? (
+              <FontAwesomeIcon icon={faCheck} />
+            ) : (
+              <FontAwesomeIcon icon={faIndent} />
+            )}
           </Button>
           <Button
             className="expression-input-action-btn"

--- a/web/ui/react-app/src/pages/graph/ExpressionInput.tsx
+++ b/web/ui/react-app/src/pages/graph/ExpressionInput.tsx
@@ -6,7 +6,7 @@ import { EditorState, Prec, Compartment } from '@codemirror/state';
 import { bracketMatching, indentOnInput, syntaxHighlighting, syntaxTree } from '@codemirror/language';
 import { defaultKeymap, history, historyKeymap, insertNewlineAndIndent } from '@codemirror/commands';
 import { highlightSelectionMatches } from '@codemirror/search';
-import { diagnosticCount, lintKeymap } from '@codemirror/lint';
+import { lintKeymap } from '@codemirror/lint';
 import {
   autocompletion,
   completionKeymap,
@@ -102,7 +102,6 @@ const ExpressionInput: FC<CMExpressionInputProps> = ({
   const [formatError, setFormatError] = useState<string | null>(null);
   const [isFormatting, setIsFormatting] = useState<boolean>(false);
   const [exprFormatted, setExprFormatted] = useState<boolean>(false);
-  const [hasLinterErrors, setHasLinterErrors] = useState<boolean>(false);
 
   // (Re)initialize editor based on settings / setting changes.
   useEffect(() => {
@@ -175,14 +174,9 @@ const ExpressionInput: FC<CMExpressionInputProps> = ({
             ])
           ),
           EditorView.updateListener.of((update: ViewUpdate): void => {
-            setHasLinterErrors(diagnosticCount(view.state) > 0);
-
             if (update.docChanged) {
               onExpressionChange(update.state.doc.toString());
-
-              if (exprFormatted) {
-                setExprFormatted(false);
-              }
+              setExprFormatted(false);
             }
           }),
         ],
@@ -276,17 +270,9 @@ const ExpressionInput: FC<CMExpressionInputProps> = ({
         <InputGroupAddon addonType="append">
           <Button
             className="expression-input-action-btn"
-            title={
-              isFormatting
-                ? 'Formatting expression'
-                : exprFormatted
-                ? 'Expression formatted'
-                : hasLinterErrors
-                ? 'Cannot format invalid expression'
-                : 'Format expression'
-            }
+            title={isFormatting ? 'Formatting expression' : exprFormatted ? 'Expression formatted' : 'Format expression'}
             onClick={formatExpression}
-            disabled={isFormatting || exprFormatted || hasLinterErrors}
+            disabled={isFormatting || exprFormatted}
           >
             {isFormatting ? (
               <FontAwesomeIcon icon={faSpinner} spin />

--- a/web/ui/react-app/src/pages/graph/ExpressionInput.tsx
+++ b/web/ui/react-app/src/pages/graph/ExpressionInput.tsx
@@ -213,11 +213,11 @@ const ExpressionInput: FC<CMExpressionInputProps> = ({
     );
   };
 
-  const formatExpression = async () => {
+  const formatExpression = () => {
     setFormatError(null);
     setIsFormatting(true);
 
-    const query = await fetch(
+    fetch(
       `${pathPrefix}/${API_PATH}/format_query?${new URLSearchParams({
         query: value,
       })}`,

--- a/web/ui/react-app/src/themes/_shared.scss
+++ b/web/ui/react-app/src/themes/_shared.scss
@@ -7,7 +7,7 @@
       Example:
 
       $foo = '#000';
- 
+
    2. Add a style rule in _shared.scss (this file) that uses new variable.
       Example:
 
@@ -58,7 +58,7 @@
 .metrics-explorer .metric:hover {
   background: $metrics-explorer-bg;
 }
-button.metrics-explorer-btn {
+button.expression-input-action-btn {
   color: $input-group-addon-color;
   background-color: $input-group-addon-bg;
   border: $input-border-width solid $input-group-addon-border-color;


### PR DESCRIPTION
Signed-off-by: Julius Volz <julius.volz@gmail.com>

**Note 1:** To be 100% correct & safe I would have to also make the text editor read-only (and visually clearly so) while a format request is in-flight, but I thought that would be over-engineering it for a request that should normally finish instantaneously.

**Note 2**: In the video below, I introduced an artificial **1-second delay** for the request so that it's possible to see the loading behavior:

https://user-images.githubusercontent.com/538008/179986435-a57a0d2d-5d93-4fc7-912d-da753003f4b4.mp4

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
