### PR TITLE
[WebUI/ScrapePoolList] Case-insensitive search of "Scrape Pools"

### DIFF
--- a/web/ui/react-app/src/pages/targets/ScrapePoolList.tsx
+++ b/web/ui/react-app/src/pages/targets/ScrapePoolList.tsx
@@ -31,6 +31,8 @@ const ScrapePoolDropDown: FC<ScrapePoolDropDownProps> = ({ selectedPool, scrapeP
 
   const [filter, setFilter] = useState<string>('');
 
+  const filteredPools = scrapePools.filter((pool) => pool.toLowerCase().includes(filter.toLowerCase()));
+
   return (
     <Dropdown isOpen={dropdownOpen} toggle={toggle}>
       <DropdownToggle caret className="mw-100 text-truncate">
@@ -51,13 +53,11 @@ const ScrapePoolDropDown: FC<ScrapePoolDropDownProps> = ({ selectedPool, scrapeP
         {scrapePools.length === 0 ? (
           <DropdownItem disabled>No scrape pools configured</DropdownItem>
         ) : (
-          scrapePools
-            .filter((name) => filter === '' || name.includes(filter))
-            .map((name) => (
-              <DropdownItem key={name} value={name} onClick={() => onScrapePoolChange(name)} active={name === selectedPool}>
-                {name}
-              </DropdownItem>
-            ))
+          filteredPools.map((name) => (
+            <DropdownItem key={name} value={name} onClick={() => onScrapePoolChange(name)} active={name === selectedPool}>
+              {name}
+            </DropdownItem>
+          ))
         )}
       </DropdownMenu>
     </Dropdown>


### PR DESCRIPTION
**What this PR does / why we need it:**
- [PROBLEM] Searching Scrape Pool targets in web UI does not support case-insensitive matching
- [FIX] This PR adds a case-insensitive search of Scrape Pool targets

Appropriate images are attached below:
<img width="1512" alt="Screenshot 2023-04-01 at 21 15 25" src="https://user-images.githubusercontent.com/46712946/229305591-54693923-4907-46fa-9410-331e1b35edea.png">
<img width="1512" alt="Screenshot 2023-04-01 at 21 15 36" src="https://user-images.githubusercontent.com/46712946/229305598-5a667440-2f56-4dbe-864e-46f5ed1aeb2f.png">

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
