### PR TITLE
Short-cut common memChunk operations

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2265,6 +2265,10 @@ type memChunk struct {
 
 // len returns the length of memChunk list, including the element it was called on.
 func (mc *memChunk) len() (count int) {
+	if mc.prev == nil {
+		return 1
+	}
+
 	elem := mc
 	for elem != nil {
 		count++
@@ -2276,6 +2280,9 @@ func (mc *memChunk) len() (count int) {
 // oldest returns the oldest element on the list.
 // For single element list this will be the same memChunk oldest() was called on.
 func (mc *memChunk) oldest() (elem *memChunk) {
+	if mc.prev == nil {
+		return mc
+	}
 	elem = mc
 	for elem.prev != nil {
 		elem = elem.prev
@@ -2287,6 +2294,9 @@ func (mc *memChunk) oldest() (elem *memChunk) {
 func (mc *memChunk) atOffset(offset int) (elem *memChunk) {
 	if offset == 0 {
 		return mc
+	}
+	if offset == 1 {
+		return mc.prev
 	}
 	if offset < 0 {
 		return nil
@@ -2301,7 +2311,6 @@ func (mc *memChunk) atOffset(offset int) (elem *memChunk) {
 			break
 		}
 	}
-
 	return elem
 }
 


### PR DESCRIPTION
memChunk is a linked list, speed up some common operations when there's no need to iterate all elements on the list.

@jesusvazquez I didn't find a good benchmark that covers this, but noticed in pprof that these can eat a bit extra cpu vs v2.46.0, so trying to compensate for this.