### PR TITLE
Handle more arithmetic operators for native histograms

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -589,8 +589,9 @@ over time and return an instant vector with per-series aggregation results:
 Note that all values in the specified interval have the same weight in the
 aggregation even if the values are not equally spaced throughout the interval.
 
-`count_over_time`, `last_over_time`, and `present_over_time` handle native
-histograms as expected. All other functions ignore histogram samples.
+`avg_over_time`, `sum_over_time`, `count_over_time`, `last_over_time`, and
+`present_over_time` handle native histograms as expected. All other functions
+ignore histogram samples.
 
 ## Trigonometric Functions
 

--- a/docs/querying/operators.md
+++ b/docs/querying/operators.md
@@ -318,19 +318,23 @@ histograms is still very limited.
 Logical/set binary operators work as expected even if histogram samples are
 involved. They only check for the existence of a vector element and don't
 change their behavior depending on the sample type of an element (float or
-histogram).
+histogram). The `count` aggregation operator works similarly.
 
-The binary `+` operator between two native histograms and the `sum` aggregation
-operator to aggregate native histograms are fully supported. Even if the
-histograms involved have different bucket layouts, the buckets are
-automatically converted appropriately so that the operation can be
+The binary `+` and `-` operators between two native histograms and the `sum`
+and `avg` aggregation operators to aggregate native histograms are fully
+supported. Even if the histograms involved have different bucket layouts, the
+buckets are automatically converted appropriately so that the operation can be
 performed. (With the currently supported bucket schemas, that's always
-possible.) If either operator has to sum up a mix of histogram samples and
+possible.) If either operator has to aggregate a mix of histogram samples and
 float samples, the corresponding vector element is removed from the output
 vector entirely.
 
-All other operators do not behave in a meaningful way. They either treat the
-histogram sample as if it were a float sample of value 0, or (in case of
-arithmetic operations between a scalar and a vector) they leave the histogram
-sample unchanged. This behavior will change to a meaningful one before native
-histograms are a stable feature.
+The binary `*` operator works between a native histogram and a float in any
+order, while the binary `/` operator can be used between a native histogram
+and a float in that exact order.
+
+All other operators (and unmentioned cases for the above operators) do not
+behave in a meaningful way. They either treat the histogram sample as if it
+were a float sample of value 0, or (in case of arithmetic operations between a
+scalar and a vector) they leave the histogram sample unchanged. This behavior
+will change to a meaningful one before native histograms are a stable feature.

--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -159,12 +159,12 @@ func (h *FloatHistogram) ZeroBucket() Bucket[float64] {
 	}
 }
 
-// Scale scales the FloatHistogram by the provided factor, i.e. it scales all
+// Mul multiplies the FloatHistogram by the provided factor, i.e. it scales all
 // bucket counts including the zero bucket and the count and the sum of
 // observations. The bucket layout stays the same. This method changes the
 // receiving histogram directly (rather than acting on a copy). It returns a
 // pointer to the receiving histogram for convenience.
-func (h *FloatHistogram) Scale(factor float64) *FloatHistogram {
+func (h *FloatHistogram) Mul(factor float64) *FloatHistogram {
 	h.ZeroCount *= factor
 	h.Count *= factor
 	h.Sum *= factor

--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -270,6 +270,40 @@ func (h *FloatHistogram) Sub(other *FloatHistogram) *FloatHistogram {
 	return h
 }
 
+// Mul multiplies a histogram by the provided float scalar, adjusting count, sum,
+// and bucket counts, and keeping the spans untouched.
+//
+// This method returns a pointer to the receiving histogram for convenience.
+func (h *FloatHistogram) Mul(scalar float64) *FloatHistogram {
+	h.ZeroCount *= scalar
+	h.Count *= scalar
+	h.Sum *= scalar
+	for i := range h.PositiveBuckets {
+		h.PositiveBuckets[i] *= scalar
+	}
+	for i := range h.NegativeBuckets {
+		h.NegativeBuckets[i] *= scalar
+	}
+	return h
+}
+
+// Div divides a histogram by the provided float scalar (assuming non-0), adjusting count, sum,
+// and bucket counts, and keeping the spans untouched.
+//
+// This method returns a pointer to the receiving histogram for convenience.
+func (h *FloatHistogram) Div(scalar float64) *FloatHistogram {
+	h.ZeroCount /= scalar
+	h.Count /= scalar
+	h.Sum /= scalar
+	for i := range h.PositiveBuckets {
+		h.PositiveBuckets[i] /= scalar
+	}
+	for i := range h.NegativeBuckets {
+		h.NegativeBuckets[i] /= scalar
+	}
+	return h
+}
+
 // Equals returns true if the given float histogram matches exactly.
 // Exact match is when there are no new buckets (even empty) and no missing buckets,
 // and all the bucket values match. Spans can have different empty length spans in between,

--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -178,6 +178,7 @@ func (h *FloatHistogram) Scale(factor float64) *FloatHistogram {
 }
 
 // Div works like Scale but divides instead of multiplies.
+// When dividing by 0, everything will be set to Inf.
 func (h *FloatHistogram) Div(scalar float64) *FloatHistogram {
 	h.ZeroCount /= scalar
 	h.Count /= scalar

--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -177,6 +177,20 @@ func (h *FloatHistogram) Scale(factor float64) *FloatHistogram {
 	return h
 }
 
+// Div works like Scale but divides instead of multiplies.
+func (h *FloatHistogram) Div(scalar float64) *FloatHistogram {
+	h.ZeroCount /= scalar
+	h.Count /= scalar
+	h.Sum /= scalar
+	for i := range h.PositiveBuckets {
+		h.PositiveBuckets[i] /= scalar
+	}
+	for i := range h.NegativeBuckets {
+		h.NegativeBuckets[i] /= scalar
+	}
+	return h
+}
+
 // Add adds the provided other histogram to the receiving histogram. Count, Sum,
 // and buckets from the other histogram are added to the corresponding
 // components of the receiving histogram. Buckets in the other histogram that do
@@ -266,40 +280,6 @@ func (h *FloatHistogram) Sub(other *FloatHistogram) *FloatHistogram {
 			b, h.NegativeSpans, h.NegativeBuckets, iSpan, iBucket, iInSpan, index,
 		)
 		index = b.Index
-	}
-	return h
-}
-
-// Mul multiplies a histogram by the provided float scalar, adjusting count, sum,
-// and bucket counts, and keeping the spans untouched.
-//
-// This method returns a pointer to the receiving histogram for convenience.
-func (h *FloatHistogram) Mul(scalar float64) *FloatHistogram {
-	h.ZeroCount *= scalar
-	h.Count *= scalar
-	h.Sum *= scalar
-	for i := range h.PositiveBuckets {
-		h.PositiveBuckets[i] *= scalar
-	}
-	for i := range h.NegativeBuckets {
-		h.NegativeBuckets[i] *= scalar
-	}
-	return h
-}
-
-// Div divides a histogram by the provided float scalar (assuming non-0), adjusting count, sum,
-// and bucket counts, and keeping the spans untouched.
-//
-// This method returns a pointer to the receiving histogram for convenience.
-func (h *FloatHistogram) Div(scalar float64) *FloatHistogram {
-	h.ZeroCount /= scalar
-	h.Count /= scalar
-	h.Sum /= scalar
-	for i := range h.PositiveBuckets {
-		h.PositiveBuckets[i] /= scalar
-	}
-	for i := range h.NegativeBuckets {
-		h.NegativeBuckets[i] /= scalar
 	}
 	return h
 }

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -1481,6 +1481,90 @@ func TestFloatHistogramSub(t *testing.T) {
 	}
 }
 
