### PR TITLE
Fix path handling in File-SD watcher to allow directory monitoring on…

### DIFF
--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -226,8 +226,8 @@ func (d *Discovery) watchFiles() {
 		panic("no watcher configured")
 	}
 	for _, p := range d.paths {
-		if idx := strings.LastIndex(p, "/"); idx > -1 {
-			p = p[:idx]
+		if dir, _ := filepath.Split(p); dir != "" {
+			p = dir
 		} else {
 			p = "./"
 		}


### PR DESCRIPTION
… Windows

Previously, `d.paths` were normalized to backslashes on Windows, even when if the config file used Unix style.  The end result meant always watching `./`, so changes for this config were always ignored:

```
    scrape_configs:
      - job_name: 'envmsc1'
        file_sd_configs:
        - files:
          - 'targets/envmsc1.d/*.yml'
          - 'targets/envmsc1.d/*.yaml'
```

Additionally, unlike the other platforms, no warning was emitted on startup about not being able to install the watch if the directory didn't exist.  Now it is logged.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
