### PR TITLE
WIP Optimize the labels memory usage

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -38,7 +38,7 @@ const (
 
 var seps = []byte{'\xff'}
 
-var dictCache = cache.NewDictCache()
+var dictCache = cache.Default
 
 type internalLabel struct {
 	name, value int64

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/cache"
 	"github.com/prometheus/prometheus/util/osutil"
 )
 
@@ -162,6 +163,8 @@ type Manager struct {
 // Run receives and saves target set updates and triggers the scraping loops reloading.
 // Reloading happens in the background so that it doesn't block receiving targets updates.
 func (m *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) error {
+	cache.Default.RunGC()
+	defer cache.Default.Stop()
 	go m.reloader()
 	for {
 		select {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/md5"
 	"fmt"
 	"io"
 	"math"
@@ -995,8 +996,17 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 	}
 }
 
+func scrapeCacheKey(met []byte) string {
+	if len(met) <= 32 {
+		return string(met)
+	}
+	h := md5.New()
+	h.Write(met)
+	return string(h.Sum(nil))
+}
+
 func (c *scrapeCache) get(met []byte) (*cacheEntry, bool) {
-	e, ok := c.series[string(met)]
+	e, ok := c.series[scrapeCacheKey(met)]
 	if !ok {
 		return nil, false
 	}
@@ -1008,16 +1018,16 @@ func (c *scrapeCache) addRef(met []byte, ref storage.SeriesRef, lset labels.Labe
 	if ref == 0 {
 		return
 	}
-	c.series[string(met)] = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
+	c.series[scrapeCacheKey(met)] = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
 }
 
 func (c *scrapeCache) addDropped(met []byte) {
 	iter := c.iter
-	c.droppedSeries[string(met)] = &iter
+	c.droppedSeries[scrapeCacheKey(met)] = &iter
 }
 
 func (c *scrapeCache) getDropped(met []byte) bool {
-	iterp, ok := c.droppedSeries[string(met)]
+	iterp, ok := c.droppedSeries[scrapeCacheKey(met)]
 	if ok {
 		*iterp = c.iter
 	}

--- a/util/cache/dict.go
+++ b/util/cache/dict.go
@@ -1,0 +1,111 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// If we decide to employ this auto generation of markdown documentation for
+// amtool and alertmanager, this package could potentially be moved to
+// prometheus/common. However, it is crucial to note that this functionality is
+// tailored specifically to the way in which the Prometheus documentation is
+// rendered, and should be avoided for use by third-party users.
+
+package cache
+
+import (
+	"sync"
+
+	"go.uber.org/atomic"
+)
+
+const (
+	shardSize = 128
+)
+
+type dictValue struct {
+	id    int64
+	value string
+}
+
+type DictCache struct {
+	dbk   []map[string]*dictValue
+	dbv   map[int64]*dictValue
+	locks []*sync.RWMutex
+	vLock *sync.RWMutex
+	inc   atomic.Int64
+}
+
+func NewDictCache() *DictCache {
+	dc := DictCache{
+		dbk:   make([]map[string]*dictValue, shardSize),
+		dbv:   make(map[int64]*dictValue),
+		locks: make([]*sync.RWMutex, shardSize),
+		vLock: &sync.RWMutex{},
+	}
+	for i := 0; i < shardSize; i++ {
+		dc.dbk[i] = make(map[string]*dictValue)
+		dc.locks[i] = &sync.RWMutex{}
+	}
+	return &dc
+}
+
+func (d *DictCache) shard(key string) int {
+	l := len(key)
+	if l == 0 {
+		return 0
+	}
+	s := int(key[0])
+	s <<= 8
+	s += int(key[l-1])
+	s %= shardSize
+	return s
+}
+
+func (d *DictCache) Get(key string) int64 {
+	l := len(key)
+	if l == 0 {
+		return 0
+	}
+	s := d.shard(key)
+
+	d.locks[s].RLock()
+	if v, ok := d.dbk[s][key]; ok {
+		d.locks[s].RUnlock()
+		return v.id
+	}
+	d.locks[s].RUnlock()
+
+	id := d.inc.Add(1)
+	d.locks[s].Lock()
+	v := &dictValue{
+		id:    id,
+		value: key,
+	}
+	d.dbk[s][key] = v
+	d.locks[s].Unlock()
+
+	d.vLock.Lock()
+	d.dbv[id] = v
+	d.vLock.Unlock()
+
+	return id
+}
+
+func (d *DictCache) Value(id int64) (value string, ok bool) {
+	if id <= 0 {
+		return "", false
+	}
+	d.vLock.RLock()
+	defer d.vLock.RUnlock()
+	if v, ok := d.dbv[id]; ok {
+		return v.value, true
+	}
+	return "", false
+}

--- a/util/cache/dict.go
+++ b/util/cache/dict.go
@@ -84,8 +84,11 @@ func (d *DictCache) Get(key string) int64 {
 	}
 	d.kLocks[s].RUnlock()
 
-	id := d.inc.Add(1)
 	d.kLocks[s].Lock()
+	if v, ok := d.dbk[s][key]; ok {
+		return v.id
+	}
+	id := d.inc.Add(1)
 	v := &dictValue{
 		id:    id,
 		value: key,

--- a/util/cache/dict_test.go
+++ b/util/cache/dict_test.go
@@ -1,0 +1,47 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// If we decide to employ this auto generation of markdown documentation for
+// amtool and alertmanager, this package could potentially be moved to
+// prometheus/common. However, it is crucial to note that this functionality is
+// tailored specifically to the way in which the Prometheus documentation is
+// rendered, and should be avoided for use by third-party users.
+
+package cache
+
+import (
+	"testing"
+)
+
+func TestDictCache(t *testing.T) {
+	dc := NewDictCache()
+	values := []string{
+		"abc",
+		"123",
+		"abc",
+		"edf",
+		"jdf",
+		"123",
+	}
+	keys := make([]int64, len(values))
+	for i := 0; i < len(values); i++ {
+		v := dc.Get(values[i])
+		keys[i] = v
+	}
+	for i := 0; i < len(keys); i++ {
+		v, ok := dc.Value(keys[i])
+		if !ok || v != values[i] {
+			t.Fatal("not match")
+		}
+	}
+}

--- a/util/cache/dict_test.go
+++ b/util/cache/dict_test.go
@@ -21,10 +21,13 @@ package cache
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDictCache(t *testing.T) {
 	dc := NewDictCache()
+	dc.RunGC()
 	values := []string{
 		"abc",
 		"123",
@@ -44,4 +47,13 @@ func TestDictCache(t *testing.T) {
 			t.Fatal("not match")
 		}
 	}
+	dc.del(values)
+	for _, db := range dc.dbv {
+		if len(db) > 0 {
+			t.Fatal("not empty dict cache")
+		}
+	}
+	require.False(t, dc.stopped, "dict gc thread not running well")
+	dc.Stop()
+	require.True(t, dc.stopped, "dict gc thread not stop well")
 }


### PR DESCRIPTION
@roidelapluie @LeviHarrison

With millions metrics，memory will be the first limitation for most cases, so we did some work for this problem.

## Optmize for labels caching

The flowing grafana is the tsdb top 10 label value pairs

![image](https://user-images.githubusercontent.com/127621/233895985-7fb30e6e-9b81-488b-b991-c93347893c33.png)

There have a lot duplicated labels in the memory store with `labels.Labels`

With go pprof heap, almost half of the memory is used by labels

So we decide use dict cache to solve the problem, but the result is better than expect.

## Results

* 4.6M metrics for mesh service
  * Memory from 43G to 14G, reduce **68%**
  * CPU from 400% to 130%, reduce **67.5%**
* Another 29M metrics instance memory compared: 200G vs 50G
* Less go gc time

---
## The metric compre grafana screenshot

![image](https://user-images.githubusercontent.com/127621/233895203-7f8e9560-0ee8-4d71-b785-19a81e2efd8a.png)

---
Best Reguards