### PR TITLE
histograms: parse float histograms from proto definition

### DIFF
--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -30,7 +30,8 @@ type Parser interface {
 
 	// Histogram returns the bytes of a series with a sparse histogram as a
 	// value, the timestamp if set, and the histogram in the current sample.
-	Histogram() ([]byte, *int64, *histogram.Histogram)
+	// Depending of the value of the fields, the histogram could be a float histogram.
+	Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram)
 
 	// Help returns the metric name and help text in the current entry.
 	// Must only be called after Next returned a help entry.

--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -30,7 +30,8 @@ type Parser interface {
 
 	// Histogram returns the bytes of a series with a sparse histogram as a
 	// value, the timestamp if set, and the histogram in the current sample.
-	// Depending of the value of the fields, the histogram could be a float histogram.
+	// Depending on the parsed input, the function returns an (integer) Histogram
+	// or a FloatHistogram, with the respective other return value being nil.
 	Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram)
 
 	// Help returns the metric name and help text in the current entry.

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -113,10 +113,10 @@ func (p *OpenMetricsParser) Series() ([]byte, *int64, float64) {
 	return p.series, nil, p.val
 }
 
-// Histogram always returns (nil, nil, nil) because OpenMetrics does not support
+// Histogram always returns (nil, nil, nil, nil) because OpenMetrics does not support
 // sparse histograms.
-func (p *OpenMetricsParser) Histogram() ([]byte, *int64, *histogram.Histogram) {
-	return nil, nil, nil
+func (p *OpenMetricsParser) Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram) {
+	return nil, nil, nil, nil
 }
 
 // Help returns the metric name and help text in the current entry.

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -168,10 +168,10 @@ func (p *PromParser) Series() ([]byte, *int64, float64) {
 	return p.series, nil, p.val
 }
 
-// Histogram always returns (nil, nil, nil) because the Prometheus text format
+// Histogram always returns (nil, nil, nil, nil) because the Prometheus text format
 // does not support sparse histograms.
-func (p *PromParser) Histogram() ([]byte, *int64, *histogram.Histogram) {
-	return nil, nil, nil
+func (p *PromParser) Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram) {
+	return nil, nil, nil, nil
 }
 
 // Help returns the metric name and help text in the current entry.

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -141,7 +141,8 @@ func (p *ProtobufParser) Histogram() ([]byte, *int64, *histogram.Histogram, *his
 		ts = m.GetTimestampMs()
 		h  = m.GetHistogram()
 	)
-	if isFloatHistogram(h) {
+	if h.GetSampleCountFloat() > 0 || h.GetZeroCountFloat() > 0 {
+		// It is a float histogram.
 		fh := histogram.FloatHistogram{
 			Count:           h.GetSampleCountFloat(),
 			Sum:             h.GetSampleSum(),

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -512,14 +512,6 @@ func isNativeHistogram(h *dto.Histogram) bool {
 // isFloatHistogram checks that processed histogram is a float histogram if it
 // some of the histogram defined with float values
 func isFloatHistogram(h *dto.Histogram) bool {
-	floatBuckets := false
-	for _, b := range h.Bucket {
-		if b.CumulativeCountFloat > 0 {
-			floatBuckets = true
-			break
-		}
-	}
 	return h.GetSampleCountFloat() > 0 ||
-		h.GetZeroCountFloat() > 0 ||
-		floatBuckets
+		h.GetZeroCountFloat() > 0
 }

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -508,10 +508,3 @@ func isNativeHistogram(h *dto.Histogram) bool {
 		h.GetZeroCount() > 0 ||
 		h.GetZeroThreshold() > 0
 }
-
-// isFloatHistogram checks that processed histogram is a float histogram if it
-// some of the histogram defined with float values
-func isFloatHistogram(h *dto.Histogram) bool {
-	return h.GetSampleCountFloat() > 0 ||
-		h.GetZeroCountFloat() > 0
-}

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -205,11 +205,11 @@ metric: <
       offset: 23
       length: 4
     >
-    negative_delta: 1
-    negative_delta: 3
-    negative_delta: -2
-    negative_delta: -1
-    negative_delta: 1
+    negative_count: 1.0
+    negative_count: 3.0
+    negative_count: -2.0
+    negative_count: -1.0
+    negative_count: 1.0
     positive_span: <
       offset: -161
       length: 1
@@ -218,10 +218,10 @@ metric: <
       offset: 8
       length: 3
     >
-    positive_delta: 1
-    positive_delta: 2
-    positive_delta: -1
-    positive_delta: -1
+    positive_count: 1.0
+    positive_count: 2.0
+    positive_count: -1.0
+    positive_count: -1.0
   >
   timestamp_ms: 1234568
 >

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1513,6 +1513,7 @@ loop:
 		t := defTime
 		if isHistogram {
 			met, parsedTimestamp, h, _ = p.Histogram()
+			// TODO: ingest float histograms in tsdb
 		} else {
 			met, parsedTimestamp, val = p.Series()
 		}
@@ -1566,7 +1567,7 @@ loop:
 		if isHistogram {
 			if h != nil {
 				ref, err = app.AppendHistogram(ref, lset, t, h)
-			} // TODO: Append float histogram
+			}
 		} else {
 			ref, err = app.Append(ref, lset, t, val)
 		}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1513,7 +1513,7 @@ loop:
 		t := defTime
 		if isHistogram {
 			met, parsedTimestamp, h, _ = p.Histogram()
-			// TODO: ingest float histograms in tsdb
+			// TODO: ingest float histograms in tsdb.
 		} else {
 			met, parsedTimestamp, val = p.Series()
 		}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1512,7 +1512,7 @@ loop:
 
 		t := defTime
 		if isHistogram {
-			met, parsedTimestamp, h = p.Histogram()
+			met, parsedTimestamp, h, _ = p.Histogram()
 		} else {
 			met, parsedTimestamp, val = p.Series()
 		}
@@ -1564,7 +1564,9 @@ loop:
 		}
 
 		if isHistogram {
-			ref, err = app.AppendHistogram(ref, lset, t, h)
+			if h != nil {
+				ref, err = app.AppendHistogram(ref, lset, t, h)
+			} // TODO: Append float histogram
 		} else {
 			ref, err = app.Append(ref, lset, t, val)
 		}


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
This PR is the first step of the processing of float histograms: identify float histograms
comming from proto definition and parse them into the enternal float histogram representation.

Float histograms are like native histograms but with the main difference that
the counts are float values. 

The next step after parsing will be ingest the float histograms in the tsdb.