### PR TITLE
Improving Performance on the API Gzip Handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/hetznercloud/hcloud-go v1.42.0
 	github.com/ionos-cloud/sdk-go/v6 v6.1.6
 	github.com/json-iterator/go v1.1.12
+	github.com/klauspost/compress v1.13.6
 	github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b
 	github.com/linode/linodego v1.16.1
 	github.com/miekg/dns v1.1.53

--- a/go.sum
+++ b/go.sum
@@ -498,6 +498,7 @@ github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0Lh
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b h1:udzkj9S/zlT5X367kqJis0QP7YMxobob6zhzq6Yre00=
 github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b/go.mod h1:pcaDhQK0/NJZEvtCO0qQPPropqV0sJOJ6YW7X+9kRwM=

--- a/util/httputil/compression.go
+++ b/util/httputil/compression.go
@@ -14,12 +14,11 @@
 package httputil
 
 import (
-	"compress/zlib"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/klauspost/compress/gzhttp"
+	"github.com/klauspost/compress/zlib"
 )
 
 const (
@@ -29,11 +28,10 @@ const (
 	deflateEncoding       = "deflate"
 )
 
-// Wrapper around http.Handler which adds suitable response compression based
-// on the client's Accept-Encoding headers.
+// Wrapper around http.ResponseWriter which adds deflate compression
 type deflatedResponseWriter struct {
 	http.ResponseWriter
-	writer io.Writer
+	writer *zlib.Writer
 }
 
 // Writes HTTP response content data.
@@ -41,14 +39,9 @@ func (c *deflatedResponseWriter) Write(p []byte) (int, error) {
 	return c.writer.Write(p)
 }
 
-// Closes the deflatedResponseWriter and ensures to flush all data before.
+// Close Closes the deflatedResponseWriter and ensures to flush all data before.
 func (c *deflatedResponseWriter) Close() {
-	if zlibWriter, ok := c.writer.(*zlib.Writer); ok {
-		zlibWriter.Flush()
-	}
-	if closer, ok := c.writer.(io.Closer); ok {
-		defer closer.Close()
-	}
+	c.writer.Close()
 }
 
 // Constructs a new deflatedResponseWriter to compress the original writer using 'deflate' compression.

--- a/util/httputil/compression.go
+++ b/util/httputil/compression.go
@@ -51,9 +51,8 @@ func (c *deflatedResponseWriter) Close() {
 	}
 }
 
