### PR TITLE
Optimize postings offset table reading

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -74,10 +74,20 @@ func TestSetCompactionFailed(t *testing.T) {
 func TestCreateBlock(t *testing.T) {
 	tmpdir := t.TempDir()
 	b, err := OpenBlock(nil, createBlock(t, tmpdir, genSeries(1, 1, 0, 10)), nil)
-	if err == nil {
-		require.NoError(t, b.Close())
-	}
 	require.NoError(t, err)
+	require.NoError(t, b.Close())
+}
+
+func BenchmarkOpenBlock(b *testing.B) {
+	tmpdir := b.TempDir()
+	blockDir := createBlock(b, tmpdir, genSeries(1e6, 20, 0, 10))
+	b.Run("benchmark", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			block, err := OpenBlock(nil, blockDir, nil)
+			require.NoError(b, err)
+			require.NoError(b, block.Close())
+		}
+	})
 }
 
 func TestCorruptedChunk(t *testing.T) {

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1435,7 +1435,7 @@ func ReadOffsetTable[T any](bs ByteSlice, off uint64, read func(d *encoding.Decb
 // PostingTableReader can be used as read function for ReadOffsetTable to read the posting offset table.
 func PostingTableReader(d *encoding.Decbuf) (labels.Label, error) {
 	if keyCount := d.Uvarint(); keyCount != 2 {
-		return labels.Label{}, errors.Errorf("unexpected key length for posting table %d", keyCount)
+		return labels.Label{}, errors.Errorf("unexpected number of keys for postings offset table %d", keyCount)
 	}
 	var lbl labels.Label
 	lbl.Name = d.UvarintStr()

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1192,9 +1192,9 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 			}
 			if valueCount%symbolFactor == 0 {
 				r.postings[string(name)] = append(r.postings[string(name)], postingOffset{value: string(value), off: off})
-				lastName, lastValue = name, value
-			} else {
 				lastName, lastValue = nil, nil
+			} else {
+				lastName, lastValue = name, value
 				lastOff = off
 			}
 			valueCount++

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1189,7 +1189,6 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 					// Always include last value for each label name.
 					r.postings[lastKey.Name] = append(r.postings[lastKey.Name], postingOffset{value: lastKey.Value, off: lastOff})
 				}
-				lastKey = labels.Label{}
 				valueCount = 0
 			}
 			if valueCount%symbolFactor == 0 {

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -210,31 +210,31 @@ func TestIndexRW_Postings(t *testing.T) {
 	require.NoError(t, p.Err())
 
 	// The label indices are no longer used, so test them by hand here.
+	labelValuesOffsets := map[string]uint64{}
+	d := encoding.NewDecbufAt(ir.b, int(ir.toc.LabelIndicesTable), castagnoliTable)
+	cnt := d.Be32()
+
+	for d.Err() == nil && d.Len() > 0 && cnt > 0 {
+		require.Equal(t, 1, d.Uvarint(), "Unexpected number of keys for label indices table")
+		lbl := d.UvarintStr()
+		off := d.Uvarint64()
+		labelValuesOffsets[lbl] = off
+		cnt--
+	}
+	require.NoError(t, d.Err())
+
 	labelIndices := map[string][]string{}
-	reader := func(d *encoding.Decbuf) (string, error) {
-		if keyCount := d.Uvarint(); keyCount != 1 {
-			return "", errors.Errorf("unexpected key length for label indices table %d", keyCount)
+	for lbl, off := range labelValuesOffsets {
+		d := encoding.NewDecbufAt(ir.b, int(off), castagnoliTable)
+		require.Equal(t, 1, d.Be32int(), "Unexpected number of label indices table names")
+		for i := d.Be32(); i > 0 && d.Err() == nil; i-- {
+			v, err := ir.lookupSymbol(d.Be32())
+			require.NoError(t, err)
+			labelIndices[lbl] = append(labelIndices[lbl], v)
 		}
-		return d.UvarintStr(), nil
+		require.NoError(t, d.Err())
 	}
 
-	require.NoError(t, ReadOffsetTable(ir.b, ir.toc.LabelIndicesTable, reader, func(key string, off uint64, _ int) error {
-		d := encoding.NewDecbufAt(ir.b, int(off), castagnoliTable)
-		vals := []string{}
-		nc := d.Be32int()
-		if nc != 1 {
-			return errors.Errorf("unexpected number of label indices table names %d", nc)
-		}
-		for i := d.Be32(); i > 0; i-- {
-			v, err := ir.lookupSymbol(d.Be32())
-			if err != nil {
-				return err
-			}
-			vals = append(vals, v)
-		}
-		labelIndices[key] = vals
-		return d.Err()
-	}))
 	require.Equal(t, map[string][]string{
 		"a": {"1"},
 		"b": {"1", "2", "3", "4"},


### PR DESCRIPTION
Instead of reading a generic-ish `[]string` slice, we now always read two []byte slices: name and value. They point to the backing buffer slice until we store them as strings, where they're copied.

Moved the label-indices specific reading mechanism to that test only, since it's not being used anywhere else.

This avoids allocating a slice that escapes to the heap, making it both faster and more efficient in terms of memory management.

Also added a benchmark for a block with 1M series and 20 labels, which I think looks really promising:

```
name                 old time/op    new time/op    delta
OpenBlock/benchmark     130ms ± 3%      44ms ±10%  -66.47%  (p=0.008 n=5+5)

name                 old alloc/op   new alloc/op   delta
OpenBlock/benchmark    53.2MB ± 0%     5.7MB ± 0%  -89.21%  (p=0.008 n=5+5)

name                 old allocs/op  new allocs/op  delta
OpenBlock/benchmark     3.00M ± 0%     0.06M ± 0%  -97.91%  (p=0.008 n=5+5)
```

<details>
<summary>Old PR description: before applying feedback and optimizing even further</summary>
Instead of reading a generic-ish `[]string` slice, we can read a generic type which would be specifically `labels.Label` for the posting offset table.

This avoids allocating a slice that escapes to the heap, making it both faster and more efficient in terms of memory management.

Also added a benchmark for a block with 1M series and 20 labels, which I think looks really promising:

```
OpenBlock/benchmark     130ms ± 3%      85ms ± 3%  -35.10%  (p=0.008 n=5+5)

name                 old alloc/op   new alloc/op   delta
OpenBlock/benchmark    53.2MB ± 0%    21.2MB ± 0%  -60.10%  (p=0.008 n=5+5)

name                 old allocs/op  new allocs/op  delta
OpenBlock/benchmark     3.00M ± 0%     2.00M ± 0%  -33.33%  (p=0.000 n=5+4)
```

---

_P.S.: is this the first generics usage in Prometheus?_
</details>