### PR TITLE
Use http constants instead of string

### DIFF
--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -365,7 +365,7 @@ func TestGetDatacenterShouldReturnError(t *testing.T) {
 		{
 			// Define a handler that will return status 500.
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(500)
+				w.WriteHeader(http.StatusInternalServerError)
 			},
 			errMessage: "Unexpected response code: 500 ()",
 		},

--- a/discovery/xds/xds_test.go
+++ b/discovery/xds/xds_test.go
@@ -74,16 +74,16 @@ func createTestHTTPServer(t *testing.T, responder discoveryResponder) *httptest.
 
 		discoveryRes, err := responder(discoveryReq)
 		if err != nil {
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
 		if discoveryRes == nil {
-			w.WriteHeader(304)
+			w.WriteHeader(http.StatusNotModified)
 			return
 		}
 
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		data, err := protoJSONMarshalOptions.Marshal(discoveryRes)
 		require.NoError(t, err)
 

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -87,7 +87,7 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 func TestClientRetryAfter(t *testing.T) {
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			http.Error(w, longErrMessage, 429)
+			http.Error(w, longErrMessage, http.StatusTooManyRequests)
 		}),
 	)
 	defer server.Close()

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2783,7 +2783,7 @@ func TestRespondSuccess(t *testing.T) {
 		t.Fatalf("Error reading response body: %s", err)
 	}
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("Return code %d expected in success response but got %d", 200, resp.StatusCode)
 	}
 	if h := resp.Header.Get("Content-Type"); h != "application/json" {


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

Using strings as arguments to http package functions is error-prone, so call http package functions in the standard way