### PR TITLE
tsdb: stop saving a copy of last 4 samples in memSeries

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1785,9 +1785,8 @@ type memSeries struct {
 
 	nextAt int64 // Timestamp at which to cut the next chunk.
 
-	// We keep the last 4 samples here (in addition to appending them to the chunk) so we don't need coordination between appender and querier.
-	// Even the most compact encoding of a sample takes 2 bits, so the last byte is not contended.
-	sampleBuf [4]sample
+	// We keep the last value here (in addition to appending it to the chunk) so we can check for duplicates.
+	lastValue float64
 
 	// Current appender for the head chunk. Set when a new head chunk is cut.
 	// It is nil only if headChunk is nil. E.g. if there was an appender that created a new series, but rolled back the commit

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -361,7 +361,7 @@ func (s *memSeries) appendable(t int64, v float64, headMaxt, minValidTime, oooTi
 			// like federation and erroring out at that time would be extremely noisy.
 			// This only checks against the latest in-order sample.
 			// The OOO headchunk has its own method to detect these duplicates.
-			if math.Float64bits(s.sampleBuf[3].v) != math.Float64bits(v) {
+			if math.Float64bits(s.lastValue) != math.Float64bits(v) {
 				return false, 0, storage.ErrDuplicateSampleForTimestamp
 			}
 			// Sample is identical (ts + value) with most current (highest ts) sample in sampleBuf.
@@ -797,11 +797,7 @@ func (s *memSeries) append(t int64, v float64, appendID uint64, chunkDiskMapper 
 	s.app.Append(t, v)
 
 	c.maxTime = t
-
-	s.sampleBuf[0] = s.sampleBuf[1]
-	s.sampleBuf[1] = s.sampleBuf[2]
-	s.sampleBuf[2] = s.sampleBuf[3]
-	s.sampleBuf[3] = sample{t: t, v: v}
+	s.lastValue = v
 
 	if appendID > 0 && s.txs != nil {
 		s.txs.add(appendID)

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -692,70 +692,17 @@ func (s *memSeries) iterator(id chunks.HeadChunkID, isoState *isolationState, ch
 			stopAfter: stopAfter,
 		}
 	}
-	// Serve the last 4 samples for the last chunk from the sample buffer
-	// as their compressed bytes may be mutated by added samples.
-	if msIter, ok := it.(*memSafeIterator); ok {
-		msIter.Iterator = c.chunk.Iterator(msIter.Iterator)
-		msIter.i = -1
-		msIter.total = numSamples
-		msIter.stopAfter = stopAfter
-		msIter.buf = s.sampleBuf
-		return msIter
+	if stopIter, ok := it.(*stopIterator); ok {
+		stopIter.Iterator = c.chunk.Iterator(stopIter.Iterator)
+		stopIter.i = -1
+		stopIter.stopAfter = stopAfter
+		return stopIter
 	}
-	return &memSafeIterator{
-		stopIterator: stopIterator{
-			Iterator:  c.chunk.Iterator(it),
-			i:         -1,
-			stopAfter: stopAfter,
-		},
-		total: numSamples,
-		buf:   s.sampleBuf,
+	return &stopIterator{
+		Iterator:  c.chunk.Iterator(it),
+		i:         -1,
+		stopAfter: stopAfter,
 	}
-}
-
-// memSafeIterator returns values from the wrapped stopIterator
-// except the last 4, which come from buf.
-type memSafeIterator struct {
-	stopIterator
-
-	total int
-	buf   [4]sample
-}
-
-func (it *memSafeIterator) Seek(t int64) bool {
-	if it.Err() != nil {
-		return false
-	}
-
-	ts, _ := it.At()
-
-	for t > ts || it.i == -1 {
-		if !it.Next() {
-			return false
-		}
-		ts, _ = it.At()
-	}
-
-	return true
-}
-
-func (it *memSafeIterator) Next() bool {
-	if it.i+1 >= it.stopAfter {
-		return false
-	}
-	it.i++
-	if it.total-it.i > 4 {
-		return it.Iterator.Next()
-	}
-	return true
-}
-
-func (it *memSafeIterator) At() (int64, float64) {
-	if it.total-it.i > 4 {
-		return it.Iterator.At()
-	}
-	s := it.buf[4-(it.total-it.i)]
-	return s.t, s.v
 }
 
 // stopIterator wraps an Iterator, but only returns the first

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -770,12 +770,12 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 	// Validate that the series' sample buffer is applied correctly to the last chunk
 	// after truncation.
 	it1 := s.iterator(s.headChunkID(len(s.mmappedChunks)), nil, chunkDiskMapper, &memChunkPool, nil)
-	_, ok := it1.(*memSafeIterator)
+	_, ok := it1.(*stopIterator)
 	require.True(t, ok)
 
 	it2 := s.iterator(s.headChunkID(len(s.mmappedChunks)-1), nil, chunkDiskMapper, &memChunkPool, nil)
-	_, ok = it2.(*memSafeIterator)
-	require.False(t, ok, "non-last chunk incorrectly wrapped with sample buffer")
+	_, ok = it2.(*stopIterator)
+	require.False(t, ok, "non-last chunk incorrectly wrapped")
 }
 
 func TestHeadDeleteSeriesWithoutSamples(t *testing.T) {
@@ -2498,7 +2498,7 @@ func TestMemSafeIteratorSeekIntoBuffer(t *testing.T) {
 	}
 
 	it := s.iterator(s.headChunkID(len(s.mmappedChunks)), nil, chunkDiskMapper, nil, nil)
-	_, ok := it.(*memSafeIterator)
+	_, ok := it.(*stopIterator)
 	require.True(t, ok)
 
 	// First point.

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -766,16 +766,6 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 	chk, _, err = s.chunk(lastID, chunkDiskMapper, &memChunkPool)
 	require.NoError(t, err)
 	require.Equal(t, lastChunk, chk)
-
-	// Validate that the series' sample buffer is applied correctly to the last chunk
-	// after truncation.
-	it1 := s.iterator(s.headChunkID(len(s.mmappedChunks)), nil, chunkDiskMapper, &memChunkPool, nil)
-	_, ok := it1.(*stopIterator)
-	require.True(t, ok)
-
-	it2 := s.iterator(s.headChunkID(len(s.mmappedChunks)-1), nil, chunkDiskMapper, &memChunkPool, nil)
-	_, ok = it2.(*stopIterator)
-	require.False(t, ok, "non-last chunk incorrectly wrapped")
 }
 
 func TestHeadDeleteSeriesWithoutSamples(t *testing.T) {
@@ -2481,7 +2471,7 @@ func BenchmarkHeadLabelValuesWithMatchers(b *testing.B) {
 	}
 }
 
-func TestMemSafeIteratorSeekIntoBuffer(t *testing.T) {
+func TestIteratorSeekIntoBuffer(t *testing.T) {
 	dir := t.TempDir()
 	// This is usually taken from the Head, but passing manually here.
 	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
@@ -2498,11 +2488,9 @@ func TestMemSafeIteratorSeekIntoBuffer(t *testing.T) {
 	}
 
 	it := s.iterator(s.headChunkID(len(s.mmappedChunks)), nil, chunkDiskMapper, nil, nil)
-	_, ok := it.(*stopIterator)
-	require.True(t, ok)
 
 	// First point.
-	ok = it.Seek(0)
+	ok := it.Seek(0)
 	require.True(t, ok)
 	ts, val := it.At()
 	require.Equal(t, int64(0), ts)


### PR DESCRIPTION
This extra copy of the last 4 samples was introduced to avoid a race condition between reading the last byte of the chunk and writing to it. ~However this race condition was fixed in f42ed03dc5be, so we don't need the copy any more.~

EDIT: But we can copy just the last byte in `bstreamReader` instead.

This change saves 56 bytes per series, which is very worthwhile when you have millions of series.

(#11280 and #11288 each remove another 8 bytes)

I kept the head snapshot binary compatible by writing zeros where the samples used to be and ignoring any values found, but perhaps we should bump the version and save the work.