-// Constructs a new deflatedResponseWriter based on client request headers.
+// Constructs a new deflatedResponseWriter to compress the original writer using 'deflate' compression.
 func newDeflateResponseWriter(writer http.ResponseWriter) *deflatedResponseWriter {
-	writer.Header().Set(contentEncodingHeader, deflateEncoding)
 	return &deflatedResponseWriter{
 		ResponseWriter: writer,
 		writer:         zlib.NewWriter(writer),
@@ -76,6 +75,7 @@ func (c CompressionHandler) ServeHTTP(writer http.ResponseWriter, req *http.Requ
 			return
 		case deflateEncoding:
 			compWriter := newDeflateResponseWriter(writer)
+			writer.Header().Set(contentEncodingHeader, deflateEncoding)
 			c.Handler.ServeHTTP(compWriter, req)
 			compWriter.Close()
 			return


### PR DESCRIPTION
Using `github.com/klauspost/compress` package to replace the current Gzip Handler on the API.


We can see significant improvements using this handler over the current one as shown in the benchmark:

For instance: for a 4mb compressed response we can see that the compression time decreased from 1.1s to 237ms (-78.64%) and the memory allocated decreased from 26.6M to 5.5M (-78.95%) while the response size only increased from 4.863M to 4.904M (0.85%)


PS: This api is already being used on Thanos: https://github.com/thanos-io/thanos/pull/6332

```
[ec2-user@ip-172-31-30-12 ~]$ ~/go/bin/benchstat /tmp/old /tmp/new
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/util/httputil
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
                                 │   /tmp/old    │              /tmp/new               │
                                 │    sec/op     │    sec/op     vs base               │
_compression/gzip-100K-labels-32   107.90m ± ∞ ¹   22.63m ± ∞ ¹  -79.03% (p=0.008 n=5)
_compression/gzip-1M-labels-32     1111.4m ± ∞ ¹   237.3m ± ∞ ¹  -78.64% (p=0.008 n=5)
_compression/gzip-10-labels-32     332.61µ ± ∞ ¹   59.47µ ± ∞ ¹  -82.12% (p=0.008 n=5)
_compression/gzip-100-labels-32     393.5µ ± ∞ ¹   102.8µ ± ∞ ¹  -73.87% (p=0.008 n=5)
_compression/gzip-1K-labels-32     1462.6µ ± ∞ ¹   357.9µ ± ∞ ¹  -75.53% (p=0.008 n=5)
_compression/gzip-10K-labels-32     9.914m ± ∞ ¹   2.359m ± ∞ ¹  -76.20% (p=0.008 n=5)
geomean                             7.814m         1.740m        -77.73%
¹ need >= 6 samples for confidence interval at level 0.95

                                 │   /tmp/old    │               /tmp/new               │
                                 │ ContentLength │ ContentLength  vs base               │
_compression/gzip-100K-labels-32    472.4k ± ∞ ¹    474.2k ± ∞ ¹   +0.37% (p=0.008 n=5)
_compression/gzip-1M-labels-32      4.863M ± ∞ ¹    4.904M ± ∞ ¹   +0.85% (p=0.008 n=5)
_compression/gzip-10-labels-32       96.00 ± ∞ ¹    171.00 ± ∞ ¹  +78.12% (p=0.008 n=5)
_compression/gzip-100-labels-32      405.0 ± ∞ ¹     397.0 ± ∞ ¹   -1.98% (p=0.008 n=5)
_compression/gzip-1K-labels-32      4.140k ± ∞ ¹    4.248k ± ∞ ¹   +2.61% (p=0.008 n=5)
_compression/gzip-10K-labels-32     47.31k ± ∞ ¹    48.24k ± ∞ ¹   +1.96% (p=0.008 n=5)
geomean                             16.11k          17.85k        +10.79%
¹ need >= 6 samples for confidence interval at level 0.95

                                 │    /tmp/old     │               /tmp/new               │
                                 │      B/op       │     B/op       vs base               │
_compression/gzip-100K-labels-32    1051.7Ki ± ∞ ¹   140.7Ki ± ∞ ¹  -86.62% (p=0.008 n=5)
_compression/gzip-1M-labels-32      26.387Mi ± ∞ ¹   5.554Mi ± ∞ ¹  -78.95% (p=0.008 n=5)
_compression/gzip-10-labels-32     804.040Ki ± ∞ ¹   4.815Ki ± ∞ ¹  -99.40% (p=0.008 n=5)
_compression/gzip-100-labels-32     804.01Ki ± ∞ ¹   10.59Ki ± ∞ ¹  -98.68% (p=0.008 n=5)
_compression/gzip-1K-labels-32      804.25Ki ± ∞ ¹   10.43Ki ± ∞ ¹  -98.70% (p=0.008 n=5)
_compression/gzip-10K-labels-32     806.23Ki ± ∞ ¹   24.60Ki ± ∞ ¹  -96.95% (p=0.008 n=5)
geomean                              1.476Mi         46.78Ki        -96.90%
¹ need >= 6 samples for confidence interval at level 0.95

                                 │   /tmp/old   │              /tmp/new               │
                                 │  allocs/op   │  allocs/op    vs base               │
_compression/gzip-100K-labels-32    325.0 ± ∞ ¹    307.0 ± ∞ ¹   -5.54% (p=0.008 n=5)
_compression/gzip-1M-labels-32     2.571k ± ∞ ¹   2.499k ± ∞ ¹   -2.80% (p=0.008 n=5)
_compression/gzip-10-labels-32      85.00 ± ∞ ¹    64.00 ± ∞ ¹  -24.71% (p=0.008 n=5)
_compression/gzip-100-labels-32     85.00 ± ∞ ¹    69.00 ± ∞ ¹  -18.82% (p=0.008 n=5)
_compression/gzip-1K-labels-32      87.00 ± ∞ ¹    73.00 ± ∞ ¹  -16.09% (p=0.008 n=5)
_compression/gzip-10K-labels-32    108.00 ± ∞ ¹    95.00 ± ∞ ¹  -12.04% (p=0.008 n=5)
geomean                             196.0          169.2        -13.66%
¹ need >= 6 samples for confidence interval at level 0.95
```
