### PR TITLE
service discovery: add name to log messages

### DIFF
--- a/discovery/legacymanager/manager.go
+++ b/discovery/legacymanager/manager.go
@@ -311,10 +311,10 @@ func (m *Manager) registerProviders(cfgs discovery.Configs, setName string) int 
 		}
 		typ := cfg.Name()
 		d, err := cfg.NewDiscoverer(discovery.DiscovererOptions{
-			Logger: log.With(m.logger, "discovery", typ),
+			Logger: log.With(m.logger, "discovery", typ, "config", setName),
 		})
 		if err != nil {
-			level.Error(m.logger).Log("msg", "Cannot create service discovery", "err", err, "type", typ)
+			level.Error(m.logger).Log("msg", "Cannot create service discovery", "err", err, "type", typ, "config", setName)
 			failed++
 			return
 		}

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -428,11 +428,11 @@ func (m *Manager) registerProviders(cfgs Configs, setName string) int {
 		}
 		typ := cfg.Name()
 		d, err := cfg.NewDiscoverer(DiscovererOptions{
-			Logger:            log.With(m.logger, "discovery", typ),
+			Logger:            log.With(m.logger, "discovery", typ, "config", setName),
 			HTTPClientOptions: m.httpOpts,
 		})
 		if err != nil {
-			level.Error(m.logger).Log("msg", "Cannot create service discovery", "err", err, "type", typ)
+			level.Error(m.logger).Log("msg", "Cannot create service discovery", "err", err, "type", typ, "config", setName)
 			failed++
 			return
 		}


### PR DESCRIPTION
This will make it easier to connect a log message with the config it relates to.

For example:
```
ts=2022-12-22T10:12:33.136Z caller=kubernetes.go:326 level=info component="discovery manager scrape" discovery=kubernetes msg="Using pod service account via in-cluster config"
```

Each SD config has a name, either the scrape job name or something like "config-0" for Alertmanager config. The word "set" is neutral between these, also this is what the code currently uses. Happy to change it if someone has a better suggestion.
