### PR TITLE
UI: Update Flot license headers

### DIFF
--- a/web/ui/react-app/src/vendor/flot/jquery.flot.crosshair.js
+++ b/web/ui/react-app/src/vendor/flot/jquery.flot.crosshair.js
@@ -1,13 +1,7 @@
-/**
- *
- * THIS FILE WAS COPIED INTO PROMETHEUS FROM GRAFANA'S VENDORED FORK OF FLOT
- * (LIVING AT https://github.com/grafana/grafana/tree/master/public/vendor/flot),
- * WHICH CONTAINS FIXES FOR DISPLAYING NULL VALUES IN STACKED GRAPHS. THE ORIGINAL
- * FLOT CODE WAS LICENSED UNDER THE MIT LICENSE AS STATED BELOW. ADDITIONAL
- * CHANGES HAVE BEEN CONTRIBUTED TO THE GRAFANA FORK UNDER AN APACHE 2 LICENSE, SEE
- * https://github.com/grafana/grafana/blob/master/license.
- *
- */
+/*
+SPDX-License-Identifier: MIT
+Source: https://github.com/grafana/grafana/blob/main/public/vendor/flot/jquery.flot.crosshair.js
+*/
 
 /* eslint-disable prefer-spread */
 /* eslint-disable no-loop-func */

--- a/web/ui/react-app/src/vendor/flot/jquery.flot.js
+++ b/web/ui/react-app/src/vendor/flot/jquery.flot.js
@@ -1,13 +1,7 @@
-/**
- *
- * THIS FILE WAS COPIED INTO PROMETHEUS FROM GRAFANA'S VENDORED FORK OF FLOT
- * (LIVING AT https://github.com/grafana/grafana/tree/master/public/vendor/flot),
- * WHICH CONTAINS FIXES FOR DISPLAYING NULL VALUES IN STACKED GRAPHS. THE ORIGINAL
- * FLOT CODE WAS LICENSED UNDER THE MIT LICENSE AS STATED BELOW. ADDITIONAL
- * CHANGES HAVE BEEN CONTRIBUTED TO THE GRAFANA FORK UNDER AN APACHE 2 LICENSE, SEE
- * https://github.com/grafana/grafana/blob/master/license.
- *
- */
+/*
+SPDX-License-Identifier: MIT
+Source: https://github.com/grafana/grafana/blob/main/public/vendor/flot/jquery.flot.js
+*/
 
 /* eslint-disable prefer-spread */
 /* eslint-disable no-loop-func */

--- a/web/ui/react-app/src/vendor/flot/jquery.flot.selection.js
+++ b/web/ui/react-app/src/vendor/flot/jquery.flot.selection.js
@@ -1,11 +1,7 @@
-/**
- *
- * THIS FILE WAS COPIED INTO PROMETHEUS FROM GRAFANA'S VENDORED FORK OF FLOT
- * (LIVING AT https://github.com/grafana/grafana/tree/v7.5.8/public/vendor/flot).
- * THE ORIGINAL FLOT CODE WAS LICENSED UNDER THE MIT LICENSE AS STATED BELOW.
- * ADDITIONAL CHANGES HAVE BEEN CONTRIBUTED TO THE GRAFANA FORK UNDER AN
- * APACHE 2 LICENSE, SEE https://github.com/grafana/grafana/blob/v7.5.8/LICENSE.
- */
+/*
+SPDX-License-Identifier: MIT
+Source: https://github.com/grafana/grafana/blob/main/public/vendor/flot/jquery.flot.selection.js
+*/
 
 /* eslint-disable prefer-spread */
 /* eslint-disable no-loop-func */

--- a/web/ui/react-app/src/vendor/flot/jquery.flot.stack.js
+++ b/web/ui/react-app/src/vendor/flot/jquery.flot.stack.js
@@ -1,13 +1,7 @@
-/**
- *
- * THIS FILE WAS COPIED INTO PROMETHEUS FROM GRAFANA'S VENDORED FORK OF FLOT
- * (LIVING AT https://github.com/grafana/grafana/tree/master/public/vendor/flot),
- * WHICH CONTAINS FIXES FOR DISPLAYING NULL VALUES IN STACKED GRAPHS. THE ORIGINAL
- * FLOT CODE WAS LICENSED UNDER THE MIT LICENSE AS STATED BELOW. ADDITIONAL
- * CHANGES HAVE BEEN CONTRIBUTED TO THE GRAFANA FORK UNDER AN APACHE 2 LICENSE, SEE
- * https://github.com/grafana/grafana/blob/master/license.
- *
- */
+/*
+SPDX-License-Identifier: MIT
+Source: https://github.com/grafana/grafana/blob/main/public/vendor/flot/jquery.flot.stock.js
+*/
 
 /* eslint-disable prefer-spread */
 /* eslint-disable no-loop-func */

--- a/web/ui/react-app/src/vendor/flot/jquery.flot.time.js
+++ b/web/ui/react-app/src/vendor/flot/jquery.flot.time.js
@@ -1,13 +1,7 @@
-/**
- *
- * THIS FILE WAS COPIED INTO PROMETHEUS FROM GRAFANA'S VENDORED FORK OF FLOT
- * (LIVING AT https://github.com/grafana/grafana/tree/master/public/vendor/flot),
- * WHICH CONTAINS FIXES FOR DISPLAYING NULL VALUES IN STACKED GRAPHS. THE ORIGINAL
- * FLOT CODE WAS LICENSED UNDER THE MIT LICENSE AS STATED BELOW. ADDITIONAL
- * CHANGES HAVE BEEN CONTRIBUTED TO THE GRAFANA FORK UNDER AN APACHE 2 LICENSE, SEE
- * https://github.com/grafana/grafana/blob/master/license.
- *
- */
+/*
+SPDX-License-Identifier: MIT
+Source: https://github.com/grafana/grafana/blob/main/public/vendor/flot/jquery.flot.time.js
+*/
 
 /* eslint-disable prefer-rest-params */
 /* eslint-disable no-useless-concat */


### PR DESCRIPTION
See #9181 for more context, but in short Grafana relicensed their Flot changes as MIT, so we need to update the headers on our copied version to indicate it is under the MIT license (also causing a few of our own changes to be relicensed).