### PR TITLE
labels: add ScratchBuilder.Overwrite for slice implementation

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -631,3 +631,9 @@ func (b *ScratchBuilder) Labels() Labels {
 	// Copy the slice, so the next use of ScratchBuilder doesn't overwrite.
 	return append([]Label{}, b.add...)
 }
+
+// Write the newly-built Labels out to ls.
+// Callers must ensure that there are no other references to ls, or any strings fetched from it.
+func (b *ScratchBuilder) Overwrite(ls *Labels) {
+	*ls = append((*ls)[:0], b.add...)
+}

--- a/model/labels/labels_string.go
+++ b/model/labels/labels_string.go
@@ -811,7 +811,7 @@ func (b *ScratchBuilder) Labels() Labels {
 }
 
 // Write the newly-built Labels out to ls, reusing an internal buffer.
-// Callers must ensure that there are no other references to ls.
+// Callers must ensure that there are no other references to ls, or any strings fetched from it.
 func (b *ScratchBuilder) Overwrite(ls *Labels) {
 	size := labelsSize(b.add)
 	if size <= cap(b.overwriteBuffer) {


### PR DESCRIPTION
This is a method used by some downstream projects; it was created to optimize the implementation in `labels_string.go` but we should have one for both implementations so the same code works with either.

Also strengthen the warning about how careful you have to be.

Mentioned at #12230 
