### PR TITLE
Display GOMEMLIMIT in runtime info

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -143,6 +143,7 @@ type RuntimeInfo struct {
 	CorruptionCount     int64     `json:"corruptionCount"`
 	GoroutineCount      int       `json:"goroutineCount"`
 	GOMAXPROCS          int       `json:"GOMAXPROCS"`
+	GOMEMLIMIT          int64     `json:"GOMEMLIMIT"`
 	GOGC                string    `json:"GOGC"`
 	GODEBUG             string    `json:"GODEBUG"`
 	StorageRetention    string    `json:"storageRetention"`

--- a/web/web.go
+++ b/web/web.go
@@ -29,6 +29,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -710,6 +711,7 @@ func (h *Handler) runtimeInfo() (api_v1.RuntimeInfo, error) {
 		CWD:            h.cwd,
 		GoroutineCount: runtime.NumGoroutine(),
 		GOMAXPROCS:     runtime.GOMAXPROCS(0),
+		GOMEMLIMIT:     debug.SetMemoryLimit(-1),
 		GOGC:           os.Getenv("GOGC"),
 		GODEBUG:        os.Getenv("GODEBUG"),
 	}


### PR DESCRIPTION
This PR updates web's runtime info, adding the current value [`GOMEMLIMIT`][1] (soft memory limit) to the UI.

In the current implementation, the limit's value is returned and displayed as-is in the bytes form — w/o any formatting — in the similar manner to other runtime's values.

[1]: https://pkg.go.dev/runtime