### PR TITLE
Add mlock when reading symbols in index reader

### DIFF
--- a/tsdb/index/reader_builder_default.go
+++ b/tsdb/index/reader_builder_default.go
@@ -1,0 +1,44 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package index
+
+import (
+	"fmt"
+	"io"
+	"syscall"
+)
+
+func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
+	r := &Reader{
+		b:        b,
+		c:        c,
+		postings: map[string][]postingOffset{},
+	}
+	r.readSymbolsFunc = func() (*Symbols, error) {
+		if err := syscall.Mlock(r.b.Range(int(r.toc.Symbols), int(r.toc.Series))); err != nil {
+			fmt.Printf("unable to call mlock, err: %v\n", err)
+		}
+		return NewSymbols(r.b, r.version, int(r.toc.Symbols))
+	}
+	r.closeReaderFunc = func() error {
+		if err := syscall.Munlock(r.b.Range(int(r.toc.Symbols), int(r.toc.Series))); err != nil {
+			fmt.Printf("unable to call munlock, err: %v\n", err)
+		}
+		return r.c.Close()
+	}
+	return createReader(r)
+}

--- a/tsdb/index/reader_builder_windows.go
+++ b/tsdb/index/reader_builder_windows.go
@@ -16,6 +16,10 @@
 
 package index
 
+import (
+	"io"
+)
+
 func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 	r := &Reader{
 		b:        b,
@@ -23,11 +27,7 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 		postings: map[string][]postingOffset{},
 	}
 	r.readSymbolsFunc = func() (*Symbols, error) {
-		symbols, err = NewSymbols(r.b, r.version, int(r.toc.Symbols))
-		if err != nil {
-			return nil, errors.Wrap(err, "read symbols")
-		}
-		return symbols, nil
+		return NewSymbols(r.b, r.version, int(r.toc.Symbols))
 	}
 	r.closeReaderFunc = func() error {
 		return r.c.Close()

--- a/tsdb/index/reader_builder_windows.go
+++ b/tsdb/index/reader_builder_windows.go
@@ -1,0 +1,36 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package index
+
+func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
+	r := &Reader{
+		b:        b,
+		c:        c,
+		postings: map[string][]postingOffset{},
+	}
+	r.readSymbolsFunc = func() (*Symbols, error) {
+		symbols, err = NewSymbols(r.b, r.version, int(r.toc.Symbols))
+		if err != nil {
+			return nil, errors.Wrap(err, "read symbols")
+		}
+		return symbols, nil
+	}
+	r.closeReaderFunc = func() error {
+		return r.c.Close()
+	}
+	return createReader(r)
+}


### PR DESCRIPTION
Use mlock for Unix binary when reading symbols in index reader to lower page IO if symbols size is huge.
