### PR TITLE
Add unit test for histogram append and various querying scenarios

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -523,7 +523,7 @@ func genSeries(totalSeries, labelCount int, mint, maxt int64) []storage.Series {
 	})
 }
 
-// genHistogramSeries generates series of histogram with a given number of labels and values.
+// genHistogramSeries generates series of histogram samples with a given number of labels and values.
 func genHistogramSeries(totalSeries, labelCount int, mint, maxt, step int64) []storage.Series {
 	return genSeriesFromSampleGenerator(totalSeries, labelCount, mint, maxt, step, func(ts int64) tsdbutil.Sample {
 		h := &histogram.Histogram{
@@ -542,7 +542,7 @@ func genHistogramSeries(totalSeries, labelCount int, mint, maxt, step int64) []s
 	})
 }
 
-// genHistogramAndFloatSeries generates series with mix of histogram and float64 with a given number of labels and values.
+// genHistogramAndFloatSeries generates series of mixed histogram and float64 samples with a given number of labels and values.
 func genHistogramAndFloatSeries(totalSeries, labelCount int, mint, maxt, step int64) []storage.Series {
 	floatSample := false
 	count := 0

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -515,8 +516,67 @@ const (
 	defaultLabelValue = "labelValue"
 )
 
-// genSeries generates series with a given number of labels and values.
+// genSeries generates series of float64 samples with a given number of labels and values.
 func genSeries(totalSeries, labelCount int, mint, maxt int64) []storage.Series {
+	return genSeriesFromSampleGenerator(totalSeries, labelCount, mint, maxt, 1, func(ts int64) tsdbutil.Sample {
+		return sample{t: ts, v: rand.Float64()}
+	})
+}
+
+// genHistogramSeries generates series of histogram with a given number of labels and values.
+func genHistogramSeries(totalSeries, labelCount int, mint, maxt, step int64) []storage.Series {
+	return genSeriesFromSampleGenerator(totalSeries, labelCount, mint, maxt, step, func(ts int64) tsdbutil.Sample {
+		h := &histogram.Histogram{
+			Count:         5 + uint64(ts*4),
+			ZeroCount:     2 + uint64(ts),
+			ZeroThreshold: 0.001,
+			Sum:           18.4 * rand.Float64(),
+			Schema:        1,
+			PositiveSpans: []histogram.Span{
+				{Offset: 0, Length: 2},
+				{Offset: 1, Length: 2},
+			},
+			PositiveBuckets: []int64{int64(ts + 1), 1, -1, 0},
+		}
+		return sample{t: ts, h: h}
+	})
+}
+
+// genHistogramAndFloatSeries generates series with mix of histogram and float64 with a given number of labels and values.
+func genHistogramAndFloatSeries(totalSeries, labelCount int, mint, maxt, step int64) []storage.Series {
+	floatSample := false
+	count := 0
+	return genSeriesFromSampleGenerator(totalSeries, labelCount, mint, maxt, step, func(ts int64) tsdbutil.Sample {
+		count++
+		var s sample
+		if floatSample {
+			s = sample{t: ts, v: rand.Float64()}
+		} else {
+			h := &histogram.Histogram{
+				Count:         5 + uint64(ts*4),
+				ZeroCount:     2 + uint64(ts),
+				ZeroThreshold: 0.001,
+				Sum:           18.4 * rand.Float64(),
+				Schema:        1,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 2},
+					{Offset: 1, Length: 2},
+				},
+				PositiveBuckets: []int64{int64(ts + 1), 1, -1, 0},
+			}
+			s = sample{t: ts, h: h}
+		}
+
+		if count%5 == 0 {
+			// Flip the sample type for every 5 samples.
+			floatSample = !floatSample
+		}
+
+		return s
+	})
+}
+
+func genSeriesFromSampleGenerator(totalSeries, labelCount int, mint, maxt, step int64, generator func(ts int64) tsdbutil.Sample) []storage.Series {
 	if totalSeries == 0 || labelCount == 0 {
 		return nil
 	}
@@ -530,8 +590,8 @@ func genSeries(totalSeries, labelCount int, mint, maxt int64) []storage.Series {
 			lbls[defaultLabelName+strconv.Itoa(j)] = defaultLabelValue + strconv.Itoa(j)
 		}
 		samples := make([]tsdbutil.Sample, 0, maxt-mint+1)
-		for t := mint; t < maxt; t++ {
-			samples = append(samples, sample{t: t, v: rand.Float64()})
+		for t := mint; t < maxt; t += step {
+			samples = append(samples, generator(t))
 		}
 		series[i] = storage.NewListSeries(labels.FromMap(lbls), samples)
 	}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -96,11 +96,13 @@ func query(t testing.TB, q storage.Querier, matchers ...*labels.Matcher) map[str
 		for typ := it.Next(); typ != chunkenc.ValNone; typ = it.Next() {
 			switch typ {
 			case chunkenc.ValFloat:
-				t, v := it.At()
-				samples = append(samples, sample{t: t, v: v})
+				ts, v := it.At()
+				samples = append(samples, sample{t: ts, v: v})
 			case chunkenc.ValHistogram:
-				t, h := it.AtHistogram()
-				samples = append(samples, sample{t: t, h: h})
+				ts, h := it.AtHistogram()
+				samples = append(samples, sample{t: ts, h: h})
+			default:
+				t.Fatalf("unknown sample type in query %s", typ.String())
 			}
 		}
 		require.NoError(t, it.Err())

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -4020,5 +4020,4 @@ func TestQueryHistogramFromBlocks(t *testing.T) {
 			genHistogramAndFloatSeries(10, 5, minute(89), minute(140), minute(3)),
 		)
 	})
