### PR TITLE
tsdb: faster postings sort with generic slices.Sort

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -169,6 +169,7 @@ require (
 	go.opentelemetry.io/otel/metric v0.31.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.18.0 // indirect
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -938,6 +938,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"golang.org/x/exp/slices"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -239,11 +240,9 @@ func (p *MemPostings) EnsureOrder() {
 
 	for i := 0; i < n; i++ {
 		go func() {
-			var sortable seriesRefSlice
 			for job := range workc {
 				for _, l := range *job {
-					sortable = l
-					sort.Sort(&sortable)
+					slices.Sort(l)
 				}
 
 				*job = (*job)[:0]
@@ -829,13 +828,6 @@ func (it *bigEndianPostings) Seek(x storage.SeriesRef) bool {
 func (it *bigEndianPostings) Err() error {
 	return nil
 }
-
-// seriesRefSlice attaches the methods of sort.Interface to []storage.SeriesRef, sorting in increasing order.
-type seriesRefSlice []storage.SeriesRef
-
-func (x seriesRefSlice) Len() int           { return len(x) }
-func (x seriesRefSlice) Less(i, j int) bool { return x[i] < x[j] }
-func (x seriesRefSlice) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
 
 // FindIntersectingPostings checks the intersection of p and candidates[i] for each i in candidates,
 // if intersection is non empty, then i is added to the indexes returned.


### PR DESCRIPTION
~Update go.mod to mandate Go 1.18 semantics so we can use generics. This will impact anyone using Prometheus as a library who has not already updated to Go 1.18.~ Edit: this was done by #11279.

Use new experimental package `golang.org/x/exp/slices`. 

For either of the above reasons you might not want to accept the change, but I thought the difference was striking.

```
name                                                old time/op    new time/op    delta
MemPostings_ensureOrder/few_values_per_label-8         591ms ± 2%     262ms ±31%  -55.74%  (p=0.008 n=5+5)
MemPostings_ensureOrder/few_refs_per_label_value-8    16.1ms ± 0%    11.9ms ± 0%  -25.93%  (p=0.016 n=4+5)
MemPostings_ensureOrder/many_values_per_label-8        543ms ± 7%      80ms ± 3%  -85.26%  (p=0.008 n=5+5)

name                                                old alloc/op   new alloc/op   delta
MemPostings_ensureOrder/few_values_per_label-8         201kB ± 0%      80kB ± 1%  -60.23%  (p=0.016 n=5+4)
MemPostings_ensureOrder/few_refs_per_label_value-8    6.51kB ± 5%    4.37kB ± 1%  -32.87%  (p=0.008 n=5+5)
MemPostings_ensureOrder/many_values_per_label-8        200kB ± 1%      31kB ± 6%  -84.60%  (p=0.008 n=5+5)

name                                                old allocs/op  new allocs/op  delta
MemPostings_ensureOrder/few_values_per_label-8          53.0 ± 8%      23.0 ±22%  -56.60%  (p=0.008 n=5+5)
MemPostings_ensureOrder/few_refs_per_label_value-8      19.0 ± 5%      10.0 ± 0%  -47.37%  (p=0.008 n=5+5)
MemPostings_ensureOrder/many_values_per_label-8         47.2 ±17%      14.8 ±15%  -68.64%  (p=0.008 n=5+5)
```

Some of the speedup comes from comparing `SeriesRef` (which is an int64) directly rather than through an interface `.Less()` call; some comes from exp/slices using "pattern-defeating quicksort(pdqsort)" which is much better on already-sorted data.

Also we don't need the funky trick from #10500.

Across Prometheus there are many other calls to `sort`; I think all the `sort.Strings` and `sort.Ints` will benefit from the same change, but I don't often see them show up in profiles.  Anyway I thought I'd post this one as a start.