### PR TITLE
Faster streaming of Labels to JSON

### DIFF
--- a/web/api/v1/json_codec.go
+++ b/web/api/v1/json_codec.go
@@ -70,12 +70,7 @@ func marshalSeriesJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	s := *((*promql.Series)(ptr))
 	stream.WriteObjectStart()
 	stream.WriteObjectField(`metric`)
-	m, err := s.Metric.MarshalJSON()
-	if err != nil {
-		stream.Error = err
-		return
-	}
-	stream.SetBuffer(append(stream.Buffer(), m...))
+	marshalLabelsJSON(s.Metric, stream)
 
 	for i, p := range s.Floats {
 		stream.WriteMore()
@@ -131,12 +126,7 @@ func marshalSampleJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	s := *((*promql.Sample)(ptr))
 	stream.WriteObjectStart()
 	stream.WriteObjectField(`metric`)
-	m, err := s.Metric.MarshalJSON()
-	if err != nil {
-		stream.Error = err
-		return
-	}
-	stream.SetBuffer(append(stream.Buffer(), m...))
+	marshalLabelsJSON(s.Metric, stream)
 	stream.WriteMore()
 	if s.H == nil {
 		stream.WriteObjectField(`value`)
@@ -196,12 +186,7 @@ func marshalExemplarJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 
 	// "labels" key.
 	stream.WriteObjectField(`labels`)
-	lbls, err := p.Labels.MarshalJSON()
-	if err != nil {
-		stream.Error = err
-		return
-	}
-	stream.SetBuffer(append(stream.Buffer(), lbls...))
+	marshalLabelsJSON(p.Labels, stream)
 
 	// "value" key.
 	stream.WriteMore()


### PR DESCRIPTION
Inspired by https://github.com/prometheus/prometheus/pull/12249, but adding in the idea I had at https://github.com/prometheus/prometheus/pull/12249#pullrequestreview-1507699841

I felt it was complicated to extend `BenchmarkSeriesRespond` from #12249 to cover the different shapes of result, so I extended the existing `BenchmarkRespond`.

```
name                              old time/op    new time/op    delta
Respond/10000_points_no_labels-8     473µs ± 2%     473µs ± 1%     ~     (p=0.699 n=6+6)
Respond/1000_labels-8                651µs ± 1%      70µs ± 0%  -89.24%  (p=0.002 n=6+6)
Respond/1000_series_10_points-8     1.17ms ± 0%    0.57ms ± 0%  -51.67%  (p=0.008 n=5+5)

name                              old alloc/op   new alloc/op   delta
Respond/10000_points_no_labels-8     214kB ± 0%     213kB ± 0%   -0.38%  (p=0.015 n=6+6)
Respond/1000_labels-8                913kB ± 0%      74kB ± 0%  -91.89%  (p=0.002 n=6+6)
Respond/1000_series_10_points-8     1.10MB ± 0%    0.26MB ± 0%  -76.25%  (p=0.002 n=6+6)

name                              old allocs/op  new allocs/op  delta
Respond/10000_points_no_labels-8      10.0 ± 0%       7.0 ± 0%  -30.00%  (p=0.002 n=6+6)
Respond/1000_labels-8                13.0k ± 0%      0.0k ± 0%  -99.95%  (p=0.002 n=6+6)
Respond/1000_series_10_points-8      13.0k ± 0%      0.0k ± 0%  -99.95%  (p=0.002 n=6+6)
```

I did run `BenchmarkSeriesRespond`, to show this PR is at least as good as #12249:

```
name             old time/op    new time/op    delta
SeriesRespond-8    85.1ms ± 4%    52.2ms ± 8%  -38.68%  (p=0.002 n=6+6)

name             old alloc/op   new alloc/op   delta
SeriesRespond-8     100MB ± 3%      55MB ± 9%  -44.74%  (p=0.002 n=6+6)

name             old allocs/op  new allocs/op  delta
SeriesRespond-8      981k ± 1%      300k ± 2%  -69.40%  (p=0.002 n=6+6)
```