### PR TITLE
feat(promtool): add `check server` command for prom API healthy/ready

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -855,7 +855,7 @@ func CheckServer(url *url.URL, roundTripper http.RoundTripper, endpoint string) 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url.JoinPath("-", endpoint).String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/-/%s", url.String(), endpoint), nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating http request: ", err)
 		return failureExitCode

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -42,6 +42,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"gopkg.in/yaml.v2"
 
 	dto "github.com/prometheus/client_model/go"
@@ -874,7 +876,9 @@ func CheckServer(url *url.URL, roundTripper http.RoundTripper, endpoint string) 
 		return failureExitCode
 	}
 
-	expectedResponse := fmt.Sprintf(promAPIExpectedResponse, strings.Title(endpoint))
+	caser := cases.Title(language.English)
+	titleEndpoint := caser.String(endpoint)
+	expectedResponse := fmt.Sprintf(promAPIExpectedResponse, titleEndpoint)
 	if !strings.Contains(string(body), expectedResponse) {
 		fmt.Fprintln(os.Stderr, "Prometheus server is not", endpoint)
 		return failureExitCode

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -90,6 +90,7 @@ func main() {
 	serverCheckCmd := checkCmd.Command("server", "Run Prometheus server checks.")
 	serverCheckCmd.Arg("server", "Prometheus server to check status of.").Required().URLVar(&serverURL)
 	serverCheckEndpoint := serverCheckCmd.Arg("endpoint", "Prometheus API healthcheck endpoint [valid: 'healthy', 'ready']").Required().String()
+	serverCheckCmd.Flag("http.config.file", "HTTP client configuration file for promtool to connect to Prometheus.").PlaceHolder("<filename>").ExistingFileVar(&httpConfigFilePath)
 
 	sdCheckCmd := checkCmd.Command("service-discovery", "Perform service discovery for the given job name and report the results, including relabeling.")
 	sdConfigFile := sdCheckCmd.Arg("config-file", "The prometheus config file.").Required().ExistingFile()

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -840,11 +840,11 @@ func checkMetricsExtended(r io.Reader) ([]metricStat, int, error) {
 func CheckServer(url *url.URL, roundTripper http.RoundTripper, endpoint string) int {
 	// Ensure API endpoint is a valid healthcheck endpoint.
 	promAPIExpectedResponse := `Prometheus Server is %s.`
+	endpoint = strings.ToLower(endpoint)
 	if endpoint != "healthy" && endpoint != "ready" {
 		fmt.Fprintln(os.Stderr, "prometheus API healthcheck endpoint unsupported: ", endpoint)
 		return failureExitCode
 	}
-	endpoint = strings.ToLower(endpoint)
 
 	if url.Scheme == "" {
 		url.Scheme = "http"

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -857,20 +857,20 @@ func CheckServer(url *url.URL, roundTripper http.RoundTripper, endpoint string) 
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url.JoinPath("-", endpoint).String(), nil)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "http request creation failed: ", err)
+		fmt.Fprintln(os.Stderr, "error creating http request: ", err)
 		return failureExitCode
 	}
 
 	res, err := client.Do(req)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "http request failed: ", err)
+		fmt.Fprintln(os.Stderr, "error making http request: ", err)
 		return failureExitCode
 	}
 	defer res.Body.Close()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "failed to read response body: ", err)
+		fmt.Fprintln(os.Stderr, "error reading response body: ", err)
 		return failureExitCode
 	}
 
@@ -880,7 +880,7 @@ func CheckServer(url *url.URL, roundTripper http.RoundTripper, endpoint string) 
 		return failureExitCode
 	}
 
-	fmt.Println(string(body))
+	fmt.Println("SUCCESS: " + string(body))
 
 	return successExitCode
 }

--- a/go.mod
+++ b/go.mod
@@ -177,7 +177,7 @@ require (
 	golang.org/x/exp v0.0.0-20230307190834-24139beb5833
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
+	golang.org/x/text v0.8.0
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect


### PR DESCRIPTION
Addresses: prometheus/prometheus#12000

This commit introduces a new subcommand for `promtool check` called
`server`. The `server` subcommand accepts a Prometheus server URL and a
Prometheus API healtcheck endpoint (`healthy` or `ready`), and reports
whether or not the specified server endpoint is healthy.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
