### PR TITLE
docs: changed from 'go install' to 'go get' in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,10 +64,10 @@ To add or update a new dependency, use the `go get` command:
 
 ```bash
 # Pick the latest tagged release.
-go install example.com/some/module/pkg@latest
+go get example.com/some/module/pkg@latest
 
 # Pick a specific version.
-go install example.com/some/module/pkg@vX.Y.Z
+go get example.com/some/module/pkg@vX.Y.Z
 ```
 
 Tidy up the `go.mod` and `go.sum` files:


### PR DESCRIPTION
'go install' is not really the correct command. It does not add the package to the go.mod file when a specific version is used. The correct command is 'go get'. See here: https://go.dev/ref/mod#go-install
