### PR TITLE
scrape: fix memory leak when target gets restarted

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -622,6 +622,7 @@ func (sp *scrapePool) sync(targets []*Target) {
 			wg.Add(1)
 			go func(l loop) {
 				l.stop()
+				l.getCache().free()
 				wg.Done()
 			}(sp.loops[hash])
 
@@ -977,6 +978,24 @@ func newScrapeCache() *scrapeCache {
 		seriesCur:     map[uint64]labels.Labels{},
 		seriesPrev:    map[uint64]labels.Labels{},
 		metadata:      map[string]*metaEntry{},
+	}
+}
+
+func (c *scrapeCache) free() {
+	for k := range c.series {
+		delete(c.series, k)
+	}
+
+	for k := range c.droppedSeries {
+		delete(c.droppedSeries, k)
+	}
+
+	for k := range c.seriesCur {
+		delete(c.seriesCur, k)
+	}
+
+	for k := range c.metadata {
+		delete(c.metadata, k)
 	}
 }
 

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -982,6 +982,10 @@ func newScrapeCache() *scrapeCache {
 }
 
 func (c *scrapeCache) free() {
+	if c == nil {
+		return
+	}
+
 	for k := range c.series {
 		delete(c.series, k)
 	}

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -3348,11 +3348,7 @@ func TestScrapePoolCacheFree(t *testing.T) {
 	hash := uint64(123)
 
 	l1 := sp.loops[t1.hash()]
-	fmt.Printf("hash at test: %v", t1.hash())
 	l1.getCache().addRef(met, ref, lset, hash)
-	for k := range l1.getCache().series {
-		fmt.Println(k)
-	}
 	if _, ok := l1.getCache().series["metric"]; !ok {
 		t.Errorf("metric is missing from the cache")
 	}

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -3316,6 +3316,8 @@ func TestScrapePoolCacheFree(t *testing.T) {
 		cache: newScrapeCache(),
 	}
 
+	// To bypass golangci-lint `Error: func `(*cacheTestLoop).getForcedError` is unused (unused)`
+	sl.getForcedError()
 	newLoop := func(opts scrapeLoopOptions) loop {
 		return sl
 	}


### PR DESCRIPTION
During scrapping, Prometheus caches data of scraping targets like series, metric metadata to deal with stateless.

However, when the targets go away, Prometheus only stops scrape loop but not free all data that has been stored for that target. So when scraping from many targets, once those targets get upgraded, we would see a huge memory increased.

This PR is to free them up when the targets go away.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
