### PR TITLE
Check `nil` err first when committing

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -930,6 +930,8 @@ func (a *headAppender) Commit() (err error) {
 
 		oooSample, _, err := series.appendable(s.T, s.V, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		switch err {
+		case nil:
+			// Do nothing.
 		case storage.ErrOutOfOrderSample:
 			samplesAppended--
 			oooRejected++
@@ -939,8 +941,6 @@ func (a *headAppender) Commit() (err error) {
 		case storage.ErrTooOldSample:
 			samplesAppended--
 			tooOldRejected++
-		case nil:
-			// Do nothing.
 		default:
 			samplesAppended--
 		}


### PR DESCRIPTION
The most common case is to have a nil error when appending series, so let's check that first instead of checking the 3 error types first.

I've ran the benchmarks and there's no difference in them, because well, these are just 3 extra comparisons, but why wasting them when we know they're not in the happy case.