### PR TITLE
tsdb/agent: ensure that new series get written to WAL on rollback

### DIFF
--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -1098,13 +1098,13 @@ func (a *appender) logSeries() error {
 	a.mtx.RLock()
 	defer a.mtx.RUnlock()
 
-	var encoder record.Encoder
-	buf := a.bufPool.Get().([]byte)
-	defer func() {
-		a.bufPool.Put(buf) //nolint:staticcheck
-	}()
-
 	if len(a.pendingSeries) > 0 {
+		buf := a.bufPool.Get().([]byte)
+		defer func() {
+			a.bufPool.Put(buf) //nolint:staticcheck
+		}()
+
+		var encoder record.Encoder
 		buf = encoder.Series(a.pendingSeries, buf)
 		if err := a.wal.Log(buf); err != nil {
 			return err

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -989,19 +989,12 @@ func (a *appender) Commit() error {
 		return err
 	}
 
-	a.pendingSeries = a.pendingSeries[:0]
-	a.pendingSamples = a.pendingSamples[:0]
-	a.pendingHistograms = a.pendingHistograms[:0]
-	a.pendingFloatHistograms = a.pendingFloatHistograms[:0]
-	a.pendingExamplars = a.pendingExamplars[:0]
-	a.sampleSeries = a.sampleSeries[:0]
-	a.histogramSeries = a.histogramSeries[:0]
-	a.floatHistogramSeries = a.floatHistogramSeries[:0]
-
+	a.clearData()
 	a.appenderPool.Put(a)
 	return nil
 }
 
+// log logs all pending data to the WAL.
 func (a *appender) log() error {
 	a.mtx.RLock()
 	defer a.mtx.RUnlock()
@@ -1075,14 +1068,9 @@ func (a *appender) log() error {
 	return nil
 }
 
-func (a *appender) Rollback() error {
-	defer func() {
-		// Clear remaining data after log is called at the bottom.
-		a.pendingSeries = a.pendingSeries[:0]
-
-		a.appenderPool.Put(a)
-	}()
-
+// clearData clears all pending data.
+func (a *appender) clearData() {
+	a.pendingSeries = a.pendingSeries[:0]
 	a.pendingSamples = a.pendingSamples[:0]
 	a.pendingHistograms = a.pendingHistograms[:0]
 	a.pendingFloatHistograms = a.pendingFloatHistograms[:0]
@@ -1090,9 +1078,39 @@ func (a *appender) Rollback() error {
 	a.sampleSeries = a.sampleSeries[:0]
 	a.histogramSeries = a.histogramSeries[:0]
 	a.floatHistogramSeries = a.floatHistogramSeries[:0]
+}
 
+func (a *appender) Rollback() error {
 	// Series are created in-memory regardless of rollback. This means we must
 	// log them to the WAL, otherwise subsequent commits may reference a series
 	// which was never written to the WAL.
-	return a.log()
+	if err := a.logSeries(); err != nil {
+		return err
+	}
+
+	a.clearData()
+	a.appenderPool.Put(a)
+	return nil
+}
+
+// logSeries logs only pending series records to the WAL.
+func (a *appender) logSeries() error {
+	a.mtx.RLock()
+	defer a.mtx.RUnlock()
+
+	var encoder record.Encoder
+	buf := a.bufPool.Get().([]byte)
+	defer func() {
+		a.bufPool.Put(buf) //nolint:staticcheck
+	}()
+
+	if len(a.pendingSeries) > 0 {
+		buf = encoder.Series(a.pendingSeries, buf)
+		if err := a.wal.Log(buf); err != nil {
+			return err
+		}
+		buf = buf[:0]
+	}
+
+	return nil
 }

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -334,7 +334,7 @@ func TestRollback(t *testing.T) {
 	}
 
 	// Check that only series get stored after calling Rollback.
-	require.Equal(t, numSeries*3, walSeriesCount, "series should not have been written to WAL")
+	require.Equal(t, numSeries*3, walSeriesCount, "series should have been written to WAL")
 	require.Equal(t, 0, walSamplesCount, "samples should not have been written to WAL")
 	require.Equal(t, 0, walExemplarsCount, "exemplars should not have been written to WAL")
 	require.Equal(t, 0, walHistogramCount, "histograms should not have been written to WAL")

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -333,8 +333,8 @@ func TestRollback(t *testing.T) {
 		}
 	}
 
-	// Check that the rollback ensured nothing got stored.
-	require.Equal(t, 0, walSeriesCount, "series should not have been written to WAL")
+	// Check that only series get stored after calling Rollback.
+	require.Equal(t, numSeries*3, walSeriesCount, "series should not have been written to WAL")
 	require.Equal(t, 0, walSamplesCount, "samples should not have been written to WAL")
 	require.Equal(t, 0, walExemplarsCount, "exemplars should not have been written to WAL")
 	require.Equal(t, 0, walHistogramCount, "histograms should not have been written to WAL")


### PR DESCRIPTION
If a new series is introduced in a storage.Appender instance, that series should be written to the WAL once the storage.Appender is closed, even on Rollback.

Previously, new series would only be written to the WAL when calling Commit. However, because the series is stored in memory regardless, subsequent calls to Commit may write samples to the WAL which reference a series ID which that was never written.

Related to #11589. It's likely that this fix also resolves this issue, but we need more testing from users to see if the problem persists after this fix; there may be more cases where samples get written to the WAL in Prometheus Agent mode without the corresponding series record.