### PR TITLE
lint(yaml) : simplify ignore path for all github workflows

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -21,8 +21,4 @@ rules:
   line-length: disable
   truthy:
     ignore: |
-      .github/workflows/codeql-analysis.yml
-      .github/workflows/funcbench.yml
-      .github/workflows/fuzzing.yml
-      .github/workflows/prombench.yml
-      .github/workflows/golangci-lint.yml
+      .github/workflows/*.yml


### PR DESCRIPTION
Simplify ignoring path based on [documentation](https://yamllint.readthedocs.io/en/stable/configuration.html#ignoring-paths) 


Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
