### PR TITLE
Add initial OTLP ingestion docs

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -126,3 +126,11 @@ still ingest those conventional histograms that do not come with a
 corresponding native histogram. However, if a native histogram is present,
 Prometheus will ignore the corresponding conventional histogram, with the
 notable exception of exemplars, which are always ingested.
+
+## OTLP Receiver
+
+`--enable-feature=otlp-write-receiver`
+
+The OTLP receiver allows Prometheus to accept [OpenTelemetry](https://opentelemetry.io/) metrics writes.
+Prometheus is best used as a Pull based system, and staleness, `up` metric, and other Pull enabled features 
+won't work when you push OTLP metrics.

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -1299,8 +1299,8 @@ endpoint is `/api/v1/write`. Find more details [here](../storage.md#overview).
 
 Prometheus can be configured as a receiver for the OTLP Metrics protocol. This 
 is not considered an efficient way of ingesting samples. Use it
-with caution for specific low-volume use cases. It is not yet suitable for
-replacing the ingestion via scraping yet.
+with caution for specific low-volume use cases. It is not suitable for
+replacing the ingestion via scraping.
 
 Enable the OTLP receiver by the feature flag
 `--enable-feature=otlp-write-receiver`. When enabled, the OTLP receiver

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -1294,3 +1294,16 @@ Enable the remote write receiver by setting
 endpoint is `/api/v1/write`. Find more details [here](../storage.md#overview).
 
 *New in v2.33*
+
+## OTLP Receiver
+
+Prometheus can be configured as a receiver for the OTLP Metrics protocol. This 
+is not considered an efficient way of ingesting samples. Use it
+with caution for specific low-volume use cases. It is not yet suitable for
+replacing the ingestion via scraping yet.
+
+Enable the OTLP receiver by the feature flag
+`--enable-feature=otlp-write-receiver`. When enabled, the OTLP receiver
+endpoint is `/otlp/v1/metrics`.
+
+*New in v2.47*

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -1304,6 +1304,6 @@ replacing the ingestion via scraping.
 
 Enable the OTLP receiver by the feature flag
 `--enable-feature=otlp-write-receiver`. When enabled, the OTLP receiver
-endpoint is `/otlp/v1/metrics`.
+endpoint is `/api/v1/otlp/v1/metrics`.
 
 *New in v2.47*


### PR DESCRIPTION
Partially addresses https://github.com/prometheus/prometheus/issues/12642

We still need a guide that we can link users to in https://github.com/prometheus/docs/tree/main/content/docs/guides This guide should show sending metrics from application directly via the OTel SDKs and also sending through the Collector.

