### PR TITLE
Bump UI version for 2.45.0-rc.0

### DIFF
--- a/web/ui/module/codemirror-promql/package.json
+++ b/web/ui/module/codemirror-promql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prometheus-io/codemirror-promql",
-  "version": "0.44.0",
+  "version": "0.45.0-rc.0",
   "description": "a CodeMirror mode for the PromQL language",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/prometheus/prometheus/blob/main/web/ui/module/codemirror-promql/README.md",
   "dependencies": {
-    "@prometheus-io/lezer-promql": "0.44.0",
+    "@prometheus-io/lezer-promql": "0.45.0-rc.0",
     "lru-cache": "^6.0.0"
   },
   "devDependencies": {

--- a/web/ui/module/lezer-promql/package.json
+++ b/web/ui/module/lezer-promql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prometheus-io/lezer-promql",
-  "version": "0.44.0",
+  "version": "0.45.0-rc.0",
   "description": "lezer-based PromQL grammar",
   "main": "dist/index.cjs",
   "type": "module",

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -28,10 +28,10 @@
     },
     "module/codemirror-promql": {
       "name": "@prometheus-io/codemirror-promql",
-      "version": "0.44.0",
+      "version": "0.45.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prometheus-io/lezer-promql": "0.44.0",
+        "@prometheus-io/lezer-promql": "0.45.0-rc.0",
         "lru-cache": "^6.0.0"
       },
       "devDependencies": {
@@ -61,7 +61,7 @@
     },
     "module/lezer-promql": {
       "name": "@prometheus-io/lezer-promql",
-      "version": "0.44.0",
+      "version": "0.45.0-rc.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.2.3",
@@ -20765,7 +20765,7 @@
     },
     "react-app": {
       "name": "@prometheus-io/app",
-      "version": "0.44.0",
+      "version": "0.45.0-rc.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.7.1",
         "@codemirror/commands": "^6.2.4",
@@ -20783,7 +20783,7 @@
         "@lezer/lr": "^1.3.6",
         "@nexucis/fuzzy": "^0.4.1",
         "@nexucis/kvsearch": "^0.8.1",
-        "@prometheus-io/codemirror-promql": "0.44.0",
+        "@prometheus-io/codemirror-promql": "0.45.0-rc.0",
         "bootstrap": "^4.6.2",
         "css.escape": "^1.5.1",
         "downshift": "^7.6.0",
@@ -23423,7 +23423,7 @@
         "@lezer/lr": "^1.3.6",
         "@nexucis/fuzzy": "^0.4.1",
         "@nexucis/kvsearch": "^0.8.1",
-        "@prometheus-io/codemirror-promql": "0.44.0",
+        "@prometheus-io/codemirror-promql": "0.45.0-rc.0",
         "@testing-library/react-hooks": "^7.0.2",
         "@types/enzyme": "^3.10.13",
         "@types/flot": "0.0.32",
@@ -23487,7 +23487,7 @@
         "@lezer/common": "^1.0.3",
         "@lezer/highlight": "^1.1.6",
         "@lezer/lr": "^1.3.6",
-        "@prometheus-io/lezer-promql": "0.44.0",
+        "@prometheus-io/lezer-promql": "0.45.0-rc.0",
         "@types/lru-cache": "^5.1.1",
         "isomorphic-fetch": "^3.0.0",
         "lru-cache": "^6.0.0",

--- a/web/ui/react-app/package.json
+++ b/web/ui/react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prometheus-io/app",
-  "version": "0.44.0",
+  "version": "0.45.0-rc.0",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.7.1",
@@ -19,7 +19,7 @@
     "@lezer/common": "^1.0.3",
     "@nexucis/fuzzy": "^0.4.1",
     "@nexucis/kvsearch": "^0.8.1",
-    "@prometheus-io/codemirror-promql": "0.44.0",
+    "@prometheus-io/codemirror-promql": "0.45.0-rc.0",
     "bootstrap": "^4.6.2",
     "css.escape": "^1.5.1",
     "downshift": "^7.6.0",


### PR DESCRIPTION
I forgot to run `make ui-bump-version` in the previous release candidate so I'm fixing it now.