### PR TITLE
histogram: Prioritize CounterResetHint to detect resets

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -438,6 +438,14 @@ func (h *FloatHistogram) Compact(maxEmptyBuckets int) *FloatHistogram {
 // information can be read directly from there rather than be detected each time
 // again.
 func (h *FloatHistogram) DetectReset(previous *FloatHistogram) bool {
+	// Use the reset hint if it's set
+	if h.CounterResetHint == CounterReset {
+		return true
+	}
+	if h.CounterResetHint == NotCounterReset {
+		return false
+	}
+
 	if h.Count < previous.Count {
 		return true
 	}

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -679,6 +679,24 @@ func TestFloatHistogramDetectReset(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"counter reset hint set to no reset",
+			nil,
+			&FloatHistogram{
+				CounterResetHint: NotCounterReset,
+				// remaining fields should not be relevant.
+			},
+			false,
+		},
+		{
+			"counter reset hint set to reset",
+			nil,
+			&FloatHistogram{
+				CounterResetHint: CounterReset,
+				// remaining fields should not be relevant.
+			},
+			true,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
The tsdb now has support for detecting resets for histogram samples at scrape time. The result of the detection is stored as a hint in the scraped sample.

This commit prioritizes the use of these hints to reduce the time it takes to calculate rates on histograms.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
