### PR TITLE
Optimizing "grafana generated" regex matchers

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -190,7 +190,14 @@ func findSetMatches(pattern string) []string {
 	}
 	escaped := false
 	sets := []*strings.Builder{{}}
-	for i := 4; i < len(pattern)-2; i++ {
+	init := 4
+	end := len(pattern) - 2
+	// If the regex is wrapped in a group we can remove the first and last parentheses
+	if pattern[init] == '(' && pattern[end-1] == ')' {
+		init++
+		end--
+	}
+	for i := init; i < end; i++ {
 		if escaped {
 			switch {
 			case isRegexMetaCharacter(pattern[i]):

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -113,6 +113,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 	jXplus := labels.MustNewMatcher(labels.MatchRegexp, "j", "X.+")
 	iCharSet := labels.MustNewMatcher(labels.MatchRegexp, "i", "1[0-9]")
 	iAlternate := labels.MustNewMatcher(labels.MatchRegexp, "i", "(1|2|3|4|5|6|20|55)")
+	iNotAlternate := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "(1|2|3|4|5|6|20|55)")
 	iXYZ := labels.MustNewMatcher(labels.MatchRegexp, "i", "X|Y|Z")
 	iNotXYZ := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "X|Y|Z")
 	cases := []struct {
@@ -131,6 +132,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 		{`j=~"XXX|YYY"`, []*labels.Matcher{jXXXYYY}},
 		{`j=~"X.+"`, []*labels.Matcher{jXplus}},
 		{`i=~"(1|2|3|4|5|6|20|55)"`, []*labels.Matcher{iAlternate}},
+		{`i!~"(1|2|3|4|5|6|20|55)"`, []*labels.Matcher{iNotAlternate}},
 		{`i=~"X|Y|Z"`, []*labels.Matcher{iXYZ}},
 		{`i!~"X|Y|Z"`, []*labels.Matcher{iNotXYZ}},
 		{`i=~".*"`, []*labels.Matcher{iStar}},
@@ -160,6 +162,8 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 
 	for _, c := range cases {
 		b.Run(c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_, err := PostingsForMatchers(ir, c.matchers...)
 				require.NoError(b, err)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1815,6 +1815,12 @@ func TestPostingsForMatchers(t *testing.T) {
 			},
 		},
 		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotRegexp, "n", "(1|2.5)")},
+			exp: []labels.Labels{
+				labels.FromStrings("n", "2"),
+			},
+		},
+		{
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "n", "1"), labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^a$")},
 			exp: []labels.Labels{
 				labels.FromStrings("n", "1"),
@@ -1876,6 +1882,13 @@ func TestPostingsForMatchers(t *testing.T) {
 			},
 		},
 		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", "(a|b)")},
+			exp: []labels.Labels{
+				labels.FromStrings("n", "1", "i", "a"),
+				labels.FromStrings("n", "1", "i", "b"),
+			},
+		},
+		{
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", "x1|2")},
 			exp: []labels.Labels{
 				labels.FromStrings("n", "2"),
@@ -1891,6 +1904,14 @@ func TestPostingsForMatchers(t *testing.T) {
 		// Empty value.
 		{
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", "c||d")},
+			exp: []labels.Labels{
+				labels.FromStrings("n", "1"),
+				labels.FromStrings("n", "2"),
+				labels.FromStrings("n", "2.5"),
+			},
+		},
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", "(c||d)")},
 			exp: []labels.Labels{
 				labels.FromStrings("n", "1"),
 				labels.FromStrings("n", "2"),


### PR DESCRIPTION
When using a multi-value variable on Grafana Dashboards the default behavior is to produce regex in the format `(a|b)`. See https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/#regex

This PR is expanding the optimization Prometheus already have on regexes like `a|b` to regexes like `(a|b)` and improve the query time and cpu utilization for dashboards with high cardinality variables substantially.

PS: Nothing will change for other types of queries even if they starts and ends with `()`, like  `(a|b)|(c|d)`

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
                                                             │     /tmp/old     │              /tmp/new               │
                                                             │      sec/op      │    sec/op     vs base               │
Querier/Head/PostingsForMatchers/i=~"(1|2|3|4|5|6|20|55)"-32   18796.184µ ± ∞ ¹   2.416µ ± ∞ ¹  -99.99% (p=0.008 n=5)
Querier/Head/PostingsForMatchers/i!~"(1|2|3|4|5|6|20|55)"-32      18.450m ± ∞ ¹   2.238m ± ∞ ¹  -87.87% (p=0.008 n=5)
geomean                                                            18.62m         73.53µ        -99.61%
¹ need >= 6 samples for confidence interval at level 0.95

                                                             │    /tmp/old     │               /tmp/new               │
                                                             │      B/op       │     B/op	vs base               │
Querier/Head/PostingsForMatchers/i=~"(1|2|3|4|5|6|20|55)"-32   1606349.0 ± ∞ ¹     848.0 ± ∞ ¹  -99.95% (p=0.008 n=5)
Querier/Head/PostingsForMatchers/i!~"(1|2|3|4|5|6|20|55)"-32     1.531Mi ± ∞ ¹   1.532Mi ± ∞ ¹   +0.04% (p=0.008 n=5)
geomean                                                          1.532Mi         36.04Ki        -97.70%
¹ need >= 6 samples for confidence interval at level 0.95

                                                             │  /tmp/old   │               /tmp/new               │
                                                             │  allocs/op  │  allocs/op    vs base                │
Querier/Head/PostingsForMatchers/i=~"(1|2|3|4|5|6|20|55)"-32   4.000 ± ∞ ¹   31.000 ± ∞ ¹  +675.00% (p=0.008 n=5)
Querier/Head/PostingsForMatchers/i!~"(1|2|3|4|5|6|20|55)"-32   7.000 ± ∞ ¹   35.000 ± ∞ ¹  +400.00% (p=0.008 n=5)
geomean                                                        5.292          32.94        +522.49%
```