### PR TITLE
Add query.network server argument to choose which network to scrape

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -137,6 +137,8 @@ type Options struct {
 	EnableProtobufNegotiation bool
 	// Option to increase the interval used by scrape manager to throttle target groups updates.
 	DiscoveryReloadInterval model.Duration
+	// Option to control which network to use for scraping: tcp,tcp4,tcp6
+	Network string
 
 	// Optional HTTP client options to use when scraping.
 	HTTPClientOptions []config_util.HTTPClientOption


### PR DESCRIPTION
Default is `tcp`, this ensures backward capability. One can also choose `tcp4`  or `tcp6` networks. 

Fixes #11624 