### PR TITLE
Optimization on `mergedStringIter`

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -954,6 +954,7 @@ type mergedStringIter struct {
 	b        index.StringIter
 	aok, bok bool
 	cur      string
+	err      error
 }
 
 func (m *mergedStringIter) Next() bool {
@@ -964,29 +965,34 @@ func (m *mergedStringIter) Next() bool {
 	if !m.aok {
 		m.cur = m.b.At()
 		m.bok = m.b.Next()
+		m.err = m.b.Err()
 	} else if !m.bok {
 		m.cur = m.a.At()
 		m.aok = m.a.Next()
+		m.err = m.a.Err()
 	} else if m.b.At() > m.a.At() {
 		m.cur = m.a.At()
 		m.aok = m.a.Next()
+		m.err = m.a.Err()
 	} else if m.a.At() > m.b.At() {
 		m.cur = m.b.At()
 		m.bok = m.b.Next()
+		m.err = m.b.Err()
 	} else { // Equal.
 		m.cur = m.b.At()
 		m.aok = m.a.Next()
+		m.err = m.a.Err()
 		m.bok = m.b.Next()
+		if m.err == nil {
+			m.err = m.b.Err()
+		}
 	}
 
 	return true
 }
 func (m mergedStringIter) At() string { return m.cur }
 func (m mergedStringIter) Err() error {
-	if m.a.Err() != nil {
-		return m.a.Err()
-	}
-	return m.b.Err()
+	return m.err
 }
 
 // DeletedIterator wraps chunk Iterator and makes sure any deleted metrics are not returned.

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -19,10 +19,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/prometheus/prometheus/tsdb/index"
-	"github.com/stretchr/testify/require"
-
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/index"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Make entries ~50B in size, to emulate real-world high cardinality.
@@ -211,7 +211,7 @@ func BenchmarkMergedStringIter(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		var it = NewMergedStringIter(index.NewStringListIter(s), index.NewStringListIter(s))
+		it := NewMergedStringIter(index.NewStringListIter(s), index.NewStringListIter(s))
 		for j := 0; j < 100; j++ {
 			it = NewMergedStringIter(it, index.NewStringListIter(s))
 		}


### PR DESCRIPTION
We are calling `Err()` recursively on every call to the `Next()` method. This is not really needed and can cause a huge overhead when merging multiples blocks into one.

https://github.com/prometheus/prometheus/blob/6c008ec56af958debf4123d7cd58a6681d17303d/tsdb/compact.go#L736

Instead of calling `Err()` for every `Next()` call we can just after calling the next on the inners iterators.

Let's have the following scenario:

```

         C
        / \
       F   \
            G
           / \
          H   I
```

Before, calling C.Next() would call `Err()` recursively for all child nodes of C (F, G, H and I) even though the it would only call the `Next()` for nodes on one path (EX: C ->  G -> H).
With this change, we are not recusing over all child of C anymore, instead we are calling `Err()` only when we call the `Next()` on the child node and storing the result. This result is now returned when `c.Err()` is called.

Benchmark Results:

```
name                 old time/op    new time/op    delta
MergedStringIter-12     4.13s ± 0%     0.36s ± 0%  -91.38%  (p=0.016 n=5+4)

name                 old alloc/op   new alloc/op   delta
MergedStringIter-12    5.62MB ± 0%    2.95MB ± 0%  -47.52%  (p=0.008 n=5+5)

name                 old allocs/op  new allocs/op  delta
MergedStringIter-12      300k ± 0%      167k ± 0%  -44.40%  (p=0.008 n=5+5)
```

Cortex Compactor  cpu flame-graph while creating the symbols table:

![Screen Shot 2023-03-13 at 4 58 28 PM](https://user-images.githubusercontent.com/4027760/224857833-2462ef05-f9c8-4d9a-a333-7b0b8e0922b5.png)

