### PR TITLE
Coloring differential output for better visualization: promtool failed cases

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -72,6 +72,7 @@ const (
 )
 
 var lintOptions = []string{lintOptionAll, lintOptionDuplicateRules, lintOptionNone}
+var diffFlag bool
 
 func main() {
 	app := kingpin.New(filepath.Base(os.Args[0]), "Tooling for the Prometheus monitoring system.").UsageWriter(os.Stdout)
@@ -279,6 +280,7 @@ func main() {
 		os.Exit(QueryLabels(*queryLabelsServer, *queryLabelsMatch, *queryLabelsName, *queryLabelsBegin, *queryLabelsEnd, p))
 
 	case testRulesCmd.FullCommand():
+		diffFlag = *testRulesDiff
 		os.Exit(RulesUnitTest(
 			promql.LazyLoaderOpts{
 				EnableAtModifier:     true,

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -166,7 +166,7 @@ func main() {
 		"test-rule-file",
 		"The unit test file.",
 	).Required().ExistingFiles()
-	testRulesDiff := testRulesCmd.Flag("diff", "Print colored differential output between expected & received output").Bool()
+	testRulesDiff := testRulesCmd.Flag("diff", "Print colored differential output between expected & received output").Default("false").Bool()
 
 	defaultDBPath := "data/"
 	tsdbCmd := app.Command("tsdb", "Run tsdb commands.")
@@ -286,7 +286,6 @@ func main() {
 				EnableAtModifier:     true,
 				EnableNegativeOffset: true,
 			},
-			testRulesDiff,
 			*testRulesFiles...),
 		)
 

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -72,7 +72,7 @@ const (
 )
 
 var lintOptions = []string{lintOptionAll, lintOptionDuplicateRules, lintOptionNone}
-var diffFlag bool
+var diffFlag = false
 
 func main() {
 	app := kingpin.New(filepath.Base(os.Args[0]), "Tooling for the Prometheus monitoring system.").UsageWriter(os.Stdout)

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -71,8 +71,10 @@ const (
 	lintOptionNone           = "none"
 )
 
-var lintOptions = []string{lintOptionAll, lintOptionDuplicateRules, lintOptionNone}
-var diffFlag = false
+var (
+	lintOptions = []string{lintOptionAll, lintOptionDuplicateRules, lintOptionNone}
+	diffFlag    bool
+)
 
 func main() {
 	app := kingpin.New(filepath.Base(os.Args[0]), "Tooling for the Prometheus monitoring system.").UsageWriter(os.Stdout)

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -165,6 +165,7 @@ func main() {
 		"test-rule-file",
 		"The unit test file.",
 	).Required().ExistingFiles()
+	testRulesDiff := testRulesCmd.Flag("diff", "Print colored differential output between expected & received output").Bool()
 
 	defaultDBPath := "data/"
 	tsdbCmd := app.Command("tsdb", "Run tsdb commands.")
@@ -283,6 +284,7 @@ func main() {
 				EnableAtModifier:     true,
 				EnableNegativeOffset: true,
 			},
+			testRulesDiff,
 			*testRulesFiles...),
 		)
 

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/mattn/go-colorable"
 	"github.com/nsf/jsondiff"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
@@ -324,6 +323,8 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 					if tg.TestGroupName != "" {
 						testName = fmt.Sprintf("    name: %s,\n", tg.TestGroupName)
 					}
+					expString := indentLines(expAlerts.String(), "            ")
+					gotString := indentLines(gotAlerts.String(), "            ")
 
 					// If empty, populates an empty value
 					if gotAlerts.Len() == 0 {
@@ -356,14 +357,8 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 					res, diff := jsondiff.Compare(expAlertsJSON, gotAlertsJSON, &diffOpts)
 					if res != jsondiff.FullMatch {
 						if runtime.GOOS == "windows" {
-							colorDiff, err := colorable.NewColorableStdout().Write([]byte(diff))
-							if err != nil {
-								errs = append(errs, fmt.Errorf("alertName: %s\nError coloring windows gotAlert to JSON: %v", tg.TestGroupName, diff))
-								continue
-							}
-							errs = append(errs, fmt.Errorf("%s    alertname: %s, time: %s, \n        diff:%v",
-								testName, testcase.Alertname, testcase.EvalTime.String(), colorDiff))
-
+							errs = append(errs, fmt.Errorf("%s    alertname: %s, time: %s, \n        exp:%v, \n        got:%v",
+								testName, testcase.Alertname, testcase.EvalTime.String(), expString, gotString))
 						} else {
 							errs = append(errs, fmt.Errorf("%s    alertname: %s, time: %s, \n        diff:%v",
 								testName, testcase.Alertname, testcase.EvalTime.String(), diff))

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -44,7 +44,7 @@ func RulesUnitTest(queryOpts promql.LazyLoaderOpts, showDiff *bool, files ...str
 	failed := false
 
 	for _, f := range files {
-		if errs := ruleUnitTest(f, *showDiff, queryOpts); errs != nil {
+		if errs := ruleUnitTest(f, queryOpts); errs != nil {
 			fmt.Fprintln(os.Stderr, "  FAILED:")
 			for _, e := range errs {
 				fmt.Fprintln(os.Stderr, e.Error())
@@ -62,7 +62,7 @@ func RulesUnitTest(queryOpts promql.LazyLoaderOpts, showDiff *bool, files ...str
 	return successExitCode
 }
 
-func ruleUnitTest(filename string, showDiff bool, queryOpts promql.LazyLoaderOpts) []error {
+func ruleUnitTest(filename string, queryOpts promql.LazyLoaderOpts) []error {
 	fmt.Println("Unit Testing: ", filename)
 
 	b, err := os.ReadFile(filename)
@@ -97,7 +97,7 @@ func ruleUnitTest(filename string, showDiff bool, queryOpts promql.LazyLoaderOpt
 	// Testing.
 	var errs []error
 	for _, t := range unitTestInp.Tests {
-		ers := t.test(evalInterval, groupOrderMap, showDiff, queryOpts, unitTestInp.RuleFiles...)
+		ers := t.test(evalInterval, groupOrderMap, queryOpts, unitTestInp.RuleFiles...)
 		if ers != nil {
 			errs = append(errs, ers...)
 		}
@@ -153,7 +153,7 @@ type testGroup struct {
 }
 
 // test performs the unit tests.
-func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]int, showDiff bool, queryOpts promql.LazyLoaderOpts, ruleFiles ...string) []error {
+func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]int, queryOpts promql.LazyLoaderOpts, ruleFiles ...string) []error {
 	// Setup testing suite.
 	suite, err := promql.NewLazyLoader(nil, tg.seriesLoadingString(), queryOpts)
 	if err != nil {
@@ -325,7 +325,7 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 					expString := indentLines(expAlerts.String(), "            ")
 					gotString := indentLines(gotAlerts.String(), "            ")
 
-					if showDiff {
+					if diffFlag {
 						// If empty, populates an empty value
 						if gotAlerts.Len() == 0 {
 							gotAlerts = append(gotAlerts, labelAndAnnotation{

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -40,7 +40,7 @@ import (
 
 // RulesUnitTest does unit testing of rules based on the unit testing files provided.
 // More info about the file format can be found in the docs.
-func RulesUnitTest(queryOpts promql.LazyLoaderOpts, showDiff *bool, files ...string) int {
+func RulesUnitTest(queryOpts promql.LazyLoaderOpts, files ...string) int {
 	failed := false
 
 	for _, f := range files {

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -291,7 +291,6 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 							})
 						}
 					}
-					// fmt.Println("arname = ", ar.Name())
 					got[ar.Name()] = append(got[ar.Name()], alerts...)
 				}
 			}
@@ -324,13 +323,14 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 						testName = fmt.Sprintf("    name: %s,\n", tg.TestGroupName)
 					}
 
+					// If empty, populates an empty value
 					if gotAlerts.Len() == 0 {
 						gotAlerts = append(gotAlerts, labelAndAnnotation{
 							Labels:      labels.Labels{},
 							Annotations: labels.Labels{},
 						})
 					}
-
+					// If empty, populates an empty value
 					if expAlerts.Len() == 0 {
 						expAlerts = append(expAlerts, labelAndAnnotation{
 							Labels:      labels.Labels{},

--- a/go.mod
+++ b/go.mod
@@ -150,7 +150,7 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-colorable v0.1.12
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -150,7 +150,7 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mattn/go-colorable v0.1.12
+	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/linode/linodego v1.9.3
 	github.com/miekg/dns v1.1.50
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
+	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/oklog/ulid v1.3.1
 	github.com/ovh/go-ovh v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -605,6 +605,8 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249 h1:NHrXEjTNQY7P0Zfx1aMrNhpgxHmow66XQtm0aQLY0AE=
+github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=


### PR DESCRIPTION
## Problem statement

`promtool` executes prometheus test cases. In case of discrepancy between test cases, it shows output of expected value & received (got) values.

For one test case discrepancy, the output looks like below. Identifying the difference between `exp` & `got` values is equivalent to finding a needle in haystack, especially when there are large number of test cases.

```
Unit Testing:  loki.all.rules.test.yml_global
  FAILED:
    alertname: LokiRingUnhealthy, time: 40m,
        exp:[
            0:
              Labels:{alertname="LokiRingUnhealthy", app="loki-service", cancel_if_apiserver_down="true", cancel_if_cluster_status_creating="true", cancel_if_cluster_status_deleting="true", cancel_if_cluster_status_updating="true", cancel_if_outside_working_hours="true", cancel_if_scrape_timeout="true", container="service", name="service", namespace="loki", pod="loki-service-676b8c897b-rq29", severity="page", topic="observability"}
              Annotations:{description="Loki pod loki-service-676b8c897b-rq298 (namespace loki) sees 1 unhealthy ring members"}
            ],
        got:[
            0:
              Labels:{alertname="LokiRingUnhealthy", area="services", cancel_if_apiserver_down="true", cancel_if_cluster_status_creating="true", cancel_if_cluster_status_deleting="true", cancel_if_cluster_status_updating="true", cancel_if_outside_working_hours="true", cancel_if_scrape_timeout="true", container="service", name="service", namespace="loki", pod="loki-service-676b8c897b-rq298", severity="page", topic="observability"}
              Annotations:{description="Loki pod loki-service-676b8c897b-rq298 (namespace loki) sees 1 unhealthy ring members"}
            ]
```

## Proposal

This PR, aims to fix this issue with colored output for differential labels.

## Present vs proposed output

### Present output

<img width="1710" alt="image" src="https://user-images.githubusercontent.com/22347290/208625306-5c91796d-8903-4c56-bdf7-b3eeb632a61a.png">

### Proposed output

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/22347290/208625421-901548f5-526e-400e-b16e-bd61b507664d.png">


### Reproduction steps

```bash
git clone -b yet-another-branch https://github.com/giantswarm/prometheus-hackathon-dec22/
cd prometheus-hackathon-dec22/cmd/promtool
# Downloads sample files for tests
wget https://gist.githubusercontent.com/rewanthtammana/d4315690bc80012cc01b1ff4dc88a80f/raw/19bfe81c7b8b6737d9a30a781aafb273717222ed/loki.all.rules.test.yml_global
wget https://gist.githubusercontent.com/rewanthtammana/564cf6493ca546f2cffc1fa5f80cc576/raw/948546cba1dedffa4f04f51552e83d228b4fe574/loki.all.rules.yml
# Downloads packages & runs promtool
go get -v ./...
go build -o promtool . && ./promtool test rules loki.all.rules.test.yml_global
```

~~### Note~~

~~The proposed approach of coloring differential output doesn't work on windows for now. Windows OS will continue to have the previous format of output.~~

## Conclusion

This colored formatting approach to highlight the differential output makes things a piece of cake for end-users to visualize the essential labels/alerts to focus on.

This also fixes https://github.com/prometheus/prometheus/issues/7568
