### PR TITLE
Remove Nomad `datacenter` field in configuration docs

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2418,7 +2418,6 @@ The following meta labels are available on targets during [relabeling](#relabel_
 # The information to access the Nomad API. It is to be defined
 # as the Nomad documentation requires.
 [ allow_stale: <boolean> | default = true ]
-[ datacenter: <string> ]
 [ namespace: <string> | default = default ]
 [ refresh_interval: <duration> | default = 60s ]
 [ region: <string> | default = global ]


### PR DESCRIPTION
There is a `datacenter` field documented in the Nomad SD configuration section even though there is no such field implemented in the actual discovery mechanism. Looking into the Nomad API client, there doesn't seem to be a place to specify the datacenter in either the [client config](https://pkg.go.dev/github.com/hashicorp/nomad/api#Config) or the [query options](https://pkg.go.dev/github.com/hashicorp/nomad/api#QueryOptions), so I'm going to assume the error is in documenting the existence of the datacenter field and not the lack of the implementation of it, as it doesn't exist.

Fixes #11776

cc @attachmentgenie