### PR TITLE
Add VM size label to azure service discovery (#11575)

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -538,10 +538,6 @@ func mapFromVM(vm compute.VirtualMachine) virtualMachine {
 		}
 	}
 
-	if vm.VirtualMachineProperties != nil && vm.VirtualMachineProperties.HardwareProfile != nil {
-		size = string(vm.VirtualMachineProperties.HardwareProfile.VMSize)
-	}
-
 	return virtualMachine{
 		ID:                *(vm.ID),
 		Name:              *(vm.Name),
@@ -580,10 +576,6 @@ func mapFromVMScaleSetVM(vm compute.VirtualMachineScaleSetVM, scaleSetName strin
 		if vm.VirtualMachineScaleSetVMProperties.HardwareProfile != nil {
 			size = string(vm.VirtualMachineScaleSetVMProperties.HardwareProfile.VMSize)
 		}
-	}
-
-	if vm.VirtualMachineScaleSetVMProperties != nil && vm.VirtualMachineScaleSetVMProperties.HardwareProfile != nil {
-		size = string(vm.VirtualMachineScaleSetVMProperties.HardwareProfile.VMSize)
 	}
 
 	return virtualMachine{

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -55,6 +55,7 @@ const (
 	azureLabelMachinePublicIP      = azureLabel + "machine_public_ip"
 	azureLabelMachineTag           = azureLabel + "machine_tag_"
 	azureLabelMachineScaleSet      = azureLabel + "machine_scale_set"
+	azureLabelMachineSize          = azureLabel + "machine_size"
 
 	authMethodOAuth           = "OAuth"
 	authMethodManagedIdentity = "ManagedIdentity"
@@ -261,6 +262,7 @@ type virtualMachine struct {
 	ScaleSet          string
 	Tags              map[string]*string
 	NetworkInterfaces []string
+	Size              string
 }
 
 // Create a new azureResource object from an ID string.
@@ -343,6 +345,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 				azureLabelMachineOSType:        model.LabelValue(vm.OsType),
 				azureLabelMachineLocation:      model.LabelValue(vm.Location),
 				azureLabelMachineResourceGroup: model.LabelValue(r.ResourceGroup),
+				azureLabelMachineSize:          model.LabelValue(vm.Size),
 			}
 
 			if vm.ScaleSet != "" {
@@ -514,6 +517,7 @@ func mapFromVM(vm compute.VirtualMachine) virtualMachine {
 	tags := map[string]*string{}
 	networkInterfaces := []string{}
 	var computerName string
+	var size string
 
 	if vm.Tags != nil {
 		tags = vm.Tags
@@ -531,6 +535,10 @@ func mapFromVM(vm compute.VirtualMachine) virtualMachine {
 		computerName = *(vm.VirtualMachineProperties.OsProfile.ComputerName)
 	}
 
+	if vm.VirtualMachineProperties != nil && vm.VirtualMachineProperties.HardwareProfile != nil {
+		size = string(vm.VirtualMachineProperties.HardwareProfile.VMSize)
+	}
+
 	return virtualMachine{
 		ID:                *(vm.ID),
 		Name:              *(vm.Name),
@@ -541,6 +549,7 @@ func mapFromVM(vm compute.VirtualMachine) virtualMachine {
 		ScaleSet:          "",
 		Tags:              tags,
 		NetworkInterfaces: networkInterfaces,
+		Size:              size,
 	}
 }
 
@@ -549,6 +558,7 @@ func mapFromVMScaleSetVM(vm compute.VirtualMachineScaleSetVM, scaleSetName strin
 	tags := map[string]*string{}
 	networkInterfaces := []string{}
 	var computerName string
+	var size string
 
 	if vm.Tags != nil {
 		tags = vm.Tags
@@ -564,6 +574,10 @@ func mapFromVMScaleSetVM(vm compute.VirtualMachineScaleSetVM, scaleSetName strin
 		computerName = *(vm.VirtualMachineScaleSetVMProperties.OsProfile.ComputerName)
 	}
 
+	if vm.VirtualMachineScaleSetVMProperties != nil && vm.VirtualMachineScaleSetVMProperties.HardwareProfile != nil {
+		size = string(vm.VirtualMachineScaleSetVMProperties.HardwareProfile.VMSize)
+	}
+
 	return virtualMachine{
 		ID:                *(vm.ID),
 		Name:              *(vm.Name),
@@ -574,6 +588,7 @@ func mapFromVMScaleSetVM(vm compute.VirtualMachineScaleSetVM, scaleSetName strin
 		ScaleSet:          scaleSetName,
 		Tags:              tags,
 		NetworkInterfaces: networkInterfaces,
+		Size:              size,
 	}
 }
 

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -529,10 +529,13 @@ func mapFromVM(vm compute.VirtualMachine) virtualMachine {
 		}
 	}
 
-	if vm.VirtualMachineProperties != nil &&
-		vm.VirtualMachineProperties.OsProfile != nil &&
-		vm.VirtualMachineProperties.OsProfile.ComputerName != nil {
-		computerName = *(vm.VirtualMachineProperties.OsProfile.ComputerName)
+	if vm.VirtualMachineProperties != nil {
+		if vm.VirtualMachineProperties.OsProfile != nil && vm.VirtualMachineProperties.OsProfile.ComputerName != nil {
+			computerName = *(vm.VirtualMachineProperties.OsProfile.ComputerName)
+		}
+		if vm.VirtualMachineProperties.HardwareProfile != nil {
+			size = string(vm.VirtualMachineProperties.HardwareProfile.VMSize)
+		}
 	}
 
 	if vm.VirtualMachineProperties != nil && vm.VirtualMachineProperties.HardwareProfile != nil {
@@ -570,8 +573,13 @@ func mapFromVMScaleSetVM(vm compute.VirtualMachineScaleSetVM, scaleSetName strin
 		}
 	}
 
-	if vm.VirtualMachineScaleSetVMProperties != nil && vm.VirtualMachineScaleSetVMProperties.OsProfile != nil {
-		computerName = *(vm.VirtualMachineScaleSetVMProperties.OsProfile.ComputerName)
+	if vm.VirtualMachineScaleSetVMProperties != nil {
+		if vm.VirtualMachineScaleSetVMProperties.OsProfile != nil && vm.VirtualMachineScaleSetVMProperties.OsProfile.ComputerName != nil {
+			computerName = *(vm.VirtualMachineScaleSetVMProperties.OsProfile.ComputerName)
+		}
+		if vm.VirtualMachineScaleSetVMProperties.HardwareProfile != nil {
+			size = string(vm.VirtualMachineScaleSetVMProperties.HardwareProfile.VMSize)
+		}
 	}
 
 	if vm.VirtualMachineScaleSetVMProperties != nil && vm.VirtualMachineScaleSetVMProperties.HardwareProfile != nil {

--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -28,6 +28,7 @@ func TestMain(m *testing.M) {
 func TestMapFromVMWithEmptyTags(t *testing.T) {
 	id := "test"
 	name := "name"
+	size := "size"
 	vmType := "type"
 	location := "westeurope"
 	computerName := "computer_name"
@@ -44,6 +45,9 @@ func TestMapFromVMWithEmptyTags(t *testing.T) {
 			},
 		},
 		NetworkProfile: &networkProfile,
+		HardwareProfile: &compute.HardwareProfile{
+			VMSize: compute.VirtualMachineSizeTypes(size),
+		},
 	}
 
 	testVM := compute.VirtualMachine{
@@ -64,6 +68,7 @@ func TestMapFromVMWithEmptyTags(t *testing.T) {
 		OsType:            "Linux",
 		Tags:              map[string]*string{},
 		NetworkInterfaces: []string{},
+		Size:              size,
 	}
 
 	actualVM := mapFromVM(testVM)
@@ -74,6 +79,7 @@ func TestMapFromVMWithEmptyTags(t *testing.T) {
 func TestMapFromVMWithTags(t *testing.T) {
 	id := "test"
 	name := "name"
+	size := "size"
 	vmType := "type"
 	location := "westeurope"
 	computerName := "computer_name"
@@ -93,6 +99,9 @@ func TestMapFromVMWithTags(t *testing.T) {
 			},
 		},
 		NetworkProfile: &networkProfile,
+		HardwareProfile: &compute.HardwareProfile{
+			VMSize: compute.VirtualMachineSizeTypes(size),
+		},
 	}
 
 	testVM := compute.VirtualMachine{
@@ -113,6 +122,7 @@ func TestMapFromVMWithTags(t *testing.T) {
 		OsType:            "Linux",
 		Tags:              tags,
 		NetworkInterfaces: []string{},
+		Size:              size,
 	}
 
 	actualVM := mapFromVM(testVM)
@@ -123,6 +133,7 @@ func TestMapFromVMWithTags(t *testing.T) {
 func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 	id := "test"
 	name := "name"
+	size := "size"
 	vmType := "type"
 	location := "westeurope"
 	computerName := "computer_name"
@@ -139,6 +150,9 @@ func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 			},
 		},
 		NetworkProfile: &networkProfile,
+		HardwareProfile: &compute.HardwareProfile{
+			VMSize: compute.VirtualMachineSizeTypes(size),
+		},
 	}
 
 	testVM := compute.VirtualMachineScaleSetVM{
@@ -161,6 +175,7 @@ func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 		Tags:              map[string]*string{},
 		NetworkInterfaces: []string{},
 		ScaleSet:          scaleSet,
+		Size:              size,
 	}
 
 	actualVM := mapFromVMScaleSetVM(testVM, scaleSet)
@@ -171,6 +186,7 @@ func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 func TestMapFromVMScaleSetVMWithTags(t *testing.T) {
 	id := "test"
 	name := "name"
+	size := "size"
 	vmType := "type"
 	location := "westeurope"
 	computerName := "computer_name"
@@ -190,6 +206,9 @@ func TestMapFromVMScaleSetVMWithTags(t *testing.T) {
 			},
 		},
 		NetworkProfile: &networkProfile,
+		HardwareProfile: &compute.HardwareProfile{
+			VMSize: compute.VirtualMachineSizeTypes(size),
+		},
 	}
 
 	testVM := compute.VirtualMachineScaleSetVM{
@@ -212,6 +231,7 @@ func TestMapFromVMScaleSetVMWithTags(t *testing.T) {
 		Tags:              tags,
 		NetworkInterfaces: []string{},
 		ScaleSet:          scaleSet,
+		Size:              size,
 	}
 
 	actualVM := mapFromVMScaleSetVM(testVM, scaleSet)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -440,6 +440,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_azure_machine_resource_group`: the machine's resource group
 * `__meta_azure_machine_tag_<tagname>`: each tag value of the machine
 * `__meta_azure_machine_scale_set`: the name of the scale set which the vm is part of (this value is only set if you are using a [scale set](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/))
+* `__meta_azure_machine_size`: the machine size
 * `__meta_azure_subscription_id`: the subscription ID
 * `__meta_azure_tenant_id`: the tenant ID
 


### PR DESCRIPTION
Signed-off-by: davidifr <davidfr.mail@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
