### PR TITLE
labels: respect Set after Del in Builder

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -533,15 +533,14 @@ func (b *Builder) Set(n, v string) *Builder {
 }
 
 func (b *Builder) Get(n string) string {
-	for _, d := range b.del {
-		if d == n {
-			return ""
-		}
-	}
+	// Del() removes entries from .add but Set() does not remove from .del, so check .add first.
 	for _, a := range b.add {
 		if a.Name == n {
 			return a.Value
 		}
+	}
+	if slices.Contains(b.del, n) {
+		return ""
 	}
 	return b.base.Get(n)
 }

--- a/model/labels/labels_string.go
+++ b/model/labels/labels_string.go
@@ -593,13 +593,14 @@ func (b *Builder) Set(n, v string) *Builder {
 }
 
 func (b *Builder) Get(n string) string {
-	if slices.Contains(b.del, n) {
-		return ""
-	}
+	// Del() removes entries from .add but Set() does not remove from .del, so check .add first.
 	for _, a := range b.add {
 		if a.Name == n {
 			return a.Value
 		}
+	}
+	if slices.Contains(b.del, n) {
+		return ""
 	}
 	return b.base.Get(n)
 }

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -607,6 +607,13 @@ func TestBuilder(t *testing.T) {
 			require.Equal(t, tcase.want.BytesWithoutLabels(nil, "aaa", "bbb"), b.Labels().Bytes(nil))
 		})
 	}
+	t.Run("set_after_del", func(t *testing.T) {
+		b := NewBuilder(FromStrings("aaa", "111"))
+		b.Del("bbb")
+		b.Set("bbb", "222")
+		require.Equal(t, FromStrings("aaa", "111", "bbb", "222"), b.Labels())
+		require.Equal(t, "222", b.Get("bbb"))
+	})
 }
 
 func TestScratchBuilder(t *testing.T) {


### PR DESCRIPTION
The implementations are not symmetric between `Set()` and `Del()`, so we must be careful. Add a test for this.

Also make the slice implementation consistent re `slices.Contains`.

Fixes #12283 