### PR TITLE
feat(promtool): add push metrics command

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -81,6 +81,7 @@ func main() {
 	var (
 		httpRoundTripper   = api.DefaultRoundTripper
 		serverURL          *url.URL
+		remoteWriteURL     *url.URL
 		httpConfigFilePath string
 	)
 
@@ -180,12 +181,12 @@ func main() {
 
 	pushCmd := app.Command("push", "Push to a Prometheus server.")
 	pushCmd.Flag("http.config.file", "HTTP client configuration file for promtool to connect to Prometheus.").PlaceHolder("<filename>").ExistingFileVar(&httpConfigFilePath)
-	pushMetricsCmd := pushCmd.Command("metrics", "Push metrics to a prometheus remote write.")
-	pushMetricsCmd.Arg("remote-write-url", "Prometheus remote write url to push metrics.").Required().URLVar(&serverURL)
+	pushMetricsCmd := pushCmd.Command("metrics", "Push metrics to a prometheus remote write (for testing purpose only).")
+	pushMetricsCmd.Arg("remote-write-url", "Prometheus remote write url to push metrics.").Required().URLVar(&remoteWriteURL)
 	metricFiles := pushMetricsCmd.Arg(
 		"metric-files",
-		"The metric files to push.",
-	).Required().ExistingFiles()
+		"The metric files to push, default is read from standard input (STDIN).",
+	).ExistingFiles()
 	metricJobLabel := pushMetricsCmd.Flag("job-label", "Job label to attach to metrics.").Default("promtool").String()
 	pushMetricsTimeout := pushMetricsCmd.Flag("timeout", "The time to wait for pushing metrics.").Default("30s").Duration()
 	pushMetricsHeaders := pushMetricsCmd.Flag("header", "Prometheus remote write header.").StringMap()
@@ -314,7 +315,7 @@ func main() {
 		os.Exit(CheckMetrics(*checkMetricsExtended))
 
 	case pushMetricsCmd.FullCommand():
-		os.Exit(PushMetrics(serverURL, httpRoundTripper, *pushMetricsHeaders, *pushMetricsTimeout, *metricJobLabel, *metricFiles...))
+		os.Exit(PushMetrics(remoteWriteURL, httpRoundTripper, *pushMetricsHeaders, *pushMetricsTimeout, *metricJobLabel, *metricFiles...))
 
 	case queryInstantCmd.FullCommand():
 		os.Exit(QueryInstant(serverURL, httpRoundTripper, *queryInstantExpr, *queryInstantTime, p))

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -185,7 +185,7 @@ func main() {
 	pushMetricsCmd.Arg("remote-write-url", "Prometheus remote write url to push metrics.").Required().URLVar(&remoteWriteURL)
 	metricFiles := pushMetricsCmd.Arg(
 		"metric-files",
-		"The metric files to push, default is read from standard input (STDIN).",
+		"The metric files to push, default is read from standard input.",
 	).ExistingFiles()
 	pushMetricsLabels := pushMetricsCmd.Flag("label", "Label to attach to metrics. Can be specified multiple times.").Default("job=promtool").StringMap()
 	pushMetricsTimeout := pushMetricsCmd.Flag("timeout", "The time to wait for pushing metrics.").Default("30s").Duration()

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -187,7 +187,7 @@ func main() {
 		"metric-files",
 		"The metric files to push, default is read from standard input (STDIN).",
 	).ExistingFiles()
-	metricJobLabel := pushMetricsCmd.Flag("job-label", "Job label to attach to metrics.").Default("promtool").String()
+	pushMetricsLabels := pushMetricsCmd.Flag("label", "Label to attach to metrics. Can be specified multiple times.").Default("job=promtool").StringMap()
 	pushMetricsTimeout := pushMetricsCmd.Flag("timeout", "The time to wait for pushing metrics.").Default("30s").Duration()
 	pushMetricsHeaders := pushMetricsCmd.Flag("header", "Prometheus remote write header.").StringMap()
 
@@ -315,7 +315,7 @@ func main() {
 		os.Exit(CheckMetrics(*checkMetricsExtended))
 
 	case pushMetricsCmd.FullCommand():
-		os.Exit(PushMetrics(remoteWriteURL, httpRoundTripper, *pushMetricsHeaders, *pushMetricsTimeout, *metricJobLabel, *metricFiles...))
+		os.Exit(PushMetrics(remoteWriteURL, httpRoundTripper, *pushMetricsHeaders, *pushMetricsTimeout, *pushMetricsLabels, *metricFiles...))
 
 	case queryInstantCmd.FullCommand():
 		os.Exit(QueryInstant(serverURL, httpRoundTripper, *queryInstantExpr, *queryInstantTime, p))

--- a/cmd/promtool/metrics.go
+++ b/cmd/promtool/metrics.go
@@ -1,0 +1,234 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/golang/snappy"
+	dto "github.com/prometheus/client_model/go"
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/storage/remote"
+)
+
+// Push metrics to a prometheus remote write.
+func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[string]string, timeout time.Duration, jobLabel string, files ...string) int {
+	// remote write should respect specification: https://prometheus.io/docs/concepts/remote_write_spec/
+	failed := false
+
+	addressURL, err := url.Parse(url.String())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return failureExitCode
+	}
+
+	// build remote write client
+	writeClient, err := remote.NewWriteClient("remote-write", &remote.ClientConfig{
+		URL:     &config_util.URL{URL: addressURL},
+		Timeout: model.Duration(timeout),
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return failureExitCode
+	}
+
+	// set custom tls config from httpConfigFilePath
+	// set custom headers to every request
+	client, ok := writeClient.(*remote.Client)
+	if !ok {
+		fmt.Fprintln(os.Stderr, fmt.Errorf("unexpected type %T", writeClient))
+		return failureExitCode
+	}
+	client.Client.Transport = &setHeadersTransport{
+		RoundTripper: roundTripper,
+		headers:      headers,
+	}
+
+	for _, f := range files {
+		var data []byte
+		var err error
+		data, err = os.ReadFile(f)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			failed = true
+			continue
+		}
+
+		fmt.Printf("Parsing metric file %s\n", f)
+		metricsData, err := parseMetricsTextAndFormat(bytes.NewReader(data), jobLabel)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			failed = true
+			continue
+		}
+
+		raw, err := metricsData.Marshal()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			failed = true
+			continue
+		}
+
+		// Encode the request body into snappy encoding.
+		compressed := snappy.Encode(nil, raw)
+		err = client.Store(context.Background(), compressed)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			failed = true
+			continue
+		}
+		fmt.Printf("Successfully pushed metric file %s\n", f)
+	}
+
+	if failed {
+		return failureExitCode
+	}
+
+	return successExitCode
+}
+
+type setHeadersTransport struct {
+	http.RoundTripper
+	headers map[string]string
+}
+
+func (s *setHeadersTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	for key, value := range s.headers {
+		req.Header.Set(key, value)
+	}
+	return s.RoundTripper.RoundTrip(req)
+}
+
+var MetricMetadataTypeValue = map[string]int32{
+	"UNKNOWN":        0,
+	"COUNTER":        1,
+	"GAUGE":          2,
+	"HISTOGRAM":      3,
+	"GAUGEHISTOGRAM": 4,
+	"SUMMARY":        5,
+	"INFO":           6,
+	"STATESET":       7,
+}
+
+// formatMetrics convert metric family to a writerequest
+func formatMetrics(mf map[string]*dto.MetricFamily, jobLabel string) (*prompb.WriteRequest, error) {
+	wr := &prompb.WriteRequest{}
+
+	// build metric list
+	sortedMetricNames := make([]string, 0, len(mf))
+	for metric := range mf {
+		sortedMetricNames = append(sortedMetricNames, metric)
+	}
+	// sort metrics name in lexicographical order
+	sort.Strings(sortedMetricNames)
+
+	for _, metricName := range sortedMetricNames {
+		// Set metadata writerequest
+		mtype := MetricMetadataTypeValue[mf[metricName].Type.String()]
+		metadata := prompb.MetricMetadata{
+			MetricFamilyName: mf[metricName].GetName(),
+			Type:             prompb.MetricMetadata_MetricType(mtype),
+			Help:             mf[metricName].GetHelp(),
+		}
+		wr.Metadata = append(wr.Metadata, metadata)
+
+		for _, metric := range mf[metricName].Metric {
+			var timeserie prompb.TimeSeries
+
+			// build labels map
+			labels := make(map[string]string, len(metric.Label)+2)
+			labels[model.MetricNameLabel] = metricName
+			labels[model.JobLabel] = jobLabel
+
+			for _, label := range metric.Label {
+				labelname := label.GetName()
+				if labelname == model.JobLabel {
+					labelname = fmt.Sprintf("%s%s", model.ExportedLabelPrefix, labelname)
+				}
+				labels[labelname] = label.GetValue()
+			}
+
+			// build labels name list
+			sortedLabelNames := make([]string, 0, len(labels))
+			for label := range labels {
+				sortedLabelNames = append(sortedLabelNames, label)
+			}
+			// sort labels name in lexicographical order
+			sort.Strings(sortedLabelNames)
+
+			for _, label := range sortedLabelNames {
+				timeserie.Labels = append(timeserie.Labels, prompb.Label{
+					Name:  label,
+					Value: labels[label],
+				})
+			}
+
+			timeserie.Samples = []prompb.Sample{
+				{
+					Timestamp: time.Now().UnixNano() / int64(time.Millisecond),
+					Value:     getMetricsValue(metric),
+				},
+			}
+
+			wr.Timeseries = append(wr.Timeseries, timeserie)
+		}
+	}
+	return wr, nil
+}
+
+// parseMetricsTextReader consumes an io.Reader and returns the MetricFamily
+func parseMetricsTextReader(input io.Reader) (map[string]*dto.MetricFamily, error) {
+	var parser expfmt.TextParser
+	mf, err := parser.TextToMetricFamilies(input)
+	if err != nil {
+		return nil, err
+	}
+	return mf, nil
+}
+
+// getMetricsValue return the value of a timeserie without the need to give value type
+func getMetricsValue(m *dto.Metric) float64 {
+	switch {
+	case m.Gauge != nil:
+		return m.GetGauge().GetValue()
+	case m.Counter != nil:
+		return m.GetCounter().GetValue()
+	case m.Untyped != nil:
+		return m.GetUntyped().GetValue()
+	default:
+		return 0.
+	}
+}
+
+// parseMetricsTextAndFormat return the data in the expected prometheus metrics write request format
+func parseMetricsTextAndFormat(input io.Reader, jobLabel string) (*prompb.WriteRequest, error) {
+	mf, err := parseMetricsTextReader(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return formatMetrics(mf, jobLabel)
+}

--- a/cmd/promtool/metrics.go
+++ b/cmd/promtool/metrics.go
@@ -102,7 +102,7 @@ func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[strin
 }
 
 func parseAndPushMetrics(client *remote.Client, data []byte, labels map[string]string) bool {
-	metricsData, err := fmtutil.ParseMetricsTextAndFormat(bytes.NewReader(data), labels)
+	metricsData, err := fmtutil.MetricTextToWriteRequest(bytes.NewReader(data), labels)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "  FAILED:", err)
 		return false

--- a/cmd/promtool/metrics.go
+++ b/cmd/promtool/metrics.go
@@ -33,8 +33,6 @@ import (
 
 // Push metrics to a prometheus remote write (for testing purpose only).
 func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[string]string, timeout time.Duration, labels map[string]string, files ...string) int {
-	failed := false
-
 	addressURL, err := url.Parse(url.String())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -63,63 +61,37 @@ func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[strin
 		headers:      headers,
 	}
 
-	// add empty string to avoid matching filename
+	var data []byte
+	var failed bool
+
 	if len(files) == 0 {
-		files = append(files, "")
+		data, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "  FAILED:", err)
+			return failureExitCode
+		}
+		fmt.Printf("Parsing standard input\n")
+		if parseAndPushMetrics(client, data, labels) {
+			fmt.Printf("  SUCCESS: metrics pushed to remote write.\n")
+			return successExitCode
+		}
+		return failureExitCode
 	}
 
 	for _, file := range files {
-		var data []byte
-		var err error
-
-		// if file is an empty string it is a stdin
-		if file == "" {
-			data, err = io.ReadAll(os.Stdin)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "  FAILED:", err)
-				failed = true
-				break
-			}
-
-			fmt.Printf("Parsing input from stdin\n")
-		} else {
-			data, err = os.ReadFile(file)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "  FAILED:", err)
-				failed = true
-				continue
-			}
-
-			fmt.Printf("Parsing input from metric file %s\n", file)
-		}
-		metricsData, err := fmtutil.ParseMetricsTextAndFormat(bytes.NewReader(data), labels)
+		data, err = os.ReadFile(file)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "  FAILED:", err)
 			failed = true
 			continue
 		}
 
