### PR TITLE
promtool: add format metrics cmd

### DIFF
--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -25,6 +25,7 @@ Tooling for the Prometheus monitoring system.
 | --- | --- |
 | help | Show help. |
 | check | Check the resources for validity. |
+| format | Rewrite the resources to canonical format. |
 | query | Run query against a Prometheus server. |
 | debug | Fetch debug information. |
 | push | Push to a Prometheus server. |
@@ -197,6 +198,39 @@ examples:
 $ cat metrics.prom | promtool check metrics
 
 $ curl -s http://localhost:9090/metrics | promtool check metrics
+
+
+
+### `promtool format`
+
+Rewrite the resources to canonical format.
+
+
+
+##### `promtool format metrics`
+
+Rewrites prometheus metrics files to a canonical format.
+
+
+
+###### Flags
+
+| Flag | Description |
+| --- | --- |
+| <code class="text-nowrap">--check</code> | Check if the input is formatted. Exit status will be 0 if all input is properly formatted and non-zero otherwise. |
+| <code class="text-nowrap">--diff</code> | Display diffs of formatting changes. |
+| <code class="text-nowrap">--list</code> | List files whose formatting differs (always disabled if using standard input) |
+| <code class="text-nowrap">--write</code> | Write to source files (always disabled if using standard input or --check) |
+
+
+
+
+###### Arguments
+
+| Argument | Description |
+| --- | --- |
+| metric-files | The metric files to format, default is read from standard input. |
+
 
 
 


### PR DESCRIPTION

Hello,

I want to add format metrics command in promtool, like `terraform fmt` command.

It could help users to better write prometheus metrics files that could be read by node exporter...

```
usage: promtool format metrics [<flags>] [<metric-files>...]

Rewrites prometheus metrics files to a canonical format.


Flags:
  -h, --[no-]help            Show context-sensitive help (also try --help-long and --help-man).
      --[no-]version         Show application version.
      --enable-feature= ...  Comma separated feature names to enable (only PromQL related and no-default-scrape-port). See https://prometheus.io/docs/prometheus/latest/feature_flags/ for the options and more details.
      --[no-]check           Check if the input is formatted. Exit status will be 0 if all input is properly formatted and non-zero otherwise.
      --[no-]diff            Display diffs of formatting changes.
      --[no-]list            List files whose formatting differs (always disabled if using standard input)
      --[no-]write           Write to source files (always disabled if using standard input or --check)
```
With `--diff` flag:
```
$ promtool format metrics /tmp/test.prom --diff
--- old//tmp/test.prom
+++ new//tmp/test.prom
@@ -1,3 +1,3 @@
 # HELP http_requests_total a description
-# Comment that's not parsed by prometheus
-http_requests_total{method="post",code="400"}  3
+# TYPE http_requests_total untyped
+http_requests_total{method="post",code="400"} 3
```

