### PR TITLE
tsdb: drop deleted series from the WAL sooner

### DIFF
--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -665,7 +665,7 @@ func (db *DB) truncate(mint int64) error {
 		}
 
 		seg, ok := db.deleted[id]
-		return ok && seg >= first
+		return ok && seg > last
 	}
 
 	db.metrics.checkpointCreationTotal.Inc()
@@ -687,7 +687,7 @@ func (db *DB) truncate(mint int64) error {
 	// The checkpoint is written and segments before it are truncated, so we
 	// no longer need to track deleted series that were being kept around.
 	for ref, segment := range db.deleted {
-		if segment < first {
+		if segment <= last {
 			delete(db.deleted, ref)
 		}
 	}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1214,7 +1214,7 @@ func (h *Head) truncateWAL(mint int64) error {
 		h.deletedMtx.Lock()
 		keepUntil, ok := h.deleted[id]
 		h.deletedMtx.Unlock()
-		return ok && keepUntil <= last
+		return ok && keepUntil > last
 	}
 	h.metrics.checkpointCreationTotal.Inc()
 	if _, err = wlog.Checkpoint(h.logger, h.wal, first, last, keep, mint); err != nil {


### PR DESCRIPTION
`head.deleted` holds the WAL segment in use at the time each series was removed from the head. At the end of `truncateWAL()` we will delete all segments up to `last`, so we can drop any series that were last seen in a segment at or before that point.

Also, we can drop series from the `deleted` map up to `last`, since all those files are now deleted.

Improves #12286, but not a full fix.
Related to #12288.

Illustrated is a Prometheus TSDB that has been collecting data since 10:00 UTC.
WAL segments are named A, B, C, ...

Consider a series `foo` which received a few samples at 10:15, then stopped.
The samples for series `foo` are in WAL segment C.

```
           10:00        12:00
Head       ┌───────────────────┐
           └───────────────────┘
WAL        A- B- C- D- E-- F- G-
```

At approx 13:00, head compaction runs.  A block is created from 10-12, and
that data is dropped from the head. Series `foo` is garbage-collected, but
the head notes in its 'deleted' map that it might be needed until WAL segment G has
been dropped.

A WAL checkpoint is created from the first two thirds of the segments, A-D.
WAL segments A-D are removed from disk.

At approx 15:00, head compaction runs again.

```
           10:00        12:00        14:00
Head                    ┌───────────────────┐
                        └───────────────────┘
Blocks     ┌────────────┐
           └────────────┘
WAL                    E-- F- G- H I- J-- K-
Checkpoint            X
```

A WAL checkpoint is created covering segments E-H.
Now series `foo` is dropped from the checkpoint, since the 'deleted' map says we need it until G, but we will be deleting G.
The 'deleted' map is cleaned of any series needed until segment 'H'.

Removing the series at 15:00 is an improvement on retaining it until 19:00 per the original issue #12286.

Let's also consider the case that was a problem for #12288: the samples are in segment J and we are truncating A-H:

```
           10:00        11:00        12:00        13:00
Head       ┌───────────────────────────────────────┐
           └───────────────────────────────────────┘
WAL        A B C D E F G H- I-- J--- K--- L--- M---
```

The `deleted` entry for samples would be J or later, so the series would be retained in the checkpoint, and in the `deleted` map.