### PR TITLE
Revert type casting removal

### DIFF
--- a/util/runtime/limits_default.go
+++ b/util/runtime/limits_default.go
@@ -39,7 +39,9 @@ func getLimits(resource int, unit string) string {
 	if err != nil {
 		panic("syscall.Getrlimit failed: " + err.Error())
 	}
-	return fmt.Sprintf("(soft=%s, hard=%s)", limitToString(rlimit.Cur, unit), limitToString(rlimit.Max, unit))
+	// rlimit.Cur and rlimit.Max are int64 on some platforms, such as dragonfly.
+	// We need to cast them explicitly to uint64.
+	return fmt.Sprintf("(soft=%s, hard=%s)", limitToString(uint64(rlimit.Cur), unit), limitToString(uint64(rlimit.Max), unit)) //nolint:unconvert
 }
 
 // FdLimits returns the soft and hard limits for file descriptors.


### PR DESCRIPTION
This reverts the removal of type casting due to an error in the dragonfly integration. The change in the type casting introduced by the commit causes a type mismatch, resulting in the following errors:

util/runtime/limits_default.go:42:57: cannot use rlimit.Cur (variable of type int64) as type uint64 in argument to limitToString
util/runtime/limits_default.go:42:90: cannot use rlimit.Max (variable of type int64) as type uint64 in argument to limitToString

Reverting this commit to resolve the type mismatch error and maintain compatibility with the dragonfly integration.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
