### PR TITLE
Adds support for prettifying rules file

### DIFF
--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -378,6 +378,41 @@ func TestCheckMetricsExtended(t *testing.T) {
 	}, stats)
 }
 
+func TestPrettifyRules(t *testing.T) {
+	cases := []struct {
+		name         string
+		inputFile    string
+		expectedFile string
+		shouldErr    bool
+	}{
+		{
+			name:         "prettify good rules file",
+			inputFile:    "./testdata/prettify-rules.input.yml",
+			expectedFile: "./testdata/prettify-rules.output.yml",
+		},
+		{
+			name:      "prettify bad rules file",
+			inputFile: "./testdata/prettify-rules.error.yml",
+			shouldErr: true,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			prettifiedContent, err := prettifyFile(test.inputFile)
+			if test.shouldErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			expectedContent, err := os.ReadFile(test.expectedFile)
+			require.NoError(t, err)
+
+			require.Equal(t, string(expectedContent), string(prettifiedContent))
+		})
+	}
+}
+
 func TestExitCodes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/cmd/promtool/testdata/prettify-rules.error.yml
+++ b/cmd/promtool/testdata/prettify-rules.error.yml
@@ -1,0 +1,5 @@
+groups:
+  - name: Test
+    rules:
+      - record: error:rule
+        expr: sum ( prometheus_http_requests_total  by ( handler )

--- a/cmd/promtool/testdata/prettify-rules.input.yml
+++ b/cmd/promtool/testdata/prettify-rules.input.yml
@@ -1,0 +1,9 @@
+groups:
+  - name: Test
+    # Comment.
+    rules:
+      - record: service:prometheus_http_requests_total:joined # Comment.
+        # Comment.
+        expr: sum ( prometheus_http_requests_total ) by ( handler ) # Comment.
+      - alert: NodeClockSkewDetected # Comment.
+        expr: (node_timex_offset_seconds > 0.05 and deriv(node_timex_offset_seconds[5m]) >= 0) or (node_timex_offset_seconds < -0.05 and deriv(node_timex_offset_seconds[5m]) <= 0)

--- a/cmd/promtool/testdata/prettify-rules.output.yml
+++ b/cmd/promtool/testdata/prettify-rules.output.yml
@@ -1,0 +1,10 @@
+groups:
+    - name: Test
+      rules:
+        - record: service:prometheus_http_requests_total:joined # Comment.
+          expr: sum by (handler) (prometheus_http_requests_total) # Comment.
+        - alert: NodeClockSkewDetected # Comment.
+          expr: |4-
+              (node_timex_offset_seconds > 0.05 and deriv(node_timex_offset_seconds[5m]) >= 0)
+            or
+              (node_timex_offset_seconds < -0.05 and deriv(node_timex_offset_seconds[5m]) <= 0)


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

This comment adds support for prettifying rules file
accepted from `promtool prettify rules <files>`.

It also adds support for prettifying a single PromQL expression via
`promtool prettify query <promql-expr>`.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
