### PR TITLE
tsdb: Remove mmMaxTime in memSeries

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1843,8 +1843,6 @@ type memSeries struct {
 	oooHeadChunk     *oooHeadChunk      // Most recent chunk for ooo samples in memory that's still being built.
 	firstOOOChunkID  chunks.HeadChunkID // HeadOOOChunkID for oooMmappedChunks[0]
 
-	mmMaxTime int64 // Max time of any mmapped chunk, only used during WAL replay.
-
 	nextAt int64 // Timestamp at which to cut the next chunk.
 
 	// We keep the last value here (in addition to appending it to the chunk) so we can check for duplicates.


### PR DESCRIPTION
`mmMaxTime` is only used for WAL replay, but we keep that variable with the memSeries all the time. This PR removes it, with negligible impact in loading WAL.

Benchmark:
```
benchmark                                                                                                             old ns/op      new ns/op      delta
BenchmarkLoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-10          289870573      294268771      +1.52%
BenchmarkLoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0-10         293923760      295168250      +0.42%
BenchmarkLoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0-10         293735146      298376448      +1.58%
BenchmarkLoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0-10        321855188      329008365      +2.22%
BenchmarkLoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-10          307255323      320213292      +4.22%
BenchmarkLoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0-10          332511927      333360771      +0.26%
BenchmarkLoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-10          106346488      107618996      +1.20%
BenchmarkLoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0-10          108636521      111356991      +2.50%
BenchmarkLoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0-10          110351396      111606796      +1.14%
BenchmarkLoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0-10         128928656      129701490      +0.60%
BenchmarkLoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-10      1083695083     1113460792     +2.75%
BenchmarkLoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800-10      1095597292     1147324917     +4.72%
BenchmarkLoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800-10      1124581458     1171130084     +4.14%
BenchmarkLoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800-10     1350186209     1351729792     +0.11%
```