### PR TITLE
tsdb/index: fix BenchmarkIntersect to do work on each loop

### DIFF
--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -280,6 +280,13 @@ func TestMultiIntersect(t *testing.T) {
 	}
 }
 
+func consumePostings(p Postings) error {
+	for p.Next() {
+		p.At()
+	}
+	return p.Err()
+}
+
 func BenchmarkIntersect(t *testing.B) {
 	t.Run("LongPostings1", func(bench *testing.B) {
 		var a, b, c, d []storage.SeriesRef
@@ -307,7 +314,7 @@ func BenchmarkIntersect(t *testing.B) {
 			i2 := newListPostings(b...)
 			i3 := newListPostings(c...)
 			i4 := newListPostings(d...)
-			if _, err := ExpandPostings(Intersect(i1, i2, i3, i4)); err != nil {
+			if err := consumePostings(Intersect(i1, i2, i3, i4)); err != nil {
 				bench.Fatal(err)
 			}
 		}
@@ -336,7 +343,7 @@ func BenchmarkIntersect(t *testing.B) {
 			i2 := newListPostings(b...)
 			i3 := newListPostings(c...)
 			i4 := newListPostings(d...)
-			if _, err := ExpandPostings(Intersect(i1, i2, i3, i4)); err != nil {
+			if err := consumePostings(Intersect(i1, i2, i3, i4)); err != nil {
 				bench.Fatal(err)
 			}
 		}
@@ -366,7 +373,7 @@ func BenchmarkIntersect(t *testing.B) {
 				lps[j].list = refs[j]
 				its[j] = lps[j]
 			}
-			if _, err := ExpandPostings(Intersect(its...)); err != nil {
+			if err := consumePostings(Intersect(its...)); err != nil {
 				bench.Fatal(err)
 			}
 		}

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -300,14 +300,13 @@ func BenchmarkIntersect(t *testing.B) {
 			d = append(d, storage.SeriesRef(i))
 		}
 
-		i1 := newListPostings(a...)
-		i2 := newListPostings(b...)
-		i3 := newListPostings(c...)
-		i4 := newListPostings(d...)
-
 		bench.ResetTimer()
 		bench.ReportAllocs()
 		for i := 0; i < bench.N; i++ {
+			i1 := newListPostings(a...)
+			i2 := newListPostings(b...)
+			i3 := newListPostings(c...)
+			i4 := newListPostings(d...)
 			if _, err := ExpandPostings(Intersect(i1, i2, i3, i4)); err != nil {
 				bench.Fatal(err)
 			}
@@ -330,14 +329,13 @@ func BenchmarkIntersect(t *testing.B) {
 			d = append(d, storage.SeriesRef(i))
 		}
 
-		i1 := newListPostings(a...)
-		i2 := newListPostings(b...)
-		i3 := newListPostings(c...)
-		i4 := newListPostings(d...)
-
 		bench.ResetTimer()
 		bench.ReportAllocs()
 		for i := 0; i < bench.N; i++ {
+			i1 := newListPostings(a...)
+			i2 := newListPostings(b...)
+			i3 := newListPostings(c...)
+			i4 := newListPostings(d...)
 			if _, err := ExpandPostings(Intersect(i1, i2, i3, i4)); err != nil {
 				bench.Fatal(err)
 			}
@@ -346,20 +344,28 @@ func BenchmarkIntersect(t *testing.B) {
 
 	// Many matchers(k >> n).
 	t.Run("ManyPostings", func(bench *testing.B) {
-		var its []Postings
+		var lps []*ListPostings
+		var refs [][]storage.SeriesRef
 
-		// 100000 matchers(k=100000).
+		// Create 100000 matchers(k=100000), making sure all memory allocation is done before starting the loop.
 		for i := 0; i < 100000; i++ {
 			var temp []storage.SeriesRef
 			for j := storage.SeriesRef(1); j < 100; j++ {
 				temp = append(temp, j)
 			}
-			its = append(its, newListPostings(temp...))
+			lps = append(lps, newListPostings(temp...))
+			refs = append(refs, temp)
 		}
 
+		its := make([]Postings, len(refs))
 		bench.ResetTimer()
 		bench.ReportAllocs()
 		for i := 0; i < bench.N; i++ {
+			// Reset the ListPostings to their original values each time round the loop.
+			for j := range refs {
+				lps[j].list = refs[j]
+				its[j] = lps[j]
+			}
 			if _, err := ExpandPostings(Intersect(its...)); err != nil {
 				bench.Fatal(err)
 			}


### PR DESCRIPTION
Previously all the postings constructed were consumed on the first iteration, so subsequent iterations did no work.

After fixing this, we see that `ExpandPostings` is causing most of the memory allocations on each iteration, so stop doing that.

Before (stress these are meaningless):
```
BenchmarkIntersect/LongPostings1-8              22208444                49.40 ns/op           96 B/op          2 allocs/op
BenchmarkIntersect/LongPostings2-8              20523910                51.64 ns/op           99 B/op          2 allocs/op
BenchmarkIntersect/ManyPostings-8                   5889            206882 ns/op              32 B/op          1 allocs/op
```

After:
```
BenchmarkIntersect/LongPostings1-8                 35192             34243 ns/op             224 B/op          6 allocs/op
BenchmarkIntersect/LongPostings2-8                    25          46704775 ns/op             224 B/op          6 allocs/op
BenchmarkIntersect/ManyPostings-8                      7         150956738 ns/op              32 B/op          1 allocs/op
```