### PR TITLE
relabel: add keepequal/dropequal relabel action

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -217,25 +217,44 @@ var expectedConf = &Config{
 					Regex:        relabel.MustNewRegexp("(.*)some-[regex]"),
 					Replacement:  "foo-${1}",
 					Action:       relabel.Replace,
-				}, {
+				},
+				{
 					SourceLabels: model.LabelNames{"abc"},
 					TargetLabel:  "cde",
 					Separator:    ";",
 					Regex:        relabel.DefaultRelabelConfig.Regex,
 					Replacement:  relabel.DefaultRelabelConfig.Replacement,
 					Action:       relabel.Replace,
-				}, {
+				},
+				{
 					TargetLabel: "abc",
 					Separator:   ";",
 					Regex:       relabel.DefaultRelabelConfig.Regex,
 					Replacement: "static",
 					Action:      relabel.Replace,
-				}, {
+				},
+				{
 					TargetLabel: "abc",
 					Separator:   ";",
 					Regex:       relabel.MustNewRegexp(""),
 					Replacement: "static",
 					Action:      relabel.Replace,
+				},
+				{
+					SourceLabels: model.LabelNames{"foo"},
+					TargetLabel:  "abc",
+					Action:       relabel.KeepEqual,
+					Regex:        relabel.DefaultRelabelConfig.Regex,
+					Replacement:  relabel.DefaultRelabelConfig.Replacement,
+					Separator:    relabel.DefaultRelabelConfig.Separator,
+				},
+				{
+					SourceLabels: model.LabelNames{"foo"},
+					TargetLabel:  "abc",
+					Action:       relabel.DropEqual,
+					Regex:        relabel.DefaultRelabelConfig.Regex,
+					Replacement:  relabel.DefaultRelabelConfig.Replacement,
+					Separator:    relabel.DefaultRelabelConfig.Separator,
 				},
 			},
 		},
@@ -1315,6 +1334,22 @@ var expectedErrors = []struct {
 	{
 		filename: "labeldrop5.bad.yml",
 		errMsg:   "labeldrop action requires only 'regex', and no other fields",
+	},
+	{
+		filename: "dropequal.bad.yml",
+		errMsg:   "relabel configuration for dropequal action requires 'target_label' value",
+	},
+	{
+		filename: "dropequal1.bad.yml",
+		errMsg:   "dropequal action requires only 'source_labels' and `target_label`, and no other fields",
+	},
+	{
+		filename: "keepequal.bad.yml",
+		errMsg:   "relabel configuration for keepequal action requires 'target_label' value",
+	},
+	{
+		filename: "keepequal1.bad.yml",
+		errMsg:   "keepequal action requires only 'source_labels' and `target_label`, and no other fields",
 	},
 	{
 		filename: "labelmap.bad.yml",

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -87,6 +87,12 @@ scrape_configs:
       - regex:
         replacement: static
         target_label: abc
+      - source_labels: [foo]
+        target_label: abc
+        action: keepequal
+      - source_labels: [foo]
+        target_label: abc
+        action: dropequal
 
     authorization:
       credentials_file: valid_token_file

--- a/config/testdata/dropequal.bad.yml
+++ b/config/testdata/dropequal.bad.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: prometheus
+    relabel_configs:
+      - source_labels: [abcdef]
+        action: dropequal

--- a/config/testdata/dropequal1.bad.yml
+++ b/config/testdata/dropequal1.bad.yml
@@ -1,0 +1,7 @@
+scrape_configs:
+  - job_name: prometheus
+    relabel_configs:
+      - source_labels: [abcdef]
+        action: dropequal
+        regex: foo
+        target_label: bar

--- a/config/testdata/keepequal.bad.yml
+++ b/config/testdata/keepequal.bad.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: prometheus
+    relabel_configs:
+      - source_labels: [abcdef]
+        action: keepequal

--- a/config/testdata/keepequal1.bad.yml
+++ b/config/testdata/keepequal1.bad.yml
@@ -1,0 +1,7 @@
+scrape_configs:
+  - job_name: prometheus
+    relabel_configs:
+      - source_labels: [abcdef]
+        action: keepequal
+        regex: foo
+        target_label: bar

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2857,6 +2857,8 @@ anchored on both ends. To un-anchor the regex, use `.*<regex>.*`.
 * `uppercase`: Maps the concatenated `source_labels` to their upper case.
 * `keep`: Drop targets for which `regex` does not match the concatenated `source_labels`.
 * `drop`: Drop targets for which `regex` matches the concatenated `source_labels`.
+* `keepequal`: Drop targets for which the concatenated `source_labels` do not match `target_label`.
+* `dropequal`: Drop targets for which the concatenated `source_labels` do match `target_label`.
 * `hashmod`: Set `target_label` to the `modulus` of a hash of the concatenated `source_labels`.
 * `labelmap`: Match `regex` against all source label names, not just those specified in `source_labels`. Then
    copy the values of the matching labels  to label names given by `replacement` with match

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -451,6 +451,74 @@ func TestRelabel(t *testing.T) {
 				"foo_uppercase": "BAR123FOO",
 			}),
 		},
+		{
+			input: labels.FromMap(map[string]string{
+				"__tmp_port": "1234",
+				"__port1":    "1234",
+				"__port2":    "5678",
+			}),
+			relabel: []*Config{
+				{
+					SourceLabels: model.LabelNames{"__tmp_port"},
+					Action:       KeepEqual,
+					TargetLabel:  "__port1",
+				},
+			},
+			output: labels.FromMap(map[string]string{
+				"__tmp_port": "1234",
+				"__port1":    "1234",
+				"__port2":    "5678",
+			}),
+		},
+		{
+			input: labels.FromMap(map[string]string{
+				"__tmp_port": "1234",
+				"__port1":    "1234",
+				"__port2":    "5678",
+			}),
+			relabel: []*Config{
+				{
+					SourceLabels: model.LabelNames{"__tmp_port"},
+					Action:       DropEqual,
+					TargetLabel:  "__port1",
+				},
+			},
+			output: nil,
+		},
+		{
+			input: labels.FromMap(map[string]string{
+				"__tmp_port": "1234",
+				"__port1":    "1234",
+				"__port2":    "5678",
+			}),
+			relabel: []*Config{
+				{
+					SourceLabels: model.LabelNames{"__tmp_port"},
+					Action:       DropEqual,
+					TargetLabel:  "__port2",
+				},
+			},
+			output: labels.FromMap(map[string]string{
+				"__tmp_port": "1234",
+				"__port1":    "1234",
+				"__port2":    "5678",
+			}),
+		},
+		{
+			input: labels.FromMap(map[string]string{
+				"__tmp_port": "1234",
+				"__port1":    "1234",
+				"__port2":    "5678",
+			}),
+			relabel: []*Config{
+				{
+					SourceLabels: model.LabelNames{"__tmp_port"},
+					Action:       KeepEqual,
+					TargetLabel:  "__port2",
+				},
+			},
+			output: nil,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fix #11556 

Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
