### PR TITLE
Use same error for instant and range query when 400

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -522,7 +522,7 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 	}
 	qry, err := api.QueryEngine.NewRangeQuery(api.Queryable, opts, r.FormValue("query"), start, end, step)
 	if err != nil {
-		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
+		return invalidParamError(err, "query")
 	}
 	// From now on, we must only return with a finalizer in the result (to
 	// be called by the caller) or call qry.Close ourselves (which is


### PR DESCRIPTION
If failed to intialize an instant query, the error is wrapped with `invalidParamError` https://github.com/prometheus/prometheus/blob/main/web/api/v1/api.go#L422.

However, we don't do the same for range query so this pr changes that and returns the same error for the two.