### PR TITLE
Fix unwanted comments in remote-read API doc

### DIFF
--- a/docs/querying/remote_read_api.md
+++ b/docs/querying/remote_read_api.md
@@ -65,8 +65,6 @@ Note: Names of query parameters that may be repeated end with `[]`.
 
 This API provides data read functionality from Prometheus. This interface expects [snappy](https://github.com/google/snappy) compression.
 The API definition is located [here](https://github.com/prometheus/prometheus/blob/master/prompb/remote.proto).
-/// Can you clarify what you mean by this?
-/// https://github.com/prometheus/prometheus/pull/7266#discussion_r426456791 Can we talk a little bit how negotiation works of sampled vs streamed ?
 
 Request are made to the following endpoint.
 ```


### PR DESCRIPTION
Some text from comments in the review at #7266 seems to have been included in the doc.

