### PR TITLE
Simplify rule group's EvalTimestamp formula

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -532,9 +532,28 @@ func (g *Group) setLastEvaluation(ts time.Time) {
 
 // EvalTimestamp returns the immediately preceding consistently slotted evaluation time.
 func (g *Group) EvalTimestamp(startTime int64) time.Time {
-	offset := (uint64(startTime) - g.hash()) % uint64(g.interval)
+	var (
+		offset = int64(g.hash() % uint64(g.interval))
 
-	return time.Unix(0, startTime-int64(offset)).UTC()
+		// This group's evaluation times differ from the perfect time intervals by `offset` nanoseconds.
+		// But we can only use `% interval` to align with the interval. And `% interval` will always
+		// align with the perfect time intervals, instead of this group's. Because of this we add
+		// `offset` _after_ aligning with the perfect time interval.
+		//
+		// There can be cases where adding `offset` to the perfect evaluation time can yield a
+		// timestamp in the future, which is not what EvalTimestamp should do.
+		// So we subtract one `offset` to make sure that `now - (now % interval) + offset` gives an
+		// evaluation time in the past.
+		adjNow = startTime - offset
+
+		// Adjust to perfect evaluation intervals.
+		base = adjNow - (adjNow % int64(g.interval))
+
+		// Add one offset to randomize the evaluation times of this group.
+		next = base + offset
+	)
+
+	return time.Unix(0, next).UTC()
 }
 
 func nameAndLabels(rule Rule) string {

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -532,13 +532,9 @@ func (g *Group) setLastEvaluation(ts time.Time) {
 
 // EvalTimestamp returns the immediately preceding consistently slotted evaluation time.
 func (g *Group) EvalTimestamp(startTime int64) time.Time {
-	var (
-		offset = int64(g.hash() % uint64(g.interval))
-		adjNow = startTime - offset
-		base   = adjNow - (adjNow % int64(g.interval))
-	)
+	offset := (uint64(startTime) - g.hash()) % uint64(g.interval)
 
-	return time.Unix(0, base+offset).UTC()
+	return time.Unix(0, startTime-int64(offset)).UTC()
 }
 
 func nameAndLabels(rule Rule) string {


### PR DESCRIPTION
I found it hard to understand how EvalTimestamp works, so I wanted to simplify the math there or explain how it actually works. 

This PR adds comments to clarify how the expressions in the method work.