### PR TITLE
docs: add `__meta_kubernetes_service_port_number`

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1675,6 +1675,7 @@ Available meta labels:
 * `__meta_kubernetes_service_labelpresent_<labelname>`: `true` for each label of the service object.
 * `__meta_kubernetes_service_name`: The name of the service object.
 * `__meta_kubernetes_service_port_name`: Name of the service port for the target.
+* `__meta_kubernetes_service_port_number`: Number of the service port for the target.
 * `__meta_kubernetes_service_port_protocol`: Protocol of the service port for the target.
 * `__meta_kubernetes_service_type`: The type of the service.
 


### PR DESCRIPTION
This PR add `__meta_kubernetes_service_port_number` for <kubernetes_sd_config>.

@beorn7 
Related to: https://github.com/prometheus/prometheus/pull/11002
Signed-off-by: yngwiewang [yngwiewang@163.com](mailto:yngwiewang@163.com)