### PR TITLE
Fix  infinite loop in native histogram scraped as classic as well

### DIFF
--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -62,7 +62,9 @@ type Parser interface {
 	// exemplar. It can be called repeatedly to retrieve multiple exemplars
 	// for the same sample. It returns false once all exemplars are
 	// retrieved (including the case where no exemplars exist at all).
-	Exemplar(l *exemplar.Exemplar) bool
+	// The caller should pass index as 0 on the first call and let the method
+	// update it. This is short of implementing full on iterators for this task.
+	Exemplar(l *exemplar.Exemplar, index *int) bool
 
 	// Next advances the parser to the next sample. It returns false if no
 	// more samples were read or an error occurred.

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -178,7 +178,7 @@ func (p *OpenMetricsParser) Metric(l *labels.Labels) string {
 // It returns whether an exemplar exists. As OpenMetrics only ever has one
 // exemplar per sample, every call after the first (for the same sample) will
 // always return false.
-func (p *OpenMetricsParser) Exemplar(e *exemplar.Exemplar) bool {
+func (p *OpenMetricsParser) Exemplar(e *exemplar.Exemplar, _ *int) bool {
 	if len(p.exemplar) == 0 {
 		return false
 	}

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -261,9 +261,12 @@ foo_total 17.0 1520879607.789 # {id="counter-test"} 5`
 		case EntrySeries:
 			m, ts, v := p.Series()
 
-			var e exemplar.Exemplar
+			var (
+				e   exemplar.Exemplar
+				idx int
+			)
 			p.Metric(&res)
-			found := p.Exemplar(&e)
+			found := p.Exemplar(&e, &idx)
 			require.Equal(t, exp[i].m, string(m))
 			require.Equal(t, exp[i].t, ts)
 			require.Equal(t, exp[i].v, v)

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -241,7 +241,7 @@ func (p *PromParser) Metric(l *labels.Labels) string {
 // Exemplar implements the Parser interface. However, since the classic
 // Prometheus text format does not support exemplars, this implementation simply
 // returns false and does nothing else.
-func (p *PromParser) Exemplar(*exemplar.Exemplar) bool {
+func (p *PromParser) Exemplar(*exemplar.Exemplar, *int) bool {
 	return false
 }
 

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -293,7 +293,7 @@ func (p *ProtobufParser) Metric(l *labels.Labels) string {
 // Exemplar writes the exemplar of the current sample into the passed
 // exemplar. It returns if an exemplar exists or not. In case of a native
 // histogram, the legacy bucket section is still used for exemplars. To ingest
-// all examplars, call the Exemplar method repeatedly until it returns false.
+// all exemplars, call the Exemplar method repeatedly until it returns false.
 func (p *ProtobufParser) Exemplar(ex *exemplar.Exemplar) bool {
 	m := p.mf.GetMetric()[p.metricPos]
 	var exProto *dto.Exemplar

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -1763,9 +1763,12 @@ func TestProtobufParse(t *testing.T) {
 				case EntrySeries:
 					m, ts, v := p.Series()
 
-					var e exemplar.Exemplar
+					var (
+						e   exemplar.Exemplar
+						idx int
+					)
 					p.Metric(&res)
-					found := p.Exemplar(&e)
+					found := p.Exemplar(&e, &idx)
 					require.Equal(t, exp[i].m, string(m), "i: %d", i)
 					if ts != nil {
 						require.Equal(t, exp[i].t, *ts, "i: %d", i)
@@ -1798,7 +1801,8 @@ func TestProtobufParse(t *testing.T) {
 						require.Equal(t, exp[i].fhs, fhs, "i: %d", i)
 					}
 					j := 0
-					for e := (exemplar.Exemplar{}); p.Exemplar(&e); j++ {
+					var idx int
+					for e := (exemplar.Exemplar{}); p.Exemplar(&e, &idx); j++ {
 						require.Equal(t, exp[i].e[j], e, "i: %d", i)
 						e = exemplar.Exemplar{}
 					}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1697,7 +1697,8 @@ loop:
 		// number of samples remaining after relabeling.
 		added++
 
-		for hasExemplar := p.Exemplar(&e); hasExemplar; hasExemplar = p.Exemplar(&e) {
+		var idx int
+		for hasExemplar := p.Exemplar(&e, &idx); hasExemplar; hasExemplar = p.Exemplar(&e, &idx) {
 			if !e.HasTs {
 				e.Ts = t
 			}

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2221,8 +2221,8 @@ metric: <
 				{metric: labels.FromStrings("__name__", "test_histogram_count"), t: 1234568, f: 175},
 				{metric: labels.FromStrings("__name__", "test_histogram_sum"), t: 1234568, f: 0.0008280461746287094},
 				{metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "-0.0004899999999999998"), t: 1234568, f: 2},
-				// {metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "-0.0003899999999999998"), t: 1234568, f: 4},
-				// {metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "-0.0002899999999999998"), t: 1234568, f: 16},
+				{metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "-0.0003899999999999998"), t: 1234568, f: 4},
+				{metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "-0.0002899999999999998"), t: 1234568, f: 16},
 				{metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "+Inf"), t: 1234568, f: 175},
 			},
 			histograms: []histogramSample{{

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2217,6 +2217,14 @@ metric: <
 `,
 			scrapeClassicHistograms: true,
 			contentType:             "application/vnd.google.protobuf",
+			floats: []floatSample{
+				{metric: labels.FromStrings("__name__", "test_histogram_count"), t: 1234568, f: 175},
+				{metric: labels.FromStrings("__name__", "test_histogram_sum"), t: 1234568, f: 0.0008280461746287094},
+				{metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "-0.0004899999999999998"), t: 1234568, f: 2},
+				// {metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "-0.0003899999999999998"), t: 1234568, f: 4},
+				// {metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "-0.0002899999999999998"), t: 1234568, f: 16},
+				{metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "+Inf"), t: 1234568, f: 175},
+			},
 			histograms: []histogramSample{{
 				t: 1234568,
 				h: &histogram.Histogram{
@@ -2238,6 +2246,8 @@ metric: <
 				},
 			}},
 			exemplars: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
+				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, Ts: 1234568, HasTs: false},
 				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
 				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, Ts: 1234568, HasTs: false},
 			},
@@ -2278,6 +2288,9 @@ metric: <
 			now := time.Now()
 
 			for i := range test.floats {
+				if test.floats[i].t != 0 {
+					continue
+				}
 				test.floats[i].t = timestamp.FromTime(now)
 			}
 

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1982,13 +1982,14 @@ func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
 
 func TestScrapeLoopAppendExemplar(t *testing.T) {
 	tests := []struct {
-		title           string
-		scrapeText      string
-		contentType     string
-		discoveryLabels []string
-		floats          []floatSample
-		histograms      []histogramSample
-		exemplars       []exemplar.Exemplar
+		title                   string
+		scrapeClassicHistograms bool
+		scrapeText              string
+		contentType             string
+		discoveryLabels         []string
+		floats                  []floatSample
+		histograms              []histogramSample
+		exemplars               []exemplar.Exemplar
 	}{
 		{
 			title:           "Metric without exemplars",
@@ -2142,6 +2143,105 @@ metric: <
 				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, Ts: 1234568, HasTs: false},
 			},
 		},
+		{
+			title: "Native histogram with two exemplars scraped as classic histogram",
+			scrapeText: `name: "test_histogram"
+help: "Test histogram with many buckets removed to keep it manageable in size."
+type: HISTOGRAM
+metric: <
+  histogram: <
+    sample_count: 175
+    sample_sum: 0.0008280461746287094
+    bucket: <
+      cumulative_count: 2
+      upper_bound: -0.0004899999999999998
+    >
+    bucket: <
+      cumulative_count: 4
+      upper_bound: -0.0003899999999999998
+      exemplar: <
+        label: <
+          name: "dummyID"
+          value: "59727"
+        >
+        value: -0.00039
+        timestamp: <
+          seconds: 1625851155
+          nanos: 146848499
+        >
+      >
+    >
+    bucket: <
+      cumulative_count: 16
+      upper_bound: -0.0002899999999999998
+      exemplar: <
+        label: <
+          name: "dummyID"
+          value: "5617"
+        >
+        value: -0.00029
+      >
+    >
+    schema: 3
+    zero_threshold: 2.938735877055719e-39
+    zero_count: 2
+    negative_span: <
+      offset: -162
+      length: 1
+    >
+    negative_span: <
+      offset: 23
+      length: 4
+    >
+    negative_delta: 1
+    negative_delta: 3
+    negative_delta: -2
+    negative_delta: -1
+    negative_delta: 1
+    positive_span: <
+      offset: -161
+      length: 1
+    >
+    positive_span: <
+      offset: 8
+      length: 3
+    >
+    positive_delta: 1
+    positive_delta: 2
+    positive_delta: -1
+    positive_delta: -1
+  >
+  timestamp_ms: 1234568
+>
+
+`,
+			scrapeClassicHistograms: true,
+			contentType:             "application/vnd.google.protobuf",
+			histograms: []histogramSample{{
+				t: 1234568,
+				h: &histogram.Histogram{
+					Count:         175,
+					ZeroCount:     2,
+					Sum:           0.0008280461746287094,
+					ZeroThreshold: 2.938735877055719e-39,
+					Schema:        3,
+					PositiveSpans: []histogram.Span{
+						{Offset: -161, Length: 1},
+						{Offset: 8, Length: 3},
+					},
+					NegativeSpans: []histogram.Span{
+						{Offset: -162, Length: 1},
+						{Offset: 23, Length: 4},
+					},
+					PositiveBuckets: []int64{1, 2, -1, -1},
+					NegativeBuckets: []int64{1, 3, -2, -1, 1},
+				},
+			}},
+			exemplars: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
+				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, Ts: 1234568, HasTs: false},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -2168,7 +2268,7 @@ metric: <
 				nil,
 				0,
 				0,
-				false,
+				test.scrapeClassicHistograms,
 				false,
 				false,
 				nil,


### PR DESCRIPTION
Fixes: #12731 

The fundamental problem is that the ProtobufParser.fieldPos field is used for two things:
* keeping track of which classic histogram bucket we need to process next
* keeping track of which exemplar we processed for a classic / native histogram

These are not compatible as soon as you want to process native histogram's classic buckets.

An alternate solution would be for the Exemplar function to return a slice, which is nicer, but introduces more memory allocations, so I'm not sure if we should do that @beorn7 