### PR TITLE
docs: fix: correct reference to native histograms feature flag

### DIFF
--- a/docs/querying/basics.md
+++ b/docs/querying/basics.md
@@ -35,7 +35,7 @@ vector is the only type that can be directly graphed.
 _Notes about the experimental native histograms:_
 
 * Ingesting native histograms has to be enabled via a [feature
-  flag](../feature_flags.md#native-histograms).
+  flag](../../feature_flags.md#native-histograms).
 * Once native histograms have been ingested into the TSDB (and even after
   disabling the feature flag again), both instant vectors and range vectors may
   now contain samples that aren't simple floating point numbers (float samples)

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -14,7 +14,7 @@ vector, which if not provided it will default to the value of the expression
 _Notes about the experimental native histograms:_
 
 * Ingesting native histograms has to be enabled via a [feature
-  flag](../feature_flags.md#native-histograms). As long as no native histograms
+  flag](../../feature_flags.md#native-histograms). As long as no native histograms
   have been ingested into the TSDB, all functions will behave as usual.
 * Functions that do not explicitly mention native histograms in their
   documentation (see below) will ignore histogram samples.

--- a/docs/querying/operators.md
+++ b/docs/querying/operators.md
@@ -310,7 +310,7 @@ so `2 ^ 3 ^ 2` is equivalent to `2 ^ (3 ^ 2)`.
 ## Operators for native histograms
 
 Native histograms are an experimental feature. Ingesting native histograms has
-to be enabled via a [feature flag](../feature_flags.md#native-histograms). Once
+to be enabled via a [feature flag](../../feature_flags.md#native-histograms). Once
 native histograms have been ingested, they can be queried (even after the
 feature flag has been disabled again). However, the operator support for native
 histograms is still very limited.


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
The original reference is to https://prometheus.io/docs/prometheus/latest/querying/feature_flags/#native-histograms which is not found. I found the correct page at https://prometheus.io/docs/prometheus/latest/feature_flags/#native-histograms and I think the changes would fix the reference.