### PR TITLE
Fix black-on-black metric name color in dark mode

### DIFF
--- a/web/ui/react-app/src/pages/graph/CMTheme.tsx
+++ b/web/ui/react-app/src/pages/graph/CMTheme.tsx
@@ -1,5 +1,5 @@
-import { EditorView } from '@codemirror/view';
 import { HighlightStyle } from '@codemirror/language';
+import { EditorView } from '@codemirror/view';
 import { tags } from '@lezer/highlight';
 
 export const baseTheme = EditorView.theme({
@@ -263,7 +263,6 @@ export const darkTheme = EditorView.theme(
 );
 
 export const promqlHighlighter = HighlightStyle.define([
-  { tag: tags.name, color: '#000' },
   { tag: tags.number, color: '#09885a' },
   { tag: tags.string, color: '#a31515' },
   { tag: tags.keyword, color: '#008080' },
@@ -279,7 +278,6 @@ export const promqlHighlighter = HighlightStyle.define([
 ]);
 
 export const darkPromqlHighlighter = HighlightStyle.define([
-  { tag: tags.name, color: '#000' },
   { tag: tags.number, color: '#22c55e' },
   { tag: tags.string, color: '#fca5a5' },
   { tag: tags.keyword, color: '#14bfad' },


### PR DESCRIPTION
The color should not be set explicitly at all. That way it simply inherits the theme's default color, as before
https://github.com/prometheus/prometheus/pull/11068.

Fixes https://github.com/prometheus/prometheus/issues/11568

Signed-off-by: Julius Volz <julius.volz@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
