### PR TITLE
fix the problem of multiplying two values of type time.Duration

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -412,12 +412,13 @@ func (g *Group) run(ctx context.Context) {
 		case <-g.done:
 			return
 		case <-tick.C:
-			missed := (time.Since(evalTimestamp) / g.interval) - 1
+			missed := int(time.Since(evalTimestamp)/g.interval) - 1
 			if missed > 0 {
-				g.metrics.IterationsMissed.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))
-				g.metrics.IterationsScheduled.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))
+				missedDuration := time.Duration(missed) * g.interval
+				g.metrics.IterationsMissed.WithLabelValues(GroupKey(g.file, g.name)).Add(missedDuration.Seconds())
+				g.metrics.IterationsScheduled.WithLabelValues(GroupKey(g.file, g.name)).Add(missedDuration.Seconds())
 			}
-			evalTimestamp = evalTimestamp.Add((missed + 1) * g.interval)
+			evalTimestamp = evalTimestamp.Add(time.Duration(missed+1) * g.interval)
 			g.evalIterationFunc(ctx, g, evalTimestamp)
 		}
 
@@ -434,12 +435,13 @@ func (g *Group) run(ctx context.Context) {
 			case <-g.done:
 				return
 			case <-tick.C:
-				missed := (time.Since(evalTimestamp) / g.interval) - 1
+				missed := int(time.Since(evalTimestamp)/g.interval) - 1
 				if missed > 0 {
-					g.metrics.IterationsMissed.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))
-					g.metrics.IterationsScheduled.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))
+					missedDuration := time.Duration(missed) * g.interval
+					g.metrics.IterationsMissed.WithLabelValues(GroupKey(g.file, g.name)).Add(missedDuration.Seconds())
+					g.metrics.IterationsScheduled.WithLabelValues(GroupKey(g.file, g.name)).Add(missedDuration.Seconds())
 				}
-				evalTimestamp = evalTimestamp.Add((missed + 1) * g.interval)
+				evalTimestamp = evalTimestamp.Add(time.Duration(missed+1) * g.interval)
 
 				g.evalIterationFunc(ctx, g, evalTimestamp)
 			}


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

The time.Duration type represents the duration of time, which uses nanoseconds as the unit. Therefore, multiplying two time.Duration values will result in an increase in the duration of time, which may not have been intended by the code author
