### PR TITLE
Fix infinite loop in index Writer when a series contains duplicated label names

### DIFF
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -864,7 +864,10 @@ func (w *Writer) writePostingsToTmpFiles() error {
 		// using more memory than a single label name can.
 		for len(names) > 0 {
 			if w.labelNames[names[0]]+c > maxPostings {
-				break
+				if c > 0 {
+					break
+				}
+				return fmt.Errorf("corruption detected when writing postings to index: label %q has %d uses, but maxPostings is %d", names[0], w.labelNames[names[0]], maxPostings)
 			}
 			batchNames = append(batchNames, names[0])
 			c += w.labelNames[names[0]]

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -471,6 +471,21 @@ func TestPersistence_index_e2e(t *testing.T) {
 	require.NoError(t, ir.Close())
 }
 
+func TestWriter_ShouldReturnErrorOnSeriesWithDuplicatedLabelNames(t *testing.T) {
+	w, err := NewWriter(context.Background(), filepath.Join(t.TempDir(), "index"))
+	require.NoError(t, err)
+
+	require.NoError(t, w.AddSymbol("__name__"))
+	require.NoError(t, w.AddSymbol("metric_1"))
+	require.NoError(t, w.AddSymbol("metric_2"))
+
+	require.NoError(t, w.AddSeries(0, labels.FromStrings("__name__", "metric_1", "__name__", "metric_2")))
+
+	err = w.Close()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "corruption detected when writing postings to index")
+}
+
 func TestDecbufUvarintWithInvalidBuffer(t *testing.T) {
 	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
 


### PR DESCRIPTION
Due to a Mimir bug, we had a case where we appended to TSDB a series with duplicated label names (in particular, it was the `__name__` label). Later, when the TSDB Head has been compacted, the index `Writer` started an infinite loop when writing postings, because it doesn't handle the case a label name has more values than the actual postings (since it shouldn't happen).

In this PR I fix the infinite loop returning error from the `Writer`, so that it's more clear and loud what's going on.