### PR TITLE
Checking context on `PostingsForMatchers` function

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -15,6 +15,7 @@
 package tsdb
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -476,7 +477,7 @@ func (r blockIndexReader) LabelValues(name string, matchers ...*labels.Matcher) 
 		return st, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
 	}
 
-	return labelValuesWithMatchers(r.ir, name, matchers...)
+	return labelValuesWithMatchers(context.Background(), r.ir, name, matchers...)
 }
 
 func (r blockIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
@@ -484,7 +485,7 @@ func (r blockIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, err
 		return r.b.LabelNames()
 	}
 
-	return labelNamesWithMatchers(r.ir, matchers...)
+	return labelNamesWithMatchers(context.Background(), r.ir, matchers...)
 }
 
 func (r blockIndexReader) Postings(name string, values ...string) (index.Postings, error) {
@@ -551,7 +552,7 @@ func (pb *Block) Delete(mint, maxt int64, ms ...*labels.Matcher) error {
 		return ErrClosing
 	}
 
-	p, err := PostingsForMatchers(pb.indexr, ms...)
+	p, err := PostingsForMatchers(context.Background(), pb.indexr, ms...)
 	if err != nil {
 		return errors.Wrap(err, "select series")
 	}

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -196,7 +196,7 @@ func TestCorruptedChunk(t *testing.T) {
 			}
 			defer func() { require.NoError(t, b.Close()) }()
 
-			querier, err := NewBlockQuerier(b, 0, 1)
+			querier, err := NewBlockQuerier(context.Background(), b, 0, 1)
 			require.NoError(t, err)
 			defer func() { require.NoError(t, querier.Close()) }()
 			set := querier.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
@@ -350,12 +350,12 @@ func TestReadIndexFormatV1(t *testing.T) {
 	block, err := OpenBlock(nil, blockDir, nil)
 	require.NoError(t, err)
 
-	q, err := NewBlockQuerier(block, 0, 1000)
+	q, err := NewBlockQuerier(context.Background(), block, 0, 1000)
 	require.NoError(t, err)
 	require.Equal(t, query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")),
 		map[string][]tsdbutil.Sample{`{foo="bar"}`: {sample{t: 1, f: 2}}})
 
-	q, err = NewBlockQuerier(block, 0, 1000)
+	q, err = NewBlockQuerier(context.Background(), block, 0, 1000)
 	require.NoError(t, err)
 	require.Equal(t, query(t, q, labels.MustNewMatcher(labels.MatchNotRegexp, "foo", "^.?$")),
 		map[string][]tsdbutil.Sample{

--- a/tsdb/blockwriter_test.go
+++ b/tsdb/blockwriter_test.go
@@ -49,7 +49,7 @@ func TestBlockWriter(t *testing.T) {
 	b, err := OpenBlock(nil, blockpath, nil)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, b.Close()) }()
-	q, err := NewBlockQuerier(b, math.MinInt64, math.MaxInt64)
+	q, err := NewBlockQuerier(context.Background(), b, math.MinInt64, math.MaxInt64)
 	require.NoError(t, err)
 	series := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "", ".*"))
 	sample1 := []tsdbutil.Sample{sample{t: ts1, f: v1}}

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1414,7 +1414,7 @@ func TestHeadCompactionWithHistograms(t *testing.T) {
 				require.NoError(t, block.Close())
 			})
 
-			q, err := NewBlockQuerier(block, block.MinTime(), block.MaxTime())
+			q, err := NewBlockQuerier(context.Background(), block, block.MinTime(), block.MaxTime())
 			require.NoError(t, err)
 
 			actHists := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -4208,7 +4208,7 @@ func TestOOOCompaction(t *testing.T) {
 			series2.String(): series2Samples,
 		}
 
-		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+		q, err := NewBlockQuerier(context.Background(), block, math.MinInt64, math.MaxInt64)
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
@@ -4339,7 +4339,7 @@ func TestOOOCompactionWithNormalCompaction(t *testing.T) {
 			series2.String(): series2Samples,
 		}
 
