### PR TITLE
Flexible scale sets skipped when retrieving VMs Azure scale sets

### DIFF
--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -237,3 +237,28 @@ func TestNewAzureResourceFromID(t *testing.T) {
 		require.Equal(t, tc.expected, actual)
 	}
 }
+
+func TestIsFlexibleScaleSet(t *testing.T) {
+	for _, tc := range []struct {
+		orchestrationMode compute.OrchestrationMode
+		expected          bool
+	}{
+		{
+			orchestrationMode: compute.OrchestrationModeFlexible,
+			expected:          true,
+		},
+		{
+			orchestrationMode: compute.OrchestrationModeUniform,
+			expected:          false,
+		},
+	}{
+		properties := &compute.VirtualMachineScaleSetProperties {
+			OrchestrationMode: tc.orchestrationMode,
+		}
+		scaleSet := compute.VirtualMachineScaleSet {
+			VirtualMachineScaleSetProperties: properties,
+		}
+		actual := isFlexibleScaleSet(scaleSet)
+		require.Equal(t, tc.expected, actual)
+	}
+}


### PR DESCRIPTION
The Azure API doesn't support retrieving VMs from Flexible Scale Sets (only Uniform Scale Sets have support for this).  This fix checks the OrchestrationMode of the Scale set, and skips over any that have OrchestrationModeFlexible.  This also bumps the version of the compute section of azure-sdk-for-go to 2021-12-01, in order to pick up the ability to read the scale set orchestration mode.

Resolves https://github.com/prometheus/prometheus/issues/11370

Signed-off-by: Derek Cheong <derekcheong@microsoft.com>
