### PR TITLE
Add sentence explaining what happens when the `for` clause is omitted

### DIFF
--- a/docs/configuration/alerting_rules.md
+++ b/docs/configuration/alerting_rules.md
@@ -32,7 +32,11 @@ groups:
 ```
 
 The optional `for` clause causes Prometheus to wait for a certain duration
-between first encountering a new expression output vector element and counting an alert as firing for this element. In this case, Prometheus will check that the alert continues to be active during each evaluation for 10 minutes before firing the alert. Elements that are active, but not firing yet, are in the pending state.
+between first encountering a new expression output vector element and counting
+an alert as firing for this element. In this case, Prometheus will check that
+the alert continues to be active during each evaluation for 10 minutes before
+firing the alert. Elements that are active, but not firing yet, are in the pending state.
+Alerting rules without the `for` clause will become active on the first evaluation.
 
 The `labels` clause allows specifying a set of additional labels to be attached
 to the alert. Any existing conflicting labels will be overwritten. The label


### PR DESCRIPTION
I was looking through the documentation for what the default behavior is when `for` is omitted from an alerting rule.  I expected the actual behavior but wanted to confirm and realized the documentation did not explain.  Just adding a statement here explaining that the default is an immediate move to "active" without a pending state.

For readability, I broke the single markdown line into multiple lines.  This should not change how it is parsed by Markdown so the change should be transparent in the actual documentation.
