### PR TITLE
Add linter gocritic, enable check boolExprSimplify and fix findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ output:
 linters:
   enable:
     - depguard
+    - gocritic
     - gofumpt
     - goimports
     - revive
@@ -17,6 +18,7 @@ linters:
 
 issues:
   max-same-issues: 0
+  max-issues-per-linter: 0
   exclude-rules:
     - path: _test.go
       linters:
@@ -34,6 +36,9 @@ linters-settings:
       - regexp: "Use github.com/grafana/regexp instead of regexp"
   errcheck:
     exclude: scripts/errcheck_excludes.txt
+  gocritic:
+    enabled-checks:
+      - boolExprSimplify
   goimports:
     local-prefixes: github.com/prometheus/prometheus
   gofumpt:

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -291,7 +291,7 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 			m := yoloString(p.l.b[p.offsets[0]:p.offsets[1]])
 			u := yoloString(p.text)
 			if len(u) > 0 {
-				if !strings.HasSuffix(m, u) || len(m) < len(u)+1 || p.l.b[p.offsets[1]-len(u)-1] != '_' {
+				if !strings.HasSuffix(m, u) || len(m) <= len(u) || p.l.b[p.offsets[1]-len(u)-1] != '_' {
 					return EntryInvalid, fmt.Errorf("unit not a suffix of metric %q", m)
 				}
 			}

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -314,7 +314,7 @@ type concreteSeriesSet struct {
 
 func (c *concreteSeriesSet) Next() bool {
 	c.cur++
-	return c.cur-1 < len(c.series)
+	return c.cur <= len(c.series)
 }
 
 func (c *concreteSeriesSet) At() storage.Series {


### PR DESCRIPTION
Enables the linter gocritic with a single check in order to keep the pr small. It also fixes the following findings:

```
model/textparse/openmetricsparse.go:294:8: boolExprSimplify: can simplify `!strings.HasSuffix(m, u) || len(m) < len(u)+1 || p.l.b[p.offsets[1]-len(u)-1] != '_'` to `!strings.HasSuffix(m, u) || len(m) <= len(u) || p.l.b[p.offsets[1]-len(u)-1] != '_'` (gocritic)
                                if !strings.HasSuffix(m, u) || len(m) < len(u)+1 || p.l.b[p.offsets[1]-len(u)-1] != '_' {
                                   ^
storage/remote/codec.go:317:9: boolExprSimplify: can simplify `c.cur-1 < len(c.series)` to `c.cur <= len(c.series)` (gocritic)
        return c.cur-1 < len(c.series)
               ^
```