### PR TITLE
Fix incorrect use of loop variable in parallel test

### DIFF
--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -308,6 +308,7 @@ func TestInitialUpdate(t *testing.T) {
 		"fixtures/valid.yml",
 		"fixtures/valid.json",
 	} {
+		tc := tc
 		t.Run(tc, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
This fixes an occurrence of a loop variable being captured in a
parallel test (`TestInitialUpdate`). Prior to this commit, only the
last test case declared in that test would actually execute. To work
around this problem, we create a copy of the range variable before the
paralllel test, as suggested in the documentation for the `testing`
package:

https://pkg.go.dev/testing#hdr-Subtests_and_Sub_benchmarks

The test immediately after the one fixed here (`TestInvalidFile`)
followed the same pattern but correctly created a copy of the loop
variable, illustrating how easy it is to forget to do this in
practice.

Issue was automatically found using the `loopvarcapture` linter.