### PR TITLE
Implement appender rollback for native histograms

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -76,6 +76,7 @@ type Head struct {
 	logger          log.Logger
 	appendPool      sync.Pool
 	exemplarsPool   sync.Pool
+	histogramsPool  sync.Pool
 	seriesPool      sync.Pool
 	bytesPool       sync.Pool
 	memChunkPool    sync.Pool


### PR DESCRIPTION
_This is pointed to the `sparsehistogram` branch_

Also added a histogram buffer pool because that seemed like a good idea