### PR TITLE
PostingsForMatchers race with creating new series

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -251,16 +251,16 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 		}
 		return (m.Type == labels.MatchNotEqual || m.Type == labels.MatchNotRegexp) && m.Matches("")
 	}
-	someSubtractingMatchers, someIntersectingMatchers := false, false
+	hasSubtractingMatchers, hasIntersectingMatchers := false, false
 	for _, m := range ms {
 		if isSubtractingMatcher(m) {
-			someSubtractingMatchers = true
+			hasSubtractingMatchers = true
 		} else {
-			someIntersectingMatchers = true
+			hasIntersectingMatchers = true
 		}
 	}
 
-	if someSubtractingMatchers && !someIntersectingMatchers {
+	if hasSubtractingMatchers && !hasIntersectingMatchers {
 		// If there's nothing to subtract from, add in everything and remove the notIts later.
 		// We prefer to get AllPostings so that the base of subtraction (i.e. allPostings)
 		// doesn't include series that may be added to the index reader during this function call.

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"golang.org/x/exp/slices"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -244,6 +245,41 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 			labelMustBeSet[m.Name] = true
 		}
 	}
+	isSubtractingMatcher := func(m *labels.Matcher) bool {
+		if !labelMustBeSet[m.Name] {
+			return true
+		}
+		return (m.Type == labels.MatchNotEqual || m.Type == labels.MatchNotRegexp) && m.Matches("")
+	}
+	someSubtractingMatchers, someIntersectingMatchers := false, false
+	for _, m := range ms {
+		if isSubtractingMatcher(m) {
+			someSubtractingMatchers = true
+		} else {
+			someIntersectingMatchers = true
+		}
+	}
+
+	if someSubtractingMatchers && !someIntersectingMatchers {
+		// If there's nothing to subtract from, add in everything and remove the notIts later.
+		// We prefer to get AllPostings so that the base of subtraction (i.e. allPostings)
+		// doesn't include series that may be added to the index reader during this function call.
+		k, v := index.AllPostingsKey()
+		allPostings, err := ix.Postings(k, v)
+		if err != nil {
+			return nil, err
+		}
+		its = append(its, allPostings)
+	}
+
+	// Sort matchers to have the intersecting matchers first.
+	// This way the base for subtraction is smaller and
+	// there is no chance that the set we subtract from
+	// contains postings of series that didn't exist when
+	// we constructed the set we subtract by.
+	slices.SortStableFunc(ms, func(i, j *labels.Matcher) bool {
+		return !isSubtractingMatcher(i) && isSubtractingMatcher(j)
+	})
 
 	for _, m := range ms {
 		switch {
@@ -310,16 +346,6 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 			}
 			notIts = append(notIts, it)
 		}
-	}
-
-	// If there's nothing to subtract from, add in everything and remove the notIts later.
-	if len(its) == 0 && len(notIts) != 0 {
-		k, v := index.AllPostingsKey()
-		allPostings, err := ix.Postings(k, v)
-		if err != nil {
-			return nil, err
-		}
-		its = append(its, allPostings)
 	}
 
 	it := index.Intersect(its...)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2210,9 +2210,9 @@ func TestQuerierIndexQueriesRace(t *testing.T) {
 		},
 		{
 			matchers: []*labels.Matcher{
-				// The first matcher should be effectively the same as AllPostings, because all series have m=0
-				// If it is evaluated first, then __name__=metric will contain more series than m=0.
-				labels.MustNewMatcher(labels.MatchNotEqual, "m", "0"),
+				// The first matcher should be effectively the same as AllPostings, because all series have always_0=0
+				// If it is evaluated first, then __name__=metric will contain more series than always_0=0.
+				labels.MustNewMatcher(labels.MatchNotEqual, "always_0", "0"),
 				labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "metric"),
 			},
 		},
@@ -2237,9 +2237,9 @@ func TestQuerierIndexQueriesRace(t *testing.T) {
 				q, err := db.Querier(ctx, math.MinInt64, math.MaxInt64)
 				require.NoError(t, err)
 
-				values, _, err := q.LabelValues("n", c.matchers...)
+				values, _, err := q.LabelValues("seq", c.matchers...)
 				require.NoError(t, err)
-				require.Emptyf(t, values, `label values for label "n" should be empty`)
+				require.Emptyf(t, values, `label values for label "seq" should be empty`)
 			}
 		})
 	}
