### PR TITLE
tsdb: simplify merge of postings in the head

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -174,6 +174,15 @@ func rangeQueryCases() []benchCase {
 		{
 			expr: "a_X + on(l) group_right a_one",
 		},
+		// Label compared to blank string.
+		{
+			expr:  "count({__name__!=\"\"})",
+			steps: 1,
+		},
+		{
+			expr:  "count({__name__!=\"\",l=\"\"})",
+			steps: 1,
+		},
 	}
 
 	// X in an expr will be replaced by different metric sizes.

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -105,18 +105,7 @@ func (h *headIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, err
 
 // Postings returns the postings list iterator for the label pairs.
 func (h *headIndexReader) Postings(name string, values ...string) (index.Postings, error) {
-	switch len(values) {
-	case 0:
-		return index.EmptyPostings(), nil
-	case 1:
-		return h.head.postings.Get(name, values[0]), nil
-	default:
-		res := make([]index.Postings, 0, len(values))
-		for _, value := range values {
-			res = append(res, h.head.postings.Get(name, value))
-		}
-		return index.Merge(res...), nil
-	}
+	return h.head.postings.Get(name, values...), nil
 }
 
 func (h *headIndexReader) SortedPostings(p index.Postings) index.Postings {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -194,19 +194,8 @@ func (b metaByMinTimeAndMinRef) Less(i, j int) bool {
 func (b metaByMinTimeAndMinRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
 
 func (oh *OOOHeadIndexReader) Postings(name string, values ...string) (index.Postings, error) {
-	switch len(values) {
-	case 0:
-		return index.EmptyPostings(), nil
-	case 1:
-		return oh.head.postings.Get(name, values[0]), nil // TODO(ganesh) Also call GetOOOPostings
-	default:
-		// TODO(ganesh) We want to only return postings for out of order series.
-		res := make([]index.Postings, 0, len(values))
-		for _, value := range values {
-			res = append(res, oh.head.postings.Get(name, value)) // TODO(ganesh) Also call GetOOOPostings
-		}
-		return index.Merge(res...), nil
-	}
+	// TODO(ganesh) We want to only return postings for out of order series.
+	return oh.head.postings.Get(name, values...), nil // TODO(ganesh) Also call GetOOOPostings
 }
 
 type OOOHeadChunkReader struct {


### PR DESCRIPTION
Postings in the tsdb head are simple slices of references, so we can merge them by concatenating into one large slice. This is ~far~ more efficient than using `mergedPostings` which builds a heap on the fly.

Also add a benchmark for matching against a blank string, which is not handled efficiently by tsdb.
 This PR makes one of the tests much faster, although it actually uses a bit more memory.

Benchmarks still running.