### PR TITLE
Bump the UI package to v2.39.0-rc.0

### DIFF
--- a/.github/actions/publish_release/action.yml
+++ b/.github/actions/publish_release/action.yml
@@ -27,11 +27,11 @@ runs:
       with:
         enable_docker_multibuild: true
     - uses: ./.github/actions/restore_artifacts
-    - run: promu crossbuild tarballs
+    - run: ~/go/bin/promu crossbuild tarballs
       shell: bash
-    - run: promu checksum .tarballs
+    - run: ~/go/bin/promu checksum .tarballs
       shell: bash
-    - run: promu release .tarballs
+    - run: ~/go/bin/promu release .tarballs
       shell: bash
     - uses: ./.github/actions/publish_release_images
       if: inputs.docker_hub_organization != '' && inputs.docker_hub_login != ''

--- a/web/ui/module/codemirror-promql/package.json
+++ b/web/ui/module/codemirror-promql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prometheus-io/codemirror-promql",
-  "version": "0.38.0",
+  "version": "0.39.0-rc.0",
   "description": "a CodeMirror mode for the PromQL language",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",

--- a/web/ui/module/lezer-promql/package.json
+++ b/web/ui/module/lezer-promql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prometheus-io/lezer-promql",
-  "version": "0.38.0",
+  "version": "0.39.0-rc.0",
   "description": "lezer-based PromQL grammar",
   "main": "index.cjs",
   "type": "module",

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -59,6 +59,15 @@
         "@lezer/common": "^1.0.1"
       }
     },
+    "module/codemirror-promql/node_modules/@prometheus-io/lezer-promql": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.38.0.tgz",
+      "integrity": "sha512-4TNQChpbYctsztar4jvWmxZlXD1CIBneN5Kin2j07Hild4kIMYoDv0nQGUr8a851w37x9emZuJEVVv0/RphIyg==",
+      "peerDependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "module/lezer-promql": {
       "name": "@prometheus-io/lezer-promql",
       "version": "0.39.0-rc.0",
@@ -17592,6 +17601,35 @@
         "@fortawesome/fontawesome-svg-core": "~1 || >=1.3.0-beta1",
         "react": ">=16.x"
       }
+    },
+    "react-app/node_modules/@prometheus-io/codemirror-promql": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/codemirror-promql/-/codemirror-promql-0.38.0.tgz",
+      "integrity": "sha512-QTnM2FJmHSDHT/LMrN6XoCgWK6IExw6eehylh9ucnZoeJSpE2PUvoDcIcg6nXHGLScH99kxz1QB/bKuiBa7K2g==",
+      "dependencies": {
+        "@prometheus-io/lezer-promql": "^0.38.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "react-app/node_modules/@prometheus-io/lezer-promql": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.38.0.tgz",
+      "integrity": "sha512-4TNQChpbYctsztar4jvWmxZlXD1CIBneN5Kin2j07Hild4kIMYoDv0nQGUr8a851w37x9emZuJEVVv0/RphIyg==",
+      "peerDependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
     }
   },
   "dependencies": {
@@ -19835,6 +19873,21 @@
           "requires": {
             "prop-types": "^15.8.1"
           }
+        },
+        "@prometheus-io/codemirror-promql": {
+          "version": "0.38.0",
+          "resolved": "https://registry.npmjs.org/@prometheus-io/codemirror-promql/-/codemirror-promql-0.38.0.tgz",
+          "integrity": "sha512-QTnM2FJmHSDHT/LMrN6XoCgWK6IExw6eehylh9ucnZoeJSpE2PUvoDcIcg6nXHGLScH99kxz1QB/bKuiBa7K2g==",
+          "requires": {
+            "@prometheus-io/lezer-promql": "^0.38.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "@prometheus-io/lezer-promql": {
+          "version": "0.38.0",
+          "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.38.0.tgz",
+          "integrity": "sha512-4TNQChpbYctsztar4jvWmxZlXD1CIBneN5Kin2j07Hild4kIMYoDv0nQGUr8a851w37x9emZuJEVVv0/RphIyg==",
+          "requires": {}
         }
       }
     },
@@ -19854,6 +19907,14 @@
         "isomorphic-fetch": "^3.0.0",
         "lru-cache": "^6.0.0",
         "nock": "^13.2.9"
+      },
+      "dependencies": {
+        "@prometheus-io/lezer-promql": {
+          "version": "0.38.0",
+          "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.38.0.tgz",
+          "integrity": "sha512-4TNQChpbYctsztar4jvWmxZlXD1CIBneN5Kin2j07Hild4kIMYoDv0nQGUr8a851w37x9emZuJEVVv0/RphIyg==",
+          "requires": {}
+        }
       }
     },
     "@prometheus-io/lezer-promql": {

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -28,7 +28,7 @@
     },
     "module/codemirror-promql": {
       "name": "@prometheus-io/codemirror-promql",
-      "version": "0.38.0",
+      "version": "0.39.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@prometheus-io/lezer-promql": "^0.38.0",
@@ -61,7 +61,7 @@
     },
     "module/lezer-promql": {
       "name": "@prometheus-io/lezer-promql",
-      "version": "0.38.0",
+      "version": "0.39.0-rc.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.1.1",
@@ -17485,7 +17485,7 @@
     },
     "react-app": {
       "name": "@prometheus-io/app",
-      "version": "0.38.0",
+      "version": "0.39.0-rc.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.2.0",
         "@codemirror/commands": "^6.1.0",

--- a/web/ui/react-app/package.json
+++ b/web/ui/react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prometheus-io/app",
-  "version": "0.38.0",
+  "version": "0.39.0-rc.0",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.2.0",


### PR DESCRIPTION
Apparently the release process was slightly modified and I wasn't aware of it. Read the release file carefully now.

Also, looks like the CI is broken for the release https://github.com/prometheus/prometheus/actions/runs/3149723579/jobs/5122024911, promu not found. I will try to fix that in this PR as well.