### PR TITLE
fix: seriesSet from chunkSeriesSet return identical data samples

### DIFF
--- a/storage/series.go
+++ b/storage/series.go
@@ -205,7 +205,7 @@ func (c *chunkSetToSeriesSet) Next() bool {
 	}
 
 	c.iter = c.ChunkSeriesSet.At().Iterator(c.iter)
-	c.sameSeriesChunks = c.sameSeriesChunks[:0]
+	c.sameSeriesChunks = nil
 
 	for c.iter.Next() {
 		c.sameSeriesChunks = append(

--- a/storage/series_test.go
+++ b/storage/series_test.go
@@ -18,7 +18,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 )
 
 func TestListSeriesIterator(t *testing.T) {
@@ -64,4 +66,62 @@ func TestListSeriesIterator(t *testing.T) {
 	require.Equal(t, chunkenc.ValNone, it.Seek(5))
 	// And we don't go back. (This exposes issue #10027.)
 	require.Equal(t, chunkenc.ValNone, it.Seek(2))
+}
+
+// TestSeriesSetToChunkSet test the property of SeriesSet that says
+// returned series should be iterable even after Next is called.
+func TestChunkSeriesSetToSeriesSet(t *testing.T) {
+	series := []struct {
+		lbs     labels.Labels
+		samples []tsdbutil.Sample
+	}{
+		{
+			lbs: labels.Labels{
+				{Name: "__name__", Value: "up"},
+				{Name: "instance", Value: "localhost:8080"},
+			},
+			samples: []tsdbutil.Sample{
+				sample{t: 1, v: 1},
+				sample{t: 2, v: 2},
+				sample{t: 3, v: 3},
+				sample{t: 4, v: 4},
+			},
+		}, {
+			lbs: labels.Labels{
+				{Name: "__name__", Value: "up"},
+				{Name: "instance", Value: "localhost:8081"},
+			},
+			samples: []tsdbutil.Sample{
+				sample{t: 1, v: 2},
+				sample{t: 2, v: 3},
+				sample{t: 3, v: 4},
+				sample{t: 4, v: 5},
+				sample{t: 5, v: 6},
+				sample{t: 6, v: 7},
+			},
+		},
+	}
+	var chunkSeries []ChunkSeries
+	for _, s := range series {
+		chunkSeries = append(chunkSeries, NewListChunkSeriesFromSamples(s.lbs, s.samples))
+	}
+	css := NewMockChunkSeriesSet(chunkSeries...)
+
+	ss := NewSeriesSetFromChunkSeriesSet(css)
+	var ssSlice []Series
+	for ss.Next() {
+		ssSlice = append(ssSlice, ss.At())
+	}
+	require.Len(t, ssSlice, 2)
+	var iter chunkenc.Iterator
+	for i, s := range ssSlice {
+		require.EqualValues(t, series[i].lbs, s.Labels())
+		iter = s.Iterator(iter)
+		j := 0
+		for iter.Next() == chunkenc.ValFloat {
+			ts, v := iter.At()
+			require.EqualValues(t, series[i].samples[j], sample{t: ts, v: v})
+			j++
+		}
+	}
 }


### PR DESCRIPTION
field ```sameSeriesChunks``` slice is reused in every iterator loop ```chunkSetToSeriesSet.Next```, 
https://github.com/prometheus/prometheus/blob/6bdecf377cea8e856509914f35234e948c4fcb80/storage/series.go#L182-L187
This may cause ```chunkSetToSeriesSet.At``` returns identical data sample but different labels.
https://github.com/prometheus/prometheus/blob/6bdecf377cea8e856509914f35234e948c4fcb80/storage/series.go#L198-L200

```
func TestSeriesSetToChunkSet1(t *testing.T) {
	tss := []timeSeries{
		{
			lbs: labels.Labels{
				{Name: "__name__", Value: "up"},
				{Name: "instance", Value: "localhost:8080"},
			},
			samples: []tsdbutil.Sample{
				sample{t: 1, v: 1}, sample{t: 2, v: 2},
				sample{t: 3, v: 3}, sample{t: 4, v: 4},
			},
		}, {
			lbs: labels.Labels{
				{Name: "__name__", Value: "up"},
				{Name: "instance", Value: "localhost:8081"},
			},
			samples: []tsdbutil.Sample{
				sample{t: 1, v: 2}, sample{t: 2, v: 3},
				sample{t: 3, v: 4}, sample{t: 4, v: 5},
				sample{t: 5, v: 6}, sample{t: 6, v: 7},
			},
		},
	}
	css := toMockChunkSeriesSet(tss)
	ss := NewSeriesSetFromChunkSeriesSet(css)
	ssSlice := make([]Series, 0)
	for ss.Next() {
		ssSlice = append(ssSlice, ss.At())
	}
	for _, one := range ssSlice {
		t.Log(one.Labels())
		iter := one.Iterator()
		for iter.Next() == chunkenc.ValFloat {
			t.Log(iter.At())
		}
	}
}

type timeSeries struct {
	lbs     labels.Labels
	samples []tsdbutil.Sample
}

func toMockChunkSeriesSet(tss []timeSeries) ChunkSeriesSet {
	css := make([]ChunkSeries, 0)
	for _, ts := range tss {
		css = append(css, NewListChunkSeriesFromSamples(ts.lbs, ts.samples))
	}
	return NewMockChunkSeriesSet(css...)
}
```

The upper unit test output:
```
    series_test.go:101: {__name__="up", instance="localhost:8080"}
    series_test.go:104: 1 2
    series_test.go:104: 2 3
    series_test.go:104: 3 4
    series_test.go:104: 4 5
    series_test.go:104: 5 6
    series_test.go:104: 6 7
    series_test.go:101: {__name__="up", instance="localhost:8081"}
    series_test.go:104: 1 2
    series_test.go:104: 2 3
    series_test.go:104: 3 4
    series_test.go:104: 4 5
    series_test.go:104: 5 6
    series_test.go:104: 6 7
````

Signed-off-by: sniper91 [kevinzhao91@outlook.com](mailto:kevinzhao91@outlook.com)
