### PR TITLE
Adds an affirmative log message for successful WAL repair

### DIFF
--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -303,6 +303,7 @@ func Open(l log.Logger, reg prometheus.Registerer, rs *remote.Storage, dir strin
 		if err := w.Repair(err); err != nil {
 			return nil, errors.Wrap(err, "repair corrupted WAL")
 		}
+		level.Info(db.logger).Log("msg", "successfully repaired WAL")
 	}
 
 	go db.run()

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -834,7 +834,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 			if err := wal.Repair(initErr); err != nil {
 				return nil, errors.Wrap(err, "repair corrupted WAL")
 			}
-			level.Info(db.logger).Log("msg", "successfully repaired WAL")
+			level.Info(db.logger).Log("msg", "Successfully repaired WAL")
 		}
 	}
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -828,11 +828,13 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 			if err := wbl.Repair(initErr); err != nil {
 				return nil, errors.Wrap(err, "repair corrupted OOO WAL")
 			}
+			level.Info(db.logger).Log("msg", "successfully repaired OOO WAL")
 		} else {
 			level.Warn(db.logger).Log("msg", "Encountered WAL read error, attempting repair", "err", initErr)
 			if err := wal.Repair(initErr); err != nil {
 				return nil, errors.Wrap(err, "repair corrupted WAL")
 			}
+			level.Info(db.logger).Log("msg", "successfully repaired WAL")
 		}
 	}
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -828,7 +828,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 			if err := wbl.Repair(initErr); err != nil {
 				return nil, errors.Wrap(err, "repair corrupted OOO WAL")
 			}
-			level.Info(db.logger).Log("msg", "successfully repaired OOO WAL")
+			level.Info(db.logger).Log("msg", "Successfully repaired OOO WAL")
 		} else {
 			level.Warn(db.logger).Log("msg", "Encountered WAL read error, attempting repair", "err", initErr)
 			if err := wal.Repair(initErr); err != nil {


### PR DESCRIPTION
This PR adds a log message affirming successful WAL repairs. This is helpful when responding to alerts related to WAL corruption. The log message makes it easy to search for the repair completion among the potentially numerous log messages in the system.
