### PR TITLE
PromQL: reduce numbers of benchmarks

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -152,7 +152,8 @@ func rangeQueryCases() []benchCase {
 			expr: "sum by (le)(h_X)",
 		},
 		{
-			expr: "count_values('value', h_X)",
+			expr:  "count_values('value', h_X)",
+			steps: 100,
 		},
 		{
 			expr: "topk(1, a_X)",
@@ -212,7 +213,6 @@ func rangeQueryCases() []benchCase {
 			tmp = append(tmp, c)
 		} else {
 			tmp = append(tmp, benchCase{expr: c.expr, steps: 1})
-			tmp = append(tmp, benchCase{expr: c.expr, steps: 10})
 			tmp = append(tmp, benchCase{expr: c.expr, steps: 100})
 			tmp = append(tmp, benchCase{expr: c.expr, steps: 1000})
 		}


### PR DESCRIPTION
Make it more likely that contributors will run the benchmark suite.

`count_values` needs more than 2GB at 1,000 steps, so just run it for 100.

And remove 10-step variant because it doesn't add much to 100 and 1000-step benchmarks.

