### PR TITLE
Revert "Remove deleted target from discovery manager"

### DIFF
--- a/discovery/legacymanager/manager.go
+++ b/discovery/legacymanager/manager.go
@@ -270,12 +270,7 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
 	}
 	for _, tg := range tgs {
 		if tg != nil { // Some Discoverers send nil target group so need to check for it to avoid panics.
-			// Remove the deleted target.
-			if len(tg.Targets) == 0 && len(tg.Labels) == 0 {
-				delete(m.targets[poolKey], tg.Source)
-			} else {
-				m.targets[poolKey][tg.Source] = tg
-			}
+			m.targets[poolKey][tg.Source] = tg
 		}
 	}
 }

--- a/discovery/legacymanager/manager_test.go
+++ b/discovery/legacymanager/manager_test.go
@@ -824,9 +824,13 @@ func TestTargetSetRecreatesEmptyStaticConfigs(t *testing.T) {
 	if !ok {
 		t.Fatalf("'%v' should be present in target groups", pkey)
 	}
-	_, ok = targetGroups[""]
-	if ok {
-		t.Fatalf("Target groups should be empty, got %v", targetGroups)
+	group, ok := targetGroups[""]
+	if !ok {
+		t.Fatalf("missing '' key in target groups %v", targetGroups)
+	}
+
+	if len(group.Targets) != 0 {
+		t.Fatalf("Invalid number of targets: expected 0, got %d", len(group.Targets))
 	}
 }
 

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -387,12 +387,7 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
 	}
 	for _, tg := range tgs {
 		if tg != nil { // Some Discoverers send nil target group so need to check for it to avoid panics.
-			// Remove the deleted target.
-			if len(tg.Targets) == 0 && len(tg.Labels) == 0 {
-				delete(m.targets[poolKey], tg.Source)
-			} else {
-				m.targets[poolKey][tg.Source] = tg
-			}
+			m.targets[poolKey][tg.Source] = tg
 		}
 	}
 }

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -1044,8 +1044,19 @@ func TestTargetSetRecreatesEmptyStaticConfigs(t *testing.T) {
 	if !ok {
 		t.Fatalf("'%v' should be present in target groups", p)
 	}
-	require.Equal(t, 0, len(targetGroups))
-	require.Equal(t, 0, len(syncedTargets))
+	group, ok := targetGroups[""]
+	if !ok {
+		t.Fatalf("missing '' key in target groups %v", targetGroups)
+	}
+
+	if len(group.Targets) != 0 {
+		t.Fatalf("Invalid number of targets: expected 0, got %d", len(group.Targets))
+	}
+	require.Equal(t, 1, len(syncedTargets))
+	require.Equal(t, 1, len(syncedTargets["prometheus"]))
+	if lbls := syncedTargets["prometheus"][0].Labels; lbls != nil {
+		t.Fatalf("Unexpected Group: expected nil Labels, got %v", lbls)
+	}
 }
 
 func TestIdenticalConfigurationsAreCoalesced(t *testing.T) {


### PR DESCRIPTION
Reverts prometheus/prometheus#12541

We have to revert this as it causes targets to always stay present under some conditions.