### PR TITLE
Add `.idea` directory to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ npm_licenses.tar.bz2
 
 # Ignore parser debug
 y.output
+
+# Ignore IntelliJ / GoLand directory
+.idea/


### PR DESCRIPTION
IntelliJ (and all other JetBrains IDEs like GoLand) create a `.idea` directory in the root of the project that is not intended to be shared with other people.

This PR adds this directory to `.gitignore`.