### PR TITLE
textparse: Remove TODO that is actually done

### DIFF
--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -565,8 +565,5 @@ metric: <
 
 		i++
 	}
-	// TODO(beorn7): Once supported by the parser, test exemplars for
-	// counters, exemplars for sparse histograms, legacy histograms including exemplars,
-	// summaries.
 	require.Equal(t, len(exp), i)
 }


### PR DESCRIPTION
I'm pretty sure this is done. Please prove me otherwise if needed.

_This is only for the sparsehistogram branch._