+func TestFloatHistogramMul(t *testing.T) {
+	cases := []struct {
+		name     string
+		fh       *FloatHistogram
+		s        float64
+		expected *FloatHistogram
+	}{
+		{
+			"simple multiplication",
+			&FloatHistogram{
+				ZeroThreshold:   0.01,
+				ZeroCount:       11,
+				Count:           30,
+				Sum:             23,
+				PositiveSpans:   []Span{{-2, 2}, {1, 3}},
+				PositiveBuckets: []float64{1, 0, 3, 4, 7},
+				NegativeSpans:   []Span{{3, 2}, {3, 2}},
+				NegativeBuckets: []float64{3, 1, 5, 6},
+			},
+			3,
+			&FloatHistogram{
+				ZeroThreshold:   0.01,
+				ZeroCount:       33,
+				Count:           90,
+				Sum:             69,
+				PositiveSpans:   []Span{{-2, 2}, {1, 3}},
+				PositiveBuckets: []float64{3, 0, 9, 12, 21},
+				NegativeSpans:   []Span{{3, 2}, {3, 2}},
+				NegativeBuckets: []float64{9, 3, 15, 18},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.expected, c.fh.Mul(c.s))
+			// Has it also happened in-place?
+			require.Equal(t, c.expected, c.fh)
+		})
+	}
+}
+
+func TestFloatHistogramDiv(t *testing.T) {
+	cases := []struct {
+		name     string
+		fh       *FloatHistogram
+		s        float64
+		expected *FloatHistogram
+	}{
+		{
+			"simple division",
+			&FloatHistogram{
+				ZeroThreshold:   0.01,
+				ZeroCount:       11,
+				Count:           30,
+				Sum:             23,
+				PositiveSpans:   []Span{{-2, 2}, {1, 3}},
+				PositiveBuckets: []float64{1, 0, 3, 4, 7},
+				NegativeSpans:   []Span{{3, 2}, {3, 2}},
+				NegativeBuckets: []float64{3, 1, 5, 6},
+			},
+			2,
+			&FloatHistogram{
+				ZeroThreshold:   0.01,
+				ZeroCount:       5.5,
+				Count:           15,
+				Sum:             11.5,
+				PositiveSpans:   []Span{{-2, 2}, {1, 3}},
+				PositiveBuckets: []float64{0.5, 0, 1.5, 2, 3.5},
+				NegativeSpans:   []Span{{3, 2}, {3, 2}},
+				NegativeBuckets: []float64{1.5, 0.5, 2.5, 3},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.expected, c.fh.Div(c.s))
+			// Has it also happened in-place?
+			require.Equal(t, c.expected, c.fh)
+		})
+	}
+}
+
 func TestFloatHistogramCopyToSchema(t *testing.T) {
 	cases := []struct {
 		name         string

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -15,6 +15,7 @@ package histogram
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -32,6 +33,30 @@ func TestFloatHistogramScale(t *testing.T) {
 			&FloatHistogram{},
 			3.1415,
 			&FloatHistogram{},
+		},
+		{
+			"zero multiplier",
+			&FloatHistogram{
+				ZeroThreshold:   0.01,
+				ZeroCount:       5.5,
+				Count:           3493.3,
+				Sum:             2349209.324,
+				PositiveSpans:   []Span{{-2, 1}, {2, 3}},
+				PositiveBuckets: []float64{1, 3.3, 4.2, 0.1},
+				NegativeSpans:   []Span{{3, 2}, {3, 2}},
+				NegativeBuckets: []float64{3.1, 3, 1.234e5, 1000},
+			},
+			0,
+			&FloatHistogram{
+				ZeroThreshold:   0.01,
+				ZeroCount:       0,
+				Count:           0,
+				Sum:             0,
+				PositiveSpans:   []Span{{-2, 1}, {2, 3}},
+				PositiveBuckets: []float64{0, 0, 0, 0},
+				NegativeSpans:   []Span{{3, 2}, {3, 2}},
+				NegativeBuckets: []float64{0, 0, 0, 0},
+			},
 		},
 		{
 			"no-op",
@@ -128,6 +153,30 @@ func TestFloatHistogramDiv(t *testing.T) {
 			&FloatHistogram{},
 			3.1415,
 			&FloatHistogram{},
+		},
+		{
+			"zero divisor",
+			&FloatHistogram{
+				ZeroThreshold:   0.01,
+				ZeroCount:       5.5,
+				Count:           3493.3,
+				Sum:             2349209.324,
+				PositiveSpans:   []Span{{-2, 1}, {2, 3}},
+				PositiveBuckets: []float64{1, 3.3, 4.2, 0.1},
+				NegativeSpans:   []Span{{3, 2}, {3, 2}},
+				NegativeBuckets: []float64{3.1, 3, 1.234e5, 1000},
+			},
+			0,
+			&FloatHistogram{
+				ZeroThreshold:   0.01,
+				ZeroCount:       math.Inf(1),
+				Count:           math.Inf(1),
+				Sum:             math.Inf(1),
+				PositiveSpans:   []Span{{-2, 1}, {2, 3}},
+				PositiveBuckets: []float64{math.Inf(1), math.Inf(1), math.Inf(1), math.Inf(1)},
+				NegativeSpans:   []Span{{3, 2}, {3, 2}},
+				NegativeBuckets: []float64{math.Inf(1), math.Inf(1), math.Inf(1), math.Inf(1)},
+			},
 		},
 		{
 			"no-op",

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFloatHistogramScale(t *testing.T) {
+func TestFloatHistogramMul(t *testing.T) {
 	cases := []struct {
 		name     string
 		in       *FloatHistogram
@@ -134,7 +134,7 @@ func TestFloatHistogramScale(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			require.Equal(t, c.expected, c.in.Scale(c.scale))
+			require.Equal(t, c.expected, c.in.Mul(c.scale))
 			// Has it also happened in-place?
 			require.Equal(t, c.expected, c.in)
 		})

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2440,7 +2440,7 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 		}
 		return lhs * rhs, nil, true
 	case parser.DIV:
-		if hlhs != nil && hrhs == nil && rhs != 0 {
+		if hlhs != nil && hrhs == nil {
 			return 0, hlhs.Copy().Div(rhs), true
 		}
 		return lhs / rhs, nil, true

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2427,15 +2427,15 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 			if hrhs.Schema >= hlhs.Schema {
 				return 0, hlhs.Copy().Sub(hrhs).Compact(0), true
 			}
-			return 0, hrhs.Copy().Scale(-1).Add(hlhs).Compact(0), true
+			return 0, hrhs.Copy().Mul(-1).Add(hlhs).Compact(0), true
 		}
 		return lhs - rhs, nil, true
 	case parser.MUL:
 		if hlhs != nil && hrhs == nil {
-			return 0, hlhs.Copy().Scale(rhs), true
+			return 0, hlhs.Copy().Mul(rhs), true
 		}
 		if hlhs == nil && hrhs != nil {
-			return 0, hrhs.Copy().Scale(lhs), true
+			return 0, hrhs.Copy().Mul(lhs), true
 		}
 		return lhs * rhs, nil, true
 	case parser.DIV:
@@ -2635,7 +2635,7 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 					// The histogram being added/subtracted must have
 					// an equal or larger schema.
 					if s.H.Schema >= group.histogramMean.Schema {
-						toAdd := right.Scale(-1).Add(left)
+						toAdd := right.Mul(-1).Add(left)
 						group.histogramMean.Add(toAdd)
 					} else {
 						toAdd := left.Sub(right)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2336,7 +2336,7 @@ func (ev *evaluator) VectorscalarBinop(op parser.ItemType, lhs Vector, rhs Scala
 	for _, lhsSample := range lhs {
 		lv, rv := lhsSample.F, rhs.V
 		var rh *histogram.FloatHistogram
-		lh, rh := lhsSample.H, nil
+		lh := lhsSample.H
 		// lhs always contains the Vector. If the original position was different
 		// swap for calculating the value.
 		if swap {
@@ -2607,9 +2607,6 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		case parser.SUM:
 			if s.H != nil {
 				group.hasHistogram = true
-				if group.hasFloat && group.hasHistogram {
-					break
-				}
 				if group.histogramValue != nil {
 					// The histogram being added must have
 					// an equal or larger schema.
@@ -2624,9 +2621,6 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 				// point in copying the histogram in that case.
 			} else {
 				group.hasFloat = true
-				if group.hasFloat && group.hasHistogram {
-					break
-				}
 				group.floatValue += s.F
 			}
 
@@ -2634,9 +2628,6 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 			group.groupCount++
 			if s.H != nil {
 				group.hasHistogram = true
-				if group.hasFloat && group.hasHistogram {
-					break
-				}
 				if group.histogramMean != nil {
 					left := s.H.Copy().Div(float64(group.groupCount))
 					right := group.histogramMean.Copy().Div(float64(group.groupCount))
@@ -2655,9 +2646,6 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 				// point in copying the histogram in that case.
 			} else {
 				group.hasFloat = true
-				if group.hasFloat && group.hasHistogram {
-					break
-				}
 				if math.IsInf(group.mean, 0) {
 					if math.IsInf(s.F, 0) && (group.mean > 0) == (s.F > 0) {
 						// The `mean` and `s.V` values are `Inf` of the same sign.  They
@@ -2753,6 +2741,7 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		case parser.AVG:
 			if aggr.hasFloat && aggr.hasHistogram {
 				// We cannot aggregate histogram sample with a float64 sample.
+				// TODO(zenador): Issue warning when plumbing is in place.
 				continue
 			}
 			if aggr.hasHistogram {
@@ -2802,6 +2791,7 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		case parser.SUM:
 			if aggr.hasFloat && aggr.hasHistogram {
 				// We cannot aggregate histogram sample with a float64 sample.
+				// TODO(zenador): Issue warning when plumbing is in place.
 				continue
 			}
 		default:

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2415,9 +2415,9 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 			// The histogram being added must have the larger schema
 			// code (i.e. the higher resolution).
 			if hrhs.Schema >= hlhs.Schema {
-				return 0, hlhs.Copy().Add(hrhs), true
+				return 0, hlhs.Copy().Add(hrhs).Compact(0), true
 			}
-			return 0, hrhs.Copy().Add(hlhs), true
+			return 0, hrhs.Copy().Add(hlhs).Compact(0), true
 		}
 		return lhs + rhs, nil, true
 	case parser.SUB:
@@ -2425,10 +2425,9 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 			// The histogram being subtracted must have the larger schema
 			// code (i.e. the higher resolution).
 			if hrhs.Schema >= hlhs.Schema {
-				return 0, hlhs.Copy().Sub(hrhs), true
+				return 0, hlhs.Copy().Sub(hrhs).Compact(0), true
 			}
-			// return 0, hrhs.Copy().Sub(hlhs).Scale(-1), true
-			return 0, hrhs.Copy().Scale(-1).Add(hlhs), true
+			return 0, hrhs.Copy().Scale(-1).Add(hlhs).Compact(0), true
 		}
 		return lhs - rhs, nil, true
 	case parser.MUL:
@@ -2745,7 +2744,7 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 				continue
 			}
 			if aggr.hasHistogram {
-				aggr.histogramValue = aggr.histogramMean
+				aggr.histogramValue = aggr.histogramMean.Compact(0)
 			} else {
 				aggr.floatValue = aggr.floatMean
 			}
@@ -2793,6 +2792,9 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 				// We cannot aggregate histogram sample with a float64 sample.
 				// TODO(zenador): Issue warning when plumbing is in place.
 				continue
+			}
+			if aggr.hasHistogram {
+				aggr.histogramValue.Compact(0)
 			}
 		default:
 			// For other aggregations, we already have the right value.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2427,16 +2427,16 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 			if hrhs.Schema >= hlhs.Schema {
 				return 0, hlhs.Copy().Sub(hrhs), true
 			}
-			// return 0, hrhs.Copy().Sub(hlhs).Mul(-1), true
-			return 0, hrhs.Copy().Mul(-1).Add(hlhs), true
+			// return 0, hrhs.Copy().Sub(hlhs).Scale(-1), true
+			return 0, hrhs.Copy().Scale(-1).Add(hlhs), true
 		}
 		return lhs - rhs, nil, true
 	case parser.MUL:
 		if hlhs != nil && hrhs == nil {
-			return 0, hlhs.Copy().Mul(rhs), true
+			return 0, hlhs.Copy().Scale(rhs), true
 		}
 		if hlhs == nil && hrhs != nil {
-			return 0, hrhs.Copy().Mul(lhs), true
+			return 0, hrhs.Copy().Scale(lhs), true
 		}
 		return lhs * rhs, nil, true
 	case parser.DIV:
@@ -2643,7 +2643,7 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 					// The histogram being added/subtracted must have
 					// an equal or larger schema.
 					if s.H.Schema >= group.histogramMean.Schema {
-						toAdd := right.Mul(-1).Add(left)
+						toAdd := right.Scale(-1).Add(left)
 						group.histogramMean.Add(toAdd)
 					} else {
 						toAdd := left.Sub(right)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2607,15 +2607,16 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 		case parser.SUM:
 			if s.H != nil {
 				group.hasHistogram = true
+				if group.hasFloat && group.hasHistogram {
+					break
+				}
 				if group.histogramValue != nil {
 					// The histogram being added must have
 					// an equal or larger schema.
 					if s.H.Schema >= group.histogramValue.Schema {
 						group.histogramValue.Add(s.H)
 					} else {
-						h := s.H.Copy()
-						h.Add(group.histogramValue)
-						group.histogramValue = h
+						group.histogramValue = s.H.Copy().Add(group.histogramValue)
 					}
 				}
 				// Otherwise the aggregation contained floats
@@ -2623,6 +2624,9 @@ func (ev *evaluator) aggregation(op parser.ItemType, grouping []string, without 
 				// point in copying the histogram in that case.
 			} else {
 				group.hasFloat = true
+				if group.hasFloat && group.hasHistogram {
+					break
+				}
 				group.floatValue += s.F
 			}
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -4345,6 +4345,22 @@ func TestNativeHistogram_SubOperator(t *testing.T) {
 func TestNativeHistogram_MulDivOperator(t *testing.T) {
 	// TODO(codesome): Integrate histograms into the PromQL testing framework
 	// and write more tests there.
+	originalHistogram := histogram.Histogram{
+		Schema:        0,
+		Count:         21,
+		Sum:           33,
+		ZeroThreshold: 0.001,
+		ZeroCount:     3,
+		PositiveSpans: []histogram.Span{
+			{Offset: 0, Length: 3},
+		},
+		PositiveBuckets: []int64{3, 0, 0},
+		NegativeSpans: []histogram.Span{
+			{Offset: 0, Length: 3},
+		},
+		NegativeBuckets: []int64{3, 0, 0},
+	}
+
 	cases := []struct {
 		scalar      float64
 		histogram   histogram.Histogram
@@ -4352,22 +4368,8 @@ func TestNativeHistogram_MulDivOperator(t *testing.T) {
 		expectedDiv histogram.FloatHistogram
 	}{
 		{
-			scalar: 3,
-			histogram: histogram.Histogram{
-				Schema:        0,
-				Count:         21,
-				Sum:           33,
-				ZeroThreshold: 0.001,
-				ZeroCount:     3,
-				PositiveSpans: []histogram.Span{
-					{Offset: 0, Length: 3},
-				},
-				PositiveBuckets: []int64{3, 0, 0},
-				NegativeSpans: []histogram.Span{
-					{Offset: 0, Length: 3},
-				},
-				NegativeBuckets: []int64{3, 0, 0},
-			},
+			scalar:    3,
+			histogram: originalHistogram,
 			expectedMul: histogram.FloatHistogram{
 				Schema:        0,
 				Count:         63,
@@ -4397,6 +4399,40 @@ func TestNativeHistogram_MulDivOperator(t *testing.T) {
 					{Offset: 0, Length: 3},
 				},
 				NegativeBuckets: []float64{1, 1, 1},
+			},
+		},
+		{
+			scalar:    0,
+			histogram: originalHistogram,
+			expectedMul: histogram.FloatHistogram{
+				Schema:        0,
+				Count:         0,
+				Sum:           0,
+				ZeroThreshold: 0.001,
+				ZeroCount:     0,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 3},
+				},
+				PositiveBuckets: []float64{0, 0, 0},
+				NegativeSpans: []histogram.Span{
+					{Offset: 0, Length: 3},
+				},
+				NegativeBuckets: []float64{0, 0, 0},
+			},
+			expectedDiv: histogram.FloatHistogram{
+				Schema:        0,
+				Count:         math.Inf(1),
+				Sum:           math.Inf(1),
+				ZeroThreshold: 0.001,
+				ZeroCount:     math.Inf(1),
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 3},
+				},
+				PositiveBuckets: []float64{math.Inf(1), math.Inf(1), math.Inf(1)},
+				NegativeSpans: []histogram.Span{
+					{Offset: 0, Length: 3},
+				},
+				NegativeBuckets: []float64{math.Inf(1), math.Inf(1), math.Inf(1)},
 			},
 		},
 	}

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3970,11 +3970,9 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 	// TODO(codesome): Integrate histograms into the PromQL testing framework
 	// and write more tests there.
 	cases := []struct {
-		histograms   []histogram.Histogram
-		expected     histogram.FloatHistogram
-		expectedAvg  histogram.FloatHistogram
-		expected2    histogram.FloatHistogram
-		expectedAvg2 histogram.FloatHistogram
+		histograms  []histogram.Histogram
+		expected    histogram.FloatHistogram
+		expectedAvg histogram.FloatHistogram
 	}{
 		{
 			histograms: []histogram.Histogram{
@@ -4049,44 +4047,6 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 				Count:            93,
 				Sum:              4691.2,
 				PositiveSpans: []histogram.Span{
-					{Offset: 0, Length: 3},
-					{Offset: 0, Length: 4},
-				},
-				PositiveBuckets: []float64{3, 8, 2, 5, 3, 2, 2},
-				NegativeSpans: []histogram.Span{
-					{Offset: 0, Length: 4},
-					{Offset: 0, Length: 2},
-					{Offset: 3, Length: 3},
-				},
-				NegativeBuckets: []float64{2, 6, 8, 4, 15, 9, 10, 10, 4},
-			},
-			expectedAvg: histogram.FloatHistogram{
-				CounterResetHint: histogram.GaugeType,
-				Schema:           0,
-				ZeroThreshold:    0.001,
-				ZeroCount:        3.5,
-				Count:            23.25,
-				Sum:              1172.8,
-				PositiveSpans: []histogram.Span{
-					{Offset: 0, Length: 3},
-					{Offset: 0, Length: 4},
-				},
-				PositiveBuckets: []float64{0.75, 2, 0.5, 1.25, 0.75, 0.5, 0.5},
-				NegativeSpans: []histogram.Span{
-					{Offset: 0, Length: 4},
-					{Offset: 0, Length: 2},
-					{Offset: 3, Length: 3},
-				},
-				NegativeBuckets: []float64{0.5, 1.5, 2, 1, 3.75, 2.25, 2.5, 2.5, 1},
-			},
-			expected2: histogram.FloatHistogram{
-				CounterResetHint: histogram.GaugeType,
-				Schema:           0,
-				ZeroThreshold:    0.001,
-				ZeroCount:        14,
-				Count:            93,
-				Sum:              4691.2,
-				PositiveSpans: []histogram.Span{
 					{Offset: 0, Length: 7},
 				},
 				PositiveBuckets: []float64{3, 8, 2, 5, 3, 2, 2},
@@ -4096,7 +4056,7 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 				},
 				NegativeBuckets: []float64{2, 6, 8, 4, 15, 9, 10, 10, 4},
 			},
-			expectedAvg2: histogram.FloatHistogram{
+			expectedAvg: histogram.FloatHistogram{
 				CounterResetHint: histogram.GaugeType,
 				Schema:           0,
 				ZeroThreshold:    0.001,
@@ -4190,11 +4150,11 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 
 				// sum_over_time().
 				queryString = fmt.Sprintf("sum_over_time(%s[%dm:1m])", seriesNameOverTime, offset)
-				queryAndCheck(queryString, newTs, []Sample{{T: newTs, H: &c.expected2, Metric: labels.EmptyLabels()}})
+				queryAndCheck(queryString, newTs, []Sample{{T: newTs, H: &c.expected, Metric: labels.EmptyLabels()}})
 
 				// avg_over_time().
 				queryString = fmt.Sprintf("avg_over_time(%s[%dm:1m])", seriesNameOverTime, offset)
-				queryAndCheck(queryString, newTs, []Sample{{T: newTs, H: &c.expectedAvg2, Metric: labels.EmptyLabels()}})
+				queryAndCheck(queryString, newTs, []Sample{{T: newTs, H: &c.expectedAvg, Metric: labels.EmptyLabels()}})
 			})
 			idx0++
 		}
@@ -4252,17 +4212,16 @@ func TestNativeHistogram_SubOperator(t *testing.T) {
 				ZeroThreshold: 0.001,
 				ZeroCount:     2,
 				PositiveSpans: []histogram.Span{
-					{Offset: 0, Length: 4},
-					{Offset: 0, Length: 0},
-					{Offset: 0, Length: 3},
-				},
-				PositiveBuckets: []float64{1, 1, 0, 2, 1, 1, 1},
-				NegativeSpans: []histogram.Span{
+					{Offset: 0, Length: 2},
 					{Offset: 1, Length: 4},
-					{Offset: 2, Length: 0},
-					{Offset: 2, Length: 3},
 				},
-				NegativeBuckets: []float64{1, 1, 0, 7, 5, 5, 2},
+				PositiveBuckets: []float64{1, 1, 2, 1, 1, 1},
+				NegativeSpans: []histogram.Span{
+					{Offset: 1, Length: 2},
+					{Offset: 1, Length: 1},
+					{Offset: 4, Length: 3},
+				},
+				NegativeBuckets: []float64{1, 1, 7, 5, 5, 2},
 			},
 		},
 		{
@@ -4309,15 +4268,13 @@ func TestNativeHistogram_SubOperator(t *testing.T) {
 				ZeroThreshold: 0.001,
 				ZeroCount:     2,
 				PositiveSpans: []histogram.Span{
-					{Offset: 0, Length: 4},
-					{Offset: 0, Length: 0},
-					{Offset: 0, Length: 3},
+					{Offset: 0, Length: 1},
+					{Offset: 1, Length: 5},
 				},
-				PositiveBuckets: []float64{1, 0, 1, 2, 1, 1, 1},
+				PositiveBuckets: []float64{1, 1, 2, 1, 1, 1},
 				NegativeSpans: []histogram.Span{
 					{Offset: 1, Length: 4},
-					{Offset: 2, Length: 0},
-					{Offset: 2, Length: 3},
+					{Offset: 4, Length: 3},
 				},
 				NegativeBuckets: []float64{-2, 2, 2, 7, 5, 5, 2},
 			},
@@ -4366,15 +4323,13 @@ func TestNativeHistogram_SubOperator(t *testing.T) {
 				ZeroThreshold: 0.001,
 				ZeroCount:     -2,
 				PositiveSpans: []histogram.Span{
-					{Offset: 0, Length: 4},
-					{Offset: 0, Length: 0},
-					{Offset: 0, Length: 3},
+					{Offset: 0, Length: 1},
+					{Offset: 1, Length: 5},
 				},
-				PositiveBuckets: []float64{-1, 0, -1, -2, -1, -1, -1},
+				PositiveBuckets: []float64{-1, -1, -2, -1, -1, -1},
 				NegativeSpans: []histogram.Span{
 					{Offset: 1, Length: 4},
-					{Offset: 2, Length: 0},
-					{Offset: 2, Length: 3},
+					{Offset: 4, Length: 3},
 				},
 				NegativeBuckets: []float64{2, -2, -2, -7, -5, -5, -2},
 			},

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3970,18 +3970,21 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 	// TODO(codesome): Integrate histograms into the PromQL testing framework
 	// and write more tests there.
 	cases := []struct {
-		histograms  []histogram.Histogram
-		expected    histogram.FloatHistogram
-		expectedAvg histogram.FloatHistogram
+		histograms   []histogram.Histogram
+		expected     histogram.FloatHistogram
+		expectedAvg  histogram.FloatHistogram
+		expected2    histogram.FloatHistogram
+		expectedAvg2 histogram.FloatHistogram
 	}{
 		{
 			histograms: []histogram.Histogram{
 				{
-					Schema:        0,
-					Count:         21,
-					Sum:           1234.5,
-					ZeroThreshold: 0.001,
-					ZeroCount:     4,
+					CounterResetHint: histogram.GaugeType,
+					Schema:           0,
+					Count:            21,
+					Sum:              1234.5,
+					ZeroThreshold:    0.001,
+					ZeroCount:        4,
 					PositiveSpans: []histogram.Span{
 						{Offset: 0, Length: 2},
 						{Offset: 1, Length: 2},
@@ -3994,11 +3997,12 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 					NegativeBuckets: []int64{2, 2, -3, 8},
 				},
 				{
-					Schema:        0,
-					Count:         36,
-					Sum:           2345.6,
-					ZeroThreshold: 0.001,
-					ZeroCount:     5,
+					CounterResetHint: histogram.GaugeType,
+					Schema:           0,
+					Count:            36,
+					Sum:              2345.6,
+					ZeroThreshold:    0.001,
+					ZeroCount:        5,
 					PositiveSpans: []histogram.Span{
 						{Offset: 0, Length: 4},
 						{Offset: 0, Length: 0},
@@ -4013,11 +4017,12 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 					NegativeBuckets: []int64{1, 3, -2, 5, -2, 0, -3},
 				},
 				{
-					Schema:        0,
-					Count:         36,
-					Sum:           1111.1,
-					ZeroThreshold: 0.001,
-					ZeroCount:     5,
+					CounterResetHint: histogram.GaugeType,
+					Schema:           0,
+					Count:            36,
+					Sum:              1111.1,
+					ZeroThreshold:    0.001,
+					ZeroCount:        5,
 					PositiveSpans: []histogram.Span{
 						{Offset: 0, Length: 4},
 						{Offset: 0, Length: 0},
@@ -4032,15 +4037,17 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 					NegativeBuckets: []int64{1, 3, -2, 5, -2, 0, -3},
 				},
 				{
-					Schema: 1, // Everything is 0 just to make the count 4 so avg has nicer numbers.
+					CounterResetHint: histogram.GaugeType,
+					Schema:           1, // Everything is 0 just to make the count 4 so avg has nicer numbers.
 				},
 			},
 			expected: histogram.FloatHistogram{
-				Schema:        0,
-				ZeroThreshold: 0.001,
-				ZeroCount:     14,
-				Count:         93,
-				Sum:           4691.2,
+				CounterResetHint: histogram.GaugeType,
+				Schema:           0,
+				ZeroThreshold:    0.001,
+				ZeroCount:        14,
+				Count:            93,
+				Sum:              4691.2,
 				PositiveSpans: []histogram.Span{
 					{Offset: 0, Length: 3},
 					{Offset: 0, Length: 4},
@@ -4054,11 +4061,12 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 				NegativeBuckets: []float64{2, 6, 8, 4, 15, 9, 10, 10, 4},
 			},
 			expectedAvg: histogram.FloatHistogram{
-				Schema:        0,
-				ZeroThreshold: 0.001,
-				ZeroCount:     3.5,
-				Count:         23.25,
-				Sum:           1172.8,
+				CounterResetHint: histogram.GaugeType,
+				Schema:           0,
+				ZeroThreshold:    0.001,
+				ZeroCount:        3.5,
+				Count:            23.25,
+				Sum:              1172.8,
 				PositiveSpans: []histogram.Span{
 					{Offset: 0, Length: 3},
 					{Offset: 0, Length: 4},
@@ -4067,6 +4075,40 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 				NegativeSpans: []histogram.Span{
 					{Offset: 0, Length: 4},
 					{Offset: 0, Length: 2},
+					{Offset: 3, Length: 3},
+				},
+				NegativeBuckets: []float64{0.5, 1.5, 2, 1, 3.75, 2.25, 2.5, 2.5, 1},
+			},
+			expected2: histogram.FloatHistogram{
+				CounterResetHint: histogram.GaugeType,
+				Schema:           0,
+				ZeroThreshold:    0.001,
+				ZeroCount:        14,
+				Count:            93,
+				Sum:              4691.2,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 7},
+				},
+				PositiveBuckets: []float64{3, 8, 2, 5, 3, 2, 2},
+				NegativeSpans: []histogram.Span{
+					{Offset: 0, Length: 6},
+					{Offset: 3, Length: 3},
+				},
+				NegativeBuckets: []float64{2, 6, 8, 4, 15, 9, 10, 10, 4},
+			},
+			expectedAvg2: histogram.FloatHistogram{
+				CounterResetHint: histogram.GaugeType,
+				Schema:           0,
+				ZeroThreshold:    0.001,
+				ZeroCount:        3.5,
+				Count:            23.25,
+				Sum:              1172.8,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 7},
+				},
+				PositiveBuckets: []float64{0.75, 2, 0.5, 1.25, 0.75, 0.5, 0.5},
+				NegativeSpans: []histogram.Span{
+					{Offset: 0, Length: 6},
 					{Offset: 3, Length: 3},
 				},
 				NegativeBuckets: []float64{0.5, 1.5, 2, 1, 3.75, 2.25, 2.5, 2.5, 1},
@@ -4083,6 +4125,7 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 				t.Cleanup(test.Close)
 
 				seriesName := "sparse_histogram_series"
+				seriesNameOverTime := "sparse_histogram_series_over_time"
 
 				engine := test.QueryEngine()
 
@@ -4097,10 +4140,20 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 						_, err = app.AppendHistogram(0, lbls, ts, h.Copy(), nil)
 					}
 					require.NoError(t, err)
+
+					lbls = labels.FromStrings("__name__", seriesNameOverTime)
+					newTs := ts + int64(idx1)*int64(time.Minute/time.Millisecond)
+					// Since we mutate h later, we need to create a copy here.
+					if floatHisto {
+						_, err = app.AppendHistogram(0, lbls, newTs, nil, h.Copy().ToFloat())
+					} else {
+						_, err = app.AppendHistogram(0, lbls, newTs, h.Copy(), nil)
+					}
+					require.NoError(t, err)
 				}
 				require.NoError(t, app.Commit())
 
-				queryAndCheck := func(queryString string, exp Vector) {
+				queryAndCheck := func(queryString string, ts int64, exp Vector) {
 					qry, err := engine.NewInstantQuery(test.context, test.Queryable(), nil, queryString, timestamp.Time(ts))
 					require.NoError(t, err)
 
@@ -4115,22 +4168,33 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 
 				// sum().
 				queryString := fmt.Sprintf("sum(%s)", seriesName)
-				queryAndCheck(queryString, []Sample{{T: ts, H: &c.expected, Metric: labels.EmptyLabels()}})
+				queryAndCheck(queryString, ts, []Sample{{T: ts, H: &c.expected, Metric: labels.EmptyLabels()}})
 
 				// + operator.
 				queryString = fmt.Sprintf(`%s{idx="0"}`, seriesName)
 				for idx := 1; idx < len(c.histograms); idx++ {
 					queryString += fmt.Sprintf(` + ignoring(idx) %s{idx="%d"}`, seriesName, idx)
 				}
-				queryAndCheck(queryString, []Sample{{T: ts, H: &c.expected, Metric: labels.EmptyLabels()}})
+				queryAndCheck(queryString, ts, []Sample{{T: ts, H: &c.expected, Metric: labels.EmptyLabels()}})
 
 				// count().
 				queryString = fmt.Sprintf("count(%s)", seriesName)
-				queryAndCheck(queryString, []Sample{{T: ts, F: 4, Metric: labels.EmptyLabels()}})
+				queryAndCheck(queryString, ts, []Sample{{T: ts, F: 4, Metric: labels.EmptyLabels()}})
 
 				// avg().
 				queryString = fmt.Sprintf("avg(%s)", seriesName)
-				queryAndCheck(queryString, []Sample{{T: ts, H: &c.expectedAvg, Metric: labels.EmptyLabels()}})
+				queryAndCheck(queryString, ts, []Sample{{T: ts, H: &c.expectedAvg, Metric: labels.EmptyLabels()}})
+
+				offset := int64(len(c.histograms) - 1)
+				newTs := ts + offset*int64(time.Minute/time.Millisecond)
+
+				// sum_over_time().
+				queryString = fmt.Sprintf("sum_over_time(%s[%dm:1m])", seriesNameOverTime, offset)
+				queryAndCheck(queryString, newTs, []Sample{{T: newTs, H: &c.expected2, Metric: labels.EmptyLabels()}})
+
+				// avg_over_time().
+				queryString = fmt.Sprintf("avg_over_time(%s[%dm:1m])", seriesNameOverTime, offset)
+				queryAndCheck(queryString, newTs, []Sample{{T: newTs, H: &c.expectedAvg2, Metric: labels.EmptyLabels()}})
 			})
 			idx0++
 		}

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -4111,6 +4111,366 @@ func TestNativeHistogram_Sum_Count_AddOperator(t *testing.T) {
 	}
 }
 
+func TestNativeHistogram_SubOperator(t *testing.T) {
+	// TODO(codesome): Integrate histograms into the PromQL testing framework
+	// and write more tests there.
+	cases := []struct {
+		histograms []histogram.Histogram
+		expected   histogram.FloatHistogram
+	}{
+		{
+			histograms: []histogram.Histogram{
+				{
+					Schema:        0,
+					Count:         36,
+					Sum:           2345.6,
+					ZeroThreshold: 0.001,
+					ZeroCount:     5,
+					PositiveSpans: []histogram.Span{
+						{Offset: 0, Length: 4},
+						{Offset: 0, Length: 0},
+						{Offset: 0, Length: 3},
+					},
+					PositiveBuckets: []int64{1, 2, -2, 1, -1, 0, 0},
+					NegativeSpans: []histogram.Span{
+						{Offset: 1, Length: 4},
+						{Offset: 2, Length: 0},
+						{Offset: 2, Length: 3},
+					},
+					NegativeBuckets: []int64{1, 3, -2, 5, -2, 0, -3},
+				},
+				{
+					Schema:        0,
+					Count:         11,
+					Sum:           1234.5,
+					ZeroThreshold: 0.001,
+					ZeroCount:     3,
+					PositiveSpans: []histogram.Span{
+						{Offset: 1, Length: 2},
+					},
+					PositiveBuckets: []int64{2, -1},
+					NegativeSpans: []histogram.Span{
+						{Offset: 2, Length: 2},
+					},
+					NegativeBuckets: []int64{3, -1},
+				},
+			},
+			expected: histogram.FloatHistogram{
+				Schema:        0,
+				Count:         25,
+				Sum:           1111.1,
+				ZeroThreshold: 0.001,
+				ZeroCount:     2,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 4},
+					{Offset: 0, Length: 0},
+					{Offset: 0, Length: 3},
+				},
+				PositiveBuckets: []float64{1, 1, 0, 2, 1, 1, 1},
+				NegativeSpans: []histogram.Span{
+					{Offset: 1, Length: 4},
+					{Offset: 2, Length: 0},
+					{Offset: 2, Length: 3},
+				},
+				NegativeBuckets: []float64{1, 1, 0, 7, 5, 5, 2},
+			},
+		},
+		{
+			histograms: []histogram.Histogram{
+				{
+					Schema:        0,
+					Count:         36,
+					Sum:           2345.6,
+					ZeroThreshold: 0.001,
+					ZeroCount:     5,
+					PositiveSpans: []histogram.Span{
+						{Offset: 0, Length: 4},
+						{Offset: 0, Length: 0},
+						{Offset: 0, Length: 3},
+					},
+					PositiveBuckets: []int64{1, 2, -2, 1, -1, 0, 0},
+					NegativeSpans: []histogram.Span{
+						{Offset: 1, Length: 4},
+						{Offset: 2, Length: 0},
+						{Offset: 2, Length: 3},
+					},
+					NegativeBuckets: []int64{1, 3, -2, 5, -2, 0, -3},
+				},
+				{
+					Schema:        1,
+					Count:         11,
+					Sum:           1234.5,
+					ZeroThreshold: 0.001,
+					ZeroCount:     3,
+					PositiveSpans: []histogram.Span{
+						{Offset: 1, Length: 2},
+					},
+					PositiveBuckets: []int64{2, -1},
+					NegativeSpans: []histogram.Span{
+						{Offset: 2, Length: 2},
+					},
+					NegativeBuckets: []int64{3, -1},
+				},
+			},
+			expected: histogram.FloatHistogram{
+				Schema:        0,
+				Count:         25,
+				Sum:           1111.1,
+				ZeroThreshold: 0.001,
+				ZeroCount:     2,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 4},
+					{Offset: 0, Length: 0},
+					{Offset: 0, Length: 3},
+				},
+				PositiveBuckets: []float64{1, 0, 1, 2, 1, 1, 1},
+				NegativeSpans: []histogram.Span{
+					{Offset: 1, Length: 4},
+					{Offset: 2, Length: 0},
+					{Offset: 2, Length: 3},
+				},
+				NegativeBuckets: []float64{-2, 2, 2, 7, 5, 5, 2},
+			},
+		},
+		{
+			histograms: []histogram.Histogram{
+				{
+					Schema:        1,
+					Count:         11,
+					Sum:           1234.5,
+					ZeroThreshold: 0.001,
+					ZeroCount:     3,
+					PositiveSpans: []histogram.Span{
+						{Offset: 1, Length: 2},
+					},
+					PositiveBuckets: []int64{2, -1},
+					NegativeSpans: []histogram.Span{
+						{Offset: 2, Length: 2},
+					},
+					NegativeBuckets: []int64{3, -1},
+				},
+				{
+					Schema:        0,
+					Count:         36,
+					Sum:           2345.6,
+					ZeroThreshold: 0.001,
+					ZeroCount:     5,
+					PositiveSpans: []histogram.Span{
+						{Offset: 0, Length: 4},
+						{Offset: 0, Length: 0},
+						{Offset: 0, Length: 3},
+					},
+					PositiveBuckets: []int64{1, 2, -2, 1, -1, 0, 0},
+					NegativeSpans: []histogram.Span{
+						{Offset: 1, Length: 4},
+						{Offset: 2, Length: 0},
+						{Offset: 2, Length: 3},
+					},
+					NegativeBuckets: []int64{1, 3, -2, 5, -2, 0, -3},
+				},
+			},
+			expected: histogram.FloatHistogram{
+				Schema:        0,
+				Count:         -25,
+				Sum:           -1111.1,
+				ZeroThreshold: 0.001,
+				ZeroCount:     -2,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 4},
+					{Offset: 0, Length: 0},
+					{Offset: 0, Length: 3},
+				},
+				PositiveBuckets: []float64{-1, 0, -1, -2, -1, -1, -1},
+				NegativeSpans: []histogram.Span{
+					{Offset: 1, Length: 4},
+					{Offset: 2, Length: 0},
+					{Offset: 2, Length: 3},
+				},
+				NegativeBuckets: []float64{2, -2, -2, -7, -5, -5, -2},
+			},
+		},
+	}
+
+	idx0 := int64(0)
+	for _, c := range cases {
+		for _, floatHisto := range []bool{true, false} {
+			t.Run(fmt.Sprintf("floatHistogram=%t %d", floatHisto, idx0), func(t *testing.T) {
+				test, err := NewTest(t, "")
+				require.NoError(t, err)
+				t.Cleanup(test.Close)
+
+				seriesName := "sparse_histogram_series"
+
+				engine := test.QueryEngine()
+
+				ts := idx0 * int64(10*time.Minute/time.Millisecond)
+				app := test.Storage().Appender(context.TODO())
+				for idx1, h := range c.histograms {
+					lbls := labels.FromStrings("__name__", seriesName, "idx", fmt.Sprintf("%d", idx1))
+					// Since we mutate h later, we need to create a copy here.
+					if floatHisto {
+						_, err = app.AppendHistogram(0, lbls, ts, nil, h.Copy().ToFloat())
+					} else {
+						_, err = app.AppendHistogram(0, lbls, ts, h.Copy(), nil)
+					}
+					require.NoError(t, err)
+				}
+				require.NoError(t, app.Commit())
+
+				queryAndCheck := func(queryString string, exp Vector) {
+					qry, err := engine.NewInstantQuery(test.context, test.Queryable(), nil, queryString, timestamp.Time(ts))
+					require.NoError(t, err)
+
+					res := qry.Exec(test.Context())
+					require.NoError(t, res.Err)
+
+					vector, err := res.Vector()
+					require.NoError(t, err)
+
+					require.Equal(t, exp, vector)
+				}
+
+				// - operator.
+				queryString := fmt.Sprintf(`%s{idx="0"}`, seriesName)
+				for idx := 1; idx < len(c.histograms); idx++ {
+					queryString += fmt.Sprintf(` - ignoring(idx) %s{idx="%d"}`, seriesName, idx)
+				}
+				queryAndCheck(queryString, []Sample{{T: ts, H: &c.expected, Metric: labels.EmptyLabels()}})
+			})
+			idx0++
+		}
+	}
+}
+
+func TestNativeHistogram_MulDivOperator(t *testing.T) {
+	// TODO(codesome): Integrate histograms into the PromQL testing framework
+	// and write more tests there.
+	cases := []struct {
+		scalar      float64
+		histogram   histogram.Histogram
+		expectedMul histogram.FloatHistogram
+		expectedDiv histogram.FloatHistogram
+	}{
+		{
+			scalar: 3,
+			histogram: histogram.Histogram{
+				Schema:        0,
+				Count:         21,
+				Sum:           33,
+				ZeroThreshold: 0.001,
+				ZeroCount:     3,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 3},
+				},
+				PositiveBuckets: []int64{3, 0, 0},
+				NegativeSpans: []histogram.Span{
+					{Offset: 0, Length: 3},
+				},
+				NegativeBuckets: []int64{3, 0, 0},
+			},
+			expectedMul: histogram.FloatHistogram{
+				Schema:        0,
+				Count:         63,
+				Sum:           99,
+				ZeroThreshold: 0.001,
+				ZeroCount:     9,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 3},
+				},
+				PositiveBuckets: []float64{9, 9, 9},
+				NegativeSpans: []histogram.Span{
+					{Offset: 0, Length: 3},
+				},
+				NegativeBuckets: []float64{9, 9, 9},
+			},
+			expectedDiv: histogram.FloatHistogram{
+				Schema:        0,
+				Count:         7,
+				Sum:           11,
+				ZeroThreshold: 0.001,
+				ZeroCount:     1,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 3},
+				},
+				PositiveBuckets: []float64{1, 1, 1},
+				NegativeSpans: []histogram.Span{
+					{Offset: 0, Length: 3},
+				},
+				NegativeBuckets: []float64{1, 1, 1},
+			},
+		},
+	}
+
+	idx0 := int64(0)
+	for _, c := range cases {
+		for _, floatHisto := range []bool{true, false} {
+			t.Run(fmt.Sprintf("floatHistogram=%t %d", floatHisto, idx0), func(t *testing.T) {
+				test, err := NewTest(t, "")
+				require.NoError(t, err)
+				t.Cleanup(test.Close)
+
+				seriesName := "sparse_histogram_series"
+				floatSeriesName := "float_series"
+
+				engine := test.QueryEngine()
+
+				ts := idx0 * int64(10*time.Minute/time.Millisecond)
+				app := test.Storage().Appender(context.TODO())
+				h := c.histogram
+				lbls := labels.FromStrings("__name__", seriesName)
+				// Since we mutate h later, we need to create a copy here.
+				if floatHisto {
+					_, err = app.AppendHistogram(0, lbls, ts, nil, h.Copy().ToFloat())
+				} else {
+					_, err = app.AppendHistogram(0, lbls, ts, h.Copy(), nil)
+				}
+				require.NoError(t, err)
+				_, err = app.Append(0, labels.FromStrings("__name__", floatSeriesName), ts, c.scalar)
+				require.NoError(t, err)
+				require.NoError(t, app.Commit())
+
+				queryAndCheck := func(queryString string, exp Vector) {
+					qry, err := engine.NewInstantQuery(test.context, test.Queryable(), nil, queryString, timestamp.Time(ts))
+					require.NoError(t, err)
+
+					res := qry.Exec(test.Context())
+					require.NoError(t, res.Err)
+
+					vector, err := res.Vector()
+					require.NoError(t, err)
+
+					require.Equal(t, exp, vector)
+				}
+
+				// histogram * scalar.
+				queryString := fmt.Sprintf(`%s * %f`, seriesName, c.scalar)
+				queryAndCheck(queryString, []Sample{{T: ts, H: &c.expectedMul, Metric: labels.EmptyLabels()}})
+
+				// scalar * histogram.
+				queryString = fmt.Sprintf(`%f * %s`, c.scalar, seriesName)
+				queryAndCheck(queryString, []Sample{{T: ts, H: &c.expectedMul, Metric: labels.EmptyLabels()}})
+
+				// histogram * float.
+				queryString = fmt.Sprintf(`%s * %s`, seriesName, floatSeriesName)
+				queryAndCheck(queryString, []Sample{{T: ts, H: &c.expectedMul, Metric: labels.EmptyLabels()}})
+
+				// float * histogram.
+				queryString = fmt.Sprintf(`%s * %s`, floatSeriesName, seriesName)
+				queryAndCheck(queryString, []Sample{{T: ts, H: &c.expectedMul, Metric: labels.EmptyLabels()}})
+
+				// histogram / scalar.
+				queryString = fmt.Sprintf(`%s / %f`, seriesName, c.scalar)
+				queryAndCheck(queryString, []Sample{{T: ts, H: &c.expectedDiv, Metric: labels.EmptyLabels()}})
+
+				// histogram / float.
+				queryString = fmt.Sprintf(`%s / %s`, seriesName, floatSeriesName)
+				queryAndCheck(queryString, []Sample{{T: ts, H: &c.expectedDiv, Metric: labels.EmptyLabels()}})
+			})
+			idx0++
+		}
+	}
+}
+
 func TestQueryLookbackDelta(t *testing.T) {
 	var (
 		load = `load 5m

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -4032,7 +4032,7 @@ func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 					NegativeBuckets: []int64{1, 3, -2, 5, -2, 0, -3},
 				},
 				{
-					Schema: 0, // Everything is 0 just to make the count 4 so avg has nicer numbers.
+					Schema: 1, // Everything is 0 just to make the count 4 so avg has nicer numbers.
 				},
 			},
 			expected: histogram.FloatHistogram{

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -467,7 +467,7 @@ func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 				// The histogram being added/subtracted must have
 				// an equal or larger schema.
 				if h.H.Schema >= mean.Schema {
-					toAdd := right.Mul(-1).Add(left)
+					toAdd := right.Scale(-1).Add(left)
 					mean.Add(toAdd)
 				} else {
 					toAdd := left.Sub(right)

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -162,7 +162,7 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 	if resultHistogram == nil {
 		resultFloat *= factor
 	} else {
-		resultHistogram.Scale(factor)
+		resultHistogram.Mul(factor)
 	}
 
 	return append(enh.Out, Sample{F: resultFloat, H: resultHistogram})
@@ -467,7 +467,7 @@ func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 				// The histogram being added/subtracted must have
 				// an equal or larger schema.
 				if h.H.Schema >= mean.Schema {
-					toAdd := right.Scale(-1).Add(left)
+					toAdd := right.Mul(-1).Add(left)
 					mean.Add(toAdd)
 				} else {
 					toAdd := left.Sub(right)

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -443,14 +443,39 @@ func aggrOverTime(vals []parser.Value, enh *EvalNodeHelper, aggrFn func(Series) 
 	return append(enh.Out, Sample{F: aggrFn(el)})
 }
 
+func aggrHistOverTime(vals []parser.Value, enh *EvalNodeHelper, aggrFn func(Series) *histogram.FloatHistogram) Vector {
+	el := vals[0].(Matrix)[0]
+
+	return append(enh.Out, Sample{H: aggrFn(el)})
+}
+
 // === avg_over_time(Matrix parser.ValueTypeMatrix) Vector ===
 func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
-	if len(vals[0].(Matrix)[0].Floats) == 0 {
-		// TODO(beorn7): The passed values only contain
-		// histograms. avg_over_time ignores histograms for now. If
-		// there are only histograms, we have to return without adding
-		// anything to enh.Out.
+	if len(vals[0].(Matrix)[0].Floats) > 0 && len(vals[0].(Matrix)[0].Histograms) > 0 {
+		// TODO(zenador): Add warning for mixed floats and histograms.
 		return enh.Out
+	}
+	if len(vals[0].(Matrix)[0].Floats) == 0 {
+		// The passed values only contain histograms.
+		return aggrHistOverTime(vals, enh, func(s Series) *histogram.FloatHistogram {
+			count := 1
+			mean := s.Histograms[0].H.Copy()
+			for _, h := range s.Histograms[1:] {
+				count++
+				left := h.H.Copy().Div(float64(count))
+				right := mean.Copy().Div(float64(count))
+				// The histogram being added/subtracted must have
+				// an equal or larger schema.
+				if h.H.Schema >= mean.Schema {
+					toAdd := right.Mul(-1).Add(left)
+					mean.Add(toAdd)
+				} else {
+					toAdd := left.Sub(right)
+					mean = toAdd.Add(mean)
+				}
+			}
+			return mean
+		})
 	}
 	return aggrOverTime(vals, enh, func(s Series) float64 {
 		var mean, count, c float64
@@ -558,12 +583,25 @@ func funcMinOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 
 // === sum_over_time(Matrix parser.ValueTypeMatrix) Vector ===
 func funcSumOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
-	if len(vals[0].(Matrix)[0].Floats) == 0 {
-		// TODO(beorn7): The passed values only contain
-		// histograms. sum_over_time ignores histograms for now. If
-		// there are only histograms, we have to return without adding
-		// anything to enh.Out.
+	if len(vals[0].(Matrix)[0].Floats) > 0 && len(vals[0].(Matrix)[0].Histograms) > 0 {
+		// TODO(zenador): Add warning for mixed floats and histograms.
 		return enh.Out
+	}
+	if len(vals[0].(Matrix)[0].Floats) == 0 {
+		// The passed values only contain histograms.
+		return aggrHistOverTime(vals, enh, func(s Series) *histogram.FloatHistogram {
+			sum := s.Histograms[0].H.Copy()
+			for _, h := range s.Histograms[1:] {
+				// The histogram being added must have
+				// an equal or larger schema.
+				if h.H.Schema >= sum.Schema {
+					sum.Add(h.H)
+				} else {
+					sum = h.H.Copy().Add(sum)
+				}
+			}
+			return sum
+		})
 	}
 	return aggrOverTime(vals, enh, func(s Series) float64 {
 		var sum, c float64


### PR DESCRIPTION
Addresses https://github.com/prometheus/prometheus/issues/12250

Works in unit tests and when manually testing on the UI with scalars and float metrics. This fixes the issue we observed with query sharding histograms with instant query splitting, however the float imprecision accumulates and the final result is very different in unit tests (tolerance was originally 1e-12 for floats but the histogram ones only passed with 1e-2).

Also added avg for native histograms as in https://github.com/prometheus/prometheus/issues/11973, to be discussed there.