### PR TITLE
Staleness handling for FloatHistogram

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1862,10 +1862,6 @@ type memSeries struct {
 	// txs is nil if isolation is disabled.
 	txs *txRing
 
-	// TODO(beorn7): The only reason we track this is to create a staleness
-	// marker as either histogram or float sample. Perhaps there is a better way.
-	isHistogramSeries bool
-
 	pendingCommit bool // Whether there are samples waiting to be committed to this series.
 }
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -350,9 +350,12 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 		}
 	}
 
-	if value.IsStaleNaN(v) && s.lastHistogramValue != nil {
-		// TODO(marctc): do we have do to the same for float histograms?
-		return a.AppendHistogram(ref, lset, t, &histogram.Histogram{Sum: v}, nil)
+	if value.IsStaleNaN(v) {
+		if s.lastHistogramValue != nil {
+			return a.AppendHistogram(ref, lset, t, &histogram.Histogram{Sum: v}, nil)
+		} else if s.lastFloatHistogramValue != nil {
+			return a.AppendHistogram(ref, lset, t, nil, &histogram.FloatHistogram{Sum: v})
+		}
 	}
 
 	s.Lock()

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -605,7 +605,6 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			if s.T <= ms.mmMaxTime {
 				continue
 			}
-			ms.isHistogramSeries = false
 			if s.T <= ms.mmMaxTime {
 				continue
 			}
@@ -634,7 +633,6 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				unknownHistogramRefs++
 				continue
 			}
-			ms.isHistogramSeries = true
 			if s.t <= ms.mmMaxTime {
 				continue
 			}


### PR DESCRIPTION
Also, removed the isHistogramSeries from memSeries along the way. We should be good to directly use the lastHistogramValue and lastFloatHistogramValue to infer what kind of memSeries it is. 