### PR TITLE
WIP: index.Reader.LabelValues: Implement matchers

### DIFF
--- a/model/labels/matcher.go
+++ b/model/labels/matcher.go
@@ -26,6 +26,7 @@ const (
 	MatchNotEqual
 	MatchRegexp
 	MatchNotRegexp
+	MatchSet
 )
 
 var matchTypeToStr = [...]string{
@@ -33,10 +34,11 @@ var matchTypeToStr = [...]string{
 	MatchNotEqual:  "!=",
 	MatchRegexp:    "=~",
 	MatchNotRegexp: "!~",
+	MatchSet:       "[isSet]",
 }
 
 func (m MatchType) String() string {
-	if m < MatchEqual || m > MatchNotRegexp {
+	if m < MatchEqual || m > MatchSet {
 		panic("unknown match type")
 	}
 	return matchTypeToStr[m]
@@ -92,8 +94,11 @@ func (m *Matcher) Matches(s string) bool {
 		return m.re.MatchString(s)
 	case MatchNotRegexp:
 		return !m.re.MatchString(s)
+	case MatchSet:
+		return true
+	default:
+		panic("labels.Matcher.Matches: invalid match type")
 	}
-	panic("labels.Matcher.Matches: invalid match type")
 }
 
 // Inverse returns a matcher that matches the opposite.
@@ -107,8 +112,9 @@ func (m *Matcher) Inverse() (*Matcher, error) {
 		return NewMatcher(MatchNotRegexp, m.Name, m.Value)
 	case MatchNotRegexp:
 		return NewMatcher(MatchRegexp, m.Name, m.Value)
+	default:
+		panic("labels.Matcher.Matches: invalid match type")
 	}
-	panic("labels.Matcher.Matches: invalid match type")
 }
 
 // GetRegexString returns the regex string.

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -75,6 +75,12 @@ type IndexReader interface {
 	// during background garbage collections.
 	Postings(name string, values ...string) (index.Postings, error)
 
+	// PostingsWithLabel returns the postings list iterator for the label name.
+	// The Postings here contain the offsets to the series inside the index.
+	// Found IDs are not strictly required to point to a valid Series, e.g.
+	// during background garbage collections.
+	PostingsWithLabel(name string) (index.Postings, error)
+
 	// SortedPostings returns a postings list that is reordered to be sorted
 	// by the label set of the underlying series.
 	SortedPostings(index.Postings) index.Postings
@@ -477,6 +483,10 @@ func (r blockIndexReader) LabelValues(name string, matchers ...*labels.Matcher) 
 	}
 
 	return labelValuesWithMatchers(r.ir, name, matchers...)
+}
+
+func (r blockIndexReader) PostingsWithLabel(name string) (index.Postings, error) {
+	return r.ir.PostingsWithLabel(name)
 }
 
 func (r blockIndexReader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -120,6 +120,10 @@ func (h *headIndexReader) Postings(name string, values ...string) (index.Posting
 	}
 }
 
+func (h *headIndexReader) PostingsWithLabel(name string) (index.Postings, error) {
+	return h.head.postings.GetWithLabel(name), nil
+}
+
 func (h *headIndexReader) SortedPostings(p index.Postings) index.Postings {
 	series := make([]*memSeries, 0, 128)
 

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -206,6 +206,10 @@ func (oh *OOOHeadIndexReader) Postings(name string, values ...string) (index.Pos
 	}
 }
 
+func (oh *OOOHeadIndexReader) PostingsWithLabel(name string) (index.Postings, error) {
+	return oh.head.postings.GetWithLabel(name), nil
+}
+
 type OOOHeadChunkReader struct {
 	head       *Head
 	mint, maxt int64
@@ -402,6 +406,10 @@ func (ir *OOOCompactionHeadIndexReader) Postings(name string, values ...string) 
 		return nil, errors.New("only AllPostingsKey is supported")
 	}
 	return index.NewListPostings(ir.ch.postings), nil
+}
+
+func (ir *OOOCompactionHeadIndexReader) PostingsWithLabel(name string) (index.Postings, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (ir *OOOCompactionHeadIndexReader) SortedPostings(p index.Postings) index.Postings {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1508,6 +1508,10 @@ func (m mockIndex) Postings(name string, values ...string) (index.Postings, erro
 	return index.Merge(res...), nil
 }
 
+func (m mockIndex) PostingsWithLabel(name string) (index.Postings, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m mockIndex) SortedPostings(p index.Postings) index.Postings {
 	ep, err := index.ExpandPostings(p)
 	if err != nil {
@@ -2387,6 +2391,10 @@ func (m mockMatcherIndex) LabelNamesFor(ids ...storage.SeriesRef) ([]string, err
 }
 
 func (m mockMatcherIndex) Postings(name string, values ...string) (index.Postings, error) {
+	return index.EmptyPostings(), nil
+}
+
+func (m mockMatcherIndex) PostingsWithLabel(name string) (index.Postings, error) {
 	return index.EmptyPostings(), nil
 }
 


### PR DESCRIPTION
Modify `index.Reader.LabelValues` so it implements the `matchers` argument, filtering the returned values accordingly. Also modify `tsdb.labelValuesWithMatchers` so it takes pre-filtered label values as input, which should be an optimization as the filtering happens when gathering the input.