### PR TITLE
Fix handling of explicit counter reset header in histograms.

### DIFF
--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -233,6 +233,11 @@ func (a *FloatHistogramAppender) appendable(h *histogram.FloatHistogram) (
 	if a.NumSamples() > 0 && a.GetCounterResetHeader() == GaugeType {
 		return
 	}
+	if h.CounterResetHint == histogram.CounterReset {
+		// Always honor the explicit counter reset hint.
+		counterReset = true
+		return
+	}
 	if value.IsStaleNaN(h.Sum) {
 		// This is a stale sample whose buckets and spans don't matter.
 		okToAppend = true
@@ -576,7 +581,10 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 			return nil, false, a, nil
 		}
 
-		if prev != nil && h.CounterResetHint != histogram.CounterReset {
+		if h.CounterResetHint == histogram.CounterReset {
+			// Always honor the explicit counter reset hint.
+			a.setCounterResetHeader(CounterReset)
+		} else if prev != nil {
 			// This is a new chunk, but continued from a previous one. We need to calculate the reset header unless already set.
 			_, _, _, counterReset := prev.appendable(h)
 			if counterReset {
@@ -584,9 +592,6 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 			} else {
 				a.setCounterResetHeader(NotCounterReset)
 			}
-		} else {
-			// Honor the explicit counter reset hint.
-			a.setCounterResetHeader(CounterResetHeader(h.CounterResetHint))
 		}
 		return nil, false, a, nil
 	}

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -581,10 +581,11 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 			return nil, false, a, nil
 		}
 
-		if h.CounterResetHint == histogram.CounterReset {
+		switch {
+		case h.CounterResetHint == histogram.CounterReset:
 			// Always honor the explicit counter reset hint.
 			a.setCounterResetHeader(CounterReset)
-		} else if prev != nil {
+		case prev != nil:
 			// This is a new chunk, but continued from a previous one. We need to calculate the reset header unless already set.
 			_, _, _, counterReset := prev.appendable(h)
 			if counterReset {

--- a/tsdb/chunkenc/float_histogram_test.go
+++ b/tsdb/chunkenc/float_histogram_test.go
@@ -467,7 +467,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 	{ // Start new chunk explicitly, and append a new histogram that is not considered appendable to the previous chunk.
 		_, hApp, ts, h1 := setup()
 		h2 := h1.Copy()
-		h2.Count = h2.Count - 1 // Make this not appendable due to counter reset.
+		h2.Count-- // Make this not appendable due to counter reset.
 
 		nextChunk := NewFloatHistogramChunk()
 		app, err := nextChunk.Appender()

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -253,6 +253,11 @@ func (a *HistogramAppender) appendable(h *histogram.Histogram) (
 	if a.NumSamples() > 0 && a.GetCounterResetHeader() == GaugeType {
 		return
 	}
+	if h.CounterResetHint == histogram.CounterReset {
+		// Always honor the explicit counter reset hint.
+		counterReset = true
+		return
+	}
 	if value.IsStaleNaN(h.Sum) {
 		// This is a stale sample whose buckets and spans don't matter.
 		okToAppend = true
@@ -611,7 +616,10 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 			return nil, false, a, nil
 		}
 
-		if prev != nil && h.CounterResetHint != histogram.CounterReset {
+		if h.CounterResetHint == histogram.CounterReset {
+			// Always honor the explicit counter reset hint.
+			a.setCounterResetHeader(CounterReset)
+		} else if prev != nil {
 			// This is a new chunk, but continued from a previous one. We need to calculate the reset header unless already set.
 			_, _, _, counterReset := prev.appendable(h)
 			if counterReset {
@@ -619,9 +627,6 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 			} else {
 				a.setCounterResetHeader(NotCounterReset)
 			}
-		} else {
-			// Honor the explicit counter reset hint.
-			a.setCounterResetHeader(CounterResetHeader(h.CounterResetHint))
 		}
 		return nil, false, a, nil
 	}

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -616,10 +616,11 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 			return nil, false, a, nil
 		}
 
-		if h.CounterResetHint == histogram.CounterReset {
+		switch {
+		case h.CounterResetHint == histogram.CounterReset:
 			// Always honor the explicit counter reset hint.
 			a.setCounterResetHeader(CounterReset)
-		} else if prev != nil {
+		case prev != nil:
 			// This is a new chunk, but continued from a previous one. We need to calculate the reset header unless already set.
 			_, _, _, counterReset := prev.appendable(h)
 			if counterReset {

--- a/tsdb/chunkenc/histogram_test.go
+++ b/tsdb/chunkenc/histogram_test.go
@@ -489,7 +489,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 	{ // Start new chunk explicitly, and append a new histogram that is not considered appendable to the previous chunk.
 		_, hApp, ts, h1 := setup()
 		h2 := h1.Copy()
-		h2.Count = h2.Count - 1 // Make this not appendable due to counter reset.
+		h2.Count-- // Make this not appendable due to counter reset.
 
 		nextChunk := NewHistogramChunk()
 		app, err := nextChunk.Appender()


### PR DESCRIPTION
Explicit counter resets were being ignored.
Also there was no unit test coverage.
Add test case for the first sample in a chunk.
Add test case for non first sample in chunk.
