### PR TITLE
promtool tsdb dump support native histogram

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -647,6 +647,14 @@ func dumpSamples(path string, mint, maxt int64, match string) (err error) {
 			ts, val := it.At()
 			fmt.Printf("%s %g %d\n", lbs, val, ts)
 		}
+		for it.Next() == chunkenc.ValFloatHistogram {
+			ts, fh := it.AtFloatHistogram()
+			fmt.Printf("%s %s %d\n", lbs, fh.String(), ts)
+		}
+		for it.Next() == chunkenc.ValHistogram {
+			ts, h := it.AtHistogram()
+			fmt.Printf("%s %s %d\n", lbs, h.String(), ts)
+		}
 		if it.Err() != nil {
 			return ss.Err()
 		}


### PR DESCRIPTION
partly fix #12146

let promtool tsdb dump support native histogram as @beorn7 suggests

> Which leaves us with tsdb dump: That would indeed be good to support native histograms. The dump uses pretty much an ad hoc format. That's a problem of its own, see discussion in https://github.com/prometheus/prometheus/issues/8281 in https://github.com/prometheus/prometheus/pull/8320 , but for now, it simplifies things here. You can essentially make something up (which could be using the String methods that are also used in the internal web UI).

The output I test looks like
```
{__name__="http_request_durations", code="200", instance="native-demo:8080", job="native-demo", service="service#9"} {count:822093, sum:4.935757323322672e+06, [-0.05,0.05]:3409, (0.044194173824159216,0.0625]:833, (0.0625,0.08838834764831843]:1792, (0.08838834764831843,0.125]:2467, (0.125,0.17677669529663687]:3574, (0.17677669529663687,0.25]:5031, (0.25,0.35355339059327373]:7107, (0.35355339059327373,0.5]:10193, (0.5,0.7071067811865475]:14093, (0.7071067811865475,1]:20101, (1,1.414213562373095]:28544, (1.414213562373095,2]:40030, (2,2.82842712474619]:56409, (2.82842712474619,4]:80098, (4,5.65685424949238]:113296, (5.65685424949238,8]:160707, (8,11.31370849898476]:227336, (11.31370849898476,16]:47073} 1693350571140
{__name__="http_request_durations", code="200", instance="native-demo:8080", job="native-demo", service="service#9"} {count:822524, sum:4.938426501507527e+06, [-0.05,0.05]:3411, (0.044194173824159216,0.0625]:835, (0.0625,0.08838834764831843]:1792, (0.08838834764831843,0.125]:2470, (0.125,0.17677669529663687]:3575, (0.17677669529663687,0.25]:5035, (0.25,0.35355339059327373]:7109, (0.35355339059327373,0.5]:10198, (0.5,0.7071067811865475]:14097, (0.7071067811865475,1]:20113, (1,1.414213562373095]:28554, (1.414213562373095,2]:40058, (2,2.82842712474619]:56437, (2.82842712474619,4]:80134, (4,5.65685424949238]:113345, (5.65685424949238,8]:160795, (8,11.31370849898476]:227473, (11.31370849898476,16]:47093} 1693350576144

```