### PR TITLE
tsdb: remove chunkRange and oooCapMax from memSeries

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1489,7 +1489,7 @@ func (h *Head) getOrCreate(hash uint64, lset labels.Labels) (*memSeries, bool, e
 
 func (h *Head) getOrCreateWithID(id chunks.HeadSeriesRef, hash uint64, lset labels.Labels) (*memSeries, bool, error) {
 	s, created, err := h.series.getOrSet(hash, lset, func() *memSeries {
-		return newMemSeries(lset, id, h.chunkRange.Load(), h.opts.OutOfOrderCapMax.Load(), h.opts.IsolationDisabled)
+		return newMemSeries(lset, id, h.opts.OutOfOrderCapMax.Load(), h.opts.IsolationDisabled)
 	})
 	if err != nil {
 		return nil, false, err
@@ -1779,9 +1779,8 @@ type memSeries struct {
 	oooHeadChunk     *oooHeadChunk      // Most recent chunk for ooo samples in memory that's still being built.
 	firstOOOChunkID  chunks.HeadChunkID // HeadOOOChunkID for oooMmappedChunks[0]
 
-	mmMaxTime  int64 // Max time of any mmapped chunk, only used during WAL replay.
-	chunkRange int64
-	oooCapMax  uint8
+	mmMaxTime int64 // Max time of any mmapped chunk, only used during WAL replay.
+	oooCapMax uint8
 
 	nextAt int64 // Timestamp at which to cut the next chunk.
 
@@ -1800,13 +1799,12 @@ type memSeries struct {
 	pendingCommit bool // Whether there are samples waiting to be committed to this series.
 }
 
-func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, chunkRange, oooCapMax int64, isolationDisabled bool) *memSeries {
+func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, oooCapMax int64, isolationDisabled bool) *memSeries {
 	s := &memSeries{
-		lset:       lset,
-		ref:        id,
-		chunkRange: chunkRange,
-		nextAt:     math.MinInt64,
-		oooCapMax:  uint8(oooCapMax),
+		lset:      lset,
+		ref:       id,
+		nextAt:    math.MinInt64,
+		oooCapMax: uint8(oooCapMax),
 	}
 	if !isolationDisabled {
 		s.txs = newTxRing(4)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1489,7 +1489,7 @@ func (h *Head) getOrCreate(hash uint64, lset labels.Labels) (*memSeries, bool, e
 
 func (h *Head) getOrCreateWithID(id chunks.HeadSeriesRef, hash uint64, lset labels.Labels) (*memSeries, bool, error) {
 	s, created, err := h.series.getOrSet(hash, lset, func() *memSeries {
-		return newMemSeries(lset, id, h.opts.OutOfOrderCapMax.Load(), h.opts.IsolationDisabled)
+		return newMemSeries(lset, id, h.opts.IsolationDisabled)
 	})
 	if err != nil {
 		return nil, false, err
@@ -1780,7 +1780,6 @@ type memSeries struct {
 	firstOOOChunkID  chunks.HeadChunkID // HeadOOOChunkID for oooMmappedChunks[0]
 
 	mmMaxTime int64 // Max time of any mmapped chunk, only used during WAL replay.
-	oooCapMax uint8
 
 	nextAt int64 // Timestamp at which to cut the next chunk.
 
@@ -1799,12 +1798,11 @@ type memSeries struct {
 	pendingCommit bool // Whether there are samples waiting to be committed to this series.
 }
 
-func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, oooCapMax int64, isolationDisabled bool) *memSeries {
+func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, isolationDisabled bool) *memSeries {
 	s := &memSeries{
-		lset:      lset,
-		ref:       id,
-		nextAt:    math.MinInt64,
-		oooCapMax: uint8(oooCapMax),
+		lset:   lset,
+		ref:    id,
+		nextAt: math.MinInt64,
 	}
 	if !isolationDisabled {
 		s.txs = newTxRing(4)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -229,7 +229,7 @@ func BenchmarkLoadWAL(b *testing.B) {
 						require.NoError(b, err)
 						for k := 0; k < c.batches*c.seriesPerBatch; k++ {
 							// Create one mmapped chunk per series, with one sample at the given time.
-							s := newMemSeries(labels.Labels{}, chunks.HeadSeriesRef(k)*101, 1, defaultIsolationDisabled)
+							s := newMemSeries(labels.Labels{}, chunks.HeadSeriesRef(k)*101, defaultIsolationDisabled)
 							s.append(c.mmappedChunkT, 42, 0, chunkDiskMapper, c.mmappedChunkT)
 							s.mmapCurrentHeadChunk(chunkDiskMapper)
 						}
@@ -739,7 +739,7 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 		},
 	}
 
-	s := newMemSeries(labels.FromStrings("a", "b"), 1, 1, defaultIsolationDisabled)
+	s := newMemSeries(labels.FromStrings("a", "b"), 1, defaultIsolationDisabled)
 
 	for i := 0; i < 4000; i += 5 {
 		ok, _ := s.append(int64(i), float64(i), 0, chunkDiskMapper, chunkRange)
@@ -1279,7 +1279,7 @@ func TestMemSeries_append(t *testing.T) {
 	}()
 	const chunkRange = 500
 
-	s := newMemSeries(labels.Labels{}, 1, 1, defaultIsolationDisabled)
+	s := newMemSeries(labels.Labels{}, 1, defaultIsolationDisabled)
 
 	// Add first two samples at the very end of a chunk range and the next two
 	// on and after it.
@@ -1334,7 +1334,7 @@ func TestMemSeries_append_atVariableRate(t *testing.T) {
 	})
 	chunkRange := DefaultBlockDuration
 
-	s := newMemSeries(labels.Labels{}, 1, 0, defaultIsolationDisabled)
+	s := newMemSeries(labels.Labels{}, 1, defaultIsolationDisabled)
 
 	// At this slow rate, we will fill the chunk in two block durations.
 	slowRate := (DefaultBlockDuration * 2) / samplesPerChunk
@@ -2496,7 +2496,7 @@ func TestMemSafeIteratorSeekIntoBuffer(t *testing.T) {
 	}()
 	const chunkRange = 500
 
-	s := newMemSeries(labels.Labels{}, 1, 1, defaultIsolationDisabled)
+	s := newMemSeries(labels.Labels{}, 1, defaultIsolationDisabled)
 
 	for i := 0; i < 7; i++ {
 		ok, _ := s.append(int64(i), float64(i), 0, chunkDiskMapper, chunkRange)

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -719,6 +719,7 @@ func (wp *wblSubsetProcessor) reuseBuf() []record.RefSample {
 func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (unknownRefs uint64) {
 	defer close(wp.output)
 
+	oooCapMax := h.opts.OutOfOrderCapMax.Load()
 	// We don't check for minValidTime for ooo samples.
 	mint, maxt := int64(math.MaxInt64), int64(math.MinInt64)
 	for samples := range wp.input {
@@ -729,7 +730,7 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (unknownRefs uint64) {
 				unknownRefs++
 				continue
 			}
-			ok, chunkCreated, _ := ms.insert(s.T, s.V, h.chunkDiskMapper)
+			ok, chunkCreated, _ := ms.insert(s.T, s.V, h.chunkDiskMapper, oooCapMax)
 			if chunkCreated {
 				h.metrics.chunksCreated.Inc()
 				h.metrics.chunks.Inc()

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -787,7 +787,7 @@ func (s *memSeries) encodeToSnapshotRecord(b []byte) []byte {
 	buf.PutByte(chunkSnapshotRecordTypeSeries)
 	buf.PutBE64(uint64(s.ref))
 	record.EncodeLabels(&buf, s.lset)
-	buf.PutBE64int64(0) // backwards-compatibility; was chunkRange but now unused
+	buf.PutBE64int64(0) // Backwards-compatibility; was chunkRange but now unused.
 
 	s.Lock()
 	if s.headChunk == nil {
@@ -821,7 +821,7 @@ func decodeSeriesFromChunkSnapshot(d *record.Decoder, b []byte) (csr chunkSnapsh
 	// TODO: figure out why DecodeLabels calls Sort(), and perhaps remove it.
 	csr.lset = d.DecodeLabels(&dec)
 
-	_ = dec.Be64int64() // backwards-compatibility: now unused
+	_ = dec.Be64int64() // Was chunkRange but now unused.
 	if dec.Uvarint() == 0 {
 		return
 	}

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -439,6 +439,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 	defer close(wp.output)
 
 	mint, maxt := int64(math.MaxInt64), int64(math.MinInt64)
+	chunkRange := h.chunkRange.Load()
 
 	for in := range wp.input {
 		if in.existingSeries != nil {
@@ -459,7 +460,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			if s.T <= ms.mmMaxTime {
 				continue
 			}
-			if _, chunkCreated := ms.append(s.T, s.V, 0, h.chunkDiskMapper); chunkCreated {
+			if _, chunkCreated := ms.append(s.T, s.V, 0, h.chunkDiskMapper, chunkRange); chunkCreated {
 				h.metrics.chunksCreated.Inc()
 				h.metrics.chunks.Inc()
 			}
@@ -773,11 +774,10 @@ const (
 )
 
 type chunkSnapshotRecord struct {
-	ref        chunks.HeadSeriesRef
-	lset       labels.Labels
-	chunkRange int64
-	mc         *memChunk
-	sampleBuf  [4]sample
+	ref       chunks.HeadSeriesRef
+	lset      labels.Labels
+	mc        *memChunk
+	sampleBuf [4]sample
 }
 
 func (s *memSeries) encodeToSnapshotRecord(b []byte) []byte {
@@ -786,7 +786,7 @@ func (s *memSeries) encodeToSnapshotRecord(b []byte) []byte {
 	buf.PutByte(chunkSnapshotRecordTypeSeries)
 	buf.PutBE64(uint64(s.ref))
 	record.EncodeLabels(&buf, s.lset)
-	buf.PutBE64int64(s.chunkRange)
+	buf.PutBE64int64(0) // backwards-compatibility; was chunkRange but now unused
 
 	s.Lock()
 	if s.headChunk == nil {
@@ -820,7 +820,7 @@ func decodeSeriesFromChunkSnapshot(d *record.Decoder, b []byte) (csr chunkSnapsh
 	// TODO: figure out why DecodeLabels calls Sort(), and perhaps remove it.
 	csr.lset = d.DecodeLabels(&dec)
 
-	csr.chunkRange = dec.Be64int64()
+	_ = dec.Be64int64() // backwards-compatibility: now unused
 	if dec.Uvarint() == 0 {
 		return
 	}
@@ -1216,7 +1216,6 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 					}
 				}
 
-				series.chunkRange = csr.chunkRange
 				if csr.mc == nil {
 					continue
 				}


### PR DESCRIPTION
`chunkRange` is the (oddly-named) configured duration for the head block.

We don't need a copy of this value per series. Pass it down where required, and remove the copy.

The value in `Head` is only updated in `resetInMemoryState()`, which also discards all `memSeries`.

Similar to #11280.

Also removed `oooCapMax` for similar reasons.