### PR TITLE
feat: health and readiness check of prometheus server in CLI (promtool)

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -398,14 +398,18 @@ func CheckServerHealth(url string) error {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "  FAILED:", err)
 		return err
+	} else if healthCheckResp.StatusCode != 200 {
+		return fmt.Errorf("health check failed: URL=%s, status=%d", url, healthCheckResp.StatusCode)
 	}
+
 	healthCheckBody, err := io.ReadAll(healthCheckResp.Body)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "  FAILED:", err)
 		return err
 	}
 
-	fmt.Printf("  SUCCESS: %v", string(healthCheckBody))
+	fmt.Fprintf(os.Stderr, "  SUCCESS: %v", string(healthCheckBody))
+	fmt.Println()
 	return nil
 }
 
@@ -419,13 +423,16 @@ func CheckServerReadiness(url string) error {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "  FAILED:", err)
 		return err
+	} else if readinessCheckResp.StatusCode != 200 {
+		return fmt.Errorf("readiness check failed: URL=%s, status=%d", url, readinessCheckResp.StatusCode)
 	}
 	readinessCheckBody, err := io.ReadAll(readinessCheckResp.Body)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "  FAILED:", err)
 		return err
 	}
-	fmt.Printf("  SUCCESS: %v", string(readinessCheckBody))
+	fmt.Fprintf(os.Stderr, "  SUCCESS: %v", string(readinessCheckBody))
+	fmt.Println()
 	return nil
 }
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -130,6 +130,54 @@ Check if the web config files are valid or not.
 
 
 
+##### `promtool check health`
+
+Check the health of a Prometheus server
+
+
+
+###### Flags
+
+| Flag | Description |
+| --- | --- |
+| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file for promtool to connect to Prometheus. |
+
+
+
+
+###### Arguments
+
+| Argument | Description |
+| --- | --- |
+| server | The URL of the Prometheus server to check (e.g. http://localhost:9090) |
+
+
+
+
+##### `promtool check ready`
+
+Check the readiness of a Prometheus server
+
+
+
+###### Flags
+
+| Flag | Description |
+| --- | --- |
+| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file for promtool to connect to Prometheus. |
+
+
+
+
+###### Arguments
+
+| Argument | Description |
+| --- | --- |
+| server | The URL of the Prometheus server to check (e.g. http://localhost:9090) |
+
+
+
+
 ##### `promtool check rules`
 
 Check if the rule files are valid or not.

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -58,6 +58,7 @@ Check the resources for validity.
 
 | Flag | Description |
 | --- | --- |
+| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file for promtool to connect to Prometheus. |
 | <code class="text-nowrap">--extended</code> | Print extended information related to the cardinality of the metrics. |
 
 
@@ -130,18 +131,9 @@ Check if the web config files are valid or not.
 
 
 
-##### `promtool check health`
+##### `promtool check healthy`
 
-Check the health of a Prometheus server
-
-
-
-###### Flags
-
-| Flag | Description |
-| --- | --- |
-| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file for promtool to connect to Prometheus. |
-
+Check if the Prometheus server is healthy.
 
 
 
@@ -156,16 +148,7 @@ Check the health of a Prometheus server
 
 ##### `promtool check ready`
 
-Check the readiness of a Prometheus server
-
-
-
-###### Flags
-
-| Flag | Description |
-| --- | --- |
-| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file for promtool to connect to Prometheus. |
-
+Check if the Prometheus server is ready.
 
 
 


### PR DESCRIPTION
### Explanation
The proposal is to add new subcommands to `promtool`,  that allow users to check the health and readiness status of a local Prometheus server. This approach is similar to what Traefik, another software project, does by adding a healthcheck command to its CLI to test if the local server is up. The proposed subcommands would internally call the existing `/-/healthy` and `/-/ready` endpoints on the local server to perform the checks

### Related Issue 
Closes #12000 

### Proposed Changes
Two new subcommands to check command 
- healthy
- ready

CheckServerHealth() & CheckServerReadiness() takes URL as input, and if URL is not provided by the user then it will be default URL i.e `http://localhost:9090`

**Usage**
`./promtool check healthy`
`./promtool check ready`
or
`./promtool check healthy http://localhost:9090`
`./promtool check ready http://localhost:9090`

### Proof Manifests 
Since there are existing testcases (`web/web_test.go`) covering api endpoints  `/-/ healthy `and` /-/ready`, removed the redundant from this new subcommands


```
$ ./promtool check healthy
  SUCCESS: Prometheus Server is Healthy.

$ ./promtool check ready 
  SUCCESS: Prometheus Server is Ready.
```

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
