### PR TITLE
ui: make targets table sortable by all but labels

### DIFF
--- a/web/ui/react-app/src/pages/targets/ScrapePoolContent.tsx
+++ b/web/ui/react-app/src/pages/targets/ScrapePoolContent.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { getColor, Target } from './target';
 import { Badge, Table } from 'reactstrap';
 import TargetLabels from './TargetLabels';
@@ -8,25 +8,35 @@ import { now } from 'moment';
 import TargetScrapeDuration from './TargetScrapeDuration';
 import EndpointLink from './EndpointLink';
 import CustomInfiniteScroll, { InfiniteScrollItemsProps } from '../../components/CustomInfiniteScroll';
-
-const columns = ['Endpoint', 'State', 'Labels', 'Last Scrape', 'Scrape Duration', 'Error'];
+import { faSort, faSortDown, faSortUp } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 interface ScrapePoolContentProps {
   targets: Target[];
 }
 
 const ScrapePoolContentTable: FC<InfiniteScrollItemsProps<Target>> = ({ items }) => {
+  const [sortState, setSortState] = useState<SortState>({ column: 'scrapeUrl', desc: true });
   return (
     <Table className={styles.table} size="sm" bordered hover striped>
       <thead>
         <tr key="header">
-          {columns.map((column) => (
-            <th key={column}>{column}</th>
-          ))}
+          <SortableColumnHeader setSortState={setSortState} column="scrapeUrl" label="Endpoint" sortState={sortState} />
+          <SortableColumnHeader setSortState={setSortState} column="health" label="State" sortState={sortState} />
+          {/* NOTE: we do not sort labels as an ordering here isn't completely obvious or useful. */}
+          <th>Labels</th>
+          <SortableColumnHeader setSortState={setSortState} column="lastScrape" label="Last Scrape" sortState={sortState} />
+          <SortableColumnHeader
+            setSortState={setSortState}
+            column="lastScrapeDuration"
+            label="Scrape Duration"
+            sortState={sortState}
+          />
+          <SortableColumnHeader setSortState={setSortState} column="lastError" label="Error" sortState={sortState} />
         </tr>
       </thead>
       <tbody>
-        {items.map((target, index) => (
+        {items.sort(compareFunc(sortState)).map((target, index) => (
           <tr key={index}>
             <td className={styles.endpoint}>
               <EndpointLink endpoint={target.scrapeUrl} globalUrl={target.globalUrl} />
@@ -61,6 +71,50 @@ const ScrapePoolContentTable: FC<InfiniteScrollItemsProps<Target>> = ({ items })
     </Table>
   );
 };
+
+const stringColumns = ['scrapeUrl', 'health', 'lastError', 'lastScrape'] as const;
+type StringColumn = typeof stringColumns[number];
+const numericColumns = ['lastScrapeDuration'] as const;
+type NumericColumn = typeof numericColumns[number];
+type SortableColumn = StringColumn | NumericColumn;
+
+const compareFunc = (sortState: SortState) => (a: Target, b: Target) => {
+  // We need to distinguish between string columns and number columns to handle
+  // sorting appropriately.
+  if (stringColumns.includes(sortState.column as StringColumn)) {
+    return (
+      (sortState.desc ? 1 : -1) * a[sortState.column as StringColumn].localeCompare(b[sortState.column as StringColumn])
+    );
+  } else if (numericColumns.includes(sortState.column as NumericColumn)) {
+    return (sortState.desc ? 1 : -1) * a[sortState.column as NumericColumn] - b[sortState.column as NumericColumn];
+  }
+
+  return 0;
+};
+
+interface SortState {
+  column: SortableColumn;
+  desc: boolean;
+}
+
+interface SortableColumnHeaderProps {
+  setSortState: (state: SortState) => void;
+  column: SortableColumn;
+  label: string;
+  sortState: SortState;
+}
+
+const SortableColumnHeader: FC<SortableColumnHeaderProps> = ({ setSortState, column, label, sortState }) => (
+  <th onClick={() => setSortState({ column, desc: !sortState.desc })} role="button">
+    <div className="d-flex justify-content-between">
+      {label}
+      <FontAwesomeIcon
+        className={column != sortState.column ? 'text-muted' : 'text-dark'}
+        icon={column != sortState.column ? faSort : sortState.desc ? faSortDown : faSortUp}
+      />
+    </div>
+  </th>
+);
 
 export const ScrapePoolContent: FC<ScrapePoolContentProps> = ({ targets }) => {
   return <CustomInfiniteScroll allItems={targets} child={ScrapePoolContentTable} />;


### PR DESCRIPTION
This adds sort icons on all table columns except labels, allowing to toggle ascending/descending by a single column. We consider if the column is a string value as is endpoint, health etc. or a number as is last scrape duration.

I've kept the sorting arrows consistent with the arrows used in `Flags.tsx` I think although my styling could probably do with some tweaking.

I wasn't sure where to put tests for this or if I should, happy to do some on request.

I'm no expert in TypeScript of React so I'm sure there's some oddities in there that need to be resolved.

Resolves https://github.com/prometheus/prometheus/issues/10896

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
