### PR TITLE
Feat: Add string interning on TSDB

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -198,6 +198,9 @@ func (c *flagConfig) setFeatureListOptions(logger log.Logger) error {
 				c.tsdb.EnableNativeHistograms = true
 				c.scrape.EnableProtobufNegotiation = true
 				level.Info(logger).Log("msg", "Experimental native histogram support enabled.")
+			case "tsdb-string-interning":
+				c.tsdb.EnableStringInterning = true
+				level.Info(logger).Log("msg", "Experimental tsdb string interning support enabled.")
 			case "":
 				continue
 			case "promql-at-modifier", "promql-negative-offset":
@@ -1528,6 +1531,7 @@ type tsdbOptions struct {
 	MaxExemplars                   int64
 	EnableMemorySnapshotOnShutdown bool
 	EnableNativeHistograms         bool
+	EnableStringInterning          bool
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -1548,6 +1552,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		EnableMemorySnapshotOnShutdown: opts.EnableMemorySnapshotOnShutdown,
 		EnableNativeHistograms:         opts.EnableNativeHistograms,
 		OutOfOrderTimeWindow:           opts.OutOfOrderTimeWindow,
+		EnableStringInterning:          opts.EnableStringInterning,
 	}
 }
 

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -126,3 +126,10 @@ still ingest those conventional histograms that do not come with a
 corresponding native histogram. However, if a native histogram is present,
 Prometheus will ignore the corresponding conventional histogram, with the
 notable exception of exemplars, which are always ingested.
+
+## TSDB String Interning
+
+`--enable-feature=tsdb-string-interning`
+
+When enabled, the TSDB Head would start interning strings to make sure that we save on memory allocations for the same string
+being seen on label keys/values.

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -178,6 +178,10 @@ type Options struct {
 	// OutOfOrderCapMax is maximum capacity for OOO chunks (in samples).
 	// If it is <=0, the default value is assumed.
 	OutOfOrderCapMax int64
+
+	// EnableStringInterning enables string interning on the TSDB Head to ensure that
+	// we save on memory usage for repeating label keys/values.
+	EnableStringInterning bool
 }
 
 type BlocksToDeleteFunc func(blocks []*Block) map[ulid.ULID]struct{}
