### PR TITLE
Add support for native histograms to fmtutil

### DIFF
--- a/util/fmtutil/format_test.go
+++ b/util/fmtutil/format_test.go
@@ -17,6 +17,8 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/prompb"
@@ -80,17 +82,17 @@ var writeRequestFixture = &prompb.WriteRequest{
 		},
 		{
 			Labels: []prompb.Label{
-				{Name: "__name__", Value: "http_request_duration_seconds_sum"},
-				{Name: "job", Value: "promtool"},
-			},
-			Samples: []prompb.Sample{{Value: 53423, Timestamp: 1}},
-		},
-		{
-			Labels: []prompb.Label{
 				{Name: "__name__", Value: "http_request_duration_seconds_count"},
 				{Name: "job", Value: "promtool"},
 			},
 			Samples: []prompb.Sample{{Value: 144320, Timestamp: 1}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "http_request_duration_seconds_sum"},
+				{Name: "job", Value: "promtool"},
+			},
+			Samples: []prompb.Sample{{Value: 53423, Timestamp: 1}},
 		},
 		{
 			Labels: []prompb.Label{
@@ -230,4 +232,200 @@ func TestMetricTextToWriteRequestErrorParsingMetricType(t *testing.T) {
 
 	_, err := MetricTextToWriteRequest(input, labels)
 	require.Equal(t, err.Error(), "text format parsing error in line 3: unknown metric type \"info\"")
+}
+
+func TestMetricFamiliesToWriteRequestWithHistograms(t *testing.T) {
+	const TS int64 = 42
+
+	type input struct {
+		generate func(*testing.T) []*dto.MetricFamily
+	}
+
+	type expected struct {
+		metadata   []prompb.MetricMetadata
+		timeseries []prompb.TimeSeries
+	}
+
+	testcases := map[string]struct {
+		input    input
+		expected expected
+	}{
+		"classic": {
+			input: input{
+				generate: func(t *testing.T) []*dto.MetricFamily {
+					h := prometheus.NewHistogram(prometheus.HistogramOpts{
+						Namespace:   "ns",
+						Subsystem:   "ss",
+						Name:        "classic",
+						Help:        "ns_ss_classic help",
+						ConstLabels: prometheus.Labels{"l1": "v1"},
+						Buckets:     []float64{0.1, 1.0, 10.0},
+					})
+
+					r := prometheus.NewPedanticRegistry()
+					r.MustRegister(h)
+
+					h.Observe(0.05)
+					h.Observe(0.5)
+					h.Observe(5)
+					h.Observe(50)
+
+					mfs, err := r.Gather()
+					require.NoError(t, err)
+
+					return mfs
+				},
+			},
+			expected: expected{
+				metadata: []prompb.MetricMetadata{
+					{
+						Type:             prompb.MetricMetadata_HISTOGRAM,
+						MetricFamilyName: "ns_ss_classic",
+						Help:             "ns_ss_classic help",
+					},
+				},
+				timeseries: []prompb.TimeSeries{
+					{
+						Labels: []prompb.Label{
+							{Name: "__name__", Value: "ns_ss_classic_bucket"},
+							{Name: "l1", Value: "v1"},
+							{Name: "le", Value: "0.1"},
+						},
+						Samples: []prompb.Sample{
+							{Timestamp: TS, Value: 1},
+						},
+					},
+					{
+						Labels: []prompb.Label{
+							{Name: "__name__", Value: "ns_ss_classic_bucket"},
+							{Name: "l1", Value: "v1"},
+							{Name: "le", Value: "1"},
+						},
+						Samples: []prompb.Sample{
+							{Timestamp: TS, Value: 2},
+						},
+					},
+					{
+						Labels: []prompb.Label{
+							{Name: "__name__", Value: "ns_ss_classic_bucket"},
+							{Name: "l1", Value: "v1"},
+							{Name: "le", Value: "10"},
+						},
+						Samples: []prompb.Sample{
+							{Timestamp: TS, Value: 3},
+						},
+					},
+					{
+						Labels: []prompb.Label{
+							{Name: "__name__", Value: "ns_ss_classic_count"},
+							{Name: "l1", Value: "v1"},
+						},
+						Samples: []prompb.Sample{
+							{Timestamp: TS, Value: 4},
+						},
+					},
+					{
+						Labels: []prompb.Label{
+							{Name: "__name__", Value: "ns_ss_classic_sum"},
+							{Name: "l1", Value: "v1"},
+						},
+						Samples: []prompb.Sample{
+							{Timestamp: TS, Value: 55.55},
+						},
+					},
+				},
+			},
+		},
+		"native with integer counts": {
+			input: input{
+				generate: func(t *testing.T) []*dto.MetricFamily {
+					h := prometheus.NewHistogram(prometheus.HistogramOpts{
+						Namespace:                    "ns",
+						Subsystem:                    "ss",
+						Name:                         "native",
+						Help:                         "ns_ss_native help",
+						ConstLabels:                  prometheus.Labels{"l1": "v1"},
+						NativeHistogramBucketFactor:  1.1,
+						NativeHistogramZeroThreshold: 0.1,
+					})
+
+					r := prometheus.NewPedanticRegistry()
+					r.MustRegister(h)
+
+					h.Observe(0.05)
+					h.Observe(0.5)
+					h.Observe(5)
+					h.Observe(50)
+
+					mfs, err := r.Gather()
+					require.NoError(t, err)
+
+					return mfs
+				},
+			},
+			expected: expected{
+				metadata: []prompb.MetricMetadata{
+					{
+						Type:             prompb.MetricMetadata_HISTOGRAM,
+						MetricFamilyName: "ns_ss_native",
+						Help:             "ns_ss_native help",
+					},
+				},
+				timeseries: []prompb.TimeSeries{
+					{
+						Labels: []prompb.Label{
+							{Name: "__name__", Value: "ns_ss_native"},
+							{Name: "l1", Value: "v1"},
+						},
+						Samples: nil,
+						Histograms: []prompb.Histogram{
+							{
+								// There's _a lot_ of magic here. The count, zero count and sum
+								// can be trivially deduced from the generating function. The
+								// ZeroThreshold is an input.
+								//
+								// The schema, negative spans, positive spans and positie deltas
+								// are computed by the histogram.
+								Count:         &prompb.Histogram_CountInt{CountInt: 4},
+								Sum:           55.55,
+								Schema:        3,
+								ZeroThreshold: 0.1,
+								ZeroCount:     &prompb.Histogram_ZeroCountInt{ZeroCountInt: 1},
+								NegativeSpans: []prompb.BucketSpan{},
+								PositiveSpans: []prompb.BucketSpan{
+									{Offset: -8, Length: 1},
+									{Offset: 26, Length: 1},
+									{Offset: 26, Length: 1},
+								},
+								PositiveDeltas: []int64{1, 0, 0},
+								Timestamp:      TS,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			mfs := testcase.input.generate(t)
+			req := make(map[string]*dto.MetricFamily)
+			ts := TS
+			for _, mf := range mfs {
+				// patch the timestamp so that the comparison succeeds
+				for _, m := range mf.GetMetric() {
+					m.TimestampMs = &ts
+				}
+				req[mf.GetName()] = mf
+			}
+
+			wr, err := MetricFamiliesToWriteRequest(req, nil)
+			require.NoError(t, err)
+			require.NotNil(t, wr)
+
+			require.Equal(t, testcase.expected.metadata, wr.GetMetadata())
+			require.Equal(t, testcase.expected.timeseries, wr.GetTimeseries())
+		})
+	}
 }


### PR DESCRIPTION
util/fmtutil supports creating a write request including histograms, but it doesn't support native histograms. This change adds that missing support.

Note that `promtool` uses `fmtutil.MetricTextToWriteRequest`, which is affected by this change. The immediate intention of this change _is not_ to get `promtool` to support native histograms, but to be able to take a set of metric families as produced by e.g. `registry.Gather` and convert that into a write request.
