### PR TITLE
Making the number of CPU cores used for sorting postings lists editable

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -129,6 +129,10 @@ type Options struct {
 	// If it is <=0, then GOMAXPROCS is used.
 	WALReplayConcurrency int
 
+	// Maximum number of CPUs that can simultaneously sort postings lists.
+	// If it is <=0, then GOMAXPROCS is used.
+	MemPostsEnsureOrderConcurrency int
+
 	// StripeSize is the size in entries of the series hash map. Reducing the size will save memory but impact performance.
 	StripeSize int
 
@@ -788,6 +792,9 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	headOpts.OutOfOrderCapMax.Store(opts.OutOfOrderCapMax)
 	if opts.WALReplayConcurrency > 0 {
 		headOpts.WALReplayConcurrency = opts.WALReplayConcurrency
+	}
+	if opts.MemPostsEnsureOrderConcurrency > 0 {
+		headOpts.MemPostingsEnsureOrderConcurrency = opts.MemPostsEnsureOrderConcurrency
 	}
 	if opts.IsolationDisabled {
 		// We only override this flag if isolation is disabled at DB level. We use the default otherwise.

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -129,10 +129,6 @@ type Options struct {
 	// If it is <=0, then GOMAXPROCS is used.
 	WALReplayConcurrency int
 
-	// Maximum number of CPUs that can simultaneously sort postings lists.
-	// If it is <=0, then GOMAXPROCS is used.
-	MemPostsEnsureOrderConcurrency int
-
 	// StripeSize is the size in entries of the series hash map. Reducing the size will save memory but impact performance.
 	StripeSize int
 
@@ -792,9 +788,6 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	headOpts.OutOfOrderCapMax.Store(opts.OutOfOrderCapMax)
 	if opts.WALReplayConcurrency > 0 {
 		headOpts.WALReplayConcurrency = opts.WALReplayConcurrency
-	}
-	if opts.MemPostsEnsureOrderConcurrency > 0 {
-		headOpts.MemPostingsEnsureOrderConcurrency = opts.MemPostsEnsureOrderConcurrency
 	}
 	if opts.IsolationDisabled {
 		// We only override this flag if isolation is disabled at DB level. We use the default otherwise.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -164,6 +164,10 @@ type HeadOptions struct {
 	// The default value is GOMAXPROCS.
 	// If it is set to a negative value or zero, the default value is used.
 	WALReplayConcurrency int
+
+	// Maximum number of CPUs that can be used for sorting postings lists.
+	// The default value is 0, meaning all available CPU cores will be used.
+	MemPostingsEnsureOrderConcurrency int
 }
 
 const (
@@ -574,7 +578,7 @@ const cardinalityCacheExpirationTime = time.Duration(30) * time.Second
 func (h *Head) Init(minValidTime int64) error {
 	h.minValidTime.Store(minValidTime)
 	defer func() {
-		h.postings.EnsureOrder()
+		h.postings.EnsureOrder(h.opts.MemPostingsEnsureOrderConcurrency)
 	}()
 	defer h.gc() // After loading the wal remove the obsolete data from the head.
 	defer func() {

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -225,7 +225,7 @@ func (p *MemPostings) All() Postings {
 // EnsureOrder ensures that all postings lists are sorted. After it returns all further
 // calls to add and addFor will insert new IDs in a sorted manner.
 // Parameter numberOfConcurrentProcesses is used to specify the maximal number of
-// CPU cores used for this operation. If it is <= 0, GOMAXPROCS(0) is used.
+// CPU cores used for this operation. If it is <= 0, GOMAXPROCS is used.
 // GOMAXPROCS(0) was the default before introducing this parameter.
 func (p *MemPostings) EnsureOrder(numberOfConcurrentProcesses int) {
 	p.mtx.Lock()

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -226,7 +226,7 @@ func (p *MemPostings) All() Postings {
 // calls to add and addFor will insert new IDs in a sorted manner.
 // Parameter numberOfConcurrentProcesses is used to specify the maximal number of
 // CPU cores used for this operation. If it is <= 0, GOMAXPROCS is used.
-// GOMAXPROCS(0) was the default before introducing this parameter.
+// GOMAXPROCS was the default before introducing this parameter.
 func (p *MemPostings) EnsureOrder(numberOfConcurrentProcesses int) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -54,7 +54,7 @@ func TestMemPostings_ensureOrder(t *testing.T) {
 		p.m["a"][v] = l
 	}
 
-	p.EnsureOrder()
+	p.EnsureOrder(0)
 
 	for _, e := range p.m {
 		for _, l := range e {
@@ -114,7 +114,7 @@ func BenchmarkMemPostings_ensureOrder(b *testing.B) {
 			b.ResetTimer()
 
 			for n := 0; n < b.N; n++ {
-				p.EnsureOrder()
+				p.EnsureOrder(0)
 				p.ordered = false
 			}
 		})


### PR DESCRIPTION
This PR changes the signature of `MemPostings.EnsureOrder()` by introducing parameter `numberOfConcurrentProcesses`, representing the maximal number of CPU cores used for this operation. If it is less or equal to 0, `GOMAXPROCS` is used. `GOMAXPROCS` was the default before introducing this parameter.