### PR TITLE
Add a feature flag to control native histogram ingestion

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -196,6 +196,9 @@ func (c *flagConfig) setFeatureListOptions(logger log.Logger) error {
 			case "no-default-scrape-port":
 				c.scrape.NoDefaultPort = true
 				level.Info(logger).Log("msg", "No default port will be appended to scrape targets' addresses.")
+			case "native-histograms":
+				c.tsdb.EnableNativeHistograms = true
+				level.Info(logger).Log("msg", "Experimental native histogram support enabled.")
 			case "":
 				continue
 			case "promql-at-modifier", "promql-negative-offset":
@@ -1542,6 +1545,7 @@ type tsdbOptions struct {
 	EnableExemplarStorage          bool
 	MaxExemplars                   int64
 	EnableMemorySnapshotOnShutdown bool
+	EnableNativeHistograms         bool
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -1560,6 +1564,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		EnableExemplarStorage:          opts.EnableExemplarStorage,
 		MaxExemplars:                   opts.MaxExemplars,
 		EnableMemorySnapshotOnShutdown: opts.EnableMemorySnapshotOnShutdown,
+		EnableNativeHistograms:         opts.EnableNativeHistograms,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -219,13 +219,12 @@ var (
 
 // Config is the top-level configuration for Prometheus's config files.
 type Config struct {
-	GlobalConfig       GlobalConfig        `yaml:"global"`
-	AlertingConfig     AlertingConfig      `yaml:"alerting,omitempty"`
-	RuleFiles          []string            `yaml:"rule_files,omitempty"`
-	ScrapeConfigs      []*ScrapeConfig     `yaml:"scrape_configs,omitempty"`
-	StorageConfig      StorageConfig       `yaml:"storage,omitempty"`
-	TracingConfig      TracingConfig       `yaml:"tracing,omitempty"`
-	ExperimentalConfig *ExperimentalConfig `yaml:"experimental,omitempty"`
+	GlobalConfig   GlobalConfig    `yaml:"global"`
+	AlertingConfig AlertingConfig  `yaml:"alerting,omitempty"`
+	RuleFiles      []string        `yaml:"rule_files,omitempty"`
+	ScrapeConfigs  []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
+	StorageConfig  StorageConfig   `yaml:"storage,omitempty"`
+	TracingConfig  TracingConfig   `yaml:"tracing,omitempty"`
 
 	RemoteWriteConfigs []*RemoteWriteConfig `yaml:"remote_write,omitempty"`
 	RemoteReadConfigs  []*RemoteReadConfig  `yaml:"remote_read,omitempty"`
@@ -503,11 +502,6 @@ func (c *ScrapeConfig) MarshalYAML() (interface{}, error) {
 // StorageConfig configures runtime reloadable configuration options.
 type StorageConfig struct {
 	ExemplarsConfig *ExemplarsConfig `yaml:"exemplars,omitempty"`
-}
-
-// ExperimentalConfig configures runtime reloadable experimental configuration options.
-type ExperimentalConfig struct {
-	EnableNativeHistograms bool `yaml:"enable_native_histograms,omitempty"`
 }
 
 type TracingClientType string

--- a/config/config.go
+++ b/config/config.go
@@ -219,12 +219,13 @@ var (
 
 // Config is the top-level configuration for Prometheus's config files.
 type Config struct {
-	GlobalConfig   GlobalConfig    `yaml:"global"`
-	AlertingConfig AlertingConfig  `yaml:"alerting,omitempty"`
-	RuleFiles      []string        `yaml:"rule_files,omitempty"`
-	ScrapeConfigs  []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
-	StorageConfig  StorageConfig   `yaml:"storage,omitempty"`
-	TracingConfig  TracingConfig   `yaml:"tracing,omitempty"`
+	GlobalConfig       GlobalConfig        `yaml:"global"`
+	AlertingConfig     AlertingConfig      `yaml:"alerting,omitempty"`
+	RuleFiles          []string            `yaml:"rule_files,omitempty"`
+	ScrapeConfigs      []*ScrapeConfig     `yaml:"scrape_configs,omitempty"`
+	StorageConfig      StorageConfig       `yaml:"storage,omitempty"`
+	TracingConfig      TracingConfig       `yaml:"tracing,omitempty"`
+	ExperimentalConfig *ExperimentalConfig `yaml:"experimental,omitempty"`
 
 	RemoteWriteConfigs []*RemoteWriteConfig `yaml:"remote_write,omitempty"`
 	RemoteReadConfigs  []*RemoteReadConfig  `yaml:"remote_read,omitempty"`
@@ -502,6 +503,11 @@ func (c *ScrapeConfig) MarshalYAML() (interface{}, error) {
 // StorageConfig configures runtime reloadable configuration options.
 type StorageConfig struct {
 	ExemplarsConfig *ExemplarsConfig `yaml:"exemplars,omitempty"`
+}
+
+// ExperimentalConfig configures runtime reloadable experimental configuration options.
+type ExperimentalConfig struct {
+	EnableNativeHistograms bool `yaml:"enable_native_histograms,omitempty"`
 }
 
 type TracingClientType string

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -36,6 +36,7 @@ var (
 	ErrDuplicateExemplar             = errors.New("duplicate exemplar")
 	ErrExemplarLabelLength           = fmt.Errorf("label length for exemplar exceeds maximum of %d UTF-8 characters", exemplar.ExemplarMaxLabelSetLength)
 	ErrExemplarsDisabled             = fmt.Errorf("exemplar storage is disabled or max exemplars is less than or equal to 0")
+	ErrNativeHistogramsDisabled      = fmt.Errorf("native histograms are disabled")
 	ErrHistogramSpanNegativeOffset   = errors.New("histogram has a span whose offset is negative")
 	ErrHistogramSpansBucketsMismatch = errors.New("histogram spans specify different number of buckets than provided")
 	ErrHistogramNegativeBucketCount  = errors.New("histogram has a bucket whose observation count is negative")

--- a/tsdb/blockwriter.go
+++ b/tsdb/blockwriter.go
@@ -71,6 +71,7 @@ func (w *BlockWriter) initHead() error {
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = w.blockSize
 	opts.ChunkDirRoot = w.chunkDir
+	opts.EnableNativeHistograms.Store(true)
 	h, err := NewHead(nil, w.logger, nil, opts, NewHeadStats())
 	if err != nil {
 		return errors.Wrap(err, "tsdb.NewHead")

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1677,6 +1677,7 @@ func TestSparseHistogramCompactionAndQuery(t *testing.T) {
 		require.NoError(t, os.RemoveAll(dir))
 	})
 	opts := DefaultOptions()
+	opts.EnableNativeHistograms = true
 	// Exactly 3 times so that level 2 of compaction happens and tombstone
 	// deletion and compaction considers the level 2 blocks to be big enough.
 	opts.MaxBlockDuration = 3 * opts.MinBlockDuration

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -854,6 +854,16 @@ func (db *DB) ApplyConfig(conf *config.Config) error {
 	return db.head.ApplyConfig(conf)
 }
 
+// EnableNativeHistograms enables the native histogram feature.
+func (db *DB) EnableNativeHistograms() {
+	db.head.EnableNativeHistograms()
+}
+
+// DisableNativeHistograms disables the native histogram feature.
+func (db *DB) DisableNativeHistograms() {
+	db.head.DisableNativeHistograms()
+}
+
 // dbAppender wraps the DB's head appender and triggers compactions on commit
 // if necessary.
 type dbAppender struct {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -160,6 +160,9 @@ type Options struct {
 
 	// Disables isolation between reads and in-flight appends.
 	IsolationDisabled bool
+
+	// EnableNativeHistograms enables the ingestion of native histograms.
+	EnableNativeHistograms bool
 }
 
 type BlocksToDeleteFunc func(blocks []*Block) map[ulid.ULID]struct{}
@@ -719,6 +722,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	headOpts.EnableExemplarStorage = opts.EnableExemplarStorage
 	headOpts.MaxExemplars.Store(opts.MaxExemplars)
 	headOpts.EnableMemorySnapshotOnShutdown = opts.EnableMemorySnapshotOnShutdown
+	headOpts.EnableNativeHistograms.Store(opts.EnableNativeHistograms)
 	if opts.IsolationDisabled {
 		// We only override this flag if isolation is disabled at DB level. We use the default otherwise.
 		headOpts.IsolationDisabled = opts.IsolationDisabled

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
@@ -4059,12 +4058,13 @@ func TestNativeHistogramFlag(t *testing.T) {
 	require.Equal(t, storage.ErrNativeHistogramsDisabled, err)
 
 	// Enable and append.
-	err = db.ApplyConfig(&config.Config{
-		ExperimentalConfig: &config.ExperimentalConfig{EnableNativeHistograms: true},
-	})
-	require.NoError(t, err)
+	db.EnableNativeHistograms()
 	_, err = app.AppendHistogram(0, l, 200, h)
 	require.NoError(t, err)
+
+	db.DisableNativeHistograms()
+	_, err = app.AppendHistogram(0, l, 300, h)
+	require.Equal(t, storage.ErrNativeHistogramsDisabled, err)
 
 	require.NoError(t, app.Commit())
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -126,6 +126,9 @@ type HeadOptions struct {
 	// https://pkg.go.dev/sync/atomic#pkg-note-BUG
 	MaxExemplars atomic.Int64
 
+	// EnableNativeHistograms enables the ingestion of native histograms.
+	EnableNativeHistograms atomic.Bool
+
 	ChunkRange int64
 	// ChunkDirRoot is the parent directory of the chunks directory.
 	ChunkDirRoot         string
@@ -725,6 +728,8 @@ func (h *Head) removeCorruptedMmappedChunks(err error) (map[chunks.HeadSeriesRef
 }
 
 func (h *Head) ApplyConfig(cfg *config.Config) error {
+	h.opts.EnableNativeHistograms.Store(cfg.ExperimentalConfig != nil && cfg.ExperimentalConfig.EnableNativeHistograms)
+
 	if !h.opts.EnableExemplarStorage {
 		return nil
 	}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -728,8 +728,6 @@ func (h *Head) removeCorruptedMmappedChunks(err error) (map[chunks.HeadSeriesRef
 }
 
 func (h *Head) ApplyConfig(cfg *config.Config) error {
-	h.opts.EnableNativeHistograms.Store(cfg.ExperimentalConfig != nil && cfg.ExperimentalConfig.EnableNativeHistograms)
-
 	if !h.opts.EnableExemplarStorage {
 		return nil
 	}
@@ -748,6 +746,16 @@ func (h *Head) ApplyConfig(cfg *config.Config) error {
 	migrated := h.exemplars.(*CircularExemplarStorage).Resize(newSize)
 	level.Info(h.logger).Log("msg", "Exemplar storage resized", "from", prevSize, "to", newSize, "migrated", migrated)
 	return nil
+}
+
+// EnableNativeHistograms enables the native histogram feature.
+func (h *Head) EnableNativeHistograms() {
+	h.opts.EnableNativeHistograms.Store(true)
+}
+
+// DisableNativeHistograms disables the native histogram feature.
+func (h *Head) DisableNativeHistograms() {
+	h.opts.EnableNativeHistograms.Store(false)
 }
 
 // PostingsCardinalityStats returns top 10 highest cardinality stats By label and value names.

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -439,6 +439,10 @@ func (a *headAppender) AppendExemplar(ref storage.SeriesRef, lset labels.Labels,
 }
 
 func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels, t int64, h *histogram.Histogram) (storage.SeriesRef, error) {
+	if !a.head.opts.EnableNativeHistograms.Load() {
+		return 0, storage.ErrNativeHistogramsDisabled
+	}
+
 	if t < a.minValidTime {
 		a.head.metrics.outOfBoundSamples.Inc()
 		return 0, storage.ErrOutOfBounds

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -61,6 +61,7 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 	opts.ChunkDirRoot = dir
 	opts.EnableExemplarStorage = true
 	opts.MaxExemplars.Store(config.DefaultExemplarsConfig.MaxExemplars)
+	opts.EnableNativeHistograms.Store(true)
 
 	h, err := NewHead(nil, nil, wlog, opts, nil)
 	require.NoError(t, err)
@@ -3476,7 +3477,9 @@ func TestHistogramCounterResetHeader(t *testing.T) {
 
 func TestAppendingDifferentEncodingToSameSeries(t *testing.T) {
 	dir := t.TempDir()
-	db, err := Open(dir, nil, nil, DefaultOptions(), nil)
+	opts := DefaultOptions()
+	opts.EnableNativeHistograms = true
+	db, err := Open(dir, nil, nil, opts, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())

--- a/util/teststorage/storage.go
+++ b/util/teststorage/storage.go
@@ -39,6 +39,7 @@ func New(t testutil.T) *TestStorage {
 	opts.MinBlockDuration = int64(24 * time.Hour / time.Millisecond)
 	opts.MaxBlockDuration = int64(24 * time.Hour / time.Millisecond)
 	opts.RetentionDuration = 0
+	opts.EnableNativeHistograms = true
 	db, err := tsdb.Open(dir, nil, nil, opts, tsdb.NewDBStats())
 	require.NoError(t, err, "unexpected error while opening test storage")
 	reg := prometheus.NewRegistry()


### PR DESCRIPTION
NOTE: sparsehistogram branch

Fixes #11168

This PR adds a runtime config to control only the ingestion of native histograms. How to control queries with this is still TBD.

I am introducing a new section in the config file for experimental features. WDYT?