### PR TITLE
scrape: Fix accept header

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -773,8 +773,8 @@ type targetScraper struct {
 var errBodySizeLimit = errors.New("body size limit exceeded")
 
 const (
-	scrapeAcceptHeader             = `encoding=delimited,application/openmetrics-text;version=1.0.0;q=0.75,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
-	scrapeAcceptHeaderWithProtobuf = `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited,application/openmetrics-text;version=1.0.0;q=0.75,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
+	scrapeAcceptHeader             = `application/openmetrics-text;version=1.0.0;q=0.75,application/openmetrics-text;q=0.6,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
+	scrapeAcceptHeaderWithProtobuf = `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited,application/openmetrics-text;version=1.0.0;q=0.75,application/openmetrics-text;q=0.6,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
 )
 
 var UserAgent = fmt.Sprintf("Prometheus/%s", version.Version)


### PR DESCRIPTION
First of all, there was a typo: `encoding=delimited` was a left-over in the `scrapeAcceptHeader`.

Second, the recently updated `version=1.0.0` prevents current versions of client_golang to negotiate OpenMetrics, as they expect `version=0.0.1` or no version at all. This commit adds, with lower priority, the latter (no version at all) to the accept header.

Fixes #11540,

Signed-off-by: beorn7 <beorn@grafana.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
