### PR TITLE
Update golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.4.0
         with:
           args: --verbose
-          version: v1.51.2
+          version: v1.53.3
   fuzzing:
     uses: ./.github/workflows/fuzzing.yml
     if: github.event_name == 'pull_request'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,3 +56,9 @@ linters-settings:
     local-prefixes: github.com/prometheus/prometheus
   gofumpt:
     extra-rules: true
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      - name: unused-parameter
+        severity: warning
+        disabled: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,14 +31,19 @@ issues:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages-with-error-message:
-      - sync/atomic: "Use go.uber.org/atomic instead of sync/atomic"
-      - github.com/stretchr/testify/assert: "Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert"
-      - github.com/go-kit/kit/log: "Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
-      - io/ioutil: "Use corresponding 'os' or 'io' functions instead."
-      - regexp: "Use github.com/grafana/regexp instead of regexp"
+    rules:
+      main:
+        deny:
+        - pkg: "sync/atomic"
+          desc: "Use go.uber.org/atomic instead of sync/atomic"
+        - pkg: "github.com/stretchr/testify/assert"
+          desc: "Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert"
+        - pkg: "github.com/go-kit/kit/log"
+          desc: "Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
+        - pkg: "io/ioutil"
+          desc: "Use corresponding 'os' or 'io' functions instead."
+        - pkg: "regexp"
+          desc: "Use github.com/grafana/regexp instead of regexp"
   errcheck:
     exclude-functions:
       # Don't flag lines such as "io.Copy(io.Discard, resp.Body)".

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.51.2
+GOLANGCI_LINT_VERSION ?= v1.53.3
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))

--- a/scripts/golangci-lint.yml
+++ b/scripts/golangci-lint.yml
@@ -1,0 +1,32 @@
+---
+# This action is synced from https://github.com/prometheus/prometheus
+name: golangci-lint
+on:
+  push:
+    paths:
+      - "go.sum"
+      - "go.mod"
+      - "**.go"
+      - "scripts/errcheck_excludes.txt"
+      - ".github/workflows/golangci-lint.yml"
+      - ".golangci.yml"
+  pull_request:
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
+      - name: Install snmp_exporter/generator dependencies
+        run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
+        if: github.repository == 'prometheus/snmp_exporter'
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3.4.0
+        with:
+          version: v1.53.3

--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -37,7 +37,7 @@ if [ -z "${GITHUB_TOKEN}" ]; then
 fi
 
 # List of files that should be synced.
-SYNC_FILES="CODE_OF_CONDUCT.md LICENSE Makefile.common SECURITY.md .yamllint .github/workflows/golangci-lint.yml"
+SYNC_FILES="CODE_OF_CONDUCT.md LICENSE Makefile.common SECURITY.md .yamllint scripts/golangci-lint.yml"
 
 # Go to the root of the repo
 cd "$(git rev-parse --show-cdup)" || exit 1
@@ -115,20 +115,23 @@ process_repo() {
   local needs_update=()
   for source_file in ${SYNC_FILES}; do
     source_checksum="$(sha256sum "${source_dir}/${source_file}" | cut -d' ' -f1)"
-
-    target_file="$(curl -sL --fail "https://raw.githubusercontent.com/${org_repo}/${default_branch}/${source_file}")"
+    if [[ "${source_file}" == 'scripts/golangci-lint.yml' ]] && ! check_go "${org_repo}" "${default_branch}" ; then
+      echo "${org_repo} is not Go, skipping golangci-lint.yml."
+      continue
+    fi
     if [[ "${source_file}" == 'LICENSE' ]] && ! check_license "${target_file}" ; then
       echo "LICENSE in ${org_repo} is not apache, skipping."
       continue
     fi
-    if [[ "${source_file}" == '.github/workflows/golangci-lint.yml' ]] && ! check_go "${org_repo}" "${default_branch}" ; then
-      echo "${org_repo} is not Go, skipping .github/workflows/golangci-lint.yml."
-      continue
+    target_filename="${source_file}"
+    if [[ "${source_file}" == 'scripts/golangci-lint.yml' ]] ; then
+      target_filename=".github/workflows/${source_file}"
     fi
+    target_file="$(curl -sL --fail "https://raw.githubusercontent.com/${org_repo}/${default_branch}/${target_filename}")"
     if [[ -z "${target_file}" ]]; then
       echo "${source_file} doesn't exist in ${org_repo}"
       case "${source_file}" in
-        CODE_OF_CONDUCT.md | SECURITY.md | .github/workflows/golangci-lint.yml)
+        CODE_OF_CONDUCT.md | SECURITY.md)
           echo "${source_file} missing in ${org_repo}, force updating."
           needs_update+=("${source_file}")
           ;;
@@ -159,8 +162,12 @@ process_repo() {
 
   # Update the files in target repo by one from prometheus/prometheus.
   for source_file in "${needs_update[@]}"; do
+    target_filename="${source_file}"
+    if [[ "${source_file}" == 'scripts/golangci-lint.yml' ]] ; then
+      target_filename=".github/workflows/${source_file}"
+    fi
     case "${source_file}" in
-      *) cp -f "${source_dir}/${source_file}" "./${source_file}" ;;
+      *) cp -f "${source_dir}/${source_file}" "./${target_filename}" ;;
     esac
   done
 


### PR DESCRIPTION
* Update golangci-lint to v1.53.3.
* Update the sync script handler for the old golanci-lint action.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
