### PR TITLE
tsdb: sort values for Postings only when required

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -174,6 +174,15 @@ func rangeQueryCases() []benchCase {
 		{
 			expr: "a_X + on(l) group_right a_one",
 		},
+		// Label compared to blank string.
+		{
+			expr:  "count({__name__!=\"\"})",
+			steps: 1,
+		},
+		{
+			expr:  "count({__name__!=\"\",l=\"\"})",
+			steps: 1,
+		},
 	}
 
 	// X in an expr will be replaced by different metric sizes.

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -72,7 +72,7 @@ type IndexReader interface {
 	// Postings returns the postings list iterator for the label pairs.
 	// The Postings here contain the offsets to the series inside the index.
 	// Found IDs are not strictly required to point to a valid Series, e.g.
-	// during background garbage collections. Input values must be sorted.
+	// during background garbage collections.
 	Postings(name string, values ...string) (index.Postings, error)
 
 	// SortedPostings returns a postings list that is reordered to be sorted

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1643,6 +1643,7 @@ func (r *Reader) Postings(name string, values ...string) (Postings, error) {
 		return EmptyPostings(), nil
 	}
 
+	slices.Sort(values) // Values must be in order so we can step through the table on disk.
 	res := make([]Postings, 0, len(values))
 	skip := 0
 	valueIndex := 0

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
-	"golang.org/x/exp/slices"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -322,7 +321,6 @@ func postingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, erro
 	if m.Type == labels.MatchRegexp {
 		setMatches := findSetMatches(m.GetRegexString())
 		if len(setMatches) > 0 {
-			slices.Sort(setMatches)
 			return ix.Postings(m.Name, setMatches...)
 		}
 	}
@@ -333,14 +331,9 @@ func postingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, erro
 	}
 
 	var res []string
-	lastVal, isSorted := "", true
 	for _, val := range vals {
 		if m.Matches(val) {
 			res = append(res, val)
-			if isSorted && val < lastVal {
-				isSorted = false
-			}
-			lastVal = val
 		}
 	}
 
@@ -348,9 +341,6 @@ func postingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, erro
 		return index.EmptyPostings(), nil
 	}
 
-	if !isSorted {
-		slices.Sort(res)
-	}
 	return ix.Postings(m.Name, res...)
 }
 
@@ -362,20 +352,12 @@ func inversePostingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Posting
 	}
 
 	var res []string
-	lastVal, isSorted := "", true
 	for _, val := range vals {
 		if !m.Matches(val) {
 			res = append(res, val)
-			if isSorted && val < lastVal {
-				isSorted = false
-			}
-			lastVal = val
 		}
 	}
 
-	if !isSorted {
-		slices.Sort(res)
-	}
 	return ix.Postings(m.Name, res...)
 }
 


### PR DESCRIPTION
In the head and in v1 postings on disk, it makes no difference whether postings are sorted. Only for v2 does the code step through in order. So, move the sorting to where it is required, and thus skip it entirely in the head.

Label values in on-disk blocks are already sorted, but `slices.Sort` is very fast on already-sorted data so we don't bother checking.

Update: I added another commit to fast-track `label=""`, which otherwise calls `append()` for every label value.
This required another change to special-case `""=""` which is apparently used in some tests to mean "everything".

Benchmarks (test data only has 100 different label values; the improvement should be much better for thousands):
```
name                                                  old time/op    new time/op    delta
RangeQuery/expr=count({__name__!=""}),steps=1-4         13.5ms ± 1%    13.5ms ± 5%    ~     (p=0.421 n=5+5)
RangeQuery/expr=count({__name__!="",l=""}),steps=1-4     807µs ± 3%     781µs ± 2%  -3.22%  (p=0.032 n=5+5)

name                                                  old alloc/op   new alloc/op   delta
RangeQuery/expr=count({__name__!=""}),steps=1-4         1.43MB ± 0%    1.43MB ± 0%    ~     (p=1.000 n=5+5)
RangeQuery/expr=count({__name__!="",l=""}),steps=1-4    33.4kB ± 0%    33.4kB ± 0%    ~     (p=0.971 n=4+4)

name                                                  old allocs/op  new allocs/op  delta
RangeQuery/expr=count({__name__!=""}),steps=1-4          14.6k ± 0%     14.6k ± 0%    ~     (p=0.571 n=4+5)
RangeQuery/expr=count({__name__!="",l=""}),steps=1-4       432 ± 0%       432 ± 0%    ~     (all equal)
```

Motivation is this profile, where this particular process spends 2.5% of all CPU time in sorting:

![image](https://user-images.githubusercontent.com/8125524/210618570-2770ea59-d5e6-4964-8145-fcf420cc80d5.png)
