### PR TITLE
Fix SanitizeLabelName for certain edge case invalid labels

### DIFF
--- a/util/strutil/strconv.go
+++ b/util/strutil/strconv.go
@@ -17,7 +17,11 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/grafana/regexp"
 )
+
+var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 // TableLinkForExpression creates an escaped relative link to the table view of
 // the provided expression.
@@ -33,9 +37,18 @@ func GraphLinkForExpression(expr string) string {
 	return fmt.Sprintf("/graph?g0.expr=%s&g0.tab=0", escapedExpression)
 }
 
-// SanitizeLabelName replaces any invalid character with an underscore, and if
-// given an empty string, returns a string containing a single underscore.
+// SanitizeLabelName replaces anything that doesn't match
+// client_label.LabelNameRE with an underscore.
+// Note: this does not handle all Prometheus label name restrictions (such as
+// not starting with a digit 0-9), and hence should only be used if the label
+// name is prefixed with a known valid string.
 func SanitizeLabelName(name string) string {
+	return invalidLabelCharRE.ReplaceAllString(name, "_")
+}
+
+// SanitizeFullLabelName replaces any invalid character with an underscore, and
+// if given an empty string, returns a string containing a single underscore.
+func SanitizeFullLabelName(name string) string {
 	if len(name) == 0 {
 		return "_"
 	}

--- a/util/strutil/strconv.go
+++ b/util/strutil/strconv.go
@@ -16,11 +16,8 @@ package strutil
 import (
 	"fmt"
 	"net/url"
-
-	"github.com/grafana/regexp"
+	"strings"
 )
-
-var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 // TableLinkForExpression creates an escaped relative link to the table view of
 // the provided expression.
@@ -36,8 +33,19 @@ func GraphLinkForExpression(expr string) string {
 	return fmt.Sprintf("/graph?g0.expr=%s&g0.tab=0", escapedExpression)
 }
 
-// SanitizeLabelName replaces anything that doesn't match
-// client_label.LabelNameRE with an underscore.
+// SanitizeLabelName replaces any invalid character with an underscore, and if
+// given an empty string, returns a string containing a single underscore.
 func SanitizeLabelName(name string) string {
-	return invalidLabelCharRE.ReplaceAllString(name, "_")
+	if len(name) == 0 {
+		return "_"
+	}
+	var validSb strings.Builder
+	for i, b := range name {
+		if !((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || (b >= '0' && b <= '9' && i > 0)) {
+			validSb.WriteRune('_')
+		} else {
+			validSb.WriteRune(b)
+		}
+	}
+	return validSb.String()
 }

--- a/util/strutil/strconv_test.go
+++ b/util/strutil/strconv_test.go
@@ -58,12 +58,22 @@ func TestSanitizeLabelName(t *testing.T) {
 	actual = SanitizeLabelName("barClient.LABEL$$##")
 	expected = "barClient_LABEL____"
 	require.Equal(t, expected, actual, "SanitizeLabelName failed for label (%s)", expected)
+}
 
-	actual = SanitizeLabelName("0zerothClient1LABEL")
+func TestSanitizeFullLabelName(t *testing.T) {
+	actual := SanitizeFullLabelName("fooClientLABEL")
+	expected := "fooClientLABEL"
+	require.Equal(t, expected, actual, "SanitizeFullLabelName failed for label (%s)", expected)
+
+	actual = SanitizeFullLabelName("barClient.LABEL$$##")
+	expected = "barClient_LABEL____"
+	require.Equal(t, expected, actual, "SanitizeFullLabelName failed for label (%s)", expected)
+
+	actual = SanitizeFullLabelName("0zerothClient1LABEL")
 	expected = "_zerothClient1LABEL"
-	require.Equal(t, expected, actual, "SanitizeLabelName failed for label (%s)", expected)
+	require.Equal(t, expected, actual, "SanitizeFullLabelName failed for label (%s)", expected)
 
-	actual = SanitizeLabelName("")
+	actual = SanitizeFullLabelName("")
 	expected = "_"
-	require.Equal(t, expected, actual, "SanitizeLabelName failed for the empty label")
+	require.Equal(t, expected, actual, "SanitizeFullLabelName failed for the empty label")
 }

--- a/util/strutil/strconv_test.go
+++ b/util/strutil/strconv_test.go
@@ -58,4 +58,12 @@ func TestSanitizeLabelName(t *testing.T) {
 	actual = SanitizeLabelName("barClient.LABEL$$##")
 	expected = "barClient_LABEL____"
 	require.Equal(t, expected, actual, "SanitizeLabelName failed for label (%s)", expected)
+
+	actual = SanitizeLabelName("0zerothClient1LABEL")
+	expected = "_zerothClient1LABEL"
+	require.Equal(t, expected, actual, "SanitizeLabelName failed for label (%s)", expected)
+
+	actual = SanitizeLabelName("")
+	expected = "_"
+	require.Equal(t, expected, actual, "SanitizeLabelName failed for the empty label")
 }


### PR DESCRIPTION
SanitizeLabelName does not correctly sanitize label names that:

1. Start with a digit (0-9)
2. Are empty

This commit changes the santization code to catch both of these edge cases and adds new tests to validate it works correctly in them both. In the first case, a leading digit will be replaced with an underscore, and in the latter, the function will return a single underscore.

@roidelapluie 

Signed-off-by: Nick Moore <nicholas.moore@grafana.com>