### PR TITLE
Use zeropool.Pool to workaround SA6002

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/aws/aws-sdk-go v1.44.217
 	github.com/cespare/xxhash/v2 v2.2.0
+	github.com/colega/zeropool v0.0.0-20230328090742-a544cfde6655
 	github.com/dennwc/varint v1.0.0
 	github.com/digitalocean/godo v1.97.0
 	github.com/docker/docker v23.0.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/cncf/xds/go v0.0.0-20230112175826-46e39c7b9b43 h1:XP+uhjN0yBCN/tPkr8Z
 github.com/cncf/xds/go v0.0.0-20230112175826-46e39c7b9b43/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/colega/zeropool v0.0.0-20230328090742-a544cfde6655 h1:mm/aADAMn10Ow8Y9dI4lLy2pvKj75vHpCdjL7m8SzcU=
+github.com/colega/zeropool v0.0.0-20230328090742-a544cfde6655/go.mod h1:OU76gHeRo8xrzGJU3F3I1CqX1ekM8dfJw0+wPeMwnp0=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/colega/zeropool"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid"
@@ -83,13 +84,13 @@ type Head struct {
 	exemplarMetrics     *ExemplarMetrics
 	exemplars           ExemplarStorage
 	logger              log.Logger
-	appendPool          sync.Pool
-	exemplarsPool       sync.Pool
-	histogramsPool      sync.Pool
-	floatHistogramsPool sync.Pool
-	metadataPool        sync.Pool
-	seriesPool          sync.Pool
-	bytesPool           sync.Pool
+	appendPool          zeropool.Pool[[]record.RefSample]
+	exemplarsPool       zeropool.Pool[[]exemplarWithSeriesRef]
+	histogramsPool      zeropool.Pool[[]record.RefHistogramSample]
+	floatHistogramsPool zeropool.Pool[[]record.RefFloatHistogramSample]
+	metadataPool        zeropool.Pool[[]record.RefMetadata]
+	seriesPool          zeropool.Pool[[]*memSeries]
+	bytesPool           zeropool.Pool[[]byte]
 	memChunkPool        sync.Pool
 
 	// All series addressable by their ID or hash.

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -199,11 +199,10 @@ func (h *Head) getAppendBuffer() []record.RefSample {
 	if b == nil {
 		return make([]record.RefSample, 0, 512)
 	}
-	return b.([]record.RefSample)
+	return b
 }
 
 func (h *Head) putAppendBuffer(b []record.RefSample) {
-	//nolint:staticcheck // Ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 	h.appendPool.Put(b[:0])
 }
 
@@ -212,7 +211,7 @@ func (h *Head) getExemplarBuffer() []exemplarWithSeriesRef {
 	if b == nil {
 		return make([]exemplarWithSeriesRef, 0, 512)
 	}
-	return b.([]exemplarWithSeriesRef)
+	return b
 }
 
 func (h *Head) putExemplarBuffer(b []exemplarWithSeriesRef) {
@@ -220,7 +219,6 @@ func (h *Head) putExemplarBuffer(b []exemplarWithSeriesRef) {
 		return
 	}
 
-	//nolint:staticcheck // Ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 	h.exemplarsPool.Put(b[:0])
 }
 
@@ -229,11 +227,10 @@ func (h *Head) getHistogramBuffer() []record.RefHistogramSample {
 	if b == nil {
 		return make([]record.RefHistogramSample, 0, 512)
 	}
-	return b.([]record.RefHistogramSample)
+	return b
 }
 
 func (h *Head) putHistogramBuffer(b []record.RefHistogramSample) {
-	//nolint:staticcheck // Ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 	h.histogramsPool.Put(b[:0])
 }
 
@@ -242,11 +239,10 @@ func (h *Head) getFloatHistogramBuffer() []record.RefFloatHistogramSample {
 	if b == nil {
 		return make([]record.RefFloatHistogramSample, 0, 512)
 	}
-	return b.([]record.RefFloatHistogramSample)
+	return b
 }
 
 func (h *Head) putFloatHistogramBuffer(b []record.RefFloatHistogramSample) {
-	//nolint:staticcheck // Ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 	h.floatHistogramsPool.Put(b[:0])
 }
 
@@ -255,11 +251,10 @@ func (h *Head) getMetadataBuffer() []record.RefMetadata {
 	if b == nil {
 		return make([]record.RefMetadata, 0, 512)
 	}
-	return b.([]record.RefMetadata)
+	return b
 }
 
 func (h *Head) putMetadataBuffer(b []record.RefMetadata) {
-	//nolint:staticcheck // Ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 	h.metadataPool.Put(b[:0])
 }
 
@@ -268,11 +263,10 @@ func (h *Head) getSeriesBuffer() []*memSeries {
 	if b == nil {
 		return make([]*memSeries, 0, 512)
 	}
-	return b.([]*memSeries)
+	return b
 }
 
 func (h *Head) putSeriesBuffer(b []*memSeries) {
-	//nolint:staticcheck // Ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 	h.seriesPool.Put(b[:0])
 }
 
@@ -281,11 +275,10 @@ func (h *Head) getBytesBuffer() []byte {
 	if b == nil {
 		return make([]byte, 0, 1024)
 	}
-	return b.([]byte)
+	return b
 }
 
 func (h *Head) putBytesBuffer(b []byte) {
-	//nolint:staticcheck // Ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 	h.bytesPool.Put(b[:0])
 }
 

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/colega/zeropool"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"go.uber.org/atomic"
@@ -74,41 +75,14 @@ func (h *Head) loadWAL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 
 		decoded                      = make(chan interface{}, 10)
 		decodeErr, seriesCreationErr error
-		seriesPool                   = sync.Pool{
-			New: func() interface{} {
-				return []record.RefSeries{}
-			},
-		}
-		samplesPool = sync.Pool{
-			New: func() interface{} {
-				return []record.RefSample{}
-			},
-		}
-		tstonesPool = sync.Pool{
-			New: func() interface{} {
-				return []tombstones.Stone{}
-			},
-		}
-		exemplarsPool = sync.Pool{
-			New: func() interface{} {
-				return []record.RefExemplar{}
-			},
-		}
-		histogramsPool = sync.Pool{
-			New: func() interface{} {
-				return []record.RefHistogramSample{}
-			},
-		}
-		floatHistogramsPool = sync.Pool{
-			New: func() interface{} {
-				return []record.RefFloatHistogramSample{}
-			},
-		}
-		metadataPool = sync.Pool{
-			New: func() interface{} {
-				return []record.RefMetadata{}
-			},
-		}
+
+		seriesPool          zeropool.Pool[[]record.RefSeries]
+		samplesPool         zeropool.Pool[[]record.RefSample]
+		tstonesPool         zeropool.Pool[[]tombstones.Stone]
+		exemplarsPool       zeropool.Pool[[]record.RefExemplar]
+		histogramsPool      zeropool.Pool[[]record.RefHistogramSample]
+		floatHistogramsPool zeropool.Pool[[]record.RefFloatHistogramSample]
+		metadataPool        zeropool.Pool[[]record.RefMetadata]
 	)
 
 	defer func() {
@@ -167,7 +141,7 @@ func (h *Head) loadWAL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 			rec := r.Record()
 			switch dec.Type(rec) {
 			case record.Series:
-				series := seriesPool.Get().([]record.RefSeries)[:0]
+				series := seriesPool.Get()[:0]
 				series, err = dec.Series(rec, series)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
@@ -179,7 +153,7 @@ func (h *Head) loadWAL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 				}
 				decoded <- series
 			case record.Samples:
-				samples := samplesPool.Get().([]record.RefSample)[:0]
+				samples := samplesPool.Get()[:0]
 				samples, err = dec.Samples(rec, samples)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
@@ -191,7 +165,7 @@ func (h *Head) loadWAL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 				}
 				decoded <- samples
 			case record.Tombstones:
