### PR TITLE
textparse: Set CounterResetHint

### DIFF
--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -170,6 +170,9 @@ func (p *ProtobufParser) Histogram() ([]byte, *int64, *histogram.Histogram, *his
 			fh.NegativeSpans[i].Offset = span.GetOffset()
 			fh.NegativeSpans[i].Length = span.GetLength()
 		}
+		if p.mf.GetType() == dto.MetricType_GAUGE_HISTOGRAM {
+			fh.CounterResetHint = histogram.GaugeType
+		}
 		fh.Compact(0)
 		if ts != 0 {
 			return p.metricBytes.Bytes(), &ts, nil, &fh
@@ -198,6 +201,9 @@ func (p *ProtobufParser) Histogram() ([]byte, *int64, *histogram.Histogram, *his
 	for i, span := range h.GetNegativeSpan() {
 		sh.NegativeSpans[i].Offset = span.GetOffset()
 		sh.NegativeSpans[i].Length = span.GetLength()
+	}
+	if p.mf.GetType() == dto.MetricType_GAUGE_HISTOGRAM {
+		sh.CounterResetHint = histogram.GaugeType
 	}
 	sh.Compact(0)
 	if ts != 0 {

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -156,10 +156,150 @@ metric: <
 >
 
 `,
+		`name: "test_gauge_histogram"
+help: "Like test_histogram but as gauge histogram."
+type: GAUGE_HISTOGRAM
+metric: <
+  histogram: <
+    sample_count: 175
+    sample_sum: 0.0008280461746287094
+    bucket: <
+      cumulative_count: 2
+      upper_bound: -0.0004899999999999998
+    >
+    bucket: <
+      cumulative_count: 4
+      upper_bound: -0.0003899999999999998
+      exemplar: <
+        label: <
+          name: "dummyID"
+          value: "59727"
+        >
+        value: -0.00039
+        timestamp: <
+          seconds: 1625851155
+          nanos: 146848499
+        >
+      >
+    >
+    bucket: <
+      cumulative_count: 16
+      upper_bound: -0.0002899999999999998
+      exemplar: <
+        label: <
+          name: "dummyID"
+          value: "5617"
+        >
+        value: -0.00029
+      >
+    >
+    schema: 3
+    zero_threshold: 2.938735877055719e-39
+    zero_count: 2
+    negative_span: <
+      offset: -162
+      length: 1
+    >
+    negative_span: <
+      offset: 23
+      length: 4
+    >
+    negative_delta: 1
+    negative_delta: 3
+    negative_delta: -2
+    negative_delta: -1
+    negative_delta: 1
+    positive_span: <
+      offset: -161
+      length: 1
+    >
+    positive_span: <
+      offset: 8
+      length: 3
+    >
+    positive_delta: 1
+    positive_delta: 2
+    positive_delta: -1
+    positive_delta: -1
+  >
+  timestamp_ms: 1234568
+>
 
+`,
 		`name: "test_float_histogram"
 help: "Test float histogram with many buckets removed to keep it manageable in size."
 type: HISTOGRAM
+metric: <
+  histogram: <
+    sample_count: 175
+	sample_count_float: 175.0
+    sample_sum: 0.0008280461746287094
+    bucket: <
+      cumulative_count_float: 2.0
+      upper_bound: -0.0004899999999999998
+    >
+    bucket: <
+      cumulative_count_float: 4.0
+      upper_bound: -0.0003899999999999998
+      exemplar: <
+        label: <
+          name: "dummyID"
+          value: "59727"
+        >
+        value: -0.00039
+        timestamp: <
+          seconds: 1625851155
+          nanos: 146848499
+        >
+      >
+    >
+    bucket: <
+      cumulative_count_float: 16
+      upper_bound: -0.0002899999999999998
+      exemplar: <
+        label: <
+          name: "dummyID"
+          value: "5617"
+        >
+        value: -0.00029
+      >
+    >
+    schema: 3
+    zero_threshold: 2.938735877055719e-39
+    zero_count_float: 2.0
+    negative_span: <
+      offset: -162
+      length: 1
+    >
+    negative_span: <
+      offset: 23
+      length: 4
+    >
+    negative_count: 1.0
+    negative_count: 3.0
+    negative_count: -2.0
+    negative_count: -1.0
+    negative_count: 1.0
+    positive_span: <
+      offset: -161
+      length: 1
+    >
+    positive_span: <
+      offset: 8
+      length: 3
+    >
+    positive_count: 1.0
+    positive_count: 2.0
+    positive_count: -1.0
+    positive_count: -1.0
+  >
+  timestamp_ms: 1234568
+>
+
+`,
+		`name: "test_gauge_float_histogram"
+help: "Like test_float_histogram but as gauge histogram."
+type: GAUGE_HISTOGRAM
 metric: <
   histogram: <
     sample_count: 175
@@ -428,6 +568,43 @@ metric: <
 			},
 		},
 		{
+			m:    "test_gauge_histogram",
+			help: "Like test_histogram but as gauge histogram.",
+		},
+		{
+			m:   "test_gauge_histogram",
+			typ: MetricTypeGaugeHistogram,
+		},
+		{
+			m: "test_gauge_histogram",
+			t: 1234568,
+			shs: &histogram.Histogram{
+				CounterResetHint: histogram.GaugeType,
+				Count:            175,
+				ZeroCount:        2,
+				Sum:              0.0008280461746287094,
+				ZeroThreshold:    2.938735877055719e-39,
+				Schema:           3,
+				PositiveSpans: []histogram.Span{
+					{Offset: -161, Length: 1},
+					{Offset: 8, Length: 3},
+				},
+				NegativeSpans: []histogram.Span{
+					{Offset: -162, Length: 1},
+					{Offset: 23, Length: 4},
+				},
+				PositiveBuckets: []int64{1, 2, -1, -1},
+				NegativeBuckets: []int64{1, 3, -2, -1, 1},
+			},
+			lset: labels.FromStrings(
+				"__name__", "test_gauge_histogram",
+			),
+			e: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+			},
+		},
+		{
 			m:    "test_float_histogram",
 			help: "Test float histogram with many buckets removed to keep it manageable in size.",
 		},
