### PR TITLE
Linode SD: cast InstanceSpec values to int64 to avoid overflows

### DIFF
--- a/discovery/linode/linode.go
+++ b/discovery/linode/linode.go
@@ -304,10 +304,10 @@ func (d *Discovery) refreshData(ctx context.Context) ([]*targetgroup.Group, erro
 			linodeLabelGroup:              model.LabelValue(instance.Group),
 			linodeLabelHypervisor:         model.LabelValue(instance.Hypervisor),
 			linodeLabelBackups:            model.LabelValue(backupsStatus),
-			linodeLabelSpecsDiskBytes:     model.LabelValue(fmt.Sprintf("%d", instance.Specs.Disk<<20)),
-			linodeLabelSpecsMemoryBytes:   model.LabelValue(fmt.Sprintf("%d", instance.Specs.Memory<<20)),
+			linodeLabelSpecsDiskBytes:     model.LabelValue(fmt.Sprintf("%d", int64(instance.Specs.Disk)<<20)),
+			linodeLabelSpecsMemoryBytes:   model.LabelValue(fmt.Sprintf("%d", int64(instance.Specs.Memory)<<20)),
 			linodeLabelSpecsVCPUs:         model.LabelValue(fmt.Sprintf("%d", instance.Specs.VCPUs)),
-			linodeLabelSpecsTransferBytes: model.LabelValue(fmt.Sprintf("%d", instance.Specs.Transfer<<20)),
+			linodeLabelSpecsTransferBytes: model.LabelValue(fmt.Sprintf("%d", int64(instance.Specs.Transfer)<<20)),
 		}
 
 		addr := net.JoinHostPort(publicIPv4, strconv.FormatUint(uint64(d.port), 10))


### PR DESCRIPTION
InstanceSpec struct members are untyped integers, so they can overflow on 32-bit arch when bit-shifted left.

Fixes failing `TestLinodeSDRefresh` test on 32-bit arch.

Please consider adding testing with `GOARCH=386` (or any 32-bit arch) to CI, to catch these oversights in future. They **regularly** cause build failures on Debian, which still supports several 32-bit archs.
