### PR TITLE
Add analyze histograms command to promtool

### DIFF
--- a/cmd/promtool/analyze.go
+++ b/cmd/promtool/analyze.go
@@ -1,0 +1,295 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/api"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/version"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type AnalyzeClassicHistogramsConfig struct {
+	address        *url.URL
+	user           string
+	key            string
+	lookback       time.Duration
+	readTimeout    time.Duration
+	scrapeInterval time.Duration
+	outputFile     string
+}
+
+// run retrieves metrics that look like conventional histograms, i.e. have _bucket
+// suffixes.
+func (c *AnalyzeClassicHistogramsConfig) run() error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.readTimeout)
+	defer cancel()
+
+	api, err := newAPI(c.address, c.user, c.key)
+	if err != nil {
+		return err
+	}
+
+	endTime := time.Now()
+	startTime := endTime.Add(-c.lookback)
+
+	bucketMetrics, err := queryBucketMetricNames(ctx, api, startTime, endTime)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Potential histogram metrics found: %d\n", len(bucketMetrics))
+
+	var out io.Writer
+	if c.outputFile != "" {
+		var err error
+		out, err = os.Create(c.outputFile)
+		if err != nil {
+			return fmt.Errorf("failed to open %q for writing: ", c.outputFile)
+		}
+	} else {
+		out = os.Stdout
+	}
+
+	for _, bucketMetricName := range bucketMetrics {
+		basename, err := metricBasename(bucketMetricName)
+		if err != nil {
+			// Just skip if something doesn't look like a good name.
+			continue
+		}
+		sumName := fmt.Sprintf("%s_sum", basename)
+		vector, err := queryLabelSets(ctx, api, sumName, endTime, c.lookback)
+		if err != nil {
+			return err
+		}
+
+		for _, sample := range vector {
+			// Get labels to match.
+			lbs := model.LabelSet(sample.Metric)
+			delete(lbs, labels.MetricName)
+			seriesSel := seriesSelector(bucketMetricName, lbs)
+			var step time.Duration
+			if c.scrapeInterval == 0 {
+				// Estimate the step.
+				stepVal := int64(math.Round(c.lookback.Seconds() / float64(sample.Value)))
+				step = time.Duration(stepVal) * time.Second
+			} else {
+				step = c.scrapeInterval
+			}
+			matrix, err := querySamples(ctx, api, seriesSel, startTime, endTime, step)
+			if err != nil {
+				return err
+			}
+			stats, err := calcBucketStatistics(matrix, step)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "%s=%v\n", seriesSel, *stats)
+		}
+	}
+
+	return nil
+}
+
+func newAPI(address *url.URL, username, password string) (v1.API, error) {
+	rt := api.DefaultRoundTripper
+	rt = config.NewUserAgentRoundTripper("promtool/"+version.Version, rt)
+	if username != "" {
+		rt = config.NewBasicAuthRoundTripper(username, config.Secret(password), "", rt)
+	}
+
+	client, err := api.NewClient(api.Config{
+		Address:      address.String(),
+		RoundTripper: rt,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return v1.NewAPI(client), nil
+}
+
+func queryBucketMetricNames(ctx context.Context, api v1.API, start, end time.Time) ([]string, error) {
+	values, _, err := api.LabelValues(ctx, labels.MetricName, []string{"{__name__=~\".*_bucket\"}"}, start, end)
+	if err != nil {
+		return nil, err
+	}
+	result := []string{}
+	for _, v := range values {
+		result = append(result, string(v))
+	}
+	return result, nil
+}
+
+func metricBasename(bucketMetricName string) (string, error) {
+	if len(bucketMetricName) <= len("_bucket") {
+		return "", fmt.Errorf("potential metric name too short: %s", bucketMetricName)
+	}
+	return bucketMetricName[:len(bucketMetricName)-len("_bucket")], nil
+}
+
+// Query the related count_over_time(*_sum[lookback]) series to double check that metricName is a
+// histogram. This keeps the result small (avoids buckets) and the count gives scrape interval
+// when dividing lookback with it.
+func queryLabelSets(ctx context.Context, api v1.API, metricName string, end time.Time, lookback time.Duration) (model.Vector, error) {
+	query := fmt.Sprintf("count_over_time(%s{}[%s])", metricName, lookback.String())
+
+	values, _, err := api.Query(ctx, query, end)
+	if err != nil {
+		return nil, err
+	}
+
+	vector, ok := values.(model.Vector)
+	if !ok {
+		return nil, fmt.Errorf("query for metrics resulted in non-Vector")
+	}
+	return vector, nil
+}
+
+func seriesSelector(bucketMetricName string, lbs model.LabelSet) string {
+	builder := strings.Builder{}
+	builder.WriteString(bucketMetricName)
+	builder.WriteRune('{')
+	first := true
+	for l, v := range lbs {
+		if first {
+			first = false
+		} else {
+			builder.WriteRune(',')
+		}
+		builder.WriteString(string(l))
+		builder.WriteString("=\"")
+		builder.WriteString(string(v))
+		builder.WriteRune('"')
+	}
+	builder.WriteRune('}')
+
+	return builder.String()
+}
+
+func querySamples(ctx context.Context, api v1.API, query string, start, end time.Time, step time.Duration) (model.Matrix, error) {
+	values, _, err := api.QueryRange(ctx, query, v1.Range{Start: start, End: end, Step: step})
+	if err != nil {
+		return nil, err
+	}
+
+	matrix, ok := values.(model.Matrix)
+	if !ok {
+		return nil, fmt.Errorf("query of buckets resulted in non-Matrix")
+	}
+
+	return matrix, nil
+}
+
+type statistics struct {
+	min, avg, max, available int
+	scrapeInterval           time.Duration
+}
+
+func (s statistics) String() string {
+	return fmt.Sprintf("Bucket min/avg/max/avail@scrape: %d/%d/%d/%d@%v", s.min, s.avg, s.max, s.available, s.scrapeInterval)
+}
+
+func calcBucketStatistics(matrix model.Matrix, step time.Duration) (*statistics, error) {
+	numBuckets := len(matrix)
+
+	stats := &statistics{
+		min:            math.MaxInt,
+		available:      numBuckets,
+		scrapeInterval: step,
+	}
+
+	if numBuckets == 0 || len(matrix[0].Values) < 2 {
+		// Not enough data.
+		return stats, nil
+	}
+
+	numSamples := len(matrix[0].Values)
+
+	sortMatrix(matrix)
+
+	prev, err := getBucketCountsAtTime(matrix, numBuckets, 0)
+	if err != nil {
+		return stats, err
+	}
+
+	sumBucketsChanged := 0
+	for timeIdx := 1; timeIdx < numSamples; timeIdx++ {
+		curr, err := getBucketCountsAtTime(matrix, numBuckets, timeIdx)
+		if err != nil {
+			return stats, err
+		}
+
+		countBucketsChanged := 0
+		for bIdx := range matrix {
+			if curr[bIdx] > prev[bIdx] {
+				countBucketsChanged++
+			} else if curr[bIdx] < prev[bIdx] {
+				return stats, fmt.Errorf("unexpected decrease in bucket %d at time %d", bIdx, timeIdx)
+			}
+		}
+
+		sumBucketsChanged += countBucketsChanged
+		if stats.min > countBucketsChanged {
+			stats.min = countBucketsChanged
+		}
+		if stats.max < countBucketsChanged {
+			stats.max = countBucketsChanged
+		}
+
+		prev = curr
+	}
+	stats.avg = sumBucketsChanged / (numSamples - 1)
+	return stats, nil
+}
+
+func sortMatrix(matrix model.Matrix) {
+	sort.SliceStable(matrix, func(i, j int) bool {
+		return getLe(matrix[i]) < getLe(matrix[j])
+	})
+}
+
+func getLe(vector *model.SampleStream) float64 {
+	lbs := model.LabelSet(vector.Metric)
+	le, _ := strconv.ParseFloat(string(lbs["le"]), 64)
+	return le
+}
+
+func getBucketCountsAtTime(matrix model.Matrix, numBuckets, timeIdx int) ([]int, error) {
+	counts := make([]int, numBuckets)
+	counts[0] = int(matrix[0].Values[timeIdx].Value)
+	for i, bucket := range matrix[1:] {
+		curr := bucket.Values[timeIdx]
+		prev := matrix[i].Values[timeIdx]
+		// Assume the results are nicely aligned.
+		if curr.Timestamp != prev.Timestamp {
+			return counts, fmt.Errorf("matrix result is not time aligned")
+		}
+		counts[i+1] = int(curr.Value - prev.Value)
+	}
+	return counts, nil
+}

--- a/cmd/promtool/analyze.go
+++ b/cmd/promtool/analyze.go
@@ -259,12 +259,13 @@ func querySamples(ctx context.Context, api v1.API, query string, start, end time
 }
 
 type statistics struct {
-	min, avg, max, available int
-	scrapeInterval           time.Duration
+	min, max, available int
+	avg                 float64
+	scrapeInterval      time.Duration
 }
 
 func (s statistics) String() string {
-	return fmt.Sprintf("Bucket min/avg/max/avail@scrape: %d/%d/%d/%d@%v", s.min, s.avg, s.max, s.available, s.scrapeInterval)
+	return fmt.Sprintf("Bucket min/avg/max/avail@scrape: %d/%.3f/%d/%d@%v", s.min, s.avg, s.max, s.available, s.scrapeInterval)
 }
 
 type calcBucketStatisticsFunc func(matrix model.Matrix, step time.Duration, histo *statshistogram) (*statistics, error)
@@ -322,7 +323,7 @@ func calcClassicBucketStatistics(matrix model.Matrix, step time.Duration, histo 
 
 		prev = curr
 	}
-	stats.avg = sumBucketsChanged / (numSamples - 1)
+	stats.avg = float64(sumBucketsChanged) / float64(numSamples-1)
 	return stats, nil
 }
 
@@ -417,7 +418,7 @@ func calcNativeBucketStatistics(matrix model.Matrix, step time.Duration, histo *
 			prev = curr
 		}
 	}
