### PR TITLE
feat(config): allow no remote write configs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -112,10 +112,6 @@ func LoadFile(filename string, agentMode, expandExternalLabels bool, logger log.
 	}
 
 	if agentMode {
-		if len(cfg.RemoteWriteConfigs) == 0 {
-			return nil, errors.New("at least one remote_write target must be specified in agent mode")
-		}
-
 		if len(cfg.AlertingConfig.AlertmanagerConfigs) > 0 || len(cfg.AlertingConfig.AlertRelabelConfigs) > 0 {
 			return nil, errors.New("field alerting is not allowed in agent mode")
 		}

--- a/config/testdata/agent_mode.good.yml
+++ b/config/testdata/agent_mode.good.yml
@@ -1,0 +1,2 @@
+remote_write:
+  - url: http://remote1/push

--- a/config/testdata/agent_mode.with_alert_manager.yml
+++ b/config/testdata/agent_mode.with_alert_manager.yml
@@ -1,0 +1,6 @@
+alerting:
+  alertmanagers:
+    - scheme: https
+      static_configs:
+        - targets:
+            - "1.2.3.4:9093"

--- a/config/testdata/agent_mode.with_alert_relabels.yml
+++ b/config/testdata/agent_mode.with_alert_relabels.yml
@@ -1,0 +1,5 @@
+alerting:
+  alert_relabel_configs:
+    - action: uppercase
+      source_labels: [instance]
+      target_label: instance

--- a/config/testdata/agent_mode.with_remote_reads.yml
+++ b/config/testdata/agent_mode.with_remote_reads.yml
@@ -1,0 +1,5 @@
+remote_read:
+  - url: http://remote1/read
+    read_recent: true
+    name: default
+    enable_http2: false

--- a/config/testdata/agent_mode.with_rule_files.yml
+++ b/config/testdata/agent_mode.with_rule_files.yml
@@ -1,0 +1,3 @@
+rule_files:
+  - "first.rules"
+  - "my/*.rules"

--- a/config/testdata/agent_mode.without_remote_writes.yml
+++ b/config/testdata/agent_mode.without_remote_writes.yml
@@ -1,0 +1,2 @@
+global:
+  scrape_interval: 15s


### PR DESCRIPTION
### What does this PR do? 

Related to: https://github.com/prometheus/prometheus/issues/11665

This PR removes the check at startup that prevents Prometheus to start in agent mode with no `remote_write` configuration set.

It also adds a test suite for all the validation logic applied in agent mode.

Hope this helps 😄 