### PR TITLE
labels: shrink stack arrays in Builder.Range

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -547,8 +547,8 @@ func (b *Builder) Get(n string) string {
 // Range calls f on each label in the Builder.
 func (b *Builder) Range(f func(l Label)) {
 	// Stack-based arrays to avoid heap allocation in most cases.
-	var addStack [1024]Label
-	var delStack [1024]string
+	var addStack [128]Label
+	var delStack [128]string
 	// Take a copy of add and del, so they are unaffected by calls to Set() or Del().
 	origAdd, origDel := append(addStack[:0], b.add...), append(delStack[:0], b.del...)
 	b.base.Range(func(l Label) {

--- a/model/labels/labels_string.go
+++ b/model/labels/labels_string.go
@@ -601,8 +601,8 @@ func (b *Builder) Get(n string) string {
 // Range calls f on each label in the Builder.
 func (b *Builder) Range(f func(l Label)) {
 	// Stack-based arrays to avoid heap allocation in most cases.
-	var addStack [1024]Label
-	var delStack [1024]string
+	var addStack [128]Label
+	var delStack [128]string
 	// Take a copy of add and del, so they are unaffected by calls to Set() or Del().
 	origAdd, origDel := append(addStack[:0], b.add...), append(delStack[:0], b.del...)
 	b.base.Range(func(l Label) {


### PR DESCRIPTION
Go spends some time initializing all the elements of these arrays to zero, so reduce the size from 1024 to 128. This is still much bigger than we ever expect for a set of labels.

(If someone does have more than 128 labels it will still work, but via heap allocation.)