@@ -2250,7 +2250,7 @@ func appendSeries(t *testing.T, ctx context.Context, wg *sync.WaitGroup, h *Head
 
 	for i := 0; ctx.Err() != nil; i++ {
 		app := h.Appender(context.Background())
-		_, err := app.Append(0, labels.FromStrings(labels.MetricName, "metric", "n", strconv.Itoa(i), "m", "0"), 0, 0)
+		_, err := app.Append(0, labels.FromStrings(labels.MetricName, "metric", "seq", strconv.Itoa(i), "always_0", "0"), 0, 0)
 		require.NoError(t, err)
 		err = app.Commit()
 		require.NoError(t, err)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2248,10 +2248,7 @@ func TestQuerierIndexQueriesRace(t *testing.T) {
 func appendSeries(t *testing.T, ctx context.Context, wg *sync.WaitGroup, h *Head) {
 	defer wg.Done()
 
-	for i := 0; ; i++ {
-		if ctx.Err() != nil {
-			return
-		}
+	for i := 0; ctx.Err() != nil; i++ {
 		app := h.Appender(context.Background())
 		_, err := app.Append(0, labels.FromStrings(labels.MetricName, "metric", "n", strconv.Itoa(i), "m", "0"), 0, 0)
 		require.NoError(t, err)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -2191,6 +2192,76 @@ func TestPostingsForMatchers(t *testing.T) {
 				t.Errorf("Evaluating %v, missing results %+v", c.matchers, exp)
 			}
 		})
+	}
+}
+
+// TestQuerierIndexQueriesRace tests the index queries with racing appends.
+func TestQuerierIndexQueriesRace(t *testing.T) {
+	const testRepeats = 1000
+
+	testCases := []struct {
+		matchers []*labels.Matcher
+	}{
+		{
+			matchers: []*labels.Matcher{
+				// This matcher should involve the AllPostings posting list in calculating the posting lists.
+				labels.MustNewMatcher(labels.MatchNotEqual, labels.MetricName, "metric"),
+			},
+		},
+		{
+			matchers: []*labels.Matcher{
+				// The first matcher should be effectively the same as AllPostings, because all series have m=0
+				// If it is evaluated first, then __name__=metric will contain more series than m=0.
+				labels.MustNewMatcher(labels.MatchNotEqual, "m", "0"),
+				labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "metric"),
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		c := c
+		t.Run(fmt.Sprintf("%v", c.matchers), func(t *testing.T) {
+			db := openTestDB(t, DefaultOptions(), nil)
+			h := db.Head()
+			t.Cleanup(func() {
+				require.NoError(t, db.Close())
+			})
+			ctx, cancel := context.WithCancel(context.Background())
+			wg := &sync.WaitGroup{}
+			wg.Add(1)
+			go appendSeries(t, ctx, wg, h)
+			t.Cleanup(wg.Wait)
+			t.Cleanup(cancel)
+
+			for i := 0; i < testRepeats; i++ {
+				q, err := db.Querier(ctx, math.MinInt64, math.MaxInt64)
+				require.NoError(t, err)
+
+				values, _, err := q.LabelValues("n", c.matchers...)
+				require.NoError(t, err)
+				require.Emptyf(t, values, `label values for label "n" should be empty`)
+			}
+		})
+	}
+}
+
+func appendSeries(t *testing.T, ctx context.Context, wg *sync.WaitGroup, h *Head) {
+	defer wg.Done()
+
+	for i := 0; ; i++ {
+		if ctx.Err() != nil {
+			return
+		}
+		app := h.Appender(context.Background())
+		_, err := app.Append(0, labels.FromStrings(labels.MetricName, "metric", "n", strconv.Itoa(i), "m", "0"), 0, 0)
+		require.NoError(t, err)
+		err = app.Commit()
+		require.NoError(t, err)
+
+		if i%10 == 0 {
+			// Throttle down the appends to keep the test somewhat nimble.
+			time.Sleep(10 * time.Millisecond)
+		}
 	}
 }
 

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2255,10 +2255,8 @@ func appendSeries(t *testing.T, ctx context.Context, wg *sync.WaitGroup, h *Head
 		err = app.Commit()
 		require.NoError(t, err)
 
-		if i%10 == 0 {
-			// Throttle down the appends to keep the test somewhat nimble.
-			time.Sleep(10 * time.Millisecond)
-		}
+		// Throttle down the appends to keep the test somewhat nimble.
+		time.Sleep(time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
### Bug

This bug can manifest when a new series is appended to the head block while PostingsForMatchers is computing its result. Then the result from PostingsForMatchers can contains series references that __do not match__ the matchers.

In particular, the posting lists which are used for subtraction (e.g. for `m != "0"`) can be computed before the other postings lists (e.g. `__name__ = "metric"`). 

This affects index queries (`/series`, LabelValues, LabelNames) even when there is transaction isolation enabled in the TSDB head. The reason is that isolation is only used for chunks filtering, but index queries do not use chunk iterators. This also affects running the TSDB with disabled transactions isolation.

### Example 1

The matchers are 
```
{datacenter!="dc1", datacenter=~"dc.*"}
```

PostingsForMatchers computes its result like so
* find the series IDs for `datacenter!=dc1`; call this $D1$
* find the series IDs for `datacenter=~dc.*`; call this $D2$
* return $P = D2 - D1$

If there is an append with a new timeseries between computing $D1$ and $D2$, then $P$ can contain more series than is correct.

* find the series IDs for `datacenter!=dc1`; call this $D1$
* __in another request__ append a new timeseries to the TSDB head `{datacenter="dc1"}`
* find the series IDs for `datacenter=~dc.*`; call this $D2$
* return $P = D2 - D1$

There is no synchronisation between the calculation of the different series sets, so now $D2$ contains the new timeseries, but $D1$ doesn't.

### Example 2

With matchers 

```
{datacenter!="dc1"}
```

The process is very similar to the one above, but the value of $D2$ is the list of all postings.



### Tests

I added two test cases that exemplify the bug. They are different but are executed similarly by PostingsForMatchers:


* `__name__ = "metric", m != "0"` - instead of using all postings, this case uses the `m=0` posting list as in example 1
* `__name__ != "metric"` - involves getting the list of all postings as in example 2

Reviewers can checkout the test commit to see them fail without the fix.


### Fix

Always compute the series IDs for intersecting matchers first and for subtracting matchers second. This means that intersected sets of series will not contain new series. Instead subtracted sets will contain new series. When the subtracted sets contain new series, then the result is still valid (only slightly outdated).

