### PR TITLE
Remove MacOS gnu-tar note

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,6 @@ make npm_licenses
 make common-docker-amd64
 ```
 
-*NB* if you are on a Mac, you will need [gnu-tar](https://formulae.brew.sh/formula/gnu-tar).
-
 ## Using Prometheus as a Go Library
 
 ### Remote Write


### PR DESCRIPTION
Follow up to #11721/#11363

Now that the regular tar command works on MacOS, the note advising users to install gnu-tar is no longer needed