### PR TITLE
rules: two places need to call EmptyLabels

### DIFF
--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -919,8 +919,8 @@ func TestAlertingEvalWithOrigin(t *testing.T) {
 		time.Second,
 		time.Minute,
 		lbs,
-		nil,
-		nil,
+		labels.EmptyLabels(),
+		labels.EmptyLabels(),
 		"",
 		true, log.NewNopLogger(),
 	)

--- a/rules/origin_test.go
+++ b/rules/origin_test.go
@@ -29,7 +29,7 @@ import (
 type unknownRule struct{}
 
 func (u unknownRule) Name() string          { return "" }
-func (u unknownRule) Labels() labels.Labels { return nil }
+func (u unknownRule) Labels() labels.Labels { return labels.EmptyLabels() }
 func (u unknownRule) Eval(ctx context.Context, time time.Time, queryFunc QueryFunc, url *url.URL, i int) (promql.Vector, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Can't assume nil is a valid value.  For compatibility with #10991.
