### PR TITLE
Retain series selection when toggling graph features

### DIFF
--- a/web/ui/react-app/src/pages/graph/Graph.tsx
+++ b/web/ui/react-app/src/pages/graph/Graph.tsx
@@ -75,19 +75,12 @@ class Graph extends PureComponent<GraphProps, GraphState> {
       this.setState({ chartData: normalizeData(this.props) }, this.plot);
     } else if (prevProps.stacked !== stacked) {
       this.setState({ chartData: normalizeData(this.props) }, () => {
-        if (this.selectedSeriesIndexes.length === 0) {
-          this.plot();
-        } else {
-          this.plot([
-            ...this.state.chartData.series.filter((_, i) => this.selectedSeriesIndexes.includes(i)),
-            ...this.state.chartData.exemplars,
-          ]);
-        }
+        this.plotSelectedSeriesIndexes();
       });
     }
 
     if (prevProps.useLocalTime !== useLocalTime) {
-      this.plot();
+      this.plotSelectedSeriesIndexes();
     }
 
     if (prevProps.showExemplars !== showExemplars && !showExemplars) {
@@ -97,9 +90,20 @@ class Graph extends PureComponent<GraphProps, GraphState> {
           selectedExemplarLabels: { exemplar: {}, series: {} },
         },
         () => {
-          this.plot();
+          this.plotSelectedSeriesIndexes();
         }
       );
+    }
+  }
+
+  plotSelectedSeriesIndexes(): void {
+    if (this.selectedSeriesIndexes.length === 0) {
+      this.plot();
+    } else {
+      this.plot([
+        ...this.state.chartData.series.filter((_, i) => this.selectedSeriesIndexes.includes(i)),
+        ...this.state.chartData.exemplars,
+      ]);
     }
   }
 

--- a/web/ui/react-app/src/pages/graph/Panel.tsx
+++ b/web/ui/react-app/src/pages/graph/Panel.tsx
@@ -95,7 +95,11 @@ class Panel extends Component<PanelProps, PanelState> {
       return;
     }
 
-    if (prevOpts.resolution !== resolution || prevOpts.type !== type || showExemplars !== prevOpts.showExemplars) {
+    if (
+      prevOpts.resolution !== resolution ||
+      prevOpts.type !== type ||
+      (showExemplars && showExemplars !== prevOpts.showExemplars)
+    ) {
       this.executeQuery();
     }
   }


### PR DESCRIPTION
When toggling certain features in the web UI graph page, such as local time or stacked graphs, the selection of series is reset to show all of them. This PR takes the current selection into account when updating the view, preserving it whenever possible. This is only possible when the graphed data set remains unaltered; feature toggles that change the graph data will still reset the selection.

Fixes #10970 