### PR TITLE
Add streaming remote read to ReadClient 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -215,6 +215,7 @@ var (
 	// DefaultRemoteReadConfig is the default remote read configuration.
 	DefaultRemoteReadConfig = RemoteReadConfig{
 		RemoteTimeout:        model.Duration(1 * time.Minute),
+		ChunkedReadLimit:     DefaultChunkedReadLimit,
 		HTTPClientConfig:     config.DefaultHTTPClientConfig,
 		FilterExternalLabels: true,
 	}
@@ -1233,13 +1234,20 @@ type MetadataConfig struct {
 	MaxSamplesPerSend int `yaml:"max_samples_per_send,omitempty"`
 }
 
+const (
+	// DefaultChunkedReadLimit is the default value for the maximum size of the protobuf frame client allows.
+	// 50MB is the default. This is equivalent to ~100k full XOR chunks and average labelset.
+	DefaultChunkedReadLimit = 5e+7
+)
+
 // RemoteReadConfig is the configuration for reading from remote storage.
 type RemoteReadConfig struct {
-	URL           *config.URL       `yaml:"url"`
-	RemoteTimeout model.Duration    `yaml:"remote_timeout,omitempty"`
-	Headers       map[string]string `yaml:"headers,omitempty"`
-	ReadRecent    bool              `yaml:"read_recent,omitempty"`
-	Name          string            `yaml:"name,omitempty"`
+	URL              *config.URL       `yaml:"url"`
+	RemoteTimeout    model.Duration    `yaml:"remote_timeout,omitempty"`
+	ChunkedReadLimit uint64            `yaml:"chunked_read_limit,omitempty"`
+	Headers          map[string]string `yaml:"headers,omitempty"`
+	ReadRecent       bool              `yaml:"read_recent,omitempty"`
+	Name             string            `yaml:"name,omitempty"`
 
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -158,10 +158,11 @@ var expectedConf = &Config{
 
 	RemoteReadConfigs: []*RemoteReadConfig{
 		{
-			URL:           mustParseURL("http://remote1/read"),
-			RemoteTimeout: model.Duration(1 * time.Minute),
-			ReadRecent:    true,
-			Name:          "default",
+			URL:              mustParseURL("http://remote1/read"),
+			RemoteTimeout:    model.Duration(1 * time.Minute),
+			ChunkedReadLimit: DefaultChunkedReadLimit,
+			ReadRecent:       true,
+			Name:             "default",
 			HTTPClientConfig: config.HTTPClientConfig{
 				FollowRedirects: true,
 				EnableHTTP2:     false,
@@ -171,6 +172,7 @@ var expectedConf = &Config{
 		{
 			URL:              mustParseURL("http://remote3/read"),
 			RemoteTimeout:    model.Duration(1 * time.Minute),
+			ChunkedReadLimit: DefaultChunkedReadLimit,
 			ReadRecent:       false,
 			Name:             "read_special",
 			RequiredMatchers: model.LabelSet{"job": "special"},

--- a/storage/remote/chunked.go
+++ b/storage/remote/chunked.go
@@ -26,10 +26,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-// DefaultChunkedReadLimit is the default value for the maximum size of the protobuf frame client allows.
-// 50MB is the default. This is equivalent to ~100k full XOR chunks and average labelset.
-const DefaultChunkedReadLimit = 5e+7
-
 // The table gets initialized with sync.Once but may still cause a race
 // with any other use of the crc32 package anywhere. Thus we initialize it
 // before.

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -392,7 +393,7 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query, sortSeries bool)
 		s := NewChunkedReader(httpResp.Body, c.chunkedReadLimit, nil)
 		return NewChunkedSeriesSet(s, httpResp.Body, query.StartTimestampMs, query.EndTimestampMs, func(err error) {
 			code := strconv.Itoa(httpResp.StatusCode)
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				code = "aborted_stream"
 			}
 			c.readQueriesTotal.WithLabelValues("chunked", code).Inc()

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -36,6 +36,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote/azuread"

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -35,7 +35,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote/azuread"
@@ -74,9 +73,7 @@ var (
 		prompb.ReadRequest_STREAMED_XOR_CHUNKS,
 		prompb.ReadRequest_SAMPLES,
 	}
-)
 
-var (
 	remoteReadQueriesTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -365,6 +365,7 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query, sortSeries bool)
 		return nil, fmt.Errorf("error sending request: %w", err)
 	}
 
+	//nolint:usestdlibvars
 	if httpResp.StatusCode/100 != 2 {
 		// Make an attempt at getting an error message.
 		body, _ := io.ReadAll(httpResp.Body)

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -23,9 +23,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
 
 var longErrMessage = strings.Repeat("error message", maxErrMsgLen)
@@ -207,4 +213,227 @@ func TestClientHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, called, "The remote server wasn't called")
+}
+
+func TestReadClient(t *testing.T) {
+	tests := []struct {
+		name                  string
+		query                 *prompb.Query
+		httpHandler           http.HandlerFunc
+		expectedLabels        []map[string]string
+		expectedSamples       [][]model.SamplePair
+		expectedErrorContains string
+		sortSeries            bool
+	}{
+		{
+			name:        "sorted sampled response",
+			httpHandler: sampledResponseHTTPHandler(t),
+			expectedLabels: []map[string]string{
+				{"foo1": "bar"},
+				{"foo2": "bar"},
+			},
+			expectedSamples: [][]model.SamplePair{
+				{
+					{Timestamp: model.Time(0), Value: model.SampleValue(3)},
+					{Timestamp: model.Time(5), Value: model.SampleValue(4)},
+				},
+				{
+					{Timestamp: model.Time(0), Value: model.SampleValue(1)},
+					{Timestamp: model.Time(5), Value: model.SampleValue(2)},
+				},
+			},
+			expectedErrorContains: "",
+			sortSeries:            true,
+		},
+		{
+			name:        "unsorted sampled response",
+			httpHandler: sampledResponseHTTPHandler(t),
+			expectedLabels: []map[string]string{
+				{"foo2": "bar"},
+				{"foo1": "bar"},
+			},
+			expectedSamples: [][]model.SamplePair{
+				{
+					{Timestamp: model.Time(0), Value: model.SampleValue(1)},
+					{Timestamp: model.Time(5), Value: model.SampleValue(2)},
+				},
+				{
+					{Timestamp: model.Time(0), Value: model.SampleValue(3)},
+					{Timestamp: model.Time(5), Value: model.SampleValue(4)},
+				},
+			},
+			expectedErrorContains: "",
+			sortSeries:            false,
+		},
+		{
+			name: "chunked response",
+			query: &prompb.Query{
+				StartTimestampMs: 4000,
+				EndTimestampMs:   12000,
+			},
+			httpHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse")
+
+				flusher, ok := w.(http.Flusher)
+				require.True(t, ok)
+
+				cw := NewChunkedWriter(w, flusher)
+				l := []prompb.Label{
+					{Name: "foo", Value: "bar"},
+				}
+
+				chunks := buildTestChunks(t)
+				for i, c := range chunks {
+					cSeries := prompb.ChunkedSeries{Labels: l, Chunks: []prompb.Chunk{c}}
+					readResp := prompb.ChunkedReadResponse{
+						ChunkedSeries: []*prompb.ChunkedSeries{&cSeries},
+						QueryIndex:    int64(i),
+					}
+
+					b, err := proto.Marshal(&readResp)
+					require.NoError(t, err)
+
+					_, err = cw.Write(b)
+					require.NoError(t, err)
+				}
+			}),
+			expectedLabels: []map[string]string{
+				{"foo": "bar"},
+				{"foo": "bar"},
+				{"foo": "bar"},
+			},
+			// This is the output of buildTestChunks minus the samples outside the query range.
+			expectedSamples: [][]model.SamplePair{
+				{
+					{Timestamp: model.Time(4000), Value: model.SampleValue(4)},
+				},
+				{
+					{Timestamp: model.Time(5000), Value: model.SampleValue(1)},
+					{Timestamp: model.Time(6000), Value: model.SampleValue(2)},
+					{Timestamp: model.Time(7000), Value: model.SampleValue(3)},
+					{Timestamp: model.Time(8000), Value: model.SampleValue(4)},
+					{Timestamp: model.Time(9000), Value: model.SampleValue(5)},
+				},
+				{
+					{Timestamp: model.Time(10000), Value: model.SampleValue(2)},
+					{Timestamp: model.Time(11000), Value: model.SampleValue(3)},
+					{Timestamp: model.Time(12000), Value: model.SampleValue(4)},
+				},
+			},
+			expectedErrorContains: "",
+		},
+		{
+			name: "unsupported content type",
+			httpHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "foobar")
+			}),
+			expectedErrorContains: "unsupported content type",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(test.httpHandler)
+			defer server.Close()
+
+			u, err := url.Parse(server.URL)
+			require.NoError(t, err)
+
+			conf := &ClientConfig{
+				URL:              &config_util.URL{URL: u},
+				Timeout:          model.Duration(5 * time.Second),
+				ChunkedReadLimit: config.DefaultChunkedReadLimit,
+			}
+			c, err := NewReadClient("test", conf)
+			require.NoError(t, err)
+
+			query := &prompb.Query{}
+			if test.query != nil {
+				query = test.query
+			}
+
+			ss, err := c.Read(context.Background(), query, test.sortSeries)
+			if test.expectedErrorContains != "" {
+				require.ErrorContains(t, err, test.expectedErrorContains)
+				return
+			}
+
+			require.NoError(t, err)
+
+			i := 0
+
+			for ss.Next() {
+				require.NoError(t, ss.Err())
+				s := ss.At()
+
+				l := s.Labels()
+				require.Equal(t, len(test.expectedLabels[i]), l.Len())
+				for k, v := range test.expectedLabels[i] {
+					require.True(t, l.Has(k))
+					require.Equal(t, v, l.Get(k))
+				}
+
+				it := s.Iterator(nil)
+				j := 0
+
+				for valType := it.Next(); valType != chunkenc.ValNone; valType = it.Next() {
+					require.NoError(t, it.Err())
+
+					ts, v := it.At()
+					expectedSample := test.expectedSamples[i][j]
+
+					require.Equal(t, int64(expectedSample.Timestamp), ts)
+					require.Equal(t, float64(expectedSample.Value), v)
+
+					j++
+				}
+
+				require.Equal(t, len(test.expectedSamples[i]), j)
+
+				i++
+			}
+
+			require.NoError(t, ss.Err())
+		})
+	}
+}
+
+func sampledResponseHTTPHandler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-protobuf")
+
+		resp := prompb.ReadResponse{
+			Results: []*prompb.QueryResult{
+				{
+					Timeseries: []*prompb.TimeSeries{
+						{
+							Labels: []prompb.Label{
+								{Name: "foo2", Value: "bar"},
+							},
+							Samples: []prompb.Sample{
+								{Value: float64(1), Timestamp: int64(0)},
+								{Value: float64(2), Timestamp: int64(5)},
+							},
+							Exemplars: []prompb.Exemplar{},
+						},
+						{
+							Labels: []prompb.Label{
+								{Name: "foo1", Value: "bar"},
+							},
+							Samples: []prompb.Sample{
+								{Value: float64(3), Timestamp: int64(0)},
+								{Value: float64(4), Timestamp: int64(5)},
+							},
+							Exemplars: []prompb.Exemplar{},
+						},
+					},
+				},
+			},
+		}
+		b, err := proto.Marshal(&resp)
+		require.NoError(t, err)
+
+		_, err = w.Write(snappy.Encode(nil, b))
+		require.NoError(t, err)
+	}
 }

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -367,7 +367,7 @@ func TestReadClient(t *testing.T) {
 				s := ss.At()
 
 				l := s.Labels()
-				require.Equal(t, len(test.expectedLabels[i]), l.Len())
+				require.Len(t, test.expectedLabels[i], l.Len())
 				for k, v := range test.expectedLabels[i] {
 					require.True(t, l.Has(k))
 					require.Equal(t, v, l.Get(k))
@@ -388,7 +388,7 @@ func TestReadClient(t *testing.T) {
 					j++
 				}
 
-				require.Equal(t, len(test.expectedSamples[i]), j)
+				require.Len(t, test.expectedSamples[i], j)
 
 				i++
 			}

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -568,7 +568,7 @@ func (s *chunkedSeriesSet) Next() bool {
 
 	err := s.chunkedReader.NextProto(res)
 	if err != nil {
-		if err != io.EOF {
+		if !errors.Is(err, io.EOF) {
 			s.err = err
 			_, _ = io.Copy(io.Discard, s.respBody)
 		}

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -15,7 +15,6 @@ package remote
 
 import (
 	"compress/gzip"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -546,13 +545,13 @@ type chunkedSeriesSet struct {
 	chunkedReader *ChunkedReader
 	respBody      io.ReadCloser
 	mint, maxt    int64
-	cancel        context.CancelFunc
+	cancel        func(error)
 
 	current storage.Series
 	err     error
 }
 
-func NewChunkedSeriesSet(chunkedReader *ChunkedReader, respBody io.ReadCloser, mint, maxt int64, cancel context.CancelFunc) storage.SeriesSet {
+func NewChunkedSeriesSet(chunkedReader *ChunkedReader, respBody io.ReadCloser, mint, maxt int64, cancel func(error)) storage.SeriesSet {
 	return &chunkedSeriesSet{
 		chunkedReader: chunkedReader,
 		respBody:      respBody,
@@ -575,7 +574,7 @@ func (s *chunkedSeriesSet) Next() bool {
 		}
 
 		_ = s.respBody.Close()
-		s.cancel()
+		s.cancel(err)
 
 		return false
 	}

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -601,15 +601,17 @@ func (s *chunkedSeriesSet) Warnings() annotations.Annotations {
 	return nil
 }
 
-// chunkedSeries implements storage.Series.
 type chunkedSeries struct {
 	labels     []prompb.Label
 	chunks     []prompb.Chunk
 	mint, maxt int64
 }
 
+var _ storage.Series = &chunkedSeries{}
+
 func (s *chunkedSeries) Labels() labels.Labels {
-	return labelProtosToLabels(s.labels)
+	b := labels.NewScratchBuilder(len(s.labels))
+	return labelProtosToLabels(&b, s.labels)
 }
 
 func (s *chunkedSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
@@ -621,7 +623,6 @@ func (s *chunkedSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
 	return newChunkedSeriesIterator(s.chunks, s.mint, s.maxt)
 }
 
-// chunkedSeriesIterator implements chunkenc.Iterator.
 type chunkedSeriesIterator struct {
 	chunks     []prompb.Chunk
 	idx        int
@@ -631,6 +632,8 @@ type chunkedSeriesIterator struct {
 
 	err error
 }
+
+var _ chunkenc.Iterator = &chunkedSeriesIterator{}
 
 func newChunkedSeriesIterator(chunks []prompb.Chunk, mint, maxt int64) *chunkedSeriesIterator {
 	it := &chunkedSeriesIterator{}
@@ -734,12 +737,12 @@ func (it *chunkedSeriesIterator) At() (ts int64, v float64) {
 	return it.cur.At()
 }
 
-func (it *chunkedSeriesIterator) AtHistogram() (int64, *histogram.Histogram) {
-	return it.cur.AtHistogram()
+func (it *chunkedSeriesIterator) AtHistogram(h *histogram.Histogram) (int64, *histogram.Histogram) {
+	return it.cur.AtHistogram(h)
 }
 
-func (it *chunkedSeriesIterator) AtFloatHistogram() (int64, *histogram.FloatHistogram) {
-	return it.cur.AtFloatHistogram()
+func (it *chunkedSeriesIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+	return it.cur.AtFloatHistogram(fh)
 }
 
 func (it *chunkedSeriesIterator) AtT() int64 {

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -541,7 +541,7 @@ func (c *concreteSeriesIterator) Err() error {
 	return nil
 }
 
-// chunkedSeriesSet implements storage.SeriesSet
+// chunkedSeriesSet implements storage.SeriesSet.
 type chunkedSeriesSet struct {
 	chunkedReader *ChunkedReader
 	respBody      io.ReadCloser
@@ -602,7 +602,7 @@ func (s *chunkedSeriesSet) Warnings() annotations.Annotations {
 	return nil
 }
 
-// chunkedSeries implements storage.Series
+// chunkedSeries implements storage.Series.
 type chunkedSeries struct {
 	labels     []prompb.Label
 	chunks     []prompb.Chunk
@@ -622,7 +622,7 @@ func (s *chunkedSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
 	return newChunkedSeriesIterator(s.chunks, s.mint, s.maxt)
 }
 
-// chunkedSeriesIterator implements chunkenc.Iterator
+// chunkedSeriesIterator implements chunkenc.Iterator.
 type chunkedSeriesIterator struct {
 	chunks     []prompb.Chunk
 	idx        int

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -820,11 +820,13 @@ func TestChunkedSeries(t *testing.T) {
 		chks := buildTestChunks(t)
 
 		s := chunkedSeries{
-			labels: []prompb.Label{
-				{Name: "foo", Value: "bar"},
-				{Name: "asdf", Value: "zxcv"},
+			ChunkedSeries: prompb.ChunkedSeries{
+				Labels: []prompb.Label{
+					{Name: "foo", Value: "bar"},
+					{Name: "asdf", Value: "zxcv"},
+				},
+				Chunks: chks,
 			},
-			chunks: chks,
 		}
 
 		require.Equal(t, labels.FromStrings("asdf", "zxcv", "foo", "bar"), s.Labels())

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -933,7 +933,7 @@ func TestChunkedSeriesSet(t *testing.T) {
 	})
 }
 
-// mockFlusher implements http.Flusher
+// mockFlusher implements http.Flusher.
 type mockFlusher struct{}
 
 func (f *mockFlusher) Flush() {}

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -868,7 +868,7 @@ func TestChunkedSeriesSet(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		ss := NewChunkedSeriesSet(r, io.NopCloser(buf), 0, 14000, func() {})
+		ss := NewChunkedSeriesSet(r, io.NopCloser(buf), 0, 14000, func(error) {})
 		require.Nil(t, ss.Err())
 		require.Nil(t, ss.Warnings())
 
@@ -923,7 +923,7 @@ func TestChunkedSeriesSet(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		ss := NewChunkedSeriesSet(r, io.NopCloser(buf), 0, 14000, func() {})
+		ss := NewChunkedSeriesSet(r, io.NopCloser(buf), 0, 14000, func(error) {})
 		require.Nil(t, ss.Err())
 		require.Nil(t, ss.Warnings())
 

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -16,6 +16,7 @@ package remote
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"sync"
 	"testing"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
@@ -704,4 +706,269 @@ func (c *mockChunkIterator) Next() bool {
 
 func (c *mockChunkIterator) Err() error {
 	return nil
+}
+
+func TestChunkedSeriesIterator(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		chks := buildTestChunks(t)
+
+		it := newChunkedSeriesIterator(chks, 2000, 12000)
+
+		require.Nil(t, it.err)
+		require.NotNil(t, it.cur)
+
+		// Initial next; advance to first valid sample of first chunk.
+		res := it.Next()
+		require.Equal(t, chunkenc.ValFloat, res)
+		require.Nil(t, it.Err())
+
+		ts, v := it.At()
+		require.Equal(t, int64(2000), ts)
+		require.Equal(t, float64(2), v)
+
+		// Next to the second sample of the first chunk.
+		res = it.Next()
+		require.Equal(t, chunkenc.ValFloat, res)
+		require.Nil(t, it.Err())
+
+		ts, v = it.At()
+		require.Equal(t, int64(3000), ts)
+		require.Equal(t, float64(3), v)
+
+		// Attempt to seek to the first sample of the first chunk (should return current sample).
+		res = it.Seek(0)
+		require.Equal(t, chunkenc.ValFloat, res)
+
+		ts, v = it.At()
+		require.Equal(t, int64(3000), ts)
+		require.Equal(t, float64(3), v)
+
+		// Seek to the end of the first chunk.
+		res = it.Seek(4000)
+		require.Equal(t, chunkenc.ValFloat, res)
+
+		ts, v = it.At()
+		require.Equal(t, int64(4000), ts)
+		require.Equal(t, float64(4), v)
+
+		// Next to the first sample of the second chunk.
+		res = it.Next()
+		require.Equal(t, chunkenc.ValFloat, res)
+		require.Nil(t, it.Err())
+
+		ts, v = it.At()
+		require.Equal(t, int64(5000), ts)
+		require.Equal(t, float64(1), v)
+
+		// Seek to the second sample of the third chunk.
+		res = it.Seek(10999)
+		require.Equal(t, chunkenc.ValFloat, res)
+		require.Nil(t, it.Err())
+
+		ts, v = it.At()
+		require.Equal(t, int64(11000), ts)
+		require.Equal(t, float64(3), v)
+
+		// Attempt to seek to something past the last sample (should return false and exhaust the iterator).
+		res = it.Seek(99999)
+		require.Equal(t, chunkenc.ValNone, res)
+		require.Nil(t, it.Err())
+
+		// Attempt to next past the last sample (should return false as the iterator is exhausted).
+		res = it.Next()
+		require.Equal(t, chunkenc.ValNone, res)
+		require.Nil(t, it.Err())
+	})
+
+	t.Run("invalid chunk encoding error", func(t *testing.T) {
+		chks := buildTestChunks(t)
+
+		// Set chunk type to an invalid value.
+		chks[0].Type = 8
+
+		it := newChunkedSeriesIterator(chks, 0, 14000)
+
+		res := it.Next()
+		require.Equal(t, chunkenc.ValNone, res)
+
+		res = it.Seek(1000)
+		require.Equal(t, chunkenc.ValNone, res)
+
+		require.ErrorContains(t, it.err, "invalid chunk encoding")
+		require.Nil(t, it.cur)
+	})
+
+	t.Run("empty chunks", func(t *testing.T) {
+		emptyChunks := make([]prompb.Chunk, 0)
+
+		it1 := newChunkedSeriesIterator(emptyChunks, 0, 1000)
+		require.Equal(t, chunkenc.ValNone, it1.Next())
+		require.Equal(t, chunkenc.ValNone, it1.Seek(1000))
+		require.NoError(t, it1.Err())
+
+		var nilChunks []prompb.Chunk
+
+		it2 := newChunkedSeriesIterator(nilChunks, 0, 1000)
+		require.Equal(t, chunkenc.ValNone, it2.Next())
+		require.Equal(t, chunkenc.ValNone, it2.Seek(1000))
+		require.NoError(t, it2.Err())
+	})
+}
+
+func TestChunkedSeries(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		chks := buildTestChunks(t)
+
+		s := chunkedSeries{
+			labels: []prompb.Label{
+				{Name: "foo", Value: "bar"},
+				{Name: "asdf", Value: "zxcv"},
+			},
+			chunks: chks,
+		}
+
+		require.Equal(t, labels.FromStrings("asdf", "zxcv", "foo", "bar"), s.Labels())
+
+		it := s.Iterator(nil)
+		res := it.Next() // Behavior is undefined w/o the initial call to Next.
+
+		require.Equal(t, chunkenc.ValFloat, res)
+		require.Nil(t, it.Err())
+
+		ts, v := it.At()
+		require.Equal(t, int64(0), ts)
+		require.Equal(t, float64(0), v)
+	})
+}
+
+func TestChunkedSeriesSet(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		flusher := &mockFlusher{}
+
+		w := NewChunkedWriter(buf, flusher)
+		r := NewChunkedReader(buf, config.DefaultChunkedReadLimit, nil)
+
+		chks := buildTestChunks(t)
+		l := []prompb.Label{
+			{Name: "foo", Value: "bar"},
+		}
+
+		for i, c := range chks {
+			cSeries := prompb.ChunkedSeries{Labels: l, Chunks: []prompb.Chunk{c}}
+			readResp := prompb.ChunkedReadResponse{
+				ChunkedSeries: []*prompb.ChunkedSeries{&cSeries},
+				QueryIndex:    int64(i),
+			}
+
+			b, err := proto.Marshal(&readResp)
+			require.NoError(t, err)
+
+			_, err = w.Write(b)
+			require.NoError(t, err)
+		}
+
+		ss := NewChunkedSeriesSet(r, io.NopCloser(buf), 0, 14000, func() {})
+		require.Nil(t, ss.Err())
+		require.Nil(t, ss.Warnings())
+
+		res := ss.Next()
+		require.True(t, res)
+		require.Nil(t, ss.Err())
+
+		s := ss.At()
+		require.Equal(t, 1, s.Labels().Len())
+		require.True(t, s.Labels().Has("foo"))
+		require.Equal(t, "bar", s.Labels().Get("foo"))
+
+		it := s.Iterator(nil)
+		it.Next()
+		ts, v := it.At()
+		require.Equal(t, int64(0), ts)
+		require.Equal(t, float64(0), v)
+
+		numResponses := 1
+		for ss.Next() {
+			numResponses++
+		}
+		require.Equal(t, numTestChunks, numResponses)
+		require.Nil(t, ss.Err())
+	})
+
+	t.Run("chunked reader error", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		flusher := &mockFlusher{}
+
+		w := NewChunkedWriter(buf, flusher)
+		r := NewChunkedReader(buf, config.DefaultChunkedReadLimit, nil)
+
+		chks := buildTestChunks(t)
+		l := []prompb.Label{
+			{Name: "foo", Value: "bar"},
+		}
+
+		for i, c := range chks {
+			cSeries := prompb.ChunkedSeries{Labels: l, Chunks: []prompb.Chunk{c}}
+			readResp := prompb.ChunkedReadResponse{
+				ChunkedSeries: []*prompb.ChunkedSeries{&cSeries},
+				QueryIndex:    int64(i),
+			}
+
+			b, err := proto.Marshal(&readResp)
+			require.NoError(t, err)
+
+			b[0] = 0xFF // Corruption!
+
+			_, err = w.Write(b)
+			require.NoError(t, err)
+		}
+
+		ss := NewChunkedSeriesSet(r, io.NopCloser(buf), 0, 14000, func() {})
+		require.Nil(t, ss.Err())
+		require.Nil(t, ss.Warnings())
+
+		res := ss.Next()
+		require.False(t, res)
+		require.ErrorContains(t, ss.Err(), "proto: illegal wireType 7")
+	})
+}
+
+// mockFlusher implements http.Flusher
+type mockFlusher struct{}
+
+func (f *mockFlusher) Flush() {}
+
+const (
+	numTestChunks          = 3
+	numSamplesPerTestChunk = 5
+)
+
+func buildTestChunks(t *testing.T) []prompb.Chunk {
+	startTime := int64(0)
+	chks := make([]prompb.Chunk, 0, numTestChunks)
+
+	time := startTime
+
+	for i := 0; i < numTestChunks; i++ {
+		c := chunkenc.NewXORChunk()
+
+		a, err := c.Appender()
+		require.NoError(t, err)
+
+		minTimeMs := time
+
+		for j := 0; j < numSamplesPerTestChunk; j++ {
+			a.Append(time, float64(i+j))
+			time += int64(1000)
+		}
+
+		chks = append(chks, prompb.Chunk{
+			MinTimeMs: minTimeMs,
+			MaxTimeMs: time,
+			Type:      prompb.Chunk_XOR,
+			Data:      c.Bytes(),
+		})
+	}
+
+	return chks
 }

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -714,13 +714,13 @@ func TestChunkedSeriesIterator(t *testing.T) {
 
 		it := newChunkedSeriesIterator(chks, 2000, 12000)
 
-		require.Nil(t, it.err)
+		require.NoError(t, it.err)
 		require.NotNil(t, it.cur)
 
 		// Initial next; advance to first valid sample of first chunk.
 		res := it.Next()
 		require.Equal(t, chunkenc.ValFloat, res)
-		require.Nil(t, it.Err())
+		require.NoError(t, it.Err())
 
 		ts, v := it.At()
 		require.Equal(t, int64(2000), ts)
@@ -729,7 +729,7 @@ func TestChunkedSeriesIterator(t *testing.T) {
 		// Next to the second sample of the first chunk.
 		res = it.Next()
 		require.Equal(t, chunkenc.ValFloat, res)
-		require.Nil(t, it.Err())
+		require.NoError(t, it.Err())
 
 		ts, v = it.At()
 		require.Equal(t, int64(3000), ts)
@@ -754,7 +754,7 @@ func TestChunkedSeriesIterator(t *testing.T) {
 		// Next to the first sample of the second chunk.
 		res = it.Next()
 		require.Equal(t, chunkenc.ValFloat, res)
-		require.Nil(t, it.Err())
+		require.NoError(t, it.Err())
 
 		ts, v = it.At()
 		require.Equal(t, int64(5000), ts)
@@ -763,7 +763,7 @@ func TestChunkedSeriesIterator(t *testing.T) {
 		// Seek to the second sample of the third chunk.
 		res = it.Seek(10999)
 		require.Equal(t, chunkenc.ValFloat, res)
-		require.Nil(t, it.Err())
+		require.NoError(t, it.Err())
 
 		ts, v = it.At()
 		require.Equal(t, int64(11000), ts)
@@ -772,12 +772,12 @@ func TestChunkedSeriesIterator(t *testing.T) {
 		// Attempt to seek to something past the last sample (should return false and exhaust the iterator).
 		res = it.Seek(99999)
 		require.Equal(t, chunkenc.ValNone, res)
-		require.Nil(t, it.Err())
+		require.NoError(t, it.Err())
 
 		// Attempt to next past the last sample (should return false as the iterator is exhausted).
 		res = it.Next()
 		require.Equal(t, chunkenc.ValNone, res)
-		require.Nil(t, it.Err())
+		require.NoError(t, it.Err())
 	})
 
 	t.Run("invalid chunk encoding error", func(t *testing.T) {
@@ -833,7 +833,7 @@ func TestChunkedSeries(t *testing.T) {
 		res := it.Next() // Behavior is undefined w/o the initial call to Next.
 
 		require.Equal(t, chunkenc.ValFloat, res)
-		require.Nil(t, it.Err())
+		require.NoError(t, it.Err())
 
 		ts, v := it.At()
 		require.Equal(t, int64(0), ts)
@@ -869,12 +869,12 @@ func TestChunkedSeriesSet(t *testing.T) {
 		}
 
 		ss := NewChunkedSeriesSet(r, io.NopCloser(buf), 0, 14000, func(error) {})
-		require.Nil(t, ss.Err())
+		require.NoError(t, ss.Err())
 		require.Nil(t, ss.Warnings())
 
 		res := ss.Next()
 		require.True(t, res)
-		require.Nil(t, ss.Err())
+		require.NoError(t, ss.Err())
 
 		s := ss.At()
 		require.Equal(t, 1, s.Labels().Len())
@@ -892,7 +892,7 @@ func TestChunkedSeriesSet(t *testing.T) {
 			numResponses++
 		}
 		require.Equal(t, numTestChunks, numResponses)
-		require.Nil(t, ss.Err())
+		require.NoError(t, ss.Err())
 	})
 
 	t.Run("chunked reader error", func(t *testing.T) {
@@ -924,7 +924,7 @@ func TestChunkedSeriesSet(t *testing.T) {
 		}
 
 		ss := NewChunkedSeriesSet(r, io.NopCloser(buf), 0, 14000, func(error) {})
-		require.Nil(t, ss.Err())
+		require.NoError(t, ss.Err())
 		require.Nil(t, ss.Warnings())
 
 		res := ss.Next()

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -165,11 +165,11 @@ func (q *querier) Select(ctx context.Context, sortSeries bool, hints *storage.Se
 		return storage.ErrSeriesSet(fmt.Errorf("toQuery: %w", err))
 	}
 
-	res, err := q.client.Read(ctx, query)
+	res, err := q.client.Read(ctx, query, sortSeries)
 	if err != nil {
 		return storage.ErrSeriesSet(fmt.Errorf("remote_read: %w", err))
 	}
-	return newSeriesSetFilter(FromQueryResult(sortSeries, res), added)
+	return newSeriesSetFilter(res, added)
 }
 
 // addExternalLabels adds matchers for each external label. External labels

--- a/storage/remote/read_handler_test.go
+++ b/storage/remote/read_handler_test.go
@@ -179,7 +179,7 @@ func BenchmarkStreamReadEndpoint(b *testing.B) {
 		require.Equal(b, 2, recorder.Code/100)
 
 		var results []*prompb.ChunkedReadResponse
-		stream := NewChunkedReader(recorder.Result().Body, DefaultChunkedReadLimit, nil)
+		stream := NewChunkedReader(recorder.Result().Body, config.DefaultChunkedReadLimit, nil)
 
 		for {
 			res := &prompb.ChunkedReadResponse{}
@@ -280,7 +280,7 @@ func TestStreamReadEndpoint(t *testing.T) {
 	require.Equal(t, "", recorder.Result().Header.Get("Content-Encoding"))
 
 	var results []*prompb.ChunkedReadResponse
-	stream := NewChunkedReader(recorder.Result().Body, DefaultChunkedReadLimit, nil)
+	stream := NewChunkedReader(recorder.Result().Body, config.DefaultChunkedReadLimit, nil)
 	for {
 		res := &prompb.ChunkedReadResponse{}
 		err := stream.NextProto(res)

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/prometheus/prometheus/util/testutil"
 )
@@ -198,7 +199,7 @@ type mockedRemoteClient struct {
 	b     labels.ScratchBuilder
 }
 
-func (c *mockedRemoteClient) Read(_ context.Context, query *prompb.Query) (*prompb.QueryResult, error) {
+func (c *mockedRemoteClient) Read(_ context.Context, query *prompb.Query, sortSeries bool) (storage.SeriesSet, error) {
 	if c.got != nil {
 		return nil, fmt.Errorf("expected only one call to remote client got: %v", query)
 	}
@@ -227,7 +228,7 @@ func (c *mockedRemoteClient) Read(_ context.Context, query *prompb.Query) (*prom
 			q.Timeseries = append(q.Timeseries, &prompb.TimeSeries{Labels: s.Labels})
 		}
 	}
-	return q, nil
+	return FromQueryResult(sortSeries, q), nil
 }
 
 func (c *mockedRemoteClient) reset() {

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -115,6 +115,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		c, err := NewReadClient(name, &ClientConfig{
 			URL:              rrConf.URL,
 			Timeout:          rrConf.RemoteTimeout,
+			ChunkedReadLimit: rrConf.ChunkedReadLimit,
 			HTTPClientConfig: rrConf.HTTPClientConfig,
 			Headers:          rrConf.Headers,
 		})

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1073,6 +1073,9 @@ func setupRemote(s storage.Storage) *httptest.Server {
 			}
 		}
 
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.Header().Set("Content-Encoding", "snappy")
+
 		if err := remote.EncodeReadResponse(&resp, w); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
Here's another attempt at closing https://github.com/prometheus/prometheus/issues/5926.

I noticed https://github.com/prometheus/prometheus/pull/8351 was stale, and I think this PR has a few improvements over it:
- I believe the implementation of `chunkSeriesIterator.Seek` wasn't correct (it allowed for backwards seeking and does not seek past the current chunk).
- I think I've simplified the implementations of  `chunkedSeriesSet`, `chunkedSeries`, and `chunkedSeriesIterator`.
- The `sizeLimit` parameter for the `ChunkedReader` used by the read client is configurable.
- The `read_queries_total` and `read_request_duration_seconds` metrics have an added `response_type` label that track whether the response from the server was `sampled` or `chunked`.
- The client filters returned samples in the chunked response that are outside of the queried range.