### PR TITLE
chunkenc: Slightly optimize xorWrite/xorRead

### DIFF
--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -528,7 +528,7 @@ func (a *HistogramAppender) Recode(
 }
 
 func (a *HistogramAppender) writeSumDelta(v float64) {
-	a.leading, a.trailing = xorWrite(a.b, v, a.sum, a.leading, a.trailing)
+	xorWrite(a.b, v, a.sum, &a.leading, &a.trailing)
 }
 
 type histogramIterator struct {
@@ -867,11 +867,10 @@ func (it *histogramIterator) Next() ValueType {
 }
 
 func (it *histogramIterator) readSum() bool {
-	sum, leading, trailing, err := xorRead(&it.br, it.sum, it.leading, it.trailing)
+	err := xorRead(&it.br, &it.sum, &it.leading, &it.trailing)
 	if err != nil {
 		it.err = err
 		return false
 	}
-	it.sum, it.leading, it.trailing = sum, leading, trailing
 	return true
 }

--- a/tsdb/chunkenc/xor_test.go
+++ b/tsdb/chunkenc/xor_test.go
@@ -1,0 +1,43 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunkenc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkXorRead(b *testing.B) {
+	c := NewXORChunk()
+	app, err := c.Appender()
+	require.NoError(b, err)
+	for i := int64(0); i < 120*1000; i += 1000 {
+		app.Append(i, float64(i)+float64(i)/10+float64(i)/100+float64(i)/1000)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var it Iterator
+	for i := 0; i < b.N; i++ {
+		var ts int64
+		var v float64
+		it = c.Iterator(it)
+		for it.Next() != ValNone {
+			ts, v = it.At()
+		}
+		_, _ = ts, v
+	}
+}


### PR DESCRIPTION
With these changes, the "happy path" when the leading and trailing number of bits don't need an update, fewer operations are needed.

The change is probably very marginal (no change in the benchmark added here, but the benchmark also doesn't cover non-changing values), and an argument could me made that avoiding pointers also has its benefits.

However, I think that reducing the number of return values improves readability. Which convinced me that I should at least propose this. (I wrote this code as a byproduct of investigating https://github.com/prometheus/prometheus/pull/11472 .)

@codesome do you think this is an improvement?