### PR TITLE
Remove codesome as codeowner from promql/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,5 @@
 /storage/remote @csmarchbanks @cstyan @bwplotka @tomwilkie
 /discovery/kubernetes @brancz
 /tsdb @codesome
-/promql @codesome @roidelapluie
+/promql @roidelapluie
 /cmd/promtool @dgl


### PR DESCRIPTION
Getting to PR reviews in a timely manner has been challenging lately (and I expect it to be this way for many weeks to come), so I am planning to keep my efforts mainly focused only on tsdb. If my review is required elsewhere, I would prefer an explicit @. So I am removing myself from promql/ as a codeowner.