### PR TITLE
Automatically remove incorrect snapshot with index that is ahead of WAL

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -18,7 +18,6 @@ import (
 	"io"
 	"math"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -571,29 +570,33 @@ func (h *Head) Init(minValidTime int64) error {
 	if h.opts.EnableMemorySnapshotOnShutdown {
 		level.Info(h.logger).Log("msg", "Chunk snapshot is enabled, replaying from the snapshot")
 		var err error
-		snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot()
-
 		// If there are any WAL files, there should be at least one WAL file with an index that is current or newer
 		// than the snapshot index. If the WAL index is behind the snapshot index somehow, the snapshot is assumed
-		// to be incorrect.
+		// to be outdated.
+		_, endAt, err := wlog.Segments(h.wal.Dir())
 		if h.wal != nil {
-			_, endAt, err := wlog.Segments(h.wal.Dir())
 			if err != nil {
 				return errors.Wrap(err, "finding WAL segments")
 			}
 
-			snapDir, _, _, err := LastChunkSnapshot(h.opts.ChunkDirRoot)
-			if err != nil {
-				level.Error(h.logger).Log("msg", "Could not find last snapshot", "err", err)
+			_, idx, _, e := LastChunkSnapshot(h.opts.ChunkDirRoot)
+			if e != nil && e != record.ErrNotFound {
+				level.Error(h.logger).Log("msg", "Could not find last snapshot", "err", e)
 			}
 
-			if err == nil && endAt < snapIdx {
-				level.Error(h.logger).Log("msg", "WAL index is behind snapshot, removing snapshot", "err", err)
-				err = os.RemoveAll(snapDir)
-				if err != nil {
-					level.Error(h.logger).Log("msg", "Error while deleting snapshot directory", "err", err)
+			if e == nil {
+				if endAt < idx {
+					level.Warn(h.logger).Log("msg", "WAL index is behind snapshot, removing snapshots")
+					err = DeleteAllChunkSnapshots(h.opts.ChunkDirRoot)
+					if err != nil {
+						level.Error(h.logger).Log("msg", "Error while deleting snapshot directories", "err", e)
+					}
+				} else {
+					snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot()
 				}
 			}
+		} else {
+			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot()
 		}
 
 		if err != nil {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -569,48 +569,47 @@ func (h *Head) Init(minValidTime int64) error {
 
 	if h.opts.EnableMemorySnapshotOnShutdown {
 		level.Info(h.logger).Log("msg", "Chunk snapshot is enabled, replaying from the snapshot")
-		var err error
 		// If there are any WAL files, there should be at least one WAL file with an index that is current or newer
 		// than the snapshot index. If the WAL index is behind the snapshot index somehow, the snapshot is assumed
 		// to be outdated.
-		_, endAt, err := wlog.Segments(h.wal.Dir())
+		loadSnapshot := true
 		if h.wal != nil {
+			_, endAt, err := wlog.Segments(h.wal.Dir())
 			if err != nil {
 				return errors.Wrap(err, "finding WAL segments")
 			}
 
-			_, idx, _, e := LastChunkSnapshot(h.opts.ChunkDirRoot)
-			if e != nil && e != record.ErrNotFound {
-				level.Error(h.logger).Log("msg", "Could not find last snapshot", "err", e)
+			_, idx, _, err := LastChunkSnapshot(h.opts.ChunkDirRoot)
+			if err != nil && err != record.ErrNotFound {
+				level.Error(h.logger).Log("msg", "Could not find last snapshot", "err", err)
 			}
 
-			if e == nil {
-				if endAt < idx {
-					level.Warn(h.logger).Log("msg", "WAL index is behind snapshot, removing snapshots")
-					err = DeleteAllChunkSnapshots(h.opts.ChunkDirRoot)
-					if err != nil {
-						level.Error(h.logger).Log("msg", "Error while deleting snapshot directories", "err", e)
-					}
-				} else {
-					snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot()
+			if err == nil && endAt < idx {
+				loadSnapshot = false
+				level.Warn(h.logger).Log("msg", "Last WAL file is behind snapshot, removing snapshots")
+				if err := DeleteChunkSnapshots(h.opts.ChunkDirRoot, math.MaxInt, math.MaxInt); err != nil {
+					level.Error(h.logger).Log("msg", "Error while deleting snapshot directories", "err", err)
 				}
 			}
-		} else {
-			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot()
 		}
+		if loadSnapshot {
+			var err error
+			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot()
+			if err == nil {
+				level.Info(h.logger).Log("msg", "Chunk snapshot loading time", "duration", time.Since(start).String())
+			}
+			if err != nil {
+				snapIdx, snapOffset = -1, 0
+				refSeries = make(map[chunks.HeadSeriesRef]*memSeries)
 
-		if err != nil {
-			snapIdx, snapOffset = -1, 0
-			refSeries = make(map[chunks.HeadSeriesRef]*memSeries)
-
-			h.metrics.snapshotReplayErrorTotal.Inc()
-			level.Error(h.logger).Log("msg", "Failed to load chunk snapshot", "err", err)
-			// We clear the partially loaded data to replay fresh from the WAL.
-			if err := h.resetInMemoryState(); err != nil {
-				return err
+				h.metrics.snapshotReplayErrorTotal.Inc()
+				level.Error(h.logger).Log("msg", "Failed to load chunk snapshot", "err", err)
+				// We clear the partially loaded data to replay fresh from the WAL.
+				if err := h.resetInMemoryState(); err != nil {
+					return err
+				}
 			}
 		}
-		level.Info(h.logger).Log("msg", "Chunk snapshot loading time", "duration", time.Since(start).String())
 	}
 
 	mmapChunkReplayStart := time.Now()

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -4793,9 +4793,10 @@ func TestSnapshotAheadOfWALError(t *testing.T) {
 	require.NoError(t, os.Rename(snapDir, path.Join(baseDir, newFilename)))
 
 	// Create new Head which should detect the incorrect index and delete the snapshot
-	w, err = wlog.NewSize(nil, nil, head.wal.Dir(), 32768, false)
+	w, _ = wlog.NewSize(nil, nil, head.wal.Dir(), 32768, false)
 	require.NoError(t, head.Init(math.MinInt64))
-	snapDir, _, _, err = LastChunkSnapshot(head.opts.ChunkDirRoot)
+	_, _, _, err = LastChunkSnapshot(head.opts.ChunkDirRoot)
+	require.Error(t, err)
 	require.NoError(t, w.Close())
 	// Verify that renamed directory does not exist anymore
 	_, err = os.Stat(filepath.Join(baseDir, newFilename))

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -4787,10 +4787,10 @@ func TestSnapshotAheadOfWALError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Corrupt the filename by increasing the snapshot index beyond the WAL index
-	baseDir := path.Dir(snapDir)
+	baseDir := filepath.Dir(snapDir)
 	newFilename := "chunk_snapshot.000003.000000000"
 
-	require.NoError(t, os.Rename(snapDir, path.Join(baseDir, newFilename)))
+	require.NoError(t, os.Rename(snapDir, filepath.Join(baseDir, newFilename)))
 
 	// Create new Head which should detect the incorrect index and delete the snapshot
 	w, _ = wlog.NewSize(nil, nil, head.wal.Dir(), 32768, false)

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1350,42 +1350,6 @@ func DeleteChunkSnapshots(dir string, maxIndex, maxOffset int) error {
 	return errs.Err()
 }
 
-// DeleteAllChunkSnapshots deletes all chunk snapshots in a directory.
-// This is used to clean up lingering outdated snapshots.
-func DeleteAllChunkSnapshots(dir string) error {
-	files, err := os.ReadDir(dir)
-	if err != nil {
-		return err
-	}
-
-	errs := tsdb_errors.NewMulti()
-	for _, fi := range files {
-		if !strings.HasPrefix(fi.Name(), chunkSnapshotPrefix) {
-			continue
-		}
-
-		splits := strings.Split(fi.Name()[len(chunkSnapshotPrefix):], ".")
-		if len(splits) != 2 {
-			continue
-		}
-
-		_, err := strconv.Atoi(splits[0])
-		if err != nil {
-			continue
-		}
-
-		_, err = strconv.Atoi(splits[1])
-		if err != nil {
-			continue
-		}
-
-		if err := os.RemoveAll(filepath.Join(dir, fi.Name())); err != nil {
-			errs.Add(err)
-		}
-	}
-	return errs.Err()
-}
-
 // loadChunkSnapshot replays the chunk snapshot and restores the Head state from it. If there was any error returned,
 // it is the responsibility of the caller to clear the contents of the Head.
 func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSeries, error) {

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1361,6 +1361,32 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 		return snapIdx, snapOffset, nil, errors.Wrap(err, "find last chunk snapshot")
 	}
 
+	// If there are any WAL files, there should be at least one WAL file with an index that is current or newer
+	// than the snapshot index. If the WAL index is behind the snapshot index somehow, the snapshot is assumed
+	// to be incorrect.
+	walFiles, err := os.ReadDir(h.wal.Dir())
+	if err != nil {
+		return snapIdx, snapOffset, nil, errors.Wrap(err, "read WAL directory")
+	}
+
+	walIsCurrent := false
+
+	for _, file := range walFiles {
+		idx, err := strconv.Atoi(file.Name())
+		if err == nil && idx >= snapIdx {
+			walIsCurrent = true
+			break
+		}
+	}
+
+	if len(walFiles) > 0 && !walIsCurrent {
+		err := os.RemoveAll(dir)
+		if err != nil {
+			return snapIdx, snapOffset, nil, errors.Wrap(err, "delete chunk snapshot")
+		}
+		return snapIdx, snapOffset, nil, errors.New("WAL index is behind snapshot, removing snapshot")
+	}
+
 	start := time.Now()
 	sr, err := wlog.NewSegmentsReader(dir)
 	if err != nil {


### PR DESCRIPTION
When loading a snapshot, the index of the snapshot is accepted without checking the WAL index, which can lead to an incorrect snapshot loading old data. This can happen, for example, when deleting the WAL but not the snapshot. As a safeguard against this, this PR checks if the WAL index is not behind the snapshot index, and automatically deletes the snapshot after recognizing it as incorrect. 

Fixes #11606 