### PR TITLE
docs: update ansible installation link

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,7 +87,7 @@ the following third-party contributions:
 
 ### Ansible
 
-* [Cloud Alchemy/ansible-prometheus](https://github.com/cloudalchemy/ansible-prometheus)
+* [prometheus-community/ansible](https://github.com/prometheus-community/ansible)
 
 ### Chef
 


### PR DESCRIPTION
Hello 👋 

I just found out that the link to the Ansible project to install Prometheus seems outdated.
Indeed it points to [Cloud Alchemy/ansible-prometheus](https://github.com/cloudalchemy/ansible-prometheus) which is archived and recommends using [prometheus-community/ansible](https://github.com/prometheus-community/ansible).
This PR updates the documentation.

Thank you for your time and your awesome work 😄 