### PR TITLE
Fix for `sampleRingIterator` with mixed histograms

### DIFF
--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -332,9 +332,11 @@ func (it *sampleRingIterator) Next() chunkenc.ValueType {
 	switch s.Type() {
 	case chunkenc.ValHistogram:
 		it.h = s.H()
+		it.fh = nil
 		return chunkenc.ValHistogram
 	case chunkenc.ValFloatHistogram:
 		it.fh = s.FH()
+		it.h = nil
 		return chunkenc.ValFloatHistogram
 	default:
 		it.f = s.F()


### PR DESCRIPTION
There is a bug in the [sampleRingIterator](https://github.com/prometheus/prometheus/blob/7309ac272195cb856b879306d6a27af7641d3346/storage/buffer.go#L299-L370) for mixed native histograms, that repeats the last seen floatHistogram when followed by histograms and calling [`AtFloatHistogram`](https://github.com/prometheus/prometheus/blob/7309ac272195cb856b879306d6a27af7641d3346/storage/buffer.go#L361-L366). 
We found this bug since it resulted in zero rate when querying a native histogram over a downsampled (always type floatHistograms) and not downsampled block (type histogram) in the Thanos promql-engine (workaround was added https://github.com/thanos-community/promql-engine/pull/227). 