### PR TITLE
Fix race condition in ChunkDiskMapper.Truncate()

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -948,12 +948,22 @@ func (cdm *ChunkDiskMapper) Truncate(fileNo uint32) error {
 	if len(chkFileIndices) == len(removedFiles) {
 		// All files were deleted. Reset the current sequence.
 		cdm.evtlPosMtx.Lock()
-		if err == nil {
-			cdm.evtlPos.setSeq(0)
-		} else {
-			// In case of error, set it to the last file number on the disk that was not deleted.
-			cdm.evtlPos.setSeq(uint64(pendingDeletes[len(pendingDeletes)-1]))
+
+		// We can safely reset the sequence only if the write queue is empty. If it's not empty,
+		// then there may be a job in the queue that will create a new segment file with an ID
+		// generated before the sequence reset.
+		//
+		// The queueIsEmpty() function must be called while holding the cdm.evtlPosMtx to avoid
+		// a race condition with WriteChunk().
+		if isSafe := cdm.writeQueue == nil || cdm.writeQueue.queueIsEmpty(); isSafe {
+			if err == nil {
+				cdm.evtlPos.setSeq(0)
+			} else {
+				// In case of error, set it to the last file number on the disk that was not deleted.
+				cdm.evtlPos.setSeq(uint64(pendingDeletes[len(pendingDeletes)-1]))
+			}
 		}
+
 		cdm.evtlPosMtx.Unlock()
 	}
 

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -955,7 +955,7 @@ func (cdm *ChunkDiskMapper) Truncate(fileNo uint32) error {
 		//
 		// The queueIsEmpty() function must be called while holding the cdm.evtlPosMtx to avoid
 		// a race condition with WriteChunk().
-		if isSafe := cdm.writeQueue == nil || cdm.writeQueue.queueIsEmpty(); isSafe {
+		if cdm.writeQueue == nil || cdm.writeQueue.queueIsEmpty() {
 			if err == nil {
 				cdm.evtlPos.setSeq(0)
 			} else {

--- a/tsdb/chunks/head_chunks_test.go
+++ b/tsdb/chunks/head_chunks_test.go
@@ -19,7 +19,9 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -354,6 +356,56 @@ func TestChunkDiskMapper_Truncate_PreservesFileSequence(t *testing.T) {
 	// Restarting checks for unsequential files.
 	hrw = createChunkDiskMapper(t, dir)
 	verifyFiles([]int{5, 6, 7})
+}
+
+func TestChunkDiskMapper_Truncate_WriteQueueRaceCondition(t *testing.T) {
+	hrw := createChunkDiskMapper(t, "")
+	t.Cleanup(func() {
+		require.NoError(t, hrw.Close())
+	})
+
+	// This test should only run when the queue is enabled.
+	if hrw.writeQueue == nil {
+		t.Skip("This test should only run when the queue is enabled")
+	}
+
+	// Add an artificial delay in the writeChunk function to easily trigger the race condition.
+	origWriteChunk := hrw.writeQueue.writeChunk
+	hrw.writeQueue.writeChunk = func(seriesRef HeadSeriesRef, mint, maxt int64, chk chunkenc.Chunk, ref ChunkDiskMapperRef, isOOO, cutFile bool) error {
+		time.Sleep(100 * time.Millisecond)
+		return origWriteChunk(seriesRef, mint, maxt, chk, ref, isOOO, cutFile)
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	// Write a chunk. Since the queue is enabled, the chunk will be written asynchronously (with the artificial delay).
+	ref := hrw.WriteChunk(1, 0, 10, randomChunk(t), false, func(err error) {
+		defer wg.Done()
+		require.NoError(t, err)
+	})
+
+	seq, _ := ref.Unpack()
+	require.Equal(t, 1, seq)
+
+	// Truncate, simulating that all chunks from segment files before 1 can be dropped.
+	require.NoError(t, hrw.Truncate(1))
+
+	// Request to cut a new file when writing the next chunk. If there's a race condition, cutting a new file will
+	// allow us to detect there's actually an issue with the sequence number (because it's checked when a new segment
+	// file is created).
+	hrw.CutNewFile()
+
+	// Write another chunk. This will cut a new file.
+	ref = hrw.WriteChunk(1, 0, 10, randomChunk(t), false, func(err error) {
+		defer wg.Done()
+		require.NoError(t, err)
+	})
+
+	seq, _ = ref.Unpack()
+	require.Equal(t, 2, seq)
+
+	wg.Wait()
 }
 
 // TestHeadReadWriter_TruncateAfterIterateChunksError tests for


### PR DESCRIPTION
In Mimir I'm adding the experimental support to prematurely compact the TSDB head in case we detect an high churning rate ([PR](https://github.com/grafana/mimir/pull/5371)). While working on unit tests, I've experienced the following panic:

```
panic: expected newly cut file to have sequence:offset 1:8, got 2:8

goroutine 1295 [running]:
github.com/prometheus/prometheus/tsdb.handleChunkWriteError({0x2e20ea0?, 0xc000e698f0?})
	/Users/marco/workspace/src/github.com/grafana/mimir/vendor/github.com/prometheus/prometheus/tsdb/head_append.go:1518 +0x76
github.com/prometheus/prometheus/tsdb/chunks.(*chunkWriteQueue).processJob(0xc000b706e0, {0x1, 0x7, 0x18906b0f1ec, 0x18906b0f263, {0x2e3ca68, 0xc002ed4f00}, 0x100000008, 0x0, 0x2a4e6f0})
	/Users/marco/workspace/src/github.com/grafana/mimir/vendor/github.com/prometheus/prometheus/tsdb/chunks/chunk_write_queue.go:150 +0x8c
github.com/prometheus/prometheus/tsdb/chunks.(*chunkWriteQueue).start.func1()
	/Users/marco/workspace/src/github.com/grafana/mimir/vendor/github.com/prometheus/prometheus/tsdb/chunks/chunk_write_queue.go:138 +0xc9
created by github.com/prometheus/prometheus/tsdb/chunks.(*chunkWriteQueue).start
	/Users/marco/workspace/src/github.com/grafana/mimir/vendor/github.com/prometheus/prometheus/tsdb/chunks/chunk_write_queue.go:119 +0x6d
```

After some investigation, I found it was caused by a race condition in `ChunkDiskMapper.Truncate()`. When the `Truncate()` deletes all segment files, it also resets the sequence number to 0. However, when the writer queue is in use, some chunks may have been already added to the queue but not written yet. In this case, the `Truncate()` resets the sequence to 0, but jobs in the queue already have been assigned a sequence, eventually leading to the experienced panic.

The fix is fairly easy: reset the sequence only if the queue is empty.