### PR TITLE
Error on amending histograms on append

### DIFF
--- a/model/histogram/histogram.go
+++ b/model/histogram/histogram.go
@@ -155,11 +155,11 @@ func (h *Histogram) CumulativeBucketIterator() BucketIterator {
 	return &cumulativeBucketIterator{h: h, posSpansIdx: -1}
 }
 
-// Matches returns true if the given histogram matches exactly.
+// Equals returns true if the given histogram matches exactly.
 // Exact match is when there are no new buckets (even empty) and no missing buckets,
 // and all the bucket values match. Spans can have different empty length spans in between,
 // but they must represent the same bucket layout to match.
-func (h *Histogram) Matches(h2 *Histogram) bool {
+func (h *Histogram) Equals(h2 *Histogram) bool {
 	if h2 == nil {
 		return false
 	}

--- a/model/histogram/histogram_test.go
+++ b/model/histogram/histogram_test.go
@@ -431,13 +431,13 @@ func TestHistogramMatches(t *testing.T) {
 	}
 
 	h2 := h1.Copy()
-	require.True(t, h1.Matches(h2))
+	require.True(t, h1.Equals(h2))
 
 	// Changed spans but same layout.
 	h2.PositiveSpans = append(h2.PositiveSpans, Span{Offset: 5})
 	h2.NegativeSpans = append(h2.NegativeSpans, Span{Offset: 2})
-	require.True(t, h1.Matches(h2))
-	require.True(t, h2.Matches(&h1))
+	require.True(t, h1.Equals(h2))
+	require.True(t, h2.Equals(&h1))
 	// Adding empty spans in between.
 	h2.PositiveSpans[1].Offset = 6
 	h2.PositiveSpans = []Span{
@@ -455,58 +455,58 @@ func TestHistogramMatches(t *testing.T) {
 		h2.NegativeSpans[1],
 		h2.NegativeSpans[2],
 	}
-	require.True(t, h1.Matches(h2))
-	require.True(t, h2.Matches(&h1))
+	require.True(t, h1.Equals(h2))
+	require.True(t, h2.Equals(&h1))
 
 	// All mismatches.
-	require.False(t, h1.Matches(nil))
+	require.False(t, h1.Equals(nil))
 
 	h2.Schema = 1
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 
 	h2 = h1.Copy()
 	h2.Count++
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 
 	h2 = h1.Copy()
 	h2.Sum++
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 
 	h2 = h1.Copy()
 	h2.ZeroThreshold++
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 
 	h2 = h1.Copy()
 	h2.ZeroCount++
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 
 	// Changing value of buckets.
 	h2 = h1.Copy()
 	h2.PositiveBuckets[len(h2.PositiveBuckets)-1]++
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 	h2 = h1.Copy()
 	h2.NegativeBuckets[len(h2.NegativeBuckets)-1]++
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 
 	// Changing bucket layout.
 	h2 = h1.Copy()
 	h2.PositiveSpans[1].Offset++
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 	h2 = h1.Copy()
 	h2.NegativeSpans[1].Offset++
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 
 	// Adding an empty bucket.
 	h2 = h1.Copy()
 	h2.PositiveSpans[0].Offset--
 	h2.PositiveSpans[0].Length++
 	h2.PositiveBuckets = append([]int64{0}, h2.PositiveBuckets...)
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 	h2 = h1.Copy()
 	h2.NegativeSpans[0].Offset--
 	h2.NegativeSpans[0].Length++
 	h2.NegativeBuckets = append([]int64{0}, h2.NegativeBuckets...)
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 
 	// Adding new bucket.
 	h2 = h1.Copy()
@@ -515,12 +515,12 @@ func TestHistogramMatches(t *testing.T) {
 		Length: 1,
 	})
 	h2.PositiveBuckets = append(h2.PositiveBuckets, 1)
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 	h2 = h1.Copy()
 	h2.NegativeSpans = append(h2.NegativeSpans, Span{
 		Offset: 1,
 		Length: 1,
 	})
 	h2.NegativeBuckets = append(h2.NegativeBuckets, 1)
-	require.False(t, h1.Matches(h2))
+	require.False(t, h1.Equals(h2))
 }

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -392,12 +392,12 @@ func (s *memSeries) appendableHistogram(t int64, h *histogram.Histogram) error {
 	if t < c.maxTime {
 		return storage.ErrOutOfOrderSample
 	}
-	// TODO(beorn7): do it for histogram.
+
 	// We are allowing exact duplicates as we can encounter them in valid cases
 	// like federation and erroring out at that time would be extremely noisy.
-	//if math.Float64bits(s.sampleBuf[3].v) != math.Float64bits(v) {
-	//	return storage.ErrDuplicateSampleForTimestamp
-	//}
+	if !h.Matches(s.sampleBuf[3].h) {
+		return storage.ErrDuplicateSampleForTimestamp
+	}
 	return nil
 }
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -395,7 +395,7 @@ func (s *memSeries) appendableHistogram(t int64, h *histogram.Histogram) error {
 
 	// We are allowing exact duplicates as we can encounter them in valid cases
 	// like federation and erroring out at that time would be extremely noisy.
-	if !h.Matches(s.sampleBuf[3].h) {
+	if !h.Equals(s.sampleBuf[3].h) {
 		return storage.ErrDuplicateSampleForTimestamp
 	}
 	return nil


### PR DESCRIPTION
NOTE: sparsehistogram branch

Closes https://github.com/prometheus/prometheus/issues/11197

Currently the logic considers any additional empty bucket or missing empty bucket as a different histogram, that case is not handled. We are however taking into account the zero length spans and comparing them accordingly. So it matches as long as the bucket layout is same with same data.