### PR TITLE
tsdb: reuse iterators to save garbage [INTERFACE CHANGE]

### DIFF
--- a/cmd/promtool/backfill_test.go
+++ b/cmd/promtool/backfill_test.go
@@ -49,7 +49,7 @@ func queryAllSeries(t testing.TB, q storage.Querier, expectedMinTime, expectedMa
 	samples := []backfillSample{}
 	for ss.Next() {
 		series := ss.At()
-		it := series.Iterator()
+		it := series.Iterator(nil)
 		require.NoError(t, it.Err())
 		for it.Next() == chunkenc.ValFloat {
 			ts, v := it.At()

--- a/cmd/promtool/rules_test.go
+++ b/cmd/promtool/rules_test.go
@@ -139,7 +139,7 @@ func TestBackfillRuleIntegration(t *testing.T) {
 					} else {
 						require.Equal(t, 3, len(series.Labels()))
 					}
-					it := series.Iterator()
+					it := series.Iterator(nil)
 					for it.Next() == chunkenc.ValFloat {
 						samplesCount++
 						ts, v := it.At()

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -644,7 +644,7 @@ func dumpSamples(path string, mint, maxt int64) (err error) {
 	for ss.Next() {
 		series := ss.At()
 		lbs := series.Labels()
-		it := series.Iterator()
+		it := series.Iterator(nil)
 		for it.Next() == chunkenc.ValFloat {
 			ts, val := it.At()
 			fmt.Printf("%s %g %d\n", lbs, val, ts)

--- a/promql/test_test.go
+++ b/promql/test_test.go
@@ -143,7 +143,7 @@ func TestLazyLoader_WithSamplesTill(t *testing.T) {
 					got := Series{
 						Metric: storageSeries.Labels(),
 					}
-					it := storageSeries.Iterator()
+					it := storageSeries.Iterator(nil)
 					for it.Next() == chunkenc.ValFloat {
 						t, v := it.At()
 						got.Points = append(got.Points, Point{T: t, V: v})

--- a/promql/value.go
+++ b/promql/value.go
@@ -363,7 +363,7 @@ func (ss *StorageSeries) Labels() labels.Labels {
 }
 
 // Iterator returns a new iterator of the data of the series.
-func (ss *StorageSeries) Iterator() chunkenc.Iterator {
+func (ss *StorageSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
 	return newStorageSeriesIterator(ss.series)
 }
 

--- a/promql/value.go
+++ b/promql/value.go
@@ -364,6 +364,10 @@ func (ss *StorageSeries) Labels() labels.Labels {
 
 // Iterator returns a new iterator of the data of the series.
 func (ss *StorageSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
+	if ssi, ok := it.(*storageSeriesIterator); ok {
+		ssi.reset(ss.series)
+		return ssi
+	}
 	return newStorageSeriesIterator(ss.series)
 }
 
@@ -377,6 +381,11 @@ func newStorageSeriesIterator(series Series) *storageSeriesIterator {
 		points: series.Points,
 		curr:   -1,
 	}
+}
+
+func (ssi *storageSeriesIterator) reset(series Series) {
+	ssi.points = series.Points
+	ssi.curr = -1
 }
 
 func (ssi *storageSeriesIterator) Seek(t int64) chunkenc.ValueType {

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -807,7 +807,7 @@ func (g *Group) RestoreForState(ts time.Time) {
 			// Series found for the 'for' state.
 			var t int64
 			var v float64
-			it := s.Iterator()
+			it := s.Iterator(nil)
 			for it.Next() == chunkenc.ValFloat {
 				t, v = it.At()
 			}

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -592,12 +592,13 @@ func TestStaleness(t *testing.T) {
 // Convert a SeriesSet into a form usable with require.Equal.
 func readSeriesSet(ss storage.SeriesSet) (map[string][]promql.Point, error) {
 	result := map[string][]promql.Point{}
+	var it chunkenc.Iterator
 
 	for ss.Next() {
 		series := ss.At()
 
 		points := []promql.Point{}
-		it := series.Iterator()
+		it := series.Iterator(it)
 		for it.Next() == chunkenc.ValFloat {
 			t, v := it.At()
 			points = append(points, promql.Point{T: t, V: v})

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2959,7 +2959,7 @@ func TestScrapeReportSingleAppender(t *testing.T) {
 
 		c := 0
 		for series.Next() {
-			i := series.At().Iterator()
+			i := series.At().Iterator(nil)
 			for i.Next() != chunkenc.ValNone {
 				c++
 			}
@@ -3032,7 +3032,7 @@ func TestScrapeReportLimit(t *testing.T) {
 
 	var found bool
 	for series.Next() {
-		i := series.At().Iterator()
+		i := series.At().Iterator(nil)
 		for i.Next() == chunkenc.ValFloat {
 			_, v := i.At()
 			require.Equal(t, 1.0, v)

--- a/storage/fanout_test.go
+++ b/storage/fanout_test.go
@@ -86,11 +86,12 @@ func TestFanout_SelectSorted(t *testing.T) {
 
 		result := make(map[int64]float64)
 		var labelsResult labels.Labels
+		var iterator chunkenc.Iterator
 		for seriesSet.Next() {
 			series := seriesSet.At()
 			seriesLabels := series.Labels()
 			labelsResult = seriesLabels
-			iterator := series.Iterator()
+			iterator := series.Iterator(iterator)
 			for iterator.Next() == chunkenc.ValFloat {
 				timestamp, value := iterator.At()
 				result[timestamp] = value
@@ -112,11 +113,12 @@ func TestFanout_SelectSorted(t *testing.T) {
 
 		result := make(map[int64]float64)
 		var labelsResult labels.Labels
+		var iterator chunkenc.Iterator
 		for seriesSet.Next() {
 			series := seriesSet.At()
 			seriesLabels := series.Labels()
 			labelsResult = seriesLabels
-			iterator := series.Iterator()
+			iterator := series.Iterator(iterator)
 			for iterator.Next() == chunkenc.ValFloat {
 				timestamp, value := iterator.At()
 				result[timestamp] = value

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -422,7 +422,7 @@ type Labels interface {
 
 type SampleIterable interface {
 	// Iterator returns an iterator of the data of the series.
-	// The iterator passed as argument is for re-use.
+	// The iterator passed as argument is for re-use, if not nil.
 	// Depending on implementation, the iterator can
 	// be re-used or a new iterator can be allocated.
 	Iterator(chunkenc.Iterator) chunkenc.Iterator

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -382,7 +382,7 @@ func (s mockSeries) Labels() labels.Labels {
 	return labels.FromStrings(s.labelSet...)
 }
 
-func (s mockSeries) Iterator() chunkenc.Iterator {
+func (s mockSeries) Iterator(chunkenc.Iterator) chunkenc.Iterator {
 	return chunkenc.MockSeriesIterator(s.timestamps, s.values)
 }
 
@@ -421,14 +421,17 @@ type Labels interface {
 }
 
 type SampleIterable interface {
-	// Iterator returns a new, independent iterator of the data of the series.
-	Iterator() chunkenc.Iterator
+	// Iterator returns an iterator of the data of the series.
+	// The iterator passed as argument is for re-use.
+	// Depending on implementation, the iterator can
+	// be re-used or a new iterator can be allocated.
+	Iterator(chunkenc.Iterator) chunkenc.Iterator
 }
 
 type ChunkIterable interface {
-	// Iterator returns a new, independent iterator that iterates over potentially overlapping
+	// Iterator returns an iterator that iterates over potentially overlapping
 	// chunks of the series, sorted by min time.
-	Iterator() chunks.Iterator
+	Iterator(chunks.Iterator) chunks.Iterator
 }
 
 type Warnings []error

--- a/storage/merge.go
+++ b/storage/merge.go
@@ -425,12 +425,8 @@ func ChainedSeriesMerge(series ...Series) Series {
 	}
 	return &SeriesEntry{
 		Lset: series[0].Labels(),
-		SampleIteratorFn: func(chunkenc.Iterator) chunkenc.Iterator {
-			iterators := make([]chunkenc.Iterator, 0, len(series))
-			for _, s := range series {
-				iterators = append(iterators, s.Iterator(nil))
-			}
-			return NewChainSampleIterator(iterators)
+		SampleIteratorFn: func(it chunkenc.Iterator) chunkenc.Iterator {
+			return ChainSampleIteratorFromSeries(it, series)
 		},
 	}
 }
@@ -446,15 +442,42 @@ type chainSampleIterator struct {
 	lastT int64
 }
 
-// NewChainSampleIterator returns a single iterator that iterates over the samples from the given iterators in a sorted
-// fashion. If samples overlap, one sample from overlapped ones is kept (randomly) and all others with the same
-// timestamp are dropped.
-func NewChainSampleIterator(iterators []chunkenc.Iterator) chunkenc.Iterator {
-	return &chainSampleIterator{
-		iterators: iterators,
-		h:         nil,
-		lastT:     math.MinInt64,
+// Return a chainSampleIterator initialized for length entries, re-using the memory from it if possible.
+func getChainSampleIterator(it chunkenc.Iterator, length int) *chainSampleIterator {
+	csi, ok := it.(*chainSampleIterator)
+	if !ok {
+		csi = &chainSampleIterator{}
 	}
+	if cap(csi.iterators) < length {
+		csi.iterators = make([]chunkenc.Iterator, length)
+	} else {
+		csi.iterators = csi.iterators[:length]
+	}
+	csi.h = nil
+	csi.lastT = math.MinInt64
+	return csi
+}
+
+func ChainSampleIteratorFromSeries(it chunkenc.Iterator, series []Series) chunkenc.Iterator {
+	csi := getChainSampleIterator(it, len(series))
+	for i, s := range series {
+		csi.iterators[i] = s.Iterator(csi.iterators[i])
+	}
+	return csi
+}
+
+func ChainSampleIteratorFromMetas(it chunkenc.Iterator, chunks []chunks.Meta) chunkenc.Iterator {
+	csi := getChainSampleIterator(it, len(chunks))
+	for i, c := range chunks {
+		csi.iterators[i] = c.Chunk.Iterator(csi.iterators[i])
+	}
+	return csi
+}
+
+func ChainSampleIteratorFromIterators(it chunkenc.Iterator, iterators []chunkenc.Iterator) chunkenc.Iterator {
+	csi := getChainSampleIterator(it, 0)
+	csi.iterators = iterators
+	return csi
 }
 
 func (c *chainSampleIterator) Seek(t int64) chunkenc.ValueType {

--- a/storage/merge.go
+++ b/storage/merge.go
@@ -425,10 +425,10 @@ func ChainedSeriesMerge(series ...Series) Series {
 	}
 	return &SeriesEntry{
 		Lset: series[0].Labels(),
-		SampleIteratorFn: func() chunkenc.Iterator {
+		SampleIteratorFn: func(chunkenc.Iterator) chunkenc.Iterator {
 			iterators := make([]chunkenc.Iterator, 0, len(series))
 			for _, s := range series {
-				iterators = append(iterators, s.Iterator())
+				iterators = append(iterators, s.Iterator(nil))
 			}
 			return NewChainSampleIterator(iterators)
 		},
@@ -607,10 +607,10 @@ func NewCompactingChunkSeriesMerger(mergeFunc VerticalSeriesMergeFunc) VerticalC
 		}
 		return &ChunkSeriesEntry{
 			Lset: series[0].Labels(),
-			ChunkIteratorFn: func() chunks.Iterator {
+			ChunkIteratorFn: func(chunks.Iterator) chunks.Iterator {
 				iterators := make([]chunks.Iterator, 0, len(series))
 				for _, s := range series {
-					iterators = append(iterators, s.Iterator())
+					iterators = append(iterators, s.Iterator(nil))
 				}
 				return &compactChunkIterator{
 					mergeFunc: mergeFunc,
@@ -693,7 +693,7 @@ func (c *compactChunkIterator) Next() bool {
 	}
 
 	// Add last as it's not yet included in overlap. We operate on same series, so labels does not matter here.
-	iter = NewSeriesToChunkEncoder(c.mergeFunc(append(overlapping, newChunkToSeriesDecoder(nil, c.curr))...)).Iterator()
+	iter = NewSeriesToChunkEncoder(c.mergeFunc(append(overlapping, newChunkToSeriesDecoder(nil, c.curr))...)).Iterator(nil)
 	if !iter.Next() {
 		if c.err = iter.Err(); c.err != nil {
 			return false
@@ -751,10 +751,10 @@ func NewConcatenatingChunkSeriesMerger() VerticalChunkSeriesMergeFunc {
 		}
 		return &ChunkSeriesEntry{
 			Lset: series[0].Labels(),
-			ChunkIteratorFn: func() chunks.Iterator {
+			ChunkIteratorFn: func(chunks.Iterator) chunks.Iterator {
 				iterators := make([]chunks.Iterator, 0, len(series))
 				for _, s := range series {
-					iterators = append(iterators, s.Iterator())
+					iterators = append(iterators, s.Iterator(nil))
 				}
 				return &concatenatingChunkIterator{
 					iterators: iterators,

--- a/storage/merge_test.go
+++ b/storage/merge_test.go
@@ -202,8 +202,8 @@ func TestMergeQuerierWithChainMerger(t *testing.T) {
 				expectedSeries := tc.expected.At()
 				require.Equal(t, expectedSeries.Labels(), actualSeries.Labels())
 
-				expSmpl, expErr := ExpandSamples(expectedSeries.Iterator(), nil)
-				actSmpl, actErr := ExpandSamples(actualSeries.Iterator(), nil)
+				expSmpl, expErr := ExpandSamples(expectedSeries.Iterator(nil), nil)
+				actSmpl, actErr := ExpandSamples(actualSeries.Iterator(nil), nil)
 				require.Equal(t, expErr, actErr)
 				require.Equal(t, expSmpl, actSmpl)
 			}
@@ -370,8 +370,8 @@ func TestMergeChunkQuerierWithNoVerticalChunkSeriesMerger(t *testing.T) {
 				expectedSeries := tc.expected.At()
 				require.Equal(t, expectedSeries.Labels(), actualSeries.Labels())
 
-				expChks, expErr := ExpandChunks(expectedSeries.Iterator())
-				actChks, actErr := ExpandChunks(actualSeries.Iterator())
+				expChks, expErr := ExpandChunks(expectedSeries.Iterator(nil))
+				actChks, actErr := ExpandChunks(actualSeries.Iterator(nil))
 				require.Equal(t, expErr, actErr)
 				require.Equal(t, expChks, actChks)
 
@@ -533,8 +533,8 @@ func TestCompactingChunkSeriesMerger(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			merged := m(tc.input...)
 			require.Equal(t, tc.expected.Labels(), merged.Labels())
-			actChks, actErr := ExpandChunks(merged.Iterator())
-			expChks, expErr := ExpandChunks(tc.expected.Iterator())
+			actChks, actErr := ExpandChunks(merged.Iterator(nil))
+			expChks, expErr := ExpandChunks(tc.expected.Iterator(nil))
 
 			require.Equal(t, expErr, actErr)
 			require.Equal(t, expChks, actChks)
@@ -667,8 +667,8 @@ func TestConcatenatingChunkSeriesMerger(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			merged := m(tc.input...)
 			require.Equal(t, tc.expected.Labels(), merged.Labels())
-			actChks, actErr := ExpandChunks(merged.Iterator())
-			expChks, expErr := ExpandChunks(tc.expected.Iterator())
+			actChks, actErr := ExpandChunks(merged.Iterator(nil))
+			expChks, expErr := ExpandChunks(tc.expected.Iterator(nil))
 
 			require.Equal(t, expErr, actErr)
 			require.Equal(t, expChks, actChks)
@@ -893,10 +893,11 @@ func benchmarkDrain(b *testing.B, makeSeriesSet func() SeriesSet) {
 	var err error
 	var t int64
 	var v float64
+	var iter chunkenc.Iterator
 	for n := 0; n < b.N; n++ {
 		seriesSet := makeSeriesSet()
 		for seriesSet.Next() {
-			iter := seriesSet.At().Iterator()
+			iter = seriesSet.At().Iterator(iter)
 			for iter.Next() == chunkenc.ValFloat {
 				t, v = iter.At()
 			}

--- a/storage/merge_test.go
+++ b/storage/merge_test.go
@@ -868,9 +868,7 @@ func TestChainSampleIteratorSeek(t *testing.T) {
 	}
 }
 
-var result []tsdbutil.Sample
-
-func makeSeriesSet(numSeries, numSamples int) SeriesSet {
+func makeSeries(numSeries, numSamples int) []Series {
 	series := []Series{}
 	for j := 0; j < numSeries; j++ {
 		labels := labels.FromStrings("foo", fmt.Sprintf("bar%d", j))
@@ -880,30 +878,38 @@ func makeSeriesSet(numSeries, numSamples int) SeriesSet {
 		}
 		series = append(series, NewListSeries(labels, samples))
 	}
-	return NewMockSeriesSet(series...)
+	return series
 }
 
-func makeMergeSeriesSet(numSeriesSets, numSeries, numSamples int) SeriesSet {
-	seriesSets := []genericSeriesSet{}
-	for i := 0; i < numSeriesSets; i++ {
-		seriesSets = append(seriesSets, &genericSeriesSetAdapter{makeSeriesSet(numSeries, numSamples)})
+func makeMergeSeriesSet(serieses [][]Series) SeriesSet {
+	seriesSets := make([]genericSeriesSet, len(serieses))
+	for i, s := range serieses {
+		seriesSets[i] = &genericSeriesSetAdapter{NewMockSeriesSet(s...)}
 	}
 	return &seriesSetAdapter{newGenericMergeSeriesSet(seriesSets, (&seriesMergerAdapter{VerticalSeriesMergeFunc: ChainedSeriesMerge}).Merge)}
 }
 
-func benchmarkDrain(seriesSet SeriesSet, b *testing.B) {
+func benchmarkDrain(b *testing.B, makeSeriesSet func() SeriesSet) {
 	var err error
+	var t int64
+	var v float64
 	for n := 0; n < b.N; n++ {
+		seriesSet := makeSeriesSet()
 		for seriesSet.Next() {
-			result, err = ExpandSamples(seriesSet.At().Iterator(), nil)
-			require.NoError(b, err)
+			iter := seriesSet.At().Iterator()
+			for iter.Next() == chunkenc.ValFloat {
+				t, v = iter.At()
+			}
+			err = iter.Err()
 		}
+		require.NoError(b, err)
+		require.NotEqual(b, t, v) // To ensure the inner loop doesn't get optimised away.
 	}
 }
 
 func BenchmarkNoMergeSeriesSet_100_100(b *testing.B) {
-	seriesSet := makeSeriesSet(100, 100)
-	benchmarkDrain(seriesSet, b)
+	series := makeSeries(100, 100)
+	benchmarkDrain(b, func() SeriesSet { return NewMockSeriesSet(series...) })
 }
 
 func BenchmarkMergeSeriesSet(b *testing.B) {
@@ -914,9 +920,12 @@ func BenchmarkMergeSeriesSet(b *testing.B) {
 		{10, 100, 100},
 		{100, 100, 100},
 	} {
-		seriesSet := makeMergeSeriesSet(bm.numSeriesSets, bm.numSeries, bm.numSamples)
+		serieses := [][]Series{}
+		for i := 0; i < bm.numSeriesSets; i++ {
+			serieses = append(serieses, makeSeries(bm.numSeries, bm.numSamples))
+		}
 		b.Run(fmt.Sprintf("%d_%d_%d", bm.numSeriesSets, bm.numSeries, bm.numSamples), func(b *testing.B) {
-			benchmarkDrain(seriesSet, b)
+			benchmarkDrain(b, func() SeriesSet { return makeMergeSeriesSet(serieses) })
 		})
 	}
 }

--- a/storage/merge_test.go
+++ b/storage/merge_test.go
@@ -809,7 +809,7 @@ func TestChainSampleIterator(t *testing.T) {
 			expected: []tsdbutil.Sample{sample{0, 0, nil, nil}, sample{1, 1, nil, nil}, sample{2, 2, nil, nil}, sample{3, 3, nil, nil}},
 		},
 	} {
-		merged := NewChainSampleIterator(tc.input)
+		merged := ChainSampleIteratorFromIterators(nil, tc.input)
 		actual, err := ExpandSamples(merged, nil)
 		require.NoError(t, err)
 		require.Equal(t, tc.expected, actual)
@@ -855,7 +855,7 @@ func TestChainSampleIteratorSeek(t *testing.T) {
 			expected: []tsdbutil.Sample{sample{0, 0, nil, nil}, sample{1, 1, nil, nil}, sample{2, 2, nil, nil}, sample{3, 3, nil, nil}},
 		},
 	} {
-		merged := NewChainSampleIterator(tc.input)
+		merged := ChainSampleIteratorFromIterators(nil, tc.input)
 		actual := []tsdbutil.Sample{}
 		if merged.Seek(tc.seek) == chunkenc.ValFloat {
 			t, v := merged.At()

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -33,6 +33,7 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
 // decodeReadLimit is the maximum size of a read request body in bytes.
@@ -115,9 +116,10 @@ func ToQuery(from, to int64, matchers []*labels.Matcher, hints *storage.SelectHi
 func ToQueryResult(ss storage.SeriesSet, sampleLimit int) (*prompb.QueryResult, storage.Warnings, error) {
 	numSamples := 0
 	resp := &prompb.QueryResult{}
+	var iter chunkenc.Iterator
 	for ss.Next() {
 		series := ss.At()
-		iter := series.Iterator()
+		iter = series.Iterator(iter)
 		samples := []prompb.Sample{}
 
 		for iter.Next() == chunkenc.ValFloat {
@@ -199,11 +201,12 @@ func StreamChunkedReadResponses(
 	var (
 		chks []prompb.Chunk
 		lbls []prompb.Label
+		iter chunks.Iterator
 	)
 
 	for ss.Next() {
 		series := ss.At()
-		iter := series.Iterator()
+		iter = series.Iterator(iter)
 		lbls = MergeLabels(labelsToLabelsProto(series.Labels(), lbls), sortedExternalLabels)
 
 		frameBytesLeft := maxBytesInFrame
@@ -346,7 +349,7 @@ func (c *concreteSeries) Labels() labels.Labels {
 	return labels.New(c.labels...)
 }
 
-func (c *concreteSeries) Iterator() chunkenc.Iterator {
+func (c *concreteSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
 	return newConcreteSeriersIterator(c)
 }
 

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -350,6 +350,10 @@ func (c *concreteSeries) Labels() labels.Labels {
 }
 
 func (c *concreteSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
+	if csi, ok := it.(*concreteSeriesIterator); ok {
+		csi.reset(c)
+		return csi
+	}
 	return newConcreteSeriersIterator(c)
 }
 
@@ -364,6 +368,11 @@ func newConcreteSeriersIterator(series *concreteSeries) chunkenc.Iterator {
 		cur:    -1,
 		series: series,
 	}
+}
+
+func (c *concreteSeriesIterator) reset(series *concreteSeries) {
+	c.cur = -1
+	c.series = series
 }
 
 // Seek implements storage.SeriesIterator.

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -215,7 +215,7 @@ func TestConcreteSeriesIterator(t *testing.T) {
 			{Value: 4, Timestamp: 4},
 		},
 	}
-	it := series.Iterator()
+	it := series.Iterator(nil)
 
 	// Seek to the first sample with ts=1.
 	require.Equal(t, chunkenc.ValFloat, it.Seek(1))

--- a/storage/series.go
+++ b/storage/series.go
@@ -287,7 +287,7 @@ func (s *seriesToChunkEncoder) Iterator(it chunks.Iterator) chunks.Iterator {
 	mint := int64(math.MaxInt64)
 	maxt := int64(math.MinInt64)
 
-	chks := []chunks.Meta{}
+	var chks []chunks.Meta
 	lcsi, existing := it.(*listChunkSeriesIterator)
 	if existing {
 		chks = lcsi.chks[:0]

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -203,7 +203,7 @@ func TestCorruptedChunk(t *testing.T) {
 
 			// Check chunk errors during iter time.
 			require.True(t, set.Next())
-			it := set.At().Iterator()
+			it := set.At().Iterator(nil)
 			require.Equal(t, chunkenc.ValNone, it.Next())
 			require.Equal(t, tc.iterErr.Error(), it.Err().Error())
 		})
@@ -505,11 +505,12 @@ func createHead(tb testing.TB, w *wlog.WL, series []storage.Series, chunkDir str
 	head, err := NewHead(nil, nil, w, nil, opts, nil)
 	require.NoError(tb, err)
 
+	var it chunkenc.Iterator
 	ctx := context.Background()
 	app := head.Appender(ctx)
 	for _, s := range series {
 		ref := storage.SeriesRef(0)
-		it := s.Iterator()
+		it = s.Iterator(it)
 		lset := s.Labels()
 		typ := it.Next()
 		lastTyp := typ
@@ -550,11 +551,12 @@ func createHeadWithOOOSamples(tb testing.TB, w *wlog.WL, series []storage.Series
 	oooSampleLabels := make([]labels.Labels, 0, len(series))
 	oooSamples := make([]tsdbutil.SampleSlice, 0, len(series))
 
+	var it chunkenc.Iterator
 	totalSamples := 0
 	app := head.Appender(context.Background())
 	for _, s := range series {
 		ref := storage.SeriesRef(0)
-		it := s.Iterator()
+		it = s.Iterator(it)
 		lset := s.Labels()
 		os := tsdbutil.SampleSlice{}
 		count := 0

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -746,8 +746,9 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 	}
 
 	var (
-		ref  = storage.SeriesRef(0)
-		chks []chunks.Meta
+		ref      = storage.SeriesRef(0)
+		chks     []chunks.Meta
+		chksIter chunks.Iterator
 	)
 
 	set := sets[0]
@@ -765,7 +766,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		default:
 		}
 		s := set.At()
-		chksIter := s.Iterator()
+		chksIter = s.Iterator(chksIter)
 		chks = chks[:0]
 		for chksIter.Next() {
 			// We are not iterating in streaming way over chunk as

--- a/tsdb/example_test.go
+++ b/tsdb/example_test.go
@@ -67,7 +67,7 @@ func Example() {
 		series := ss.At()
 		fmt.Println("series:", series.Labels().String())
 
-		it := series.Iterator()
+		it := series.Iterator(nil)
 		for it.Next() == chunkenc.ValFloat {
 			_, v := it.At() // We ignore the timestamp here, only to have a predictable output we can test against (below)
 			fmt.Println("sample", v)

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -503,11 +503,7 @@ func (o mergedOOOChunks) Appender() (chunkenc.Appender, error) {
 }
 
 func (o mergedOOOChunks) Iterator(iterator chunkenc.Iterator) chunkenc.Iterator {
-	iterators := make([]chunkenc.Iterator, 0, len(o.chunks))
-	for _, c := range o.chunks {
-		iterators = append(iterators, c.Chunk.Iterator(nil))
-	}
-	return storage.NewChainSampleIterator(iterators)
+	return storage.ChainSampleIteratorFromMetas(iterator, o.chunks)
 }
 
 func (o mergedOOOChunks) NumSamples() int {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -924,8 +924,8 @@ func TestHeadDeleteSimple(t *testing.T) {
 
 						require.Equal(t, expSeries.Labels(), actSeries.Labels())
 
-						smplExp, errExp := storage.ExpandSamples(expSeries.Iterator(), nil)
-						smplRes, errRes := storage.ExpandSamples(actSeries.Iterator(), nil)
+						smplExp, errExp := storage.ExpandSamples(expSeries.Iterator(nil), nil)
+						smplRes, errRes := storage.ExpandSamples(actSeries.Iterator(nil), nil)
 
 						require.Equal(t, errExp, errRes)
 						require.Equal(t, smplExp, smplRes)
@@ -959,7 +959,7 @@ func TestDeleteUntilCurMax(t *testing.T) {
 	res := q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
 	require.True(t, res.Next(), "series is not present")
 	s := res.At()
-	it := s.Iterator()
+	it := s.Iterator(nil)
 	require.Equal(t, chunkenc.ValNone, it.Next(), "expected no samples")
 	for res.Next() {
 	}
@@ -976,7 +976,7 @@ func TestDeleteUntilCurMax(t *testing.T) {
 	res = q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
 	require.True(t, res.Next(), "series don't exist")
 	exps := res.At()
-	it = exps.Iterator()
+	it = exps.Iterator(nil)
 	resSamples, err := storage.ExpandSamples(it, newSample)
 	require.NoError(t, err)
 	require.Equal(t, []tsdbutil.Sample{sample{11, 1, nil, nil}}, resSamples)
@@ -1163,7 +1163,7 @@ func TestDelete_e2e(t *testing.T) {
 				eok, rok := expSs.Next(), ss.Next()
 				// Skip a series if iterator is empty.
 				if rok {
-					for ss.At().Iterator().Next() == chunkenc.ValNone {
+					for ss.At().Iterator(nil).Next() == chunkenc.ValNone {
 						rok = ss.Next()
 						if !rok {
 							break
@@ -1177,8 +1177,8 @@ func TestDelete_e2e(t *testing.T) {
 				sexp := expSs.At()
 				sres := ss.At()
 				require.Equal(t, sexp.Labels(), sres.Labels())
-				smplExp, errExp := storage.ExpandSamples(sexp.Iterator(), nil)
-				smplRes, errRes := storage.ExpandSamples(sres.Iterator(), nil)
+				smplExp, errExp := storage.ExpandSamples(sexp.Iterator(nil), nil)
+				smplRes, errRes := storage.ExpandSamples(sres.Iterator(nil), nil)
 				require.Equal(t, errExp, errRes)
 				require.Equal(t, smplExp, smplRes)
 			}
@@ -2635,7 +2635,7 @@ func TestChunkNotFoundHeadGCRace(t *testing.T) {
 	<-time.After(3 * time.Second)
 
 	// Now consume after compaction when it's gone.
-	it := s.Iterator()
+	it := s.Iterator(nil)
 	for it.Next() == chunkenc.ValFloat {
 		_, _ = it.At()
 	}
@@ -2643,7 +2643,7 @@ func TestChunkNotFoundHeadGCRace(t *testing.T) {
 	require.NoError(t, it.Err())
 	for ss.Next() {
 		s = ss.At()
-		it := s.Iterator()
+		it = s.Iterator(it)
 		for it.Next() == chunkenc.ValFloat {
 			_, _ = it.At()
 		}
@@ -2841,7 +2841,7 @@ func TestAppendHistogram(t *testing.T) {
 			s := ss.At()
 			require.False(t, ss.Next())
 
-			it := s.Iterator()
+			it := s.Iterator(nil)
 			actHistograms := make([]timedHistogram, 0, len(expHistograms))
 			for it.Next() == chunkenc.ValHistogram {
 				t, h := it.AtHistogram()
@@ -3304,7 +3304,7 @@ func TestHistogramStaleSample(t *testing.T) {
 		s := ss.At()
 		require.False(t, ss.Next())
 
-		it := s.Iterator()
+		it := s.Iterator(nil)
 		actHistograms := make([]timedHistogram, 0, len(expHistograms))
 		for it.Next() == chunkenc.ValHistogram {
 			t, h := it.AtHistogram()
@@ -3581,7 +3581,7 @@ func TestAppendingDifferentEncodingToSameSeries(t *testing.T) {
 	ss := q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
 	require.True(t, ss.Next())
 	s := ss.At()
-	it := s.Iterator()
+	it := s.Iterator(nil)
 	expIdx := 0
 loop:
 	for {

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -838,7 +838,7 @@ func (b *blockSeriesSet) At() storage.Series {
 	currIterFn := b.currIterFn
 	return &storage.SeriesEntry{
 		Lset: b.currLabels,
-		SampleIteratorFn: func() chunkenc.Iterator {
+		SampleIteratorFn: func(chunkenc.Iterator) chunkenc.Iterator {
 			return currIterFn().toSeriesIterator()
 		},
 	}
@@ -872,7 +872,7 @@ func (b *blockChunkSeriesSet) At() storage.ChunkSeries {
 	currIterFn := b.currIterFn
 	return &storage.ChunkSeriesEntry{
 		Lset: b.currLabels,
-		ChunkIteratorFn: func() chunks.Iterator {
+		ChunkIteratorFn: func(chunks.Iterator) chunks.Iterator {
 			return currIterFn().toChunkSeriesIterator()
 		},
 	}

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -426,7 +426,7 @@ func labelNamesWithMatchers(r IndexReader, matchers ...*labels.Matcher) ([]strin
 	return r.LabelNamesFor(postings...)
 }
 
-// These are the things fetched when we move from one series to another.
+// seriesData, used inside other iterators, are updated when we move from one series to another.
 type seriesData struct {
 	chks      []chunks.Meta
 	intervals tombstones.Intervals

--- a/tsdb/tsdbblockutil.go
+++ b/tsdb/tsdbblockutil.go
@@ -49,10 +49,11 @@ func CreateBlock(series []storage.Series, dir string, chunkRange int64, logger l
 	const commitAfter = 10000
 	ctx := context.Background()
 	app := w.Appender(ctx)
+	var it chunkenc.Iterator
 
 	for _, s := range series {
 		ref := storage.SeriesRef(0)
-		it := s.Iterator()
+		it = s.Iterator(it)
 		lset := s.Labels()
 		typ := it.Next()
 		lastTyp := typ

--- a/web/federate.go
+++ b/web/federate.go
@@ -102,12 +102,14 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 
 	set := storage.NewMergeSeriesSet(sets, storage.ChainedSeriesMerge)
 	it := storage.NewBuffer(int64(h.lookbackDelta / 1e6))
+	var chkIter chunkenc.Iterator
 	for set.Next() {
 		s := set.At()
 
 		// TODO(fabxc): allow fast path for most recent sample either
 		// in the storage itself or caching layer in Prometheus.
-		it.Reset(s.Iterator())
+		chkIter = s.Iterator(chkIter)
+		it.Reset(chkIter)
 
 		var t int64
 		var v float64


### PR DESCRIPTION
Patterned after `Chunk.Iterator()`: pass the old iterator in so it can be re-used to avoid allocating a new object.

The PR is split into 5 commits which I think make review easier.

This requires a change to `chunks.Iterator` and `chunkenc.Iterator` interfaces.  I think this breaking change is worth it because garbage comes down by half on some benchmarks and it's very easy to match the new interface by passing `nil` or ignoring the new parameter.

In `tsdb/querier.go` we turn two levels of function closure into a single object that
 holds the required data.

In `NewListSeries` we hoist the conversion to an interface value out so it only allocates once.

In `blockBaseSeriesSet.Next()` we re-use chunk metadata structs which saves a lot when scanning the index.

And a fix to `BenchmarkMergeSeriesSet()`, which was only really doing one iteration before, regardless of what N was passed in.

<details> 
<summary><b>Benchmarks:</b></summary>

```
name                          old time/op    new time/op    delta
NoMergeSeriesSet_100_100-8      99.3µs ± 0%    96.6µs ± 1%   -2.79%  (p=0.008 n=5+5)
MergeSeriesSet/1_100_100-8       101µs ± 0%      97µs ± 0%   -4.79%  (p=0.008 n=5+5)
MergeSeriesSet/10_100_100-8     10.7ms ± 1%    10.9ms ± 2%     ~     (p=0.310 n=5+5)
MergeSeriesSet/100_100_100-8     186ms ± 2%     187ms ± 1%     ~     (p=0.151 n=5+5)

name                          old alloc/op   new alloc/op   delta
NoMergeSeriesSet_100_100-8      4.90kB ± 0%    0.10kB ± 3%  -97.95%  (p=0.008 n=5+5)
MergeSeriesSet/1_100_100-8      4.91kB ± 0%    0.11kB ± 0%  -97.72%  (p=0.008 n=5+5)
MergeSeriesSet/10_100_100-8      211kB ± 0%     139kB ± 0%  -34.13%  (p=0.008 n=5+5)
MergeSeriesSet/100_100_100-8    1.86MB ± 0%    1.19MB ± 0%  -35.85%  (p=0.008 n=5+5)
```

Here I filtered to just the ones operating on a hundred or more series; the smaller ones show less benefit.
```
name                                                                                                      old time/op    new time/op    delta
RangeQuery/expr=a_hundred,steps=1-8                                                                          216µs ± 0%     201µs ± 0%   -6.68%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=10-8                                                                         238µs ± 4%     217µs ± 0%   -8.59%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=100-8                                                                        551µs ± 1%     530µs ± 0%   -3.90%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=1000-8                                                                      2.99ms ± 1%    2.89ms ± 1%   -3.54%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-8                                                                242µs ± 2%     224µs ± 0%   -7.23%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-8                                                               297µs ± 0%     281µs ± 0%   -5.38%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                                             1.02ms ± 0%    1.01ms ± 0%   -1.83%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-8                                                            7.15ms ± 1%    7.10ms ± 2%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-8                                                           78.5ms ± 1%    78.2ms ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-8                                             37.4ms ± 1%    37.0ms ± 0%   -1.06%  (p=0.016 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-8                                            89.6ms ± 0%    89.8ms ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8                                            615ms ± 1%     617ms ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-8                                           5.86s ± 0%     5.86s ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-8                                                            27.3ms ± 1%    27.2ms ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-8                                                           36.0ms ± 1%    35.7ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                                                           122ms ± 1%     122ms ± 0%     ~     (p=0.905 n=5+4)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-8                                                          976ms ± 1%     970ms ± 0%   -0.60%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-8                                                               27.6ms ± 1%    27.2ms ± 1%   -1.77%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-8                                                              36.2ms ± 1%    36.1ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                                              123ms ± 3%     122ms ± 2%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-8                                                             979ms ± 0%     983ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-8                                                   26.6ms ± 0%    26.4ms ± 1%   -0.88%  (p=0.016 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-8                                                  30.5ms ± 1%    30.3ms ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                                                 67.5ms ± 0%    67.4ms ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-8                                                 435ms ± 0%     436ms ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=-a_hundred,steps=1-8                                                                         237µs ± 0%     224µs ± 1%   -5.61%  (p=0.016 n=4+5)
RangeQuery/expr=-a_hundred,steps=10-8                                                                        254µs ± 1%     239µs ± 0%   -6.07%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-8                                                                       579µs ± 0%     560µs ± 0%   -3.37%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-8                                                                     3.10ms ± 0%    2.99ms ± 1%   -3.62%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-8                                                              552µs ± 0%     524µs ± 0%   -5.17%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-8                                                             944µs ± 0%     915µs ± 0%   -3.01%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                                                           5.19ms ± 0%    5.18ms ± 2%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                                                          46.6ms ± 1%    46.3ms ± 0%   -0.55%  (p=0.032 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-8                                                          473ms ± 0%     473ms ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-8                                             392µs ± 0%     374µs ± 1%   -4.58%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-8                                            555µs ± 0%     536µs ± 0%   -3.43%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8                                          2.42ms ± 0%    2.40ms ± 1%   -1.06%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8                                         20.1ms ± 0%    20.0ms ± 0%   -0.78%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-8                                              423µs ± 0%     405µs ± 0%   -4.25%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-8                                             671µs ± 0%     655µs ± 0%   -2.29%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8                                           3.41ms ± 1%    3.38ms ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8                                          29.9ms ± 1%    29.7ms ± 0%   -0.67%  (p=0.016 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-8                                          394µs ± 1%     375µs ± 0%   -4.93%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-8                                         560µs ± 2%     538µs ± 0%   -4.04%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8                                       2.43ms ± 0%    2.40ms ± 0%   -1.15%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8                                      20.1ms ± 0%    20.0ms ± 1%   -0.84%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1-8                                              223µs ± 0%     210µs ± 0%   -5.75%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=10-8                                             251µs ± 0%     238µs ± 0%   -5.40%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8                                            691µs ± 0%     670µs ± 0%   -3.11%  (p=0.016 n=4+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-8                                          4.33ms ± 0%    4.18ms ± 0%   -3.56%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1-8                                                                     296µs ± 2%     281µs ± 0%   -5.25%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=10-8                                                                    514µs ± 0%     500µs ± 0%   -2.78%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-8                                                                  2.86ms ± 0%    2.86ms ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-8                                                                 25.7ms ± 0%    26.1ms ± 4%   +1.61%  (p=0.016 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-8                                  337µs ± 0%     325µs ± 1%   -3.44%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-8                                 591µs ± 0%     581µs ± 0%   -1.74%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8                               3.29ms ± 1%    3.28ms ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8                              29.7ms ± 0%    29.7ms ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-8                                         319µs ± 1%     308µs ± 1%   -3.57%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-8                                        573µs ± 0%     561µs ± 0%   -2.23%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8                                      3.28ms ± 1%    3.25ms ± 0%   -0.80%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8                                     29.8ms ± 0%    29.5ms ± 0%   -0.82%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1-8                                                                     221µs ± 1%     206µs ± 0%   -6.78%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=10-8                                                                    267µs ±11%     243µs ± 0%   -8.84%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-8                                                                   793µs ± 0%     776µs ± 1%   -2.10%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-8                                                                 5.43ms ± 1%    5.27ms ± 1%   -2.81%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-8                                                        2.34ms ± 0%    2.20ms ± 0%   -6.06%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-8                                                       2.76ms ± 1%    2.62ms ± 0%   -4.85%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                                                      8.92ms ± 1%    8.77ms ± 3%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-8                                                     74.0ms ± 1%    73.7ms ± 3%     ~     (p=0.548 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-8                                                       2.40ms ± 1%    2.28ms ± 1%   -4.76%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-8                                                      3.13ms ± 0%    2.99ms ± 1%   -4.34%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                                                     12.3ms ± 0%    12.1ms ± 1%   -2.20%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-8                                                     102ms ± 0%     101ms ± 0%   -0.79%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-8                                                             2.39ms ± 1%    2.27ms ± 1%   -4.96%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-8                                                            3.13ms ± 0%    3.01ms ± 1%   -3.87%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                                                           12.4ms ± 0%    12.3ms ± 2%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-8                                                           102ms ± 0%     101ms ± 0%   -0.72%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-8                                                            2.33ms ± 1%    2.20ms ± 0%   -5.40%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-8                                                           2.79ms ± 0%    2.67ms ± 2%   -4.28%  (p=0.016 n=4+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                                                          9.35ms ± 0%    9.07ms ± 1%   -3.04%  (p=0.016 n=4+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-8                                                         73.1ms ± 0%    71.6ms ± 0%   -2.11%  (p=0.008 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=1-8                                                  3.96ms ± 0%    3.85ms ± 2%   -2.61%  (p=0.016 n=4+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=10-8                                                 15.0ms ± 0%    14.9ms ± 0%   -0.52%  (p=0.032 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                                                 150ms ± 1%     149ms ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=1000-8                                                6.89s ± 3%     6.73s ± 4%     ~     (p=0.486 n=4+4)
RangeQuery/expr=topk(1,_a_hundred),steps=1-8                                                                 222µs ± 0%     209µs ± 0%   -5.87%  (p=0.016 n=4+5)
RangeQuery/expr=topk(1,_a_hundred),steps=10-8                                                                265µs ± 3%     258µs ± 5%     ~     (p=0.095 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=100-8                                                               845µs ± 1%     843µs ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-8                                                             5.90ms ± 1%    5.95ms ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-8                                          597µs ± 0%     573µs ± 3%   -3.98%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-8                                        1.05ms ± 0%    1.02ms ± 0%   -2.56%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8                                       5.88ms ± 0%    5.89ms ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-8                                      52.5ms ± 1%    52.5ms ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-8                                               249µs ± 1%     233µs ± 0%   -6.39%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-8                                              325µs ± 1%     312µs ± 0%   -3.98%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                                            1.27ms ± 0%    1.26ms ± 0%   -0.96%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-8                                           9.52ms ± 0%    9.50ms ± 0%     ~     (p=0.286 n=5+4)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-8        497µs ± 0%     469µs ± 0%   -5.79%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-8       654µs ± 0%     627µs ± 0%   -4.14%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-8     2.56ms ± 0%    2.54ms ± 0%   -1.03%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-8    19.3ms ± 0%    19.4ms ± 1%     ~     (p=0.190 n=4+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-8                                      3.22ms ± 1%    3.09ms ± 0%   -3.99%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-8                                     5.08ms ± 3%    4.94ms ± 0%   -2.78%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8                                    24.7ms ± 0%    24.6ms ± 0%     ~     (p=0.111 n=4+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-8                                    220ms ± 0%     221ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1-8                                                244µs ± 0%     232µs ± 0%   -5.02%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=10-8                                               326µs ± 0%     314µs ± 0%   -3.63%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8                                             1.30ms ± 0%    1.29ms ± 0%   -0.94%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8                                            10.3ms ± 0%    10.2ms ± 0%   -0.51%  (p=0.008 n=5+5)

name                                                                                                      old alloc/op   new alloc/op   delta
RangeQuery/expr=a_hundred,steps=1-8                                                                         92.6kB ± 0%    64.9kB ± 0%  -29.97%  (p=0.029 n=4+4)
RangeQuery/expr=a_hundred,steps=10-8                                                                        92.6kB ± 0%    64.9kB ± 0%  -29.97%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=100-8                                                                        118kB ± 0%      79kB ± 0%  -32.92%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=1000-8                                                                       423kB ± 0%     341kB ± 0%  -19.21%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-8                                                                127kB ± 0%      99kB ± 0%  -21.87%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-8                                                               127kB ± 0%      99kB ± 0%  -21.92%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                                              153kB ± 0%     114kB ± 0%  -25.54%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-8                                                             387kB ± 0%     307kB ± 0%  -20.79%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-8                                                           6.58MB ± 0%    6.51MB ± 0%   -1.08%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-8                                             6.94MB ± 0%    6.88MB ± 0%   -0.99%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-8                                            7.07MB ± 1%    7.02MB ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8                                           6.94MB ± 4%    6.95MB ± 4%     ~     (p=0.500 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-8                                          7.67MB ± 2%    7.77MB ±30%     ~     (p=0.667 n=4+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-8                                                            6.18MB ± 0%    6.09MB ± 0%   -1.45%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-8                                                           6.18MB ± 0%    6.10MB ± 0%   -1.29%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                                                          6.23MB ± 0%    6.21MB ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-8                                                         6.93MB ± 4%    6.85MB ± 4%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-8                                                               6.17MB ± 0%    6.09MB ± 0%   -1.33%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-8                                                              6.17MB ± 0%    6.09MB ± 0%   -1.27%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                                             6.23MB ± 0%    6.18MB ± 1%     ~     (p=0.730 n=4+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-8                                                            7.22MB ± 0%    7.01MB ± 5%   -2.96%  (p=0.016 n=4+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-8                                                   6.19MB ± 0%    6.11MB ± 0%   -1.31%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-8                                                  6.21MB ± 0%    6.13MB ± 0%   -1.28%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                                                 6.55MB ± 1%    6.44MB ± 1%   -1.75%  (p=0.032 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-8                                                9.47MB ± 3%    9.39MB ± 0%     ~     (p=0.175 n=5+4)
RangeQuery/expr=-a_hundred,steps=1-8                                                                         125kB ± 0%      97kB ± 0%  -22.17%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=10-8                                                                        125kB ± 0%      97kB ± 0%  -22.16%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-8                                                                       151kB ± 0%     112kB ± 0%  -25.81%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-8                                                                      455kB ± 0%     374kB ± 0%  -17.83%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-8                                                              295kB ± 0%     239kB ± 0%  -18.86%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-8                                                             319kB ± 0%     264kB ± 0%  -17.41%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                                                            615kB ± 0%     537kB ± 0%  -12.67%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                                                          3.66MB ± 0%    3.50MB ± 0%   -4.43%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-8                                                         40.3MB ± 0%    40.2MB ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-8                                             203kB ± 0%     161kB ± 0%  -20.47%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-8                                            232kB ± 0%     190kB ± 0%  -17.95%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8                                           558kB ± 0%     500kB ± 0%  -10.45%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8                                         3.89MB ± 0%    3.77MB ± 0%   -3.10%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-8                                              215kB ± 0%     173kB ± 0%  -19.36%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-8                                             277kB ± 0%     235kB ± 0%  -15.01%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8                                            937kB ± 0%     878kB ± 0%   -6.23%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8                                          7.60MB ± 0%    7.48MB ± 0%   -1.59%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-8                                          203kB ± 0%     162kB ± 0%  -20.51%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-8                                         232kB ± 0%     190kB ± 0%  -17.95%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8                                        558kB ± 0%     500kB ± 0%  -10.44%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8                                      3.89MB ± 0%    3.77MB ± 0%   -3.16%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1-8                                              128kB ± 0%     100kB ± 0%  -21.69%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=10-8                                             128kB ± 0%     101kB ± 0%  -21.62%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8                                            158kB ± 0%     119kB ± 0%  -24.58%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-8                                           506kB ± 0%     425kB ± 0%  -16.05%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1-8                                                                     169kB ± 0%     141kB ± 0%  -16.45%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=10-8                                                                    184kB ± 0%     156kB ± 0%  -15.10%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-8                                                                   360kB ± 0%     321kB ± 0%  -10.83%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-8                                                                 2.17MB ± 0%    2.08MB ± 0%   -3.75%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-8                                  203kB ± 0%     175kB ± 0%  -13.67%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-8                                 219kB ± 0%     191kB ± 0%  -12.67%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8                                404kB ± 0%     364kB ± 0%   -9.69%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8                              2.30MB ± 0%    2.21MB ± 0%   -3.56%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-8                                         188kB ± 0%     160kB ± 0%  -14.78%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-8                                        204kB ± 0%     177kB ± 0%  -13.58%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8                                       395kB ± 0%     356kB ± 0%   -9.87%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8                                     2.34MB ± 0%    2.26MB ± 0%   -3.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1-8                                                                     125kB ± 0%      98kB ± 0%  -22.15%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=10-8                                                                    130kB ± 0%     102kB ± 0%  -21.42%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-8                                                                   198kB ± 0%     159kB ± 0%  -19.69%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-8                                                                  927kB ± 0%     846kB ± 0%   -8.77%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-8                                                        1.41MB ± 0%    1.10MB ± 0%  -21.95%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-8                                                       1.44MB ± 0%    1.13MB ± 0%  -21.51%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                                                      2.02MB ± 0%    1.58MB ± 0%  -21.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-8                                                     8.31MB ± 0%    7.41MB ± 0%  -10.75%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-8                                                       1.47MB ± 0%    1.16MB ± 0%  -21.03%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-8                                                      1.74MB ± 0%    1.43MB ± 0%  -17.76%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                                                     4.72MB ± 0%    4.29MB ± 0%   -9.15%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-8                                                    35.1MB ± 0%    34.2MB ± 0%   -2.55%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-8                                                             1.47MB ± 0%    1.16MB ± 0%  -21.04%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-8                                                            1.74MB ± 0%    1.43MB ± 0%  -17.76%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                                                           4.72MB ± 0%    4.29MB ± 0%   -9.14%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-8                                                          35.1MB ± 0%    34.2MB ± 0%   -2.54%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-8                                                            1.41MB ± 0%    1.10MB ± 0%  -21.94%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-8                                                           1.44MB ± 0%    1.13MB ± 0%  -21.49%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                                                          2.01MB ± 0%    1.58MB ± 0%  -21.43%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-8                                                         8.31MB ± 0%    7.42MB ± 0%  -10.75%  (p=0.016 n=5+4)
RangeQuery/expr=count_values('value',_h_hundred),steps=1-8                                                  3.07MB ± 0%    2.77MB ± 0%  -10.05%  (p=0.008 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=10-8                                                 13.0MB ± 0%    12.6MB ± 0%   -2.39%  (p=0.016 n=4+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                                                 126MB ± 0%     126MB ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=1000-8                                               1.20GB ± 4%    1.19GB ± 0%   -1.48%  (p=0.029 n=4+4)
RangeQuery/expr=topk(1,_a_hundred),steps=1-8                                                                 126kB ± 0%      99kB ± 0%  -21.94%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=10-8                                                                131kB ± 0%     103kB ± 0%  -21.17%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=100-8                                                               204kB ± 0%     165kB ± 0%  -19.13%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-8                                                              976kB ± 0%     895kB ± 0%   -8.31%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-8                                          358kB ± 0%     302kB ± 0%  -15.56%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-8                                         382kB ± 0%     326kB ± 0%  -14.55%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8                                        677kB ± 0%     599kB ± 0%  -11.52%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-8                                      3.59MB ± 0%    3.43MB ± 0%   -4.50%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-8                                               160kB ± 0%     132kB ± 0%  -17.38%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-8                                              164kB ± 0%     136kB ± 0%  -16.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                                             229kB ± 0%     190kB ± 0%  -17.06%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-8                                            860kB ± 0%     779kB ± 0%   -9.38%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-8        321kB ± 0%     266kB ± 0%  -17.30%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-8       330kB ± 0%     274kB ± 0%  -16.86%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-8      465kB ± 0%     387kB ± 0%  -16.83%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-8    1.77MB ± 0%    1.61MB ± 0%   -9.02%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-8                                      1.84MB ± 0%    1.53MB ± 0%  -16.84%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-8                                     1.87MB ± 0%    1.56MB ± 0%  -16.54%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8                                    2.52MB ± 0%    2.09MB ± 0%  -17.18%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-8                                   9.54MB ± 0%    8.65MB ± 0%   -9.40%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1-8                                                155kB ± 0%     127kB ± 0%  -17.96%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=10-8                                               164kB ± 0%     136kB ± 0%  -16.95%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8                                              281kB ± 0%     242kB ± 0%  -13.95%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8                                            1.50MB ± 0%    1.42MB ± 0%   -5.45%  (p=0.008 n=5+5)
```
</details>

<details>
<summary>Previous benchmarks from when first posted</summary>
```
name                          old time/op    new time/op    delta
NoMergeSeriesSet_100_100-8      77.1µs ± 2%    73.4µs ± 1%   -4.77%  (p=0.008 n=5+5)
MergeSeriesSet/1_100_100-8      77.7µs ± 1%    75.6µs ± 2%   -2.74%  (p=0.008 n=5+5)
MergeSeriesSet/10_100_100-8     12.1ms ± 1%    12.0ms ± 1%   -1.42%  (p=0.008 n=5+5)
MergeSeriesSet/100_100_100-8     223ms ± 4%     222ms ± 3%     ~     (p=1.000 n=5+5)

name                          old alloc/op   new alloc/op   delta
NoMergeSeriesSet_100_100-8      4.88kB ± 0%    0.08kB ± 1%  -98.45%  (p=0.008 n=5+5)
MergeSeriesSet/1_100_100-8      4.91kB ± 0%    0.11kB ± 0%  -97.72%  (p=0.008 n=5+5)
MergeSeriesSet/10_100_100-8      211kB ± 0%     139kB ± 0%  -34.13%  (p=0.008 n=5+5)
MergeSeriesSet/100_100_100-8    1.86MB ± 0%    1.19MB ± 0%  -35.85%  (p=0.008 n=5+5)

name                                                                                                      old time/op    new time/op    delta
RangeQuery/expr=a_hundred,steps=1-8                                                                          240µs ± 5%     218µs ± 2%   -9.08%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=10-8                                                                         256µs ± 1%     230µs ± 1%   -9.98%  (p=0.016 n=5+4)
RangeQuery/expr=a_hundred,steps=100-8                                                                        574µs ± 1%     565µs ± 7%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred,steps=1000-8                                                                      2.79ms ± 1%    2.76ms ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-8                                                                250µs ± 1%     228µs ± 1%   -8.79%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-8                                                               299µs ± 1%     276µs ± 1%   -7.73%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                                              949µs ± 1%     931µs ± 1%   -1.90%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-8                                                            6.05ms ± 0%    6.24ms ± 8%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-8                                                           68.4ms ± 0%    68.5ms ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-8                                             35.2ms ± 2%    35.6ms ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-8                                            86.7ms ± 1%    86.2ms ± 0%     ~     (p=0.556 n=5+4)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8                                            602ms ± 0%     603ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-8                                           5.72s ± 1%     5.78s ± 0%   +0.97%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-8                                                            25.2ms ± 1%    25.4ms ± 3%     ~     (p=0.548 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-8                                                           32.2ms ± 1%    31.9ms ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                                                           102ms ± 1%     103ms ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-8                                                          797ms ± 1%     800ms ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-8                                                               24.9ms ± 1%    26.0ms ± 3%   +4.20%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-8                                                              32.0ms ± 1%    33.2ms ± 3%   +3.88%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                                              102ms ± 1%     106ms ± 4%   +4.19%  (p=0.032 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-8                                                             802ms ± 5%     823ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-8                                                   24.1ms ± 2%    24.5ms ± 3%     ~     (p=0.095 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-8                                                  26.4ms ± 2%    26.7ms ± 2%     ~     (p=0.151 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                                                 47.8ms ± 2%    48.7ms ± 8%     ~     (p=1.000 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-8                                                 258ms ± 1%     260ms ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=-a_hundred,steps=1-8                                                                         255µs ± 1%     231µs ± 0%   -9.51%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=10-8                                                                        275µs ± 0%     250µs ± 1%   -8.95%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-8                                                                       602µs ± 0%     580µs ± 1%   -3.70%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-8                                                                     2.87ms ± 1%    2.89ms ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-8                                                              583µs ± 0%     541µs ± 3%   -7.17%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-8                                                             981µs ± 0%     939µs ± 4%   -4.27%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                                                           5.20ms ± 0%    5.19ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                                                          45.7ms ± 1%    45.9ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-8                                                          471ms ± 0%     474ms ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-8                                             424µs ± 1%     391µs ± 3%   -7.83%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-8                                            591µs ± 1%     554µs ± 0%   -6.27%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8                                          2.43ms ± 0%    2.41ms ± 1%   -1.06%  (p=0.032 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8                                         19.8ms ± 1%    19.8ms ± 2%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-8                                              454µs ± 0%     417µs ± 0%   -8.12%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-8                                             705µs ± 1%     681µs ± 2%   -3.46%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8                                           3.43ms ± 3%    3.41ms ± 3%     ~     (p=0.310 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8                                          29.5ms ± 2%    29.4ms ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-8                                          424µs ± 0%     393µs ± 5%   -7.30%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-8                                         590µs ± 1%     560µs ± 2%   -5.22%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8                                       2.44ms ± 0%    2.45ms ± 1%     ~     (p=0.190 n=4+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8                                      20.1ms ± 4%    19.7ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1-8                                              242µs ± 1%     220µs ± 3%   -9.18%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=10-8                                             272µs ± 0%     256µs ± 8%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8                                            705µs ± 0%     685µs ± 3%   -2.93%  (p=0.016 n=4+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-8                                          4.03ms ± 0%    4.02ms ± 1%     ~     (p=0.841 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1-8                                                                     309µs ± 1%     285µs ± 1%   -7.77%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=10-8                                                                    535µs ± 0%     513µs ± 1%   -4.21%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-8                                                                  2.91ms ± 0%    2.91ms ± 2%     ~     (p=0.310 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-8                                                                 25.9ms ± 2%    25.9ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-8                                  352µs ± 1%     333µs ± 5%   -5.44%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-8                                 608µs ± 0%     583µs ± 3%   -4.07%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8                               3.29ms ± 0%    3.26ms ± 1%   -1.14%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8                              29.4ms ± 1%    29.3ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-8                                         334µs ± 0%     310µs ± 1%   -7.16%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-8                                        595µs ± 2%     565µs ± 0%   -4.99%  (p=0.016 n=5+4)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8                                      3.28ms ± 1%    3.25ms ± 1%   -0.68%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8                                     29.4ms ± 1%    29.4ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1-8                                                                     236µs ± 0%     212µs ± 0%  -10.32%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=10-8                                                                    276µs ± 0%     255µs ± 4%   -7.51%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-8                                                                   801µs ± 1%     798µs ± 3%     ~     (p=0.548 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-8                                                                 5.06ms ± 1%    5.05ms ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-8                                                        2.58ms ± 3%    2.29ms ± 0%  -11.14%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-8                                                       3.02ms ± 0%    2.77ms ± 1%   -8.16%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                                                      9.12ms ± 3%    9.06ms ± 3%     ~     (p=1.000 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-8                                                     60.9ms ± 0%    61.5ms ± 4%     ~     (p=0.548 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-8                                                       2.63ms ± 0%    2.40ms ± 1%   -8.73%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-8                                                      3.33ms ± 0%    3.24ms ± 5%   -2.76%  (p=0.032 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                                                     11.9ms ± 1%    11.8ms ± 7%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-8                                                    87.7ms ± 0%    88.6ms ± 1%   +1.08%  (p=0.032 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-8                                                             2.63ms ± 0%    2.41ms ± 2%   -8.18%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-8                                                            3.34ms ± 0%    3.09ms ± 3%   -7.42%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                                                           12.0ms ± 1%    11.9ms ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-8                                                          89.1ms ± 1%    89.4ms ± 3%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-8                                                            2.57ms ± 0%    2.36ms ± 2%   -8.29%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-8                                                           3.03ms ± 0%    2.93ms ± 6%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                                                          9.10ms ± 1%    9.06ms ± 6%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-8                                                         61.1ms ± 1%    61.0ms ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=1-8                                                  4.24ms ± 4%    3.97ms ± 2%   -6.39%  (p=0.008 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=10-8                                                 15.0ms ± 0%    14.7ms ± 1%   -1.75%  (p=0.008 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                                                 147ms ± 1%     147ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=1000-8                                                6.48s ±28%     5.93s ±27%     ~     (p=0.222 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1-8                                                                 240µs ± 1%     215µs ± 1%  -10.25%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=10-8                                                                283µs ± 0%     258µs ± 1%   -8.78%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=100-8                                                               858µs ± 6%     826µs ± 0%   -3.67%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-8                                                             5.52ms ± 1%    5.44ms ± 1%   -1.41%  (p=0.032 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-8                                          613µs ± 1%     569µs ± 2%   -7.04%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-8                                        1.04ms ± 0%    1.00ms ± 1%   -4.22%  (p=0.016 n=4+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8                                       5.75ms ± 1%    5.66ms ± 0%   -1.53%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-8                                      49.9ms ± 1%    50.0ms ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-8                                               256µs ± 0%     232µs ± 0%   -9.62%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-8                                              326µs ± 0%     303µs ± 1%   -6.86%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                                            1.18ms ± 0%    1.16ms ± 0%   -1.69%  (p=0.016 n=4+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-8                                           8.34ms ± 0%    8.31ms ± 0%   -0.31%  (p=0.032 n=5+4)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-8        514µs ± 1%     466µs ± 0%   -9.43%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-8       657µs ± 0%     606µs ± 0%   -7.68%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-8     2.39ms ± 0%    2.34ms ± 1%   -2.24%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-8    17.0ms ± 0%    16.9ms ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-8                                      3.34ms ± 1%    3.09ms ± 1%   -7.41%  (p=0.016 n=5+4)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-8                                     5.10ms ± 0%    4.86ms ± 1%   -4.74%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8                                    23.8ms ± 3%    23.6ms ± 1%     ~     (p=0.841 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-8                                    199ms ± 0%     199ms ± 0%     ~     (p=0.905 n=4+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1-8                                                261µs ± 0%     237µs ± 1%   -9.07%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=10-8                                               345µs ± 0%     321µs ± 0%   -6.99%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8                                             1.30ms ± 0%    1.28ms ± 0%   -1.92%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8                                            9.86ms ± 0%    9.97ms ± 2%     ~     (p=0.690 n=5+5)

name                                                                                                      old alloc/op   new alloc/op   delta
RangeQuery/expr=a_hundred,steps=1-8                                                                          104kB ± 0%      54kB ± 0%  -48.12%  (p=0.016 n=5+4)
RangeQuery/expr=a_hundred,steps=10-8                                                                         104kB ± 0%      54kB ± 0%  -48.12%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=100-8                                                                        129kB ± 0%      91kB ± 0%  -30.07%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred,steps=1000-8                                                                       349kB ± 0%     310kB ± 0%  -11.17%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-8                                                                138kB ± 0%      88kB ± 0%  -36.25%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10-8                                                               138kB ± 0%      88kB ± 0%  -36.25%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                                              164kB ± 0%     125kB ± 0%  -23.83%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-8                                                             356kB ± 0%     317kB ± 0%  -10.97%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-8                                                           6.45MB ± 0%    6.37MB ± 0%   -1.26%  (p=0.016 n=4+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-8                                             6.00MB ± 0%    5.96MB ± 0%   -0.79%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=10-8                                            5.99MB ± 0%    5.95MB ± 0%   -0.65%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8                                           6.00MB ± 2%    5.95MB ± 3%     ~     (p=0.222 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-8                                          6.50MB ± 5%    6.82MB ±27%     ~     (p=0.667 n=4+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-8                                                            5.52MB ± 0%    5.48MB ± 0%   -0.79%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=10-8                                                           5.51MB ± 0%    5.48MB ± 0%   -0.71%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                                                          5.62MB ± 0%    5.56MB ± 1%   -1.06%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-8                                                         6.34MB ± 0%    6.15MB ± 2%   -2.93%  (p=0.016 n=4+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-8                                                               5.52MB ± 0%    5.48MB ± 0%   -0.74%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=10-8                                                              5.52MB ± 0%    5.48MB ± 0%   -0.71%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                                             5.60MB ± 1%    5.53MB ± 0%   -1.23%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-8                                                            6.34MB ± 0%    6.15MB ± 2%   -2.93%  (p=0.016 n=4+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-8                                                   5.51MB ± 0%    5.48MB ± 0%   -0.59%  (p=0.016 n=5+4)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=10-8                                                  5.54MB ± 0%    5.49MB ± 0%   -0.89%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                                                 5.77MB ± 0%    5.72MB ± 0%   -0.80%  (p=0.016 n=4+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-8                                                7.79MB ± 1%    7.73MB ± 1%     ~     (p=0.071 n=5+5)
RangeQuery/expr=-a_hundred,steps=1-8                                                                         136kB ± 0%      86kB ± 0%  -36.61%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=10-8                                                                        136kB ± 0%      86kB ± 0%  -36.62%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-8                                                                       162kB ± 0%     123kB ± 0%  -24.03%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-8                                                                      382kB ± 0%     343kB ± 0%  -10.21%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-8                                                              312kB ± 0%     212kB ± 0%  -32.03%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10-8                                                             335kB ± 0%     235kB ± 0%  -29.86%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                                                            616kB ± 0%     538kB ± 0%  -12.66%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                                                          3.35MB ± 0%    3.27MB ± 0%   -2.33%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-8                                                         38.4MB ± 0%    38.3MB ± 0%   -0.33%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-8                                             218kB ± 0%     143kB ± 0%  -34.33%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=10-8                                            246kB ± 0%     172kB ± 0%  -30.33%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8                                           572kB ± 0%     514kB ± 0%  -10.20%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8                                         3.78MB ± 0%    3.72MB ± 0%   -1.56%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-8                                              229kB ± 0%     155kB ± 0%  -32.58%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=10-8                                             291kB ± 0%     217kB ± 0%  -25.63%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8                                            951kB ± 0%     892kB ± 0%   -6.17%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8                                          7.49MB ± 0%    7.43MB ± 0%   -0.80%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-8                                          218kB ± 0%     143kB ± 0%  -34.36%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=10-8                                         246kB ± 0%     172kB ± 0%  -30.34%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8                                        573kB ± 0%     514kB ± 0%  -10.15%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8                                      3.78MB ± 0%    3.72MB ± 0%   -1.53%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1-8                                              137kB ± 0%      88kB ± 0%  -36.30%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=10-8                                             138kB ± 0%      88kB ± 0%  -36.19%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8                                            168kB ± 0%     129kB ± 0%  -23.17%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-8                                           431kB ± 0%     392kB ± 0%   -9.02%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1-8                                                                     178kB ± 0%     128kB ± 0%  -28.00%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=10-8                                                                    193kB ± 0%     143kB ± 0%  -25.82%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-8                                                                   369kB ± 0%     330kB ± 0%  -10.56%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-8                                                                 2.09MB ± 0%    2.05MB ± 0%   -1.85%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-8                                  205kB ± 0%     155kB ± 0%  -24.40%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=10-8                                 221kB ± 0%     171kB ± 0%  -22.64%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8                                405kB ± 0%     366kB ± 0%   -9.61%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8                              2.21MB ± 0%    2.17MB ± 0%   -1.78%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-8                                         198kB ± 0%     148kB ± 0%  -25.27%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=10-8                                        214kB ± 0%     164kB ± 0%  -23.34%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8                                       404kB ± 0%     365kB ± 0%   -9.62%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8                                     2.27MB ± 0%    2.23MB ± 0%   -1.74%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1-8                                                                     135kB ± 0%      85kB ± 0%  -37.02%  (p=0.000 n=5+4)
RangeQuery/expr=sum(a_hundred),steps=10-8                                                                    139kB ± 0%      89kB ± 0%  -35.92%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-8                                                                   206kB ± 0%     167kB ± 0%  -18.93%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-8                                                                  836kB ± 0%     797kB ± 0%   -4.66%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-8                                                        1.51MB ± 0%    0.96MB ± 0%  -36.69%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=10-8                                                       1.54MB ± 0%    0.99MB ± 0%  -36.02%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                                                      2.10MB ± 0%    1.67MB ± 0%  -20.51%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-8                                                     7.31MB ± 0%    6.88MB ± 0%   -5.91%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-8                                                       1.57MB ± 0%    1.01MB ± 0%  -35.36%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=10-8                                                      1.82MB ± 0%    1.27MB ± 0%  -30.40%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                                                     4.67MB ± 0%    4.23MB ± 0%   -9.25%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-8                                                    32.6MB ± 0%    32.2MB ± 0%   -1.33%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-8                                                             1.57MB ± 0%    1.01MB ± 0%  -35.36%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=10-8                                                            1.82MB ± 0%    1.27MB ± 0%  -30.40%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                                                           4.66MB ± 0%    4.23MB ± 0%   -9.25%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-8                                                          32.6MB ± 0%    32.2MB ± 0%   -1.33%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-8                                                            1.51MB ± 0%    0.96MB ± 0%  -36.69%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=10-8                                                           1.54MB ± 0%    0.99MB ± 0%  -36.02%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                                                          2.10MB ± 0%    1.67MB ± 0%  -20.52%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-8                                                         7.31MB ± 0%    6.88MB ± 0%   -5.91%  (p=0.008 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=1-8                                                  3.14MB ± 0%    2.59MB ± 0%  -17.66%  (p=0.008 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=10-8                                                 12.8MB ± 0%    12.3MB ± 0%   -4.33%  (p=0.008 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                                                 125MB ± 0%     124MB ± 0%   -0.68%  (p=0.008 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=1000-8                                               1.17GB ± 0%    1.17GB ± 0%   -0.05%  (p=0.029 n=4+4)
RangeQuery/expr=topk(1,_a_hundred),steps=1-8                                                                 136kB ± 0%      86kB ± 0%  -36.71%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=10-8                                                                141kB ± 0%      91kB ± 0%  -35.53%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=100-8                                                               212kB ± 0%     173kB ± 0%  -18.40%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-8                                                              885kB ± 0%     846kB ± 0%   -4.40%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-8                                          373kB ± 0%     274kB ± 0%  -26.76%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=10-8                                         396kB ± 0%     297kB ± 0%  -25.19%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8                                        678kB ± 0%     599kB ± 0%  -11.57%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-8                                      3.36MB ± 0%    3.28MB ± 0%   -2.39%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-8                                               169kB ± 0%     119kB ± 0%  -29.57%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=10-8                                              173kB ± 0%     123kB ± 0%  -28.92%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                                             237kB ± 0%     198kB ± 0%  -16.43%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-8                                            811kB ± 0%     772kB ± 0%   -4.77%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-8        340kB ± 0%     240kB ± 0%  -29.41%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=10-8       348kB ± 0%     248kB ± 0%  -28.74%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-8      480kB ± 0%     402kB ± 0%  -16.23%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-8    1.67MB ± 0%    1.59MB ± 0%   -4.61%  (p=0.016 n=5+4)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-8                                      1.93MB ± 0%    1.38MB ± 0%  -28.74%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=10-8                                     1.97MB ± 0%    1.41MB ± 0%  -28.21%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8                                    2.62MB ± 0%    2.19MB ± 0%  -16.50%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-8                                   8.71MB ± 0%    8.28MB ± 0%   -4.93%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1-8                                                161kB ± 0%     111kB ± 0%  -30.96%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=10-8                                               169kB ± 0%     119kB ± 0%  -29.54%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8                                              272kB ± 0%     233kB ± 0%  -14.36%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8                                            1.26MB ± 0%    1.22MB ± 0%   -3.20%  (p=0.008 n=5+5)
```
</details>
