### PR TITLE
Dockerfile: change the way file permissions are set at build-time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY npm_licenses.tar.bz2                   /npm_licenses.tar.bz2
 
 WORKDIR /prometheus
 RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/ && \
-    chown -R nobody:nobody /etc/prometheus /prometheus
+    chgrp -R 0 /prometheus && chmod -R g+rwX /prometheus /etc/prometheus /prometheus
 
 USER       nobody
 EXPOSE     9090


### PR DESCRIPTION
This Pull request tries to fix the container starting and landing in a reboot loop because of permission issues, as discussed in: https://github.com/prometheus/prometheus/issues/3441#issuecomment-1616114258

a user tried a custom build image where he modified the dockerfile in the way suggested in this pull request. The reasons to change it are outlined here: https://github.com/prometheus/prometheus/issues/3441#issuecomment-1616114258

@SuperQ or @roidelapluie do you need any further context to review this ?