### PR TITLE
fix ui bump version on mac

### DIFF
--- a/scripts/ui_release.sh
+++ b/scripts/ui_release.sh
@@ -75,12 +75,17 @@ function bumpVersion() {
   if [[ "${version}" == v* ]]; then
     version="${version:1}"
   fi
-  # increase the version on all packages
-  npm version "${version}" --workspaces
   # upgrade the @prometheus-io/* dependencies on all packages
   for workspace in ${workspaces}; do
-    sed -E -i "s|(\"@prometheus-io/.+\": )\".+\"|\1\"\^${version}\"|" "${workspace}"/package.json
+    # sed -i syntax is different on mac and linux
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      sed -E -i "" "s|(\"@prometheus-io/.+\": )\".+\"|\1\"${version}\"|" "${workspace}"/package.json
+    else
+      sed -E -i "s|(\"@prometheus-io/.+\": )\".+\"|\1\"${version}\"|" "${workspace}"/package.json
+    fi
   done
+   # increase the version on all packages
+    npm version "${version}" --workspaces
 }
 
 if [[ "$1" == "--copy" ]]; then

--- a/scripts/ui_release.sh
+++ b/scripts/ui_release.sh
@@ -84,8 +84,8 @@ function bumpVersion() {
       sed -E -i "s|(\"@prometheus-io/.+\": )\".+\"|\1\"${version}\"|" "${workspace}"/package.json
     fi
   done
-   # increase the version on all packages
-    npm version "${version}" --workspaces
+  # increase the version on all packages
+  npm version "${version}" --workspaces
 }
 
 if [[ "$1" == "--copy" ]]; then


### PR DESCRIPTION
The script that bumps the version of the different package in the UI doesn't work properly on mac, which may explain why sometimes some release Shepard had some hard time to proceed to do it.

This shouldn't be an issue anymore with this PR :)

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
