### PR TITLE
Add version in web/ui/package-lock.json

### DIFF
--- a/scripts/ui_release.sh
+++ b/scripts/ui_release.sh
@@ -85,7 +85,7 @@ function bumpVersion() {
     fi
   done
   # increase the version on all packages
-  npm version "${version}" --workspaces
+  npm version "${version}" --workspaces  --include-workspace-root
 }
 
 if [[ "$1" == "--copy" ]]; then

--- a/web/ui/README.md
+++ b/web/ui/README.md
@@ -1,9 +1,9 @@
 ## Overview
 The `ui` directory contains static files and templates used in the web UI. For
-easier distribution they are compressed (c.f. Makefile) and statically compiled 
+easier distribution they are compressed (c.f. Makefile) and statically compiled
 into the Prometheus binary using the embed package.
 
-During development it is more convenient to always use the files on disk to 
+During development it is more convenient to always use the files on disk to
 directly see changes without recompiling.
 To make this work, remove the `builtinassets` build tag in the `flags` entry
 in `.promu.yml`, and then `make build` (or build Prometheus using

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "prometheus-io",
+  "version": "0.46.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prometheus-io",
+      "version": "0.46.0",
       "workspaces": [
         "react-app",
         "module/*"

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -27,5 +27,6 @@
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.0",
     "typescript": "^4.9.5"
-  }
+  },
+  "version": "0.46.0"
 }


### PR DESCRIPTION
This PR adds the option --include-workspace-root in ui_release.sh npm scripts
in order to also include the version in web/ui/package.json and
package-lock.json files when bumping the ui version. This also avoids issues
when building directly with npm install on some systems that would expect this
version field to show up on the workspace root files.

