### PR TITLE
enhance FloatHistogram CopyToSchema method

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -971,7 +971,7 @@ func targetIdx(idx, originSchema, targetSchema int32) int32 {
 	return ((idx - 1) >> (originSchema - targetSchema)) + 1
 }
 
-// mergeToSchema is used to merge a FloatHistogram's Spans and Buckets (no matter if 
+// mergeToSchema is used to merge a FloatHistogram's Spans and Buckets (no matter if
 // positive or negative) from the original schema to the target schema.
 // The target schema must be smaller than the original schema.
 func mergeToSchema(originSpans []Span, originBuckets []float64, originSchema, targetSchema int32) ([]Span, []float64) {

--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -979,7 +979,7 @@ func mergeToSchema(originSpans []Span, originBuckets []float64, originSchema, ta
 		targetSpans         []Span    // The spans in the target schema.
 		targetBuckets       []float64 // The buckets in the target schema.
 		bucketIdx           int32     // The index of bucket in the origin schema.
-		lastTargetBucketIdx int32     // The index of bucket which is the last bucket for current targetSpans and targetBuckets.
+		lastTargetBucketIdx int32     // The index of the last added target bucket.
 		origBucketIdx       int       // The position of a bucket in originBuckets slice.
 	)
 

--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -971,8 +971,9 @@ func targetIdx(idx, originSchema, targetSchema int32) int32 {
 	return ((idx - 1) >> (originSchema - targetSchema)) + 1
 }
 
-// mergeToSchema is used to merge a FloatHistogram's Spans and Buckets (no matter positive or negative) from original schema to target schema
-// the target schema must smaller than original schema
+// mergeToSchema is used to merge a FloatHistogram's Spans and Buckets (no matter if 
+// positive or negative) from the original schema to the target schema.
+// The target schema must be smaller than the original schema.
 func mergeToSchema(originSpans []Span, originBuckets []float64, originSchema, targetSchema int32) ([]Span, []float64) {
 	var (
 		targetSpans         []Span    // The spans in the target schema.


### PR DESCRIPTION
Fix #11270

The basic idea behind the current implementation of the CopyToSchema method is

- first convert the `FloatHistogram.PositiveSpans/NegativeSpans` into targetSchema  by `floatBucketIterator`
- then got each bucket in targetSchema by `Next()`
- then add back to the target `FloatHistogram` object

Basically we can summarize the process is OriginalSpan[] -> TargetBucket[] -> TargetSpan[]

So I think we could enhance this process into OriginalSpan[] -> TargetSpan, by directly processing the Spans

So I wrote a simple implementation in this idea, with Function name `CopyToSchemaNew` and wrote a benchmark test for `CopyToSchema` and `CopyToSchemaNew`

The test result shows that the enhanced one is 50% faster than orignal one on my laptop

```
BenchmarkCopyToSchema-8      	 1176043	      1023 ns/op
BenchmarkCopyToSchemaNew-8   	 2502216	       498.0 ns/op
```



