### PR TITLE
Fix count() for histograms and add test case

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2366,11 +2366,11 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 				mean:       s.V,
 				groupCount: 1,
 			}
-			if s.H != nil {
+			if s.H == nil {
+				newAgg.hasFloat = true
+			} else if op == parser.SUM {
 				newAgg.histogramValue = s.H.Copy()
 				newAgg.hasHistogram = true
-			} else {
-				newAgg.hasFloat = true
 			}
 
 			result[groupingKey] = newAgg


### PR DESCRIPTION
NOTE: this is for sparsehistogram branch.

This PR fixes the count() for histograms. Without this fix, the result vector of count() has both float64 value and a histogram.

The test for count() is the last required from the list in #11171. Everything else has a unit test.