### PR TITLE
fix: RLIM_INFINITY type is uint64 on loong64

### DIFF
--- a/util/runtime/limits_default.go
+++ b/util/runtime/limits_default.go
@@ -18,16 +18,18 @@ package runtime
 
 import (
 	"fmt"
+	"math"
 	"syscall"
 )
 
-// syscall.RLIM_INFINITY is a constant and its default type is int.
-// It needs to be converted to an int64 variable to be compared with uint64 values.
-// See https://golang.org/ref/spec#Conversions
-var unlimited int64 = syscall.RLIM_INFINITY
+// syscall.RLIM_INFINITY is a constant.
+// Its type is int on most architectures but there are exceptions such as loong64.
+// Uniform it to uint accorind to the standard.
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_resource.h.html
+var unlimited uint64 = syscall.RLIM_INFINITY & math.MaxUint64
 
 func limitToString(v uint64, unit string) string {
-	if v == uint64(unlimited) {
+	if v == unlimited {
 		return "unlimited"
 	}
 	return fmt.Sprintf("%d%s", v, unit)


### PR DESCRIPTION
When I ported prometheus to loong64 I got this problem. I fix the problem by this PR.

Also I don't want to use build constraints to solve this, it doesn't look worth it. 
[zerrors_linux_amd64.go](https://github.com/golang/go/blob/master/src/syscall/zerrors_linux_amd64.go#L780)
[zerrors_linux_loong64.go](https://github.com/golang/go/blob/master/src/syscall/zerrors_linux_loong64.go#L1164)

I think the root problem is caused by golang. So I consulted the golang comminuty,  Bran C. Mills and peterGo gave me some advices but still can't explain how exactly this difference arises.
[https://groups.google.com/g/golang-nuts/c/XTKcN5q8DaQ](https://groups.google.com/g/golang-nuts/c/XTKcN5q8DaQ)

A test for this.
https://go.dev/play/p/MJpePQDL-1A

I don't know how to sign CNCF's Developer Certificate, a reference link maybe help me.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
