### PR TITLE
Fixed typo in the Remote Read API docs

### DIFF
--- a/docs/querying/remote_read_api.md
+++ b/docs/querying/remote_read_api.md
@@ -5,7 +5,7 @@ sort_rank: 7
 
 # Remote Read API
 
-This is not currently considered par of the stable API and is subject to change
+This is not currently considered part of the stable API and is subject to change
 even between non-major version releases of Prometheus.
 
 ## Format overview


### PR DESCRIPTION
Signed-off-by: Pablo Ley <pablo_ley@hotmail.com>

Just a trivial PR adding a missing 't' to the Remote Read API docs. @roidelapluie please take a look.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
