### PR TITLE
Use DefaultSamplesPerChunk in tsdb

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -640,6 +640,9 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64) {
 	if opts.HeadChunksWriteQueueSize < 0 {
 		opts.HeadChunksWriteQueueSize = chunks.DefaultWriteQueueSize
 	}
+	if opts.SamplesPerChunk <= 0 {
+		opts.SamplesPerChunk = DefaultSamplesPerChunk
+	}
 	if opts.MaxBlockChunkSegmentSize <= 0 {
 		opts.MaxBlockChunkSegmentSize = chunks.DefaultChunkSegmentSize
 	}


### PR DESCRIPTION
Follow up to https://github.com/prometheus/prometheus/pull/12055 which added the flag `storage.tsdb.samples-per-chunk`. The default of 120 wasn't applied in some cases (causing test failures in Mimir), so applying it here.