### PR TITLE
Fix inconsistency in histogramIterator

### DIFF
--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -704,7 +704,7 @@ func (it *histogramIterator) Next() ValueType {
 				for i := 0; i < numNBuckets; i++ {
 					it.nBuckets = append(it.nBuckets, 0)
 					it.nBucketsDelta = append(it.nBucketsDelta, 0)
-					it.pFloatBuckets = append(it.pFloatBuckets, 0)
+					it.nFloatBuckets = append(it.nFloatBuckets, 0)
 				}
 			}
 		}


### PR DESCRIPTION
Struct fields are split into 'p' for positive and 'n' for negative; this line is in a stanza modifying 'n' so should be consistent.

