### PR TITLE
Add SubQueryStep to distinguish whether the vectorSelector was wrapped in a SubQuery

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -853,14 +853,10 @@ func (ng *Engine) populateSeries(querier storage.Querier, s *parser.EvalStmt) {
 		case *parser.VectorSelector:
 			start, end := ng.getTimeRangesForSelector(s, n, path, evalRange)
 			subqInterval := ng.getLastSubqueryInterval(path)
-			interval := subqInterval
-			if subqInterval == 0 {
-				interval = s.Interval
-			}
 			hints := &storage.SelectHints{
 				Start:        start,
 				End:          end,
-				Step:         durationMilliseconds(interval),
+				Step:         durationMilliseconds(s.Interval),
 				SubQueryStep: durationMilliseconds(subqInterval),
 				Range:        durationMilliseconds(evalRange),
 				Func:         extractFuncFromPath(path),

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -852,16 +852,18 @@ func (ng *Engine) populateSeries(querier storage.Querier, s *parser.EvalStmt) {
 		switch n := node.(type) {
 		case *parser.VectorSelector:
 			start, end := ng.getTimeRangesForSelector(s, n, path, evalRange)
-			interval := ng.getLastSubqueryInterval(path)
-			if interval == 0 {
+			subqInterval := ng.getLastSubqueryInterval(path)
+			interval := subqInterval
+			if subqInterval == 0 {
 				interval = s.Interval
 			}
 			hints := &storage.SelectHints{
-				Start: start,
-				End:   end,
-				Step:  durationMilliseconds(interval),
-				Range: durationMilliseconds(evalRange),
-				Func:  extractFuncFromPath(path),
+				Start:        start,
+				End:          end,
+				Step:         durationMilliseconds(interval),
+				SubQueryStep: durationMilliseconds(subqInterval),
+				Range:        durationMilliseconds(evalRange),
+				Func:         extractFuncFromPath(path),
 			}
 			evalRange = 0
 			hints.By, hints.Grouping = extractGroupsFromPath(path)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -858,8 +858,9 @@ func (ng *Engine) populateSeries(querier storage.Querier, s *parser.EvalStmt) {
 				End:          end,
 				Step:         durationMilliseconds(s.Interval),
 				SubQueryStep: durationMilliseconds(subqInterval),
-				Range:        durationMilliseconds(evalRange),
-				Func:         extractFuncFromPath(path),
+
+				Range: durationMilliseconds(evalRange),
+				Func:  extractFuncFromPath(path),
 			}
 			evalRange = 0
 			hints.By, hints.Grouping = extractGroupsFromPath(path)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -858,9 +858,8 @@ func (ng *Engine) populateSeries(querier storage.Querier, s *parser.EvalStmt) {
 				End:          end,
 				Step:         durationMilliseconds(s.Interval),
 				SubQueryStep: durationMilliseconds(subqInterval),
-
-				Range: durationMilliseconds(evalRange),
-				Func:  extractFuncFromPath(path),
+				Range:        durationMilliseconds(evalRange),
+				Func:         extractFuncFromPath(path),
 			}
 			evalRange = 0
 			hints.By, hints.Grouping = extractGroupsFromPath(path)

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -333,56 +333,56 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 		}, {
 			query: "foo[2m:1s]", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: 175000, End: 300000, Step: 1000, SubQueryStep: 1000},
+				{Start: 175000, End: 300000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s])", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: 175000, End: 300000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
+				{Start: 175000, End: 300000, Func: "count_over_time", SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s] @ 300)", start: 200000,
 			expected: []*storage.SelectHints{
-				{Start: 175000, End: 300000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
+				{Start: 175000, End: 300000, Func: "count_over_time", SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s] @ 200)", start: 200000,
 			expected: []*storage.SelectHints{
-				{Start: 75000, End: 200000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
+				{Start: 75000, End: 200000, Func: "count_over_time", SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s] @ 100)", start: 200000,
 			expected: []*storage.SelectHints{
-				{Start: -25000, End: 100000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
+				{Start: -25000, End: 100000, Func: "count_over_time", SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s] offset 10s)", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: 165000, End: 290000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
+				{Start: 165000, End: 290000, Func: "count_over_time", SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time((foo offset 10s)[2m:1s] offset 10s)", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: 155000, End: 280000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
+				{Start: 155000, End: 280000, Func: "count_over_time", SubQueryStep: 1000},
 			},
 		}, {
 			// When the @ is on the vector selector, the enclosing subquery parameters
 			// don't affect the hint ranges.
 			query: "count_over_time((foo @ 200 offset 10s)[2m:1s] offset 10s)", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: 185000, End: 190000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
+				{Start: 185000, End: 190000, Func: "count_over_time", SubQueryStep: 1000},
 			},
 		}, {
 			// When the @ is on the vector selector, the enclosing subquery parameters
 			// don't affect the hint ranges.
 			query: "count_over_time((foo @ 200 offset 10s)[2m:1s] @ 100 offset 10s)", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: 185000, End: 190000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
+				{Start: 185000, End: 190000, Func: "count_over_time", SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time((foo offset 10s)[2m:1s] @ 100 offset 10s)", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: -45000, End: 80000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
+				{Start: -45000, End: 80000, Func: "count_over_time", SubQueryStep: 1000},
 			},
 		}, {
 			query: "foo", start: 10000, end: 20000,
@@ -432,7 +432,7 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 		}, {
 			query: "rate(foo[2m:1m])", start: 300000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: 175000, End: 500000, Func: "rate", Step: 60000, SubQueryStep: 60000},
+				{Start: 175000, End: 500000, Func: "rate", Step: 1000, SubQueryStep: 60000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s])", start: 300000, end: 500000,
@@ -506,13 +506,13 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 		}, {
 			query: "(max by (dim1) (foo))[5s:1s]", start: 10000,
 			expected: []*storage.SelectHints{
-				{Start: 0, End: 10000, Func: "max", By: true, Grouping: []string{"dim1"}, Step: 1000, SubQueryStep: 1000},
+				{Start: 0, End: 10000, Func: "max", By: true, Grouping: []string{"dim1"}, SubQueryStep: 1000},
 			},
 		}, {
 			query: "(sum(http_requests{group=~\"p.*\"})+max(http_requests{group=~\"c.*\"}))[20s:5s]", start: 120000,
 			expected: []*storage.SelectHints{
-				{Start: 95000, End: 120000, Func: "sum", By: true, Step: 5000, SubQueryStep: 5000},
-				{Start: 95000, End: 120000, Func: "max", By: true, Step: 5000, SubQueryStep: 5000},
+				{Start: 95000, End: 120000, Func: "sum", By: true, SubQueryStep: 5000},
+				{Start: 95000, End: 120000, Func: "max", By: true, SubQueryStep: 5000},
 			},
 		}, {
 			query: "foo @ 50 + bar @ 250 + baz @ 900", start: 100000, end: 500000,
@@ -552,12 +552,12 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 		}, { // Hints are based on the inner most subquery timestamp.
 			query: `sum_over_time(sum_over_time(metric{job="1"}[100s])[100s:25s] @ 50)[3s:1s] @ 3000`, start: 100000,
 			expected: []*storage.SelectHints{
-				{Start: -150000, End: 50000, Range: 100000, Func: "sum_over_time", Step: 25000, SubQueryStep: 25000},
+				{Start: -150000, End: 50000, Range: 100000, Func: "sum_over_time", SubQueryStep: 25000},
 			},
 		}, { // Hints are based on the inner most subquery timestamp.
 			query: `sum_over_time(sum_over_time(metric{job="1"}[100s])[100s:25s] @ 3000)[3s:1s] @ 50`,
 			expected: []*storage.SelectHints{
-				{Start: 2800000, End: 3000000, Range: 100000, Func: "sum_over_time", Step: 25000, SubQueryStep: 25000},
+				{Start: 2800000, End: 3000000, Range: 100000, Func: "sum_over_time", SubQueryStep: 25000},
 			},
 		},
 	} {

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -333,56 +333,56 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 		}, {
 			query: "foo[2m:1s]", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: 175000, End: 300000, Step: 1000},
