### PR TITLE
remote: Convert to RecoverableError using errors.As

### DIFF
--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -109,10 +109,11 @@ func TestClientRetryAfter(t *testing.T) {
 		RetryOnRateLimit: false,
 	}
 
+	var recErr RecoverableError
+
 	c := getClient(conf)
 	err = c.Store(context.Background(), []byte{})
-	_, ok := err.(RecoverableError)
-	require.False(t, ok, "Recoverable error not expected.")
+	require.False(t, errors.As(err, &recErr), "Recoverable error not expected.")
 
 	conf = &ClientConfig{
 		URL:              &config_util.URL{URL: serverURL},
@@ -122,8 +123,7 @@ func TestClientRetryAfter(t *testing.T) {
 
 	c = getClient(conf)
 	err = c.Store(context.Background(), []byte{})
-	_, ok = err.(RecoverableError)
-	require.True(t, ok, "Recoverable error was expected.")
+	require.True(t, errors.As(err, &recErr), "Recoverable error was expected.")
 }
 
 func TestRetryAfterDuration(t *testing.T) {

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1569,8 +1569,8 @@ func sendWriteRequestWithBackoff(ctx context.Context, cfg config.QueueConfig, l 
 		}
 
 		// If the error is unrecoverable, we should not retry.
-		backoffErr, ok := err.(RecoverableError)
-		if !ok {
+		var backoffErr RecoverableError
+		if !errors.As(err, &backoffErr) {
 			return err
 		}
 


### PR DESCRIPTION
In storage/remote, try converting to RecoverableError using [`errors.As`](https://pkg.go.dev/errors#As), instead of through direct casting.

I figure using `errors.As`/`errors.Is` should be preferred to asserting error types directly, in the face of potentially wrapped errors.