### PR TITLE
PoC/draft: make build reproducible

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -23,7 +23,7 @@ build:
         -X github.com/prometheus/common/version.Version={{.Version}}
         -X github.com/prometheus/common/version.Revision={{.Revision}}
         -X github.com/prometheus/common/version.Branch={{.Branch}}
-        -X github.com/prometheus/common/version.BuildUser={{user}}@{{host}}
+        -X github.com/prometheus/common/version.BuildUser=reproducible@reproducible
         -X github.com/prometheus/common/version.BuildDate={{date "20060102-15:04:05"}}
 tarball:
     # Whenever there are new files to include in the tarball,


### PR DESCRIPTION
While working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds), I found that our [`golang-github-prometheus-prometheus`](https://code.opensuse.org/package/golang-github-prometheus-prometheus/blob/master/f/golang-github-prometheus-prometheus.spec#_87) package varied between builds because our Open Build Service randomly selects worker nodes from its pool and prometheus embeds the buildhost name in its binaries.

I'd like to avoid to carry this patch downstream,
but don't know enough about the build system to override BuildUser from the outside.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
