### PR TITLE
Improve WAL/mmap chunks test for histograms

### DIFF
--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -44,10 +44,10 @@ const (
 	Tombstones Type = 3
 	// Exemplars is used to match WAL records of type Exemplars.
 	Exemplars Type = 4
-	// Histograms is used to match WAL records of type Histograms.
-	Histograms Type = 5
 	// Metadata is used to match WAL records of type Metadata.
 	Metadata Type = 6
+	// Histograms is used to match WAL records of type Histograms.
+	Histograms Type = 7
 )
 
 func (rt Type) String() string {

--- a/tsdb/record/record_test.go
+++ b/tsdb/record/record_test.go
@@ -15,11 +15,13 @@
 package record
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
@@ -107,6 +109,50 @@ func TestRecord_EncodeDecode(t *testing.T) {
 	decExemplars, err := dec.Exemplars(enc.Exemplars(exemplars, nil), nil)
 	require.NoError(t, err)
 	require.Equal(t, exemplars, decExemplars)
+
+	histograms := []RefHistogram{
+		{
+			Ref: 56,
+			T:   1234,
+			H: &histogram.Histogram{
+				Count:         5,
+				ZeroCount:     2,
+				ZeroThreshold: 0.001,
+				Sum:           18.4 * rand.Float64(),
+				Schema:        1,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 2},
+					{Offset: 1, Length: 2},
+				},
+				PositiveBuckets: []int64{1, 1, -1, 0},
+			},
+		},
+		{
+			Ref: 42,
+			T:   5678,
+			H: &histogram.Histogram{
+				Count:         11,
+				ZeroCount:     4,
+				ZeroThreshold: 0.001,
+				Sum:           35.5,
+				Schema:        1,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 2},
+					{Offset: 2, Length: 2},
+				},
+				PositiveBuckets: []int64{1, 1, -1, 0},
+				NegativeSpans: []histogram.Span{
+					{Offset: 0, Length: 1},
+					{Offset: 1, Length: 2},
+				},
+				NegativeBuckets: []int64{1, 2, -1},
+			},
+		},
+	}
+
+	decHistograms, err := dec.Histograms(enc.Histograms(histograms, nil), nil)
+	require.NoError(t, err)
+	require.Equal(t, histograms, decHistograms)
 }
 
 // TestRecord_Corrupted ensures that corrupted records return the correct error.
@@ -170,6 +216,31 @@ func TestRecord_Corrupted(t *testing.T) {
 		_, err := dec.Metadata(corrupted, nil)
 		require.Equal(t, errors.Cause(err), encoding.ErrInvalidSize)
 	})
+
+	t.Run("Test corrupted histogram record", func(t *testing.T) {
+		histograms := []RefHistogram{
+			{
+				Ref: 56,
+				T:   1234,
+				H: &histogram.Histogram{
+					Count:         5,
+					ZeroCount:     2,
+					ZeroThreshold: 0.001,
+					Sum:           18.4 * rand.Float64(),
+					Schema:        1,
+					PositiveSpans: []histogram.Span{
+						{Offset: 0, Length: 2},
+						{Offset: 1, Length: 2},
+					},
+					PositiveBuckets: []int64{1, 1, -1, 0},
+				},
+			},
+		}
+
+		corrupted := enc.Histograms(histograms, nil)[:8]
+		_, err := dec.Histograms(corrupted, nil)
+		require.Equal(t, errors.Cause(err), encoding.ErrInvalidSize)
+	})
 }
 
 func TestRecord_Type(t *testing.T) {
@@ -191,6 +262,27 @@ func TestRecord_Type(t *testing.T) {
 	metadata := []RefMetadata{{Ref: 147, Type: uint8(Counter), Unit: "unit", Help: "help"}}
 	recordType = dec.Type(enc.Metadata(metadata, nil))
 	require.Equal(t, Metadata, recordType)
+
+	histograms := []RefHistogram{
+		{
+			Ref: 56,
+			T:   1234,
+			H: &histogram.Histogram{
+				Count:         5,
+				ZeroCount:     2,
+				ZeroThreshold: 0.001,
+				Sum:           18.4 * rand.Float64(),
+				Schema:        1,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 2},
+					{Offset: 1, Length: 2},
+				},
+				PositiveBuckets: []int64{1, 1, -1, 0},
+			},
+		},
+	}
+	recordType = dec.Type(enc.Histograms(histograms, nil))
+	require.Equal(t, Histograms, recordType)
 
 	recordType = dec.Type(nil)
 	require.Equal(t, Unknown, recordType)


### PR DESCRIPTION
NOTE: this is for sparsehistogram branch.

This PR build on top of https://github.com/prometheus/prometheus/pull/11194

This PR improves unit test to take care of all these points from https://github.com/prometheus/prometheus/issues/11171.


	- [ ] WAL/M-map
		- [ ] Writing to WAL
		- [ ] Reading from WAL
		- [ ] M-mapping histogram chunks
		- [ ] Replay of data on restart
			- [ ] Series having only histograms
				- [ ] With m-map chunks
			- [ ] Series having a mix of histograms and float
				- [ ] With m-map chunks having both histograms and float

TSDB does not support histograms in checkpointing of WAL (which is one of the test case specified in #11171). I will take care of it in a follow up PR.