-	stats.avg = sumBucketsChanged / (len(matrix[0].Histograms) - 1)
+	stats.avg = float64(sumBucketsChanged) / float64(len(matrix[0].Histograms)-1)
 	stats.available = len(overall)
 	return stats, nil
 }
@@ -467,7 +468,7 @@ func (ms metastatistics) String() string {
 
 func (ms *metastatistics) update(s *statistics) {
 	ms.min.update(s.min)
-	ms.avg.update(s.avg)
+	ms.avg.update(int(s.avg))
 	ms.max.update(s.max)
 	ms.available.update(s.available)
 }

--- a/cmd/promtool/analyze.go
+++ b/cmd/promtool/analyze.go
@@ -253,7 +253,9 @@ func calcBucketStatistics(matrix model.Matrix, step time.Duration, histo *statsh
 			if curr[bIdx] > prev[bIdx] {
 				countBucketsChanged++
 			} else if curr[bIdx] < prev[bIdx] {
-				return stats, fmt.Errorf("unexpected decrease in bucket %d at time %d", bIdx, timeIdx)
+				countBucketsChanged++
+				fmt.Println("unexpected decrease in bucket %d at time %d", bIdx, timeIdx)
+				// return stats, fmt.Errorf("unexpected decrease in bucket %d at time %d", bIdx, timeIdx)
 			}
 		}
 

--- a/cmd/promtool/analyze.go
+++ b/cmd/promtool/analyze.go
@@ -306,7 +306,7 @@ func calcClassicBucketStatistics(matrix model.Matrix, step time.Duration, histo 
 				countBucketsChanged++
 			} else if curr[bIdx] < prev[bIdx] {
 				countBucketsChanged++
-				fmt.Println("unexpected decrease in bucket %d at time %d", bIdx, timeIdx)
+				fmt.Printf("unexpected decrease in bucket %d at time %d\n", bIdx, timeIdx)
 				// return stats, fmt.Errorf("unexpected decrease in bucket %d at time %d", bIdx, timeIdx)
 			}
 		}

--- a/cmd/promtool/analyze.go
+++ b/cmd/promtool/analyze.go
@@ -33,16 +33,16 @@ import (
 )
 
 type AnalyzeHistogramsConfig struct {
-	histogramType  string
+	metricType     string
 	lookback       time.Duration
 	scrapeInterval time.Duration
 }
 
 // run retrieves metrics that look like conventional histograms (i.e. have _bucket