-		raw, err := metricsData.Marshal()
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "  FAILED:", err)
-			failed = true
+		fmt.Printf("Parsing metrics file %s\n", file)
+		if parseAndPushMetrics(client, data, labels) {
+			fmt.Printf("  SUCCESS: metrics file %s pushed to remote write.\n", file)
 			continue
 		}
-
-		// Encode the request body into snappy encoding.
-		compressed := snappy.Encode(nil, raw)
-		err = client.Store(context.Background(), compressed)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "  FAILED:", err)
-			failed = true
-			continue
-		}
-
-		if file == "" {
-			fmt.Printf("  SUCCESS: metric pushed to remote write.\n")
-		} else {
-			fmt.Printf("  SUCCESS: metric file %s pushed to remote write.\n", file)
-		}
+		failed = true
 	}
 
 	if failed {
@@ -127,6 +99,30 @@ func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[strin
 	}
 
 	return successExitCode
+}
+
+func parseAndPushMetrics(client *remote.Client, data []byte, labels map[string]string) bool {
+	metricsData, err := fmtutil.ParseMetricsTextAndFormat(bytes.NewReader(data), labels)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "  FAILED:", err)
+		return false
+	}
+
+	raw, err := metricsData.Marshal()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "  FAILED:", err)
+		return false
+	}
+
+	// Encode the request body into snappy encoding.
+	compressed := snappy.Encode(nil, raw)
+	err = client.Store(context.Background(), compressed)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "  FAILED:", err)
+		return false
+	}
+
+	return true
 }
 
 type setHeadersTransport struct {

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -410,7 +410,7 @@ Push metrics to a prometheus remote write (for testing purpose only).
 | Argument | Description | Required |
 | --- | --- | --- |
 | remote-write-url | Prometheus remote write url to push metrics. | Yes |
-| metric-files | The metric files to push, default is read from standard input (STDIN). |  |
+| metric-files | The metric files to push, default is read from standard input. |  |
 
 
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -27,6 +27,7 @@ Tooling for the Prometheus monitoring system.
 | check | Check the resources for validity. |
 | query | Run query against a Prometheus server. |
 | debug | Fetch debug information. |
+| push | Push to a Prometheus server. |
 | test | Unit testing. |
 | tsdb | Run tsdb commands. |
 
@@ -368,6 +369,48 @@ Fetch all debug information.
 | Argument | Description | Required |
 | --- | --- | --- |
 | server | Prometheus server to get all debug information from. | Yes |
+
+
+
+
+### `promtool push`
+
+Push to a Prometheus server.
+
+
+
+#### Flags
+
+| Flag | Description |
+| --- | --- |
+| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file for promtool to connect to Prometheus. |
+
+
+
+
+##### `promtool push metrics`
+
+Push metrics to a prometheus remote write.
+
+
+
+###### Flags
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| <code class="text-nowrap">--job-label</code> | Job label to attach to metrics. | `promtool` |
+| <code class="text-nowrap">--timeout</code> | The time to wait for pushing metrics. | `30s` |
+| <code class="text-nowrap">--header</code> | Prometheus remote write header. |  |
+
+
+
+
+###### Arguments
+
+| Argument | Description | Required |
+| --- | --- | --- |
+| remote-write-url | Prometheus remote write url to push metrics. | Yes |
+| metric-files | The metric files to push. | Yes |
 
 
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -398,7 +398,7 @@ Push metrics to a prometheus remote write (for testing purpose only).
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| <code class="text-nowrap">--job-label</code> | Job label to attach to metrics. | `promtool` |
+| <code class="text-nowrap">--label</code> | Label to attach to metrics. Can be specified multiple times. | `job=promtool` |
 | <code class="text-nowrap">--timeout</code> | The time to wait for pushing metrics. | `30s` |
 | <code class="text-nowrap">--header</code> | Prometheus remote write header. |  |
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -390,7 +390,7 @@ Push to a Prometheus server.
 
 ##### `promtool push metrics`
 
-Push metrics to a prometheus remote write.
+Push metrics to a prometheus remote write (for testing purpose only).
 
 
 
@@ -410,7 +410,7 @@ Push metrics to a prometheus remote write.
 | Argument | Description | Required |
 | --- | --- | --- |
 | remote-write-url | Prometheus remote write url to push metrics. | Yes |
-| metric-files | The metric files to push. | Yes |
+| metric-files | The metric files to push, default is read from standard input (STDIN). |  |
 
 
 

--- a/util/fmtutil/format.go
+++ b/util/fmtutil/format.go
@@ -1,0 +1,142 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fmtutil
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/prompb"
+)
+
+var MetricMetadataTypeValue = map[string]int32{
+	"UNKNOWN":        0,
+	"COUNTER":        1,
+	"GAUGE":          2,
+	"HISTOGRAM":      3,
+	"GAUGEHISTOGRAM": 4,
+	"SUMMARY":        5,
+	"INFO":           6,
+	"STATESET":       7,
+}
+
+// FormatMetrics convert metric family to a writerequest.
+func FormatMetrics(mf map[string]*dto.MetricFamily, jobLabel string) (*prompb.WriteRequest, error) {
+	wr := &prompb.WriteRequest{}
+
+	// build metric list
+	sortedMetricNames := make([]string, 0, len(mf))
+	for metric := range mf {
+		sortedMetricNames = append(sortedMetricNames, metric)
+	}
+	// sort metrics name in lexicographical order
+	sort.Strings(sortedMetricNames)
+
+	for _, metricName := range sortedMetricNames {
+		// Set metadata writerequest
+		mtype := MetricMetadataTypeValue[mf[metricName].Type.String()]
+		metadata := prompb.MetricMetadata{
+			MetricFamilyName: mf[metricName].GetName(),
+			Type:             prompb.MetricMetadata_MetricType(mtype),
+			Help:             mf[metricName].GetHelp(),
+		}
+		wr.Metadata = append(wr.Metadata, metadata)
+
+		for _, metric := range mf[metricName].Metric {
+			var timeserie prompb.TimeSeries
+
+			// build labels map
+			labels := make(map[string]string, len(metric.Label)+2)
+			labels[model.MetricNameLabel] = metricName
+			labels[model.JobLabel] = jobLabel
+
+			for _, label := range metric.Label {
+				labelname := label.GetName()
+				if labelname == model.JobLabel {
+					labelname = fmt.Sprintf("%s%s", model.ExportedLabelPrefix, labelname)
+				}
+				labels[labelname] = label.GetValue()
+			}
+
+			// build labels name list
+			sortedLabelNames := make([]string, 0, len(labels))
+			for label := range labels {
+				sortedLabelNames = append(sortedLabelNames, label)
+			}
+			// sort labels name in lexicographical order
+			sort.Strings(sortedLabelNames)
+
+			for _, label := range sortedLabelNames {
+				timeserie.Labels = append(timeserie.Labels, prompb.Label{
+					Name:  label,
+					Value: labels[label],
+				})
+			}
+
+			timestamp := metric.GetTimestampMs()
+			if timestamp == 0 {
+				timestamp = time.Now().UnixNano() / int64(time.Millisecond)
+			}
+
+			timeserie.Samples = []prompb.Sample{
+				{
+					Timestamp: timestamp,
+					Value:     getMetricsValue(metric),
+				},
+			}
+
+			wr.Timeseries = append(wr.Timeseries, timeserie)
+		}
+	}
+	return wr, nil
+}
+
+// getMetricsValue return the value of a timeserie without the need to give value type
+func getMetricsValue(m *dto.Metric) float64 {
+	switch {
+	case m.Gauge != nil:
+		return m.GetGauge().GetValue()
+	case m.Counter != nil:
+		return m.GetCounter().GetValue()
+	case m.Untyped != nil:
+		return m.GetUntyped().GetValue()
+	default:
+		return 0.
+	}
+}
+
+// ParseMetricsTextReader consumes an io.Reader and returns the MetricFamily.
+func ParseMetricsTextReader(input io.Reader) (map[string]*dto.MetricFamily, error) {
+	var parser expfmt.TextParser
+	mf, err := parser.TextToMetricFamilies(input)
+	if err != nil {
+		return nil, err
+	}
+	return mf, nil
+}
+
+// ParseMetricsTextAndFormat return the data in the expected prometheus metrics write request format.
+func ParseMetricsTextAndFormat(input io.Reader, jobLabel string) (*prompb.WriteRequest, error) {
+	mf, err := ParseMetricsTextReader(input)
+	if err != nil {
+		return nil, err
+	}
+	return FormatMetrics(mf, jobLabel)
+}

