### PR TITLE
Attempt to append ooo sample at the end first

### DIFF
--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -194,13 +194,16 @@ func BenchmarkRemoteWriteOOOSamples(b *testing.B) {
 	require.Equal(b, http.StatusNoContent, recorder.Code)
 	require.Equal(b, h.NumSeries(), uint64(1000))
 
-	b.ResetTimer()
-
+	var bufRequests [][]byte
 	for i := 0; i < 100; i++ {
 		buf, _, err = buildWriteRequest(genSeriesWithSample(1000, int64(80+i)*time.Minute.Milliseconds()), nil, nil, nil)
 		require.NoError(b, err)
+		bufRequests = append(bufRequests, buf)
+	}
 
-		req, err = http.NewRequest("", "", bytes.NewReader(buf))
+	b.ResetTimer()
+	for i := 0; i < 100; i++ {
+		req, err = http.NewRequest("", "", bytes.NewReader(bufRequests[i]))
 		require.NoError(b, err)
 
 		recorder = httptest.NewRecorder()

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -54,7 +54,7 @@ func (o *OOOChunk) Insert(t int64, v float64) bool {
 		return true
 	}
 
-	// duplicate sample for timestamp is not allowed
+	// Duplicate sample for timestamp is not allowed.
 	if o.samples[i].t == t {
 		return false
 	}

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -36,6 +36,18 @@ func NewOOOChunk() *OOOChunk {
 // Insert inserts the sample such that order is maintained.
 // Returns false if insert was not possible due to the same timestamp already existing.
 func (o *OOOChunk) Insert(t int64, v float64) bool {
+	// Although out-of-order samples can be out-of-order amongst themselves, we
+	// are opinionated and expect them to be usually in-order meaning we could
+	// try to append at the end first if the new timestamp is higher than the
+	// last known timestamp.
+	if len(o.samples) > 0 {
+		if t > o.samples[len(o.samples)-1].t {
+			// append it at the end
+			o.samples = append(o.samples, sample{t, v, nil, nil})
+			return true
+		}
+	}
+
 	// Find index of sample we should replace.
 	i := sort.Search(len(o.samples), func(i int) bool { return o.samples[i].t >= t })
 
@@ -45,6 +57,7 @@ func (o *OOOChunk) Insert(t int64, v float64) bool {
 		return true
 	}
 
+	// duplicate sample for timestamp is not allowed
 	if o.samples[i].t == t {
 		return false
 	}

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -40,12 +40,9 @@ func (o *OOOChunk) Insert(t int64, v float64) bool {
 	// are opinionated and expect them to be usually in-order meaning we could
 	// try to append at the end first if the new timestamp is higher than the
 	// last known timestamp.
-	if len(o.samples) > 0 {
-		if t > o.samples[len(o.samples)-1].t {
-			// append it at the end
-			o.samples = append(o.samples, sample{t, v, nil, nil})
-			return true
-		}
+	if len(o.samples) == 0 || t > o.samples[len(o.samples)-1].t {
+		o.samples = append(o.samples, sample{t, v, nil, nil})
+		return true
 	}
 
 	// Find index of sample we should replace.


### PR DESCRIPTION
This is an optimization on the existing sample append in the `OOOChunk`.

What we've been doing so far is find the place inside the out-of-order slice where the new sample should go in and then place it there and move any samples to the right if necessary. This is OK but requires a binary search every time the slice is bigger than 0.

The optimization is opinionated and suggests that although out-of-order samples can be out-of-order amongst themselves they'll probably be in order thus we can probably optimistically append at the end and if not do the binary search.

OOOChunks are capped to 30 samples by default so this is a small optimization but everything adds up, specially if you handle many active timeseries with out-of-order samples.

cc @codesome for review