### PR TITLE
TestConcurrentRangeQueries: log query with error

### DIFF
--- a/promql/promql_test.go
+++ b/promql/promql_test.go
@@ -87,6 +87,7 @@ func TestConcurrentRangeQueries(t *testing.T) {
 			}
 			res := qry.Exec(context.Background())
 			if res.Err != nil {
+				t.Logf("Query: %q, steps: %d, result: %s", c.expr, c.steps, res.Err)
 				return res.Err
 			}
 			qry.Close()


### PR DESCRIPTION
We've seen some timeouts in CI, and wanted to know what queries are involved.

Example output (I reduced the timeout to provoke this):

```
--- FAIL: TestConcurrentRangeQueries (12.82s)
    promql_test.go:90: Query: "holt_winters(a_hundred[1d], 0.3, 0.3)", steps: 1000, result: query timed out in expression evaluation
    promql_test.go:99: 
                Error Trace:    /home/vagrant/src/github.com/prometheus/prometheus/promql/promql_test.go:99
                Error:          Received unexpected error:
                                query timed out in expression evaluation
                Test:           TestConcurrentRangeQueries
FAIL
FAIL    github.com/prometheus/prometheus/promql 12.843s
FAIL
```