### PR TITLE
storage/remote: allow propagating HTTPClientOptions to clients

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -584,7 +584,7 @@ func main() {
 	var (
 		localStorage  = &readyStorage{stats: tsdb.NewDBStats()}
 		scraper       = &readyScrapeManager{}
-		remoteStorage = remote.NewStorage(log.With(logger, "component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper)
+		remoteStorage = remote.NewStorage(log.With(logger, "component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, nil)
 		fanoutStorage = storage.NewFanout(logger, localStorage, remoteStorage)
 	)
 

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -108,8 +108,12 @@ type ReadClient interface {
 }
 
 // NewReadClient creates a new client for remote read.
-func NewReadClient(name string, conf *ClientConfig) (ReadClient, error) {
-	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client")
+func NewReadClient(name string, conf *ClientConfig, options *Options) (ReadClient, error) {
+	var clientOptions []config_util.HTTPClientOption
+	if options != nil {
+		clientOptions = options.HTTPClientOptions
+	}
+	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client", clientOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -132,8 +136,12 @@ func NewReadClient(name string, conf *ClientConfig) (ReadClient, error) {
 }
 
 // NewWriteClient creates a new client for remote write.
-func NewWriteClient(name string, conf *ClientConfig) (WriteClient, error) {
-	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_write_client")
+func NewWriteClient(name string, conf *ClientConfig, options *Options) (WriteClient, error) {
+	var clientOptions []config_util.HTTPClientOption
+	if options != nil {
+		clientOptions = options.HTTPClientOptions
+	}
+	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_write_client", clientOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -70,7 +70,7 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 
 		hash, err := toHash(conf)
 		require.NoError(t, err)
-		c, err := NewWriteClient(hash, conf)
+		c, err := NewWriteClient(hash, conf, nil)
 		require.NoError(t, err)
 
 		err = c.Store(context.Background(), []byte{})
@@ -95,7 +95,7 @@ func TestClientRetryAfter(t *testing.T) {
 	getClient := func(conf *ClientConfig) WriteClient {
 		hash, err := toHash(conf)
 		require.NoError(t, err)
-		c, err := NewWriteClient(hash, conf)
+		c, err := NewWriteClient(hash, conf, nil)
 		require.NoError(t, err)
 		return c
 	}

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -80,7 +80,7 @@ func TestSampleDelivery(t *testing.T) {
 
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, nil)
 	defer s.Close()
 
 	queueConfig := config.DefaultQueueConfig

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -91,7 +91,7 @@ func TestNoDuplicateReadConfigs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
-			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, nil)
 			conf := &config.Config{
 				GlobalConfig:      config.DefaultGlobalConfig,
 				RemoteReadConfigs: tc.cfgs,

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -27,7 +27,7 @@ import (
 func TestStorageLifecycle(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, nil)
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
@@ -54,7 +54,7 @@ func TestStorageLifecycle(t *testing.T) {
 func TestUpdateRemoteReadConfigs(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, nil)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},
@@ -75,7 +75,7 @@ func TestUpdateRemoteReadConfigs(t *testing.T) {
 func TestFilterExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, nil)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{
@@ -100,7 +100,7 @@ func TestFilterExternalLabels(t *testing.T) {
 func TestIgnoreExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, nil)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -56,9 +56,10 @@ var (
 
 // WriteStorage represents all the remote write storage.
 type WriteStorage struct {
-	logger log.Logger
-	reg    prometheus.Registerer
-	mtx    sync.Mutex
+	options *Options
+	logger  log.Logger
+	reg     prometheus.Registerer
+	mtx     sync.Mutex
 
 	watcherMetrics    *wlog.WatcherMetrics
 	liveReaderMetrics *wlog.LiveReaderMetrics
@@ -76,11 +77,12 @@ type WriteStorage struct {
 }
 
 // NewWriteStorage creates and runs a WriteStorage.
-func NewWriteStorage(logger log.Logger, reg prometheus.Registerer, dir string, flushDeadline time.Duration, sm ReadyScrapeManager) *WriteStorage {
+func NewWriteStorage(logger log.Logger, reg prometheus.Registerer, dir string, flushDeadline time.Duration, sm ReadyScrapeManager, options *Options) *WriteStorage {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
 	rws := &WriteStorage{
+		options:           options,
 		queues:            make(map[string]*QueueManager),
 		watcherMetrics:    wlog.NewWatcherMetrics(reg),
 		liveReaderMetrics: wlog.NewLiveReaderMetrics(reg),
@@ -160,7 +162,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			SigV4Config:      rwConf.SigV4Config,
 			Headers:          rwConf.Headers,
 			RetryOnRateLimit: rwConf.QueueConfig.RetryOnRateLimit,
-		})
+		}, rws.options)
 		if err != nil {
 			return err
 		}

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -111,7 +111,7 @@ func TestNoDuplicateWriteConfigs(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil)
+		s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, nil)
 		conf := &config.Config{
 			GlobalConfig:       config.DefaultGlobalConfig,
 			RemoteWriteConfigs: tc.cfgs,
@@ -133,7 +133,7 @@ func TestRestartOnNameChange(t *testing.T) {
 	hash, err := toHash(cfg)
 	require.NoError(t, err)
 
-	s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil)
+	s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, nil)
 
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
@@ -158,7 +158,7 @@ func TestRestartOnNameChange(t *testing.T) {
 func TestUpdateWithRegisterer(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Millisecond, nil)
+	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Millisecond, nil, nil)
 	c1 := &config.RemoteWriteConfig{
 		Name: "named",
 		URL: &common_config.URL{
@@ -198,7 +198,7 @@ func TestUpdateWithRegisterer(t *testing.T) {
 func TestWriteStorageLifecycle(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, nil)
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
@@ -215,7 +215,7 @@ func TestWriteStorageLifecycle(t *testing.T) {
 func TestUpdateExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Second, nil)
+	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Second, nil, nil)
 
 	externalLabels := labels.FromStrings("external", "true")
 	conf := &config.Config{
@@ -244,7 +244,7 @@ func TestUpdateExternalLabels(t *testing.T) {
 func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, nil)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},
@@ -270,7 +270,7 @@ func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
 func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, nil)
 
 	c0 := &config.RemoteWriteConfig{
 		RemoteTimeout: model.Duration(10 * time.Second),

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -87,7 +87,7 @@ func createTestAgentDB(t *testing.T, reg prometheus.Registerer, opts *Options) *
 	t.Helper()
 
 	dbDir := t.TempDir()
-	rs := remote.NewStorage(log.NewNopLogger(), reg, startTime, dbDir, time.Second*30, nil)
+	rs := remote.NewStorage(log.NewNopLogger(), reg, startTime, dbDir, time.Second*30, nil, nil)
 	t.Cleanup(func() {
 		require.NoError(t, rs.Close())
 	})
@@ -583,7 +583,7 @@ func TestLockfile(t *testing.T) {
 	tsdbutil.TestDirLockerUsage(t, func(t *testing.T, data string, createLock bool) (*tsdbutil.DirLocker, testutil.Closer) {
 		logger := log.NewNopLogger()
 		reg := prometheus.NewRegistry()
-		rs := remote.NewStorage(logger, reg, startTime, data, time.Second*30, nil)
+		rs := remote.NewStorage(logger, reg, startTime, data, time.Second*30, nil, nil)
 		t.Cleanup(func() {
 			require.NoError(t, rs.Close())
 		})
@@ -603,7 +603,7 @@ func TestLockfile(t *testing.T) {
 
 func Test_ExistingWAL_NextRef(t *testing.T) {
 	dbDir := t.TempDir()
-	rs := remote.NewStorage(log.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil)
+	rs := remote.NewStorage(log.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, nil)
 	defer func() {
 		require.NoError(t, rs.Close())
 	}()

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -416,7 +416,7 @@ func TestEndpoints(t *testing.T) {
 
 		remote := remote.NewStorage(promlog.New(&promlogConfig), prometheus.DefaultRegisterer, func() (int64, error) {
 			return 0, nil
-		}, dbDir, 1*time.Second, nil)
+		}, dbDir, 1*time.Second, nil, nil)
 
 		err = remote.ApplyConfig(&config.Config{
 			RemoteReadConfigs: []*config.RemoteReadConfig{


### PR DESCRIPTION
Allow HTTPClientOptions to be passed to remote_write and remote_read clients so callers can customize the generated HTTP clients.

Related to prometheus/common#434, where I want to be able to use io/fs.FS for TLS certificates with generated remote_write clients. 

I only need this for remote_write, but I also added it to remote_read for consistency. 