### PR TITLE
Add LoadBalancerIP to discovered services

### DIFF
--- a/discovery/kubernetes/service.go
+++ b/discovery/kubernetes/service.go
@@ -153,6 +153,7 @@ const (
 	servicePortNumberLabel         = metaLabelPrefix + "service_port_number"
 	servicePortProtocolLabel       = metaLabelPrefix + "service_port_protocol"
 	serviceClusterIPLabel          = metaLabelPrefix + "service_cluster_ip"
+	serviceLoadBalancerIP          = metaLabelPrefix + "service_loadbalancer_ip"
 	serviceExternalNameLabel       = metaLabelPrefix + "service_external_name"
 	serviceType                    = metaLabelPrefix + "service_type"
 )
@@ -199,6 +200,10 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
 			labelSet[serviceExternalNameLabel] = lv(svc.Spec.ExternalName)
 		} else {
 			labelSet[serviceClusterIPLabel] = lv(svc.Spec.ClusterIP)
+		}
+
+		if svc.Spec.Type == apiv1.ServiceTypeLoadBalancer {
+			labelSet[serviceLoadBalancerIP] = lv(svc.Spec.LoadBalancerIP)
 		}
 
 		tg.Targets = append(tg.Targets, labelSet)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1678,6 +1678,7 @@ Available meta labels:
 * `__meta_kubernetes_service_annotation_<annotationname>`: Each annotation from the service object.
 * `__meta_kubernetes_service_annotationpresent_<annotationname>`: "true" for each annotation of the service object.
 * `__meta_kubernetes_service_cluster_ip`: The cluster IP address of the service. (Does not apply to services of type ExternalName)
+* `__meta_kubernetes_service_loadbalancer_ip`: The IP address of the loadbalancer. (Applies to services of type LoadBalancer)
 * `__meta_kubernetes_service_external_name`: The DNS name of the service. (Applies to services of type ExternalName)
 * `__meta_kubernetes_service_label_<labelname>`: Each label from the service object.
 * `__meta_kubernetes_service_labelpresent_<labelname>`: `true` for each label of the service object.


### PR DESCRIPTION
This PR adds the LoadBalancerIP for discovered services of type LoadBalancer to the service metadata labels.

**Use case example:**
To check the function of a Loadbalancer the Blackbox exporter can probe the internal and external IP of the service. If the internal IP works as expected but the external IP doesn't, the Loadbalancer is somehow broken. 

In order to write a service discovery config to do this, the Loadbalancer IP needs to be available in the relabeling config to set it as the target for the Blackbox exporter.