### PR TITLE
/-/{healthy,ready}/ respond to HEAD

### DIFF
--- a/docs/management_api.md
+++ b/docs/management_api.md
@@ -12,6 +12,7 @@ Prometheus provides a set of management APIs to facilitate automation and integr
 
 ```
 GET /-/healthy
+HEAD /-/healthy
 ```
 
 This endpoint always returns 200 and should be used to check Prometheus health.
@@ -21,6 +22,7 @@ This endpoint always returns 200 and should be used to check Prometheus health.
 
 ```
 GET /-/ready
+HEAD /-/ready
 ```
 
 This endpoint returns 200 when Prometheus is ready to serve traffic (i.e. respond to queries).

--- a/web/web.go
+++ b/web/web.go
@@ -471,9 +471,15 @@ func New(logger log.Logger, o *Options) *Handler {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, o.AppName+" is Healthy.\n")
 	})
+	router.Head("/-/healthy", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
 	router.Get("/-/ready", readyf(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, o.AppName+" is Ready.\n")
+	}))
+	router.Head("/-/ready", readyf(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
 	}))
 
 	return h

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -126,10 +126,20 @@ func TestReadyAndHealthy(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	cleanupTestResponse(t, resp)
 
+	resp, err = http.Head(baseURL + "/-/healthy")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	cleanupTestResponse(t, resp)
+
 	for _, u := range []string{
 		baseURL + "/-/ready",
 	} {
 		resp, err = http.Get(u)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+		cleanupTestResponse(t, resp)
+
+		resp, err = http.Head(u)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 		cleanupTestResponse(t, resp)
@@ -153,6 +163,11 @@ func TestReadyAndHealthy(t *testing.T) {
 		baseURL + "/-/ready",
 	} {
 		resp, err = http.Get(u)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		cleanupTestResponse(t, resp)
+
+		resp, err = http.Head(u)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		cleanupTestResponse(t, resp)


### PR DESCRIPTION
Some frameworks issue HEAD requests to determine health.

This resolves prometheus/prometheus#11159

Signed-off-by: Nicolas Dumazet <nicdumz.commits@gmail.com>
