### PR TITLE
wlog: use filepath for getting checkpoint number

### DIFF
--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -18,7 +18,7 @@ import (
 	"io"
 	"math"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -156,7 +156,7 @@ func NewWatcher(metrics *WatcherMetrics, readerMetrics *LiveReaderMetrics, logge
 		writer:         writer,
 		metrics:        metrics,
 		readerMetrics:  readerMetrics,
-		walDir:         path.Join(dir, "wal"),
+		walDir:         filepath.Join(dir, "wal"),
 		name:           name,
 		sendExemplars:  sendExemplars,
 		sendHistograms: sendHistograms,
@@ -691,7 +691,7 @@ func (w *Watcher) readCheckpoint(checkpointDir string, readFn segmentReadFn) err
 func checkpointNum(dir string) (int, error) {
 	// Checkpoint dir names are in the format checkpoint.000001
 	// dir may contain a hidden directory, so only check the base directory
-	chunks := strings.Split(path.Base(dir), ".")
+	chunks := strings.Split(filepath.Base(dir), ".")
 	if len(chunks) != 2 {
 		return 0, errors.Errorf("invalid checkpoint dir string: %s", dir)
 	}


### PR DESCRIPTION
This changes usage of path to be replaced with path/filepath, allowing for filepath.Base to properly return the base directory on systems where `/` is not the standard path separator.

This resolves an issue on Windows where intermediate folders containing a `.` were incorrectly considered to be a part of the checkpoint name.

The rest of `wlog` already uses path/filepath; this was the only file which didn't use it.

Related to grafana/agent#3826.
