### PR TITLE
tsdb: re-use iterator when stepping through chunks

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -682,7 +682,7 @@ func (p *populateWithDelSeriesIterator) Next() chunkenc.ValueType {
 		if p.currDelIter != nil {
 			p.curr = p.currDelIter
 		} else {
-			p.curr = p.currChkMeta.Chunk.Iterator(nil)
+			p.curr = p.currChkMeta.Chunk.Iterator(p.curr)
 		}
 		if valueType := p.curr.Next(); valueType != chunkenc.ValNone {
 			return valueType


### PR DESCRIPTION
Saves memory allocations, hence reduces garbage-collection overheads.

Benchmarks say it isn't particularly faster, but it does regularly save on allocations: 
```
name                                                                            old time/op    new time/op    delta
RangeQuery/expr=a_one,steps=100-4                                                 43.3µs ± 3%    43.2µs ± 4%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_one,steps=1000-4                                                 175µs ± 5%     172µs ± 5%     ~     (p=0.421 n=5+5)
RangeQuery/expr=a_hundred,steps=100-4                                             2.92ms ± 2%    2.87ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred,steps=1000-4                                            15.6ms ± 2%    16.0ms ± 4%     ~     (p=0.095 n=5+5)
RangeQuery/expr={l!="",le=""},steps=100-4                                         7.53ms ± 6%    7.70ms ± 8%     ~     (p=0.690 n=5+5)
RangeQuery/expr={l!="",le=""},steps=1000-4                                        36.0ms ± 2%    35.6ms ± 2%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=100-4                                       62.3µs ± 3%    63.6µs ± 4%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1000-4                                       296µs ± 2%     291µs ± 2%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-4                                   3.85ms ± 1%    3.88ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-4                                  26.9ms ± 3%    26.4ms ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=10000-4                                     3.34ms ± 1%    3.33ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-4                                  326ms ± 2%     328ms ±10%     ~     (p=0.421 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-4                     7.77ms ± 1%    7.76ms ± 3%     ~     (p=0.690 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-4                    61.5ms ± 4%    61.5ms ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-4                  714ms ± 3%     728ms ± 6%     ~     (p=0.421 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-4                 6.00s ± 1%     5.94s ± 1%   -1.07%  (p=0.032 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=100-4                                    2.88ms ± 2%    2.88ms ± 3%     ~     (p=1.000 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=1000-4                                   14.7ms ± 1%    15.0ms ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-4                                 257ms ± 5%     254ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-4                                1.45s ± 2%     1.44s ± 1%     ~     (p=0.548 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=100-4                                       2.85ms ± 2%    2.85ms ± 2%     ~     (p=1.000 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=1000-4                                      14.7ms ± 3%    14.8ms ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-4                                    258ms ± 6%     249ms ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-4                                   1.42s ± 3%     1.42s ± 3%     ~     (p=0.690 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-4                           1.95ms ± 2%    1.98ms ± 3%     ~     (p=0.310 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-4                          5.47ms ± 6%    5.44ms ± 3%     ~     (p=0.690 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-4                        159ms ± 4%     155ms ± 2%     ~     (p=0.056 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-4                       537ms ± 6%     513ms ± 3%     ~     (p=0.056 n=5+5)
RangeQuery/expr=-a_one,steps=100-4                                                46.8µs ± 6%    47.2µs ± 4%     ~     (p=0.421 n=5+5)
RangeQuery/expr=-a_one,steps=1000-4                                                177µs ± 3%     176µs ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-4                                            3.17ms ± 5%    2.98ms ± 3%   -5.93%  (p=0.016 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-4                                           16.0ms ± 1%    15.8ms ± 1%   -1.30%  (p=0.032 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=100-4                                          144µs ± 1%     147µs ± 2%   +2.10%  (p=0.032 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1000-4                                         950µs ± 3%     953µs ± 1%     ~     (p=0.421 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-4                                 13.7ms ± 5%    13.6ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-4                                 105ms ± 2%     104ms ± 2%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-4                                       10.6ms ± 2%    10.4ms ± 2%   -2.38%  (p=0.016 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-4                                1.21s ±14%     1.14s ± 4%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-4                         156µs ± 8%     145µs ± 4%   -6.85%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-4                        527µs ± 8%     485µs ± 3%     ~     (p=0.095 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-4                7.45ms ±14%    7.32ms ± 4%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-4               49.0ms ± 1%    49.9ms ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-4                          156µs ± 1%     159µs ± 5%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-4                         575µs ± 3%     584µs ± 4%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-4                 8.76ms ± 2%    8.80ms ± 4%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-4                65.5ms ± 2%    65.5ms ± 5%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-4                      158µs ± 3%     158µs ± 3%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-4                     588µs ± 3%     592µs ± 4%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-4             7.34ms ± 3%    7.37ms ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-4            50.0ms ± 3%    49.4ms ± 1%     ~     (p=0.548 n=5+5)
RangeQuery/expr=a_one_and_b_one{l='notfound'},steps=100-4                         80.3µs ± 3%    80.1µs ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_one_and_b_one{l='notfound'},steps=1000-4                         422µs ± 2%     416µs ± 2%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-4                 3.25ms ± 4%    3.16ms ± 2%     ~     (p=0.310 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-4                18.7ms ± 4%    18.4ms ± 2%     ~     (p=0.548 n=5+5)
RangeQuery/expr=abs(a_one),steps=100-4                                            83.6µs ± 2%    83.9µs ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=abs(a_one),steps=1000-4                                            489µs ± 3%     491µs ± 0%     ~     (p=0.730 n=5+4)
RangeQuery/expr=abs(a_hundred),steps=100-4                                        6.53ms ± 6%    6.34ms ± 3%     ~     (p=0.095 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-4                                       48.9ms ± 4%    48.6ms ± 1%     ~     (p=1.000 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-4          125µs ± 3%     126µs ± 4%     ~     (p=0.222 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4         708µs ± 1%     723µs ± 2%     ~     (p=0.056 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-4     7.10ms ± 2%    7.01ms ± 4%     ~     (p=0.421 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4    55.5ms ± 4%    53.8ms ± 2%     ~     (p=0.151 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-4                 138µs ± 8%     134µs ± 3%     ~     (p=0.690 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-4                853µs ± 1%     856µs ± 2%     ~     (p=1.000 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-4            7.39ms ±14%    7.11ms ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-4           56.0ms ± 1%    54.6ms ± 3%     ~     (p=0.190 n=4+5)
RangeQuery/expr=sum(a_one),steps=100-4                                             125µs ± 6%     122µs ± 4%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum(a_one),steps=1000-4                                            863µs ± 2%     866µs ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-4                                        3.38ms ± 5%    3.33ms ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-4                                       20.9ms ± 2%    20.5ms ± 1%   -1.85%  (p=0.032 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-4                                1.00ms ± 2%    0.98ms ± 1%     ~     (p=0.111 n=4+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-4                               8.16ms ± 2%    7.99ms ± 2%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-4                            43.6ms ± 5%    39.8ms ± 2%   -8.83%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-4                            252ms ± 8%     240ms ± 1%   -4.84%  (p=0.016 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-4                                456µs ± 1%     453µs ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-4                              2.87ms ± 9%    2.76ms ± 1%   -3.88%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-4                           45.3ms ± 2%    44.4ms ± 3%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-4                           301ms ± 2%     295ms ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-4                                      457µs ± 3%     460µs ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-4                                    2.84ms ± 1%    2.82ms ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-4                                 44.5ms ± 2%    45.3ms ± 3%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-4                                 306ms ± 5%     305ms ± 4%     ~     (p=0.548 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-4                                    1.00ms ± 3%    0.98ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-4                                   8.03ms ± 1%    8.10ms ± 2%     ~     (p=0.548 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-4                                40.8ms ± 7%    39.4ms ± 2%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-4                                252ms ± 6%     252ms ± 6%     ~     (p=0.841 n=5+5)
RangeQuery/expr=count_values('value',_h_one),steps=100-4                          2.62ms ± 2%    2.66ms ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-4                       350ms ± 5%     375ms ±25%     ~     (p=1.000 n=5+5)
RangeQuery/expr=topk(1,_a_one),steps=100-4                                         156µs ± 6%     157µs ± 8%     ~     (p=0.690 n=5+5)
RangeQuery/expr=topk(1,_a_one),steps=1000-4                                       1.18ms ± 5%    1.18ms ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4                                    3.46ms ± 2%    3.64ms ± 9%     ~     (p=0.151 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4                                   21.3ms ± 2%    21.3ms ± 1%     ~     (p=0.841 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-4                      177µs ± 2%     175µs ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-4                    1.12ms ± 1%    1.09ms ± 1%   -2.47%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-4             14.5ms ± 2%    14.4ms ± 3%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-4             116ms ± 1%     119ms ± 2%     ~     (p=0.063 n=4+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-4                       140µs ± 2%     140µs ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-4                      978µs ± 1%     988µs ± 5%     ~     (p=1.000 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-4                  4.33ms ± 2%    4.39ms ± 3%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-4                 31.8ms ± 9%    31.9ms ± 4%     ~     (p=0.548 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-4               740µs ± 2%     769µs ± 4%   +3.88%  (p=0.016 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-4             5.30ms ± 2%    5.44ms ± 6%     ~     (p=0.421 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-4          74.5ms ± 0%    75.0ms ± 3%     ~     (p=0.730 n=4+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-4          564ms ± 1%     583ms ±10%     ~     (p=0.056 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=100-4                        170µs ±11%     175µs ± 9%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=1000-4                      1.09ms ± 2%    1.11ms ± 3%     ~     (p=0.421 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-4                   4.12ms ± 3%    4.20ms ± 4%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-4                  27.6ms ± 3%    27.4ms ± 3%     ~     (p=0.905 n=5+4)

name                                                                            old alloc/op   new alloc/op   delta
RangeQuery/expr=a_one,steps=100-4                                                 6.04kB ± 0%    6.04kB ± 0%     ~     (p=0.095 n=4+5)
RangeQuery/expr=a_one,steps=1000-4                                                10.0kB ± 0%     9.2kB ± 0%   -7.92%  (p=0.016 n=5+4)
RangeQuery/expr=a_hundred,steps=100-4                                             80.8kB ± 0%    81.2kB ± 1%     ~     (p=0.190 n=4+5)
RangeQuery/expr=a_hundred,steps=1000-4                                             301kB ± 0%     222kB ± 0%  -26.16%  (p=0.016 n=4+5)
RangeQuery/expr={l!="",le=""},steps=100-4                                          185kB ± 0%     185kB ± 0%     ~     (p=0.686 n=4+4)
RangeQuery/expr={l!="",le=""},steps=1000-4                                         666kB ± 0%     494kB ± 0%  -25.80%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=100-4                                       8.53kB ± 0%    8.53kB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1000-4                                      12.3kB ± 0%    11.6kB ± 0%   -5.57%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-4                                    112kB ± 0%     112kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-4                                   306kB ± 0%     238kB ± 0%  -22.17%  (p=0.016 n=4+5)
RangeQuery/expr=rate(a_one[1m]),steps=10000-4                                      100kB ± 1%      90kB ± 1%   -9.36%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-4                                 5.81MB ± 0%    4.84MB ± 1%  -16.65%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-4                     1.95MB ± 0%    1.94MB ± 0%   -0.43%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-4                    1.98MB ± 0%    1.97MB ± 0%   -0.48%  (p=0.008 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-4                 6.88MB ± 0%    6.07MB ± 0%  -11.79%  (p=0.016 n=4+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-4                7.38MB ± 0%    6.50MB ± 1%  -11.99%  (p=0.029 n=4+4)
RangeQuery/expr=changes(a_one[1d]),steps=100-4                                    1.12MB ± 0%    1.11MB ± 0%   -0.83%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=1000-4                                   1.14MB ± 0%    1.13MB ± 1%   -0.97%  (p=0.016 n=4+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-4                                6.12MB ± 0%    5.06MB ± 0%  -17.29%  (p=0.029 n=4+4)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-4                               7.12MB ±10%    7.01MB ±59%     ~     (p=0.413 n=4+5)
RangeQuery/expr=rate(a_one[1d]),steps=100-4                                       1.12MB ± 0%    1.11MB ± 0%   -0.88%  (p=0.016 n=4+5)
RangeQuery/expr=rate(a_one[1d]),steps=1000-4                                      1.13MB ± 1%    1.12MB ± 1%   -1.24%  (p=0.032 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-4                                   6.05MB ± 3%    5.27MB ± 0%  -12.99%  (p=0.016 n=5+4)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-4                                  8.10MB ±61%    6.48MB ± 0%     ~     (p=0.667 n=5+4)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-4                           1.13MB ± 0%    1.12MB ± 0%   -0.87%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-4                          1.15MB ± 0%    1.14MB ± 0%   -0.74%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-4                       6.21MB ± 1%    5.45MB ± 0%  -12.18%  (p=0.016 n=5+4)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-4                      9.09MB ± 3%    8.20MB ± 3%   -9.74%  (p=0.008 n=5+5)
RangeQuery/expr=-a_one,steps=100-4                                                6.81kB ± 0%    6.81kB ± 0%     ~     (p=0.333 n=5+4)
RangeQuery/expr=-a_one,steps=1000-4                                               10.8kB ± 0%    10.0kB ± 0%   -7.26%  (p=0.008 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-4                                             110kB ± 0%     110kB ± 0%     ~     (p=0.722 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-4                                            330kB ± 0%     252kB ± 0%  -23.75%  (p=0.029 n=4+4)
RangeQuery/expr=a_one_-_b_one,steps=100-4                                         17.6kB ± 0%    17.6kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1000-4                                        68.8kB ± 0%    67.3kB ± 0%   -2.28%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-4                                  544kB ± 0%     544kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-4                                3.49MB ± 0%    3.33MB ± 0%   -4.61%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-4                                        676kB ± 0%     657kB ± 0%   -2.70%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-4                               39.6MB ± 1%    37.7MB ± 0%   -4.72%  (p=0.029 n=4+4)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-4                        26.3kB ± 0%    26.3kB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-4                       73.6kB ± 0%    72.8kB ± 0%   -1.07%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-4                 503kB ± 0%     503kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-4               3.72MB ± 0%    3.60MB ± 0%   -3.17%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-4                         26.3kB ± 0%    26.3kB ± 0%     ~     (p=0.063 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-4                        73.7kB ± 0%    72.9kB ± 0%   -1.05%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-4                  883kB ± 0%     883kB ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-4                7.44MB ± 0%    7.33MB ± 0%   -1.59%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-4                     26.3kB ± 0%    26.4kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-4                    73.6kB ± 0%    72.9kB ± 0%   -1.02%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-4              503kB ± 0%     503kB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-4            3.72MB ± 0%    3.60MB ± 0%   -3.13%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_and_b_one{l='notfound'},steps=100-4                         14.8kB ± 0%    14.8kB ± 0%     ~     (p=0.532 n=5+5)
RangeQuery/expr=a_one_and_b_one{l='notfound'},steps=1000-4                        62.0kB ± 0%    61.3kB ± 0%   -1.24%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-4                  120kB ± 0%     121kB ± 0%   +0.02%  (p=0.040 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-4                 384kB ± 0%     305kB ± 0%  -20.50%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_one),steps=100-4                                            10.2kB ± 0%    10.2kB ± 0%     ~     (p=0.571 n=5+5)
RangeQuery/expr=abs(a_one),steps=1000-4                                           35.8kB ± 0%    35.0kB ± 0%   -2.18%  (p=0.008 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-4                                         319kB ± 0%     319kB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-4                                       2.04MB ± 0%    1.96MB ± 0%   -3.86%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-4         26.1kB ± 0%    26.1kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4         138kB ± 0%     137kB ± 0%   -0.58%  (p=0.008 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-4      369kB ± 0%     369kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4    2.18MB ± 0%    2.10MB ± 0%   -3.62%  (p=0.008 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-4                29.6kB ± 0%    29.6kB ± 0%     ~     (p=0.762 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-4                199kB ± 0%     198kB ± 0%   -0.39%  (p=0.016 n=5+4)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-4             360kB ± 0%     360kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-4           2.23MB ± 0%    2.15MB ± 0%   -3.51%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=100-4                                            48.6kB ± 0%    48.6kB ± 0%     ~     (p=0.429 n=5+5)
RangeQuery/expr=sum(a_one),steps=1000-4                                            420kB ± 0%     419kB ± 0%   -0.19%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-4                                         154kB ± 0%     154kB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-4                                        741kB ± 0%     663kB ± 0%  -10.61%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-4                                 281kB ± 0%     281kB ± 0%     ~     (p=0.111 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-4                               2.64MB ± 0%    2.63MB ± 0%   -0.33%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-4                            1.53MB ± 0%    1.53MB ± 0%   -0.04%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-4                           6.27MB ± 0%    5.41MB ± 0%  -13.76%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-4                               59.8kB ± 0%    59.8kB ± 0%     ~     (p=0.984 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-4                               453kB ± 0%     444kB ± 0%   -1.91%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-4                           3.67MB ± 0%    3.66MB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-4                          27.3MB ± 0%    26.5MB ± 0%   -3.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-4                                     59.8kB ± 0%    59.8kB ± 0%     ~     (p=0.365 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-4                                     453kB ± 0%     444kB ± 0%   -1.90%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-4                                 3.67MB ± 0%    3.66MB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-4                                27.3MB ± 0%    26.5MB ± 0%   -3.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-4                                     281kB ± 0%     281kB ± 0%     ~     (p=0.286 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-4                                   2.63MB ± 0%    2.63MB ± 0%   -0.33%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-4                                1.53MB ± 0%    1.53MB ± 0%   +0.14%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-4                               6.27MB ± 0%    5.41MB ± 0%  -13.78%  (p=0.008 n=5+5)
RangeQuery/expr=count_values('value',_h_one),steps=100-4                           976kB ± 0%     976kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-4                       108MB ± 0%     108MB ± 0%     ~     (p=0.730 n=5+4)
RangeQuery/expr=topk(1,_a_one),steps=100-4                                        54.5kB ± 0%    54.9kB ± 0%   +0.81%  (p=0.016 n=5+4)
RangeQuery/expr=topk(1,_a_one),steps=1000-4                                        469kB ± 0%     472kB ± 0%   +0.69%  (p=0.016 n=5+4)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4                                     160kB ± 0%     160kB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4                                    790kB ± 0%     712kB ± 0%   -9.92%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-4                     22.4kB ± 0%    22.4kB ± 0%     ~     (p=0.730 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-4                    73.2kB ± 0%    71.8kB ± 0%   -1.91%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-4              604kB ± 0%     603kB ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-4            3.50MB ± 0%    3.36MB ± 0%   -3.89%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-4                      51.2kB ± 0%    51.7kB ± 0%   +0.98%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-4                      423kB ± 0%     426kB ± 0%   +0.72%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-4                   185kB ± 0%     185kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-4                  746kB ± 0%     678kB ± 0%   -9.10%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-4              34.1kB ± 0%    34.1kB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-4              125kB ± 0%     116kB ± 0%   -6.93%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-4          2.11MB ± 0%    2.11MB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-4         8.23MB ± 0%    7.38MB ± 0%  -10.32%  (p=0.008 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=100-4                       30.8kB ± 0%    30.7kB ± 0%     ~     (p=0.127 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=1000-4                       197kB ± 0%     196kB ± 0%   -0.79%  (p=0.008 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-4                    250kB ± 0%     249kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-4                  1.44MB ± 0%    1.36MB ± 0%   -5.55%  (p=0.008 n=5+5)
```