### PR TITLE
Use secrets.GITHUB_TOKEN and clean up workflows

### DIFF
--- a/.github/workflows/buf-lint.yml
+++ b/.github/workflows/buf-lint.yml
@@ -1,5 +1,5 @@
 name: buf.build
-on:  # yamllint disable-line rule:truthy
+on:
   pull_request:
     paths:
       - ".github/workflows/buf-lint.yml"
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1.9.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: bufbuild/buf-lint-action@v1
         with:
           input: 'prompb'

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -1,5 +1,5 @@
 name: buf.build
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - main

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1.9.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: bufbuild/buf-lint-action@v1
         with:
           input: 'prompb'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 ---
 name: CI
-on:  # yamllint disable-line rule:truthy
+on:
   pull_request:
   push:
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,7 @@
 ---
 name: "CodeQL"
 
-on:  # yamllint disable-line rule:truthy
+on:
   workflow_call:
   schedule:
     - cron: "26 14 * * 1"

--- a/.github/workflows/funcbench.yml
+++ b/.github/workflows/funcbench.yml
@@ -1,4 +1,4 @@
-on:  # yamllint disable-line rule:truthy
+on:
   repository_dispatch:
     types: [funcbench_start]
 name: Funcbench Workflow

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,5 +1,5 @@
 name: CIFuzz
-on:  # yamllint disable-line rule:truthy
+on:
   workflow_call:
 jobs:
   Fuzzing:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,6 +1,6 @@
 name: 'Lock Threads'
 
-on:  # yamllint disable-line rule:truthy
+on:
   schedule:
     - cron: '13 23 * * *'
   workflow_dispatch:

--- a/.github/workflows/prombench.yml
+++ b/.github/workflows/prombench.yml
@@ -1,4 +1,4 @@
-on:  # yamllint disable-line rule:truthy
+on:
   repository_dispatch:
     types: [prombench_start, prombench_restart, prombench_stop]
 name: Prombench Workflow

--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -1,6 +1,6 @@
 ---
 name: Sync repo files
-on:  # yamllint disable-line rule:truthy
+on:
   schedule:
     - cron: '44 17 * * *'
 jobs:


### PR DESCRIPTION
Hi ! This will increase the rate limit on 
bufbuild/buf-setup-action@ usage.
I also removed the comments which are useless now
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
