### PR TITLE
[lezer-promql] Fix package.json main to point to correct cjs module

### DIFF
--- a/web/ui/module/lezer-promql/package.json
+++ b/web/ui/module/lezer-promql/package.json
@@ -2,7 +2,7 @@
   "name": "@prometheus-io/lezer-promql",
   "version": "0.41.0-rc.0",
   "description": "lezer-based PromQL grammar",
-  "main": "index.cjs",
+  "main": "dist/index.cjs",
   "type": "module",
   "exports": {
     "import": "./dist/index.es.js",


### PR DESCRIPTION
This addresses #11887.

Updates lezer-prom package.json `main` to point to `dist/index.cjs` instead of `index.cjs`

Signed-off-by: Shan Aminzadeh <shan.aminzadeh@chronosphere.io>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
