### PR TITLE
Add link to best practices in "Defining Recording Rules" page

### DIFF
--- a/docs/configuration/recording_rules.md
+++ b/docs/configuration/recording_rules.md
@@ -133,7 +133,7 @@ annotations:
 ```
 
 See also the
-[best practices for naming recording rules](https://prometheus.io/docs/practices/rules/#recording-rules).
+[best practices for naming metrics created by recording rules](https://prometheus.io/docs/practices/rules/#recording-rules).
 
 # Limiting alerts and series
 

--- a/docs/configuration/recording_rules.md
+++ b/docs/configuration/recording_rules.md
@@ -132,6 +132,9 @@ annotations:
   [ <labelname>: <tmpl_string> ]
 ```
 
+See also the
+[best practices for naming recording rules](https://prometheus.io/docs/practices/rules/#recording-rules).
+
 # Limiting alerts and series
 
 A limit for alerts produced by alerting rules and series produced recording rules


### PR DESCRIPTION
Just have a minor suggestion to add a link to the best practices for naming recording rules in the "Defining recording rules" page for better visibility. @juliusv

Signed-off-by: John Carlo Roberto <10111643+Irizwaririz@users.noreply.github.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
