### PR TITLE
Cherry-pick bugfix #12322 and create v2.43.1+stringlabels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2.43.1+stringlabels / 2023-05-04
+
+Special release build that incorporates performance improvements using
+the stringlabels Go tag. This release aims to provide a more efficient and
+faster solution for users managing large-scale deployments or facing performance
+issues with the default Prometheus binaries.
+
+The new labels data structure replaces the existing label/value storage with a
+single string, reducing heap size and improving performance in most cases. It
+enables Prometheus to use fewer system resources, particularly in
+memory-intensive environments.
+
+## 2.43.1 / 2023-05-03
+
+* [BUGFIX] Labels: `Set()` after `Del()` would be ignored, which broke some relabeling rules. #12322
+
 ## 2.43.0+stringlabels / 2023-03-21
 
 Special release build that incorporates performance improvements using

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.43.0+stringlabels
+2.43.1+stringlabels

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -531,15 +531,14 @@ func (b *Builder) Set(n, v string) *Builder {
 }
 
 func (b *Builder) Get(n string) string {
-	for _, d := range b.del {
-		if d == n {
-			return ""
-		}
-	}
+	// Del() removes entries from .add but Set() does not remove from .del, so check .add first.
 	for _, a := range b.add {
 		if a.Name == n {
 			return a.Value
 		}
+	}
+	if slices.Contains(b.del, n) {
+		return ""
 	}
 	return b.base.Get(n)
 }

--- a/model/labels/labels_string.go
+++ b/model/labels/labels_string.go
@@ -587,13 +587,14 @@ func (b *Builder) Set(n, v string) *Builder {
 }
 
 func (b *Builder) Get(n string) string {
-	if slices.Contains(b.del, n) {
-		return ""
-	}
+	// Del() removes entries from .add but Set() does not remove from .del, so check .add first.
 	for _, a := range b.add {
 		if a.Name == n {
 			return a.Value
 		}
+	}
+	if slices.Contains(b.del, n) {
+		return ""
 	}
 	return b.base.Get(n)
 }

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -607,6 +607,13 @@ func TestBuilder(t *testing.T) {
 			require.Equal(t, tcase.want.BytesWithoutLabels(nil, "aaa", "bbb"), b.Labels(tcase.base).Bytes(nil))
 		})
 	}
+	t.Run("set_after_del", func(t *testing.T) {
+		b := NewBuilder(FromStrings("aaa", "111"))
+		b.Del("bbb")
+		b.Set("bbb", "222")
+		require.Equal(t, FromStrings("aaa", "111", "bbb", "222"), b.Labels(EmptyLabels()))
+		require.Equal(t, "222", b.Get("bbb"))
+	})
 }
 
 func TestScratchBuilder(t *testing.T) {

--- a/web/ui/module/codemirror-promql/package.json
+++ b/web/ui/module/codemirror-promql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prometheus-io/codemirror-promql",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "a CodeMirror mode for the PromQL language",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/prometheus/prometheus/blob/main/web/ui/module/codemirror-promql/README.md",
   "dependencies": {
-    "@prometheus-io/lezer-promql": "0.43.0",
+    "@prometheus-io/lezer-promql": "0.43.1",
     "lru-cache": "^6.0.0"
   },
   "devDependencies": {

--- a/web/ui/module/lezer-promql/package.json
+++ b/web/ui/module/lezer-promql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prometheus-io/lezer-promql",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "lezer-based PromQL grammar",
   "main": "dist/index.cjs",
   "type": "module",

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -28,10 +28,10 @@
     },
     "module/codemirror-promql": {
       "name": "@prometheus-io/codemirror-promql",
-      "version": "0.43.0",
+      "version": "0.43.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prometheus-io/lezer-promql": "0.43.0",
+        "@prometheus-io/lezer-promql": "0.43.1",
         "lru-cache": "^6.0.0"
       },
       "devDependencies": {
@@ -61,7 +61,7 @@
     },
     "module/lezer-promql": {
       "name": "@prometheus-io/lezer-promql",
-      "version": "0.43.0",
+      "version": "0.43.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.2.2",
@@ -20763,7 +20763,7 @@
     },
     "react-app": {
       "name": "@prometheus-io/app",
-      "version": "0.43.0",
+      "version": "0.43.1",
       "dependencies": {
         "@codemirror/autocomplete": "^6.4.0",
         "@codemirror/commands": "^6.2.0",
@@ -20781,7 +20781,7 @@
         "@lezer/lr": "^1.3.1",
         "@nexucis/fuzzy": "^0.4.1",
         "@nexucis/kvsearch": "^0.8.1",
-        "@prometheus-io/codemirror-promql": "0.43.0",
+        "@prometheus-io/codemirror-promql": "0.43.1",
         "bootstrap": "^4.6.2",
         "css.escape": "^1.5.1",
         "downshift": "^7.2.0",
@@ -23417,7 +23417,7 @@
         "@lezer/lr": "^1.3.1",
         "@nexucis/fuzzy": "^0.4.1",
         "@nexucis/kvsearch": "^0.8.1",
-        "@prometheus-io/codemirror-promql": "0.43.0",
+        "@prometheus-io/codemirror-promql": "0.43.1",
         "@testing-library/react-hooks": "^7.0.2",
         "@types/enzyme": "^3.10.12",
         "@types/flot": "0.0.32",
@@ -23468,7 +23468,7 @@
         "@lezer/common": "^1.0.2",
         "@lezer/highlight": "^1.1.3",
         "@lezer/lr": "^1.3.1",
-        "@prometheus-io/lezer-promql": "0.43.0",
+        "@prometheus-io/lezer-promql": "0.43.1",
         "@types/lru-cache": "^5.1.1",
         "isomorphic-fetch": "^3.0.0",
         "lru-cache": "^6.0.0",

--- a/web/ui/react-app/package.json
+++ b/web/ui/react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prometheus-io/app",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.4.0",
@@ -19,7 +19,7 @@
     "@lezer/common": "^1.0.2",
     "@nexucis/fuzzy": "^0.4.1",
     "@nexucis/kvsearch": "^0.8.1",
-    "@prometheus-io/codemirror-promql": "0.43.0",
+    "@prometheus-io/codemirror-promql": "0.43.1",
     "bootstrap": "^4.6.2",
     "css.escape": "^1.5.1",
     "downshift": "^7.2.0",


### PR DESCRIPTION
* labels: respect Set after Del in Builder (#12322)

The implementations are not symmetric between `Set()` and `Del()`, so we must be careful. Add tests for this, both in labels and in relabel where the issue was reported.

Also make the slice implementation consistent re `slices.Contains`.

* Create v2.43.1 with bugfix

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
