### PR TITLE
Add target_limit to global config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -301,6 +301,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 		}
 
+		if scfg.TargetLimit == 0 {
+			scfg.TargetLimit = c.GlobalConfig.TargetLimit
+		}
+
 		if _, ok := jobNames[scfg.JobName]; ok {
 			return fmt.Errorf("found multiple scrape configs with job name %q", scfg.JobName)
 		}
@@ -344,6 +348,9 @@ type GlobalConfig struct {
 	QueryLogFile string `yaml:"query_log_file,omitempty"`
 	// The labels to add to any timeseries that this Prometheus instance scrapes.
 	ExternalLabels labels.Labels `yaml:"external_labels,omitempty"`
+	// More than this many targets after the target relabeling will cause the
+	// scrapes to fail.
+	TargetLimit uint `yaml:"target_limit,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.


### PR DESCRIPTION
This was part of KubeCon22 ContribFest. I will add the test later.

This is related to issue: https://github.com/prometheus/prometheus/issues/11494 

Signed-off-by: Vasudev Bongale <vasudev2111@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
