### PR TITLE
feat: Add support for `unittest` output for promtool queries

### DIFF
--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -68,14 +68,17 @@ func TestQueryRange(t *testing.T) {
 	require.NoError(t, err)
 
 	p := &promqlPrinter{}
-	exitCode := QueryRange(urlObject, http.DefaultTransport, map[string]string{}, "up", "0", "300", 0, p)
+	qr, err := newQueryRange("0", "300", 0)
+	require.NoError(t, err)
+	exitCode := QueryRange(urlObject, http.DefaultTransport, map[string]string{}, "up", qr, p)
 	require.Equal(t, "/api/v1/query_range", getRequest().URL.Path)
 	form := getRequest().Form
 	require.Equal(t, "up", form.Get("query"))
 	require.Equal(t, "1", form.Get("step"))
 	require.Equal(t, 0, exitCode)
 
-	exitCode = QueryRange(urlObject, http.DefaultTransport, map[string]string{}, "up", "0", "300", 10*time.Millisecond, p)
+	qr, err = newQueryRange("0", "300", 10*time.Millisecond)
+	exitCode = QueryRange(urlObject, http.DefaultTransport, map[string]string{}, "up", qr, p)
 	require.Equal(t, "/api/v1/query_range", getRequest().URL.Path)
 	form = getRequest().Form
 	require.Equal(t, "up", form.Get("query"))
@@ -92,7 +95,9 @@ func TestQueryInstant(t *testing.T) {
 	require.NoError(t, err)
 
 	p := &promqlPrinter{}
-	exitCode := QueryInstant(urlObject, http.DefaultTransport, "up", "300", p)
+	qr, err := newQueryRange("300", "", time.Second)
+	require.NoError(t, err)
+	exitCode := QueryInstant(urlObject, http.DefaultTransport, "up", qr, p)
 	require.Equal(t, "/api/v1/query", getRequest().URL.Path)
 	form := getRequest().Form
 	require.Equal(t, "up", form.Get("query"))

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -212,7 +212,7 @@ Run query against a Prometheus server.
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| <code class="text-nowrap">-o</code>, <code class="text-nowrap">--format</code> | Output format of the query. | `promql` |
+| <code class="text-nowrap">-o</code>, <code class="text-nowrap">--format</code> | Output format of the query: promql, json, unittest. Unittest output is experimental. | `promql` |
 | <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file for promtool to connect to Prometheus. |  |
 
 


### PR DESCRIPTION
This adds support for a new output type `unittest` to make it easier to seed unit test input series values from real data.

I think there's still room for improvement, but figured it'd be worth getting some early feedback. 

```
% go run ./cmd/promtool query instant https://prometheus.demo.do.prometheus.io up     -o unittest                                           
rule_files: []
group_eval_order: []
tests:
- interval: 0s
  input_series:
  - series: up{env="demo", instance="demo.do.prometheus.io:9093", job="alertmanager"}
    values: "1"
  - series: up{instance="demo.do.prometheus.io:8998", job="random"}
    values: "1"
  - series: up{instance="demo.do.prometheus.io:8999", job="random"}
    values: "1"
  - series: up{instance="http://localhost:9100", job="blackbox"}
    values: "1"
  - series: up{env="demo", instance="demo.do.prometheus.io:9100", job="node"}
    values: "1"
  - series: up{instance="demo.do.prometheus.io:3000", job="grafana"}
    values: "1"
  - series: up{instance="demo.do.prometheus.io:8996", job="random"}
    values: "1"
  - series: up{instance="demo.do.prometheus.io:8997", job="random"}
    values: "1"
  - series: up{instance="demo.do.prometheus.io:9090", job="prometheus"}
    values: "1"
  - series: up{instance="localhost:2019", job="caddy"}
    values: "1"
```

```
% go run ./cmd/promtool query range --start=$(( $(date +%s)-60 )) --end=$(date +%s) https://prometheus.demo.do.prometheus.io 'up' -o unittest
rule_files: []
group_eval_order: []
tests:
- interval: 0s
  input_series:
  - series: up{instance="demo.do.prometheus.io:8996", job="random"}
    values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
      1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
  - series: up{instance="localhost:2019", job="caddy"}
    values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
      1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
  - series: up{env="demo", instance="demo.do.prometheus.io:9093", job="alertmanager"}
    values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
      1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
  - series: up{instance="demo.do.prometheus.io:3000", job="grafana"}
    values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
      1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
  - series: up{instance="demo.do.prometheus.io:8998", job="random"}
    values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
      1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
  - series: up{instance="demo.do.prometheus.io:8999", job="random"}
    values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
      1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
  - series: up{instance="demo.do.prometheus.io:9090", job="prometheus"}
    values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
      1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
  - series: up{instance="http://localhost:9100", job="blackbox"}
    values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
      1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
  - series: up{env="demo", instance="demo.do.prometheus.io:9100", job="node"}
    values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
      1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
  - series: up{instance="demo.do.prometheus.io:8997", job="random"}
    values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
      1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
```

Signed-off-by: Brad Beam <brad.beam@b-rad.info>