### PR TITLE
Create query function for predict linear with at operator

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -924,6 +924,21 @@ func funcPredictLinear(vals []parser.Value, args parser.Expressions, enh *EvalNo
 	return append(enh.Out, Sample{F: slope*duration + intercept})
 }
 
+// === predict_linear_at(node parser.ValueTypeMatrix, k parser.ValueTypeScalar) Vector ===
+func funcPredictLinearAt(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	samples := vals[0].(Matrix)[0]
+	pred_point := vals[1].(Vector)[0].F
+
+	// No sense in trying to predict anything without at least two points.
+	// Drop this Vector element.
+	if len(samples.Floats) < 2 {
+		return enh.Out
+	}
+	_, intercept := linearRegression(samples.Floats, int64(pred_point))
+
+	return append(enh.Out, Sample{F: intercept})
+}
+
 // === histogram_count(Vector parser.ValueTypeVector) Vector ===
 func funcHistogramCount(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
 	inVec := vals[0].(Vector)

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -272,6 +272,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeMatrix, ValueTypeScalar},
 		ReturnType: ValueTypeVector,
 	},
+	"predict_linear_at": {
+		Name:       "predict_linear_at",
+		ArgTypes:   []ValueType{ValueTypeMatrix, ValueTypeScalar},
+		ReturnType: ValueTypeVector,
+	},
 	"present_over_time": {
 		Name:       "present_over_time",
 		ArgTypes:   []ValueType{ValueTypeMatrix},


### PR DESCRIPTION
This PR is aimed at addressing [issie 11708](https://github.com/prometheus/prometheus/issues/11708). It introduces a new query function `predict_linear_at(v range-vector, t scalar)`, which instead of calculating the predicted value at every timestamp, returns a singular float value for the prediction. The first argument is the range vector used to calculate the slope. The second argument is the time that you wish to get the predicted value for, which will be extrapolated from the range-vector.

This design is more consistent with functions such as `deriv()` and `rate()`, which return a fixed value regardless of the timestamp and are therefore compatible with the "@" operator.