### PR TITLE
Set `CounterResetHint` and use in recording rules

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -192,6 +192,8 @@ func (h *FloatHistogram) Scale(factor float64) *FloatHistogram {
 //
 // This method returns a pointer to the receiving histogram for convenience.
 func (h *FloatHistogram) Add(other *FloatHistogram) *FloatHistogram {
+	// TODO(trevorwhitney): If other.CounterResetHint != h.CounterResetHint then
+	// we should return some warning.
 	otherZeroCount := h.reconcileZeroBuckets(other)
 	h.ZeroCount += otherZeroCount
 	h.Count += other.Count
@@ -438,6 +440,15 @@ func (h *FloatHistogram) Compact(maxEmptyBuckets int) *FloatHistogram {
 // information can be read directly from there rather than be detected each time
 // again.
 func (h *FloatHistogram) DetectReset(previous *FloatHistogram) bool {
+	if h.CounterResetHint == CounterReset {
+		return true
+	}
+	if h.CounterResetHint == NotCounterReset {
+		return false
+	}
+	// In all other cases of CounterResetHint, we go on as we would otherwise.
+	// Even in the GaugeHistogram case, we pretend this is a counter histogram
+	// for consistency.
 	if h.Count < previous.Count {
 		return true
 	}

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3155,8 +3155,7 @@ func TestNativeHistogramRate(t *testing.T) {
 	require.Len(t, vector, 1)
 	actualHistogram := vector[0].H
 	expectedHistogram := &histogram.FloatHistogram{
-		// TODO(beorn7): This should be GaugeType. Change it once supported by PromQL.
-		CounterResetHint: histogram.NotCounterReset,
+		CounterResetHint: histogram.GaugeType,
 		Schema:           1,
 		ZeroThreshold:    0.001,
 		ZeroCount:        1. / 15.,
@@ -3200,8 +3199,7 @@ func TestNativeFloatHistogramRate(t *testing.T) {
 	require.Len(t, vector, 1)
 	actualHistogram := vector[0].H
 	expectedHistogram := &histogram.FloatHistogram{
-		// TODO(beorn7): This should be GaugeType. Change it once supported by PromQL.
-		CounterResetHint: histogram.NotCounterReset,
+		CounterResetHint: histogram.GaugeType,
 		Schema:           1,
 		ZeroThreshold:    0.001,
 		ZeroCount:        1. / 15.,

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -187,6 +187,7 @@ func histogramRate(points []Point, isCounter bool) *histogram.FloatHistogram {
 		if curr == nil {
 			return nil // Range contains a mix of histograms and floats.
 		}
+		// TODO(trevorwhitney): Check if isCounter is consistent with curr.CounterResetHint.
 		if !isCounter {
 			continue
 		}
@@ -208,6 +209,8 @@ func histogramRate(points []Point, isCounter bool) *histogram.FloatHistogram {
 			prev = curr
 		}
 	}
+
+	h.CounterResetHint = histogram.GaugeType
 	return h.Compact(0)
 }
 

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -31,7 +31,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
-	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -671,9 +670,6 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 
 			for _, s := range vector {
 				if s.H != nil {
-					// We assume that all native histogram results are gauge histograms.
-					// TODO(codesome): once PromQL can give the counter reset info, remove this assumption.
-					s.H.CounterResetHint = histogram.GaugeType
 					_, err = app.AppendHistogram(0, s.Metric, s.T, nil, s.H)
 				} else {
 					_, err = app.Append(0, s.Metric, s.T, s.V)

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -30,7 +30,6 @@ import (
 	"go.uber.org/goleak"
 	"gopkg.in/yaml.v2"
 
-	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -1393,7 +1392,6 @@ func TestNativeHistogramsInRecordingRules(t *testing.T) {
 	for _, h := range hists[1:] {
 		expHist = expHist.Add(h.ToFloat())
 	}
-	expHist.CounterResetHint = histogram.GaugeType
 
 	it := s.Iterator(nil)
 	require.Equal(t, chunkenc.ValFloatHistogram, it.Next())


### PR DESCRIPTION
Set `CounterResetHint` correctly after histogram rate and addition. Use the correctly set `CounterResetHint ` during rule evaluation.

Utilize `CounterResetHint` in counter reset detection.