### PR TITLE
docs (label_replace): illustrate use of named capturing group 

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -292,13 +292,13 @@ For each timeseries in `v`, `label_replace(v instant-vector, dst_label string, r
 matches the regular expression `regex` against the value of the label `src_label`. If it
 matches, the value of the label `dst_label` in the returned timeseries will be the expansion
 of `replacement`, together with the original labels in the input. Capturing groups in the
-regular expression can be referenced with `$1`, `$2`, etc. If the regular expression doesn't
-match then the timeseries is returned unchanged.
+regular expression can be referenced with `$1`, `$2`, etc. Named capturing groups in the regular expression can be referenced with `$name` (where `name` is the  capturing group name). If the regular expression doesn't match then the timeseries is returned unchanged.
 
-This example will return timeseries with the values `a:c` at label `service` and `a` at label `foo`:
+These two examples will both return timeseries with the values `a:c` at label `service` and `a` at label `foo`:
 
 ```
 label_replace(up{job="api-server",service="a:c"}, "foo", "$1", "service", "(.*):.*")
+label_replace(up{job="api-server",service="a:c"}, "foo", "$name", "service", "(?P<name>.*):(?P<version>.*)")
 ```
 
 ## `ln()`

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -304,6 +304,7 @@ This second example has the same effect than the first example, and illustrates 
 ```
 label_replace(up{job="api-server",service="a:c"}, "foo", "$name", "service", "(?P<name>.*):(?P<version>.*)")
 ```
+
 ## `ln()`
 
 `ln(v instant-vector)` calculates the natural logarithm for all elements in `v`.

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -289,7 +289,7 @@ label_join(up{job="api-server",src1="a",src2="b",src3="c"}, "foo", ",", "src1", 
 ## `label_replace()`
 
 For each timeseries in `v`, `label_replace(v instant-vector, dst_label string, replacement string, src_label string, regex string)`
-matches the regular expression `regex` against the value of the label `src_label`. If it
+matches the [regular expression](https://github.com/google/re2/wiki/Syntax) `regex` against the value of the label `src_label`. If it
 matches, the value of the label `dst_label` in the returned timeseries will be the expansion
 of `replacement`, together with the original labels in the input. Capturing groups in the
 regular expression can be referenced with `$1`, `$2`, etc. Named capturing groups in the regular expression can be referenced with `$name` (where `name` is the  capturing group name). If the regular expression doesn't match then the timeseries is returned unchanged.
@@ -300,6 +300,10 @@ This example will return timeseries with the values `a:c` at label `service` and
 label_replace(up{job="api-server",service="a:c"}, "foo", "$1", "service", "(.*):.*")
 ```
 
+This second example has the same effect than the first example, and illustrates use of named capturing groups:
+```
+label_replace(up{job="api-server",service="a:c"}, "foo", "$name", "service", "(?P<name>.*):(?P<version>.*)")
+```
 ## `ln()`
 
 `ln(v instant-vector)` calculates the natural logarithm for all elements in `v`.

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -294,11 +294,10 @@ matches, the value of the label `dst_label` in the returned timeseries will be t
 of `replacement`, together with the original labels in the input. Capturing groups in the
 regular expression can be referenced with `$1`, `$2`, etc. Named capturing groups in the regular expression can be referenced with `$name` (where `name` is the  capturing group name). If the regular expression doesn't match then the timeseries is returned unchanged.
 
-These two examples will both return timeseries with the values `a:c` at label `service` and `a` at label `foo`:
+This example will return timeseries with the values `a:c` at label `service` and `a` at label `foo`:
 
 ```
 label_replace(up{job="api-server",service="a:c"}, "foo", "$1", "service", "(.*):.*")
-label_replace(up{job="api-server",service="a:c"}, "foo", "$name", "service", "(?P<name>.*):(?P<version>.*)")
 ```
 
 ## `ln()`


### PR DESCRIPTION
Illustrate use of named capturing group syntax available from https://github.com/google/re2/wiki/Syntax and their usage in the replacement field

Signed-off-by: Guillaume Berche <guillaume.berche@orange.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