--- a/util/fmtutil/format_test.go
+++ b/util/fmtutil/format_test.go
@@ -25,12 +25,129 @@ import (
 var writeRequestFixture = &prompb.WriteRequest{
 	Metadata: []prompb.MetricMetadata{
 		{
+			MetricFamilyName: "http_request_duration_seconds",
+			Type:             3,
+			Help:             "A histogram of the request duration.",
+		},
+		{
+			MetricFamilyName: "http_requests_total",
+			Type:             1,
+			Help:             "The total number of HTTP requests.",
+		},
+		{
+			MetricFamilyName: "rpc_duration_seconds",
+			Type:             5,
+			Help:             "A summary of the RPC duration in seconds.",
+		},
+		{
 			MetricFamilyName: "test_metric1",
 			Type:             2,
-			Help:             "this is a test metric",
+			Help:             "This is a test metric.",
 		},
 	},
 	Timeseries: []prompb.TimeSeries{
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "http_request_duration_seconds_bucket"},
+				{Name: "job", Value: "promtool"},
+				{Name: "le", Value: "0.1"},
+			},
+			Samples: []prompb.Sample{{Value: 33444, Timestamp: 1}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "http_request_duration_seconds_bucket"},
+				{Name: "job", Value: "promtool"},
+				{Name: "le", Value: "0.5"},
+			},
+			Samples: []prompb.Sample{{Value: 129389, Timestamp: 1}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "http_request_duration_seconds_bucket"},
+				{Name: "job", Value: "promtool"},
+				{Name: "le", Value: "1"},
+			},
+			Samples: []prompb.Sample{{Value: 133988, Timestamp: 1}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "http_request_duration_seconds_bucket"},
+				{Name: "job", Value: "promtool"},
+				{Name: "le", Value: "+Inf"},
+			},
+			Samples: []prompb.Sample{{Value: 144320, Timestamp: 1}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "http_request_duration_seconds_sum"},
+				{Name: "job", Value: "promtool"},
+			},
+			Samples: []prompb.Sample{{Value: 53423, Timestamp: 1}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "http_request_duration_seconds_count"},
+				{Name: "job", Value: "promtool"},
+			},
+			Samples: []prompb.Sample{{Value: 144320, Timestamp: 1}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "http_requests_total"},
+				{Name: "code", Value: "200"},
+				{Name: "job", Value: "promtool"},
+				{Name: "method", Value: "post"},
+			},
+			Samples: []prompb.Sample{{Value: 1027, Timestamp: 1395066363000}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "http_requests_total"},
+				{Name: "code", Value: "400"},
+				{Name: "job", Value: "promtool"},
+				{Name: "method", Value: "post"},
+			},
+			Samples: []prompb.Sample{{Value: 3, Timestamp: 1395066363000}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "rpc_duration_seconds"},
+				{Name: "job", Value: "promtool"},
+				{Name: "quantile", Value: "0.01"},
+			},
+			Samples: []prompb.Sample{{Value: 3102, Timestamp: 1}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "rpc_duration_seconds"},
+				{Name: "job", Value: "promtool"},
+				{Name: "quantile", Value: "0.5"},
+			},
+			Samples: []prompb.Sample{{Value: 4773, Timestamp: 1}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "rpc_duration_seconds"},
+				{Name: "job", Value: "promtool"},
+				{Name: "quantile", Value: "0.99"},
+			},
+			Samples: []prompb.Sample{{Value: 76656, Timestamp: 1}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "rpc_duration_seconds_sum"},
+				{Name: "job", Value: "promtool"},
+			},
+			Samples: []prompb.Sample{{Value: 1.7560473e+07, Timestamp: 1}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "rpc_duration_seconds_count"},
+				{Name: "job", Value: "promtool"},
+			},
+			Samples: []prompb.Sample{{Value: 2693, Timestamp: 1}},
+		},
 		{
 			Labels: []prompb.Label{
 				{Name: "__name__", Value: "test_metric1"},
@@ -58,7 +175,26 @@ var writeRequestFixture = &prompb.WriteRequest{
 
 func TestParseMetricsTextAndFormat(t *testing.T) {
 	input := bytes.NewReader([]byte(`
-	# HELP test_metric1 this is a test metric
+	# HELP http_request_duration_seconds A histogram of the request duration.
+	# TYPE http_request_duration_seconds histogram
+	http_request_duration_seconds_bucket{le="0.1"} 33444 1
+	http_request_duration_seconds_bucket{le="0.5"} 129389 1
+	http_request_duration_seconds_bucket{le="1"} 133988 1
+	http_request_duration_seconds_bucket{le="+Inf"} 144320 1
+	http_request_duration_seconds_sum 53423 1
+	http_request_duration_seconds_count 144320 1
+	# HELP http_requests_total The total number of HTTP requests.
+	# TYPE http_requests_total counter
+	http_requests_total{method="post",code="200"} 1027 1395066363000
+	http_requests_total{method="post",code="400"}    3 1395066363000
+	# HELP rpc_duration_seconds A summary of the RPC duration in seconds.
+	# TYPE rpc_duration_seconds summary
+	rpc_duration_seconds{quantile="0.01"} 3102 1
+	rpc_duration_seconds{quantile="0.5"} 4773 1
+	rpc_duration_seconds{quantile="0.99"} 76656 1
+	rpc_duration_seconds_sum 1.7560473e+07 1
+	rpc_duration_seconds_count 2693 1
+	# HELP test_metric1 This is a test metric.
 	# TYPE test_metric1 gauge
 	test_metric1{b="c",baz="qux",d="e",foo="bar"} 1 1
 	test_metric1{b="c",baz="qux",d="e",foo="bar"} 2 1

--- a/util/fmtutil/format_test.go
+++ b/util/fmtutil/format_test.go
@@ -63,8 +63,9 @@ func TestParseMetricsTextAndFormat(t *testing.T) {
 	test_metric1{b="c",baz="qux",d="e",foo="bar"} 1 1
 	test_metric1{b="c",baz="qux",d="e",foo="bar"} 2 1
 	`))
+	labels := map[string]string{"job": "promtool"}
 
-	expected, err := ParseMetricsTextAndFormat(input, "promtool")
+	expected, err := ParseMetricsTextAndFormat(input, labels)
 	require.NoError(t, err)
 
 	require.Equal(t, writeRequestFixture, expected)

--- a/util/fmtutil/format_test.go
+++ b/util/fmtutil/format_test.go
@@ -1,0 +1,71 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fmtutil
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/prompb"
+)
+
+var writeRequestFixture = &prompb.WriteRequest{
+	Metadata: []prompb.MetricMetadata{
+		{
+			MetricFamilyName: "test_metric1",
+			Type:             2,
+			Help:             "this is a test metric",
+		},
+	},
+	Timeseries: []prompb.TimeSeries{
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "test_metric1"},
+				{Name: "b", Value: "c"},
+				{Name: "baz", Value: "qux"},
+				{Name: "d", Value: "e"},
+				{Name: "foo", Value: "bar"},
+				{Name: "job", Value: "promtool"},
+			},
+			Samples: []prompb.Sample{{Value: 1, Timestamp: 1}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "test_metric1"},
+				{Name: "b", Value: "c"},
+				{Name: "baz", Value: "qux"},
+				{Name: "d", Value: "e"},
+				{Name: "foo", Value: "bar"},
+				{Name: "job", Value: "promtool"},
+			},
+			Samples: []prompb.Sample{{Value: 2, Timestamp: 1}},
+		},
+	},
+}
+
+func TestParseMetricsTextAndFormat(t *testing.T) {
+	input := bytes.NewReader([]byte(`
+	# HELP test_metric1 this is a test metric
+	# TYPE test_metric1 gauge
+	test_metric1{b="c",baz="qux",d="e",foo="bar"} 1 1
+	test_metric1{b="c",baz="qux",d="e",foo="bar"} 2 1
+	`))
+
+	expected, err := ParseMetricsTextAndFormat(input, "promtool")
+	require.NoError(t, err)
+
+	require.Equal(t, writeRequestFixture, expected)
+}

