### PR TITLE
Fix LabelValueStats in posting stats

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -184,8 +184,9 @@ func (p *MemPostings) Stats(label string) *PostingsStats {
 			if n == label {
 				metrics.push(Stat{Name: name, Count: uint64(len(values))})
 			}
-			labelValuePairs.push(Stat{Name: n + "=" + name, Count: uint64(len(values))})
-			size += uint64(len(name))
+			seriesCnt := uint64(len(values))
+			labelValuePairs.push(Stat{Name: n + "=" + name, Count: seriesCnt})
+			size += uint64(len(name)) * seriesCnt
 		}
 		labelValueLength.push(Stat{Name: n, Count: size})
 	}

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -916,6 +916,35 @@ func BenchmarkPostings_Stats(b *testing.B) {
 	}
 }
 
+func TestMemPostingsStats(t *testing.T) {
+	// create a new MemPostings
+	p := NewMemPostings()
+
+	// add some postings to the MemPostings
+	p.Add(1, labels.FromStrings("label", "value1"))
+	p.Add(1, labels.FromStrings("label", "value2"))
+	p.Add(1, labels.FromStrings("label", "value3"))
+	p.Add(2, labels.FromStrings("label", "value1"))
+
+	// call the Stats method to calculate the cardinality statistics
+	stats := p.Stats("label")
+
+	// assert that the expected statistics were calculated
+	require.Equal(t, uint64(2), stats.CardinalityMetricsStats[0].Count)
+	require.Equal(t, "value1", stats.CardinalityMetricsStats[0].Name)
+
+	require.Equal(t, uint64(3), stats.CardinalityLabelStats[0].Count)
+	require.Equal(t, "label", stats.CardinalityLabelStats[0].Name)
+
+	require.Equal(t, uint64(24), stats.LabelValueStats[0].Count)
+	require.Equal(t, "label", stats.LabelValueStats[0].Name)
+
+	require.Equal(t, uint64(2), stats.LabelValuePairsStats[0].Count)
+	require.Equal(t, "label=value1", stats.LabelValuePairsStats[0].Name)
+
+	require.Equal(t, 3, stats.NumLabelPairs)
+}
+
 func TestMemPostings_Delete(t *testing.T) {
 	p := NewMemPostings()
 	p.Add(1, labels.FromStrings("lbl1", "a"))


### PR DESCRIPTION
**Problem**: LabelValueStats - Provide a list of the label names and memory used in bytes. It is calculated by adding the length of all values for a given label name. But internally prometheus stores the name and the value independently for each series.

**Solution**: MemPostings struct maintains the slices of series ref to values map which is used as index to get the series list for the given label value. Using that LabelValueStats is calculated as: len(_seriesRefSlice_) * len(value) for all the values of the label.

Fix: #11530

**Testing**:
1) Added UT
2) Verified in Prometheus dashboard


<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
