### PR TITLE
Advertise correct flag to enable remote write receiver

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1494,7 +1494,7 @@ func (api *API) remoteWrite(w http.ResponseWriter, r *http.Request) {
 	if api.remoteWriteHandler != nil {
 		api.remoteWriteHandler.ServeHTTP(w, r)
 	} else {
-		http.Error(w, "remote write receiver needs to be enabled with --enable-feature=remote-write-receiver", http.StatusNotFound)
+		http.Error(w, "remote write receiver needs to be enabled with --web.enable-remote-write-receiver", http.StatusNotFound)
 	}
 }
 


### PR DESCRIPTION
If the remote write receiver is not enabled but another Prometheus instance still tries to send metrics to that endpoint, Prometheus writes an error message that hints the user to enabling the remote write receiver feature with a deprecated feature flag (see https://prometheus.io/docs/prometheus/latest/feature_flags/). 

This PR simply adapts the error message to advertise the correct flag, that is `--web.enable-remote-write-receiver`.