### PR TITLE
Added yamllint rule to ignore "on" in github actions

### DIFF
--- a/.github/workflows/buf-lint.yml
+++ b/.github/workflows/buf-lint.yml
@@ -1,5 +1,5 @@
 name: buf.build
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request:
     paths:
       - ".github/workflows/buf-lint.yml"

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -1,5 +1,5 @@
 name: buf.build
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 ---
 name: CI
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request:
   push:
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,7 @@
 ---
 name: "CodeQL"
 
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_call:
   schedule:
     - cron: "26 14 * * 1"

--- a/.github/workflows/funcbench.yml
+++ b/.github/workflows/funcbench.yml
@@ -1,4 +1,4 @@
-on:
+on:  # yamllint disable-line rule:truthy
   repository_dispatch:
     types: [funcbench_start]
 name: Funcbench Workflow

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,5 +1,5 @@
 name: CIFuzz
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_call:
 jobs:
   Fuzzing:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,6 +1,6 @@
 name: 'Lock Threads'
 
-on:
+on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '13 23 * * *'
   workflow_dispatch:

--- a/.github/workflows/prombench.yml
+++ b/.github/workflows/prombench.yml
@@ -1,4 +1,4 @@
-on:
+on:  # yamllint disable-line rule:truthy
   repository_dispatch:
     types: [prombench_start, prombench_restart, prombench_stop]
 name: Prombench Workflow

--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -1,6 +1,6 @@
 ---
 name: Sync repo files
-on:
+on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '44 17 * * *'
 jobs:


### PR DESCRIPTION
Currently all the github actions return warnings because the "on" keyword in the yaml files are being interpreted as a "truthy" value by yamllint. To ignore this behavior I added a rule which ignores the "on". See https://github.com/adrienverge/yamllint/issues/430.

Signed-off-by: Gabriel Goller <gabriel.goller@acs.it>
