### PR TITLE
promql: force mmap of head chunks in BenchmarkRangeQuery

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -66,6 +66,8 @@ func setupRangeQueryTestData(stor *teststorage.TestStorage, _ *Engine, interval,
 			return err
 		}
 	}
+	stor.DB.ForceHeadMMap() // Ensure we have at most one head chunk for every series.
+	stor.DB.Compact()
 	return nil
 }
 
@@ -222,6 +224,7 @@ func rangeQueryCases() []benchCase {
 
 func BenchmarkRangeQuery(b *testing.B) {
 	stor := teststorage.New(b)
+	stor.DB.DisableCompactions() // Don't want auto-compaction disrupting timings.
 	defer stor.Close()
 	opts := EngineOpts{
 		Logger:     nil,

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1797,6 +1797,11 @@ func (db *DB) EnableCompactions() {
 	level.Info(db.logger).Log("msg", "Compactions enabled")
 }
 
+// ForceHeadMMap is intended for use only in tests and benchmarks.
+func (db *DB) ForceHeadMMap() {
+	db.head.mmapHeadChunks()
+}
+
 // Snapshot writes the current data to the directory. If withHead is set to true it
 // will create a new block containing all data that's currently in the memory buffer/WAL.
 func (db *DB) Snapshot(dir string, withHead bool) error {


### PR DESCRIPTION
Otherwise we have a highly unusual situation of over 100 chunks in the headChunks list of each series, which heavily skews performance.

Example before and after:
```
BenchmarkRangeQuery/expr=a_hundred,steps=1-4                 332           3370400 ns/op           65255 B/op        909 allocs/op
BenchmarkRangeQuery/expr=a_hundred,steps=1-4                1260            868358 ns/op           65835 B/op        909 allocs/op
```

This was a highly confusing bug to track down, because `DB.run()` does call `mmapHeadChunks` every 1 minute, so depending on what benchmarks you run you can get the faster performance.

To avoid `Compact()` disrupting performance every minute I disabled auto-compacting.  However this previously ran after every commit, so I call `Compact()` once all the data is ready.
