### PR TITLE
Mark 2.45 as LTS

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,7 +49,7 @@ Release cadence of first pre-releases being cut is 6 weeks.
 | v2.42          | 2023-01-25                                 | Kemal Akkoyun (GitHub: @kakkoyun)           |
 | v2.43          | 2023-03-08                                 | Julien Pivotto (GitHub: @roidelapluie)      |
 | v2.44          | 2023-04-19                                 | Bryan Boreham (GitHub: @bboreham)           |
-| v2.45          | 2023-05-31                                 | Jesus Vazquez (Github: @jesusvazquez)       |
+| v2.45 LTS      | 2023-05-31                                 | Jesus Vazquez (Github: @jesusvazquez)       |
 | v2.46          | 2023-07-12                                 | **searching for volunteer**                 |
 
 If you are interested in volunteering please create a pull request against the [prometheus/prometheus](https://github.com/prometheus/prometheus) repository and propose yourself for the release series of your choice.


### PR DESCRIPTION
As the 2.37 LTS is going EOL in July 2023, let's mark 2.45 as LTS. I have synced with Jesus about this. He will bootstrap the release and after a few week I will do the maintenance for the lifetime of the LTS.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
