### PR TITLE
Apply relevant label matchers in LabelValues before fetching extra postings

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -391,6 +391,24 @@ func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Mat
 	if err != nil {
 		return nil, errors.Wrapf(err, "fetching values of label %s", name)
 	}
+
+	// If we have a matcher for the label name, we can filter out values that don't match
+	// before we fetch postings. This is especially useful for labels with many values.
+	// e.g. __name__ with a selector like {__name__="xyz"}
+	for _, m := range matchers {
+		if m.Name != name {
+			continue
+		}
+
+		for i := len(allValues) - 1; i >= 0; i-- {
+			if m.Matches(allValues[i]) {
+				continue
+			}
+
+			allValues = append(allValues[:i], allValues[i+1:]...)
+		}
+	}
+
 	valuesPostings := make([]index.Postings, len(allValues))
 	for i, value := range allValues {
 		valuesPostings[i], err = r.Postings(name, value)

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -400,13 +400,15 @@ func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Mat
 			continue
 		}
 
-		for i := len(allValues) - 1; i >= 0; i-- {
-			if m.Matches(allValues[i]) {
-				continue
+		// re-use the allValues slice to avoid allocations
+		// this is safe because the iteration is always ahead of the append
+		filteredValues := allValues[:0]
+		for _, v := range allValues {
+			if m.Matches(v) {
+				filteredValues = append(filteredValues, v)
 			}
-
-			allValues = append(allValues[:i], allValues[i+1:]...)
 		}
+		allValues = filteredValues
 	}
 
 	valuesPostings := make([]index.Postings, len(allValues))

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -180,6 +180,7 @@ func benchmarkLabelValuesWithMatchers(b *testing.B, ir IndexReader) {
 		labelName string
 		matchers  []*labels.Matcher
 	}{
+		{`i with i="1"`, "i", []*labels.Matcher{i1}},
 		// i has 100k values.
 		{`i with n="1"`, "i", []*labels.Matcher{n1}},
 		{`i with n="^.+$"`, "i", []*labels.Matcher{nPlus}},


### PR DESCRIPTION
This PR applies applicable label matchers to the set of label values before reading postings for each value. While experimenting with cardinality analysis in Mimir, I noticed that we often call `LabelValues` with the label name `__name__` and a selector like `{__name__="foo"}`. Before this PR, we would:

1. Load postings for `{__name__="foo"}`
2. List label values for `__name__`
3. Load postings for each value of `__name__` (essentially all postings)
4. Intersect 1 with 3 and determine that the result is `["foo"]`

Rather than specifically optimize that special case in cardinality analysis, it seems better to apply the matchers to the set of label values fetched in (2) before loading excess postings in (3). This optimization can then also benefit for cases like `LabelValues("__name__", "{__name__=\"foo.+\"})`.

This PR was originally here in mimir-prometheus: https://github.com/grafana/mimir-prometheus/pull/483

I added a new case to the benchmarks to expose this behavior and include the full results here:

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
                                                                         │  before.txt  │              after.txt              │
                                                                         │    sec/op    │   sec/op     vs base                │
Querier/Head/labelValuesWithMatchers/i_with_i="1"-10                       19.899m ± 2%   1.312m ± 0%  -93.41% (p=0.000 n=10)
Querier/Head/labelValuesWithMatchers/i_with_n="1"-10                        102.3m ± 1%   100.9m ± 1%   -1.42% (p=0.004 n=10)
Querier/Head/labelValuesWithMatchers/i_with_n="^.+$"-10                     129.7m ± 1%   128.7m ± 8%        ~ (p=0.218 n=10)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j!="foo"-10               121.3m ± 2%   119.5m ± 2%   -1.41% (p=0.015 n=10)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-10               19.79m ± 2%   19.20m ± 1%   -3.00% (p=0.000 n=10)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-10           19.66m ± 2%   19.20m ± 1%   -2.33% (p=0.000 n=10)
Querier/Head/labelValuesWithMatchers/i_with_n="X",j!="foo"-10               90.37m ± 1%   89.68m ± 1%   -0.76% (p=0.007 n=10)
Querier/Head/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-10     124.1m ± 2%   123.0m ± 1%        ~ (p=0.315 n=10)
Querier/Head/labelValuesWithMatchers/n_with_j!="foo"-10                     250.7m ± 1%   251.4m ± 0%        ~ (p=0.165 n=10)
Querier/Head/labelValuesWithMatchers/n_with_i="1"-10                        5.095µ ± 1%   5.076µ ± 0%        ~ (p=0.078 n=10)
Querier/Block/labelValuesWithMatchers/i_with_i="1"-10                      45.283m ± 0%   1.499m ± 3%  -96.69% (p=0.000 n=10)
Querier/Block/labelValuesWithMatchers/i_with_n="1"-10                       110.7m ± 0%   110.8m ± 4%        ~ (p=0.280 n=10)
Querier/Block/labelValuesWithMatchers/i_with_n="^.+$"-10                    100.1m ± 1%   100.9m ± 0%   +0.76% (p=0.015 n=10)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j!="foo"-10              122.2m ± 1%   122.2m ± 0%        ~ (p=0.853 n=10)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-10              45.43m ± 0%   45.47m ± 1%        ~ (p=0.315 n=10)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-10          45.33m ± 0%   45.48m ± 5%   +0.32% (p=0.043 n=10)
Querier/Block/labelValuesWithMatchers/i_with_n="X",j!="foo"-10              94.87m ± 0%   94.68m ± 0%        ~ (p=0.143 n=10)
Querier/Block/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-10    123.8m ± 1%   124.6m ± 0%   +0.64% (p=0.029 n=10)
Querier/Block/labelValuesWithMatchers/n_with_j!="foo"-10                    284.4m ± 1%   283.8m ± 1%        ~ (p=0.684 n=10)
Querier/Block/labelValuesWithMatchers/n_with_i="1"-10                       2.380m ± 0%   2.380m ± 0%        ~ (p=0.684 n=10)
geomean                                                                     40.99m        30.03m       -26.73%

                                                                         │  before.txt   │               after.txt                │
                                                                         │     B/op      │     B/op      vs base                  │
Querier/Head/labelValuesWithMatchers/i_with_i="1"-10                       10.695Mi ± 0%   1.531Mi ± 0%  -85.68% (p=0.000 n=10)
Querier/Head/labelValuesWithMatchers/i_with_n="1"-10                        16.14Mi ± 0%   16.14Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="^.+$"-10                     32.31Mi ± 0%   32.31Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="1",j!="foo"-10               16.14Mi ± 0%   16.14Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-10               10.69Mi ± 0%   10.69Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-10           10.69Mi ± 0%   10.69Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="X",j!="foo"-10               16.14Mi ± 0%   16.14Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-10     17.67Mi ± 0%   17.67Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/n_with_j!="foo"-10                     5.562Ki ± 0%   5.562Ki ± 0%        ~ (p=1.000 n=10)
Querier/Head/labelValuesWithMatchers/n_with_i="1"-10                        4.445Ki ± 0%   4.445Ki ± 0%        ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_i="1"-10                      12.221Mi ± 0%   1.531Mi ± 0%  -87.47% (p=0.000 n=10)
Querier/Block/labelValuesWithMatchers/i_with_n="1"-10                       17.66Mi ± 0%   17.66Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="^.+$"-10                    33.84Mi ± 0%   33.84Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="1",j!="foo"-10              17.66Mi ± 0%   17.66Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-10              12.22Mi ± 0%   12.22Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-10          12.22Mi ± 0%   12.22Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="X",j!="foo"-10              17.67Mi ± 0%   17.67Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-10    19.20Mi ± 0%   19.20Mi ± 0%        ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/n_with_j!="foo"-10                    8.094Ki ± 0%   8.094Ki ± 0%        ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/n_with_i="1"-10                       5.977Ki ± 0%   5.977Ki ± 0%        ~ (p=1.000 n=10) ¹
geomean                                                                     3.281Mi        2.683Mi       -18.21%
¹ all samples are equal

                                                                         │   before.txt    │               after.txt                │
                                                                         │    allocs/op    │  allocs/op   vs base                   │
Querier/Head/labelValuesWithMatchers/i_with_i="1"-10                       200007.000 ± 0%    5.000 ± 0%  -100.00% (p=0.000 n=10)
Querier/Head/labelValuesWithMatchers/i_with_n="1"-10                           200.0k ± 0%   200.0k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="^.+$"-10                        300.1k ± 0%   300.1k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="1",j!="foo"-10                  200.0k ± 0%   200.0k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-10                  200.0k ± 0%   200.0k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-10              200.0k ± 0%   200.0k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="X",j!="foo"-10                  200.0k ± 0%   200.0k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-10        200.0k ± 0%   200.0k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/n_with_j!="foo"-10                         99.00 ± 0%    99.00 ± 0%         ~ (p=1.000 n=10) ¹
Querier/Head/labelValuesWithMatchers/n_with_i="1"-10                            87.00 ± 0%    87.00 ± 0%         ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_i="1"-10                      300009.000 ± 0%    7.000 ± 0%  -100.00% (p=0.000 n=10)
Querier/Block/labelValuesWithMatchers/i_with_n="1"-10                          300.0k ± 0%   300.0k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="^.+$"-10                       400.1k ± 0%   400.1k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="1",j!="foo"-10                 300.0k ± 0%   300.0k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-10                 300.0k ± 0%   300.0k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-10             300.0k ± 0%   300.0k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="X",j!="foo"-10                 300.0k ± 0%   300.0k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-10       300.0k ± 0%   300.0k ± 0%         ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/n_with_j!="foo"-10                        143.0 ± 0%    143.0 ± 0%         ~ (p=1.000 n=10) ¹
Querier/Block/labelValuesWithMatchers/n_with_i="1"-10                           129.0 ± 0%    129.0 ± 0%         ~ (p=1.000 n=10) ¹
geomean                                                                        54.50k        18.82k        -65.46%
¹ all samples are equal
****
```