-				tstones := tstonesPool.Get().([]tombstones.Stone)[:0]
+				tstones := tstonesPool.Get()[:0]
 				tstones, err = dec.Tombstones(rec, tstones)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
@@ -203,7 +177,7 @@ func (h *Head) loadWAL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 				}
 				decoded <- tstones
 			case record.Exemplars:
-				exemplars := exemplarsPool.Get().([]record.RefExemplar)[:0]
+				exemplars := exemplarsPool.Get()[:0]
 				exemplars, err = dec.Exemplars(rec, exemplars)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
@@ -215,7 +189,7 @@ func (h *Head) loadWAL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 				}
 				decoded <- exemplars
 			case record.HistogramSamples:
-				hists := histogramsPool.Get().([]record.RefHistogramSample)[:0]
+				hists := histogramsPool.Get()[:0]
 				hists, err = dec.HistogramSamples(rec, hists)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
@@ -227,7 +201,7 @@ func (h *Head) loadWAL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 				}
 				decoded <- hists
 			case record.FloatHistogramSamples:
-				hists := floatHistogramsPool.Get().([]record.RefFloatHistogramSample)[:0]
+				hists := floatHistogramsPool.Get()[:0]
 				hists, err = dec.FloatHistogramSamples(rec, hists)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
@@ -239,7 +213,7 @@ func (h *Head) loadWAL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 				}
 				decoded <- hists
 			case record.Metadata:
