### PR TITLE
Run Windows tests only for releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,8 +141,10 @@ workflows:
               only: /.*/
       - test_windows:
           filters:
+            branches:
+              only: /^(release-.*|.*build-all.*)$/
             tags:
-              only: /.*/
+              only: /^v2(\.[0-9]+){2}(-.+|[^-.]*)$/
       - prometheus/build:
           name: build
           parallelism: 3


### PR DESCRIPTION
This is an alternative to PR #11153. Instead of removing Windows tests entirely, let's keep them but only run them for the release branch / release tags, so we can still catch permanent Windows problems for those.

Signed-off-by: Julius Volz <julius.volz@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