-		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+		q, err := NewBlockQuerier(context.Background(), block, math.MinInt64, math.MaxInt64)
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
@@ -4439,7 +4439,7 @@ func TestOOOCompactionWithDisabledWriteLog(t *testing.T) {
 			series2.String(): series2Samples,
 		}
 
-		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+		q, err := NewBlockQuerier(context.Background(), block, math.MinInt64, math.MaxInt64)
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
@@ -5227,7 +5227,7 @@ func TestOOOCompactionFailure(t *testing.T) {
 			series1.String(): series1Samples,
 		}
 
-		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+		q, err := NewBlockQuerier(context.Background(), block, math.MinInt64, math.MaxInt64)
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -14,6 +14,7 @@
 package tsdb
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math"
@@ -1425,7 +1426,7 @@ func (h *Head) Delete(mint, maxt int64, ms ...*labels.Matcher) error {
 
 	ir := h.indexRange(mint, maxt)
 
-	p, err := PostingsForMatchers(ir, ms...)
+	p, err := PostingsForMatchers(context.Background(), ir, ms...)
 	if err != nil {
 		return errors.Wrap(err, "select series")
 	}

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -84,7 +84,7 @@ func (h *headIndexReader) LabelValues(name string, matchers ...*labels.Matcher) 
 		return h.head.postings.LabelValues(name), nil
 	}
 
-	return labelValuesWithMatchers(h, name, matchers...)
+	return labelValuesWithMatchers(context.Background(), h, name, matchers...)
 }
 
 // LabelNames returns all the unique label names present in the head
@@ -100,7 +100,7 @@ func (h *headIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, err
 		return labelNames, nil
 	}
 