-				meta := metadataPool.Get().([]record.RefMetadata)[:0]
+				meta := metadataPool.Get()[:0]
 				meta, err := dec.Metadata(rec, meta)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
@@ -278,7 +252,6 @@ Outer:
 				idx := uint64(mSeries.ref) % uint64(concurrency)
 				processors[idx].input <- walSubsetProcessorInputItem{walSeriesRef: walSeries.Ref, existingSeries: mSeries}
 			}
-			//nolint:staticcheck // Ignore SA6002 relax staticcheck verification.
 			seriesPool.Put(v)
 		case []record.RefSample:
 			samples := v
@@ -315,7 +288,6 @@ Outer:
 				}
 				samples = samples[m:]
 			}
-			//nolint:staticcheck // Ignore SA6002 relax staticcheck verification.
 			samplesPool.Put(v)
 		case []tombstones.Stone:
 			for _, s := range v {
@@ -330,13 +302,11 @@ Outer:
 					h.tombstones.AddInterval(storage.SeriesRef(s.Ref), itv)
 				}
 			}
-			//nolint:staticcheck // Ignore SA6002 relax staticcheck verification.
 			tstonesPool.Put(v)
 		case []record.RefExemplar:
 			for _, e := range v {
 				exemplarsInput <- e
 			}
-			//nolint:staticcheck // Ignore SA6002 relax staticcheck verification.
 			exemplarsPool.Put(v)
 		case []record.RefHistogramSample:
 			samples := v
@@ -373,7 +343,6 @@ Outer:
 				}
 				samples = samples[m:]
 			}
-			//nolint:staticcheck // Ignore SA6002 relax staticcheck verification.
 			histogramsPool.Put(v)
 		case []record.RefFloatHistogramSample:
 			samples := v
@@ -410,7 +379,6 @@ Outer:
 				}
 				samples = samples[m:]
 			}
-			//nolint:staticcheck // Ignore SA6002 relax staticcheck verification.
 			floatHistogramsPool.Put(v)
 		case []record.RefMetadata:
 			for _, m := range v {
@@ -425,7 +393,6 @@ Outer:
 					Help: m.Help,
 				}
 			}
-			//nolint:staticcheck // Ignore SA6002 relax staticcheck verification.
 			metadataPool.Put(v)
 		default:
 			panic(fmt.Errorf("unexpected decoded type: %T", d))
@@ -793,7 +760,6 @@ func (h *Head) loadWBL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 				}
 				samples = samples[m:]
 			}
-			//nolint:staticcheck // Ignore SA6002 relax staticcheck verification.
 			samplesPool.Put(d)
 		case []record.RefMmapMarker:
 			markers := v

