### PR TITLE
scrape: extend staleness logic to series with explicit timestamps

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -476,6 +476,7 @@ func main() {
 	}
 	if cfgFile.StorageConfig.TSDBConfig != nil {
 		cfg.tsdb.OutOfOrderTimeWindow = cfgFile.StorageConfig.TSDBConfig.OutOfOrderTimeWindow
+		cfg.scrape.OutOfOrderIngestionEnabled = cfg.tsdb.OutOfOrderTimeWindow > 0
 	}
 
 	// Now that the validity of the config is established, set the config

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -140,6 +140,8 @@ type Options struct {
 
 	// Optional HTTP client options to use when scraping.
 	HTTPClientOptions []config_util.HTTPClientOption
+	// Prometheus is configured to allow out-of-order ingestion
+	OutOfOrderIngestionEnabled bool
 }
 
 // Manager maintains a set of scrape pools and manages start/stop cycles


### PR DESCRIPTION
The TSDB recently added functionality to ingest out-of-order samples. If out-of-order ingestion is enabled, there is no longer a reason to bypass the addition of staleness markers on series with explicit timestamps.

Fixes: #11565 