### PR TITLE
Validate the metric name and label names

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/prometheus/common/model"
 )
 
 // Well-known label names used by Prometheus components.
@@ -309,6 +310,19 @@ func (ls Labels) WithoutEmpty() Labels {
 		return els
 	}
 	return ls
+}
+
+// IsValid checks if the metric name or label names are valid.
+func (ls Labels) IsValid() bool {
+	for _, l := range ls {
+		if l.Name == model.MetricNameLabel && !model.IsValidMetricName(model.LabelValue(l.Value)) {
+			return false
+		}
+		if !model.LabelName(l.Name).IsValid() || !model.LabelValue(l.Value).IsValid() {
+			return false
+		}
+	}
+	return true
 }
 
 // Equal returns whether the two label sets are equal.

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -216,6 +216,62 @@ func TestLabels_WithoutEmpty(t *testing.T) {
 	}
 }
 
+func TestLabels_IsValid(t *testing.T) {
+	for _, test := range []struct {
+		input    Labels
+		expected bool
+	}{
+		{
+			input: FromStrings(
+				"__name__", "test",
+				"hostname", "localhost",
+				"job", "check",
+			),
+			expected: true,
+		},
+		{
+			input: FromStrings(
+				"__name__", "test:ms",
+				"hostname_123", "localhost",
+				"_job", "check",
+			),
+			expected: true,
+		},
+		{
+			input:    FromStrings("__name__", "test-ms"),
+			expected: false,
+		},
+		{
+			input:    FromStrings("__name__", "0zz"),
+			expected: false,
+		},
+		{
+			input:    FromStrings("abc:xyz", "invalid"),
+			expected: false,
+		},
+		{
+			input:    FromStrings("123abc", "invalid"),
+			expected: false,
+		},
+		{
+			input:    FromStrings("中文abc", "invalid"),
+			expected: false,
+		},
+		{
+			input:    FromStrings("invalid", "aa\xe2"),
+			expected: false,
+		},
+		{
+			input:    FromStrings("invalid", "\xF7\xBF\xBF\xBF"),
+			expected: false,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			require.Equal(t, test.expected, test.input.IsValid())
+		})
+	}
+}
+
 func TestLabels_Equal(t *testing.T) {
 	labels := FromStrings(
 		"aaa", "111",

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1609,6 +1609,10 @@ loop:
 				err = errNameLabelMandatory
 				break loop
 			}
+			if !lset.IsValid() {
+				err = fmt.Errorf("invalid metric name or label names: %s", lset.String())
+				break loop
+			}
 
 			// If any label limits is exceeded the scrape should fail.
 			if err = verifyLabelLimits(lset, sl.labelLimits); err != nil {


### PR DESCRIPTION
According to the documentation: https://prometheus.io/docs/concepts/data_model/
> The metric name must match the regex [a-zA-Z_:][a-zA-Z0-9_:]*.
   Label names must match the regex [a-zA-Z_][a-zA-Z0-9_]*.

Prometheus isn't validating the metric name and label names consistently, which may cause problems since the alertmanager will [validate those labels](https://github.com/prometheus/alertmanager/blob/6c6bed4a7e541b4b5abb48cc56868cd2a0a189da/api/v1/api.go#L447).

I don't know if we should validate them on the tsdb layer.

