### PR TITLE
Check health & ready: move to flags

### DIFF
--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -58,7 +58,6 @@ Check the resources for validity.
 
 | Flag | Description |
 | --- | --- |
-| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file for promtool to connect to Prometheus. |
 | <code class="text-nowrap">--extended</code> | Print extended information related to the cardinality of the metrics. |
 
 
@@ -137,11 +136,12 @@ Check if the Prometheus server is healthy.
 
 
 
-###### Arguments
+###### Flags
 
-| Argument | Description |
-| --- | --- |
-| server | The URL of the Prometheus server to check (e.g. http://localhost:9090) |
+| Flag | Description | Default |
+| --- | --- | --- |
+| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file for promtool to connect to Prometheus. |  |
+| <code class="text-nowrap">--url</code> | The URL for the Prometheus server. | `http://localhost:9090` |
 
 
 
@@ -152,11 +152,12 @@ Check if the Prometheus server is ready.
 
 
 
-###### Arguments
+###### Flags
 
-| Argument | Description |
-| --- | --- |
-| server | The URL of the Prometheus server to check (e.g. http://localhost:9090) |
+| Flag | Description | Default |
+| --- | --- | --- |
+| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file for promtool to connect to Prometheus. |  |
+| <code class="text-nowrap">--url</code> | The URL for the Prometheus server. | `http://localhost:9090` |
 
 
 


### PR DESCRIPTION
This makes it more consistent with other command like import rules. We don't have stricts rules and uniformity accross promtool unfortunately, but I think it's better to only have the http config on relevant check commands to avoid thinking Prometheus can e.g. check the config over the wire.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
