### PR TITLE
documentation/mixin: use prometheus metrics for dashboard variables

### DIFF
--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -314,7 +314,7 @@ local template = grafana.template;
         template.new(
           'cluster',
           '$datasource',
-          'label_values(kube_pod_container_info{image=~".*prometheus.*"}, cluster)' % $._config,
+          'label_values(prometheus_build_info, cluster)' % $._config,
           refresh='time',
           current={
             selected: true,


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Instead of using a metric coming from kubernetes (kube-state-metrics) as a source of dashboard variable, let's use prometheus one. This removes a requirement of using kubernetes in leaf clusters to use this dashboard.