### PR TITLE
ci(deps): group k8s and opentelemetry dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      k8s.io:
+          patterns:
+            - "k8s.io/*"
+      go.opentelemetry.io:
+          patterns:
+            - "go.opentelemetry.io/*"
   - package-ecosystem: "gomod"
     directory: "/documentation/examples/remote_storage"
     schedule:


### PR DESCRIPTION
Dependabot allows to group dependencies by a list of pattern. This allows it on k8s.io and opentelemetry dependencies separately

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
