### PR TITLE
scraping: limit detail on dropped targets, to save memory

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -409,6 +409,9 @@ type GlobalConfig struct {
 	// More than this label value length post metric-relabeling will cause the
 	// scrape to fail. 0 means no limit.
 	LabelValueLengthLimit uint `yaml:"label_value_length_limit,omitempty"`
+	// Keep no more than this many dropped targets per job.
+	// 0 means no limit.
+	KeepDroppedTargets uint `yaml:"keep_dropped_targets,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.
@@ -610,6 +613,9 @@ func (c *ScrapeConfig) Validate(globalConfig GlobalConfig) error {
 	}
 	if c.LabelValueLengthLimit == 0 {
 		c.LabelValueLengthLimit = globalConfig.LabelValueLengthLimit
+	}
+	if c.KeepDroppedTargets == 0 {
+		c.KeepDroppedTargets = globalConfig.KeepDroppedTargets
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -155,7 +155,6 @@ var (
 		HonorLabels:             false,
 		HonorTimestamps:         true,
 		HTTPClientConfig:        config.DefaultHTTPClientConfig,
-		KeepDroppedTargets:      100,
 	}
 
 	// DefaultAlertmanagerConfig is the default alertmanager configuration.
@@ -516,6 +515,7 @@ type ScrapeConfig struct {
 	// fail.
 	NativeHistogramBucketLimit uint `yaml:"native_histogram_bucket_limit,omitempty"`
 	// Keep no more than this many dropped targets per job.
+	// 0 means no limit.
 	KeepDroppedTargets uint `yaml:"keep_dropped_targets,omitempty"`
 
 	// We cannot do proper Go type embedding below as the parser will then parse

--- a/config/config.go
+++ b/config/config.go
@@ -155,6 +155,7 @@ var (
 		HonorLabels:             false,
 		HonorTimestamps:         true,
 		HTTPClientConfig:        config.DefaultHTTPClientConfig,
+		KeepDroppedTargets:      100,
 	}
 
 	// DefaultAlertmanagerConfig is the default alertmanager configuration.
@@ -514,6 +515,8 @@ type ScrapeConfig struct {
 	// More than this many buckets in a native histogram will cause the scrape to
 	// fail.
 	NativeHistogramBucketLimit uint `yaml:"native_histogram_bucket_limit,omitempty"`
+	// Keep no more than this many dropped targets per job.
+	KeepDroppedTargets uint `yaml:"keep_dropped_targets,omitempty"`
 
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -75,6 +75,7 @@ const (
 	globLabelLimit            = 30
 	globLabelNameLengthLimit  = 200
 	globLabelValueLengthLimit = 200
+	globKeepDroppedTargets    = 100
 )
 
 var expectedConf = &Config{
@@ -191,6 +192,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
@@ -292,6 +294,7 @@ var expectedConf = &Config{
 			LabelLimit:            35,
 			LabelNameLengthLimit:  210,
 			LabelValueLengthLimit: 210,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			HTTPClientConfig: config.HTTPClientConfig{
 				BasicAuth: &config.BasicAuth{
@@ -387,6 +390,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -440,6 +444,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath: "/metrics",
 			Scheme:      "http",
@@ -471,6 +476,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -508,6 +514,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
@@ -545,6 +552,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -571,6 +579,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -606,6 +615,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -638,6 +648,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -677,6 +688,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -706,6 +718,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -738,6 +751,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -763,6 +777,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -791,6 +806,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      "/federate",
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -819,6 +835,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -847,6 +864,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -872,6 +890,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -905,6 +924,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -937,6 +957,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -965,6 +986,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -993,6 +1015,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1025,6 +1048,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1060,6 +1084,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1114,6 +1139,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1139,6 +1165,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			HTTPClientConfig: config.DefaultHTTPClientConfig,
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
@@ -1175,6 +1202,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			HTTPClientConfig: config.DefaultHTTPClientConfig,
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
@@ -1217,6 +1245,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1250,6 +1279,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			HTTPClientConfig: config.DefaultHTTPClientConfig,
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
@@ -1277,6 +1307,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1307,6 +1338,7 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
+			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -2009,6 +2041,7 @@ func TestGetScrapeConfigs(t *testing.T) {
 					},
 				},
 			},
+			KeepDroppedTargets: globKeepDroppedTargets,
 		}
 	}
 
@@ -2070,6 +2103,7 @@ func TestGetScrapeConfigs(t *testing.T) {
 							},
 						},
 					},
+					KeepDroppedTargets: globKeepDroppedTargets,
 				},
 				{
 					JobName: "node",
@@ -2103,6 +2137,7 @@ func TestGetScrapeConfigs(t *testing.T) {
 							RefreshInterval: model.Duration(60 * time.Second),
 						},
 					},
+					KeepDroppedTargets: globKeepDroppedTargets,
 				},
 			},
 		},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -75,7 +75,6 @@ const (
 	globLabelLimit            = 30
 	globLabelNameLengthLimit  = 200
 	globLabelValueLengthLimit = 200
-	globKeepDroppedTargets    = 100
 )
 
 var expectedConf = &Config{
@@ -192,7 +191,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
@@ -294,7 +292,6 @@ var expectedConf = &Config{
 			LabelLimit:            35,
 			LabelNameLengthLimit:  210,
 			LabelValueLengthLimit: 210,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			HTTPClientConfig: config.HTTPClientConfig{
 				BasicAuth: &config.BasicAuth{
@@ -390,7 +387,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -444,7 +440,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath: "/metrics",
 			Scheme:      "http",
@@ -476,7 +471,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -514,7 +508,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath: DefaultScrapeConfig.MetricsPath,
 			Scheme:      DefaultScrapeConfig.Scheme,
@@ -552,7 +545,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -579,7 +571,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -615,7 +606,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -648,7 +638,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -688,7 +677,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -718,7 +706,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -751,7 +738,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -777,7 +763,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -806,7 +791,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      "/federate",
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -835,7 +819,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -864,7 +847,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -890,7 +872,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -924,7 +905,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -957,7 +937,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -986,7 +965,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1015,7 +993,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1048,7 +1025,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1084,7 +1060,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1139,7 +1114,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1165,7 +1139,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			HTTPClientConfig: config.DefaultHTTPClientConfig,
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
@@ -1202,7 +1175,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			HTTPClientConfig: config.DefaultHTTPClientConfig,
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
@@ -1245,7 +1217,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1279,7 +1250,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			HTTPClientConfig: config.DefaultHTTPClientConfig,
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
@@ -1307,7 +1277,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -1338,7 +1307,6 @@ var expectedConf = &Config{
 			LabelLimit:            globLabelLimit,
 			LabelNameLengthLimit:  globLabelNameLengthLimit,
 			LabelValueLengthLimit: globLabelValueLengthLimit,
-			KeepDroppedTargets:    globKeepDroppedTargets,
 
 			MetricsPath:      DefaultScrapeConfig.MetricsPath,
 			Scheme:           DefaultScrapeConfig.Scheme,
@@ -2041,7 +2009,6 @@ func TestGetScrapeConfigs(t *testing.T) {
 					},
 				},
 			},
-			KeepDroppedTargets: globKeepDroppedTargets,
 		}
 	}
 
@@ -2103,7 +2070,6 @@ func TestGetScrapeConfigs(t *testing.T) {
 							},
 						},
 					},
-					KeepDroppedTargets: globKeepDroppedTargets,
 				},
 				{
 					JobName: "node",
@@ -2137,7 +2103,6 @@ func TestGetScrapeConfigs(t *testing.T) {
 							RefreshInterval: model.Duration(60 * time.Second),
 						},
 					},
-					KeepDroppedTargets: globKeepDroppedTargets,
 				},
 			},
 		},

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -106,6 +106,10 @@ global:
   # change in the future.
   [ target_limit: <int> | default = 0 ]
 
+  # Per-job limit on the number of targets dropped by relabeling
+  # that will be kept in memory. 0 means no limit.
+	[ keep_dropped_targets: <int> | default = 0 ]
+
 # Rule files specifies a list of globs. Rules and alerts are read from
 # all matching files.
 rule_files:
@@ -414,6 +418,10 @@ metric_relabel_configs:
 # 0 means no limit. This is an experimental feature, this behaviour could
 # change in the future.
 [ target_limit: <int> | default = 0 ]
+
+# Per-job limit on the number of targets dropped by relabeling
+# that will be kept in memory. 0 means no limit.
+[ keep_dropped_targets: <int> | default = 0 ]
 
 # Limit on total number of positive and negative buckets allowed in a single
 # native histogram. If this is exceeded, the entire scrape will be treated as

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -106,9 +106,9 @@ global:
   # change in the future.
   [ target_limit: <int> | default = 0 ]
 
-  # Per-job limit on the number of targets dropped by relabeling
+  # Limit per scrape config on the number of targets dropped by relabeling
   # that will be kept in memory. 0 means no limit.
-	[ keep_dropped_targets: <int> | default = 0 ]
+  [ keep_dropped_targets: <int> | default = 0 ]
 
 # Rule files specifies a list of globs. Rules and alerts are read from
 # all matching files.

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -543,6 +543,7 @@ GET /api/v1/targets
 ```
 
 Both the active and dropped targets are part of the response by default.
+Dropped targets are subject to `keep_dropped_targets` limit.
 `labels` represents the label set after relabeling has occurred.
 `discoveredLabels` represent the unmodified labels retrieved during service discovery before relabeling has occurred.
 

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -543,7 +543,7 @@ GET /api/v1/targets
 ```
 
 Both the active and dropped targets are part of the response by default.
-Dropped targets are subject to `keep_dropped_targets` limit.
+Dropped targets are subject to `keep_dropped_targets` limit, if set.
 `labels` represents the label set after relabeling has occurred.
 `discoveredLabels` represent the unmodified labels retrieved during service discovery before relabeling has occurred.
 

--- a/documentation/examples/prometheus-kubernetes.yml
+++ b/documentation/examples/prometheus-kubernetes.yml
@@ -8,6 +8,11 @@
 # If you are using Kubernetes 1.7.2 or earlier, please take note of the comments
 # for the kubernetes-cadvisor job; you will need to edit or remove this job.
 
+# Keep at most 100 sets of details of targets dropped by relabeling.
+# This information is used to display in the UI for troubleshooting.
+global:
+  keep_dropped_targets: 100
+
 # Scrape config for API servers.
 #
 # Kubernetes exposes API servers as endpoints to the default/kubernetes

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -357,7 +357,7 @@ func (m *Manager) TargetsActive() map[string][]*Target {
 	return targets
 }
 
-// TargetsDropped returns the dropped targets during relabelling.
+// TargetsDropped returns the dropped targets during relabelling, subject to KeepDroppedTargets limit.
 func (m *Manager) TargetsDropped() map[string][]*Target {
 	m.mtxScrape.Lock()
 	defer m.mtxScrape.Unlock()

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -368,3 +368,14 @@ func (m *Manager) TargetsDropped() map[string][]*Target {
 	}
 	return targets
 }
+
+func (m *Manager) TargetsDroppedCounts() map[string]int {
+	m.mtxScrape.Lock()
+	defer m.mtxScrape.Unlock()
+
+	counts := make(map[string]int, len(m.scrapePools))
+	for tset, sp := range m.scrapePools {
+		counts[tset] = sp.droppedTargetsCount
+	}
+	return counts
+}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -242,8 +242,9 @@ type scrapePool struct {
 	targetMtx sync.Mutex
 	// activeTargets and loops must always be synchronized to have the same
 	// set of hashes.
-	activeTargets  map[uint64]*Target
-	droppedTargets []*Target
+	activeTargets       map[uint64]*Target
+	droppedTargets      []*Target // Subject to KeepDroppedTargets limit.
+	droppedTargetsCount int       // Count of all dropped targets.
 
 	// Constructor for new scrape loops. This is settable for testing convenience.
 	newLoop func(scrapeLoopOptions) loop
@@ -354,10 +355,17 @@ func (sp *scrapePool) ActiveTargets() []*Target {
 	return tActive
 }
 
+// Return dropped targets, subject to KeepDroppedTargets limit.
 func (sp *scrapePool) DroppedTargets() []*Target {
 	sp.targetMtx.Lock()
 	defer sp.targetMtx.Unlock()
 	return sp.droppedTargets
+}
+
+func (sp *scrapePool) DroppedTargetsCount() int {
+	sp.targetMtx.Lock()
+	defer sp.targetMtx.Unlock()
+	return sp.droppedTargetsCount
 }
 
 // stop terminates all scrape loops and returns after they all terminated.
@@ -506,6 +514,7 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 	var targets []*Target
 	lb := labels.NewBuilder(labels.EmptyLabels())
 	sp.droppedTargets = []*Target{}
+	sp.droppedTargetsCount = 0
 	for _, tg := range tgs {
 		targets, failures := TargetsFromGroup(tg, sp.config, sp.noDefaultPort, targets, lb)
 		for _, err := range failures {
@@ -523,6 +532,7 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 				if uint(len(sp.droppedTargets)) < sp.config.KeepDroppedTargets {
 					sp.droppedTargets = append(sp.droppedTargets, t)
 				}
+				sp.droppedTargetsCount++
 			}
 		}
 	}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -520,7 +520,9 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 			case nonEmpty:
 				all = append(all, t)
 			case !t.discoveredLabels.IsEmpty():
-				sp.droppedTargets = append(sp.droppedTargets, t)
+				if uint(len(sp.droppedTargets)) < sp.config.KeepDroppedTargets {
+					sp.droppedTargets = append(sp.droppedTargets, t)
+				}
 			}
 		}
 	}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -529,7 +529,7 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 			case nonEmpty:
 				all = append(all, t)
 			case !t.discoveredLabels.IsEmpty():
-				if uint(len(sp.droppedTargets)) < sp.config.KeepDroppedTargets {
+				if sp.config.KeepDroppedTargets != 0 && uint(len(sp.droppedTargets)) < sp.config.KeepDroppedTargets {
 					sp.droppedTargets = append(sp.droppedTargets, t)
 				}
 				sp.droppedTargetsCount++

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -88,6 +88,7 @@ func TestDroppedTargetsList(t *testing.T) {
 					SourceLabels: model.LabelNames{"job"},
 				},
 			},
+			KeepDroppedTargets: 1,
 		}
 		tgs = []*targetgroup.Group{
 			{

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -100,6 +100,7 @@ type ScrapePoolsRetriever interface {
 type TargetRetriever interface {
 	TargetsActive() map[string][]*scrape.Target
 	TargetsDropped() map[string][]*scrape.Target
+	TargetsDroppedCounts() map[string]int
 }
 
 // AlertmanagerRetriever provides a list of all/dropped AlertManager URLs.
@@ -898,8 +899,9 @@ type DroppedTarget struct {
 
 // TargetDiscovery has all the active targets.
 type TargetDiscovery struct {
-	ActiveTargets  []*Target        `json:"activeTargets"`
-	DroppedTargets []*DroppedTarget `json:"droppedTargets"`
+	ActiveTargets       []*Target        `json:"activeTargets"`
+	DroppedTargets      []*DroppedTarget `json:"droppedTargets"`
+	DroppedTargetCounts map[string]int   `json:"droppedTargetCounts"`
 }
 
 // GlobalURLOptions contains fields used for deriving the global URL for local targets.
@@ -1038,6 +1040,9 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 		}
 	} else {
 		res.ActiveTargets = []*Target{}
+	}
+	if showDropped {
+		res.DroppedTargetCounts = api.targetRetriever(r.Context()).TargetsDroppedCounts()
 	}
 	if showDropped {
 		targetsDropped := api.targetRetriever(r.Context()).TargetsDropped()

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -137,6 +137,14 @@ func (t testTargetRetriever) TargetsDropped() map[string][]*scrape.Target {
 	return t.droppedTargets
 }
 
+func (t testTargetRetriever) TargetsDroppedCounts() map[string]int {
+	r := make(map[string]int)
+	for k, v := range t.droppedTargets {
+		r[k] = len(v)
+	}
+	return r
+}
+
 func (t *testTargetRetriever) SetMetadataStoreForTargets(identifier string, metadata scrape.MetricMetadataStore) error {
 	targets, ok := t.activeTargets[identifier]
 
@@ -1384,6 +1392,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						},
 					},
 				},
+				DroppedTargetCounts: map[string]int{"blackbox": 1},
 			},
 		},
 		{
@@ -1436,6 +1445,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						},
 					},
 				},
+				DroppedTargetCounts: map[string]int{"blackbox": 1},
 			},
 		},
 		{
@@ -1498,6 +1508,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						},
 					},
 				},
+				DroppedTargetCounts: map[string]int{"blackbox": 1},
 			},
 		},
 		// With a matching metric.

--- a/web/api/v1/errors_test.go
+++ b/web/api/v1/errors_test.go
@@ -229,6 +229,11 @@ func (DummyTargetRetriever) TargetsDropped() map[string][]*scrape.Target {
 	return map[string][]*scrape.Target{}
 }
 
+// TargetsDroppedCounts implements targetRetriever.
+func (DummyTargetRetriever) TargetsDroppedCounts() map[string]int {
+	return nil
+}
+
 // DummyAlertmanagerRetriever implements AlertmanagerRetriever.
 type DummyAlertmanagerRetriever struct{}
 

--- a/web/ui/react-app/src/pages/serviceDiscovery/Services.tsx
+++ b/web/ui/react-app/src/pages/serviceDiscovery/Services.tsx
@@ -10,7 +10,6 @@ import { API_PATH } from '../../constants/constants';
 import { KVSearch } from '@nexucis/kvsearch';
 import { Container } from 'reactstrap';
 import SearchBar from '../../components/SearchBar';
-import internal from 'stream';
 
 interface ServiceMap {
   activeTargets: Target[];


### PR DESCRIPTION
Fixes #12482

It's possible (quite common on Kubernetes) to have a service discovery return thousands of targets then drop most of them in relabel rules. The main place this data is used is to display in the web UI, where you don't want thousands of lines of display.

Set a default limit of 100 per job to store full detail, which I picked to be consistent with #4212. It seems that behaviour, of limiting the number drawn in the UI, has disappeared.

Update 2: needed to extend the API to let the UI show correct counts.
Please note I know nothing at all about React programming.