### PR TITLE
TSDB: Protect NewOOOCompactionHead from an uninitialized wbl

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1207,6 +1207,10 @@ func (h *Head) truncateOOO(lastWBLFile int, minOOOMmapRef chunks.ChunkDiskMapper
 		}
 	}
 
+	if h.wbl == nil {
+		return nil
+	}
+
 	return h.wbl.Truncate(lastWBLFile)
 }
 

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -276,16 +276,18 @@ type OOOCompactionHead struct {
 // All the above together have a bit of CPU and memory overhead, and can have a bit of impact
 // on the sample append latency. So call NewOOOCompactionHead only right before compaction.
 func NewOOOCompactionHead(head *Head) (*OOOCompactionHead, error) {
-	newWBLFile, err := head.wbl.NextSegmentSync()
-	if err != nil {
-		return nil, err
-	}
-
 	ch := &OOOCompactionHead{
 		chunkRange:  head.chunkRange.Load(),
 		mint:        math.MaxInt64,
 		maxt:        math.MinInt64,
-		lastWBLFile: newWBLFile,
+		lastWBLFile: 0,
+	}
+	if head.wbl != nil {
+		lastWBLFile, err := head.wbl.NextSegmentSync()
+		if err != nil {
+			return nil, err
+		}
+		ch.lastWBLFile = lastWBLFile
 	}
 
 	ch.oooIR = NewOOOHeadIndexReader(head, math.MinInt64, math.MaxInt64)

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -277,11 +277,11 @@ type OOOCompactionHead struct {
 // on the sample append latency. So call NewOOOCompactionHead only right before compaction.
 func NewOOOCompactionHead(head *Head) (*OOOCompactionHead, error) {
 	ch := &OOOCompactionHead{
-		chunkRange:  head.chunkRange.Load(),
-		mint:        math.MaxInt64,
-		maxt:        math.MinInt64,
-		lastWBLFile: 0,
+		chunkRange: head.chunkRange.Load(),
+		mint:       math.MaxInt64,
+		maxt:       math.MinInt64,
 	}
+
 	if head.wbl != nil {
 		lastWBLFile, err := head.wbl.NextSegmentSync()
 		if err != nil {


### PR DESCRIPTION
We're investigating an issue in Mimir where the ooo head was compacted without the wbl being initialized. I'm uncertain about how can we get to this scenario and have not found the root issue yet.

In Prometheus though this may happen naturally if the WAL is disabled. For this reason I'm starting a PR to protect the Compact logic from this.
