### PR TITLE
GetRefByhash() will query a label's ref with hash value rather than lset.Hash().

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -237,7 +237,8 @@ type GetRef interface {
 	// Returns reference number that can be used to pass to Appender.Append(),
 	// and a set of labels that will not cause another copy when passed to Appender.Append().
 	// 0 means the appender does not have a reference to this series.
-	GetRef(lset labels.Labels) (SeriesRef, labels.Labels)
+	// hash should be a hash of lset.
+	GetRef(lset labels.Labels, hash uint64) (SeriesRef, labels.Labels)
 }
 
 // ExemplarAppender provides an interface for adding samples to exemplar storage, which

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -983,9 +983,9 @@ type dbAppender struct {
 
 var _ storage.GetRef = dbAppender{}
 
-func (a dbAppender) GetRef(lset labels.Labels) (storage.SeriesRef, labels.Labels) {
+func (a dbAppender) GetRef(lset labels.Labels, hash uint64) (storage.SeriesRef, labels.Labels) {
 	if g, ok := a.Appender.(storage.GetRef); ok {
-		return g.GetRef(lset)
+		return g.GetRef(lset, hash)
 	}
 	return 0, nil
 }

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -86,9 +86,9 @@ func (h *Head) initTime(t int64) {
 	h.maxTime.CompareAndSwap(math.MinInt64, t)
 }
 
-func (a *initAppender) GetRef(lset labels.Labels) (storage.SeriesRef, labels.Labels) {
+func (a *initAppender) GetRef(lset labels.Labels, hash uint64) (storage.SeriesRef, labels.Labels) {
 	if g, ok := a.app.(storage.GetRef); ok {
-		return g.GetRef(lset)
+		return g.GetRef(lset, hash)
 	}
 	return 0, nil
 }
@@ -455,8 +455,8 @@ func (a *headAppender) UpdateMetadata(ref storage.SeriesRef, lset labels.Labels,
 
 var _ storage.GetRef = &headAppender{}
 
-func (a *headAppender) GetRef(lset labels.Labels) (storage.SeriesRef, labels.Labels) {
-	s := a.head.series.getByHash(lset.Hash(), lset)
+func (a *headAppender) GetRef(lset labels.Labels, hash uint64) (storage.SeriesRef, labels.Labels) {
+	s := a.head.series.getByHash(hash, lset)
 	if s == nil {
 		return 0, nil
 	}


### PR DESCRIPTION
GetRef() computes label's Hash in `
a.head.series.getByHash(lset.Hash(), lset)
`.
But we find a case that (1) label's Hash will be used twice in a function and (2) there will be a hash cache to speed up some operations in future. So Hash may be computed in advance.
For case (1) GetRefByhash will query a label's ref with hash value rather than lset.Hash(). 
Full details will be found in Cortex's PR https://github.com/cortexproject/cortex/issues/4915
Please @alanprot @yeya24 help to review. 