### PR TITLE
Set SourceMap to false to fix UI in MCR builds

### DIFF
--- a/web/ui/module/codemirror-promql/tsconfig.json
+++ b/web/ui/module/codemirror-promql/tsconfig.json
@@ -7,7 +7,7 @@
     "declaration": true,
     "outDir": "dist",
     "strict": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
Previous issue that also saw the problem - https://github.com/prometheus/prometheus/issues/11906

The prometheus UI has not been working from MCR builds since version 2.40.7.

From looking at the log data the sourceMap inside codemirror-promql is generating a warning during the azure pipeline build -`Failed to parse source map from ...`.

After lots of digging, it seems the UI component of the build is launched from `web/ui/build_ui.sh`  which uses `npm run build -w @prometheus-io/app`. Github issues from other projects seem to indicate that there is an underlying issue where `npm run build` can hit a problem with the sourceMap that generates the warnings and causes problems in a build. - [https://github.com/sveltejs/template/issues/174](https://github.com/sveltejs/template/issues/174)

After forking the repository and setting the sourceMap to false, the UI returns. 

Having the sourceMap does not seem to be a necessity for production builds as it is mostly used in development. 