### PR TITLE
file sd: create and increment an inotify error counter when file-SD i…

### DIFF
--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -53,8 +53,8 @@ var (
 	fileSDTimeStamp        = NewTimestampCollector()
 	fileWatcherErrorsCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "prometheus_inotify_errors_total",
-			Help: "The number of File-SD errors caused by inotify.",
+			Name: "prometheus_sd_file_watcher_errors_total",
+			Help: "The number of File-SD errors caused by filesystem watch failures.",
 		})
 
 	patFileSDName = regexp.MustCompile(`^[^*]*(\*[^/]*)?\.(json|yml|yaml|JSON|YML|YAML)$`)

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -39,18 +39,23 @@ import (
 )
 
 var (
+	fileSDReadErrorsCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "prometheus_sd_file_read_errors_total",
+			Help: "The number of File-SD read errors.",
+		})
 	fileSDScanDuration = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Name:       "prometheus_sd_file_scan_duration_seconds",
 			Help:       "The duration of the File-SD scan in seconds.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		})
-	fileSDReadErrorsCount = prometheus.NewCounter(
+	fileSDTimeStamp        = NewTimestampCollector()
+	fileWatcherErrorsCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "prometheus_sd_file_read_errors_total",
-			Help: "The number of File-SD read errors.",
+			Name: "prometheus_inotify_errors_total",
+			Help: "The number of File-SD errors caused by inotify.",
 		})
-	fileSDTimeStamp = NewTimestampCollector()
 
 	patFileSDName = regexp.MustCompile(`^[^*]*(\*[^/]*)?\.(json|yml|yaml|JSON|YML|YAML)$`)
 
@@ -62,7 +67,7 @@ var (
 
 func init() {
 	discovery.RegisterConfig(&SDConfig{})
-	prometheus.MustRegister(fileSDScanDuration, fileSDReadErrorsCount, fileSDTimeStamp)
+	prometheus.MustRegister(fileSDReadErrorsCount, fileSDScanDuration, fileSDTimeStamp, fileWatcherErrorsCount)
 }
 
 // SDConfig is the configuration for file based discovery.
@@ -237,6 +242,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		level.Error(d.logger).Log("msg", "Error adding file watcher", "err", err)
+		fileWatcherErrorsCount.Inc()
 		return
 	}
 	d.watcher = watcher


### PR DESCRIPTION
…s unable to watch files. Additionally, order metrics alphabetically.

cc: @roidelapluie @LeviHarrison (there's no dedicated file-SD maintainer listed - apologies if this ping is in error!)

Signed-off-by: Michael Fuller <mfuller@digitalocean.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
