### PR TITLE
Optimize constant label pair adding with relabel.Replace

### DIFF
--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -269,13 +269,8 @@ func relabel(cfg *Config, lb *labels.Builder) (keep bool) {
 	case Replace:
 		// Fast path to add or delete label pair.
 		if val == "" && cfg.Regex == DefaultRelabelConfig.Regex &&
-			!containsNewLine(cfg.TargetLabel) &&
 			!varInRegexTemplate(cfg.TargetLabel) && !varInRegexTemplate(cfg.Replacement) {
-			if !model.LabelName(cfg.TargetLabel).IsValid() || cfg.Replacement == "" {
-				lb.Del(cfg.TargetLabel)
-			} else {
-				lb.Set(cfg.TargetLabel, cfg.Replacement)
-			}
+			lb.Set(cfg.TargetLabel, cfg.Replacement)
 			break
 		}
 
@@ -331,8 +326,4 @@ func relabel(cfg *Config, lb *labels.Builder) (keep bool) {
 
 func varInRegexTemplate(template string) bool {
 	return strings.Contains(template, "$")
-}
-
-func containsNewLine(s string) bool {
-	return strings.Contains(s, "\r\n") || strings.Contains(s, "\n")
 }

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -269,6 +269,7 @@ func relabel(cfg *Config, lb *labels.Builder) (keep bool) {
 	case Replace:
 		// Fast path to add or delete label pair.
 		if val == "" && cfg.Regex == DefaultRelabelConfig.Regex &&
+			!containsNewLine(cfg.TargetLabel) &&
 			!varInRegexTemplate(cfg.TargetLabel) && !varInRegexTemplate(cfg.Replacement) {
 			if !model.LabelName(cfg.TargetLabel).IsValid() || cfg.Replacement == "" {
 				lb.Del(cfg.TargetLabel)
@@ -330,4 +331,8 @@ func relabel(cfg *Config, lb *labels.Builder) (keep bool) {
 
 func varInRegexTemplate(template string) bool {
 	return strings.Contains(template, "$")
+}
+
+func containsNewLine(s string) bool {
+	return strings.Contains(s, "\r\n") || strings.Contains(s, "\n")
 }

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -267,6 +267,17 @@ func relabel(cfg *Config, lb *labels.Builder) (keep bool) {
 			return false
 		}
 	case Replace:
+		// Fast path to add or delete label pair.
+		if val == "" && cfg.Regex == DefaultRelabelConfig.Regex &&
+			!varInRegexTemplate(cfg.TargetLabel) && !varInRegexTemplate(cfg.Replacement) {
+			if !model.LabelName(cfg.TargetLabel).IsValid() || cfg.Replacement == "" {
+				lb.Del(cfg.TargetLabel)
+			} else {
+				lb.Set(cfg.TargetLabel, cfg.Replacement)
+			}
+			break
+		}
+
 		indexes := cfg.Regex.FindStringSubmatchIndex(val)
 		// If there is no match no replacement must take place.
 		if indexes == nil {
@@ -315,4 +326,8 @@ func relabel(cfg *Config, lb *labels.Builder) (keep bool) {
 	}
 
 	return true
+}
+
+func varInRegexTemplate(template string) bool {
+	return strings.Contains(template, "$")
 }

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -905,8 +905,7 @@ func BenchmarkRelabel_ReplaceAddLabel(b *testing.B) {
 			labels.Label{Name: "abcdefg12", Value: "hijklmn12"},
 			labels.Label{Name: "abcdefg13", Value: "hijklmn13"},
 		}
-		actual, _ := Process(lset, cfgs...)
-		var _ = actual
+		_, _ = Process(lset, cfgs...)
 		// require.Equal(b, actual, expectLset)
 	}
 }

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -15,6 +15,7 @@ package relabel
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -848,5 +849,64 @@ func BenchmarkRelabel(b *testing.B) {
 				_, _ = Process(tt.lbls, tt.cfgs...)
 			}
 		})
+	}
+}
+
+func BenchmarkRelabel_ReplaceAddLabel(b *testing.B) {
+	cfgs := []*Config{}
+	for k, v := range map[string]string{
+		"wwwwww":       "wwwwww",
+		"xxxxxxxxx":    "xxxxxxxxx",
+		"yyyyyyyyyyyy": "yyyyyyyyyyyy",
+		"${0}":         "dropped",
+		"dropped":      "${0}",
+	} {
+		cfgs = append(cfgs, &Config{
+			Action:      DefaultRelabelConfig.Action,
+			Separator:   DefaultRelabelConfig.Separator,
+			Regex:       DefaultRelabelConfig.Regex,
+			TargetLabel: k,
+			Replacement: v,
+		})
+	}
+	expectLset := labels.Labels{
+		labels.Label{Name: "abcdefg01", Value: "hijklmn1"},
+		labels.Label{Name: "abcdefg02", Value: "hijklmn2"},
+		labels.Label{Name: "abcdefg03", Value: "hijklmn3"},
+		labels.Label{Name: "abcdefg04", Value: "hijklmn4"},
+		labels.Label{Name: "abcdefg05", Value: "hijklmn5"},
+		labels.Label{Name: "abcdefg06", Value: "hijklmn6"},
+		labels.Label{Name: "abcdefg07", Value: "hijklmn7"},
+		labels.Label{Name: "abcdefg08", Value: "hijklmn8"},
+		labels.Label{Name: "abcdefg09", Value: "hijklmn9"},
+		labels.Label{Name: "abcdefg10", Value: "hijklmn10"},
+		labels.Label{Name: "abcdefg11", Value: "hijklmn11"},
+		labels.Label{Name: "abcdefg12", Value: "hijklmn12"},
+		labels.Label{Name: "abcdefg13", Value: "hijklmn13"},
+		labels.Label{Name: "wwwwww", Value: "wwwwww"},
+		labels.Label{Name: "xxxxxxxxx", Value: "xxxxxxxxx"},
+		labels.Label{Name: "yyyyyyyyyyyy", Value: "yyyyyyyyyyyy"},
+	}
+	sort.Sort(expectLset)
+
+	for i := 0; i < b.N; i++ {
+		lset := labels.Labels{
+			labels.Label{Name: "abcdefg01", Value: "hijklmn1"},
+			labels.Label{Name: "abcdefg02", Value: "hijklmn2"},
+			labels.Label{Name: "abcdefg03", Value: "hijklmn3"},
+			labels.Label{Name: "abcdefg04", Value: "hijklmn4"},
+			labels.Label{Name: "abcdefg05", Value: "hijklmn5"},
+			labels.Label{Name: "abcdefg06", Value: "hijklmn6"},
+			labels.Label{Name: "abcdefg07", Value: "hijklmn7"},
+			labels.Label{Name: "abcdefg08", Value: "hijklmn8"},
+			labels.Label{Name: "abcdefg09", Value: "hijklmn9"},
+			labels.Label{Name: "abcdefg10", Value: "hijklmn10"},
+			labels.Label{Name: "abcdefg11", Value: "hijklmn11"},
+			labels.Label{Name: "abcdefg12", Value: "hijklmn12"},
+			labels.Label{Name: "abcdefg13", Value: "hijklmn13"},
+		}
+		actual, _ := Process(lset, cfgs...)
+		var _ = actual
+		// require.Equal(b, actual, expectLset)
 	}
 }

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -858,6 +858,8 @@ func BenchmarkRelabel_ReplaceAddLabel(b *testing.B) {
 		"wwwwww":       "wwwwww",
 		"xxxxxxxxx":    "xxxxxxxxx",
 		"yyyyyyyyyyyy": "yyyyyyyyyyyy",
+		"new\nline1":   "dropped",
+		"new\r\nline2": "dropped",
 		"${0}":         "dropped",
 		"dropped":      "${0}",
 	} {
@@ -905,7 +907,7 @@ func BenchmarkRelabel_ReplaceAddLabel(b *testing.B) {
 			labels.Label{Name: "abcdefg12", Value: "hijklmn12"},
 			labels.Label{Name: "abcdefg13", Value: "hijklmn13"},
 		}
-		_, _ = Process(lset, cfgs...)
-		// require.Equal(b, actual, expectLset)
+		actual, _ := Process(lset, cfgs...)
+		require.Equal(b, actual, expectLset)
 	}
 }


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
```
name                       old time/op    new time/op    delta
Relabel/example-8            2.30µs ±69%    1.49µs ±26%  -35.20%  (p=0.000 n=20+20)
Relabel/kubernetes-8         6.02µs ± 5%    5.87µs ± 4%   -2.39%  (p=0.000 n=18+20)
Relabel_ReplaceAddLabel-8     973ns ±16%     546ns ±24%  -43.91%  (p=0.000 n=20+20)

name                       old alloc/op   new alloc/op   delta
Relabel/example-8              633B ± 4%      574B ± 4%   -9.24%  (p=0.000 n=20+20)
Relabel/kubernetes-8         1.46kB ± 1%    1.38kB ± 2%   -5.37%  (p=0.000 n=20+20)
Relabel_ReplaceAddLabel-8    1.81kB ± 0%    1.55kB ± 0%  -14.22%  (p=0.000 n=20+20)

name                       old allocs/op  new allocs/op  delta
Relabel/example-8              17.0 ± 0%      12.0 ± 0%  -29.41%  (p=0.000 n=20+20)
Relabel/kubernetes-8           36.0 ± 0%      31.0 ± 0%  -13.89%  (p=0.000 n=20+20)
Relabel_ReplaceAddLabel-8      19.0 ± 0%       4.0 ± 0%  -78.95%  (p=0.000 n=20+20)
```