### PR TITLE
Add counters to measure append attempts during scrapes

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -197,6 +197,18 @@ var (
 			Help: "Total number of scrapes that hit the native histogram bucket limit and were rejected.",
 		},
 	)
+	targetScrapeAppendAttemptsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "prometheus_target_scrape_append_attempts_total",
+			Help: "Total number of append attempts",
+		},
+	)
+	targetScrapeAppendErrorsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "prometheus_target_scrape_append_errors_total",
+			Help: "Total number of errors during append attempts",
+		},
+	)
 )
 
 func init() {
@@ -223,6 +235,8 @@ func init() {
 		targetScrapePoolExceededLabelLimits,
 		targetSyncFailed,
 		targetScrapeNativeHistogramBucketLimit,
+		targetScrapeAppendAttemptsTotal,
+		targetScrapeAppendErrorsTotal,
 	)
 }
 
@@ -1380,6 +1394,7 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 
 	// A failed scrape is the same as an empty scrape,
 	// we still call sl.append to trigger stale markers.
+	targetScrapeAppendAttemptsTotal.Inc()
 	total, added, seriesAdded, appErr = sl.append(app, b, contentType, appendTime)
 	if appErr != nil {
 		app.Rollback()
@@ -1388,6 +1403,7 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 		// The append failed, probably due to a parse error or sample limit.
 		// Call sl.append again with an empty scrape to trigger stale markers.
 		if _, _, _, err := sl.append(app, []byte{}, "", appendTime); err != nil {
+			targetScrapeAppendErrorsTotal.Inc()
 			app.Rollback()
 			app = sl.appender(sl.appenderCtx)
 			level.Warn(sl.l).Log("msg", "Append failed", "err", err)


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Adds 2 new counters, aiming to monitor append success ratio during scrapes.

Fix #12585 