### PR TITLE
Drop metric name for "atan2" binary operator

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2874,7 +2874,7 @@ func btos(b bool) float64 {
 // result of the op operation.
 func shouldDropMetricName(op parser.ItemType) bool {
 	switch op {
-	case parser.ADD, parser.SUB, parser.DIV, parser.MUL, parser.POW, parser.MOD:
+	case parser.ADD, parser.SUB, parser.DIV, parser.MUL, parser.POW, parser.MOD, parser.ATAN2:
 		return true
 	default:
 		return false

--- a/promql/testdata/operators.test
+++ b/promql/testdata/operators.test
@@ -477,10 +477,10 @@ load 5m
     trigNaN{} NaN
 
 eval instant at 5m trigy atan2 trigx
-    trigy{} 0.4636476090008061
+    {} 0.4636476090008061
 
 eval instant at 5m trigy atan2 trigNaN
-    trigy{} NaN
+    {} NaN
 
 eval instant at 5m 10 atan2 20
     0.4636476090008061


### PR DESCRIPTION
The operator changes the meaning of the metric, so the metric name should be dropped. Technically this would be a breaking change, but it's also very obviously a bug and not likely that anyone depends on it.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