--- a/tsdb/wal.go
+++ b/tsdb/wal.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/colega/zeropool"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
@@ -870,9 +871,9 @@ func (r *walReader) Read(
 	// Historically, the processing is the bottleneck with reading and decoding using only
 	// 15% of the CPU.
 	var (
-		seriesPool sync.Pool
-		samplePool sync.Pool
-		deletePool sync.Pool
+		seriesPool zeropool.Pool[[]record.RefSeries]
+		samplePool zeropool.Pool[[]record.RefSample]
+		deletePool zeropool.Pool[[]tombstones.Stone]
 	)
 	donec := make(chan struct{})
 	datac := make(chan interface{}, 100)
@@ -886,19 +887,16 @@ func (r *walReader) Read(
 				if seriesf != nil {
 					seriesf(v)
 				}
-				//nolint:staticcheck // Ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 				seriesPool.Put(v[:0])
 			case []record.RefSample:
 				if samplesf != nil {
 					samplesf(v)
 				}
-				//nolint:staticcheck // Ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 				samplePool.Put(v[:0])
 			case []tombstones.Stone:
 				if deletesf != nil {
 					deletesf(v)
 				}
-				//nolint:staticcheck // Ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
 				deletePool.Put(v[:0])
 			default:
 				level.Error(r.logger).Log("msg", "unexpected data type")
@@ -915,11 +913,9 @@ func (r *walReader) Read(
 		// Those should generally be caught by entry decoding before.
 		switch et {
 		case WALEntrySeries:
-			var series []record.RefSeries
-			if v := seriesPool.Get(); v == nil {
+			series := seriesPool.Get()
+			if series == nil {
 				series = make([]record.RefSeries, 0, 512)
-			} else {
-				series = v.([]record.RefSeries)
 			}
 
 			err = r.decodeSeries(flag, b, &series)
@@ -936,11 +932,9 @@ func (r *walReader) Read(
 				}
 			}
 		case WALEntrySamples:
-			var samples []record.RefSample
-			if v := samplePool.Get(); v == nil {
+			samples := samplePool.Get()
+			if samples == nil {
 				samples = make([]record.RefSample, 0, 512)
-			} else {
-				samples = v.([]record.RefSample)
 			}
 
 			err = r.decodeSamples(flag, b, &samples)
@@ -958,11 +952,9 @@ func (r *walReader) Read(
 				}
 			}
 		case WALEntryDeletes:
-			var deletes []tombstones.Stone
-			if v := deletePool.Get(); v == nil {
+			deletes := deletePool.Get()
+			if deletes == nil {
 				deletes = make([]tombstones.Stone, 0, 512)
-			} else {
-				deletes = v.([]tombstones.Stone)
 			}
 
 			err = r.decodeDeletes(flag, b, &deletes)


### PR DESCRIPTION
I built[^1] a tiny library called [zeropool](https://github.com/colega/zeropool) to workaround the SA6002 staticheck issue.

While searching for the references of that SA6002 staticheck issues on Github first results was Prometheus itself, with quite a lot of ignores of it.

This changes the usages of `sync.Pool` to `zeropool.Pool[T]` where a pointer is not available.

Also added a benchmark for HeadAppender Append/Commit when series already exist, which is one of the most usual cases IMO, as I didn't find any.

I think the code is cleaner now, and the benchmarks results are quite promising:

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz
                                                                                                         │      old      │                 new                 │
                                                                                                         │    sec/op     │   sec/op     vs base                │
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-16         250.7m ±  1%   235.7m ± 0%   -5.97% (p=0.002 n=10)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0-16        253.5m ±  3%   237.1m ± 1%   -6.47% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0-16        256.9m ±  5%   241.2m ± 1%   -6.14% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0-16       287.6m ±  4%   271.2m ± 1%   -5.73% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-16         357.7m ±  3%   303.9m ± 1%  -15.04% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0-16         374.4m ±  4%   324.1m ± 1%  -13.45% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-16         97.35m ± 17%   88.43m ± 1%   -9.17% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0-16        124.87m ± 33%   90.69m ± 1%  -27.37% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0-16        106.26m ±  7%   93.65m ± 1%  -11.86% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0-16        127.4m ± 13%   112.5m ± 1%  -11.63% (p=0.000 n=10)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-16      1.151 ±  7%    1.038 ± 1%   -9.77% (p=0.000 n=10)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800-16      1.146 ± 17%    1.077 ± 2%   -6.03% (p=0.005 n=10)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800-16      1.140 ± 42%    1.113 ± 3%        ~ (p=0.247 n=10)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800-16     1.315 ± 20%    1.280 ± 1%   -2.69% (p=0.002 n=10)
geomean                                                                                                     332.8m         300.3m        -9.78%

                                                                                                         │     old      │                 new                 │
                                                                                                         │     B/op     │     B/op      vs base               │
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-16        38.95Mi ± 5%   37.28Mi ± 0%  -4.27% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0-16       42.65Mi ± 4%   39.12Mi ± 0%  -8.27% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0-16       44.33Mi ± 0%   40.79Mi ± 0%  -7.98% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0-16      57.71Mi ± 0%   55.98Mi ± 0%  -2.99% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-16        230.5Mi ± 2%   227.6Mi ± 2%       ~ (p=0.165 n=10)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0-16        259.2Mi ± 2%   249.4Mi ± 5%  -3.79% (p=0.001 n=10)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-16        44.44Mi ± 3%   43.36Mi ± 2%  -2.43% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0-16        47.79Mi ± 4%   44.94Mi ± 1%  -5.96% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0-16        48.77Mi ± 2%   46.28Mi ± 2%  -5.11% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0-16       58.40Mi ± 1%   56.54Mi ± 1%  -3.18% (p=0.000 n=10)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-16    293.5Mi ± 3%   278.9Mi ± 4%  -4.99% (p=0.001 n=10)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800-16    301.1Mi ± 2%   290.3Mi ± 3%  -3.59% (p=0.002 n=10)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800-16    307.2Mi ± 8%   305.4Mi ± 3%       ~ (p=0.123 n=10)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800-16   398.0Mi ± 3%   393.6Mi ± 1%  -1.11% (p=0.023 n=10)
geomean                                                                                                    103.7Mi        99.54Mi       -3.99%

                                                                                                         │     old     │                 new                 │
                                                                                                         │  allocs/op  │  allocs/op   vs base                │
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0-16        514.5k ± 3%   442.2k ± 0%  -14.05% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0-16       636.9k ± 2%   550.6k ± 0%  -13.54% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0-16       745.7k ± 0%   659.0k ± 0%  -11.62% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0-16      1.616M ± 0%   1.540M ± 0%   -4.68% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0-16        2.194M ± 0%   2.193M ± 0%        ~ (p=0.105 n=10)
LoadWAL/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0-16        2.795M ± 0%   2.792M ± 0%   -0.12% (p=0.001 n=10)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0-16        435.7k ± 1%   427.7k ± 0%   -1.84% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0-16        502.7k ± 2%   487.2k ± 0%   -3.07% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0-16        589.1k ± 0%   577.9k ± 0%   -1.90% (p=0.000 n=10)
LoadWAL/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0-16       1.163M ± 0%   1.154M ± 0%   -0.77% (p=0.000 n=10)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800-16    3.473M ± 1%   3.394M ± 1%   -2.26% (p=0.000 n=10)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800-16    4.067M ± 0%   3.995M ± 0%   -1.77% (p=0.000 n=10)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800-16    4.948M ± 1%   4.897M ± 0%   -1.02% (p=0.000 n=10)
LoadWAL/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800-16   10.66M ± 0%   10.60M ± 0%   -0.54% (p=0.000 n=10)
geomean                                                                                                    1.492M        1.429M        -4.22%
```

```
                                             │     old     │                new                 │
                                             │   sec/op    │   sec/op     vs base               │
HeadAppender_Append_Commit_ExistingSeries-16   343.0µ ± 2%   313.6µ ± 1%  -8.58% (p=0.000 n=10)

                                             │     old      │                 new                 │
                                             │     B/op     │     B/op      vs base               │
HeadAppender_Append_Commit_ExistingSeries-16   53.11Ki ± 0%   52.72Ki ± 0%  -0.74% (p=0.000 n=10)

                                             │    old     │                new                │
                                             │ allocs/op  │ allocs/op   vs base               │
HeadAppender_Append_Commit_ExistingSeries-16   624.5 ± 0%   617.0 ± 0%  -1.20% (p=0.000 n=10)
```

[^1]: Shameless self plug.