### PR TITLE
tsdb: improve blockBaseSeriesSet scan

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -481,10 +481,10 @@ func (b *blockBaseSeriesSet) Next() bool {
 			if chk.MinTime > b.maxt {
 				continue
 			}
-
-			if !(tombstones.Interval{Mint: chk.MinTime, Maxt: chk.MaxTime}.IsSubrange(intervals)) {
-				chks = append(chks, chk)
+			if (tombstones.Interval{Mint: chk.MinTime, Maxt: chk.MaxTime}.IsSubrange(intervals)) {
+				continue
 			}
+			chks = append(chks, chk)
 
 			// If still not entirely deleted, check if trim is needed based on requested time range.
 			if !b.disableTrimming {


### PR DESCRIPTION
Something I noticed while working on #11631.

Inverting the test for chunks deleted by tombstones makes all three rejections consistent, and also avoids the case where a chunk is excluded but still causes `trimFront` or `trimBack` to be set.

