### PR TITLE
Avoid unnecessary allocations in recording rule evaluation

### DIFF
--- a/rules/recording.go
+++ b/rules/recording.go
@@ -91,7 +91,8 @@ func (rule *RecordingRule) Eval(ctx context.Context, ts time.Time, query QueryFu
 			lb.Set(l.Name, l.Value)
 		})
 
-		sample.Metric = lb.Labels(labels.EmptyLabels())
+		labelSetSize := len(sample.Metric) + len(rule.labels) + 1 // additional 1 for rule name
+		sample.Metric = lb.Labels(make(labels.Labels, 0, labelSetSize))
 	}
 
 	// Check that the rule does not produce identical metrics after applying

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -81,7 +81,7 @@ func (rule *RecordingRule) Eval(ctx context.Context, ts time.Time, query QueryFu
 	}
 
 	// Override the metric name and labels.
-	lb := labels.NewBuilder(nil)
+	lb := labels.NewBuilder(labels.EmptyLabels())
 
 	for i := range vector {
 		sample := &vector[i]

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -79,20 +79,21 @@ func (rule *RecordingRule) Eval(ctx context.Context, ts time.Time, query QueryFu
 	if err != nil {
 		return nil, err
 	}
+
 	// Override the metric name and labels.
+	lb := labels.NewBuilder(nil)
+
 	for i := range vector {
 		sample := &vector[i]
 
-		lb := labels.NewBuilder(sample.Metric)
-
+		lb.Reset(sample.Metric)
 		lb.Set(labels.MetricName, rule.name)
 
 		rule.labels.Range(func(l labels.Label) {
 			lb.Set(l.Name, l.Value)
 		})
 
-		labelSetSize := len(sample.Metric) + len(rule.labels) + 1 // additional 1 for rule name
-		sample.Metric = lb.Labels(make(labels.Labels, 0, labelSetSize))
+		sample.Metric = lb.Labels(sample.Metric)
 	}
 
 	// Check that the rule does not produce identical metrics after applying

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -27,20 +27,18 @@ import (
 	"github.com/prometheus/prometheus/util/teststorage"
 )
 
-type testScenario struct {
-	name       string
-	ruleLabels labels.Labels
-	expr       parser.Expr
-	expected   promql.Vector
-}
-
 var (
 	ruleEvaluationTime       = time.Unix(0, 0).UTC()
 	exprWithMetricName, _    = parser.ParseExpr(`metric`)
 	exprWithoutMetricName, _ = parser.ParseExpr(`metric + metric`)
 )
 
-var scenarios = []testScenario{
+var ruleEvalTestScenarios = []struct {
+	name       string
+	ruleLabels labels.Labels
+	expr       parser.Expr
+	expected   promql.Vector
+}{
 	{
 		name:       "no labels in recording rule, metric name in query result",
 		ruleLabels: labels.EmptyLabels(),
@@ -120,7 +118,7 @@ func TestRuleEval(t *testing.T) {
 
 	require.NoError(t, suite.Run())
 
-	for _, scenario := range scenarios {
+	for _, scenario := range ruleEvalTestScenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			rule := NewRecordingRule("test_rule", scenario.expr, scenario.ruleLabels)
 			result, err := rule.Eval(suite.Context(), ruleEvaluationTime, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil, 0)
@@ -136,7 +134,7 @@ func BenchmarkRuleEval(b *testing.B) {
 
 	require.NoError(b, suite.Run())
 
-	for _, scenario := range scenarios {
+	for _, scenario := range ruleEvalTestScenarios {
 		b.Run(scenario.name, func(b *testing.B) {
 			rule := NewRecordingRule("test_rule", scenario.expr, scenario.ruleLabels)
 

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -29,8 +29,8 @@ import (
 
 var (
 	ruleEvaluationTime       = time.Unix(0, 0).UTC()
-	exprWithMetricName, _    = parser.ParseExpr(`metric`)
-	exprWithoutMetricName, _ = parser.ParseExpr(`metric + metric`)
+	exprWithMetricName, _    = parser.ParseExpr(`sort(metric)`)
+	exprWithoutMetricName, _ = parser.ParseExpr(`sort(metric + metric)`)
 )
 
 var ruleEvalTestScenarios = []struct {
@@ -50,7 +50,7 @@ var ruleEvalTestScenarios = []struct {
 			},
 			promql.Sample{
 				Metric: labels.FromStrings("__name__", "test_rule", "label_a", "2", "label_b", "4"),
-				Point:  promql.Point{V: 1, T: timestamp.FromTime(ruleEvaluationTime)},
+				Point:  promql.Point{V: 10, T: timestamp.FromTime(ruleEvaluationTime)},
 			},
 		},
 	},
@@ -65,7 +65,7 @@ var ruleEvalTestScenarios = []struct {
 			},
 			promql.Sample{
 				Metric: labels.FromStrings("__name__", "test_rule", "label_a", "2", "label_b", "4", "extra_from_rule", "foo"),
-				Point:  promql.Point{V: 1, T: timestamp.FromTime(ruleEvaluationTime)},
+				Point:  promql.Point{V: 10, T: timestamp.FromTime(ruleEvaluationTime)},
 			},
 		},
 	},
@@ -80,7 +80,7 @@ var ruleEvalTestScenarios = []struct {
 			},
 			promql.Sample{
 				Metric: labels.FromStrings("__name__", "test_rule", "label_a", "from_rule", "label_b", "4"),
-				Point:  promql.Point{V: 1, T: timestamp.FromTime(ruleEvaluationTime)},
+				Point:  promql.Point{V: 10, T: timestamp.FromTime(ruleEvaluationTime)},
 			},
 		},
 	},
@@ -95,7 +95,7 @@ var ruleEvalTestScenarios = []struct {
 			},
 			promql.Sample{
 				Metric: labels.FromStrings("__name__", "test_rule", "label_a", "2", "label_b", "4"),
-				Point:  promql.Point{V: 2, T: timestamp.FromTime(ruleEvaluationTime)},
+				Point:  promql.Point{V: 20, T: timestamp.FromTime(ruleEvaluationTime)},
 			},
 		},
 	},
@@ -105,7 +105,7 @@ func setUpRuleEvalTest(t require.TestingT) *promql.Test {
 	suite, err := promql.NewTest(t, `
 		load 1m
 			metric{label_a="1",label_b="3"} 1
-			metric{label_a="2",label_b="4"} 1
+			metric{label_a="2",label_b="4"} 10
 	`)
 	require.NoError(t, err)
 

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -34,9 +34,11 @@ type testScenario struct {
 	expected   promql.Vector
 }
 
-var ruleEvaluationTime = time.Unix(0, 0).UTC()
-var exprWithMetricName, _ = parser.ParseExpr(`metric`)
-var exprWithoutMetricName, _ = parser.ParseExpr(`metric + metric`)
+var (
+	ruleEvaluationTime       = time.Unix(0, 0).UTC()
+	exprWithMetricName, _    = parser.ParseExpr(`metric`)
+	exprWithoutMetricName, _ = parser.ParseExpr(`metric + metric`)
+)
 
 var scenarios = []testScenario{
 	{
@@ -142,7 +144,6 @@ func BenchmarkRuleEval(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				_, err := rule.Eval(suite.Context(), ruleEvaluationTime, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil, 0)
-
 				if err != nil {
 					require.NoError(b, err)
 				}

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -27,143 +27,112 @@ import (
 	"github.com/prometheus/prometheus/util/teststorage"
 )
 
-func TestRuleEval(t *testing.T) {
-	storage := teststorage.New(t)
-	defer storage.Close()
-
-	opts := promql.EngineOpts{
-		Logger:     nil,
-		Reg:        nil,
-		MaxSamples: 10,
-		Timeout:    10 * time.Second,
-	}
-
-	engine := promql.NewEngine(opts)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
-
-	now := time.Now()
-
-	suite := []struct {
-		name   string
-		expr   parser.Expr
-		labels labels.Labels
-		result promql.Vector
-		err    string
-	}{
-		{
-			name:   "nolabels",
-			expr:   &parser.NumberLiteral{Val: 1},
-			labels: labels.Labels{},
-			result: promql.Vector{promql.Sample{
-				Metric: labels.FromStrings("__name__", "nolabels"),
-				Point:  promql.Point{V: 1, T: timestamp.FromTime(now)},
-			}},
-		},
-		{
-			name:   "labels",
-			expr:   &parser.NumberLiteral{Val: 1},
-			labels: labels.FromStrings("foo", "bar"),
-			result: promql.Vector{promql.Sample{
-				Metric: labels.FromStrings("__name__", "labels", "foo", "bar"),
-				Point:  promql.Point{V: 1, T: timestamp.FromTime(now)},
-			}},
-		},
-	}
-
-	for _, test := range suite {
-		rule := NewRecordingRule(test.name, test.expr, test.labels)
-		result, err := rule.Eval(ctx, now, EngineQueryFunc(engine, storage), nil, 0)
-		if test.err == "" {
-			require.NoError(t, err)
-		} else {
-			require.Equal(t, test.err, err.Error())
-		}
-		require.Equal(t, test.result, result)
-	}
+type testScenario struct {
+	name       string
+	ruleLabels labels.Labels
+	expr       parser.Expr
+	expected   promql.Vector
 }
 
-func BenchmarkRuleEval(b *testing.B) {
-	suite, err := promql.NewTest(b, `
+var ruleEvaluationTime = time.Unix(0, 0).UTC()
+var exprWithMetricName, _ = parser.ParseExpr(`metric`)
+var exprWithoutMetricName, _ = parser.ParseExpr(`metric + metric`)
+
+var scenarios = []testScenario{
+	{
+		name:       "no labels in recording rule, metric name in query result",
+		ruleLabels: labels.EmptyLabels(),
+		expr:       exprWithMetricName,
+		expected: promql.Vector{
+			promql.Sample{
+				Metric: labels.FromStrings("__name__", "test_rule", "label_a", "1", "label_b", "3"),
+				Point:  promql.Point{V: 1, T: timestamp.FromTime(ruleEvaluationTime)},
+			},
+			promql.Sample{
+				Metric: labels.FromStrings("__name__", "test_rule", "label_a", "2", "label_b", "4"),
+				Point:  promql.Point{V: 1, T: timestamp.FromTime(ruleEvaluationTime)},
+			},
+		},
+	},
+	{
+		name:       "only new labels in recording rule, metric name in query result",
+		ruleLabels: labels.FromStrings("extra_from_rule", "foo"),
+		expr:       exprWithMetricName,
+		expected: promql.Vector{
+			promql.Sample{
+				Metric: labels.FromStrings("__name__", "test_rule", "label_a", "1", "label_b", "3", "extra_from_rule", "foo"),
+				Point:  promql.Point{V: 1, T: timestamp.FromTime(ruleEvaluationTime)},
+			},
+			promql.Sample{
+				Metric: labels.FromStrings("__name__", "test_rule", "label_a", "2", "label_b", "4", "extra_from_rule", "foo"),
+				Point:  promql.Point{V: 1, T: timestamp.FromTime(ruleEvaluationTime)},
+			},
+		},
+	},
+	{
+		name:       "some replacement labels in recording rule, metric name in query result",
+		ruleLabels: labels.FromStrings("label_a", "from_rule"),
+		expr:       exprWithMetricName,
+		expected: promql.Vector{
+			promql.Sample{
+				Metric: labels.FromStrings("__name__", "test_rule", "label_a", "from_rule", "label_b", "3"),
+				Point:  promql.Point{V: 1, T: timestamp.FromTime(ruleEvaluationTime)},
+			},
+			promql.Sample{
+				Metric: labels.FromStrings("__name__", "test_rule", "label_a", "from_rule", "label_b", "4"),
+				Point:  promql.Point{V: 1, T: timestamp.FromTime(ruleEvaluationTime)},
+			},
+		},
+	},
+	{
+		name:       "no labels in recording rule, no metric name in query result",
+		ruleLabels: labels.EmptyLabels(),
+		expr:       exprWithoutMetricName,
+		expected: promql.Vector{
+			promql.Sample{
+				Metric: labels.FromStrings("__name__", "test_rule", "label_a", "1", "label_b", "3"),
+				Point:  promql.Point{V: 2, T: timestamp.FromTime(ruleEvaluationTime)},
+			},
+			promql.Sample{
+				Metric: labels.FromStrings("__name__", "test_rule", "label_a", "2", "label_b", "4"),
+				Point:  promql.Point{V: 2, T: timestamp.FromTime(ruleEvaluationTime)},
+			},
+		},
+	},
+}
+
+func setUpRuleEvalTest(t require.TestingT) *promql.Test {
+	suite, err := promql.NewTest(t, `
 		load 1m
 			metric{label_a="1",label_b="3"} 1
 			metric{label_a="2",label_b="4"} 1
 	`)
-	require.NoError(b, err)
+	require.NoError(t, err)
+
+	return suite
+}
+
+func TestRuleEval(t *testing.T) {
+	suite := setUpRuleEvalTest(t)
+	defer suite.Close()
+
+	require.NoError(t, suite.Run())
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			rule := NewRecordingRule("test_rule", scenario.expr, scenario.ruleLabels)
+			result, err := rule.Eval(suite.Context(), ruleEvaluationTime, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil, 0)
+			require.NoError(t, err)
+			require.Equal(t, scenario.expected, result)
+		})
+	}
+}
+
+func BenchmarkRuleEval(b *testing.B) {
+	suite := setUpRuleEvalTest(b)
 	defer suite.Close()
 
 	require.NoError(b, suite.Run())
-	ts := time.Unix(0, 0).UTC()
-	exprWithMetricName, _ := parser.ParseExpr(`metric`)
-	exprWithoutMetricName, _ := parser.ParseExpr(`metric + metric`)
-
-	scenarios := []struct {
-		name       string
-		ruleLabels labels.Labels
-		expr       parser.Expr
-		expected   promql.Vector
-	}{
-		{
-			name:       "no labels in recording rule, metric name in query result",
-			ruleLabels: labels.EmptyLabels(),
-			expr:       exprWithMetricName,
-			expected: promql.Vector{
-				promql.Sample{
-					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "1", "label_b", "3"),
-					Point:  promql.Point{V: 1, T: timestamp.FromTime(ts)},
-				},
-				promql.Sample{
-					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "2", "label_b", "4"),
-					Point:  promql.Point{V: 1, T: timestamp.FromTime(ts)},
-				},
-			},
-		},
-		{
-			name:       "only new labels in recording rule, metric name in query result",
-			ruleLabels: labels.FromStrings("extra_from_rule", "foo"),
-			expr:       exprWithMetricName,
-			expected: promql.Vector{
-				promql.Sample{
-					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "1", "label_b", "3", "extra_from_rule", "foo"),
-					Point:  promql.Point{V: 1, T: timestamp.FromTime(ts)},
-				},
-				promql.Sample{
-					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "2", "label_b", "4", "extra_from_rule", "foo"),
-					Point:  promql.Point{V: 1, T: timestamp.FromTime(ts)},
-				},
-			},
-		},
-		{
-			name:       "some replacement labels in recording rule, metric name in query result",
-			ruleLabels: labels.FromStrings("label_a", "from_rule"),
-			expr:       exprWithMetricName,
-			expected: promql.Vector{
-				promql.Sample{
-					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "from_rule", "label_b", "3"),
-					Point:  promql.Point{V: 1, T: timestamp.FromTime(ts)},
-				},
-				promql.Sample{
-					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "from_rule", "label_b", "4"),
-					Point:  promql.Point{V: 1, T: timestamp.FromTime(ts)},
-				},
-			},
-		},
-		{
-			name:       "no labels in recording rule, no metric name in query result",
-			ruleLabels: labels.EmptyLabels(),
-			expr:       exprWithoutMetricName,
-			expected: promql.Vector{
-				promql.Sample{
-					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "1", "label_b", "3"),
-					Point:  promql.Point{V: 2, T: timestamp.FromTime(ts)},
-				},
-				promql.Sample{
-					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "2", "label_b", "4"),
-					Point:  promql.Point{V: 2, T: timestamp.FromTime(ts)},
-				},
-			},
-		},
-	}
 
 	for _, scenario := range scenarios {
 		b.Run(scenario.name, func(b *testing.B) {
@@ -172,10 +141,11 @@ func BenchmarkRuleEval(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				result, err := rule.Eval(suite.Context(), ts, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil, 0)
+				_, err := rule.Eval(suite.Context(), ruleEvaluationTime, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil, 0)
 
-				require.NoError(b, err)
-				require.ElementsMatch(b, scenario.expected, result)
+				if err != nil {
+					require.NoError(b, err)
+				}
 			}
 		})
 	}

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -83,6 +83,104 @@ func TestRuleEval(t *testing.T) {
 	}
 }
 
+func BenchmarkRuleEval(b *testing.B) {
+	suite, err := promql.NewTest(b, `
+		load 1m
+			metric{label_a="1",label_b="3"} 1
+			metric{label_a="2",label_b="4"} 1
+	`)
+	require.NoError(b, err)
+	defer suite.Close()
+
+	require.NoError(b, suite.Run())
+	ts := time.Unix(0, 0).UTC()
+	exprWithMetricName, _ := parser.ParseExpr(`metric`)
+	exprWithoutMetricName, _ := parser.ParseExpr(`metric + metric`)
+
+	scenarios := []struct {
+		name       string
+		ruleLabels labels.Labels
+		expr       parser.Expr
+		expected   promql.Vector
+	}{
+		{
+			name:       "no labels in recording rule, metric name in query result",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       exprWithMetricName,
+			expected: promql.Vector{
+				promql.Sample{
+					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "1", "label_b", "3"),
+					Point:  promql.Point{V: 1, T: timestamp.FromTime(ts)},
+				},
+				promql.Sample{
+					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "2", "label_b", "4"),
+					Point:  promql.Point{V: 1, T: timestamp.FromTime(ts)},
+				},
+			},
+		},
+		{
+			name:       "only new labels in recording rule, metric name in query result",
+			ruleLabels: labels.FromStrings("extra_from_rule", "foo"),
+			expr:       exprWithMetricName,
+			expected: promql.Vector{
+				promql.Sample{
+					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "1", "label_b", "3", "extra_from_rule", "foo"),
+					Point:  promql.Point{V: 1, T: timestamp.FromTime(ts)},
+				},
+				promql.Sample{
+					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "2", "label_b", "4", "extra_from_rule", "foo"),
+					Point:  promql.Point{V: 1, T: timestamp.FromTime(ts)},
+				},
+			},
+		},
+		{
+			name:       "some replacement labels in recording rule, metric name in query result",
+			ruleLabels: labels.FromStrings("label_a", "from_rule"),
+			expr:       exprWithMetricName,
+			expected: promql.Vector{
+				promql.Sample{
+					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "from_rule", "label_b", "3"),
+					Point:  promql.Point{V: 1, T: timestamp.FromTime(ts)},
+				},
+				promql.Sample{
+					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "from_rule", "label_b", "4"),
+					Point:  promql.Point{V: 1, T: timestamp.FromTime(ts)},
+				},
+			},
+		},
+		{
+			name:       "no labels in recording rule, no metric name in query result",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       exprWithoutMetricName,
+			expected: promql.Vector{
+				promql.Sample{
+					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "1", "label_b", "3"),
+					Point:  promql.Point{V: 2, T: timestamp.FromTime(ts)},
+				},
+				promql.Sample{
+					Metric: labels.FromStrings("__name__", "test_rule", "label_a", "2", "label_b", "4"),
+					Point:  promql.Point{V: 2, T: timestamp.FromTime(ts)},
+				},
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		b.Run(scenario.name, func(b *testing.B) {
+			rule := NewRecordingRule("test_rule", scenario.expr, scenario.ruleLabels)
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				result, err := rule.Eval(suite.Context(), ts, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil, 0)
+
+				require.NoError(b, err)
+				require.ElementsMatch(b, scenario.expected, result)
+			}
+		})
+	}
+}
+
 // TestRuleEvalDuplicate tests for duplicate labels in recorded metrics, see #5529.
 func TestRuleEvalDuplicate(t *testing.T) {
 	storage := teststorage.New(t)


### PR DESCRIPTION
When evaluating a rule, `RecordingRule.Eval()` uses a `labels.Builder` instance to build the label set for the recorded samples.

`Builder.Labels()` assumes that most of the time, the `Builder` is being used to remove or replace labels in the existing label set rather than add to them. 

But in the case of a recording rule, we're likely adding or replacing labels from the rule definition, so `Builder.Labels()` ends up allocating two `Labels` instances (once [here](https://github.com/prometheus/prometheus/blob/fa0f04bbc6f41708782d4e259fd1fb38896bb904/model/labels/labels.go#L542), and another later on in `append()` [here](https://github.com/prometheus/prometheus/blob/fa0f04bbc6f41708782d4e259fd1fb38896bb904/model/labels/labels.go#L564)). 

Instead, during rule evaluation, we can calculate the upper bound of the length of the label set and allocate just one `Labels` instance ahead of time. This reduces allocations at the risk of slightly overallocating - if the rule overrides some of the labels returned in the query, we won't need quite so much space in the label set.

For one Mimir cluster, we've seen that `Builder.Labels()` is responsible for ~6% of allocations attributable to rule evaluation. (Note that in Mimir, the behaviour is slightly different as we perform a remote query and parse the JSON response, whereas in Prometheus, the query is performed locally.)

There's a similar improvement to be had in `AlertingRule.Eval()` as well - I will address this in a later PR.

## Benchmark results 

Note that this benchmark includes the cost of evaluating the query used in the benchmark's rule.

```
name                                                                                old time/op    new time/op    delta
RuleEval/no_labels_in_recording_rule,_metric_name_in_query_result-10                  7.07µs ± 2%    6.69µs ± 0%  -5.38%  (p=0.008 n=5+5)
RuleEval/only_new_labels_in_recording_rule,_metric_name_in_query_result-10            7.21µs ± 0%    6.93µs ± 0%  -3.95%  (p=0.008 n=5+5)
RuleEval/some_replacement_labels_in_recording_rule,_metric_name_in_query_result-10    7.05µs ± 0%    6.70µs ± 1%  -4.89%  (p=0.008 n=5+5)
RuleEval/no_labels_in_recording_rule,_no_metric_name_in_query_result-10               14.3µs ± 1%    14.4µs ± 0%    ~     (p=0.690 n=5+5)

name                                                                                old alloc/op   new alloc/op   delta
RuleEval/no_labels_in_recording_rule,_metric_name_in_query_result-10                  7.13kB ± 0%    6.44kB ± 0%  -9.66%  (p=0.008 n=5+5)
RuleEval/only_new_labels_in_recording_rule,_metric_name_in_query_result-10            7.13kB ± 0%    6.83kB ± 0%  -4.26%  (p=0.029 n=4+4)
RuleEval/some_replacement_labels_in_recording_rule,_metric_name_in_query_result-10    6.94kB ± 0%    6.44kB ± 0%  -7.16%  (p=0.008 n=5+5)
RuleEval/no_labels_in_recording_rule,_no_metric_name_in_query_result-10               15.2kB ± 0%    14.8kB ± 0%  -2.83%  (p=0.008 n=5+5)

name                                                                                old allocs/op  new allocs/op  delta
RuleEval/no_labels_in_recording_rule,_metric_name_in_query_result-10                     127 ± 0%       119 ± 0%  -6.30%  (p=0.008 n=5+5)
RuleEval/only_new_labels_in_recording_rule,_metric_name_in_query_result-10               127 ± 0%       121 ± 0%  -4.72%  (p=0.008 n=5+5)
RuleEval/some_replacement_labels_in_recording_rule,_metric_name_in_query_result-10       125 ± 0%       119 ± 0%  -4.80%  (p=0.008 n=5+5)
RuleEval/no_labels_in_recording_rule,_no_metric_name_in_query_result-10                  239 ± 0%       233 ± 0%  -2.51%  (p=0.008 n=5+5)
```