### PR TITLE
Promql: reuse LabelBuilder in aggregations

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2360,15 +2360,14 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		}
 	}
 
-	lb := labels.NewBuilder(labels.EmptyLabels())
 	var buf []byte
 	for si, s := range vec {
 		metric := s.Metric
 
 		if op == parser.COUNT_VALUES {
-			lb.Reset(metric)
-			lb.Set(valueLabel, strconv.FormatFloat(s.V, 'f', -1, 64))
-			metric = lb.Labels(labels.EmptyLabels())
+			enh.resetBuilder(metric)
+			enh.lb.Set(valueLabel, strconv.FormatFloat(s.V, 'f', -1, 64))
+			metric = enh.lb.Labels(labels.EmptyLabels())
 
 			// We've changed the metric so we have to recompute the grouping key.
 			recomputeGroupingKey = true
@@ -2385,14 +2384,14 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		group, ok := result[groupingKey]
 		// Add a new group if it doesn't exist.
 		if !ok {
-			lb.Reset(metric)
+			enh.resetBuilder(metric)
 			if without {
-				lb.Del(grouping...)
-				lb.Del(labels.MetricName)
+				enh.lb.Del(grouping...)
+				enh.lb.Del(labels.MetricName)
 			} else {
-				lb.Keep(grouping...)
+				enh.lb.Keep(grouping...)
 			}
-			m := lb.Labels(labels.EmptyLabels())
+			m := enh.lb.Labels(labels.EmptyLabels())
 			newAgg := &groupedAggregation{
 				labels:     m,
 				value:      s.V,

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2384,14 +2384,18 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		group, ok := result[groupingKey]
 		// Add a new group if it doesn't exist.
 		if !ok {
+			var m labels.Labels
 			enh.resetBuilder(metric)
 			if without {
 				enh.lb.Del(grouping...)
 				enh.lb.Del(labels.MetricName)
-			} else {
+				m = enh.lb.Labels(labels.EmptyLabels())
+			} else if len(grouping) > 0 {
 				enh.lb.Keep(grouping...)
+				m = enh.lb.Labels(labels.EmptyLabels())
+			} else {
+				m = labels.EmptyLabels()
 			}
-			m := enh.lb.Labels(labels.EmptyLabels())
 			newAgg := &groupedAggregation{
 				labels:     m,
 				value:      s.V,

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1032,6 +1032,14 @@ type EvalNodeHelper struct {
 	resultMetric map[string]labels.Labels
 }
 
+func (enh *EvalNodeHelper) resetBuilder(lbls labels.Labels) {
+	if enh.lb == nil {
+		enh.lb = labels.NewBuilder(lbls)
+	} else {
+		enh.lb.Reset(lbls)
+	}
+}
+
 // DropMetricName is a cached version of DropMetricName.
 func (enh *EvalNodeHelper) DropMetricName(l labels.Labels) labels.Labels {
 	if enh.Dmn == nil {
@@ -2152,12 +2160,7 @@ func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.V
 		enh.resultMetric = make(map[string]labels.Labels, len(enh.Out))
 	}
 
-	if enh.lb == nil {
-		enh.lb = labels.NewBuilder(lhs)
-	} else {
-		enh.lb.Reset(lhs)
-	}
-
+	enh.resetBuilder(lhs)
 	buf := bytes.NewBuffer(enh.lblResultBuf[:0])
 	enh.lblBuf = lhs.Bytes(enh.lblBuf)
 	buf.Write(enh.lblBuf)


### PR DESCRIPTION
We have a LabelBuilder in EvalNodeHelper; use it instead of creating a new one at every step.

This avoids memory allocations hence goes faster.

We do need to take some care that different uses of `enh.lb` do not overlap.

Also small extra optimisation for an aggregation with no labels - given a query like `sum (foo)` we can quickly skip to the empty labels that its result needs.

Benchmarks show a decent improvement for `sum(...)`, no impact elsewhere, except for the `changes` cases which do seem to have been impacted slightly but I cannot see why since they don't run the changed code:
```
name                                                                            old time/op    new time/op    delta
RangeQuery/expr=a_one,steps=100-4                                                 44.4µs ± 5%    44.4µs ± 4%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_one,steps=1000-4                                                 182µs ± 3%     180µs ± 1%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred,steps=100-4                                             2.95ms ± 3%    2.98ms ± 2%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred,steps=1000-4                                            16.8ms ± 4%    16.4ms ± 1%     ~     (p=0.095 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=100-4                                       64.8µs ± 3%    65.4µs ± 3%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1000-4                                       301µs ± 2%     297µs ± 3%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-4                                   3.89ms ± 2%    4.06ms ±10%     ~     (p=0.056 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-4                                  26.8ms ± 1%    27.3ms ± 6%     ~     (p=0.548 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=10000-4                                     3.33ms ± 5%    3.34ms ± 7%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-4                                  321ms ± 2%     321ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-4                     7.77ms ± 3%    7.62ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-4                    60.6ms ± 1%    60.8ms ± 5%     ~     (p=0.690 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-4                  695ms ± 0%     703ms ± 2%     ~     (p=0.190 n=4+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-4                 5.92s ± 1%     5.93s ± 2%     ~     (p=1.000 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=100-4                                    2.89ms ± 4%    2.97ms ± 0%     ~     (p=0.190 n=5+4)
RangeQuery/expr=changes(a_one[1d]),steps=1000-4                                   14.9ms ± 2%    15.5ms ± 1%   +3.72%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-4                                 251ms ± 1%     259ms ± 3%   +3.29%  (p=0.008 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-4                                1.42s ± 2%     1.49s ± 1%   +4.88%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=100-4                                       2.84ms ± 2%    2.90ms ± 1%   +2.15%  (p=0.016 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=1000-4                                      14.5ms ± 2%    14.7ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-4                                    253ms ± 3%     256ms ± 3%     ~     (p=0.548 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-4                                   1.39s ± 2%     1.44s ± 1%   +3.60%  (p=0.008 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-4                           1.96ms ± 3%    1.99ms ± 2%     ~     (p=0.310 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-4                          5.52ms ± 6%    5.53ms ± 4%     ~     (p=1.000 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-4                        155ms ± 2%     164ms ± 7%     ~     (p=0.056 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-4                       506ms ± 5%     504ms ± 4%     ~     (p=0.841 n=5+5)
RangeQuery/expr=-a_one,steps=100-4                                                47.7µs ± 1%    48.0µs ± 3%     ~     (p=1.000 n=5+5)
RangeQuery/expr=-a_one,steps=1000-4                                                184µs ± 1%     185µs ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-4                                            3.01ms ± 5%    3.07ms ± 3%     ~     (p=0.310 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-4                                           16.8ms ± 5%    16.5ms ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=100-4                                          151µs ± 4%     150µs ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1000-4                                         950µs ± 1%     954µs ± 2%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-4                                 13.4ms ± 1%    13.8ms ± 8%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-4                                 103ms ± 1%     106ms ± 2%   +2.82%  (p=0.032 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-4                                       10.4ms ± 2%    10.3ms ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-4                                1.15s ± 3%     1.17s ± 3%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-4                         149µs ± 4%     146µs ± 2%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-4                        501µs ± 1%     491µs ± 4%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-4                7.29ms ± 3%    7.19ms ± 4%     ~     (p=0.548 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-4               49.8ms ± 2%    50.1ms ± 2%     ~     (p=0.548 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-4                          160µs ± 3%     160µs ± 2%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-4                         598µs ± 1%     606µs ± 4%     ~     (p=0.310 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-4                 8.82ms ± 4%    8.86ms ± 1%     ~     (p=0.548 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-4                66.7ms ± 3%    65.2ms ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-4                      160µs ± 2%     159µs ± 3%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-4                     595µs ± 3%     590µs ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-4             7.45ms ± 4%    7.25ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-4            51.1ms ± 3%    50.0ms ± 2%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_one_and_b_one{l='notfound'},steps=100-4                         82.7µs ± 5%    82.1µs ± 2%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_one_and_b_one{l='notfound'},steps=1000-4                         426µs ± 3%     420µs ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-4                 3.25ms ± 5%    3.22ms ± 3%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-4                18.9ms ± 2%    19.0ms ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=abs(a_one),steps=100-4                                            82.5µs ± 1%    83.9µs ± 3%     ~     (p=0.548 n=5+5)
RangeQuery/expr=abs(a_one),steps=1000-4                                            508µs ± 4%     500µs ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-4                                        6.31ms ± 2%    6.35ms ± 3%     ~     (p=0.690 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-4                                       48.7ms ± 2%    49.0ms ± 3%     ~     (p=0.841 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-4          128µs ± 2%     128µs ± 5%     ~     (p=0.421 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4         753µs ± 3%     731µs ± 2%   -2.93%  (p=0.032 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-4     7.30ms ± 9%    7.02ms ± 1%     ~     (p=0.056 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4    56.9ms ± 7%    55.4ms ± 3%     ~     (p=0.310 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-4                 137µs ± 2%     135µs ± 6%     ~     (p=0.151 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-4                916µs ± 5%     884µs ± 2%     ~     (p=0.095 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-4            6.93ms ± 1%    7.00ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-4           55.3ms ± 2%    56.2ms ± 3%     ~     (p=0.310 n=5+5)
RangeQuery/expr=sum(a_one),steps=100-4                                             122µs ± 1%     103µs ± 4%  -15.10%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1000-4                                            869µs ± 2%     665µs ± 2%  -23.44%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-4                                        3.41ms ± 1%    3.36ms ± 1%   -1.36%  (p=0.016 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-4                                       21.2ms ± 1%    20.9ms ± 1%   -1.57%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-4                                1.00ms ± 3%    0.99ms ± 4%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-4                               8.26ms ± 4%    7.98ms ± 2%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-4                            40.0ms ± 4%    39.6ms ± 3%     ~     (p=0.548 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-4                            249ms ± 2%     252ms ± 1%     ~     (p=0.730 n=5+4)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-4                                465µs ± 2%     454µs ± 8%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-4                              2.92ms ± 1%    2.68ms ± 0%   -8.35%  (p=0.016 n=5+4)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-4                           45.7ms ± 5%    44.4ms ± 3%     ~     (p=0.151 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-4                           301ms ± 2%     297ms ± 2%     ~     (p=0.310 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-4                                      477µs ± 3%     422µs ± 1%  -11.60%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-4                                    2.89ms ± 3%    2.55ms ± 2%  -11.75%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-4                                 44.6ms ± 2%    44.2ms ± 2%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-4                                 298ms ± 4%     291ms ± 2%     ~     (p=0.056 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-4                                    1.01ms ± 2%    0.97ms ± 2%   -4.81%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-4                                   8.13ms ± 3%    8.10ms ± 6%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-4                                39.4ms ± 1%    39.6ms ± 4%     ~     (p=0.841 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-4                                255ms ± 5%     241ms ± 2%   -5.27%  (p=0.016 n=5+5)
RangeQuery/expr=count_values('value',_h_one),steps=100-4                          2.66ms ± 2%    2.64ms ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-4                       331ms ± 5%     342ms ± 8%     ~     (p=0.690 n=5+5)
RangeQuery/expr=topk(1,_a_one),steps=100-4                                         156µs ± 2%     135µs ± 2%  -13.68%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_one),steps=1000-4                                       1.19ms ± 6%    0.96ms ± 2%  -19.99%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4                                    3.43ms ± 1%    3.46ms ± 3%     ~     (p=0.421 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4                                   21.4ms ± 2%    21.5ms ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-4                      182µs ± 2%     178µs ± 2%     ~     (p=0.056 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-4                    1.18ms ± 7%    1.13ms ± 4%     ~     (p=0.222 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-4             15.0ms ± 1%    14.8ms ± 2%     ~     (p=0.056 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-4             119ms ± 2%     121ms ± 4%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-4                       142µs ± 1%     123µs ± 6%  -13.02%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-4                     1.00ms ± 4%    0.81ms ± 2%  -19.14%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-4                  4.52ms ± 3%    4.37ms ± 4%     ~     (p=0.095 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-4                 31.8ms ± 2%    31.7ms ± 2%     ~     (p=0.841 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-4               760µs ± 4%     750µs ± 2%     ~     (p=0.690 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-4             5.41ms ± 2%    5.37ms ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-4          74.8ms ± 1%    74.2ms ± 2%     ~     (p=0.421 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-4          575ms ± 3%     577ms ± 0%     ~     (p=0.730 n=5+4)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=100-4                        171µs ± 5%     170µs ± 6%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=1000-4                      1.11ms ± 1%    1.11ms ± 2%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=100-4                        467µs ± 2%     473µs ± 3%     ~     (p=0.548 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=1000-4                      2.92ms ± 2%    2.96ms ± 2%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-4                   4.09ms ± 1%    4.17ms ± 3%     ~     (p=0.095 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-4                  27.9ms ± 5%    27.9ms ± 3%     ~     (p=0.548 n=5+5)

name                                                                            old alloc/op   new alloc/op   delta
RangeQuery/expr=a_one,steps=100-4                                                 6.48kB ± 0%    6.48kB ± 0%     ~     (p=0.683 n=5+5)
RangeQuery/expr=a_one,steps=1000-4                                                13.2kB ± 0%    13.2kB ± 0%     ~     (p=0.714 n=5+4)
RangeQuery/expr=a_hundred,steps=100-4                                             81.0kB ± 1%    80.8kB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_hundred,steps=1000-4                                             574kB ± 0%     574kB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=100-4                                       8.97kB ± 0%    8.98kB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=1000-4                                      15.1kB ± 0%    15.1kB ± 0%     ~     (p=0.516 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-4                                    112kB ± 0%     112kB ± 0%     ~     (p=0.595 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-4                                   548kB ± 0%     548kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=rate(a_one[1m]),steps=10000-4                                     96.5kB ± 1%    96.7kB ± 1%     ~     (p=0.310 n=5+5)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-4                                 5.39MB ± 0%    5.46MB ± 0%   +1.34%  (p=0.029 n=4+4)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-4                     1.95MB ± 0%    1.95MB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-4                    1.98MB ± 0%    1.98MB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-4                 6.64MB ± 0%    6.64MB ± 0%     ~     (p=0.873 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-4                7.11MB ± 0%    7.08MB ± 0%     ~     (p=0.171 n=4+4)
RangeQuery/expr=changes(a_one[1d]),steps=100-4                                    1.12MB ± 0%    1.12MB ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=changes(a_one[1d]),steps=1000-4                                   1.13MB ± 0%    1.13MB ± 1%     ~     (p=1.000 n=4+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-4                                5.80MB ± 3%    5.90MB ± 0%     ~     (p=0.286 n=5+4)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-4                               7.71MB ±72%    6.48MB ± 0%     ~     (p=0.667 n=5+4)
RangeQuery/expr=rate(a_one[1d]),steps=100-4                                       1.12MB ± 0%    1.12MB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=rate(a_one[1d]),steps=1000-4                                      1.13MB ± 1%    1.13MB ± 1%     ~     (p=0.690 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-4                                   5.84MB ± 3%    5.89MB ± 4%     ~     (p=0.841 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-4                                  7.90MB ±67%    7.06MB ± 0%     ~     (p=0.492 n=5+4)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-4                           1.12MB ± 0%    1.12MB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-4                          1.15MB ± 0%    1.15MB ± 0%   -0.05%  (p=0.016 n=4+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-4                       6.03MB ± 0%    6.09MB ± 1%   +0.90%  (p=0.048 n=4+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-4                      8.73MB ± 3%    8.88MB ± 1%     ~     (p=0.111 n=5+5)
RangeQuery/expr=-a_one,steps=100-4                                                7.25kB ± 0%    7.25kB ± 0%     ~     (p=1.000 n=4+5)
RangeQuery/expr=-a_one,steps=1000-4                                               14.0kB ± 0%    14.0kB ± 0%     ~     (p=0.897 n=5+5)
RangeQuery/expr=-a_hundred,steps=100-4                                             110kB ± 0%     110kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=-a_hundred,steps=1000-4                                            604kB ± 0%     604kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=100-4                                         18.5kB ± 0%    18.5kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=1000-4                                        75.2kB ± 0%    75.2kB ± 0%   -0.02%  (p=0.048 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-4                                  544kB ± 0%     544kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-4                                4.04MB ± 0%    4.03MB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-4                                        669kB ± 0%     670kB ± 0%     ~     (p=0.413 n=5+4)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-4                               38.6MB ± 0%    38.8MB ± 1%     ~     (p=0.200 n=4+4)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-4                        26.7kB ± 0%    26.7kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-4                       76.8kB ± 0%    76.8kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-4                 504kB ± 0%     503kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-4               4.13MB ± 0%    4.13MB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-4                         26.8kB ± 0%    26.8kB ± 0%     ~     (p=0.849 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-4                        76.9kB ± 0%    76.9kB ± 0%     ~     (p=0.595 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-4                  884kB ± 0%     884kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-4                7.86MB ± 0%    7.86MB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-4                     26.8kB ± 0%    26.8kB ± 0%     ~     (p=0.460 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-4                    77.0kB ± 0%    76.9kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-4              504kB ± 0%     503kB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-4            4.13MB ± 0%    4.13MB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_one_and_b_one{l='notfound'},steps=100-4                         15.3kB ± 0%    15.3kB ± 0%     ~     (p=0.190 n=5+5)
RangeQuery/expr=a_one_and_b_one{l='notfound'},steps=1000-4                        65.2kB ± 0%    65.2kB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-4                  121kB ± 0%     121kB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-4                 657kB ± 0%     657kB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=abs(a_one),steps=100-4                                            10.6kB ± 0%    10.6kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=abs(a_one),steps=1000-4                                           38.9kB ± 0%    38.9kB ± 0%     ~     (p=0.810 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=100-4                                         319kB ± 0%     319kB ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-4                                       2.31MB ± 0%    2.31MB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-4         26.6kB ± 0%    26.6kB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4         141kB ± 0%     141kB ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-4      369kB ± 0%     369kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4    2.45MB ± 0%    2.45MB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-4                30.0kB ± 0%    30.0kB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-4                202kB ± 0%     202kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-4             360kB ± 0%     360kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-4           2.50MB ± 0%    2.50MB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=sum(a_one),steps=100-4                                            49.0kB ± 0%    25.1kB ± 0%  -48.80%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1000-4                                            423kB ± 0%     183kB ± 0%  -56.73%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-4                                         154kB ± 0%     130kB ± 0%  -15.56%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-4                                       1.01MB ± 0%    0.78MB ± 0%  -23.64%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-4                                 286kB ± 0%     262kB ± 0%   -8.38%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-4                               2.67MB ± 0%    2.43MB ± 0%   -8.99%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-4                            1.53MB ± 0%    1.51MB ± 0%   -1.53%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-4                           9.29MB ± 0%    9.04MB ± 0%   -2.61%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-4                               64.6kB ± 0%    40.7kB ± 0%  -37.06%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-4                               488kB ± 0%     248kB ± 0%  -49.21%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-4                           3.67MB ± 0%    3.64MB ± 0%   -0.66%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-4                          30.3MB ± 0%    30.1MB ± 0%   -0.79%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-4                                     64.6kB ± 0%    35.9kB ± 0%  -44.44%  (p=0.016 n=5+4)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-4                                     488kB ± 0%     204kB ± 0%  -58.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-4                                 3.67MB ± 0%    3.64MB ± 0%   -0.73%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-4                                30.3MB ± 0%    26.2MB ± 0%  -13.56%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-4                                     286kB ± 0%     257kB ± 0%  -10.07%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-4                                   2.67MB ± 0%    2.39MB ± 0%  -10.64%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-4                                1.53MB ± 0%    1.51MB ± 0%   -1.66%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-4                               9.28MB ± 0%    5.16MB ± 0%  -44.37%  (p=0.008 n=5+5)
RangeQuery/expr=count_values('value',_h_one),steps=100-4                           981kB ± 0%     957kB ± 0%   -2.46%  (p=0.008 n=5+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-4                       108MB ± 0%     108MB ± 0%     ~     (p=0.063 n=5+4)
RangeQuery/expr=topk(1,_a_one),steps=100-4                                        54.9kB ± 0%    31.0kB ± 0%  -43.58%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_one),steps=1000-4                                        472kB ± 0%     232kB ± 0%  -50.84%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4                                     160kB ± 0%     136kB ± 0%  -14.98%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4                                   1.06MB ± 0%    0.82MB ± 0%  -22.55%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-4                     23.3kB ± 0%    23.3kB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-4                    78.9kB ± 0%    78.9kB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-4              604kB ± 0%     604kB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-4            3.98MB ± 0%    3.99MB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-4                      51.7kB ± 0%    27.7kB ± 0%  -46.46%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-4                      426kB ± 0%     186kB ± 0%  -56.45%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-4                   185kB ± 0%     161kB ± 0%  -12.83%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-4                  988kB ± 0%     748kB ± 0%  -24.33%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-4              38.9kB ± 0%    38.8kB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-4              160kB ± 0%     160kB ± 0%   -0.12%  (p=0.032 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-4          2.11MB ± 0%    2.11MB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-4         11.2MB ± 0%    11.2MB ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=100-4                       31.6kB ± 0%    31.6kB ± 0%     ~     (p=0.119 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=1000-4                       204kB ± 0%     204kB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=100-4                       29.9kB ± 0%    29.9kB ± 0%     ~     (p=0.786 n=5+5)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=1000-4                       142kB ± 0%     142kB ± 0%   +0.17%  (p=0.016 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-4                    250kB ± 0%     250kB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-4                  1.72MB ± 0%    1.72MB ± 0%     ~     (p=0.548 n=5+5)

name                                                                            old allocs/op  new allocs/op  delta
RangeQuery/expr=a_one,steps=100-4                                                    125 ± 0%       125 ± 0%     ~     (all equal)
RangeQuery/expr=a_one,steps=1000-4                                                   201 ± 0%       201 ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred,steps=100-4                                              1.31k ± 0%     1.31k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred,steps=1000-4                                             8.62k ± 0%     8.62k ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m]),steps=100-4                                          171 ± 0%       171 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m]),steps=1000-4                                         238 ± 0%       238 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-4                                    1.67k ± 0%     1.67k ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-4                                   8.07k ± 0%     8.07k ± 0%     ~     (p=0.556 n=4+5)
RangeQuery/expr=rate(a_one[1m]),steps=10000-4                                        981 ± 0%       981 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-4                                  78.4k ± 0%     78.4k ± 0%     ~     (p=0.143 n=5+5)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=100-4                        932 ± 0%       932 ± 0%     ~     (all equal)
RangeQuery/expr=holt_winters(a_one[1d],_0.3,_0.3),steps=1000-4                     1.00k ± 0%     0.99k ± 0%     ~     (p=0.333 n=5+4)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-4                  67.6k ± 0%     67.6k ± 0%     ~     (p=0.825 n=5+5)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-4                 74.0k ± 0%     73.9k ± 0%     ~     (p=0.063 n=5+4)
RangeQuery/expr=changes(a_one[1d]),steps=100-4                                       846 ± 0%       846 ± 0%     ~     (all equal)
RangeQuery/expr=changes(a_one[1d]),steps=1000-4                                      909 ± 0%       909 ± 0%     ~     (all equal)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-4                                 67.5k ± 0%     67.5k ± 0%     ~     (p=0.738 n=5+5)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-4                                73.8k ± 0%     66.0k ± 0%  -10.64%  (p=0.029 n=4+4)
RangeQuery/expr=rate(a_one[1d]),steps=100-4                                          846 ± 0%       846 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1d]),steps=1000-4                                         909 ± 0%       909 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-4                                    67.5k ± 0%     67.5k ± 0%     ~     (p=0.873 n=5+5)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-4                                   73.8k ± 0%     73.8k ± 0%     ~     (p=0.171 n=4+4)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=100-4                              846 ± 0%       846 ± 0%     ~     (all equal)
RangeQuery/expr=absent_over_time(a_one[1d]),steps=1000-4                             909 ± 0%       909 ± 0%     ~     (all equal)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-4                        67.5k ± 0%     67.5k ± 0%     ~     (p=0.341 n=5+5)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-4                       73.8k ± 0%     73.8k ± 0%     ~     (p=0.413 n=5+5)
RangeQuery/expr=-a_one,steps=100-4                                                   143 ± 0%       143 ± 0%     ~     (all equal)
RangeQuery/expr=-a_one,steps=1000-4                                                  219 ± 0%       219 ± 0%     ~     (all equal)
RangeQuery/expr=-a_hundred,steps=100-4                                             1.64k ± 0%     1.64k ± 0%     ~     (all equal)
RangeQuery/expr=-a_hundred,steps=1000-4                                            8.94k ± 0%     8.94k ± 0%     ~     (all equal)
RangeQuery/expr=a_one_-_b_one,steps=100-4                                            427 ± 0%       427 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_-_b_one,steps=1000-4                                         2.38k ± 0%     2.38k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-4                                  4.47k ± 0%     4.47k ± 0%     ~     (p=0.524 n=5+5)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-4                                 29.3k ± 0%     29.3k ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_one_-_b_one,steps=10000-4                                        21.8k ± 0%     21.8k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-4                                 271k ± 0%      271k ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=100-4                           511 ± 0%       511 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_and_b_one{l=~'.*[0-4]$'},steps=1000-4                        2.39k ± 0%     2.39k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-4                 3.75k ± 0%     3.75k ± 0%     ~     (p=0.571 n=5+5)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-4                26.2k ± 0%     26.2k ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=100-4                            513 ± 0%       513 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_or_b_one{l=~'.*[0-4]$'},steps=1000-4                         2.39k ± 0%     2.39k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-4                  4.31k ± 0%     4.31k ± 0%     ~     (p=0.373 n=5+5)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-4                 31.3k ± 0%     31.3k ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=100-4                        513 ± 0%       513 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_unless_b_one{l=~'.*[0-4]$'},steps=1000-4                     2.39k ± 0%     2.39k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-4              3.75k ± 0%     3.75k ± 0%     ~     (p=0.341 n=5+5)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-4             26.2k ± 0%     26.2k ± 0%     ~     (p=0.286 n=5+5)
RangeQuery/expr=a_one_and_b_one{l='notfound'},steps=100-4                            397 ± 0%       397 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_and_b_one{l='notfound'},steps=1000-4                         2.27k ± 0%     2.27k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-4                  1.79k ± 0%     1.79k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-4                 10.9k ± 0%     10.9k ± 0%     ~     (p=0.333 n=4+5)
RangeQuery/expr=abs(a_one),steps=100-4                                               263 ± 0%       263 ± 0%     ~     (all equal)
RangeQuery/expr=abs(a_one),steps=1000-4                                            1.24k ± 0%     1.24k ± 0%     ~     (all equal)
RangeQuery/expr=abs(a_hundred),steps=100-4                                         2.60k ± 0%     2.60k ± 0%     ~     (p=0.143 n=5+5)
RangeQuery/expr=abs(a_hundred),steps=1000-4                                        17.4k ± 0%     17.4k ± 0%     ~     (p=0.889 n=5+5)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-4            794 ± 0%       794 ± 0%     ~     (all equal)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4         5.37k ± 0%     5.37k ± 0%     ~     (all equal)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-4      3.82k ± 0%     3.82k ± 0%     ~     (p=0.976 n=5+5)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4     22.2k ± 0%     22.2k ± 0%     ~     (p=0.643 n=5+5)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-4                   952 ± 0%       952 ± 0%     ~     (all equal)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-4                7.33k ± 0%     7.33k ± 0%     ~     (all equal)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-4             3.68k ± 0%     3.68k ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-4            23.9k ± 0%     23.9k ± 0%   -0.05%  (p=0.024 n=5+5)
RangeQuery/expr=sum(a_one),steps=100-4                                               765 ± 0%       566 ± 0%  -26.01%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_one),steps=1000-4                                            6.24k ± 0%     4.24k ± 0%  -32.03%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=100-4                                         2.06k ± 0%     1.86k ± 0%   -9.68%  (p=0.008 n=5+5)
RangeQuery/expr=sum(a_hundred),steps=1000-4                                        14.8k ± 0%     12.8k ± 0%  -13.54%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=100-4                                 3.73k ± 0%     3.54k ± 0%     ~     (p=0.079 n=4+5)
RangeQuery/expr=sum_without_(l)(h_one),steps=1000-4                                34.5k ± 0%     32.5k ± 0%   -5.79%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-4                             17.8k ± 0%     17.6k ± 0%   -1.11%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-4                             128k ± 0%      126k ± 0%   -1.57%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=100-4                                  964 ± 0%       765 ± 0%  -20.64%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_one),steps=1000-4                               7.17k ± 0%     5.17k ± 0%  -27.88%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-4                            37.6k ± 0%     37.4k ± 0%   -0.52%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-4                            323k ± 0%      321k ± 0%   -0.62%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=100-4                                        964 ± 0%       699 ± 0%  -27.49%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_one),steps=1000-4                                     7.17k ± 0%     4.58k ± 0%  -36.16%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-4                                  37.6k ± 0%     37.4k ± 0%   -0.55%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-4                                  323k ± 0%      268k ± 0%  -16.97%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=100-4                                     3.73k ± 0%     3.47k ± 0%     ~     (p=0.079 n=4+5)
RangeQuery/expr=sum_by_(le)(h_one),steps=1000-4                                    34.5k ± 0%     31.9k ± 0%   -7.52%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-4                                 17.8k ± 0%     17.6k ± 0%   -1.13%  (p=0.008 n=5+5)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-4                                 128k ± 0%       73k ± 0%  -42.77%  (p=0.008 n=5+5)
RangeQuery/expr=count_values('value',_h_one),steps=100-4                           11.8k ± 0%     11.6k ± 0%   -1.68%  (p=0.000 n=4+5)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-4                       1.02M ± 0%     1.02M ± 0%   -0.02%  (p=0.016 n=5+4)
RangeQuery/expr=topk(1,_a_one),steps=100-4                                           890 ± 0%       691 ± 0%  -22.36%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_one),steps=1000-4                                        7.27k ± 0%     5.27k ± 0%  -27.51%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4                                     2.18k ± 0%     1.98k ± 0%   -9.13%  (p=0.008 n=5+5)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4                                    15.8k ± 0%     13.8k ± 0%  -12.66%  (p=0.008 n=5+5)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=100-4                        511 ± 0%       511 ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_one[1m])_+_rate(b_one[1m]),steps=1000-4                     2.44k ± 0%     2.44k ± 0%     ~     (all equal)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-4              5.16k ± 0%     5.17k ± 0%     ~     (p=0.254 n=5+5)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-4             28.2k ± 0%     28.2k ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=100-4                         811 ± 0%       612 ± 0%  -24.54%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_one[1m])),steps=1000-4                      6.28k ± 0%     4.28k ± 0%  -31.84%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-4                   2.41k ± 0%     2.21k ± 0%   -8.27%  (p=0.008 n=5+5)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-4                  14.2k ± 0%     12.2k ± 0%  -14.06%  (p=0.008 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=100-4                 769 ± 0%       769 ± 0%     ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_one[5m])),steps=1000-4              4.28k ± 0%     4.28k ± 0%     ~     (all equal)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-4           30.1k ± 0%     30.1k ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-4           209k ± 0%      209k ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=100-4                          636 ± 0%       636 ± 0%     ~     (all equal)
RangeQuery/expr=a_one_+_on(l)_group_right_a_one,steps=1000-4                       4.39k ± 0%     4.39k ± 0%     ~     (all equal)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=100-4                          553 ± 0%       553 ± 0%     ~     (all equal)
RangeQuery/expr=a_ten_+_on(l)_group_right_a_one,steps=1000-4                       3.18k ± 0%     3.18k ± 0%     ~     (all equal)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-4                    2.00k ± 0%     2.00k ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-4                   12.8k ± 0%     12.8k ± 0%     ~     (p=0.413 n=5+5)
```