### PR TITLE
Optimize and test MemoizedSeriesIterator

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1850,7 +1850,7 @@ func (ev *evaluator) vectorSelectorSingle(it *storage.MemoizedSeriesIterator, no
 		}
 	case chunkenc.ValFloat:
 		t, v = it.At()
-	case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
+	case chunkenc.ValFloatHistogram:
 		t, h = it.AtFloatHistogram()
 	default:
 		panic(fmt.Errorf("unknown value type %v", valueType))

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1857,7 +1857,7 @@ func (ev *evaluator) vectorSelectorSingle(it *storage.MemoizedSeriesIterator, no
 	}
 	if valueType == chunkenc.ValNone || t > refTime {
 		var ok bool
-		t, v, _, h, ok = it.PeekPrev()
+		t, v, h, ok = it.PeekPrev()
 		if !ok || t < refTime-durationMilliseconds(ev.lookbackDelta) {
 			return 0, 0, nil, false
 		}


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

https://github.com/prometheus/prometheus/issues/11274

This PR makes a couple of changes to `MemorizedSeriesIterator`:
- Remove support for `AtHistogram()`; this iterator is only used in the PromQL engine which only works with float histograms.
- Automatically convert integer histograms to float histograms when calling `AtFloatHistogram()` (I'm not sure about this change; it looks like the iterator can point to an integer histogram but we want an auto-converted float histogram? Or is it that the iterator can never point to an integer histogram? I'm guessing the former, but let me know if I'm wrong!)

This PR also adds tests testing the iterator's support native histograms.