--- a/util/fmtutil/format_test.go
+++ b/util/fmtutil/format_test.go
@@ -201,13 +201,13 @@ func TestParseAndPushMetricsTextAndFormat(t *testing.T) {
 	`))
 	labels := map[string]string{"job": "promtool"}
 
-	expected, err := ParseMetricsTextAndFormat(input, labels)
+	expected, err := MetricTextToWriteRequest(input, labels)
 	require.NoError(t, err)
 
 	require.Equal(t, writeRequestFixture, expected)
 }
 
-func TestParseMetricsTextAndFormatErrorParsingFloatValue(t *testing.T) {
+func TestMetricTextToWriteRequestErrorParsingFloatValue(t *testing.T) {
 	input := bytes.NewReader([]byte(`
 	# HELP http_requests_total The total number of HTTP requests.
 	# TYPE http_requests_total counter
@@ -216,11 +216,11 @@ func TestParseMetricsTextAndFormatErrorParsingFloatValue(t *testing.T) {
 	`))
 	labels := map[string]string{"job": "promtool"}
 
-	_, err := ParseMetricsTextAndFormat(input, labels)
+	_, err := MetricTextToWriteRequest(input, labels)
 	require.Equal(t, err.Error(), "text format parsing error in line 4: expected float as value, got \"1027Error\"")
 }
 
-func TestParseMetricsTextAndFormatErrorParsingMetricType(t *testing.T) {
+func TestMetricTextToWriteRequestErrorParsingMetricType(t *testing.T) {
 	input := bytes.NewReader([]byte(`
 	# HELP node_info node info summary.
 	# TYPE node_info info
@@ -228,6 +228,6 @@ func TestParseMetricsTextAndFormatErrorParsingMetricType(t *testing.T) {
 	`))
 	labels := map[string]string{"job": "promtool"}
 
-	_, err := ParseMetricsTextAndFormat(input, labels)
+	_, err := MetricTextToWriteRequest(input, labels)
 	require.Equal(t, err.Error(), "text format parsing error in line 3: unknown metric type \"info\"")
 }


### PR DESCRIPTION
Hello,

I want to add `push metrics` command in promtool, like
```
$ promtool push metrics https://my-prometheus-remote-write:9090/api/v1/push /tmp/metrics
Parsing metric file /tmp/metrics
Successfully pushed metric file /tmp/metrics
```
It could be usefull to quickly test the ability to ingest metrics from client perspective (test the connectivity, check tls and get the result in a graph) without setup a prometheus agent with config scrapping etc.

Initially I would add this feature in mimirtool https://github.com/grafana/mimir/pull/4715 but they redirect me here as it make more sense as it is remote write.
