### PR TITLE
labels-as-strings: size buffer for added labels

### DIFF
--- a/model/labels/labels_string.go
+++ b/model/labels/labels_string.go
@@ -599,7 +599,8 @@ func (b *Builder) Labels(res Labels) Labels {
 	sort.Strings(b.del)
 	a, d := 0, 0
 
-	buf := make([]byte, 0, len(b.base.data)) // TODO: see if we can re-use the buffer from res.
+	bufSize := len(b.base.data) + labelsSize(b.add)
+	buf := make([]byte, 0, bufSize) // TODO: see if we can re-use the buffer from res.
 	for pos := 0; pos < len(b.base.data); {
 		oldPos := pos
 		var lName string


### PR DESCRIPTION
(This code is only used when Prometheus is built with `-tags stringlabels`.)

This makes the buffer the correct size for the common case that labels have only been added. It will be too large for the case that labels are changed, but the current buffer resize logic in `appendLabelTo` doubles the buffer, so a small over-estimate is better.
