### PR TITLE
Support include scrape config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,44 @@ func Load(s string, expandExternalLabels bool, logger log.Logger) (*Config, erro
 		return nil, err
 	}
 
+	// if had scrape configs need to include
+	if len(cfg.IncludeScrapeConfigs) > 0 {
+		for _, rf := range cfg.IncludeScrapeConfigs {
+			if !patRulePath.MatchString(rf) {
+				return nil, fmt.Errorf("invalid include file path %q", rf)
+			}
+		}
+
+		for _, includeFiles := range cfg.IncludeScrapeConfigs {
+			files, err := filepath.Glob(includeFiles)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, f := range files {
+				content, err := os.ReadFile(f)
+				if err != nil {
+					return nil, err
+				}
+
+				var includeScrapeConfigs struct {
+					ScrapeConfigs []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
+				}
+				if err := yaml.Unmarshal(content, &includeScrapeConfigs); err != nil {
+					return nil, err
+				}
+
+				cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, includeScrapeConfigs.ScrapeConfigs...)
+
+			}
+		}
+	}
+
+	// when all the scrape configs had loaded from above, process them together
+	if err := cfg.mergeScrapeConfig(); err != nil {
+		return nil, err
+	}
+
 	if !expandExternalLabels {
 		return cfg, nil
 	}
@@ -107,6 +145,7 @@ func LoadFile(filename string, agentMode, expandExternalLabels bool, logger log.
 	if err != nil {
 		return nil, err
 	}
+
 	cfg, err := Load(string(content), expandExternalLabels, logger)
 	if err != nil {
 		return nil, fmt.Errorf("parsing YAML file %s: %w", filename, err)
@@ -216,15 +255,15 @@ var (
 
 // Config is the top-level configuration for Prometheus's config files.
 type Config struct {
-	GlobalConfig   GlobalConfig    `yaml:"global"`
-	AlertingConfig AlertingConfig  `yaml:"alerting,omitempty"`
-	RuleFiles      []string        `yaml:"rule_files,omitempty"`
-	ScrapeConfigs  []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
-	StorageConfig  StorageConfig   `yaml:"storage,omitempty"`
-	TracingConfig  TracingConfig   `yaml:"tracing,omitempty"`
-
-	RemoteWriteConfigs []*RemoteWriteConfig `yaml:"remote_write,omitempty"`
-	RemoteReadConfigs  []*RemoteReadConfig  `yaml:"remote_read,omitempty"`
+	GlobalConfig         GlobalConfig         `yaml:"global"`
+	AlertingConfig       AlertingConfig       `yaml:"alerting,omitempty"`
+	RuleFiles            []string             `yaml:"rule_files,omitempty"`
+	ScrapeConfigs        []*ScrapeConfig      `yaml:"scrape_configs,omitempty"`
+	StorageConfig        StorageConfig        `yaml:"storage,omitempty"`
+	TracingConfig        TracingConfig        `yaml:"tracing,omitempty"`
+	IncludeScrapeConfigs []string             `yaml:"include_scrape_configs"`
+	RemoteWriteConfigs   []*RemoteWriteConfig `yaml:"remote_write,omitempty"`
+	RemoteReadConfigs    []*RemoteReadConfig  `yaml:"remote_read,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.
@@ -254,28 +293,9 @@ func (c Config) String() string {
 	return string(b)
 }
 
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	*c = DefaultConfig
-	// We want to set c to the defaults and then overwrite it with the input.
-	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
-	// again, we have to hide it using a type indirection.
-	type plain Config
-	if err := unmarshal((*plain)(c)); err != nil {
-		return err
-	}
-
-	// If a global block was open but empty the default global config is overwritten.
-	// We have to restore it here.
-	if c.GlobalConfig.isZero() {
-		c.GlobalConfig = DefaultGlobalConfig
-	}
-
-	for _, rf := range c.RuleFiles {
-		if !patRulePath.MatchString(rf) {
-			return fmt.Errorf("invalid rule file path %q", rf)
-		}
-	}
+// separate ScrapeConfigs handler from Config UnmarshalYAML function.
+// used by include scrape config content merge with origin file scrape config and process together
+func (c *Config) mergeScrapeConfig() error {
 	// Do global overrides and validate unique names.
 	jobNames := map[string]struct{}{}
 	for _, scfg := range c.ScrapeConfigs {
@@ -302,6 +322,31 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			return fmt.Errorf("found multiple scrape configs with job name %q", scfg.JobName)
 		}
 		jobNames[scfg.JobName] = struct{}{}
+	}
+	return nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultConfig
+	// We want to set c to the defaults and then overwrite it with the input.
+	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
+	// again, we have to hide it using a type indirection.
+	type plain Config
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+
+	// If a global block was open but empty the default global config is overwritten.
+	// We have to restore it here.
+	if c.GlobalConfig.isZero() {
+		c.GlobalConfig = DefaultGlobalConfig
+	}
+
+	for _, rf := range c.RuleFiles {
+		if !patRulePath.MatchString(rf) {
+			return fmt.Errorf("invalid rule file path %q", rf)
+		}
 	}
 	rwNames := map[string]struct{}{}
 	for _, rwcfg := range c.RemoteWriteConfigs {

--- a/config/testdata/include_configs.yml
+++ b/config/testdata/include_configs.yml
@@ -1,0 +1,10 @@
+#example, same as the scrape_configs section.
+scrape_configs:
+  - job_name: include_job
+    static_configs:
+      - targets:
+          - localhost:9090
+          - localhost:9191
+        labels:
+          name: ljq
+          env: dev

--- a/config/testdata/roundtrip.good.yml
+++ b/config/testdata/roundtrip.good.yml
@@ -15,7 +15,8 @@ alerting:
             - 1.2.3.4:9093
             - 1.2.3.5:9093
             - 1.2.3.6:9093
-
+include_scrape_configs:
+  - include_configs.yml
 scrape_configs:
   - job_name: foo
     static_configs:
@@ -27,7 +28,6 @@ scrape_configs:
           your: label
 
   - job_name: bar
-
     azure_sd_configs:
       - environment: AzurePublicCloud
         authentication_method: OAuth


### PR DESCRIPTION
# Purpose

used the separate scrape config instead of writes all scrape in one yaml config. can make more well in concise and well in manage

# Syntax
the syntax is same as `rule` section
```shell
include_scrape_configs:
  - include_configs.yml
```

the `include_configs.yml` syntax is same as `scrape_configs` section
```shell
#example, same as the scrape_configs section
scrape_configs:
  - job_name: include_job
    static_configs:
      - targets:
          - localhost:9090
          - localhost:9191
        labels:
          name: ljq
          env: dev

```