### PR TITLE
Hide `which` stderr output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ assets-tarball: assets
 .PHONY: parser
 parser:
 	@echo ">> running goyacc to generate the .go file."
-ifeq (, $(shell which goyacc))
+ifeq (, $(shell which goyacc 2>/dev/null))
 	@echo "goyacc not installed so skipping"
 	@echo "To install: go install golang.org/x/tools/cmd/goyacc@v0.6.0"
 else

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ assets-tarball: assets
 .PHONY: parser
 parser:
 	@echo ">> running goyacc to generate the .go file."
-ifeq (, $(shell which goyacc 2>/dev/null))
+ifeq (, $(shell command -v goyacc > /dev/null))
 	@echo "goyacc not installed so skipping"
 	@echo "To install: go install golang.org/x/tools/cmd/goyacc@v0.6.0"
 else

--- a/Makefile.common
+++ b/Makefile.common
@@ -49,7 +49,7 @@ endif
 GOTEST := $(GO) test
 GOTEST_DIR :=
 ifneq ($(CIRCLE_JOB),)
-ifneq ($(shell which gotestsum),)
+ifneq ($(shell command -v gotestsum > /dev/null),)
 	GOTEST_DIR := test-results
 	GOTEST := gotestsum --junitfile $(GOTEST_DIR)/unit-tests.xml --
 endif
@@ -178,7 +178,7 @@ endif
 .PHONY: common-yamllint
 common-yamllint:
 	@echo ">> running yamllint on all YAML files in the repository"
-ifeq (, $(shell which yamllint 2>/dev/null))
+ifeq (, $(shell command -v yamllint > /dev/null))
 	@echo "yamllint not installed so skipping"
 else
 	yamllint .

--- a/Makefile.common
+++ b/Makefile.common
@@ -178,7 +178,7 @@ endif
 .PHONY: common-yamllint
 common-yamllint:
 	@echo ">> running yamllint on all YAML files in the repository"
-ifeq (, $(shell which yamllint))
+ifeq (, $(shell which yamllint 2>/dev/null))
 	@echo "yamllint not installed so skipping"
 else
 	yamllint .


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

When running `Makefile` and `Makefile.common` right now `which` prints whole path when program is not installed. Since there is error message already, this standard error output is unnecessary. 

![image](https://github.com/prometheus/prometheus/assets/32748145/2b22ca8e-b506-4dc5-8cc1-82fdadf201cc)