@@ -457,6 +634,43 @@ metric: <
 			},
 			lset: labels.FromStrings(
 				"__name__", "test_float_histogram",
+			),
+			e: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+			},
+		},
+		{
+			m:    "test_gauge_float_histogram",
+			help: "Like test_float_histogram but as gauge histogram.",
+		},
+		{
+			m:   "test_gauge_float_histogram",
+			typ: MetricTypeGaugeHistogram,
+		},
+		{
+			m: "test_gauge_float_histogram",
+			t: 1234568,
+			fhs: &histogram.FloatHistogram{
+				CounterResetHint: histogram.GaugeType,
+				Count:            175.0,
+				ZeroCount:        2.0,
+				Sum:              0.0008280461746287094,
+				ZeroThreshold:    2.938735877055719e-39,
+				Schema:           3,
+				PositiveSpans: []histogram.Span{
+					{Offset: -161, Length: 1},
+					{Offset: 8, Length: 3},
+				},
+				NegativeSpans: []histogram.Span{
+					{Offset: -162, Length: 1},
+					{Offset: 23, Length: 4},
+				},
+				PositiveBuckets: []float64{1.0, 2.0, -1.0, -1.0},
+				NegativeBuckets: []float64{1.0, 3.0, -2.0, -1.0, 1.0},
+			},
+			lset: labels.FromStrings(
+				"__name__", "test_gauge_float_histogram",
 			),
 			e: []exemplar.Exemplar{
 				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},


### PR DESCRIPTION
If a (float or integer) histogram is a gauge histogram, set the CounterResetHint accordingly. (The default value is fine for the normal counter histograms.)

Signed-off-by: beorn7 <beorn@grafana.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
