### PR TITLE
Do not publish latest docker image for LTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,23 @@ include Makefile.common
 
 DOCKER_IMAGE_NAME       ?= prometheus
 
+docker-tag-latest:
+	@echo Skipping latest
+
+docker-publish:
+ifneq ($(DOCKER_IMAGE_TAG),latest)
+	$(MAKE) common-docker-publish
+else
+	@echo Skipping latest
+endif
+
+docker-manifest:
+ifneq ($(DOCKER_IMAGE_TAG),latest)
+	$(MAKE) common-docker-manifest
+else
+	@echo Skipping latest
+endif
+
 .PHONY: update-npm-deps
 update-npm-deps:
 	@echo ">> updating npm dependencies"


### PR DESCRIPTION
2.45 is a LTS version, so it will get releases for a year.

However, we do not want to push :latest for the LTS, so we skip them in this release branch.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
