### PR TITLE
promtool: read from stdin if no filenames are provided in check rules

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -131,7 +131,7 @@ func main() {
 	checkRulesCmd := checkCmd.Command("rules", "Check if the rule files are valid or not.")
 	ruleFiles := checkRulesCmd.Arg(
 		"rule-files",
-		"The rule files to check, default is read from standard input (STDIN).",
+		"The rule files to check, default is read from standard input.",
 	).ExistingFiles()
 	checkRulesLint := checkRulesCmd.Flag(
 		"lint",
@@ -690,7 +690,7 @@ func CheckRules(ls lintConfig, files ...string) int {
 	failed := false
 	hasErrors := false
 
-	// add empty string to avoid matching filename
+	// Add empty string to avoid matching filename.
 	if len(files) == 0 {
 		files = append(files, "")
 	}
@@ -723,7 +723,7 @@ func checkRules(filename string, lintSettings lintConfig) (int, []error) {
 	var rgs *rulefmt.RuleGroups
 	var errs []error
 
-	// if filename is an empty string it is a stdin
+	// Empty string is stdin input.
 	if filename == "" {
 		data, err := io.ReadAll(os.Stdin)
 		if err != nil {

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -448,20 +448,12 @@ func CheckConfig(agentMode, checkSyntaxOnly bool, lintSettings lintConfig, files
 		}
 		fmt.Println()
 
-		for _, rf := range ruleFiles {
-			if n, errs := checkRules(rf, lintSettings); len(errs) > 0 {
-				fmt.Fprintln(os.Stderr, "  FAILED:")
-				for _, err := range errs {
-					fmt.Fprintln(os.Stderr, "    ", err)
-				}
-				failed = true
-				for _, err := range errs {
-					hasErrors = hasErrors || !errors.Is(err, lintError)
-				}
-			} else {
-				fmt.Printf("  SUCCESS: %d rules found\n", n)
-			}
-			fmt.Println()
+		rulesFailed, rulesHasErrors := checkRules(ruleFiles, lintSettings)
+		if rulesFailed {
+			failed = rulesFailed
+		}
+		if rulesHasErrors {
+			hasErrors = rulesHasErrors
 		}
 	}
 	if failed && hasErrors {
@@ -689,14 +681,57 @@ func checkSDFile(filename string) ([]*targetgroup.Group, error) {
 func CheckRules(ls lintConfig, files ...string) int {
 	failed := false
 	hasErrors := false
-
-	// Add empty string to avoid matching filename.
 	if len(files) == 0 {
-		files = append(files, "")
+		fmt.Println("Checking standard input")
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "  FAILED:", err)
+			return failureExitCode
+		}
+		rgs, errs := rulefmt.Parse(data)
+		for _, e := range errs {
+			fmt.Fprintln(os.Stderr, e.Error())
+			return failureExitCode
+		}
+		if n, errs := checkRuleGroups(rgs, ls); errs != nil {
+			fmt.Fprintln(os.Stderr, "  FAILED:")
+			for _, e := range errs {
+				fmt.Fprintln(os.Stderr, e.Error())
+			}
+			failed = true
+			for _, err := range errs {
+				hasErrors = hasErrors || !errors.Is(err, lintError)
+			}
+		} else {
+			fmt.Printf("  SUCCESS: %d rules found\n", n)
+		}
+		fmt.Println()
+	} else {
+		failed, hasErrors = checkRules(files, ls)
 	}
 
+	if failed && hasErrors {
+		return failureExitCode
+	}
+	if failed && ls.fatal {
+		return lintErrExitCode
+	}
+
+	return successExitCode
+}
+
+// checkRules validates rule files.
+func checkRules(files []string, ls lintConfig) (bool, bool) {
+	failed := false
+	hasErrors := false
 	for _, f := range files {
-		if n, errs := checkRules(f, ls); errs != nil {
+		fmt.Println("Checking", f)
+		rgs, errs := rulefmt.ParseFile(f)
+		if errs != nil {
+			failed = true
+			continue
+		}
+		if n, errs := checkRuleGroups(rgs, ls); errs != nil {
 			fmt.Fprintln(os.Stderr, "  FAILED:")
 			for _, e := range errs {
 				fmt.Fprintln(os.Stderr, e.Error())
@@ -710,37 +745,10 @@ func CheckRules(ls lintConfig, files ...string) int {
 		}
 		fmt.Println()
 	}
-	if failed && hasErrors {
-		return failureExitCode
-	}
-	if failed && ls.fatal {
-		return lintErrExitCode
-	}
-	return successExitCode
+	return failed, hasErrors
 }
 
-func checkRules(filename string, lintSettings lintConfig) (int, []error) {
-	var rgs *rulefmt.RuleGroups
-	var errs []error
-
-	// Empty string is stdin input.
-	if filename == "" {
-		data, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			errs = append(errs, err)
-			return failureExitCode, errs
-		}
-		fmt.Println("Checking stdin")
-		rgs, errs = rulefmt.Parse(data)
-	} else {
-		fmt.Println("Checking", filename)
-		rgs, errs = rulefmt.ParseFile(filename)
-	}
-
-	if errs != nil {
-		return successExitCode, errs
-	}
-
+func checkRuleGroups(rgs *rulefmt.RuleGroups, lintSettings lintConfig) (int, []error) {
 	numRules := 0
 	for _, rg := range rgs.Groups {
 		numRules += len(rg.Rules)

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -181,7 +181,7 @@ Check if the rule files are valid or not.
 
 | Argument | Description |
 | --- | --- |
-| rule-files | The rule files to check, default is read from standard input (STDIN). |
+| rule-files | The rule files to check, default is read from standard input. |
 
 
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -179,9 +179,9 @@ Check if the rule files are valid or not.
 
 ###### Arguments
 
-| Argument | Description | Default |
-| --- | --- | --- |
-| rule-files | The rule files to check, default is read from standard input (STDIN). | `-` |
+| Argument | Description |
+| --- | --- |
+| rule-files | The rule files to check, default is read from standard input (STDIN). |
 
 
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -179,9 +179,9 @@ Check if the rule files are valid or not.
 
 ###### Arguments
 
-| Argument | Description | Required |
+| Argument | Description | Default |
 | --- | --- | --- |
-| rule-files | The rule files to check. | Yes |
+| rule-files | The rule files to check, default is read from standard input (STDIN). | `-` |
 
 
 


### PR DESCRIPTION
Hello,

I want to add stdin support in promtool check rules, like this
```
$ cat /tmp/fgx.yaml | promtool check rules
Checking stdin
  SUCCESS: 1 rules found
```

We could do it with `promtool check rules /dev/stdin` but it's not supported by all platform like windows.

It remove the check `ExistingFiles` in command line, but this checks is performed later.

```
$ promtool check rules /tmp/nofile.yaml /tmp/fgx.yaml
Checking /tmp/nofile.yaml
  FAILED:
/tmp/nofile.yaml: open /tmp/nofile.yaml: no such file or directory

Checking /tmp/fgx.yaml
  SUCCESS: 1 rules found
```

Let me know if it could be merged.