-
 }

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -553,7 +553,7 @@ func ValidateHistogram(h *histogram.Histogram) error {
 	if c := negativeCount + positiveCount; c > h.Count {
 		return errors.Wrap(
 			storage.ErrHistogramCountNotBigEnough,
-			fmt.Sprintf("%d observations found in buckets, but overall count is %d", c, h.Count),
+			fmt.Sprintf("%d observations found in buckets, but the Count field is %d", c, h.Count),
 		)
 	}
 
@@ -712,7 +712,6 @@ func (a *headAppender) Commit() (err error) {
 	defer a.head.putHistogramBuffer(a.histograms)
 	defer a.head.putMetadataBuffer(a.metadata)
 	defer a.head.iso.closeAppend(a.appendID)
-
 	total := len(a.samples)
 	var series *memSeries
 	for i, s := range a.samples {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3886,7 +3886,7 @@ func TestHistogramValidation(t *testing.T) {
 				NegativeBuckets: []int64{1},
 				PositiveBuckets: []int64{1},
 			},
-			errMsg: `2 observations found in buckets, but overall count is 0`,
+			errMsg: `2 observations found in buckets, but the Count field is 0`,
 		},
 	}
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -696,7 +696,6 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 	if !p.next() {
 		return false
 	}
-
 	p.curr = p.currChkMeta
 	if p.currDelIter == nil {
 		return true

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -74,6 +74,8 @@ func CreateBlock(series []storage.Series, dir string, chunkRange int64, logger l
 			case chunkenc.ValHistogram:
 				t, h := it.AtHistogram()
 				ref, err = app.AppendHistogram(ref, lset, t, h)
+			default:
+				return "", fmt.Errorf("unknown sample type %s", typ.String())
 			}
 			if err != nil {
 				return "", err

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -54,14 +54,32 @@ func CreateBlock(series []storage.Series, dir string, chunkRange int64, logger l
 		ref := storage.SeriesRef(0)
 		it := s.Iterator()
 		lset := s.Labels()
-		for it.Next() == chunkenc.ValFloat {
-			// TODO(beorn7): Add histogram support.
-			t, v := it.At()
-			ref, err = app.Append(ref, lset, t, v)
+		typ := it.Next()
+		lastTyp := typ
+		for ; typ != chunkenc.ValNone; typ = it.Next() {
+			if lastTyp != typ {
+				// The behaviour of appender is undefined if samples of different types
+				// are appended to the same series in a single Commit().
+				if err = app.Commit(); err != nil {
+					return "", err
+				}
+				app = w.Appender(ctx)
+				sampleCount = 0
+			}
+
+			switch typ {
+			case chunkenc.ValFloat:
+				t, v := it.At()
+				ref, err = app.Append(ref, lset, t, v)
+			case chunkenc.ValHistogram:
+				t, h := it.AtHistogram()
+				ref, err = app.AppendHistogram(ref, lset, t, h)
+			}
 			if err != nil {
 				return "", err
 			}
 			sampleCount++
+			lastTyp = typ
 		}
 		if it.Err() != nil {
 			return "", it.Err()


### PR DESCRIPTION
NOTE: this is for sparsehistogram branch

This PR aims to add tests for the following cases from https://github.com/prometheus/prometheus/issues/11171


- [ ] TSDB
	- [x] Ingestion
		- [x] The happy path, series starts with histograms
		- [x] Series has float already, and now gets histograms
		- [x] Series has histograms, and gets float now
		- [x] Change in schema (including zero threshold) but same observations
		- [x] Buckets missing
		- [x] New buckets coming
	- [x] Querying
		- [x] series with only histograms
			- [x] Changing layout
			- [x] Changing schema
		- [x] series with mix of histograms and float
		- [x] query returning multiple series with all the combinations of float and histograms among the series (only float, only histograms, both float and histograms)
		- [x] Query touching multiple blocks, all blocks having the histograms
		- [x] Querying of overlapping blocks