### PR TITLE
tsdb: comment reason for isolation tracking reads

### DIFF
--- a/tsdb/isolation.go
+++ b/tsdb/isolation.go
@@ -122,7 +122,8 @@ func (i *isolation) State(mint, maxt int64) *isolationState {
 	i.appendMtx.RLock() // Take append mutex before read mutex.
 	defer i.appendMtx.RUnlock()
 
-	// We need to track the reads even when isolation is disabled.
+	// We need to track reads even when isolation is disabled, so that head
+	// truncation can wait till reads overlapping that range have finished.
 	isoState := &isolationState{
 		maxAppendID:       i.appendsOpenList.appendID,
 		lowWatermark:      i.appendsOpenList.next.appendID, // Lowest appendID from appenders, or lastAppendId.


### PR DESCRIPTION
I find it useful to know why a restriction exists, to check whether that reason still applies, or in which other places it might apply.

This is based on the note here: https://github.com/prometheus/prometheus/pull/9270#pullrequestreview-743820956 on the PR where the original comment was added.

