### PR TITLE
Update test_golang_oldest to 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     # The go verson in this image should be N-1 wrt test_go.
     container:
-      image: quay.io/prometheus/golang-builder:1.18-base
+      image: quay.io/prometheus/golang-builder:1.19-base
     steps:
       - uses: actions/checkout@v3
       - run: make build


### PR DESCRIPTION
Since test_go is on 1.20, and `test_golang_oldest` should use the previous version.

