### PR TITLE
labels: cope with mutating Builder during Range call

### DIFF
--- a/model/labels/labels_string.go
+++ b/model/labels/labels_string.go
@@ -599,9 +599,12 @@ func (b *Builder) Get(n string) string {
 }
 
 // Range calls f on each label in the Builder.
-// If f calls Set or Del on b then this may affect what callbacks subsequently happen.
 func (b *Builder) Range(f func(l Label)) {
-	origAdd, origDel := b.add, b.del
+	// Stack-based arrays to avoid heap allocation in most cases.
+	var addStack [1024]Label
+	var delStack [1024]string
+	// Take a copy of add and del, so they are unaffected by calls to Set() or Del().
+	origAdd, origDel := append(addStack[:0], b.add...), append(delStack[:0], b.del...)
 	b.base.Range(func(l Label) {
 		if !slices.Contains(origDel, l.Name) && !contains(origAdd, l.Name) {
 			f(l)

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -531,6 +531,11 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			base: FromStrings("aaa", "111", "bbb", "222", "ccc", "333"),
+			set:  []Label{{"aaa", "444"}, {"bbb", "555"}, {"ccc", "666"}},
+			want: FromStrings("aaa", "444", "bbb", "555", "ccc", "666"),
+		},
+		{
+			base: FromStrings("aaa", "111", "bbb", "222", "ccc", "333"),
 			del:  []string{"bbb"},
 			want: FromStrings("aaa", "111", "ccc", "333"),
 		},
@@ -591,7 +596,15 @@ func TestBuilder(t *testing.T) {
 				b.Keep(tcase.keep...)
 			}
 			b.Del(tcase.del...)
-			require.Equal(t, tcase.want, b.Labels(tcase.base))
+			require.Equal(t, tcase.want, b.Labels(EmptyLabels()))
+
+			// Check what happens when we call Range and mutate the builder.
+			b.Range(func(l Label) {
+				if l.Name == "aaa" || l.Name == "bbb" {
+					b.Del(l.Name)
+				}
+			})
+			require.Equal(t, tcase.want.BytesWithoutLabels(nil, "aaa", "bbb"), b.Labels(tcase.base).Bytes(nil))
 		})
 	}
 }


### PR DESCRIPTION
Although we had a different slice, the underlying memory was the same so any changes meant we could skip some values.

Fixes #12129 