-	return labelNamesWithMatchers(h, matchers...)
+	return labelNamesWithMatchers(context.Background(), h, matchers...)
 }
 
 // Postings returns the postings list iterator for the label pairs.

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -412,7 +412,7 @@ func TestHead_HighConcurrencyReadAndWrite(t *testing.T) {
 
 	// queryHead is a helper to query the head for a given time range and labelset.
 	queryHead := func(mint, maxt uint64, label labels.Label) (map[string][]tsdbutil.Sample, error) {
-		q, err := NewBlockQuerier(head, int64(mint), int64(maxt))
+		q, err := NewBlockQuerier(context.Background(), head, int64(mint), int64(maxt))
 		if err != nil {
 			return nil, err
 		}
@@ -652,7 +652,7 @@ func TestHead_WALMultiRef(t *testing.T) {
 		require.NoError(t, head.Close())
 	}()
 
-	q, err := NewBlockQuerier(head, 0, 2100)
+	q, err := NewBlockQuerier(context.Background(), head, 0, 2100)
 	require.NoError(t, err)
 	series := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 	// The samples before the new ref should be discarded since Head truncation
@@ -959,7 +959,7 @@ func TestHeadDeleteSimple(t *testing.T) {
 				// Compare the query results for both heads - before and after the reloadBlocks.
 			Outer:
 				for _, h := range []*Head{head, reloadedHead} {
-					q, err := NewBlockQuerier(h, h.MinTime(), h.MaxTime())
+					q, err := NewBlockQuerier(context.Background(), h, h.MinTime(), h.MaxTime())
 					require.NoError(t, err)
 					actSeriesSet := q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, lblDefault.Name, lblDefault.Value))
 					require.NoError(t, q.Close())
@@ -1019,7 +1019,7 @@ func TestDeleteUntilCurMax(t *testing.T) {
 	require.NoError(t, hb.Delete(0, 10000, labels.MustNewMatcher(labels.MatchEqual, "a", "b")))
 
 	// Test the series returns no samples. The series is cleared only after compaction.
-	q, err := NewBlockQuerier(hb, 0, 100000)
+	q, err := NewBlockQuerier(context.Background(), hb, 0, 100000)
 	require.NoError(t, err)
 	res := q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
 	require.True(t, res.Next(), "series is not present")
@@ -1036,7 +1036,7 @@ func TestDeleteUntilCurMax(t *testing.T) {
 	_, err = app.Append(0, labels.FromStrings("a", "b"), 11, 1)
 	require.NoError(t, err)
 	require.NoError(t, app.Commit())
-	q, err = NewBlockQuerier(hb, 0, 100000)
+	q, err = NewBlockQuerier(context.Background(), hb, 0, 100000)
 	require.NoError(t, err)
 	res = q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
 	require.True(t, res.Next(), "series don't exist")
@@ -1207,7 +1207,7 @@ func TestDelete_e2e(t *testing.T) {
 		}
 		sort.Sort(matched)
 		for i := 0; i < numRanges; i++ {
-			q, err := NewBlockQuerier(hb, 0, 100000)
+			q, err := NewBlockQuerier(context.Background(), hb, 0, 100000)
 			require.NoError(t, err)
 			defer q.Close()
 			ss := q.Select(true, nil, del.ms...)
@@ -1608,7 +1608,7 @@ func TestUncommittedSamplesNotLostOnTruncate(t *testing.T) {
 
 	require.NoError(t, app.Commit())
 
-	q, err := NewBlockQuerier(h, 1500, 2500)
+	q, err := NewBlockQuerier(context.Background(), h, 1500, 2500)
 	require.NoError(t, err)
 	defer q.Close()
 
@@ -1638,7 +1638,7 @@ func TestRemoveSeriesAfterRollbackAndTruncate(t *testing.T) {
 
 	require.NoError(t, app.Rollback())
 
-	q, err := NewBlockQuerier(h, 1500, 2500)
+	q, err := NewBlockQuerier(context.Background(), h, 1500, 2500)
 	require.NoError(t, err)
 
 	ss := q.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "1"))
@@ -1906,6 +1906,7 @@ func TestMemSeriesIsolation(t *testing.T) {
 		require.NoError(t, err)
 		// Hm.. here direct block chunk querier might be required?
 		querier := blockQuerier{
+			ctx: context.Background(),
 			blockBaseQuerier: &blockBaseQuerier{
 				index:      idx,
 				chunks:     chunks,
@@ -2274,7 +2275,7 @@ func testHeadSeriesChunkRace(t *testing.T) {
 
 	var wg sync.WaitGroup
 	matcher := labels.MustNewMatcher(labels.MatchEqual, "", "")
-	q, err := NewBlockQuerier(h, 18, 22)
+	q, err := NewBlockQuerier(context.Background(), h, 18, 22)
 	require.NoError(t, err)
 	defer q.Close()
 
@@ -2944,7 +2945,7 @@ func TestAppendHistogram(t *testing.T) {
 
 			require.NoError(t, app.Commit())
 
-			q, err := NewBlockQuerier(head, head.MinTime(), head.MaxTime())
+			q, err := NewBlockQuerier(context.Background(), head, head.MinTime(), head.MaxTime())
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				require.NoError(t, q.Close())
@@ -3153,7 +3154,7 @@ func TestHistogramInWALAndMmapChunk(t *testing.T) {
 	require.Equal(t, expHeadChunkSamples, ms.headChunk.chunk.NumSamples())
 
 	testQuery := func() {
-		q, err := NewBlockQuerier(head, head.MinTime(), head.MaxTime())
+		q, err := NewBlockQuerier(context.Background(), head, head.MinTime(), head.MaxTime())
 		require.NoError(t, err)
 		act := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "a", "b.*"))
 		compareSeries(t, exp, act)
@@ -3199,7 +3200,7 @@ func TestChunkSnapshot(t *testing.T) {
 	}
 
 	checkSamples := func() {
-		q, err := NewBlockQuerier(head, math.MinInt64, math.MaxInt64)
+		q, err := NewBlockQuerier(context.Background(), head, math.MinInt64, math.MaxInt64)
 		require.NoError(t, err)
 		series := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"))
 		require.Equal(t, expSeries, series)
@@ -3535,7 +3536,7 @@ func testHistogramStaleSampleHelper(t *testing.T, floatHistogram bool) {
 	expHistograms := make([]timedHistogram, 0, numHistograms)
 
 	testQuery := func(numStale int) {
-		q, err := NewBlockQuerier(head, head.MinTime(), head.MaxTime())
+		q, err := NewBlockQuerier(context.Background(), head, head.MinTime(), head.MaxTime())
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, q.Close())
@@ -3987,7 +3988,7 @@ func TestChunkSnapshotReplayBug(t *testing.T) {
 
 	// Querying `request_duration{status_code!="200"}` should return no series since all of
 	// them have status_code="200".
-	q, err := NewBlockQuerier(head, math.MinInt64, math.MaxInt64)
+	q, err := NewBlockQuerier(context.Background(), head, math.MinInt64, math.MaxInt64)
 	require.NoError(t, err)
 	series := query(t, q,
 		labels.MustNewMatcher(labels.MatchEqual, "__name__", "request_duration"),
@@ -4403,7 +4404,7 @@ func TestReplayAfterMmapReplayError(t *testing.T) {
 	require.Equal(t, 2, len(files))
 
 	// Querying should not panic.
-	q, err := NewBlockQuerier(h, 0, lastTs)
+	q, err := NewBlockQuerier(context.Background(), h, 0, lastTs)
 	require.NoError(t, err)
 	res := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "__name__", "testing"))
 	require.Equal(t, map[string][]tsdbutil.Sample{lbls.String(): expSamples}, res)

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -15,6 +15,7 @@
 package tsdb
 
 import (
+	"context"
 	"errors"
 	"math"
 	"sort"
@@ -165,7 +166,7 @@ func (oh *OOOHeadIndexReader) LabelValues(name string, matchers ...*labels.Match
 		return oh.head.postings.LabelValues(name), nil
 	}
 
-	return labelValuesWithMatchers(oh, name, matchers...)
+	return labelValuesWithMatchers(context.Background(), oh, name, matchers...)
 }
 
 type chunkMetaAndChunkDiskMapperRef struct {

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -14,6 +14,7 @@
 package tsdb
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -113,15 +114,16 @@ func (q *blockBaseQuerier) Close() error {
 
 type blockQuerier struct {
 	*blockBaseQuerier
+	ctx context.Context
 }
 
 // NewBlockQuerier returns a querier against the block reader and requested min and max time range.
-func NewBlockQuerier(b BlockReader, mint, maxt int64) (storage.Querier, error) {
+func NewBlockQuerier(ctx context.Context, b BlockReader, mint, maxt int64) (storage.Querier, error) {
 	q, err := newBlockBaseQuerier(b, mint, maxt)
 	if err != nil {
 		return nil, err
 	}
-	return &blockQuerier{blockBaseQuerier: q}, nil
+	return &blockQuerier{blockBaseQuerier: q, ctx: ctx}, nil
 }
 
 func (q *blockQuerier) Select(sortSeries bool, hints *storage.SelectHints, ms ...*labels.Matcher) storage.SeriesSet {
@@ -129,7 +131,7 @@ func (q *blockQuerier) Select(sortSeries bool, hints *storage.SelectHints, ms ..
 	maxt := q.maxt
 	disableTrimming := false
 
-	p, err := PostingsForMatchers(q.index, ms...)
+	p, err := PostingsForMatchers(q.ctx, q.index, ms...)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}
@@ -153,15 +155,16 @@ func (q *blockQuerier) Select(sortSeries bool, hints *storage.SelectHints, ms ..
 // blockChunkQuerier provides chunk querying access to a single block database.
 type blockChunkQuerier struct {
 	*blockBaseQuerier
+	ctx context.Context
 }
 
 // NewBlockChunkQuerier returns a chunk querier against the block reader and requested min and max time range.
-func NewBlockChunkQuerier(b BlockReader, mint, maxt int64) (storage.ChunkQuerier, error) {
+func NewBlockChunkQuerier(ctx context.Context, b BlockReader, mint, maxt int64) (storage.ChunkQuerier, error) {
 	q, err := newBlockBaseQuerier(b, mint, maxt)
 	if err != nil {
 		return nil, err
 	}
-	return &blockChunkQuerier{blockBaseQuerier: q}, nil
+	return &blockChunkQuerier{blockBaseQuerier: q, ctx: ctx}, nil
 }
 
 func (q *blockChunkQuerier) Select(sortSeries bool, hints *storage.SelectHints, ms ...*labels.Matcher) storage.ChunkSeriesSet {
@@ -173,7 +176,7 @@ func (q *blockChunkQuerier) Select(sortSeries bool, hints *storage.SelectHints, 
 		maxt = hints.End
 		disableTrimming = hints.DisableTrimming
 	}
-	p, err := PostingsForMatchers(q.index, ms...)
+	p, err := PostingsForMatchers(q.ctx, q.index, ms...)
 	if err != nil {
 		return storage.ErrChunkSeriesSet(err)
 	}
@@ -227,7 +230,7 @@ func findSetMatches(pattern string) []string {
 
 // PostingsForMatchers assembles a single postings iterator against the index reader
 // based on the given matchers. The resulting postings are not ordered by series.
-func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings, error) {
+func PostingsForMatchers(ctx context.Context, ix IndexReader, ms ...*labels.Matcher) (index.Postings, error) {
 	var its, notIts []index.Postings
 	// See which label must be non-empty.
 	// Optimization for case like {l=~".", l!="1"}.
@@ -239,6 +242,9 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 	}
 
 	for _, m := range ms {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		switch {
 		case m.Name == "" && m.Value == "": // Special-case for AllPostings, used in tests at least.
 			k, v := index.AllPostingsKey()
@@ -260,7 +266,7 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 					return nil, err
 				}
 
-				it, err := postingsForMatcher(ix, inverse)
+				it, err := postingsForMatcher(ctx, ix, inverse)
 				if err != nil {
 					return nil, err
 				}
@@ -273,7 +279,7 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 					return nil, err
 				}
 
-				it, err := inversePostingsForMatcher(ix, inverse)
+				it, err := inversePostingsForMatcher(ctx, ix, inverse)
 				if err != nil {
 					return nil, err
 				}
@@ -283,7 +289,7 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 				its = append(its, it)
 			default: // l="a"
 				// Non-Not matcher, use normal postingsForMatcher.
-				it, err := postingsForMatcher(ix, m)
+				it, err := postingsForMatcher(ctx, ix, m)
 				if err != nil {
 					return nil, err
 				}
@@ -297,7 +303,7 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 			// the series which don't have the label name set too. See:
 			// https://github.com/prometheus/prometheus/issues/3575 and
 			// https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555
-			it, err := inversePostingsForMatcher(ix, m)
+			it, err := inversePostingsForMatcher(ctx, ix, m)
 			if err != nil {
 				return nil, err
 			}
@@ -324,7 +330,7 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 	return it, nil
 }
 
-func postingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, error) {
+func postingsForMatcher(ctx context.Context, ix IndexReader, m *labels.Matcher) (index.Postings, error) {
 	// This method will not return postings for missing labels.
 
 	// Fast-path for equal matching.
@@ -347,6 +353,9 @@ func postingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, erro
 
 	var res []string
 	for _, val := range vals {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		if m.Matches(val) {
 			res = append(res, val)
 		}
@@ -360,7 +369,7 @@ func postingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, erro
 }
 
 // inversePostingsForMatcher returns the postings for the series with the label name set but not matching the matcher.
-func inversePostingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, error) {
+func inversePostingsForMatcher(ctx context.Context, ix IndexReader, m *labels.Matcher) (index.Postings, error) {
 	vals, err := ix.LabelValues(m.Name)
 	if err != nil {
 		return nil, err
@@ -380,6 +389,10 @@ func inversePostingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Posting
 			}
 		}
 		for _, val := range vals {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+
 			if !m.Matches(val) {
 				res = append(res, val)
 			}
@@ -389,8 +402,8 @@ func inversePostingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Posting
 	return ix.Postings(m.Name, res...)
 }
 
-func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Matcher) ([]string, error) {
-	p, err := PostingsForMatchers(r, matchers...)
+func labelValuesWithMatchers(ctx context.Context, r IndexReader, name string, matchers ...*labels.Matcher) ([]string, error) {
+	p, err := PostingsForMatchers(ctx, r, matchers...)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching postings for matchers")
 	}
@@ -419,8 +432,8 @@ func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Mat
 	return values, nil
 }
 
-func labelNamesWithMatchers(r IndexReader, matchers ...*labels.Matcher) ([]string, error) {
-	p, err := PostingsForMatchers(r, matchers...)
+func labelNamesWithMatchers(ctx context.Context, r IndexReader, matchers ...*labels.Matcher) ([]string, error) {
+	p, err := PostingsForMatchers(ctx, r, matchers...)
 	if err != nil {
 		return nil, err
 	}

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -161,7 +161,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 	for _, c := range cases {
 		b.Run(c.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err := PostingsForMatchers(ir, c.matchers...)
+				_, err := PostingsForMatchers(context.Background(), ir, c.matchers...)
 				require.NoError(b, err)
 			}
 		})
@@ -199,7 +199,7 @@ func benchmarkLabelValuesWithMatchers(b *testing.B, ir IndexReader) {
 	for _, c := range cases {
 		b.Run(c.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err := labelValuesWithMatchers(ir, c.labelName, c.matchers...)
+				_, err := labelValuesWithMatchers(context.Background(), ir, c.labelName, c.matchers...)
 				require.NoError(b, err)
 			}
 		})
@@ -247,7 +247,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 		matcher := labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")
 		for s := 1; s <= numSeries; s *= 10 {
 			b.Run(fmt.Sprintf("%dof%d", s, numSeries), func(b *testing.B) {
-				q, err := NewBlockQuerier(br, 0, int64(s-1))
+				q, err := NewBlockQuerier(context.Background(), br, 0, int64(s-1))
 				require.NoError(b, err)
 
 				b.ResetTimer()

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -170,6 +170,7 @@ type blockQuerierTestCase struct {
 func testBlockQuerier(t *testing.T, c blockQuerierTestCase, ir IndexReader, cr ChunkReader, stones *tombstones.MemTombstones) {
 	t.Run("sample", func(t *testing.T) {
 		q := blockQuerier{
+			ctx: context.Background(),
 			blockBaseQuerier: &blockBaseQuerier{
 				index:      ir,
 				chunks:     cr,
@@ -206,6 +207,7 @@ func testBlockQuerier(t *testing.T, c blockQuerierTestCase, ir IndexReader, cr C
 
 	t.Run("chunk", func(t *testing.T) {
 		q := blockChunkQuerier{
+			ctx: context.Background(),
 			blockBaseQuerier: &blockBaseQuerier{
 				index:      ir,
 				chunks:     cr,
@@ -1373,7 +1375,7 @@ func BenchmarkQueryIterator(b *testing.B) {
 
 				qblocks := make([]storage.Querier, 0, len(blocks))
 				for _, blk := range blocks {
-					q, err := NewBlockQuerier(blk, math.MinInt64, math.MaxInt64)
+					q, err := NewBlockQuerier(context.Background(), blk, math.MinInt64, math.MaxInt64)
 					require.NoError(b, err)
 					qblocks = append(qblocks, q)
 				}
@@ -1436,7 +1438,7 @@ func BenchmarkQuerySeek(b *testing.B) {
 
 				qblocks := make([]storage.Querier, 0, len(blocks))
 				for _, blk := range blocks {
-					q, err := NewBlockQuerier(blk, math.MinInt64, math.MaxInt64)
+					q, err := NewBlockQuerier(context.Background(), blk, math.MinInt64, math.MaxInt64)
 					require.NoError(b, err)
 					qblocks = append(qblocks, q)
 				}
@@ -1571,7 +1573,7 @@ func BenchmarkSetMatcher(b *testing.B) {
 
 		qblocks := make([]storage.Querier, 0, len(blocks))
 		for _, blk := range blocks {
-			q, err := NewBlockQuerier(blk, math.MinInt64, math.MaxInt64)
+			q, err := NewBlockQuerier(context.Background(), blk, math.MinInt64, math.MaxInt64)
 			require.NoError(b, err)
 			qblocks = append(qblocks, q)
 		}
@@ -1915,7 +1917,7 @@ func TestPostingsForMatchers(t *testing.T) {
 			for _, l := range c.exp {
 				exp[l.String()] = struct{}{}
 			}
-			p, err := PostingsForMatchers(ir, c.matchers...)
+			p, err := PostingsForMatchers(context.Background(), ir, c.matchers...)
 			require.NoError(t, err)
 
 			var builder labels.ScratchBuilder
@@ -2035,7 +2037,7 @@ func BenchmarkQueries(b *testing.B) {
 				for x := 0; x <= 10; x++ {
 					block, err := OpenBlock(nil, createBlock(b, dir, series), nil)
 					require.NoError(b, err)
-					q, err := NewBlockQuerier(block, 1, nSamples)
+					q, err := NewBlockQuerier(context.Background(), block, 1, nSamples)
 					require.NoError(b, err)
 					qs = append(qs, q)
 				}
@@ -2046,7 +2048,7 @@ func BenchmarkQueries(b *testing.B) {
 
 				chunkDir := b.TempDir()
 				head := createHead(b, nil, series, chunkDir)
-				qHead, err := NewBlockQuerier(NewRangeHead(head, 1, nSamples), 1, nSamples)
+				qHead, err := NewBlockQuerier(context.Background(), NewRangeHead(head, 1, nSamples), 1, nSamples)
 				require.NoError(b, err)
 				queryTypes = append(queryTypes, qt{"_Head", qHead})
 
@@ -2056,9 +2058,9 @@ func BenchmarkQueries(b *testing.B) {
 					oooSampleFrequency := int(nSamples) / totalOOOSamples
 					head := createHeadWithOOOSamples(b, nil, series, chunkDir, oooSampleFrequency)
 
-					qHead, err := NewBlockQuerier(NewRangeHead(head, 1, nSamples), 1, nSamples)
+					qHead, err := NewBlockQuerier(context.Background(), NewRangeHead(head, 1, nSamples), 1, nSamples)
 					require.NoError(b, err)
-					qOOOHead, err := NewBlockQuerier(NewOOORangeHead(head, 1, nSamples), 1, nSamples)
+					qOOOHead, err := NewBlockQuerier(context.Background(), NewOOORangeHead(head, 1, nSamples), 1, nSamples)
 					require.NoError(b, err)
 
 					queryTypes = append(queryTypes, qt{
@@ -2172,7 +2174,7 @@ func TestPostingsForMatcher(t *testing.T) {
 
 	for _, tc := range cases {
 		ir := &mockMatcherIndex{}
-		_, err := postingsForMatcher(ir, tc.matcher)
+		_, err := postingsForMatcher(context.Background(), ir, tc.matcher)
 		if tc.hasError {
 			require.Error(t, err)
 		} else {


### PR DESCRIPTION
Checking the context while evaluating the `PostingsForMatchers` function to avoid wasting cpu if the context was already cancelled.

The context is received by the db.Querier and is currently not being used:

https://github.com/prometheus/prometheus/blob/5c5fa5c319fca713506fa144ec6768fddf00d466/tsdb/db.go#L1776-L1777