### PR TITLE
Feat: metrics for head_chunks & wal folders

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -323,6 +323,7 @@ type headMetrics struct {
 	mmapChunkCorruptionTotal  prometheus.Counter
 	snapshotReplayErrorTotal  prometheus.Counter // Will be either 0 or 1.
 	oooHistogram              prometheus.Histogram
+	headChunksStorageSize     prometheus.GaugeFunc
 }
 
 const (
@@ -447,6 +448,17 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 				60 * 60 * 12, // 12h
 			},
 		}),
+		headChunksStorageSize: prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "prometheus_tsdb_head_chunks_storage_size_bytes",
+			Help: "Size of the chunks_head directory.",
+		}, func() float64 {
+			val, err := h.chunkDiskMapper.Size()
+			if err != nil {
+				level.Error(h.logger).Log("msg", "Failed to calculate size of \"chunks_head\" dir",
+					"err", err.Error())
+			}
+			return float64(val)
+		}),
 	}
 
 	if r != nil {
@@ -476,6 +488,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.checkpointCreationTotal,
 			m.mmapChunkCorruptionTotal,
 			m.snapshotReplayErrorTotal,
+			m.headChunksStorageSize,
 			// Metrics bound to functions and not needed in tests
 			// can be created and registered on the spot.
 			prometheus.NewGaugeFunc(prometheus.GaugeOpts{

--- a/tsdb/wlog/wlog.go
+++ b/tsdb/wlog/wlog.go
@@ -199,9 +199,10 @@ type wlMetrics struct {
 	truncateTotal   prometheus.Counter
 	currentSegment  prometheus.Gauge
 	writesFailed    prometheus.Counter
+	walFileSize     prometheus.GaugeFunc
 }
 
-func newWLMetrics(r prometheus.Registerer) *wlMetrics {
+func newWLMetrics(w *WL, r prometheus.Registerer) *wlMetrics {
 	m := &wlMetrics{}
 
 	m.fsyncDuration = prometheus.NewSummary(prometheus.SummaryOpts{
@@ -233,6 +234,19 @@ func newWLMetrics(r prometheus.Registerer) *wlMetrics {
 		Name: "writes_failed_total",
 		Help: "Total number of write log writes that failed.",
 	})
+	m.walFileSize = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "storage_size_bytes",
+		Help: "Size of the WAL directory.",
+	}, func() float64 {
+		w.mtx.RLock()
+		defer w.mtx.RUnlock()
+		val, err := w.Size()
+		if err != nil {
+			level.Error(w.logger).Log("msg", "Failed to calculate size of \"wal\" dir",
+				"err", err.Error())
+		}
+		return float64(val)
+	})
 
 	if r != nil {
 		r.MustRegister(
@@ -243,6 +257,7 @@ func newWLMetrics(r prometheus.Registerer) *wlMetrics {
 			m.truncateTotal,
 			m.currentSegment,
 			m.writesFailed,
+			m.walFileSize,
 		)
 	}
 
@@ -279,7 +294,7 @@ func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSi
 	if filepath.Base(dir) == WblDirName {
 		prefix = "prometheus_tsdb_out_of_order_wbl_"
 	}
-	w.metrics = newWLMetrics(prometheus.WrapRegistererWithPrefix(prefix, reg))
+	w.metrics = newWLMetrics(w, prometheus.WrapRegistererWithPrefix(prefix, reg))
 
 	_, last, err := Segments(w.Dir())
 	if err != nil {

--- a/tsdb/wlog/wlog.go
+++ b/tsdb/wlog/wlog.go
@@ -236,10 +236,8 @@ func newWLMetrics(w *WL, r prometheus.Registerer) *wlMetrics {
 	})
 	m.walFileSize = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "storage_size_bytes",
-		Help: "Size of the WAL directory.",
+		Help: "Size of the write log directory.",
 	}, func() float64 {
-		w.mtx.RLock()
-		defer w.mtx.RUnlock()
 		val, err := w.Size()
 		if err != nil {
 			level.Error(w.logger).Log("msg", "Failed to calculate size of \"wal\" dir",

--- a/tsdb/wlog/wlog_test.go
+++ b/tsdb/wlog/wlog_test.go
@@ -557,3 +557,20 @@ func BenchmarkWAL_Log(b *testing.B) {
 		})
 	}
 }
+
+func TestWALStorageSizeMetric(t *testing.T) {
+	const (
+		segmentSize = pageSize
+		recordSize  = (pageSize / 2) - recordHeaderSize
+	)
+
+	dirPath := t.TempDir()
+
+	w, err := NewSize(nil, nil, dirPath, segmentSize, false)
+	require.NoError(t, err)
+
+	buf := make([]byte, recordSize)
+	require.NoError(t, w.Log(buf))
+	require.Greater(t, client_testutil.ToFloat64(w.metrics.walFileSize), 0.0)
+	require.NoError(t, w.Close())
+}

--- a/tsdb/wlog/wlog_test.go
+++ b/tsdb/wlog/wlog_test.go
@@ -557,20 +557,3 @@ func BenchmarkWAL_Log(b *testing.B) {
 		})
 	}
 }
-
-func TestWALStorageSizeMetric(t *testing.T) {
-	const (
-		segmentSize = pageSize
-		recordSize  = (pageSize / 2) - recordHeaderSize
-	)
-
-	dirPath := t.TempDir()
-
-	w, err := NewSize(nil, nil, dirPath, segmentSize, false)
-	require.NoError(t, err)
-
-	buf := make([]byte, recordSize)
-	require.NoError(t, w.Log(buf))
-	require.Greater(t, client_testutil.ToFloat64(w.metrics.walFileSize), 0.0)
-	require.NoError(t, w.Close())
-}


### PR DESCRIPTION
## Explanation
Implemented storage metrics for the head_chunks & wal folders in prometheus server using gauge functions to monitor.

## Related Issue
Closes #11478 

## Proposed Changes
Two new metrics added to monitor the storage of head_chunks & wal folders.
`prometheus_tsdb_head_chunks_storage_size_bytes`
`prometheus_tsdb_wal_storage_size_bytes`
Also added unit test case for the above mentioned metrics.

### Proof Manifests
head_chunks storage size from `/metrics` endpoint.
```html
# HELP prometheus_tsdb_head_chunks_storage_size_bytes Size of the chunks_head directory.
# TYPE prometheus_tsdb_head_chunks_storage_size_bytes gauge
prometheus_tsdb_head_chunks_storage_size_bytes 292707
```
wal storage size from `/metrics` endpoint.
```html
# HELP prometheus_tsdb_wal_storage_size_bytes Size of the WAL directory.
# TYPE prometheus_tsdb_wal_storage_size_bytes gauge
prometheus_tsdb_wal_storage_size_bytes 2.331617e+06
```
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
