### PR TITLE
fix: get block by id directly on promtool analyze

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -398,24 +398,28 @@ func openBlock(path, blockID string) (*tsdb.DBReadOnly, tsdb.BlockReader, error)
 	if err != nil {
 		return nil, nil, err
 	}
-	blocks, err := db.Blocks()
-	if err != nil {
-		return nil, nil, err
-	}
+
 	var block tsdb.BlockReader
 	if blockID != "" {
-		for _, b := range blocks {
-			if b.Meta().ULID.String() == blockID {
-				block = b
-				break
-			}
+		b, err := db.Block(nil, filepath.Join(path, blockID))
+		if err != nil {
+			return nil, nil, err
 		}
-	} else if len(blocks) > 0 {
-		block = blocks[len(blocks)-1]
+		block = b
+	} else {
+		blocks, err := db.Blocks()
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(blocks) > 0 {
+			block = blocks[len(blocks)-1]
+		}
 	}
+
 	if block == nil {
 		return nil, nil, fmt.Errorf("block %s not found", blockID)
 	}
+
 	return db, block, nil
 }
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -534,6 +534,16 @@ func (db *DBReadOnly) ChunkQuerier(ctx context.Context, mint, maxt int64) (stora
 	return q.ChunkQuerier(ctx, mint, maxt)
 }
 
+// Block returns a block reader by given block id.
+func (db *DBReadOnly) Block(logger log.Logger, blockID string) (BlockReader, error) {
+	block, err := OpenBlock(logger, filepath.Join(db.dir, blockID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return block, nil
+}
+
 // Blocks returns a slice of block readers for persisted blocks.
 func (db *DBReadOnly) Blocks() ([]BlockReader, error) {
 	select {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -536,10 +536,17 @@ func (db *DBReadOnly) ChunkQuerier(ctx context.Context, mint, maxt int64) (stora
 
 // Block returns a block reader by given block id.
 func (db *DBReadOnly) Block(logger log.Logger, blockID string) (BlockReader, error) {
+	select {
+	case <-db.closed:
+		return nil, ErrClosed
+	default:
+	}
+
 	block, err := OpenBlock(logger, filepath.Join(db.dir, blockID), nil)
 	if err != nil {
 		return nil, err
 	}
+	db.closers = append(db.closers, block)
 
 	return block, nil
 }


### PR DESCRIPTION
related issue: https://github.com/prometheus/prometheus/issues/10822

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
