### PR TITLE
promql: disable some slow cases in TestConcurrentRangeQueries

### DIFF
--- a/promql/promql_test.go
+++ b/promql/promql_test.go
@@ -73,6 +73,9 @@ func TestConcurrentRangeQueries(t *testing.T) {
 		if strings.Contains(c.expr, "count_values") && c.steps > 10 {
 			continue // This test is too big to run with -race.
 		}
+		if strings.Contains(c.expr, "[1d]") && c.steps > 100 {
+			continue // This test is too slow.
+		}
 		<-sem
 		g.Go(func() error {
 			defer func() {


### PR DESCRIPTION
`TestConcurrentRangeQueries` runs many queries, up to 4 at the same time, to try to expose any race conditions.
This change stops four of them from running with a thousand or more steps:

    holt_winters(a_X[1d], 0.3, 0.3)
    changes(a_X[1d])
    rate(a_X[1d])
    absent_over_time(a_X[1d])

Particularly when the test runs with `-race` in CI, this reduces the time and resources required.
