### PR TITLE
promql: add test for race conditions in query engine

### DIFF
--- a/promql/promql_test.go
+++ b/promql/promql_test.go
@@ -14,10 +14,16 @@
 package promql
 
 import (
+	"context"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/prometheus/prometheus/util/teststorage"
 )
 
 func TestEvaluations(t *testing.T) {
@@ -33,4 +39,61 @@ func TestEvaluations(t *testing.T) {
 			test.Close()
 		})
 	}
+}
+
+// Run a lot of queries at the same time, to check for race conditions.
+func TestConcurrentRangeQueries(t *testing.T) {
+	stor := teststorage.New(t)
+	defer stor.Close()
+	opts := EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 50000000,
+		Timeout:    100 * time.Second,
+	}
+	engine := NewEngine(opts)
+
+	const interval = 10000 // 10s interval.
+	// A day of data plus 10k steps.
+	numIntervals := 8640 + 10000
+	err := setupRangeQueryTestData(stor, engine, interval, numIntervals)
+	require.NoError(t, err)
+
+	cases := rangeQueryCases()
+
+	// Limit the number of queries running at the same time.
+	const numConcurrent = 4
+	sem := make(chan struct{}, numConcurrent)
+	for i := 0; i < numConcurrent; i++ {
+		sem <- struct{}{}
+	}
+	var g errgroup.Group
+	for _, c := range cases {
+		c := c
+		if strings.Contains(c.expr, "count_values") && c.steps > 10 {
+			continue // This test is too big to run with -race.
+		}
+		g.Go(func() error {
+			<-sem
+			defer func() {
+				sem <- struct{}{}
+			}()
+			qry, err := engine.NewRangeQuery(
+				stor, nil, c.expr,
+				time.Unix(int64((numIntervals-c.steps)*10), 0),
+				time.Unix(int64(numIntervals*10), 0), time.Second*10)
+			if err != nil {
+				return err
+			}
+			res := qry.Exec(context.Background())
+			if res.Err != nil {
+				return res.Err
+			}
+			qry.Close()
+			return nil
+		})
+	}
+
+	err = g.Wait()
+	require.NoError(t, err)
 }

--- a/promql/promql_test.go
+++ b/promql/promql_test.go
@@ -73,8 +73,8 @@ func TestConcurrentRangeQueries(t *testing.T) {
 		if strings.Contains(c.expr, "count_values") && c.steps > 10 {
 			continue // This test is too big to run with -race.
 		}
+		<-sem
 		g.Go(func() error {
-			<-sem
 			defer func() {
 				sem <- struct{}{}
 			}()


### PR DESCRIPTION
This is extracted from #10887; it runs a lot of queries at the same time, to check for race conditions.
It's a valid thing to test regardless of how Labels are implemented.

Note we skip large `count_values` queries - `count_values` allocates a slice per unique value in the output, and this test has unique values on every step of every series so it adds up to a lot of slices. Add Go runtime overhead for checking `-race`, and it chews up many gigabytes.
