### PR TITLE
Fix time.Since() in defer. Wrap in anonymous function

### DIFF
--- a/discovery/refresh/refresh.go
+++ b/discovery/refresh/refresh.go
@@ -114,7 +114,10 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 
 func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	now := time.Now()
-	defer d.duration.Observe(time.Since(now).Seconds())
+	defer func() {
+		d.duration.Observe(time.Since(now).Seconds())
+	}()
+
 	tgs, err := d.refreshf(ctx)
 	if err != nil {
 		d.failures.Inc()

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1939,7 +1939,9 @@ func (db *DB) CleanTombstones() (err error) {
 	defer db.cmtx.Unlock()
 
 	start := time.Now()
-	defer db.metrics.tombCleanTimer.Observe(time.Since(start).Seconds())
+	defer func() {
+		db.metrics.tombCleanTimer.Observe(time.Since(start).Seconds())
+	}()
 
 	cleanUpCompleted := false
 	// Repeat cleanup until there is no tombstones left.


### PR DESCRIPTION
Function arguments in defer evaluated during definition of defer, not during execution

Using time.Since in defer needs to we wrapped in anonymous function, otherwise, time.Since gives not the time that happened before calling defer, but time, before just defining defer. Compare this (proper) https://go.dev/play/p/9WfdoCzkVzh and this (buggy) https://go.dev/play/p/D47_U-LZpUI