### PR TITLE
tsdb tests: allocate more reasonable sample slice

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -678,7 +678,7 @@ func genSeriesFromSampleGenerator(totalSeries, labelCount int, mint, maxt, step 
 		for j := 1; len(lbls) < labelCount; j++ {
 			lbls[defaultLabelName+strconv.Itoa(j)] = defaultLabelValue + strconv.Itoa(j)
 		}
-		samples := make([]tsdbutil.Sample, 0, maxt-mint+1)
+		samples := make([]tsdbutil.Sample, 0, (maxt-mint)/step+1)
 		for t := mint; t < maxt; t += step {
 			samples = append(samples, generator(t))
 		}


### PR DESCRIPTION
Typical parameters are one hour  by 1 minute step, where the function would allocate a slice of 3.6 million samples instead of 60.

I noticed this when tsdb tests like `TestQueryHistogramFromBlocksWithCompaction` would fail in flaky ways.  They also run about 5x faster on my desktop with this fix.

I also raised an eyebrow that the loop goes up to `< maxt`, unlike the very similar function below which goes to `<= maxt`.
Perhaps someone who is familiar in this area can comment?
