### PR TITLE
promql: simplify inner loop of rangeEval

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1187,42 +1187,27 @@ func (ev *evaluator) rangeEval(prepSeries func(labels.Labels, *EvalSeriesHelper)
 				bufHelpers[i] = bufHelpers[i][:0]
 			}
 
-			for si, series := range matrixes[i] {
-				for _, point := range series.Floats {
-					if point.T == ts {
-						if ev.currentSamples < ev.maxSamples {
-							vectors[i] = append(vectors[i], Sample{Metric: series.Metric, F: point.F, T: ts})
-							if prepSeries != nil {
-								bufHelpers[i] = append(bufHelpers[i], seriesHelpers[i][si])
-							}
-
-							// Move input vectors forward so we don't have to re-scan the same
-							// past points at the next step.
-							matrixes[i][si].Floats = series.Floats[1:]
-							ev.currentSamples++
-						} else {
-							ev.error(ErrTooManySamples(env))
-						}
-					}
-					break
+			add := func(si int, s Sample) {
+				vectors[i] = append(vectors[i], s)
+				if prepSeries != nil {
+					bufHelpers[i] = append(bufHelpers[i], seriesHelpers[i][si])
 				}
-				for _, point := range series.Histograms {
-					if point.T == ts {
-						if ev.currentSamples < ev.maxSamples {
-							vectors[i] = append(vectors[i], Sample{Metric: series.Metric, H: point.H, T: ts})
-							if prepSeries != nil {
-								bufHelpers[i] = append(bufHelpers[i], seriesHelpers[i][si])
-							}
+				ev.currentSamples++
+			}
 
-							// Move input vectors forward so we don't have to re-scan the same
-							// past points at the next step.
-							matrixes[i][si].Histograms = series.Histograms[1:]
-							ev.currentSamples++
-						} else {
-							ev.error(ErrTooManySamples(env))
-						}
-					}
-					break
+			for si, series := range matrixes[i] {
+				if len(series.Floats) > 0 && series.Floats[0].T == ts {
+					add(si, Sample{Metric: series.Metric, F: series.Floats[0].F, T: ts})
+					// Move input vectors forward so we don't have to re-scan the same
+					// past points at the next step.
+					matrixes[i][si].Floats = series.Floats[1:]
+				}
+				if len(series.Histograms) > 0 && series.Histograms[0].T == ts {
+					add(si, Sample{Metric: series.Metric, H: series.Histograms[0].H, T: ts})
+					matrixes[i][si].Histograms = series.Histograms[1:]
+				}
+				if ev.currentSamples > ev.maxSamples {
+					ev.error(ErrTooManySamples(env))
 				}
 			}
 			args[i] = vectors[i]

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1188,15 +1188,16 @@ func (ev *evaluator) rangeEval(prepSeries func(labels.Labels, *EvalSeriesHelper)
 			}
 
 			for si, series := range matrixes[i] {
-				if len(series.Floats) > 0 && series.Floats[0].T == ts {
+				switch {
+				case len(series.Floats) > 0 && series.Floats[0].T == ts:
 					vectors[i] = append(vectors[i], Sample{Metric: series.Metric, F: series.Floats[0].F, T: ts})
 					// Move input vectors forward so we don't have to re-scan the same
 					// past points at the next step.
 					matrixes[i][si].Floats = series.Floats[1:]
-				} else if len(series.Histograms) > 0 && series.Histograms[0].T == ts {
+				case len(series.Histograms) > 0 && series.Histograms[0].T == ts:
 					vectors[i] = append(vectors[i], Sample{Metric: series.Metric, H: series.Histograms[0].H, T: ts})
 					matrixes[i][si].Histograms = series.Histograms[1:]
-				} else {
+				default:
 					continue
 				}
 				if prepSeries != nil {


### PR DESCRIPTION
Instead of a loop that breaks after one iteration, write an if-statement (actually a switch because lint complained).
We know that we can't get both float and histogram on the same timestep, so pull common code after both cases.
