### PR TITLE
Do not check for sample type everytime in sampleRingIterator.Next

### DIFF
--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -227,12 +227,14 @@ func (r *sampleRing) reset() {
 func (r *sampleRing) iterator() chunkenc.Iterator {
 	r.it.r = r
 	r.it.i = -1
+	r.it.typ = chunkenc.ValNone
 	return &r.it
 }
 
 type sampleRingIterator struct {
-	r *sampleRing
-	i int
+	r   *sampleRing
+	i   int
+	typ chunkenc.ValueType
 }
 
 func (it *sampleRingIterator) Next() chunkenc.ValueType {
@@ -240,15 +242,19 @@ func (it *sampleRingIterator) Next() chunkenc.ValueType {
 	if it.i >= it.r.l {
 		return chunkenc.ValNone
 	}
+	if it.typ != chunkenc.ValNone {
+		return it.typ
+	}
 	s := it.r.at(it.i)
 	switch {
 	case s.h != nil:
-		return chunkenc.ValHistogram
+		it.typ = chunkenc.ValHistogram
 	case s.fh != nil:
-		return chunkenc.ValFloatHistogram
+		it.typ = chunkenc.ValFloatHistogram
 	default:
-		return chunkenc.ValFloat
+		it.typ = chunkenc.ValFloat
 	}
+	return it.typ
 }
 
 func (it *sampleRingIterator) Seek(int64) chunkenc.ValueType {


### PR DESCRIPTION
NOTE: sparsehistogram branch

It does not make a huge difference, but a small optimisation.

This is the profile difference of testhing PromQL benchmark for `absent_over_time` alone.

Before:
<img width="820" alt="Screenshot 2022-10-20 at 5 49 03 PM" src="https://user-images.githubusercontent.com/15064823/196947117-9222640f-e859-4632-a1a1-644f9e11013c.png">

After:
<img width="817" alt="Screenshot 2022-10-20 at 5 49 12 PM" src="https://user-images.githubusercontent.com/15064823/196947162-cec9f42a-ec20-4e4c-be0d-f37a8c24075f.png">

