### PR TITLE
Perform integer/float histogram type checking on conversions

### DIFF
--- a/prompb/custom.go
+++ b/prompb/custom.go
@@ -20,6 +20,11 @@ import (
 func (m Sample) T() int64   { return m.Timestamp }
 func (m Sample) V() float64 { return m.Value }
 
+func (h Histogram) IsFloatHistogram() bool {
+	_, ok := h.GetCount().(*Histogram_CountFloat)
+	return ok
+}
+
 func (r *ChunkedReadResponse) PooledMarshal(p *sync.Pool) ([]byte, error) {
 	size := r.Size()
 	data, ok := p.Get().(*[]byte)

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -624,10 +624,11 @@ func exemplarProtoToExemplar(ep prompb.Exemplar) exemplar.Exemplar {
 }
 
 // HistogramProtoToHistogram extracts a (normal integer) Histogram from the
-// provided proto message.
+// provided proto message. The caller has to make sure that the proto message
+// represents an integer histogram and not a float histogram, or it panics.
 func HistogramProtoToHistogram(hp prompb.Histogram) *histogram.Histogram {
 	if hp.IsFloatHistogram() {
-		panic("don't call HistogramProtoToHistogram on a float histogram")
+		panic("HistogramProtoToHistogram called with a float histogram")
 	}
 	return &histogram.Histogram{
 		CounterResetHint: histogram.CounterResetHint(hp.ResetHint),
@@ -644,10 +645,12 @@ func HistogramProtoToHistogram(hp prompb.Histogram) *histogram.Histogram {
 }
 
 // FloatHistogramProtoToFloatHistogram extracts a float Histogram from the
-// provided proto message to a Float Histogram.
+// provided proto message to a Float Histogram. The caller has to make sure that
+// the proto message represents a float histogram and not an integer histogram,
+// or it panics.
 func FloatHistogramProtoToFloatHistogram(hp prompb.Histogram) *histogram.FloatHistogram {
 	if !hp.IsFloatHistogram() {
-		panic("don't call FloatHistogramProtoToFloatHistogram on an integer histogram")
+		panic("FloatHistogramProtoToFloatHistogram called with an integer histogram")
 	}
 	return &histogram.FloatHistogram{
 		CounterResetHint: histogram.CounterResetHint(hp.ResetHint),
@@ -664,10 +667,11 @@ func FloatHistogramProtoToFloatHistogram(hp prompb.Histogram) *histogram.FloatHi
 }
 
 // HistogramProtoToFloatHistogram extracts and converts a (normal integer) histogram from the provided proto message
-// to a float histogram.
+// to a float histogram. The caller has to make sure that the proto message represents an integer histogram and not a
+// float histogram, or it panics.
 func HistogramProtoToFloatHistogram(hp prompb.Histogram) *histogram.FloatHistogram {
 	if hp.IsFloatHistogram() {
-		panic("don't call HistogramProtoToFloatHistogram on a float histogram")
+		panic("HistogramProtoToFloatHistogram called with a float histogram")
 	}
 	return &histogram.FloatHistogram{
 		CounterResetHint: histogram.CounterResetHint(hp.ResetHint),

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -455,10 +455,10 @@ func (c *concreteSeriesIterator) Seek(t int64) chunkenc.ValueType {
 }
 
 func getHistogramValType(h *prompb.Histogram) chunkenc.ValueType {
-	if _, isInt := h.GetCount().(*prompb.Histogram_CountInt); isInt {
-		return chunkenc.ValHistogram
+	if h.IsFloatHistogram() {
+		return chunkenc.ValFloatHistogram
 	}
-	return chunkenc.ValFloatHistogram
+	return chunkenc.ValHistogram
 }
 
 // At implements chunkenc.Iterator.
@@ -624,9 +624,11 @@ func exemplarProtoToExemplar(ep prompb.Exemplar) exemplar.Exemplar {
 }
 
 // HistogramProtoToHistogram extracts a (normal integer) Histogram from the
-// provided proto message. The caller has to make sure that the proto message
-// represents an integer histogram and not a float histogram.
+// provided proto message.
 func HistogramProtoToHistogram(hp prompb.Histogram) *histogram.Histogram {
+	if hp.IsFloatHistogram() {
+		panic("don't call HistogramProtoToHistogram on a float histogram")
+	}
 	return &histogram.Histogram{
 		CounterResetHint: histogram.CounterResetHint(hp.ResetHint),
 		Schema:           hp.Schema,
@@ -642,9 +644,11 @@ func HistogramProtoToHistogram(hp prompb.Histogram) *histogram.Histogram {
 }
 
 // FloatHistogramProtoToFloatHistogram extracts a float Histogram from the
-// provided proto message to a Float Histogram. The caller has to make sure that
-// the proto message represents a float histogram and not an integer histogram.
+// provided proto message to a Float Histogram.
 func FloatHistogramProtoToFloatHistogram(hp prompb.Histogram) *histogram.FloatHistogram {
+	if !hp.IsFloatHistogram() {
+		panic("don't call FloatHistogramProtoToFloatHistogram on an integer histogram")
+	}
 	return &histogram.FloatHistogram{
 		CounterResetHint: histogram.CounterResetHint(hp.ResetHint),
 		Schema:           hp.Schema,
@@ -660,9 +664,11 @@ func FloatHistogramProtoToFloatHistogram(hp prompb.Histogram) *histogram.FloatHi
 }
 
 // HistogramProtoToFloatHistogram extracts and converts a (normal integer) histogram from the provided proto message
-// to a float histogram. The caller has to make sure that the proto message represents an integer histogram and not a
-// float histogram.
+// to a float histogram.
 func HistogramProtoToFloatHistogram(hp prompb.Histogram) *histogram.FloatHistogram {
+	if hp.IsFloatHistogram() {
+		panic("don't call HistogramProtoToFloatHistogram on a float histogram")
+	}
 	return &histogram.FloatHistogram{
 		CounterResetHint: histogram.CounterResetHint(hp.ResetHint),
 		Schema:           hp.Schema,

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -528,7 +528,7 @@ func TestNilHistogramProto(*testing.T) {
 	// This function will panic if it impromperly handles nil
 	// values, causing the test to fail.
 	HistogramProtoToHistogram(prompb.Histogram{})
-	FloatHistogramProtoToFloatHistogram(prompb.Histogram{})
+	HistogramProtoToFloatHistogram(prompb.Histogram{})
 }
 
 func exampleHistogram() histogram.Histogram {

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -802,7 +802,7 @@ func (c *TestWriteClient) Store(_ context.Context, req []byte) error {
 
 		for _, histogram := range ts.Histograms {
 			count++
-			if histogram.GetCountFloat() > 0 || histogram.GetZeroCountFloat() > 0 {
+			if histogram.IsFloatHistogram() {
 				c.receivedFloatHistograms[seriesName] = append(c.receivedFloatHistograms[seriesName], histogram)
 			} else {
 				c.receivedHistograms[seriesName] = append(c.receivedHistograms[seriesName], histogram)

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -125,7 +125,7 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 		}
 
 		for _, hp := range ts.Histograms {
-			if hp.GetCountFloat() > 0 || hp.GetZeroCountFloat() > 0 { // It is a float histogram.
+			if hp.IsFloatHistogram() {
 				fhs := FloatHistogramProtoToFloatHistogram(hp)
 				_, err = app.AppendHistogram(0, labels, hp.Timestamp, nil, fhs)
 			} else {

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -68,7 +68,7 @@ func TestRemoteWriteHandler(t *testing.T) {
 		}
 
 		for _, hp := range ts.Histograms {
-			if hp.GetCountFloat() > 0 || hp.GetZeroCountFloat() > 0 { // It is a float histogram.
+			if hp.IsFloatHistogram() {
 				fh := FloatHistogramProtoToFloatHistogram(hp)
 				require.Equal(t, mockHistogram{labels, hp.Timestamp, nil, fh}, appendable.histograms[k])
 			} else {


### PR DESCRIPTION
Currently the conversion methods from prompb.Histogram to histogram.(Float)Histogram do not check the type of histogram, and leaves it to the caller to enforce, which can cause errors that are hard to debug (especially since `HistogramProtoToFloatHistogram` has changed behaviour in recent commits without changing method name or signature - it used to take float histograms as input and now it takes integer histograms) and will result in invalid histograms where the spans do not match the buckets. It's up to the maintainers to decide if it's worth the overhead of checking or if you prefer to leave it to the caller.

This also has a new method to distinguish between integer/float histograms for consistency. Previously this was determined by looking for non-zero integer/float counts which is not always reliable as zero count histograms are possible.