### PR TITLE
labels: improve Has() method for stringlabels build 

### DIFF
--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -472,16 +472,22 @@ func BenchmarkLabels_Get(b *testing.B) {
 			for _, scenario := range []struct {
 				desc, label string
 			}{
-				{"get first label", allLabels[0].Name},
-				{"get middle label", allLabels[size/2].Name},
-				{"get last label", allLabels[size-1].Name},
-				{"get not-found label", "benchmark"},
+				{"first label", allLabels[0].Name},
+				{"middle label", allLabels[size/2].Name},
+				{"last label", allLabels[size-1].Name},
+				{"not-found label", "benchmark"},
 			} {
 				b.Run(scenario.desc, func(b *testing.B) {
-					b.ResetTimer()
-					for i := 0; i < b.N; i++ {
-						_ = labels.Get(scenario.label)
-					}
+					b.Run("get", func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							_ = labels.Get(scenario.label)
+						}
+					})
+					b.Run("has", func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							_ = labels.Has(scenario.label)
+						}
+					})
 				})
 			}
 		})


### PR DESCRIPTION
Exactly the same optimisation as #12485.  `Has()` is used during scraping, and I also want this for a downstream project.

I extended the benchmark to cover `Has()`.
```
name                                             old time/op  new time/op  delta
Labels_Get/with_5_labels/first_label/has-8       5.33ns ± 0%  4.90ns ± 8%   -8.05%  (p=0.016 n=4+5)
Labels_Get/with_5_labels/middle_label/has-8      10.4ns ± 1%   7.4ns ± 2%  -28.26%  (p=0.008 n=5+5)
Labels_Get/with_5_labels/last_label/has-8        15.4ns ± 0%  10.0ns ± 0%  -34.61%  (p=0.008 n=5+5)
Labels_Get/with_5_labels/not-found_label/has-8   15.7ns ± 1%   5.3ns ± 1%  -65.97%  (p=0.008 n=5+5)
Labels_Get/with_10_labels/first_label/has-8      5.31ns ± 0%  4.43ns ± 0%  -16.68%  (p=0.008 n=5+5)
Labels_Get/with_10_labels/middle_label/has-8     20.4ns ± 1%  11.8ns ± 0%  -42.10%  (p=0.008 n=5+5)
Labels_Get/with_10_labels/last_label/has-8       29.8ns ± 0%  18.6ns ± 0%  -37.82%  (p=0.008 n=5+5)
Labels_Get/with_10_labels/not-found_label/has-8  29.8ns ± 0%   5.3ns ± 0%  -82.16%  (p=0.008 n=5+5)
Labels_Get/with_30_labels/first_label/has-8      5.31ns ± 0%  4.43ns ± 0%  -16.63%  (p=0.008 n=5+5)
Labels_Get/with_30_labels/middle_label/has-8     49.5ns ± 0%  34.1ns ± 0%  -31.05%  (p=0.008 n=5+5)
Labels_Get/with_30_labels/last_label/has-8        105ns ±14%    75ns ± 0%  -28.58%  (p=0.000 n=5+4)
Labels_Get/with_30_labels/not-found_label/has-8   112ns ± 8%     5ns ± 0%  -95.25%  (p=0.008 n=5+5)
```