### PR TITLE
Fix error output of the Prometheus parser to display the right tokens

### DIFF
--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -340,7 +340,7 @@ func (p *PromParser) Next() (Entry, error) {
 			t2 = p.nextToken()
 		}
 		if t2 != tValue {
-			return EntryInvalid, parseError("expected value after metric", t)
+			return EntryInvalid, parseError("expected value after metric", t2)
 		}
 		if p.val, err = parseFloat(yoloString(p.l.buf())); err != nil {
 			return EntryInvalid, err
@@ -350,7 +350,7 @@ func (p *PromParser) Next() (Entry, error) {
 			p.val = math.Float64frombits(value.NormalNaN)
 		}
 		p.hasTS = false
-		switch p.nextToken() {
+		switch t := p.nextToken(); t {
 		case tLinebreak:
 			break
 		case tTimestamp:
@@ -359,7 +359,7 @@ func (p *PromParser) Next() (Entry, error) {
 				return EntryInvalid, err
 			}
 			if t2 := p.nextToken(); t2 != tLinebreak {
-				return EntryInvalid, parseError("expected next entry after timestamp", t)
+				return EntryInvalid, parseError("expected next entry after timestamp", t2)
 			}
 		default:
 			return EntryInvalid, parseError("expected timestamp or new record", t)

--- a/model/textparse/promparse_test.go
+++ b/model/textparse/promparse_test.go
@@ -219,7 +219,7 @@ func TestPromParseErrors(t *testing.T) {
 	}{
 		{
 			input: "a",
-			err:   "expected value after metric, got \"MNAME\"",
+			err:   "expected value after metric, got \"INVALID\"",
 		},
 		{
 			input: "a{b='c'} 1\n",
@@ -263,7 +263,7 @@ func TestPromParseErrors(t *testing.T) {
 		},
 		{
 			input: "foo 0 1_2\n",
-			err:   "expected next entry after timestamp, got \"MNAME\"",
+			err:   "expected next entry after timestamp, got \"INVALID\"",
 		},
 		{
 			input: `{a="ok"} 1`,
@@ -325,7 +325,11 @@ func TestPromNullByteHandling(t *testing.T) {
 		},
 		{
 			input: "a\x00{b=\"ddd\"} 1",
-			err:   "expected value after metric, got \"MNAME\"",
+			err:   "expected value after metric, got \"INVALID\"",
+		},
+		{
+			input: "a 0 1\x00",
+			err:   "expected next entry after timestamp, got \"INVALID\"",
 		},
 	}
 


### PR DESCRIPTION
In some cases, the Prometheus HTTP format parser was not returning the right token in the error output which made debugging impossible.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
