### PR TITLE
Remove comments from the remote read docs

### DIFF
--- a/docs/querying/remote_read_api.md
+++ b/docs/querying/remote_read_api.md
@@ -65,8 +65,6 @@ Note: Names of query parameters that may be repeated end with `[]`.
 
 This API provides data read functionality from Prometheus. This interface expects [snappy](https://github.com/google/snappy) compression.
 The API definition is located [here](https://github.com/prometheus/prometheus/blob/master/prompb/remote.proto).
-/// Can you clarify what you mean by this?
-/// https://github.com/prometheus/prometheus/pull/7266#discussion_r426456791 Can we talk a little bit how negotiation works of sampled vs streamed ?
 
 Request are made to the following endpoint.
 ```
@@ -74,12 +72,10 @@ Request are made to the following endpoint.
 ```
 
 ### Samples
-/// Does it return a message that includes a list, or does it return a list of raw samples?
 
 This returns a message that includes a list of raw samples.
 
 ### Streamed Chunks
-/// This is a little much detail, the relevant point is they're the internal implementation of the chunks.
 
 These streamed chunks utilize an XOR algorithm inspired by the [Gorilla](http://www.vldb.org/pvldb/vol8/p1816-teller.pdf)
 compression to encode the chunks. However, it provides resolution to the millisecond instead of to the second.


### PR DESCRIPTION
I think these are not intended to be here (they're visible on the rendered page).