### PR TITLE
Add context argument to IndexReader.Postings

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -372,7 +372,7 @@ func main() {
 		os.Exit(checkErr(benchmarkWrite(*benchWriteOutPath, *benchSamplesFile, *benchWriteNumMetrics, *benchWriteNumScrapes)))
 
 	case tsdbAnalyzeCmd.FullCommand():
-		os.Exit(checkErr(analyzeBlock(*analyzePath, *analyzeBlockID, *analyzeLimit, *analyzeRunExtended)))
+		os.Exit(checkErr(analyzeBlock(ctx, *analyzePath, *analyzeBlockID, *analyzeLimit, *analyzeRunExtended)))
 
 	case tsdbListCmd.FullCommand():
 		os.Exit(checkErr(listBlocks(*listPath, *listHumanReadable)))

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -413,7 +413,7 @@ func openBlock(path, blockID string) (*tsdb.DBReadOnly, tsdb.BlockReader, error)
 	return db, b, nil
 }
 
-func analyzeBlock(path, blockID string, limit int, runExtended bool) error {
+func analyzeBlock(ctx context.Context, path, blockID string, limit int, runExtended bool) error {
 	db, block, err := openBlock(path, blockID)
 	if err != nil {
 		return err
@@ -460,7 +460,7 @@ func analyzeBlock(path, blockID string, limit int, runExtended bool) error {
 	labelpairsUncovered := map[string]uint64{}
 	labelpairsCount := map[string]uint64{}
 	entries := 0
-	p, err := ir.Postings("", "") // The special all key.
+	p, err := ir.Postings(ctx, "", "") // The special all key.
 	if err != nil {
 		return err
 	}
@@ -543,7 +543,7 @@ func analyzeBlock(path, blockID string, limit int, runExtended bool) error {
 		return err
 	}
 	for _, n := range lv {
-		postings, err := ir.Postings("__name__", n)
+		postings, err := ir.Postings(ctx, "__name__", n)
 		if err != nil {
 			return err
 		}
@@ -560,14 +560,15 @@ func analyzeBlock(path, blockID string, limit int, runExtended bool) error {
 	printInfo(postingInfos)
 
 	if runExtended {
-		return analyzeCompaction(block, ir)
+		return analyzeCompaction(ctx, block, ir)
 	}
 
 	return nil
 }
 
-func analyzeCompaction(block tsdb.BlockReader, indexr tsdb.IndexReader) (err error) {
-	postingsr, err := indexr.Postings(index.AllPostingsKey())
+func analyzeCompaction(ctx context.Context, block tsdb.BlockReader, indexr tsdb.IndexReader) (err error) {
+	n, v := index.AllPostingsKey()
+	postingsr, err := indexr.Postings(ctx, n, v)
 	if err != nil {
 		return err
 	}

--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func setupRangeQueryTestData(stor *teststorage.TestStorage, _ *Engine, interval, numIntervals int) error {
+	ctx := context.Background()
+
 	metrics := []labels.Labels{}
 	metrics = append(metrics, labels.FromStrings("__name__", "a_one"))
 	metrics = append(metrics, labels.FromStrings("__name__", "b_one"))
@@ -67,7 +69,7 @@ func setupRangeQueryTestData(stor *teststorage.TestStorage, _ *Engine, interval,
 		}
 	}
 	stor.DB.ForceHeadMMap() // Ensure we have at most one head chunk for every series.
-	stor.DB.Compact()
+	stor.DB.Compact(ctx)
 	return nil
 }
 

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -74,7 +74,7 @@ type IndexReader interface {
 	// The Postings here contain the offsets to the series inside the index.
 	// Found IDs are not strictly required to point to a valid Series, e.g.
 	// during background garbage collections.
-	Postings(name string, values ...string) (index.Postings, error)
+	Postings(ctx context.Context, name string, values ...string) (index.Postings, error)
 
 	// SortedPostings returns a postings list that is reordered to be sorted
 	// by the label set of the underlying series.
@@ -488,8 +488,8 @@ func (r blockIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, err
 	return labelNamesWithMatchers(r.ir, matchers...)
 }
 
-func (r blockIndexReader) Postings(name string, values ...string) (index.Postings, error) {
-	p, err := r.ir.Postings(name, values...)
+func (r blockIndexReader) Postings(ctx context.Context, name string, values ...string) (index.Postings, error) {
+	p, err := r.ir.Postings(ctx, name, values...)
 	if err != nil {
 		return p, errors.Wrapf(err, "block: %s", r.b.Meta().ULID)
 	}

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -731,7 +731,7 @@ func (c DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compa
 		closers = append(closers, tombsr)
 
 		k, v := index.AllPostingsKey()
-		all, err := indexr.Postings(k, v)
+		all, err := indexr.Postings(ctx, k, v)
 		if err != nil {
 			return err
 		}

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1268,6 +1268,8 @@ func TestDeleteCompactionBlockAfterFailedReload(t *testing.T) {
 
 	for title, bootStrap := range tests {
 		t.Run(title, func(t *testing.T) {
+			ctx := context.Background()
+
 			db := openTestDB(t, nil, []int64{1, 100})
 			defer func() {
 				require.NoError(t, db.Close())
@@ -1291,7 +1293,7 @@ func TestDeleteCompactionBlockAfterFailedReload(t *testing.T) {
 			// Do the compaction and check the metrics.
 			// Compaction should succeed, but the reloadBlocks should fail and
 			// the new block created from the compaction should be deleted.
-			require.Error(t, db.Compact())
+			require.Error(t, db.Compact(ctx))
 			require.Equal(t, 1.0, prom_testutil.ToFloat64(db.metrics.reloadsFailed), "'failed db reloadBlocks' count metrics mismatch")
 			require.Equal(t, 1.0, prom_testutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.Ran), "`compaction` count metric mismatch")
 			require.Equal(t, 1.0, prom_testutil.ToFloat64(db.metrics.compactionsFailed), "`compactions failed` count metric mismatch")

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -103,7 +103,7 @@ func (h *headIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, err
 }
 
 // Postings returns the postings list iterator for the label pairs.
-func (h *headIndexReader) Postings(name string, values ...string) (index.Postings, error) {
+func (h *headIndexReader) Postings(ctx context.Context, name string, values ...string) (index.Postings, error) {
 	switch len(values) {
 	case 0:
 		return index.EmptyPostings(), nil
@@ -116,7 +116,7 @@ func (h *headIndexReader) Postings(name string, values ...string) (index.Posting
 				res = append(res, p)
 			}
 		}
-		return index.Merge(res...), nil
+		return index.Merge(ctx, res...), nil
 	}
 }
 

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -15,6 +15,7 @@ package index
 
 import (
 	"container/heap"
+	"context"
 	"encoding/binary"
 	"runtime"
 	"sort"
@@ -519,7 +520,7 @@ func (it *intersectPostings) Err() error {
 }
 
 // Merge returns a new iterator over the union of the input iterators.
-func Merge(its ...Postings) Postings {
+func Merge(ctx context.Context, its ...Postings) Postings {
 	if len(its) == 0 {
 		return EmptyPostings()
 	}
@@ -527,7 +528,7 @@ func Merge(its ...Postings) Postings {
 		return its[0]
 	}
 
-	p, ok := newMergedPostings(its)
+	p, ok := newMergedPostings(ctx, its)
 	if !ok {
 		return EmptyPostings()
 	}
@@ -559,12 +560,14 @@ type mergedPostings struct {
 	err         error
 }
 
-func newMergedPostings(p []Postings) (m *mergedPostings, nonEmpty bool) {
+func newMergedPostings(ctx context.Context, p []Postings) (m *mergedPostings, nonEmpty bool) {
 	ph := make(postingsHeap, 0, len(p))
 
 	for _, it := range p {
 		// NOTE: mergedPostings struct requires the user to issue an initial Next.
 		switch {
+		case ctx.Err() != nil:
+			return &mergedPostings{err: ctx.Err()}, true
 		case it.Next():
 			ph = append(ph, it)
 		case it.Err() != nil:

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -385,7 +385,7 @@ func TestMultiMerge(t *testing.T) {
 	i2 := newListPostings(2, 4, 5, 6, 7, 8, 999, 1001)
 	i3 := newListPostings(1, 2, 5, 6, 7, 8, 1001, 1200)
 
-	res, err := ExpandPostings(Merge(i1, i2, i3))
+	res, err := ExpandPostings(Merge(context.Background(), i1, i2, i3))
 	require.NoError(t, err)
 	require.Equal(t, []storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8, 999, 1000, 1001, 1200}, res)
 }
@@ -473,10 +473,12 @@ func TestMergedPostings(t *testing.T) {
 				t.Fatal("merge result expectancy cannot be nil")
 			}
 
+			ctx := context.Background()
+
 			expected, err := ExpandPostings(c.res)
 			require.NoError(t, err)
 
-			m := Merge(c.in...)
+			m := Merge(ctx, c.in...)
 
 			if c.res == EmptyPostings() {
 				require.Equal(t, EmptyPostings(), m)
@@ -537,10 +539,12 @@ func TestMergedPostingsSeek(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		ctx := context.Background()
+
 		a := newListPostings(c.a...)
 		b := newListPostings(c.b...)
 
-		p := Merge(a, b)
+		p := Merge(ctx, a, b)
 
 		require.Equal(t, c.success, p.Seek(c.seek))
 
@@ -796,6 +800,7 @@ func TestIntersectWithMerge(t *testing.T) {
 	a := newListPostings(21, 22, 23, 24, 25, 30)
 
 	b := Merge(
+		context.Background(),
 		newListPostings(10, 20, 30),
 		newListPostings(15, 26, 30),
 	)

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -266,7 +266,7 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 		// We prefer to get AllPostings so that the base of subtraction (i.e. allPostings)
 		// doesn't include series that may be added to the index reader during this function call.
 		k, v := index.AllPostingsKey()
-		allPostings, err := ix.Postings(k, v)
+		allPostings, err := ix.Postings(context.TODO(), k, v)
 		if err != nil {
 			return nil, err
 		}
@@ -286,7 +286,7 @@ func PostingsForMatchers(ix IndexReader, ms ...*labels.Matcher) (index.Postings,
 		switch {
 		case m.Name == "" && m.Value == "": // Special-case for AllPostings, used in tests at least.
 			k, v := index.AllPostingsKey()
-			allPostings, err := ix.Postings(k, v)
+			allPostings, err := ix.Postings(context.TODO(), k, v)
 			if err != nil {
 				return nil, err
 			}
@@ -363,14 +363,14 @@ func postingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, erro
 
 	// Fast-path for equal matching.
 	if m.Type == labels.MatchEqual {
-		return ix.Postings(m.Name, m.Value)
+		return ix.Postings(context.TODO(), m.Name, m.Value)
 	}
 
 	// Fast-path for set matching.
 	if m.Type == labels.MatchRegexp {
 		setMatches := findSetMatches(m.GetRegexString())
 		if len(setMatches) > 0 {
-			return ix.Postings(m.Name, setMatches...)
+			return ix.Postings(context.TODO(), m.Name, setMatches...)
 		}
 	}
 
@@ -390,7 +390,7 @@ func postingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Postings, erro
 		return index.EmptyPostings(), nil
 	}
 
-	return ix.Postings(m.Name, res...)
+	return ix.Postings(context.TODO(), m.Name, res...)
 }
 
 // inversePostingsForMatcher returns the postings for the series with the label name set but not matching the matcher.
@@ -401,14 +401,14 @@ func inversePostingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Posting
 	if m.Type == labels.MatchNotRegexp {
 		setMatches := findSetMatches(m.GetRegexString())
 		if len(setMatches) > 0 {
-			return ix.Postings(m.Name, setMatches...)
+			return ix.Postings(context.TODO(), m.Name, setMatches...)
 		}
 	}
 
 	// Fast-path for MatchNotEqual matching.
 	// Inverse of a MatchNotEqual is MatchEqual (double negation).
 	if m.Type == labels.MatchNotEqual {
-		return ix.Postings(m.Name, m.Value)
+		return ix.Postings(context.TODO(), m.Name, m.Value)
 	}
 
 	vals, err := ix.LabelValues(m.Name)
@@ -428,7 +428,7 @@ func inversePostingsForMatcher(ix IndexReader, m *labels.Matcher) (index.Posting
 		}
 	}
 
-	return ix.Postings(m.Name, res...)
+	return ix.Postings(context.TODO(), m.Name, res...)
 }
 
 func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Matcher) ([]string, error) {
@@ -463,7 +463,7 @@ func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Mat
 
 	valuesPostings := make([]index.Postings, len(allValues))
 	for i, value := range allValues {
-		valuesPostings[i], err = r.Postings(name, value)
+		valuesPostings[i], err = r.Postings(context.TODO(), name, value)
 		if err != nil {
 			return nil, errors.Wrapf(err, "fetching postings for %s=%q", name, value)
 		}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -504,6 +504,7 @@ func TestBlockQuerier_AgainstHeadWithOpenChunks(t *testing.T) {
 }
 
 func TestBlockQuerier_TrimmingDoesNotModifyOriginalTombstoneIntervals(t *testing.T) {
+	ctx := context.Background()
 	c := blockQuerierTestCase{
 		mint: 2,
 		maxt: 6,
@@ -527,7 +528,7 @@ func TestBlockQuerier_TrimmingDoesNotModifyOriginalTombstoneIntervals(t *testing
 	}
 	ir, cr, _, _ := createIdxChkReaders(t, testData)
 	stones := tombstones.NewMemTombstones()
-	p, err := ir.Postings("a", "a")
+	p, err := ir.Postings(ctx, "a", "a")
 	require.NoError(t, err)
 	refs, err := index.ExpandPostings(p)
 	require.NoError(t, err)
@@ -1500,13 +1501,13 @@ func (m mockIndex) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {
 	return names, nil
 }
 
-func (m mockIndex) Postings(name string, values ...string) (index.Postings, error) {
+func (m mockIndex) Postings(ctx context.Context, name string, values ...string) (index.Postings, error) {
 	res := make([]index.Postings, 0, len(values))
 	for _, value := range values {
 		l := labels.Label{Name: name, Value: value}
 		res = append(res, index.NewListPostings(m.postings[l]))
 	}
-	return index.Merge(res...), nil
+	return index.Merge(ctx, res...), nil
 }
 
 func (m mockIndex) SortedPostings(p index.Postings) index.Postings {
@@ -2452,7 +2453,7 @@ func (m mockMatcherIndex) LabelNamesFor(ids ...storage.SeriesRef) ([]string, err
 	return nil, errors.New("label names for for called")
 }
 
-func (m mockMatcherIndex) Postings(name string, values ...string) (index.Postings, error) {
+func (m mockMatcherIndex) Postings(context.Context, string, ...string) (index.Postings, error) {
 	return index.EmptyPostings(), nil
 }
 

--- a/tsdb/repair_test.go
+++ b/tsdb/repair_test.go
@@ -14,6 +14,7 @@
 package tsdb
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,6 +29,7 @@ import (
 
 func TestRepairBadIndexVersion(t *testing.T) {
 	tmpDir := t.TempDir()
+	ctx := context.Background()
 
 	// The broken index used in this test was written by the following script
 	// at a broken revision.
@@ -78,7 +80,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	// Read current index to check integrity.
 	r, err := index.NewFileReader(filepath.Join(tmpDbDir, indexFilename))
 	require.NoError(t, err)
-	p, err := r.Postings("b", "1")
+	p, err := r.Postings(ctx, "b", "1")
 	require.NoError(t, err)
 	var builder labels.ScratchBuilder
 	for p.Next() {
@@ -97,7 +99,7 @@ func TestRepairBadIndexVersion(t *testing.T) {
 	r, err = index.NewFileReader(filepath.Join(tmpDbDir, indexFilename))
 	require.NoError(t, err)
 	defer r.Close()
-	p, err = r.Postings("b", "1")
+	p, err = r.Postings(ctx, "b", "1")
 	require.NoError(t, err)
 	res := []labels.Labels{}
 


### PR DESCRIPTION
Add context argument to `tsdb.IndexReader.Postings`. This is in preparation for `tsdb.PostingsForMatchers` [gaining a context argument](https://github.com/prometheus/prometheus/pull/12359), the motivation being to respect context cancellation.

Part of https://github.com/prometheus/prometheus/issues/12836.