### PR TITLE
Add unit for uptime column in Prometheus stats dashboard

### DIFF
--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -27,7 +27,7 @@ local template = grafana.template;
             instance: { alias: 'Instance' },
             version: { alias: 'Version' },
             'Value #A': { alias: 'Count', type: 'hidden' },
-            'Value #B': { alias: 'Uptime' },
+            'Value #B': { alias: 'Uptime', type: 'number', unit: 's' },
           })
         )
       )


### PR DESCRIPTION
Prior to this fix uptime column interpreted as number and the higher values are suffixed with raw units like `K`. This commit adds unit for the column as `second` to make visual interpretation easy.

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
