### PR TITLE
fix minor code unreachability error

### DIFF
--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -159,10 +159,10 @@ func TestMarathonSDRemoveApp(t *testing.T) {
 	tg2 := tgs[0]
 
 	if tg2.Source != tg1.Source {
-		t.Fatalf("Source is different: %s != %s", tg1.Source, tg2.Source)
 		if len(tg2.Targets) > 0 {
-			t.Fatalf("Got a non-empty target set: %s", tg2.Targets)
+			t.Errorf("Got a non-empty target set: %s", tg2.Targets)
 		}
+		t.Fatalf("Source is different: %s != %s", tg1.Source, tg2.Source)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

https://pkg.go.dev/testing#T.Fatalf
> `Fatalf` is equivalent to `Logf` followed by `FailNow`.

https://pkg.go.dev/testing#T.Fatalf
> FailNow marks the function as having failed and stops its execution by calling runtime.Goexit (which then runs all deferred calls in the current goroutine).

https://github.com/prometheus/prometheus/blob/b57deb6eb02f7333c2c5da5c908f1264fa9a4e06/discovery/marathon/marathon_test.go#L161-L166

So if line 162 use Fatalf, line163 to line 165 will never run.
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
