### PR TITLE
Fix block compaction failed when shutting down

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -471,7 +471,7 @@ func (c *LeveledCompactor) Compact(dest string, dirs []string, open []*Block) (u
 	}
 
 	errs := tsdb_errors.NewMulti(err)
-	if err != context.Canceled {
+	if !errors.Is(err, context.Canceled) {
 		for _, b := range bs {
 			if err := b.setCompactionFailed(); err != nil {
 				errs.Add(errors.Wrapf(err, "setting compaction failed for block: %s", b.Dir()))

--- a/tsdb/errors/errors.go
+++ b/tsdb/errors/errors.go
@@ -16,6 +16,7 @@ package errors
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -77,6 +78,19 @@ func (es nonNilMultiError) Error() string {
 	}
 
 	return buf.String()
+}
+
+// Is attempts to match the provided error against errors in the error list.
+//
+// This function allows errors.Is to traverse the values stored in the MultiError.
+// It returns true if any of the errors in the list match the target.
+func (es nonNilMultiError) Is(target error) bool {
+	for _, err := range es.errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
 }
 
 // CloseAll closes all given closers while recording error in MultiError.


### PR DESCRIPTION
`*LeveledCompactor.Compact` doesn't handle the `context.Canceled` errors properly for two reasons:
- `err` is never `== context.Canceled`: it's wrapped through `errors.Wrap()` and sometimes wrapped through `tsdb_errors.NewMulti(err)`.
- That `tsdb_errors.NewMulti(err)` is opaque to `errors.Is(...)` call.

This causes multiple issues:
- We mark block compaction as failed, which isn't the case.
- We log some extra wrong errors here and there.
- Downstream projects extending Prometheus [get an error](https://github.com/grafana/mimir/issues/4564) that can't be checked to be `errors.Is(err, context.Canceled)` so they misinterpret compaction as failed rather than a normal shutdown.
