### PR TITLE
textparse/scrape: Add option to scrape both classic and native histograms

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -146,13 +146,14 @@ var (
 
 	// DefaultScrapeConfig is the default scrape configuration.
 	DefaultScrapeConfig = ScrapeConfig{
-		// ScrapeTimeout and ScrapeInterval default to the
-		// configured globals.
-		MetricsPath:      "/metrics",
-		Scheme:           "http",
-		HonorLabels:      false,
-		HonorTimestamps:  true,
-		HTTPClientConfig: config.DefaultHTTPClientConfig,
+		// ScrapeTimeout and ScrapeInterval default to the configured
+		// globals.
+		ScrapeClassicHistograms: false,
+		MetricsPath:             "/metrics",
+		Scheme:                  "http",
+		HonorLabels:             false,
+		HonorTimestamps:         true,
+		HTTPClientConfig:        config.DefaultHTTPClientConfig,
 	}
 
 	// DefaultAlertmanagerConfig is the default alertmanager configuration.
@@ -467,6 +468,8 @@ type ScrapeConfig struct {
 	ScrapeInterval model.Duration `yaml:"scrape_interval,omitempty"`
 	// The timeout for scraping targets of this config.
 	ScrapeTimeout model.Duration `yaml:"scrape_timeout,omitempty"`
+	// Whether to scrape a classic histogram that is also exposed as a native histogram.
+	ScrapeClassicHistograms bool `yaml:"scrape_classic_histograms,omitempty"`
 	// The HTTP resource path on which to fetch metrics from targets.
 	MetricsPath string `yaml:"metrics_path,omitempty"`
 	// The URL scheme with which to fetch metrics from targets.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -134,6 +134,10 @@ job_name: <job_name>
 # Per-scrape timeout when scraping this job.
 [ scrape_timeout: <duration> | default = <global_config.scrape_timeout> ]
 
+# Whether to scrape a classic histogram that is also exposed as a native
+# histogram (has no effect without --enable-feature=native-histograms).
+[ scrape_classic_histograms: <boolean> | default = false ]
+
 # The HTTP resource path on which to fetch metrics from targets.
 [ metrics_path: <path> | default = /metrics ]
 

--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -71,7 +71,7 @@ type Parser interface {
 //
 // This function always returns a valid parser, but might additionally
 // return an error if the content type cannot be parsed.
-func New(b []byte, contentType string) (Parser, error) {
+func New(b []byte, contentType string, parseClassicHistograms bool) (Parser, error) {
 	if contentType == "" {
 		return NewPromParser(b), nil
 	}
@@ -84,7 +84,7 @@ func New(b []byte, contentType string) (Parser, error) {
 	case "application/openmetrics-text":
 		return NewOpenMetricsParser(b), nil
 	case "application/vnd.google.protobuf":
-		return NewProtobufParser(b), nil
+		return NewProtobufParser(b, parseClassicHistograms), nil
 	default:
 		return NewPromParser(b), nil
 	}
@@ -100,7 +100,7 @@ const (
 	EntrySeries    Entry = 2 // A series with a simple float64 as value.
 	EntryComment   Entry = 3
 	EntryUnit      Entry = 4
-	EntryHistogram Entry = 5 // A series with a sparse histogram as a value.
+	EntryHistogram Entry = 5 // A series with a native histogram as a value.
 )
 
 // MetricType represents metric type values.

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -91,7 +91,7 @@ func TestNewParser(t *testing.T) {
 			tt := tt // Copy to local variable before going parallel.
 			t.Parallel()
 
-			p, err := New([]byte{}, tt.contentType)
+			p, err := New([]byte{}, tt.contentType, false)
 			tt.validateParser(t, p)
 			if tt.err == "" {
 				require.NoError(t, err)

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -30,8 +30,8 @@ import (
 	dto "github.com/prometheus/prometheus/prompb/io/prometheus/client"
 )
 
-func TestProtobufParse(t *testing.T) {
-	textMetricFamilies := []string{
+func createTestProtoBuf(t *testing.T) *bytes.Buffer {
+	testMetricFamilies := []string{
 		`name: "go_build_info"
 help: "Build information about the main Go module."
 type: GAUGE
@@ -231,8 +231,7 @@ help: "Test float histogram with many buckets removed to keep it manageable in s
 type: HISTOGRAM
 metric: <
   histogram: <
-    sample_count: 175
-	sample_count_float: 175.0
+    sample_count_float: 175.0
     sample_sum: 0.0008280461746287094
     bucket: <
       cumulative_count_float: 2.0
@@ -302,8 +301,7 @@ help: "Like test_float_histogram but as gauge histogram."
 type: GAUGE_HISTOGRAM
 metric: <
   histogram: <
-    sample_count: 175
-	sample_count_float: 175.0
+    sample_count_float: 175.0
     sample_sum: 0.0008280461746287094
     bucket: <
       cumulative_count_float: 2.0
@@ -450,9 +448,9 @@ metric: <
 	}
 
 	varintBuf := make([]byte, binary.MaxVarintLen32)
-	inputBuf := &bytes.Buffer{}
+	buf := &bytes.Buffer{}
 
-	for _, tmf := range textMetricFamilies {
+	for _, tmf := range testMetricFamilies {
 		pb := &dto.MetricFamily{}
 		// From text to proto message.
 		require.NoError(t, proto.UnmarshalText(tmf, pb))
@@ -462,11 +460,15 @@ metric: <
 
 		// Write first length, then binary protobuf.
 		varintLength := binary.PutUvarint(varintBuf, uint64(len(protoBuf)))
-		inputBuf.Write(varintBuf[:varintLength])
-		inputBuf.Write(protoBuf)
+		buf.Write(varintBuf[:varintLength])
+		buf.Write(protoBuf)
 	}
 
-	exp := []struct {
+	return buf
+}
+
+func TestProtobufParse(t *testing.T) {
+	type parseResult struct {
 		lset    labels.Labels
 		m       string
 		t       int64
@@ -478,417 +480,1006 @@ metric: <
 		shs     *histogram.Histogram
 		fhs     *histogram.FloatHistogram
 		e       []exemplar.Exemplar
+	}
+
+	inputBuf := createTestProtoBuf(t)
+
+	scenarios := []struct {
+		name     string
+		parser   Parser
+		expected []parseResult
 	}{
 		{
-			m:    "go_build_info",
-			help: "Build information about the main Go module.",
-		},
-		{
-			m:   "go_build_info",
-			typ: MetricTypeGauge,
-		},
-		{
-			m: "go_build_info\xFFchecksum\xFF\xFFpath\xFFgithub.com/prometheus/client_golang\xFFversion\xFF(devel)",
-			v: 1,
-			lset: labels.FromStrings(
-				"__name__", "go_build_info",
-				"checksum", "",
-				"path", "github.com/prometheus/client_golang",
-				"version", "(devel)",
-			),
-		},
-		{
-			m:    "go_memstats_alloc_bytes_total",
-			help: "Total number of bytes allocated, even if freed.",
-		},
-		{
-			m:   "go_memstats_alloc_bytes_total",
-			typ: MetricTypeCounter,
-		},
-		{
-			m: "go_memstats_alloc_bytes_total",
-			v: 1.546544e+06,
-			lset: labels.FromStrings(
-				"__name__", "go_memstats_alloc_bytes_total",
-			),
-			e: []exemplar.Exemplar{
-				{Labels: labels.FromStrings("dummyID", "42"), Value: 12, HasTs: true, Ts: 1625851151233},
-			},
-		},
-		{
-			m:    "something_untyped",
-			help: "Just to test the untyped type.",
-		},
-		{
-			m:   "something_untyped",
-			typ: MetricTypeUnknown,
-		},
-		{
-			m: "something_untyped",
-			t: 1234567,
-			v: 42,
-			lset: labels.FromStrings(
-				"__name__", "something_untyped",
-			),
-		},
-		{
-			m:    "test_histogram",
-			help: "Test histogram with many buckets removed to keep it manageable in size.",
-		},
-		{
-			m:   "test_histogram",
-			typ: MetricTypeHistogram,
-		},
-		{
-			m: "test_histogram",
-			t: 1234568,
-			shs: &histogram.Histogram{
-				Count:         175,
-				ZeroCount:     2,
-				Sum:           0.0008280461746287094,
-				ZeroThreshold: 2.938735877055719e-39,
-				Schema:        3,
-				PositiveSpans: []histogram.Span{
-					{Offset: -161, Length: 1},
-					{Offset: 8, Length: 3},
+			name:   "ignore classic buckets of native histograms",
+			parser: NewProtobufParser(inputBuf.Bytes(), false),
+			expected: []parseResult{
+				{
+					m:    "go_build_info",
+					help: "Build information about the main Go module.",
 				},
-				NegativeSpans: []histogram.Span{
-					{Offset: -162, Length: 1},
-					{Offset: 23, Length: 4},
+				{
+					m:   "go_build_info",
+					typ: MetricTypeGauge,
 				},
-				PositiveBuckets: []int64{1, 2, -1, -1},
-				NegativeBuckets: []int64{1, 3, -2, -1, 1},
-			},
-			lset: labels.FromStrings(
-				"__name__", "test_histogram",
-			),
-			e: []exemplar.Exemplar{
-				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
-				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
-			},
-		},
-		{
-			m:    "test_gauge_histogram",
-			help: "Like test_histogram but as gauge histogram.",
-		},
-		{
-			m:   "test_gauge_histogram",
-			typ: MetricTypeGaugeHistogram,
-		},
-		{
-			m: "test_gauge_histogram",
-			t: 1234568,
-			shs: &histogram.Histogram{
-				CounterResetHint: histogram.GaugeType,
-				Count:            175,
-				ZeroCount:        2,
-				Sum:              0.0008280461746287094,
-				ZeroThreshold:    2.938735877055719e-39,
-				Schema:           3,
-				PositiveSpans: []histogram.Span{
-					{Offset: -161, Length: 1},
-					{Offset: 8, Length: 3},
+				{
+					m: "go_build_info\xFFchecksum\xFF\xFFpath\xFFgithub.com/prometheus/client_golang\xFFversion\xFF(devel)",
+					v: 1,
+					lset: labels.FromStrings(
+						"__name__", "go_build_info",
+						"checksum", "",
+						"path", "github.com/prometheus/client_golang",
+						"version", "(devel)",
+					),
 				},
-				NegativeSpans: []histogram.Span{
-					{Offset: -162, Length: 1},
-					{Offset: 23, Length: 4},
+				{
+					m:    "go_memstats_alloc_bytes_total",
+					help: "Total number of bytes allocated, even if freed.",
 				},
-				PositiveBuckets: []int64{1, 2, -1, -1},
-				NegativeBuckets: []int64{1, 3, -2, -1, 1},
-			},
-			lset: labels.FromStrings(
-				"__name__", "test_gauge_histogram",
-			),
-			e: []exemplar.Exemplar{
-				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
-				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
-			},
-		},
-		{
-			m:    "test_float_histogram",
-			help: "Test float histogram with many buckets removed to keep it manageable in size.",
-		},
-		{
-			m:   "test_float_histogram",
-			typ: MetricTypeHistogram,
-		},
-		{
-			m: "test_float_histogram",
-			t: 1234568,
-			fhs: &histogram.FloatHistogram{
-				Count:         175.0,
-				ZeroCount:     2.0,
-				Sum:           0.0008280461746287094,
-				ZeroThreshold: 2.938735877055719e-39,
-				Schema:        3,
-				PositiveSpans: []histogram.Span{
-					{Offset: -161, Length: 1},
-					{Offset: 8, Length: 3},
+				{
+					m:   "go_memstats_alloc_bytes_total",
+					typ: MetricTypeCounter,
 				},
-				NegativeSpans: []histogram.Span{
-					{Offset: -162, Length: 1},
-					{Offset: 23, Length: 4},
+				{
+					m: "go_memstats_alloc_bytes_total",
+					v: 1.546544e+06,
+					lset: labels.FromStrings(
+						"__name__", "go_memstats_alloc_bytes_total",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "42"), Value: 12, HasTs: true, Ts: 1625851151233},
+					},
 				},
-				PositiveBuckets: []float64{1.0, 2.0, -1.0, -1.0},
-				NegativeBuckets: []float64{1.0, 3.0, -2.0, -1.0, 1.0},
-			},
-			lset: labels.FromStrings(
-				"__name__", "test_float_histogram",
-			),
-			e: []exemplar.Exemplar{
-				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
-				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
-			},
-		},
-		{
-			m:    "test_gauge_float_histogram",
-			help: "Like test_float_histogram but as gauge histogram.",
-		},
-		{
-			m:   "test_gauge_float_histogram",
-			typ: MetricTypeGaugeHistogram,
-		},
-		{
-			m: "test_gauge_float_histogram",
-			t: 1234568,
-			fhs: &histogram.FloatHistogram{
-				CounterResetHint: histogram.GaugeType,
-				Count:            175.0,
-				ZeroCount:        2.0,
-				Sum:              0.0008280461746287094,
-				ZeroThreshold:    2.938735877055719e-39,
-				Schema:           3,
-				PositiveSpans: []histogram.Span{
-					{Offset: -161, Length: 1},
-					{Offset: 8, Length: 3},
+				{
+					m:    "something_untyped",
+					help: "Just to test the untyped type.",
 				},
-				NegativeSpans: []histogram.Span{
-					{Offset: -162, Length: 1},
-					{Offset: 23, Length: 4},
+				{
+					m:   "something_untyped",
+					typ: MetricTypeUnknown,
 				},
-				PositiveBuckets: []float64{1.0, 2.0, -1.0, -1.0},
-				NegativeBuckets: []float64{1.0, 3.0, -2.0, -1.0, 1.0},
+				{
+					m: "something_untyped",
+					t: 1234567,
+					v: 42,
+					lset: labels.FromStrings(
+						"__name__", "something_untyped",
+					),
+				},
+				{
+					m:    "test_histogram",
+					help: "Test histogram with many buckets removed to keep it manageable in size.",
+				},
+				{
+					m:   "test_histogram",
+					typ: MetricTypeHistogram,
+				},
+				{
+					m: "test_histogram",
+					t: 1234568,
+					shs: &histogram.Histogram{
+						Count:         175,
+						ZeroCount:     2,
+						Sum:           0.0008280461746287094,
+						ZeroThreshold: 2.938735877055719e-39,
+						Schema:        3,
+						PositiveSpans: []histogram.Span{
+							{Offset: -161, Length: 1},
+							{Offset: 8, Length: 3},
+						},
+						NegativeSpans: []histogram.Span{
+							{Offset: -162, Length: 1},
+							{Offset: 23, Length: 4},
+						},
+						PositiveBuckets: []int64{1, 2, -1, -1},
+						NegativeBuckets: []int64{1, 3, -2, -1, 1},
+					},
+					lset: labels.FromStrings(
+						"__name__", "test_histogram",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{
+					m:    "test_gauge_histogram",
+					help: "Like test_histogram but as gauge histogram.",
+				},
+				{
+					m:   "test_gauge_histogram",
+					typ: MetricTypeGaugeHistogram,
+				},
+				{
+					m: "test_gauge_histogram",
+					t: 1234568,
+					shs: &histogram.Histogram{
+						CounterResetHint: histogram.GaugeType,
+						Count:            175,
+						ZeroCount:        2,
+						Sum:              0.0008280461746287094,
+						ZeroThreshold:    2.938735877055719e-39,
+						Schema:           3,
+						PositiveSpans: []histogram.Span{
+							{Offset: -161, Length: 1},
+							{Offset: 8, Length: 3},
+						},
+						NegativeSpans: []histogram.Span{
+							{Offset: -162, Length: 1},
+							{Offset: 23, Length: 4},
+						},
+						PositiveBuckets: []int64{1, 2, -1, -1},
+						NegativeBuckets: []int64{1, 3, -2, -1, 1},
+					},
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_histogram",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{
+					m:    "test_float_histogram",
+					help: "Test float histogram with many buckets removed to keep it manageable in size.",
+				},
+				{
+					m:   "test_float_histogram",
+					typ: MetricTypeHistogram,
+				},
+				{
+					m: "test_float_histogram",
+					t: 1234568,
+					fhs: &histogram.FloatHistogram{
+						Count:         175.0,
+						ZeroCount:     2.0,
+						Sum:           0.0008280461746287094,
+						ZeroThreshold: 2.938735877055719e-39,
+						Schema:        3,
+						PositiveSpans: []histogram.Span{
+							{Offset: -161, Length: 1},
+							{Offset: 8, Length: 3},
+						},
+						NegativeSpans: []histogram.Span{
+							{Offset: -162, Length: 1},
+							{Offset: 23, Length: 4},
+						},
+						PositiveBuckets: []float64{1.0, 2.0, -1.0, -1.0},
+						NegativeBuckets: []float64{1.0, 3.0, -2.0, -1.0, 1.0},
+					},
+					lset: labels.FromStrings(
+						"__name__", "test_float_histogram",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{
+					m:    "test_gauge_float_histogram",
+					help: "Like test_float_histogram but as gauge histogram.",
+				},
+				{
+					m:   "test_gauge_float_histogram",
+					typ: MetricTypeGaugeHistogram,
+				},
+				{
+					m: "test_gauge_float_histogram",
+					t: 1234568,
+					fhs: &histogram.FloatHistogram{
+						CounterResetHint: histogram.GaugeType,
+						Count:            175.0,
+						ZeroCount:        2.0,
+						Sum:              0.0008280461746287094,
+						ZeroThreshold:    2.938735877055719e-39,
+						Schema:           3,
+						PositiveSpans: []histogram.Span{
+							{Offset: -161, Length: 1},
+							{Offset: 8, Length: 3},
+						},
+						NegativeSpans: []histogram.Span{
+							{Offset: -162, Length: 1},
+							{Offset: 23, Length: 4},
+						},
+						PositiveBuckets: []float64{1.0, 2.0, -1.0, -1.0},
+						NegativeBuckets: []float64{1.0, 3.0, -2.0, -1.0, 1.0},
+					},
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_float_histogram",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{
+					m:    "test_histogram2",
+					help: "Similar histogram as before but now without sparse buckets.",
+				},
+				{
+					m:   "test_histogram2",
+					typ: MetricTypeHistogram,
+				},
+				{
+					m: "test_histogram2_count",
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram2_count",
+					),
+				},
+				{
+					m: "test_histogram2_sum",
+					v: 0.000828,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram2_sum",
+					),
+				},
+				{
+					m: "test_histogram2_bucket\xffle\xff-0.00048",
+					v: 2,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram2_bucket",
+						"le", "-0.00048",
+					),
+				},
+				{
+					m: "test_histogram2_bucket\xffle\xff-0.00038",
+					v: 4,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram2_bucket",
+						"le", "-0.00038",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00038, HasTs: true, Ts: 1625851153146},
+					},
+				},
+				{
+					m: "test_histogram2_bucket\xffle\xff1.0",
+					v: 16,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram2_bucket",
+						"le", "1.0",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.000295, HasTs: false},
+					},
+				},
+				{
+					m: "test_histogram2_bucket\xffle\xff+Inf",
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram2_bucket",
+						"le", "+Inf",
+					),
+				},
+				{
+					m:    "rpc_durations_seconds",
+					help: "RPC latency distributions.",
+				},
+				{
+					m:   "rpc_durations_seconds",
+					typ: MetricTypeSummary,
+				},
+				{
+					m: "rpc_durations_seconds_count\xffservice\xffexponential",
+					v: 262,
+					lset: labels.FromStrings(
+						"__name__", "rpc_durations_seconds_count",
+						"service", "exponential",
+					),
+				},
+				{
+					m: "rpc_durations_seconds_sum\xffservice\xffexponential",
+					v: 0.00025551262820703587,
+					lset: labels.FromStrings(
+						"__name__", "rpc_durations_seconds_sum",
+						"service", "exponential",
+					),
+				},
+				{
+					m: "rpc_durations_seconds\xffservice\xffexponential\xffquantile\xff0.5",
+					v: 6.442786329648548e-07,
+					lset: labels.FromStrings(
+						"__name__", "rpc_durations_seconds",
+						"quantile", "0.5",
+						"service", "exponential",
+					),
+				},
+				{
+					m: "rpc_durations_seconds\xffservice\xffexponential\xffquantile\xff0.9",
+					v: 1.9435742936658396e-06,
+					lset: labels.FromStrings(
+						"__name__", "rpc_durations_seconds",
+						"quantile", "0.9",
+						"service", "exponential",
+					),
+				},
+				{
+					m: "rpc_durations_seconds\xffservice\xffexponential\xffquantile\xff0.99",
+					v: 4.0471608667037015e-06,
+					lset: labels.FromStrings(
+						"__name__", "rpc_durations_seconds",
+						"quantile", "0.99",
+						"service", "exponential",
+					),
+				},
+				{
+					m:    "without_quantiles",
+					help: "A summary without quantiles.",
+				},
+				{
+					m:   "without_quantiles",
+					typ: MetricTypeSummary,
+				},
+				{
+					m: "without_quantiles_count",
+					v: 42,
+					lset: labels.FromStrings(
+						"__name__", "without_quantiles_count",
+					),
+				},
+				{
+					m: "without_quantiles_sum",
+					v: 1.234,
+					lset: labels.FromStrings(
+						"__name__", "without_quantiles_sum",
+					),
+				},
 			},
-			lset: labels.FromStrings(
-				"__name__", "test_gauge_float_histogram",
-			),
-			e: []exemplar.Exemplar{
-				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
-				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+		},
+		{
+			name:   "parse classic and native buckets",
+			parser: NewProtobufParser(inputBuf.Bytes(), true),
+			expected: []parseResult{
+				{ // 0
+					m:    "go_build_info",
+					help: "Build information about the main Go module.",
+				},
+				{ // 1
+					m:   "go_build_info",
+					typ: MetricTypeGauge,
+				},
+				{ // 2
+					m: "go_build_info\xFFchecksum\xFF\xFFpath\xFFgithub.com/prometheus/client_golang\xFFversion\xFF(devel)",
+					v: 1,
+					lset: labels.FromStrings(
+						"__name__", "go_build_info",
+						"checksum", "",
+						"path", "github.com/prometheus/client_golang",
+						"version", "(devel)",
+					),
+				},
+				{ // 3
+					m:    "go_memstats_alloc_bytes_total",
+					help: "Total number of bytes allocated, even if freed.",
+				},
+				{ // 4
+					m:   "go_memstats_alloc_bytes_total",
+					typ: MetricTypeCounter,
+				},
+				{ // 5
+					m: "go_memstats_alloc_bytes_total",
+					v: 1.546544e+06,
+					lset: labels.FromStrings(
+						"__name__", "go_memstats_alloc_bytes_total",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "42"), Value: 12, HasTs: true, Ts: 1625851151233},
+					},
+				},
+				{ // 6
+					m:    "something_untyped",
+					help: "Just to test the untyped type.",
+				},
+				{ // 7
+					m:   "something_untyped",
+					typ: MetricTypeUnknown,
+				},
+				{ // 8
+					m: "something_untyped",
+					t: 1234567,
+					v: 42,
+					lset: labels.FromStrings(
+						"__name__", "something_untyped",
+					),
+				},
+				{ // 9
+					m:    "test_histogram",
+					help: "Test histogram with many buckets removed to keep it manageable in size.",
+				},
+				{ // 10
+					m:   "test_histogram",
+					typ: MetricTypeHistogram,
+				},
+				{ // 11
+					m: "test_histogram",
+					t: 1234568,
+					shs: &histogram.Histogram{
+						Count:         175,
+						ZeroCount:     2,
+						Sum:           0.0008280461746287094,
+						ZeroThreshold: 2.938735877055719e-39,
+						Schema:        3,
+						PositiveSpans: []histogram.Span{
+							{Offset: -161, Length: 1},
+							{Offset: 8, Length: 3},
+						},
+						NegativeSpans: []histogram.Span{
+							{Offset: -162, Length: 1},
+							{Offset: 23, Length: 4},
+						},
+						PositiveBuckets: []int64{1, 2, -1, -1},
+						NegativeBuckets: []int64{1, 3, -2, -1, 1},
+					},
+					lset: labels.FromStrings(
+						"__name__", "test_histogram",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{ // 12
+					m: "test_histogram_count",
+					t: 1234568,
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_count",
+					),
+				},
+				{ // 13
+					m: "test_histogram_sum",
+					t: 1234568,
+					v: 0.0008280461746287094,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_sum",
+					),
+				},
+				{ // 14
+					m: "test_histogram_bucket\xffle\xff-0.0004899999999999998",
+					t: 1234568,
+					v: 2,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_bucket",
+						"le", "-0.0004899999999999998",
+					),
+				},
+				{ // 15
+					m: "test_histogram_bucket\xffle\xff-0.0003899999999999998",
+					t: 1234568,
+					v: 4,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_bucket",
+						"le", "-0.0003899999999999998",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+					},
+				},
+				{ // 16
+					m: "test_histogram_bucket\xffle\xff-0.0002899999999999998",
+					t: 1234568,
+					v: 16,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_bucket",
+						"le", "-0.0002899999999999998",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{ // 17
+					m: "test_histogram_bucket\xffle\xff+Inf",
+					t: 1234568,
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_bucket",
+						"le", "+Inf",
+					),
+				},
+				{ // 18
+					m:    "test_gauge_histogram",
+					help: "Like test_histogram but as gauge histogram.",
+				},
+				{ // 19
+					m:   "test_gauge_histogram",
+					typ: MetricTypeGaugeHistogram,
+				},
+				{ // 20
+					m: "test_gauge_histogram",
+					t: 1234568,
+					shs: &histogram.Histogram{
+						CounterResetHint: histogram.GaugeType,
+						Count:            175,
+						ZeroCount:        2,
+						Sum:              0.0008280461746287094,
+						ZeroThreshold:    2.938735877055719e-39,
+						Schema:           3,
+						PositiveSpans: []histogram.Span{
+							{Offset: -161, Length: 1},
+							{Offset: 8, Length: 3},
+						},
+						NegativeSpans: []histogram.Span{
+							{Offset: -162, Length: 1},
+							{Offset: 23, Length: 4},
+						},
+						PositiveBuckets: []int64{1, 2, -1, -1},
+						NegativeBuckets: []int64{1, 3, -2, -1, 1},
+					},
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_histogram",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{ // 21
+					m: "test_gauge_histogram_count",
+					t: 1234568,
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_histogram_count",
+					),
+				},
+				{ // 22
+					m: "test_gauge_histogram_sum",
+					t: 1234568,
+					v: 0.0008280461746287094,
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_histogram_sum",
+					),
+				},
+				{ // 23
+					m: "test_gauge_histogram_bucket\xffle\xff-0.0004899999999999998",
+					t: 1234568,
+					v: 2,
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_histogram_bucket",
+						"le", "-0.0004899999999999998",
+					),
+				},
+				{ // 24
+					m: "test_gauge_histogram_bucket\xffle\xff-0.0003899999999999998",
+					t: 1234568,
+					v: 4,
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_histogram_bucket",
+						"le", "-0.0003899999999999998",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+					},
+				},
+				{ // 25
+					m: "test_gauge_histogram_bucket\xffle\xff-0.0002899999999999998",
+					t: 1234568,
+					v: 16,
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_histogram_bucket",
+						"le", "-0.0002899999999999998",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{ // 26
+					m: "test_gauge_histogram_bucket\xffle\xff+Inf",
+					t: 1234568,
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_histogram_bucket",
+						"le", "+Inf",
+					),
+				},
+				{ // 27
+					m:    "test_float_histogram",
+					help: "Test float histogram with many buckets removed to keep it manageable in size.",
+				},
+				{ // 28
+					m:   "test_float_histogram",
+					typ: MetricTypeHistogram,
+				},
+				{ // 29
+					m: "test_float_histogram",
+					t: 1234568,
+					fhs: &histogram.FloatHistogram{
+						Count:         175.0,
+						ZeroCount:     2.0,
+						Sum:           0.0008280461746287094,
+						ZeroThreshold: 2.938735877055719e-39,
+						Schema:        3,
+						PositiveSpans: []histogram.Span{
+							{Offset: -161, Length: 1},
+							{Offset: 8, Length: 3},
+						},
+						NegativeSpans: []histogram.Span{
+							{Offset: -162, Length: 1},
+							{Offset: 23, Length: 4},
+						},
+						PositiveBuckets: []float64{1.0, 2.0, -1.0, -1.0},
+						NegativeBuckets: []float64{1.0, 3.0, -2.0, -1.0, 1.0},
+					},
+					lset: labels.FromStrings(
+						"__name__", "test_float_histogram",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{ // 30
+					m: "test_float_histogram_count",
+					t: 1234568,
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_float_histogram_count",
+					),
+				},
+				{ // 31
+					m: "test_float_histogram_sum",
+					t: 1234568,
+					v: 0.0008280461746287094,
+					lset: labels.FromStrings(
+						"__name__", "test_float_histogram_sum",
+					),
+				},
+				{ // 32
+					m: "test_float_histogram_bucket\xffle\xff-0.0004899999999999998",
+					t: 1234568,
+					v: 2,
+					lset: labels.FromStrings(
+						"__name__", "test_float_histogram_bucket",
+						"le", "-0.0004899999999999998",
+					),
+				},
+				{ // 33
+					m: "test_float_histogram_bucket\xffle\xff-0.0003899999999999998",
+					t: 1234568,
+					v: 4,
+					lset: labels.FromStrings(
+						"__name__", "test_float_histogram_bucket",
+						"le", "-0.0003899999999999998",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+					},
+				},
+				{ // 34
+					m: "test_float_histogram_bucket\xffle\xff-0.0002899999999999998",
+					t: 1234568,
+					v: 16,
+					lset: labels.FromStrings(
+						"__name__", "test_float_histogram_bucket",
+						"le", "-0.0002899999999999998",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{ // 35
+					m: "test_float_histogram_bucket\xffle\xff+Inf",
+					t: 1234568,
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_float_histogram_bucket",
+						"le", "+Inf",
+					),
+				},
+				{ // 36
+					m:    "test_gauge_float_histogram",
+					help: "Like test_float_histogram but as gauge histogram.",
+				},
+				{ // 37
+					m:   "test_gauge_float_histogram",
+					typ: MetricTypeGaugeHistogram,
+				},
+				{ // 38
+					m: "test_gauge_float_histogram",
+					t: 1234568,
+					fhs: &histogram.FloatHistogram{
+						CounterResetHint: histogram.GaugeType,
+						Count:            175.0,
+						ZeroCount:        2.0,
+						Sum:              0.0008280461746287094,
+						ZeroThreshold:    2.938735877055719e-39,
+						Schema:           3,
+						PositiveSpans: []histogram.Span{
+							{Offset: -161, Length: 1},
+							{Offset: 8, Length: 3},
+						},
+						NegativeSpans: []histogram.Span{
+							{Offset: -162, Length: 1},
+							{Offset: 23, Length: 4},
+						},
+						PositiveBuckets: []float64{1.0, 2.0, -1.0, -1.0},
+						NegativeBuckets: []float64{1.0, 3.0, -2.0, -1.0, 1.0},
+					},
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_float_histogram",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{ // 39
+					m: "test_gauge_float_histogram_count",
+					t: 1234568,
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_float_histogram_count",
+					),
+				},
+				{ // 40
+					m: "test_gauge_float_histogram_sum",
+					t: 1234568,
+					v: 0.0008280461746287094,
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_float_histogram_sum",
+					),
+				},
+				{ // 41
+					m: "test_gauge_float_histogram_bucket\xffle\xff-0.0004899999999999998",
+					t: 1234568,
+					v: 2,
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_float_histogram_bucket",
+						"le", "-0.0004899999999999998",
+					),
+				},
+				{ // 42
+					m: "test_gauge_float_histogram_bucket\xffle\xff-0.0003899999999999998",
+					t: 1234568,
+					v: 4,
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_float_histogram_bucket",
+						"le", "-0.0003899999999999998",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+					},
+				},
+				{ // 43
+					m: "test_gauge_float_histogram_bucket\xffle\xff-0.0002899999999999998",
+					t: 1234568,
+					v: 16,
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_float_histogram_bucket",
+						"le", "-0.0002899999999999998",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{ // 44
+					m: "test_gauge_float_histogram_bucket\xffle\xff+Inf",
+					t: 1234568,
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_gauge_float_histogram_bucket",
+						"le", "+Inf",
+					),
+				},
+				{ // 45
+					m:    "test_histogram2",
+					help: "Similar histogram as before but now without sparse buckets.",
+				},
+				{ // 46
+					m:   "test_histogram2",
+					typ: MetricTypeHistogram,
+				},
+				{ // 47
+					m: "test_histogram2_count",
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram2_count",
+					),
+				},
+				{ // 48
+					m: "test_histogram2_sum",
+					v: 0.000828,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram2_sum",
+					),
+				},
+				{ // 49
+					m: "test_histogram2_bucket\xffle\xff-0.00048",
+					v: 2,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram2_bucket",
+						"le", "-0.00048",
+					),
+				},
+				{ // 50
+					m: "test_histogram2_bucket\xffle\xff-0.00038",
+					v: 4,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram2_bucket",
+						"le", "-0.00038",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00038, HasTs: true, Ts: 1625851153146},
+					},
+				},
+				{ // 51
+					m: "test_histogram2_bucket\xffle\xff1.0",
+					v: 16,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram2_bucket",
+						"le", "1.0",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.000295, HasTs: false},
+					},
+				},
+				{ // 52
+					m: "test_histogram2_bucket\xffle\xff+Inf",
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram2_bucket",
+						"le", "+Inf",
+					),
+				},
+				{ // 53
+					m:    "rpc_durations_seconds",
+					help: "RPC latency distributions.",
+				},
+				{ // 54
+					m:   "rpc_durations_seconds",
+					typ: MetricTypeSummary,
+				},
+				{ // 55
+					m: "rpc_durations_seconds_count\xffservice\xffexponential",
+					v: 262,
+					lset: labels.FromStrings(
+						"__name__", "rpc_durations_seconds_count",
+						"service", "exponential",
+					),
+				},
+				{ // 56
+					m: "rpc_durations_seconds_sum\xffservice\xffexponential",
+					v: 0.00025551262820703587,
+					lset: labels.FromStrings(
+						"__name__", "rpc_durations_seconds_sum",
+						"service", "exponential",
+					),
+				},
+				{ // 57
+					m: "rpc_durations_seconds\xffservice\xffexponential\xffquantile\xff0.5",
+					v: 6.442786329648548e-07,
+					lset: labels.FromStrings(
+						"__name__", "rpc_durations_seconds",
+						"quantile", "0.5",
+						"service", "exponential",
+					),
+				},
+				{ // 58
+					m: "rpc_durations_seconds\xffservice\xffexponential\xffquantile\xff0.9",
+					v: 1.9435742936658396e-06,
+					lset: labels.FromStrings(
+						"__name__", "rpc_durations_seconds",
+						"quantile", "0.9",
+						"service", "exponential",
+					),
+				},
+				{ // 59
+					m: "rpc_durations_seconds\xffservice\xffexponential\xffquantile\xff0.99",
+					v: 4.0471608667037015e-06,
+					lset: labels.FromStrings(
+						"__name__", "rpc_durations_seconds",
+						"quantile", "0.99",
+						"service", "exponential",
+					),
+				},
+				{ // 60
+					m:    "without_quantiles",
+					help: "A summary without quantiles.",
+				},
+				{ // 61
+					m:   "without_quantiles",
+					typ: MetricTypeSummary,
+				},
+				{ // 62
+					m: "without_quantiles_count",
+					v: 42,
+					lset: labels.FromStrings(
+						"__name__", "without_quantiles_count",
+					),
+				},
+				{ // 63
+					m: "without_quantiles_sum",
+					v: 1.234,
+					lset: labels.FromStrings(
+						"__name__", "without_quantiles_sum",
+					),
+				},
 			},
-		},
-		{
-			m:    "test_histogram2",
-			help: "Similar histogram as before but now without sparse buckets.",
-		},
-		{
-			m:   "test_histogram2",
-			typ: MetricTypeHistogram,
-		},
-		{
-			m: "test_histogram2_count",
-			v: 175,
-			lset: labels.FromStrings(
-				"__name__", "test_histogram2_count",
-			),
-		},
-		{
-			m: "test_histogram2_sum",
-			v: 0.000828,
-			lset: labels.FromStrings(
-				"__name__", "test_histogram2_sum",
-			),
-		},
-		{
-			m: "test_histogram2_bucket\xffle\xff-0.00048",
-			v: 2,
-			lset: labels.FromStrings(
-				"__name__", "test_histogram2_bucket",
-				"le", "-0.00048",
-			),
-		},
-		{
-			m: "test_histogram2_bucket\xffle\xff-0.00038",
-			v: 4,
-			lset: labels.FromStrings(
-				"__name__", "test_histogram2_bucket",
-				"le", "-0.00038",
-			),
-			e: []exemplar.Exemplar{
-				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00038, HasTs: true, Ts: 1625851153146},
-			},
-		},
-		{
-			m: "test_histogram2_bucket\xffle\xff1.0",
-			v: 16,
-			lset: labels.FromStrings(
-				"__name__", "test_histogram2_bucket",
-				"le", "1.0",
-			),
-			e: []exemplar.Exemplar{
-				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.000295, HasTs: false},
-			},
-		},
-		{
-			m: "test_histogram2_bucket\xffle\xff+Inf",
-			v: 175,
-			lset: labels.FromStrings(
-				"__name__", "test_histogram2_bucket",
-				"le", "+Inf",
-			),
-		},
-		{
-			m:    "rpc_durations_seconds",
-			help: "RPC latency distributions.",
-		},
-		{
-			m:   "rpc_durations_seconds",
-			typ: MetricTypeSummary,
-		},
-		{
-			m: "rpc_durations_seconds_count\xffservice\xffexponential",
-			v: 262,
-			lset: labels.FromStrings(
-				"__name__", "rpc_durations_seconds_count",
-				"service", "exponential",
-			),
-		},
-		{
-			m: "rpc_durations_seconds_sum\xffservice\xffexponential",
-			v: 0.00025551262820703587,
-			lset: labels.FromStrings(
-				"__name__", "rpc_durations_seconds_sum",
-				"service", "exponential",
-			),
-		},
-		{
-			m: "rpc_durations_seconds\xffservice\xffexponential\xffquantile\xff0.5",
-			v: 6.442786329648548e-07,
-			lset: labels.FromStrings(
-				"__name__", "rpc_durations_seconds",
-				"quantile", "0.5",
-				"service", "exponential",
-			),
-		},
-		{
-			m: "rpc_durations_seconds\xffservice\xffexponential\xffquantile\xff0.9",
-			v: 1.9435742936658396e-06,
-			lset: labels.FromStrings(
-				"__name__", "rpc_durations_seconds",
-				"quantile", "0.9",
-				"service", "exponential",
-			),
-		},
-		{
-			m: "rpc_durations_seconds\xffservice\xffexponential\xffquantile\xff0.99",
-			v: 4.0471608667037015e-06,
-			lset: labels.FromStrings(
-				"__name__", "rpc_durations_seconds",
-				"quantile", "0.99",
-				"service", "exponential",
-			),
-		},
-		{
-			m:    "without_quantiles",
-			help: "A summary without quantiles.",
-		},
-		{
-			m:   "without_quantiles",
-			typ: MetricTypeSummary,
-		},
-		{
-			m: "without_quantiles_count",
-			v: 42,
-			lset: labels.FromStrings(
-				"__name__", "without_quantiles_count",
-			),
-		},
-		{
-			m: "without_quantiles_sum",
-			v: 1.234,
-			lset: labels.FromStrings(
-				"__name__", "without_quantiles_sum",
-			),
 		},
 	}
 
-	p := NewProtobufParser(inputBuf.Bytes())
-	i := 0
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			var (
+				i   int
+				res labels.Labels
+				p   = scenario.parser
+				exp = scenario.expected
+			)
 
-	var res labels.Labels
+			for {
+				et, err := p.Next()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				require.NoError(t, err)
 
-	for {
-		et, err := p.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		require.NoError(t, err)
+				switch et {
+				case EntrySeries:
+					m, ts, v := p.Series()
 
-		switch et {
-		case EntrySeries:
-			m, ts, v := p.Series()
+					var e exemplar.Exemplar
+					p.Metric(&res)
+					found := p.Exemplar(&e)
+					require.Equal(t, exp[i].m, string(m))
+					if ts != nil {
+						require.Equal(t, exp[i].t, *ts)
+					} else {
+						require.Equal(t, exp[i].t, int64(0))
+					}
+					require.Equal(t, exp[i].v, v)
+					require.Equal(t, exp[i].lset, res)
+					if len(exp[i].e) == 0 {
+						require.Equal(t, false, found)
+					} else {
+						require.Equal(t, true, found)
+						require.Equal(t, exp[i].e[0], e)
+					}
 
-			var e exemplar.Exemplar
-			p.Metric(&res)
-			found := p.Exemplar(&e)
-			require.Equal(t, exp[i].m, string(m))
-			if ts != nil {
-				require.Equal(t, exp[i].t, *ts)
-			} else {
-				require.Equal(t, exp[i].t, int64(0))
+				case EntryHistogram:
+					m, ts, shs, fhs := p.Histogram()
+					p.Metric(&res)
+					require.Equal(t, exp[i].m, string(m))
+					if ts != nil {
+						require.Equal(t, exp[i].t, *ts)
+					} else {
+						require.Equal(t, exp[i].t, int64(0))
+					}
+					require.Equal(t, exp[i].lset, res)
+					require.Equal(t, exp[i].m, string(m))
+					if shs != nil {
+						require.Equal(t, exp[i].shs, shs)
+					} else {
+						require.Equal(t, exp[i].fhs, fhs)
+					}
+					j := 0
+					for e := (exemplar.Exemplar{}); p.Exemplar(&e); j++ {
+						require.Equal(t, exp[i].e[j], e)
+						e = exemplar.Exemplar{}
+					}
+					require.Equal(t, len(exp[i].e), j, "not enough exemplars found")
+
+				case EntryType:
+					m, typ := p.Type()
+					require.Equal(t, exp[i].m, string(m))
+					require.Equal(t, exp[i].typ, typ)
+
+				case EntryHelp:
+					m, h := p.Help()
+					require.Equal(t, exp[i].m, string(m))
+					require.Equal(t, exp[i].help, string(h))
+
+				case EntryUnit:
+					m, u := p.Unit()
+					require.Equal(t, exp[i].m, string(m))
+					require.Equal(t, exp[i].unit, string(u))
+
+				case EntryComment:
+					require.Equal(t, exp[i].comment, string(p.Comment()))
+				}
+
+				i++
 			}
-			require.Equal(t, exp[i].v, v)
-			require.Equal(t, exp[i].lset, res)
-			if len(exp[i].e) == 0 {
-				require.Equal(t, false, found)
-			} else {
-				require.Equal(t, true, found)
-				require.Equal(t, exp[i].e[0], e)
-			}
-
-		case EntryHistogram:
-			m, ts, shs, fhs := p.Histogram()
-			p.Metric(&res)
-			require.Equal(t, exp[i].m, string(m))
-			if ts != nil {
-				require.Equal(t, exp[i].t, *ts)
-			} else {
-				require.Equal(t, exp[i].t, int64(0))
-			}
-			require.Equal(t, exp[i].lset, res)
-			require.Equal(t, exp[i].m, string(m))
-			if shs != nil {
-				require.Equal(t, exp[i].shs, shs)
-			} else {
-				require.Equal(t, exp[i].fhs, fhs)
-			}
-			j := 0
-			for e := (exemplar.Exemplar{}); p.Exemplar(&e); j++ {
-				require.Equal(t, exp[i].e[j], e)
-				e = exemplar.Exemplar{}
-			}
-			require.Equal(t, len(exp[i].e), j, "not enough exemplars found")
-
-		case EntryType:
-			m, typ := p.Type()
-			require.Equal(t, exp[i].m, string(m))
-			require.Equal(t, exp[i].typ, typ)
-
-		case EntryHelp:
-			m, h := p.Help()
-			require.Equal(t, exp[i].m, string(m))
-			require.Equal(t, exp[i].help, string(h))
-
-		case EntryUnit:
-			m, u := p.Unit()
-			require.Equal(t, exp[i].m, string(m))
-			require.Equal(t, exp[i].unit, string(u))
-
-		case EntryComment:
-			require.Equal(t, exp[i].comment, string(p.Comment()))
-		}
-
-		i++
+			require.Equal(t, len(exp), i)
+		})
 	}
-	require.Equal(t, len(exp), i)
 }

--- a/promql/fuzz.go
+++ b/promql/fuzz.go
@@ -58,7 +58,7 @@ const (
 )
 
 func fuzzParseMetricWithContentType(in []byte, contentType string) int {
-	p, warning := textparse.New(in, contentType)
+	p, warning := textparse.New(in, contentType, false)
 	if warning != nil {
 		// An invalid content type is being passed, which should not happen
 		// in this context.

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -633,6 +633,7 @@ func TestScrapeLoopStopBeforeRun(t *testing.T) {
 		0,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -703,6 +704,7 @@ func TestScrapeLoopStop(t *testing.T) {
 		nil,
 		10*time.Millisecond,
 		time.Hour,
+		false,
 		false,
 		false,
 		nil,
@@ -781,6 +783,7 @@ func TestScrapeLoopRun(t *testing.T) {
 		time.Hour,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -834,6 +837,7 @@ func TestScrapeLoopRun(t *testing.T) {
 		nil,
 		time.Second,
 		100*time.Millisecond,
+		false,
 		false,
 		false,
 		nil,
@@ -895,6 +899,7 @@ func TestScrapeLoopForcedErr(t *testing.T) {
 		time.Hour,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -953,6 +958,7 @@ func TestScrapeLoopMetadata(t *testing.T) {
 		0,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -1008,6 +1014,7 @@ func simpleTestScrapeLoop(t testing.TB) (context.Context, *scrapeLoop) {
 		nil,
 		0,
 		0,
+		false,
 		false,
 		false,
 		nil,
@@ -1068,6 +1075,7 @@ func TestScrapeLoopFailWithInvalidLabelsAfterRelabel(t *testing.T) {
 		nil,
 		0,
 		0,
+		false,
 		false,
 		false,
 		nil,
@@ -1148,6 +1156,7 @@ func TestScrapeLoopRunCreatesStaleMarkersOnFailedScrape(t *testing.T) {
 		time.Hour,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -1209,6 +1218,7 @@ func TestScrapeLoopRunCreatesStaleMarkersOnParseFailure(t *testing.T) {
 		nil,
 		10*time.Millisecond,
 		time.Hour,
+		false,
 		false,
 		false,
 		nil,
@@ -1275,6 +1285,7 @@ func TestScrapeLoopCache(t *testing.T) {
 		nil,
 		10*time.Millisecond,
 		time.Hour,
+		false,
 		false,
 		false,
 		nil,
@@ -1358,6 +1369,7 @@ func TestScrapeLoopCacheMemoryExhaustionProtection(t *testing.T) {
 		nil,
 		10*time.Millisecond,
 		time.Hour,
+		false,
 		false,
 		false,
 		nil,
@@ -1474,6 +1486,7 @@ func TestScrapeLoopAppend(t *testing.T) {
 			0,
 			false,
 			false,
+			false,
 			nil,
 			false,
 		)
@@ -1563,7 +1576,7 @@ func TestScrapeLoopAppendForConflictingPrefixedLabels(t *testing.T) {
 					return mutateSampleLabels(l, &Target{labels: labels.FromStrings(tc.targetLabels...)}, false, nil)
 				},
 				nil,
-				func(ctx context.Context) storage.Appender { return app }, nil, 0, true, 0, 0, nil, 0, 0, false, false, nil, false,
+				func(ctx context.Context) storage.Appender { return app }, nil, 0, true, 0, 0, nil, 0, 0, false, false, false, nil, false,
 			)
 			slApp := sl.appender(context.Background())
 			_, _, _, err := sl.append(slApp, []byte(tc.exposedLabels), "", time.Date(2000, 1, 1, 1, 0, 0, 0, time.UTC))
@@ -1600,6 +1613,7 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 		0,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -1607,7 +1621,7 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 	fakeRef := storage.SeriesRef(1)
 	expValue := float64(1)
 	metric := []byte(`metric{n="1"} 1`)
-	p, warning := textparse.New(metric, "")
+	p, warning := textparse.New(metric, "", false)
 	require.NoError(t, warning)
 
 	var lset labels.Labels
@@ -1656,6 +1670,7 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 		nil,
 		0,
 		0,
+		false,
 		false,
 		false,
 		nil,
@@ -1733,6 +1748,7 @@ func TestScrapeLoop_HistogramBucketLimit(t *testing.T) {
 		nil,
 		0,
 		0,
+		false,
 		false,
 		false,
 		nil,
@@ -1833,6 +1849,7 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 		0,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -1879,6 +1896,7 @@ func TestScrapeLoopAppendStaleness(t *testing.T) {
 		nil,
 		0,
 		0,
+		false,
 		false,
 		false,
 		nil,
@@ -1930,6 +1948,7 @@ func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
 		nil,
 		0,
 		0,
+		false,
 		false,
 		false,
 		nil,
@@ -2043,6 +2062,7 @@ metric_total{n="2"} 2 # {t="2"} 2.0 20000
 				0,
 				false,
 				false,
+				false,
 				nil,
 				false,
 			)
@@ -2108,6 +2128,7 @@ func TestScrapeLoopAppendExemplarSeries(t *testing.T) {
 		0,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -2160,6 +2181,7 @@ func TestScrapeLoopRunReportsTargetDownOnScrapeError(t *testing.T) {
 		time.Hour,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -2194,6 +2216,7 @@ func TestScrapeLoopRunReportsTargetDownOnInvalidUTF8(t *testing.T) {
 		nil,
 		10*time.Millisecond,
 		time.Hour,
+		false,
 		false,
 		false,
 		nil,
@@ -2245,6 +2268,7 @@ func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T
 		0,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -2288,6 +2312,7 @@ func TestScrapeLoopOutOfBoundsTimeError(t *testing.T) {
 		nil,
 		0,
 		0,
+		false,
 		false,
 		false,
 		nil,
@@ -2562,6 +2587,7 @@ func TestScrapeLoop_RespectTimestamps(t *testing.T) {
 		0,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -2603,6 +2629,7 @@ func TestScrapeLoop_DiscardTimestamps(t *testing.T) {
 		0,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -2641,6 +2668,7 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 		nil,
 		0,
 		0,
+		false,
 		false,
 		false,
 		nil,
@@ -2699,6 +2727,7 @@ func TestScrapeLoopDiscardUnnamedMetrics(t *testing.T) {
 		nil,
 		0,
 		0,
+		false,
 		false,
 		false,
 		nil,
@@ -2964,6 +2993,7 @@ func TestScrapeAddFast(t *testing.T) {
 		0,
 		false,
 		false,
+		false,
 		nil,
 		false,
 	)
@@ -3048,6 +3078,7 @@ func TestScrapeReportSingleAppender(t *testing.T) {
 		nil,
 		10*time.Millisecond,
 		time.Hour,
+		false,
 		false,
 		false,
 		nil,
@@ -3250,6 +3281,7 @@ func TestScrapeLoopLabelLimit(t *testing.T) {
 			&test.labelLimits,
 			0,
 			0,
+			false,
 			false,
 			false,
 			nil,

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -378,7 +378,7 @@ func TestFederationWithNativeHistograms(t *testing.T) {
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
-	p := textparse.NewProtobufParser(body)
+	p := textparse.NewProtobufParser(body, false)
 	var actVec promql.Vector
 	metricFamilies := 0
 	l := labels.Labels{}


### PR DESCRIPTION
So far, if a target exposes a histogram with both classic and native buckets, a native-histogram enabled Prometheus would ignore the classic buckets. With the new scrape config option `scrape_classic_histograms` set, both buckets will be ingested, creating all the series of a classic histogram in parallel to the native histogram series. For example, a histogram `foo` would create a native histogram series `foo` and classic series called `foo_sum`, `foo_count`, and `foo_bucket`.

This feature can be used in a migration strategy from classic to native histograms, where it is desired to have a transition period during which both native and classic histograms are present.

Note that two bugs in classic histogram parsing were found and fixed as a byproduct of testing the new feature:

1. Series created from classic _gauge_ histograms didn't get the _sum/_count/_bucket prefix set.
2. Values of classic _float_ histograms weren't parsed properly.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
