### PR TITLE
Log a warning when alerts fire but there are no Alertmanagers configured.

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -469,6 +469,11 @@ func (n *Manager) sendAll(alerts ...*Alert) bool {
 	amSets := n.alertmanagers
 	n.mtx.RUnlock()
 
+	if len(amSets) == 0 {
+		level.Warn(n.logger).Log("msg", "Attempted to send one or more alerts to Alertmanager, but no Alertmanagers are configured.")
+		return false
+	}
+
 	var (
 		wg         sync.WaitGroup
 		numSuccess atomic.Uint64


### PR DESCRIPTION
This PR adds a warning that is logged whenever an alert fires but there are no Alertmanager instances configured.

Without this, it may not be apparent what the problem is - the only other signal that alerts are being dropped is the `prometheus_notifications_dropped_total` metric.