### PR TITLE
Fix dropped targets

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -529,7 +529,7 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 			case nonEmpty:
 				all = append(all, t)
 			case !t.discoveredLabels.IsEmpty():
-				if sp.config.KeepDroppedTargets != 0 && uint(len(sp.droppedTargets)) < sp.config.KeepDroppedTargets {
+				if sp.config.KeepDroppedTargets == 0 || uint(len(sp.droppedTargets)) < sp.config.KeepDroppedTargets {
 					sp.droppedTargets = append(sp.droppedTargets, t)
 				}
 				sp.droppedTargetsCount++


### PR DESCRIPTION
#12647 introduced a bug: the zero value of `keep_dropped_targets` kept none of them.

I extended the test to check both zero and nonzero values.
