### PR TITLE
labels: faster Compare function when using -tags stringlabels 

### DIFF
--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -425,13 +425,15 @@ func FromStrings(ss ...string) Labels {
 // TODO: replace with Less function - Compare is never needed.
 // TODO: just compare the underlying strings when we don't need alphanumeric sorting.
 func Compare(a, b Labels) int {
+	if len(a.data) == 0 {
+		return -len(b.data)
+	} else if len(b.data) == 0 {
+		return len(a.data)
+	}
 	// Find the first byte in the string where a and b differ.
 	shorter, longer := a.data, b.data
 	if len(b.data) < len(a.data) {
 		shorter, longer = b.data, a.data
-	}
-	if len(shorter) == 0 {
-		return len(longer)
 	}
 	i := 0
 	_ = longer[len(shorter)-1] // Get compiler to do bounds-check on longer just once here.

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -449,9 +449,8 @@ func Compare(a, b Labels) int {
 		} else if firstCharDifferent == len(a.data) {
 			// All labels in a were also in b; the set with fewer labels compares lower.
 			return -1
-		} else if firstCharDifferent == len(b.data) {
-			return +1
 		}
+		return +1 // b is a prefix of a.
 	}
 
 	// Now we know that there is some difference before the end of a and b.

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -422,8 +422,6 @@ func FromStrings(ss ...string) Labels {
 
 // Compare compares the two label sets.
 // The result will be 0 if a==b, <0 if a < b, and >0 if a > b.
-// TODO: replace with Less function - Compare is never needed.
-// TODO: just compare the underlying strings when we don't need alphanumeric sorting.
 func Compare(a, b Labels) int {
 	// Find the first byte in the string where a and b differ.
 	shorter, longer := a.data, b.data

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -363,6 +363,18 @@ func TestLabels_Compare(t *testing.T) {
 		},
 		{
 			compared: FromStrings(
+				"aaa", "111",
+				"bb", "222"),
+			expected: 1,
+		},
+		{
+			compared: FromStrings(
+				"aaa", "111",
+				"bbbb", "222"),
+			expected: -1,
+		},
+		{
+			compared: FromStrings(
 				"aaa", "111"),
 			expected: 1,
 		},
@@ -468,31 +480,49 @@ func BenchmarkLabels_Get(b *testing.B) {
 	}
 }
 
+var comparisonBenchmarkScenarios = []struct {
+	desc        string
+	base, other Labels
+}{
+	{
+		"equal",
+		FromStrings("a_label_name", "a_label_value", "another_label_name", "another_label_value"),
+		FromStrings("a_label_name", "a_label_value", "another_label_name", "another_label_value"),
+	},
+	{
+		"not equal",
+		FromStrings("a_label_name", "a_label_value", "another_label_name", "another_label_value"),
+		FromStrings("a_label_name", "a_label_value", "another_label_name", "a_different_label_value"),
+	},
+	{
+		"different sizes",
+		FromStrings("a_label_name", "a_label_value", "another_label_name", "another_label_value"),
+		FromStrings("a_label_name", "a_label_value"),
+	},
+	{
+		"lots",
+		FromStrings("aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh", "iii", "jjj", "kkk", "lll", "mmm", "nnn", "ooo", "ppp", "qqq", "rrz"),
+		FromStrings("aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh", "iii", "jjj", "kkk", "lll", "mmm", "nnn", "ooo", "ppp", "qqq", "rrr"),
+	},
+}
+
 func BenchmarkLabels_Equals(b *testing.B) {
-	for _, scenario := range []struct {
-		desc        string
-		base, other Labels
-	}{
-		{
-			"equal",
-			FromStrings("a_label_name", "a_label_value", "another_label_name", "another_label_value"),
-			FromStrings("a_label_name", "a_label_value", "another_label_name", "another_label_value"),
-		},
-		{
-			"not equal",
-			FromStrings("a_label_name", "a_label_value", "another_label_name", "another_label_value"),
-			FromStrings("a_label_name", "a_label_value", "another_label_name", "a_different_label_value"),
-		},
-		{
-			"different sizes",
-			FromStrings("a_label_name", "a_label_value", "another_label_name", "another_label_value"),
-			FromStrings("a_label_name", "a_label_value"),
-		},
-	} {
+	for _, scenario := range comparisonBenchmarkScenarios {
 		b.Run(scenario.desc, func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = Equal(scenario.base, scenario.other)
+			}
+		})
+	}
+}
+
+func BenchmarkLabels_Compare(b *testing.B) {
+	for _, scenario := range comparisonBenchmarkScenarios {
+		b.Run(scenario.desc, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = Compare(scenario.base, scenario.other)
 			}
 		})
 	}

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -392,6 +392,10 @@ func TestLabels_Compare(t *testing.T) {
 				"bbb", "222"),
 			expected: 0,
 		},
+		{
+			compared: EmptyLabels(),
+			expected: 1,
+		},
 	}
 
 	sign := func(a int) int {
@@ -407,6 +411,8 @@ func TestLabels_Compare(t *testing.T) {
 	for i, test := range tests {
 		got := Compare(labels, test.compared)
 		require.Equal(t, sign(test.expected), sign(got), "unexpected comparison result for test case %d", i)
+		got = Compare(test.compared, labels)
+		require.Equal(t, -sign(test.expected), sign(got), "unexpected comparison result for reverse test case %d", i)
 	}
 }
 


### PR DESCRIPTION
Instead of unpacking every individual string, we skip to the point where there is a difference.

Added a benchmark to illustrate.

[benchmark results updated 2023-06-15T1513]
Before/after this PR with `-tags stringlabels`:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                                 │  before.txt  │             after.txt              │
                                 │    sec/op    │   sec/op     vs base               │
Labels_Compare/equal-4              71.13n ± 6%   13.40n ± 2%  -81.16% (p=0.002 n=6)
Labels_Compare/not_equal-4          69.54n ± 2%   33.32n ± 2%  -52.09% (p=0.002 n=6)
Labels_Compare/different_sizes-4   39.050n ± 2%   9.840n ± 4%  -74.80% (p=0.002 n=6)
Labels_Compare/lots-4              300.85n ± 9%   46.59n ± 4%  -84.51% (p=0.002 n=6)
geomean                             87.31n        21.27n       -75.64%
```

After this PR, without/with `-tags stringlabels`:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                                 │  slice.txt   │             after.txt              │
                                 │    sec/op    │   sec/op     vs base               │
Labels_Compare/equal-4              23.25n ± 3%   13.40n ± 2%  -42.35% (p=0.002 n=6)
Labels_Compare/not_equal-4          25.02n ± 7%   33.32n ± 2%  +33.20% (p=0.002 n=6)
Labels_Compare/different_sizes-4   14.365n ± 6%   9.840n ± 4%  -31.50% (p=0.002 n=6)
Labels_Compare/lots-4               92.77n ± 3%   46.59n ± 4%  -49.77% (p=0.002 n=6)
geomean                             29.67n        21.27n       -28.31%
```
