### PR TITLE
labels: small optimization to stringlabels

### DIFF
--- a/model/labels/labels_string.go
+++ b/model/labels/labels_string.go
@@ -56,8 +56,14 @@ func (ls labelSlice) Swap(i, j int)      { ls[i], ls[j] = ls[j], ls[i] }
 func (ls labelSlice) Less(i, j int) bool { return ls[i].Name < ls[j].Name }
 
 func decodeSize(data string, index int) (int, int) {
-	var size int
-	for shift := uint(0); ; shift += 7 {
+	// Fast-path for common case of a single byte, value 0..127.
+	b := data[index]
+	index++
+	if b < 0x80 {
+		return int(b), index
+	}
+	size := int(b & 0x7F)
+	for shift := uint(7); ; shift += 7 {
 		// Just panic if we go of the end of data, since all Labels strings are constructed internally and
 		// malformed data indicates a bug, or memory corruption.
 		b := data[index]


### PR DESCRIPTION
Add a fast path for the common case that a string is less than 127 bytes long, to skip a shift and the loop.

The overhead is not much in the big scheme of things, but shows up in microbenchmarks:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                                             │  before.txt  │             after.txt              │
                                             │    sec/op    │   sec/op     vs base               │
Labels_Get/with_5_labels/get_first_label-4      15.56n ± 5%   13.16n ± 2%  -15.45% (p=0.002 n=6)
Labels_Get/with_5_labels/get_middle_label-4     37.14n ± 3%   29.70n ± 2%  -20.06% (p=0.002 n=6)
Labels_Get/with_5_labels/get_last_label-4       59.48n ± 5%   45.41n ± 1%  -23.67% (p=0.002 n=6)
Labels_Get/with_10_labels/get_first_label-4     15.49n ± 3%   13.30n ± 2%  -14.11% (p=0.002 n=6)
Labels_Get/with_10_labels/get_middle_label-4    70.45n ± 2%   54.50n ± 2%  -22.64% (p=0.002 n=6)
Labels_Get/with_10_labels/get_last_label-4     121.30n ± 2%   87.47n ± 5%  -27.89% (p=0.002 n=6)
Labels_Get/with_30_labels/get_first_label-4     15.65n ± 3%   13.25n ± 2%  -15.34% (p=0.002 n=6)
Labels_Get/with_30_labels/get_middle_label-4    186.8n ± 2%   143.9n ± 2%  -22.97% (p=0.002 n=6)
Labels_Get/with_30_labels/get_last_label-4      344.8n ± 1%   262.5n ± 3%  -23.86% (p=0.002 n=6)
geomean                                         54.98n        43.55n       -20.79%
```