### PR TITLE
Prevent Prometheus from overallocating memory on subquery with large amount of steps.

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1927,6 +1927,12 @@ func (ev *evaluator) pointsSliceSize(numSteps, step, numberOfSeries int) int {
 	remainingSteps := numSteps - step
 	// spread the remaining allowed samples across all the series in the result.
 	allowedSamples := (ev.maxSamples - ev.currentSamples) / numberOfSeries
+
+	// This is here just to prevent potential negative values (and panic)
+	if allowedSamples < 0 {
+		allowedSamples = 0
+	}
+
 	if remainingSteps > allowedSamples {
 		return allowedSamples
 	}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1925,7 +1925,7 @@ var (
 func (ev *evaluator) pointsSliceSize(numSteps, step, numberOfSeries int) int {
 	// Subtract the current step from the numSteps as at this point we know the given series does not have data before this step
 	remainingSteps := numSteps - step
-	// spread the remaining allowed samples across all the series in the result.
+	// Spread the remaining allowed samples across all the series in the result.
 	allowedSamples := (ev.maxSamples - ev.currentSamples) / numberOfSeries
 
 	if allowedSamples < 0 {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1923,7 +1923,7 @@ var (
 // pointsSliceSize calculates a reasonable initial capacity for the point slices when running a query
 // taking in consideration the remaining number of steps, maxSamples and number of series in the result
 func (ev *evaluator) pointsSliceSize(numSteps, step, numberOfSeries int) int {
-	// Subtract the current step from the numSteps as at this point we know the given series does not have data before this step
+	// Subtract the current step from the numSteps as at this point we know the given series does not have data before this step.
 	remainingSteps := numSteps - step
 	// Spread the remaining allowed samples across all the series in the result.
 	allowedSamples := (ev.maxSamples - ev.currentSamples) / numberOfSeries

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1920,8 +1920,9 @@ var (
 	hPointPool zeropool.Pool[[]HPoint]
 )
 
-// pointsSliceSize calculates a reasonable initial capacity for the point slices when running a query
-// taking in consideration the remaining number of steps, maxSamples and number of series in the result
+// pointsSliceSize calculates a reasonable initial capacity for the point slices when running a query.
+// It takes in consideration the remaining number of steps, maxSamples and number of series in the result.
+// It allows preventing OOMs caused by unexpected pre-allocation before we hit ErrTooManySamples.
 func (ev *evaluator) pointsSliceSize(numSteps, step, numberOfSeries int) int {
 	// Subtract the current step from the numSteps as at this point we know the given series does not have data before this step.
 	remainingSteps := numSteps - step

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -61,6 +61,8 @@ const (
 	minInt64 = -9223372036854775808
 
 	// Max initial size for the pooled points slices.
+	// The getHPointSlice and getFPointSlice functions are called with an estimated size which often can be
+	// over-estimated.
 	maxPointsSliceSize = 5000
 )
 
@@ -1933,12 +1935,16 @@ func getFPointSlice(sz int) []FPoint {
 	return make([]FPoint, 0, sz)
 }
 
+// putFPointSlice will return a FPoint slice of size max(maxPointsSliceSize, sz).
+// This function is called with an estimated size which often can be over-estimated.
 func putFPointSlice(p []FPoint) {
 	if p != nil {
 		fPointPool.Put(p[:0])
 	}
 }
 
+// getHPointSlice will return a HPoint slice of size max(maxPointsSliceSize, sz).
+// This function is called with an estimated size which often can be over-estimated.
 func getHPointSlice(sz int) []HPoint {
 	if p := hPointPool.Get(); p != nil {
 		return p

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1928,7 +1928,6 @@ func (ev *evaluator) pointsSliceSize(numSteps, step, numberOfSeries int) int {
 	// spread the remaining allowed samples across all the series in the result.
 	allowedSamples := (ev.maxSamples - ev.currentSamples) / numberOfSeries
 
-	// This is here just to prevent potential negative values (and panic)
 	if allowedSamples < 0 {
 		allowedSamples = 0
 	}


### PR DESCRIPTION
Hi,

We just noticed that we can cause OOM on prometheus if we run queries like `avg_over_time(metric[30d:30s])` before it hit the `ErrTooManySamples` as we allocate slices with the `expected number of steps` in the beginning of the query evaluation. 

See for instance :
https://github.com/prometheus/prometheus/blob/c579144f66b73de12f06981c99288bf03538d3ce/promql/engine.go#L1695-L1700

This has 2 main consequences:

* Prometheus may go OOM even if the query would eventually hit the `ErrTooManySamples`
* Prometheus may use way more memory than needed to execute queries over sparse timeseries.

Ex:

Imagine that the query `avg_over_time(metric[30d:30s])` match 10K series but each series only have 3 days worth of data. We also have a host with 50Gb and `query.max-samples` set to 50M (default limit) - with this config we would expect a single query would use at most ~= 6Gb (50M x 128 <del>bytes</del> bits - each `FPoint` has size of [128](https://github.com/prometheus/prometheus/blob/c579144f66b73de12f06981c99288bf03538d3ce/promql/value.go#L89-L92) <del>bytes</del> bits)

Now for this query we have:
* Total number of samples queried per series matched (samplesPerSeries):
   * 3d/30s = 8640
* Total number of samples queried
     * 10K * 8640 = 86.4M samples
     * This is above the default limit (50M) so this query should fail with `ErrTooManySamples`
 * For each of the 10K series, we will allocate a slice of size `30d/30s` = 86.4K` (instead of 8.6k as needed)

In this scenario we will only hit the `ErrTooManySamples` when we already evaluated 50M/8640 series = 5.7K series (limit/samplesPerSeries).  At this point we have already allocated 5.7K * 86.4K * 128 <del>bytes</del> bits ~= 58Gb causing OOM (way more than the expected 6Gb).

This can also lead to use way more memory than needed even if we don't hit the `ErrTooManySamples`


### Proposed solution

This PR is trying to get a more sensible initial capacity for the points slices in cases we have too many steps or series in order to allow the engine to throw `ErrTooManySamples` before going OOM. In order to do so, instead of always allocating the slices with capacity equals to the number of steps we would be calculating it by the following function:

```
func sizeToAllocate(numSteps, step, currentSamples, maxSamples, numberOfSeries int) int {
        // Subtract the current step from the numSteps as at this point we know the given series does not have data before this step
	remainingSteps := numSteps - step
        // spread the remaining allowed samples across all the series in the result.
	allowedSamples := (maxSamples - currentSamples) / numberOfSeries
	if remainingSteps > allowedSamples {
		return allowedSamples
	}
	return remainingSteps
}
```

In the case before, instead of allocating 86.4K points per series we would be allocating ~5K (50M/10K)which is less than the 8.6K needed but is a good start point. Its is also important to note that this should only make a difference if the query is relatively close to the `query.max-samples` limits - otherwise we will return the same number of steps.

