### PR TITLE
promql: use faster heap method for topk/bottomk 

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -157,6 +157,9 @@ func rangeQueryCases() []benchCase {
 		{
 			expr: "topk(1, a_X)",
 		},
+		{
+			expr: "topk(5, a_X)",
+		},
 		// Combinations.
 		{
 			expr: "rate(a_X[1m]) + rate(b_X[1m])",

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2508,39 +2508,39 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 			group.value += delta * (s.V - group.mean)
 
 		case parser.TOPK:
-			if int64(len(group.heap)) < k || group.heap[0].V < s.V || math.IsNaN(group.heap[0].V) {
-				if int64(len(group.heap)) == k {
-					if k == 1 { // For k==1 we can replace in-situ.
-						group.heap[0] = Sample{
-							Point:  Point{V: s.V},
-							Metric: s.Metric,
-						}
-						break
-					}
-					heap.Pop(&group.heap)
-				}
+			// We build a heap of up to k elements, with the smallest element at heap[0].
+			if int64(len(group.heap)) < k {
 				heap.Push(&group.heap, &Sample{
 					Point:  Point{V: s.V},
 					Metric: s.Metric,
 				})
+			} else if group.heap[0].V < s.V || (math.IsNaN(group.heap[0].V) && !math.IsNaN(s.V)) {
+				// This new element is bigger than the previous smallest element - overwrite that.
+				group.heap[0] = Sample{
+					Point:  Point{V: s.V},
+					Metric: s.Metric,
+				}
+				if k > 1 {
+					heap.Fix(&group.heap, 0) // Maintain the heap invariant.
+				}
 			}
 
 		case parser.BOTTOMK:
-			if int64(len(group.reverseHeap)) < k || group.reverseHeap[0].V > s.V || math.IsNaN(group.reverseHeap[0].V) {
-				if int64(len(group.reverseHeap)) == k {
-					if k == 1 { // For k==1 we can replace in-situ.
-						group.reverseHeap[0] = Sample{
-							Point:  Point{V: s.V},
-							Metric: s.Metric,
-						}
-						break
-					}
-					heap.Pop(&group.reverseHeap)
-				}
+			// We build a heap of up to k elements, with the biggest element at heap[0].
+			if int64(len(group.reverseHeap)) < k {
 				heap.Push(&group.reverseHeap, &Sample{
 					Point:  Point{V: s.V},
 					Metric: s.Metric,
 				})
+			} else if group.reverseHeap[0].V > s.V || (math.IsNaN(group.reverseHeap[0].V) && !math.IsNaN(s.V)) {
+				// This new element is smaller than the previous biggest element - overwrite that.
+				group.reverseHeap[0] = Sample{
+					Point:  Point{V: s.V},
+					Metric: s.Metric,
+				}
+				if k > 1 {
+					heap.Fix(&group.reverseHeap, 0) // Maintain the heap invariant.
+				}
 			}
 
 		case parser.QUANTILE:


### PR DESCRIPTION
Call `Fix()` instead of `Pop()` followed by `Push()`.

The [`heap.Fix()` function](https://pkg.go.dev/container/heap#Fix) is documented to be more efficient:
> Changing the value of the element at index i and then calling Fix is equivalent to, but less expensive than, calling Remove(h, i) followed by a Push of the new value. 

I re-ordered the code in a way which I think is clearer, and also changed it to avoid churning NaN values.
`topk(1)` was previously special-cased to avoid heap shuffling, so we need a new benchmark to see the benefit of this change:

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/promql
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                                                │  before.txt  │              after.txt              │
                                                │    sec/op    │    sec/op     vs base               │
RangeQuery/expr=topk(1,_a_one),steps=100-4        149.7µ ±  3%   152.1µ ±  6%        ~ (p=0.485 n=6)
RangeQuery/expr=topk(1,_a_one),steps=1000-4       1.058m ±  3%   1.044m ±  4%        ~ (p=0.240 n=6)
RangeQuery/expr=topk(1,_a_ten),steps=100-4        490.8µ ±  7%   463.1µ ± 11%        ~ (p=0.132 n=6)
RangeQuery/expr=topk(1,_a_ten),steps=1000-4       2.962m ±  3%   2.944m ±  3%        ~ (p=0.699 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4    3.803m ±  8%   3.741m ±  5%        ~ (p=0.485 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4   23.00m ±  6%   22.64m ±  3%        ~ (p=0.065 n=6)
RangeQuery/expr=topk(5,_a_one),steps=100-4        144.4µ ±  7%   146.7µ ±  3%        ~ (p=0.937 n=6)
RangeQuery/expr=topk(5,_a_one),steps=1000-4       1.049m ±  5%   1.048m ±  5%        ~ (p=0.937 n=6)
RangeQuery/expr=topk(5,_a_ten),steps=100-4        844.4µ ±  4%   771.9µ ±  4%   -8.58% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_ten),steps=1000-4       6.759m ±  5%   5.808m ±  8%  -14.08% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=100-4    6.855m ±  5%   5.142m ± 11%  -24.99% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=1000-4   52.98m ± 10%   34.60m ±  3%  -34.68% (p=0.002 n=6)
geomean                                           2.074m         1.902m         -8.26%

                                                │  before.txt   │              after.txt               │
                                                │     B/op      │     B/op       vs base               │
RangeQuery/expr=topk(1,_a_one),steps=100-4         30.01Ki ± 0%    30.01Ki ± 0%        ~ (p=0.517 n=6)
RangeQuery/expr=topk(1,_a_one),steps=1000-4        224.5Ki ± 0%    224.6Ki ± 0%        ~ (p=0.240 n=6)
RangeQuery/expr=topk(1,_a_ten),steps=100-4         39.06Ki ± 0%    39.06Ki ± 0%        ~ (p=0.892 n=6)
RangeQuery/expr=topk(1,_a_ten),steps=1000-4        259.1Ki ± 0%    259.1Ki ± 0%        ~ (p=0.065 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4     127.9Ki ± 0%    127.9Ki ± 0%        ~ (p=0.563 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4    602.8Ki ± 2%    603.0Ki ± 0%        ~ (p=0.937 n=6)
RangeQuery/expr=topk(5,_a_one),steps=100-4         30.00Ki ± 1%    30.01Ki ± 0%        ~ (p=0.058 n=6)
RangeQuery/expr=topk(5,_a_one),steps=1000-4        224.5Ki ± 0%    224.6Ki ± 0%        ~ (p=0.065 n=6)
RangeQuery/expr=topk(5,_a_ten),steps=100-4        128.56Ki ± 0%    81.20Ki ± 0%  -36.84% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_ten),steps=1000-4       1143.4Ki ± 0%    674.1Ki ± 0%  -41.05% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=100-4    1070.0Ki ± 0%    170.0Ki ± 0%  -84.11% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=1000-4   9937.5Ki ± 0%   1018.3Ki ± 0%  -89.75% (p=0.002 n=6)
geomean                                            248.5Ki         162.4Ki       -34.65%
```
