### PR TITLE
fix:add label validation to remote write receiver

### DIFF
--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -684,6 +684,10 @@ func DecodeWriteRequest(r io.Reader) (*prompb.WriteRequest, error) {
 	if err := proto.Unmarshal(reqBuf, &req); err != nil {
 		return nil, err
 	}
-
+	for _, ts := range req.Timeseries {
+		if err := validateLabelsAndMetricName(ts.Labels); err != nil {
+			return nil, err
+		}
+	}
 	return &req, nil
 }

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -362,6 +362,21 @@ func TestDecodeWriteRequest(t *testing.T) {
 	actual, err := DecodeWriteRequest(bytes.NewReader(buf))
 	require.NoError(t, err)
 	require.Equal(t, writeRequestFixture, actual)
+
+	tss := append(writeRequestFixture.Timeseries, prompb.TimeSeries{
+		Labels: []prompb.Label{
+			{Name: "__name__", Value: "test_metric3"},
+			{Name: "b-c", Value: "c"},
+			{Name: "baz", Value: "qux"},
+		},
+		Samples: []prompb.Sample{{Value: 1, Timestamp: 0}},
+	})
+	buf, _, err = buildWriteRequest(tss, nil, nil, nil)
+	require.NoError(t, err)
+
+	actual, err = DecodeWriteRequest(bytes.NewReader(buf))
+	require.Error(t, err)
+	require.Nil(t, actual)
 }
 
 func TestNilHistogramProto(t *testing.T) {


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
