### PR TITLE
Add `__meta_ec2_region` and `__meta_lightsail_region` SD meta labels

### DIFF
--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -57,6 +57,7 @@ const (
 	ec2LabelPrivateIP         = ec2Label + "private_ip"
 	ec2LabelPublicDNS         = ec2Label + "public_dns_name"
 	ec2LabelPublicIP          = ec2Label + "public_ip"
+	ec2LabelRegion            = ec2Label + "region"
 	ec2LabelSubnetID          = ec2Label + "subnet_id"
 	ec2LabelTag               = ec2Label + "tag_"
 	ec2LabelVPCID             = ec2Label + "vpc_id"
@@ -242,6 +243,7 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 
 				labels := model.LabelSet{
 					ec2LabelInstanceID: model.LabelValue(*inst.InstanceId),
+					ec2LabelRegion:     model.LabelValue(d.cfg.Region),
 				}
 
 				if r.OwnerId != nil {

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -49,6 +49,7 @@ const (
 	lightsailLabelIPv6Addresses       = lightsailLabel + "ipv6_addresses"
 	lightsailLabelPrivateIP           = lightsailLabel + "private_ip"
 	lightsailLabelPublicIP            = lightsailLabel + "public_ip"
+	lightsailLabelRegion              = lightsailLabel + "region"
 	lightsailLabelTag                 = lightsailLabel + "tag_"
 	lightsailLabelSeparator           = ","
 )
@@ -199,6 +200,7 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 			lightsailLabelInstanceState:       model.LabelValue(*inst.State.Name),
 			lightsailLabelInstanceSupportCode: model.LabelValue(*inst.SupportCode),
 			lightsailLabelPrivateIP:           model.LabelValue(*inst.PrivateIpAddress),
+			lightsailLabelRegion:              model.LabelValue(d.cfg.Region),
 		}
 
 		addr := net.JoinHostPort(*inst.PrivateIpAddress, fmt.Sprintf("%d", d.cfg.Port))

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1016,6 +1016,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_ec2_private_ip`: the private IP address of the instance, if present
 * `__meta_ec2_public_dns_name`: the public DNS name of the instance, if available
 * `__meta_ec2_public_ip`: the public IP address of the instance, if available
+* `__meta_ec2_region`: the region of the instance
 * `__meta_ec2_subnet_id`: comma separated list of subnets IDs in which the instance is running, if available
 * `__meta_ec2_tag_<tagkey>`: each tag value of the instance
 * `__meta_ec2_vpc_id`: the ID of the VPC in which the instance is running, if available
@@ -1968,6 +1969,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_lightsail_ipv6_addresses`: comma separated list of IPv6 addresses assigned to the instance's network interfaces, if present
 * `__meta_lightsail_private_ip`: the private IP address of the instance
 * `__meta_lightsail_public_ip`: the public IP address of the instance, if available
+* `__meta_lightsail_region`: the region of the instance
 * `__meta_lightsail_tag_<tagkey>`: each tag value of the instance
 
 See below for the configuration options for Lightsail discovery:


### PR DESCRIPTION
Fixes #11320

-----
@juliusv:
I don't know whether `model.LabelValue` with an empty string is valid.  However, as far as I can see, `d.cfg.Region` can never be empty string anyway (if it were, the [AWS API client](https://github.com/aws/aws-sdk-go/blob/v1.44.100/aws/ec2metadata/api.go#L198-L200) would return an error). Hence I haven't checked for this condition.

I have tested this with EC2 only. I don't use Lightsail, but I've made the corresponding change for that too for consistency.

I have not put anything in CHANGELOG, I don't know which branch this will end up being applied to.