### PR TITLE
web: Initialize requestCounter metrics to 0 with handler and 200 labels

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -158,7 +158,7 @@ func (m *metrics) instrumentHandlerWithPrefix(prefix string) func(handlerName st
 }
 
 func (m *metrics) instrumentHandler(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
-	m.requestCounter.WithLabelValues(handlerName, "200").Add(0)
+	m.requestCounter.WithLabelValues(handlerName, "200")
 	return promhttp.InstrumentHandlerCounter(
 		m.requestCounter.MustCurryWith(prometheus.Labels{"handler": handlerName}),
 		promhttp.InstrumentHandlerDuration(

--- a/web/web.go
+++ b/web/web.go
@@ -158,6 +158,7 @@ func (m *metrics) instrumentHandlerWithPrefix(prefix string) func(handlerName st
 }
 
 func (m *metrics) instrumentHandler(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
+	m.requestCounter.WithLabelValues(handlerName, "200").Add(0)
 	return promhttp.InstrumentHandlerCounter(
 		m.requestCounter.MustCurryWith(prometheus.Labels{"handler": handlerName}),
 		promhttp.InstrumentHandlerDuration(


### PR DESCRIPTION
This will register all handlers and also set their counter metrics to be `0` by default.

Pyrra has a SLOMetricAbsent that will alert if metrics are missing. Since we match on `/api/*` the metrics aren't showing up until someone runs a query. 

```
# HELP prometheus_http_requests_total Counter of HTTP requests.
# TYPE prometheus_http_requests_total counter
prometheus_http_requests_total{code="200",handler="/"} 0
prometheus_http_requests_total{code="200",handler="/-/healthy"} 0
prometheus_http_requests_total{code="200",handler="/-/quit"} 0
prometheus_http_requests_total{code="200",handler="/-/ready"} 0
prometheus_http_requests_total{code="200",handler="/-/reload"} 0
prometheus_http_requests_total{code="200",handler="/alerts"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/*path"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/admin/tsdb/clean_tombstones"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/admin/tsdb/delete_series"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/admin/tsdb/snapshot"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/alertmanagers"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/alerts"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/format_query"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/label/:name/values"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/labels"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/metadata"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/query"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/query_exemplars"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/query_range"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/read"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/rules"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/scrape_pools"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/series"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/status/buildinfo"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/status/config"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/status/flags"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/status/runtimeinfo"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/status/tsdb"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/status/walreplay"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/targets"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/targets/metadata"} 0
prometheus_http_requests_total{code="200",handler="/api/v1/write"} 0
prometheus_http_requests_total{code="200",handler="/classic/static/*filepath"} 0
prometheus_http_requests_total{code="200",handler="/config"} 0
prometheus_http_requests_total{code="200",handler="/consoles/*filepath"} 0
prometheus_http_requests_total{code="200",handler="/debug/*subpath"} 0
prometheus_http_requests_total{code="200",handler="/favicon.ico"} 0
prometheus_http_requests_total{code="200",handler="/federate"} 0
prometheus_http_requests_total{code="200",handler="/flags"} 0
prometheus_http_requests_total{code="200",handler="/graph"} 0
prometheus_http_requests_total{code="200",handler="/manifest.json"} 0
prometheus_http_requests_total{code="200",handler="/metrics"} 1
prometheus_http_requests_total{code="200",handler="/rules"} 0
prometheus_http_requests_total{code="200",handler="/service-discovery"} 0
prometheus_http_requests_total{code="200",handler="/starting"} 0
prometheus_http_requests_total{code="200",handler="/static/*filepath"} 0
prometheus_http_requests_total{code="200",handler="/status"} 0
prometheus_http_requests_total{code="200",handler="/targets"} 0
prometheus_http_requests_total{code="200",handler="/tsdb-status"} 0
prometheus_http_requests_total{code="200",handler="/version"} 0
```