@@ -645,7 +649,6 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64) {
 	if opts.OutOfOrderTimeWindow < 0 {
 		opts.OutOfOrderTimeWindow = 0
 	}
-
 	if len(rngs) == 0 {
 		// Start with smallest block duration and create exponential buckets until the exceed the
 		// configured maximum block duration.
@@ -786,6 +789,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		// We only override this flag if isolation is disabled at DB level. We use the default otherwise.
 		headOpts.IsolationDisabled = opts.IsolationDisabled
 	}
+	headOpts.EnableStringInterning = opts.EnableStringInterning
 	db.head, err = NewHead(r, l, wal, wbl, headOpts, stats.Head)
 	if err != nil {
 		return nil, err

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -789,7 +789,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		// We only override this flag if isolation is disabled at DB level. We use the default otherwise.
 		headOpts.IsolationDisabled = opts.IsolationDisabled
 	}
-	headOpts.EnableStringInterning = opts.EnableStringInterning
+	headOpts.EnableStringInterning = true
 	db.head, err = NewHead(r, l, wal, wbl, headOpts, stats.Head)
 	if err != nil {
 		return nil, err

--- a/tsdb/intern.go
+++ b/tsdb/intern.go
@@ -1,0 +1,124 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// ReferenceCountedStringPool manages a pool of reference counted strings and is safe for concurrent use.
+type ReferenceCountedStringPool struct {
+	mu   sync.RWMutex
+	refs map[string]*stringRef
+}
+
+type stringRef struct {
+	cnt uint64
+	str string
+}
+
+// Intern increases the reference count for a pooled instance of s and returns it.
+func (p *ReferenceCountedStringPool) Intern(s string) string {
+	p.mu.RLock()
+	ref, ok := p.refs[s]
+	if ok {
+		atomic.AddUint64(&ref.cnt, 1)
+	}
+	p.mu.RUnlock()
+	if ok {
+		return ref.str
+	}
+	return p.intern(s)
+}
+
+// InternBytes increases the reference count for a pooled instance of b's string representation and returns it.
+func (p *ReferenceCountedStringPool) InternBytes(b []byte) string {
+	p.mu.RLock()
+	ref, ok := p.refs[string(b)] // compiler is smart enough to not allocate on map key lookup
+	if ok {
+		atomic.AddUint64(&ref.cnt, 1)
+	}
+	p.mu.RUnlock()
+	if ok {
+		return ref.str
+	}
+	return p.intern(string(b))
+}
+
+func (p *ReferenceCountedStringPool) intern(s string) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if ref, ok := p.refs[s]; ok {
+		atomic.AddUint64(&ref.cnt, 1)
+		return ref.str
+	}
+
+	if p.refs == nil {
+		p.refs = map[string]*stringRef{}
+	}
+	p.refs[s] = &stringRef{
+		cnt: 1,
+		str: s,
+	}
+	return s
+}
+
+// Release decreases the reference count for a pooled instance of s and removes it if the count reaches zero.
+func (p *ReferenceCountedStringPool) Release(s string) {
+	var (
+		cnt uint64
+	)
+
+	p.mu.RLock()
+	ref, ok := p.refs[s]
+	if ok {
+		cnt = atomic.AddUint64(&ref.cnt, ^uint64(0))
+	}
+	p.mu.RUnlock()
+
+	if cnt == 0 && ok {
+		p.mu.Lock()
+		if atomic.LoadUint64(&ref.cnt) == 0 {
+			delete(p.refs, s)
+		}
+		p.mu.Unlock()
+	}
+}
+
+type interner struct {
+	strings ReferenceCountedStringPool
+}
+
+func (in *interner) Intern(lset labels.Labels) error {
+	for i, l := range lset {
+		lset[i] = labels.Label{
+			Name:  in.strings.Intern(l.Name),
+			Value: in.strings.Intern(l.Value),
+		}
+	}
+	return nil
+}
+
+func (in *interner) Release(lsets ...labels.Labels) {
+	for _, lset := range lsets {
+		for _, l := range lset {
+			in.strings.Release(l.Name)
+			in.strings.Release(l.Value)
+		}
+	}
+}

--- a/tsdb/intern.go
+++ b/tsdb/intern.go
@@ -81,9 +81,7 @@ func (p *ReferenceCountedStringPool) intern(s string) string {
 
 // Release decreases the reference count for a pooled instance of s and removes it if the count reaches zero.
 func (p *ReferenceCountedStringPool) Release(s string) {
-	var (
-		cnt uint64
-	)
+	var cnt uint64
 
 	p.mu.RLock()
 	ref, ok := p.refs[s]
@@ -105,14 +103,13 @@ type interner struct {
 	strings ReferenceCountedStringPool
 }
 
-func (in *interner) Intern(lset labels.Labels) error {
+func (in *interner) Intern(lset labels.Labels) {
 	for i, l := range lset {
 		lset[i] = labels.Label{
 			Name:  in.strings.Intern(l.Name),
 			Value: in.strings.Intern(l.Value),
 		}
 	}
-	return nil
 }
 
 func (in *interner) Release(lsets ...labels.Labels) {


### PR DESCRIPTION
This PR adds string interning directly on the TSDB. This ensures that samples coming in from both the receiver and the scrape manager benefit from the interning especially on the head. We at eBay, have been running this feature using a `SeriesLifeCycleCallBack` and we have benefited from ~20% memory savings. Cheers to @npordash for the original internal implementation.

This PR adds something similar using a reference counted string pool to intern all strings seen by head. The feature is added behind a feature flag in turned off state.
