### PR TITLE
tsdb: use smaller allocation in blockBaseSeriesSet

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -471,7 +471,14 @@ func (b *blockBaseSeriesSet) Next() bool {
 		var trimFront, trimBack bool
 
 		// Copy chunks as iterables are reusable.
-		chks := make([]chunks.Meta, 0, len(b.bufChks))
+		// Count those in range to size allocation (roughly - ignoring tombstones).
+		nChks := 0
+		for _, chk := range b.bufChks {
+			if !(chk.MaxTime < b.mint || chk.MinTime > b.maxt) {
+				nChks++
+			}
+		}
+		chks := make([]chunks.Meta, 0, nChks)
 
 		// Prefilter chunks and pick those which are not entirely deleted or totally outside of the requested range.
 		for _, chk := range b.bufChks {


### PR DESCRIPTION
This reduces garbage, hence goes faster, when a short time range is required compared to the amount of chunks in the block. For example recording rules and alerts often look only at the last few minutes.

Benchmarks 
```
name                                         old time/op    new time/op    delta
QuerierSelect/Head/1of1000000-8                 179ms ± 7%     165ms ± 3%    -7.91%  (p=0.008 n=5+5)
QuerierSelect/Head/10of1000000-8                187ms ± 7%     163ms ± 3%   -13.23%  (p=0.008 n=5+5)
QuerierSelect/Head/100of1000000-8               191ms ±10%     162ms ± 0%   -15.00%  (p=0.008 n=5+5)
QuerierSelect/Head/1000of1000000-8              195ms ± 5%     163ms ± 3%   -16.29%  (p=0.008 n=5+5)
QuerierSelect/Head/10000of1000000-8             182ms ± 3%     165ms ± 3%    -8.99%  (p=0.008 n=5+5)
QuerierSelect/Head/100000of1000000-8            199ms ± 7%     173ms ± 2%   -13.19%  (p=0.008 n=5+5)
QuerierSelect/Head/1000000of1000000-8           283ms ±11%     269ms ± 5%      ~     (p=0.222 n=5+5)
QuerierSelect/SortedHead/1of1000000-8           761ms ± 0%     750ms ± 1%    -1.40%  (p=0.008 n=5+5)
QuerierSelect/SortedHead/10of1000000-8          762ms ± 1%     748ms ± 0%    -1.91%  (p=0.008 n=5+5)
QuerierSelect/SortedHead/100of1000000-8         760ms ± 0%     758ms ± 2%      ~     (p=0.690 n=5+5)
QuerierSelect/SortedHead/1000of1000000-8        760ms ± 0%     753ms ± 2%      ~     (p=0.151 n=5+5)
QuerierSelect/SortedHead/10000of1000000-8       762ms ± 0%     744ms ± 1%    -2.38%  (p=0.008 n=5+5)
QuerierSelect/SortedHead/100000of1000000-8      770ms ± 1%     756ms ± 1%    -1.77%  (p=0.008 n=5+5)
QuerierSelect/SortedHead/1000000of1000000-8     845ms ± 1%     844ms ± 1%      ~     (p=0.841 n=5+5)
QuerierSelect/Block/1of1000000-8                257ms ± 0%     241ms ± 1%    -6.01%  (p=0.008 n=5+5)
QuerierSelect/Block/10of1000000-8               257ms ± 1%     244ms ± 2%    -5.20%  (p=0.008 n=5+5)
QuerierSelect/Block/100of1000000-8              258ms ± 0%     246ms ± 2%    -4.56%  (p=0.008 n=5+5)
QuerierSelect/Block/1000of1000000-8             258ms ± 0%     242ms ± 0%    -5.84%  (p=0.016 n=5+4)
QuerierSelect/Block/10000of1000000-8            258ms ± 1%     248ms ± 4%    -3.98%  (p=0.016 n=5+5)
QuerierSelect/Block/100000of1000000-8           266ms ± 0%     253ms ± 0%    -4.80%  (p=0.016 n=5+4)
QuerierSelect/Block/1000000of1000000-8          361ms ± 7%     364ms ± 2%      ~     (p=1.000 n=5+5)

name                                         old alloc/op   new alloc/op   delta
QuerierSelect/Head/1of1000000-8                64.0MB ± 0%     0.0MB ± 0%  -100.00%  (p=0.000 n=5+4)
QuerierSelect/Head/10of1000000-8               64.0MB ± 0%     0.0MB ± 0%  -100.00%  (p=0.008 n=5+5)
QuerierSelect/Head/100of1000000-8              64.0MB ± 0%     0.0MB ± 0%   -99.97%  (p=0.008 n=5+5)
QuerierSelect/Head/1000of1000000-8             64.1MB ± 0%     0.2MB ± 0%   -99.67%  (p=0.008 n=5+5)
QuerierSelect/Head/10000of1000000-8            65.4MB ± 0%     2.1MB ± 0%   -96.82%  (p=0.008 n=5+5)
QuerierSelect/Head/100000of1000000-8           78.4MB ± 0%    20.8MB ± 0%   -73.47%  (p=0.000 n=5+4)
QuerierSelect/Head/1000000of1000000-8           208MB ± 0%     208MB ± 0%      ~     (p=0.333 n=5+4)
QuerierSelect/SortedHead/1of1000000-8           114MB ± 0%      50MB ± 0%   -56.30%  (p=0.008 n=5+5)
QuerierSelect/SortedHead/10of1000000-8          114MB ± 0%      50MB ± 0%   -56.30%  (p=0.008 n=5+5)
QuerierSelect/SortedHead/100of1000000-8         114MB ± 0%      50MB ± 0%   -56.28%  (p=0.008 n=5+5)
QuerierSelect/SortedHead/1000of1000000-8        114MB ± 0%      50MB ± 0%   -56.17%  (p=0.008 n=5+5)
QuerierSelect/SortedHead/10000of1000000-8       115MB ± 0%      52MB ± 0%   -55.04%  (p=0.008 n=5+5)
QuerierSelect/SortedHead/100000of1000000-8      128MB ± 0%      70MB ± 0%   -44.97%  (p=0.008 n=5+5)
QuerierSelect/SortedHead/1000000of1000000-8     258MB ± 0%     258MB ± 0%      ~     (all equal)
QuerierSelect/Block/1of1000000-8                115MB ± 0%      51MB ± 0%   -55.56%  (p=0.008 n=5+5)
QuerierSelect/Block/10of1000000-8               115MB ± 0%      51MB ± 0%   -55.55%  (p=0.008 n=5+5)
QuerierSelect/Block/100of1000000-8              115MB ± 0%      51MB ± 0%   -55.54%  (p=0.008 n=5+5)
QuerierSelect/Block/1000of1000000-8             115MB ± 0%      51MB ± 0%   -55.44%  (p=0.008 n=5+5)
QuerierSelect/Block/10000of1000000-8            116MB ± 0%      53MB ± 0%   -54.40%  (p=0.008 n=5+5)
QuerierSelect/Block/100000of1000000-8           128MB ± 0%      70MB ± 0%   -45.00%  (p=0.008 n=5+5)
QuerierSelect/Block/1000000of1000000-8          243MB ± 0%     243MB ± 0%      ~     (p=0.476 n=5+5)
```