### PR TITLE
Remove 'metadata-storage' CLI flag

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -180,9 +180,6 @@ func (c *flagConfig) setFeatureListOptions(logger log.Logger) error {
 			case "extra-scrape-metrics":
 				c.scrape.ExtraMetrics = true
 				level.Info(logger).Log("msg", "Experimental additional scrape metrics enabled")
-			case "metadata-storage":
-				c.scrape.EnableMetadataStorage = true
-				level.Info(logger).Log("msg", "Experimental in-memory metadata storage enabled")
 			case "new-service-discovery-manager":
 				c.enableNewSDManager = true
 				level.Info(logger).Log("msg", "Experimental service discovery manager")


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalist0@gmail.com>

As noted in #11344, we should remove the CLI flag that enables metadata storage, since there is no way to use them from the WAL right now.

The flag will be added back after the v2.39.0 release, when the remote_write functionality is added for the stored metadata.