### PR TITLE
Add secret for repo sync

### DIFF
--- a/.github/workflows/funcbench.yml
+++ b/.github/workflows/funcbench.yml
@@ -12,7 +12,7 @@ jobs:
       BRANCH: ${{ github.event.client_payload.BRANCH }}
       BENCH_FUNC_REGEX: ${{ github.event.client_payload.BENCH_FUNC_REGEX }}
       PACKAGE_PATH: ${{ github.event.client_payload.PACKAGE_PATH }}
-      GITHUB_TOKEN: ${{ secrets.PROMBOT_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.PROMBOT_GITHUB_TOKEN }}
       GITHUB_ORG: prometheus
       GITHUB_REPO: prometheus
       GITHUB_STATUS_TARGET_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -10,3 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/sync_repo_files.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROMBOT_GITHUB_TOKEN }}

--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -1,4 +1,5 @@
 ---
+name: Sync repo files
 on:
   schedule:
     - cron: '44 17 * * *'


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
