### PR TITLE
handle better clock changes when deciding if rule evaluation was missed.

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -407,7 +407,14 @@ func (g *Group) run(ctx context.Context) {
 		case <-g.done:
 			return
 		case <-tick.C:
-			missed := (time.Since(evalTimestamp) / g.interval) - 1
+			delta := time.Since(evalTimestamp)
+			if delta < g.interval {
+				delta = delta.Round(g.interval)
+				if delta >= g.interval {
+					evalTimestamp = evalTimestamp.Add(-time.Millisecond)
+				}
+			}
+			missed := (delta / g.interval) - 1
 			if missed > 0 {
 				g.metrics.IterationsMissed.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))
 				g.metrics.IterationsScheduled.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))
@@ -429,7 +436,14 @@ func (g *Group) run(ctx context.Context) {
 			case <-g.done:
 				return
 			case <-tick.C:
-				missed := (time.Since(evalTimestamp) / g.interval) - 1
+				delta := time.Since(evalTimestamp)
+				if delta < g.interval {
+					delta = delta.Round(g.interval)
+					if delta >= g.interval {
+						evalTimestamp = evalTimestamp.Add(-time.Millisecond)
+					}
+				}
+				missed := (delta / g.interval) - 1
 				if missed > 0 {
 					g.metrics.IterationsMissed.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))
 					g.metrics.IterationsScheduled.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))


### PR DESCRIPTION
Alternative solution to #10698.

I'm running prometheus on a host on which propably the wall clock jumps by miliseconds instantly without adjustement.
When that happens, the rule timer starts triggering one or two milisecond earlier then before and `time.Since(evalTimestamp)` now returns values sometimes lesser,  sometimes greater then a rule's interval and missed evaluation are reported.

So I am handling a special case, when delta from last evaluation is lower than rule's interval by rounding delta to the interval.
I'm adjusting `evalTimestamp` by one millisecond step to synchronize it back to rule's timer so the futures deltas will be greater then interval again.

Signed-off-by: Rostislav Benes <r.dee.b.b@gmail.com>
