### PR TITLE
Optimise sync of scraping targets

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -1250,8 +1250,11 @@ func checkTargetGroupsForAlertmanager(targetGroups []*targetgroup.Group, amcfg *
 }
 
 func checkTargetGroupsForScrapeConfig(targetGroups []*targetgroup.Group, scfg *config.ScrapeConfig) error {
+	var targets []*scrape.Target
+	lb := labels.NewBuilder(labels.EmptyLabels())
 	for _, tg := range targetGroups {
-		_, failures := scrape.TargetsFromGroup(tg, scfg, false)
+		var failures []error
+		targets, failures = scrape.TargetsFromGroup(tg, scfg, false, targets, lb)
 		if len(failures) > 0 {
 			first := failures[0]
 			return first

--- a/cmd/promtool/sd.go
+++ b/cmd/promtool/sd.go
@@ -109,22 +109,22 @@ outerLoop:
 
 func getSDCheckResult(targetGroups []*targetgroup.Group, scrapeConfig *config.ScrapeConfig, noDefaultScrapePort bool) []sdCheckResult {
 	sdCheckResults := []sdCheckResult{}
+	lb := labels.NewBuilder(labels.EmptyLabels())
 	for _, targetGroup := range targetGroups {
 		for _, target := range targetGroup.Targets {
-			labelSlice := make([]labels.Label, 0, len(target)+len(targetGroup.Labels))
+			lb.Reset(labels.EmptyLabels())
 
 			for name, value := range target {
-				labelSlice = append(labelSlice, labels.Label{Name: string(name), Value: string(value)})
+				lb.Set(string(name), string(value))
 			}
 
 			for name, value := range targetGroup.Labels {
 				if _, ok := target[name]; !ok {
-					labelSlice = append(labelSlice, labels.Label{Name: string(name), Value: string(value)})
+					lb.Set(string(name), string(value))
 				}
 			}
 
-			targetLabels := labels.New(labelSlice...)
-			res, orig, err := scrape.PopulateLabels(targetLabels, scrapeConfig, noDefaultScrapePort)
+			res, orig, err := scrape.PopulateLabels(lb, scrapeConfig, noDefaultScrapePort)
 			result := sdCheckResult{
 				DiscoveredLabels: orig,
 				Labels:           res,

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -530,6 +530,43 @@ func (b *Builder) Set(n, v string) *Builder {
 	return b
 }
 
+func (b *Builder) Get(n string) string {
+	for _, d := range b.del {
+		if d == n {
+			return ""
+		}
+	}
+	for _, a := range b.add {
+		if a.Name == n {
+			return a.Value
+		}
+	}
+	return b.base.Get(n)
+}
+
+// Range calls f on each label in the Builder.
+// If f calls Set or Del on b then this may affect what callbacks subsequently happen.
+func (b *Builder) Range(f func(l Label)) {
+	origAdd, origDel := b.add, b.del
+	b.base.Range(func(l Label) {
+		if !slices.Contains(origDel, l.Name) && !contains(origAdd, l.Name) {
+			f(l)
+		}
+	})
+	for _, a := range origAdd {
+		f(a)
+	}
+}
+
+func contains(s []Label, n string) bool {
+	for _, a := range s {
+		if a.Name == n {
+			return true
+		}
+	}
+	return false
+}
+
 // Labels returns the labels from the builder, adding them to res if non-nil.
 // Argument res can be the same as b.base, if caller wants to overwrite that slice.
 // If no modifications were made, the original labels are returned.
@@ -545,20 +582,12 @@ func (b *Builder) Labels(res Labels) Labels {
 	} else {
 		res = res[:0]
 	}
-Outer:
 	// Justification that res can be the same slice as base: in this loop
 	// we move forward through base, and either skip an element or assign
 	// it to res at its current position or an earlier position.
 	for _, l := range b.base {
-		for _, n := range b.del {
-			if l.Name == n {
-				continue Outer
-			}
-		}
-		for _, la := range b.add {
-			if l.Name == la.Name {
-				continue Outer
-			}
+		if slices.Contains(b.del, l.Name) || contains(b.add, l.Name) {
+			continue
 		}
 		res = append(res, l)
 	}

--- a/model/labels/labels_string.go
+++ b/model/labels/labels_string.go
@@ -587,6 +587,41 @@ func (b *Builder) Set(n, v string) *Builder {
 	return b
 }
 
+func (b *Builder) Get(n string) string {
+	if slices.Contains(b.del, n) {
+		return ""
+	}
+	for _, a := range b.add {
+		if a.Name == n {
+			return a.Value
+		}
+	}
+	return b.base.Get(n)
+}
+
+// Range calls f on each label in the Builder.
+// If f calls Set or Del on b then this may affect what callbacks subsequently happen.
+func (b *Builder) Range(f func(l Label)) {
+	origAdd, origDel := b.add, b.del
+	b.base.Range(func(l Label) {
+		if !slices.Contains(origDel, l.Name) && !contains(origAdd, l.Name) {
+			f(l)
+		}
+	})
+	for _, a := range origAdd {
+		f(a)
+	}
+}
+
+func contains(s []Label, n string) bool {
+	for _, a := range s {
+		if a.Name == n {
+			return true
+		}
+	}
+	return false
+}
+
 // Labels returns the labels from the builder, adding them to res if non-nil.
 // Argument res can be the same as b.base, if caller wants to overwrite that slice.
 // If no modifications were made, the original labels are returned.

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -443,7 +443,7 @@ func TestPopulateLabels(t *testing.T) {
 	}
 }
 
-func loadConfiguration(t *testing.T, c string) *config.Config {
+func loadConfiguration(t testing.TB, c string) *config.Config {
 	t.Helper()
 
 	cfg := &config.Config{}

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -431,7 +431,7 @@ func TestPopulateLabels(t *testing.T) {
 	for _, c := range cases {
 		in := c.in.Copy()
 
-		res, orig, err := PopulateLabels(c.in, c.cfg, c.noDefaultPort)
+		res, orig, err := PopulateLabels(labels.NewBuilder(c.in), c.cfg, c.noDefaultPort)
 		if c.err != "" {
 			require.EqualError(t, err, c.err)
 		} else {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -490,9 +490,11 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 
 	sp.targetMtx.Lock()
 	var all []*Target
+	var targets []*Target
+	lb := labels.NewBuilder(labels.EmptyLabels())
 	sp.droppedTargets = []*Target{}
 	for _, tg := range tgs {
-		targets, failures := TargetsFromGroup(tg, sp.config, sp.noDefaultPort)
+		targets, failures := TargetsFromGroup(tg, sp.config, sp.noDefaultPort, targets, lb)
 		for _, err := range failures {
 			level.Error(sp.logger).Log("msg", "Creating target failed", "err", err)
 		}

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -482,11 +482,10 @@ func PopulateLabels(lb *labels.Builder, cfg *config.ScrapeConfig, noDefaultPort 
 }
 
 // TargetsFromGroup builds targets based on the given TargetGroup and config.
-func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig, noDefaultPort bool) ([]*Target, []error) {
-	targets := make([]*Target, 0, len(tg.Targets))
+func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig, noDefaultPort bool, targets []*Target, lb *labels.Builder) ([]*Target, []error) {
+	targets = targets[:0]
 	failures := []error{}
 
-	lb := labels.NewBuilder(labels.EmptyLabels())
 	for i, tlset := range tg.Targets {
 		lb.Reset(labels.EmptyLabels())
 

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -386,3 +386,91 @@ func TestTargetsFromGroup(t *testing.T) {
 		t.Fatalf("Expected error %s, got %s", expectedError, failures[0])
 	}
 }
+
+func BenchmarkTargetsFromGroup(b *testing.B) {
+	// Simulate Kubernetes service-discovery and use subset of rules from typical Prometheus config.
+	cfgText := `
+scrape_configs:
+  - job_name: job1
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    relabel_configs:
+    - source_labels: [__meta_kubernetes_pod_container_port_name]
+      separator: ;
+      regex: .*-metrics
+      replacement: $1
+      action: keep
+    - source_labels: [__meta_kubernetes_pod_phase]
+      separator: ;
+      regex: Succeeded|Failed
+      replacement: $1
+      action: drop
+    - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_name]
+      separator: /
+      regex: (.*)
+      target_label: job
+      replacement: $1
+      action: replace
+    - source_labels: [__meta_kubernetes_namespace]
+      separator: ;
+      regex: (.*)
+      target_label: namespace
+      replacement: $1
+      action: replace
+    - source_labels: [__meta_kubernetes_pod_name]
+      separator: ;
+      regex: (.*)
+      target_label: pod
+      replacement: $1
+      action: replace
+    - source_labels: [__meta_kubernetes_pod_container_name]
+      separator: ;
+      regex: (.*)
+      target_label: container
+      replacement: $1
+      action: replace
+    - source_labels: [__meta_kubernetes_pod_name, __meta_kubernetes_pod_container_name,
+        __meta_kubernetes_pod_container_port_name]
+      separator: ':'
+      regex: (.*)
+      target_label: instance
+      replacement: $1
+      action: replace
+    - separator: ;
+      regex: (.*)
+      target_label: cluster
+      replacement: dev-us-central-0
+      action: replace
+`
+	config := loadConfiguration(b, cfgText)
+	for _, nTargets := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("%d_targets", nTargets), func(b *testing.B) {
+			targets := []model.LabelSet{}
+			for i := 0; i < nTargets; i++ {
+				labels := model.LabelSet{
+					model.AddressLabel:                            model.LabelValue(fmt.Sprintf("localhost:%d", i)),
+					"__meta_kubernetes_namespace":                 "some_namespace",
+					"__meta_kubernetes_pod_container_name":        "some_container",
+					"__meta_kubernetes_pod_container_port_name":   "http-metrics",
+					"__meta_kubernetes_pod_container_port_number": "80",
+					"__meta_kubernetes_pod_label_name":            "some_name",
+					"__meta_kubernetes_pod_name":                  "some_pod",
+					"__meta_kubernetes_pod_phase":                 "Running",
+				}
+				// Add some more labels, because Kubernetes SD generates a lot
+				for i := 0; i < 10; i++ {
+					labels[model.LabelName(fmt.Sprintf("__meta_kubernetes_pod_label_extra%d", i))] = "a_label_abcdefgh"
+					labels[model.LabelName(fmt.Sprintf("__meta_kubernetes_pod_labelpresent_extra%d", i))] = "true"
+				}
+				targets = append(targets, labels)
+			}
+			group := &targetgroup.Group{Targets: targets}
+			for i := 0; i < b.N; i++ {
+				targets, _ := TargetsFromGroup(group, config.ScrapeConfigs[0], false)
+				if len(targets) != nTargets {
+					b.Fatalf("Expected %d targets, got %d", nTargets, len(targets))
+				}
+			}
+		})
+	}
+}

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -375,7 +375,8 @@ func TestTargetsFromGroup(t *testing.T) {
 		ScrapeTimeout:  model.Duration(10 * time.Second),
 		ScrapeInterval: model.Duration(1 * time.Minute),
 	}
-	targets, failures := TargetsFromGroup(&targetgroup.Group{Targets: []model.LabelSet{{}, {model.AddressLabel: "localhost:9090"}}}, &cfg, false)
+	lb := labels.NewBuilder(labels.EmptyLabels())
+	targets, failures := TargetsFromGroup(&targetgroup.Group{Targets: []model.LabelSet{{}, {model.AddressLabel: "localhost:9090"}}}, &cfg, false, nil, lb)
 	if len(targets) != 1 {
 		t.Fatalf("Expected 1 target, got %v", len(targets))
 	}
@@ -464,9 +465,11 @@ scrape_configs:
 				}
 				targets = append(targets, labels)
 			}
+			var tgets []*Target
+			lb := labels.NewBuilder(labels.EmptyLabels())
 			group := &targetgroup.Group{Targets: targets}
 			for i := 0; i < b.N; i++ {
-				targets, _ := TargetsFromGroup(group, config.ScrapeConfigs[0], false)
+				tgets, _ = TargetsFromGroup(group, config.ScrapeConfigs[0], false, tgets, lb)
 				if len(targets) != nTargets {
 					b.Fatalf("Expected %d targets, got %d", nTargets, len(targets))
 				}


### PR DESCRIPTION
Scraping targets are synced by creating the full set, then adding/removing any which have changed.
This PR speeds up the process of creating the full set.

I added a benchmark for `TargetsFromGroup`; it uses configuration from a typical Kubernetes SD.

The crux of the change is to do relabeling inside `labels.Builder` instead of converting to `labels.Labels` and back again for every rule.  The change is broken into several commits for easier review.

This is a breaking change to `scrape.PopulateLabels()`, but `relabel.Process` is left as-is, with a new `relabel.ProcessBuilder` option.

Benchmarks, first with the slice version of `labels.Labels`:
```
                               │    sec/op    │    sec/op     vs base               │
TargetsFromGroup/1_targets-4     51.35µ ± 14%   34.24µ ± 48%  -33.31% (p=0.032 n=5)
TargetsFromGroup/10_targets-4    515.8µ ± 37%   318.0µ ± 14%  -38.35% (p=0.008 n=5)
TargetsFromGroup/100_targets-4   5.890m ± 44%   3.204m ± 11%  -45.61% (p=0.008 n=5)

                               │     B/op      │     B/op      vs base               │
TargetsFromGroup/1_targets-4     10.599Ki ± 1%   3.734Ki ± 0%  -64.77% (p=0.008 n=5)
TargetsFromGroup/10_targets-4    105.94Ki ± 0%   37.60Ki ± 1%  -64.50% (p=0.008 n=5)
TargetsFromGroup/100_targets-4   1056.1Ki ± 0%   374.5Ki ± 0%  -64.54% (p=0.008 n=5)

                               │  allocs/op   │  allocs/op   vs base               │
TargetsFromGroup/1_targets-4       65.00 ± 0%    43.00 ± 0%  -33.85% (p=0.008 n=5)
TargetsFromGroup/10_targets-4      641.0 ± 0%    430.0 ± 0%  -32.92% (p=0.008 n=5)
TargetsFromGroup/100_targets-4    6.419k ± 0%   4.310k ± 0%  -32.86% (p=0.008 n=5)
```

and then with `-tags stringlabels`:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/scrape
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                               │    sec/op    │    sec/op     vs base               │
TargetsFromGroup/1_targets-4     62.81µ ± 17%   32.47µ ± 14%  -48.31% (p=0.008 n=5)
TargetsFromGroup/10_targets-4    560.6µ ± 29%   333.0µ ± 11%  -40.59% (p=0.008 n=5)
TargetsFromGroup/100_targets-4   5.696m ± 22%   3.234m ±  7%  -43.22% (p=0.008 n=5)

                               │     B/op      │     B/op      vs base               │
TargetsFromGroup/1_targets-4     19.099Ki ± 0%   4.365Ki ± 1%  -77.14% (p=0.008 n=5)
TargetsFromGroup/10_targets-4    191.46Ki ± 0%   43.55Ki ± 1%  -77.26% (p=0.008 n=5)
TargetsFromGroup/100_targets-4   1907.5Ki ± 0%   435.2Ki ± 1%  -77.18% (p=0.008 n=5)

                               │  allocs/op  │  allocs/op   vs base               │
TargetsFromGroup/1_targets-4      61.00 ± 0%    43.00 ± 0%  -29.51% (p=0.008 n=5)
TargetsFromGroup/10_targets-4     602.0 ± 0%    430.0 ± 0%  -28.57% (p=0.008 n=5)
TargetsFromGroup/100_targets-4   6.025k ± 0%   4.309k ± 0%  -28.48% (p=0.008 n=5)
```
