### PR TITLE
Correct statement in docs about query results returning either floats or histograms but not both.

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -449,9 +449,7 @@ raw numbers.
 
 The keys `"histogram"` and `"histograms"` only show up if the experimental
 native histograms are present in the response. Their placeholder `<histogram>`
-is explained in detail in its own section below. Any one object could have
-the `"value"`/`"values"` key, the `"histogram"`/`"histograms"` key, or 
-both.
+is explained in detail in its own section below. 
 
 ### Range vectors
 
@@ -469,6 +467,9 @@ Range vectors are returned as result type `matrix`. The corresponding
 ]
 ```
 
+Each series could have the `"values"` key, or the `"histograms"` key, or both. 
+For a given timestamp, there will only be one sample of either float or histogram type.
+
 ### Instant vectors
 
 Instant vectors are returned as result type `vector`. The corresponding
@@ -484,6 +485,8 @@ Instant vectors are returned as result type `vector`. The corresponding
   ...
 ]
 ```
+
+Each series could have the `"value"` key, or the `"histogram"` key, but not both.
 
 ### Scalars
 

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -449,8 +449,8 @@ raw numbers.
 
 The keys `"histogram"` and `"histograms"` only show up if the experimental
 native histograms are present in the response. Their placeholder `<histogram>`
-is explained in detail in its own section below. Any one object will only have
-the `"value"`/`"values"` key or the `"histogram"`/`"histograms"` key, but not
+is explained in detail in its own section below. Any one object could have
+the `"value"`/`"values"` key, the `"histogram"`/`"histograms"` key, or 
 both.
 
 ### Range vectors


### PR DESCRIPTION
Based on discussion with @bboreham and @codesome, a single series could contain both float values and histogram values, but the documentation for the query API says that a series will only contain one or the other.

This PR updates the documentation to match the current behaviour.