### PR TITLE
Optimize `MatchNotRegexp` and `MatchNotEqual`

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -361,6 +361,22 @@ func postingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, erro
 
 // inversePostingsForMatcher returns the postings for the series with the label name set but not matching the matcher.
 func inversePostingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, error) {
+	// Fast-path for MatchNotRegexp matching.
+	// Inverse of a MatchNotRegexp is MatchRegexp (double negation).
+	// Fast-path for set matching.
+	if m.Type == labels.MatchNotRegexp {
+		setMatches := findSetMatches(m.GetRegexString())
+		if len(setMatches) > 0 {
+			return ix.Postings(m.Name, setMatches...)
+		}
+	}
+
+	// Fast-path for MatchNotEqual matching.
+	// Inverse of a MatchNotEqual is MatchEqual (double negation).
+	if m.Type == labels.MatchNotEqual {
+		return ix.Postings(m.Name, m.Value)
+	}
+
 	vals, err := ix.LabelValues(m.Name)
 	if err != nil {
 		return nil, err
@@ -371,14 +387,6 @@ func inversePostingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Posting
 	if m.Type == labels.MatchEqual && m.Value == "" {
 		res = vals
 	} else {
-		// Inverse of a MatchNotRegexp is MatchRegexp (double negation).
-		// Fast-path for set matching.
-		if m.Type == labels.MatchNotRegexp {
-			setMatches := findSetMatches(m.GetRegexString())
-			if len(setMatches) > 0 {
-				return ix.Postings(m.Name, setMatches...)
-			}
-		}
 		for _, val := range vals {
 			if !m.Matches(val) {
 				res = append(res, val)

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -125,6 +125,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 		{`n="X",j="foo"`, []*labels.Matcher{nX, jFoo}},
 		{`j="foo",n="1"`, []*labels.Matcher{jFoo, n1}},
 		{`n="1",j!="foo"`, []*labels.Matcher{n1, jNotFoo}},
+		{`n="1",i!="2"`, []*labels.Matcher{n1, iNot2}},
 		{`n="X",j!="foo"`, []*labels.Matcher{nX, jNotFoo}},
 		{`i=~"1[0-9]",j=~"foo|bar"`, []*labels.Matcher{iCharSet, jFooBar}},
 		{`j=~"foo|bar"`, []*labels.Matcher{jFooBar}},


### PR DESCRIPTION
Follow up of https://github.com/prometheus/prometheus/pull/12351

There is 2 changes here:
* Implementing the same logic from `MatchNotRegexp` to `MatchNotEqual`
* Avoiding calling `ix.LabelValues(m.Name)` if we go on the optimized path.

Benchmark with `!=` and `~!` matchers: https://gist.github.com/alanprot/20cbf24f046c40173c3e7e21d18b1e85

Relevant results:

```
                                                                     │    /tmp/old    │              /tmp/new              │
                                                                     │     sec/op     │   sec/op     vs base               │
Querier/Head/PostingsForMatchers/n="1",j!="foo"-32                       1081.0n ± 0%   865.5n ± 0%  -19.94% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i!="2"-32                      2570293.0n ± 2%   885.4n ± 0%  -99.97% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i!~"X|Y|Z"-32                         2216.055µ ± 3%   1.523µ ± 0%  -99.93% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i!~"X|Y|Z",j="foo"-32           2225.281µ ± 0%   1.911µ ± 1%  -99.91% (p=0.002 n=6)

                                                                     │    /tmp/old    │               /tmp/new                │
                                                                     │      B/op      │     B/op      vs base                 │
Querier/Head/PostingsForMatchers/n="1",j!="foo"-32                         208.0 ± 0%     176.0 ± 0%  -15.38% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i!="2"-32                     1. 605808.0 ± 0%     176.0 ± 0%  -99.99% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i!~"X|Y|Z"-32                         1606040.0 ± 0%     408.0 ± 0%  -99.97% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i=~".*",i!="2",j="foo"-32         3.063Mi ± 0%   1.532Mi ± 0%  -49.99% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i!~"X|Y|Z",j="foo"-32           1606152.0 ± 0%     520.0 ± 0%  -99.97% (p=0.002 n=6)

                                                                     │  /tmp/old   │               /tmp/new               │
                                                                     │  allocs/op  │  allocs/op   vs base                 │
Querier/Head/PostingsForMatchers/n="1",j!="foo"-32                      8.000 ± 0%    7.000 ± 0%  -12.50% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i!="2"-32                        8.000 ± 0%    7.000 ± 0%  -12.50% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i!~"X|Y|Z"-32                          19.00 ± 0%    18.00 ± 0%   -5.26% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i=~".*",i!="2",j="foo"-32        15.00 ± 0%    14.00 ± 0%   -6.67% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i!~"X|Y|Z",j="foo"-32            23.00 ± 0%    22.00 ± 0%   -4.35% (p=0.002 n=6)
```


@jesusvazquez 🥺 

PS: This logic is already tested [here](https://github.com/prometheus/prometheus/blob/e53478a08dc684cfb049173a65f821b7abfa75bf/tsdb/querier_test.go#L1752-L1784) 
