### PR TITLE
golangci-lint: remove skip-cache and restore singleCaseSwitch rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,6 @@ jobs:
         uses: golangci/golangci-lint-action@v3.4.0
         with:
           args: --verbose
-          skip-cache: true
           version: v1.51.2
   fuzzing:
     uses: ./.github/workflows/fuzzing.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,9 +24,6 @@ issues:
     - linters:
         - gocritic
       text: "appendAssign"
-    - linters:
-        - gocritic
-      text: "singleCaseSwitch"
     - path: _test.go
       linters:
         - errcheck

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -757,8 +757,7 @@ func subqueryTimes(path []parser.Node) (time.Duration, time.Duration, *int64) {
 		ts                    int64 = math.MaxInt64
 	)
 	for _, node := range path {
-		switch n := node.(type) {
-		case *parser.SubqueryExpr:
+		if n, ok := node.(*parser.SubqueryExpr); ok {
 			subqOffset += n.OriginalOffset
 			subqRange += n.Range
 			if n.Timestamp != nil {
@@ -847,8 +846,7 @@ func (ng *Engine) getTimeRangesForSelector(s *parser.EvalStmt, n *parser.VectorS
 func (ng *Engine) getLastSubqueryInterval(path []parser.Node) time.Duration {
 	var interval time.Duration
 	for _, node := range path {
-		switch n := node.(type) {
-		case *parser.SubqueryExpr:
+		if n, ok := node.(*parser.SubqueryExpr); ok {
 			interval = n.Step
 			if n.Step == 0 {
 				interval = time.Duration(ng.noStepSubqueryIntervalFn(durationMilliseconds(n.Range))) * time.Millisecond
@@ -914,8 +912,7 @@ func extractGroupsFromPath(p []parser.Node) (bool, []string) {
 	if len(p) == 0 {
 		return false, nil
 	}
-	switch n := p[len(p)-1].(type) {
-	case *parser.AggregateExpr:
+	if n, ok := p[len(p)-1].(*parser.AggregateExpr); ok {
 		return !n.Without, n.Grouping
 	}
 	return false, nil


### PR DESCRIPTION
HI @beorn7 and @roidelapluie ,

After your comments in #12241, this PR removes skip-cache from golangci-lint-action and restores singleCaseSwitch rule from gocritic.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>