### PR TITLE
improve incorrect doc comment

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -977,7 +977,7 @@ func (h *Head) DisableNativeHistograms() {
 	h.opts.EnableNativeHistograms.Store(false)
 }
 
-// PostingsCardinalityStats returns top 10 highest cardinality stats By label and value names.
+// PostingsCardinalityStats returns highest cardinality stats by label and value names.
 func (h *Head) PostingsCardinalityStats(statsByLabelName string, limit int) *index.PostingsStats {
 	h.cardinalityMutex.Lock()
 	defer h.cardinalityMutex.Unlock()


### PR DESCRIPTION
`PostingsCardinalityStats` used to return top 10 highest stats but now accepts a `limit` argument that allows the caller to determine the number of stats returned.