### PR TITLE
TSDB: re-use iterator when moving between series

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -622,7 +622,7 @@ func (p *populateWithDelGenericSeriesIterator) reset(blockID ulid.ULID, cr Chunk
 	p.chks = chks
 	p.i = -1
 	p.err = nil
-	p.bufIter.Iter = nil
+	// Note we don't touch p.bufIter.Iter; it is holding on to an iterator we might reuse in next().
 	p.bufIter.Intervals = p.bufIter.Intervals[:0]
 	p.intervals = intervals
 	p.currDelIter = nil


### PR DESCRIPTION
It was already commented that `bufIter` exists only to hold the value for re-use, so we should not erase the value each time round.

Made possible by #11334.

Benchmark results after #12755:
<details><summary>TL;DR: up to 5% faster, 10% less garbage</summary>
<p>

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/promql
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                                                                                                         │  before.txt  │             after.txt              │
                                                                                                         │    sec/op    │    sec/op     vs base              │
RangeQuery/expr=a_hundred,steps=1-4                                                                        923.6µ ±  6%   914.7µ ±  5%       ~ (p=0.589 n=6)
RangeQuery/expr=a_hundred,steps=100-4                                                                      3.105m ±  5%   3.000m ±  4%  -3.39% (p=0.041 n=6)
RangeQuery/expr=a_hundred,steps=1000-4                                                                     16.34m ±  8%   15.76m ±  3%  -3.55% (p=0.026 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-4                                                              782.1µ ±  5%   773.1µ ±  4%       ~ (p=0.937 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-4                                                            4.366m ±  2%   4.323m ±  4%       ~ (p=0.485 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-4                                                           30.12m ±  2%   30.06m ± 10%       ~ (p=1.000 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-4                                                          353.7m ±  2%   353.6m ±  3%       ~ (p=0.937 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-4                                            135.5m ±  2%   135.9m ±  3%       ~ (p=0.589 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-4                                          718.3m ±  2%   702.9m ±  4%       ~ (p=0.132 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-4                                          5.918 ±  2%    5.838 ±  0%  -1.36% (p=0.041 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-4                                                           129.9m ±  3%   126.4m ±  3%       ~ (p=0.132 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-4                                                         252.0m ±  2%   245.2m ±  2%  -2.69% (p=0.026 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-4                                                         1.333 ±  2%    1.341 ±  2%       ~ (p=0.394 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-4                                                              127.6m ± 10%   126.2m ±  2%       ~ (p=0.180 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-4                                                            197.3m ±  6%   194.9m ±  4%  -1.22% (p=0.041 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-4                                                           833.1m ±  3%   819.5m ±  2%       ~ (p=0.485 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-4                                                  127.4m ±  4%   128.6m ±  4%       ~ (p=0.937 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-4                                                149.3m ±  1%   148.8m ±  3%       ~ (p=0.394 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-4                                               352.6m ±  5%   367.3m ±  4%  +4.17% (p=0.015 n=6)
RangeQuery/expr=-a_hundred,steps=1-4                                                                       955.7µ ± 10%   934.7µ ±  7%       ~ (p=0.818 n=6)
RangeQuery/expr=-a_hundred,steps=100-4                                                                     3.112m ±  2%   3.066m ±  1%  -1.48% (p=0.015 n=6)
RangeQuery/expr=-a_hundred,steps=1000-4                                                                    16.08m ±  1%   16.40m ±  4%       ~ (p=0.132 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-4                                                            2.085m ±  4%   2.068m ±  3%       ~ (p=0.699 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-4                                                          12.76m ±  6%   12.37m ±  3%       ~ (p=0.065 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-4                                                         95.97m ±  8%   94.47m ±  3%       ~ (p=0.394 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-4                                                         1.085 ±  5%    1.093 ±  5%       ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-4                                           1.595m ±  3%   1.576m ±  3%       ~ (p=0.485 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-4                                         6.755m ±  2%   6.583m ±  3%  -2.54% (p=0.041 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                        44.50m ±  2%   43.74m ±  8%       ~ (p=0.394 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-4                                            1.666m ±  3%   1.668m ±  4%       ~ (p=0.818 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-4                                          7.785m ±  3%   7.664m ±  9%       ~ (p=0.310 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                         54.59m ±  3%   52.68m ±  4%       ~ (p=0.065 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-4                                        1.592m ±  1%   1.555m ±  5%       ~ (p=0.180 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-4                                      6.906m ±  2%   6.586m ±  2%  -4.63% (p=0.002 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                     44.12m ±  2%   44.41m ±  4%       ~ (p=0.818 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1-4                                            908.0µ ±  2%   907.8µ ±  2%       ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-4                                          3.336m ±  2%   3.217m ±  4%       ~ (p=0.065 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-4                                         18.30m ±  4%   18.27m ±  3%       ~ (p=0.485 n=6)
RangeQuery/expr=abs(a_hundred),steps=1-4                                                                   1.080m ±  7%   1.020m ±  4%  -5.56% (p=0.026 n=6)
RangeQuery/expr=abs(a_hundred),steps=100-4                                                                 5.526m ±  6%   5.373m ±  2%  -2.77% (p=0.009 n=6)
RangeQuery/expr=abs(a_hundred),steps=1000-4                                                                38.57m ±  2%   38.65m ±  2%       ~ (p=0.937 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-4                                1.164m ±  8%   1.122m ±  2%  -3.63% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-4                              5.974m ± 12%   5.687m ±  2%  -4.80% (p=0.009 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4                             41.99m ± 23%   41.34m ± 13%       ~ (p=0.589 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-4                                       1.180m ± 27%   1.099m ±  4%       ~ (p=0.310 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-4                                     5.773m ±  3%   5.619m ±  8%       ~ (p=0.132 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-4                                    41.55m ±  2%   41.76m ±  2%       ~ (p=0.394 n=6)
RangeQuery/expr=sum(a_hundred),steps=1-4                                                                   927.9µ ±  5%   892.6µ ±  3%  -3.80% (p=0.041 n=6)
RangeQuery/expr=sum(a_hundred),steps=100-4                                                                 3.477m ±  4%   3.767m ± 14%       ~ (p=0.093 n=6)
RangeQuery/expr=sum(a_hundred),steps=1000-4                                                                20.69m ±  7%   21.03m ± 16%       ~ (p=0.937 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-4                                                       10.37m ±  5%   10.46m ±  3%       ~ (p=0.818 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-4                                                     39.78m ±  5%   39.90m ±  3%       ~ (p=0.937 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-4                                                    247.7m ±  5%   243.1m ±  3%       ~ (p=0.132 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-4                                                      10.78m ±  2%   10.30m ±  4%  -4.47% (p=0.009 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-4                                                    45.31m ±  3%   44.95m ±  3%       ~ (p=0.394 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-4                                                   291.1m ±  7%   283.7m ±  1%  -2.52% (p=0.004 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-4                                                            11.07m ±  6%   10.32m ±  2%  -6.80% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-4                                                          47.20m ±  5%   45.25m ±  4%       ~ (p=0.065 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-4                                                         293.4m ±  2%   288.8m ±  5%       ~ (p=0.240 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-4                                                           10.67m ±  2%   10.59m ±  5%       ~ (p=0.485 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-4                                                         40.95m ±  2%   42.15m ± 10%  +2.95% (p=0.041 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-4                                                        249.8m ± 12%   254.7m ± 16%       ~ (p=0.394 n=6)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-4                                               302.7m ±  1%   302.0m ±  4%       ~ (p=0.485 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=1-4                                                               934.8µ ±  3%   921.8µ ±  7%       ~ (p=0.485 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4                                                             3.556m ±  5%   3.464m ±  2%  -2.60% (p=0.041 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4                                                            21.25m ±  3%   20.90m ±  2%       ~ (p=0.065 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=1-4                                                               944.0µ ±  3%   921.7µ ±  3%  -2.36% (p=0.026 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=100-4                                                             4.705m ±  2%   4.685m ± 10%       ~ (p=0.937 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=1000-4                                                            32.33m ±  4%   31.83m ±  3%       ~ (p=0.485 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-4                                        1.869m ±  5%   1.775m ±  2%  -5.03% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-4                                      15.30m ±  5%   14.34m ±  8%  -6.26% (p=0.041 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-4                                     115.7m ±  2%   114.2m ±  1%  -1.23% (p=0.026 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-4                                             815.3µ ±  9%   784.8µ ±  4%  -3.74% (p=0.015 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-4                                           4.910m ±  9%   4.770m ±  3%  -2.85% (p=0.041 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-4                                          34.34m ± 10%   34.25m ±  3%       ~ (p=0.394 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-4      1.738m ± 16%   1.608m ±  1%  -7.52% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-4    9.913m ±  5%   9.869m ±  7%       ~ (p=0.937 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-4   69.42m ±  3%   69.45m ±  5%       ~ (p=0.937 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-4                                     13.02m ±  4%   12.96m ±  4%       ~ (p=0.818 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-4                                   76.34m ±  4%   73.98m ±  4%       ~ (p=0.240 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-4                                  569.8m ±  5%   561.8m ±  3%       ~ (p=0.310 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1-4                                              976.9µ ±  3%   943.8µ ±  4%  -3.38% (p=0.041 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-4                                            4.310m ±  9%   4.161m ±  3%  -3.45% (p=0.026 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-4                                           27.50m ±  4%   27.08m ±  2%       ~ (p=0.132 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1-4                                                             1.067m ±  4%   1.049m ±  4%       ~ (p=0.394 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=100-4                                                           5.632m ±  2%   5.546m ±  3%       ~ (p=0.240 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1000-4                                                          40.14m ±  4%   40.60m ±  4%       ~ (p=0.818 n=6)
geomean                                                                                                    18.27m         17.98m        -1.58%

                                                                                                         │    before.txt    │               after.txt                │
                                                                                                         │       B/op       │      B/op        vs base               │
RangeQuery/expr=a_hundred,steps=1-4                                                                         63.71Ki ±    1%   52.88Ki ±    1%  -16.99% (p=0.002 n=6)
RangeQuery/expr=a_hundred,steps=100-4                                                                       95.90Ki ±    0%   85.07Ki ±    0%  -11.29% (p=0.002 n=6)
RangeQuery/expr=a_hundred,steps=1000-4                                                                      380.6Ki ±    0%   369.9Ki ±    0%   -2.81% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-4                                                               93.45Ki ±    0%   82.63Ki ±    0%  -11.59% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-4                                                             125.7Ki ±    0%   114.8Ki ±    0%   -8.64% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-4                                                            377.4Ki ±    0%   366.6Ki ±    0%   -2.86% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-4                                                           3.158Mi ±    1%   3.110Mi ±    2%   -1.52% (p=0.015 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-4                                             3.509Mi ±    0%   3.498Mi ±    0%   -0.30% (p=0.002 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-4                                           3.360Mi ±    7%   3.466Mi ±    3%        ~ (p=0.394 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-4                                          3.405Mi ±   67%   3.832Mi ±   41%        ~ (p=0.589 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-4                                                            3.141Mi ±    2%   3.131Mi ±    2%        ~ (p=0.132 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-4                                                          3.112Mi ±    3%   3.149Mi ±    2%        ~ (p=0.699 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-4                                                         3.806Mi ±   11%   3.797Mi ±   12%        ~ (p=0.310 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-4                                                               3.084Mi ±    2%   3.124Mi ±    2%        ~ (p=0.818 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-4                                                             3.187Mi ±    2%   3.180Mi ±    3%        ~ (p=0.132 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-4                                                            3.578Mi ±    6%   3.343Mi ±    7%   -6.59% (p=0.009 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-4                                                   3.114Mi ±    1%   3.073Mi ±    2%        ~ (p=0.063 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-4                                                 3.313Mi ±    1%   3.303Mi ±    1%        ~ (p=0.141 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-4                                                5.072Mi ±    3%   4.980Mi ±    2%   -1.81% (p=0.009 n=6)
RangeQuery/expr=-a_hundred,steps=1-4                                                                        92.40Ki ±    0%   81.57Ki ±    0%  -11.72% (p=0.002 n=6)
RangeQuery/expr=-a_hundred,steps=100-4                                                                      124.6Ki ±    0%   113.8Ki ±    0%   -8.69% (p=0.002 n=6)
RangeQuery/expr=-a_hundred,steps=1000-4                                                                     409.6Ki ±    0%   398.4Ki ±    0%   -2.71% (p=0.002 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-4                                                             240.4Ki ±    0%   218.7Ki ±    0%   -9.02% (p=0.002 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-4                                                           414.9Ki ±    0%   392.6Ki ±    0%   -5.38% (p=0.002 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-4                                                          1.936Mi ±    1%   1.919Mi ±    0%   -0.84% (p=0.002 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-4                                                         17.29Mi ± 1046%   17.21Mi ± 1051%        ~ (p=0.589 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-4                                            165.2Ki ±    0%   149.1Ki ±    0%   -9.78% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-4                                          445.0Ki ±    0%   428.7Ki ±    0%   -3.67% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                         2.907Mi ±    0%   2.890Mi ±    0%   -0.58% (p=0.002 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-4                                             176.2Ki ±    0%   160.0Ki ±    0%   -9.20% (p=0.002 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-4                                           734.0Ki ±    0%   717.7Ki ±    0%   -2.23% (p=0.002 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                          5.658Mi ±    0%   5.642Mi ±    0%   -0.29% (p=0.002 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-4                                         165.2Ki ±    0%   149.0Ki ±    0%   -9.78% (p=0.002 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-4                                       445.0Ki ±    0%   428.7Ki ±    0%   -3.66% (p=0.002 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                      2.907Mi ±    0%   2.892Mi ±    0%   -0.53% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1-4                                            104.97Ki ±    0%   94.15Ki ±    0%  -10.32% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-4                                           141.8Ki ±    0%   131.0Ki ±    0%   -7.64% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-4                                          469.0Ki ±    0%   458.0Ki ±    0%   -2.35% (p=0.002 n=6)
RangeQuery/expr=abs(a_hundred),steps=1-4                                                                    140.3Ki ±    0%   129.5Ki ±    0%   -7.71% (p=0.002 n=6)
RangeQuery/expr=abs(a_hundred),steps=100-4                                                                  174.9Ki ±    0%   164.1Ki ±    0%   -6.18% (p=0.002 n=6)
RangeQuery/expr=abs(a_hundred),steps=1000-4                                                                 481.7Ki ±    0%   470.7Ki ±    0%   -2.29% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-4                                 166.8Ki ±    0%   156.0Ki ±    0%   -6.51% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-4                               210.6Ki ±    0%   199.8Ki ±    0%   -5.14% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4                              602.1Ki ±    0%   591.0Ki ±    0%   -1.85% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-4                                        150.5Ki ±    0%   139.7Ki ±    0%   -7.21% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-4                                      200.6Ki ±    0%   189.7Ki ±    0%   -5.44% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-4                                     648.4Ki ±    0%   637.3Ki ±    0%   -1.71% (p=0.002 n=6)
RangeQuery/expr=sum(a_hundred),steps=1-4                                                                   102.62Ki ±    0%   91.79Ki ±    0%  -10.55% (p=0.002 n=6)
RangeQuery/expr=sum(a_hundred),steps=100-4                                                                  152.6Ki ±    0%   141.8Ki ±    0%   -7.09% (p=0.002 n=6)
RangeQuery/expr=sum(a_hundred),steps=1000-4                                                                 599.4Ki ±    0%   588.6Ki ±    0%   -1.80% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-4                                                        1.128Mi ±    0%   1.011Mi ±    0%  -10.40% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-4                                                      1.688Mi ±    0%   1.570Mi ±    0%   -6.95% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-4                                                     6.687Mi ±    0%   6.569Mi ±    0%   -1.77% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-4                                                       1.175Mi ±    0%   1.058Mi ±    0%   -9.99% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-4                                                     3.714Mi ±    0%   3.597Mi ±    0%   -3.17% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-4                                                    26.71Mi ±    0%   26.59Mi ±    0%   -0.44% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-4                                                             1.175Mi ±    0%   1.058Mi ±    0%  -10.00% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-4                                                           3.714Mi ±    0%   3.597Mi ±    0%   -3.17% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-4                                                          26.71Mi ±    0%   26.59Mi ±    0%   -0.42% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-4                                                            1.128Mi ±    0%   1.011Mi ±    0%  -10.40% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-4                                                          1.688Mi ±    0%   1.571Mi ±    0%   -6.93% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-4                                                         6.687Mi ±    0%   6.575Mi ±    0%   -1.68% (p=0.002 n=6)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-4                                                108.1Mi ±    0%   108.0Mi ±    0%   -0.10% (p=0.002 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=1-4                                                               103.75Ki ±    0%   92.92Ki ±    0%  -10.44% (p=0.002 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4                                                              158.4Ki ±    0%   147.5Ki ±    0%   -6.84% (p=0.002 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4                                                             647.4Ki ±    0%   636.6Ki ±    0%   -1.67% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=1-4                                                               104.87Ki ±    0%   94.05Ki ±    0%  -10.32% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=100-4                                                              200.5Ki ±    0%   189.7Ki ±    0%   -5.39% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=1000-4                                                             1.038Mi ±    0%   1.027Mi ±    0%   -1.04% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-4                                         296.5Ki ±    0%   274.8Ki ±    0%   -7.31% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-4                                       471.1Ki ±    0%   448.3Ki ±    0%   -4.83% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-4                                      1.929Mi ±    1%   1.902Mi ±    1%   -1.40% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-4                                              132.4Ki ±    0%   121.6Ki ±    0%   -8.18% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-4                                            185.5Ki ±    0%   174.7Ki ±    0%   -5.84% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-4                                           627.3Ki ±    0%   616.4Ki ±    0%   -1.73% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-4       266.8Ki ±    0%   245.2Ki ±    0%   -8.11% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-4     377.0Ki ±    0%   355.4Ki ±    0%   -5.74% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-4    1.268Mi ±    0%   1.247Mi ±    0%   -1.67% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-4                                      1.483Mi ±    0%   1.366Mi ±    0%   -7.90% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-4                                    1.829Mi ±    0%   1.712Mi ±    0%   -6.44% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-4                                   4.890Mi ±    0%   4.772Mi ±    0%   -2.39% (p=0.002 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1-4                                               131.5Ki ±    0%   120.6Ki ±    0%   -8.25% (p=0.002 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-4                                             267.9Ki ±    0%   257.0Ki ±    0%   -4.06% (p=0.002 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-4                                            1.466Mi ±    0%   1.457Mi ±    0%   -0.61% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1-4                                                              180.2Ki ±    0%   180.2Ki ±    0%        ~ (p=0.965 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=100-4                                                            686.5Ki ±    0%   686.6Ki ±    0%        ~ (p=0.485 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1000-4                                                           5.158Mi ±    0%   5.158Mi ±    0%        ~ (p=0.937 n=6)
geomean                                                                                                     781.6Ki           746.1Ki           -4.55%

                                                                                                         │  before.txt  │              after.txt               │
                                                                                                         │  allocs/op   │  allocs/op   vs base                 │
RangeQuery/expr=a_hundred,steps=1-4                                                                          909.0 ± 0%    810.0 ± 0%  -10.89% (p=0.002 n=6)
RangeQuery/expr=a_hundred,steps=100-4                                                                       1.410k ± 0%   1.311k ± 0%   -7.02% (p=0.002 n=6)
RangeQuery/expr=a_hundred,steps=1000-4                                                                      5.513k ± 0%   5.414k ± 0%   -1.80% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=1-4                                                               1.257k ± 0%   1.158k ± 0%   -7.88% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-4                                                             1.758k ± 0%   1.659k ± 0%   -5.63% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-4                                                            5.362k ± 0%   5.263k ± 0%   -1.85% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=10000-4                                                           45.30k ± 0%   45.10k ± 0%   -0.44% (p=0.002 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1-4                                             37.97k ± 0%   37.87k ± 0%   -0.26% (p=0.002 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-4                                           38.48k ± 0%   38.38k ± 0%   -0.25% (p=0.002 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-4                                          41.98k ± 0%   41.89k ± 0%   -0.23% (p=0.041 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=1-4                                                            37.88k ± 0%   37.78k ± 0%   -0.26% (p=0.002 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-4                                                          38.38k ± 0%   38.28k ± 0%   -0.25% (p=0.002 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-4                                                         41.91k ± 0%   41.82k ± 0%   -0.23% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=1-4                                                               37.88k ± 0%   37.78k ± 0%   -0.26% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-4                                                             38.38k ± 0%   38.28k ± 0%   -0.26% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-4                                                            41.90k ± 0%   41.79k ± 0%   -0.25% (p=0.002 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1-4                                                   37.97k ± 0%   37.87k ± 0%   -0.26% (p=0.002 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-4                                                 38.47k ± 0%   38.37k ± 0%   -0.26% (p=0.002 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-4                                                41.98k ± 0%   41.88k ± 0%   -0.24% (p=0.002 n=6)
RangeQuery/expr=-a_hundred,steps=1-4                                                                        1.232k ± 0%   1.133k ± 0%   -8.04% (p=0.002 n=6)
RangeQuery/expr=-a_hundred,steps=100-4                                                                      1.733k ± 0%   1.634k ± 0%   -5.71% (p=0.002 n=6)
RangeQuery/expr=-a_hundred,steps=1000-4                                                                     5.836k ± 0%   5.737k ± 0%   -1.70% (p=0.002 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1-4                                                             2.422k ± 0%   2.224k ± 0%   -8.18% (p=0.002 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-4                                                           3.819k ± 0%   3.620k ± 0%   -5.21% (p=0.002 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-4                                                          15.63k ± 0%   15.44k ± 0%   -1.21% (p=0.002 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=10000-4                                                         130.6k ± 2%   130.2k ± 2%   -0.33% (p=0.041 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1-4                                            1.827k ± 0%   1.679k ± 0%   -8.10% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-4                                          3.296k ± 0%   3.147k ± 0%   -4.51% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                         15.97k ± 0%   15.82k ± 0%   -0.92% (p=0.002 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1-4                                             1.835k ± 0%   1.687k ± 0%   -8.07% (p=0.002 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-4                                           3.614k ± 0%   3.465k ± 0%   -4.11% (p=0.002 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                          19.10k ± 0%   18.95k ± 0%   -0.79% (p=0.002 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1-4                                         1.827k ± 0%   1.679k ± 0%   -8.10% (p=0.002 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-4                                       3.295k ± 0%   3.147k ± 0%   -4.49% (p=0.002 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-4                                      15.97k ± 0%   15.83k ± 0%   -0.88% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1-4                                             1.180k ± 0%   1.081k ± 0%   -8.39% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-4                                           1.879k ± 0%   1.780k ± 0%   -5.27% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-4                                          7.782k ± 0%   7.683k ± 0%   -1.27% (p=0.002 n=6)
RangeQuery/expr=abs(a_hundred),steps=1-4                                                                    1.258k ± 0%   1.159k ± 0%   -7.87% (p=0.002 n=6)
RangeQuery/expr=abs(a_hundred),steps=100-4                                                                  1.858k ± 0%   1.759k ± 0%   -5.33% (p=0.002 n=6)
RangeQuery/expr=abs(a_hundred),steps=1000-4                                                                 6.862k ± 0%   6.763k ± 0%   -1.44% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-4                                 1.780k ± 0%   1.681k ± 0%   -5.56% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-4                               2.776k ± 0%   2.677k ± 0%   -3.57% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-4                              11.38k ± 0%   11.28k ± 0%   -0.87% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-4                                        1.449k ± 0%   1.350k ± 0%   -6.83% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-4                                      2.643k ± 0%   2.544k ± 0%   -3.75% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-4                                     13.05k ± 0%   12.95k ± 0%   -0.77% (p=0.002 n=6)
RangeQuery/expr=sum(a_hundred),steps=1-4                                                                    1054.0 ± 0%    955.0 ± 0%   -9.39% (p=0.002 n=6)
RangeQuery/expr=sum(a_hundred),steps=100-4                                                                  1.951k ± 0%   1.852k ± 0%   -5.07% (p=0.002 n=6)
RangeQuery/expr=sum(a_hundred),steps=1000-4                                                                 9.654k ± 0%   9.555k ± 0%   -1.03% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-4                                                       10.114k ± 0%   9.015k ± 0%  -10.87% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-4                                                      18.44k ± 0%   17.34k ± 0%   -5.96% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-4                                                     89.39k ± 0%   88.29k ± 0%   -1.23% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-4                                                      10.491k ± 0%   9.392k ± 0%  -10.48% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-4                                                     37.47k ± 0%   36.37k ± 0%   -2.93% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-4                                                    278.0k ± 0%   276.9k ± 0%   -0.39% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-4                                                            10.491k ± 0%   9.392k ± 0%  -10.48% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-4                                                           37.47k ± 0%   36.37k ± 0%   -2.93% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-4                                                          278.0k ± 0%   276.9k ± 0%   -0.39% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-4                                                           10.114k ± 0%   9.015k ± 0%  -10.87% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-4                                                          18.44k ± 0%   17.34k ± 0%   -5.96% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-4                                                         89.39k ± 0%   88.29k ± 0%   -1.22% (p=0.002 n=6)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-4                                                580.8k ± 0%   579.6k ± 0%   -0.19% (p=0.002 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=1-4                                                                1079.0 ± 0%    980.0 ± 0%   -9.18% (p=0.002 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=100-4                                                              2.075k ± 0%   1.976k ± 0%   -4.77% (p=0.002 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-4                                                             10.68k ± 0%   10.58k ± 0%   -0.93% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=1-4                                                                1091.0 ± 0%    992.0 ± 0%   -9.07% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=100-4                                                              2.681k ± 0%   2.582k ± 0%   -3.69% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=1000-4                                                             16.68k ± 0%   16.59k ± 0%   -0.59% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1-4                                         3.110k ± 0%   2.912k ± 0%   -6.37% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-4                                       4.509k ± 0%   4.308k ± 0%   -4.46% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-4                                      15.33k ± 0%   15.12k ± 0%   -1.35% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-4                                              1.404k ± 0%   1.305k ± 0%   -7.05% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-4                                            2.400k ± 0%   2.301k ± 0%   -4.13% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-4                                           10.50k ± 0%   10.40k ± 0%   -0.94% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-4       2.791k ± 0%   2.593k ± 0%   -7.09% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-4     4.972k ± 0%   4.774k ± 0%   -3.97% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-4    22.92k ± 0%   22.72k ± 0%   -0.86% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1-4                                      13.35k ± 0%   12.25k ± 0%   -8.24% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-4                                    18.89k ± 0%   17.79k ± 0%   -5.82% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-4                                   64.60k ± 0%   63.50k ± 0%   -1.70% (p=0.002 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1-4                                               1.212k ± 0%   1.113k ± 0%   -8.17% (p=0.002 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-4                                             2.093k ± 0%   1.994k ± 0%   -4.73% (p=0.002 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-4                                            9.644k ± 0%   9.547k ± 0%   -1.00% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1-4                                                              1.560k ± 0%   1.560k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=timestamp(a_hundred),steps=100-4                                                            2.358k ± 0%   2.358k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1000-4                                                           9.162k ± 0%   9.163k ± 0%        ~ (p=1.000 n=6)
geomean                                                                                                     8.138k        7.822k        -3.89%
¹ all samples are equal
```

</p>
</details> 
