### PR TITLE
add alert for sd refresh failure

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -23,15 +23,15 @@
           {
             alert: 'PrometheusSDRefreshFailure',
             expr: |||
-              rate(prometheus_sd_refresh_failures_total{%(prometheusSelector)s}[5m]) > 0
+              increase(prometheus_sd_refresh_failures_total{%(prometheusSelector)s}[10m]) > 0
             ||| % $._config,
-            'for': '10m',
+            'for': '20m',
             labels: {
               severity: 'warning',
             },
             annotations: {
               summary: 'Failed Prometheus SD refresh.',
-              description: 'Prometheus %(prometheusName)s has failed to refresh sd with mechanism {{$labels.mechanism}}' % $._config,
+              description: 'Prometheus %(prometheusName)s has failed to refresh SD with mechanism {{$labels.mechanism}}.' % $._config,
             },
           },
           {

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -21,6 +21,20 @@
             },
           },
           {
+            alert: 'PrometheusSDRefreshFailure',
+            expr: |||
+              rate(prometheus_sd_refresh_failures_total{%(prometheusSelector)s}[5m]) > 0
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Failed Prometheus SD refresh.',
+              description: 'Prometheus %(prometheusName)s has failed to refresh sd with mechanism {{$labels.mechanism}}' % $._config,
+            },
+          },
+          {
             alert: 'PrometheusNotificationQueueRunningFull',
             expr: |||
               # Without min_over_time, failed scrapes could create false negatives, see


### PR DESCRIPTION
Due to config error or sd service down, prometheus may fail to refresh sd resource, which may lead to scrape fail or irrelevant metrics.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
