### PR TITLE
Add histogram validation

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3897,7 +3897,7 @@ func TestSparseHistogram_Sum_AddOperator(t *testing.T) {
 			histograms: []histogram.Histogram{
 				{
 					Schema:        0,
-					Count:         9,
+					Count:         21,
 					Sum:           1234.5,
 					ZeroThreshold: 0.001,
 					ZeroCount:     4,
@@ -3955,7 +3955,7 @@ func TestSparseHistogram_Sum_AddOperator(t *testing.T) {
 				Schema:        0,
 				ZeroThreshold: 0.001,
 				ZeroCount:     14,
-				Count:         81,
+				Count:         93,
 				Sum:           4691.2,
 				PositiveSpans: []histogram.Span{
 					{Offset: 0, Length: 3},
@@ -3988,8 +3988,8 @@ func TestSparseHistogram_Sum_AddOperator(t *testing.T) {
 				lbls := labels.FromStrings("__name__", seriesName, "idx", fmt.Sprintf("%d", idx))
 				// Since we mutate h later, we need to create a copy here.
 				_, err = app.AppendHistogram(0, lbls, ts, h.Copy())
+				require.NoError(t, err)
 			}
-			require.NoError(t, err)
 			require.NoError(t, app.Commit())
 
 			queryAndCheck := func(queryString string) {

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3914,7 +3914,7 @@ func TestSparseHistogram_Sum_AddOperator(t *testing.T) {
 				},
 				{
 					Schema:        0,
-					Count:         15,
+					Count:         36,
 					Sum:           2345.6,
 					ZeroThreshold: 0.001,
 					ZeroCount:     5,
@@ -3933,7 +3933,7 @@ func TestSparseHistogram_Sum_AddOperator(t *testing.T) {
 				},
 				{
 					Schema:        0,
-					Count:         15,
+					Count:         36,
 					Sum:           1111.1,
 					ZeroThreshold: 0.001,
 					ZeroCount:     5,
@@ -3955,7 +3955,7 @@ func TestSparseHistogram_Sum_AddOperator(t *testing.T) {
 				Schema:        0,
 				ZeroThreshold: 0.001,
 				ZeroCount:     14,
-				Count:         39,
+				Count:         81,
 				Sum:           4691.2,
 				PositiveSpans: []histogram.Span{
 					{Offset: 0, Length: 3},

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -37,6 +37,8 @@ var (
 	ErrExemplarsDisabled             = fmt.Errorf("exemplar storage is disabled or max exemplars is less than or equal to 0")
 	ErrHistogramSpanNegativeOffset   = errors.New("histogram has a span whose offset is negative")
 	ErrHistogramSpansBucketsMismatch = errors.New("histogram spans specify different number of buckets than provided")
+	ErrHistogramNegativeBucketCount  = errors.New("histogram has a bucket whose observation count is negative")
+	ErrHistogramCountNotBigEnough    = errors.New("histogram's observation count should be at least the number of observations found in the buckets")
 )
 
 // SeriesRef is a generic series reference. In prometheus it is either a

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -27,14 +27,16 @@ import (
 
 // The errors exposed.
 var (
-	ErrNotFound                    = errors.New("not found")
-	ErrOutOfOrderSample            = errors.New("out of order sample")
-	ErrDuplicateSampleForTimestamp = errors.New("duplicate sample for timestamp")
-	ErrOutOfBounds                 = errors.New("out of bounds")
-	ErrOutOfOrderExemplar          = errors.New("out of order exemplar")
-	ErrDuplicateExemplar           = errors.New("duplicate exemplar")
-	ErrExemplarLabelLength         = fmt.Errorf("label length for exemplar exceeds maximum of %d UTF-8 characters", exemplar.ExemplarMaxLabelSetLength)
-	ErrExemplarsDisabled           = fmt.Errorf("exemplar storage is disabled or max exemplars is less than or equal to 0")
+	ErrNotFound                             = errors.New("not found")
+	ErrOutOfOrderSample                     = errors.New("out of order sample")
+	ErrDuplicateSampleForTimestamp          = errors.New("duplicate sample for timestamp")
+	ErrOutOfBounds                          = errors.New("out of bounds")
+	ErrOutOfOrderExemplar                   = errors.New("out of order exemplar")
+	ErrDuplicateExemplar                    = errors.New("duplicate exemplar")
+	ErrExemplarLabelLength                  = fmt.Errorf("label length for exemplar exceeds maximum of %d UTF-8 characters", exemplar.ExemplarMaxLabelSetLength)
+	ErrExemplarsDisabled                    = fmt.Errorf("exemplar storage is disabled or max exemplars is less than or equal to 0")
+	ErrHistogramSpanNegativeOffset          = errors.New("histogram has a span whose offset is negative")
+	ErrHistogramDifferentNumberSpansBuckets = errors.New("histogram spans specify different number of buckets than provided")
 )
 
 // SeriesRef is a generic series reference. In prometheus it is either a

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -27,16 +27,16 @@ import (
 
 // The errors exposed.
 var (
-	ErrNotFound                             = errors.New("not found")
-	ErrOutOfOrderSample                     = errors.New("out of order sample")
-	ErrDuplicateSampleForTimestamp          = errors.New("duplicate sample for timestamp")
-	ErrOutOfBounds                          = errors.New("out of bounds")
-	ErrOutOfOrderExemplar                   = errors.New("out of order exemplar")
-	ErrDuplicateExemplar                    = errors.New("duplicate exemplar")
-	ErrExemplarLabelLength                  = fmt.Errorf("label length for exemplar exceeds maximum of %d UTF-8 characters", exemplar.ExemplarMaxLabelSetLength)
-	ErrExemplarsDisabled                    = fmt.Errorf("exemplar storage is disabled or max exemplars is less than or equal to 0")
-	ErrHistogramSpanNegativeOffset          = errors.New("histogram has a span whose offset is negative")
-	ErrHistogramDifferentNumberSpansBuckets = errors.New("histogram spans specify different number of buckets than provided")
+	ErrNotFound                      = errors.New("not found")
+	ErrOutOfOrderSample              = errors.New("out of order sample")
+	ErrDuplicateSampleForTimestamp   = errors.New("duplicate sample for timestamp")
+	ErrOutOfBounds                   = errors.New("out of bounds")
+	ErrOutOfOrderExemplar            = errors.New("out of order exemplar")
+	ErrDuplicateExemplar             = errors.New("duplicate exemplar")
+	ErrExemplarLabelLength           = fmt.Errorf("label length for exemplar exceeds maximum of %d UTF-8 characters", exemplar.ExemplarMaxLabelSetLength)
+	ErrExemplarsDisabled             = fmt.Errorf("exemplar storage is disabled or max exemplars is less than or equal to 0")
+	ErrHistogramSpanNegativeOffset   = errors.New("histogram has a span whose offset is negative")
+	ErrHistogramSpansBucketsMismatch = errors.New("histogram spans specify different number of buckets than provided")
 )
 
 // SeriesRef is a generic series reference. In prometheus it is either a

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -520,20 +520,16 @@ func checkHistogramBuckets(buckets []int64) (uint64, error) {
 	for i := 0; i < len(buckets); i++ {
 		c := last + buckets[i]
 		if c < 0 {
-			return 0, checkBucketsErr(i+1, c)
+			return 0, errors.Wrap(
+				storage.ErrHistogramNegativeBucketCount,
+				fmt.Sprintf("bucket number %d has observation count of %d", i+1, c),
+			)
 		}
 		last = c
 		count += uint64(c)
 	}
 
 	return count, nil
-}
-
-func checkBucketsErr(n int, c int64) error {
-	return errors.Wrap(
-		storage.ErrHistogramNegativeBucketCount,
-		fmt.Sprintf("bucket number %d has observation count of %d", n, c),
-	)
 }
 
 var _ storage.GetRef = &headAppender{}

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -466,7 +466,7 @@ func validateHistogram(h *histogram.Histogram) error {
 	checkSpans := func(sign string, spans []histogram.Span, buckets []int64) error {
 		var spanBuckets uint32
 		for n, span := range spans {
-			if span.Offset < 0 {
+			if n > 0 && span.Offset < 0 {
 				return errors.Wrap(
 					storage.ErrHistogramSpanNegativeOffset,
 					fmt.Sprintf("%s span number %d with offset %d", sign, n+1, span.Offset),

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3843,17 +3843,17 @@ func TestDistributor_Push_HistogramValidation(t *testing.T) {
 		},
 		"rejects a histogram which has a negative span with a negative offset": {
 			h: &histogram.Histogram{
-				NegativeSpans:   []histogram.Span{{Offset: -1, Length: 1}},
-				NegativeBuckets: []int64{1},
+				NegativeSpans:   []histogram.Span{{Offset: -1, Length: 1}, {Offset: -1, Length: 1}},
+				NegativeBuckets: []int64{1, 2},
 			},
-			errMsg: `negative span number 1 with offset -1`,
+			errMsg: `negative span number 2 with offset -1`,
 		},
 		"rejects a histogram which has a positive span with a negative offset": {
 			h: &histogram.Histogram{
-				PositiveSpans:   []histogram.Span{{Offset: -1, Length: 1}},
-				PositiveBuckets: []int64{1},
+				PositiveSpans:   []histogram.Span{{Offset: -1, Length: 1}, {Offset: -1, Length: 1}},
+				PositiveBuckets: []int64{1, 2},
 			},
-			errMsg: `positive span number 1 with offset -1`,
+			errMsg: `positive span number 2 with offset -1`,
 		},
 	}
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3805,7 +3805,7 @@ func TestReplayAfterMmapReplayError(t *testing.T) {
 	require.NoError(t, h.Close())
 }
 
-func TestDistributor_Push_HistogramValidation(t *testing.T) {
+func TestHistogramValidation(t *testing.T) {
 	tests := map[string]struct {
 		h      *histogram.Histogram
 		errMsg string
@@ -3818,48 +3818,48 @@ func TestDistributor_Push_HistogramValidation(t *testing.T) {
 				NegativeSpans:   []histogram.Span{{Offset: 0, Length: 1}},
 				NegativeBuckets: []int64{},
 			},
-			errMsg: `negative spans need 1 buckets, have 0 negative buckets`,
+			errMsg: `negative side: spans need 1 buckets, have 0 buckets`,
 		},
 		"rejects histogram who has too few positive buckets": {
 			h: &histogram.Histogram{
 				PositiveSpans:   []histogram.Span{{Offset: 0, Length: 1}},
 				PositiveBuckets: []int64{},
 			},
-			errMsg: `positive spans need 1 buckets, have 0 positive buckets`,
+			errMsg: `positive side: spans need 1 buckets, have 0 buckets`,
 		},
 		"rejects histogram who has too many negative buckets": {
 			h: &histogram.Histogram{
 				NegativeSpans:   []histogram.Span{{Offset: 0, Length: 1}},
 				NegativeBuckets: []int64{1, 2},
 			},
-			errMsg: `negative spans need 1 buckets, have 2 negative buckets`,
+			errMsg: `negative side: spans need 1 buckets, have 2 buckets`,
 		},
 		"rejects histogram who has too many positive buckets": {
 			h: &histogram.Histogram{
 				PositiveSpans:   []histogram.Span{{Offset: 0, Length: 1}},
 				PositiveBuckets: []int64{1, 2},
 			},
-			errMsg: `positive spans need 1 buckets, have 2 positive buckets`,
+			errMsg: `positive side: spans need 1 buckets, have 2 buckets`,
 		},
 		"rejects a histogram which has a negative span with a negative offset": {
 			h: &histogram.Histogram{
 				NegativeSpans:   []histogram.Span{{Offset: -1, Length: 1}, {Offset: -1, Length: 1}},
 				NegativeBuckets: []int64{1, 2},
 			},
-			errMsg: `negative span number 2 with offset -1`,
+			errMsg: `negative side: span number 2 with offset -1`,
 		},
 		"rejects a histogram which has a positive span with a negative offset": {
 			h: &histogram.Histogram{
 				PositiveSpans:   []histogram.Span{{Offset: -1, Length: 1}, {Offset: -1, Length: 1}},
 				PositiveBuckets: []int64{1, 2},
 			},
-			errMsg: `positive span number 2 with offset -1`,
+			errMsg: `positive side: span number 2 with offset -1`,
 		},
 	}
 
 	for testName, tc := range tests {
 		t.Run(testName, func(t *testing.T) {
-			err := validateHistogram(tc.h)
+			err := ValidateHistogram(tc.h)
 			if tc.errMsg != "" {
 				require.ErrorContains(t, err, tc.errMsg)
 			} else {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2865,6 +2865,7 @@ func TestHistogramInWAL(t *testing.T) {
 	}
 	expHistograms := make([]timedHistogram, 0, numHistograms)
 	for i, h := range GenerateTestHistograms(numHistograms) {
+		h.Count = h.Count * 2
 		h.NegativeSpans = h.PositiveSpans
 		h.NegativeBuckets = h.PositiveBuckets
 		_, err := app.AppendHistogram(0, l, int64(i), h)
@@ -3369,8 +3370,9 @@ func TestHistogramCounterResetHeader(t *testing.T) {
 		h.NegativeSpans = append([]histogram.Span{}, h.PositiveSpans...)
 		h.NegativeBuckets = append([]int64{}, h.PositiveBuckets...)
 	}
-	h.PositiveBuckets[0] = 100
-	h.NegativeBuckets[0] = 100
+	h.PositiveBuckets = []int64{100, 1, 1, 1}
+	h.NegativeBuckets = []int64{100, 1, 1, 1}
+	h.Count = 1000
 
 	// First histogram is UnknownCounterReset.
 	appendHistogram(h)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3855,6 +3855,30 @@ func TestHistogramValidation(t *testing.T) {
 			},
 			errMsg: `positive side: span number 2 with offset -1`,
 		},
+		"rejects a histogram which has a negative bucket with a negative count": {
+			h: &histogram.Histogram{
+				NegativeSpans:   []histogram.Span{{Offset: -1, Length: 1}},
+				NegativeBuckets: []int64{-1},
+			},
+			errMsg: `negative side: bucket number 1 has observation count of -1`,
+		},
+		"rejects a histogram which has a positive bucket with a negative count": {
+			h: &histogram.Histogram{
+				PositiveSpans:   []histogram.Span{{Offset: -1, Length: 1}},
+				PositiveBuckets: []int64{-1},
+			},
+			errMsg: `positive side: bucket number 1 has observation count of -1`,
+		},
+		"rejects a histogram which which has a lower count than count in buckets": {
+			h: &histogram.Histogram{
+				Count:           0,
+				NegativeSpans:   []histogram.Span{{Offset: -1, Length: 1}},
+				PositiveSpans:   []histogram.Span{{Offset: -1, Length: 1}},
+				NegativeBuckets: []int64{1},
+				PositiveBuckets: []int64{1},
+			},
+			errMsg: `2 observations found in buckets, but overall count is 0`,
+		},
 	}
 
 	for testName, tc := range tests {


### PR DESCRIPTION
_This is to the sparsehistogram branch_

This PR implements the following validation checks:

1. Do any of the histogram's spans have a negative offset
2. Are there the appropriate number of negative and positive buckets based on their respective spans