### PR TITLE
Implemetation of target_sd_info metric

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -448,6 +448,8 @@ type ScrapeConfig struct {
 	RelabelConfigs []*relabel.Config `yaml:"relabel_configs,omitempty"`
 	// List of metric relabel configurations.
 	MetricRelabelConfigs []*relabel.Config `yaml:"metric_relabel_configs,omitempty"`
+	// List of target info relabel configurations.
+	TargetInfoRelabelConfigs []*relabel.Config `yaml:"target_info_relabel_configs,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.


### PR DESCRIPTION
With the help of @camathieu

**Context**
https://github.com/prometheus/prometheus/issues/11362

Regularly, we need to group metrics by the characteristics of the target they are coming from the target such as the version of the software, the version of the container, the type of machine it's running on or even the rack placement. As target's service discovery metadata is dropped after relabel_config phase, we can only add piece of metadata to all metrics. We have tried to add service discovery at relabel_config and then drop them on most metrics except on a target_metadata one, but this is expensive CPU wise (around +10-15% usage).

Most of the time such metadata metric cannot be exposed by the scrapped application as those metrics are very specific to the deployment and it would unrealistic to have them all accounted for in the application's code.

**Proposal**

I propose to add a new target metric meant to be relabeled with service discovery metadata: **target_info_sd**. This metric will have an additional relabel config phase called **target_info_relabel_config** right after the relabel_config. This phase will only be for this metric alone. If this target_info_relabel_config is not present or if the relabel drops the target, the target_info_sd metric will not be exposed for the target.

Example
prometheus.yml

```
  - job_name: 'my-service'
    consul_sd_configs:
      - services:
          - 'my-service'

    target_info_relabel_configs:
      - source_labels: [ '__meta_consul_metadata_server_type' ]
        target_label: 'server_type'
        regex: '(.+?)'
        replacement: '${1}'

```
This will add
`target_sd_info{job="my-service", instance="...", server_type="..."}`

Some usage examples:

Aggregate the instances by metadata
`count(target_sd_info) by (server_type)`

Add the metadata label to a metric
`my_metric * on(instance) group_left(server_type) target_sd_info`

Aggregate an  application metric by it's target metadata
`sum by (server_type)(my_metric * on(instance) group_left(server_type) target_sd_info)`


**Naming and compatibility**

The name was chosen from [OpenTelemetry specification](https://opentelemetry.io/docs/reference/specification/compatibility/prometheus_and_openmetrics/#info) with the additional sd to prevent direct collision with [prometheus exporter counterpart](https://github.com/open-telemetry/opentelemetry-go/pull/3285/commits). We do not need the ability to create customizable metric names as we can implement it with recording rules.

If the metric is already exposed by the target, there will be no out-of-order samples as each report metrics names have a \xff character at the end.

I could be tempting to rename the metric like this:

```
  - source_labels: [ '__name__' ]
    target_label: '__name__'
    replacement: 'some_other_target_info'
```

but the name is removed when the reserved labels are removed and it would require adding a special case for the __name__ and that would not be ideal.

**Left to do**
Tests and doc