### PR TITLE
API: change HTTP status code from 503/422 to 499 if a request is canceled

### DIFF
--- a/web/api/v1/errors_test.go
+++ b/web/api/v1/errors_test.go
@@ -58,7 +58,7 @@ func TestApiStatusCodes(t *testing.T) {
 		"promql.ErrQueryCanceled": {
 			err:            promql.ErrQueryCanceled("some error"),
 			expectedString: "query was canceled",
-			expectedCode:   http.StatusServiceUnavailable,
+			expectedCode:   statusClientClosedConnection,
 		},
 
 		"promql.ErrQueryTimeout": {
@@ -76,7 +76,7 @@ func TestApiStatusCodes(t *testing.T) {
 		"context.Canceled": {
 			err:            context.Canceled,
 			expectedString: "context canceled",
-			expectedCode:   http.StatusUnprocessableEntity,
+			expectedCode:   statusClientClosedConnection,
 		},
 	} {
 		for k, q := range map[string]storage.SampleAndChunkQueryable{


### PR DESCRIPTION
Grafana Mimir uses the Prometheus API. I noticed the query API returns 503 when the request is canceled. As a side effect, this causes canceled queries to be reported as 5xx in "HTTP request total" metric tracked by Mimir itself, which just wraps the API.

Generally speaking, I think it's not much correct reporting 5xx for a canceled query. In my opinion, a 4xx looks more suitable, so that if you alert on 5xx errors you won't be alerted for canceled queries.

What's your sentiment changing the mapping in Prometheus API to return 499 instead?