### PR TITLE
doc: Add notes about feature not yet supported for native histograms

### DIFF
--- a/docs/configuration/recording_rules.md
+++ b/docs/configuration/recording_rules.md
@@ -17,6 +17,10 @@ Rule files use YAML.
 The rule files can be reloaded at runtime by sending `SIGHUP` to the Prometheus
 process. The changes are only applied if all rule files are well-formatted.
 
+_Note about native histograms (experimental feature): Rules evaluating to
+native histograms do not yet work as expected. Instead of a native histogram,
+the sample stored is just a floating point value of zero._
+
 ## Syntax-checking rules
 
 To quickly check whether a rule file is syntactically correct without starting

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -8,6 +8,9 @@ sort_rank: 6
 Federation allows a Prometheus server to scrape selected time series from
 another Prometheus server.
 
+_Note about native histograms (experimental feature): Federation does not
+support native histograms yet._
+
 ## Use cases
 
 There are different use cases for federation. Commonly, it is used to either


### PR DESCRIPTION
Namely federation and recording rules.
