### PR TITLE
sd: change hetzner role type and constants to be exportable

### DIFF
--- a/discovery/hetzner/hcloud.go
+++ b/discovery/hetzner/hcloud.go
@@ -91,7 +91,7 @@ func (d *hcloudDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 	targets := make([]model.LabelSet, len(servers))
 	for i, server := range servers {
 		labels := model.LabelSet{
-			hetznerLabelRole:              model.LabelValue(hetznerRoleHcloud),
+			hetznerLabelRole:              model.LabelValue(HetznerRoleHcloud),
 			hetznerLabelServerID:          model.LabelValue(fmt.Sprintf("%d", server.ID)),
 			hetznerLabelServerName:        model.LabelValue(server.Name),
 			hetznerLabelDatacenter:        model.LabelValue(server.Datacenter.Name),

--- a/discovery/hetzner/hetzner.go
+++ b/discovery/hetzner/hetzner.go
@@ -57,7 +57,7 @@ type SDConfig struct {
 
 	RefreshInterval model.Duration `yaml:"refresh_interval"`
 	Port            int            `yaml:"port"`
-	Role            role           `yaml:"role"`
+	Role            Role           `yaml:"role"`
 	hcloudEndpoint  string         // For tests only.
 	robotEndpoint   string         // For tests only.
 }
@@ -74,26 +74,26 @@ type refresher interface {
 	refresh(context.Context) ([]*targetgroup.Group, error)
 }
 
-// role is the role of the target within the Hetzner Ecosystem.
-type role string
+// Role is the Role of the target within the Hetzner Ecosystem.
+type Role string
 
 // The valid options for role.
 const (
 	// Hetzner Robot Role (Dedicated Server)
 	// https://robot.hetzner.com
-	hetznerRoleRobot role = "robot"
+	HetznerRoleRobot Role = "robot"
 	// Hetzner Cloud Role
 	// https://console.hetzner.cloud
-	hetznerRoleHcloud role = "hcloud"
+	HetznerRoleHcloud Role = "hcloud"
 )
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *role) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal((*string)(c)); err != nil {
 		return err
 	}
 	switch *c {
-	case hetznerRoleRobot, hetznerRoleHcloud:
+	case HetznerRoleRobot, HetznerRoleHcloud:
 		return nil
 	default:
 		return fmt.Errorf("unknown role %q", *c)
@@ -143,12 +143,12 @@ func NewDiscovery(conf *SDConfig, logger log.Logger) (*refresh.Discovery, error)
 
 func newRefresher(conf *SDConfig, l log.Logger) (refresher, error) {
 	switch conf.Role {
-	case hetznerRoleHcloud:
+	case HetznerRoleHcloud:
 		if conf.hcloudEndpoint == "" {
 			conf.hcloudEndpoint = hcloud.Endpoint
 		}
 		return newHcloudDiscovery(conf, l)
-	case hetznerRoleRobot:
+	case HetznerRoleRobot:
 		if conf.robotEndpoint == "" {
 			conf.robotEndpoint = "https://robot-ws.your-server.de"
 		}

--- a/discovery/hetzner/robot.go
+++ b/discovery/hetzner/robot.go
@@ -105,7 +105,7 @@ func (d *robotDiscovery) refresh(context.Context) ([]*targetgroup.Group, error) 
 	targets := make([]model.LabelSet, len(servers))
 	for i, server := range servers {
 		labels := model.LabelSet{
-			hetznerLabelRole:           model.LabelValue(hetznerRoleRobot),
+			hetznerLabelRole:           model.LabelValue(HetznerRoleRobot),
 			hetznerLabelServerID:       model.LabelValue(strconv.Itoa(server.Server.ServerNumber)),
 			hetznerLabelServerName:     model.LabelValue(server.Server.ServerName),
 			hetznerLabelDatacenter:     model.LabelValue(strings.ToLower(server.Server.Dc)),


### PR DESCRIPTION
This PR changes hetzner's service discovery `Role` to be exportable. The same for `HetznerRoleRobot` and `HetznerRoleHcloud` constants. This is needed when doing conversions from a config format to internal prometheus config, like what we are doing [here](https://github.com/grafana/agent/pull/4648/files#diff-230101458ee37badde2c44abdc88f1b89048dfc634967e5adf463356cb06b196R63-R67).