### PR TITLE
Use protobuf encoding in kubernetes discovery

### DIFF
--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -336,6 +336,7 @@ func New(l log.Logger, conf *SDConfig) (*Discovery, error) {
 	}
 
 	kcfg.UserAgent = userAgent
+	kcfg.ContentType = "application/vnd.kubernetes.protobuf"
 
 	c, err := kubernetes.NewForConfig(kcfg)
 	if err != nil {


### PR DESCRIPTION
By default, kubernetes client is using json encoding [1] which is requires more server-side and client-side resources than protobuf encoding (see e.g. effectively disables watch-side optimizations in kube-apiserver:  https://github.com/kubernetes/kubernetes/issues/110146)

This PR changes the encoding used in kubernetes discovery client to use more efficient protobuf:
* Overall rationale behind protobuf vs json change: https://github.com/kubernetes/design-proposals-archive/blob/main/api-machinery/protobuf.md
* This is how kube-apiserver does the calls against itself: https://github.com/kubernetes/kubernetes/blob/588a4569a768306ea91821ff916185d65faa85a8/cmd/kube-apiserver/app/server.go#L506-L506
* This is how kubernetes components are doing: https://github.com/kubernetes/kubernetes/blob/588a4569a768306ea91821ff916185d65faa85a8/staging/src/k8s.io/component-base/config/v1alpha1/defaults.go#L67-L67

[1] JSON as default: see comments for "AcceptContentTypes" and "ContentType" fields in 
https://pkg.go.dev/k8s.io/client-go@v0.25.2/rest#ClientContentConfig

