### PR TITLE
Fix reset of a histogram chunk iterator

### DIFF
--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -624,9 +624,9 @@ func (it *histogramIterator) Err() error {
 }
 
 func (it *histogramIterator) Reset(b []byte) {
-	// The first 2 bytes contain chunk headers.
+	// The first 3 bytes contain chunk headers.
 	// We skip that for actual samples.
-	it.br = newBReader(b[2:])
+	it.br = newBReader(b[3:])
 	it.numTotal = binary.BigEndian.Uint16(b)
 	it.numRead = 0
 

--- a/tsdb/chunkenc/histogram_test.go
+++ b/tsdb/chunkenc/histogram_test.go
@@ -84,14 +84,14 @@ func TestHistogramChunkSameBuckets(t *testing.T) {
 	require.Equal(t, exp, act)
 
 	// 2. Expand second iterator while reusing first one.
-	// it2 := c.Iterator(it1)
-	// var res2 []pair
-	// for it2.Next() {
-	//	ts, v := it2.At()
-	//	res2 = append(res2, pair{t: ts, v: v})
-	//	}
-	//	require.NoError(t, it2.Err())
-	//	require.Equal(t, exp, res2)
+	it2 := c.Iterator(it)
+	var res2 []res
+	for it2.Next() == ValHistogram {
+		ts, h := it2.AtHistogram()
+		res2 = append(res2, res{t: ts, h: h})
+	}
+	require.NoError(t, it2.Err())
+	require.Equal(t, exp, res2)
 
 	// 3. Test iterator Seek.
 	//	mid := len(exp) / 2


### PR DESCRIPTION
I found this bug while working on float histograms. This can make native histogram queries return wrong results. I will cut a new patch release for 2.40.x with this.