### PR TITLE
feat(storage): enable client's bulk query read from remote storage

### DIFF
--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/storage"
 )
 
 type sampleAndChunkQueryableClient struct {

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/prompb"
 )
 
 type sampleAndChunkQueryableClient struct {
@@ -167,11 +168,11 @@ func (q *querier) Select(sortSeries bool, hints *storage.SelectHints, matchers .
 		return storage.ErrSeriesSet(fmt.Errorf("toQuery: %w", err))
 	}
 
-	res, err := q.client.Read(q.ctx, query)
+	res, err := q.client.Read(q.ctx, []*prompb.Query{query})
 	if err != nil {
 		return storage.ErrSeriesSet(fmt.Errorf("remote_read: %w", err))
 	}
-	return newSeriesSetFilter(FromQueryResult(sortSeries, res), added)
+	return newSeriesSetFilter(FromQueryResult(sortSeries, res[0]), added)
 }
 
 // addExternalLabels adds matchers for each external label. External labels

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -202,7 +202,7 @@ func (c *mockedRemoteClient) Read(_ context.Context, queries []*prompb.Query) ([
 	}
 	c.got = queries
 
-	q := make ([]*prompb.QueryResult, len(queries))
+	q := make([]*prompb.QueryResult, len(queries))
 	for i, query := range queries {
 		q[i] = &prompb.QueryResult{}
 
@@ -401,8 +401,8 @@ func TestSampleAndChunkQueryableClient(t *testing.T) {
 			callback:   func() (i int64, err error) { return 20, nil },
 			readRecent: false,
 
-			expectedQueries:  nil,
-			expectedSeries: nil, // Noop should be used.
+			expectedQueries: nil,
+			expectedSeries:  nil, // Noop should be used.
 		},
 		{
 			name: "required matcher specified, user also specifies same",
@@ -463,8 +463,8 @@ func TestSampleAndChunkQueryableClient(t *testing.T) {
 				labels.MustNewMatcher(labels.MatchEqual, "a", "b2"),
 			},
 
-			expectedQueries:  nil,
-			expectedSeries: nil, // Given matchers does not match with required ones, noop expected.
+			expectedQueries: nil,
+			expectedSeries:  nil, // Given matchers does not match with required ones, noop expected.
 		},
 		{
 			name: "required matcher specified, given matcher does not match2",
@@ -476,8 +476,8 @@ func TestSampleAndChunkQueryableClient(t *testing.T) {
 			requiredMatchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "a", "b2"),
 			},
-			expectedQueries:  nil,
-			expectedSeries: nil, // Given matchers does not match with required ones, noop expected.
+			expectedQueries: nil,
+			expectedSeries:  nil, // Given matchers does not match with required ones, noop expected.
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
## Context
See #11597. This is an improvement by slightly changing the interface to accept a query slice instead of a pointer, and yields multiple query results. The effort was just refactoring storage calls that must pass a slice instead, and already existing function calls that support a single query result are not affected.

## Changes
- Change client's `Read` function to receive a slice of `*prompb.Query`, and return a slice of `*prompb.QueryResult`.

## Additional information
N/A.