### PR TITLE
Validate the metric names and labels in the remote write handler

### DIFF
--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,7 +45,7 @@ func TestRemoteWriteHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	appendable := &mockAppendable{}
-	handler := NewWriteHandler(nil, appendable)
+	handler := NewWriteHandler(nil, nil, appendable)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -94,7 +96,7 @@ func TestOutOfOrderSample(t *testing.T) {
 	appendable := &mockAppendable{
 		latestSample: 100,
 	}
-	handler := NewWriteHandler(log.NewNopLogger(), appendable)
+	handler := NewWriteHandler(log.NewNopLogger(), nil, appendable)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -119,7 +121,7 @@ func TestOutOfOrderExemplar(t *testing.T) {
 	appendable := &mockAppendable{
 		latestExemplar: 100,
 	}
-	handler := NewWriteHandler(log.NewNopLogger(), appendable)
+	handler := NewWriteHandler(log.NewNopLogger(), nil, appendable)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -142,13 +144,41 @@ func TestOutOfOrderHistogram(t *testing.T) {
 	appendable := &mockAppendable{
 		latestHistogram: 100,
 	}
-	handler := NewWriteHandler(log.NewNopLogger(), appendable)
+	handler := NewWriteHandler(log.NewNopLogger(), nil, appendable)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
 
 	resp := recorder.Result()
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func BenchmarkRemoteWritehandler(b *testing.B) {
+	const labelValue = "abcdefg'hijlmn234!@#$%^&*()_+~`\"{}[],./<>?hello0123hiOlá你好Dzieńdobry9Zd8ra765v4stvuyte"
+	reqs := []*http.Request{}
+	for i := 0; i < b.N; i++ {
+		num := strings.Repeat(strconv.Itoa(i), 16)
+		buf, _, err := buildWriteRequest([]prompb.TimeSeries{{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "test_metric"},
+				{Name: "test_label_name_" + num, Value: labelValue + num},
+			},
+			Histograms: []prompb.Histogram{HistogramToHistogramProto(0, &testHistogram)},
+		}}, nil, nil, nil)
+		require.NoError(b, err)
+		req, err := http.NewRequest("", "", bytes.NewReader(buf))
+		require.NoError(b, err)
+		reqs = append(reqs, req)
+	}
+
+	appendable := &mockAppendable{}
+	handler := NewWriteHandler(log.NewNopLogger(), nil, appendable)
+	recorder := httptest.NewRecorder()
+
+	b.ResetTimer()
+	for _, req := range reqs {
+		handler.ServeHTTP(recorder, req)
+	}
 }
 
 func TestCommitErr(t *testing.T) {
@@ -161,7 +191,7 @@ func TestCommitErr(t *testing.T) {
 	appendable := &mockAppendable{
 		commitErr: fmt.Errorf("commit error"),
 	}
-	handler := NewWriteHandler(log.NewNopLogger(), appendable)
+	handler := NewWriteHandler(log.NewNopLogger(), nil, appendable)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -187,7 +217,7 @@ func BenchmarkRemoteWriteOOOSamples(b *testing.B) {
 		require.NoError(b, db.Close())
 	})
 
-	handler := NewWriteHandler(log.NewNopLogger(), db.Head())
+	handler := NewWriteHandler(log.NewNopLogger(), nil, db.Head())
 
 	buf, _, err := buildWriteRequest(genSeriesWithSample(1000, 200*time.Minute.Milliseconds()), nil, nil, nil)
 	require.NoError(b, err)

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -284,7 +284,7 @@ func NewAPI(
 	}
 
 	if ap != nil {
-		a.remoteWriteHandler = remote.NewWriteHandler(logger, ap)
+		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap)
 	}
 
 	return a


### PR DESCRIPTION
Ref: https://github.com/prometheus/prometheus/pull/11074

I think the performance cost is negligible:
```
name                   old time/op    new time/op    delta
RemoteWritehandler-10    1.58µs ±14%    1.76µs ±10%  +11.05%  (p=0.000 n=94+96)

name                   old alloc/op   new alloc/op   delta
RemoteWritehandler-10    2.32kB ± 0%    2.32kB ± 0%     ~     (all equal)

name                   old allocs/op  new allocs/op  delta
RemoteWritehandler-10      24.0 ± 0%      24.0 ± 0%     ~     (all equal)
```


<details>
<summary>Raw benchmark stats</summary>
main@bb323db61
<pre><code>
goos: darwin
goarch: amd64
pkg: github.com/prometheus/prometheus/storage/remote
cpu: VirtualApple @ 2.50GHz
BenchmarkRemoteWritehandler
BenchmarkRemoteWritehandler-10    	   10000	      2395 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1588 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1775 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1613 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1843 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1801 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1587 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1768 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1621 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1527 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1860 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1955 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1651 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1739 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1771 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1667 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1549 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1524 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1767 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      2434 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1475 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1590 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      2166 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1568 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1512 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1478 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1497 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1546 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1544 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1600 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1428 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1488 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1539 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1385 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1455 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1576 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1496 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1518 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1533 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1556 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1492 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1581 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1435 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1590 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1623 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1590 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1514 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1692 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1693 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1697 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1592 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1521 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1622 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1579 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1519 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1619 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1593 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1470 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1467 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1466 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1492 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1584 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1635 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1670 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1478 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1582 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1528 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1483 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1471 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1542 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1578 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1594 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1601 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1625 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1682 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1600 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1546 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1586 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1658 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1644 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1642 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1645 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1678 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1564 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1748 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1581 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1674 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1632 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1588 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1596 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1629 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1524 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1531 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1515 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1559 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1528 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1512 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1776 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1585 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1654 ns/op	    2320 B/op	      24 allocs/op
PASS
ok  	github.com/prometheus/prometheus/storage/remote	5.341s
</code></pre>

this branch
<pre><code>
goos: darwin
goarch: amd64
pkg: github.com/prometheus/prometheus/storage/remote
cpu: VirtualApple @ 2.50GHz
BenchmarkRemoteWritehandler
BenchmarkRemoteWritehandler-10    	   10000	      2176 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1890 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1950 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1902 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1761 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1783 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1688 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1819 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1824 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1673 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1777 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1761 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1763 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1740 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1770 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1775 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1793 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1886 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1848 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1689 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1792 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1843 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1690 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1710 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1646 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1730 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1750 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1977 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1807 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1783 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1729 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1701 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1775 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1835 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1729 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1797 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1809 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1644 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1799 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1698 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1808 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1714 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1752 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1837 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1692 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1686 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1740 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1768 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1705 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1701 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1764 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1669 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1771 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1685 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1684 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1755 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1772 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1706 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1728 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1841 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1782 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1754 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1738 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1834 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1826 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1764 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1736 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1738 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1779 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1810 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1850 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1770 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1591 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1763 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1644 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1715 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1682 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1793 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1750 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1777 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1820 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1694 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1833 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1729 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1722 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1828 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1714 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1853 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1732 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1955 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1750 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1743 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1772 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1799 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1834 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1705 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1694 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1791 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1799 ns/op	    2320 B/op	      24 allocs/op
BenchmarkRemoteWritehandler-10    	   10000	      1699 ns/op	    2320 B/op	      24 allocs/op
PASS
ok  	github.com/prometheus/prometheus/storage/remote	5.385s
</code></pre>
<details>