### PR TITLE
Implementing Regex optimization on the `MatchNotRegexp` matcher type

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -371,6 +371,14 @@ func inversePostingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Posting
 	if m.Type == labels.MatchEqual && m.Value == "" {
 		res = vals
 	} else {
+		// Inverse of a MatchNotRegexp is MatchRegexp (double negation).
+		// Fast-path for set matching.
+		if m.Type == labels.MatchNotRegexp {
+			setMatches := findSetMatches(m.GetRegexString())
+			if len(setMatches) > 0 {
+				return ix.Postings(m.Name, setMatches...)
+			}
+		}
 		for _, val := range vals {
 			if !m.Matches(val) {
 				res = append(res, val)

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -114,6 +114,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 	iCharSet := labels.MustNewMatcher(labels.MatchRegexp, "i", "1[0-9]")
 	iAlternate := labels.MustNewMatcher(labels.MatchRegexp, "i", "(1|2|3|4|5|6|20|55)")
 	iXYZ := labels.MustNewMatcher(labels.MatchRegexp, "i", "X|Y|Z")
+	iNotXYZ := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "X|Y|Z")
 	cases := []struct {
 		name     string
 		matchers []*labels.Matcher
@@ -131,6 +132,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 		{`j=~"X.+"`, []*labels.Matcher{jXplus}},
 		{`i=~"(1|2|3|4|5|6|20|55)"`, []*labels.Matcher{iAlternate}},
 		{`i=~"X|Y|Z"`, []*labels.Matcher{iXYZ}},
+		{`i!~"X|Y|Z"`, []*labels.Matcher{iNotXYZ}},
 		{`i=~".*"`, []*labels.Matcher{iStar}},
 		{`i=~"1.*"`, []*labels.Matcher{i1Star}},
 		{`i=~".*1"`, []*labels.Matcher{iStar1}},
@@ -146,6 +148,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 		{`n="1",i!="",j=~"X.+"`, []*labels.Matcher{n1, iNotEmpty, jXplus}},
 		{`n="1",i!="",j=~"XXX|YYY"`, []*labels.Matcher{n1, iNotEmpty, jXXXYYY}},
 		{`n="1",i=~"X|Y|Z",j="foo"`, []*labels.Matcher{n1, iXYZ, jFoo}},
+		{`n="1",i!~"X|Y|Z",j="foo"`, []*labels.Matcher{n1, iNotXYZ, jFoo}},
 		{`n="1",i=~".+",j="foo"`, []*labels.Matcher{n1, iPlus, jFoo}},
 		{`n="1",i=~"1.+",j="foo"`, []*labels.Matcher{n1, i1Plus, jFoo}},
 		{`n="1",i=~".*1.*",j="foo"`, []*labels.Matcher{n1, iStar1Star, jFoo}},


### PR DESCRIPTION
This PR brings the same regex optimization that already exists on the `MatchRegexp` to the `MatchNotRegexp` matcher.

With this change not regex matchers like `i!~"X|Y|Z` will be optimized to get the posting for `X`, `Y` and `Z` instead of evaluating the regex.


```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
                                                                     │   /tmp/old    │              /tmp/new               │
                                                                     │    sec/op     │    sec/op     vs base               │
Querier/Head/PostingsForMatchers/i!~"X|Y|Z"-32                         10.348m ± ∞ ¹   2.155m ± ∞ ¹  -79.17% (p=0.008 n=5)
Querier/Head/PostingsForMatchers/n="1",i!~"X|Y|Z",j="foo"-32           10.544m ± ∞ ¹   2.169m ± ∞ ¹  -79.43% (p=0.008 n=5)
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!~"2.*",j="foo"-32      130.6m ± ∞ ¹   132.3m ± ∞ ¹        ~ (p=0.222 n=5)
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!~".*2.*",j="foo"-32    204.0m ± ∞ ¹   204.9m ± ∞ ¹        ~ (p=0.310 n=5)
Querier/Head/PostingsForMatchers/n="X",i=~".+",i!~".*2.*",j="foo"-32    671.1n ± ∞ ¹   678.0n ± ∞ ¹   +1.03% (p=0.008 n=5)
geomean                                                                 4.551m         2.437m        -46.45%
```