### PR TITLE
Update example rules file to be valid with the default scrape config

### DIFF
--- a/docs/configuration/recording_rules.md
+++ b/docs/configuration/recording_rules.md
@@ -71,7 +71,7 @@ groups:
   - name: example
     rules:
     - record: code:prometheus_http_requests_total:sum
-      expr: sum by(code) (prometheus_http_requests_total)
+      expr: sum by (code) (prometheus_http_requests_total)
 ```
 
 ### `<rule_group>`

--- a/docs/configuration/recording_rules.md
+++ b/docs/configuration/recording_rules.md
@@ -70,8 +70,8 @@ A simple example rules file would be:
 groups:
   - name: example
     rules:
-    - record: job:http_inprogress_requests:sum
-      expr: sum by (job) (http_inprogress_requests)
+    - record: code:prometheus_http_requests_total:sum
+      expr: sum by(code) (prometheus_http_requests_total)
 ```
 
 ### `<rule_group>`


### PR DESCRIPTION
The prometheus download includes a default config to scrape itself.
This self-scraping prometheus doesn't include any metric named as
`http_inprogress_requests`, but does include one named
`prometheus_http_requests_total`.
Updating this example rule in the docs to one which can be used
out-of-the-box with the default download would be a nice improvement.
