### PR TITLE
tsdb: fix up sort call with faster slices.Sort

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -198,7 +198,7 @@ func (bm *BlockMetaCompaction) SetOutOfOrder() {
 		return
 	}
 	bm.Hints = append(bm.Hints, CompactionHintFromOutOfOrder)
-	sort.Strings(bm.Hints)
+	slices.Sort(bm.Hints)
 }
 
 func (bm *BlockMetaCompaction) FromOutOfOrder() bool {


### PR DESCRIPTION
This call was added by PR #11075 merged before #11318 which changed all similar calls to `sort.Sort` into a faster one.

Without some change like this the main branch will not compile.
