### PR TITLE
discover/openstack: add compute API microversion conf

### DIFF
--- a/discovery/openstack/hypervisor.go
+++ b/discovery/openstack/hypervisor.go
@@ -45,15 +45,16 @@ type HypervisorDiscovery struct {
 	logger       log.Logger
 	port         int
 	availability gophercloud.Availability
+	microversion string
 }
 
 // newHypervisorDiscovery returns a new hypervisor discovery.
 func newHypervisorDiscovery(provider *gophercloud.ProviderClient, opts *gophercloud.AuthOptions,
-	port int, region string, availability gophercloud.Availability, l log.Logger,
+	port int, region string, availability gophercloud.Availability, l log.Logger, microversion string,
 ) *HypervisorDiscovery {
 	return &HypervisorDiscovery{
 		provider: provider, authOpts: opts,
-		region: region, port: port, availability: availability, logger: l,
+		region: region, port: port, availability: availability, logger: l, microversion: microversion,
 	}
 }
 
@@ -69,6 +70,10 @@ func (h *HypervisorDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not create OpenStack compute session: %w", err)
+	}
+
+	if h.microversion != "" {
+		client.Microversion = h.microversion
 	}
 
 	tg := &targetgroup.Group{

--- a/discovery/openstack/hypervisor.go
+++ b/discovery/openstack/hypervisor.go
@@ -72,9 +72,7 @@ func (h *HypervisorDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group
 		return nil, fmt.Errorf("could not create OpenStack compute session: %w", err)
 	}
 
-	if h.microversion != "" {
-		client.Microversion = h.microversion
-	}
+	client.Microversion = h.microversion
 
 	tg := &targetgroup.Group{
 		Source: fmt.Sprintf("OS_" + h.region),

--- a/discovery/openstack/instance.go
+++ b/discovery/openstack/instance.go
@@ -89,9 +89,7 @@ func (i *InstanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 		return nil, fmt.Errorf("could not create OpenStack compute session: %w", err)
 	}
 
-	if i.microversion != "" {
-		client.Microversion = i.microversion
-	}
+	client.Microversion = i.microversion
 
 	// OpenStack API reference
 	// https://developer.openstack.org/api-ref/compute/#list-floating-ips

--- a/discovery/openstack/instance.go
+++ b/discovery/openstack/instance.go
@@ -54,18 +54,19 @@ type InstanceDiscovery struct {
 	port         int
 	allTenants   bool
 	availability gophercloud.Availability
+	microversion string
 }
 
 // NewInstanceDiscovery returns a new instance discovery.
 func newInstanceDiscovery(provider *gophercloud.ProviderClient, opts *gophercloud.AuthOptions,
-	port int, region string, allTenants bool, availability gophercloud.Availability, l log.Logger,
+	port int, region string, allTenants bool, availability gophercloud.Availability, l log.Logger, microversion string,
 ) *InstanceDiscovery {
 	if l == nil {
 		l = log.NewNopLogger()
 	}
 	return &InstanceDiscovery{
 		provider: provider, authOpts: opts,
-		region: region, port: port, allTenants: allTenants, availability: availability, logger: l,
+		region: region, port: port, allTenants: allTenants, availability: availability, logger: l, microversion: microversion,
 	}
 }
 
@@ -86,6 +87,10 @@ func (i *InstanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not create OpenStack compute session: %w", err)
+	}
+
+	if i.microversion != "" {
+		client.Microversion = i.microversion
 	}
 
 	// OpenStack API reference

--- a/discovery/openstack/openstack.go
+++ b/discovery/openstack/openstack.go
@@ -63,6 +63,7 @@ type SDConfig struct {
 	AllTenants                  bool             `yaml:"all_tenants,omitempty"`
 	TLSConfig                   config.TLSConfig `yaml:"tls_config,omitempty"`
 	Availability                string           `yaml:"availability,omitempty"`
+	ComputeMicroversion         string           `yaml:"compute_microversion"`
 }
 
 // Name returns the name of the Config.
@@ -192,9 +193,9 @@ func newRefresher(conf *SDConfig, l log.Logger) (refresher, error) {
 	availability := gophercloud.Availability(conf.Availability)
 	switch conf.Role {
 	case OpenStackRoleHypervisor:
-		return newHypervisorDiscovery(client, &opts, conf.Port, conf.Region, availability, l), nil
+		return newHypervisorDiscovery(client, &opts, conf.Port, conf.Region, availability, l, conf.ComputeMicroversion), nil
 	case OpenStackRoleInstance:
-		return newInstanceDiscovery(client, &opts, conf.Port, conf.Region, conf.AllTenants, availability, l), nil
+		return newInstanceDiscovery(client, &opts, conf.Port, conf.Region, conf.AllTenants, availability, l, conf.ComputeMicroversion), nil
 	}
 	return nil, errors.New("unknown OpenStack discovery role")
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1181,7 +1181,6 @@ tls_config:
 
 # Microversion to use when connecting to OpenStack Compute API.
 # https://specs.openstack.org/openstack/api-wg/guidelines/microversion_specification.html
-compute_microversion:
 [ compute_microversion: <string> ]
 ```
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1178,6 +1178,11 @@ region: <string>
 # TLS configuration.
 tls_config:
   [ <tls_config> ]
+
+# Microversion to use when connecting to OpenStack Compute API.
+# https://specs.openstack.org/openstack/api-wg/guidelines/microversion_specification.html
+compute_microversion:
+[ compute_microversion: <string> ]
 ```
 
 ### `<ovhcloud_sd_config>`


### PR DESCRIPTION
Configuration for compute API microversion. My use case is that my OS provider has a low version as default, and therefore prometheus can't read the instance tags.

https://github.com/gophercloud/gophercloud/blob/48fe8d1e08fec45a3cf08f1d704575458cdc7740/docs/MICROVERSIONS.md