### PR TITLE
benchmarks: fix reported MB/sec values

### DIFF
--- a/model/textparse/promparse_test.go
+++ b/model/textparse/promparse_test.go
@@ -367,7 +367,7 @@ func BenchmarkParse(b *testing.B) {
 			b.Run(parserName+"/no-decode-metric/"+fn, func(b *testing.B) {
 				total := 0
 
-				b.SetBytes(int64(len(buf) * (b.N / promtestdataSampleCount)))
+				b.SetBytes(int64(len(buf) / promtestdataSampleCount))
 				b.ReportAllocs()
 				b.ResetTimer()
 
@@ -395,7 +395,7 @@ func BenchmarkParse(b *testing.B) {
 			b.Run(parserName+"/decode-metric/"+fn, func(b *testing.B) {
 				total := 0
 
-				b.SetBytes(int64(len(buf) * (b.N / promtestdataSampleCount)))
+				b.SetBytes(int64(len(buf) / promtestdataSampleCount))
 				b.ReportAllocs()
 				b.ResetTimer()
 
@@ -428,7 +428,7 @@ func BenchmarkParse(b *testing.B) {
 				total := 0
 				res := make(labels.Labels, 0, 5)
 
-				b.SetBytes(int64(len(buf) * (b.N / promtestdataSampleCount)))
+				b.SetBytes(int64(len(buf) / promtestdataSampleCount))
 				b.ReportAllocs()
 				b.ResetTimer()
 
@@ -458,7 +458,10 @@ func BenchmarkParse(b *testing.B) {
 				_ = total
 			})
 			b.Run("expfmt-text/"+fn, func(b *testing.B) {
-				b.SetBytes(int64(len(buf) * (b.N / promtestdataSampleCount)))
+				if parserName != "prometheus" {
+					b.Skip()
+				}
+				b.SetBytes(int64(len(buf) / promtestdataSampleCount))
 				b.ReportAllocs()
 				b.ResetTimer()
 
@@ -507,7 +510,7 @@ func BenchmarkGzip(b *testing.B) {
 			k := b.N / promtestdataSampleCount
 
 			b.ReportAllocs()
-			b.SetBytes(int64(k) * int64(n))
+			b.SetBytes(int64(n) / promtestdataSampleCount)
 			b.ResetTimer()
 
 			total := 0

--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -176,7 +176,7 @@ func BenchmarkBufferedSeriesIterator(b *testing.B) {
 	// Simulate a 5 minute rate.
 	it := NewBufferIterator(newFakeSeriesIterator(int64(b.N), 30), 5*60)
 
-	b.SetBytes(int64(b.N * 16))
+	b.SetBytes(16)
 	b.ReportAllocs()
 	b.ResetTimer()
 

--- a/storage/memoized_iterator_test.go
+++ b/storage/memoized_iterator_test.go
@@ -75,7 +75,7 @@ func BenchmarkMemoizedSeriesIterator(b *testing.B) {
 	// Simulate a 5 minute rate.
 	it := NewMemoizedIterator(newFakeSeriesIterator(int64(b.N), 30), 5*60)
 
-	b.SetBytes(int64(b.N * 16))
+	b.SetBytes(16)
 	b.ReportAllocs()
 	b.ResetTimer()
 


### PR DESCRIPTION
Where the code was multiplying bytes by number of operations, this resulted in absurdly high throughput numbers.

Also, in `BenchmarkParse()`, don't run the `expfmt` case twice.

Before:
```
BenchmarkParse/prometheus/no-decode-metric/promtestdata.txt-4            5742394               196.1 ns/op      2382441516.80 MB/s             0 B/op          0 allocs/op
BenchmarkParse/prometheus/decode-metric/promtestdata.txt-4               1374633               747.7 ns/op      149580304.63 MB/s            136 B/op          2 allocs/op
BenchmarkParse/prometheus/decode-metric-reuse/promtestdata.txt-4         3640053               420.0 ns/op      705253307.79 MB/s             44 B/op          1 allocs/op
BenchmarkParse/expfmt-text/promtestdata.txt-4                             301303              4223 ns/op        5798781.28 MB/s     1310 B/op         30 allocs/op
BenchmarkParse/prometheus/no-decode-metric/promtestdata.nometa.txt-4     7545040               157.1 ns/op      2960254705.71 MB/s             0 B/op          0 allocs/op
BenchmarkParse/prometheus/decode-metric/promtestdata.nometa.txt-4        3487747               358.5 ns/op      599505347.25 MB/s            135 B/op          2 allocs/op
BenchmarkParse/prometheus/decode-metric-reuse/promtestdata.nometa.txt-4                  4529750               253.0 ns/op      1103379506.60 MB/s            43 B/op          1 allocs/op
BenchmarkParse/expfmt-text/promtestdata.nometa.txt-4                                      465786              2416 ns/op        11878397.29 MB/s             911 B/op         24 allocs/op
BenchmarkParse/openmetrics/no-decode-metric/promtestdata.txt-4                           6259776               185.0 ns/op      2753135317.41 MB/s             0 B/op          0 allocs/op
BenchmarkParse/openmetrics/decode-metric/promtestdata.txt-4                              3124977               633.3 ns/op      401485272.83 MB/s            136 B/op          2 allocs/op
BenchmarkParse/openmetrics/decode-metric-reuse/promtestdata.txt-4                        4334462               288.3 ns/op      1223264576.28 MB/s            44 B/op          1 allocs/op
BenchmarkParse/expfmt-text/promtestdata.txt#01-4                                          323378              4270 ns/op        6156788.63 MB/s     1311 B/op         30 allocs/op
BenchmarkParse/openmetrics/no-decode-metric/promtestdata.nometa.txt-4                    7522870               153.3 ns/op      3023439227.10 MB/s             0 B/op          0 allocs/op
BenchmarkParse/openmetrics/decode-metric/promtestdata.nometa.txt-4                       3702561               499.8 ns/op      456440137.86 MB/s            136 B/op          2 allocs/op
BenchmarkParse/openmetrics/decode-metric-reuse/promtestdata.nometa.txt-4                 4875309               261.9 ns/op      1147097886.12 MB/s            44 B/op          1 allocs/op
BenchmarkParse/expfmt-text/promtestdata.nometa.txt#01-4                                   379833              3000 ns/op        7799197.22 MB/s      911 B/op         24 allocs/op
BenchmarkGzip/promtestdata.txt-4                                                         2642210               494.9 ns/op      434427650.85 MB/s            476 B/op          0 allocs/op
BenchmarkGzip/promtestdata.nometa.txt-4                                                  3998251               491.8 ns/op      500976862.15 MB/s            376 B/op          0 allocs/op
BenchmarkBufferedSeriesIterator-4       25542231                45.37 ns/op     9007667882.16 MB/s             0 B/op          0 allocs/op
BenchmarkMemoizedSeriesIterator-4       30485252                37.06 ns/op     13162820730.73 MB/s            0 B/op          0 allocs/op
```

After:
```
BenchmarkParse/prometheus/no-decode-metric/promtestdata.txt-4            6288852               200.2 ns/op       404.64 MB/s           0 B/op          0 allocs/op
BenchmarkParse/prometheus/decode-metric/promtestdata.txt-4               3298872               417.7 ns/op       193.93 MB/s         136 B/op          2 allocs/op
BenchmarkParse/prometheus/decode-metric-reuse/promtestdata.txt-4         4184289               346.0 ns/op       234.08 MB/s          44 B/op          1 allocs/op
BenchmarkParse/expfmt-text/promtestdata.txt-4                             311756              4427 ns/op          18.30 MB/s        1311 B/op         30 allocs/op
BenchmarkParse/prometheus/no-decode-metric/promtestdata.nometa.txt-4     7396953               160.7 ns/op       379.61 MB/s           0 B/op          0 allocs/op
BenchmarkParse/prometheus/decode-metric/promtestdata.nometa.txt-4        3645106               422.1 ns/op       144.51 MB/s         135 B/op          2 allocs/op
BenchmarkParse/prometheus/decode-metric-reuse/promtestdata.nometa.txt-4                  4671568               248.9 ns/op       245.09 MB/s          43 B/op          1 allocs/op
BenchmarkParse/expfmt-text/promtestdata.nometa.txt-4                                      511802              2616 ns/op          23.32 MB/s         911 B/op         24 allocs/op
BenchmarkParse/openmetrics/no-decode-metric/promtestdata.txt-4                           6055753               190.8 ns/op       424.59 MB/s           0 B/op          0 allocs/op
BenchmarkParse/openmetrics/decode-metric/promtestdata.txt-4                              3047530               498.7 ns/op       162.42 MB/s         136 B/op          2 allocs/op
BenchmarkParse/openmetrics/decode-metric-reuse/promtestdata.txt-4                        3333412               386.4 ns/op       209.65 MB/s          44 B/op          1 allocs/op
BenchmarkParse/openmetrics/no-decode-metric/promtestdata.nometa.txt-4                    6645669               155.4 ns/op       392.55 MB/s           0 B/op          0 allocs/op
BenchmarkParse/openmetrics/decode-metric/promtestdata.nometa.txt-4                       3367836               464.6 ns/op       131.29 MB/s         136 B/op          2 allocs/op
BenchmarkParse/openmetrics/decode-metric-reuse/promtestdata.nometa.txt-4                 4843976               283.5 ns/op       215.18 MB/s          44 B/op          1 allocs/op
BenchmarkGzip/promtestdata.txt-4                                                         2772752               483.5 ns/op       167.52 MB/s         476 B/op          0 allocs/op
BenchmarkGzip/promtestdata.nometa.txt-4                                                  3472620               355.4 ns/op       171.63 MB/s         376 B/op          0 allocs/op
BenchmarkBufferedSeriesIterator-4       25363485                45.85 ns/op      348.97 MB/s           0 B/op          0 allocs/op
BenchmarkMemoizedSeriesIterator-4       29897880                37.33 ns/op      428.60 MB/s           0 B/op          0 allocs/op
```