+				{Start: 175000, End: 300000, Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s])", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: 175000, End: 300000, Func: "count_over_time", Step: 1000},
+				{Start: 175000, End: 300000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s] @ 300)", start: 200000,
 			expected: []*storage.SelectHints{
-				{Start: 175000, End: 300000, Func: "count_over_time", Step: 1000},
+				{Start: 175000, End: 300000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s] @ 200)", start: 200000,
 			expected: []*storage.SelectHints{
-				{Start: 75000, End: 200000, Func: "count_over_time", Step: 1000},
+				{Start: 75000, End: 200000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s] @ 100)", start: 200000,
 			expected: []*storage.SelectHints{
-				{Start: -25000, End: 100000, Func: "count_over_time", Step: 1000},
+				{Start: -25000, End: 100000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s] offset 10s)", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: 165000, End: 290000, Func: "count_over_time", Step: 1000},
+				{Start: 165000, End: 290000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time((foo offset 10s)[2m:1s] offset 10s)", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: 155000, End: 280000, Func: "count_over_time", Step: 1000},
+				{Start: 155000, End: 280000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			// When the @ is on the vector selector, the enclosing subquery parameters
 			// don't affect the hint ranges.
 			query: "count_over_time((foo @ 200 offset 10s)[2m:1s] offset 10s)", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: 185000, End: 190000, Func: "count_over_time", Step: 1000},
+				{Start: 185000, End: 190000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			// When the @ is on the vector selector, the enclosing subquery parameters
 			// don't affect the hint ranges.
 			query: "count_over_time((foo @ 200 offset 10s)[2m:1s] @ 100 offset 10s)", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: 185000, End: 190000, Func: "count_over_time", Step: 1000},
+				{Start: 185000, End: 190000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time((foo offset 10s)[2m:1s] @ 100 offset 10s)", start: 300000,
 			expected: []*storage.SelectHints{
-				{Start: -45000, End: 80000, Func: "count_over_time", Step: 1000},
+				{Start: -45000, End: 80000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "foo", start: 10000, end: 20000,
@@ -427,56 +427,61 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 		}, {
 			query: "rate(foo[2m:1s])", start: 300000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: 175000, End: 500000, Func: "rate", Step: 1000},
+				{Start: 175000, End: 500000, Func: "rate", Step: 1000, SubQueryStep: 1000},
+			},
+		}, {
+			query: "rate(foo[2m:1m])", start: 300000, end: 500000,
+			expected: []*storage.SelectHints{
+				{Start: 175000, End: 500000, Func: "rate", Step: 60000, SubQueryStep: 60000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s])", start: 300000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: 175000, End: 500000, Func: "count_over_time", Step: 1000},
+				{Start: 175000, End: 500000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s] offset 10s)", start: 300000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: 165000, End: 490000, Func: "count_over_time", Step: 1000},
+				{Start: 165000, End: 490000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s] @ 300)", start: 200000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: 175000, End: 300000, Func: "count_over_time", Step: 1000},
+				{Start: 175000, End: 300000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s] @ 200)", start: 200000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: 75000, End: 200000, Func: "count_over_time", Step: 1000},
+				{Start: 75000, End: 200000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time(foo[2m:1s] @ 100)", start: 200000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: -25000, End: 100000, Func: "count_over_time", Step: 1000},
+				{Start: -25000, End: 100000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time((foo offset 10s)[2m:1s] offset 10s)", start: 300000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: 155000, End: 480000, Func: "count_over_time", Step: 1000},
+				{Start: 155000, End: 480000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			// When the @ is on the vector selector, the enclosing subquery parameters
 			// don't affect the hint ranges.
 			query: "count_over_time((foo @ 200 offset 10s)[2m:1s] offset 10s)", start: 300000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: 185000, End: 190000, Func: "count_over_time", Step: 1000},
+				{Start: 185000, End: 190000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			// When the @ is on the vector selector, the enclosing subquery parameters
 			// don't affect the hint ranges.
 			query: "count_over_time((foo @ 200 offset 10s)[2m:1s] @ 100 offset 10s)", start: 300000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: 185000, End: 190000, Func: "count_over_time", Step: 1000},
+				{Start: 185000, End: 190000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "count_over_time((foo offset 10s)[2m:1s] @ 100 offset 10s)", start: 300000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: -45000, End: 80000, Func: "count_over_time", Step: 1000},
+				{Start: -45000, End: 80000, Func: "count_over_time", Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "sum by (dim1) (foo)", start: 10000,
@@ -501,13 +506,13 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 		}, {
 			query: "(max by (dim1) (foo))[5s:1s]", start: 10000,
 			expected: []*storage.SelectHints{
-				{Start: 0, End: 10000, Func: "max", By: true, Grouping: []string{"dim1"}, Step: 1000},
+				{Start: 0, End: 10000, Func: "max", By: true, Grouping: []string{"dim1"}, Step: 1000, SubQueryStep: 1000},
 			},
 		}, {
 			query: "(sum(http_requests{group=~\"p.*\"})+max(http_requests{group=~\"c.*\"}))[20s:5s]", start: 120000,
 			expected: []*storage.SelectHints{
-				{Start: 95000, End: 120000, Func: "sum", By: true, Step: 5000},
-				{Start: 95000, End: 120000, Func: "max", By: true, Step: 5000},
+				{Start: 95000, End: 120000, Func: "sum", By: true, Step: 5000, SubQueryStep: 5000},
+				{Start: 95000, End: 120000, Func: "max", By: true, Step: 5000, SubQueryStep: 5000},
 			},
 		}, {
 			query: "foo @ 50 + bar @ 250 + baz @ 900", start: 100000, end: 500000,
@@ -533,26 +538,26 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 		}, {
 			query: "rate(foo[2s:1s] @ 50) + bar + baz", start: 100000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: 43000, End: 50000, Step: 1000, Func: "rate"},
+				{Start: 43000, End: 50000, Step: 1000, Func: "rate", SubQueryStep: 1000},
 				{Start: 95000, End: 500000, Step: 1000},
 				{Start: 95000, End: 500000, Step: 1000},
 			},
 		}, {
 			query: "rate(foo[2s:1s] @ 50) + bar + rate(baz[2m:1s] @ 900 offset 2m) ", start: 100000, end: 500000,
 			expected: []*storage.SelectHints{
-				{Start: 43000, End: 50000, Step: 1000, Func: "rate"},
+				{Start: 43000, End: 50000, Step: 1000, Func: "rate", SubQueryStep: 1000},
 				{Start: 95000, End: 500000, Step: 1000},
-				{Start: 655000, End: 780000, Step: 1000, Func: "rate"},
+				{Start: 655000, End: 780000, Step: 1000, Func: "rate", SubQueryStep: 1000},
 			},
 		}, { // Hints are based on the inner most subquery timestamp.
 			query: `sum_over_time(sum_over_time(metric{job="1"}[100s])[100s:25s] @ 50)[3s:1s] @ 3000`, start: 100000,
 			expected: []*storage.SelectHints{
-				{Start: -150000, End: 50000, Range: 100000, Func: "sum_over_time", Step: 25000},
+				{Start: -150000, End: 50000, Range: 100000, Func: "sum_over_time", Step: 25000, SubQueryStep: 25000},
 			},
 		}, { // Hints are based on the inner most subquery timestamp.
 			query: `sum_over_time(sum_over_time(metric{job="1"}[100s])[100s:25s] @ 3000)[3s:1s] @ 50`,
 			expected: []*storage.SelectHints{
-				{Start: 2800000, End: 3000000, Range: 100000, Func: "sum_over_time", Step: 25000},
+				{Start: 2800000, End: 3000000, Range: 100000, Func: "sum_over_time", Step: 25000, SubQueryStep: 25000},
 			},
 		},
 	} {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -186,7 +186,9 @@ type SelectHints struct {
 	Start int64 // Start time in milliseconds for this select.
 	End   int64 // End time in milliseconds for this select.
 
-	Step int64  // Query step size in milliseconds.
+	Step         int64 // Query step size in milliseconds.
+	SubQueryStep int64 // SubQuery step size in milliseconds.
+
 	Func string // String representation of surrounding function or aggregation.
 
 	Grouping []string // List of label names used in aggregation.


### PR DESCRIPTION
The Select() of Querier interface supports the unexpandedSeriesSet for VectorSelector. The step in SelectHints is a global parameter, and it can't adapt to the VectorSelector which is embedded in a subquery, for example, query: max_over_time(metric[6m:10s])、step: 20s.

For the inner VectorSelector, it should choose 10s not 20s as the step parameter. So, I suggest adding the ``SubQueryStep`` parameter in SelectHints.

Currently, the latest version has already reset the interval, i.e., 
```go
func (ng *Engine) populateSeries(querier storage.Querier, s *parser.EvalStmt) {
	var evalRange time.Duration
	parser.Inspect(s.Expr, func(node parser.Node, path []parser.Node) error {
		switch n := node.(type) {
		case *parser.VectorSelector:
			start, end := ng.getTimeRangesForSelector(s, n, path, evalRange)
			interval := ng.getLastSubqueryInterval(path)
			if interval == 0 {
				interval = s.Interval // the interval has been reset
			}
.............
.............
```

Now, I need to distinguish whether the vectorSelector was wrapped in a subQuery by ``SubQueryStep``, then I can optimize the ``Select()`` process of vectorSelector.