-// suffixes) or native histograms, depending on histogramType flag.
+// suffixes) or native histograms, depending on metricType flag.
 func (c *AnalyzeHistogramsConfig) run(url *url.URL, roundtripper http.RoundTripper) error {
-	if c.histogramType != "classic" && c.histogramType != "native" {
-		return fmt.Errorf("histogram type is %s, must be 'classic' or 'native'", c.histogramType)
+	if c.metricType != "classichistograms" && c.metricType != "nativehistograms" {
+		return fmt.Errorf("histogram type is %s, must be 'classichistograms' or 'nativehistograms'", c.metricType)
 	}
 
 	ctx := context.Background()
@@ -55,7 +55,7 @@ func (c *AnalyzeHistogramsConfig) run(url *url.URL, roundtripper http.RoundTripp
 	endTime := time.Now()
 	startTime := endTime.Add(-c.lookback)
 
-	if c.histogramType == "native" {
+	if c.metricType == "nativehistograms" {
 		histoMetrics, err := queryMetadataForHistograms(ctx, api, "", "1000")
 		if err != nil {
 			return err

--- a/cmd/promtool/analyze.go
+++ b/cmd/promtool/analyze.go
@@ -165,9 +165,9 @@ func queryLabelSets(ctx context.Context, api v1.API, metricName string, end time
 	return vector, nil
 }
 
-func seriesSelector(bucketMetricName string, duration time.Duration) string {
+func seriesSelector(metricName string, duration time.Duration) string {
 	builder := strings.Builder{}
-	builder.WriteString(bucketMetricName)
+	builder.WriteString(metricName)
 	builder.WriteRune('[')
 	builder.WriteString(duration.String())
 	builder.WriteRune(']')
@@ -175,9 +175,9 @@ func seriesSelector(bucketMetricName string, duration time.Duration) string {
 	return builder.String()
 }
 
-func seriesSelectorWithLabels(bucketMetricName string, lbs model.LabelSet, duration time.Duration) string {
+func seriesSelectorWithLabels(metricName string, lbs model.LabelSet, duration time.Duration) string {
 	builder := strings.Builder{}
-	builder.WriteString(bucketMetricName)
+	builder.WriteString(metricName)
 	builder.WriteRune('{')
 	first := true
 	for l, v := range lbs {

--- a/cmd/promtool/analyze.go
+++ b/cmd/promtool/analyze.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -99,7 +100,7 @@ func (c *QueryAnalyzeConfig) getStatsFromMetrics(ctx context.Context, api v1.API
 			if len(series.Values) == 0 {
 				stats, err := calcNativeBucketStatistics(series)
 				if err != nil {
-					if err == errNotNativeHistogram || err == errNotEnoughData {
+					if errors.Is(err, errNotNativeHistogram) || errors.Is(err, errNotEnoughData) {
 						continue
 					}
 					return err
@@ -125,7 +126,7 @@ func (c *QueryAnalyzeConfig) getStatsFromMetrics(ctx context.Context, api v1.API
 		for key, matrix := range matrices {
 			stats, err := calcClassicBucketStatistics(matrix)
 			if err != nil {
-				if err == errNotEnoughData {
+				if errors.Is(err, errNotEnoughData) {
 					continue
 				}
 				return err

--- a/cmd/promtool/analyze.go
+++ b/cmd/promtool/analyze.go
@@ -245,8 +245,16 @@ func getLe(series *model.SampleStream) float64 {
 
 func getBucketCountsAtTime(matrix model.Matrix, numBuckets, timeIdx int) ([]int, error) {
 	counts := make([]int, numBuckets)
+	if timeIdx >= len(matrix[0].Values) {
+		// Just return zeroes instead of erroring out so we can get partial results.
+		return counts, nil
+	}
 	counts[0] = int(matrix[0].Values[timeIdx].Value)
 	for i, bucket := range matrix[1:] {
+		if timeIdx >= len(bucket.Values) {
+			// Just return zeroes instead of erroring out so we can get partial results.
+			return counts, nil
+		}
 		curr := bucket.Values[timeIdx]
 		prev := matrix[i].Values[timeIdx]
 		// Assume the results are nicely aligned.

--- a/cmd/promtool/analyze.go
+++ b/cmd/promtool/analyze.go
@@ -106,7 +106,7 @@ func (c *QueryAnalyzeConfig) getStatsFromMetrics(ctx context.Context, api v1.API
 			for _, vector := range matrix {
 				stats, err := calcNativeBucketStatistics(vector, metahistogram)
 				if err != nil {
-					if err == errNotNativeHistogram {
+					if err == errNotNativeHistogram || err == errNotEnoughData {
 						continue
 					}
 					return err
@@ -367,6 +367,9 @@ func calcNativeBucketStatistics(vector *model.SampleStream, histo *statshistogra
 	totalPop := 0
 	if len(vector.Histograms) == 0 {
 		return nil, errNotNativeHistogram
+	}
+	if len(vector.Histograms) == 1 {
+		return nil, errNotEnoughData
 	}
 	prev := make(map[bucketBounds]float64)
 	for _, bucket := range vector.Histograms[0].Histogram.Buckets {

--- a/cmd/promtool/analyze_test.go
+++ b/cmd/promtool/analyze_test.go
@@ -1,0 +1,171 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/common/model"
+)
+
+var (
+	exampleMatrix = model.Matrix{
+		&model.SampleStream{
+			Metric: model.Metric{
+				"le": "+Inf",
+			},
+			Values: []model.SamplePair{
+				{
+					Value:     31,
+					Timestamp: 100,
+				},
+				{
+					Value:     32,
+					Timestamp: 200,
+				},
+				{
+					Value:     40,
+					Timestamp: 300,
+				},
+			},
+		},
+		&model.SampleStream{
+			Metric: model.Metric{
+				"le": "0.5",
+			},
+			Values: []model.SamplePair{
+				{
+					Value:     10,
+					Timestamp: 100,
+				},
+				{
+					Value:     11,
+					Timestamp: 200,
+				},
+				{
+					Value:     11,
+					Timestamp: 300,
+				},
+			},
+		},
+		&model.SampleStream{
+			Metric: model.Metric{
+				"le": "10",
+			},
+			Values: []model.SamplePair{
+				{
+					Value:     30,
+					Timestamp: 100,
+				},
+				{
+					Value:     31,
+					Timestamp: 200,
+				},
+				{
+					Value:     37,
+					Timestamp: 300,
+				},
+			},
+		},
+		&model.SampleStream{
+			Metric: model.Metric{
+				"le": "2",
+			},
+			Values: []model.SamplePair{
+				{
+					Value:     25,
+					Timestamp: 100,
+				},
+				{
+					Value:     26,
+					Timestamp: 200,
+				},
+				{
+					Value:     27,
+					Timestamp: 300,
+				},
+			},
+		},
+	}
+	exampleMatrixLength = len(exampleMatrix)
+)
+
+func init() {
+	sortMatrix(exampleMatrix)
+}
+
+func TestGetBucketCountsAtTime(t *testing.T) {
+	cases := []struct {
+		matrix   model.Matrix
+		length   int
+		timeIdx  int
+		expected []int
+	}{
+		{
+			exampleMatrix,
+			exampleMatrixLength,
+			0,
+			[]int{10, 15, 5, 1},
+		},
+		{
+			exampleMatrix,
+			exampleMatrixLength,
+			1,
+			[]int{11, 15, 5, 1},
+		},
+		{
+			exampleMatrix,
+			exampleMatrixLength,
+			2,
+			[]int{11, 16, 10, 3},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("exampleMatrix@%d", c.timeIdx), func(t *testing.T) {
+			res, err := getBucketCountsAtTime(c.matrix, c.length, c.timeIdx)
+			require.NoError(t, err)
+			require.Equal(t, c.expected, res)
+		})
+	}
+}
+
+func TestCalcBucketStatistics(t *testing.T) {
+	cases := []struct {
+		matrix   model.Matrix
+		expected *statistics
+	}{
+		{
+			exampleMatrix,
+			&statistics{
+				min:            1,
+				avg:            2,
+				max:            3,
+				available:      4,
+				scrapeInterval: 100,
+			},
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			res, err := calcBucketStatistics(c.matrix, 100)
+			require.NoError(t, err)
+			require.Equal(t, c.expected, res)
+		})
+	}
+}

--- a/cmd/promtool/analyze_test.go
+++ b/cmd/promtool/analyze_test.go
@@ -144,7 +144,7 @@ func TestGetBucketCountsAtTime(t *testing.T) {
 	}
 }
 
-func TestCalcBucketStatistics(t *testing.T) {
+func TestCalcClassicBucketStatistics(t *testing.T) {
 	cases := []struct {
 		matrix   model.Matrix
 		expected *statistics
@@ -163,7 +163,7 @@ func TestCalcBucketStatistics(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			res, err := calcBucketStatistics(c.matrix, 100)
+			res, err := calcClassicBucketStatistics(c.matrix, 100, newStatsHistogram())
 			require.NoError(t, err)
 			require.Equal(t, c.expected, res)
 		})

--- a/cmd/promtool/analyze_test.go
+++ b/cmd/promtool/analyze_test.go
@@ -152,11 +152,15 @@ func TestCalcClassicBucketStatistics(t *testing.T) {
 		{
 			exampleMatrix,
 			&statistics{
-				min:            1,
-				avg:            2,
-				max:            3,
-				available:      4,
-				scrapeInterval: 100,
+				min:       1,
+				avg:       2,
+				max:       3,
+				populated: 4,
+				available: 4,
+				minDelta:  1,
+				maxDelta:  8,
+				avgDelta:  4.5,
+				step:      100,
 			},
 		},
 	}

--- a/cmd/promtool/analyze_test.go
+++ b/cmd/promtool/analyze_test.go
@@ -152,22 +152,23 @@ func TestCalcClassicBucketStatistics(t *testing.T) {
 		{
 			exampleMatrix,
 			&statistics{
-				min:       1,
-				avg:       2,
-				max:       3,
-				populated: 4,
-				available: 4,
-				minDelta:  1,
-				maxDelta:  8,
-				avgDelta:  4.5,
-				step:      100,
+				minChanged: 1,
+				avgChanged: 2,
+				maxChanged: 3,
+				minDelta:   1,
+				maxDelta:   8,
+				avgDelta:   4.5,
+				minPop:     4,
+				avgPop:     4,
+				maxPop:     4,
+				total:      4,
 			},
 		},
 	}
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			res, err := calcClassicBucketStatistics(c.matrix, 100, newStatsHistogram())
+			res, err := calcClassicBucketStatistics(c.matrix, newStatsHistogram())
 			require.NoError(t, err)
 			require.Equal(t, c.expected, res)
 		})

--- a/cmd/promtool/analyze_test.go
+++ b/cmd/promtool/analyze_test.go
@@ -152,23 +152,17 @@ func TestCalcClassicBucketStatistics(t *testing.T) {
 		{
 			exampleMatrix,
 			&statistics{
-				minChanged: 1,
-				avgChanged: 2,
-				maxChanged: 3,
-				minDelta:   1,
-				maxDelta:   8,
-				avgDelta:   4.5,
-				minPop:     4,
-				avgPop:     4,
-				maxPop:     4,
-				total:      4,
+				minPop: 4,
+				avgPop: 4,
+				maxPop: 4,
+				total:  4,
 			},
 		},
 	}
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			res, err := calcClassicBucketStatistics(c.matrix, newStatsHistogram())
+			res, err := calcClassicBucketStatistics(c.matrix)
 			require.NoError(t, err)
 			require.Equal(t, c.expected, res)
 		})

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -273,16 +273,17 @@ func main() {
 	tenantIDEnvVar := "TENANT_ID"
 	apiKeyEnvVar := "API_KEY"
 
-	analyzeCfg := &AnalyzeClassicHistogramsConfig{}
+	analyzeCfg := &AnalyzeHistogramsConfig{}
 	analyzeCmd := app.Command("analyze", "Run analysis against your Prometheus to see which metrics are being used and exported.")
-	analyzeClassicHistogramsCmd := analyzeCmd.Command("classichistograms", "Analyze the usage pattern of classic histograms.")
-	analyzeClassicHistogramsCmd.Flag("address", "Address of the Prometheus or Grafana Mimir instance; alternatively, set "+addressEnvVar+".").Envar(addressEnvVar).Required().URLVar(&analyzeCfg.address)
-	analyzeClassicHistogramsCmd.Flag("id", "Username to use when contacting Prometheus or Grafana Mimir; alternatively, set "+tenantIDEnvVar+".").Envar(tenantIDEnvVar).Default("").StringVar(&analyzeCfg.user)
-	analyzeClassicHistogramsCmd.Flag("key", "Password to use when contacting Prometheus or Grafana Mimir; alternatively, set "+apiKeyEnvVar+".").Envar(apiKeyEnvVar).Default("").StringVar(&analyzeCfg.key)
-	analyzeClassicHistogramsCmd.Flag("lookback", "Time frame to analyze.").Default("1h").DurationVar(&analyzeCfg.lookback)
-	analyzeClassicHistogramsCmd.Flag("timeout", "Timeout for read requests.").Default("5m").DurationVar(&analyzeCfg.readTimeout)
-	analyzeClassicHistogramsCmd.Flag("scrape-interval", "Scrape interval.").DurationVar(&analyzeCfg.scrapeInterval)
-	analyzeClassicHistogramsCmd.Flag("output", "Path for the output file.").StringVar(&analyzeCfg.outputFile)
+	analyzeHistogramsCmd := analyzeCmd.Command("histograms", "Analyze the usage pattern of histograms.")
+	analyzeHistogramsCmd.Flag("type", "Type of histogram: classic/native.").StringVar(&analyzeCfg.histogramType)
+	analyzeHistogramsCmd.Flag("address", "Address of the Prometheus or Grafana Mimir instance; alternatively, set "+addressEnvVar+".").Envar(addressEnvVar).Required().URLVar(&analyzeCfg.address)
+	analyzeHistogramsCmd.Flag("id", "Username to use when contacting Prometheus or Grafana Mimir; alternatively, set "+tenantIDEnvVar+".").Envar(tenantIDEnvVar).Default("").StringVar(&analyzeCfg.user)
+	analyzeHistogramsCmd.Flag("key", "Password to use when contacting Prometheus or Grafana Mimir; alternatively, set "+apiKeyEnvVar+".").Envar(apiKeyEnvVar).Default("").StringVar(&analyzeCfg.key)
+	analyzeHistogramsCmd.Flag("lookback", "Time frame to analyze.").Default("1h").DurationVar(&analyzeCfg.lookback)
+	analyzeHistogramsCmd.Flag("timeout", "Timeout for read requests.").Default("5m").DurationVar(&analyzeCfg.readTimeout)
+	analyzeHistogramsCmd.Flag("scrape-interval", "Scrape interval.").DurationVar(&analyzeCfg.scrapeInterval)
+	analyzeHistogramsCmd.Flag("output", "Path for the output file.").StringVar(&analyzeCfg.outputFile)
 
 	featureList := app.Flag("enable-feature", "Comma separated feature names to enable (only PromQL related and no-default-scrape-port). See https://prometheus.io/docs/prometheus/latest/feature_flags/ for the options and more details.").Default("").Strings()
 
@@ -405,7 +406,7 @@ func main() {
 	case importRulesCmd.FullCommand():
 		os.Exit(checkErr(importRules(serverURL, httpRoundTripper, *importRulesStart, *importRulesEnd, *importRulesOutputDir, *importRulesEvalInterval, *maxBlockDuration, *importRulesFiles...)))
 
-	case analyzeClassicHistogramsCmd.FullCommand():
+	case analyzeHistogramsCmd.FullCommand():
 		os.Exit(checkErr(analyzeCfg.run()))
 
 	case documentationCmd.FullCommand():

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -269,21 +269,15 @@ func main() {
 	promQLLabelsDeleteQuery := promQLLabelsDeleteCmd.Arg("query", "PromQL query.").Required().String()
 	promQLLabelsDeleteName := promQLLabelsDeleteCmd.Arg("name", "Name of the label to delete.").Required().String()
 
-	addressEnvVar := "ADDRESS"
-	tenantIDEnvVar := "TENANT_ID"
-	apiKeyEnvVar := "API_KEY"
-
 	analyzeCfg := &AnalyzeHistogramsConfig{}
 	analyzeCmd := app.Command("analyze", "Run analysis against your Prometheus to see which metrics are being used and exported.")
 	analyzeHistogramsCmd := analyzeCmd.Command("histograms", "Analyze the usage pattern of histograms.")
 	analyzeHistogramsCmd.Flag("type", "Type of histogram: classic/native.").StringVar(&analyzeCfg.histogramType)
-	analyzeHistogramsCmd.Flag("address", "Address of the Prometheus or Grafana Mimir instance; alternatively, set "+addressEnvVar+".").Envar(addressEnvVar).Required().URLVar(&analyzeCfg.address)
-	analyzeHistogramsCmd.Flag("id", "Username to use when contacting Prometheus or Grafana Mimir; alternatively, set "+tenantIDEnvVar+".").Envar(tenantIDEnvVar).Default("").StringVar(&analyzeCfg.user)
-	analyzeHistogramsCmd.Flag("key", "Password to use when contacting Prometheus or Grafana Mimir; alternatively, set "+apiKeyEnvVar+".").Envar(apiKeyEnvVar).Default("").StringVar(&analyzeCfg.key)
+	analyzeHistogramsCmd.Flag("address", "Address of the Prometheus instance.").Required().URLVar(&analyzeCfg.address)
+	analyzeHistogramsCmd.Flag("id", "Username to use when contacting Prometheus.").Default("").StringVar(&analyzeCfg.user)
+	analyzeHistogramsCmd.Flag("key", "Password to use when contacting Prometheus.").Default("").StringVar(&analyzeCfg.key)
 	analyzeHistogramsCmd.Flag("lookback", "Time frame to analyze.").Default("1h").DurationVar(&analyzeCfg.lookback)
-	analyzeHistogramsCmd.Flag("timeout", "Timeout for read requests.").Default("5m").DurationVar(&analyzeCfg.readTimeout)
 	analyzeHistogramsCmd.Flag("scrape-interval", "Scrape interval.").DurationVar(&analyzeCfg.scrapeInterval)
-	analyzeHistogramsCmd.Flag("output", "Path for the output file.").StringVar(&analyzeCfg.outputFile)
 
 	featureList := app.Flag("enable-feature", "Comma separated feature names to enable (only PromQL related and no-default-scrape-port). See https://prometheus.io/docs/prometheus/latest/feature_flags/ for the options and more details.").Default("").Strings()
 

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -35,9 +35,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/google/pprof/profile"
 	"github.com/prometheus/client_golang/api"
-	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -273,9 +271,7 @@ func main() {
 	analyzeCmd := app.Command("analyze", "Run analysis against your Prometheus to see which metrics are being used and exported.")
 	analyzeHistogramsCmd := analyzeCmd.Command("histograms", "Analyze the usage pattern of histograms.")
 	analyzeHistogramsCmd.Flag("type", "Type of histogram: classic/native.").StringVar(&analyzeCfg.histogramType)
-	analyzeHistogramsCmd.Flag("address", "Address of the Prometheus instance.").Required().URLVar(&analyzeCfg.address)
-	analyzeHistogramsCmd.Flag("id", "Username to use when contacting Prometheus.").Default("").StringVar(&analyzeCfg.user)
-	analyzeHistogramsCmd.Flag("key", "Password to use when contacting Prometheus.").Default("").StringVar(&analyzeCfg.key)
+	analyzeHistogramsCmd.Flag("server", "Prometheus server to query.").Default("http://localhost:9090").URLVar(&serverURL)
 	analyzeHistogramsCmd.Flag("lookback", "Time frame to analyze.").Default("1h").DurationVar(&analyzeCfg.lookback)
 	analyzeHistogramsCmd.Flag("scrape-interval", "Scrape interval.").DurationVar(&analyzeCfg.scrapeInterval)
 
@@ -401,7 +397,7 @@ func main() {
 		os.Exit(checkErr(importRules(serverURL, httpRoundTripper, *importRulesStart, *importRulesEnd, *importRulesOutputDir, *importRulesEvalInterval, *maxBlockDuration, *importRulesFiles...)))
 
 	case analyzeHistogramsCmd.FullCommand():
-		os.Exit(checkErr(analyzeCfg.run()))
+		os.Exit(checkErr(analyzeCfg.run(serverURL, httpRoundTripper)))
 
 	case documentationCmd.FullCommand():
 		os.Exit(checkErr(documentcli.GenerateMarkdown(app.Model(), os.Stdout)))
@@ -1010,246 +1006,6 @@ func checkMetricsExtended(r io.Reader) ([]metricStat, int, error) {
 	return stats, total, nil
 }
 
-// QueryInstant performs an instant query against a Prometheus server.
-func QueryInstant(url *url.URL, roundTripper http.RoundTripper, query, evalTime string, p printer) int {
-	if url.Scheme == "" {
-		url.Scheme = "http"
-	}
-	config := api.Config{
-		Address:      url.String(),
-		RoundTripper: roundTripper,
-	}
-
-	// Create new client.
-	c, err := api.NewClient(config)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "error creating API client:", err)
-		return failureExitCode
-	}
-
-	eTime := time.Now()
-	if evalTime != "" {
-		eTime, err = parseTime(evalTime)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "error parsing evaluation time:", err)
-			return failureExitCode
-		}
-	}
-
-	// Run query against client.
-	api := v1.NewAPI(c)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	val, _, err := api.Query(ctx, query, eTime) // Ignoring warnings for now.
-	cancel()
-	if err != nil {
-		return handleAPIError(err)
-	}
-
-	p.printValue(val)
-
-	return successExitCode
-}
-
-// QueryRange performs a range query against a Prometheus server.
-func QueryRange(url *url.URL, roundTripper http.RoundTripper, headers map[string]string, query, start, end string, step time.Duration, p printer) int {
-	if url.Scheme == "" {
-		url.Scheme = "http"
-	}
-	config := api.Config{
-		Address:      url.String(),
-		RoundTripper: roundTripper,
-	}
-
-	if len(headers) > 0 {
-		config.RoundTripper = promhttp.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			for key, value := range headers {
-				req.Header.Add(key, value)
-			}
-			return roundTripper.RoundTrip(req)
-		})
-	}
-
-	// Create new client.
-	c, err := api.NewClient(config)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "error creating API client:", err)
-		return failureExitCode
-	}
-
-	var stime, etime time.Time
-
-	if end == "" {
-		etime = time.Now()
-	} else {
-		etime, err = parseTime(end)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "error parsing end time:", err)
-			return failureExitCode
-		}
-	}
-
-	if start == "" {
-		stime = etime.Add(-5 * time.Minute)
-	} else {
-		stime, err = parseTime(start)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "error parsing start time:", err)
-			return failureExitCode
-		}
-	}
-
-	if !stime.Before(etime) {
-		fmt.Fprintln(os.Stderr, "start time is not before end time")
-		return failureExitCode
-	}
-
-	if step == 0 {
-		resolution := math.Max(math.Floor(etime.Sub(stime).Seconds()/250), 1)
-		// Convert seconds to nanoseconds such that time.Duration parses correctly.
-		step = time.Duration(resolution) * time.Second
-	}
-
-	// Run query against client.
-	api := v1.NewAPI(c)
-	r := v1.Range{Start: stime, End: etime, Step: step}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	val, _, err := api.QueryRange(ctx, query, r) // Ignoring warnings for now.
-	cancel()
-
-	if err != nil {
-		return handleAPIError(err)
-	}
-
-	p.printValue(val)
-	return successExitCode
-}
-
-// QuerySeries queries for a series against a Prometheus server.
-func QuerySeries(url *url.URL, roundTripper http.RoundTripper, matchers []string, start, end string, p printer) int {
-	if url.Scheme == "" {
-		url.Scheme = "http"
-	}
-	config := api.Config{
-		Address:      url.String(),
-		RoundTripper: roundTripper,
-	}
-
-	// Create new client.
-	c, err := api.NewClient(config)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "error creating API client:", err)
-		return failureExitCode
-	}
-
-	stime, etime, err := parseStartTimeAndEndTime(start, end)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return failureExitCode
-	}
-
-	// Run query against client.
-	api := v1.NewAPI(c)
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	val, _, err := api.Series(ctx, matchers, stime, etime) // Ignoring warnings for now.
-	cancel()
-
-	if err != nil {
-		return handleAPIError(err)
-	}
-
-	p.printSeries(val)
-	return successExitCode
-}
-
-// QueryLabels queries for label values against a Prometheus server.
-func QueryLabels(url *url.URL, roundTripper http.RoundTripper, matchers []string, name, start, end string, p printer) int {
-	if url.Scheme == "" {
-		url.Scheme = "http"
-	}
-	config := api.Config{
-		Address:      url.String(),
-		RoundTripper: roundTripper,
-	}
-
-	// Create new client.
-	c, err := api.NewClient(config)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "error creating API client:", err)
-		return failureExitCode
-	}
-
-	stime, etime, err := parseStartTimeAndEndTime(start, end)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return failureExitCode
-	}
-
-	// Run query against client.
-	api := v1.NewAPI(c)
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	val, warn, err := api.LabelValues(ctx, name, matchers, stime, etime)
-	cancel()
-
-	for _, v := range warn {
-		fmt.Fprintln(os.Stderr, "query warning:", v)
-	}
-	if err != nil {
-		return handleAPIError(err)
-	}
-
-	p.printLabelValues(val)
-	return successExitCode
-}
-
-func handleAPIError(err error) int {
-	var apiErr *v1.Error
-	if errors.As(err, &apiErr) && apiErr.Detail != "" {
-		fmt.Fprintf(os.Stderr, "query error: %v (detail: %s)\n", apiErr, strings.TrimSpace(apiErr.Detail))
-	} else {
-		fmt.Fprintln(os.Stderr, "query error:", err)
-	}
-
-	return failureExitCode
-}
-
-func parseStartTimeAndEndTime(start, end string) (time.Time, time.Time, error) {
-	var (
-		minTime = time.Now().Add(-9999 * time.Hour)
-		maxTime = time.Now().Add(9999 * time.Hour)
-		err     error
-	)
-
-	stime := minTime
-	etime := maxTime
-
-	if start != "" {
-		stime, err = parseTime(start)
-		if err != nil {
-			return stime, etime, fmt.Errorf("error parsing start time: %w", err)
-		}
-	}
-
-	if end != "" {
-		etime, err = parseTime(end)
-		if err != nil {
-			return stime, etime, fmt.Errorf("error parsing end time: %w", err)
-		}
-	}
-	return stime, etime, nil
-}
-
-func parseTime(s string) (time.Time, error) {
-	if t, err := strconv.ParseFloat(s, 64); err == nil {
-		s, ns := math.Modf(t)
-		return time.Unix(int64(s), int64(ns*float64(time.Second))).UTC(), nil
-	}
-	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-		return t, nil
-	}
-	return time.Time{}, fmt.Errorf("cannot parse %q to a valid timestamp", s)
-}
-
 type endpointsGroup struct {
 	urlToFilename map[string]string
 	postProcess   func(b []byte) ([]byte, error)
@@ -1403,15 +1159,12 @@ func importRules(url *url.URL, roundTripper http.RoundTripper, start, end, outpu
 		evalInterval:     evalInterval,
 		maxBlockDuration: maxBlockDuration,
 	}
-	client, err := api.NewClient(api.Config{
-		Address:      url.String(),
-		RoundTripper: roundTripper,
-	})
+	api, err := newAPI(url, roundTripper, nil)
 	if err != nil {
 		return fmt.Errorf("new api client error: %w", err)
 	}
 
-	ruleImporter := newRuleImporter(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), cfg, v1.NewAPI(client))
+	ruleImporter := newRuleImporter(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), cfg, api)
 	errs := ruleImporter.loadGroups(ctx, files)
 	for _, err := range errs {
 		if err != nil {

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -187,8 +187,9 @@ func main() {
 	queryAnalyzeCmd := queryCmd.Command("analyze", "Run queries against your Prometheus to analyze the usage pattern of certain metrics.")
 	queryAnalyzeCmd.Flag("server", "Prometheus server to query.").Default("http://localhost:9090").URLVar(&serverURL)
 	queryAnalyzeCmd.Flag("type", "Type of metric: classichistograms/nativehistograms.").StringVar(&queryAnalyzeCfg.metricType)
-	queryAnalyzeCmd.Flag("lookback", "Time frame to analyze.").Default("1h").DurationVar(&queryAnalyzeCfg.lookback)
-	queryAnalyzeCmd.Flag("scrape-interval", "Scrape interval.").DurationVar(&queryAnalyzeCfg.scrapeInterval)
+	queryAnalyzeCmd.Flag("duration", "Time frame to analyze.").Default("1h").DurationVar(&queryAnalyzeCfg.duration)
+	queryAnalyzeCmd.Flag("end", "Query end time (RFC3339 or Unix timestamp), defaults to now.").StringVar(&queryAnalyzeCfg.end)
+	queryAnalyzeCmd.Flag("step", "Query step size (duration).").DurationVar(&queryAnalyzeCfg.step)
 
 	pushCmd := app.Command("push", "Push to a Prometheus server.")
 	pushCmd.Flag("http.config.file", "HTTP client configuration file for promtool to connect to Prometheus.").PlaceHolder("<filename>").ExistingFileVar(&httpConfigFilePath)

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -190,6 +190,7 @@ func main() {
 	queryAnalyzeCmd.Flag("duration", "Time frame to analyze.").Default("1h").DurationVar(&queryAnalyzeCfg.duration)
 	queryAnalyzeCmd.Flag("end", "Query end time (RFC3339 or Unix timestamp), defaults to now.").StringVar(&queryAnalyzeCfg.end)
 	queryAnalyzeCmd.Flag("step", "Query step size (duration).").DurationVar(&queryAnalyzeCfg.step)
+	queryAnalyzeCmd.Flag("match", "Series selector. Can be specified multiple times.").StringsVar(&queryAnalyzeCfg.matchers)
 
 	pushCmd := app.Command("push", "Push to a Prometheus server.")
 	pushCmd.Flag("http.config.file", "HTTP client configuration file for promtool to connect to Prometheus.").PlaceHolder("<filename>").ExistingFileVar(&httpConfigFilePath)

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -183,14 +183,13 @@ func main() {
 	queryLabelsEnd := queryLabelsCmd.Flag("end", "End time (RFC3339 or Unix timestamp).").String()
 	queryLabelsMatch := queryLabelsCmd.Flag("match", "Series selector. Can be specified multiple times.").Strings()
 
-	queryAnalyzeCfg := &AnalyzeHistogramsConfig{}
+	queryAnalyzeCfg := &QueryAnalyzeConfig{}
 	queryAnalyzeCmd := queryCmd.Command("analyze", "Run queries against your Prometheus to analyze the usage pattern of certain metrics.")
-	queryAnalyzeCmd.Flag("server", "Prometheus server to query.").Default("http://localhost:9090").URLVar(&serverURL)
-	queryAnalyzeCmd.Flag("type", "Type of metric: classichistograms/nativehistograms.").StringVar(&queryAnalyzeCfg.metricType)
+	queryAnalyzeCmd.Flag("server", "Prometheus server to query.").Required().URLVar(&serverURL)
+	queryAnalyzeCmd.Flag("type", "Type of metric: classichistograms/nativehistograms.").Required().StringVar(&queryAnalyzeCfg.metricType)
 	queryAnalyzeCmd.Flag("duration", "Time frame to analyze.").Default("1h").DurationVar(&queryAnalyzeCfg.duration)
-	queryAnalyzeCmd.Flag("end", "Query end time (RFC3339 or Unix timestamp), defaults to now.").StringVar(&queryAnalyzeCfg.end)
-	queryAnalyzeCmd.Flag("step", "Query step size (duration).").DurationVar(&queryAnalyzeCfg.step)
-	queryAnalyzeCmd.Flag("match", "Series selector. Can be specified multiple times.").StringsVar(&queryAnalyzeCfg.matchers)
+	queryAnalyzeCmd.Flag("time", "Query time (RFC3339 or Unix timestamp), defaults to now.").StringVar(&queryAnalyzeCfg.time)
+	queryAnalyzeCmd.Flag("match", "Series selector. Can be specified multiple times.").Required().StringsVar(&queryAnalyzeCfg.matchers)
 
 	pushCmd := app.Command("push", "Push to a Prometheus server.")
 	pushCmd.Flag("http.config.file", "HTTP client configuration file for promtool to connect to Prometheus.").PlaceHolder("<filename>").ExistingFileVar(&httpConfigFilePath)

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -186,7 +186,7 @@ func main() {
 	queryAnalyzeCfg := &QueryAnalyzeConfig{}
 	queryAnalyzeCmd := queryCmd.Command("analyze", "Run queries against your Prometheus to analyze the usage pattern of certain metrics.")
 	queryAnalyzeCmd.Flag("server", "Prometheus server to query.").Required().URLVar(&serverURL)
-	queryAnalyzeCmd.Flag("type", "Type of metric: classichistograms/nativehistograms.").Required().StringVar(&queryAnalyzeCfg.metricType)
+	queryAnalyzeCmd.Flag("type", "Type of metric: histogram.").Required().StringVar(&queryAnalyzeCfg.metricType)
 	queryAnalyzeCmd.Flag("duration", "Time frame to analyze.").Default("1h").DurationVar(&queryAnalyzeCfg.duration)
 	queryAnalyzeCmd.Flag("time", "Query time (RFC3339 or Unix timestamp), defaults to now.").StringVar(&queryAnalyzeCfg.time)
 	queryAnalyzeCmd.Flag("match", "Series selector. Can be specified multiple times.").Required().StringsVar(&queryAnalyzeCfg.matchers)

--- a/cmd/promtool/query.go
+++ b/cmd/promtool/query.go
@@ -1,0 +1,251 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/api"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	_ "github.com/prometheus/prometheus/plugins" // Register plugins.
+)
+
+func newAPI(url *url.URL, roundTripper http.RoundTripper, headers map[string]string) (v1.API, error) {
+	if url.Scheme == "" {
+		url.Scheme = "http"
+	}
+	config := api.Config{
+		Address:      url.String(),
+		RoundTripper: roundTripper,
+	}
+
+	if len(headers) > 0 {
+		config.RoundTripper = promhttp.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			for key, value := range headers {
+				req.Header.Add(key, value)
+			}
+			return roundTripper.RoundTrip(req)
+		})
+	}
+
+	// Create new client.
+	client, err := api.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	api := v1.NewAPI(client)
+	return api, nil
+}
+
+// QueryInstant performs an instant query against a Prometheus server.
+func QueryInstant(url *url.URL, roundTripper http.RoundTripper, query, evalTime string, p printer) int {
+	api, err := newAPI(url, roundTripper, nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating API client:", err)
+		return failureExitCode
+	}
+
+	eTime := time.Now()
+	if evalTime != "" {
+		eTime, err = parseTime(evalTime)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error parsing evaluation time:", err)
+			return failureExitCode
+		}
+	}
+
+	// Run query against client.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	val, _, err := api.Query(ctx, query, eTime) // Ignoring warnings for now.
+	cancel()
+	if err != nil {
+		return handleAPIError(err)
+	}
+
+	p.printValue(val)
+
+	return successExitCode
+}
+
+// QueryRange performs a range query against a Prometheus server.
+func QueryRange(url *url.URL, roundTripper http.RoundTripper, headers map[string]string, query, start, end string, step time.Duration, p printer) int {
+	api, err := newAPI(url, roundTripper, headers)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating API client:", err)
+		return failureExitCode
+	}
+
+	var stime, etime time.Time
+
+	if end == "" {
+		etime = time.Now()
+	} else {
+		etime, err = parseTime(end)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error parsing end time:", err)
+			return failureExitCode
+		}
+	}
+
+	if start == "" {
+		stime = etime.Add(-5 * time.Minute)
+	} else {
+		stime, err = parseTime(start)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error parsing start time:", err)
+			return failureExitCode
+		}
+	}
+
+	if !stime.Before(etime) {
+		fmt.Fprintln(os.Stderr, "start time is not before end time")
+		return failureExitCode
+	}
+
+	if step == 0 {
+		resolution := math.Max(math.Floor(etime.Sub(stime).Seconds()/250), 1)
+		// Convert seconds to nanoseconds such that time.Duration parses correctly.
+		step = time.Duration(resolution) * time.Second
+	}
+
+	// Run query against client.
+	r := v1.Range{Start: stime, End: etime, Step: step}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	val, _, err := api.QueryRange(ctx, query, r) // Ignoring warnings for now.
+	cancel()
+
+	if err != nil {
+		return handleAPIError(err)
+	}
+
+	p.printValue(val)
+	return successExitCode
+}
+
+// QuerySeries queries for a series against a Prometheus server.
+func QuerySeries(url *url.URL, roundTripper http.RoundTripper, matchers []string, start, end string, p printer) int {
+	api, err := newAPI(url, roundTripper, nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating API client:", err)
+		return failureExitCode
+	}
+
+	stime, etime, err := parseStartTimeAndEndTime(start, end)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return failureExitCode
+	}
+
+	// Run query against client.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	val, _, err := api.Series(ctx, matchers, stime, etime) // Ignoring warnings for now.
+	cancel()
+
+	if err != nil {
+		return handleAPIError(err)
+	}
+
+	p.printSeries(val)
+	return successExitCode
+}
+
+// QueryLabels queries for label values against a Prometheus server.
+func QueryLabels(url *url.URL, roundTripper http.RoundTripper, matchers []string, name, start, end string, p printer) int {
+	api, err := newAPI(url, roundTripper, nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error creating API client:", err)
+		return failureExitCode
+	}
+
+	stime, etime, err := parseStartTimeAndEndTime(start, end)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return failureExitCode
+	}
+
+	// Run query against client.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	val, warn, err := api.LabelValues(ctx, name, matchers, stime, etime)
+	cancel()
+
+	for _, v := range warn {
+		fmt.Fprintln(os.Stderr, "query warning:", v)
+	}
+	if err != nil {
+		return handleAPIError(err)
+	}
+
+	p.printLabelValues(val)
+	return successExitCode
+}
+
+func handleAPIError(err error) int {
+	var apiErr *v1.Error
+	if errors.As(err, &apiErr) && apiErr.Detail != "" {
+		fmt.Fprintf(os.Stderr, "query error: %v (detail: %s)\n", apiErr, strings.TrimSpace(apiErr.Detail))
+	} else {
+		fmt.Fprintln(os.Stderr, "query error:", err)
+	}
+
+	return failureExitCode
+}
+
+func parseStartTimeAndEndTime(start, end string) (time.Time, time.Time, error) {
+	var (
+		minTime = time.Now().Add(-9999 * time.Hour)
+		maxTime = time.Now().Add(9999 * time.Hour)
+		err     error
+	)
+
+	stime := minTime
+	etime := maxTime
+
+	if start != "" {
+		stime, err = parseTime(start)
+		if err != nil {
+			return stime, etime, fmt.Errorf("error parsing start time: %w", err)
+		}
+	}
+
+	if end != "" {
+		etime, err = parseTime(end)
+		if err != nil {
+			return stime, etime, fmt.Errorf("error parsing end time: %w", err)
+		}
+	}
+	return stime, etime, nil
+}
+
+func parseTime(s string) (time.Time, error) {
+	if t, err := strconv.ParseFloat(s, 64); err == nil {
+		s, ns := math.Modf(t)
+		return time.Unix(int64(s), int64(ns*float64(time.Second))).UTC(), nil
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("cannot parse %q to a valid timestamp", s)
+}

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -699,9 +699,9 @@ Run analysis against your Prometheus to see which metrics are being used and exp
 
 
 
-##### `promtool analyze classichistograms`
+##### `promtool analyze histograms`
 
-Analyze the usage pattern of classic histograms.
+Analyze the usage pattern of histograms.
 
 
 
@@ -709,6 +709,7 @@ Analyze the usage pattern of classic histograms.
 
 | Flag | Description | Default |
 | --- | --- | --- |
+| <code class="text-nowrap">--type</code> | Type of histogram: classic/native. |  |
 | <code class="text-nowrap">--address</code> | Address of the Prometheus or Grafana Mimir instance; alternatively, set ADDRESS. |  |
 | <code class="text-nowrap">--id</code> | Username to use when contacting Prometheus or Grafana Mimir; alternatively, set TENANT_ID. |  |
 | <code class="text-nowrap">--key</code> | Password to use when contacting Prometheus or Grafana Mimir; alternatively, set API_KEY. |  |

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -32,6 +32,7 @@ Tooling for the Prometheus monitoring system.
 | test | Unit testing. |
 | tsdb | Run tsdb commands. |
 | promql | PromQL formatting and editing. Requires the --experimental flag. |
+| analyze | Run analysis against your Prometheus to see which metrics are being used and exported. |
 
 
 
@@ -688,5 +689,32 @@ Delete a label from the query.
 | --- | --- | --- |
 | query | PromQL query. | Yes |
 | name | Name of the label to delete. | Yes |
+
+
+
+
+### `promtool analyze`
+
+Run analysis against your Prometheus to see which metrics are being used and exported.
+
+
+
+##### `promtool analyze classichistograms`
+
+Analyze the usage pattern of classic histograms.
+
+
+
+###### Flags
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| <code class="text-nowrap">--address</code> | Address of the Prometheus or Grafana Mimir instance; alternatively, set ADDRESS. |  |
+| <code class="text-nowrap">--id</code> | Username to use when contacting Prometheus or Grafana Mimir; alternatively, set TENANT_ID. |  |
+| <code class="text-nowrap">--key</code> | Password to use when contacting Prometheus or Grafana Mimir; alternatively, set API_KEY. |  |
+| <code class="text-nowrap">--lookback</code> | Time frame to analyze. | `1h` |
+| <code class="text-nowrap">--timeout</code> | Timeout for read requests. | `5m` |
+| <code class="text-nowrap">--scrape-interval</code> | Scrape interval. |  |
+| <code class="text-nowrap">--output</code> | Path for the output file. |  |
 
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -32,7 +32,6 @@ Tooling for the Prometheus monitoring system.
 | test | Unit testing. |
 | tsdb | Run tsdb commands. |
 | promql | PromQL formatting and editing. Requires the --experimental flag. |
-| analyze | Run analysis against your Prometheus to see which metrics are being used and exported. |
 
 
 
@@ -321,6 +320,26 @@ Run labels query.
 | --- | --- | --- |
 | server | Prometheus server to query. | Yes |
 | name | Label name to provide label values for. | Yes |
+
+
+
+
+##### `promtool query analyze`
+
+Run queries against your Prometheus to analyze the usage pattern of certain metrics.
+
+
+
+###### Flags
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| <code class="text-nowrap">--server</code> | Prometheus server to query. | `http://localhost:9090` |
+| <code class="text-nowrap">--type</code> | Type of metric: classichistograms/nativehistograms. |  |
+| <code class="text-nowrap">--duration</code> | Time frame to analyze. | `1h` |
+| <code class="text-nowrap">--end</code> | Query end time (RFC3339 or Unix timestamp), defaults to now. |  |
+| <code class="text-nowrap">--step</code> | Query step size (duration). |  |
+| <code class="text-nowrap">--match</code> | Series selector. Can be specified multiple times. |  |
 
 
 
@@ -689,33 +708,5 @@ Delete a label from the query.
 | --- | --- | --- |
 | query | PromQL query. | Yes |
 | name | Name of the label to delete. | Yes |
-
-
-
-
-### `promtool analyze`
-
-Run analysis against your Prometheus to see which metrics are being used and exported.
-
-
-
-##### `promtool analyze histograms`
-
-Analyze the usage pattern of histograms.
-
-
-
-###### Flags
-
-| Flag | Description | Default |
-| --- | --- | --- |
-| <code class="text-nowrap">--type</code> | Type of histogram: classic/native. |  |
-| <code class="text-nowrap">--address</code> | Address of the Prometheus or Grafana Mimir instance; alternatively, set ADDRESS. |  |
-| <code class="text-nowrap">--id</code> | Username to use when contacting Prometheus or Grafana Mimir; alternatively, set TENANT_ID. |  |
-| <code class="text-nowrap">--key</code> | Password to use when contacting Prometheus or Grafana Mimir; alternatively, set API_KEY. |  |
-| <code class="text-nowrap">--lookback</code> | Time frame to analyze. | `1h` |
-| <code class="text-nowrap">--timeout</code> | Timeout for read requests. | `5m` |
-| <code class="text-nowrap">--scrape-interval</code> | Scrape interval. |  |
-| <code class="text-nowrap">--output</code> | Path for the output file. |  |
 
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -335,7 +335,7 @@ Run queries against your Prometheus to analyze the usage pattern of certain metr
 | Flag | Description | Default |
 | --- | --- | --- |
 | <code class="text-nowrap">--server</code> | Prometheus server to query. |  |
-| <code class="text-nowrap">--type</code> | Type of metric: classichistograms/nativehistograms. |  |
+| <code class="text-nowrap">--type</code> | Type of metric: histogram. |  |
 | <code class="text-nowrap">--duration</code> | Time frame to analyze. | `1h` |
 | <code class="text-nowrap">--time</code> | Query time (RFC3339 or Unix timestamp), defaults to now. |  |
 | <code class="text-nowrap">--match</code> | Series selector. Can be specified multiple times. |  |

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -334,11 +334,10 @@ Run queries against your Prometheus to analyze the usage pattern of certain metr
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| <code class="text-nowrap">--server</code> | Prometheus server to query. | `http://localhost:9090` |
+| <code class="text-nowrap">--server</code> | Prometheus server to query. |  |
 | <code class="text-nowrap">--type</code> | Type of metric: classichistograms/nativehistograms. |  |
 | <code class="text-nowrap">--duration</code> | Time frame to analyze. | `1h` |
-| <code class="text-nowrap">--end</code> | Query end time (RFC3339 or Unix timestamp), defaults to now. |  |
-| <code class="text-nowrap">--step</code> | Query step size (duration). |  |
+| <code class="text-nowrap">--time</code> | Query time (RFC3339 or Unix timestamp), defaults to now. |  |
 | <code class="text-nowrap">--match</code> | Series selector. Can be specified multiple times. |  |
 
 


### PR DESCRIPTION
Porting https://github.com/grafana/mimir/pull/4837 from mimirtool to promtool, which adds a command to retrieve basic statistics for recent usage of classic and native histograms.

Purpose: to get some insight into classic/native histograms bucket utilization with the goal of predicting cost increase/saving when switching from/to native histograms. This is just an estimate for the case when the actual blocks are not available.

Example command for classic histograms (metric name must end in `_sum`): `promtool query analyze --server=https://<TENANT>:<API_KEY>@<URL>/api/prom --type=classichistograms --duration=1h --match="{__name__=~\".*_sum\"}"`

Example result line for classic histograms: `cortex_request_duration_seconds_bucket{cluster="dev-us-central-0",container="store-gateway",instance="store-gateway-zone-a-0:store-gateway:http-metrics",prometheus_job="nativehistogram",route="metrics",job="mimir-dev-12/store-gateway-zone-a",method="GET",namespace="mimir-dev-12",pod="store-gateway-zone-a-0",status_code="200",ws="false"}[1h0m0s]=Bucket stats (min/avg/max) - number of buckets changed: 1/1.891/3 total delta of changed buckets: 3/3.996/4 number of populated buckets: 4/4.000/4. total number of buckets: 15`

Example command for native histograms: `promtool query analyze --server=https://<TENANT>:<API_KEY>@<URL>/api/prom --type=nativehistograms --duration=1h --match="{__name__=~\"cortex_request_.*\"}"`

Example result line for native histograms: `cortex_request_duration_seconds{container="store-gateway",instance="store-gateway-zone-c-0:store-gateway:http-metrics",method="GET",namespace="mimir-dev-12",status_code="200",cluster="dev-us-central-0",job="mimir-dev-12/store-gateway-zone-c",pod="store-gateway-zone-c-0",prometheus_job="nativehistogram",route="metrics",ws="false"}[1h0m0s]=Bucket stats (min/avg/max) - number of buckets changed: 2/3.347/4 total delta of changed buckets: 3/3.987/4 number of populated buckets: 12/16.301/17. total number of buckets: 17`

Example summary for classic histograms:
```
minChanged - min/avg/max: 0/0.531/2
avgChanged - min/avg/max: 0/0.633/2
maxChanged - min/avg/max: 0/1.272/5
minDelta - min/avg/max: 0/17.599/482
avgDelta - min/avg/max: 0/18.163/483
maxDelta - min/avg/max: 0/21.837/491
minPop - min/avg/max: 1/2.000/9
avgPop - min/avg/max: 1/2.041/9
maxPop - min/avg/max: 1/2.190/9
total - min/avg/max: 15/15.000/15
count - 147
&{map[0:14972 1:13411 2:4146 3:1746 4:35 5:3]}
```

Example summary for native histograms:
```
minChanged - min/avg/max: 0/0.898/10
avgChanged - min/avg/max: 0/1.660/15
maxChanged - min/avg/max: 0/3.646/30
minDelta - min/avg/max: 0/17.599/482
avgDelta - min/avg/max: 0/18.238/483
maxDelta - min/avg/max: 0/21.837/491
minPop - min/avg/max: 1/13.687/83
avgPop - min/avg/max: 1/14.694/83
maxPop - min/avg/max: 1/15.769/83
total - min/avg/max: 1/15.769/83
count - 147
&{map[0:15035 1:4196 2:4075 3:3992 4:3501 5:1504 6:211 7:261 8:286 9:221 10:188 11:205 12:215 13:161 14:108 15:89 16:49 17:36 18:16 19:12 20:5 21:4 22:4 23:2 24:2 25:2 26:1 30:1]}
```

Just from these overall stats, we can see a pattern of native histograms having higher resolution (more buckets), and higher efficiency (fewer unpopulated buckets).

------

Update:

New command: `promtool query analyze --server=https://<TENANT>:<API_KEY>@<URL>/api/prom --type=histogram --duration=1h --match="{__name__=~\"cortex_request_.*\"}"`

Aggregated results:
```
Native histogram series (229 in total):
- min populated: 1/32.590/86
- avg populated: 1/32.590/86
- max populated: 1/32.655/87

Classic histogram series (229 in total):
- min populated: 1/3.205/11
- avg populated: 1/3.205/11
- max populated: 1/3.210/11
- total: 15/15.000/15
```