### PR TITLE
scrape: fix prometheus_target_scrape_pool_target_limit metric not set on creating scrape pool

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -328,7 +328,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed 
 			options.PassMetadataInContext,
 		)
 	}
-
+	targetScrapePoolTargetLimit.WithLabelValues(sp.config.JobName).Set(float64(sp.config.TargetLimit))
 	return sp, nil
 }
 


### PR DESCRIPTION
fix issue #12001