### PR TITLE
labels: add extra tests

### DIFF
--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -641,6 +641,7 @@ func TestLabels_BytesWithLabels(t *testing.T) {
 
 func TestLabels_BytesWithoutLabels(t *testing.T) {
 	require.Equal(t, Labels{{"aaa", "111"}}.Bytes(nil), Labels{{"aaa", "111"}, {"bbb", "222"}, {"ccc", "333"}}.BytesWithoutLabels(nil, "bbb", "ccc"))
+	require.Equal(t, Labels{{MetricName, "333"}, {"aaa", "111"}}.Bytes(nil), Labels{{MetricName, "333"}, {"aaa", "111"}, {"bbb", "222"}}.BytesWithoutLabels(nil, "bbb"))
 	require.Equal(t, Labels{{"aaa", "111"}}.Bytes(nil), Labels{{MetricName, "333"}, {"aaa", "111"}, {"bbb", "222"}}.BytesWithoutLabels(nil, MetricName, "bbb"))
 }
 

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -571,19 +571,19 @@ func TestLabels_Get(t *testing.T) {
 // Labels_Get/with_30_labels/get_last_label       169ns ± 0%      29ns ± 0%   ~     (p=1.000 n=1+1)
 func BenchmarkLabels_Get(b *testing.B) {
 	maxLabels := 30
-	allLabels := make(Labels, maxLabels)
+	allLabels := make([]Label, maxLabels)
 	for i := 0; i < maxLabels; i++ {
 		allLabels[i] = Label{Name: strings.Repeat(string('a'+byte(i)), 5)}
 	}
 	for _, size := range []int{5, 10, maxLabels} {
 		b.Run(fmt.Sprintf("with %d labels", size), func(b *testing.B) {
-			labels := allLabels[:size]
+			labels := New(allLabels[:size]...)
 			for _, scenario := range []struct {
 				desc, label string
 			}{
-				{"get first label", labels[0].Name},
-				{"get middle label", labels[size/2].Name},
-				{"get last label", labels[size-1].Name},
+				{"get first label", allLabels[0].Name},
+				{"get middle label", allLabels[size/2].Name},
+				{"get last label", allLabels[size-1].Name},
 			} {
 				b.Run(scenario.desc, func(b *testing.B) {
 					b.ResetTimer()

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -730,7 +730,6 @@ func TestLabels_Hash(t *testing.T) {
 		{Name: "baz", Value: "qux"},
 	}
 	require.Equal(t, lbls.Hash(), lbls.Hash())
-	require.NotEqual(t, lbls.Hash(), Labels{lbls[1], lbls[0]}.Hash(), "unordered labels match.")
 	require.NotEqual(t, lbls.Hash(), Labels{lbls[0]}.Hash(), "different labels match.")
 }
 

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -503,9 +503,19 @@ func TestLabels_Compare(t *testing.T) {
 		},
 	}
 
+	sign := func(a int) int {
+		switch {
+		case a < 0:
+			return -1
+		case a > 0:
+			return 1
+		}
+		return 0
+	}
+
 	for i, test := range tests {
 		got := Compare(labels, test.compared)
-		require.Equal(t, test.expected, got, "unexpected comparison result for test case %d", i)
+		require.Equal(t, sign(test.expected), sign(got), "unexpected comparison result for test case %d", i)
 	}
 }
 


### PR DESCRIPTION
This PR is a subset of #10887 to make that one easier to work with.

It has a couple of small changes to tests to make them less reliant on internal details, and adds one new test for JSON and YAML marshalling.