### PR TITLE
Replace sort.Sort with faster slices.SortFunc

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -450,7 +450,7 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm *chunks.ChunkDiskMapper
 
 	// Next we want to sort all the collected chunks by min time so we can find
 	// those that overlap and stop when we know the rest don't.
-	sort.Sort(byMinTimeAndMinRef(tmpChks))
+	slices.SortFunc(tmpChks, refLessByMinTimeAndMinRef)
 
 	mc := &mergedOOOChunks{}
 	absoluteMax := int64(math.MinInt64)

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -924,7 +924,7 @@ func (w *Writer) writePostingsToTmpFiles() error {
 				values = append(values, v)
 			}
 			// Symbol numbers are in order, so the strings will also be in order.
-			sort.Sort(uint32slice(values))
+			slices.Sort(values)
 			for _, v := range values {
 				value, err := w.symbols.Lookup(v)
 				if err != nil {
@@ -1016,12 +1016,6 @@ func (w *Writer) writePostings() error {
 	w.fP = nil
 	return nil
 }
-
-type uint32slice []uint32
-
-func (s uint32slice) Len() int           { return len(s) }
-func (s uint32slice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s uint32slice) Less(i, j int) bool { return s[i] < s[j] }
 
 type labelIndexHashEntry struct {
 	keys   []string

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -17,7 +17,8 @@ package tsdb
 import (
 	"errors"
 	"math"
-	"sort"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -130,7 +131,7 @@ func (oh *OOOHeadIndexReader) series(ref storage.SeriesRef, builder *labels.Scra
 
 	// Next we want to sort all the collected chunks by min time so we can find
 	// those that overlap.
-	sort.Sort(metaByMinTimeAndMinRef(tmpChks))
+	slices.SortFunc(tmpChks, lessByMinTimeAndMinRef)
 
 	// Next we want to iterate the sorted collected chunks and only return the
 	// chunks Meta the first chunk that overlaps with others.
@@ -175,29 +176,19 @@ type chunkMetaAndChunkDiskMapperRef struct {
 	origMaxT int64
 }
 
-type byMinTimeAndMinRef []chunkMetaAndChunkDiskMapperRef
-
-func (b byMinTimeAndMinRef) Len() int { return len(b) }
-func (b byMinTimeAndMinRef) Less(i, j int) bool {
-	if b[i].meta.MinTime == b[j].meta.MinTime {
-		return b[i].meta.Ref < b[j].meta.Ref
+func refLessByMinTimeAndMinRef(a, b chunkMetaAndChunkDiskMapperRef) bool {
+	if a.meta.MinTime == b.meta.MinTime {
+		return a.meta.Ref < b.meta.Ref
 	}
-	return b[i].meta.MinTime < b[j].meta.MinTime
+	return a.meta.MinTime < b.meta.MinTime
 }
 
-func (b byMinTimeAndMinRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
-
-type metaByMinTimeAndMinRef []chunks.Meta
-
-func (b metaByMinTimeAndMinRef) Len() int { return len(b) }
-func (b metaByMinTimeAndMinRef) Less(i, j int) bool {
-	if b[i].MinTime == b[j].MinTime {
-		return b[i].Ref < b[j].Ref
+func lessByMinTimeAndMinRef(a, b chunks.Meta) bool {
+	if a.MinTime == b.MinTime {
+		return a.Ref < b.Ref
 	}
-	return b[i].MinTime < b[j].MinTime
+	return a.MinTime < b.MinTime
 }
-
-func (b metaByMinTimeAndMinRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
 
 func (oh *OOOHeadIndexReader) Postings(name string, values ...string) (index.Postings, error) {
 	switch len(values) {

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -337,7 +338,7 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 						}
 						expChunks = append(expChunks, meta)
 					}
-					sort.Sort(metaByMinTimeAndMinRef(expChunks)) // we always want the chunks to come back sorted by minTime asc
+					slices.SortFunc(expChunks, lessByMinTimeAndMinRef) // We always want the chunks to come back sorted by minTime asc.
 
 					if headChunk && len(intervals) > 0 {
 						// Put the last interval in the head chunk
@@ -1116,7 +1117,7 @@ func TestSortByMinTimeAndMinRef(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("name=%s", tc.name), func(t *testing.T) {
-			sort.Sort(byMinTimeAndMinRef(tc.input))
+			slices.SortFunc(tc.input, refLessByMinTimeAndMinRef)
 			require.Equal(t, tc.exp, tc.input)
 		})
 	}
@@ -1180,7 +1181,7 @@ func TestSortMetaByMinTimeAndMinRef(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("name=%s", tc.name), func(t *testing.T) {
-			sort.Sort(metaByMinTimeAndMinRef(tc.inputMetas))
+			slices.SortFunc(tc.inputMetas, lessByMinTimeAndMinRef)
 			require.Equal(t, tc.expMetas, tc.inputMetas)
 		})
 	}


### PR DESCRIPTION
Continuing the work from #11318 - the generic version is more efficient.

Here we can drop a few types such as `metaByMinTimeAndMinRef` that exist only to hold a `Less` method.
