### PR TITLE
Provide extended action capabilities for relabel, allowing developers to customize relabel actions when integrating promtherus.

### DIFF
--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -154,7 +154,12 @@ func (d *Discovery) Refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	req.Header.Set("X-Prometheus-Refresh-Interval-Seconds", strconv.FormatFloat(d.refreshInterval.Seconds(), 'f', -1, 64))
 
 	for k, v := range d.headers {
+		if k == "Host" || k == "host" {
+			req.Host = v
+		}
+
 		req.Header.Set(k, v)
+
 	}
 
 	resp, err := d.client.Do(req.WithContext(ctx))

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -106,7 +106,7 @@ type Config struct {
 	Replacement string `yaml:"replacement,omitempty"`
 	// Action is the action to be performed for the relabeling.
 	Action Action `yaml:"action,omitempty"`
-	Ext string `yaml:"ext,omitempty"`
+	Ext    string `yaml:"ext,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -41,9 +41,11 @@ var (
 )
 
 // Action is the action to be performed on relabeling.
-type Action string
-type Predicate func(cfg *Config) bool
-type ActionFun func(lb *labels.Builder, cfg *Config, val string) (bool, bool)
+type (
+	Action    string
+	Predicate func(cfg *Config) bool
+	ActionFun func(lb *labels.Builder, cfg *Config, val string) (bool, bool)
+)
 
 const (
 	// Replace performs a regex replacement.

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -34,10 +34,16 @@ var (
 		Regex:       MustNewRegexp("(.*)"),
 		Replacement: "$1",
 	}
+
+	CustomerActions = make(map[Action]ActionFun)
+
+	Predicates = make(map[Action]Predicate)
 )
 
 // Action is the action to be performed on relabeling.
 type Action string
+type Predicate func(cfg *Config) bool
+type ActionFun func(lb *labels.Builder, cfg *Config, val string) (bool, bool)
 
 const (
 	// Replace performs a regex replacement.
@@ -75,6 +81,10 @@ func (a *Action) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		*a = act
 		return nil
 	}
+	if act := Action(strings.ToLower(s)); CustomerActions[act] != nil {
+		*a = act
+		return nil
+	}
 	return fmt.Errorf("unknown relabel action %q", s)
 }
 
@@ -96,6 +106,7 @@ type Config struct {
 	Replacement string `yaml:"replacement,omitempty"`
 	// Action is the action to be performed for the relabeling.
 	Action Action `yaml:"action,omitempty"`
+	Ext    string `yaml:"ext,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -148,7 +159,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			return fmt.Errorf("%s action requires only 'regex', and no other fields", c.Action)
 		}
 	}
-
+	if p := Predicates[c.Action]; p != nil {
+		if !p(c) {
+			return fmt.Errorf("relabel action check fail action=%s ", c.Action)
+		}
+	}
 	return nil
 }
 
@@ -302,7 +317,13 @@ func relabel(cfg *Config, lb *labels.Builder) (keep bool) {
 			}
 		})
 	default:
-		panic(fmt.Errorf("relabel: unknown relabel action type %q", cfg.Action))
+		if caf := CustomerActions[cfg.Action]; caf != nil {
+			if needReturn, result := caf(lb, cfg, val); needReturn {
+				return result
+			}
+		} else {
+			panic(fmt.Errorf("relabel: unknown relabel action type %q", cfg.Action))
+		}
 	}
 
 	return true

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -106,7 +106,7 @@ type Config struct {
 	Replacement string `yaml:"replacement,omitempty"`
 	// Action is the action to be performed for the relabeling.
 	Action Action `yaml:"action,omitempty"`
-	Ext    string `yaml:"ext,omitempty"`
+	Ext string `yaml:"ext,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -106,7 +106,8 @@ type Config struct {
 	Replacement string `yaml:"replacement,omitempty"`
 	// Action is the action to be performed for the relabeling.
 	Action Action `yaml:"action,omitempty"`
-	Ext    string `yaml:"ext,omitempty"`
+	// Ext is the ext config to be used for the custom actions.
+	Ext string `yaml:"ext,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestRelabel(t *testing.T) {
-
 	testPreFixAction := Action("testprefixaction")
 	Predicates[testPreFixAction] = func(cfg *Config) bool {
 		return true

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -24,6 +24,19 @@ import (
 )
 
 func TestRelabel(t *testing.T) {
+
+	testPreFixAction := Action("testprefixaction")
+	Predicates[testPreFixAction] = func(cfg *Config) bool {
+		return true
+	}
+	CustomerActions[testPreFixAction] = func(lb *labels.Builder, cfg *Config, val string) (bool, bool) {
+		prefix := cfg.Ext
+		lb.Range(func(l labels.Label) {
+			lb.Set(l.Name, prefix+l.Value)
+		})
+		return true, true
+	}
+
 	tests := []struct {
 		input   labels.Labels
 		relabel []*Config
@@ -547,6 +560,24 @@ func TestRelabel(t *testing.T) {
 				},
 			},
 			drop: true,
+		},
+		{
+			input: labels.FromMap(map[string]string{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+			}),
+			relabel: []*Config{
+				{
+					Action: "testprefixaction",
+					Ext:    "test-",
+				},
+			},
+			output: labels.FromMap(map[string]string{
+				"a": "test-foo",
+				"b": "test-bar",
+				"c": "test-baz",
+			}),
 		},
 	}
 


### PR DESCRIPTION
Provide extended action capabilities for relabel, allowing developers to customize relabel actions when integrating promtherus.

Once developers want to relabel some labels，bug the buildin actions can not meet their needs,they can register their own action function to handle it.

For example, we want to add prefix to all label values,we can register our action function like this

	testPreFixAction := relabel.Action("testprefixaction") 
	relabel.Predicates[testPreFixAction] = func(cfg *[Config](javascript:volid(0))) bool { 
	  return true 
	} 
	
	relabel.CustomerActions[testPreFixAction] = func([lb](javascript:volid(0)) *labels.Builder, cfg *Config, val string) (bool, bool) { 
	  prefix := cfg.Ext 
	  lb.Range(func(l labels.Label) { 
	     lb.Set(l.Name, prefix+l.Value) 
	    }) 
	  return true, true 
    } 

then we can config the relabel config like this

metric_relabel_configs:
     \- action: testprefixaction
     ext: 'test-'

then all label values will be added a prefix 'test-'

