### PR TITLE
labels: improve Get method for stringlabels build

### DIFF
--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -274,12 +274,16 @@ func (ls Labels) Copy() Labels {
 // Returns an empty string if the label doesn't exist.
 func (ls Labels) Get(name string) string {
 	for i := 0; i < len(ls.data); {
-		var lName, lValue string
-		lName, i = decodeString(ls.data, i)
-		lValue, i = decodeString(ls.data, i)
+		var size int
+		size, i = decodeSize(ls.data, i)
+		lName := ls.data[i : i+size]
+		i += size
 		if lName == name {
+			lValue, _ := decodeString(ls.data, i)
 			return lValue
 		}
+		size, i = decodeSize(ls.data, i)
+		i += size
 	}
 	return ""
 }

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -273,14 +273,24 @@ func (ls Labels) Copy() Labels {
 // Get returns the value for the label with the given name.
 // Returns an empty string if the label doesn't exist.
 func (ls Labels) Get(name string) string {
+	if name == "" { // Avoid crash in loop if someone asks for "".
+		return "" // Prometheus does not store blank label names.
+	}
 	for i := 0; i < len(ls.data); {
 		var size int
 		size, i = decodeSize(ls.data, i)
-		lName := ls.data[i : i+size]
-		i += size
-		if lName == name {
-			lValue, _ := decodeString(ls.data, i)
-			return lValue
+		if ls.data[i] == name[0] {
+			lName := ls.data[i : i+size]
+			i += size
+			if lName == name {
+				lValue, _ := decodeString(ls.data, i)
+				return lValue
+			}
+		} else {
+			if ls.data[i] > name[0] { // Stop looking if we've gone past.
+				break
+			}
+			i += size
 		}
 		size, i = decodeSize(ls.data, i)
 		i += size

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -475,6 +475,7 @@ func BenchmarkLabels_Get(b *testing.B) {
 				{"get first label", allLabels[0].Name},
 				{"get middle label", allLabels[size/2].Name},
 				{"get last label", allLabels[size-1].Name},
+				{"get not-found label", "benchmark"},
 			} {
 				b.Run(scenario.desc, func(b *testing.B) {
 					b.ResetTimer()

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -443,7 +443,8 @@ func TestLabels_Has(t *testing.T) {
 
 func TestLabels_Get(t *testing.T) {
 	require.Equal(t, "", FromStrings("aaa", "111", "bbb", "222").Get("foo"))
-	require.Equal(t, "111", FromStrings("aaa", "111", "bbb", "222").Get("aaa"))
+	require.Equal(t, "111", FromStrings("aaaa", "111", "bbb", "222").Get("aaaa"))
+	require.Equal(t, "222", FromStrings("aaaa", "111", "bbb", "222").Get("bbb"))
 }
 
 // BenchmarkLabels_Get was written to check whether a binary search can improve the performance vs the linear search implementation
@@ -463,7 +464,7 @@ func BenchmarkLabels_Get(b *testing.B) {
 	maxLabels := 30
 	allLabels := make([]Label, maxLabels)
 	for i := 0; i < maxLabels; i++ {
-		allLabels[i] = Label{Name: strings.Repeat(string('a'+byte(i)), 5)}
+		allLabels[i] = Label{Name: strings.Repeat(string('a'+byte(i)), 5+(i%5))}
 	}
 	for _, size := range []int{5, 10, maxLabels} {
 		b.Run(fmt.Sprintf("with %d labels", size), func(b *testing.B) {


### PR DESCRIPTION
Inline one call to `decodeString`, and skip decoding the value string until we find a match for the name.

Check the first character before doing full string comparison, and exit early if that character is greater than the target name, since labels are held in order.

Also, make sure the tests work with varying lengths - it's not typical for Prometheus labels to all be the same length.

Benchmarks:
```
name                                             old time/op  new time/op  delta
Labels_Get/with_5_labels/get_first_label-8       5.32ns ± 0%  5.33ns ± 1%     ~     (p=0.368 n=6+6)
Labels_Get/with_5_labels/get_middle_label-8      10.4ns ± 0%   8.4ns ± 3%  -18.42%  (p=0.002 n=6+6)
Labels_Get/with_5_labels/get_last_label-8        15.5ns ± 0%  10.9ns ± 0%  -29.51%  (p=0.002 n=6+6)
Labels_Get/with_5_labels/get_not-found_label-8   15.6ns ± 0%   5.4ns ± 0%  -65.53%  (p=0.004 n=5+6)
Labels_Get/with_10_labels/get_first_label-8      5.31ns ± 0%  5.31ns ± 0%     ~     (p=0.403 n=5+6)
Labels_Get/with_10_labels/get_middle_label-8     20.4ns ± 0%  12.7ns ± 1%  -37.58%  (p=0.004 n=5+6)
Labels_Get/with_10_labels/get_last_label-8       30.5ns ± 2%  19.9ns ± 0%  -34.53%  (p=0.002 n=6+6)
Labels_Get/with_10_labels/get_not-found_label-8  30.7ns ± 3%   5.4ns ± 0%  -82.45%  (p=0.004 n=6+5)
Labels_Get/with_30_labels/get_first_label-8      5.30ns ± 0%  5.45ns ± 2%   +2.82%  (p=0.004 n=5+6)
Labels_Get/with_30_labels/get_middle_label-8     49.5ns ± 0%  36.8ns ± 0%  -25.73%  (p=0.004 n=6+5)
Labels_Get/with_30_labels/get_last_label-8        109ns ± 0%    78ns ± 0%  -29.02%  (p=0.004 n=6+5)
Labels_Get/with_30_labels/get_not-found_label-8   105ns ± 1%     5ns ± 1%  -94.86%  (p=0.002 n=6+6)
```

[I feel it should be possible to go a lot faster, but I spent several hours trying different ideas and nothing was better than this.]
