### PR TITLE
docs: use actual flag for signing off commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
     Don't forget!
 
-    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.
+    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.
 
     - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
 


### PR DESCRIPTION
Flag is documented as --signoff: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff

Noticed this when I tried to sign my commit for #12569.