### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/buf-lint.yml
+++ b/.github/workflows/buf-lint.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - ".github/workflows/buf-lint.yml"
       - "**.proto"
+permissions:
+  contents: read
+
 jobs:
   buf:
     name: lint

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+
 jobs:
   buf:
     name: lint and publish

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "26 14 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   analyze:

--- a/.github/workflows/funcbench.yml
+++ b/.github/workflows/funcbench.yml
@@ -2,6 +2,9 @@ on:
   repository_dispatch:
     types: [funcbench_start]
 name: Funcbench Workflow
+permissions:
+  contents: read
+
 jobs:
   run_funcbench:
     name: Running funcbench

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,6 +1,9 @@
 name: CIFuzz
 on:
   workflow_call:
+permissions:
+  contents: read
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -2,6 +2,9 @@
 on:
   schedule:
     - cron: '44 17 * * *'
+permissions:
+  contents: read
+
 jobs:
   repo_sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

GitHub Actions workflows have a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflows:
https://github.com/prometheus/prometheus/runs/8238094120?check_suite_focus=true#step:1:19

The ['Lock Threads' workflow](https://github.com/prometheus/prometheus/blob/main/.github/workflows/lock.yml#L8) already has the minimum token permission set. After this change, the scopes will be reduced to the minimum needed for other workflows.

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- GitHub recommends defining minimum GITHUB_TOKEN permissions.
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>